### PR TITLE
skills: improve claude-skills description for better activation

### DIFF
--- a/.claude/skills/claude-skills/SKILL.md
+++ b/.claude/skills/claude-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-skills
-description: Reference documentation for developing Claude Code Skills. Use when creating new skills, debugging skill activation, or understanding skill architecture and best practices.
+description: Guide for creating, structuring, and troubleshooting Claude Code Skills. Use this skill whenever creating new skills, converting content to skills, or modifying existing skills to ensure proper structure and best practices.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, WebFetch(domain:docs.claude.com)]
 ---
 


### PR DESCRIPTION
Improves the `claude-skills` skill description to be more action-oriented and explicit about when it should activate. The skill wasn't activating reliably for skill creation tasks—even with prompts like "convert each item to a claude skill," Claude would proceed without consulting the skill.

## Changes

- Changes description from "Reference documentation" to "Guide for creating, structuring, and troubleshooting"
- Adds "Use this skill **whenever**" directive for stronger activation
- Adds "converting content to skills" as explicit trigger phrase
- Reorders triggers to prioritize creation/conversion over troubleshooting

**Before:**
> Reference documentation for developing Claude Code Skills. Use when creating new skills, debugging skill activation, or understanding skill architecture and best practices.

**After:**
> Guide for creating, structuring, and troubleshooting Claude Code Skills. Use this skill whenever creating new skills, converting content to skills, or modifying existing skills to ensure proper structure and best practices.