### PR TITLE
skills: add parallel-prs for batch issue processing

### DIFF
--- a/.claude/skills/parallel-prs/SKILL.md
+++ b/.claude/skills/parallel-prs/SKILL.md
@@ -6,45 +6,20 @@ allowed-tools: Bash(git:*)
 
 # Parallel PRs
 
-Batch-process issues into draft PRs using git worktrees for isolation.
-
 ## Constraints
 
-- **Batch size**: 5 issues max per round (larger batches split automatically)
+- **Batch size**: 5 issues max (larger batches split automatically)
 - **No worktree cleanup**: PRs may need iteration after CI feedback
-- **Issue linking**: Include `Closes #123` or `Closes ENG-XXX` in PR body (not commit)
+- **Issue linking**: `Closes #123` in PR body (not commit)
 
 ## Workflow
 
-1. **Gather issues** - Load `linear`, `github`, or `gitlab` skill and fetch details, split into batches of 5
-2. **Clarify requirements** - Use AskUserQuestion upfront to resolve ambiguities
-3. **Plan all issues** - Run planning agents in parallel (verify paths, line numbers)
-4. **Create worktrees** - One per issue in `.worktrees/`
-5. **Implement in parallel** - Agents commit, push, and write PR body to file
-6. **Create PRs** - Parent runs `gh pr create` or `glab mr create` with `--body-file`
-7. **Monitor CI** - Dispatch agent to watch for failures across branches
+1. Load `linear`, `github`, or `gitlab` skill; fetch issue details
+2. Ask user to clarify ambiguities upfront
+3. Plan agents verify paths/line numbers in parallel
+4. Create worktrees in `.worktrees/{slug}`
+5. Implementation agents commit, push, write PR body to `tmp/{branch}/pr-body.md`
+6. Parent creates PRs with `--body-file` (subagents cannot use Skill tool)
+7. Monitor CI for failures
 
-See [workflow.md](workflow.md) for detailed steps.
-
-## Critical: Skill Inheritance
-
-Subagents **cannot** use the Skill tool - skills don't inherit to child agents.
-
-**Implementation agents must**:
-- Commit and push changes
-- Write PR body to `tmp/{branch}/pr-body.md`
-- Return control to parent (NOT create PR)
-
-**Parent agent must**:
-- Run `gh pr create --body-file` mechanically
-- Implementation agent already wrote the content
-
-See [agents.md](agents.md) for agent configuration.
-
-## Quick Start
-
-```
-/parallel-prs ENG-101 ENG-102 ENG-103
-```
-
-Load the appropriate skill (`github`, `gitlab`, or `linear`) for vendor-specific instructions.
+See [workflow.md](workflow.md) and [agents.md](agents.md).

--- a/.claude/skills/parallel-prs/agents.md
+++ b/.claude/skills/parallel-prs/agents.md
@@ -1,37 +1,7 @@
-# Agent Configuration
+# Agents
 
-## Planning Agent (Plan)
-
-**Outputs**:
-- Verified file paths
-- Current line numbers for modifications
-- Conflict analysis with other issues in batch
-- Test commands to validate changes
-
-## Implementation Agent (general-purpose)
-
-**Does**:
-- Work within assigned worktree
-- Commit and push changes
-- Write PR body to `tmp/{branch}/pr-body.md` with issue linking
-
-**Does not**:
-- Create PRs (parent does this)
-- Modify issues directly
-- Work outside worktree directory
-
-## CI Monitor Agent (github-actions-monitor)
-
-**Outputs**:
-- Pass/fail status per PR
-- Failure logs for debugging
-
-## Parallel Execution
-
-```
-Task(subagent_type: general-purpose, prompt: "...", run_in_background: true) → agent_1
-Task(subagent_type: general-purpose, prompt: "...", run_in_background: true) → agent_2
-
-TaskOutput(task_id: agent_1, block: true)
-TaskOutput(task_id: agent_2, block: true)
-```
+| Agent | Type | Key Constraint |
+|-------|------|----------------|
+| Planning | `Plan` | Verify paths/line numbers, detect conflicts |
+| Implementation | `general-purpose` | Stay in worktree, write PR body to file, do NOT create PR |
+| CI Monitor | `github-actions-monitor` | Report failures with logs |

--- a/.claude/skills/parallel-prs/workflow.md
+++ b/.claude/skills/parallel-prs/workflow.md
@@ -2,84 +2,33 @@
 
 ## Gather Issues
 
-Parse arguments as issue identifiers and load the appropriate skill (`github`, `gitlab`, or `linear`).
-
-Validate:
-- All issues exist and are accessible
-- Split into batches of 5 if more issues provided
-- Process each batch sequentially (all PRs from batch 1 before starting batch 2)
+Load `github`, `gitlab`, or `linear` skill. Validate issues exist. Split into batches of 5, process sequentially.
 
 ## Clarify Requirements
 
-Before planning, use AskUserQuestion to resolve ambiguities upfront:
-- Implementation approach choices
-- Scope boundaries (what's in/out)
-- Dependencies between issues
-
-Gathering requirements early enables autonomous execution later.
+Ask user upfront about approach choices, scope boundaries, and dependencies between issues.
 
 ## Plan All Issues
 
-Launch planning agents in parallel using Task tool:
-
-```
-subagent_type: Plan
-prompt: |
-  Plan implementation for issue {issue-ref}: {title}
-
-  {description}
-
-  Verify:
-  - File paths exist
-  - Line numbers are current
-  - Proposed changes don't conflict
-
-  Return a structured plan with:
-  - Files to modify
-  - Key changes per file
-  - Test commands to run
-```
-
-Wait for all plans before proceeding. Review for conflicts between issues.
+Plan agents (in parallel) verify file paths exist, line numbers are current, and check for conflicts between issues.
 
 ## Create Worktrees
 
-For each issue, create an isolated worktree:
-
 ```bash
-git worktree add .worktrees/{slug} -b {branch-name} main
+git worktree add .worktrees/{slug} -b {type}/{issue-id}-{slug} main
 ```
-
-Branch naming: `{type}/{issue-id}-{slug}` (e.g., `fix/eng-101-timeout-handling`)
 
 ## Implement in Parallel
 
-Launch implementation agents with explicit boundaries:
-
-```
-subagent_type: general-purpose
-prompt: |
-  Working directory: {repo}/.worktrees/{slug}
-
-  Implement: {plan}
-
-  After implementation:
-  1. Commit changes
-  2. Push to remote
-  3. Write PR body to tmp/{branch}/pr-body.md following pull-request skill format:
-     - Title line (first line)
-     - 1-3 sentence summary
-     - Include "Closes {issue-ref}" for issue linking
-     - ## sections as needed (Issue, Changes, Testing)
-  4. Return - DO NOT create the PR itself
-
-  DO NOT use Skill tool (not available in subagents)
-```
+Implementation agents work in assigned worktree, then:
+1. Commit and push
+2. Write PR body to `tmp/{branch}/pr-body.md` with `Closes {issue-ref}`
+3. Return (do NOT create PR - subagents cannot use Skill tool)
 
 ## Create PRs
 
-After all implementations complete, create PRs mechanically using `--body-file tmp/{branch}/pr-body.md`. Load the `github` or `gitlab` skill for the appropriate CLI command.
+Parent creates PRs using `--body-file tmp/{branch}/pr-body.md`.
 
 ## Monitor CI
 
-After all PRs created, launch CI monitoring agent to watch for failures and report logs.
+Launch agent to watch for failures and report logs.


### PR DESCRIPTION
Adds a skill for batch-processing multiple issues into draft PRs using parallel git worktrees.

## Changes

- Add `parallel-prs` skill with `SKILL.md` entry point
- Document agent responsibilities and skill inheritance limitations in `agents.md`
- Define step-by-step workflow in `workflow.md` covering issue gathering through CI monitoring

## Design

- **Batch size**: 5 issues max per round (larger batches split automatically)
- **Skill inheritance**: Implementation agents write PR bodies to files; parent runs `gh pr create --body-file` mechanically
- **Clarification upfront**: Use `AskUserQuestion` before parallel execution to enable autonomous work
- **No worktree cleanup**: PRs may need iteration after CI feedback
