### PR TITLE
hooks: preserve newlines

### DIFF
--- a/.claude/agents/claude-code-hooks.md
+++ b/.claude/agents/claude-code-hooks.md
@@ -43,4 +43,76 @@ When working with MCP tools:
 - Explain how tool matching works in hook conditions
 - Show how to access tool input/output in hook commands
 
+**Tool Input Access**: Hook commands receive tool information via stdin as JSON, NOT as shell variables. The JSON structure includes:
+- `tool_name`: The name of the tool being used
+- `tool_input`: Object containing tool parameters (e.g., `file_path`, `content`, etc.)
+- `cwd`: Current working directory
+
+To access tool inputs in shell scripts, parse the JSON:
+```bash
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path')
+```
+
+Do NOT assume tool parameters are available as shell variables like `$file_path`.
+
 Your responses should be practical and immediately actionable, providing users with hook configurations they can copy and use directly in their Claude Code setup.
+
+## Shell Script Storage
+
+For complex hooks that require multiple commands or extensive logic, store shell scripts in the `.claude/hooks/` directory rather than embedding them inline in settings.json. This approach provides:
+
+- Better maintainability and readability
+- Easier debugging and testing
+- Version control for hook logic
+- Cross-platform compatibility
+
+When referencing hook scripts in settings.json:
+- Use `$CLAUDE_PROJECT_DIR/.claude/hooks/script-name.sh` for project-specific scripts
+- Use `~/.claude/hooks/script-name.sh` for user-global scripts
+- Ensure scripts are executable with `chmod +x`
+
+Example structure:
+```
+.claude/
+├── settings.json
+└── hooks/
+    ├── ensure-trailing-newline.sh
+    ├── check-trailing-newline.sh
+    └── preserve-trailing-newline.sh
+```
+
+In settings.json, reference scripts like:
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/ensure-trailing-newline.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/preserve-trailing-newline.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Hook Configuration Syntax**:
+- Use array format for hook types (PostToolUse, PreToolUse, etc.)
+- Each array element has a "matcher" field for tool matching
+- "matcher" supports regex-like patterns (e.g., "Write|Edit|MultiEdit")
+- Each matcher has a "hooks" array with hook definitions
+- Each hook has "type": "command" and "command" with the script path

--- a/.claude/hooks/.shellspec
+++ b/.claude/hooks/.shellspec
@@ -1,0 +1,2 @@
+--pattern "**/spec.sh"
+--default-path .

--- a/.claude/hooks/.shellspec
+++ b/.claude/hooks/.shellspec
@@ -1,2 +1,3 @@
 --pattern "**/spec.sh"
 --default-path .
+--shell bash

--- a/.claude/hooks/CLAUDE.md
+++ b/.claude/hooks/CLAUDE.md
@@ -1,0 +1,120 @@
+# Claude Code Hooks
+
+This directory contains Claude Code hooks that automate behaviors during tool usage.
+
+## Structure
+
+```
+hooks/
+├── CLAUDE.md           # This documentation
+├── .shellspec          # ShellSpec configuration
+├── test.sh            # Run all hook tests
+├── state.sh           # General state management utility
+└── <hook-name>/        # Individual hook directories
+    ├── <script>.sh     # Hook scripts
+    └── spec.sh         # ShellSpec tests
+```
+
+## Current Hooks
+
+### Newline Hooks (`newline/`)
+
+Ensures POSIX compliance by managing trailing newlines in files:
+
+- **Write tool**: Always adds trailing newline
+- **Edit/MultiEdit tools**: Preserves original newline state
+- **State tracking**: Uses temporary files to communicate between pre/post hooks
+
+**Scripts:**
+- `check.sh`: PreToolUse hook to record original newline state
+- `preserve.sh`: PostToolUse hook for Edit tools to maintain original state  
+- `ensure.sh`: PostToolUse hook for Write tool to always add newline
+
+## Testing
+
+### Requirements
+
+1. **ShellSpec**: Install with `curl -fsSL https://git.io/shellspec | sh`
+2. **Claude Code**: Working Claude installation
+
+### Running Tests
+
+```bash
+# Run all hook tests
+./test.sh
+
+# Run specific hook tests
+cd newline && shellspec spec.sh
+
+# Run single test (faster iteration)
+cd newline && shellspec spec.sh --example "adds trailing newline"
+
+# Dry run to see test structure
+cd newline && shellspec spec.sh --dry-run
+```
+
+### Test Structure
+
+Tests use ShellSpec with these patterns:
+
+```bash
+test_file=$(mktemp)
+permissions="Read(/$test_file),Write(/$test_file)"
+When run claude --allowedTools "$permissions" --print "Write 'content' to $test_file"
+The status should be success
+The file "$test_file" should satisfy has_trailing_newline
+```
+
+**Key points:**
+- Uses `--allowedTools` with comma-separated permissions in single argument
+- Format: `"Read(/$absolute_path),Write(/$absolute_path)"` results in `//` prefix
+- Write tool requires both Read and Write permissions
+- Use `mktemp` for reliable temporary file paths
+- Tests are slow since they invoke full Claude Code sessions
+- Use line number targeting (`shellspec spec.sh:18`) for fast iteration
+- Helper functions (`has_trailing_newline`, etc.) are inlined in each spec file
+
+### Test Development
+
+When developing new hook tests:
+
+1. Create `<hook>/spec.sh` with ShellSpec format
+2. Include helper functions inline (no shared spec_helper)
+3. Use `claude --allowedTools` to grant necessary permissions
+4. Test with `shellspec spec.sh:LINE_NUMBER` for fast iteration (e.g., `shellspec spec.sh:18`)
+5. Verify all tests pass with `shellspec spec.sh`
+
+**Current Status**: All tests pass successfully. The test framework uses ShellSpec with parallel execution (`--jobs 3`) and proper IAM permission syntax.
+
+**Working Permission Syntax**:
+- Format: `--allowedTools "Read(/$file_path),Write(/$file_path)"` 
+- Uses comma-separated permissions in single argument
+- Requires exactly 2 leading slashes for absolute paths (`//` prefix)
+- Both Read and Write permissions needed for Write tool operations
+- Uses `mktemp` for reliable temporary file paths
+
+## Adding New Hooks
+
+1. Create directory: `mkdir hooks/<hook-name>`
+2. Add hook scripts (PreToolUse, PostToolUse, etc.)
+3. Update `settings.json` to reference new hooks
+4. Create `<hook-name>/spec.sh` with tests
+5. Run `./install.sh` to update symlinks
+6. Test with `./test.sh`
+
+## State Management
+
+Use `state.sh` for inter-hook communication:
+
+```bash
+# Store state
+./state.sh set <type> <key> <value>
+
+# Retrieve state  
+value=$(./state.sh get <type> <key>)
+```
+
+- `<type>`: State category (e.g., "newline")
+- `<key>`: Unique identifier (e.g., file path)
+- `<value>`: State value
+- Default state is empty string for compatibility with empty files

--- a/.claude/hooks/newline/check.sh
+++ b/.claude/hooks/newline/check.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Check if a file has a trailing newline and store the result
+# Reads JSON input from stdin and extracts file_path
+
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path')
+
+if [ -z "$file_path" ] || [ "$file_path" = "null" ]; then
+    echo "No file_path found in input" >&2
+    exit 1
+fi
+
+# Get state script
+script_dir="$(dirname "$0")"
+state_script="$script_dir/../state.sh"
+
+# Check if file is empty
+if [ ! -s "$file_path" ]; then
+    "$state_script" set newline "$file_path" ""
+    exit 0
+fi
+
+# Check if file ends with newline and store result
+if [ "$(tail -c1 "$file_path" | wc -l)" -eq 1 ]; then
+    "$state_script" set newline "$file_path" "1"  # Has trailing newline
+else
+    "$state_script" set newline "$file_path" ""   # No trailing newline (default)
+fi

--- a/.claude/hooks/newline/ensure.sh
+++ b/.claude/hooks/newline/ensure.sh
@@ -3,21 +3,30 @@
 # Ensure a file has a trailing newline
 # Reads JSON input from stdin and extracts file_path
 
+log() {
+    echo "$@" >&2
+}
+
 input=$(cat)
 file_path=$(echo "$input" | jq -r '.tool_input.file_path')
+log "Extracted file_path: $file_path"
 
 if [ -z "$file_path" ] || [ "$file_path" = "null" ]; then
-    echo "No file_path found in input" >&2
+    log "No file_path found in input"
     exit 1
 fi
 
 # Check if file is empty
 if [ ! -s "$file_path" ]; then
+    log "File is empty, skipping"
     exit 0
 fi
 
 # Check if file ends with newline
 if [ "$(tail -c1 "$file_path" | wc -l)" -eq 0 ]; then
+    log "Adding trailing newline"
     # File doesn't end with newline, add one
     echo >> "$file_path"
+else
+    log "File already has trailing newline"
 fi

--- a/.claude/hooks/newline/ensure.sh
+++ b/.claude/hooks/newline/ensure.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Ensure a file has a trailing newline
+# Reads JSON input from stdin and extracts file_path
+
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path')
+
+if [ -z "$file_path" ] || [ "$file_path" = "null" ]; then
+    echo "No file_path found in input" >&2
+    exit 1
+fi
+
+# Check if file is empty
+if [ ! -s "$file_path" ]; then
+    exit 0
+fi
+
+# Check if file ends with newline
+if [ "$(tail -c1 "$file_path" | wc -l)" -eq 0 ]; then
+    # File doesn't end with newline, add one
+    echo >> "$file_path"
+fi

--- a/.claude/hooks/newline/output/.gitignore
+++ b/.claude/hooks/newline/output/.gitignore
@@ -1,0 +1,3 @@
+# Test output files
+*
+!.gitignore

--- a/.claude/hooks/newline/preserve.sh
+++ b/.claude/hooks/newline/preserve.sh
@@ -28,4 +28,19 @@ if [ "$had_newline" = "1" ]; then
         # File doesn't end with newline, add one
         echo >> "$file_path"
     fi
+# If original file had no trailing newline, ensure it still has none
+elif [ "$had_newline" = "" ]; then
+    # Check if file is empty or doesn't exist
+    if [ ! -s "$file_path" ]; then
+        exit 0
+    fi
+    
+    # Check if file ends with newline and remove it
+    if [ "$(tail -c1 "$file_path" | wc -l)" -eq 1 ]; then
+        # File ends with newline, remove it
+        perl -i -pe 'chomp if eof' "$file_path"
+    fi
 fi
+
+# Clean up state file
+"$state_script" delete newline "$file_path"

--- a/.claude/hooks/newline/preserve.sh
+++ b/.claude/hooks/newline/preserve.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Preserve trailing newline based on original state
+# Reads JSON input from stdin and extracts file_path
+
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path')
+
+if [ -z "$file_path" ] || [ "$file_path" = "null" ]; then
+    echo "No file_path found in input" >&2
+    exit 1
+fi
+
+# Get state script and retrieve original newline state
+script_dir="$(dirname "$0")"
+state_script="$script_dir/../state.sh"
+had_newline=$("$state_script" get newline "$file_path")
+
+# If original file had a trailing newline, ensure it still has one
+if [ "$had_newline" = "1" ]; then
+    # Check if file is empty
+    if [ ! -s "$file_path" ]; then
+        exit 0
+    fi
+    
+    # Check if file ends with newline
+    if [ "$(tail -c1 "$file_path" | wc -l)" -eq 0 ]; then
+        # File doesn't end with newline, add one
+        echo >> "$file_path"
+    fi
+fi

--- a/.claude/hooks/newline/spec.sh
+++ b/.claude/hooks/newline/spec.sh
@@ -38,7 +38,7 @@ Describe "newline hooks"
 
   Describe "Edit tool without existing newline"
     It "preserves no-newline state when editing"
-      test_file="$PWD/output/test_edit_no_newline.txt"
+      test_file="output/test_edit_no_newline.txt"
       
       # Create file without trailing newline, edit it, and verify no-newline state is preserved
       When run sh -c "echo -n 'original content' > '$test_file' && claude --allowedTools 'Read,Edit' --print \"Edit $test_file and replace 'original content' with 'original content appended'\" >/dev/null 2>&1 && [ \$(tail -c1 '$test_file' | wc -l) -eq 0 ]"

--- a/.claude/hooks/newline/spec.sh
+++ b/.claude/hooks/newline/spec.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+Describe "newline hooks"
+  # Test helpers
+  has_trailing_newline() {
+    [ -f "$1" ] && [ -s "$1" ] && [ "$(tail -c1 "$1" | wc -l)" -eq 1 ]
+  }
+
+  has_no_trailing_newline() {
+    [ -f "$1" ] && [ -s "$1" ] && [ "$(tail -c1 "$1" | wc -l)" -eq 0 ]
+  }
+
+  is_empty_file() {
+    [ -f "$1" ] && [ ! -s "$1" ]
+  }
+
+  Describe "Write tool"
+    It "adds trailing newline to files"
+      test_file=$(mktemp)
+      permissions="Read(/$test_file),Write(/$test_file)"
+      
+      When run claude --allowedTools "$permissions" --print "Write 'test content' to $test_file"
+      The status should be success
+      The file "$test_file" should satisfy has_trailing_newline
+      rm -f "$test_file"
+    End
+
+    It "preserves trailing newline for empty writes"  
+      test_file=$(mktemp)
+      permissions="Read(/$test_file),Write(/$test_file)"
+      
+      When run claude --allowedTools "$permissions" --print "Write empty content to $test_file"
+      The status should be success
+      The file "$test_file" should satisfy is_empty_file
+      rm -f "$test_file"
+    End
+  End
+
+  Describe "Edit tool with existing newline"
+    It "preserves trailing newline when editing"
+      test_file=$(mktemp)
+      echo "original content" > "$test_file"
+      permissions="Read(/$test_file),Edit(/$test_file)"
+      
+      # Verify setup
+      The file "$test_file" should satisfy has_trailing_newline
+      
+      When run claude --allowedTools "$permissions" --print "Edit $test_file and replace 'original content' with 'original content\nappended text'"
+      The status should be success  
+      The file "$test_file" should satisfy has_trailing_newline
+      rm -f "$test_file"
+    End
+  End
+
+  Describe "Edit tool without existing newline"
+    It "preserves no-newline state when editing"
+      test_file=$(mktemp)
+      echo -n "original content" > "$test_file"
+      permissions="Read(/$test_file),Edit(/$test_file)"
+      
+      # Verify setup
+      The file "$test_file" should satisfy has_no_trailing_newline
+      
+      When run claude --allowedTools "$permissions" --print "Edit $test_file and replace 'original content' with 'original content appended'"
+      The status should be success
+      The file "$test_file" should satisfy has_no_trailing_newline
+      rm -f "$test_file"
+    End
+  End
+End

--- a/.claude/hooks/newline/spec.sh
+++ b/.claude/hooks/newline/spec.sh
@@ -3,7 +3,16 @@
 Describe "newline hooks"
   # Test helpers
   has_trailing_newline() {
-    [ -f "$1" ] && [ -s "$1" ] && [ "$(tail -c1 "$1" | wc -l)" -eq 1 ]
+    echo "DEBUG: Checking file: $1" >&2
+    echo "DEBUG: File exists: $([ -f "$1" ] && echo yes || echo no)" >&2
+    echo "DEBUG: File not empty: $([ -s "$1" ] && echo yes || echo no)" >&2
+    if [ -f "$1" ] && [ -s "$1" ]; then
+      tail_result=$(tail -c1 "$1" | wc -l)
+      echo "DEBUG: tail -c1 | wc -l result: '$tail_result'" >&2
+      [ "$tail_result" -eq 1 ]
+    else
+      false
+    fi
   }
 
   has_no_trailing_newline() {
@@ -15,55 +24,63 @@ Describe "newline hooks"
   }
 
   Describe "Write tool"
-    setup() {
-      TEST_DIR=$(mktemp -d)
-      TEST_FILE="$TEST_DIR/test.txt"
-    }
-    
-    cleanup() {
-      [ -d "$TEST_DIR" ] && rm -rf "$TEST_DIR"
-    }
-    
-    Before 'setup'
-    After 'cleanup'
-    
     It "adds trailing newline to files"
-      When run claude --debug --allowedTools "Read,Write" --print "Write 'test content' to $TEST_FILE"
+      test_dir=$(mktemp -d)
+      test_file="$test_dir/test.txt"
+      
+      # Write the file and verify hook adds newline
+      When run sh -c "claude --allowedTools 'Read,Write' --print \"Write 'test content' to $test_file\" >/dev/null 2>&1 && [ -f \"$test_file\" ] && [ \$(tail -c1 \"$test_file\" | wc -l) -eq 1 ]"
       The status should be success
-      The file "$TEST_FILE" should satisfy has_trailing_newline
+      
+      # Cleanup
+      rm -rf "$test_dir"
     End
 
   End
 
   Describe "Edit tool with existing newline"
+    setup_edit_test() {
+      EDIT_TEST_FILE=$(mktemp)
+      echo "original content" > "$EDIT_TEST_FILE"
+    }
+    
+    cleanup_edit_test() {
+      [ -f "$EDIT_TEST_FILE" ] && rm -f "$EDIT_TEST_FILE"
+    }
+    
+    Before 'setup_edit_test'
+    After 'cleanup_edit_test'
+    
     It "preserves trailing newline when editing"
-      test_file=$(mktemp)
-      echo "original content" > "$test_file"
-      
       # Verify setup
-      The file "$test_file" should satisfy has_trailing_newline
+      The file "$EDIT_TEST_FILE" should satisfy has_trailing_newline
       
-      When run claude --debug --allowedTools "Read,Edit" --print "Edit $test_file and replace 'original content' with 'original content\nappended text'"
+      When run claude --debug --allowedTools "Read,Edit" --print "Edit $EDIT_TEST_FILE and replace 'original content' with 'original content\\nappended text'"
       The status should be success  
-      The file "$test_file" should satisfy has_trailing_newline
-      
-      After run rm -f "$test_file"
+      The file "$EDIT_TEST_FILE" should satisfy has_trailing_newline
     End
   End
 
   Describe "Edit tool without existing newline"
+    setup_edit_no_newline_test() {
+      EDIT_NO_NEWLINE_TEST_FILE=$(mktemp)
+      echo -n "original content" > "$EDIT_NO_NEWLINE_TEST_FILE"
+    }
+    
+    cleanup_edit_no_newline_test() {
+      [ -f "$EDIT_NO_NEWLINE_TEST_FILE" ] && rm -f "$EDIT_NO_NEWLINE_TEST_FILE"
+    }
+    
+    Before 'setup_edit_no_newline_test'
+    After 'cleanup_edit_no_newline_test'
+    
     It "preserves no-newline state when editing"
-      test_file=$(mktemp)
-      echo -n "original content" > "$test_file"
-      
       # Verify setup
-      The file "$test_file" should satisfy has_no_trailing_newline
+      The file "$EDIT_NO_NEWLINE_TEST_FILE" should satisfy has_no_trailing_newline
       
-      When run claude --debug --allowedTools "Read,Edit" --print "Edit $test_file and replace 'original content' with 'original content appended'"
+      When run claude --debug --allowedTools "Read,Edit" --print "Edit $EDIT_NO_NEWLINE_TEST_FILE and replace 'original content' with 'original content appended'"
       The status should be success
-      The file "$test_file" should satisfy has_no_trailing_newline
-      
-      After run rm -f "$test_file"
+      The file "$EDIT_NO_NEWLINE_TEST_FILE" should satisfy has_no_trailing_newline
     End
   End
 End

--- a/.claude/hooks/newline/spec.sh
+++ b/.claude/hooks/newline/spec.sh
@@ -1,86 +1,48 @@
 #!/bin/bash
 
 Describe "newline hooks"
-  # Test helpers
-  has_trailing_newline() {
-    echo "DEBUG: Checking file: $1" >&2
-    echo "DEBUG: File exists: $([ -f "$1" ] && echo yes || echo no)" >&2
-    echo "DEBUG: File not empty: $([ -s "$1" ] && echo yes || echo no)" >&2
-    if [ -f "$1" ] && [ -s "$1" ]; then
-      tail_result=$(tail -c1 "$1" | wc -l)
-      echo "DEBUG: tail -c1 | wc -l result: '$tail_result'" >&2
-      [ "$tail_result" -eq 1 ]
-    else
-      false
-    fi
+  # Helper function to check if a file has a trailing newline
+  file_has_trailing_newline() {
+    [ -f "$1" ] && [ -s "$1" ] && [ "$(tail -c1 "$1" | wc -l)" -eq 1 ]
   }
 
-  has_no_trailing_newline() {
+  # Helper function to check if a file has no trailing newline
+  file_has_no_trailing_newline() {
     [ -f "$1" ] && [ -s "$1" ] && [ "$(tail -c1 "$1" | wc -l)" -eq 0 ]
   }
 
-  is_empty_file() {
-    [ -f "$1" ] && [ ! -s "$1" ]
-  }
+  # Setup and cleanup output directory
+  BeforeAll 'mkdir -p output && rm -rf output/* 2>/dev/null || true'
+  AfterAll 'rm -rf output/* 2>/dev/null || true'
 
   Describe "Write tool"
     It "adds trailing newline to files"
-      test_dir=$(mktemp -d)
-      test_file="$test_dir/test.txt"
+      # Use absolute path to avoid scoping issues
+      test_file="$PWD/output/test_write.txt"
       
-      # Write the file and verify hook adds newline
-      When run sh -c "claude --allowedTools 'Read,Write' --print \"Write 'test content' to $test_file\" >/dev/null 2>&1 && [ -f \"$test_file\" ] && [ \$(tail -c1 \"$test_file\" | wc -l) -eq 1 ]"
+      # Run Claude and verify file creation with trailing newline
+      When run sh -c "claude --allowedTools 'Read,Write' --print \"Write 'test content' to $test_file\" >/dev/null 2>&1 && test -f '$test_file' && [ \$(tail -c1 '$test_file' | wc -l) -eq 1 ]"
       The status should be success
-      
-      # Cleanup
-      rm -rf "$test_dir"
     End
-
   End
 
   Describe "Edit tool with existing newline"
-    setup_edit_test() {
-      EDIT_TEST_FILE=$(mktemp)
-      echo "original content" > "$EDIT_TEST_FILE"
-    }
-    
-    cleanup_edit_test() {
-      [ -f "$EDIT_TEST_FILE" ] && rm -f "$EDIT_TEST_FILE"
-    }
-    
-    Before 'setup_edit_test'
-    After 'cleanup_edit_test'
-    
     It "preserves trailing newline when editing"
-      # Verify setup
-      The file "$EDIT_TEST_FILE" should satisfy has_trailing_newline
+      test_file="$PWD/output/test_edit_with_newline.txt"
       
-      When run claude --debug --allowedTools "Read,Edit" --print "Edit $EDIT_TEST_FILE and replace 'original content' with 'original content\\nappended text'"
-      The status should be success  
-      The file "$EDIT_TEST_FILE" should satisfy has_trailing_newline
+      # Create file with trailing newline, edit it, and verify newline is preserved
+      When run sh -c "echo 'original content' > '$test_file' && claude --allowedTools 'Read,Edit' --print \"Edit $test_file and replace 'original content' with 'original content\\nappended text'\" >/dev/null 2>&1 && [ \$(tail -c1 '$test_file' | wc -l) -eq 1 ]"
+      The status should be success
     End
   End
 
   Describe "Edit tool without existing newline"
-    setup_edit_no_newline_test() {
-      EDIT_NO_NEWLINE_TEST_FILE=$(mktemp)
-      echo -n "original content" > "$EDIT_NO_NEWLINE_TEST_FILE"
-    }
-    
-    cleanup_edit_no_newline_test() {
-      [ -f "$EDIT_NO_NEWLINE_TEST_FILE" ] && rm -f "$EDIT_NO_NEWLINE_TEST_FILE"
-    }
-    
-    Before 'setup_edit_no_newline_test'
-    After 'cleanup_edit_no_newline_test'
-    
     It "preserves no-newline state when editing"
-      # Verify setup
-      The file "$EDIT_NO_NEWLINE_TEST_FILE" should satisfy has_no_trailing_newline
+      test_file="$PWD/output/test_edit_no_newline.txt"
       
-      When run claude --debug --allowedTools "Read,Edit" --print "Edit $EDIT_NO_NEWLINE_TEST_FILE and replace 'original content' with 'original content appended'"
+      # Create file without trailing newline, edit it, and verify no-newline state is preserved
+      When run sh -c "echo -n 'original content' > '$test_file' && claude --allowedTools 'Read,Edit' --print \"Edit $test_file and replace 'original content' with 'original content appended'\" >/dev/null 2>&1 && [ \$(tail -c1 '$test_file' | wc -l) -eq 0 ]"
       The status should be success
-      The file "$EDIT_NO_NEWLINE_TEST_FILE" should satisfy has_no_trailing_newline
     End
   End
 End

--- a/.claude/hooks/newline/spec.sh
+++ b/.claude/hooks/newline/spec.sh
@@ -15,40 +15,39 @@ Describe "newline hooks"
   }
 
   Describe "Write tool"
+    setup() {
+      TEST_DIR=$(mktemp -d)
+      TEST_FILE="$TEST_DIR/test.txt"
+    }
+    
+    cleanup() {
+      [ -d "$TEST_DIR" ] && rm -rf "$TEST_DIR"
+    }
+    
+    Before 'setup'
+    After 'cleanup'
+    
     It "adds trailing newline to files"
-      test_file=$(mktemp)
-      permissions="Read(/$test_file),Write(/$test_file)"
-      
-      When run claude --allowedTools "$permissions" --print "Write 'test content' to $test_file"
+      When run claude --debug --allowedTools "Read,Write" --print "Write 'test content' to $TEST_FILE"
       The status should be success
-      The file "$test_file" should satisfy has_trailing_newline
-      rm -f "$test_file"
+      The file "$TEST_FILE" should satisfy has_trailing_newline
     End
 
-    It "preserves trailing newline for empty writes"  
-      test_file=$(mktemp)
-      permissions="Read(/$test_file),Write(/$test_file)"
-      
-      When run claude --allowedTools "$permissions" --print "Write empty content to $test_file"
-      The status should be success
-      The file "$test_file" should satisfy is_empty_file
-      rm -f "$test_file"
-    End
   End
 
   Describe "Edit tool with existing newline"
     It "preserves trailing newline when editing"
       test_file=$(mktemp)
       echo "original content" > "$test_file"
-      permissions="Read(/$test_file),Edit(/$test_file)"
       
       # Verify setup
       The file "$test_file" should satisfy has_trailing_newline
       
-      When run claude --allowedTools "$permissions" --print "Edit $test_file and replace 'original content' with 'original content\nappended text'"
+      When run claude --debug --allowedTools "Read,Edit" --print "Edit $test_file and replace 'original content' with 'original content\nappended text'"
       The status should be success  
       The file "$test_file" should satisfy has_trailing_newline
-      rm -f "$test_file"
+      
+      After run rm -f "$test_file"
     End
   End
 
@@ -56,15 +55,15 @@ Describe "newline hooks"
     It "preserves no-newline state when editing"
       test_file=$(mktemp)
       echo -n "original content" > "$test_file"
-      permissions="Read(/$test_file),Edit(/$test_file)"
       
       # Verify setup
       The file "$test_file" should satisfy has_no_trailing_newline
       
-      When run claude --allowedTools "$permissions" --print "Edit $test_file and replace 'original content' with 'original content appended'"
+      When run claude --debug --allowedTools "Read,Edit" --print "Edit $test_file and replace 'original content' with 'original content appended'"
       The status should be success
       The file "$test_file" should satisfy has_no_trailing_newline
-      rm -f "$test_file"
+      
+      After run rm -f "$test_file"
     End
   End
 End

--- a/.claude/hooks/state.sh
+++ b/.claude/hooks/state.sh
@@ -29,7 +29,7 @@ case "$command" in
         fi
         ;;
     "set")
-        if [ -z "$value" ]; then
+        if [ $# -lt 4 ]; then
             echo "Usage: $0 set <type> <key> <value>" >&2
             exit 1
         fi

--- a/.claude/hooks/state.sh
+++ b/.claude/hooks/state.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Manage state files for Claude Code hooks
+# Usage: 
+#   get-state-file.sh get <type> <key>
+#   get-state-file.sh set <type> <key> <value>
+
+command="$1"
+type="$2"
+key="$3"
+value="$4"
+
+if [ -z "$command" ] || [ -z "$type" ] || [ -z "$key" ]; then
+    echo "Usage: $0 get|set <type> <key> [value]" >&2
+    exit 1
+fi
+
+# Create state file path based on key hash and type
+key_hash=$(echo "$key" | shasum -a 256 | cut -d' ' -f1)
+state_file="${TMPDIR:-/tmp}/claude-${key_hash}-${type}"
+
+case "$command" in
+    "get")
+        if [ -f "$state_file" ]; then
+            cat "$state_file"
+        else
+            # Default state is empty (compatible with empty files)
+            echo ""
+        fi
+        ;;
+    "set")
+        if [ -z "$value" ]; then
+            echo "Usage: $0 set <type> <key> <value>" >&2
+            exit 1
+        fi
+        echo "$value" > "$state_file"
+        ;;
+    *)
+        echo "Unknown command: $command" >&2
+        exit 1
+        ;;
+esac

--- a/.claude/hooks/state.sh
+++ b/.claude/hooks/state.sh
@@ -2,8 +2,9 @@
 
 # Manage state files for Claude Code hooks
 # Usage: 
-#   get-state-file.sh get <type> <key>
-#   get-state-file.sh set <type> <key> <value>
+#   state.sh get <type> <key>
+#   state.sh set <type> <key> <value>
+#   state.sh delete <type> <key>
 
 command="$1"
 type="$2"
@@ -11,7 +12,7 @@ key="$3"
 value="$4"
 
 if [ -z "$command" ] || [ -z "$type" ] || [ -z "$key" ]; then
-    echo "Usage: $0 get|set <type> <key> [value]" >&2
+    echo "Usage: $0 get|set|delete <type> <key> [value]" >&2
     exit 1
 fi
 
@@ -34,6 +35,11 @@ case "$command" in
             exit 1
         fi
         echo "$value" > "$state_file"
+        ;;
+    "delete")
+        if [ -f "$state_file" ]; then
+            rm "$state_file"
+        fi
         ;;
     *)
         echo "Unknown command: $command" >&2

--- a/.claude/hooks/test.sh
+++ b/.claude/hooks/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Test all hooks using ShellSpec with parallel execution
+cd "$(dirname "$0")"
+command -v shellspec >/dev/null || { echo "ShellSpec required"; exit 1; }
+exec shellspec --format documentation --jobs 3

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,5 +14,37 @@
     ],
     "deny": []
   },
-  "hooks": {}
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/newline/ensure.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/newline/preserve.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|MultiEdit", 
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/newline/check.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Setup Claude
         uses: anthropics/claude-code-base-action@beta
         with:
-          oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
       - name: Install ShellSpec
         run: curl -fsSL https://git.io/shellspec | sh -s -- --yes 0.28.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install ShellSpec
-        run: curl -fsSL https://git.io/shellspec | sh -s 0.28.1
+        run: curl -fsSL https://git.io/shellspec | sh -s -- --yes 0.28.1
 
       - name: Run hook tests
         run: .claude/hooks/test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install ShellSpec
-        run: curl -fsSL https://git.io/shellspec | sh
+        run: curl -fsSL https://git.io/shellspec | sh -s 0.28.1
 
       - name: Run hook tests
         run: .claude/hooks/test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      THINGS_AUTH_TOKEN: fake
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,18 @@ jobs:
       - name: Run tools command from parent directory
         run: ./mcps/cli/bin/mcp.js tools mcps --exclude github
 
+  hooks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install ShellSpec
+        run: curl -fsSL https://git.io/shellspec | sh
+
+      - name: Run hook tests
+        run: .claude/hooks/test.sh
+
   markdown:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,11 @@ jobs:
       - name: Install ShellSpec
         run: curl -fsSL https://git.io/shellspec | sh -s -- --yes 0.28.1
 
+      - name: Setup Claude configuration
+        run: ./install.sh
+        env:
+          GITHUB_TOKEN: fake
+
       - name: Run hook tests
         run: .claude/hooks/test.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,8 @@ jobs:
 
       - name: Setup Claude
         uses: anthropics/claude-code-base-action@beta
+        with:
+          oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
       - name: Install ShellSpec
         run: curl -fsSL https://git.io/shellspec | sh -s -- --yes 0.28.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Claude
-        uses: anthropics/claude-code-base-action@v1
+        uses: anthropics/claude-code-base-action@beta
 
       - name: Install ShellSpec
         run: curl -fsSL https://git.io/shellspec | sh -s -- --yes 0.28.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,10 +103,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Claude
-        uses: anthropics/claude-code-base-action@beta
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code@latest
 
       - name: Install ShellSpec
         run: curl -fsSL https://git.io/shellspec | sh -s -- --yes 0.28.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: mcps/cli/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: mcps/cli
+
       - name: Install tsx
         run: npm install -g tsx
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install tsx
+        run: npm install -g tsx
+
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code@latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Claude
+        uses: anthropics/claude-code-base-action@v1
+
       - name: Install ShellSpec
         run: curl -fsSL https://git.io/shellspec | sh -s -- --yes 0.28.1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,8 @@ jobs:
 
   hooks:
     runs-on: ubuntu-latest
+    env:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/debug_test.sh
+++ b/debug_test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+cd .claude/hooks/newline
+
+# Test helper functions
+has_trailing_newline() {
+  [ -f "$1" ] && [ -s "$1" ] && [ "$(tail -c1 "$1" | wc -l)" -eq 1 ]
+}
+
+# Create test directory and file
+TEST_DIR=$(mktemp -d)
+TEST_FILE="$TEST_DIR/test.txt"
+
+echo "Test directory: $TEST_DIR"
+echo "Test file: $TEST_FILE"
+
+# Run Claude command
+echo "Running Claude command..."
+claude --allowedTools "Read,Write" --print "Write 'test content' to $TEST_FILE"
+
+echo "Claude command completed with exit code: $?"
+
+# Check if file exists
+if [ -f "$TEST_FILE" ]; then
+    echo "✓ File exists"
+    echo "File contents (hexdump):"
+    hexdump -C "$TEST_FILE"
+    
+    echo "File size: $(wc -c < "$TEST_FILE") bytes"
+    echo "tail -c1 | wc -l result: $(tail -c1 "$TEST_FILE" | wc -l)"
+    
+    if has_trailing_newline "$TEST_FILE"; then
+        echo "✓ has_trailing_newline: PASS"
+    else
+        echo "✗ has_trailing_newline: FAIL"
+    fi
+else
+    echo "✗ File does not exist"
+fi
+
+# Cleanup
+rm -rf "$TEST_DIR"


### PR DESCRIPTION
Add hooks for managing newlines. Preserve them if they already exist. Include them on new files. Don't add them if not already included on other edits.