### PR TITLE
Add astral-sh plugin and update python skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -94,13 +94,20 @@
     "linear@claude-plugins-official": true,
     "ralph-wiggum@claude-code-plugins": true,
     "code-simplifier@claude-plugins-official": true,
-    "github@claude-plugins-official": true
+    "github@claude-plugins-official": true,
+    "astral@astral-sh": true
   },
   "extraKnownMarketplaces": {
     "bendrucker": {
       "source": {
         "source": "github",
         "repo": "bendrucker/claude"
+      }
+    },
+    "astral-sh": {
+      "source": {
+        "source": "github",
+        "repo": "astral-sh/claude-code-plugins"
       }
     }
   },

--- a/plugins/python/skills/python/SKILL.md
+++ b/plugins/python/skills/python/SKILL.md
@@ -6,11 +6,9 @@ description: Python coding standards, best practices, type hints, and testing pa
 
 - Use the latest Python language features appropriate for the project's minimum supported version.
 
-## Package Management
+## Tooling
 
-- Use `uv` for dependency management and package execution instead of virtual environments.
-- Run scripts with `uv run <script>`.
-- Add dependencies with `uv add <package>`.
+Load the `astral:uv`, `astral:ruff`, and `astral:ty` skills for detailed guidance on Python tooling.
 
 ## Documentation
 


### PR DESCRIPTION
Add astral-sh/claude-code-plugins as a third-party marketplace and enable the astral plugin for Python tooling (uv, ruff, ty).

Update the python skill to reference astral skills instead of inline package management docs.