### PR TITLE
chore: remove /pr command shorthand

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,4 +1,0 @@
----
-description: Create a pull request
----
-/pull-request:create $ARGUMENTS


### PR DESCRIPTION
Removes the `/pr` command shorthand that was forwarding to `/pull-request:create`. This avoids potential interference with the full namespaced skill and encourages direct use of `/pull-request:create`.

## Changes

- Delete `.claude/commands/pr.md` which defined the `/pr` shorthand
