### PR TITLE
feat: add plan mode conciseness instructions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,6 +17,13 @@
 - Break code into multiple files where appropriate first before splitting across directories.
 - Do not number steps or phases in code (e.g., "Phase 1:", "Step 2:"). Use descriptive function names and call them in sequence. Numbering creates tight coupling, obscures whether order matters, and impedes inserting new steps.
 
+## Plan Mode
+
+When writing plans, be extremely concise. Sacrifice grammar for the sake of concision.
+
+- End every plan with a numbered list of concrete steps
+- List any unresolved questions at the end (edge cases, error handling, unclear requirements)
+
 ## Workflow
 
 - The user has carefully curated skills for their common workflows. Load skills when possible to adhere to the user's preferences and navigate their projects efficiently.


### PR DESCRIPTION
Add a `## Plan Mode` section to `CLAUDE.md` with conciseness-focused instructions based on Matt Pocock's recommendations.

## Changes

- Add "sacrifice grammar for the sake of concision" as the core principle
- Require numbered list of concrete steps at end of every plan
- Require listing unresolved questions at end (edge cases, error handling, unclear requirements)

## References

- [Matt Pocock's plan mode tips](https://x.com/mattpocockuk/status/2011092347254182097)
- [My AGENTS.md file for building plans you actually read](https://www.aihero.dev/my-agents-md-file-for-building-plans-you-actually-read)
