### PR TITLE
refactor(pull-request): use bang syntax in update skill

### DIFF
--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -10,24 +10,18 @@ allowed-tools: Bash(gh:*), Bash(git:*), mcp__github
 
 The PR body documents what will happen when merged, not the journey. Don't echo review feedback. Only mention changes if the ultimate result is user-facing.
 
-## Workflow
+## Context
 
-1. Identify the PR number from the current branch:
-   ```
-   gh pr view --json number --jq '.number'
-   ```
-2. Get the repo owner and name:
-   ```
-   gh repo view --json owner,name --jq '[.owner.login, .name] | join(" ")'
-   ```
-3. Fetch PR context via GraphQL using [`assets/pr-context.graphql`](assets/pr-context.graphql):
-   ```
-   gh api graphql -F owner=OWNER -F repo=REPO -F number=NUMBER -f query="$(cat assets/pr-context.graphql)"
-   ```
-4. Filter commits after `lastEditedAt` to identify new work since the body was last written. If `lastEditedAt` is `null` (never edited), treat all commits as new work.
-5. Analyze the changes introduced by those commits.
-6. Rewrite the PR body following the same title and body rules as the create skill. See [`sections.md`](sections.md) for section guidance.
-7. Write the updated body to a temp file and apply:
-   ```
-   gh pr edit NUMBER --body-file tmp/pr-body-<branch>.md
-   ```
+- Branch: !`git branch --show-current`
+- PR: !`gh api graphql -F owner="$(gh repo view --json owner --jq '.owner.login')" -F repo="$(gh repo view --json name --jq '.name')" -F number="$(gh pr view --json number --jq '.number')" -f query="$(cat ${CLAUDE_SKILL_ROOT}/assets/pr-context.graphql)" 2>/dev/null || echo "No PR found for current branch"`
+- Diff: !`gh pr diff 2>/dev/null`
+
+## Analysis
+
+1. Filter commits after `lastEditedAt` to identify new work since the body was last written. If `lastEditedAt` is `null` (never edited), treat all commits as new work.
+2. Analyze the changes introduced by those commits.
+
+## Writing
+
+1. Rewrite the PR body following the same title and body rules as the create skill. See [`sections.md`](sections.md) for section guidance.
+2. Write the updated body to a temp file (e.g., `tmp/pr-body-<branch>.md`) and apply with `gh pr edit --body-file`.


### PR DESCRIPTION
Simplifies the `pull-request:update` skill by using bang syntax to pre-fetch all context at skill load time, matching the pattern used by `pull-request:create`.

## Changes

- Replaces step-by-step workflow instructions with `## Context` section using bang syntax
- Pre-fetches branch name, PR metadata (title, body, `lastEditedAt`, commits) via GraphQL, and PR diff
- Adds error handling for cases with no PR on the current branch
- Streamlines `## Analysis` and `## Writing` sections to focus on what Claude needs to do
