### PR TITLE
hooks: add debugging reference for troubleshooting failures

### DIFF
--- a/plugins/claude-code/skills/hooks/SKILL.md
+++ b/plugins/claude-code/skills/hooks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hooks
-description: Use this skill when you need to configure, create, or troubleshoot Claude Code hooks. This includes setting up PreToolUse hooks, PostToolUse hooks, UserPromptSubmit hooks, or any automation within Claude Code. Examples include "I want to run tests before every file edit", "My hook isn't firing", or "How do I create a hook that formats JSON output with jq?"
+description: Use this skill when you need to configure, create, or troubleshoot Claude Code hooks. This includes setting up PreToolUse hooks, PostToolUse hooks, UserPromptSubmit hooks, debugging hook failures, or any automation within Claude Code. Examples include "I want to run tests before every file edit", "My hook isn't firing", "1 out of 2 hooks ran", or "How do I create a hook that formats JSON output with jq?"
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, WebFetch(domain:docs.anthropic.com)]
 ---
 
@@ -122,3 +122,7 @@ See these repositories for hook implementations:
 - Input modification: [plugins/linear/hooks/](plugins/linear/hooks/)
 - Permission decisions: [plugins/github/scripts/](plugins/github/scripts/)
 - PostToolUse feedback: [hooks/biome/](hooks/biome/)
+
+## Debugging
+
+For troubleshooting hook failures, see [debugging](references/debugging.md).

--- a/plugins/claude-code/skills/hooks/references/debugging.md
+++ b/plugins/claude-code/skills/hooks/references/debugging.md
@@ -1,0 +1,65 @@
+# Debugging Hooks
+
+Diagnose hook failures when you see errors like "N out of M hooks run".
+
+## Viewing Hook Output
+
+Hook script output (stdout/stderr) is silent by default. To see it:
+
+| Method | When to use |
+|--------|-------------|
+| `ctrl+o` (verbose mode) | Real-time output during session |
+| `claude --debug` | Detailed logs written to disk |
+| `/hooks` | Verify hooks are registered |
+
+With `--debug`, hook execution details appear in `~/.claude/debug/latest`:
+
+```
+[DEBUG] Executing hook command: <command> with timeout 60000ms
+[DEBUG] Hook command completed with status 0: <stdout>
+```
+
+## Debug Log Patterns
+
+The debug log (`~/.claude/debug/latest`) contains Claude Code's internal hook processing:
+
+| Pattern | Meaning |
+|---------|---------|
+| `Loaded hooks from standard location for plugin X` | Hook registered |
+| `Getting matching hook commands for PostToolUse with query: Write` | Matching attempt |
+| `Matched N unique hooks for query "X"` | Hooks that matched |
+| `Hooks: Parsed initial response: {...}` | Hook output parsed |
+| `Hook output does not start with {` | Non-JSON output (treated as text) |
+| `[ERROR]` | Actual errors |
+
+### Diagnostic Commands
+
+```bash
+# Find hook registrations
+grep "Loaded hooks from" ~/.claude/debug/latest
+
+# Find matches for a specific tool
+grep "matching hook commands.*Write" ~/.claude/debug/latest
+
+# Find hook script output
+grep "Hook command completed" ~/.claude/debug/latest
+
+# Find errors
+grep -E "\[ERROR\]" ~/.claude/debug/latest | grep -i hook
+```
+
+## Configuration Locations
+
+- User: `~/.claude/settings.json`
+- Project: `.claude/settings.json`
+- Plugin: `~/.claude/plugins/cache/<org>/<plugin>/<version>/hooks/hooks.json`
+
+## Common Issues
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Hook not triggering | Matcher doesn't match tool name | Check regex pattern with `/hooks` |
+| Non-JSON output treated as text | Script outputs plain text | Return JSON with `hookSpecificOutput` |
+| Hook runs but no effect | Missing `hookEventName` in output | Add `hookEventName: "PostToolUse"` |
+| Script not found | Bad path or `CLAUDE_PLUGIN_ROOT` | Use absolute path or verify env var |
+| Can't see script output | Output silent by default | Use `ctrl+o` or `--debug` |


### PR DESCRIPTION
Add debugging documentation to the hooks skill as a reference file for diagnosing hook failures.

## Changes

- Add `references/debugging.md` covering debug log location, key patterns to search, diagnostic commands, and common issues
- Update skill description to include debugging trigger terms ("debugging hook failures", "1 out of 2 hooks ran")
- Add Debugging section linking to the reference file
