### PR TITLE
pull-request: add worktree-aware PR skills

### DIFF
--- a/plugins/pull-request/README.md
+++ b/plugins/pull-request/README.md
@@ -7,3 +7,14 @@ Create and update pull requests (PRs), merge requests (MRs), and change requests
 - **Skill**: `pull-request:create` — Create a PR/MR with proper title formatting, body structure, and section organization
 - **Skill**: `pull-request:update` — Update a PR/MR body to reflect the current state of changes
 - **Hook**: Validates PR body content before creation or edit
+
+## Worktree Support
+
+Both skills support targeting branches in separate git worktrees. When invoking from a default branch (main/master), specify the target branch as an argument:
+
+```
+/pull-request:create feature/my-branch
+/pull-request:update feature/my-branch
+```
+
+The skills resolve the branch to its worktree path and run git/gh commands there. When already in a feature branch worktree, the argument is optional.

--- a/plugins/pull-request/scripts/pr-context.sh
+++ b/plugins/pull-request/scripts/pr-context.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Fetch PR context for update skill
+# Args: <branch> <graphql-query-file>
+
+branch="$1"
+query_file="$2"
+script_dir="${0%/*}"
+wt_gh="$script_dir/wt-gh.sh"
+
+owner=$("$wt_gh" "$branch" repo view --json owner --jq '.owner.login') || exit 1
+repo=$("$wt_gh" "$branch" repo view --json name --jq '.name') || exit 1
+number=$("$wt_gh" "$branch" pr view --json number --jq '.number') || exit 1
+
+"$wt_gh" "$branch" api graphql \
+  -F owner="$owner" \
+  -F repo="$repo" \
+  -F number="$number" \
+  -f query="$(cat "$query_file")"

--- a/plugins/pull-request/scripts/test-utils.ts
+++ b/plugins/pull-request/scripts/test-utils.ts
@@ -1,0 +1,52 @@
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+export interface TestRepo {
+  repoPath: string;
+  worktreePath: string;
+  cleanup: () => void;
+}
+
+export function createTestRepo(prefix: string): TestRepo {
+  const repoPath = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`)));
+  const worktreePath = `${repoPath}-wt`;
+
+  execSync("git init -q -b main", { cwd: repoPath, stdio: "pipe" });
+  execSync('git config user.email "test@example.com"', { cwd: repoPath, stdio: "pipe" });
+  execSync('git config user.name "Test User"', { cwd: repoPath, stdio: "pipe" });
+  fs.writeFileSync(path.join(repoPath, "README.md"), "# Test");
+  execSync("git add README.md", { cwd: repoPath, stdio: "pipe" });
+  execSync('git commit -q -m "Initial commit"', { cwd: repoPath, stdio: "pipe" });
+
+  return {
+    repoPath,
+    worktreePath,
+    cleanup() {
+      try {
+        execSync(`git worktree remove "${worktreePath}" --force 2>/dev/null || true`, {
+          cwd: repoPath,
+          stdio: "pipe",
+        });
+      } catch {
+        // ignore
+      }
+      fs.rmSync(repoPath, { recursive: true, force: true });
+      if (fs.existsSync(worktreePath)) {
+        fs.rmSync(worktreePath, { recursive: true, force: true });
+      }
+    },
+  };
+}
+
+export function createRunner(scriptPath: string) {
+  return function runScript(args: string[], cwd?: string): string {
+    const quotedArgs = args.map((a) => `"${a}"`).join(" ");
+    return execSync(`"${scriptPath}" ${quotedArgs}`, {
+      encoding: "utf-8",
+      cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  };
+}

--- a/plugins/pull-request/scripts/wt-gh.sh
+++ b/plugins/pull-request/scripts/wt-gh.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Worktree-aware gh wrapper
+# Args: <branch> <gh-subcommand...>
+
+branch="$1"; shift
+wt_path=$("${0%/*}/wt-resolve.sh" "$branch")
+if [ -n "$wt_path" ]; then
+  cd "$wt_path" || exit 1
+fi
+exec gh "$@"

--- a/plugins/pull-request/scripts/wt-gh.test.ts
+++ b/plugins/pull-request/scripts/wt-gh.test.ts
@@ -1,0 +1,27 @@
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createRunner, createTestRepo, type TestRepo } from "./test-utils";
+
+const runScript = createRunner(path.join(import.meta.dirname, "wt-gh.sh"));
+
+describe("wt-gh.sh", () => {
+  let repo: TestRepo;
+
+  beforeEach(() => {
+    repo = createTestRepo("wt-gh-test");
+  });
+
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  it("passes through when no branch argument given", () => {
+    const result = runScript(["", "--version"], repo.repoPath);
+    expect(result).toMatch(/gh version/);
+  });
+
+  it("runs in current directory when branch not in worktree", () => {
+    const result = runScript(["nonexistent-branch", "--version"], repo.repoPath);
+    expect(result).toMatch(/gh version/);
+  });
+});

--- a/plugins/pull-request/scripts/wt-git.sh
+++ b/plugins/pull-request/scripts/wt-git.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Worktree-aware git wrapper
+# Args: <branch> <git-subcommand...>
+
+branch="$1"; shift
+wt_path=$("${0%/*}/wt-resolve.sh" "$branch")
+exec git ${wt_path:+-C "$wt_path"} "$@"

--- a/plugins/pull-request/scripts/wt-git.test.ts
+++ b/plugins/pull-request/scripts/wt-git.test.ts
@@ -1,0 +1,48 @@
+import { execSync } from "node:child_process";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createRunner, createTestRepo, type TestRepo } from "./test-utils";
+
+const runScript = createRunner(path.join(import.meta.dirname, "wt-git.sh"));
+
+describe("wt-git.sh", () => {
+  let repo: TestRepo;
+
+  beforeEach(() => {
+    repo = createTestRepo("wt-git-test");
+  });
+
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  it("passes through when no branch argument given", () => {
+    const result = runScript(["", "branch", "--show-current"], repo.repoPath);
+    expect(result).toBe("main");
+  });
+
+  it("runs in current directory when branch not in worktree", () => {
+    const result = runScript(["nonexistent-branch", "branch", "--show-current"], repo.repoPath);
+    expect(result).toBe("main");
+  });
+
+  it("resolves branch to worktree path and runs there", () => {
+    execSync(`git worktree add "${repo.worktreePath}" -b feature-branch`, {
+      cwd: repo.repoPath,
+      stdio: "pipe",
+    });
+
+    const result = runScript(["feature-branch", "branch", "--show-current"], repo.repoPath);
+    expect(result).toBe("feature-branch");
+  });
+
+  it("handles branches with slashes in name", () => {
+    execSync(`git worktree add "${repo.worktreePath}" -b feature/nested/branch`, {
+      cwd: repo.repoPath,
+      stdio: "pipe",
+    });
+
+    const result = runScript(["feature/nested/branch", "branch", "--show-current"], repo.repoPath);
+    expect(result).toBe("feature/nested/branch");
+  });
+});

--- a/plugins/pull-request/scripts/wt-resolve.sh
+++ b/plugins/pull-request/scripts/wt-resolve.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Resolve branch to worktree path
+# Outputs the worktree path if found, empty otherwise
+# Args: <branch>
+
+branch="$1"
+[ -z "$branch" ] && exit 0
+
+git worktree list --porcelain 2>/dev/null | awk -v b="refs/heads/$branch" '
+  /^worktree/ { p = $2 }
+  /^branch/ { if ($2 == b) print p }
+'

--- a/plugins/pull-request/scripts/wt-resolve.test.ts
+++ b/plugins/pull-request/scripts/wt-resolve.test.ts
@@ -1,0 +1,48 @@
+import { execSync } from "node:child_process";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createRunner, createTestRepo, type TestRepo } from "./test-utils";
+
+const runScript = createRunner(path.join(import.meta.dirname, "wt-resolve.sh"));
+
+describe("wt-resolve.sh", () => {
+  let repo: TestRepo;
+
+  beforeEach(() => {
+    repo = createTestRepo("wt-resolve-test");
+  });
+
+  afterEach(() => {
+    repo.cleanup();
+  });
+
+  it("outputs nothing when branch is empty", () => {
+    const result = runScript([""], repo.repoPath);
+    expect(result).toBe("");
+  });
+
+  it("outputs nothing when branch not in worktree", () => {
+    const result = runScript(["nonexistent-branch"], repo.repoPath);
+    expect(result).toBe("");
+  });
+
+  it("outputs worktree path when branch exists in worktree", () => {
+    execSync(`git worktree add "${repo.worktreePath}" -b feature-branch`, {
+      cwd: repo.repoPath,
+      stdio: "pipe",
+    });
+
+    const result = runScript(["feature-branch"], repo.repoPath);
+    expect(result).toBe(repo.worktreePath);
+  });
+
+  it("handles branches with slashes in name", () => {
+    execSync(`git worktree add "${repo.worktreePath}" -b feature/nested/branch`, {
+      cwd: repo.repoPath,
+      stdio: "pipe",
+    });
+
+    const result = runScript(["feature/nested/branch"], repo.repoPath);
+    expect(result).toBe(repo.worktreePath);
+  });
+});

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -11,10 +11,10 @@ allowed-tools: Bash(gh:*), Bash(git:*), Bash(glab:*), mcp__github
 
 ## Context
 
-- Status: !`git status --short`
-- Branch: !`git branch --show-current`
-- Log: !`git log --oneline -20`
-- Diff: !`git diff HEAD`
+- Branch: !`"${CLAUDE_PLUGIN_ROOT}/scripts/wt-git.sh" "$0" branch --show-current`
+- Status: !`"${CLAUDE_PLUGIN_ROOT}/scripts/wt-git.sh" "$0" status --short`
+- Log: !`"${CLAUDE_PLUGIN_ROOT}/scripts/wt-git.sh" "$0" log --oneline -20`
+- Diff: !`"${CLAUDE_PLUGIN_ROOT}/scripts/wt-git.sh" "$0" diff HEAD`
 
 ## Title
 
@@ -43,10 +43,7 @@ When an issue is referenced:
 
 ## Workflow
 
-1. If on a default branch, create a branch first, named based on the subject/type of changes:
-   - Example: `fix/add-timeout-to-request`
-   - Example: `aws-provider-v6`
-   - Example: `refactor-user-service`
+1. **Branch validation**: If the context shows you're on a default branch (main/master) and no `$0` argument was provided, stop and tell the user to specify the target branch: `/pull-request:create <branch>`. When a branch argument is provided, all git/gh commands must run in that branch's worktree using the wrapper scripts.
 2. Stage changes if not already staged.
 3. Commit if there are no commits yet on the branch. Follow the same format for the commit message as for the pull request title (conventional or subject-oriented based on repo standard).
 4. Push the branch to remote.

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -13,9 +13,13 @@ The PR body documents what will happen when merged, not the journey. Don't echo 
 
 ## Context
 
-- Branch: !`git branch --show-current`
-- PR: !`gh api graphql -F owner="$(gh repo view --json owner --jq '.owner.login')" -F repo="$(gh repo view --json name --jq '.name')" -F number="$(gh pr view --json number --jq '.number')" -f query="$(cat ${CLAUDE_SKILL_ROOT}/assets/pr-context.graphql)" 2>/dev/null || echo "No PR found for current branch"`
-- Diff: !`gh pr diff 2>/dev/null`
+- Branch: !`"${CLAUDE_PLUGIN_ROOT}/scripts/wt-git.sh" "$0" branch --show-current`
+- PR: !`"${CLAUDE_PLUGIN_ROOT}/scripts/pr-context.sh" "$0" "${CLAUDE_SKILL_ROOT}/assets/pr-context.graphql" 2>/dev/null || echo "No PR found for current branch"`
+- Diff: !`"${CLAUDE_PLUGIN_ROOT}/scripts/wt-gh.sh" "$0" pr diff 2>/dev/null`
+
+## Workflow
+
+1. **Branch validation**: If on a default branch (main/master) and no `$0` argument was provided, stop and tell the user to specify the target branch: `/pull-request:update <branch>`. When a branch argument is provided, all git/gh commands must run in that branch's worktree using the wrapper scripts.
 
 ## Analysis
 


### PR DESCRIPTION
Enable creating and updating PRs for branches in separate git worktrees. When invoked from a default branch (main/master), the skills now accept a branch argument and resolve it to the appropriate worktree path for running git/gh commands.

## Changes

- Add `wt-resolve.sh` to resolve branch names to worktree paths via `git worktree list --porcelain`
- Add `wt-git.sh` and `wt-gh.sh` wrappers that use `wt-resolve.sh` to run commands in the correct worktree
- Add `pr-context.sh` to simplify the update skill's GraphQL context fetching
- Update both skills to use wrapper scripts with `$0` (skill argument) for branch targeting
- Add branch validation to stop and prompt users when on a default branch without a branch argument

## Testing

- Unit tests for `wt-resolve.sh`, `wt-git.sh`, and `wt-gh.sh` covering:
  - Empty branch passthrough
  - Non-existent branch fallback
  - Worktree resolution with simple and nested branch names
- Shared test utilities extracted to `test-utils.ts`
