### PR TITLE
docs(things): document moving todos out of inbox without area

### DIFF
--- a/.claude/skills/things/SKILL.md
+++ b/.claude/skills/things/SKILL.md
@@ -76,3 +76,4 @@ Load detailed guides as needed:
 - **Verification**: ALWAYS verify updates succeeded by reading back the todo with JXA
 - **Repeating tasks**: Filter by comparing `creationDate` to midnight (see [troubleshooting.md](troubleshooting.md))
 - **TypeScript mode**: Use `scripts/run-jxa.sh` for type-safe JXA with autocomplete
+- **Moving out of inbox**: Set `when=anytime` to move a todo out of inbox without assigning an area


### PR DESCRIPTION
## Summary
- Documents that `when=anytime` moves a todo out of inbox without requiring an area assignment

## Context
When processing inbox items, some todos don't belong to any area but should still leave the inbox. Setting `when=anytime` accomplishes this.