### PR TITLE
docs(skills): recommend specific matchers over internal filtering in hooks

### DIFF
--- a/plugins/claude-code/agents/hooks.md
+++ b/plugins/claude-code/agents/hooks.md
@@ -113,6 +113,10 @@ In settings.json, reference scripts like:
 **Hook Configuration Syntax**:
 - Use array format for hook types (PostToolUse, PreToolUse, etc.)
 - Each array element has a "matcher" field for tool matching
-- "matcher" supports regex-like patterns (e.g., "Write|Edit|MultiEdit")
+- "matcher" supports regex-like patterns (e.g., `Write|Edit|MultiEdit`)
+- "matcher" supports tool argument patterns (e.g., `Bash(osascript:*)`, `Bash(npm:*)`)
+- Combine matchers with `|`: `Bash(osascript:*)|Bash(open:*)`
 - Each matcher has a "hooks" array with hook definitions
 - Each hook has "type": "command" and "command" with the script path
+- Use YAML multi-line syntax (`|`) for readable inline commands
+- Use `jq -n` for static JSON responses instead of escaped echo strings

--- a/plugins/claude-code/skills/skills/references/patterns.md
+++ b/plugins/claude-code/skills/skills/references/patterns.md
@@ -146,6 +146,42 @@ hooks:
 
 Skill hooks are scoped to the skill's execution and cleaned up when the skill finishes.
 
+### Prefer Specific Matchers
+
+Use tool argument patterns instead of generic tool names with internal filtering. Combine multiple patterns with `|`:
+
+```yaml
+# Preferred: specific matchers, combined with pipe, readable multi-line YAML
+hooks:
+  PreToolUse:
+    - matcher: "Bash(osascript:*)|Bash(open:*)"
+      hooks:
+        - type: command
+          command: |
+            jq -n '{
+              hookSpecificOutput: {
+                hookEventName: "PreToolUse",
+                updatedInput: { dangerouslyDisableSandbox: true }
+              }
+            }'
+```
+
+```yaml
+# Avoid: generic matcher with internal filtering
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/maybe-disable-sandbox.sh"
+```
+
+**Best practices:**
+- Use specific matchers (`Bash(osascript:*)`) over generic ones (`Bash`)
+- Combine related matchers with `|` instead of duplicating hook entries
+- Use YAML multi-line syntax (`|`) for readable commands
+- Use `jq -n` for static JSON responses instead of escaped echo strings
+
 ## Content Guidelines
 
 - **Consistent Terminology**: One term per concept


### PR DESCRIPTION
Adds guidance to the skill patterns documentation for hook matchers, recommending specific tool argument matchers over generic matchers with internal filtering, and inline static JSON responses over separate script files.

## Changes

- Recommend using specific matchers (e.g., `Bash(osascript:*)`) instead of generic `Bash` with internal filtering
- Recommend inlining static JSON responses with `echo` rather than creating separate script files
