### PR TITLE
fix(things): improve auth error message and document markdown support

### DIFF
--- a/plugins/things/skills/things/SKILL.md
+++ b/plugins/things/skills/things/SKILL.md
@@ -74,6 +74,18 @@ Load detailed guides as needed:
 - **[1password.md](1password.md)** - Auth token setup and keychain configuration
 - **[troubleshooting.md](troubleshooting.md)** - Common issues, best practices, repeating task detection
 
+## Notes Formatting
+
+Things supports [Markdown in notes](https://culturedcode.com/things/support/articles/4651820/). Use formatting for readability:
+
+- **Headings**: Use `#`, `##`, `###` at line start
+- **Bold**: Use `**text**` for emphasis
+- **Highlights**: Use `::text::` for highlighted text
+- **Code blocks**: Wrap commands or code in triple backticks
+- **Inline code**: Use backticks for `identifiers`, `file paths`, `commands`
+- **Links**: Use `[title](url)` for clickable links
+- **Lists**: Use `-` or `1.` for bulleted/numbered lists
+
 ## Essential Tips
 
 - **Verification**: ALWAYS verify updates succeeded by reading back the todo with JXA

--- a/plugins/things/skills/things/scripts/url.js
+++ b/plugins/things/skills/things/scripts/url.js
@@ -28,9 +28,15 @@ function requiresAuth(command) {
  * @returns {string}
  */
 function getAuthToken(app) {
-  return app.doShellScript(
-    'security find-generic-password -a "$USER" -s "things-auth-token" -w'
-  );
+  try {
+    return app.doShellScript(
+      'security find-generic-password -a "$USER" -s "things-auth-token" -w'
+    );
+  } catch (e) {
+    throw new Error(
+      'Things auth token not found in keychain. See 1password.md for setup instructions.'
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
Improves the Things skill with two changes:

## Auth Token Error Handling

When the keychain auth token is missing, url.js now catches the error and provides a helpful message pointing to setup instructions instead of crashing with an opaque security framework error.

**Before:**
```
security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.
```

**After:**
```
Error: Things auth token not found in keychain. See 1password.md for setup instructions.
```

## Markdown Documentation

Added a Notes Formatting section to SKILL.md documenting Things' Markdown support including headings, bold, highlights, code blocks, links, and lists.

Includes a link to the [official Markdown guide](https://culturedcode.com/things/support/articles/4651820/).