### PR TITLE
feat(webfetch-auth): add PreToolUse hook for authenticated URLs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -180,6 +180,11 @@
       "name": "plan",
       "description": "Planning mode guidelines and context injection",
       "source": "./plugins/plan"
+    },
+    {
+      "name": "webfetch-auth",
+      "description": "Blocks WebFetch for authenticated URLs and suggests MCP alternatives",
+      "source": "./plugins/webfetch-auth"
     }
   ]
 }

--- a/plugins/webfetch-auth/.claude-plugin/plugin.json
+++ b/plugins/webfetch-auth/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "webfetch-auth",
+  "description": "Blocks WebFetch for authenticated URLs and suggests MCP alternatives",
+  "author": {
+    "name": "Ben Drucker",
+    "email": "bvdrucker@gmail.com"
+  }
+}

--- a/plugins/webfetch-auth/README.md
+++ b/plugins/webfetch-auth/README.md
@@ -1,0 +1,22 @@
+# WebFetch Auth
+
+Blocks WebFetch for URLs that require authentication and suggests MCP alternatives.
+
+## Contents
+
+- **Hook**: PreToolUse hook that intercepts WebFetch calls
+
+## Authenticated Domains
+
+| Domain | Alternative |
+|--------|-------------|
+| `docs.google.com` | Google Drive MCP or export as PDF |
+| `*.atlassian.net` | Confluence/Jira MCP |
+| `*.notion.so` | Notion MCP |
+| `linear.app` | Linear MCP (`linear:linear` skill) |
+
+## Testing
+
+```sh
+bun test plugins/webfetch-auth
+```

--- a/plugins/webfetch-auth/hooks/hooks.json
+++ b/plugins/webfetch-auth/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Blocks WebFetch for authenticated URLs and suggests MCP alternatives",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/check.ts"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/webfetch-auth/scripts/check.test.ts
+++ b/plugins/webfetch-auth/scripts/check.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "bun:test";
+import type {
+  PreToolUseHookInput,
+  PreToolUseHookSpecificOutput,
+} from "@anthropic-ai/claude-agent-sdk";
+import { formatOutput, processInput } from "./check";
+
+function mockInput(url: string): PreToolUseHookInput {
+  return {
+    hook_event_name: "PreToolUse",
+    session_id: "test",
+    transcript_path: "/tmp/test",
+    cwd: "/tmp",
+    tool_name: "WebFetch",
+    tool_input: { url, prompt: "test" },
+    tool_use_id: "test",
+  };
+}
+
+function getOutput(input: PreToolUseHookInput): PreToolUseHookSpecificOutput | null {
+  const result = processInput(input);
+  if (!result) return null;
+  return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
+}
+
+describe("formatOutput", () => {
+  it("formats deny decision", () => {
+    const output = formatOutput("deny", "Use MCP instead");
+    expect(output).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Use MCP instead",
+      },
+    });
+  });
+
+  it("formats ask decision", () => {
+    const output = formatOutput("ask", "Unknown pattern");
+    expect(output).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "ask",
+        permissionDecisionReason: "Unknown pattern",
+      },
+    });
+  });
+});
+
+describe("processInput", () => {
+  it("returns null for non-authenticated URLs", () => {
+    expect(processInput(mockInput("https://example.com"))).toBeNull();
+    expect(processInput(mockInput("https://github.com/owner/repo"))).toBeNull();
+    expect(processInput(mockInput("https://docs.anthropic.com/en/api"))).toBeNull();
+  });
+
+  it("denies Google Docs URLs", () => {
+    const output = getOutput(mockInput("https://docs.google.com/document/d/abc123/edit"));
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toBe(
+      "Google Docs requires authentication. Use Google Drive MCP or export as PDF.",
+    );
+  });
+
+  it("denies Google Sheets URLs", () => {
+    const output = getOutput(mockInput("https://docs.google.com/spreadsheets/d/abc123/edit"));
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toContain("Google Docs");
+  });
+
+  it("denies Atlassian Confluence URLs", () => {
+    const output = getOutput(
+      mockInput("https://mycompany.atlassian.net/wiki/spaces/ABC/pages/123"),
+    );
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toBe(
+      "Atlassian sites require authentication. Use Confluence or Jira MCP.",
+    );
+  });
+
+  it("denies Atlassian Jira URLs", () => {
+    const output = getOutput(mockInput("https://mycompany.atlassian.net/browse/PROJ-123"));
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toContain("Atlassian");
+  });
+
+  it("denies Notion URLs", () => {
+    const output = getOutput(mockInput("https://www.notion.so/myworkspace/Page-abc123"));
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toBe(
+      "Notion requires authentication. Use Notion MCP.",
+    );
+  });
+
+  it("denies Notion workspace URLs", () => {
+    const output = getOutput(mockInput("https://myworkspace.notion.so/doc/abc123"));
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toContain("Notion");
+  });
+
+  it("denies Linear URLs", () => {
+    const output = getOutput(mockInput("https://linear.app/myteam/issue/ABC-123"));
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toBe(
+      "Linear requires authentication. Use Linear MCP or load `linear:linear` skill.",
+    );
+  });
+
+  it("denies Linear project URLs", () => {
+    const output = getOutput(mockInput("https://linear.app/myteam/project/abc123"));
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toContain("Linear");
+  });
+
+  it("handles missing tool_input", () => {
+    const input: PreToolUseHookInput = {
+      hook_event_name: "PreToolUse",
+      session_id: "test",
+      transcript_path: "/tmp/test",
+      cwd: "/tmp",
+      tool_name: "WebFetch",
+      tool_input: undefined as unknown as Record<string, unknown>,
+      tool_use_id: "test",
+    };
+    const output = getOutput(input);
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toContain("invalid input");
+  });
+
+  it("handles missing url in tool_input", () => {
+    const input: PreToolUseHookInput = {
+      hook_event_name: "PreToolUse",
+      session_id: "test",
+      transcript_path: "/tmp/test",
+      cwd: "/tmp",
+      tool_name: "WebFetch",
+      tool_input: { prompt: "test" },
+      tool_use_id: "test",
+    };
+    const output = getOutput(input);
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toContain("invalid URL");
+  });
+});

--- a/plugins/webfetch-auth/scripts/check.ts
+++ b/plugins/webfetch-auth/scripts/check.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env bun
+
+import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+
+export type WebFetchInput = { url: string; prompt: string };
+
+type AuthenticatedDomain = {
+  pattern: RegExp;
+  suggestion: string;
+};
+
+const authenticatedDomains: AuthenticatedDomain[] = [
+  {
+    pattern: /^https:\/\/docs\.google\.com\//,
+    suggestion: "Google Docs requires authentication. Use Google Drive MCP or export as PDF.",
+  },
+  {
+    pattern: /^https:\/\/[^/]+\.atlassian\.net\//,
+    suggestion: "Atlassian sites require authentication. Use Confluence or Jira MCP.",
+  },
+  {
+    pattern: /^https:\/\/[^/]+\.notion\.so\//,
+    suggestion: "Notion requires authentication. Use Notion MCP.",
+  },
+  {
+    pattern: /^https:\/\/linear\.app\//,
+    suggestion: "Linear requires authentication. Use Linear MCP or load `linear:linear` skill.",
+  },
+];
+
+export function formatOutput(
+  decision: "allow" | "deny" | "ask",
+  reason: string,
+): SyncHookJSONOutput {
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: decision,
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
+export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {
+  const toolInput = input.tool_input;
+
+  if (!toolInput || typeof toolInput !== "object") {
+    return formatOutput(
+      "deny",
+      "webfetch-auth hook received invalid input. Blocking as a safety measure.",
+    );
+  }
+
+  const { url } = toolInput as WebFetchInput;
+
+  if (typeof url !== "string") {
+    return formatOutput(
+      "deny",
+      "webfetch-auth hook received invalid URL. Blocking as a safety measure.",
+    );
+  }
+
+  const match = authenticatedDomains.find((domain) => domain.pattern.test(url));
+  return match ? formatOutput("deny", match.suggestion) : null;
+}
+
+async function main(): Promise<void> {
+  let input: PreToolUseHookInput;
+  try {
+    input = await readStdinJson<PreToolUseHookInput>();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[webfetch-auth/check] Failed to parse hook input: ${message}`);
+    writeStdoutJson(
+      formatOutput("deny", `webfetch-auth hook error: ${message}. Blocking as a safety measure.`),
+    );
+    return;
+  }
+
+  const output = processInput(input);
+  if (output) {
+    writeStdoutJson(output);
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(
+      `[webfetch-auth/check] Unexpected error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Block WebFetch for URLs requiring authentication and suggest MCP alternatives.

## Changes

- Add PreToolUse hook that intercepts WebFetch calls
- Check URLs against authenticated domain patterns
- Return deny with suggestion for appropriate MCP alternative

## Authenticated Domains

| Domain | Alternative |
|--------|-------------|
| `docs.google.com` | Google Drive MCP or export as PDF |
| `*.atlassian.net` | Confluence/Jira MCP |
| `*.notion.so` | Notion MCP |
| `linear.app` | Linear MCP (`linear:linear` skill) |