### PR TITLE
biome: add Stop and PreToolUse hooks for validation

### DIFF
--- a/.claude/hooks/biome/fixtures/fixable.ts
+++ b/.claude/hooks/biome/fixtures/fixable.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number): number {
+  return a + b
+}

--- a/.claude/hooks/biome/fixtures/unfixable.ts
+++ b/.claude/hooks/biome/fixtures/unfixable.ts
@@ -1,0 +1,2 @@
+const obj = { key: "value", key: "other" };
+export { obj };

--- a/.claude/hooks/biome/fixtures/valid.ts
+++ b/.claude/hooks/biome/fixtures/valid.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number): number {
+  return a + b;
+}

--- a/.claude/hooks/biome/index.test.ts
+++ b/.claude/hooks/biome/index.test.ts
@@ -1,9 +1,23 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import type { PostToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { processInput, runBiome } from ".";
+import { join } from "node:path";
+import type {
+  PostToolUseHookInput,
+  PreToolUseHookInput,
+  StopHookInput,
+} from "@anthropic-ai/claude-agent-sdk";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  parseTranscript,
+  processInput,
+  processPostToolUse,
+  processPreToolUse,
+  processStop,
+  runBiomeCheck,
+  runBiomeFix,
+} from ".";
+
+const FIXTURES_DIR = join(import.meta.dirname, "fixtures");
 
 let tempDir: string;
 
@@ -23,47 +37,192 @@ function mockPostToolUseInput(
   };
 }
 
-const VALID_TS = `export function add(a: number, b: number): number {
-  return a + b;
+function mockPreToolUseInput(command: string): PreToolUseHookInput {
+  return {
+    session_id: "test-session",
+    hook_event_name: "PreToolUse",
+    tool_name: "Bash",
+    tool_input: { command },
+    transcript_path: "/tmp/transcript.json",
+    cwd: process.cwd(),
+    tool_use_id: "test",
+  };
 }
-`;
 
-const INVALID_TS = `export function add(a, b) {
-  var unused = 1
-  return a + b
+function mockStopHookInput(transcriptPath: string, stopHookActive = false): StopHookInput {
+  return {
+    session_id: "test-session",
+    hook_event_name: "Stop",
+    transcript_path: transcriptPath,
+    cwd: process.cwd(),
+    stop_hook_active: stopHookActive,
+  };
 }
-`;
+
+function createTranscriptContent(files: Array<{ path: string; tool: string }>): string {
+  return files
+    .map((f) =>
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              name: f.tool,
+              input: { file_path: f.path },
+            },
+          ],
+        },
+      }),
+    )
+    .join("\n");
+}
+
+async function copyFixture(name: string, destDir: string): Promise<string> {
+  const source = join(FIXTURES_DIR, name);
+  const dest = join(destDir, `${Date.now()}-${Math.random()}-${name}`);
+  const content = await readFile(source, "utf-8");
+  await writeFile(dest, content);
+  return dest;
+}
 
 describe("biome hook", () => {
-  beforeAll(() => {
-    tempDir = mkdtempSync(join(tmpdir(), "biome-test-"));
-    writeFileSync(join(tempDir, "valid.ts"), VALID_TS);
-    writeFileSync(join(tempDir, "invalid.ts"), INVALID_TS);
+  beforeAll(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "biome-test-"));
   });
 
-  afterAll(() => {
-    rmSync(tempDir, { recursive: true, force: true });
+  afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true });
   });
 
-  describe("processInput", () => {
-    it("returns null for non-Edit/Write tools", () => {
-      const input = mockPostToolUseInput("Read", { file_path: join(tempDir, "valid.ts") });
-      expect(processInput(input)).toBeNull();
+  describe("runBiomeCheck", () => {
+    it("returns null for valid files", async () => {
+      const filePath = await copyFixture("valid.ts", tempDir);
+      expect(await runBiomeCheck(filePath)).toBeNull();
     });
 
-    it("returns null for non-Biome file extensions", () => {
+    it("returns errors for files with fixable issues", async () => {
+      const filePath = await copyFixture("fixable.ts", tempDir);
+      const result = await runBiomeCheck(filePath);
+      expect(result).not.toBeNull();
+      expect(result).toContain("format");
+    });
+
+    it("returns errors for files with unfixable issues", async () => {
+      const filePath = await copyFixture("unfixable.ts", tempDir);
+      const result = await runBiomeCheck(filePath);
+      expect(result).not.toBeNull();
+      expect(result).toContain("noDuplicateObjectKeys");
+    });
+  });
+
+  describe("runBiomeFix", () => {
+    it("fixes auto-fixable issues", async () => {
+      const filePath = await copyFixture("fixable.ts", tempDir);
+      expect(await runBiomeCheck(filePath)).not.toBeNull();
+      await runBiomeFix(filePath);
+      expect(await runBiomeCheck(filePath)).toBeNull();
+    });
+
+    it("does not fix unsafe issues", async () => {
+      const filePath = await copyFixture("unfixable.ts", tempDir);
+      expect(await runBiomeCheck(filePath)).not.toBeNull();
+      await runBiomeFix(filePath);
+      expect(await runBiomeCheck(filePath)).not.toBeNull();
+    });
+  });
+
+  describe("parseTranscript", () => {
+    it("returns empty array for non-existent transcript", async () => {
+      expect(await parseTranscript("/nonexistent/path.jsonl")).toEqual([]);
+    });
+
+    it("extracts file paths from Edit tool uses", async () => {
+      const filePath = await copyFixture("valid.ts", tempDir);
+      const transcriptPath = join(tempDir, `transcript-edit-${Date.now()}.jsonl`);
+      await writeFile(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Edit" }]));
+
+      const files = await parseTranscript(transcriptPath);
+      expect(files).toContain(filePath);
+    });
+
+    it("extracts file paths from Write tool uses", async () => {
+      const filePath = await copyFixture("valid.ts", tempDir);
+      const transcriptPath = join(tempDir, `transcript-write-${Date.now()}.jsonl`);
+      await writeFile(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Write" }]));
+
+      const files = await parseTranscript(transcriptPath);
+      expect(files).toContain(filePath);
+    });
+
+    it("ignores non-Biome files", async () => {
+      const mdPath = join(tempDir, "readme.md");
+      await writeFile(mdPath, "# Test");
+      const transcriptPath = join(tempDir, `transcript-md-${Date.now()}.jsonl`);
+      await writeFile(transcriptPath, createTranscriptContent([{ path: mdPath, tool: "Write" }]));
+
+      const files = await parseTranscript(transcriptPath);
+      expect(files).toEqual([]);
+    });
+
+    it("ignores non-Edit/Write tools", async () => {
+      const filePath = await copyFixture("valid.ts", tempDir);
+      const transcriptPath = join(tempDir, `transcript-read-${Date.now()}.jsonl`);
+      await writeFile(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Read" }]));
+
+      const files = await parseTranscript(transcriptPath);
+      expect(files).toEqual([]);
+    });
+
+    it("deduplicates file paths", async () => {
+      const filePath = await copyFixture("valid.ts", tempDir);
+      const transcriptPath = join(tempDir, `transcript-dup-${Date.now()}.jsonl`);
+      await writeFile(
+        transcriptPath,
+        createTranscriptContent([
+          { path: filePath, tool: "Edit" },
+          { path: filePath, tool: "Edit" },
+        ]),
+      );
+
+      const files = await parseTranscript(transcriptPath);
+      expect(files).toHaveLength(1);
+    });
+
+    it("filters out deleted files", async () => {
+      const transcriptPath = join(tempDir, `transcript-deleted-${Date.now()}.jsonl`);
+      await writeFile(
+        transcriptPath,
+        createTranscriptContent([{ path: "/nonexistent/deleted.ts", tool: "Write" }]),
+      );
+
+      const files = await parseTranscript(transcriptPath);
+      expect(files).toEqual([]);
+    });
+  });
+
+  describe("processPostToolUse", () => {
+    it("returns null for non-Edit/Write tools", async () => {
+      const filePath = await copyFixture("valid.ts", tempDir);
+      const input = mockPostToolUseInput("Read", { file_path: filePath });
+      expect(await processPostToolUse(input)).toBeNull();
+    });
+
+    it("returns null for non-Biome file extensions", async () => {
       const input = mockPostToolUseInput("Write", { file_path: "test.md" });
-      expect(processInput(input)).toBeNull();
+      expect(await processPostToolUse(input)).toBeNull();
     });
 
-    it("returns null when biome check passes", () => {
-      const input = mockPostToolUseInput("Edit", { file_path: join(tempDir, "valid.ts") });
-      expect(processInput(input)).toBeNull();
+    it("returns null when biome check passes", async () => {
+      const filePath = await copyFixture("valid.ts", tempDir);
+      const input = mockPostToolUseInput("Edit", { file_path: filePath });
+      expect(await processPostToolUse(input)).toBeNull();
     });
 
-    it("returns additionalContext when biome finds issues", () => {
-      const input = mockPostToolUseInput("Write", { file_path: join(tempDir, "invalid.ts") });
-      const result = processInput(input);
+    it("returns additionalContext for fixable issues", async () => {
+      const filePath = await copyFixture("fixable.ts", tempDir);
+      const input = mockPostToolUseInput("Write", { file_path: filePath });
+      const result = await processPostToolUse(input);
 
       expect(result).not.toBeNull();
       expect(result?.hookSpecificOutput).toMatchObject({
@@ -73,31 +232,135 @@ describe("biome hook", () => {
       const additionalContext = (result?.hookSpecificOutput as { additionalContext: string })
         .additionalContext;
       expect(additionalContext).toContain("Biome found issues");
-      expect(additionalContext).toContain("noUnusedVariables");
     });
 
-    it("handles Write tool", () => {
-      const input = mockPostToolUseInput("Write", { file_path: join(tempDir, "invalid.ts") });
-      const result = processInput(input);
-      expect(result).not.toBeNull();
-    });
+    it("returns additionalContext for unfixable issues", async () => {
+      const filePath = await copyFixture("unfixable.ts", tempDir);
+      const input = mockPostToolUseInput("Edit", { file_path: filePath });
+      const result = await processPostToolUse(input);
 
-    it("handles Edit tool", () => {
-      const input = mockPostToolUseInput("Edit", { file_path: join(tempDir, "invalid.ts") });
-      const result = processInput(input);
       expect(result).not.toBeNull();
+      const additionalContext = (result?.hookSpecificOutput as { additionalContext: string })
+        .additionalContext;
+      expect(additionalContext).toContain("noDuplicateObjectKeys");
     });
   });
 
-  describe("runBiome", () => {
-    it("returns null when check passes", () => {
-      expect(runBiome(join(tempDir, "valid.ts"))).toBeNull();
+  describe("processStop", () => {
+    it("returns null when stop_hook_active is true", async () => {
+      const filePath = await copyFixture("unfixable.ts", tempDir);
+      const transcriptPath = join(tempDir, `transcript-active-${Date.now()}.jsonl`);
+      await writeFile(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Edit" }]));
+
+      const input = mockStopHookInput(transcriptPath, true);
+      expect(await processStop(input)).toBeNull();
     });
 
-    it("returns error output when check fails", () => {
-      const result = runBiome(join(tempDir, "invalid.ts"));
+    it("returns null when no files were modified", async () => {
+      const transcriptPath = join(tempDir, `transcript-empty-${Date.now()}.jsonl`);
+      await writeFile(transcriptPath, "");
+
+      const input = mockStopHookInput(transcriptPath);
+      expect(await processStop(input)).toBeNull();
+    });
+
+    it("returns null when all files pass biome check", async () => {
+      const filePath = await copyFixture("valid.ts", tempDir);
+      const transcriptPath = join(tempDir, `transcript-valid-${Date.now()}.jsonl`);
+      await writeFile(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Edit" }]));
+
+      const input = mockStopHookInput(transcriptPath);
+      expect(await processStop(input)).toBeNull();
+    });
+
+    it("auto-fixes fixable issues and allows stop", async () => {
+      const filePath = await copyFixture("fixable.ts", tempDir);
+      const transcriptPath = join(tempDir, `transcript-fixable-${Date.now()}.jsonl`);
+      await writeFile(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Write" }]));
+
+      const input = mockStopHookInput(transcriptPath);
+      const result = await processStop(input);
+
+      expect(result).toBeNull();
+      expect(await runBiomeCheck(filePath)).toBeNull();
+    });
+
+    it("returns block decision when issues cannot be auto-fixed", async () => {
+      const filePath = await copyFixture("unfixable.ts", tempDir);
+      const transcriptPath = join(tempDir, `transcript-unfixable-${Date.now()}.jsonl`);
+      await writeFile(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Write" }]));
+
+      const input = mockStopHookInput(transcriptPath);
+      const result = await processStop(input);
+
       expect(result).not.toBeNull();
-      expect(result).toContain("noUnusedVariables");
+      expect(result?.decision).toBe("block");
+      expect(result?.reason).toContain("Biome found issues");
+      expect(result?.reason).toContain("noDuplicateObjectKeys");
+    });
+
+    it("processes multiple files in parallel", async () => {
+      const [validPath, fixablePath, unfixablePath] = await Promise.all([
+        copyFixture("valid.ts", tempDir),
+        copyFixture("fixable.ts", tempDir),
+        copyFixture("unfixable.ts", tempDir),
+      ]);
+
+      const transcriptPath = join(tempDir, `transcript-multi-${Date.now()}.jsonl`);
+      await writeFile(
+        transcriptPath,
+        createTranscriptContent([
+          { path: validPath, tool: "Edit" },
+          { path: fixablePath, tool: "Write" },
+          { path: unfixablePath, tool: "Edit" },
+        ]),
+      );
+
+      const input = mockStopHookInput(transcriptPath);
+      const result = await processStop(input);
+
+      expect(result).not.toBeNull();
+      expect(result?.decision).toBe("block");
+      expect(result?.reason).toContain(unfixablePath);
+      expect(result?.reason).not.toContain(validPath);
+      expect(result?.reason).not.toContain(fixablePath);
+    });
+  });
+
+  describe("processPreToolUse", () => {
+    // Note: Command filtering is handled by the hook matcher in settings.json
+    // The hook itself just checks staged files when invoked
+
+    it("returns null when no staged files", async () => {
+      // In test environment, there are no staged git files
+      const input = mockPreToolUseInput("git commit -m 'test'");
+      expect(await processPreToolUse(input)).toBeNull();
+    });
+  });
+
+  describe("processInput", () => {
+    it("routes PostToolUse events correctly", async () => {
+      const filePath = await copyFixture("unfixable.ts", tempDir);
+      const input = mockPostToolUseInput("Write", { file_path: filePath });
+      const result = await processInput(input);
+
+      expect(result?.hookSpecificOutput).toBeDefined();
+    });
+
+    it("routes Stop events correctly", async () => {
+      const filePath = await copyFixture("unfixable.ts", tempDir);
+      const transcriptPath = join(tempDir, `transcript-route-${Date.now()}.jsonl`);
+      await writeFile(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Write" }]));
+
+      const input = mockStopHookInput(transcriptPath);
+      const result = await processInput(input);
+
+      expect(result?.decision).toBe("block");
+    });
+
+    it("returns null for unknown event types", async () => {
+      const input = { hook_event_name: "Unknown" } as unknown as PostToolUseHookInput;
+      expect(await processInput(input)).toBeNull();
     });
   });
 });

--- a/.claude/hooks/biome/index.ts
+++ b/.claude/hooks/biome/index.ts
@@ -1,13 +1,32 @@
 #!/usr/bin/env bun
 
-import { execSync } from "node:child_process";
-import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { exec } from "node:child_process";
+import { access, readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import type {
+  PostToolUseHookInput,
+  PreToolUseHookInput,
+  StopHookInput,
+  SyncHookJSONOutput,
+} from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
-export type WriteInput = { file_path: string };
-export type EditInput = { file_path: string };
+const execAsync = promisify(exec);
 
 const BIOME_EXTENSIONS = new Set(["ts", "tsx", "js", "jsx", "json", "jsonc"]);
+
+type HookInput = PostToolUseHookInput | PreToolUseHookInput | StopHookInput;
+
+interface TranscriptEntry {
+  type?: string;
+  message?: {
+    content?: Array<{
+      type: string;
+      name?: string;
+      input?: { file_path?: string };
+    }>;
+  };
+}
 
 function getExtension(filePath: string): string {
   const parts = filePath.split(".");
@@ -19,21 +38,65 @@ function isBiomeFile(filePath: string): boolean {
   return BIOME_EXTENSIONS.has(ext);
 }
 
-function hasBiome(): boolean {
+async function fileExists(filePath: string): Promise<boolean> {
   try {
-    execSync("command -v biome", { stdio: ["pipe", "pipe", "pipe"] });
+    await access(filePath);
     return true;
   } catch {
     return false;
   }
 }
 
-export function runBiome(filePath: string): string | null {
+async function hasBiome(): Promise<boolean> {
   try {
-    execSync(`biome check "${filePath}"`, {
-      encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+    await execAsync("command -v biome");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function parseTranscript(transcriptPath: string): Promise<string[]> {
+  if (!(await fileExists(transcriptPath))) {
+    return [];
+  }
+
+  const content = await readFile(transcriptPath, "utf-8");
+  const files = new Set<string>();
+  const existChecks: Array<Promise<{ path: string; exists: boolean }>> = [];
+
+  for (const line of content.split("\n")) {
+    if (!line.trim()) continue;
+
+    try {
+      const entry = JSON.parse(line) as TranscriptEntry;
+      if (entry.type !== "assistant" || !entry.message?.content) continue;
+
+      for (const block of entry.message.content) {
+        if (block.type !== "tool_use") continue;
+        if (block.name !== "Edit" && block.name !== "Write") continue;
+
+        const filePath = block.input?.file_path;
+        if (filePath && isBiomeFile(filePath)) {
+          existChecks.push(fileExists(filePath).then((exists) => ({ path: filePath, exists })));
+        }
+      }
+    } catch {}
+  }
+
+  const results = await Promise.all(existChecks);
+  for (const { path, exists } of results) {
+    if (exists) {
+      files.add(path);
+    }
+  }
+
+  return [...files];
+}
+
+export async function runBiomeCheck(filePath: string): Promise<string | null> {
+  try {
+    await execAsync(`biome check "${filePath}"`);
     return null;
   } catch (error) {
     const execError = error as { stdout?: string; stderr?: string };
@@ -42,51 +105,170 @@ export function runBiome(filePath: string): string | null {
   }
 }
 
-export function formatOutput(additionalContext: string): SyncHookJSONOutput {
+export async function runBiomeFix(filePath: string): Promise<void> {
+  try {
+    await execAsync(`biome check --write "${filePath}"`);
+  } catch {
+    // biome check --write exits non-zero if there are unfixable issues
+  }
+}
+
+function formatPostToolUseOutput(filePath: string, errors: string): SyncHookJSONOutput {
   return {
     hookSpecificOutput: {
       hookEventName: "PostToolUse",
-      additionalContext,
+      additionalContext: `Biome found issues in ${filePath}:\n\n${errors}\n\nFix these issues.`,
     },
   };
 }
 
-export function processInput(input: PostToolUseHookInput): SyncHookJSONOutput | null {
+function formatStopOutput(issues: Map<string, string>): SyncHookJSONOutput {
+  const details = [...issues.entries()].map(([file, errors]) => `${file}:\n${errors}`).join("\n\n");
+
+  return {
+    decision: "block",
+    reason: `Biome found issues that could not be auto-fixed:\n\n${details}\n\nFix these issues before stopping.`,
+  };
+}
+
+export async function processPostToolUse(
+  input: PostToolUseHookInput,
+): Promise<SyncHookJSONOutput | null> {
   const toolName = input.tool_name;
-
-  let filePath: string;
-  if (toolName === "Write") {
-    filePath = (input.tool_input as WriteInput).file_path;
-  } else if (toolName === "Edit") {
-    filePath = (input.tool_input as EditInput).file_path;
-  } else {
+  if (toolName !== "Edit" && toolName !== "Write") {
     return null;
   }
 
-  if (!isBiomeFile(filePath)) {
+  const filePath = (input.tool_input as { file_path?: string }).file_path;
+  if (!filePath || !isBiomeFile(filePath)) {
     return null;
   }
 
-  if (!hasBiome()) {
+  if (!(await hasBiome())) {
     return null;
   }
 
-  const errors = runBiome(filePath);
+  const errors = await runBiomeCheck(filePath);
   if (!errors) {
     return null;
   }
 
-  return formatOutput(`Biome found issues in ${filePath}:
+  return formatPostToolUseOutput(filePath, errors);
+}
 
-${errors}
+export async function processStop(input: StopHookInput): Promise<SyncHookJSONOutput | null> {
+  if (input.stop_hook_active) {
+    return null;
+  }
 
-Fix these issues before continuing.`);
+  if (!(await hasBiome())) {
+    return null;
+  }
+
+  const files = await parseTranscript(input.transcript_path);
+  if (files.length === 0) {
+    return null;
+  }
+
+  await Promise.all(files.map(runBiomeFix));
+
+  const checkResults = await Promise.all(
+    files.map(async (file) => ({ file, errors: await runBiomeCheck(file) })),
+  );
+
+  const remainingIssues = new Map<string, string>();
+  for (const { file, errors } of checkResults) {
+    if (errors) {
+      remainingIssues.set(file, errors);
+    }
+  }
+
+  if (remainingIssues.size === 0) {
+    return null;
+  }
+
+  return formatStopOutput(remainingIssues);
+}
+
+async function getStagedBiomeFiles(): Promise<string[]> {
+  try {
+    const { stdout } = await execAsync("git diff --cached --name-only --diff-filter=ACMR");
+    const files = stdout
+      .trim()
+      .split("\n")
+      .filter((f) => f && isBiomeFile(f));
+
+    const cwd = process.cwd();
+    const existChecks = files.map(async (f) => {
+      const fullPath = f.startsWith("/") ? f : `${cwd}/${f}`;
+      return { path: fullPath, exists: await fileExists(fullPath) };
+    });
+
+    const results = await Promise.all(existChecks);
+    return results.filter((r) => r.exists).map((r) => r.path);
+  } catch {
+    return [];
+  }
+}
+
+function formatPreToolUseBlockOutput(issues: Map<string, string>): SyncHookJSONOutput {
+  const details = [...issues.entries()].map(([file, errors]) => `${file}:\n${errors}`).join("\n\n");
+
+  return {
+    decision: "block",
+    reason: `Biome found issues in staged files:\n\n${details}\n\nFix these issues before committing.`,
+  };
+}
+
+export async function processPreToolUse(
+  _input: PreToolUseHookInput,
+): Promise<SyncHookJSONOutput | null> {
+  if (!(await hasBiome())) {
+    return null;
+  }
+
+  const files = await getStagedBiomeFiles();
+  if (files.length === 0) {
+    return null;
+  }
+
+  await Promise.all(files.map(runBiomeFix));
+
+  const checkResults = await Promise.all(
+    files.map(async (file) => ({ file, errors: await runBiomeCheck(file) })),
+  );
+
+  const remainingIssues = new Map<string, string>();
+  for (const { file, errors } of checkResults) {
+    if (errors) {
+      remainingIssues.set(file, errors);
+    }
+  }
+
+  if (remainingIssues.size === 0) {
+    return null;
+  }
+
+  return formatPreToolUseBlockOutput(remainingIssues);
+}
+
+export async function processInput(input: HookInput): Promise<SyncHookJSONOutput | null> {
+  if (input.hook_event_name === "PreToolUse") {
+    return processPreToolUse(input as PreToolUseHookInput);
+  }
+  if (input.hook_event_name === "PostToolUse") {
+    return processPostToolUse(input as PostToolUseHookInput);
+  }
+  if (input.hook_event_name === "Stop") {
+    return processStop(input as StopHookInput);
+  }
+  return null;
 }
 
 async function main(): Promise<void> {
-  let input: PostToolUseHookInput;
+  let input: HookInput;
   try {
-    input = await readStdinJson<PostToolUseHookInput>();
+    input = await readStdinJson<HookInput>();
   } catch (error) {
     console.error(
       `[biome] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -94,7 +276,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const output = processInput(input);
+  const output = await processInput(input);
   if (output) {
     writeStdoutJson(output);
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,34 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash(git commit:*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/biome\""
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",
-            "command": "bun ./.claude/hooks/biome"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/biome\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/biome\""
           }
         ]
       }

--- a/biome.json
+++ b/biome.json
@@ -29,6 +29,15 @@
   },
   "overrides": [
     {
+      "includes": ["**/fixtures/**"],
+      "linter": {
+        "enabled": false
+      },
+      "formatter": {
+        "enabled": false
+      }
+    },
+    {
       "includes": ["**/*.d.ts"],
       "linter": {
         "enabled": false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,6 @@
     "moduleDetection": "force",
     "skipLibCheck": true
   },
-  "include": ["./**/*.ts", ".claude/**/*.ts"]
+  "include": ["./**/*.ts", ".claude/**/*.ts"],
+  "exclude": ["**/fixtures/**"]
 }


### PR DESCRIPTION
Expands the Biome hook from a simple PostToolUse check to a multi-event system that provides guidance during editing and enforces validation before commits and session exit.

## Changes

- **PostToolUse** (`Edit|Write`): Non-blocking feedback on individual file edits as guidance
- **PreToolUse** (`Bash(git commit:*)`): Blocks commits if staged Biome files have unfixable errors after auto-fix
- **Stop**: Parses transcript to find all modified files, auto-fixes what it can, blocks exit if unfixable issues remain

The hook now uses async operations throughout for parallel file processing. Command filtering for `git commit` is handled entirely by hook matchers rather than custom code.

## Testing

- Added test fixtures (`valid.ts`, `fixable.ts`, `unfixable.ts`) with distinct Biome behaviors
- Tests copy fixtures to temp directories where Biome still checks them (fixtures dir is excluded in `biome.json`)
- Covers transcript parsing, auto-fix behavior, blocking decisions, and event routing
