### PR TITLE
feat(things): add reorder script for list item positioning

### DIFF
--- a/plugins/things/README.md
+++ b/plugins/things/README.md
@@ -2,9 +2,26 @@
 
 Interacting with Things 3 task manager for Mac via Claude Code.
 
+## Philosophy
+
+This plugin uses only **public APIs** provided by Cultured Code:
+
+- **URL scheme** (`things:///`) for writes (create, update, reorder)
+- **JXA/AppleScript** for reads (queries, filtering, status checks)
+
+Unlike many Things integrations that read or write directly to the SQLite database, this plugin avoids database access entirely. This ensures compatibility with future Things updates and respects the application's data integrity guarantees.
+
+## Features
+
+- Full CRUD operations via official APIs
+- List reordering (Today, Anytime, Someday) without SQLite writes
+- Type-safe JXA scripting via TypeScript
+- Auth token management via macOS Keychain
+
 ## Contents
 
-- **Skill**: Guidance on Things 3 integration via JXA scripting and URL schemes
+- **Skill**: Comprehensive guidance on JXA scripting and URL scheme usage
+- **Scripts**: Reusable automation scripts (`url.js`, `reorder.js`)
 
 ## Activation
 

--- a/plugins/things/skills/things/SKILL.md
+++ b/plugins/things/skills/things/SKILL.md
@@ -35,6 +35,12 @@ osascript scripts/url.js update id=ABC-123 append-notes="Additional info"
 osascript scripts/url.js show id=today
 ```
 
+**Reorder a list or project items:**
+```bash
+osascript scripts/reorder.js [--list today|anytime|someday] <id1> <id2> <id3> ...
+```
+Items appear at the top of the list in the order specified. Default list is `today`. Also works for items within a project - use the `--list` value matching the items' current scheduling state.
+
 ## Built-in List IDs
 
 - `TMInboxListSource` - Inbox

--- a/plugins/things/skills/things/scripts/reorder.js
+++ b/plugins/things/skills/things/scripts/reorder.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env osascript -l JavaScript
+// @ts-check
+/// <reference path="../src/jxa-globals.d.ts" />
+/// <reference path="../src/url.d.ts" />
+
+/**
+ * Reorder items in a Things list
+ * Usage: osascript scripts/reorder.js [--list <list>] <id1> <id2> <id3> ...
+ *
+ * Options:
+ *   --list <list>  Target list: today (default), anytime, someday
+ *
+ * Items are placed in the list in the order specified.
+ * Items not in the arguments retain their relative position after the specified items.
+ */
+
+const INTERMEDIATE_LIST = {
+  today: 'anytime',
+  anytime: 'someday',
+  someday: 'anytime'
+};
+
+/**
+ * @param {import('../src/url').JXAApplication} app
+ * @returns {string}
+ */
+function getAuthToken(app) {
+  return app.doShellScript(
+    'security find-generic-password -a "$USER" -s "things-auth-token" -w'
+  );
+}
+
+/**
+ * @param {import('../src/url').JXAApplication} app
+ * @param {string} token
+ * @param {Array<{type: string, operation: string, id: string, attributes: object}>} data
+ */
+function executeJsonUpdate(app, token, data) {
+  const url = 'things:///json?auth-token=' +
+    encodeURIComponent(token) +
+    '&data=' +
+    encodeURIComponent(JSON.stringify(data));
+  app.openLocation(url);
+}
+
+/**
+ * @param {string[]} argv
+ */
+function run(argv) {
+  let targetList = 'today';
+  let ids = [];
+
+  // Parse arguments
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--list' && i + 1 < argv.length) {
+      targetList = argv[i + 1];
+      i++;
+    } else {
+      ids.push(argv[i]);
+    }
+  }
+
+  if (ids.length === 0) {
+    console.log('Usage: osascript scripts/reorder.js [--list <list>] <id1> <id2> ...');
+    console.log('Lists: today (default), anytime, someday');
+    return JSON.stringify({ error: 'No IDs provided' });
+  }
+
+  const intermediate = INTERMEDIATE_LIST[targetList];
+  if (!intermediate) {
+    return JSON.stringify({ error: 'Invalid list: ' + targetList });
+  }
+
+  /** @type {import('../src/url').JXAApplication} */
+  const app = Application.currentApplication();
+  app.includeStandardAdditions = true;
+
+  const token = getAuthToken(app);
+
+  // Move all items to intermediate list (clears their position)
+  const intermediateData = ids.map(id => ({
+    type: 'to-do',
+    operation: 'update',
+    id: id,
+    attributes: { when: intermediate }
+  }));
+  executeJsonUpdate(app, token, intermediateData);
+
+  // Move items to target list in desired order (assigns sequential indices)
+  const targetData = ids.map(id => ({
+    type: 'to-do',
+    operation: 'update',
+    id: id,
+    attributes: { when: targetList }
+  }));
+  executeJsonUpdate(app, token, targetData);
+
+  return JSON.stringify({ success: true, list: targetList, reordered: ids.length });
+}


### PR DESCRIPTION
Add `reorder.js` script that reorders items in Things lists (Today, Anytime, Someday) and within projects using only public APIs. Also adds a philosophy section to README explaining the public API approach.

## Changes

- Add `reorder.js` script using batch JSON URL scheme updates
- Support `--list` flag for targeting Today (default), Anytime, or Someday
- Works for items within projects by manipulating their `when` state
- Document philosophy in README: public APIs only, no SQLite writes
- Add reorder command documentation to `SKILL.md`

## How It Works

The script reorders items by moving them to an intermediate list (clears position) then back to the target list in desired order. Things assigns sequential index values based on array order in the JSON batch update.

```bash
# Reorder Today (default)
osascript scripts/reorder.js <id1> <id2> <id3>

# Reorder Anytime
osascript scripts/reorder.js --list anytime <id1> <id2> <id3>
```

## Testing

Verified reordering works for Today list, Anytime list, and items within projects. Confirmed batch JSON updates execute without race conditions—no delays needed between the two URL scheme calls.
