### PR TITLE
mcp: add Things 3 server integration

### DIFF
--- a/mcps/CLAUDE.md
+++ b/mcps/CLAUDE.md
@@ -55,7 +55,7 @@ MCP servers are defined in `mcps.json`:
 Each runner type has specific configuration:
 
 - **npm**: `{ "package": "pkg-name", "binary": "bin-name" }`
-- **uvx**: `{ "package": "pkg-name", "env": {...} }`
+- **uvx**: `{ "package": "pkg-name", "binary": "bin-name", "env": {...} }`
 - **docker**: `{ "service": "service-name" }`
 - **go**: `{ "module": "module-path", "args": [...] }`
 - **binary**: `{ "path": "/path/to/bin", "args": [...] }`

--- a/mcps/cli/lib/config.ts
+++ b/mcps/cli/lib/config.ts
@@ -25,6 +25,7 @@ export interface GoConfig extends EnvConfig {
 
 export interface UvxConfig extends EnvConfig {
   package: string;
+  binary?: string;
 }
 
 export interface NpmConfig extends EnvConfig {
@@ -145,10 +146,16 @@ export function createServerConfig(runner: Runner, directory: string): ServerCon
   }
   
   if ('uvx' in runner) {
+    const args = ['--directory', directory];
+    if (runner.uvx.binary) {
+      args.push('--from', runner.uvx.package, runner.uvx.binary);
+    } else {
+      args.push(runner.uvx.package);
+    }
     return {
       type: 'stdio',
       command: 'uvx',
-      args: ['--directory', directory, runner.uvx.package],
+      args,
       env: runner.uvx.env || {},
       cwd: directory
     };

--- a/mcps/mcps.json
+++ b/mcps/mcps.json
@@ -101,6 +101,20 @@
       "targets": {
         "scope": "user"
       }
+    },
+    "things": {
+      "runner": {
+        "uvx": {
+          "package": "git+https://github.com/bendrucker/things-fastmcp.git@ben",
+          "binary": "things3-enhanced-mcp",
+          "env": {
+            "THINGS_AUTH_TOKEN": "${THINGS_AUTH_TOKEN}"
+          }
+        }
+      },
+      "targets": {
+        "scope": "user"
+      }
     }
   }
 }


### PR DESCRIPTION
Add Things 3 MCP server to enable task management through Claude.

## Changes

- Add Things 3 MCP server configuration to `mcps.json`
- Extend uvx runner to support binary override for git packages
- Update documentation for uvx binary parameter

## Requirements

Requires `THINGS_AUTH_TOKEN` environment variable to be set for authentication with Things 3 app.

## Testing

The server provides tools for:
- Task management (create, search, update)
- Project management
- Area and tag management
- Inbox and scheduled task access