### PR TITLE
feat(user): add pull-request:create skill override to workflow

### DIFF
--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -21,6 +21,7 @@
 
 - The user has carefully curated skills for their common workflows. Load skills when possible to adhere to the user's preferences and navigate their projects efficiently.
 - For questions about Claude Code features or usage, use the Task tool with `subagent_type='claude-code-guide'` to consult official documentation.
+- Always use the `pull-request:create` skill to create pull requests. If the skill is unavailable, create the PR with an empty body.
 - When executing build commands, output to `/dev/null` to avoid creating binaries.
 - Store temporary files in `tmp/` directory.
 - Use `pbcopy` and `pbpaste` for clipboard interaction.


### PR DESCRIPTION
Adds a workflow instruction to always use the `pull-request:create` skill for creating PRs instead of the built-in Bash PR workflow. Falls back to creating a PR with an empty body if the skill is unavailable.