### PR TITLE
claude-code: avoid bang-backtick syntax in inline code

### DIFF
--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -73,7 +73,7 @@ hooks:                                    # Optional: skill-scoped hooks
 
 ### Dynamic Context Injection
 
-The `!`command`` syntax runs shell commands **before** the skill content is sent to Claude. The command output replaces the placeholder — Claude only sees the final result, not the command.
+The bang-backtick syntax (see examples below) runs shell commands **before** the skill content is sent to Claude. The command output replaces the placeholder — Claude only sees the final result, not the command.
 
 ```markdown
 - PR diff: !`gh pr diff`
@@ -138,7 +138,7 @@ Load detailed guides as needed:
 
 **Common Patterns**: Read-only (`[Read, Grep, Glob]`), Script-based (`[Read, Bash, Write]`), Template-based (`[Read, Write, Edit]`)
 
-**Content Features**: `$ARGUMENTS` / `$N` for arguments, `!`command`` for dynamic context injection
+**Content Features**: `$ARGUMENTS` / `$N` for arguments, bang-backtick for dynamic context injection
 
 **Anti-Patterns**: Windows paths, too many options, vague descriptions, nested references, scripts that punt errors
 

--- a/plugins/claude-code/skills/skill/references/patterns.md
+++ b/plugins/claude-code/skills/skill/references/patterns.md
@@ -43,7 +43,7 @@ For simple edits, modify XML directly.
 
 ## Dynamic Context Injection
 
-The `!`command`` syntax runs shell commands as preprocessing before Claude sees the skill content. The output replaces the placeholder inline, so Claude receives rendered data.
+The bang-backtick syntax runs shell commands as preprocessing before Claude sees the skill content. The output replaces the placeholder inline, so Claude receives rendered data.
 
 ### Syntax
 
@@ -52,11 +52,11 @@ The `!`command`` syntax runs shell commands as preprocessing before Claude sees 
 - Recent commits: !`git log --oneline -5`
 ```
 
-When the skill runs, each `!`command`` executes immediately and its stdout replaces the placeholder. Claude never sees the command — only the output.
+When the skill runs, each bang-backtick expression executes immediately and its stdout replaces the placeholder. Claude never sees the command — only the output.
 
 ### When to Use
 
-Prefer `!`command`` over asking Claude to run the same command with Bash when:
+Prefer bang-backtick over asking Claude to run the same command with Bash when:
 
 - The data is **always needed** — every invocation requires it, so there's no decision for Claude to make
 - The data **shapes the task** — Claude needs the output to understand what to do, not just as supplementary info
@@ -132,7 +132,7 @@ Write a commit message for the staged changes. $ARGUMENTS
 
 Dynamic context works alongside other skill features:
 
-- `$ARGUMENTS` is substituted separately from `!`command``. Both can appear in the same skill.
+- `$ARGUMENTS` is substituted separately from bang-backtick expressions. Both can appear in the same skill.
 - `context: fork` — commands run in the current working directory before the subagent starts. The subagent receives the rendered output.
 - Supporting files — commands only run in `SKILL.md` content, not in referenced files.
 
@@ -140,7 +140,7 @@ Dynamic context works alongside other skill features:
 
 - Commands run in the **project root**, not the skill directory. Use `${CLAUDE_SKILL_ROOT}` to reference skill-local scripts.
 - **stderr is discarded** — only stdout replaces the placeholder.
-- Failed commands produce empty output. Handle this in the command itself: `!`some-cmd 2>/dev/null || echo "unavailable"``
+- Failed commands produce empty output. Handle this in the command itself with a fallback (e.g., `some-cmd 2>/dev/null || echo "unavailable"`).
 - Commands run **synchronously and sequentially**. Avoid slow commands that would delay skill loading.
 
 ## Argument Substitutions


### PR DESCRIPTION
Claude Code's skill parser executes `` !`command` `` patterns even when they appear in inline code formatting. The `claude-code:skill` skill documents this syntax with inline examples, causing the literal word `command` to be executed during skill initialization.

Replace inline code examples with prose ("bang-backtick") to avoid triggering the parser. Code block examples remain unchanged since they demonstrate actual usage.
