### PR TITLE
feat(style): add anti-numbering hooks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -84,6 +84,11 @@
       "source": "./plugins/newline"
     },
     {
+      "name": "style",
+      "description": "Code style enforcement hooks",
+      "source": "./plugins/style"
+    },
+    {
       "name": "github",
       "description": "GitHub workflow, Actions monitoring, and rulesets management",
       "source": "./plugins/github"

--- a/plugins/style/.claude-plugin/plugin.json
+++ b/plugins/style/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "style",
+  "description": "Code style enforcement hooks",
+  "author": {
+    "name": "Ben Drucker",
+    "email": "bvdrucker@gmail.com"
+  }
+}

--- a/plugins/style/README.md
+++ b/plugins/style/README.md
@@ -1,0 +1,13 @@
+# Style
+
+Code style enforcement hooks.
+
+## Contents
+
+- **Hooks**: Anti-numbering detection for Write and Edit tools
+
+## Testing
+
+```sh
+shellspec plugins/style/spec.sh
+```

--- a/plugins/style/hooks/anti-numbering.sh
+++ b/plugins/style/hooks/anti-numbering.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# PreToolUse hook to detect inappropriate numbered sequences
+# Usage: anti-numbering.sh <mode>
+# Modes:
+#   write - Block files with numbered patterns (more confident)
+#   edit  - Warn about numbered patterns being added (softer guidance)
+
+mode="${1:-write}"
+input=$(cat)
+tool_name=$(echo "$input" | jq -r '.tool_name')
+
+# Extract content based on tool type
+if [[ "$tool_name" == "Write" ]]; then
+  content=$(echo "$input" | jq -r '.tool_input.content // empty')
+  file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
+elif [[ "$tool_name" == "Edit" ]]; then
+  content=$(echo "$input" | jq -r '.tool_input.new_string // empty')
+  file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
+else
+  exit 0
+fi
+
+# Skip if no content
+[[ -z "$content" ]] && exit 0
+
+# Skip non-text files that commonly use numbering
+case "$file_path" in
+  *.md|*.txt|*.rst)
+    # Documentation files - check for numbered headers
+    ;;
+  *.sh|*.bash|*.py|*.go|*.js|*.ts|*.rb|*.java|*.c|*.cpp|*.h|*.hpp|*.rs)
+    # Code files - check for step comments and numbered identifiers
+    ;;
+  *)
+    # Other files - skip
+    exit 0
+    ;;
+esac
+
+# Patterns to detect
+# 1. Numbered headers: # 1. Something, ## Step 2:, ### Phase 3, etc.
+# 2. Step/Phase comments: // Step 1:, # Phase 2, /* Step 3 */
+# 3. Numbered function/variable names: step1_, phase2Handler, doStep3
+
+issues=()
+
+# Check for numbered markdown headers
+if echo "$content" | grep -qE '^#{1,6}\s+(([0-9]+\.)|((Step|Phase|Part)\s+[0-9]+))'; then
+  issues+=("Numbered headers (e.g., '# 1. Something' or '## Step 2:')")
+fi
+
+# Check for step/phase comments in code
+if echo "$content" | grep -qE '(//|#|/\*|\*)\s*(Step|Phase|Part)\s+[0-9]+'; then
+  issues+=("Step/Phase comments (e.g., '// Step 1:')")
+fi
+
+# Check for numbered function/variable names (but not test cases or legitimate uses)
+# Look for patterns like step1, phase2, doStep3, handlePhase4
+if echo "$content" | grep -qE '\b(step|phase|part)[0-9]+|[0-9]+(step|phase|part)\b' | grep -vqE '(test|spec|example)'; then
+  # More targeted check - look for definition patterns
+  if echo "$content" | grep -qE '(func|function|def|const|let|var|type)\s+\w*(step|phase|part)[0-9]+'; then
+    issues+=("Numbered identifiers in definitions (e.g., 'func step1()')")
+  fi
+fi
+
+# No issues found
+if [[ ${#issues[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+# Build the reason message
+reason="Detected numbered sequences that create tight coupling:\n"
+for issue in "${issues[@]}"; do
+  reason+="- $issue\n"
+done
+reason+="\nUse descriptive names instead. See CLAUDE.md Organization guidelines."
+
+# Output based on mode
+output_json() {
+  local decision="$1"
+  local reason="$2"
+  jq -n \
+    --arg decision "$decision" \
+    --arg reason "$reason" \
+    '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: $decision,
+        permissionDecisionReason: $reason
+      }
+    }'
+}
+
+if [[ "$mode" == "write" ]]; then
+  # For Write: block with clear message
+  output_json "deny" "$reason"
+else
+  # For Edit: softer guidance - ask instead of deny
+  # This allows editing existing documents that already use these patterns
+  output_json "ask" "This edit introduces numbered sequences. $reason"
+fi

--- a/plugins/style/hooks/hooks.json
+++ b/plugins/style/hooks/hooks.json
@@ -1,0 +1,25 @@
+{
+  "description": "Detects inappropriate numbered sequences in code and documentation",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/anti-numbering.sh write"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/anti-numbering.sh edit"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/style/spec.sh
+++ b/plugins/style/spec.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+
+# ShellSpec tests for style anti-numbering hook
+
+Describe 'Anti-numbering hook'
+  run_hook() {
+    local mode="$1"
+    local tool="$2"
+    local content="$3"
+    local file_path="${4:-test.md}"
+
+    if [[ "$tool" == "Write" ]]; then
+      jq -n \
+        --arg content "$content" \
+        --arg path "$file_path" \
+        '{tool_name: "Write", tool_input: {file_path: $path, content: $content}}' \
+        | ./hooks/anti-numbering.sh "$mode"
+    else
+      jq -n \
+        --arg content "$content" \
+        --arg path "$file_path" \
+        '{tool_name: "Edit", tool_input: {file_path: $path, new_string: $content, old_string: "placeholder"}}' \
+        | ./hooks/anti-numbering.sh "$mode"
+    fi
+  }
+
+  has_decision() {
+    [ "$1" = "$(echo "${has_decision}" | jq -r '.hookSpecificOutput.permissionDecision')" ]
+  }
+
+  contains_reason() {
+    echo "${contains_reason}" | jq -r '.hookSpecificOutput.permissionDecisionReason' | grep -q "$1"
+  }
+
+  Context 'Numbered markdown headers'
+    It 'detects "# 1. Something" pattern'
+      When run run_hook "write" "Write" "# 1. Introduction
+Some content here"
+      The status should be success
+      The output should satisfy has_decision "deny"
+      The output should satisfy contains_reason "Numbered headers"
+    End
+
+    It 'detects "## Step 2:" pattern'
+      When run run_hook "write" "Write" "## Step 2: Configuration
+Configure the system"
+      The status should be success
+      The output should satisfy has_decision "deny"
+      The output should satisfy contains_reason "Numbered headers"
+    End
+
+    It 'detects "### Phase 3" pattern'
+      When run run_hook "write" "Write" "### Phase 3
+Implementation details"
+      The status should be success
+      The output should satisfy has_decision "deny"
+      The output should satisfy contains_reason "Numbered headers"
+    End
+
+    It 'allows headers without numbers'
+      When run run_hook "write" "Write" "# Introduction
+## Configuration
+### Implementation"
+      The status should be success
+      The output should be blank
+    End
+  End
+
+  Context 'Step/Phase comments in code'
+    It 'detects "// Step 1:" in code'
+      When run run_hook "write" "Write" "// Step 1: Initialize
+func init() {}" "main.go"
+      The status should be success
+      The output should satisfy has_decision "deny"
+      The output should satisfy contains_reason "Step/Phase comments"
+    End
+
+    It 'detects "# Phase 2" in Python'
+      When run run_hook "write" "Write" "# Phase 2 - Processing
+def process():" "script.py"
+      The status should be success
+      The output should satisfy has_decision "deny"
+      The output should satisfy contains_reason "Step/Phase comments"
+    End
+
+    It 'allows regular comments without step numbers'
+      When run run_hook "write" "Write" "// Initialize the system
+func init() {}" "main.go"
+      The status should be success
+      The output should be blank
+    End
+  End
+
+  Context 'Write vs Edit mode'
+    It 'blocks Write tool with deny'
+      When run run_hook "write" "Write" "# 1. First Step"
+      The status should be success
+      The output should satisfy has_decision "deny"
+    End
+
+    It 'asks for Edit tool instead of deny'
+      When run run_hook "edit" "Edit" "# 1. First Step"
+      The status should be success
+      The output should satisfy has_decision "ask"
+    End
+  End
+
+  Context 'File type filtering'
+    It 'checks markdown files'
+      When run run_hook "write" "Write" "# 1. First" "doc.md"
+      The status should be success
+      The output should satisfy has_decision "deny"
+    End
+
+    It 'checks code files'
+      When run run_hook "write" "Write" "// Step 1: Init" "main.go"
+      The status should be success
+      The output should satisfy has_decision "deny"
+    End
+
+    It 'skips JSON files'
+      When run run_hook "write" "Write" '{"step1": "value"}' "config.json"
+      The status should be success
+      The output should be blank
+    End
+
+    It 'skips YAML files'
+      When run run_hook "write" "Write" "step1: value" "config.yaml"
+      The status should be success
+      The output should be blank
+    End
+  End
+
+  Context 'Legitimate uses'
+    It 'allows numbered list items in markdown body'
+      When run run_hook "write" "Write" "# Installation
+
+1. Clone the repository
+2. Run npm install
+3. Start the server"
+      The status should be success
+      The output should be blank
+    End
+
+    It 'allows version numbers'
+      When run run_hook "write" "Write" "# Version 2.0 Release Notes" "CHANGELOG.md"
+      The status should be success
+      The output should be blank
+    End
+  End
+End


### PR DESCRIPTION
## Summary

- Add new `style` plugin with hooks to detect inappropriate numbered sequences in code and documentation
- Detects numbered headers (`# 1. Something`, `## Step 2:`), step/phase comments, and numbered identifiers
- Write tool calls are blocked with a clear message; Edit tool calls ask for confirmation to allow editing existing documents

## Test plan

- [x] Run `shellspec plugins/style/spec.sh` - 15 tests pass
- [ ] Test with a Write that introduces `# 1. First Step` - should be blocked
- [ ] Test with an Edit that adds step comments - should prompt for confirmation