### PR TITLE
Add `context: fork` to research-heavy skills

### DIFF
--- a/plugins/research/skills/prior-art/SKILL.md
+++ b/plugins/research/skills/prior-art/SKILL.md
@@ -2,6 +2,8 @@
 name: prior-art
 description: |
   Research existing solutions when exploring a new problem space. Use when the user mentions "prior art", "existing solutions", "what libraries exist for", or wants to understand the landscape before building.
+context: fork
+agent: Explore
 ---
 
 Research prior art for: $ARGUMENTS

--- a/plugins/review/skills/peer/SKILL.md
+++ b/plugins/review/skills/peer/SKILL.md
@@ -3,6 +3,8 @@ name: peer
 description: |
   Review a pull request when requested by a peer. Use when reviewing PRs, providing code review feedback, or analyzing proposed changes. Supports GitHub and GitLab.
 allowed-tools: Bash(gh:*), mcp__github
+context: fork
+agent: Explore
 ---
 
 # Peer Review

--- a/plugins/review/skills/self/SKILL.md
+++ b/plugins/review/skills/self/SKILL.md
@@ -3,6 +3,7 @@ name: self
 description: |
   Self-review your own code changes using a visual diff viewer. Opens a GitHub-style web UI where you can add comments on changed lines. Comments are returned to Claude for action.
 allowed-tools: Bash(npx:*)
+context: fork
 ---
 
 # Self Review


### PR DESCRIPTION
Closes #195

## Summary

- Add `context: fork` and `agent: Explore` to `prior-art` skill
- Add `context: fork` and `agent: Explore` to `peer` review skill
- Add `context: fork` to `self` review skill (no agent override needed)