### PR TITLE
parallel-prs: have implementation agents create PRs directly

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -96,7 +96,8 @@
     "ralph-wiggum@claude-code-plugins": true,
     "code-simplifier@claude-plugins-official": true,
     "github@claude-plugins-official": true,
-    "astral@astral-sh": true
+    "astral@astral-sh": true,
+    "agents-md@bendrucker": true
   },
   "extraKnownMarketplaces": {
     "bendrucker": {

--- a/plugins/parallel-prs/skills/parallel-prs/SKILL.md
+++ b/plugins/parallel-prs/skills/parallel-prs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: parallel-prs
 description: Batch-process multiple issues into draft PRs using parallel worktrees. Use when implementing several related issues simultaneously, creating multiple PRs in parallel, or batch-processing a backlog.
-allowed-tools: Bash(git:*)
+allowed-tools: Bash(git:*), Bash(gh:*)
 ---
 
 # parallel-prs
@@ -18,8 +18,7 @@ allowed-tools: Bash(git:*)
 2. Ask user to clarify ambiguities upfront
 3. Plan agents verify paths/line numbers in parallel
 4. Create worktrees in `.worktrees/{slug}`
-5. Implementation agents commit, push, write PR body to `tmp/{branch}/pr-body.md`
-6. Parent creates PRs with `--body-file` (subagents cannot use Skill tool)
-7. Monitor CI for failures
+5. Implementation agents commit, push, load `pull-request` skill, create PR
+6. Monitor CI for failures
 
 See [workflow.md](workflow.md) and [agents.md](agents.md).

--- a/plugins/parallel-prs/skills/parallel-prs/agents.md
+++ b/plugins/parallel-prs/skills/parallel-prs/agents.md
@@ -3,5 +3,5 @@
 | Agent | Type | Key Constraint |
 |-------|------|----------------|
 | Planning | `Plan` | Verify paths/line numbers, detect conflicts |
-| Implementation | `general-purpose` | Stay in worktree, write PR body to file, do NOT create PR |
+| Implementation | `general-purpose` | Stay in worktree, load `pull-request` skill, create PR |
 | CI Monitor | `github-actions-monitor` | Report failures with logs |

--- a/plugins/parallel-prs/skills/parallel-prs/workflow.md
+++ b/plugins/parallel-prs/skills/parallel-prs/workflow.md
@@ -22,12 +22,7 @@ git worktree add .worktrees/{slug} -b {type}/{issue-id}-{slug} main
 
 Implementation agents work in assigned worktree, then:
 1. Commit and push
-2. Write PR body to `tmp/{branch}/pr-body.md` with `Closes {issue-ref}`
-3. Return (do NOT create PR - subagents cannot use Skill tool)
-
-## Create PRs
-
-Parent creates PRs using `--body-file tmp/{branch}/pr-body.md`.
+2. Load `pull-request` skill and create PR (write body to `tmp/{branch}/pr-body.md` first)
 
 ## Monitor CI
 


### PR DESCRIPTION
Implementation agents now load the `pull-request` skill and create PRs directly, removing the two-phase approach where agents wrote PR bodies to files and the parent created PRs afterward.

## Changes

- Update `SKILL.md` to add `Bash(gh:*)` to allowed tools and simplify workflow steps
- Update `agents.md` to instruct implementation agents to load the skill and create PRs
- Update `workflow.md` to remove the separate "Create PRs" phase
- Enable `agents-md@bendrucker` plugin in settings
