### PR TITLE
fix(sandbox): add bun cache to sandbox write allowlist

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -21,7 +21,8 @@
       "Edit(~/.cache/uv/**)",
       "Edit(~/Library/Caches/go-build/**)",
       "Edit(~/src/go/pkg/mod/**)",
-      "Edit(~/src/go/pkg/sumdb/**)"
+      "Edit(~/src/go/pkg/sumdb/**)",
+      "Edit(~/.bun/**)"
     ],
     "deny": []
   },


### PR DESCRIPTION
Add `~/.bun/**` to Edit permissions, allowing bun to write to its cache directory without disabling sandbox entirely.

## Changes

- Add `Edit(~/.bun/**)` to `permissions.allow` in user settings

This follows the same pattern used for other package managers:
- `~/.cache/uv/**` for uv
- `~/.npm/**` for npm

Unlike the previous approach (PR #300), this keeps bun running within the sandbox but grants it permission to write to its cache directory.