### PR TITLE
commands: add branch checkout step to /pr

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -46,10 +46,11 @@ Create a pull request with the following pre-captured state:
 ## Instructions
 
 1. Change to the working directory
-2. Push the branch: `git push -u origin <branch>`
-3. Load the pull-request skill for formatting guidelines
-4. Create the PR with `gh pr create --base <base-branch>`
-5. Return the PR URL
+2. Checkout the branch: `git checkout <branch>`
+3. Push the branch: `git push -u origin <branch>`
+4. Load the pull-request skill for formatting guidelines
+5. Create the PR with `gh pr create --base <base-branch>`
+6. Return the PR URL
 
 ## Constraints
 


### PR DESCRIPTION
The background agent instructions in the `/pr` command now explicitly checkout the captured branch before pushing. This ensures the agent operates on the correct branch even if git state changes between the synchronous capture and background execution.

## Changes

- Adds `git checkout <branch>` step before pushing in the background agent instructions
- Renumbers subsequent steps