### PR TITLE
fix(pull-request): add scoped bun permission for context scripts

### DIFF
--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Create a pull request, merge request, or change request with proper formatting and content guidelines.
   Invoke when the user wants to create, open, or submit a PR, MR, or CR—including after committing changes.
 
-allowed-tools: Bash(gh:*), Bash(git:*), Bash(glab:*), mcp__github
+allowed-tools: Bash(bun:${CLAUDE_PLUGIN_ROOT}/scripts/*), Bash(gh:*), Bash(git:*), Bash(glab:*), mcp__github
 ---
 
 # Create Pull Request

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Update a pull request or merge request body to reflect the current state of changes.
   Use when a PR/MR has evolved through additional commits and the body needs to reflect what will be merged.
 
-allowed-tools: Bash(gh:*), Bash(git:*), Bash(glab:*), mcp__github
+allowed-tools: Bash(bun:${CLAUDE_PLUGIN_ROOT}/scripts/*), Bash(gh:*), Bash(git:*), Bash(glab:*), mcp__github
 ---
 
 # Update Pull Request


### PR DESCRIPTION
The `pull-request:create` and `pull-request:update` skills run `bun` in their context blocks to execute `detect-provider.ts` and `pr-context.ts`, but `allowed-tools` only permitted `gh`, `git`, and `glab` commands. This caused a permission error on skill initialization.

Adds `Bash(bun:${CLAUDE_PLUGIN_ROOT}/scripts/*)` to scope the permission to only plugin-owned scripts rather than blanket `bun` access.
