### PR TITLE
feat(things): add url.js script for URL scheme operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5094,7 +5094,8 @@
         "@jxa/run": "^1.4.0",
         "@jxa/sdef-to-dts": "^1.4.0",
         "@types/node": "^25.0.5",
-        "esbuild": "^0.27.2"
+        "esbuild": "^0.27.2",
+        "typescript": "^5.7.3"
       }
     }
   }

--- a/plugins/things/skills/things/SKILL.md
+++ b/plugins/things/skills/things/SKILL.md
@@ -11,8 +11,7 @@ Interact with Things 3, the user's personal task manager for Mac.
 ## Quick Start
 
 **Read operations**: Use TypeScript with esbuild to write type-safe JXA code via `scripts/run-jxa.sh`
-**Write operations**: Use `things://` URL schemes (`things:///add`, `things:///update`, `things:///json`)
-**Auth token**: `security find-generic-password -a "$USER" -s "things-auth-token" -w` (see `@1password.md` for setup)
+**Write operations**: Use `osascript scripts/url.js` which handles auth tokens and URL encoding automatically
 
 ## Common Commands
 
@@ -23,18 +22,17 @@ scripts/run-jxa.sh 'const app = Application("Things3"); const today = app.lists.
 
 **Create a todo:**
 ```bash
-open "things:///add?title=Task%20name&when=today&tags=Work"
+osascript scripts/url.js add title="Task name" when=today tags=Work
 ```
 
 **Update a todo:**
 ```bash
-auth_token=$(security find-generic-password -a "$USER" -s "things-auth-token" -w)
-open "things:///update?id=ABC-123&auth-token=$auth_token&append-notes=Additional%20info"
+osascript scripts/url.js update id=ABC-123 append-notes="Additional info"
 ```
 
 **Navigate to today:**
 ```bash
-open "things:///show?id=today"
+osascript scripts/url.js show id=today
 ```
 
 ## Built-in List IDs
@@ -72,8 +70,8 @@ Load detailed guides as needed:
 
 ## Essential Tips
 
-- **URL encoding**: Always URL-encode parameters (spaces → `%20`, newlines → `%0a`)
 - **Verification**: ALWAYS verify updates succeeded by reading back the todo with JXA
 - **Repeating tasks**: Filter by comparing `creationDate` to midnight (see [troubleshooting.md](troubleshooting.md))
 - **TypeScript mode**: Use `scripts/run-jxa.sh` for type-safe JXA with autocomplete
 - **Moving out of inbox**: Set `when=anytime` to move a todo out of inbox without assigning an area
+- **Raw URL scheme**: For edge cases not covered by `url.js`, use `open "things:///..."` directly (see [url-scheme.md](url-scheme.md))

--- a/plugins/things/skills/things/examples.md
+++ b/plugins/things/skills/things/examples.md
@@ -7,19 +7,21 @@ Practical examples for common Things automation tasks.
 ### Simple Todo
 
 ```bash
-open "things:///add?title=Call%20dentist&when=today"
+osascript scripts/url.js add title="Call dentist" when=today
 ```
 
 ### Todo with Full Details
 
 ```bash
-open "things:///add?title=Quarterly%20Review&notes=Review%20goals%20and%20metrics&when=2025-11-01&deadline=2025-11-07&tags=Work,Planning"
+osascript scripts/url.js add title="Quarterly Review" notes="Review goals and metrics" when=2025-11-01 deadline=2025-11-07 tags=Work,Planning
 ```
 
 ### Multiple Todos at Once
 
 ```bash
-open "things:///add?titles=Buy%20milk%0aPick%20up%20dry%20cleaning%0aWalk%20dog&when=today"
+osascript scripts/url.js add titles="Buy milk
+Pick up dry cleaning
+Walk dog" when=today
 ```
 
 ### Todo with Checklist
@@ -45,15 +47,11 @@ open "things:///json?data=$(echo "$data" | jq -sRr @uri)"
 
 ```bash
 # By project name
-open "things:///add?title=Write%20chapter%203&list=Book%20Writing&when=anytime"
+osascript scripts/url.js add title="Write chapter 3" list="Book Writing" when=anytime
 
 # Or get project ID via JXA and use list-id
-project_id=$(osascript -l JavaScript -e '
-const app = Application("Things3");
-const project = app.projects.whose({name: "Book Writing"})[0];
-project ? project.id() : "";
-')
-open "things:///add?title=Write%20chapter%203&list-id=$project_id&when=anytime"
+project_id=$(scripts/run-jxa.sh 'const app = Application("Things3"); const p = app.projects.whose({name: "Book Writing"})[0]; p ? p.id() : "";')
+osascript scripts/url.js add title="Write chapter 3" list-id="$project_id" when=anytime
 ```
 
 ## Creating Projects
@@ -61,19 +59,22 @@ open "things:///add?title=Write%20chapter%203&list-id=$project_id&when=anytime"
 ### Simple Project
 
 ```bash
-open "things:///add-project?title=Website%20Redesign&when=today&tags=Work"
+osascript scripts/url.js add-project title="Website Redesign" when=today tags=Work
 ```
 
 ### Project with Todos
 
 ```bash
-open "things:///add-project?title=Plan%20vacation&when=tomorrow&to-dos=Research%20destinations%0aBook%20flights%0aBook%20hotel%0aCreate%20itinerary"
+osascript scripts/url.js add-project title="Plan vacation" when=tomorrow to-dos="Research destinations
+Book flights
+Book hotel
+Create itinerary"
 ```
 
 ### Project in Area
 
 ```bash
-open "things:///add-project?title=Kitchen%20renovation&area=Home&when=someday"
+osascript scripts/url.js add-project title="Kitchen renovation" area=Home when=someday
 ```
 
 ### Complex Project with JSON
@@ -230,27 +231,24 @@ if (project) {
 
 ## Updating Todos
 
-**Prerequisite**: `AUTH_TOKEN=$(security find-generic-password -a "$USER" -s "things-auth-token" -w)` (see `@1password.md` for setup)
+Auth token is fetched automatically by `osascript scripts/url.js` (see `@1password.md` for setup).
 
 ### Append Notes
 
 ```bash
-todo_id=$(osascript -l JavaScript -e '
-const app = Application("Things3");
-const todo = app.lists.byId("TMTodayListSource").toDos().whose({name: "Call dentist"})[0];
-todo ? todo.id() : "";
-')
-open "things:///update?id=$todo_id&auth-token=$AUTH_TOKEN&append-notes=Appointment%20at%202pm"
+todo_id=$(scripts/run-jxa.sh 'const app = Application("Things3"); const t = app.lists.byId("TMTodayListSource").toDos().whose({name: "Call dentist"})[0]; t ? t.id() : "";')
+osascript scripts/url.js update id="$todo_id" append-notes="Appointment at 2pm"
 ```
 
 ### Add Tags / Move / Reschedule / Complete
 
 ```bash
-open "things:///update?id=ABC-123&auth-token=$AUTH_TOKEN&add-tags=Urgent,Important"
-open "things:///update?id=ABC-123&auth-token=$AUTH_TOKEN&list=New%20Project"
-open "things:///update?id=ABC-123&auth-token=$AUTH_TOKEN&when=tomorrow"
-open "things:///update?id=ABC-123&auth-token=$AUTH_TOKEN&completed=true"
-open "things:///update?id=ABC-123&auth-token=$AUTH_TOKEN&append-checklist-items=Item%201%0aItem%202"
+osascript scripts/url.js update id=ABC-123 add-tags=Urgent,Important
+osascript scripts/url.js update id=ABC-123 list="New Project"
+osascript scripts/url.js update id=ABC-123 when=tomorrow
+osascript scripts/url.js update id=ABC-123 completed=true
+osascript scripts/url.js update id=ABC-123 append-checklist-items="Item 1
+Item 2"
 ```
 
 ## Navigation
@@ -258,41 +256,29 @@ open "things:///update?id=ABC-123&auth-token=$AUTH_TOKEN&append-checklist-items=
 ### Show Built-in Lists
 
 ```bash
-# Show Today
-open "things:///show?id=today"
-
-# Show Inbox
-open "things:///show?id=inbox"
-
-# Show Upcoming
-open "things:///show?id=upcoming"
-
-# Show Anytime
-open "things:///show?id=anytime"
+osascript scripts/url.js show id=today
+osascript scripts/url.js show id=inbox
+osascript scripts/url.js show id=upcoming
+osascript scripts/url.js show id=anytime
 ```
 
 ### Show Specific Todo
 
 ```bash
-todo_id="ABC-123"
-open "things:///show?id=$todo_id"
+osascript scripts/url.js show id=ABC-123
 ```
 
 ### Show Project
 
 ```bash
-project_id=$(osascript -l JavaScript -e '
-const app = Application("Things3");
-const project = app.projects.whose({name: "Website Redesign"})[0];
-project ? project.id() : "";
-')
-open "things:///show?id=$project_id"
+project_id=$(scripts/run-jxa.sh 'const app = Application("Things3"); const p = app.projects.whose({name: "Website Redesign"})[0]; p ? p.id() : "";')
+osascript scripts/url.js show id="$project_id"
 ```
 
 ### Search
 
 ```bash
-open "things:///search?query=meeting%20notes"
+osascript scripts/url.js search query="meeting notes"
 ```
 
 ## Advanced Workflows
@@ -304,19 +290,10 @@ open "things:///search?query=meeting%20notes"
 
 # Get today's todos
 echo "Today's Todos:"
-osascript -l JavaScript -e '
-const app = Application("Things3");
-const today = app.lists.byId("TMTodayListSource");
-const todos = today.toDos().map(todo => ({
-  name: todo.name(),
-  project: todo.project()?.name() || "None",
-  dueDate: todo.dueDate()?.toString() || "None"
-}));
-console.log(JSON.stringify(todos, null, 2));
-'
+scripts/run-jxa.sh 'const app = Application("Things3"); const today = app.lists.byId("TMTodayListSource"); JSON.stringify(today.toDos().map(t => ({name: t.name(), project: t.project()?.name() || "None", dueDate: t.dueDate()?.toString() || "None"})), null, 2);'
 
 # Show Today list
-open "things:///show?id=today"
+osascript scripts/url.js show id=today
 ```
 
 ### Create Weekly Review Project
@@ -348,13 +325,10 @@ open "things:///json?data=$(echo "$data" | jq -sRr @uri)"
 ### Bulk Tag All Inbox Items
 
 ```bash
-todo_ids=$(osascript -l JavaScript -e '
-const app = Application("Things3");
-JSON.stringify(app.lists.byId("TMInboxListSource").toDos().map(t => t.id()));
-' | jq -r '.[]')
+todo_ids=$(scripts/run-jxa.sh 'const app = Application("Things3"); JSON.stringify(app.lists.byId("TMInboxListSource").toDos().map(t => t.id()));' | jq -r '.[]')
 
 for todo_id in $todo_ids; do
-  open "things:///update?id=$todo_id&auth-token=$AUTH_TOKEN&add-tags=Needs%20Review"
+  osascript scripts/url.js update id="$todo_id" add-tags="Needs Review"
   sleep 0.1
 done
 ```

--- a/plugins/things/skills/things/package.json
+++ b/plugins/things/skills/things/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "types:generate": "sdef-to-dts /Applications/Things3.app --output src/Things3.d.ts",
-    "build": "esbuild src/example.ts --bundle --platform=neutral --format=iife --log-level=error > /dev/null"
+    "build": "esbuild src/example.ts --bundle --platform=neutral --format=iife --log-level=error > /dev/null",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",
@@ -16,6 +17,7 @@
     "@jxa/run": "^1.4.0",
     "@jxa/sdef-to-dts": "^1.4.0",
     "@types/node": "^25.0.5",
-    "esbuild": "^0.27.2"
+    "esbuild": "^0.27.2",
+    "typescript": "^5.7.3"
   }
 }

--- a/plugins/things/skills/things/scripts/url.js
+++ b/plugins/things/skills/things/scripts/url.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env osascript -l JavaScript
+// @ts-check
+/// <reference path="../src/jxa-globals.d.ts" />
+/// <reference path="../src/url.d.ts" />
+
+/**
+ * Things URL scheme wrapper
+ * Usage: osascript scripts/url.js <command> [key=value ...]
+ * Examples:
+ *   osascript scripts/url.js add title="Buy milk" when=today
+ *   osascript scripts/url.js update id=ABC-123 append-notes="Done!"
+ *   osascript scripts/url.js show id=today
+ */
+
+/** @type {import('../src/url').AuthRequiredCommand[]} */
+const AUTH_REQUIRED_COMMANDS = ['update', 'update-project', 'json'];
+
+/**
+ * @param {string} command
+ * @returns {command is import('../src/url').AuthRequiredCommand}
+ */
+function requiresAuth(command) {
+  return AUTH_REQUIRED_COMMANDS.includes(/** @type {any} */ (command));
+}
+
+/**
+ * @param {import('../src/url').JXAApplication} app
+ * @returns {string}
+ */
+function getAuthToken(app) {
+  return app.doShellScript(
+    'security find-generic-password -a "$USER" -s "things-auth-token" -w'
+  );
+}
+
+/**
+ * @param {string} command
+ * @returns {command is import('../src/url').Command}
+ */
+function isValidCommand(command) {
+  return ['add', 'add-project', 'update', 'update-project', 'show', 'search', 'json', 'version'].includes(command);
+}
+
+/**
+ * @param {string[]} argv
+ */
+function run(argv) {
+  const command = argv[0];
+  if (!command || !isValidCommand(command)) {
+    console.log('Usage: osascript scripts/url.js <command> [key=value ...]');
+    console.log('Commands: add, add-project, update, update-project, show, search, json');
+    return;
+  }
+
+  /** @type {import('../src/url').JXAApplication} */
+  const app = Application.currentApplication();
+  app.includeStandardAdditions = true;
+
+  /** @type {string[]} */
+  const params = [];
+
+  if (requiresAuth(command)) {
+    const authToken = getAuthToken(app);
+    params.push(`auth-token=${encodeURIComponent(authToken)}`);
+  }
+
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i];
+    const eqIndex = arg.indexOf('=');
+    if (eqIndex === -1) continue;
+
+    const key = arg.substring(0, eqIndex);
+    const value = arg.substring(eqIndex + 1);
+    params.push(`${key}=${encodeURIComponent(value)}`);
+  }
+
+  let url = `things:///${command}`;
+  if (params.length > 0) {
+    url += '?' + params.join('&');
+  }
+
+  app.openLocation(url);
+}

--- a/plugins/things/skills/things/src/jxa-globals.d.ts
+++ b/plugins/things/skills/things/src/jxa-globals.d.ts
@@ -4,6 +4,12 @@
 
 declare function Application(name: string): any;
 
+declare namespace Application {
+  function currentApplication(): any;
+}
+
 declare const console: {
   log(...args: any[]): void;
 };
+
+declare function encodeURIComponent(str: string): string;

--- a/plugins/things/skills/things/src/url.d.ts
+++ b/plugins/things/skills/things/src/url.d.ts
@@ -1,0 +1,138 @@
+/**
+ * Things URL Scheme type definitions
+ * Used for validating url.js via TypeScript
+ */
+
+/** Commands that require auth-token */
+export type AuthRequiredCommand = 'update' | 'update-project' | 'json';
+
+/** Commands that don't require auth-token */
+export type PublicCommand = 'add' | 'add-project' | 'show' | 'search' | 'version';
+
+/** All valid Things URL scheme commands */
+export type Command = AuthRequiredCommand | PublicCommand;
+
+/** When values for scheduling */
+export type WhenValue =
+  | 'today'
+  | 'tomorrow'
+  | 'evening'
+  | 'anytime'
+  | 'someday'
+  | string; // Also accepts ISO dates, natural language
+
+/** Parameters for 'add' command */
+export interface AddParams {
+  title?: string;
+  titles?: string;
+  notes?: string;
+  when?: WhenValue;
+  deadline?: string;
+  tags?: string;
+  'checklist-items'?: string;
+  list?: string;
+  'list-id'?: string;
+  heading?: string;
+  'heading-id'?: string;
+  completed?: 'true' | 'false';
+  canceled?: 'true' | 'false';
+  reveal?: 'true' | 'false';
+}
+
+/** Parameters for 'add-project' command */
+export interface AddProjectParams {
+  title?: string;
+  notes?: string;
+  when?: WhenValue;
+  deadline?: string;
+  tags?: string;
+  area?: string;
+  'area-id'?: string;
+  'to-dos'?: string;
+  completed?: 'true' | 'false';
+  canceled?: 'true' | 'false';
+  reveal?: 'true' | 'false';
+}
+
+/** Parameters for 'update' command */
+export interface UpdateParams {
+  id: string;
+  'auth-token': string;
+  title?: string;
+  notes?: string;
+  'prepend-notes'?: string;
+  'append-notes'?: string;
+  when?: WhenValue;
+  deadline?: string;
+  tags?: string;
+  'add-tags'?: string;
+  'checklist-items'?: string;
+  'prepend-checklist-items'?: string;
+  'append-checklist-items'?: string;
+  list?: string;
+  'list-id'?: string;
+  heading?: string;
+  'heading-id'?: string;
+  completed?: 'true' | 'false';
+  canceled?: 'true' | 'false';
+  duplicate?: 'true' | 'false';
+  reveal?: 'true' | 'false';
+}
+
+/** Parameters for 'update-project' command */
+export interface UpdateProjectParams extends UpdateParams {
+  area?: string;
+  'area-id'?: string;
+}
+
+/** Parameters for 'show' command */
+export interface ShowParams {
+  id?: string;
+  query?: string;
+  filter?: string;
+}
+
+/** Parameters for 'search' command */
+export interface SearchParams {
+  query?: string;
+}
+
+/** Parameters for 'json' command */
+export interface JsonParams {
+  'auth-token'?: string;
+  data: string;
+  reveal?: 'true' | 'false';
+}
+
+/** Map of commands to their parameter types */
+export interface CommandParamsMap {
+  add: AddParams;
+  'add-project': AddProjectParams;
+  update: UpdateParams;
+  'update-project': UpdateProjectParams;
+  show: ShowParams;
+  search: SearchParams;
+  json: JsonParams;
+  version: Record<string, never>;
+}
+
+/** JXA Application with standard additions */
+export interface JXAApplication {
+  includeStandardAdditions: boolean;
+  doShellScript(command: string): string;
+  openLocation(url: string): void;
+}
+
+/** Built-in list IDs for 'show' command */
+export type BuiltInListId =
+  | 'inbox'
+  | 'today'
+  | 'anytime'
+  | 'upcoming'
+  | 'someday'
+  | 'logbook'
+  | 'tomorrow'
+  | 'deadlines'
+  | 'repeating'
+  | 'all-projects'
+  | 'logged-projects';

--- a/plugins/things/skills/things/tsconfig.json
+++ b/plugins/things/skills/things/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "scripts/**/*"]
+}


### PR DESCRIPTION
Add `scripts/url.js` to simplify Things URL scheme operations. The script handles auth token fetching automatically from keychain and URL encodes parameters, providing a cleaner interface than inline bash.

## Context

This addresses usability issues with the Things skill where URL scheme operations required complex inline bash:

```bash
# Before: complex, hard to read, error-prone
auth_token=$(security find-generic-password -a "$USER" -s "things-auth-token" -w)
open "things:///update?id=ABC-123&auth-token=$auth_token&append-notes=Some%20text"

# After: clean, handles auth and encoding automatically
osascript scripts/url.js update id=ABC-123 append-notes="Some text"
```

## Issue

Related sandbox issue: [anthropics/claude-code#10524](https://github.com/anthropics/claude-code/issues/10524)

The original approach failed because `excludedCommands` requires a `:*` suffix to match commands with arguments. Without it, `osascript` only matches the exact command with no args. This was fixed separately in ff96920.

Even with sandbox working, `url.js` provides value:
- Automatic auth token injection from keychain
- Automatic URL encoding (no manual `%20`, `%0a`)
- Type safety via JSDoc + TypeScript for CI validation
- Cleaner, more readable commands

Raw `open "things://..."` commands still work as an escape hatch for edge cases.

## Changes

- Add `scripts/url.js` - JXA script invoked via `osascript` for URL scheme operations
- Add `src/url.d.ts` - TypeScript definitions for URL scheme command parameters
- Add `tsconfig.json` - Enables `npm run typecheck` for CI validation
- Update `src/jxa-globals.d.ts` - Add `Application.currentApplication()` and `encodeURIComponent`
- Update `SKILL.md` and `examples.md` to use new script syntax

## Usage

```bash
# Create a todo
osascript scripts/url.js add title="Buy milk" when=today tags=Errands

# Update a todo (auth token fetched automatically)
osascript scripts/url.js update id=ABC-123 append-notes="Done\!"

# Navigate
osascript scripts/url.js show id=today

# Multi-line values work naturally
osascript scripts/url.js add title="Shopping" checklist-items="Milk
Eggs
Bread"
```

## Testing

- Verified read operations via `run-jxa.sh`
- Tested add command - created todo successfully
- Tested update command - appended notes with auto auth token
- Tested show command - navigated to Today view
- Confirmed `npm run typecheck` passes