### PR TITLE
fix(settings): remove cwd maintenance for worktrunk

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "env": {
-    "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": "true"
-  },
   "includeCoAuthoredBy": false,
   "permissions": {
     "allow": [


### PR DESCRIPTION
Remove `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR` to allow worktrunk shell integration to manage directory changes instead of Claude Code resetting to project root after bash commands.
