### PR TITLE
feat(style): add heading style hook and fix bun module resolution

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -57,6 +57,8 @@
     "plugins/style": {
       "name": "@bendrucker/claude-style",
       "dependencies": {
+        "@constellos/claude-code-kit": "^0.4.0",
+        "ap-style-title-case": "^2.0.0",
         "mdast-util-from-markdown": "^2.0.2",
         "unist-util-visit": "^5.1.0",
       },
@@ -450,6 +452,8 @@
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
+    "ap-style-title-case": ["ap-style-title-case@2.0.0", "", {}, "sha512-8vCoCer8ZTXjvCK+JQLU0YW0EWI+70lyP9Q33mafLG0VRT7UY1BHoDq7WzaQYwzh9t+eG94tEJuVHrEDcRP1Fg=="],
+
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "arrify": ["arrify@1.0.1", "", {}, "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA=="],
@@ -712,7 +716,7 @@
 
     "ini": ["ini@4.1.3", "", {}, "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg=="],
 
-    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+    "internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
@@ -1258,8 +1262,6 @@
 
     "chevrotain/lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
 
-    "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
     "cli-color/ansi-regex": ["ansi-regex@2.1.1", "", {}, "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="],
 
     "cross-spawn/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
@@ -1371,8 +1373,6 @@
     "@npmcli/promise-spawn/which/isexe": ["isexe@3.1.1", "", {}, "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ=="],
 
     "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
-
-    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 

--- a/plugins/style/README.md
+++ b/plugins/style/README.md
@@ -4,10 +4,14 @@ Code style enforcement hooks.
 
 ## Contents
 
-- **Hooks**: Anti-numbering detection for Write and Edit tools
+- **Hooks**: Numbering detection and heading style enforcement for Write and Edit tools
+
+## Hook Commands
+
+Each hook command runs `bun install --cwd ${CLAUDE_PLUGIN_ROOT}` before the hook script. Installed plugins have no `node_modules` — bun auto-installs dependencies from its global cache, but packages like `unist-util-visit-parents` use self-referencing subpath exports that fail without a local `node_modules`. Running `bun install` ensures Node.js-style resolution works. With everything already installed, `bun install` completes in ~50ms.
 
 ## Testing
 
 ```sh
-npm test -- plugins/style
+bun test plugins/style
 ```

--- a/plugins/style/hooks/headings.test.ts
+++ b/plugins/style/hooks/headings.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "bun:test";
+import type {
+  PreToolUseHookInput,
+  PreToolUseHookSpecificOutput,
+} from "@anthropic-ai/claude-agent-sdk";
+import { checkBoldAsHeading, checkTitleCase, processInput } from "./headings";
+
+function mockWriteInput(filePath: string, content: string): PreToolUseHookInput {
+  return {
+    hook_event_name: "PreToolUse",
+    session_id: "test",
+    transcript_path: "/tmp/test",
+    cwd: "/tmp",
+    tool_name: "Write",
+    tool_input: { file_path: filePath, content },
+    tool_use_id: "test",
+  };
+}
+
+function getOutput(input: PreToolUseHookInput): PreToolUseHookSpecificOutput | null {
+  const result = processInput(input);
+  if (!result) return null;
+  return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
+}
+
+const titleCaseCases: { description: string; content: string; match: boolean }[] = [
+  { description: "lowercase heading", content: "# introduction", match: true },
+  { description: "correctly cased heading", content: "# Introduction", match: false },
+  { description: "mixed case heading", content: "## setup and Configuration", match: true },
+  {
+    description: "correctly cased multi-word",
+    content: "## Setup and Configuration",
+    match: false,
+  },
+  { description: "all inline code children", content: "## `context: fork`", match: false },
+  {
+    description: "correct case with inline code",
+    content: "## Using `context: fork` in Skills",
+    match: false,
+  },
+  {
+    description: "bad case with inline code",
+    content: "## using `context: fork` in skills",
+    match: true,
+  },
+  { description: "uncapitalized first word (stop word)", content: "# the Guide", match: true },
+  { description: "stop words mid-heading", content: "# The Guide to Everything", match: false },
+  { description: "heading inside code block", content: "```\n# introduction\n```", match: false },
+];
+
+describe("checkTitleCase", () => {
+  for (const { description, content, match } of titleCaseCases) {
+    it(description, () => {
+      const result = checkTitleCase(content);
+      if (match) {
+        expect(result).not.toBeNull();
+      } else {
+        expect(result).toBeNull();
+      }
+    });
+  }
+});
+
+const boldAsHeadingCases: { description: string; content: string; match: boolean }[] = [
+  {
+    description: "bold text ending with colon",
+    content: "**Configuration:**\nSome text",
+    match: true,
+  },
+  { description: "standalone bold-colon line", content: "**Setup Guide:**", match: true },
+  { description: "bold mid-sentence", content: "Some text with **bold** words", match: false },
+  {
+    description: "bold without colon at start",
+    content: "**Important** note about things",
+    match: false,
+  },
+  { description: "bold inside code block", content: "```\n**Configuration:**\n```", match: false },
+];
+
+describe("checkBoldAsHeading", () => {
+  for (const { description, content, match } of boldAsHeadingCases) {
+    it(description, () => {
+      const result = checkBoldAsHeading(content);
+      if (match) {
+        expect(result).not.toBeNull();
+      } else {
+        expect(result).toBeNull();
+      }
+    });
+  }
+});
+
+describe("processInput", () => {
+  it("returns title case guidance", () => {
+    const output = getOutput(mockWriteInput("README.md", "# introduction"));
+    expect(output?.additionalContext).toContain("AP-style title case");
+  });
+
+  it("returns bold-as-heading guidance", () => {
+    const output = getOutput(mockWriteInput("README.md", "**Configuration:**\nSome text"));
+    expect(output?.additionalContext).toContain("markdown heading");
+  });
+
+  it("skips non-markdown files", () => {
+    expect(getOutput(mockWriteInput("app.ts", "# introduction"))).toBeNull();
+  });
+
+  it("returns null for unknown tool", () => {
+    const input: PreToolUseHookInput = {
+      hook_event_name: "PreToolUse",
+      session_id: "test",
+      transcript_path: "/tmp/test",
+      cwd: "/tmp",
+      tool_name: "Bash",
+      tool_input: { command: "echo hello" },
+      tool_use_id: "test",
+    };
+    expect(getOutput(input)).toBeNull();
+  });
+});

--- a/plugins/style/hooks/headings.ts
+++ b/plugins/style/hooks/headings.ts
@@ -1,0 +1,141 @@
+#!/usr/bin/env bun
+
+import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { apStyleTitleCase } from "ap-style-title-case";
+import type { Heading, Paragraph, Strong, Text } from "mdast";
+import { fromMarkdown } from "mdast-util-from-markdown";
+import { visit } from "unist-util-visit";
+import {
+  type EditInput,
+  formatContext,
+  getExtension,
+  isMarkdownFile,
+  type SyncHookJSONOutput,
+  type WriteInput,
+} from "./markdown";
+
+const PLACEHOLDER = "\0";
+
+export function checkTitleCase(content: string): string | null {
+  const ast = fromMarkdown(content);
+  let result: string | null = null;
+
+  visit(ast, "heading", (node: Heading) => {
+    if (result) return;
+
+    const allCode = node.children.every((child) => child.type === "inlineCode");
+    if (allCode) return;
+
+    const parts: string[] = [];
+    for (const child of node.children) {
+      if (child.type === "text") {
+        parts.push(child.value);
+      } else if (child.type === "inlineCode") {
+        parts.push(PLACEHOLDER);
+      }
+    }
+
+    const combined = parts.join("");
+    const titleCased = apStyleTitleCase(combined);
+
+    const originalParts = combined.split(PLACEHOLDER);
+    const titleParts = titleCased.split(PLACEHOLDER);
+
+    for (let i = 0; i < originalParts.length; i++) {
+      if (originalParts[i] !== titleParts[i]) {
+        const text = node.children
+          .filter((child): child is Text => child.type === "text")
+          .map((child) => child.value)
+          .join("");
+        result = `Heading "${text.trim()}" should be title case`;
+        return;
+      }
+    }
+  });
+
+  return result;
+}
+
+export function checkBoldAsHeading(content: string): string | null {
+  const ast = fromMarkdown(content);
+  let result: string | null = null;
+
+  visit(ast, "paragraph", (node: Paragraph) => {
+    if (result) return;
+
+    const first = node.children[0];
+    if (first?.type !== "strong") return;
+
+    const strong = first as Strong;
+    const text = strong.children
+      .filter((child): child is Text => child.type === "text")
+      .map((child) => child.value)
+      .join("");
+
+    if (text.endsWith(":")) {
+      result = `Bold text "${text}" should be a heading`;
+    }
+  });
+
+  return result;
+}
+
+export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {
+  const toolName = input.tool_name;
+
+  let content: string;
+  let filePath: string;
+
+  if (toolName === "Write") {
+    const toolInput = input.tool_input as WriteInput;
+    content = toolInput.content;
+    filePath = toolInput.file_path;
+  } else if (toolName === "Edit") {
+    const toolInput = input.tool_input as EditInput;
+    content = toolInput.new_string;
+    filePath = toolInput.file_path;
+  } else {
+    return null;
+  }
+
+  const ext = getExtension(filePath);
+  if (!isMarkdownFile(ext)) return null;
+
+  const titleCase = checkTitleCase(content);
+  if (titleCase) {
+    return formatContext(
+      `${titleCase}. Apply AP-style title case: capitalize major words, lowercase articles/prepositions (a, an, the, in, of, etc.) unless they start the heading.`,
+    );
+  }
+
+  const boldHeading = checkBoldAsHeading(content);
+  if (boldHeading) {
+    return formatContext(
+      `${boldHeading}. Replace the bold-colon pattern with a markdown heading (## ) at the appropriate level.`,
+    );
+  }
+
+  return null;
+}
+
+async function main(): Promise<void> {
+  let input: PreToolUseHookInput;
+  try {
+    input = await readStdinJson<PreToolUseHookInput>();
+  } catch (error) {
+    console.error(
+      `[style/headings] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  const output = processInput(input);
+  if (output) {
+    writeStdoutJson(output);
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/plugins/style/hooks/hooks.json
+++ b/plugins/style/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Detects numbered identifiers in code using ast-grep",
+  "description": "Detects style violations in markdown and code",
   "hooks": {
     "PreToolUse": [
       {
@@ -7,7 +7,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts write"
+            "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts write"
+          },
+          {
+            "type": "command",
+            "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts"
           }
         ]
       },
@@ -16,7 +20,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts edit"
+            "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts edit"
+          },
+          {
+            "type": "command",
+            "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts"
           }
         ]
       }

--- a/plugins/style/hooks/markdown.ts
+++ b/plugins/style/hooks/markdown.ts
@@ -1,0 +1,33 @@
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+export type { SyncHookJSONOutput };
+
+export type WriteInput = { file_path: string; content: string };
+export type EditInput = { file_path: string; new_string: string };
+
+export function getExtension(filePath: string): string {
+  const parts = filePath.split(".");
+  return parts.length > 1 ? (parts.at(-1) ?? "") : "";
+}
+
+export function isMarkdownFile(ext: string): boolean {
+  return ext === "md" || ext === "markdown";
+}
+
+export function formatDecision(decision: "deny" | "ask", reason: string): SyncHookJSONOutput {
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: decision,
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
+export function formatContext(context: string): SyncHookJSONOutput {
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      additionalContext: context,
+    },
+  };
+}

--- a/plugins/style/hooks/numbering.test.ts
+++ b/plugins/style/hooks/numbering.test.ts
@@ -4,7 +4,8 @@ import type {
   PreToolUseHookInput,
   PreToolUseHookSpecificOutput,
 } from "@anthropic-ai/claude-agent-sdk";
-import { checkCode, checkMarkdown, formatOutput, processInput } from "./numbering";
+import { formatDecision } from "./markdown";
+import { checkCode, checkMarkdown, processInput } from "./numbering";
 
 function hasSg(): boolean {
   try {
@@ -49,9 +50,9 @@ function getOutput(
   return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
 }
 
-describe("formatOutput", () => {
+describe("formatDecision", () => {
   it("formats deny decision", () => {
-    const output = formatOutput("deny", "Test reason");
+    const output = formatDecision("deny", "Test reason");
     expect(output).toEqual({
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
@@ -62,7 +63,7 @@ describe("formatOutput", () => {
   });
 
   it("formats ask decision", () => {
-    const output = formatOutput("ask", "Test reason");
+    const output = formatDecision("ask", "Test reason");
     expect(output).toEqual({
       hookSpecificOutput: {
         hookEventName: "PreToolUse",

--- a/plugins/style/hooks/numbering.ts
+++ b/plugins/style/hooks/numbering.ts
@@ -5,14 +5,19 @@ import { unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import type { Heading, Text } from "mdast";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { visit } from "unist-util-visit";
-
-export type WriteInput = { file_path: string; content: string };
-export type EditInput = { file_path: string; new_string: string };
+import {
+  type EditInput,
+  formatDecision,
+  getExtension,
+  isMarkdownFile,
+  type SyncHookJSONOutput,
+  type WriteInput,
+} from "./markdown";
 
 type Mode = "write" | "edit";
 
@@ -27,15 +32,6 @@ type AstGrepMatch = {
 };
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-
-function getExtension(filePath: string): string {
-  const parts = filePath.split(".");
-  return parts.length > 1 ? (parts.at(-1) ?? "") : "";
-}
-
-function isMarkdownFile(ext: string): boolean {
-  return ext === "md" || ext === "markdown";
-}
 
 export function checkMarkdown(content: string): string | null {
   const ast = fromMarkdown(content);
@@ -110,16 +106,6 @@ export function checkCode(content: string, ext: string): string | null {
   return null;
 }
 
-export function formatOutput(decision: "deny" | "ask", reason: string): SyncHookJSONOutput {
-  return {
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: decision,
-      permissionDecisionReason: reason,
-    },
-  };
-}
-
 export function processInput(input: PreToolUseHookInput, mode: Mode): SyncHookJSONOutput | null {
   const toolName = input.tool_name;
 
@@ -157,9 +143,9 @@ ${match}
 Use descriptive names instead. See CLAUDE.md Organization guidelines.`;
 
   if (mode === "write") {
-    return formatOutput("deny", reason);
+    return formatDecision("deny", reason);
   } else {
-    return formatOutput("ask", `This edit introduces numbered sequences. ${reason}`);
+    return formatDecision("ask", `This edit introduces numbered sequences. ${reason}`);
   }
 }
 

--- a/plugins/style/package.json
+++ b/plugins/style/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@constellos/claude-code-kit": "^0.4.0",
+    "ap-style-title-case": "^2.0.0",
     "mdast-util-from-markdown": "^2.0.2",
     "unist-util-visit": "^5.1.0"
   },


### PR DESCRIPTION
Add a PreToolUse hook to the style plugin that enforces markdown heading conventions: AP-style title case and detecting bold-as-heading patterns (`**Foo:**` should be a heading). The hook is advisory-only — it surfaces guidance via `additionalContext` rather than making permission decisions, so Claude corrects headings on subsequent turns without blocking writes.

Fix a bun module resolution bug affecting installed plugins. Packages like `unist-util-visit-parents` use self-referencing subpath exports that fail when bun auto-installs from its global cache without a local `node_modules`. Hook commands now run `bun install --cwd` before each script to ensure Node.js-style resolution works.

## Changes

- Add `headings.ts` hook with `checkTitleCase` (uses `ap-style-title-case` with placeholder strategy for inline code spans) and `checkBoldAsHeading` (detects `**text:**` at paragraph start)
- Each detection pattern returns distinct guidance (title case rules vs. heading replacement)
- Extract shared utilities (`getExtension`, `isMarkdownFile`, `formatDecision`, `formatContext`) from `numbering.ts` into `markdown.ts`
- Add `@constellos/claude-code-kit` and `ap-style-title-case` to plugin `package.json`
- Prefix all hook commands with `bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null`

## Testing

- Table-driven unit tests cover title case detection including inline code spans, stop word behavior, and code block exclusion
- Table-driven unit tests cover bold-as-heading detection including mid-sentence bold and code block exclusion
- `processInput` tests verify `additionalContext` output for both heading checks
