### PR TITLE
mcp: replace markdownify with Microsoft's markitdown

### DIFF
--- a/mcps/mcps.json
+++ b/mcps/mcps.json
@@ -94,11 +94,10 @@
         }
       }
     },
-    "markdownify": {
+    "markitdown": {
       "runner": {
-        "npm": {
-          "package": "mcp-markdownify-server",
-          "binary": "mcp-markdownify-server"
+        "uvx": {
+          "package": "markitdown-mcp"
         }
       },
       "targets": {

--- a/mcps/package-lock.json
+++ b/mcps/package-lock.json
@@ -11,7 +11,6 @@
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "chalk": "^5.3.0",
-        "mcp-markdownify-server": "https://github.com/zcaceres/markdownify-mcp/archive/224cf89f0d58616d2a5522f60f184e8391d1c9e3.tar.gz",
         "package-registry-mcp": "1.1.0"
       },
       "bin": {
@@ -27,12 +26,6 @@
         "typescript-language-server": "^4.3.4",
         "yargs": "^18.0.0"
       }
-    },
-    "node_modules/@chainsafe/is-ip": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.1.0.tgz",
-      "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==",
-      "license": "MIT"
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.5",
@@ -938,18 +931,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/ip-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -1038,32 +1019,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/mcp-markdownify-server": {
-      "version": "0.0.1",
-      "resolved": "https://github.com/zcaceres/markdownify-mcp/archive/224cf89f0d58616d2a5522f60f184e8391d1c9e3.tar.gz",
-      "integrity": "sha512-O6jF9GoOHlba+/qJTXB6ZFZ+0gL+FtsIFyvr88+Cn2wBpLYENCao2P3NQRBQKOTSITW2KLRchurCli3uKFchyw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@modelcontextprotocol/sdk": "1.0.1",
-        "private-ip": "^3.0.2",
-        "zod": "^3.24.1"
-      },
-      "bin": {
-        "mcp-markdownify-server": "dist/index.js"
-      }
-    },
-    "node_modules/mcp-markdownify-server/node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.0.1.tgz",
-      "integrity": "sha512-slLdFaxQJ9AlRg+hw28iiTtGvShAOgOKXcD0F91nUcRYiOMuS9ZBYjcdNZRXW9G5JQ511GRTdUy1zQVZDpJ+4w==",
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^1.0.5",
-        "raw-body": "^3.0.0",
-        "zod": "^3.23.8"
-      }
-    },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -1134,15 +1089,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -1358,30 +1304,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/private-ip": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-3.0.2.tgz",
-      "integrity": "sha512-2pkOVPGYD/4QyAg95c6E/4bLYXPthT5Xw4ocXYzIIsMBhskOMn6IwkWXmg6ZiA6K58+O6VD/n02r1hDhk7vDPw==",
-      "license": "MIT",
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "ip-regex": "^5.0.0",
-        "ipaddr.js": "^2.1.0",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
-    "node_modules/private-ip/node_modules/ipaddr.js": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
-      "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/proxy-addr": {

--- a/mcps/package.json
+++ b/mcps/package.json
@@ -17,7 +17,6 @@
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "chalk": "^5.3.0",
-    "mcp-markdownify-server": "https://github.com/zcaceres/markdownify-mcp/archive/224cf89f0d58616d2a5522f60f184e8391d1c9e3.tar.gz",
     "package-registry-mcp": "1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Replaced third-party markdownify-mcp wrapper with Microsoft's official markitdown-mcp server
- Uses uvx runner instead of npm since markitdown-mcp is a native Python package
- Provides the same `convert_to_markdown` tool functionality

## Testing
- Ran `npm run tools -- --exclude github` - markitdown server successfully lists `convert_to_markdown` tool
- All other MCP servers continue to work correctly

## References
- https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp