### PR TITLE
fix(things): open URL scheme commands in background

### DIFF
--- a/plugins/things/skills/things/SKILL.md
+++ b/plugins/things/skills/things/SKILL.md
@@ -104,5 +104,5 @@ Things supports [Markdown in notes](https://culturedcode.com/things/support/arti
 - **Verification**: ALWAYS verify updates succeeded by reading back the todo with JXA
 - **Repeating tasks**: Filter by comparing `creationDate` to midnight (see [troubleshooting.md](troubleshooting.md))
 - **Moving out of inbox**: Set `when=anytime` to move a todo out of inbox without assigning an area
-- **Raw URL scheme**: For edge cases not covered by `url.js`, use `open "things:///..."` directly (see [url-scheme.md](url-scheme.md))
+- **Raw URL scheme**: For edge cases not covered by `url.js`, use `open -g "things:///..."` directly (see [url-scheme.md](url-scheme.md))
 - **Type reference**: See [jxa.md](jxa.md) for the complete Things3 JXA API

--- a/plugins/things/skills/things/scripts/url.js
+++ b/plugins/things/skills/things/scripts/url.js
@@ -85,5 +85,5 @@ function run(argv) {
     url += '?' + params.join('&');
   }
 
-  app.openLocation(url);
+  app.doShellScript(`open -g "${url}"`);
 }

--- a/plugins/things/skills/things/url-scheme.md
+++ b/plugins/things/skills/things/url-scheme.md
@@ -38,7 +38,7 @@ Creates new to-do items in Things.
 
 **Example:**
 ```bash
-open "things:///add?title=Buy%20milk&notes=Low%20fat&when=evening&tags=Errand"
+open -g "things:///add?title=Buy%20milk&notes=Low%20fat&when=evening&tags=Errand"
 ```
 
 ### add-project - Create Projects
@@ -59,7 +59,7 @@ Creates new projects with optional to-dos and areas.
 
 **Example:**
 ```bash
-open "things:///add-project?title=Build%20treehouse&when=today&area=Home"
+open -g "things:///add-project?title=Build%20treehouse&when=today&area=Home"
 ```
 
 ### update - Modify To-dos
@@ -88,7 +88,7 @@ Updates existing to-do properties. **Requires `auth-token` and `id`.**
 
 **Example:**
 ```bash
-open "things:///update?id=4BE64FEA-8FEF-4F4F-B8B2-4E74605D5FA5&auth-token=YOUR_TOKEN&append-notes=Updated%20info"
+open -g "things:///update?id=4BE64FEA-8FEF-4F4F-B8B2-4E74605D5FA5&auth-token=YOUR_TOKEN&append-notes=Updated%20info"
 ```
 
 **Notes:**
@@ -127,8 +127,8 @@ Navigates to specific items or built-in lists.
 
 **Example:**
 ```bash
-open "things:///show?id=today"
-open "things:///show?query=Weekly%20Review&filter=Work,Planning"
+open -g "things:///show?id=today"
+open -g "things:///show?query=Weekly%20Review&filter=Work,Planning"
 ```
 
 ### search - Open Search
@@ -140,7 +140,7 @@ Invokes the search interface.
 
 **Example:**
 ```bash
-open "things:///search?query=meeting%20notes"
+open -g "things:///search?query=meeting%20notes"
 ```
 
 ### version - Check Compatibility
@@ -149,7 +149,7 @@ Returns app and URL scheme version information.
 
 **Example:**
 ```bash
-open "things:///version"
+open -g "things:///version"
 ```
 
 ---
@@ -186,7 +186,7 @@ The `json` command enables creating complex structures with projects, to-dos, he
 **Basic Usage:**
 ```bash
 data='[{"type":"to-do","attributes":{"title":"Task name"}}]'
-open "things:///json?data=$(echo "$data" | jq -sRr @uri)"
+open -g "things:///json?data=$(echo "$data" | jq -sRr @uri)"
 ```
 
 ### Supported Object Types
@@ -297,7 +297,7 @@ data='[
     }
   }
 ]'
-open "things:///json?data=$(echo "$data" | jq -sRr @uri)"
+open -g "things:///json?data=$(echo "$data" | jq -sRr @uri)"
 ```
 
 ---


### PR DESCRIPTION
Use `open -g` instead of `app.openLocation()` for URL scheme commands so Things stays in the background instead of coming to the foreground.

## Changes

- `scripts/url.js`: Use `app.doShellScript('open -g "..."')` instead of `app.openLocation(url)`
- `SKILL.md` and `url-scheme.md`: Update examples to use `open -g`
