### PR TITLE
sandbox: expand excluded commands for system access

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -87,7 +87,25 @@
     "excludedCommands": [
       "code",
       "git",
-      "docker"
+      "docker",
+      "pbcopy",
+      "pbpaste",
+      "open",
+      "osascript",
+      "ssh",
+      "scp",
+      "security",
+      "defaults",
+      "launchctl",
+      "rsync",
+      "screencapture",
+      "aws",
+      "gcloud",
+      "az",
+      "say",
+      "afplay",
+      "diskutil",
+      "networksetup"
     ],
     "network": {
       "allowUnixSockets": [


### PR DESCRIPTION
Add commands to `sandbox.excludedCommands` that require system access beyond what the sandbox allows.

## Changes

- **Clipboard**: `pbcopy`, `pbpaste`
- **macOS integration**: `open`, `osascript`, `defaults`, `launchctl`, `screencapture`
- **Remote access**: `ssh`, `scp`, `rsync`
- **Cloud CLIs**: `aws`, `gcloud`, `az`
- **Audio**: `say`, `afplay`
- **System**: `security`, `diskutil`, `networksetup`
