### PR TITLE
feat(linear): add default state hook for issue creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,53 @@ Each plugin in `plugins/` contains:
 - `hooks/`: Optional hook definitions (`hooks.json`)
 - `commands/`: Optional slash commands
 - `agents/`: Optional agent definitions
+- `spec.sh`: ShellSpec test file (run with `shellspec plugins/<name>/spec.sh`)
+
+## Hooks
+
+Hooks intercept tool calls and can modify inputs, block execution, or request user confirmation. Define hooks in `hooks/hooks.json`:
+
+```json
+{
+  "description": "Sets default state for new issues",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__linear__create_issue",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/default-state.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The `matcher` field supports regex patterns (e.g., `Edit|MultiEdit|Write`). Hook scripts receive JSON on stdin with `tool_name` and `tool_input`.
+
+### PreToolUse Hook Outputs
+
+Hook scripts can output JSON to control behavior:
+
+- **Modify input**: Return `updatedInput` to merge fields into the tool input
+  ```json
+  {"hookSpecificOutput": {"hookEventName": "PreToolUse", "updatedInput": {"state": "Todo"}}}
+  ```
+- **Block execution**: Return `permissionDecision: "deny"` with a reason
+  ```json
+  {"hookSpecificOutput": {"permissionDecision": "deny", "permissionDecisionReason": "Use: gh repo view"}}
+  ```
+- **Request confirmation**: Return `permissionDecision: "ask"` with a reason
+- **Allow without modification**: Exit with no output
+
+See [plugins/linear/hooks/](plugins/linear/hooks/) for input modification and [plugins/github/scripts/](plugins/github/scripts/) for permission decisions.
+
+## Testing
+
+Plugins use [ShellSpec](https://shellspec.info/) for testing. Each plugin should have a `spec.sh` file that tests hook scripts directly by piping JSON input. See [plugins/linear/spec.sh](plugins/linear/spec.sh) and [plugins/github/spec.sh](plugins/github/spec.sh) for examples.
 
 ## Workflow
 

--- a/plugins/linear/hooks/default-state.sh
+++ b/plugins/linear/hooks/default-state.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# PreToolUse hook for mcp__linear__create_issue
+# Sets default state based on assignee when state is not specified
+
+input=$(cat)
+state=$(echo "$input" | jq -r '.tool_input.state // empty')
+
+# Only modify if state is not set
+if [[ -n "$state" ]]; then
+  exit 0
+fi
+
+assignee=$(echo "$input" | jq -r '.tool_input.assignee // empty')
+
+if [[ -n "$assignee" ]]; then
+  default_state="Todo"
+else
+  default_state="Backlog"
+fi
+
+jq -n \
+  --arg state "$default_state" \
+  '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      updatedInput: {
+        state: $state
+      }
+    }
+  }'

--- a/plugins/linear/hooks/hooks.json
+++ b/plugins/linear/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Sets default state for new issues based on assignee",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__linear__create_issue",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/default-state.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/linear/spec.sh
+++ b/plugins/linear/spec.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# ShellSpec tests for Linear default-state hook
+
+Describe 'Linear default-state hook'
+  run_hook() {
+    local json="$1"
+    echo "$json" | ./hooks/default-state.sh
+  }
+
+  has_state() {
+    [ "$1" = "$(echo "${has_state}" | jq -r '.hookSpecificOutput.updatedInput.state')" ]
+  }
+
+  Context 'when state is not set'
+    It 'defaults to Backlog when no assignee'
+      When run run_hook '{"tool_input":{"title":"Test issue","team":"ENG"}}'
+      The status should be success
+      The output should satisfy has_state "Backlog"
+    End
+
+    It 'defaults to Todo when assignee is set'
+      When run run_hook '{"tool_input":{"title":"Test issue","team":"ENG","assignee":"me"}}'
+      The status should be success
+      The output should satisfy has_state "Todo"
+    End
+
+    It 'defaults to Backlog when assignee is empty string'
+      When run run_hook '{"tool_input":{"title":"Test issue","team":"ENG","assignee":""}}'
+      The status should be success
+      The output should satisfy has_state "Backlog"
+    End
+  End
+
+  Context 'when state is already set'
+    It 'does not modify the input'
+      When run run_hook '{"tool_input":{"title":"Test issue","team":"ENG","state":"In Progress"}}'
+      The status should be success
+      The output should be blank
+    End
+
+    It 'does not modify even with assignee set'
+      When run run_hook '{"tool_input":{"title":"Test issue","team":"ENG","state":"Done","assignee":"me"}}'
+      The status should be success
+      The output should be blank
+    End
+  End
+End


### PR DESCRIPTION
Adds a PreToolUse hook to the Linear plugin that sets a default state when creating issues via `mcp__linear__create_issue` without an explicit state:

- **With assignee**: defaults to "Todo"
- **No assignee**: defaults to "Backlog"

This prevents issues from landing in Triage when created programmatically.

## Changes

- `plugins/linear/hooks/hooks.json`: Hook configuration targeting the create issue tool
- `plugins/linear/hooks/default-state.sh`: Script that checks assignee and sets state
- `plugins/linear/spec.sh`: ShellSpec tests for the hook
- `CLAUDE.md`: Documents hooks system and testing conventions