### PR TITLE
feat(git): add conflicts skill

### DIFF
--- a/plugins/git/skills/conflicts/SKILL.md
+++ b/plugins/git/skills/conflicts/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: conflicts
+description: Resolving git merge conflicts. Use when rebasing, merging, or cherry-picking results in conflicts.
+allowed-tools: [Read, Edit, Bash(git:*), Grep, Glob]
+---
+
+# Resolve Git Conflicts
+
+Resolve merge conflicts during rebase, merge, or cherry-pick operations.
+
+## Detection
+
+Check for conflict state:
+
+```bash
+git status
+```
+
+Look for "Unmerged paths" or "both modified" indicators.
+
+## Workflow
+
+1. **List conflicted files**:
+   ```bash
+   git diff --name-only --diff-filter=U
+   ```
+
+2. **For each file**, read and identify conflict markers. See [references/markers.md](references/markers.md) for marker format.
+
+3. **Resolve** by editing to remove markers and keep correct content.
+
+4. **Stage** resolved files:
+   ```bash
+   git add <file>
+   ```
+
+5. **Continue** the interrupted operation:
+   - Rebase: `git rebase --continue`
+   - Merge: `git merge --continue`
+   - Cherry-pick: `git cherry-pick --continue`
+
+## Resolution Strategies
+
+- **Ours**: Keep the current branch version (HEAD)
+- **Theirs**: Keep the incoming version
+- **Manual**: Combine both changes or write new code
+
+For complex conflicts, understand the intent of both changes before resolving.

--- a/plugins/git/skills/conflicts/references/markers.md
+++ b/plugins/git/skills/conflicts/references/markers.md
@@ -1,0 +1,60 @@
+# Conflict Markers
+
+Git conflict markers indicate where changes from different branches overlap.
+
+## Format
+
+```
+<<<<<<< HEAD
+Current branch content (ours)
+=======
+Incoming branch content (theirs)
+>>>>>>> branch-name
+```
+
+## Marker Meanings
+
+| Marker | Description |
+|--------|-------------|
+| `<<<<<<< HEAD` | Start of current branch content |
+| `=======` | Separator between versions |
+| `>>>>>>> branch` | End of incoming branch content |
+
+## Extended Format (diff3)
+
+With `merge.conflictStyle = diff3`:
+
+```
+<<<<<<< HEAD
+Current branch content
+||||||| parent
+Original content before both changes
+=======
+Incoming branch content
+>>>>>>> branch-name
+```
+
+The `|||||||` section shows the common ancestor, helping understand what each branch changed.
+
+## Resolution
+
+Remove all markers and keep the desired content:
+
+```diff
+-<<<<<<< HEAD
+-Current branch content (ours)
+-=======
+ Incoming branch content (theirs)
+->>>>>>> branch-name
+```
+
+Or combine both:
+
+```diff
+-<<<<<<< HEAD
+ Current branch content (ours)
+-=======
+-Incoming branch content (theirs)
++Additional merged content
+->>>>>>> branch-name
+```


### PR DESCRIPTION
Add skill for resolving git merge conflicts during rebase, merge, or cherry-pick operations.

## Changes

- Add `plugins/git/skills/resolve-conflicts/SKILL.md` with workflow steps
- Add `plugins/git/skills/resolve-conflicts/references/markers.md` documenting conflict marker format

## Usage

Invoke when rebasing, merging, or cherry-picking results in conflicts. The skill guides through:

1. Listing conflicted files
2. Understanding conflict markers
3. Resolving conflicts
4. Staging and continuing the operation