### PR TITLE
feat: add ast-grep skill to settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -55,7 +55,8 @@
     "code-simplifier@claude-plugins-official": true,
     "github@claude-plugins-official": true,
     "astral@astral-sh": true,
-    "agents-md@bendrucker": true
+    "agents-md@bendrucker": true,
+    "ast-grep@ast-grep": true
   },
   "extraKnownMarketplaces": {
     "bendrucker": {
@@ -68,6 +69,12 @@
       "source": {
         "source": "github",
         "repo": "astral-sh/claude-code-plugins"
+      }
+    },
+    "ast-grep": {
+      "source": {
+        "source": "github",
+        "repo": "ast-grep/claude-skill"
       }
     }
   },


### PR DESCRIPTION
Adds the [ast-grep skill](https://github.com/ast-grep/claude-skill) from the `ast-grep` marketplace for interactive AST-aware code pattern matching in conversations.

Separate from the style plugin's numbering hook (#184), which uses the `sg` CLI directly.