### PR TITLE
refactor: convert webfetch-auth plugin to userspace hook

### DIFF
--- a/user/hooks/webfetch-block/index.test.ts
+++ b/user/hooks/webfetch-block/index.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "bun:test";
+import type {
+  PreToolUseHookInput,
+  PreToolUseHookSpecificOutput,
+} from "@anthropic-ai/claude-agent-sdk";
+import { formatOutput, processInput } from "./index";
+
+function mockInput(url: string): PreToolUseHookInput {
+  return {
+    hook_event_name: "PreToolUse",
+    session_id: "test",
+    transcript_path: "/tmp/test",
+    cwd: "/tmp",
+    tool_name: "WebFetch",
+    tool_input: { url, prompt: "test" },
+    tool_use_id: "test",
+  };
+}
+
+function getOutput(input: PreToolUseHookInput): PreToolUseHookSpecificOutput | null {
+  const result = processInput(input);
+  if (!result) return null;
+  return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
+}
+
+describe("formatOutput", () => {
+  it("formats deny decision", () => {
+    const output = formatOutput("deny", "Use MCP instead");
+    expect(output).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Use MCP instead",
+      },
+    });
+  });
+
+  it("formats ask decision", () => {
+    const output = formatOutput("ask", "Unknown pattern");
+    expect(output).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "ask",
+        permissionDecisionReason: "Unknown pattern",
+      },
+    });
+  });
+});
+
+describe("processInput", () => {
+  it("returns null for non-authenticated URLs", () => {
+    expect(processInput(mockInput("https://example.com"))).toBeNull();
+    expect(processInput(mockInput("https://github.com/owner/repo"))).toBeNull();
+    expect(processInput(mockInput("https://docs.anthropic.com/en/api"))).toBeNull();
+  });
+
+  it("denies Google Docs URLs", () => {
+    const output = getOutput(mockInput("https://docs.google.com/document/d/abc123/edit"));
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toBe(
+      "Google Docs requires authentication. Use Google Drive MCP or export as PDF.",
+    );
+  });
+
+  it("denies Google Sheets URLs", () => {
+    const output = getOutput(mockInput("https://docs.google.com/spreadsheets/d/abc123/edit"));
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toContain("Google Docs");
+  });
+
+  it("denies Atlassian Confluence URLs", () => {
+    const output = getOutput(
+      mockInput("https://mycompany.atlassian.net/wiki/spaces/ABC/pages/123"),
+    );
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toBe(
+      "Atlassian sites require authentication. Use Confluence or Jira MCP.",
+    );
+  });
+
+  it("denies Atlassian Jira URLs", () => {
+    const output = getOutput(mockInput("https://mycompany.atlassian.net/browse/PROJ-123"));
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toContain("Atlassian");
+  });
+
+  it("denies Notion URLs", () => {
+    const output = getOutput(mockInput("https://www.notion.so/myworkspace/Page-abc123"));
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toBe(
+      "Notion requires authentication. Use Notion MCP.",
+    );
+  });
+
+  it("denies Notion workspace URLs", () => {
+    const output = getOutput(mockInput("https://myworkspace.notion.so/doc/abc123"));
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toContain("Notion");
+  });
+
+  it("denies Linear URLs", () => {
+    const output = getOutput(mockInput("https://linear.app/myteam/issue/ABC-123"));
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toBe(
+      "Linear requires authentication. Use Linear MCP or load `linear:linear` skill.",
+    );
+  });
+
+  it("denies Linear project URLs", () => {
+    const output = getOutput(mockInput("https://linear.app/myteam/project/abc123"));
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toContain("Linear");
+  });
+});

--- a/user/hooks/webfetch-block/index.ts
+++ b/user/hooks/webfetch-block/index.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env bun
+
+import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+
+export type WebFetchInput = { url: string; prompt: string };
+
+type AuthenticatedDomain = {
+  pattern: RegExp;
+  suggestion: string;
+};
+
+const authenticatedDomains: AuthenticatedDomain[] = [
+  {
+    pattern: /^https:\/\/docs\.google\.com\//,
+    suggestion: "Google Docs requires authentication. Use Google Drive MCP or export as PDF.",
+  },
+  {
+    pattern: /^https:\/\/[^/]+\.atlassian\.net\//,
+    suggestion: "Atlassian sites require authentication. Use Confluence or Jira MCP.",
+  },
+  {
+    pattern: /^https:\/\/[^/]+\.notion\.so\//,
+    suggestion: "Notion requires authentication. Use Notion MCP.",
+  },
+  {
+    pattern: /^https:\/\/linear\.app\//,
+    suggestion: "Linear requires authentication. Use Linear MCP or load `linear:linear` skill.",
+  },
+];
+
+export function formatOutput(
+  decision: "allow" | "deny" | "ask",
+  reason: string,
+): SyncHookJSONOutput {
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: decision,
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
+export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {
+  const { url } = input.tool_input as WebFetchInput;
+
+  for (const domain of authenticatedDomains) {
+    if (domain.pattern.test(url)) {
+      return formatOutput("deny", domain.suggestion);
+    }
+  }
+
+  return null;
+}
+
+async function main(): Promise<void> {
+  let input: PreToolUseHookInput;
+  try {
+    input = await readStdinJson<PreToolUseHookInput>();
+  } catch (error) {
+    console.error(
+      `[webfetch-block] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  const output = processInput(input);
+  if (output) {
+    writeStdoutJson(output);
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/user/settings.json
+++ b/user/settings.json
@@ -35,6 +35,15 @@
             "command": "bun ~/.claude/hooks/worktree"
           }
         ]
+      },
+      {
+        "matcher": "WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun ~/.claude/hooks/webfetch-block"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
Convert `webfetch-auth` plugin to a simpler userspace hook. The plugin was overkill—no skills, commands, or agents, just a single hook with personal domain preferences. Userspace hooks don't require marketplace distribution.

## Changes

- Converts `webfetch-auth` plugin to userspace hook at `user/hooks/webfetch-block/`
- Removes plugin indirection (no plugin.json, hooks.json)
- Adds PreToolUse hook to `user/settings.json` for WebFetch matcher

## Testing

- Tests cover all blocked domains (Google Docs, Atlassian, Notion, Linear) and passthrough for non-authenticated URLs
- Manual verification needed: WebFetch on `docs.google.com` should be blocked with MCP suggestion