### PR TITLE
ci: add marketplace verification script

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -114,6 +114,11 @@
       "source": "./plugins/interview"
     },
     {
+      "name": "research",
+      "description": "Research existing solutions when exploring a new problem space",
+      "source": "./plugins/research"
+    },
+    {
       "name": "agents-md",
       "description": "Loads AGENTS.md files automatically into Claude Code sessions",
       "source": { "source": "github", "repo": "bendrucker/claude-code-agents-md" }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,10 @@
     ],
     "deny": []
   },
+  "statusLine": {
+    "type": "command",
+    "command": "wt list statusline --claude-code"
+  },
   "enabledPlugins": {
     "pr-review-toolkit@claude-code-plugins": true,
     "go@bendrucker": true,
@@ -49,7 +53,6 @@
     "pull-request@bendrucker": true,
     "parallel-prs@bendrucker": true,
     "interview@bendrucker": true,
-    "pr-review-toolkit@claude-plugins-official": true,
     "linear@claude-plugins-official": true,
     "ralph-wiggum@claude-code-plugins": true,
     "code-simplifier@claude-plugins-official": true,
@@ -116,9 +119,5 @@
       "networksetup:*"
     ]
   },
-  "alwaysThinkingEnabled": true,
-  "statusLine": {
-    "type": "command",
-    "command": "wt list statusline --claude-code"
-  }
+  "alwaysThinkingEnabled": true
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  marketplace:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Check marketplace completeness
+        run: ./scripts/check-marketplace.sh
+
   json-schema:
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,10 @@ See [plugins/linear/hooks/](plugins/linear/hooks/) for input modification and [p
 
 Plugins use [ShellSpec](https://shellspec.info/) for testing. Each plugin should have a `spec.sh` file that tests hook scripts directly by piping JSON input. See [plugins/linear/spec.sh](plugins/linear/spec.sh) and [plugins/github/spec.sh](plugins/github/spec.sh) for examples.
 
+## Verification
+
+Run `scripts/check-marketplace.sh` to verify all plugin directories are listed in `marketplace.json`. This check runs in CI and should pass before merging.
+
 ## Workflow
 
 - The `.claude/` directory is symlinked to `~/.claude/`. New files are immediately available without re-running `install.sh`.

--- a/scripts/check-marketplace.sh
+++ b/scripts/check-marketplace.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+plugin_dirs=$(ls -1 plugins/ | sort)
+marketplace_plugins=$(jq -r '.plugins[] | select(.source | type == "string" and startswith("./plugins/")) | .source | ltrimstr("./plugins/")' .claude-plugin/marketplace.json | sort)
+
+missing=$(comm -23 <(echo "$plugin_dirs") <(echo "$marketplace_plugins"))
+
+if [[ -n "$missing" ]]; then
+  echo "Plugins missing from marketplace.json:"
+  echo "$missing" | sed 's/^/  /'
+  exit 1
+fi
+
+echo "All plugin directories are listed in marketplace.json"


### PR DESCRIPTION
Adds automated verification that all plugin directories are listed in the marketplace manifest. This prevents plugins from being silently omitted from distribution.

## Changes

- Add `scripts/check-marketplace.sh` to verify all `plugins/*/` directories appear in `marketplace.json`
- Add CI job in `test.yml` to run marketplace verification on every push/PR
- Add missing `research` plugin to `marketplace.json`
- Document the verification script in `CLAUDE.md`

## Testing

Run locally with `./scripts/check-marketplace.sh` to verify all plugins are listed.
