### PR TITLE
sandbox: configure for common developer tools

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,19 @@
       "WebFetch(domain:raw.githubusercontent.com)",
       "WebFetch(domain:modelcontextprotocol.io)",
       "WebFetch(domain:docs.anthropic.com)",
-      "Bash(man:*)"
+      "Bash(man:*)",
+      "WebFetch(domain:proxy.golang.org)",
+      "WebFetch(domain:sum.golang.org)",
+      "WebFetch(domain:api.github.com)",
+      "Edit(/tmp/**)",
+      "Edit(.git/config)",
+      "Edit(.git/config.lock)",
+      "Edit(~/.npm/**)",
+      "Edit(~/.terraform.d/plugin-cache/**)",
+      "Edit(~/.cache/uv/**)",
+      "Edit(~/Library/Caches/go-build/**)",
+      "Edit(~/src/go/pkg/mod/**)",
+      "Edit(~/src/go/pkg/sumdb/**)"
     ],
     "deny": []
   },
@@ -71,7 +83,17 @@
   },
   "sandbox": {
     "enabled": true,
-    "autoAllowBashIfSandboxed": true
+    "autoAllowBashIfSandboxed": true,
+    "excludedCommands": [
+      "code",
+      "git",
+      "docker"
+    ],
+    "network": {
+      "allowUnixSockets": [
+        "~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+      ]
+    }
   },
   "alwaysThinkingEnabled": true
 }


### PR DESCRIPTION
Configures sandbox settings to allow common developer tools to work properly within the sandbox, including SSH authentication, package manager caches, VS Code integration, and bash heredocs.

## Changes

- Adds `/tmp/**` write permission to fix bash heredoc temporary file creation
- Adds cache directory write permissions for:
  - UV: `~/.cache/uv/**`
  - Go: `~/Library/Caches/go-build/**`, `~/src/go/pkg/mod/**`, `~/src/go/pkg/sumdb/**`
  - npm: `~/.npm/**`
  - Terraform: `~/.terraform.d/plugin-cache/**`
- Adds network access for Go package manager (`proxy.golang.org`, `sum.golang.org`) and GitHub API (`api.github.com`)
- Configures Secretive SSH agent socket access (`~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh`) for Git operations
- Excludes commands from sandbox (while maintaining permission prompts):
  - `code` - VS Code CLI
  - `git` - Avoids `.git/config` write errors
  - `docker` - Maintains visibility into Docker operations via prompts