### PR TITLE
chore: remove @anthropic-ai/claude-code devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
       },
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.20",
-        "@anthropic-ai/claude-code": "^2.1.20",
         "@biomejs/biome": "^2.3.13",
         "@constellos/claude-code-kit": "^0.4.0",
         "@linear/sdk": "^71.0.0",
@@ -65,29 +64,6 @@
       },
       "peerDependencies": {
         "zod": "^4.0.0"
-      }
-    },
-    "node_modules/@anthropic-ai/claude-code": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.20.tgz",
-      "integrity": "sha512-5r9OEF5TTmkhOKWtJ9RYqdn/vchwQWABO3dvgZVXftqlBZV/IiKjHVISu0dKtqWzByLBolchwePrhY68ul0QrA==",
-      "dev": true,
-      "license": "SEE LICENSE IN README.md",
-      "bin": {
-        "claude": "cli.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "^0.33.5",
-        "@img/sharp-darwin-x64": "^0.33.5",
-        "@img/sharp-linux-arm": "^0.33.5",
-        "@img/sharp-linux-arm64": "^0.33.5",
-        "@img/sharp-linux-x64": "^0.33.5",
-        "@img/sharp-linuxmusl-arm64": "^0.33.5",
-        "@img/sharp-linuxmusl-x64": "^0.33.5",
-        "@img/sharp-win32-x64": "^0.33.5"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.20",
-    "@anthropic-ai/claude-code": "^2.1.20",
     "@biomejs/biome": "^2.3.13",
     "@constellos/claude-code-kit": "^0.4.0",
     "@linear/sdk": "^71.0.0",


### PR DESCRIPTION
Eliminates dependabot noise for a package that doesn't need to be installed via npm.