### PR TITLE
fix(hooks): match both standard and plugin MCP tool names

### DIFF
--- a/plugins/claude-code/skills/hook/SKILL.md
+++ b/plugins/claude-code/skills/hook/SKILL.md
@@ -52,6 +52,8 @@ Reference for creating and configuring Claude Code hooks. When uncertain about s
 - Multiple: `"Edit|Write|MultiEdit"`
 - With args: `"Bash(npm:*)"`, `"Bash(osascript:*)|Bash(open:*)"`
 - MCP tools: `"mcp__linear__create_issue"`
+- Plugin MCP tools: `"mcp__plugin_<plugin>_<namespace>__<tool>"`
+- Both patterns: `"mcp__linear__create_issue|mcp__plugin_linear_linear__create_issue"`
 
 ## Hook Input
 

--- a/plugins/linear/hooks/default-state.test.ts
+++ b/plugins/linear/hooks/default-state.test.ts
@@ -2,13 +2,16 @@ import { describe, expect, it } from "bun:test";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { getDefaultState, processInput } from "./default-state";
 
-function mockInput(toolInput: Record<string, unknown>): PreToolUseHookInput {
+function mockInput(
+  toolInput: Record<string, unknown>,
+  toolName = "mcp__linear__create_issue",
+): PreToolUseHookInput {
   return {
     hook_event_name: "PreToolUse",
     session_id: "test",
     transcript_path: "/tmp/test",
     cwd: "/tmp",
-    tool_name: "mcp__linear__create_issue",
+    tool_name: toolName,
     tool_input: toolInput,
     tool_use_id: "test",
   };
@@ -82,5 +85,19 @@ describe("processInput", () => {
       }),
     );
     expect(output).toBeNull();
+  });
+
+  it("works with plugin MCP tool name pattern", () => {
+    const output = processInput(
+      mockInput({ title: "Test issue", team: "ENG" }, "mcp__plugin_linear_linear__create_issue"),
+    );
+    expect(output).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        updatedInput: {
+          state: "Backlog",
+        },
+      },
+    });
   });
 });

--- a/plugins/linear/hooks/hooks.json
+++ b/plugins/linear/hooks/hooks.json
@@ -12,7 +12,7 @@
         ]
       },
       {
-        "matcher": "mcp__linear__create_issue",
+        "matcher": "mcp__linear__create_issue|mcp__plugin_linear_linear__create_issue",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
Hook matchers like `mcp__linear__create_issue` don't match plugin-loaded MCP tools, which use the pattern `mcp__plugin_<plugin>_<namespace>__<tool>`.

## Changes

- Update Linear `create_issue` hook matcher to match both standard and plugin tool name patterns
- Add test case for plugin MCP tool name pattern
- Document plugin MCP tool naming in hook skill reference
