### PR TITLE
fix(pull-request): add worktree script permission for skill context

### DIFF
--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Create a pull request, merge request, or change request with proper formatting and content guidelines.
   Invoke when the user wants to create, open, or submit a PR, MR, or CR—including after committing changes.
 
-allowed-tools: Bash(bun:${CLAUDE_PLUGIN_ROOT}/scripts/*), Bash(gh:*), Bash(git:*), Bash(glab:*), mcp__github
+allowed-tools: Bash(bun:${CLAUDE_PLUGIN_ROOT}/scripts/*), Bash(${CLAUDE_PLUGIN_ROOT}/scripts/worktree/*), Bash(gh:*), Bash(git:*), Bash(glab:*), mcp__github
 ---
 
 # Create Pull Request

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Update a pull request or merge request body to reflect the current state of changes.
   Use when a PR/MR has evolved through additional commits and the body needs to reflect what will be merged.
 
-allowed-tools: Bash(bun:${CLAUDE_PLUGIN_ROOT}/scripts/*), Bash(gh:*), Bash(git:*), Bash(glab:*), mcp__github
+allowed-tools: Bash(bun:${CLAUDE_PLUGIN_ROOT}/scripts/*), Bash(${CLAUDE_PLUGIN_ROOT}/scripts/worktree/*), Bash(gh:*), Bash(git:*), Bash(glab:*), mcp__github
 ---
 
 # Update Pull Request


### PR DESCRIPTION
The `allowed-tools` patterns in the `pull-request:create` and `pull-request:update` skills didn't cover direct invocations of worktree wrapper scripts (`git.sh`, `gh.sh`, `glab.sh`), causing skill context `!` commands to fail permission checks with:

```
Error: Bash command permission check failed for pattern "!`".../scripts/worktree/git.sh" "" branch --show-current`":
This command requires approval
```

Adds `Bash(${CLAUDE_PLUGIN_ROOT}/scripts/worktree/*)` to both skills' `allowed-tools`.
