### PR TITLE
mcp: use `npm exec` over `npx`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,9 +56,6 @@ jobs:
 
   tools:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: mcps
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -81,12 +78,14 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        working-directory: mcps
 
       - name: Install TypeScript language server
         run: npm install -g typescript-language-server typescript
 
       - name: Validate configuration
         run: npx tsx cli.ts validate
+        working-directory: mcps
 
       - name: Install uv and uvx
         run: |
@@ -95,8 +94,8 @@ jobs:
           # Verify uvx is available
           $HOME/.cargo/bin/uvx --version || echo "uvx not found, using uv tool run"
 
-      - name: Run tools command
-        run: npm run tools -- --exclude github
+      - name: Run tools command from parent directory
+        run: npm run --prefix mcps tools -- --exclude github
 
   markdown:
     runs-on: ubuntu-latest

--- a/mcps/lib/config.ts
+++ b/mcps/lib/config.ts
@@ -28,7 +28,7 @@ export interface UvxConfig extends EnvConfig {
 
 export interface NpmConfig extends EnvConfig {
   package: string;
-  binary?: string;
+  binary: string;
 }
 
 export interface DockerConfig extends EnvConfig {
@@ -157,8 +157,8 @@ export function createServerConfig(runner: Runner): ServerConfig {
   if ('npm' in runner) {
     return {
       type: 'stdio',
-      command: 'npx',
-      args: ['--prefix', baseDir, '--no-install', runner.npm.binary || runner.npm.package],
+      command: 'npm',
+      args: ['exec', '--prefix', baseDir, '--', runner.npm.binary],
       env: runner.npm.env || {},
       cwd: baseDir
     };

--- a/mcps/mcps.json
+++ b/mcps/mcps.json
@@ -83,7 +83,8 @@
     "playwright": {
       "runner": {
         "npm": {
-          "package": "@playwright/mcp"
+          "package": "@playwright/mcp",
+          "binary": "mcp-server-playwright"
         }
       },
       "targets": {

--- a/mcps/schema/runners/npm.json
+++ b/mcps/schema/runners/npm.json
@@ -7,7 +7,7 @@
   "properties": {
     "npm": {
       "type": "object",
-      "required": ["package"],
+      "required": ["package", "binary"],
       "properties": {
         "package": {
           "type": "string",


### PR DESCRIPTION
`npx --prefix` doesn't work with `npm bin` and won't discover package binaries. `npm exec --prefix` works as expected. Use that and explicitly specify the binary. For the moment, `package` is now unused. 