### PR TITLE
feat: add interview plugin for planning and clarification

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -104,6 +104,11 @@
       "source": "./plugins/parallel-prs"
     },
     {
+      "name": "interview",
+      "description": "Interview-driven planning and clarification",
+      "source": "./plugins/interview"
+    },
+    {
       "name": "agents-md",
       "description": "Loads AGENTS.md files automatically into Claude Code sessions",
       "source": { "source": "github", "repo": "bendrucker/claude-code-agents-md" }

--- a/plugins/interview/.claude-plugin/plugin.json
+++ b/plugins/interview/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "interview",
+  "description": "Interview-driven planning and clarification using AskUserQuestion",
+  "author": {
+    "name": "Ben Drucker",
+    "email": "bvdrucker@gmail.com"
+  }
+}

--- a/plugins/interview/skills/clarify/SKILL.md
+++ b/plugins/interview/skills/clarify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: clarify
+description: |
+  Targeted interview for execution-time clarification. Use when you hit an ambiguity or decision point during implementation that needs user input before proceeding.
+---
+
+# Clarification Interview
+
+Ask targeted questions using `AskUserQuestion` to resolve a specific blocker.
+
+## When to Use
+
+- Implementation detail is ambiguous
+- Multiple valid approaches exist
+- Edge case behavior is undefined
+- User preference affects the solution
+
+## Interview Style
+
+- **Focused** - Address the immediate blocker, not comprehensive coverage
+- **Targeted** - Usually 1-2 questions at a time
+- **Actionable** - Each question should unblock progress
+- **Context-rich** - Explain why you're asking and what the options mean
+
+## Output
+
+Resume implementation after receiving answers. Do not write to files.

--- a/plugins/interview/skills/plan/SKILL.md
+++ b/plugins/interview/skills/plan/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: plan
+description: |
+  Comprehensive interview for planning new features or changes. Use when the user wants thorough upfront planning before implementation, or when starting work on a complex feature.
+---
+
+# Planning Interview
+
+Interview the user comprehensively about their requested change using `AskUserQuestion`.
+
+## Interview Topics
+
+Cover these areas, adapting to context:
+
+- **Requirements** - What exactly should this do? What shouldn't it do?
+- **Technical implementation** - Architecture, data flow, dependencies, APIs
+- **UI/UX** - User interactions, feedback, error states, edge cases
+- **Constraints** - Performance, compatibility, security, accessibility
+- **Tradeoffs** - What are you willing to sacrifice? What's non-negotiable?
+- **Scope boundaries** - What's explicitly out of scope for this change?
+- **Validation** - How will we know it works? What does success look like?
+
+## Interview Style
+
+- **Non-obvious questions** - Skip questions with obvious answers
+- **In-depth** - Dig into specifics, follow interesting threads
+- **Batch questions** - Use up to 4 questions per `AskUserQuestion` call
+- **Continue until complete** - Keep interviewing until the plan feels solid
+- **Challenge assumptions** - Surface implicit decisions that deserve explicit consideration
+
+## Output
+
+The interview informs the conversation. Do not write to files unless the user requests it.


### PR DESCRIPTION
Adds a new `interview` plugin with two skills for conducting user interviews via `AskUserQuestion`. The `plan` skill provides comprehensive upfront planning interviews for new features, while `clarify` offers targeted execution-time clarification when hitting blockers or ambiguities.

## Changes

- Adds `plan` skill for comprehensive feature planning interviews covering requirements, technical implementation, UI/UX, constraints, and scope
- Adds `clarify` skill for focused, targeted questions to resolve specific implementation blockers
- Registers the plugin in the marketplace

## References

- https://x.com/trq212/status/2005315275026260309
- https://x.com/filippkowalski/status/2010317972774994085
