### PR TITLE
skill-lint: add package for validating skills

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,6 +177,14 @@ jobs:
         if: steps.inspect.outputs.has_skills == 'true'
         run: npx remark "plugins/${{ matrix.plugin }}/skills/*/SKILL.md"
 
+      - name: Setup Bun
+        if: steps.inspect.outputs.has_skills == 'true'
+        uses: oven-sh/setup-bun@v2
+
+      - name: Lint skills
+        if: steps.inspect.outputs.has_skills == 'true'
+        run: bunx skill-lint "plugins/${{ matrix.plugin }}/skills/*"
+
       - name: Validate agent frontmatter
         if: steps.inspect.outputs.has_agents == 'true'
         run: npx remark "plugins/${{ matrix.plugin }}/agents/*.md"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "@bendrucker/claude",
       "workspaces": [
+        "packages/skill-lint",
         "plugins/claude-code/skills/session",
         "plugins/style",
         "plugins/things/skills/things",
@@ -5521,6 +5522,10 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/skill-lint": {
+      "resolved": "packages/skill-lint",
+      "link": true
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6845,6 +6850,30 @@
     "packages/hooks": {
       "name": "@bendrucker/hooks",
       "extraneous": true
+    },
+    "packages/skill-lint": {
+      "version": "0.0.1",
+      "dependencies": {
+        "yaml": "^2.7.1"
+      },
+      "bin": {
+        "skill-lint": "src/cli.ts"
+      }
+    },
+    "packages/skill-lint/node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "plugins/claude-code/skills/session": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "workspaces": [
+    "packages/skill-lint",
     "plugins/claude-code/skills/session",
     "plugins/style",
     "plugins/things/skills/things",

--- a/packages/skill-lint/package.json
+++ b/packages/skill-lint/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "skill-lint",
+  "version": "0.0.1",
+  "type": "module",
+  "bin": {
+    "skill-lint": "./src/cli.ts"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest"
+  },
+  "dependencies": {
+    "yaml": "^2.7.1"
+  }
+}

--- a/packages/skill-lint/src/cli.ts
+++ b/packages/skill-lint/src/cli.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env bun
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { parseArgs } from "node:util";
+import { formatJson, formatText } from "./format";
+import { lintSkill } from "./index";
+
+const { values, positionals } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    json: { type: "boolean", default: false },
+    strict: { type: "boolean", default: false },
+    help: { type: "boolean", short: "h", default: false },
+  },
+  allowPositionals: true,
+});
+
+if (values.help || positionals.length === 0) {
+  console.log(`skill-lint - Lint Claude Code skills
+
+Usage:
+  skill-lint [options] <skill-dir>...
+
+Options:
+  --json     Output JSON instead of text
+  --strict   Fail on warnings (exit code 2)
+  -h, --help Show this help
+
+Examples:
+  skill-lint plugins/linear/skills/linear/
+  skill-lint plugins/terraform/skills/*/
+  skill-lint --json plugins/*/skills/*
+
+Exit codes:
+  0  All rules pass
+  1  Errors found
+  2  Warnings only (with --strict)`);
+  process.exit(0);
+}
+
+const skillDirs = positionals.flatMap((pattern) => {
+  if (pattern.includes("*")) {
+    const base = pattern.split("*")[0] ?? "";
+    const suffix = pattern.split("*").slice(1).join("*");
+
+    if (!fs.existsSync(base)) return [];
+
+    return fs
+      .readdirSync(base, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => path.join(base, d.name, suffix.replace(/^\*?\/?/, "")))
+      .filter((p) => fs.existsSync(path.join(p, "SKILL.md")));
+  }
+
+  if (fs.existsSync(path.join(pattern, "SKILL.md"))) {
+    return [pattern];
+  }
+
+  return [];
+});
+
+if (skillDirs.length === 0) {
+  console.error("No skill directories found");
+  process.exit(1);
+}
+
+const results = skillDirs.map((dir) => lintSkill(dir));
+
+if (values.json) {
+  console.log(formatJson(results));
+} else {
+  console.log(formatText(results));
+}
+
+const hasErrors = results.some((r) => r.errors > 0);
+const hasWarnings = results.some((r) => r.warnings > 0);
+
+if (hasErrors) {
+  process.exit(1);
+} else if (hasWarnings && values.strict) {
+  process.exit(2);
+} else {
+  process.exit(0);
+}

--- a/packages/skill-lint/src/format.ts
+++ b/packages/skill-lint/src/format.ts
@@ -1,0 +1,57 @@
+import type { ReferenceResult, RuleResult, SkillLintResult } from "./types";
+
+function statusIcon(result: RuleResult): string {
+  if (result.severity === "info") return "info";
+  return result.passed ? "pass" : result.severity;
+}
+
+function formatResult(result: RuleResult): string {
+  return `  [${statusIcon(result)}] ${result.rule}: ${result.message}`;
+}
+
+function formatReference(ref: ReferenceResult): string {
+  const lines = [`    ${ref.path}:`];
+  for (const result of ref.results) {
+    lines.push(`      [${statusIcon(result)}] ${result.message}`);
+  }
+  return lines.join("\n");
+}
+
+export function formatText(results: SkillLintResult[]): string {
+  const output: string[] = [];
+
+  for (const skill of results) {
+    output.push(skill.path);
+    output.push("");
+    output.push(`Errors: ${skill.errors} | Warnings: ${skill.warnings}`);
+    output.push("");
+
+    for (const result of skill.results) {
+      output.push(formatResult(result));
+    }
+
+    if (skill.references.length > 0) {
+      output.push("");
+      output.push("  references/");
+      for (const ref of skill.references) {
+        output.push(formatReference(ref));
+      }
+    }
+
+    const tokenResult = skill.results.find((r) => r.rule === "tokens");
+    if (tokenResult && skill.tokens.total !== skill.tokens.skill) {
+      output.push("");
+      output.push(
+        `  [info] tokens: ~${skill.tokens.skill.toLocaleString()} (SKILL.md) / ~${skill.tokens.total.toLocaleString()} (total)`,
+      );
+    }
+
+    output.push("");
+  }
+
+  return output.join("\n");
+}
+
+export function formatJson(results: SkillLintResult[]): string {
+  return JSON.stringify(results, null, 2);
+}

--- a/packages/skill-lint/src/index.ts
+++ b/packages/skill-lint/src/index.ts
@@ -1,0 +1,58 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { estimateTokens, parseSkill } from "./parse";
+import { allRules, findReferences, lintReference } from "./rules";
+import type { RuleResult, SkillLintResult } from "./types";
+
+export function lintSkill(skillDir: string): SkillLintResult {
+  const skillPath = path.join(skillDir, "SKILL.md");
+  const raw = fs.readFileSync(skillPath, "utf-8");
+  const content = parseSkill(raw);
+
+  const results: RuleResult[] = [];
+
+  for (const rule of allRules) {
+    const result = rule.check(content, skillDir);
+    if (Array.isArray(result)) {
+      results.push(...result);
+    } else {
+      results.push(result);
+    }
+  }
+
+  const refs = findReferences(content.body);
+  const referenceResults = refs.map((ref) => lintReference(skillDir, ref));
+
+  let totalTokens = estimateTokens(raw);
+  for (const ref of referenceResults) {
+    const refPath = path.join(skillDir, ref.path);
+    try {
+      const refContent = fs.readFileSync(refPath, "utf-8");
+      totalTokens += estimateTokens(refContent);
+    } catch {
+      // Reference doesn't exist, already reported
+    }
+  }
+
+  for (const ref of referenceResults) {
+    results.push(...ref.results);
+  }
+
+  const errors = results.filter((r) => r.severity === "error" && !r.passed).length;
+  const warnings = results.filter((r) => r.severity === "warn" && !r.passed).length;
+
+  return {
+    path: skillPath,
+    errors,
+    warnings,
+    results: results.filter((r) => r.severity !== "info" || r.rule === "tokens"),
+    references: referenceResults,
+    tokens: {
+      skill: estimateTokens(raw),
+      total: totalTokens,
+    },
+  };
+}
+
+export { parseSkill } from "./parse";
+export type { RuleResult, SkillLintResult } from "./types";

--- a/packages/skill-lint/src/parse.ts
+++ b/packages/skill-lint/src/parse.ts
@@ -1,0 +1,40 @@
+import { parse as parseYaml } from "yaml";
+import type { SkillContent } from "./types";
+
+const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/;
+
+export function parseSkill(raw: string): SkillContent {
+  const match = raw.match(FRONTMATTER_REGEX);
+
+  if (!match) {
+    return {
+      frontmatter: {},
+      body: raw,
+      raw,
+    };
+  }
+
+  const [, yamlContent, body] = match;
+  let frontmatter: Record<string, unknown> = {};
+
+  try {
+    frontmatter = parseYaml(yamlContent ?? "") ?? {};
+  } catch {
+    frontmatter = {};
+  }
+
+  return {
+    frontmatter,
+    body: body ?? "",
+    raw,
+  };
+}
+
+export function countLines(text: string): number {
+  if (!text) return 0;
+  return text.split("\n").length;
+}
+
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}

--- a/packages/skill-lint/src/rules/body.ts
+++ b/packages/skill-lint/src/rules/body.ts
@@ -1,0 +1,32 @@
+import { countLines } from "../parse";
+import type { Rule, RuleResult, SkillContent } from "../types";
+
+const SPEC_URL = "https://agentskills.io/specification";
+
+const MAX_BODY_LINES = 500;
+
+export const bodyLines: Rule = {
+  name: "body-lines",
+  severity: "warn",
+  check(content: SkillContent): RuleResult {
+    const lines = countLines(content.body);
+
+    if (lines > MAX_BODY_LINES) {
+      return {
+        rule: "body-lines",
+        severity: "warn",
+        passed: false,
+        message: `${lines} lines (max ${MAX_BODY_LINES})\n  > "Keep your main SKILL.md under 500 lines. Move detailed reference material to separate files."\n  ${SPEC_URL}#progressive-disclosure`,
+      };
+    }
+
+    return {
+      rule: "body-lines",
+      severity: "warn",
+      passed: true,
+      message: `${lines} lines (max ${MAX_BODY_LINES})`,
+    };
+  },
+};
+
+export const bodyRules: Rule[] = [bodyLines];

--- a/packages/skill-lint/src/rules/frontmatter.ts
+++ b/packages/skill-lint/src/rules/frontmatter.ts
@@ -1,0 +1,205 @@
+import type { Rule, RuleResult, SkillContent } from "../types";
+
+const SPEC_URL = "https://agentskills.io/specification";
+
+const NAME_PATTERN = /^[a-z0-9-]+$/;
+const MAX_NAME_LENGTH = 64;
+const MAX_DESCRIPTION_LENGTH = 1024;
+
+export const nameFormat: Rule = {
+  name: "name-format",
+  severity: "error",
+  check(content: SkillContent): RuleResult {
+    const name = content.frontmatter.name;
+
+    if (typeof name !== "string") {
+      return {
+        rule: "name-format",
+        severity: "error",
+        passed: false,
+        message: `name is missing or not a string\n  > "May only contain unicode lowercase alphanumeric characters and hyphens"\n  ${SPEC_URL}#name-field`,
+      };
+    }
+
+    if (!NAME_PATTERN.test(name)) {
+      return {
+        rule: "name-format",
+        severity: "error",
+        passed: false,
+        message: `"${name}" contains invalid characters\n  > "May only contain unicode lowercase alphanumeric characters and hyphens"\n  ${SPEC_URL}#name-field`,
+      };
+    }
+
+    return {
+      rule: "name-format",
+      severity: "error",
+      passed: true,
+      message: `"${name}" (${name.length} chars)`,
+    };
+  },
+};
+
+export const nameLength: Rule = {
+  name: "name-length",
+  severity: "error",
+  check(content: SkillContent): RuleResult {
+    const name = content.frontmatter.name;
+
+    if (typeof name !== "string") {
+      return {
+        rule: "name-length",
+        severity: "error",
+        passed: false,
+        message: `name is missing\n  > "Must be 1-64 characters"\n  ${SPEC_URL}#name-field`,
+      };
+    }
+
+    if (name.length > MAX_NAME_LENGTH) {
+      return {
+        rule: "name-length",
+        severity: "error",
+        passed: false,
+        message: `"${name}" is ${name.length} chars (max ${MAX_NAME_LENGTH})\n  > "Must be 1-64 characters"\n  ${SPEC_URL}#name-field`,
+      };
+    }
+
+    return {
+      rule: "name-length",
+      severity: "error",
+      passed: true,
+      message: `${name.length} chars (max ${MAX_NAME_LENGTH})`,
+    };
+  },
+};
+
+export const nameEdgeHyphens: Rule = {
+  name: "name-edge-hyphens",
+  severity: "error",
+  check(content: SkillContent): RuleResult {
+    const name = content.frontmatter.name;
+
+    if (typeof name !== "string") {
+      return {
+        rule: "name-edge-hyphens",
+        severity: "error",
+        passed: true,
+        message: "name is missing (checked by other rules)",
+      };
+    }
+
+    if (name.startsWith("-") || name.endsWith("-")) {
+      return {
+        rule: "name-edge-hyphens",
+        severity: "error",
+        passed: false,
+        message: `"${name}" starts or ends with hyphen\n  > "Must not start or end with -"\n  ${SPEC_URL}#name-field`,
+      };
+    }
+
+    return {
+      rule: "name-edge-hyphens",
+      severity: "error",
+      passed: true,
+      message: "no leading/trailing hyphens",
+    };
+  },
+};
+
+export const nameConsecutiveHyphens: Rule = {
+  name: "name-consecutive-hyphens",
+  severity: "error",
+  check(content: SkillContent): RuleResult {
+    const name = content.frontmatter.name;
+
+    if (typeof name !== "string") {
+      return {
+        rule: "name-consecutive-hyphens",
+        severity: "error",
+        passed: true,
+        message: "name is missing (checked by other rules)",
+      };
+    }
+
+    if (name.includes("--")) {
+      return {
+        rule: "name-consecutive-hyphens",
+        severity: "error",
+        passed: false,
+        message: `"${name}" contains consecutive hyphens\n  > "Must not contain consecutive hyphens (--)"\n  ${SPEC_URL}#name-field`,
+      };
+    }
+
+    return {
+      rule: "name-consecutive-hyphens",
+      severity: "error",
+      passed: true,
+      message: "no consecutive hyphens",
+    };
+  },
+};
+
+export const descriptionRequired: Rule = {
+  name: "description-required",
+  severity: "error",
+  check(content: SkillContent): RuleResult {
+    const description = content.frontmatter.description;
+
+    if (typeof description !== "string" || description.trim().length === 0) {
+      return {
+        rule: "description-required",
+        severity: "error",
+        passed: false,
+        message: `description is required\n  > "Must be 1-1024 characters"\n  ${SPEC_URL}#description-field`,
+      };
+    }
+
+    return {
+      rule: "description-required",
+      severity: "error",
+      passed: true,
+      message: `${description.length} chars`,
+    };
+  },
+};
+
+export const descriptionLength: Rule = {
+  name: "description-length",
+  severity: "error",
+  check(content: SkillContent): RuleResult {
+    const description = content.frontmatter.description;
+
+    if (typeof description !== "string") {
+      return {
+        rule: "description-length",
+        severity: "error",
+        passed: true,
+        message: "description is missing (checked by other rules)",
+      };
+    }
+
+    if (description.length > MAX_DESCRIPTION_LENGTH) {
+      return {
+        rule: "description-length",
+        severity: "error",
+        passed: false,
+        message: `${description.length} chars (max ${MAX_DESCRIPTION_LENGTH})\n  > "Must be 1-1024 characters"\n  ${SPEC_URL}#description-field`,
+      };
+    }
+
+    return {
+      rule: "description-length",
+      severity: "error",
+      passed: true,
+      message: `${description.length} chars (max ${MAX_DESCRIPTION_LENGTH})`,
+    };
+  },
+};
+
+export const frontmatterRules: Rule[] = [
+  nameFormat,
+  nameLength,
+  nameEdgeHyphens,
+  nameConsecutiveHyphens,
+  descriptionRequired,
+  descriptionLength,
+];

--- a/packages/skill-lint/src/rules/index.ts
+++ b/packages/skill-lint/src/rules/index.ts
@@ -1,0 +1,8 @@
+import type { Rule } from "../types";
+import { bodyRules } from "./body";
+import { frontmatterRules } from "./frontmatter";
+import { tokenRules } from "./tokens";
+
+export const allRules: Rule[] = [...frontmatterRules, ...bodyRules, ...tokenRules];
+
+export { findReferences, lintReference } from "./references";

--- a/packages/skill-lint/src/rules/references.ts
+++ b/packages/skill-lint/src/rules/references.ts
@@ -1,0 +1,67 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { countLines } from "../parse";
+import type { ReferenceResult, RuleResult } from "../types";
+
+const SPEC_URL = "https://agentskills.io/specification";
+
+const REFERENCE_LINK_PATTERN = /\[.*?\]\((?!https?:\/\/)(references\/[^)]+)\)/g;
+
+export function findReferences(body: string): string[] {
+  const matches = body.matchAll(REFERENCE_LINK_PATTERN);
+  const refs = new Set<string>();
+
+  for (const match of matches) {
+    const ref = match[1];
+    if (ref) refs.add(ref);
+  }
+
+  return Array.from(refs);
+}
+
+export function getDepth(refPath: string): number {
+  const parts = refPath.split("/").filter(Boolean);
+  return parts.length - 1;
+}
+
+export function lintReference(skillDir: string, refPath: string): ReferenceResult {
+  const fullPath = path.join(skillDir, refPath);
+  const results: RuleResult[] = [];
+  let lines = 0;
+  const depth = getDepth(refPath);
+
+  try {
+    const content = fs.readFileSync(fullPath, "utf-8");
+    lines = countLines(content);
+
+    if (depth > 1) {
+      results.push({
+        rule: "reference-depth",
+        severity: "warn",
+        passed: false,
+        message: `depth ${depth} (max 1)\n  > "Keep file references one level deep from SKILL.md. Avoid deeply nested reference chains."\n  ${SPEC_URL}#file-references`,
+      });
+    } else {
+      results.push({
+        rule: "reference-depth",
+        severity: "warn",
+        passed: true,
+        message: `depth ${depth}`,
+      });
+    }
+  } catch {
+    results.push({
+      rule: "reference-exists",
+      severity: "error",
+      passed: false,
+      message: `file not found: ${refPath}`,
+    });
+  }
+
+  return {
+    path: refPath,
+    lines,
+    depth,
+    results,
+  };
+}

--- a/packages/skill-lint/src/rules/tokens.ts
+++ b/packages/skill-lint/src/rules/tokens.ts
@@ -1,0 +1,19 @@
+import { estimateTokens } from "../parse";
+import type { Rule, RuleResult, SkillContent } from "../types";
+
+export const tokensInfo: Rule = {
+  name: "tokens",
+  severity: "info",
+  check(content: SkillContent): RuleResult {
+    const tokens = estimateTokens(content.raw);
+
+    return {
+      rule: "tokens",
+      severity: "info",
+      passed: true,
+      message: `~${tokens.toLocaleString()} (SKILL.md)`,
+    };
+  },
+};
+
+export const tokenRules: Rule[] = [tokensInfo];

--- a/packages/skill-lint/src/types.ts
+++ b/packages/skill-lint/src/types.ts
@@ -1,0 +1,44 @@
+export type Severity = "error" | "warn" | "info";
+
+export interface RuleResult {
+  rule: string;
+  severity: Severity;
+  passed: boolean;
+  message: string;
+  line?: number;
+}
+
+export interface ReferenceResult {
+  path: string;
+  lines: number;
+  depth: number;
+  results: RuleResult[];
+}
+
+export interface SkillLintResult {
+  path: string;
+  errors: number;
+  warnings: number;
+  results: RuleResult[];
+  references: ReferenceResult[];
+  tokens: {
+    skill: number;
+    total: number;
+  };
+}
+
+export interface SkillContent {
+  frontmatter: {
+    name?: string;
+    description?: string;
+    [key: string]: unknown;
+  };
+  body: string;
+  raw: string;
+}
+
+export interface Rule {
+  name: string;
+  severity: Severity;
+  check: (content: SkillContent, path: string) => RuleResult | RuleResult[];
+}

--- a/packages/skill-lint/test/fixtures/invalid-name/SKILL.md
+++ b/packages/skill-lint/test/fixtures/invalid-name/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: Invalid_Name
+description: A skill with an invalid name format.
+---
+
+# Invalid Name
+
+This skill has an invalid name.

--- a/packages/skill-lint/test/fixtures/missing-description/SKILL.md
+++ b/packages/skill-lint/test/fixtures/missing-description/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: missing-desc
+---
+
+# Missing Description
+
+This skill has no description.

--- a/packages/skill-lint/test/fixtures/valid/SKILL.md
+++ b/packages/skill-lint/test/fixtures/valid/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: valid-skill
+description: A valid skill for testing purposes.
+---
+
+# Valid Skill
+
+This is a valid skill body.

--- a/packages/skill-lint/test/fixtures/with-references/SKILL.md
+++ b/packages/skill-lint/test/fixtures/with-references/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: with-refs
+description: A skill with references.
+---
+
+# With References
+
+See the [language guide](references/language.md) for more details.

--- a/packages/skill-lint/test/fixtures/with-references/references/language.md
+++ b/packages/skill-lint/test/fixtures/with-references/references/language.md
@@ -1,0 +1,11 @@
+# Language Guide
+
+This is a reference file with content.
+
+## Section 1
+
+Some content here.
+
+## Section 2
+
+More content here.

--- a/packages/skill-lint/test/rules.test.ts
+++ b/packages/skill-lint/test/rules.test.ts
@@ -1,0 +1,192 @@
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { lintSkill } from "../src/index";
+import { parseSkill } from "../src/parse";
+import {
+  descriptionLength,
+  descriptionRequired,
+  nameConsecutiveHyphens,
+  nameEdgeHyphens,
+  nameFormat,
+  nameLength,
+} from "../src/rules/frontmatter";
+import type { RuleResult } from "../src/types";
+
+const fixturesDir = path.join(import.meta.dirname, "fixtures");
+
+function single(result: RuleResult | RuleResult[]): RuleResult {
+  if (Array.isArray(result)) {
+    throw new Error("Expected single result");
+  }
+  return result;
+}
+
+describe("parseSkill", () => {
+  it("parses frontmatter and body", () => {
+    const content = parseSkill(`---
+name: test
+description: A test skill
+---
+
+# Body
+
+Content here.`);
+
+    expect(content.frontmatter.name).toBe("test");
+    expect(content.frontmatter.description).toBe("A test skill");
+    expect(content.body).toContain("# Body");
+  });
+
+  it("handles missing frontmatter", () => {
+    const content = parseSkill("# No Frontmatter\n\nJust content.");
+
+    expect(content.frontmatter).toEqual({});
+    expect(content.body).toContain("# No Frontmatter");
+  });
+});
+
+describe("frontmatter rules", () => {
+  describe("nameFormat", () => {
+    it("passes for valid names", () => {
+      const content = parseSkill("---\nname: valid-name\n---\n");
+      const result = single(nameFormat.check(content, ""));
+      expect(result.passed).toBe(true);
+    });
+
+    it("fails for uppercase", () => {
+      const content = parseSkill("---\nname: Invalid\n---\n");
+      const result = single(nameFormat.check(content, ""));
+      expect(result.passed).toBe(false);
+    });
+
+    it("fails for underscores", () => {
+      const content = parseSkill("---\nname: invalid_name\n---\n");
+      const result = single(nameFormat.check(content, ""));
+      expect(result.passed).toBe(false);
+    });
+
+    it("allows numbers", () => {
+      const content = parseSkill("---\nname: skill123\n---\n");
+      const result = single(nameFormat.check(content, ""));
+      expect(result.passed).toBe(true);
+    });
+  });
+
+  describe("nameLength", () => {
+    it("passes for short names", () => {
+      const content = parseSkill("---\nname: short\n---\n");
+      const result = single(nameLength.check(content, ""));
+      expect(result.passed).toBe(true);
+    });
+
+    it("fails for names over 64 chars", () => {
+      const longName = "a".repeat(65);
+      const content = parseSkill(`---\nname: ${longName}\n---\n`);
+      const result = single(nameLength.check(content, ""));
+      expect(result.passed).toBe(false);
+    });
+  });
+
+  describe("nameEdgeHyphens", () => {
+    it("passes for valid names", () => {
+      const content = parseSkill("---\nname: valid-name\n---\n");
+      const result = single(nameEdgeHyphens.check(content, ""));
+      expect(result.passed).toBe(true);
+    });
+
+    it("fails for leading hyphen", () => {
+      const content = parseSkill("---\nname: -invalid\n---\n");
+      const result = single(nameEdgeHyphens.check(content, ""));
+      expect(result.passed).toBe(false);
+    });
+
+    it("fails for trailing hyphen", () => {
+      const content = parseSkill("---\nname: invalid-\n---\n");
+      const result = single(nameEdgeHyphens.check(content, ""));
+      expect(result.passed).toBe(false);
+    });
+  });
+
+  describe("nameConsecutiveHyphens", () => {
+    it("passes for single hyphens", () => {
+      const content = parseSkill("---\nname: valid-name\n---\n");
+      const result = single(nameConsecutiveHyphens.check(content, ""));
+      expect(result.passed).toBe(true);
+    });
+
+    it("fails for consecutive hyphens", () => {
+      const content = parseSkill("---\nname: invalid--name\n---\n");
+      const result = single(nameConsecutiveHyphens.check(content, ""));
+      expect(result.passed).toBe(false);
+    });
+  });
+
+  describe("descriptionRequired", () => {
+    it("passes when description exists", () => {
+      const content = parseSkill("---\ndescription: Some description\n---\n");
+      const result = single(descriptionRequired.check(content, ""));
+      expect(result.passed).toBe(true);
+    });
+
+    it("fails when description is missing", () => {
+      const content = parseSkill("---\nname: test\n---\n");
+      const result = single(descriptionRequired.check(content, ""));
+      expect(result.passed).toBe(false);
+    });
+
+    it("fails when description is empty", () => {
+      const content = parseSkill("---\ndescription: ''\n---\n");
+      const result = single(descriptionRequired.check(content, ""));
+      expect(result.passed).toBe(false);
+    });
+  });
+
+  describe("descriptionLength", () => {
+    it("passes for short descriptions", () => {
+      const content = parseSkill("---\ndescription: Short\n---\n");
+      const result = single(descriptionLength.check(content, ""));
+      expect(result.passed).toBe(true);
+    });
+
+    it("fails for descriptions over 1024 chars", () => {
+      const longDesc = "a".repeat(1025);
+      const content = parseSkill(`---\ndescription: ${longDesc}\n---\n`);
+      const result = single(descriptionLength.check(content, ""));
+      expect(result.passed).toBe(false);
+    });
+  });
+});
+
+describe("lintSkill", () => {
+  it("passes valid skill", () => {
+    const result = lintSkill(path.join(fixturesDir, "valid"));
+    expect(result.errors).toBe(0);
+    expect(result.warnings).toBe(0);
+  });
+
+  it("reports invalid name format", () => {
+    const result = lintSkill(path.join(fixturesDir, "invalid-name"));
+    expect(result.errors).toBeGreaterThan(0);
+    const nameError = result.results.find((r) => r.rule === "name-format");
+    expect(nameError?.passed).toBe(false);
+  });
+
+  it("reports missing description", () => {
+    const result = lintSkill(path.join(fixturesDir, "missing-description"));
+    expect(result.errors).toBeGreaterThan(0);
+    const descError = result.results.find((r) => r.rule === "description-required");
+    expect(descError?.passed).toBe(false);
+  });
+
+  it("detects references", () => {
+    const result = lintSkill(path.join(fixturesDir, "with-references"));
+    expect(result.references).toHaveLength(1);
+    expect(result.references[0]?.path).toBe("references/language.md");
+  });
+
+  it("calculates token counts", () => {
+    const result = lintSkill(path.join(fixturesDir, "valid"));
+    expect(result.tokens.skill).toBeGreaterThan(0);
+    expect(result.tokens.total).toBeGreaterThanOrEqual(result.tokens.skill);
+  });
+});

--- a/packages/skill-lint/tsconfig.json
+++ b/packages/skill-lint/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -80,6 +80,10 @@ Keep references one level deep. For files >100 lines, include a table of content
 - Observe navigation patterns
 - Refine based on behavior
 
+## Validation
+
+Run `bunx skill-lint path/to/skill/` to check for issues before committing. CI runs this automatically.
+
 ## References
 
 Load detailed guides as needed:


### PR DESCRIPTION
Adds a `skill-lint` package that validates Claude Code skills against the [Agent Skills specification](https://agentskills.io). All rules include citations with direct quotes and links to the spec.

## Changes

- Validates skill frontmatter: `name` format/length/hyphens, `description` required/length
- Validates body line count and reference file depth
- Outputs results in console or JSON format
- Integrates with CI to run per-plugin via `--files` flag

## Testing

Run `npm test -- packages/skill-lint` to execute unit tests.
