### PR TITLE
refactor(claude-code): update skill schema and docs for new features

### DIFF
--- a/plugins/claude-code/skills/claude-code/SKILL.md
+++ b/plugins/claude-code/skills/claude-code/SKILL.md
@@ -20,13 +20,37 @@ Reference for developing effective skills. The context window is a public good -
 ---
 name: skill-name
 description: Third-person capability description with trigger terms
-allowed-tools: [Optional tool restrictions]
+allowed-tools: [Read, Grep, Glob]         # Optional: tool restrictions
+model: claude-sonnet-4-20250514           # Optional: override model
+context: fork                             # Optional: run in isolated subagent
+agent: Explore                            # Optional: agent type for fork
+user-invocable: false                     # Optional: hide from slash menu
+hooks:                                    # Optional: skill-scoped hooks
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/validate.sh"
+          once: true
 ---
 ```
 
-**Storage**: `~/.claude/skills/` (personal), `.claude/skills/` (project), plugins (bundled)
+**Required Fields**:
+- `name`: Lowercase letters, numbers, hyphens only (max 64 chars). Match directory name.
+- `description`: Third-person, includes trigger terms and use cases (max 1024 chars).
 
-**Description**: Third-person, includes trigger terms and use cases. This is the primary activation mechanism.
+**Optional Fields**:
+- `allowed-tools`: Tools Claude can use without permission when skill is active
+- `model`: Override the conversation's model
+- `context`: Set to `fork` to run in isolated subagent context
+- `agent`: Agent type when `context: fork` (`Explore`, `Plan`, `general-purpose`, or custom)
+- `user-invocable`: Hide from slash menu when `false` (default: `true`)
+- `disable-model-invocation`: Block programmatic invocation via Skill tool
+- `hooks`: Skill-scoped hooks (`PreToolUse`, `PostToolUse`, `Stop`)
+
+**Naming**: Use gerund form (verb + -ing): `processing-pdfs`, `analyzing-data`, `managing-databases`. Avoid vague names like `helper`, `utils`.
+
+**Storage**: `~/.claude/skills/` (personal), `.claude/skills/` (project), plugins (bundled)
 
 ## Bundled Resources
 
@@ -38,24 +62,24 @@ skill-name/
 └── assets/ (templates, images for output)
 ```
 
-**Naming**: Reserve ALL CAPS for files with special meaning (SKILL.md, README.md, CONTRIBUTING.md). Use lowercase for all other files (setup.md, examples.md, troubleshooting.md).
+**File Naming**: Reserve ALL CAPS for files with special meaning (SKILL.md, README.md). Use lowercase for all other files (setup.md, examples.md).
 
 Keep references one level deep. For files >100 lines, include a table of contents.
 
 ## Development Process
 
-1. Define 3 test scenarios before documentation
-2. Measure baseline without skill
-3. Iterative: one instance creates, another tests
-4. Observe navigation patterns
-5. Refine based on behavior
+- Define 3 test scenarios before documentation
+- Measure baseline without skill
+- Iterative: one instance creates, another tests
+- Observe navigation patterns
+- Refine based on behavior
 
 ## References
 
 Load detailed guides as needed:
 
-- **[references/patterns.md](references/patterns.md)** - Progressive disclosure patterns, output templates, workflow design
-- **[references/troubleshooting.md](references/troubleshooting.md)** - Activation issues, YAML errors, path problems, checklist
+- **[references/patterns.md](references/patterns.md)** - Progressive disclosure, templates, workflows, subagent integration
+- **[references/troubleshooting.md](references/troubleshooting.md)** - Activation issues, YAML errors, plugin cache, checklist
 
 ## Quick Reference
 
@@ -65,5 +89,5 @@ Load detailed guides as needed:
 
 ## Resources
 
-- [Claude Code Skills](https://docs.claude.com/en/docs/claude-code/skills.md)
-- [Agent Skills Best Practices](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices.md)
+- [Claude Code Skills](https://docs.claude.com/en/docs/claude-code/skills)
+- [Agent Skills Best Practices](https://docs.anthropic.com/en/docs/agents-and-tools/agent-skills/best-practices)

--- a/plugins/claude-code/skills/claude-code/references/patterns.md
+++ b/plugins/claude-code/skills/claude-code/references/patterns.md
@@ -92,6 +92,60 @@ Output: feat(auth): implement JWT-based authentication
    **Editing?** → Follow editing workflow
 ```
 
+## Skills and Subagents
+
+### Give a subagent access to skills
+
+Custom agents in `.claude/agents/` can list skills in their `skills` field:
+
+```yaml
+# .claude/agents/code-reviewer.md
+---
+name: code-reviewer
+description: Review code for quality and best practices
+skills: pr-review, security-check
+---
+```
+
+Skills listed here are injected into the subagent's context at startup. Built-in agents (Explore, Plan, general-purpose) do not inherit skills.
+
+### Run a skill in a subagent context
+
+Use `context: fork` to run a skill in an isolated subagent:
+
+```yaml
+---
+name: code-analysis
+description: Analyze code quality and generate detailed reports
+context: fork
+agent: Explore
+---
+```
+
+The skill runs with its own conversation history, avoiding clutter in the main conversation.
+
+## Skill-Scoped Hooks
+
+Define hooks that run during the skill's lifecycle:
+
+```yaml
+---
+name: secure-operations
+description: Perform operations with additional security checks
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/security-check.sh"
+          once: true
+---
+```
+
+**`once: true`**: Run the hook only once per session. After first successful execution, the hook is removed. Useful for one-time validation or setup.
+
+Skill hooks are scoped to the skill's execution and cleaned up when the skill finishes.
+
 ## Content Guidelines
 
 - **Consistent Terminology**: One term per concept

--- a/plugins/claude-code/skills/claude-code/references/troubleshooting.md
+++ b/plugins/claude-code/skills/claude-code/references/troubleshooting.md
@@ -2,11 +2,11 @@
 
 ## Skill Not Activating
 
-1. Verify description includes specific trigger terms
-2. Check YAML syntax (no tabs, proper `---` delimiters)
-3. Confirm file location (`~/.claude/skills/` or `.claude/skills/`)
-4. Test with explicit trigger phrases
-5. For syntax questions, use Task tool with `subagent_type='claude-code-guide'`
+- Verify description includes specific trigger terms
+- Check YAML syntax (no tabs, proper `---` delimiters)
+- Confirm file location (`~/.claude/skills/` or `.claude/skills/`)
+- Test with explicit trigger phrases
+- For syntax questions, use Task tool with `subagent_type='claude-code-guide'`
 
 ## YAML Errors
 
@@ -19,6 +19,31 @@
 - Use forward slashes everywhere (not Windows-style)
 - Verify paths exist
 - Use `~` for home directory in personal skills
+
+## Plugin Skills Not Appearing
+
+Clear plugin cache and reinstall:
+
+```bash
+rm -rf ~/.claude/plugins/cache
+```
+
+Restart Claude Code and reinstall:
+
+```
+/plugin install plugin-name@marketplace-name
+```
+
+Verify directory structure:
+
+```
+my-plugin/
+├── .claude-plugin/
+│   └── plugin.json
+└── skills/
+    └── my-skill/
+        └── SKILL.md
+```
 
 ## Deployment Checklist
 

--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -6,20 +6,111 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "The name of the skill"
+      "description": "Skill name. Lowercase letters, numbers, and hyphens only (max 64 characters). Should match the directory name.",
+      "pattern": "^[a-z0-9-]+$",
+      "maxLength": 64
     },
     "description": {
       "type": "string",
-      "description": "Third-person capability description with trigger terms"
+      "description": "Third-person capability description with trigger terms (max 1024 characters). Claude uses this to decide when to apply the skill.",
+      "maxLength": 1024
     },
     "allowed-tools": {
       "type": ["string", "array"],
       "items": {
         "type": "string"
       },
-      "description": "List of tools the skill can use"
+      "description": "Tools Claude can use without asking permission when this skill is active"
+    },
+    "model": {
+      "type": "string",
+      "description": "Model to use when this skill is active (e.g., claude-sonnet-4-20250514). Defaults to the conversation's model."
+    },
+    "context": {
+      "type": "string",
+      "enum": ["fork"],
+      "description": "Set to 'fork' to run the skill in a forked sub-agent context with its own conversation history"
+    },
+    "agent": {
+      "type": "string",
+      "description": "Agent type to use when context: fork is set (e.g., Explore, Plan, general-purpose, or custom agent name). Defaults to general-purpose."
+    },
+    "hooks": {
+      "type": "object",
+      "description": "Hooks scoped to this skill's lifecycle",
+      "properties": {
+        "PreToolUse": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/hookMatcher"
+          }
+        },
+        "PostToolUse": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/hookMatcher"
+          }
+        },
+        "Stop": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/hookEntry"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "user-invocable": {
+      "type": "boolean",
+      "default": true,
+      "description": "Controls whether the skill appears in the slash command menu. Does not affect the Skill tool or automatic discovery."
+    },
+    "disable-model-invocation": {
+      "type": "boolean",
+      "default": false,
+      "description": "Block programmatic invocation via the Skill tool. Does not affect slash menu or auto-discovery."
     }
   },
   "required": ["name", "description"],
-  "additionalProperties": false
+  "additionalProperties": false,
+  "$defs": {
+    "hookMatcher": {
+      "type": "object",
+      "properties": {
+        "matcher": {
+          "type": "string",
+          "description": "Regex pattern to match tool names"
+        },
+        "hooks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/hookEntry"
+          }
+        }
+      },
+      "required": ["matcher", "hooks"],
+      "additionalProperties": false
+    },
+    "hookEntry": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["command"],
+          "description": "Hook type"
+        },
+        "command": {
+          "type": "string",
+          "description": "Shell command to execute"
+        },
+        "once": {
+          "type": "boolean",
+          "default": false,
+          "description": "Run the hook only once per session"
+        }
+      },
+      "required": ["type", "command"],
+      "additionalProperties": false
+    }
+  }
 }


### PR DESCRIPTION
Align with latest Claude Code Skills documentation by adding support for new frontmatter fields and patterns.

## Changes

**`schemas/skill.schema.json`**
- Add `model`, `context`, `agent`, `hooks`, `user-invocable`, `disable-model-invocation` fields
- Add validation: `name` pattern (`^[a-z0-9-]+$`), max lengths
- Add `$defs` for hook structures with `once` option

**`plugins/claude-code/skills/claude-code/SKILL.md`**
- Expand frontmatter example with all new fields
- Add Required/Optional fields documentation
- Add gerund naming convention guidance
- Fix documentation URLs (remove `.md` extensions)

**`references/patterns.md`**
- Add "Skills and Subagents" section (giving subagents skill access, `context: fork`)
- Add "Skill-Scoped Hooks" section with `once: true` pattern

**`references/troubleshooting.md`**
- Add "Plugin Skills Not Appearing" section with cache clearing and structure verification