### PR TITLE
settings: exclude wt from sandbox

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -117,7 +117,8 @@
       "say:*",
       "afplay:*",
       "diskutil:*",
-      "networksetup:*"
+      "networksetup:*",
+      "wt:*"
     ]
   },
   "alwaysThinkingEnabled": true,


### PR DESCRIPTION
Allow worktrunk commands to run without sandbox restrictions since they need filesystem access to create worktrees.