### PR TITLE
Set `user-invocable: false` for language convention skills

### DIFF
--- a/plugins/go/skills/go/SKILL.md
+++ b/plugins/go/skills/go/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: go
 description: Go language coding standards, best practices, and testing patterns. Use when writing or reviewing Go code, implementing tests, or discussing Go language features.
+user-invocable: false
 ---
 # Go
 

--- a/plugins/javascript/skills/javascript/SKILL.md
+++ b/plugins/javascript/skills/javascript/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: javascript
 description: JavaScript coding standards and best practices for JavaScript and TypeScript. Use when writing or reviewing JavaScript code, working with promises, or discussing JavaScript patterns.
+user-invocable: false
 ---
 # JavaScript
 

--- a/plugins/json/skills/json/SKILL.md
+++ b/plugins/json/skills/json/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: json
 description: JSON processing and handling best practices using jq. Use when working with JSON data, parsing JSON files, generating JSON output, or processing JSON from APIs.
+user-invocable: false
 ---
 # JSON
 

--- a/plugins/python/skills/python/SKILL.md
+++ b/plugins/python/skills/python/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: python
 description: Python coding standards, best practices, type hints, and testing patterns. Use when writing or reviewing Python code, implementing tests, or discussing Python language features.
+user-invocable: false
 ---
 # Python
 

--- a/plugins/shell/skills/shell/SKILL.md
+++ b/plugins/shell/skills/shell/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: shell
 description: Shell scripting best practices and conventions for Bash commands. Use when writing shell scripts, bash commands, or working with command-line tools on macOS.
+user-invocable: false
 ---
 # Shell
 

--- a/plugins/typescript/skills/typescript/SKILL.md
+++ b/plugins/typescript/skills/typescript/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: typescript
 description: TypeScript coding standards and best practices. Use when writing or reviewing TypeScript code, working with type definitions, or discussing TypeScript patterns.
+user-invocable: false
 ---
 # TypeScript
 


### PR DESCRIPTION
Closes #196

Language convention skills (go, python, typescript, javascript, shell, json) are designed to be auto-loaded based on file context rather than manually invoked by users. This PR adds `user-invocable: false` to their front matter to hide them from the slash command list while retaining automatic activation.