### PR TITLE
fix(ci): use lax mode for SchemaStore settings validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           file: '.claude/settings.json'
           schema: 'https://www.schemastore.org/claude-code-settings.json'
+          mode: lax
 
   json-schema:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The SchemaStore schema uses `allowTrailingCommas` which is not supported by the validator in strict mode.

This fixes the settings job failure on all branches.