### PR TITLE
Add bun plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -114,6 +114,11 @@
       "source": "./plugins/interview"
     },
     {
+      "name": "bun",
+      "description": "Bun runtime patterns, bunx, shell scripting, lockfile, and testing",
+      "source": "./plugins/bun"
+    },
+    {
       "name": "calendar",
       "description": "Reading and managing macOS Calendar events",
       "source": "./plugins/calendar"

--- a/plugins/bun/.claude-plugin/plugin.json
+++ b/plugins/bun/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "bun",
+  "description": "Bun runtime patterns, bunx, shell scripting, lockfile, and testing",
+  "author": {
+    "name": "Ben Drucker",
+    "email": "bvdrucker@gmail.com"
+  }
+}

--- a/plugins/bun/README.md
+++ b/plugins/bun/README.md
@@ -1,0 +1,7 @@
+# Bun Plugin
+
+Bun runtime patterns, bunx, shell scripting, lockfile management, and testing.
+
+## Contents
+
+- **Skill**: Bun runtime guidance with references for bunx, lockfile, resolution, shell, and testing

--- a/plugins/bun/skills/bun/SKILL.md
+++ b/plugins/bun/skills/bun/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: bun
+description: >-
+  Bun runtime patterns and best practices. Use when running scripts with bun,
+  using bunx, writing Bun shell scripts, managing bun.lock, or running bun test.
+user-invocable: false
+---
+
+# Bun
+
+## bunx
+
+Use `--bun` before the executable name to force the Bun runtime over Node shebangs. Use `-p`/`--package` when the binary name differs from the package name (e.g., `bunx -p @angular/cli ng`).
+
+See [references/bunx.md](references/bunx.md)
+
+## Lockfile
+
+`bun.lock` is a text-based lockfile. Resolve merge conflicts by deleting it and running `bun install` to regenerate from scratch — never attempt to merge lockfile contents.
+
+See [references/lockfile.md](references/lockfile.md)
+
+## Resolution
+
+Runtime flags must precede the script path: `bun --cwd ./packages/app run dev`. Never use `.js` extensions in TypeScript imports — Bun resolves them natively.
+
+See [references/resolution.md](references/resolution.md)
+
+## Shell
+
+`Bun.$` is a tagged template for shell execution. Use `.text()` for string output, `.nothrow()` to handle failures without exceptions.
+
+See [references/shell.md](references/shell.md)
+
+## Testing
+
+Bun runs tests in a single process. Set `AGENT=1` to suppress passing test output. Use `--bail` to stop after first failure, `-t` for name filtering.
+
+See [references/testing.md](references/testing.md)

--- a/plugins/bun/skills/bun/references/bunx.md
+++ b/plugins/bun/skills/bun/references/bunx.md
@@ -1,0 +1,13 @@
+# bunx
+
+`--bun` must come **before** the executable name to force the Bun runtime instead of respecting Node shebangs:
+
+```bash
+bunx --bun tsc --noEmit
+```
+
+`-p` / `--package` specifies the package when the binary name differs:
+
+```bash
+bunx -p @angular/cli ng new my-app
+```

--- a/plugins/bun/skills/bun/references/lockfile.md
+++ b/plugins/bun/skills/bun/references/lockfile.md
@@ -1,0 +1,13 @@
+# Lockfile
+
+`bun.lock` is a text-based lockfile. Bun populates integrity hashes for all platforms from the registry, even for packages not downloaded locally.
+
+## Conflict Resolution
+
+Regenerate from scratch:
+
+```bash
+rm bun.lock && bun install
+```
+
+Do **not** use `git checkout origin/main -- bun.lock && bun install`. This produces empty integrity hashes for platform-specific packages (e.g., `@img/sharp-libvips-linux-x64`), breaking CI on other platforms.

--- a/plugins/bun/skills/bun/references/resolution.md
+++ b/plugins/bun/skills/bun/references/resolution.md
@@ -1,0 +1,18 @@
+# Resolution
+
+## Flag Ordering
+
+Runtime flags must precede the script path:
+
+```bash
+bun --cwd ./packages/app run dev
+```
+
+## TypeScript Imports
+
+Never use `.js` extensions in TypeScript imports. Bun resolves `.ts`, `.tsx`, `.jsx`, and `.js` files natively.
+
+```ts
+import { handler } from "./routes/auth";  // correct
+import { handler } from "./routes/auth.js";  // wrong
+```

--- a/plugins/bun/skills/bun/references/shell.md
+++ b/plugins/bun/skills/bun/references/shell.md
@@ -1,0 +1,23 @@
+# Bun Shell
+
+`Bun.$` is a tagged template for shell execution. Interpolated values are auto-escaped.
+
+```ts
+import { $ } from "bun";
+const text = await $`echo hello`.text();
+```
+
+Use `.nothrow()` to suppress exceptions on non-zero exit codes:
+
+```ts
+const { exitCode, stdout } = await $`cmd`.nothrow().quiet();
+```
+
+Per-command configuration:
+
+```ts
+await $`pwd`.cwd("/tmp");
+await $`echo $FOO`.env({ ...process.env, FOO: "bar" });
+```
+
+Bypass escaping with `{ raw: "..." }` when shell expansion is needed.

--- a/plugins/bun/skills/bun/references/testing.md
+++ b/plugins/bun/skills/bun/references/testing.md
@@ -1,0 +1,18 @@
+# Testing
+
+Bun's test runner executes all tests in a single process, not worker-per-file like Vitest or Jest.
+
+## Key Flags
+
+| Flag | Description |
+|------|-------------|
+| `--bail` / `--bail=N` | Stop after N failures (default: 1) |
+| `-t` / `--test-name-pattern` | Filter by name (regex, not globs) |
+
+## Agent Output
+
+Set `AGENT=1` to suppress passing test output while preserving failure details:
+
+```bash
+AGENT=1 bun test
+```


### PR DESCRIPTION
## Summary

- New `bun` plugin with always-on skill covering runtime patterns Claude gets wrong
- References for bunx flag ordering, lockfile conflict resolution, module resolution, Bun shell API, and test runner behavior
- Aggressively scoped to corrections and non-obvious behavior only

## Test plan

- [x] `scripts/check-marketplace.sh` passes
- [x] `bun run skill-lint "plugins/bun/skills/*"` passes
- [ ] CI passes