### PR TITLE
session: fix script paths and use bun for auto-install

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,16 @@ Root-level tests (e.g., `hooks/`) run in a dedicated job since they're not part 
 - **No `.js` imports in TypeScript**: Import from `./module` not `./module.js`. The bundler/runtime handles resolution.
 - **Prefer skills over agents**: Skills are invocable via the Skill tool. Agents require the Task tool. If something should be directly invocable, make it a skill.
 
+### Local Plugin Testing
+
+To test a plugin end-to-end without publishing, use `--plugin-dir` with `--setting-sources local` to isolate from user/project settings:
+
+```bash
+claude --plugin-dir ./plugins/<name> --setting-sources local
+```
+
+This loads only the specified plugin directory, bypassing marketplace-installed versions. Use this workflow to verify skills, hooks, and scripts work correctly before committing.
+
 ## Verification
 
 Run `scripts/check-marketplace.sh` to verify all plugin directories are listed in `marketplace.json`. This check runs in CI and should pass before merging.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ It also contains my `settings.json` to synchronize my shared settings across mac
 
 Browse the [`plugins/`](plugins/) directory to see available plugins. Each plugin has its own README describing its contents.
 
+## Development
+
+To test a plugin locally without publishing:
+
+```bash
+claude --plugin-dir ./plugins/<name> --setting-sources local
+```
+
+This isolates the session from user/project settings, loading only the specified plugin. Use this to verify changes before committing.
+
 ## License
 
 MIT © [Ben Drucker](http://bendrucker.me)

--- a/plugins/claude-code/skills/session/SKILL.md
+++ b/plugins/claude-code/skills/session/SKILL.md
@@ -15,7 +15,7 @@ Access details about the current Claude Code session or search past conversation
 Run the info script to get full session details:
 
 ```bash
-npx tsx scripts/info.ts "${CLAUDE_SESSION_ID}"
+bun ${CLAUDE_PLUGIN_ROOT}/skills/session/scripts/info.ts "${CLAUDE_SESSION_ID}"
 ```
 
 ## Search History
@@ -24,13 +24,13 @@ Search past conversations or get a digest of recent work:
 
 ```bash
 # Search for specific topics
-npx tsx scripts/search.ts "error handling"
+bun ${CLAUDE_PLUGIN_ROOT}/skills/session/scripts/search.ts "error handling"
 
 # Get today's conversation digest
-npx tsx scripts/search.ts --digest today
+bun ${CLAUDE_PLUGIN_ROOT}/skills/session/scripts/search.ts --digest today
 
 # Search with date filters
-npx tsx scripts/search.ts "auth" --after yesterday
+bun ${CLAUDE_PLUGIN_ROOT}/skills/session/scripts/search.ts "auth" --after yesterday
 ```
 
 See [search.md](mdc:search.md) for advanced filtering options.


### PR DESCRIPTION
Fix the session skill to work correctly when loaded from the plugin cache.

## Changes

- Use `${CLAUDE_PLUGIN_ROOT}/skills/session/scripts/` for absolute paths instead of relative paths that get incorrectly expanded
- Switch from `npx tsx` to `bun` for running TypeScript scripts
- Document local plugin testing workflow (`--plugin-dir` with `--setting-sources local`) in `CLAUDE.md` and `README.md`

## Why `bun`

The committed SKILL.md used relative paths (`scripts/search.ts`) with `npx tsx`. This fails because when the skill runs, the working directory is the user's project, not the skill directory.

The fix:
1. Use absolute paths via `${CLAUDE_PLUGIN_ROOT}/skills/session/scripts/search.ts`
2. Use `bun` instead of `npx tsx` because `bun` auto-installs dependencies from the skill's `package.json` without needing `npm install` first

I tested with a clean state (deleted node_modules entirely) and `bun` resolved `chrono-node` automatically via its global cache. The workspace setup in root `package.json` isn't needed for `bun` - it was there for npm compatibility during development.