### PR TITLE
type-ignore: use bun instead of npx tsx

### DIFF
--- a/plugins/type-ignore/hooks/hooks.json
+++ b/plugins/type-ignore/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/detect.ts"
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/detect.ts"
           }
         ]
       }


### PR DESCRIPTION
tsx creates IPC pipes that fail with EPERM in the sandbox. Bun runs TypeScript natively without this issue.