### PR TITLE
Fix json-schema-ref-parser security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,17 +32,15 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.1.0.tgz",
-      "integrity": "sha512-g/VW9ZQEFJAOwAyUb8JFf7MLiLy2uEB4rU270rGzDwICxnxMlPy0O11KVePSgS36K1NI29gSlK84n5INGhd4Ag==",
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.13",
-        "@types/lodash.clonedeep": "^4.5.7",
-        "js-yaml": "^4.1.0",
-        "lodash.clonedeep": "^4.5.0"
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -847,16 +845,6 @@
       "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/lodash.clonedeep": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.9.tgz",
-      "integrity": "sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
@@ -2363,13 +2351,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   },
   "dependencies": {
     "typescript": "^5.9.3"
+  },
+  "overrides": {
+    "@apidevtools/json-schema-ref-parser": "^11.2.0"
   }
 }


### PR DESCRIPTION
Add npm override to force @apidevtools/json-schema-ref-parser to ^11.2.0, fixing CVE-2024-29651 (prototype pollution vulnerability).

The vulnerable version is a transitive dependency of remark-lint-frontmatter-schema, which has not yet updated upstream.