### PR TITLE
skills: convert tool memory files to skills

### DIFF
--- a/.claude/skills/git/SKILL.md
+++ b/.claude/skills/git/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: git
+description: Git workflow and branching best practices. Use when working with git commands, creating branches, or pushing changes.
+---
+# Git
+
+* **Never** `git push` to the default branch (usually `main` or `master`) unless I explicitly instruct you to do so.
+* **Always** use a topic branch a with a few brief word hyphenated name

--- a/.claude/skills/github/SKILL.md
+++ b/.claude/skills/github/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: github
+description: GitHub workflow best practices and tool selection. Use when working with GitHub repositories, pull requests, issues, or GitHub API interactions.
+---
+# GitHub
+
+- Prefer using the `github` MCP for GitHub tasks, since calling `gh` from a shell can introduce escaping issues in text inputs.
+- Use `gh` CLI commands if needed, especially when the `github` MCP does not support a specific action and the CLI command is straightforward.
+- Use `gh api` for advanced GitHub API interactions that are not natively supported by `gh` commands.
+- Always assume GitHub URLs may refer to private repositories and use `gh` or `mcp__github` for authentication.
+
+## Workflows
+
+### Pull Request
+
+- You must `git push` a branch before creating a pull request with `gh pr create`.
+
+## MCP Tools
+
+- `search_issues`: always include `is:issue` or `is:pr` in the query, depending on the desired result type.

--- a/.claude/skills/graphite/SKILL.md
+++ b/.claude/skills/graphite/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: graphite
+description: Graphite CLI for managing stacked pull requests on GitHub. Use when working with stacked PRs, managing PR stacks, or using gt commands.
+---
+# Graphite
+
+CLI tool for managing stacked pull requests on GitHub. Always use `--no-interactive` flag.
+
+Workflow: Work towards a logical milestone, then `gt create` to create a new stack entry.
+
+Commands:
+- `gt add`: Stage files
+- `gt create <name>`: Create stack entry, branch, and commit
+- `gt submit`: Push stack and open/update PRs
+- `gt modify`: Modify current PR
+- `gt log`: View stack
+- `gt track`: Track existing branch
+- `gt restack`: Rebase stack
+- `gt sync`: Fetch updates

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: pull-request
-description: Code review request formatting guidelines for GitHub pull requests, GitLab merge requests, and Gerrit change requests. Use when creating or updating pull requests, merge requests, change requests, or writing PR/MR descriptions and titles.
+description: |
+  Formatting and content guidelines for GitHub pull requests and equivalents (GitLab: merge request, Gerrit: change request). MUST be used anytime you are creating or updating a pull request's body (description) and title.
 ---
-# Code Review Request Guidelines
+# Pull Request Guidelines
 
 Use these guidelines when creating pull requests (GitHub), merge requests (GitLab), or change requests (Gerrit):
 


### PR DESCRIPTION
## Summary

Converts tool-specific memory files from `.claude/memory/tools/` to individual Claude Code skills:

- **git**: Workflow and branching practices
- **github**: GitHub tool selection and workflows  
- **graphite**: Stacked PR management

Each skill activates automatically when working with the relevant tools or concepts, providing context-specific guidance.

## Test plan

- [x] Verify skills appear in available skills list
- [ ] Test activation when working with git commands
- [ ] Test activation when working with GitHub
- [ ] Test activation when working with Graphite stacks