### PR TITLE
fix: restore schema files for remark-lint validation

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -8,13 +8,13 @@ const remarkConfig = {
 			remarkLintFrontmatterSchema,
 			{
 				schemas: {
-					'.claude/agents/schema.json': [
+					'schemas/agent.schema.json': [
 						'.claude/agents/*.md'
 					],
-					'.claude/commands/schema.json': [
+					'schemas/command.schema.json': [
 						'.claude/commands/*.md'
 					],
-					'.claude/skills/schema.json': [
+					'schemas/skill.schema.json': [
 						'.claude/skills/*/SKILL.md'
 					]
 				}

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Claude Code Agent Schema",
+  "description": "Schema for Claude Code agent YAML frontmatter - https://docs.anthropic.com/en/docs/claude-code/agents",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the agent"
+    },
+    "description": {
+      "type": "string",
+      "description": "Description of the agent's purpose and when to use it"
+    },
+    "tools": {
+      "type": "string",
+      "description": "Comma-separated list of tools the agent can use"
+    },
+    "model": {
+      "type": "string",
+      "enum": ["haiku", "sonnet", "opus"],
+      "description": "The model to use for this agent"
+    },
+    "color": {
+      "type": "string",
+      "description": "Color for the agent in the UI"
+    }
+  },
+  "required": ["name", "description"],
+  "additionalProperties": false
+}

--- a/schemas/command.schema.json
+++ b/schemas/command.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Claude Code Command Schema",
+  "description": "Schema for Claude Code command YAML frontmatter - https://docs.anthropic.com/en/docs/claude-code/slash-commands",
+  "type": "object",
+  "properties": {
+    "description": {
+      "type": "string",
+      "description": "Brief description of the command"
+    },
+    "allowed-tools": {
+      "type": ["string", "array"],
+      "items": {
+        "type": "string"
+      },
+      "description": "List of tools the command can use"
+    },
+    "argument-hint": {
+      "type": "string",
+      "description": "The arguments expected for the slash command. This hint is shown to the user when auto-completing the slash command."
+    }
+  },
+  "required": ["description"],
+  "additionalProperties": false
+}

--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Claude Code Skill Schema",
+  "description": "Schema for Claude Code skill YAML frontmatter - https://docs.claude.com/en/docs/claude-code/skills",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the skill"
+    },
+    "description": {
+      "type": "string",
+      "description": "Third-person capability description with trigger terms"
+    },
+    "allowed-tools": {
+      "type": ["string", "array"],
+      "items": {
+        "type": "string"
+      },
+      "description": "List of tools the skill can use"
+    }
+  },
+  "required": ["name", "description"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
The agent, command, and skill schema.json files were accidentally deleted in the plugin architecture refactor. This restores them to the `schemas/` directory and updates `.remarkrc.mjs` to point to the new paths.