### PR TITLE
Add `context: fork` to interview skills

### DIFF
--- a/plugins/interview/skills/clarify/SKILL.md
+++ b/plugins/interview/skills/clarify/SKILL.md
@@ -2,6 +2,7 @@
 name: clarify
 description: |
   Targeted interview for execution-time clarification. Use when you hit an ambiguity or decision point during implementation that needs user input before proceeding.
+context: fork
 ---
 
 # Clarification Interview

--- a/plugins/interview/skills/plan/SKILL.md
+++ b/plugins/interview/skills/plan/SKILL.md
@@ -2,6 +2,8 @@
 name: plan
 description: |
   Comprehensive interview for planning new features or changes. Use when the user wants thorough upfront planning before implementation, or when starting work on a complex feature.
+context: fork
+agent: Plan
 ---
 
 # Planning Interview


### PR DESCRIPTION
Closes #199

Adds `context: fork` to both interview skills so they run in a forked conversation context:

- **plan**: Also adds `agent: Plan` for a custom agent personality
- **clarify**: Fork only, no agent override