### PR TITLE
personal-review: expand to four-inbox orchestration

### DIFF
--- a/plugins/personal-review/README.md
+++ b/plugins/personal-review/README.md
@@ -1,9 +1,9 @@
 # Personal Review
 
-Cross-tool daily review workflow for Things, Calendar, and other personal tools.
+Cross-tool daily review workflow for Calendar, Things, GitHub, and Linear.
 
 ## Contents
 
 ### Skills
 
-- **review** — Interactive daily review for inbox processing, today planning, and priorities
+- **review** — Interactive daily/weekly review orchestrating four inboxes in fixed order: Calendar → Things → GitHub → Linear

--- a/plugins/personal-review/skills/review/SKILL.md
+++ b/plugins/personal-review/skills/review/SKILL.md
@@ -1,72 +1,91 @@
 ---
 name: review
-description: Interactive daily review workflow for inbox, today, and priorities across Things and Calendar. Use when the user asks for a daily review, morning review, or evening review.
+description: Interactive daily review workflow across Calendar, Things, GitHub, and Linear. Use when the user asks for a daily review, morning review, evening review, or weekly review.
 ---
 
 # Daily Review
 
-Interactive process for clearing inbox, reviewing today, and planning ahead. Orchestrates across Things and Calendar.
+Process four inboxes in fixed order: Calendar → Things → GitHub → Linear.
 
 ## Variants
 
-**Morning Review**: Planning-focused. Process inbox, review today's calendar and tasks, set priorities.
+| Variant | Calendar | Things | GitHub | Linear |
+|---------|----------|--------|--------|--------|
+| Morning | Full scan + prep | Full processing | Full triage | Full review |
+| Evening | Tomorrow preview | Quick triage | Mark read, defer | Skip |
 
-**Evening Review**: Shutdown-focused. Capture loose ends, prepare tomorrow, clear mental load.
+Ask which variant if not specified.
 
 ## Workflow
 
-### Process Inbox
+### 1. Calendar Scan
 
-Load the `things:jxa` skill. Read all inbox items and batch by pattern (project hints, tags, keywords). For each batch, use `AskUserQuestion`:
+See [calendar.md](calendar.md).
 
-- **Schedule**: today, tomorrow, next week, someday
-- **Assign**: to project, area, or standalone
-- **Tag**: add relevant tags
-- **Do it now**: complete quick tasks (1-2 min) immediately
-- **Delete**: if no longer relevant (confirm first)
+Calculate time budget:
+- Available hours (workday minus meetings)
+- Focus windows (90+ min gaps)
+- Meetings needing prep tasks
 
-Process until inbox is empty.
+### 2. Things Inbox
 
-### Review Calendar
+See [things.md](things.md).
 
-Load the `calendar` skill. Check today's events. Surface scheduling conflicts with today's task list. Note any meetings that need preparation tasks.
+Batch items by pattern, ask user for each batch:
+- Schedule (today/tomorrow/next week/someday)
+- Assign (project/area/standalone)
+- Quick do (< 2 min)
+- Delete
 
-### Review Today
+Goal: inbox count = 0
 
-Load the `things:jxa` skill. Read today's tasks, filtering out repeating instances. For stale or unclear items, use `AskUserQuestion`:
+### 3. GitHub Notifications
 
-- **Keep**: remains on today
-- **Defer**: move to tomorrow or upcoming
-- **Clarify**: break into smaller tasks
-- **Complete/Delete**: if done or irrelevant
+See [github.md](github.md).
 
-### Set Priorities (Morning Only)
+Group by reason, typical actions:
 
-Present today's tasks and let the user select priority order. Reorder using the `things:url` skill's reorder script.
+| Reason | Actions |
+|--------|---------|
+| `REVIEW_REQUESTED` | Review now, defer to Things |
+| `ASSIGN` | Review now, defer to Things |
+| `CI_ACTIVITY` | Check status, mark done |
+| `MENTION`/`COMMENT` | Read, respond, mark done |
 
-### Create Follow-ups
+### 4. Linear Inbox
 
-When deferring or breaking down tasks, use `things:url` to create linked follow-ups:
+See [linear.md](linear.md).
 
-```
-things:///show?id=ORIGINAL_ID
-```
+Review assigned issues:
+- **Todo** — start now, keep on radar, defer to Things
+- **In Progress** — check for blockers
 
-### Summary
+### 5. Summary
 
-Display:
-- Items processed from inbox
-- Calendar highlights
+Present progress:
+- Time budget from Calendar
+- Things items processed (inbox now at 0)
+- GitHub notifications triaged (done/deferred)
+- Linear issues reviewed
 - Today's plan in priority order
-- Items deferred
 
-## Evening Variant
+## Defer-to-Things Format
 
-Skip priority setting. Focus on:
+Items deferred from GitHub/Linear:
 
-1. Quick inbox scan (capture remaining thoughts)
-2. Review incomplete today items → defer to tomorrow
-3. Preview tomorrow's calendar and tasks
-4. Confirm tomorrow looks achievable
+- **Title**: `{Source}: {identifier} - {summary}`
+- **Notes**: Markdown link to source
+- **Tags**: Source name (GitHub, Linear)
 
-End with: "Your system is clear. Tomorrow's plan is ready."
+## Skills Used
+
+- `calendar:calendar` — Event queries
+- `things:jxa` — Read Things data
+- `things:url` — Update Things items
+- `things:inbox` — Quick captures
+- `github:notifications` — Notification triage
+- `linear:linear` — Issue queries
+
+## Future
+
+See [automation.md](automation.md) for planned auto-handling patterns.

--- a/plugins/personal-review/skills/review/automation.md
+++ b/plugins/personal-review/skills/review/automation.md
@@ -1,0 +1,43 @@
+# Automation Extension Points
+
+Future automation for common patterns.
+
+## Auto-Handle Candidates
+
+Patterns that could be handled without user input:
+
+### GitHub
+
+- **CI passed on my PR**: Mark done automatically
+- **PR merged**: Mark done automatically
+- **Stale subscription**: Auto-unsubscribe after N ignores
+
+### Linear
+
+- **Blocked issues**: Auto-defer to Things with blocker context
+- **Stale in-progress**: Flag for review if no activity in N days
+
+### Things
+
+- **Repeating inbox items**: Auto-apply last decision
+- **Project-hinted items**: Auto-assign to matching project
+
+## Decision Logging
+
+To enable automation, log decisions:
+
+```json
+{
+  "source": "github",
+  "identifier": "owner/repo#123",
+  "reason": "REVIEW_REQUESTED",
+  "action": "defer",
+  "timestamp": "<ISO 8601>"
+}
+```
+
+Pattern detection from logged decisions enables smart defaults.
+
+## Not Yet Implemented
+
+This file documents extension points. No automation is active yet. All items require user decision.

--- a/plugins/personal-review/skills/review/calendar.md
+++ b/plugins/personal-review/skills/review/calendar.md
@@ -1,0 +1,42 @@
+# Calendar Scan
+
+Query today's events and calculate time budget for focused work.
+
+## Time Budget
+
+Calculate from a standard workday (9am-6pm, 9 hours):
+
+- **Available hours**: Workday minus meeting time
+- **Focus windows**: Gaps of 90+ minutes between meetings
+- **Prep needs**: Meetings requiring preparation tasks
+
+## Query
+
+Load the `calendar:calendar` skill. Query today's events using the date range for today only.
+
+## Analysis
+
+For each event, note:
+- Duration (end - start)
+- Whether it's an all-day event (exclude from meeting time)
+- Whether it requires preparation (complex topics, presentations)
+
+Sum meeting durations to calculate:
+- Total meeting hours
+- Available hours = 9 - meeting hours
+- List focus windows with start time and duration
+
+## Output
+
+Present:
+- Today's events (time, title)
+- Available hours for focused work
+- Focus windows (start time and duration)
+- Meetings needing prep → suggest creating Things tasks
+
+## Evening Variant
+
+Preview tomorrow only:
+- Query tomorrow's date range
+- Summarize event count and total meeting time
+- Flag early meetings (before 10am) or long days (6+ meeting hours)

--- a/plugins/personal-review/skills/review/github.md
+++ b/plugins/personal-review/skills/review/github.md
@@ -1,0 +1,47 @@
+# GitHub Notifications
+
+Triage notifications inbox by reason.
+
+## Query
+
+Load the `github:notifications` skill. Query active notifications (not done).
+
+## Group by Reason
+
+| Reason | Typical Actions |
+|--------|-----------------|
+| `REVIEW_REQUESTED` | Review now, defer to Things |
+| `ASSIGN` | Review now, defer to Things |
+| `CI_ACTIVITY` | Check status, mark done |
+| `MENTION` / `COMMENT` | Read, respond, mark done |
+| `STATE_CHANGE` | Acknowledge, mark done |
+| `SUBSCRIBED` | Read if relevant, unsubscribe if noisy |
+
+## Actions
+
+For each notification, use `AskUserQuestion`:
+
+| Action | API |
+|--------|-----|
+| Mark done | `DELETE /notifications/threads/{summaryId}` |
+| Mark read | `PATCH /notifications/threads/{summaryId}` |
+| Unsubscribe | `DELETE /notifications/threads/{summaryId}/subscription` |
+| Defer to Things | Create task, then mark done |
+
+## Defer to Things
+
+Load the `things:inbox` skill. Create task with:
+
+- **Title**: `GitHub: {identifier} - {title}`
+- **Notes**: Markdown link to notification URL
+- **Tags**: `GitHub`
+
+Example: `GitHub: owner/repo#123 - Fix authentication bug`
+
+## Evening Variant
+
+Simplified triage:
+- Mark read anything already seen
+- Defer blockers (review requests, assignments) to Things
+- Mark done completed CI activity
+- Skip detailed reading

--- a/plugins/personal-review/skills/review/linear.md
+++ b/plugins/personal-review/skills/review/linear.md
@@ -1,0 +1,36 @@
+# Linear Inbox
+
+Review issues assigned to me.
+
+## Query
+
+Load the `linear:linear` skill. Query issues with `assignee: "me"`.
+
+Filter by state:
+- **Todo** — Ready to start
+- **In Progress** — Check for blockers
+
+## Review
+
+For each issue, use `AskUserQuestion`:
+
+| Action | Description |
+|--------|-------------|
+| Start now | Begin working on this issue |
+| Keep on radar | Leave in current state, no action needed |
+| Defer to Things | Create tracking task in Things |
+| Unassign | Remove self, return to backlog |
+
+## Defer to Things
+
+Load the `things:inbox` skill. Create task with:
+
+- **Title**: `Linear: {identifier} - {title}`
+- **Notes**: Markdown link (MCP tools return full URLs)
+- **Tags**: `Linear`
+
+Example: `Linear: ENG-123 - Implement user authentication`
+
+## Evening Variant
+
+Skip entirely. Linear issues are for focused work, not evening triage.

--- a/plugins/personal-review/skills/review/things.md
+++ b/plugins/personal-review/skills/review/things.md
@@ -1,0 +1,43 @@
+# Things Inbox
+
+Process inbox items to zero using batch triage.
+
+## Query
+
+Load the `things:jxa` skill. Query inbox items using `TMInboxListSource`.
+
+## Batch Processing
+
+Group items by pattern:
+- Project hints — items mentioning "PR", "review", or repo names batch as code review
+- Tags — similar tags or topics (e.g., all `errands` items)
+- Keywords — related subjects (e.g., multiple items about the same feature)
+- Source — items captured from same context (e.g., meeting notes)
+
+For each batch, use `AskUserQuestion`:
+
+| Action | Description |
+|--------|-------------|
+| Schedule | today, tomorrow, next week, someday |
+| Assign | to project, area, or standalone |
+| Tag | add relevant tags |
+| Quick do | complete immediately (< 2 min) |
+| Delete | no longer relevant (confirm first) |
+
+## Execution
+
+Load the `things:url` skill for mutations:
+- Use `update` to set `when`, `list-id`, or `tags`
+- Use `add` to create follow-ups if breaking down tasks
+- For quick-do items, mark complete or just tell user to do it now
+
+## Goal
+
+Inbox count = 0
+
+## Evening Variant
+
+Quick triage only:
+- Capture remaining thoughts as new inbox items
+- Defer stale items to tomorrow
+- Skip detailed organization


### PR DESCRIPTION
## Changes

- Restructure the review skill around four inboxes processed in fixed order: Calendar → Things → GitHub → Linear
- Define morning and evening variants with per-inbox behavior (evening skips Linear, simplifies GitHub, previews tomorrow's calendar)
- Extract each inbox into a dedicated reference file with query, action, and evening variant sections
- Standardize a defer-to-Things format for items from GitHub and Linear: `{Source}: {identifier} - {summary}`
- Add `automation.md` documenting future auto-handle candidates and decision logging

## Testing

- Load skill with `/review` and run morning variant to verify all four inboxes process in order
- Run evening variant to confirm Linear is skipped and other inboxes use simplified behavior
