### PR TITLE
fix(pr): use unique PR body filename per branch

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -52,11 +52,11 @@ Create a pull request with the following pre-captured state:
 1. Change to the working directory
 2. Push the branch: `git push -u origin <branch>`
 3. Load the pull-request skill for formatting guidelines
-4. Write the PR body to `tmp/pr-body.md` following the skill format:
+4. Write the PR body to `tmp/pr-body-<branch>.md` following the skill format:
    - Start with 1-3 sentences summarizing the change (NO leading ## header)
    - Use `## Changes` for bulleted list of changes
    - Use `## Testing` only if tests were added or manual testing is needed
-5. Create the PR: `gh pr create --base <base-branch> --head <branch> --title "..." --body-file tmp/pr-body.md`
+5. Create the PR: `gh pr create --base <base-branch> --head <branch> --title "..." --body-file tmp/pr-body-<branch>.md`
 6. Return the PR URL
 
 ## Constraints

--- a/.claude/skills/pull-request/workflow.md
+++ b/.claude/skills/pull-request/workflow.md
@@ -10,6 +10,7 @@ When creating a pull request:
 3. Commit if there are no commits yet on the branch. Follow the same format for the commit message as for the pull request title (conventional or subject-oriented based on repo standard).
 4. Push the branch to remote.
 5. Create the pull request:
-   - Write the PR body to a temp file first (e.g., `tmp/pr-body.md`)
-   - Use `gh pr create --title "..." --body-file tmp/pr-body.md`
+   - Write the PR body to a temp file first (e.g., `tmp/pr-body-<branch>.md`)
+   - Use `gh pr create --title "..." --body-file tmp/pr-body-<branch>.md`
+   - Include the branch name in the filename to avoid conflicts with concurrent agents
    - This avoids escaping issues with heredocs in shell commands


### PR DESCRIPTION
Uses a unique filename for PR body temp files by including the branch name. This prevents file contention when multiple agents create PRs concurrently.

## Changes

- Update `/pr` command to use `tmp/pr-body-<branch>.md` instead of `tmp/pr-body.md`
- Update pull-request skill workflow with the same pattern
