### PR TITLE
workflow: split test and eval jobs

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -15,13 +15,11 @@ permissions:
   checks: read
 
 jobs:
-  evaluate:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -37,6 +35,23 @@ jobs:
 
       - name: Type check
         run: npm run type-check
+
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run evaluation
         run: npm run eval run


### PR DESCRIPTION
Separates the evaluation workflow into two parallel jobs for better performance and faster feedback.

## Changes

- Split the single `evaluate` job into two parallel jobs:
  - `test`: runs `npm test` and `npm run type-check` 
  - `eval`: runs `npm run eval run`
- Removed unnecessary `fetch-depth: 10` from the test job since it only needs basic checkout
- Both jobs can now run in parallel, providing faster feedback on test failures