### PR TITLE
feat(linear): add WebFetch hook for Linear URLs

### DIFF
--- a/plugins/linear/hooks/hooks.json
+++ b/plugins/linear/hooks/hooks.json
@@ -1,7 +1,16 @@
 {
-  "description": "Sets default state for new issues based on assignee",
+  "description": "Linear plugin hooks for WebFetch blocking and issue defaults",
   "hooks": {
     "PreToolUse": [
+      {
+        "matcher": "WebFetch(domain:linear.app)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts"
+          }
+        ]
+      },
       {
         "matcher": "mcp__linear__create_issue",
         "hooks": [

--- a/plugins/linear/scripts/fetch.test.ts
+++ b/plugins/linear/scripts/fetch.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import type {
+  PreToolUseHookInput,
+  PreToolUseHookSpecificOutput,
+} from "@anthropic-ai/claude-agent-sdk";
+import { isPublicUrl, processInput } from "./fetch";
+
+function mockInput(url: string): PreToolUseHookInput {
+  return {
+    hook_event_name: "PreToolUse",
+    session_id: "test",
+    transcript_path: "/tmp/test",
+    cwd: "/tmp",
+    tool_name: "WebFetch",
+    tool_input: { url, prompt: "test" },
+    tool_use_id: "test",
+  };
+}
+
+function getOutput(input: PreToolUseHookInput): PreToolUseHookSpecificOutput | null {
+  const result = processInput(input);
+  if (!result) return null;
+  return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
+}
+
+describe("isPublicUrl", () => {
+  it("allows docs URLs", () => {
+    expect(isPublicUrl("https://linear.app/docs")).toBe(true);
+    expect(isPublicUrl("https://linear.app/docs/due-dates")).toBe(true);
+    expect(isPublicUrl("https://linear.app/docs/due-dates.md")).toBe(true);
+  });
+
+  it("allows developers URLs", () => {
+    expect(isPublicUrl("https://linear.app/developers")).toBe(true);
+    expect(isPublicUrl("https://linear.app/developers/api")).toBe(true);
+  });
+
+  it("allows changelog URLs", () => {
+    expect(isPublicUrl("https://linear.app/changelog")).toBe(true);
+    expect(isPublicUrl("https://linear.app/changelog/2024")).toBe(true);
+  });
+
+  it("blocks workspace URLs", () => {
+    expect(isPublicUrl("https://linear.app/myteam/issue/ABC-123")).toBe(false);
+    expect(isPublicUrl("https://linear.app/myteam/project/abc")).toBe(false);
+  });
+});
+
+describe("processInput", () => {
+  it("allows public docs URLs", () => {
+    expect(processInput(mockInput("https://linear.app/docs/due-dates"))).toBeNull();
+    expect(processInput(mockInput("https://linear.app/developers"))).toBeNull();
+    expect(processInput(mockInput("https://linear.app/changelog"))).toBeNull();
+  });
+
+  it("denies workspace issue URLs", () => {
+    const output = getOutput(mockInput("https://linear.app/myteam/issue/ABC-123"));
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toContain("Linear MCP");
+  });
+
+  it("denies workspace project URLs", () => {
+    const output = getOutput(mockInput("https://linear.app/myteam/project/abc123"));
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toContain("Linear MCP");
+  });
+});

--- a/plugins/linear/scripts/fetch.ts
+++ b/plugins/linear/scripts/fetch.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env bun
+
+import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+
+export type WebFetchInput = { url: string };
+
+const PUBLIC_PATH_PREFIXES = ["/docs", "/developers", "/changelog"];
+
+export function isPublicUrl(url: string): boolean {
+  const path = new URL(url).pathname;
+  return PUBLIC_PATH_PREFIXES.some((prefix) => path === prefix || path.startsWith(`${prefix}/`));
+}
+
+export function formatOutput(reason: string): SyncHookJSONOutput {
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
+export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {
+  const { url } = input.tool_input as WebFetchInput;
+
+  if (isPublicUrl(url)) {
+    return null;
+  }
+
+  return formatOutput(
+    "Linear requires authentication. Use Linear MCP instead. Run /linear for guidance.",
+  );
+}
+
+async function main(): Promise<void> {
+  let input: PreToolUseHookInput;
+  try {
+    input = await readStdinJson<PreToolUseHookInput>();
+  } catch (error) {
+    console.error(
+      `[linear/fetch] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  const output = processInput(input);
+  if (output) {
+    writeStdoutJson(output);
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/user/hooks/webfetch-block/CLAUDE.md
+++ b/user/hooks/webfetch-block/CLAUDE.md
@@ -1,0 +1,11 @@
+# webfetch-block
+
+Catch-all hook for blocking WebFetch on authenticated services without dedicated plugins.
+
+## Scope
+
+Only add domains here when:
+- The service requires authentication for useful content
+- No plugin exists that provides authenticated access (via MCP or CLI)
+
+Services with plugins (GitHub, GitLab, Linear) handle their own WebFetch blocking and provide specific guidance for their tools.

--- a/user/hooks/webfetch-block/index.test.ts
+++ b/user/hooks/webfetch-block/index.test.ts
@@ -50,8 +50,13 @@ describe("formatOutput", () => {
 describe("processInput", () => {
   it("returns null for non-authenticated URLs", () => {
     expect(processInput(mockInput("https://example.com"))).toBeNull();
-    expect(processInput(mockInput("https://github.com/owner/repo"))).toBeNull();
     expect(processInput(mockInput("https://docs.anthropic.com/en/api"))).toBeNull();
+  });
+
+  it("returns null for URLs handled by dedicated plugins", () => {
+    expect(processInput(mockInput("https://github.com/owner/repo"))).toBeNull();
+    expect(processInput(mockInput("https://gitlab.com/owner/repo"))).toBeNull();
+    expect(processInput(mockInput("https://linear.app/myteam/issue/ABC-123"))).toBeNull();
   });
 
   it("denies Google Docs URLs", () => {
@@ -96,19 +101,5 @@ describe("processInput", () => {
     const output = getOutput(mockInput("https://myworkspace.notion.so/doc/abc123"));
     expect(output?.permissionDecision).toBe("deny");
     expect(output?.permissionDecisionReason).toContain("Notion");
-  });
-
-  it("denies Linear URLs", () => {
-    const output = getOutput(mockInput("https://linear.app/myteam/issue/ABC-123"));
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe(
-      "Linear requires authentication. Use Linear MCP or load `linear:linear` skill.",
-    );
-  });
-
-  it("denies Linear project URLs", () => {
-    const output = getOutput(mockInput("https://linear.app/myteam/project/abc123"));
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toContain("Linear");
   });
 });

--- a/user/hooks/webfetch-block/index.ts
+++ b/user/hooks/webfetch-block/index.ts
@@ -10,6 +10,8 @@ type AuthenticatedDomain = {
   suggestion: string;
 };
 
+// Catch-all for authenticated services without dedicated plugins.
+// Services with plugins (GitHub, GitLab, Linear) handle blocking in their own hooks.
 const authenticatedDomains: AuthenticatedDomain[] = [
   {
     pattern: /^https:\/\/docs\.google\.com\//,
@@ -22,10 +24,6 @@ const authenticatedDomains: AuthenticatedDomain[] = [
   {
     pattern: /^https:\/\/[^/]+\.notion\.so\//,
     suggestion: "Notion requires authentication. Use Notion MCP.",
-  },
-  {
-    pattern: /^https:\/\/linear\.app\//,
-    suggestion: "Linear requires authentication. Use Linear MCP or load `linear:linear` skill.",
   },
 ];
 


### PR DESCRIPTION
Move Linear URL blocking from userspace catch-all to the Linear plugin, allowing public docs to pass through.

## Changes

- Adds `scripts/fetch.ts` hook to block WebFetch on `linear.app` workspace URLs
- Allows public URLs (`/docs`, `/developers`, `/changelog`) to pass through
- Removes Linear from userspace `webfetch-block` hook
- Documents that userspace hook is a catch-all for services without dedicated plugins

## Testing

- Tests cover public URL allowlist and workspace URL blocking
- Userspace tests updated to verify Linear passes through (handled by plugin)