### PR TITLE
feat(ci): validate settings against SchemaStore schema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check marketplace completeness
         run: ./scripts/check-marketplace.sh
 
-  json-schema:
+  settings:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -30,7 +30,13 @@ jobs:
         uses: cardinalby/schema-validator-action@v3
         with:
           file: '.claude/settings.json'
-          mode: lax
+          schema: 'https://www.schemastore.org/claude-code-settings.json'
+
+  json-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
 
       - name: Validate marketplace.json
         uses: cardinalby/schema-validator-action@v3

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -69,36 +69,70 @@
   "$defs": {
     "hookMatcher": {
       "type": "object",
+      "description": "Hook matcher configuration with multiple hooks",
+      "additionalProperties": false,
+      "required": ["hooks"],
       "properties": {
         "matcher": {
           "type": "string",
-          "description": "Regex pattern to match tool names"
+          "description": "Pattern to match tool names, case-sensitive (only for PreToolUse and PostToolUse)"
         },
         "hooks": {
           "type": "array",
+          "description": "Array of hooks to execute",
           "items": {
             "$ref": "#/$defs/hookEntry"
           }
         }
-      },
-      "required": ["matcher", "hooks"],
-      "additionalProperties": false
+      }
     },
     "hookEntry": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["command"],
-          "description": "Hook type"
+      "anyOf": [
+        {
+          "type": "object",
+          "description": "Bash command hook",
+          "additionalProperties": false,
+          "required": ["type", "command"],
+          "properties": {
+            "type": {
+              "const": "command",
+              "description": "Hook type"
+            },
+            "command": {
+              "type": "string",
+              "description": "Shell command to execute",
+              "minLength": 1
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Timeout in seconds",
+              "exclusiveMinimum": 0
+            }
+          }
         },
-        "command": {
-          "type": "string",
-          "description": "Shell command to execute"
+        {
+          "type": "object",
+          "description": "LLM prompt hook",
+          "additionalProperties": false,
+          "required": ["type", "prompt"],
+          "properties": {
+            "type": {
+              "const": "prompt",
+              "description": "Hook type"
+            },
+            "prompt": {
+              "type": "string",
+              "description": "Prompt to evaluate with LLM. Use $ARGUMENTS placeholder for hook input JSON.",
+              "minLength": 1
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Timeout in seconds",
+              "exclusiveMinimum": 0
+            }
+          }
         }
-      },
-      "required": ["type", "command"],
-      "additionalProperties": false
+      ]
     }
   }
 }

--- a/schemas/hooks.schema.json
+++ b/schemas/hooks.schema.json
@@ -31,41 +31,80 @@
   "$defs": {
     "hookMatcher": {
       "type": "object",
+      "description": "Hook matcher configuration with multiple hooks",
+      "additionalProperties": false,
+      "required": ["hooks"],
       "properties": {
         "matcher": {
           "type": "string",
-          "description": "Regex pattern to match tool names"
+          "description": "Pattern to match tool names, case-sensitive (only for PreToolUse and PostToolUse)"
         },
         "hooks": {
           "type": "array",
+          "description": "Array of hooks to execute",
           "items": {
             "$ref": "#/$defs/hookEntry"
           }
         }
-      },
-      "required": ["matcher", "hooks"],
-      "additionalProperties": false
+      }
     },
     "hookEntry": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["command"],
-          "description": "Hook type"
+      "anyOf": [
+        {
+          "type": "object",
+          "description": "Bash command hook",
+          "additionalProperties": false,
+          "required": ["type", "command"],
+          "properties": {
+            "type": {
+              "const": "command",
+              "description": "Hook type"
+            },
+            "command": {
+              "type": "string",
+              "description": "Shell command to execute",
+              "minLength": 1
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Timeout in seconds",
+              "exclusiveMinimum": 0
+            },
+            "once": {
+              "type": "boolean",
+              "default": false,
+              "description": "Run the hook only once per session"
+            }
+          }
         },
-        "command": {
-          "type": "string",
-          "description": "Shell command to execute"
-        },
-        "once": {
-          "type": "boolean",
-          "default": false,
-          "description": "Run the hook only once per session"
+        {
+          "type": "object",
+          "description": "LLM prompt hook",
+          "additionalProperties": false,
+          "required": ["type", "prompt"],
+          "properties": {
+            "type": {
+              "const": "prompt",
+              "description": "Hook type"
+            },
+            "prompt": {
+              "type": "string",
+              "description": "Prompt to evaluate with LLM. Use $ARGUMENTS placeholder for hook input JSON.",
+              "minLength": 1
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Timeout in seconds",
+              "exclusiveMinimum": 0
+            },
+            "once": {
+              "type": "boolean",
+              "default": false,
+              "description": "Run the hook only once per session"
+            }
+          }
         }
-      },
-      "required": ["type", "command"],
-      "additionalProperties": false
+      ]
     }
   }
 }


### PR DESCRIPTION
Adds a `settings` CI job that validates `.claude/settings.json` against the [SchemaStore schema](https://www.schemastore.org/claude-code-settings.json).

Also updates local hook schemas to match SchemaStore's structure:
- `hookEntry` supports both `command` and `prompt` types
- Adds `timeout` field
- `matcher` is optional (only needed for PreToolUse/PostToolUse)
