### PR TITLE
things: fix run-jxa.sh returning no output

### DIFF
--- a/.claude/skills/things/scripts/run-jxa.sh
+++ b/.claude/skills/things/scripts/run-jxa.sh
@@ -43,7 +43,7 @@ fi
 ESBUILD_ARGS=(
   --bundle
   --platform=neutral
-  --format=iife
+  --format=esm
   --log-level=error
 )
 


### PR DESCRIPTION
Fixes `run-jxa.sh` returning no output by changing esbuild's `--format` from `iife` to `esm`.

## Issue

The `iife` format wraps bundled code in an immediately-invoked function expression:
```javascript
(() => {
  var app = Application("Things3");
  JSON.stringify(app.running());
})();
```

This IIFE doesn't return the last expression's value, so `osascript` outputs nothing. With `esm` format, the code isn't wrapped and `osascript` correctly returns the last expression.
