### PR TITLE
hooks: add GitHub Actions URL support

### DIFF
--- a/.claude/hooks/github/fetch.sh
+++ b/.claude/hooks/github/fetch.sh
@@ -51,6 +51,20 @@ if [[ "$url" =~ github\.com/([^/]+)/([^/]+) ]]; then
     fi
     exit 0
   fi
+
+  # Actions job logs
+  if [[ "$url" =~ /actions/runs/([0-9]+)/job/([0-9]+)$ ]]; then
+    job_id="${BASH_REMATCH[2]}"
+    output_json "deny" "Use: gh run view --job $job_id --log"
+    exit 0
+  fi
+
+  # Actions workflow run
+  if [[ "$url" =~ /actions/runs/([0-9]+)$ ]]; then
+    run_id="${BASH_REMATCH[1]}"
+    output_json "deny" "Use: gh run view $run_id"
+    exit 0
+  fi
 fi
 
 # Unknown GitHub URL pattern - ask user

--- a/.claude/hooks/github/spec.sh
+++ b/.claude/hooks/github/spec.sh
@@ -89,6 +89,22 @@ Describe 'GitHub fetch hook'
       End
     End
 
+    Context 'when fetching Actions workflow runs'
+      It 'denies and suggests gh run view for workflow run'
+        When run run_hook "https://github.com/owner/repo/actions/runs/12345"
+        The status should be success
+        The output should satisfy has_decision "deny"
+        The output should satisfy has_exact_reason "Use: gh run view 12345"
+      End
+
+      It 'denies and suggests gh run view with job flag for specific job'
+        When run run_hook "https://github.com/terraform-linters/tflint/actions/runs/19917285716/job/57098829490"
+        The status should be success
+        The output should satisfy has_decision "deny"
+        The output should satisfy has_exact_reason "Use: gh run view --job 57098829490 --log"
+      End
+    End
+
     Context 'when encountering unknown GitHub URL'
       It 'asks user for guidance'
         When run run_hook "https://github.com/explore"


### PR DESCRIPTION
The GitHub hook now intercepts Actions workflow run and job URLs, suggesting efficient `gh` CLI commands instead of HTML fetches. This prevents wasteful web scraping when you reference Actions URLs.

## Changes

- Added URL pattern matching for GitHub Actions workflow runs (`/actions/runs/{run_id}`)
- Added URL pattern matching for specific job logs (`/actions/runs/{run_id}/job/{job_id}`)
- Hook suggests `gh run view {run_id}` for workflow run URLs
- Hook suggests `gh run view --job {job_id} --log` for job URLs
- Added comprehensive unit tests covering both URL patterns

## Testing

Unit tests verify the hook correctly identifies and suggests appropriate commands for both workflow run and job URLs.