### PR TITLE
ci: warn when marketplace plugins are not enabled

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -58,6 +58,8 @@
     "code-simplifier@claude-plugins-official": true,
     "github@claude-plugins-official": true,
     "astral@astral-sh": true,
+    "research@bendrucker": true,
+    "style@bendrucker": true,
     "agents-md@bendrucker": true,
     "ast-grep@ast-grep": true,
     "worktrunk@worktrunk": true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,21 @@ jobs:
       - name: Check marketplace completeness
         run: ./scripts/check-marketplace.sh
 
+      - name: Check for unenabled plugins
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! output=$(./scripts/check-enabled-plugins.sh 2>&1); then
+            gh pr comment ${{ github.event.pull_request.number }} --body "⚠️ **Warning:** Some marketplace plugins are not enabled in \`.claude/settings.json\`:
+
+          \`\`\`
+          $output
+          \`\`\`
+
+          Consider adding these to \`enabledPlugins\` if they should be active."
+          fi
+
       - name: List local plugins
         id: list
         env:
@@ -44,6 +59,7 @@ jobs:
             --always=scripts/
             --always=.github/workflows/test.yml
             --always=.claude-plugin/marketplace.json
+            --always=.claude/settings.json
           )
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             readarray -t files < <(gh pr view ${{ github.event.pull_request.number }} --json files -q '.files[].path')

--- a/scripts/check-enabled-plugins.sh
+++ b/scripts/check-enabled-plugins.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+marketplace_plugins=$(jq -r '.plugins[].name' .claude-plugin/marketplace.json | sort)
+enabled_plugins=$(jq -r '.enabledPlugins | keys[] | select(endswith("@bendrucker")) | sub("@bendrucker$"; "")' .claude/settings.json | sort)
+
+missing=$(comm -23 <(echo "$marketplace_plugins") <(echo "$enabled_plugins"))
+
+if [[ -n "$missing" ]]; then
+  echo "Plugins in marketplace but not enabled in settings.json:"
+  echo "$missing" | sed 's/^/  /'
+  exit 1
+fi
+
+echo "All marketplace plugins are enabled in settings.json"


### PR DESCRIPTION
Adds a CI check that warns via PR comment when plugins exist in the marketplace but are not enabled in `settings.json`. Also enables `research`, `style`, and `agents-md` plugins that were missing.

## Changes

- Add `scripts/check-enabled-plugins.sh` to compare marketplace plugins against `enabledPlugins`
- Add CI step that runs the check on PRs and posts a warning comment if plugins are unenabled
- Add `settings.json` to the always-check list for plugin validation
- Enable `research@bendrucker` and `style@bendrucker` in settings
