### PR TITLE
fix: replace CLAUDE_SKILL_ROOT with CLAUDE_PLUGIN_ROOT in context commands

### DIFF
--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -69,7 +69,7 @@ hooks:                                    # Optional: skill-scoped hooks
 | `$ARGUMENTS`           | All arguments passed when invoking the skill. Appended automatically if absent.  |
 | `$ARGUMENTS[N]` / `$N` | Access a specific argument by 0-based index.                                     |
 | `${CLAUDE_SESSION_ID}` | Current session ID.                                                              |
-| `${CLAUDE_SKILL_ROOT}` | Absolute path to the skill's directory. Use in hooks and script references.      |
+| `${CLAUDE_SKILL_ROOT}` | Absolute path to the skill's directory. Works in hooks and allowed-tools, but NOT in `!` context. |
 
 ### Dynamic Context Injection
 

--- a/plugins/claude-code/skills/skill/references/patterns.md
+++ b/plugins/claude-code/skills/skill/references/patterns.md
@@ -138,7 +138,7 @@ Dynamic context works alongside other skill features:
 
 ### Gotchas
 
-- Commands run in the **project root**, not the skill directory. Use `${CLAUDE_SKILL_ROOT}` to reference skill-local scripts.
+- Commands run in the **project root**, not the skill directory. For plugin skills, use `${CLAUDE_PLUGIN_ROOT}/skills/<skill-name>` to reference skill-local scripts. `${CLAUDE_SKILL_ROOT}` works in hooks and allowed-tools but NOT in `!` context.
 - **stderr is discarded** — only stdout replaces the placeholder.
 - Failed commands produce empty output. Handle this in the command itself with a fallback (e.g., `some-cmd 2>/dev/null || echo "unavailable"`).
 - Commands run **synchronously and sequentially**. Avoid slow commands that would delay skill loading.

--- a/plugins/git/skills/conflicts/SKILL.md
+++ b/plugins/git/skills/conflicts/SKILL.md
@@ -15,24 +15,24 @@ allowed-tools:
   - Bash(git merge:*)
   - Bash(git cherry-pick:*)
   - Bash(git rerere:*)
-  - Bash(bun ${CLAUDE_SKILL_ROOT}/scripts/*:*)
+  - Bash(bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/*:*)
 hooks:
   PreToolUse:
     - matcher: "Bash(git commit:*)|Bash(git rebase --continue:*)|Bash(git merge --continue:*)|Bash(git cherry-pick --continue:*)"
       hooks:
         - type: command
-          command: "bun ${CLAUDE_SKILL_ROOT}/scripts/check-markers.ts"
+          command: "bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/check-markers.ts"
 ---
 
 # Git Conflicts
 
 ## Status
 
-!`bun ${CLAUDE_SKILL_ROOT}/scripts/status.ts 2>/dev/null || echo "Run status.ts manually"`
+!`bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/status.ts 2>/dev/null || echo "Run status.ts manually"`
 
 ## Context
 
-!`bun ${CLAUDE_SKILL_ROOT}/scripts/context.ts 2>/dev/null || echo "Run context.ts manually"`
+!`bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/context.ts 2>/dev/null || echo "Run context.ts manually"`
 
 ## Three-Way Access
 

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -15,7 +15,7 @@ The PR body documents what will happen when merged, not the journey. Don't echo 
 
 - Provider: !`bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts"`
 - Branch: !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" branch --show-current`
-- PR: !`bun "${CLAUDE_PLUGIN_ROOT}/scripts/pr-context.ts" "$0" "${CLAUDE_SKILL_ROOT}/assets/pr-context.graphql" 2>/dev/null || echo "No PR found for current branch"`
+- PR: !`bun "${CLAUDE_PLUGIN_ROOT}/scripts/pr-context.ts" "$0" "${CLAUDE_PLUGIN_ROOT}/skills/update/assets/pr-context.graphql" 2>/dev/null || echo "No PR found for current branch"`
 - Diff (GitHub): !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/gh.sh" "$0" pr diff 2>/dev/null`
 - Diff (GitLab): !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/glab.sh" "$0" mr diff 2>/dev/null`
 


### PR DESCRIPTION
`${CLAUDE_SKILL_ROOT}` doesn't work in skill `!` context commands—it fails with "Command contains ${} parameter substitution". Only `${CLAUDE_PLUGIN_ROOT}` is supported for dynamic context injection.

## Changes

- **`git:conflicts`**: Replace `${CLAUDE_SKILL_ROOT}` with `${CLAUDE_PLUGIN_ROOT}/skills/conflicts` in `!` context, hooks, and allowed-tools
- **`pull-request:update`**: Replace `${CLAUDE_SKILL_ROOT}` with `${CLAUDE_PLUGIN_ROOT}/skills/update` in `!` context
- **Documentation**: Update `claude-code:skill` to clarify that `${CLAUDE_SKILL_ROOT}` works in hooks and allowed-tools but NOT in `!` context
