### PR TITLE
fix: remove duplicate hooks from settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,48 +27,6 @@
     ],
     "deny": []
   },
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/newline/ensure.sh"
-          }
-        ]
-      },
-      {
-        "matcher": "Edit|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/newline/preserve.sh"
-          }
-        ]
-      }
-    ],
-    "PreToolUse": [
-      {
-        "matcher": "Edit|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/newline/check.sh"
-          }
-        ]
-      },
-      {
-        "matcher": "WebFetch",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/github/fetch.sh"
-          }
-        ]
-      }
-    ]
-  },
   "enabledPlugins": {
     "pr-review-toolkit@claude-code-plugins": true,
     "go@bendrucker": true,
@@ -96,7 +54,8 @@
     "ralph-wiggum@claude-code-plugins": true,
     "code-simplifier@claude-plugins-official": true,
     "github@claude-plugins-official": true,
-    "astral@astral-sh": true
+    "astral@astral-sh": true,
+    "agents-md@bendrucker": true
   },
   "extraKnownMarketplaces": {
     "bendrucker": {


### PR DESCRIPTION
The hooks for newline and github WebFetch were defined both in `settings.json` and in the `newline@bendrucker` and `github@bendrucker` plugins. This caused "PostToolUse:Edit hook error" because the settings.json paths (`~/.claude/hooks/newline/*.sh`) don't exist.

The plugins already provide these hooks, so the duplicate entries are removed.

## Testing

Verified the error no longer appears after Edit/Write operations.