### PR TITLE
mcps: refactor install to use CLI subcommand

### DIFF
--- a/mcps/cli.ts
+++ b/mcps/cli.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env npx tsx
+
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+async function main() {
+  await yargs(hideBin(process.argv))
+    .command('install [mcp]', 'Install MCP servers', 
+      (yargs) => {
+        return yargs
+          .positional('mcp', {
+            describe: 'Name of specific MCP to install (installs all if not specified)',
+            type: 'string'
+          })
+          .option('print', {
+            type: 'boolean',
+            description: 'Print MCP configuration as JSON (compatible with Claude Desktop)',
+            default: false
+          });
+      },
+      async (argv) => {
+        const { install } = await import('./install.js');
+        await install(argv);
+      }
+    )
+    .demandCommand(1, 'You need to specify a command')
+    .strict()
+    .help()
+    .parseAsync();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(error => {
+    console.error('Error:', error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/mcps/install.ts
+++ b/mcps/install.ts
@@ -358,6 +358,23 @@ class McpInstaller {
   }
 }
 
+export async function install(argv: { mcp?: string; print?: boolean }): Promise<void> {
+  try {
+    const installer = new McpInstaller();
+    await installer.init();
+
+    if (argv.print) {
+      await installer.printConfig();
+    } else {
+      await installer.install(argv.mcp);
+    }
+  } catch (error) {
+    console.error('Error:', error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}
+
+// Keep backward compatibility for direct execution
 async function main() {
   const args = await yargs(hideBin(process.argv))
     .command('$0 [mcp]', 'Install MCP servers', (yargs) => {
@@ -375,19 +392,7 @@ async function main() {
     .help()
     .parseAsync();
 
-  try {
-    const installer = new McpInstaller();
-    await installer.init();
-
-    if (args.print) {
-      await installer.printConfig();
-    } else {
-      await installer.install(args.mcp as string | undefined);
-    }
-  } catch (error) {
-    console.error('Error:', error instanceof Error ? error.message : error);
-    process.exit(1);
-  }
+  await install({ mcp: args.mcp as string | undefined, print: args.print as boolean });
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/mcps/package.json
+++ b/mcps/package.json
@@ -2,8 +2,12 @@
   "name": "@bendrucker/claude-mcp-servers",
   "private": true,
   "type": "module",
+  "bin": {
+    "@mcps": "./cli.ts"
+  },
   "scripts": {
     "test": "echo 'No tests yet'",
+    "mcp-install": "tsx cli.ts install",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
Converts the standalone install.ts script to work as a subcommand of the new @mcps CLI.

- Creates mcps/cli.ts as the main CLI entry point with subcommands
- Refactors install.ts to export an install() function
- Maintains backward compatibility for direct execution of install.ts
- Adds bin entry to package.json for @mcps command