### PR TITLE
Cancel previous GitHub Actions jobs on pull requests

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   hooks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add concurrency controls to both workflows that use Claude Code OAuth tokens. This ensures that when pushing sequentially to a PR, previous in-progress jobs are cancelled automatically, preventing unnecessary API usage.

- test.yml: Group by workflow and git ref (branch/PR)
- claude.yml: Group by workflow and issue/PR number