### PR TITLE
feat(things): add daily review workflow reference

### DIFF
--- a/plugins/things/skills/things/SKILL.md
+++ b/plugins/things/skills/things/SKILL.md
@@ -73,6 +73,7 @@ Load detailed guides as needed:
 - **[url-scheme.md](url-scheme.md)** - URL scheme commands and parameters
 - **[1password.md](1password.md)** - Auth token setup and keychain configuration
 - **[troubleshooting.md](troubleshooting.md)** - Common issues, best practices, repeating task detection
+- **[daily-review.md](daily-review.md)** - Interactive daily review workflow for inbox, today, and priorities
 
 ## Notes Formatting
 

--- a/plugins/things/skills/things/daily-review.md
+++ b/plugins/things/skills/things/daily-review.md
@@ -1,0 +1,141 @@
+# Daily Review Workflow
+
+Interactive process for clearing inbox, reviewing today, and planning ahead. Use `AskUserQuestion` at decision points throughout.
+
+## Variants
+
+**Morning Review** (10-15 min): Planning-focused. Process inbox, review today, set priorities.
+
+**Evening Review** (5-10 min): Shutdown-focused. Capture loose ends, prepare tomorrow, clear mental load.
+
+## Workflow Steps
+
+### 1. Process Inbox
+
+Read all inbox items:
+
+```bash
+scripts/run-jxa.sh '
+const app = Application("Things3");
+const inbox = app.lists.byId("TMInboxListSource");
+const todos = inbox.toDos().map(t => ({
+  id: t.id(),
+  name: t.name(),
+  notes: t.notes() || "",
+  tags: t.tagNames(),
+  createdAt: t.creationDate()?.toISOString()
+}));
+JSON.stringify(todos, null, 2);
+'
+```
+
+**Batch by pattern**: Group items by project hints, tags, or keywords before asking. For each batch, use `AskUserQuestion`:
+
+- **Schedule**: today, tomorrow, next week, someday
+- **Assign**: to existing project, to area, or leave standalone
+- **Tag**: add relevant tags
+- **Delete**: if no longer relevant (confirm first)
+
+Process until inbox is empty.
+
+### 2. Review Today
+
+Read today's list:
+
+```bash
+scripts/run-jxa.sh '
+const app = Application("Things3");
+const today = app.lists.byId("TMTodayListSource");
+const todos = today.toDos().filter(t => {
+  const props = t.properties();
+  // Exclude repeating instances (created at midnight)
+  if (!props.creationDate) return true;
+  return props.creationDate.getHours() !== 0 ||
+         props.creationDate.getMinutes() !== 0 ||
+         props.creationDate.getSeconds() !== 0;
+}).map(t => ({
+  id: t.id(),
+  name: t.name(),
+  project: t.project()?.name() || null,
+  notes: t.notes() || ""
+}));
+JSON.stringify(todos, null, 2);
+'
+```
+
+For items that look stale or unclear, use `AskUserQuestion`:
+
+- **Keep**: remains on today
+- **Defer**: move to tomorrow or upcoming
+- **Clarify**: break into smaller tasks
+- **Complete/Delete**: if done or no longer needed
+
+### 3. Review Tomorrow/Upcoming
+
+Check what's scheduled for the next few days:
+
+```bash
+scripts/run-jxa.sh '
+const app = Application("Things3");
+const upcoming = app.lists.byId("TMCalendarListSource");
+const todos = upcoming.toDos().slice(0, 20).map(t => ({
+  id: t.id(),
+  name: t.name(),
+  when: t.activationDate()?.toISOString(),
+  deadline: t.dueDate()?.toISOString()
+}));
+JSON.stringify(todos, null, 2);
+'
+```
+
+Use `AskUserQuestion`: Should any of these move to today?
+
+### 4. Set Priorities (Morning Only)
+
+After reviewing today's list, use `AskUserQuestion` to confirm priority order:
+
+> "Here are your tasks for today. Which should be your top priorities? Select in order of importance."
+
+Present current today items and let user select/reorder.
+
+Then reorder using the new order (highest priority first):
+
+```bash
+osascript scripts/reorder.js <first-id> <second-id> <third-id> ...
+```
+
+### 5. Summary
+
+Display:
+- Items processed from inbox
+- Changes made to today list
+- Today's plan in priority order
+- Any items deferred to later
+
+## Example Session
+
+**Morning review prompt from user**: "Let's do my daily review"
+
+1. Read inbox → 5 items found
+2. Group by pattern: 3 work-related, 2 personal
+3. `AskUserQuestion`: "3 work items in inbox. Where should they go?"
+4. User selects: today for 2, next week for 1
+5. Process personal items similarly
+6. Read today → 8 items (after inbox processing)
+7. `AskUserQuestion`: "Here's today. Any to defer or clarify?"
+8. User keeps all
+9. `AskUserQuestion`: "What's your priority order for today?"
+10. User selects top 3
+11. Reorder with `scripts/reorder.js`
+12. Display summary
+
+## Evening Variant
+
+Skip priority setting. Focus on:
+
+1. Quick inbox scan (capture any remaining thoughts)
+2. Review what's left on today → defer to tomorrow if incomplete
+3. Preview tomorrow's schedule
+4. Confirm tomorrow looks achievable
+
+End with: "Your system is clear. Tomorrow's plan is ready."


### PR DESCRIPTION
Add interactive daily review workflow for processing inbox, reviewing today list, and setting priorities. Supports morning (planning) and evening (shutdown) variants.



## Changes

- Add `daily-review.md` reference file with GTD-inspired workflow
- Morning variant: planning-focused (inbox, today, priorities)
- Evening variant: shutdown-focused (capture, defer, preview tomorrow)
- Uses `AskUserQuestion` at decision points for interactive clarification
- Integrates with `reorder.js` for priority ordering

## Workflow Steps

1. Process inbox to zero (batch by pattern)
2. Review today list (defer stale items)
3. Review upcoming (pull forward if needed)
4. Set priorities via reorder (morning only)

## Research

- [Secrets of the Daily Review](https://facilethings.com/blog/en/the-daily-review) - FacileThings
- [Daily Reviews](https://www.gtd.be/en/how-to-get-started/maintaining-the-system/daily-reviews) - GTD.be
- [GTD Journey: Daily Plans, Shutdown Routines and Weekly Reviews](https://noisydeadlines.net/gtd-journey-daily-plans-shutdown-routines-and-weekly-reviews) - Noisy Deadlines
- [Daily, Weekly, Monthly, and Annual Reviews](https://omalab.gitbook.io/guide/operating-model/gtd/daily-weekly-monthly-annual-reviews) - OMAlab
- [My Simple Daily Review](https://www.impactsociety.co/articles/my-simple-daily-review) - Impact Society
- [What to do during a daily planning and during a daily review](https://forum.gettingthingsdone.com/threads/what-to-do-during-a-daily-planning-and-during-a-daily-review.17059/) - GTD Forums
