### PR TITLE
skill: add refine-issue for expanding brief issues

### DIFF
--- a/.claude/skills/refine-issue/SKILL.md
+++ b/.claude/skills/refine-issue/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: refine-issue
+description: Refining issues with technical context and structured details. Use when expanding a brief bug, feature, or refactor description into a detailed issue suitable for developers and AI agents.
+---
+
+# Issue Refinement
+
+Expand brief issue descriptions into structured issues for developers and AI agents.
+
+## Issue Types
+
+| Type | When to Use | Guide |
+|------|-------------|-------|
+| Bug | Something is broken | `bug.md` |
+| Feature | New capability | `feature.md` |
+| Refactor | Internal improvement, no behavior change | `refactor.md` |
+
+## Workflow
+
+1. Identify type and read the corresponding guide
+2. Gather context from code and related issues
+3. Draft refinement following the type-specific structure
+4. Output for user approval before updating the issue
+
+## Output Structure
+
+All issues share this skeleton. Type guides add sections in between.
+
+```markdown
+## Summary
+
+One to two sentences.
+
+[Type-specific sections from guide]
+
+## Context
+
+### Related Code
+
+Files that need changes or inform the work.
+
+### Related Issues
+
+Links to related issues, prior attempts, upstream work.
+```
+
+## Style
+
+- **Direct** - Facts, not hedging
+- **Specific** - Name the function, file, behavior
+- **Concise** - Every sentence adds information
+- **Link to code** - Permalinks for GitHub (`https://github.com/{owner}/{repo}/blob/{sha}/path#L10-L20`), file paths elsewhere (`path/to/file:10-20`)
+
+## Issue Trackers
+
+Fetch with `get_issue`, output refinement for review, update only after approval.
+
+- Linear: `mcp__linear__get_issue`, `mcp__linear__update_issue`
+- GitHub: `mcp__github__get_issue`, `mcp__github__update_issue`

--- a/.claude/skills/refine-issue/bug.md
+++ b/.claude/skills/refine-issue/bug.md
@@ -1,0 +1,26 @@
+# Bug
+
+## Sections
+
+### Symptoms
+
+What the user or system observes. Error messages, unexpected behavior, failed operations.
+
+### Root Cause
+
+Why this happens. Link to the responsible code.
+
+### Reproduction
+
+Steps to trigger the bug. Include inputs, environment, state.
+
+### Requirements
+
+What the fix must accomplish. Behavioral changes, edge cases, constraints.
+
+## Key Questions
+
+- What's observed vs. expected?
+- When did this start? What changed?
+- Always or only under certain conditions?
+- Blast radius - users/systems affected?

--- a/.claude/skills/refine-issue/feature.md
+++ b/.claude/skills/refine-issue/feature.md
@@ -1,0 +1,36 @@
+# Feature
+
+## Sections
+
+### Goal
+
+What this enables users to do. Outcomes, not implementation.
+
+### Requirements
+
+Specific behaviors, inputs/outputs, error handling.
+
+#### Out of Scope
+
+What this does not include.
+
+### Design
+
+#### Approach
+
+High-level implementation. Reference existing patterns.
+
+#### Changes
+
+Files and components to modify.
+
+#### Open Questions
+
+Decisions needed before or during implementation.
+
+## Key Questions
+
+- What problem does this solve? Who has it?
+- Simplest version that solves the core problem?
+- What patterns should this follow?
+- Dependencies or blockers?

--- a/.claude/skills/refine-issue/refactor.md
+++ b/.claude/skills/refine-issue/refactor.md
@@ -1,0 +1,26 @@
+# Refactor
+
+## Sections
+
+### Motivation
+
+Why now. Pain points, what it unblocks, cost of inaction.
+
+### Scope
+
+What changes, what doesn't. State behavior changes explicitly (usually none).
+
+### Approach
+
+Strategy (incremental vs. big bang), key transformations, risks.
+
+### Validation
+
+How to verify correctness. Test coverage, manual checks, metrics.
+
+## Key Questions
+
+- Why now? What's the trigger?
+- Incremental or atomic?
+- Rollback plan?
+- How do we know it worked?


### PR DESCRIPTION
Adds a skill for refining issues (bugs, features, refactors) from brief descriptions into structured issues suitable for developers and AI agents.

## Changes

- Adds `refine-issue` skill with type-specific guides for bugs, features, and refactors
- Main `SKILL.md` provides shared skeleton (Summary, Context sections) and style guidance
- Type guides (`bug.md`, `feature.md`, `refactor.md`) contain unique sections and key questions
- Supports both Linear and GitHub Issues via MCP tools
- Requires user approval before updating issues