### PR TITLE
feat(session): use chrono-node for natural language dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "@bendrucker/claude",
       "workspaces": [
+        "plugins/claude-code/skills/session",
         "plugins/things/skills/things"
       ],
       "dependencies": {
@@ -1702,6 +1703,15 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chrono-node": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.9.0.tgz",
+      "integrity": "sha512-glI4YY2Jy6JII5l3d5FN6rcrIbKSQqKPhWsIRYPK2IK8Mm4Q1ZZFdYIaDqglUNf7gNwG+kWIzTn0omzzE0VkvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/ci-info": {
@@ -4836,6 +4846,10 @@
         "node": ">=10"
       }
     },
+    "node_modules/session": {
+      "resolved": "plugins/claude-code/skills/session",
+      "link": true
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5249,6 +5263,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5326,6 +5341,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -5870,6 +5886,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6076,6 +6093,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6089,6 +6107,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6352,6 +6371,12 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "plugins/claude-code/skills/session": {
+      "version": "1.0.0",
+      "dependencies": {
+        "chrono-node": "^2.7.7"
       }
     },
     "plugins/things/skills/things": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "workspaces": [
+    "plugins/claude-code/skills/session",
     "plugins/things/skills/things"
   ],
   "scripts": {

--- a/plugins/claude-code/skills/session/SKILL.md
+++ b/plugins/claude-code/skills/session/SKILL.md
@@ -15,7 +15,7 @@ Access details about the current Claude Code session or search past conversation
 Run the info script to get full session details:
 
 ```bash
-./scripts/info.sh "${CLAUDE_SESSION_ID}"
+scripts/info.sh "${CLAUDE_SESSION_ID}"
 ```
 
 ## Search History
@@ -24,13 +24,13 @@ Search past conversations or get a digest of recent work:
 
 ```bash
 # Search for specific topics
-tsx ./scripts/search.ts "error handling"
+npx tsx scripts/search.ts "error handling"
 
 # Get today's conversation digest
-tsx ./scripts/search.ts --digest today
+npx tsx scripts/search.ts --digest today
 
 # Search with date filters
-tsx ./scripts/search.ts "auth" --after yesterday
+npx tsx scripts/search.ts "auth" --after yesterday
 ```
 
 See [search.md](mdc:search.md) for advanced filtering options.

--- a/plugins/claude-code/skills/session/package.json
+++ b/plugins/claude-code/skills/session/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "session",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "chrono-node": "^2.7.7"
+  }
+}

--- a/plugins/claude-code/skills/session/scripts/search.test.ts
+++ b/plugins/claude-code/skills/session/scripts/search.test.ts
@@ -259,8 +259,8 @@ describe('parseDate', () => {
     expect(date.getDate()).toBe(expected.getDate())
   })
 
-  it('parses "week" as 7 days ago', () => {
-    const date = parseDate('week')
+  it('parses "last week" as 7 days ago', () => {
+    const date = parseDate('last week')
     const expected = new Date()
     expected.setDate(expected.getDate() - 7)
     expect(date.getFullYear()).toBe(expected.getFullYear())
@@ -276,7 +276,7 @@ describe('parseDate', () => {
   })
 
   it('throws on invalid date strings', () => {
-    expect(() => parseDate('not-a-date')).toThrow('Invalid date')
+    expect(() => parseDate('not-a-date')).toThrow('Unable to parse date')
   })
 
   it('is case insensitive for keywords', () => {

--- a/plugins/claude-code/skills/session/scripts/search.ts
+++ b/plugins/claude-code/skills/session/scripts/search.ts
@@ -3,6 +3,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
+import * as chrono from 'chrono-node'
 
 export interface ToolUse {
   readonly name: string
@@ -373,26 +374,11 @@ export function formatSearchResults(results: SearchResult[]): string {
 }
 
 export function parseDate(dateStr: string): Date {
-  const lower = dateStr.toLowerCase()
-  const today = startOfDay(new Date())
-
-  switch (lower) {
-    case 'today':
-      return today
-    case 'yesterday':
-      today.setDate(today.getDate() - 1)
-      return today
-    case 'this week':
-    case 'week':
-      today.setDate(today.getDate() - WEEK_DAYS)
-      return today
+  const parsed = chrono.parseDate(dateStr)
+  if (!parsed) {
+    throw new Error(`Unable to parse date: "${dateStr}"`)
   }
-
-  const parsed = new Date(dateStr)
-  if (isNaN(parsed.getTime())) {
-    throw new Error(`Invalid date: "${dateStr}". Use ISO format (2024-01-15) or keywords (today, yesterday, week)`)
-  }
-  return parsed
+  return startOfDay(parsed)
 }
 
 function printUsage(): void {
@@ -492,7 +478,7 @@ async function main(): Promise<void> {
 const isMain = import.meta.url === `file://${process.argv[1]}`
 if (isMain) {
   main().catch(err => {
-    console.error(err)
+    console.error(err instanceof Error ? err.message : err)
     process.exit(1)
   })
 }

--- a/plugins/claude-code/skills/session/search.md
+++ b/plugins/claude-code/skills/session/search.md
@@ -5,7 +5,7 @@ Advanced options for searching conversation history.
 ## CLI Options
 
 ```
-tsx search.ts [query] [options]
+npx tsx scripts/search.ts [query] [options]
 
 Options:
   --digest         Show digest of recent conversations (no query needed)
@@ -18,23 +18,22 @@ Options:
 
 ## Date Filtering
 
-Natural language dates:
+Uses [chrono-node](https://github.com/wanasit/chrono) for natural language date parsing:
 
-- `today` - Start of current day
-- `yesterday` - Start of yesterday
-- `this week` or `week` - 7 days ago
-
-ISO dates work as well: `2024-01-15`
+- `today`, `yesterday`
+- `last week`, `2 days ago`, `last month`
+- `January 15`, `Jan 15 2024`
+- ISO dates: `2024-01-15`
 
 ```bash
 # Conversations from the last week
-tsx search.ts --digest week
+npx tsx scripts/search.ts --digest "last week"
 
 # Search only today's sessions
-tsx search.ts "error" --after today
+npx tsx scripts/search.ts "error" --after today
 
 # Range query
-tsx search.ts "refactor" --after 2024-01-01 --before 2024-01-31
+npx tsx scripts/search.ts "refactor" --after 2024-01-01 --before 2024-01-31
 ```
 
 ## Project Filtering
@@ -43,10 +42,10 @@ Filter by project path:
 
 ```bash
 # Only search in a specific project
-tsx search.ts "bug" --project /Users/ben/src/myproject
+npx tsx scripts/search.ts "bug" --project /Users/ben/src/myproject
 
 # Partial path matching works
-tsx search.ts "test" --project myproject
+npx tsx scripts/search.ts "test" --project myproject
 ```
 
 ## JSON Output
@@ -55,10 +54,10 @@ Use `--format json` for programmatic access:
 
 ```bash
 # Pipe search results to jq
-tsx search.ts "auth" --format json | jq '.[] | .conversation.summary'
+npx tsx scripts/search.ts "auth" --format json | jq '.[] | .conversation.summary'
 
 # Get session IDs from digest
-tsx search.ts --digest today --format json | jq '.[].sessionId'
+npx tsx scripts/search.ts --digest today --format json | jq '.[].sessionId'
 ```
 
 ## Relevance Scoring


### PR DESCRIPTION
Replaces brittle manual date parsing in the session skill with `chrono-node` for natural language date support. Also fixes script invocation issues that prevented the search command from running.

## Changes

- Replace manual `parseDate` switch statement with `chrono-node` for parsing dates like "last week", "2 days ago", "last month"
- Use `npx tsx` instead of `tsx` (not available in PATH)
- Remove `./` prefix from script paths that caused expansion issues in skill instructions
- Output clean error messages without stack traces for user-facing errors
- Add `plugins/claude-code/skills/session` as npm workspace for `chrono-node` dependency

## Testing

Existing tests updated to use `chrono-node` semantics (e.g., "last week" instead of "week").
