### PR TITLE
feat(git): add conflicts skill

### DIFF
--- a/plugins/git/skills/conflicts/SKILL.md
+++ b/plugins/git/skills/conflicts/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: conflicts
+description: Resolving git merge conflicts. Use when rebasing, merging, or cherry-picking results in conflicts.
+allowed-tools:
+  - Read
+  - Edit
+  - Grep
+  - Glob
+  - Bash(git status:*)
+  - Bash(git diff:*)
+  - Bash(git show :*:*)
+  - Bash(git add:*)
+  - Bash(git log:*)
+  - Bash(git rebase:*)
+  - Bash(git merge:*)
+  - Bash(git cherry-pick:*)
+  - Bash(git rerere:*)
+  - Bash(bun ${CLAUDE_SKILL_ROOT}/scripts/*:*)
+hooks:
+  PreToolUse:
+    - matcher: "Bash(git commit:*)|Bash(git rebase --continue:*)|Bash(git merge --continue:*)|Bash(git cherry-pick --continue:*)"
+      hooks:
+        - type: command
+          command: "bun ${CLAUDE_SKILL_ROOT}/scripts/check-markers.ts"
+---
+
+# Git Conflicts
+
+## Status
+
+!`bun ${CLAUDE_SKILL_ROOT}/scripts/status.ts 2>/dev/null || echo "Run status.ts manually"`
+
+## Context
+
+!`bun ${CLAUDE_SKILL_ROOT}/scripts/context.ts 2>/dev/null || echo "Run context.ts manually"`
+
+## Three-Way Access
+
+Git stores three versions in staging slots during conflicts:
+
+| Slot | Version | Command |
+|------|---------|---------|
+| `:1:path` | Base (common ancestor) | `git show :1:path` |
+| `:2:path` | Ours (HEAD) | `git show :2:path` |
+| `:3:path` | Theirs (incoming) | `git show :3:path` |
+
+## References
+
+- [rerere.md](references/rerere.md) — Automatic resolution reuse for repeated rebases

--- a/plugins/git/skills/conflicts/references/rerere.md
+++ b/plugins/git/skills/conflicts/references/rerere.md
@@ -1,0 +1,30 @@
+# Rerere
+
+Git's "reuse recorded resolution" remembers conflict resolutions and auto-applies them.
+
+## Enable
+
+```bash
+git config --global rerere.enabled true
+```
+
+## How It Works
+
+1. Resolve a conflict manually
+2. Git records the resolution
+3. Same conflict later: git auto-applies the recorded resolution
+4. Verify with `git diff` before committing
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `git rerere status` | Files with recorded resolutions |
+| `git rerere diff` | What rerere would apply |
+| `git rerere forget <file>` | Delete recorded resolution |
+
+## Use Cases
+
+- Repeated rebases onto updated main
+- Long-running feature branches
+- Backporting fixes across branches

--- a/plugins/git/skills/conflicts/scripts/check-markers.ts
+++ b/plugins/git/skills/conflicts/scripts/check-markers.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env bun
+
+import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { $ } from "bun";
+
+function formatOutput(reason: string): SyncHookJSONOutput {
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  let _input: PreToolUseHookInput;
+  try {
+    _input = await readStdinJson<PreToolUseHookInput>();
+  } catch (error) {
+    console.error(
+      `[git/conflicts/check-markers] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  const result = await $`git diff --cached --check`.quiet().nothrow();
+
+  if (result.exitCode !== 0) {
+    const output = result.stderr.toString() || result.stdout.toString();
+    const markers = output
+      .split("\n")
+      .filter((line) => line.includes("conflict marker"))
+      .slice(0, 5)
+      .join(", ");
+
+    writeStdoutJson(
+      formatOutput(
+        `Conflict markers in staged files: ${markers || "run 'git diff --cached --check' for details"}`,
+      ),
+    );
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/plugins/git/skills/conflicts/scripts/context.ts
+++ b/plugins/git/skills/conflicts/scripts/context.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env bun
+
+import { $ } from "bun";
+
+type Operation = "rebase" | "merge" | "cherry-pick" | null;
+
+async function detectOperation(): Promise<{ op: Operation; ref: string | null }> {
+  const checks: Array<{ op: Operation; ref: string }> = [
+    { op: "rebase", ref: "REBASE_HEAD" },
+    { op: "merge", ref: "MERGE_HEAD" },
+    { op: "cherry-pick", ref: "CHERRY_PICK_HEAD" },
+  ];
+
+  for (const { op, ref } of checks) {
+    const result = await $`git rev-parse --verify ${ref}`.quiet().nothrow();
+    if (result.exitCode === 0) {
+      return { op, ref };
+    }
+  }
+
+  return { op: null, ref: null };
+}
+
+const { op, ref } = await detectOperation();
+
+if (!op || !ref) {
+  console.log("No conflict operation in progress");
+  process.exit(0);
+}
+
+console.log(`Operation: ${op}`);
+console.log("");
+
+const conflictedFiles = await $`git diff --name-only --diff-filter=U`.text();
+if (!conflictedFiles.trim()) {
+  console.log("No conflicted files");
+  process.exit(0);
+}
+
+console.log("Incoming commits:");
+const files = conflictedFiles.trim().split("\n");
+const logs = await $`git log --oneline ${ref} -10 -- ${files}`.text();
+console.log(logs.trim() || "(none found)");

--- a/plugins/git/skills/conflicts/scripts/status.ts
+++ b/plugins/git/skills/conflicts/scripts/status.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env bun
+
+import { $ } from "bun";
+
+const files = await $`git diff --name-only --diff-filter=U`.text();
+
+if (!files.trim()) {
+  console.log("No conflicted files");
+  process.exit(0);
+}
+
+for (const file of files.trim().split("\n")) {
+  try {
+    const content = await Bun.file(file).text();
+    const count = (content.match(/^<{7} /gm) || []).length;
+    console.log(`- ${file} (${count} conflict${count !== 1 ? "s" : ""})`);
+  } catch {
+    console.log(`- ${file} (unreadable)`);
+  }
+}

--- a/plugins/git/skills/conflicts/tests/fixtures/setup.ts
+++ b/plugins/git/skills/conflicts/tests/fixtures/setup.ts
@@ -1,0 +1,38 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { $ } from "bun";
+
+export type Fixture = {
+  path: string;
+  cleanup: () => Promise<void>;
+};
+
+export async function createConflictFixture(): Promise<Fixture> {
+  const path = await mkdtemp(join(tmpdir(), "git-conflicts-test-"));
+
+  const git = (args: string) => $`git ${args.split(" ")}`.cwd(path).quiet();
+
+  await git("init -b main");
+  await git("config user.email test@test.com");
+  await git("config user.name Test");
+
+  await Bun.write(join(path, "file.txt"), "line 1\nline 2\nline 3\n");
+  await git("add file.txt");
+  await git("commit -m initial");
+
+  await git("checkout -b feature");
+  await Bun.write(join(path, "file.txt"), "line 1\nfeature change\nline 3\n");
+  await git("commit -am feature");
+
+  await git("checkout main");
+  await Bun.write(join(path, "file.txt"), "line 1\nmain change\nline 3\n");
+  await git("commit -am main");
+
+  await $`git merge feature`.cwd(path).quiet().nothrow();
+
+  return {
+    path,
+    cleanup: () => rm(path, { recursive: true }),
+  };
+}

--- a/plugins/git/skills/conflicts/tests/scripts.test.ts
+++ b/plugins/git/skills/conflicts/tests/scripts.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { $ } from "bun";
+import { createConflictFixture, type Fixture } from "./fixtures/setup";
+
+const scriptsDir = join(import.meta.dirname, "..", "scripts");
+
+describe("conflicts scripts", () => {
+  let fixture: Fixture;
+
+  beforeAll(async () => {
+    fixture = await createConflictFixture();
+  });
+
+  afterAll(async () => {
+    await fixture.cleanup();
+  });
+
+  describe("status.ts", () => {
+    test("lists conflicted files with counts", async () => {
+      const result = await $`bun ${join(scriptsDir, "status.ts")}`.cwd(fixture.path).text();
+
+      expect(result).toContain("file.txt");
+      expect(result).toMatch(/\d+ conflict/);
+    });
+  });
+
+  describe("context.ts", () => {
+    test("shows operation type and incoming commits", async () => {
+      const result = await $`bun ${join(scriptsDir, "context.ts")}`.cwd(fixture.path).text();
+
+      expect(result).toContain("Operation: merge");
+      expect(result).toContain("Incoming commits:");
+    });
+  });
+
+  describe("check-markers.ts", () => {
+    const hookInput = JSON.stringify({ tool_name: "Bash", tool_input: { command: "git commit" } });
+
+    test("outputs deny JSON when markers in staged files", async () => {
+      await $`git add file.txt`.cwd(fixture.path).quiet();
+
+      const result = await $`echo ${hookInput} | bun ${join(scriptsDir, "check-markers.ts")}`
+        .cwd(fixture.path)
+        .text();
+
+      const output = JSON.parse(result);
+      expect(output.hookSpecificOutput.permissionDecision).toBe("deny");
+      expect(output.hookSpecificOutput.permissionDecisionReason).toContain("Conflict markers");
+    });
+
+    test("outputs nothing when no markers", async () => {
+      await Bun.write(join(fixture.path, "file.txt"), "resolved content\n");
+      await $`git add file.txt`.cwd(fixture.path).quiet();
+
+      const result = await $`echo ${hookInput} | bun ${join(scriptsDir, "check-markers.ts")}`
+        .cwd(fixture.path)
+        .text();
+
+      expect(result.trim()).toBe("");
+    });
+  });
+});


### PR DESCRIPTION
Add skill for resolving git merge conflicts with programmatic tooling.

## Contents

- **status.ts**: List conflicted files with conflict counts
- **context.ts**: Show operation type and incoming commits (worktree-safe ref detection)
- **check-markers.ts**: PreToolUse hook blocking commits with conflict markers
- **rerere.md**: Guide to automatic resolution reuse

## Features

- Bang syntax context showing conflicts and incoming commits at skill load
- Three-way staging slot documentation (`:1:`, `:2:`, `:3:`)
- Restrictive allowed-tools for conflict resolution workflow
- PreToolUse hook on commit/continue to catch forgotten conflict markers