### PR TITLE
ci: use glob pattern for dependabot npm directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,26 +6,7 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "npm"
-    directory: "/mcps"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "gomod"
-    directory: "/mcps"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "pip"
-    directory: "/mcps"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "docker"
-    directory: "/mcps"
+    directories:
+      - "/**/*"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
- Use `/**/*` glob pattern to automatically detect all npm packages in the monorepo
- Remove orphaned gomod/pip/docker entries that had no matching manifest files in `/mcps`