### PR TITLE
fix(things): rename `_run` to `run` in JXA scripts

### DIFF
--- a/plugins/things/scripts/reorder.js
+++ b/plugins/things/scripts/reorder.js
@@ -45,7 +45,7 @@ function executeJsonUpdate(app, token, data) {
 /**
  * @param {string[]} argv
  */
-function _run(argv) {
+function run(argv) {
   let targetList = "today";
   const ids = [];
 

--- a/plugins/things/skills/jxa/scripts/export-markdown.js
+++ b/plugins/things/skills/jxa/scripts/export-markdown.js
@@ -12,7 +12,7 @@
 /**
  * @param {string[]} argv
  */
-function _run(argv) {
+function run(argv) {
   const listId = argv[0] || "TMTodayListSource";
 
   const app = Application("Things3");

--- a/plugins/things/skills/jxa/scripts/find-todos.js
+++ b/plugins/things/skills/jxa/scripts/find-todos.js
@@ -11,7 +11,7 @@
 /**
  * @param {string[]} argv
  */
-function _run(argv) {
+function run(argv) {
   let mode = null;
   let value = null;
 

--- a/plugins/things/skills/jxa/scripts/query-list.js
+++ b/plugins/things/skills/jxa/scripts/query-list.js
@@ -13,7 +13,7 @@
 /**
  * @param {string[]} argv
  */
-function _run(argv) {
+function run(argv) {
   const listId = argv[0];
   if (!listId) {
     console.log("Usage: osascript scripts/query-list.js <list-id>");

--- a/plugins/things/skills/jxa/scripts/query-logbook.js
+++ b/plugins/things/skills/jxa/scripts/query-logbook.js
@@ -14,7 +14,7 @@
 /**
  * @param {string[]} argv
  */
-function _run(argv) {
+function run(argv) {
   let days = null;
   let startDate = null;
   let endDate = null;

--- a/plugins/things/skills/jxa/scripts/query-metadata.js
+++ b/plugins/things/skills/jxa/scripts/query-metadata.js
@@ -10,7 +10,7 @@
 /**
  * @param {string[]} argv
  */
-function _run(argv) {
+function run(argv) {
   const type = argv[0];
   if (!type || !["projects", "areas", "tags"].includes(type)) {
     console.log("Usage: osascript scripts/query-metadata.js projects|areas|tags");

--- a/plugins/things/skills/jxa/setup.md
+++ b/plugins/things/skills/jxa/setup.md
@@ -17,6 +17,18 @@ osascript -l JavaScript -e 'const app = Application("Things3"); const tags = app
 osascript -l JavaScript -e 'const app = Application("Things3"); const inbox = app.lists.byId("TMInboxListSource"); const todos = []; const items = inbox.toDos(); for (let i = 0; i < items.length; i++) { todos.push({id: items[i].id(), name: items[i].name()}); } JSON.stringify(todos, null, 2);'
 ```
 
+For script files, define a `run(argv)` function. `osascript` calls it automatically and prints the return value:
+
+```javascript
+#!/usr/bin/env osascript -l JavaScript
+function run(argv) {
+  const app = Application("Things3");
+  return JSON.stringify({ count: app.toDos().length });
+}
+```
+
+**Important**: The function must be named `run`, not `_run`. `osascript` does not call `_run`.
+
 ## JXA Arrays vs JavaScript Arrays
 
 **CRITICAL**: JXA arrays (from methods like `list.toDos()`) are NOT JavaScript arrays.

--- a/plugins/things/skills/jxa/troubleshooting.md
+++ b/plugins/things/skills/jxa/troubleshooting.md
@@ -75,6 +75,7 @@ scripts/run-jxa.sh 'const app = Application("Things3"); const todo = app.toDos.b
 **Missing auth token**: All updates require `auth-token` parameter
 **URL encoding**: Notes with special characters must be URL-encoded
 **Rate limiting**: Max 250 operations per 10 seconds
+**Completed items**: Setting `list-id` (area) on a completed item silently fails — the item moves to Logbook instead. Assign areas before completing.
 **Moving to area**: Use `list-id` (not `area-id`) when moving a todo to an area:
 ```bash
 # Does NOT work:


### PR DESCRIPTION
All JXA scripts defined `function _run(argv)` as their entry point, but `osascript -l JavaScript` calls `run()` (no underscore). The scripts silently returned empty output with no error.

## Changes

- Rename `_run` to `run` in all 6 JXA script files
- Document the `run` vs `_run` distinction in `setup.md`
- Document that completed items can't be assigned to areas in `troubleshooting.md`
