### PR TITLE
chore: remove redundant plugins

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -64,8 +64,6 @@
     "parallel-prs@bendrucker": true,
     "interview@bendrucker": true,
     "linear@claude-plugins-official": true,
-    "ralph-wiggum@claude-code-plugins": true,
-    "code-simplifier@claude-plugins-official": true,
     "github@claude-plugins-official": true,
     "astral@astral-sh": true,
     "personal-review@bendrucker": true,


### PR DESCRIPTION
## Summary

- Remove `code-simplifier@claude-plugins-official` (already available via `pr-review-toolkit`)
- Remove `ralph-wiggum@claude-code-plugins` (unused, external bash loop preferred)

## Test plan

- [ ] Verify PR Review Toolkit still provides code simplification