### PR TITLE
Update python skill to reference astral plugin skills

### DIFF
--- a/plugins/python/skills/python/SKILL.md
+++ b/plugins/python/skills/python/SKILL.md
@@ -6,11 +6,9 @@ description: Python coding standards, best practices, type hints, and testing pa
 
 - Use the latest Python language features appropriate for the project's minimum supported version.
 
-## Package Management
+## Tooling
 
-- Use `uv` for dependency management and package execution instead of virtual environments.
-- Run scripts with `uv run <script>`.
-- Add dependencies with `uv add <package>`.
+Load the `astral:uv`, `astral:ruff`, and `astral:ty` skills for detailed guidance on Python tooling.
 
 ## Documentation
 


### PR DESCRIPTION
Replace the inline package management guidance with a reference to the astral plugin skills (uv, ruff, ty) for more comprehensive Python tooling documentation.