### PR TITLE
fix(pull-request): strengthen testing section guidance and add validation hook

### DIFF
--- a/plugins/pull-request/hooks/hooks.json
+++ b/plugins/pull-request/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Validates PR body content before creation",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash(gh pr create:*)|Bash(gh pr edit:*)|Bash(glab mr create:*)|Bash(glab mr update:*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate-pr.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/pull-request/scripts/validate-pr.sh
+++ b/plugins/pull-request/scripts/validate-pr.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# PreToolUse hook to validate PR body content
+# Blocks PR creation if test counts are mentioned
+
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+output_json() {
+  local decision="$1"
+  local reason="$2"
+  jq -n \
+    --arg decision "$decision" \
+    --arg reason "$reason" \
+    '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: $decision,
+        permissionDecisionReason: $reason
+      }
+    }'
+}
+
+body_file=""
+if [[ "$command" =~ --body-file[[:space:]]+([^[:space:]]+) ]]; then
+  body_file="${BASH_REMATCH[1]}"
+elif [[ "$command" =~ --body-file=([^[:space:]]+) ]]; then
+  body_file="${BASH_REMATCH[1]}"
+fi
+
+[[ -z "$body_file" ]] && exit 0
+[[ ! -f "$body_file" ]] && exit 0
+
+body=$(cat "$body_file")
+
+if echo "$body" | grep -qiE '[Aa]dded [0-9]+ (unit |integration )?tests|[0-9]+ (unit |integration )?tests'; then
+  output_json "deny" "Testing section should not mention test counts. Describe what is covered instead."
+  exit 0
+fi
+
+exit 0

--- a/plugins/pull-request/skills/pull-request/sections.md
+++ b/plugins/pull-request/skills/pull-request/sections.md
@@ -25,22 +25,29 @@ High-level bulleted description of changes made.
 
 ## Testing
 
-Only include if tests were added/modified or manual testing was performed. Omit entirely if no testing discussion occurred.
+Only include if tests were added/modified or manual testing was performed. Omit entirely if no testing discussion is relevant.
 
-Focus on qualitative insights about coverage and approach:
+**NEVER mention test counts** - phrases like "Added N tests" or "13 unit tests" provide no value. The number of tests doesn't indicate coverage quality, and readers can count tests themselves if they care.
+
+Focus on **what** is covered and **why** it matters:
 
 **Good examples:**
 - "Tests cover error handling for malformed JSON responses"
-- "Added integration tests for full request/response cycle"
-- "Extended auth tests to cover new OAuth flow"
-- "Manually verified screen reader behavior on iOS Safari"
+- "Added integration tests for the full request/response cycle"
+- "Extended auth tests to cover the new OAuth flow"
+- "Verified edge cases: empty input, null values, and Unicode handling"
 
-**Bad examples (avoid):**
+**Coverage gaps**: Note anything that merited testing but was difficult to automate:
+- "Rate limiting behavior requires manual verification against live API"
+- "Visual layout changes verified in browser but not covered by snapshot tests"
+
+**Manual verification**: Include any testing done outside of automated tests—running commands, checking output, verifying behavior in a browser or tool. This counts whether performed by the user or by Claude during the session.
+
+**Patterns to avoid:**
+- "Added N tests" or "N unit tests" (counts are noise)
 - "All tests passed" (CI shows this)
-- "Added 5 unit tests" (quantity is unimportant)
 - "Tests work correctly" (too vague)
-
-Include manual testing steps as `###` checklist only if actually performed.
+- Listing test file names without explaining coverage
 
 ## References
 


### PR DESCRIPTION
Strengthens the testing section guidance in the pull-request skill to more aggressively discourage test count mentions, and adds a validation hook to block PR creation when test counts appear in the body.

## Changes

- Updates `sections.md` testing guidance with stronger "NEVER mention test counts" language and expanded examples of patterns to avoid
- Adds `hooks.json` with a PreToolUse matcher for `gh pr create`, `gh pr edit`, `glab mr create`, and `glab mr update` commands
- Creates `validate-pr.sh` script that extracts the body file from the command, scans for test count patterns, and denies with guidance if found

## Testing

The validation hook detects patterns like "Added N tests" and "N unit tests" in PR body files. Manual testing confirmed the hook correctly blocks commands containing these patterns while allowing properly written testing sections through.
