### PR TITLE
Create custom agents that bundle related skills

### DIFF
--- a/.claude/agents/full-stack-reviewer.md
+++ b/.claude/agents/full-stack-reviewer.md
@@ -1,0 +1,5 @@
+---
+name: full-stack-reviewer
+description: Review code across languages and frameworks
+skills: review:peer, go, typescript, python, terraform
+---

--- a/.claude/agents/issue-worker.md
+++ b/.claude/agents/issue-worker.md
@@ -1,0 +1,5 @@
+---
+name: issue-worker
+description: Implement issues with full context
+skills: implement-issue, refine-issue, pull-request, git
+---

--- a/.claude/agents/research.md
+++ b/.claude/agents/research.md
@@ -1,0 +1,5 @@
+---
+name: research
+description: Research existing solutions and patterns
+skills: prior-art, github
+---


### PR DESCRIPTION
Closes #197

Creates three custom agents in `.claude/agents/` that bundle related skills:

- **issue-worker**: Combines `implement-issue`, `refine-issue`, `pull-request`, and `git` for implementing issues end-to-end
- **full-stack-reviewer**: Combines `review:peer` with language skills (`go`, `typescript`, `python`, `terraform`) for comprehensive code review
- **research**: Combines `prior-art` and `github` for researching existing solutions and patterns