### PR TITLE
feat(git): add fix-conflicts command

### DIFF
--- a/plugins/git/.claude-plugin/plugin.json
+++ b/plugins/git/.claude-plugin/plugin.json
@@ -4,5 +4,6 @@
   "author": {
     "name": "Ben Drucker",
     "email": "bvdrucker@gmail.com"
-  }
+  },
+  "commands": "./commands"
 }

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -6,11 +6,14 @@ Git workflow and branching best practices for Claude Code.
 
 - **Skills**:
   - `git`: Git commands, branching, and commit message formatting
+  - `conflicts`: Resolving git merge conflicts during rebase, merge, or cherry-pick
+- **Commands**:
+  - `fix-conflicts`: Fix merge conflicts, commit, and push
 - **Hooks**:
   - Blocks direct commits to the default branch
 
 ## Testing
 
 ```bash
-npm test -- plugins/git
+bun test plugins/git
 ```

--- a/plugins/git/commands/fix-conflicts.md
+++ b/plugins/git/commands/fix-conflicts.md
@@ -1,0 +1,40 @@
+---
+description: "Fix merge conflicts, commit, and push"
+allowed-tools:
+  - Read
+  - Edit
+  - Grep
+  - Glob
+  - Bash
+  - Task
+  - Skill
+  - AskUserQuestion
+---
+
+# Fix Merge Conflicts
+
+Fix all merge conflicts in the working tree, then commit and push the result.
+
+## Workflow
+
+1. **Load the conflicts skill** via the Skill tool (`git:conflicts`) to get conflict status, context, and resolution tooling.
+
+2. **Assess complexity.** After the skill loads, count the conflicted files and conflict markers:
+   - **Simple** (all conflicts are in generated files like lockfiles, or fewer than 3 conflicts across 1-2 files with obvious resolutions): proceed without confirmation.
+   - **Complex** (3+ files, non-trivial code conflicts, or ambiguous intent): summarize the conflicts and ask the user for confirmation before resolving.
+
+3. **Resolve conflicts.** For each conflicted file:
+   - Use three-way access (`:1:`, `:2:`, `:3:` slots via `git show`) to understand base, ours, and theirs.
+   - Edit the file to produce the correct merged result.
+   - `git add` the resolved file.
+   - For generated files (lockfiles, build artifacts), prefer deleting and regenerating over manual merge.
+
+4. **Continue the operation.** Run the appropriate continuation command (`git rebase --continue`, `git merge --continue`, or `git cherry-pick --continue`).
+
+5. **Push.** Run `git push` to update the remote branch.
+
+## Notes
+
+- Follow the project's `CLAUDE.md` for any lockfile-specific guidance (e.g., regenerating `bun.lock` from scratch).
+- If a conflict is in a file you don't understand, ask the user rather than guessing.
+- Never silently drop changes from either side — when in doubt, keep both and ask.


### PR DESCRIPTION
Adds a `git:fix-conflicts` command that handles the full merge conflict workflow: load the `conflicts` skill, resolve conflicts, commit, and push.

## Changes

- New `plugins/git/commands/fix-conflicts.md` — inline command (no `context: fork`) so it retains awareness of the outer session
- Registers `commands` path in `plugin.json`
- Simple conflicts (lockfiles, few markers) proceed automatically; complex ones prompt for confirmation
- Delegates to the existing `git:conflicts` skill for three-way access, status, and marker checking

## Design

Runs inline rather than forked so the agent has full conversation context (e.g., understanding _why_ a merge is happening). The `conflicts` skill provides the resolution tooling; the command adds the prescriptive workflow around it (assess, resolve, continue operation, push).
