### PR TITLE
tech-spec: add plugin for creating and reviewing technical specifications

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -165,6 +165,11 @@
       "name": "mermaid",
       "description": "Create, validate, and render Mermaid diagrams",
       "source": "./plugins/mermaid"
+    },
+    {
+      "name": "tech-spec",
+      "description": "Create and review technical specifications",
+      "source": "./plugins/tech-spec"
     }
   ]
 }

--- a/plugins/tech-spec/.claude-plugin/plugin.json
+++ b/plugins/tech-spec/.claude-plugin/plugin.json
@@ -1,0 +1,4 @@
+{
+  "name": "tech-spec",
+  "description": "Create technical specifications through interactive planning and expert review"
+}

--- a/plugins/tech-spec/README.md
+++ b/plugins/tech-spec/README.md
@@ -1,0 +1,14 @@
+# Tech Spec
+
+Create and review technical specifications through interactive planning and expert review.
+
+## Contents
+
+- **Skills**:
+  - `create`: Interactive workflow for authoring a technical specification from product requirements
+  - `review`: Expert review of an existing tech spec to surface gaps and improvements
+
+## Dependencies
+
+- `interview`: Planning interview via `interview:plan`
+- `mermaid`: Architecture diagrams via `mermaid:diagram`

--- a/plugins/tech-spec/skills/create/SKILL.md
+++ b/plugins/tech-spec/skills/create/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: create
+description: |
+  Create a technical specification through interactive planning and expert review. Use when starting a new feature or project that needs documented architecture, implementation approach, and design decisions. Invoke with product requirements (PRD, brief, or similar).
+---
+
+# Create Technical Specification
+
+## Workflow
+
+### Gather Inputs
+
+Ask the user to provide:
+
+- **Product requirements**: PRD, product brief, or similar. Accept local files (`@path/to/file.md`), URLs (fetch via appropriate tools), or pasted content.
+- **Project tracking context**: A project, epic, or initiative in their task management system (Linear, GitHub, Jira, etc.). Use available MCP tools to fetch details.
+- **Output path**: Where to write the spec (e.g., `tmp/feature-tech-spec.md`).
+
+Be flexible about input sources. Don't assume specific tools or formats.
+
+### Explore Codebases
+
+Discuss with the user which repositories need exploration:
+
+- Suggest likely candidates based on the project scope
+- Ask the user to confirm or identify additional repos
+- Dispatch background explore agents for breadth-first discovery while the user is away
+
+Scan for:
+- Relevant existing patterns and conventions
+- Database schemas and models
+- API structure and routing
+- Frontend component architecture
+- Infrastructure and deployment configuration
+
+### Planning Interview
+
+Invoke `interview:plan` to clarify requirements. Guide the interview toward:
+
+- Requirements clarification
+- Scope boundaries (what's in, what's out)
+- Technical constraints
+- Integration points
+- Rollout strategy
+
+### Write Initial Draft
+
+Write incrementally to the output file. Use the template structure from [references/template.md](references/template.md).
+
+For architecture diagrams, always use `mermaid:diagram` to ensure proper syntax and rendering.
+
+Write sections incrementally.
+
+### Expert Review
+
+Invoke `tech-spec:review` on the draft spec.
+
+### Iterate
+
+Continue refining until the user is satisfied. Long sessions with incremental changes create drift—validate consistency before concluding:
+
+- **Stale references**: Scope changes in one section may leave dangling references elsewhere
+- **Contradictions**: Later decisions may conflict with earlier sections
+- **Orphaned details**: Implementation details that no longer match the architecture
+- **Milestone alignment**: Ensure milestones still reflect the current scope
+
+Also address:
+- Expanding under-specified sections
+- Adding missing edge cases or error handling
+- Refining milestones for incremental delivery
+
+## Design Decisions Table
+
+Captures architecture trade-offs:
+
+| Decision | Choice | Alternatives | Rationale | Notes |
+|----------|--------|--------------|-----------|-------|
+| Brief description | What we chose | What we didn't | Why this choice | Caveats, follow-ups |
+
+Populate this table throughout the process as decisions emerge. Focus on:
+- Choices that required deliberation
+- Trade-offs between valid alternatives
+- Decisions that future readers would question
+
+Capture decision highlights, not interview dialogue.
+
+## Style
+
+- Describe structure and approach, not implementation details
+- Use Mermaid for architecture diagrams
+- Reference related code, docs, and issues inline

--- a/plugins/tech-spec/skills/create/references/template.md
+++ b/plugins/tech-spec/skills/create/references/template.md
@@ -1,0 +1,61 @@
+# Template Structure
+
+## Required Sections
+
+### Title
+
+The feature or project name.
+
+### Problem
+
+Restate the problem from product requirements. Keep it concise.
+
+### Architecture
+
+High-level system design:
+
+- **Diagram**: Mermaid flowchart showing components and data flow (use `mermaid:diagram`)
+- **Data Flow**: Numbered steps explaining the sequence
+- **Design Decisions**: Table capturing trade-offs (see main skill for format)
+
+### Implementation
+
+Scaffolding for the technical work. Subsections vary by project. Common categories:
+
+| Section | When to Include |
+|---------|-----------------|
+| Database | Schema changes, new tables, migrations |
+| API | New endpoints, request/response schemas |
+| App | Frontend components, state management |
+| Infrastructure | Secrets, environment variables, deployment |
+| Services | Background jobs, integrations, external APIs |
+| Security | Auth, permissions, data protection |
+
+Adapt based on what's relevant. Add sections as needed during exploration.
+
+For each subsection:
+- Code snippets only when they clarify the change
+- Reference existing patterns in the codebase
+- Note dependencies between components
+
+### Milestones
+
+Incremental delivery plan:
+
+- What logical units can ship independently?
+- Customer-facing value at each stage?
+- Feature flag strategy
+- Internal testing approach
+
+Focus on deliverables and validation, not implementation.
+
+### References
+
+Links to related resources:
+
+- Project tracking (Linear project, GitHub milestone, etc.)
+- Product requirements document
+- Related documentation
+- External API docs or specs
+
+High-level navigation; prefer inline links elsewhere.

--- a/plugins/tech-spec/skills/review/SKILL.md
+++ b/plugins/tech-spec/skills/review/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: review
+description: |
+  Review a technical specification through expert lenses. Use to identify gaps, risks, and missing considerations in an existing spec. Works on any tech spec, not just those created with tech-spec:create.
+---
+
+# Review Technical Specification
+
+## Inputs
+
+Ask the user to provide:
+
+- **Tech spec**: Path to the specification file, or pasted content
+- **Focus areas** (optional): Specific concerns to prioritize (e.g., "security", "API design")
+- **Repositories** (optional): Codebases to consult when verifying spec claims
+
+## Code Exploration
+
+When repositories are provided, consult code to verify:
+- Proposed patterns match existing conventions
+- Referenced files and structures exist
+- Implementation assumptions are accurate
+
+Explore on demand during review rather than upfront.
+
+## Review Process
+
+### Identify Expert Perspectives
+
+Select relevant personas from [references/experts.md](references/experts.md):
+- Always include standard personas (security, API, database, etc.)
+- Add dynamic personas based on spec content (integrations, analytics, etc.)
+- User-specified focus areas get priority
+
+### Conduct Review
+
+For each relevant persona:
+
+1. Scan the spec for areas within their expertise
+2. Identify findings: gaps, risks, unclear decisions, missing considerations
+3. Rate severity: blocking, important, or nice-to-have
+
+### Present Findings
+
+Group related findings into batches and present via `AskUserQuestion`:
+
+- Batch by persona or topic when findings cluster naturally
+- Present individually when no natural grouping exists
+- Include severity and recommendations
+
+### Interview for Resolution
+
+For findings with meaningful trade-offs:
+- Discuss alternatives with the user
+- Capture decisions in the Design Decisions table
+- Update the spec with resolutions
+
+### Update Spec
+
+Apply agreed changes directly to the spec file:
+- Add missing sections or considerations
+- Expand the Design Decisions table
+- Clarify ambiguous areas

--- a/plugins/tech-spec/skills/review/references/experts.md
+++ b/plugins/tech-spec/skills/review/references/experts.md
@@ -1,0 +1,38 @@
+# Expert Review Personas
+
+## Standard Personas
+
+Always consider these perspectives:
+
+| Persona | Focus Areas |
+|---------|-------------|
+| Security | Auth, data protection, input validation, secrets management |
+| API design | Endpoint structure, naming, versioning, error handling |
+| Database | Schema design, indexing, migrations, query performance |
+| Frontend | Component structure, state management, user experience |
+| Infrastructure | Deployment, secrets, environment config, observability |
+| Reliability | Error handling, retries, fallbacks, graceful degradation |
+
+## Dynamic Personas
+
+Generate additional personas based on spec content:
+
+| Persona | When to Include |
+|---------|-----------------|
+| Integrations | Connecting to external APIs (Linear, Stripe, etc.) |
+| Privacy | Handling user data or PII |
+| Performance | Latency or throughput is critical |
+| Accessibility | Adding user-facing features |
+| Mobile | Changes affect mobile clients |
+| Analytics | Adding telemetry or metrics |
+| Data pipelines | ETL, batch processing, or data warehousing |
+
+## Example Finding Batch
+
+> **Security Findings**
+>
+> 1. API key storage: spec mentions environment variable but doesn't specify secret rotation strategy
+> 2. Input validation: feedback comment has max length but no sanitization mentioned
+> 3. Rate limiting: no mention of rate limits on feedback endpoint
+>
+> How should we address these?


### PR DESCRIPTION
Add a plugin for creating and reviewing technical specifications through interactive planning and expert review.

## Changes

- `tech-spec:create`: Interactive workflow for authoring a tech spec from product requirements
  - Gathers inputs (requirements doc, project tracking, output path)
  - Dispatches background explore agents for codebase discovery
  - Invokes `interview:plan` for requirements clarification
  - Writes incrementally using `mermaid:diagram` for architecture
  - Invokes `tech-spec:review` for expert review
  - Validates consistency after long sessions with incremental changes

- `tech-spec:review`: Standalone expert review of any tech spec
  - Standard personas: Security, API design, Database, Frontend, Infrastructure, Reliability
  - Dynamic personas based on spec content (Integrations, Privacy, Performance, etc.)
  - Groups findings into batches for interview resolution
  - Captures trade-offs in a Design Decisions table

## Dependencies

- `interview` plugin for `interview:plan`
- `mermaid` plugin for `mermaid:diagram`
