### PR TITLE
Add astral-sh marketplace and enable astral plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -89,13 +89,25 @@
     "github@bendrucker": true,
     "claude-code@bendrucker": true,
     "pull-request@bendrucker": true,
-    "parallel-prs@bendrucker": true
+    "parallel-prs@bendrucker": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "linear@claude-plugins-official": true,
+    "ralph-wiggum@claude-code-plugins": true,
+    "code-simplifier@claude-plugins-official": true,
+    "github@claude-plugins-official": true,
+    "astral@astral-sh": true
   },
   "extraKnownMarketplaces": {
     "bendrucker": {
       "source": {
         "source": "github",
         "repo": "bendrucker/claude"
+      }
+    },
+    "astral-sh": {
+      "source": {
+        "source": "github",
+        "repo": "astral-sh/claude-code-plugins"
       }
     }
   },


### PR DESCRIPTION
Register astral-sh/claude-code-plugins as a third-party marketplace and enable the astral plugin for Python tooling (uv, ruff, ty).