### PR TITLE
trim memories

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,11 +20,9 @@ Adhere to these guidelines when performing your work.
 
 ## Workflow
 
-- Look for a project `CLAUDE.md` file with instructions on how to operate in the current project.
-- If the project does not have `CLAUDE.md`, fall back on `README.md` for high level project information.
-- When executing any build command to check for compilation errors, output to `/dev/null` to avoid creating a binary.
-- You may store temporary files in any project directory under `tmp/`. `~/.gitignore` ignored this directory.
-- You can interact with my macOS pasteboard (clipboard) using the `pbcopy` and `pbpaste` commands
+- When executing build commands, output to `/dev/null` to avoid creating binaries.
+- Store temporary files in `tmp/` directory.
+- Use `pbcopy` and `pbpaste` for clipboard interaction.
 
 ## Tasks
 

--- a/.claude/memory/languages/go.md
+++ b/.claude/memory/languages/go.md
@@ -4,15 +4,9 @@
 
 ## Tests
 
-Write table-style tests.
+Write table-style tests:
 
 ```go
-package mypackage_test
-
-import (
-  "testing"
-)
-
 func TestMyFunction(t *testing.T) {
   for _, tc := range []struct {
     name     string
@@ -31,9 +25,7 @@ func TestMyFunction(t *testing.T) {
     },
   } {
     t.Run(tc.name, func(t *testing.T) {
-      result := MyFunction(tc.input)
-      
-      if result != tc.expected {
+      if result := MyFunction(tc.input); result != tc.expected {
         t.Errorf("expected %s, got %s", tc.expected, result)
       }
     })
@@ -41,7 +33,5 @@ func TestMyFunction(t *testing.T) {
 }
 ```
 
-### Rules
-
-- A `name` field should be included in test cases to describe the test. Go will automatically format this with underscores to a valid test name so use space delimited words and Go will handle it.
-- The `name` of a test **shall not** be passed to any function except `t.Run` or in the message part of `Errorf`. Test names should **never** be used to control test behavior.
+- Include a `name` field in test cases. Use space-delimited words.
+- Never use test names to control test behavior.

--- a/.claude/memory/languages/typescript.md
+++ b/.claude/memory/languages/typescript.md
@@ -1,5 +1,3 @@
 # TypeScript
 
-These rules are specific to TypeScript. Anything that applies to both JavaScript and TypeScript should be documented in `javascript.md`.
-
 - Avoid using `any` type. Use specific types or `unknown` if necessary.

--- a/.claude/memory/tasks/pull-request.md
+++ b/.claude/memory/tasks/pull-request.md
@@ -1,35 +1,18 @@
 # Pull Request
 
-Use the following style guidelines when creating a GitHub pull request via any tool, including:
-
-* `github` MCP
-* `gh` CLI
-* `gt` CLI (Graphite)
+Use these guidelines when creating GitHub pull requests:
 
 ### Title
 
-- Use `$subject: $summary` format. Subject can be an area of the code (e.g., package name) or a type of change, typicall `fix` for bugfixes.
-- Use a concise summary of the change, ideally under 50 characters, at absolute most 100.
-- Use imperative mood, e.g., "add timeout to request" instead of "added timeout."
-- Use lowercase for the subject and summary, except for proper nouns or acronyms.
+- Use `$subject: $summary` format (e.g., `fix: add timeout to request`)
+- Keep under 50 characters, max 100
+- Use imperative mood, lowercase except proper nouns
 
 ### Body
 
-#### Preamble
-
-- Do not include a header at the top of the body.
-- Start with 1-3 sentences summarizing the change. For very small PRs, this might be the entire body.
-- For small summaries, fragments like "Updates the docs to..." or "Fixes an issue with..." are acceptable.
-- For bigger changes, "This PR <verb>" is a good starting point.
-
-#### Sections
-
-- Use sections to organize the body of the PR. Each section should be a `##` header.
-- Common sections include:
-  - `## Issue`: Provide root cause analysis of an issue, typically for bug fixes. If an existing GitHub issue already thoroughly describes the issue, link to it and provide a brief summary.
-  - `## Changes`: Describe the changes made in the PR at high level.
-  - `## Testing`: Describe how the changes were tested, including a summary of notable test cases.
-    - `### Manual`: Describe any manual testing done, including steps to reproduce. Only include this if manual testing was done.
-    - `### Automated`: Summarize automated tests added or modified. Highlight any notable additions in coverage. Be concise, don't repeat the test code.
-  - `## References`: Link to any relevant issues, PRs, or external resources that provide context for the changes.
-    - Include `Closes #<issue>` here if the PR resolves an issue.
+- Start with 1-3 sentences summarizing the change
+- Use `##` sections for larger PRs:
+  - `## Issue`: Root cause analysis, link existing issues
+  - `## Changes`: High-level description
+  - `## Testing`: Manual/automated testing summary
+  - `## References`: Bulleted list of links or related issues/PRs, use `Closes #<issue>` if applicable

--- a/.claude/memory/tools/gemini.md
+++ b/.claude/memory/tools/gemini.md
@@ -4,7 +4,6 @@ Use `gemini --prompt` to leverage Google Gemini's large context window when anal
 
 ## Syntax
 
-Use `@` to include files/directories:
 - `@src/file.py` - single file
 - `@src/ @tests/` - multiple directories  
 - `@./` - current directory and subdirectories
@@ -15,12 +14,5 @@ Use `@` to include files/directories:
 - Analyzing entire codebases or large directories
 - Files totaling more than 100KB
 - Verifying implementations across the entire codebase
-- Understanding project-wide patterns or architecture
 
-## Examples
-
-```bash
-gemini --prompt "@src/ Summarize the architecture of this codebase"
-gemini --prompt "@src/ @tests/ Has authentication been implemented? Show relevant files"
-gemini --all-files --prompt "Analyze the project structure and dependencies"
-```
+Example: `gemini --prompt "@src/ Summarize the architecture of this codebase"`

--- a/.claude/memory/tools/graphite.md
+++ b/.claude/memory/tools/graphite.md
@@ -1,18 +1,15 @@
 # Graphite
 
-Graphite is a CLI tool and web service for managing stacked pull requests on GitHub. It provides an [`llms.txt`](https://graphite.dev/docs/llms.txt) index of its documentation. Its CLI is `gt`.
+CLI tool for managing stacked pull requests on GitHub. Always use `--no-interactive` flag.
 
+Workflow: Work towards a checkpoint, then commit to a new branch. **Do not** create empty branches.
 
-- Every command must include the `--no-interactive` flag to avoid prompts.
-- With Graphite, instead of creating a new branch write away, you work towards a checkpoint and then commit it to a new branch. **Do not** create an empty branch to start.
-
-
+Commands:
 - `gt add`: Stage files
-- `gt create <name>`: Create a new stack entry by name. Creates a branch and commits the staged changes.
-- `gt submit` Push the stack up to the current entry and open pull requests for new entries or update existing ones.
-- `gt modify`: modify the current PR in the stack
-- `gt log`: view the current stack of PRs
-- `gt track`: Track an existing branch created outside of Graphite
-- `gt help`: view available commands
-- `gt restack`: rebase the current stack entry and all entries below
-- `gt sync`: fetch new data from Graphite, updating any branches that have changed
+- `gt create <name>`: Create stack entry, branch, and commit
+- `gt submit`: Push stack and open/update PRs
+- `gt modify`: Modify current PR
+- `gt log`: View stack
+- `gt track`: Track existing branch
+- `gt restack`: Rebase stack
+- `gt sync`: Fetch updates


### PR DESCRIPTION
Trims superfluous words and instructions from `memory/`, to reduce context usage and improve instruction following.

## Changes

### Go

- Removed package/import boilerplate from example
- Condensed verbose rules section
- Simplified test structure while preserving field names

### Pull Request

- Removed redundant tool list
- Condensed guidelines into bullet points
- Simplified section structure

### Gemini

- Removed verbose examples section
- Kept one inline example
- Condensed "When to Use" section

### Graphite

- Removed detailed explanation 
- Condensed workflow and commands

### TypeScript

- Removed confusing reference to non-existent javascript.md

### Main CLAUDE.md

- Removed redundant workflow items (project file discovery handled automatically)
- Condensed remaining items

Total reduction: ~30% less content while preserving all essential information.