### PR TITLE
pull-request: improve skill activation for GitLab

### DIFF
--- a/plugins/pull-request/README.md
+++ b/plugins/pull-request/README.md
@@ -1,9 +1,9 @@
 # pull-request
 
-Create and update pull requests with proper formatting and content guidelines.
+Create and update pull requests (PRs), merge requests (MRs), and change requests (CRs) with proper formatting and content guidelines.
 
 ## Contents
 
-- **Skill**: `pull-request:create` — Guidelines for creating PRs with proper title formatting, body structure, and section organization
-- **Skill**: `pull-request:update` — Update a PR body to reflect the current state of changes
+- **Skill**: `pull-request:create` — Create a PR/MR with proper title formatting, body structure, and section organization
+- **Skill**: `pull-request:update` — Update a PR/MR body to reflect the current state of changes
 - **Hook**: Validates PR body content before creation or edit

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: create
 description: |
-  Create a GitHub pull request (PR) with proper formatting and content guidelines.
-  Invoke this skill whenever the user wants to create, open, or submit a PR (or GitLab MR, Gerrit CR).
+  Create a pull request, merge request, or change request with proper formatting and content guidelines.
+  Invoke when the user wants to create, open, or submit a PR, MR, or CR—including after committing changes.
+
 allowed-tools: Bash(gh:*), Bash(git:*), Bash(glab:*), mcp__github
 ---
 

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: update
 description: |
-  Update a pull request body to reflect the current state of changes. Use when a PR has evolved
-  through additional commits and the body needs to reflect what will be merged.
-allowed-tools: Bash(gh:*), Bash(git:*), mcp__github
+  Update a pull request or merge request body to reflect the current state of changes.
+  Use when a PR/MR has evolved through additional commits and the body needs to reflect what will be merged.
+
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(glab:*), mcp__github
 ---
 
 # Update Pull Request


### PR DESCRIPTION
Make skill descriptions platform-agnostic so they activate reliably in GitLab repos.

## Changes

- Remove "GitHub" as the primary framing from `pull-request:create`
- Explicitly mention "merge request" and "MR" in both skill descriptions
- Add `Bash(glab:*)` to allowed-tools for the `update` skill
- Add "including after committing changes" trigger phrase to `create` skill
