### PR TITLE
feat(github): add notifications inbox skill

### DIFF
--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -4,7 +4,9 @@ GitHub workflow, Actions monitoring, and rulesets management for Claude Code.
 
 ## Contents
 
-- **Skill**: Best practices for GitHub CLI and MCP tool selection
+- **Skills**:
+  - `gh`: Best practices for GitHub CLI and MCP tool selection
+  - `notifications`: Inbox management (list, filter, mark read/done, unsubscribe)
 - **Agents**:
   - `github-actions-monitor`: Track workflow runs and retrieve failure logs
   - `github-rulesets-manager`: Configure repository rulesets and branch protection

--- a/plugins/github/skills/notifications/SKILL.md
+++ b/plugins/github/skills/notifications/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: notifications
+description: Managing GitHub notifications inbox. Use when listing, filtering, or triaging notifications (mark read, done, unsubscribe).
+---
+
+# GitHub Notifications
+
+Manage the inbox via GraphQL (list) and REST (actions). Requires `notifications` scope.
+
+## Listing (Inbox)
+
+Query: `graphql/inbox.graphql`
+
+```bash
+gh api graphql -f query="$(cat graphql/inbox.graphql)" \
+  --jq '[.data.viewer.notificationThreads.nodes[] | select(.isDone == false)]'
+```
+
+### Fields
+
+| Field | Description |
+|-------|-------------|
+| `id` | GraphQL node ID for mutations |
+| `summaryId` | Numeric ID for REST actions |
+| `isUnread` | Unread status |
+| `isDone` | Done status (hidden from inbox) |
+| `isSaved` | Saved for later |
+| `reason` | `ASSIGN`, `AUTHOR`, `COMMENT`, `MANUAL`, `MENTION`, `REVIEW_REQUESTED`, `SUBSCRIBED`, `CI_ACTIVITY`, `STATE_CHANGE` |
+| `url` | Browser URL (direct, no transform needed) |
+
+## Actions
+
+REST (use `summaryId`):
+
+```bash
+gh api -X PATCH /notifications/threads/{summaryId}                      # Mark read
+gh api -X DELETE /notifications/threads/{summaryId}                     # Mark done
+gh api -X PUT /notifications                                           # Mark all read
+gh api -X DELETE /notifications/threads/{summaryId}/subscription        # Unsubscribe
+gh api -X PUT /notifications/threads/{summaryId}/subscription -f ignored=true  # Mute
+```
+
+GraphQL mutations (use `id`):
+
+```bash
+gh api graphql -f query='mutation { markNotificationAsUnread(input: {id: "{id}"}) { success } }'
+gh api graphql -f query='mutation { markNotificationAsUndone(input: {id: "{id}"}) { success } }'
+```
+
+## Filtering
+
+Filter in jq after the GraphQL query:
+
+```bash
+# By reason
+... --jq '[.data.viewer.notificationThreads.nodes[] | select(.isDone == false and .reason == "MENTION")]'
+
+# Unread only
+... --jq '[.data.viewer.notificationThreads.nodes[] | select(.isDone == false and .isUnread == true)]'
+```
+
+## Bulk Mark Done
+
+```bash
+gh api graphql -f query='...' --jq '.data.viewer.notificationThreads.nodes[] | select(.isDone == false) | .summaryId' | \
+  xargs -I {} gh api -X DELETE /notifications/threads/{}
+```

--- a/plugins/github/skills/notifications/graphql/inbox.graphql
+++ b/plugins/github/skills/notifications/graphql/inbox.graphql
@@ -1,0 +1,16 @@
+query Inbox {
+  viewer {
+    notificationThreads(first: 50, filterBy: {statuses: [UNREAD, READ]}) {
+      nodes {
+        id
+        summaryId
+        title
+        isUnread
+        isDone
+        isSaved
+        reason
+        url
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add skill for managing GitHub notifications inbox, matching the web UI behavior.

## Changes

- Add `notifications` skill with GraphQL listing and REST/GraphQL actions
- Use `notificationThreads` query with `isDone` filtering to match the web inbox exactly
- Document both ID types: `summaryId` for REST actions, `id` for GraphQL mutations
- Extract GraphQL query to `graphql/inbox.graphql` for syntax highlighting

## Notes

Requires `notifications` scope on `gh` token:

```bash
gh auth refresh -h github.com -s notifications
```