### PR TITLE
Replace tsx with bun for running TypeScript

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -139,7 +139,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx hooks/biome"
+            "command": "bun hooks/biome"
           }
         ]
       }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,9 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Install dependencies
         run: npm ci
 
@@ -120,9 +123,9 @@ jobs:
           )
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             readarray -t files < <(gh pr view ${{ github.event.pull_request.number }} --json files -q '.files[].path')
-            plugins=$(npx tsx scripts/list-plugins.ts "${always_args[@]}" "${files[@]}")
+            plugins=$(bun scripts/list-plugins.ts "${always_args[@]}" "${files[@]}")
           else
-            plugins=$(npx tsx scripts/list-plugins.ts)
+            plugins=$(bun scripts/list-plugins.ts)
           fi
           echo "plugins=$plugins" >> "$GITHUB_OUTPUT"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,13 +35,17 @@ Do not include installation instructions or skill activation details—the READM
 
 ### Dependencies
 
-The root `package.json` contains shared tooling (vitest, tsx, typescript) and dependencies used across multiple plugins (e.g., `url-pattern`). Plugin-specific dependencies belong in their own `package.json`:
+The root `package.json` contains shared tooling (vitest, typescript) and dependencies used across multiple plugins (e.g., `url-pattern`). Plugin-specific dependencies belong in their own `package.json`:
 
 - Create `plugins/<name>/package.json` for plugin-specific dependencies
 - Add the plugin to the root `workspaces` array
 - Run `npm install` to link the workspace
 
 Avoid collecting all dependencies in the root package.json. Each plugin should be self-contained where practical.
+
+### Bun
+
+Hooks and scripts use [Bun](https://bun.sh) to run TypeScript. Bun auto-installs missing dependencies on first run, eliminating the need to run `npm install` before executing scripts. This simplifies hook execution since hooks run in isolated contexts where `node_modules` may not be readily available.
 
 ## Hooks
 
@@ -57,7 +61,7 @@ Hooks intercept tool calls and can modify inputs, block execution, or request us
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/default-state.ts"
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/default-state.ts"
           }
         ]
       }
@@ -107,7 +111,7 @@ Hooks can also be defined at the project level in `.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx hooks/biome"
+            "command": "bun hooks/biome"
           }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This repository provides plugins for Claude Code, organized as a plugin marketpl
 
 It also contains my `settings.json` to synchronize my shared settings across machines.
 
+## Prerequisites
+
+Many plugins include TypeScript hooks and scripts that require [Bun](https://bun.sh) to run. See [Bun's installation guide](https://bun.sh/docs/installation) for setup instructions. Bun runs TypeScript natively and auto-installs missing dependencies on first run.
+
 ## Plugins
 
 Browse the [`plugins/`](plugins/) directory to see available plugins. Each plugin has its own README describing its contents.

--- a/hooks/biome/index.ts
+++ b/hooks/biome/index.ts
@@ -1,8 +1,8 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env bun
 
 import { execSync } from "node:child_process";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 export type WriteInput = { file_path: string };
 export type EditInput = { file_path: string };

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "remark-frontmatter": "^5.0.0",
         "remark-lint": "^10.0.1",
         "remark-lint-frontmatter-schema": "^3.15.4",
-        "tsx": "^4.21.0",
         "vitest": "^4.0.18"
       }
     },
@@ -1232,41 +1231,6 @@
         "node": ">=18.x"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@npmcli/config": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@npmcli/config/-/config-8.3.4.tgz",
@@ -2107,6 +2071,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2176,12 +2141,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "license": "MIT"
-    },
     "node_modules/babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
@@ -2238,6 +2197,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2302,6 +2262,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.5.0.tgz",
       "integrity": "sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -2424,15 +2385,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/concat-stream": {
@@ -2578,18 +2530,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2613,12 +2553,6 @@
       "dependencies": {
         "once": "^1.4.0"
       }
-    },
-    "node_modules/eol": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
-      "integrity": "sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==",
-      "license": "MIT"
     },
     "node_modules/err-code": {
       "version": "2.0.3",
@@ -2953,22 +2887,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -2985,15 +2903,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
     },
     "node_modules/fault": {
       "version": "2.0.1",
@@ -3013,6 +2922,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3096,18 +3006,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-stdin": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
-      "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -3119,19 +3017,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/get-tsconfig": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
-      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -3159,6 +3044,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -3181,34 +3067,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/globby": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
-      "license": "MIT",
-      "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.3.0",
-        "ignore": "^5.2.4",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/globby/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/graphql": {
@@ -3431,6 +3289,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3450,6 +3309,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -3472,6 +3332,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -3505,18 +3366,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-var-name": {
@@ -3678,14 +3527,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/json2xml": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/json2xml/-/json2xml-0.1.3.tgz",
-      "integrity": "sha512-yfTe9HnbrE3oRUEQL9mn7BueLd7RCTb7ig/mAFI6xY4RNYOEXF26x0qHFR7mb8ZrKgfE57wxkq0N3TboyFm6UA==",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3707,32 +3548,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/leasot": {
-      "version": "14.4.0",
-      "resolved": "https://registry.npmjs.org/leasot/-/leasot-14.4.0.tgz",
-      "integrity": "sha512-QGPf5zuauwsHPRMg5bqa+u6IrSrdx4XiqvIkWFVXVRFHyyI7828+oXsKJDX/0o9qXG/lLwOzsnC6d7lep+HXdA==",
-      "license": "MIT",
-      "dependencies": {
-        "async": "^3.2.4",
-        "chalk": "^5.0.1",
-        "commander": "^9.4.0",
-        "eol": "^0.9.1",
-        "get-stdin": "^9.0.0",
-        "globby": "^13.1.2",
-        "json2xml": "^0.1.3",
-        "lodash": "^4.17.21",
-        "log-symbols": "^5.1.0",
-        "strip-ansi": "^7.0.1",
-        "text-table": "^0.2.0"
-      },
-      "bin": {
-        "leasot": "dist/cli/leasot.js",
-        "leasot-reporter": "dist/cli/leasot-reporter.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/lines-and-columns": {
@@ -3780,23 +3595,8 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/log-symbols": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
-      "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.0.0",
-        "is-unicode-supported": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -4115,15 +3915,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/micromark": {
@@ -4585,19 +4376,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -5003,15 +4781,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -5030,6 +4799,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -5131,26 +4901,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
@@ -5620,16 +5370,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -5638,16 +5378,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {
@@ -5693,29 +5423,6 @@
         "@rollup/rollup-win32-x64-gnu": "4.56.0",
         "@rollup/rollup-win32-x64-msvc": "4.56.0",
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -5812,18 +5519,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/source-map-js": {
@@ -5988,6 +5683,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -6087,6 +5783,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/thenify": {
@@ -6209,6 +5906,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -6236,26 +5934,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type": {
@@ -7194,10 +6872,7 @@
       }
     },
     "plugins/type-ignore": {
-      "name": "@bendrucker/type-ignore",
-      "dependencies": {
-        "leasot": "^14.4.0"
-      }
+      "name": "@bendrucker/type-ignore"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "remark-frontmatter": "^5.0.0",
     "remark-lint": "^10.0.1",
     "remark-lint-frontmatter-schema": "^3.15.4",
-    "tsx": "^4.21.0",
     "vitest": "^4.0.18"
   },
   "dependencies": {

--- a/plugins/claude-code/skills/hooks/SKILL.md
+++ b/plugins/claude-code/skills/hooks/SKILL.md
@@ -38,7 +38,7 @@ Reference for creating and configuring Claude Code hooks. When uncertain about s
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx hooks/biome"
+            "command": "bun hooks/biome"
           }
         ]
       }
@@ -113,7 +113,7 @@ Store complex hooks in `.claude/hooks/` or project `hooks/` directory:
 
 Reference with:
 ```json
-"command": "npx tsx $CLAUDE_PROJECT_DIR/.claude/hooks/my-hook.ts"
+"command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/my-hook.ts"
 ```
 
 ## Examples

--- a/plugins/claude-code/skills/session/scripts/search.ts
+++ b/plugins/claude-code/skills/session/scripts/search.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env tsx
+#!/usr/bin/env bun
 
 import { parseDate } from "./search/date";
 import { formatDigest, formatSearchResults } from "./search/format";

--- a/plugins/claude-code/skills/session/search.md
+++ b/plugins/claude-code/skills/session/search.md
@@ -5,7 +5,7 @@ Advanced options for searching conversation history.
 ## CLI Options
 
 ```
-npx tsx scripts/search.ts [query] [options]
+bun scripts/search.ts [query] [options]
 
 Options:
   --digest         Show digest of recent conversations (no query needed)
@@ -27,13 +27,13 @@ Uses [chrono-node](https://github.com/wanasit/chrono) for natural language date 
 
 ```bash
 # Conversations from the last week
-npx tsx scripts/search.ts --digest "last week"
+bun scripts/search.ts --digest "last week"
 
 # Search only today's sessions
-npx tsx scripts/search.ts "error" --after today
+bun scripts/search.ts "error" --after today
 
 # Range query
-npx tsx scripts/search.ts "refactor" --after 2024-01-01 --before 2024-01-31
+bun scripts/search.ts "refactor" --after 2024-01-01 --before 2024-01-31
 ```
 
 ## Project Filtering
@@ -42,10 +42,10 @@ Filter by project path:
 
 ```bash
 # Only search in a specific project
-npx tsx scripts/search.ts "bug" --project /Users/ben/src/myproject
+bun scripts/search.ts "bug" --project /Users/ben/src/myproject
 
 # Partial path matching works
-npx tsx scripts/search.ts "test" --project myproject
+bun scripts/search.ts "test" --project myproject
 ```
 
 ## JSON Output
@@ -54,10 +54,10 @@ Use `--format json` for programmatic access:
 
 ```bash
 # Pipe search results to jq
-npx tsx scripts/search.ts "auth" --format json | jq '.[] | .conversation.summary'
+bun scripts/search.ts "auth" --format json | jq '.[] | .conversation.summary'
 
 # Get session IDs from digest
-npx tsx scripts/search.ts --digest today --format json | jq '.[].sessionId'
+bun scripts/search.ts --digest today --format json | jq '.[].sessionId'
 ```
 
 ## Relevance Scoring

--- a/plugins/claude-code/skills/skills/SKILL.md
+++ b/plugins/claude-code/skills/skills/SKILL.md
@@ -7,7 +7,7 @@ hooks:
     - matcher: "Write|Edit"
       hooks:
         - type: command
-          command: "npx tsx ${CLAUDE_SKILL_ROOT}/scripts/check-namespace.ts"
+          command: "bun ${CLAUDE_SKILL_ROOT}/scripts/check-namespace.ts"
 ---
 
 # Claude Code Skills Development

--- a/plugins/claude-code/skills/skills/scripts/check-namespace.ts
+++ b/plugins/claude-code/skills/skills/scripts/check-namespace.ts
@@ -1,9 +1,9 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env bun
 
 import { readFileSync } from "node:fs";
 import { basename } from "node:path";
-import { readStdinJson } from "@constellos/claude-code-kit/runners";
 import type { PostToolUseInput } from "@constellos/claude-code-kit";
+import { readStdinJson } from "@constellos/claude-code-kit/runners";
 
 export function extractPluginName(filePath: string): string | null {
   const match = filePath.match(/plugins\/([^/]+)\//);

--- a/plugins/git/hooks/hooks.json
+++ b/plugins/git/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/scripts/block-default-branch-commit.ts"
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/block-default-branch-commit.ts"
           }
         ]
       }

--- a/plugins/git/scripts/block-default-branch-commit.ts
+++ b/plugins/git/scripts/block-default-branch-commit.ts
@@ -1,11 +1,11 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env bun
 
 import { execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 export type BashInput = {
   command?: string;

--- a/plugins/github/hooks/hooks.json
+++ b/plugins/github/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts"
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts"
           }
         ]
       }

--- a/plugins/github/scripts/fetch.ts
+++ b/plugins/github/scripts/fetch.ts
@@ -1,8 +1,8 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env bun
 
-import UrlPattern from "url-pattern";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import UrlPattern from "url-pattern";
 
 export type WebFetchInput = { url: string; prompt: string };
 

--- a/plugins/gitlab/hooks/hooks.json
+++ b/plugins/gitlab/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts"
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts"
           }
         ]
       }

--- a/plugins/gitlab/scripts/fetch.ts
+++ b/plugins/gitlab/scripts/fetch.ts
@@ -1,8 +1,8 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env bun
 
-import UrlPattern from "url-pattern";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import UrlPattern from "url-pattern";
 
 export type WebFetchInput = { url: string; prompt: string };
 

--- a/plugins/go/hooks/hooks.json
+++ b/plugins/go/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/scripts/check.ts"
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/check.ts"
           }
         ]
       }

--- a/plugins/go/scripts/check.ts
+++ b/plugins/go/scripts/check.ts
@@ -1,8 +1,8 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env bun
 
 import { existsSync, readFileSync } from "node:fs";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 export type FileInput = {
   file_path?: string;

--- a/plugins/linear/hooks/default-state.ts
+++ b/plugins/linear/hooks/default-state.ts
@@ -1,7 +1,7 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env bun
 
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 export type CreateIssueInput = {
   title?: string;

--- a/plugins/linear/hooks/hooks.json
+++ b/plugins/linear/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/default-state.ts"
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/default-state.ts"
           }
         ]
       }

--- a/plugins/linear/skills/linear/api.md
+++ b/plugins/linear/skills/linear/api.md
@@ -22,7 +22,7 @@ For ad-hoc queries and automation, use the `@linear/sdk` package with `npx` and 
 The skill includes `scripts/query.ts` for executing GraphQL queries. Run it with:
 
 ```bash
-LINEAR_API_KEY=lin_api_xxx npx tsx scripts/query.ts "query { viewer { id name } }"
+LINEAR_API_KEY=lin_api_xxx bun scripts/query.ts "query { viewer { id name } }"
 ```
 
 **Environment Variable**: The script requires `LINEAR_API_KEY` to be set. If not provided to the Claude process, you cannot execute GraphQL queries automatically.
@@ -158,5 +158,5 @@ for (const issue of issues.nodes) {
 Use GraphQL introspection to discover the API schema:
 
 ```bash
-LINEAR_API_KEY=lin_api_xxx npx tsx scripts/query.ts "{ __schema { types { name description } } }"
+LINEAR_API_KEY=lin_api_xxx bun scripts/query.ts "{ __schema { types { name description } } }"
 ```

--- a/plugins/linear/skills/linear/scripts/query.sh
+++ b/plugins/linear/skills/linear/scripts/query.sh
@@ -18,4 +18,4 @@ if [ -z "${LINEAR_API_KEY:-}" ]; then
   exit 1
 fi
 
-npx tsx "$SCRIPT_DIR/query.ts" "$@"
+bun "$SCRIPT_DIR/query.ts" "$@"

--- a/plugins/linear/skills/linear/scripts/query.ts
+++ b/plugins/linear/skills/linear/scripts/query.ts
@@ -1,11 +1,11 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env bun
 
 /**
  * Execute ad-hoc GraphQL queries against the Linear API
  *
  * Usage:
- *   LINEAR_API_KEY=lin_api_xxx npx tsx query.ts "query { viewer { id name } }"
- *   LINEAR_API_KEY=lin_api_xxx npx tsx query.ts "query { viewer { id name } }" '{"var": "value"}'
+ *   LINEAR_API_KEY=lin_api_xxx bun query.ts "query { viewer { id name } }"
+ *   LINEAR_API_KEY=lin_api_xxx bun query.ts "query { viewer { id name } }" '{"var": "value"}'
  */
 
 import { LinearClient } from "@linear/sdk";
@@ -33,7 +33,7 @@ async function main() {
     console.error("Error: LINEAR_API_KEY environment variable is required");
     console.error("");
     console.error("Usage:");
-    console.error('  LINEAR_API_KEY=lin_api_xxx npx tsx query.ts "query { viewer { id name } }"');
+    console.error('  LINEAR_API_KEY=lin_api_xxx bun query.ts "query { viewer { id name } }"');
     process.exit(1);
   }
 
@@ -44,9 +44,9 @@ async function main() {
     console.error("Error: Query argument is required");
     console.error("");
     console.error("Usage:");
-    console.error('  LINEAR_API_KEY=lin_api_xxx npx tsx query.ts "query { viewer { id name } }"');
+    console.error('  LINEAR_API_KEY=lin_api_xxx bun query.ts "query { viewer { id name } }"');
     console.error(
-      '  LINEAR_API_KEY=lin_api_xxx npx tsx query.ts "query($id: String!) { issue(id: $id) { title } }" \'{"id": "ISSUE_ID"}\'',
+      '  LINEAR_API_KEY=lin_api_xxx bun query.ts "query($id: String!) { issue(id: $id) { title } }" \'{"id": "ISSUE_ID"}\'',
     );
     process.exit(1);
   }

--- a/plugins/linear/skills/linear/sdk.md
+++ b/plugins/linear/skills/linear/sdk.md
@@ -19,7 +19,7 @@ For complex Linear operations involving loops, mapping, or conditional logic, wr
 - Better error handling than raw GraphQL
 - Easier debugging
 
-Run scripts with: `npx tsx script.ts`
+Run scripts with: `bun script.ts`
 
 ## Basic Setup
 
@@ -197,7 +197,7 @@ for (const issue of issues.nodes) {
 ## Script Template
 
 ```typescript
-#!/usr/bin/env tsx
+#!/usr/bin/env bun
 import { LinearClient } from '@linear/sdk'
 
 const LINEAR_API_KEY = process.env.LINEAR_API_KEY
@@ -238,10 +238,10 @@ main().catch(error => {
 
 ```bash
 # Direct execution
-npx tsx automation.ts
+bun automation.ts
 
 # With environment variable
-LINEAR_API_KEY=lin_api_xxx npx tsx automation.ts
+LINEAR_API_KEY=lin_api_xxx bun automation.ts
 
 # Make executable (requires shebang)
 chmod +x automation.ts
@@ -272,7 +272,7 @@ chmod +x automation.ts
 
 Scripts require:
 - `@linear/sdk` package
-- `tsx` for execution (via npx or installed)
+- `bun` for execution
 - `LINEAR_API_KEY` environment variable
 
 Install in project: `npm install @linear/sdk`

--- a/plugins/newline/hooks/hooks.json
+++ b/plugins/newline/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/scripts/check.ts"
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/check.ts"
           }
         ]
       }
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/scripts/ensure.ts"
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/ensure.ts"
           }
         ]
       },
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/scripts/preserve.ts"
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/preserve.ts"
           }
         ]
       }

--- a/plugins/newline/scripts/check.ts
+++ b/plugins/newline/scripts/check.ts
@@ -1,8 +1,8 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env bun
 
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { readStdinJson } from "@constellos/claude-code-kit/runners";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson } from "@constellos/claude-code-kit/runners";
 import { setState } from "./state";
 
 type ToolInput = {

--- a/plugins/newline/scripts/ensure.ts
+++ b/plugins/newline/scripts/ensure.ts
@@ -1,8 +1,8 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env bun
 
-import { existsSync, readFileSync, writeFileSync, statSync } from "node:fs";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 type ToolInput = {
   file_path?: string;

--- a/plugins/newline/scripts/preserve.ts
+++ b/plugins/newline/scripts/preserve.ts
@@ -1,9 +1,9 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env bun
 
-import { existsSync, readFileSync, writeFileSync, statSync } from "node:fs";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { getState, clearState } from "./state";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { clearState, getState } from "./state";
 
 type ToolInput = {
   file_path?: string;

--- a/plugins/style/hooks/hooks.json
+++ b/plugins/style/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts write"
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts write"
           }
         ]
       },
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts edit"
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts edit"
           }
         ]
       }

--- a/plugins/style/hooks/numbering.ts
+++ b/plugins/style/hooks/numbering.ts
@@ -1,15 +1,15 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env bun
 
 import { execSync } from "node:child_process";
-import { writeFileSync, unlinkSync } from "node:fs";
+import { unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import type { Heading, Text } from "mdast";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { visit } from "unist-util-visit";
-import type { Heading, Text } from "mdast";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
-import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 
 export type WriteInput = { file_path: string; content: string };
 export type EditInput = { file_path: string; new_string: string };


### PR DESCRIPTION
Switch all TypeScript hooks and scripts from `npx tsx` to `bun`. Bun runs TypeScript natively without needing IPC pipes, avoiding sandbox `EPERM` errors that occur when tsx tries to create Unix sockets in `/tmp/claude/tsx-*/`. Bun also auto-installs missing dependencies on first run.

## Changes

- Replace `npx tsx` with `bun` in all hook commands and script invocations
- Update shebangs from `#!/usr/bin/env npx tsx` to `#!/usr/bin/env bun`
- Remove `tsx` from root `package.json` devDependencies
- Add `oven-sh/setup-bun@v2` to CI workflow
- Document Bun requirement in README.md
- Document Bun auto-installation benefit in CLAUDE.md
