### PR TITLE
feat(ci): add Swift syntax validation to plugin tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,6 +140,7 @@ jobs:
           echo "has_commands=$([[ -d "plugins/$plugin/commands" ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "has_package=$([[ -f "plugins/$plugin/package.json" ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "has_tests=$(find "plugins/$plugin" \( -name '*.test.ts' -o -name '*.integration.ts' \) | grep -q . && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "has_swift=$(find "plugins/$plugin" -name '*.swift' | grep -q . && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -171,6 +172,14 @@ jobs:
       - name: Lint skills
         if: steps.inspect.outputs.has_skills == 'true'
         run: bun run skill-lint "plugins/${{ matrix.plugin }}/skills/*"
+
+      - name: Setup Swift
+        if: steps.inspect.outputs.has_swift == 'true'
+        uses: swift-actions/setup-swift@v2
+
+      - name: Validate Swift syntax
+        if: steps.inspect.outputs.has_swift == 'true'
+        run: find "plugins/${{ matrix.plugin }}" -name "*.swift" -exec swiftc -parse {} +
 
       - name: Validate agent frontmatter
         if: steps.inspect.outputs.has_agents == 'true'


### PR DESCRIPTION
Adds `swiftc -parse` to the plugin CI matrix for plugins containing `.swift` files. This catches syntax errors without requiring macOS frameworks — `-parse` is syntax-only and won't fail on `import AppKit` or similar.

## Changes

- Adds `has_swift` flag to the plugin inspection step
- Installs Swift via `swift-actions/setup-swift@v2` when needed
- Runs `swiftc -parse` on all `.swift` files in the plugin

Applies to x-callback-url, calendar, and shortcuts plugins.