### PR TITLE
github: add reviews reference for MCP gaps

### DIFF
--- a/.claude/skills/github/SKILL.md
+++ b/.claude/skills/github/SKILL.md
@@ -9,6 +9,10 @@ description: GitHub workflow best practices and tool selection. Use when working
 - Use `gh api` for advanced GitHub API interactions that are not natively supported by `gh` commands.
 - Always assume GitHub URLs may refer to private repositories and use `gh` or `mcp__github` for authentication.
 
+## Reference Files
+
+- **reviews.md**: Pull request review operations not supported by the MCP
+
 ## Workflows
 
 ### Pull Request

--- a/.claude/skills/github/reviews.md
+++ b/.claude/skills/github/reviews.md
@@ -1,0 +1,29 @@
+# Pull Request Reviews
+
+Operations not natively supported by the GitHub MCP server.
+
+## Updating Pending Review Comments
+
+```bash
+gh api graphql \
+  -F query=@query.graphql \
+  -f id='PRRC_xxx' \
+  -F body=@body.txt
+```
+
+With `query.graphql`:
+
+```graphql
+mutation UpdatePullRequestReviewComment($id: ID!, $body: String!) {
+  updatePullRequestReviewComment(input: {pullRequestReviewCommentId: $id, body: $body}) {
+    pullRequestReviewComment {
+      id
+      body
+    }
+  }
+}
+```
+
+Use `-F` (not `-f`) with `@` prefix to read file contents. This avoids shell escaping issues with special characters in the body.
+
+The `pull_request_read` MCP tool with `method: get_review_comments` returns comment node IDs in the format `PRRC_xxx`.


### PR DESCRIPTION
Adds reference documentation for GitHub pull request review operations not supported by the MCP server, specifically updating pending review comments via GraphQL.

## Changes

- Add `reviews.md` reference file documenting GraphQL mutation for updating pending review comments
- Update GitHub skill `SKILL.md` to reference the new reviews documentation