### PR TITLE
fix(schemas): update schemas to match official docs

### DIFF
--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -1,31 +1,104 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Claude Code Agent Schema",
-  "description": "Schema for Claude Code agent YAML frontmatter - https://docs.anthropic.com/en/docs/claude-code/agents",
+  "description": "Schema for Claude Code agent YAML frontmatter - https://code.claude.com/docs/en/sub-agents",
   "type": "object",
   "properties": {
     "name": {
       "type": "string",
-      "description": "The name of the agent"
+      "description": "Unique identifier using lowercase letters and hyphens"
     },
     "description": {
       "type": "string",
-      "description": "Description of the agent's purpose and when to use it"
+      "description": "When Claude should delegate to this agent"
     },
     "tools": {
       "type": "string",
-      "description": "Comma-separated list of tools the agent can use"
+      "description": "Comma-separated list of tools the agent can use. Inherits all tools if omitted."
+    },
+    "disallowedTools": {
+      "type": "string",
+      "description": "Comma-separated list of tools to deny, removed from inherited or specified list"
     },
     "model": {
       "type": "string",
-      "enum": ["haiku", "sonnet", "opus"],
-      "description": "The model to use for this agent"
+      "enum": ["haiku", "sonnet", "opus", "inherit"],
+      "description": "The model to use for this agent. Defaults to sonnet if omitted."
+    },
+    "permissionMode": {
+      "type": "string",
+      "enum": ["default", "acceptEdits", "dontAsk", "bypassPermissions", "plan"],
+      "description": "Permission mode for the agent"
+    },
+    "skills": {
+      "type": "string",
+      "description": "Comma-separated list of skills to load into the agent's context at startup"
+    },
+    "hooks": {
+      "type": "object",
+      "description": "Lifecycle hooks scoped to this agent",
+      "properties": {
+        "PreToolUse": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/hookMatcher"
+          }
+        },
+        "PostToolUse": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/hookMatcher"
+          }
+        },
+        "Stop": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/hookEntry"
+          }
+        }
+      },
+      "additionalProperties": false
     },
     "color": {
       "type": "string",
-      "description": "Color for the agent in the UI"
+      "description": "Color for the agent status line in the UI"
     }
   },
   "required": ["name", "description"],
-  "additionalProperties": false
+  "additionalProperties": false,
+  "$defs": {
+    "hookMatcher": {
+      "type": "object",
+      "properties": {
+        "matcher": {
+          "type": "string",
+          "description": "Regex pattern to match tool names"
+        },
+        "hooks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/hookEntry"
+          }
+        }
+      },
+      "required": ["matcher", "hooks"],
+      "additionalProperties": false
+    },
+    "hookEntry": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["command"],
+          "description": "Hook type"
+        },
+        "command": {
+          "type": "string",
+          "description": "Shell command to execute"
+        }
+      },
+      "required": ["type", "command"],
+      "additionalProperties": false
+    }
+  }
 }

--- a/schemas/command.schema.json
+++ b/schemas/command.schema.json
@@ -1,12 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Claude Code Command Schema",
-  "description": "Schema for Claude Code command YAML frontmatter - https://docs.anthropic.com/en/docs/claude-code/slash-commands",
+  "description": "Schema for Claude Code command YAML frontmatter - https://code.claude.com/docs/en/slash-commands",
   "type": "object",
   "properties": {
     "description": {
       "type": "string",
-      "description": "Brief description of the command"
+      "description": "Brief description of the command. Defaults to the first line from the prompt if not specified."
     },
     "allowed-tools": {
       "type": ["string", "array"],
@@ -17,9 +17,29 @@
     },
     "argument-hint": {
       "type": "string",
-      "description": "The arguments expected for the slash command. This hint is shown to the user when auto-completing the slash command."
+      "description": "Expected arguments for the slash command. Shown during auto-complete."
+    },
+    "context": {
+      "type": "string",
+      "enum": ["fork"],
+      "description": "Set to 'fork' to run in a forked sub-agent context with its own conversation history"
+    },
+    "agent": {
+      "type": "string",
+      "description": "Agent type to use when context: fork is set. Defaults to general-purpose."
+    },
+    "model": {
+      "type": "string",
+      "description": "Specific Claude model to use. Inherits from the conversation if not specified."
+    },
+    "hooks": {
+      "$ref": "hooks.schema.json"
+    },
+    "disable-model-invocation": {
+      "type": "boolean",
+      "default": false,
+      "description": "Prevent the Skill tool from calling this command"
     }
   },
-  "required": ["description"],
   "additionalProperties": false
 }

--- a/schemas/hooks.schema.json
+++ b/schemas/hooks.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/bendrucker/claude/main/schemas/hooks.schema.json",
+  "title": "Claude Code Hooks Schema",
+  "description": "Schema for Claude Code lifecycle hooks - https://code.claude.com/docs/en/hooks",
+  "type": "object",
+  "properties": {
+    "PreToolUse": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/hookMatcher"
+      },
+      "description": "Hooks that run before a tool is executed"
+    },
+    "PostToolUse": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/hookMatcher"
+      },
+      "description": "Hooks that run after a tool is executed"
+    },
+    "Stop": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/hookEntry"
+      },
+      "description": "Hooks that run when the agent stops"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "hookMatcher": {
+      "type": "object",
+      "properties": {
+        "matcher": {
+          "type": "string",
+          "description": "Regex pattern to match tool names"
+        },
+        "hooks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/hookEntry"
+          }
+        }
+      },
+      "required": ["matcher", "hooks"],
+      "additionalProperties": false
+    },
+    "hookEntry": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["command"],
+          "description": "Hook type"
+        },
+        "command": {
+          "type": "string",
+          "description": "Shell command to execute"
+        },
+        "once": {
+          "type": "boolean",
+          "default": false,
+          "description": "Run the hook only once per session"
+        }
+      },
+      "required": ["type", "command"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Claude Code Skill Schema",
-  "description": "Schema for Claude Code skill YAML frontmatter - https://docs.claude.com/en/docs/claude-code/skills",
+  "description": "Schema for Claude Code skill YAML frontmatter - https://code.claude.com/docs/en/skills",
   "type": "object",
   "properties": {
     "name": {
@@ -36,29 +36,7 @@
       "description": "Agent type to use when context: fork is set (e.g., Explore, Plan, general-purpose, or custom agent name). Defaults to general-purpose."
     },
     "hooks": {
-      "type": "object",
-      "description": "Hooks scoped to this skill's lifecycle",
-      "properties": {
-        "PreToolUse": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/hookMatcher"
-          }
-        },
-        "PostToolUse": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/hookMatcher"
-          }
-        },
-        "Stop": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/hookEntry"
-          }
-        }
-      },
-      "additionalProperties": false
+      "$ref": "hooks.schema.json"
     },
     "user-invocable": {
       "type": "boolean",
@@ -72,45 +50,5 @@
     }
   },
   "required": ["name", "description"],
-  "additionalProperties": false,
-  "$defs": {
-    "hookMatcher": {
-      "type": "object",
-      "properties": {
-        "matcher": {
-          "type": "string",
-          "description": "Regex pattern to match tool names"
-        },
-        "hooks": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/hookEntry"
-          }
-        }
-      },
-      "required": ["matcher", "hooks"],
-      "additionalProperties": false
-    },
-    "hookEntry": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["command"],
-          "description": "Hook type"
-        },
-        "command": {
-          "type": "string",
-          "description": "Shell command to execute"
-        },
-        "once": {
-          "type": "boolean",
-          "default": false,
-          "description": "Run the hook only once per session"
-        }
-      },
-      "required": ["type", "command"],
-      "additionalProperties": false
-    }
-  }
+  "additionalProperties": false
 }


### PR DESCRIPTION
Updates all Claude Code schemas to match the official documentation at code.claude.com.

## Changes

### `hooks.schema.json` (new)
- Shared schema for lifecycle hooks (PreToolUse, PostToolUse, Stop)
- Includes `once` field (supported by skills and commands)

### `agent.schema.json`
- Adds missing fields: `disallowedTools`, `permissionMode`, `skills`
- Updates `model` enum to include `inherit` option
- Defines hooks inline without `once` (not supported for agents)
- Updates documentation URL

### `skill.schema.json`
- References shared hooks schema
- Updates documentation URL

### `command.schema.json`
- Adds missing fields: `context`, `agent`, `model`, `disable-model-invocation`
- References shared hooks schema
- Updates documentation URL
- Removes required constraint on `description`
