### PR TITLE
skills: add git worktrees management

### DIFF
--- a/.claude/skills/git/SKILL.md
+++ b/.claude/skills/git/SKILL.md
@@ -1,8 +1,12 @@
 ---
 name: git
-description: Git workflow and branching best practices. Use when working with git commands, creating branches, or pushing changes.
+description: Git workflow and branching best practices. Use when working with git commands, creating branches, pushing changes, or managing worktrees.
 ---
 # Git
 
 * **Never** `git push` to the default branch (usually `main` or `master`) unless I explicitly instruct you to do so.
 * **Always** use a topic branch a with a few brief word hyphenated name
+
+## Worktrees
+
+See `worktrees.md` for managing git worktrees.

--- a/.claude/skills/git/worktrees.md
+++ b/.claude/skills/git/worktrees.md
@@ -1,0 +1,29 @@
+# Git Worktrees
+
+When the user asks to start a worktree for a task:
+
+1. **Location**: Create worktrees in `.worktrees/` subdirectory within the repository
+2. **Naming**: Generate a short, hyphenated slug from the task description (e.g., "fix-auth-bug", "add-logging")
+3. **Base branch**: Always branch from the default branch (main/master)
+4. **Cleanup**: Proactively offer to remove worktrees after the associated PR is merged or work is complete
+
+## Workflow
+
+```bash
+# Create worktree
+git worktree add .worktrees/<slug> -b <branch-name>
+
+# List worktrees
+git worktree list
+
+# Remove worktree (when done)
+git worktree remove .worktrees/<slug>
+```
+
+## Example
+
+User: "start a worktree to work on fixing authentication bug"
+
+```bash
+git worktree add .worktrees/fix-auth-bug -b fix-auth-bug
+```


### PR DESCRIPTION
Adds git worktree management to the git skill using progressive disclosure pattern. When you ask Claude to start a worktree for a task, it will create a worktree in `.worktrees/` with an appropriate slug name, branching from the default branch.

## Changes

- Updates git skill description to include worktree management
- Adds `worktrees.md` with detailed worktree workflow instructions
- Configures worktrees to be created in `.worktrees/` subdirectory
- Uses short hyphenated slugs for worktree/branch naming
- Always branches from default branch (main/master)
- Includes proactive cleanup after PR completion