### PR TITLE
Automate plugin updates with nightly sync and Renovate

### DIFF
--- a/bin/claude-upgrade
+++ b/bin/claude-upgrade
@@ -104,17 +104,23 @@ update_marketplaces() {
 update_plugins() {
   log "Updating plugins..."
 
-  local settings_file="$CLAUDE_REPO_HOME/.claude/settings.json"
+  local marketplace_file="$CLAUDE_REPO_HOME/.claude-plugin/marketplace.json"
+  local marketplace_name
+  marketplace_name=$(jq -r '.name' "$marketplace_file")
+
+  local settings_file="$HOME/.claude/settings.json"
   if [[ ! -f "$settings_file" ]]; then
     log "WARNING: settings.json not found at $settings_file"
     return 0
   fi
 
   local plugins
-  plugins=$(jq -r '.enabledPlugins // {} | keys[]' "$settings_file" 2>/dev/null)
+  plugins=$(jq -r --arg m "$marketplace_name" \
+    '.enabledPlugins // {} | keys[] | select(endswith("@" + $m))' \
+    "$settings_file" 2>/dev/null)
 
   if [[ -z "$plugins" ]]; then
-    log "No enabled plugins found"
+    log "No first-party plugins found"
     return 0
   fi
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,37 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:recommended"],
+  enabledManagers: ["custom.regex"],
+  customManagers: [
+    {
+      customType: "regex",
+      description: "Third-party marketplaces pinned to semver tags via ref",
+      managerFilePatterns: ["user/settings.json"],
+      matchStrings: [
+        '"repo":\\s*"(?<depName>[^"]+/[^"]+)"[^}]*"ref":\\s*"(?<currentValue>v[^"]+)"',
+      ],
+      datasourceTemplate: "github-releases",
+      versioningTemplate: "semver-coerced",
+    },
+    {
+      customType: "regex",
+      description: "Third-party marketplaces pinned to commit digests via sha",
+      managerFilePatterns: ["user/settings.json"],
+      matchStrings: [
+        '"repo":\\s*"(?<depName>[^"]+/[^"]+)"[^}]*"sha":\\s*"(?<currentDigest>[0-9a-f]{40})"',
+      ],
+      currentValueTemplate: "main",
+      datasourceTemplate: "git-refs",
+      versioningTemplate: "git",
+    },
+  ],
+  packageRules: [
+    {
+      matchManagers: ["custom.regex"],
+      matchFileNames: ["user/settings.json"],
+      commitMessagePrefix: "chore(plugins):",
+      additionalBranchPrefix: "plugin-",
+      semanticCommits: "disabled",
+    },
+  ],
+}

--- a/user/settings.json
+++ b/user/settings.json
@@ -53,7 +53,7 @@
     "command": "wt list statusline --claude-code"
   },
   "enabledPlugins": {
-    "pr-review-toolkit@claude-code-plugins": true,
+    "pr-review-toolkit@claude-plugins-official": true,
     "go@bendrucker": true,
     "terraform@bendrucker": true,
     "python@bendrucker": true,
@@ -96,22 +96,32 @@
         "repo": "bendrucker/claude"
       }
     },
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official",
+        "sha": "27d2b86d72da27c64585150857cee8472ad47abb"
+      }
+    },
     "astral-sh": {
       "source": {
         "source": "github",
-        "repo": "astral-sh/claude-code-plugins"
+        "repo": "astral-sh/claude-code-plugins",
+        "sha": "f8034678a15ad751aae6a2b684daebac416267a1"
       }
     },
     "ast-grep": {
       "source": {
         "source": "github",
-        "repo": "ast-grep/claude-skill"
+        "repo": "ast-grep/claude-skill",
+        "sha": "577f4d4507678f2c8cee150fae25e6ce309f70b1"
       }
     },
     "worktrunk": {
       "source": {
         "source": "github",
-        "repo": "max-sixty/worktrunk"
+        "repo": "max-sixty/worktrunk",
+        "ref": "v0.21.0"
       }
     }
   },


### PR DESCRIPTION
Split plugin update strategy: first-party plugins update nightly via `claude-upgrade`, third-party plugins get pinned and updated via Renovate PRs.

## Changes

- **`bin/claude-upgrade`**: Fix settings path from project to user settings. Filter `enabledPlugins` to first-party plugins only (keys ending with `@bendrucker`) so nightly updates don't touch third-party plugins.
- **`user/settings.json`**: Switch `pr-review-toolkit` from `@claude-code-plugins` (built-in, no repo) to `@claude-plugins-official` (pinnable). Add `claude-plugins-official` to `extraKnownMarketplaces`. Pin all third-party marketplaces: `sha` for digest-pinned repos (`claude-plugins-official`, `astral-sh`, `ast-grep`), `ref` for tag-pinned repos (`worktrunk`).
- **`renovate.json5`**: Two custom regex managers for `user/settings.json` — one for `ref` fields (semver tags via `github-releases`) and one for `sha` fields (commit digests via `git-refs`). `enabledManagers: ["custom.regex"]` avoids overlap with Dependabot.

## Testing

- `renovate-config-validator` passes