### PR TITLE
typescript: add tsconfig and type checking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,9 @@
   "packages": {
     "": {
       "name": "@bendrucker/claude",
+      "dependencies": {
+        "typescript": "^5.9.3"
+      },
       "devDependencies": {
         "remark": "^15.0.1",
         "remark-cli": "^12.0.1",
@@ -2607,6 +2610,19 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "build": "tsc --noEmit",
     "lint:commands": "remark .claude/commands/*.md"
   },
   "devDependencies": {
@@ -11,5 +12,8 @@
     "remark-frontmatter": "^5.0.0",
     "remark-lint": "^10.0.1",
     "remark-lint-frontmatter-schema": "^3.15.4"
+  },
+  "dependencies": {
+    "typescript": "^5.9.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "target": "esnext",
+    "types": [],
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "strict": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true
+  },
+  "include": [
+    "./**/*.ts",
+    ".claude/**/*.ts"
+  ]
+}


### PR DESCRIPTION
Adds TypeScript configuration to type-check files in the `.claude/` directory along with a build script.

## Changes

- Adds `tsconfig.json` with strict type checking enabled
- Includes `.claude/**/*.ts` pattern to override TypeScript's default exclusion of dot directories
- Adds `build` script to run type checking via `tsc --noEmit`
- Installs TypeScript as a dependency