### PR TITLE
docs(things): clarify list-id for moving todos to areas

### DIFF
--- a/.claude/skills/things/troubleshooting.md
+++ b/.claude/skills/things/troubleshooting.md
@@ -48,6 +48,14 @@ scripts/run-jxa.sh 'const app = Application("Things3"); const todo = app.toDos.b
 **Missing auth token**: All updates require `auth-token` parameter
 **URL encoding**: Notes with special characters must be URL-encoded
 **Rate limiting**: Max 250 operations per 10 seconds
+**Moving to area**: Use `list-id` (not `area-id`) when moving a todo to an area:
+```bash
+# Does NOT work:
+open "things:///update?id=TODO_ID&auth-token=$auth_token&area-id=AREA_ID"
+
+# Works:
+open "things:///update?id=TODO_ID&auth-token=$auth_token&list-id=AREA_ID"
+```
 
 ## Filtering Repeating Tasks
 

--- a/.claude/skills/things/url-scheme.md
+++ b/.claude/skills/things/url-scheme.md
@@ -93,6 +93,7 @@ open "things:///update?id=4BE64FEA-8FEF-4F4F-B8B2-4E74605D5FA5&auth-token=YOUR_T
 
 **Notes:**
 - Cannot update `when` or `deadline` on repeating to-dos
+- To move to an area, use `list-id` with the area ID (not `area-id`)
 - Projects require all child to-dos completed before marking complete
 
 ### update-project - Modify Projects


### PR DESCRIPTION
## Summary
- Documents that `list-id` (not `area-id`) must be used when moving a todo to an area via the update URL scheme

## Test plan
- [x] Verified behavior manually while updating Things inbox items