### PR TITLE
Enable third-party plugins from official marketplaces

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -89,7 +89,12 @@
     "github@bendrucker": true,
     "claude-code@bendrucker": true,
     "pull-request@bendrucker": true,
-    "parallel-prs@bendrucker": true
+    "parallel-prs@bendrucker": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "linear@claude-plugins-official": true,
+    "ralph-wiggum@claude-code-plugins": true,
+    "code-simplifier@claude-plugins-official": true,
+    "github@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "bendrucker": {


### PR DESCRIPTION
Enable plugins from claude-plugins-official and claude-code-plugins:

- pr-review-toolkit@claude-plugins-official
- linear@claude-plugins-official
- code-simplifier@claude-plugins-official
- github@claude-plugins-official
- ralph-wiggum@claude-code-plugins