### PR TITLE
fix(git): add guidance to avoid heredocs in commit messages

### DIFF
--- a/plugins/git/skills/git/SKILL.md
+++ b/plugins/git/skills/git/SKILL.md
@@ -7,6 +7,18 @@ description: Git workflow and branching best practices. Use when working with gi
 * **Never** `git push` to the default branch (usually `main` or `master`) unless I explicitly instruct you to do so.
 * **Always** use a topic branch a with a few brief word hyphenated name
 
+## Commit Messages
+
+For multi-line commit messages:
+
+- **Simple (subject + body):** Use multiple `-m` flags. Each `-m` creates a separate paragraph:
+  ```bash
+  git commit -m "Subject line" -m "Body paragraph here."
+  ```
+- **Complex:** Use the Write tool to write to `tmp/commit-msg.md`, then `git commit -F tmp/commit-msg.md`
+
+**Do not use heredocs** — they create temp files that fail in sandbox environments. This includes `git commit -m "$(cat <<'EOF' ... EOF)"` and `cat > file << 'EOF'`.
+
 ## Worktrees
 
 See `worktrees.md` for managing git worktrees.


### PR DESCRIPTION
Adds guidance to the git skill to avoid heredocs in commit messages, which create temp files that fail in Claude Code's sandbox environment.

## Changes

- Documents two alternatives for multi-line commit messages: multiple `-m` flags for simple cases, or `Write` tool + `git commit -F` for complex ones
- Explicitly warns against heredoc patterns including `$(cat <<'EOF' ... EOF)` and `cat > file << 'EOF'`
