### PR TITLE
docs: add checkout instruction to pr command

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -19,4 +19,4 @@ allowed-tools: Bash(gh:*), mcp__github
   - Example: refactor-user-service
 - Commit first if there are no staged changes. Follow the same format for the commit message as for the pull request title.
 - Follow instructions in @../memory/tasks/pull-request.md.
-
+- When you're done, after summarizing the pull request URL, checkout the default branch.


### PR DESCRIPTION
Adds instruction to checkout the default branch after PR creation in the `/pr` command documentation. This ensures the user is returned to the main branch after the PR workflow completes.