### PR TITLE
refactor: convert language memory files to skills

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -32,13 +32,6 @@ Adhere to these guidelines when performing your work.
 - Graphite (`gt`): @memory/tools/graphite.md
 - Gemini CLI (`gemini`): @memory/tools/gemini.md
 
-## Languages
-
-- Shell: @memory/languages/shell.md
-- TypeScript: @memory/languages/typescript.md
-- Go: @memory/languages/go.md
-- JSON: @memory/languages/json.md
-
 ## Personal Details
 
 - Standard username: `@bendrucker`. Refer to any actions performed by this user as "you."

--- a/.claude/memory/languages/javascript.md
+++ b/.claude/memory/languages/javascript.md
@@ -1,5 +1,0 @@
-# JavaScript
-
-The following rules apply to both JavaScript and the Javascript-subset of TypeScript:
-
-- Use existing APIs that return promises instead of constructing promises with `new`.

--- a/.claude/memory/languages/shell.md
+++ b/.claude/memory/languages/shell.md
@@ -1,2 +1,0 @@
-- Use `--long-flags` where available for human readability
-- Use macOS compatible commands, don't expect GNU tools

--- a/.claude/memory/languages/typescript.md
+++ b/.claude/memory/languages/typescript.md
@@ -1,3 +1,0 @@
-# TypeScript
-
-- Avoid using `any` type. Use specific types or `unknown` if necessary.

--- a/.claude/skills/go/SKILL.md
+++ b/.claude/skills/go/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: go
+description: Go language coding standards, best practices, and testing patterns. Use when writing or reviewing Go code, implementing tests, or discussing Go language features.
+---
 # Go
 
 - Use the latest Go language features within the version given in `go.mod`.

--- a/.claude/skills/javascript/SKILL.md
+++ b/.claude/skills/javascript/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: javascript
+description: JavaScript coding standards and best practices for JavaScript and TypeScript. Use when writing or reviewing JavaScript code, working with promises, or discussing JavaScript patterns.
+---
+# JavaScript
+
+The following rules apply to both JavaScript and the Javascript-subset of TypeScript:
+
+- Use existing APIs that return promises instead of constructing promises with `new`.

--- a/.claude/skills/json/SKILL.md
+++ b/.claude/skills/json/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: json
+description: JSON processing and handling best practices using jq. Use when working with JSON data, parsing JSON files, generating JSON output, or processing JSON from APIs.
+---
 # JSON
 
 - ALWAYS use `jq` for producing JSON output to ensure validity.

--- a/.claude/skills/shell/SKILL.md
+++ b/.claude/skills/shell/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: shell
+description: Shell scripting best practices and conventions for Bash commands. Use when writing shell scripts, bash commands, or working with command-line tools on macOS.
+---
+# Shell
+
+- Use `--long-flags` where available for human readability
+- Use macOS compatible commands, don't expect GNU tools

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: typescript
+description: TypeScript coding standards and best practices. Use when writing or reviewing TypeScript code, working with type definitions, or discussing TypeScript patterns.
+---
+# TypeScript
+
+- Avoid using `any` type. Use specific types or `unknown` if necessary.


### PR DESCRIPTION
Converts language-specific memory files from `.claude/memory/languages/` to skills in `.claude/skills/`. This makes language guidelines discoverable as skills and removes the need for manual @ references in CLAUDE.md, as well as trims context. 

Changes:
- Creates skills for shell, typescript, go, json, and javascript
- Removes language section from CLAUDE.md
- Deletes `.claude/memory/languages/` directory