### PR TITLE
things: add keychain-based authentication

### DIFF
--- a/.claude/skills/things/1password.md
+++ b/.claude/skills/things/1password.md
@@ -1,0 +1,26 @@
+# Things 3 Authentication
+
+## Quick Start
+
+```bash
+# One-time setup: Store token in keychain
+AUTH_TOKEN=$(op item get 5iene5gxngiqrxknafb7gslm4q --fields label=credential)
+security add-generic-password -a "$USER" -s "things-auth-token" -w "$AUTH_TOKEN" -U
+unset AUTH_TOKEN
+
+# Usage: Retrieve from keychain (no prompts, works for launchd)
+AUTH_TOKEN=$(security find-generic-password -a "$USER" -s "things-auth-token" -w)
+```
+
+## Why Keychain?
+
+- **No approval prompts**: Works unattended for background processes
+- **Secure**: Token stored in macOS Keychain, not filesystem
+- **1Password source of truth**: Manual updates sync from 1Password item `5iene5gxngiqrxknafb7gslm4q`
+
+## Update Token
+
+```bash
+security delete-generic-password -a "$USER" -s "things-auth-token"
+# Then re-run setup
+```

--- a/.claude/skills/things/SKILL.md
+++ b/.claude/skills/things/SKILL.md
@@ -13,6 +13,10 @@ Interact with Things 3, the user's personal task manager for Mac.
 - **Read operations**: Use JXA (JavaScript for Automation) via `osascript -l JavaScript`
 - **Write operations**: Use `things://` URL schemes (`things:///add`, `things:///json`)
 - **Updates**: Require auth token from Things > Settings > General
+  - **Auth token**: Store in keychain for automated access: `security find-generic-password -a "$USER" -s "things-auth-token" -w`
+  - **Initial setup**: Get token from 1Password and store in keychain (one-time, see `@1password.md`)
+  - **Background processes**: Keychain access works without prompts for launchd agents and automation
+  - See `@1password.md` for setup and authentication guide
 - **URL encoding**: Always URL-encode parameters (spaces → `%20`, newlines → `%0a`)
 
 ## Common Operations
@@ -66,7 +70,8 @@ JSON.stringify(todos, null, 2);
 ### Update a Todo
 
 ```bash
-open "things:///update?id=ABC-123&auth-token=YOUR_TOKEN&append-notes=More%20info"
+AUTH_TOKEN=$(security find-generic-password -a "$USER" -s "things-auth-token" -w)
+open "things:///update?id=ABC-123&auth-token=$AUTH_TOKEN&append-notes=More%20info"
 ```
 
 ### Navigate to List
@@ -81,6 +86,7 @@ open "things:///show?id=today"
 
 - Complete URL scheme reference: `@url-scheme.md`
 - JXA object model and properties: `@jxa.md`
+- 1Password authentication setup: `@1password.md`
 - Usage examples: `@examples.md`
 
 ## Quick Reference

--- a/.claude/skills/things/examples.md
+++ b/.claude/skills/things/examples.md
@@ -230,60 +230,27 @@ if (project) {
 
 ## Updating Todos
 
+**Prerequisite**: `AUTH_TOKEN=$(security find-generic-password -a "$USER" -s "things-auth-token" -w)` (see `@1password.md` for setup)
+
 ### Append Notes
 
 ```bash
-# First get the todo ID
 todo_id=$(osascript -l JavaScript -e '
 const app = Application("Things3");
-const today = app.lists.byId("TMTodayListSource");
-const todo = today.toDos().whose({name: "Call dentist"})[0];
+const todo = app.lists.byId("TMTodayListSource").toDos().whose({name: "Call dentist"})[0];
 todo ? todo.id() : "";
 ')
-
-# Then update with auth token
-auth_token="YOUR_AUTH_TOKEN"
-open "things:///update?id=$todo_id&auth-token=$auth_token&append-notes=Appointment%20at%202pm"
+open "things:///update?id=$todo_id&auth-token=$AUTH_TOKEN&append-notes=Appointment%20at%202pm"
 ```
 
-### Add Tags
+### Add Tags / Move / Reschedule / Complete
 
 ```bash
-todo_id="ABC-123"
-auth_token="YOUR_AUTH_TOKEN"
-open "things:///update?id=$todo_id&auth-token=$auth_token&add-tags=Urgent,Important"
-```
-
-### Move to Different Project
-
-```bash
-todo_id="ABC-123"
-auth_token="YOUR_AUTH_TOKEN"
-open "things:///update?id=$todo_id&auth-token=$auth_token&list=New%20Project"
-```
-
-### Reschedule Todo
-
-```bash
-todo_id="ABC-123"
-auth_token="YOUR_AUTH_TOKEN"
-open "things:///update?id=$todo_id&auth-token=$auth_token&when=tomorrow"
-```
-
-### Mark Complete
-
-```bash
-todo_id="ABC-123"
-auth_token="YOUR_AUTH_TOKEN"
-open "things:///update?id=$todo_id&auth-token=$auth_token&completed=true"
-```
-
-### Add Checklist Items
-
-```bash
-todo_id="ABC-123"
-auth_token="YOUR_AUTH_TOKEN"
-open "things:///update?id=$todo_id&auth-token=$auth_token&append-checklist-items=New%20item%201%0aNew%20item%202"
+open "things:///update?id=ABC-123&auth-token=$AUTH_TOKEN&add-tags=Urgent,Important"
+open "things:///update?id=ABC-123&auth-token=$AUTH_TOKEN&list=New%20Project"
+open "things:///update?id=ABC-123&auth-token=$AUTH_TOKEN&when=tomorrow"
+open "things:///update?id=ABC-123&auth-token=$AUTH_TOKEN&completed=true"
+open "things:///update?id=ABC-123&auth-token=$AUTH_TOKEN&append-checklist-items=Item%201%0aItem%202"
 ```
 
 ## Navigation
@@ -381,20 +348,14 @@ open "things:///json?data=$(echo "$data" | jq -sRr @uri)"
 ### Bulk Tag All Inbox Items
 
 ```bash
-auth_token="YOUR_AUTH_TOKEN"
-
-# Get all inbox todo IDs
 todo_ids=$(osascript -l JavaScript -e '
 const app = Application("Things3");
-const inbox = app.lists.byId("TMInboxListSource");
-const ids = inbox.toDos().map(todo => todo.id());
-JSON.stringify(ids);
+JSON.stringify(app.lists.byId("TMInboxListSource").toDos().map(t => t.id()));
 ' | jq -r '.[]')
 
-# Tag each one
 for todo_id in $todo_ids; do
-  open "things:///update?id=$todo_id&auth-token=$auth_token&add-tags=Needs%20Review"
-  sleep 0.1  # Rate limiting
+  open "things:///update?id=$todo_id&auth-token=$AUTH_TOKEN&add-tags=Needs%20Review"
+  sleep 0.1
 done
 ```
 


### PR DESCRIPTION
Adds macOS Keychain integration for storing the Things auth token, enabling unattended access for background processes like launchd agents.

## Changes

- Adds `1password.md` with setup guide for storing auth token in keychain
  - One-time setup retrieves token from 1Password item `5iene5gxngiqrxknafb7gslm4q`
  - Stores in keychain with `-U` flag for programmatic access without approval prompts
  - Works for background processes (launchd, automation scripts)
- Updates `SKILL.md` to prioritize keychain authentication
  - Replaces placeholder `YOUR_TOKEN` with keychain retrieval command
  - Documents background process compatibility
- Consolidates `examples.md` to reduce repetition
  - Single prerequisite note instead of repeated token retrieval in each example
  - Combines 5 separate update examples into one code block
  - Simplifies JXA expressions and reduces verbosity