### PR TITLE
fix(pull-request): guard update skill diffs by provider

### DIFF
--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -16,8 +16,8 @@ The PR body documents what will happen when merged, not the journey. Don't echo 
 - Provider: !`bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts"`
 - Branch: !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" branch --show-current`
 - PR: !`bun "${CLAUDE_PLUGIN_ROOT}/scripts/pr-context.ts" "$0" "${CLAUDE_PLUGIN_ROOT}/skills/update/assets/pr-context.graphql" 2>/dev/null || echo "No PR found for current branch"`
-- Diff (GitHub): !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/gh.sh" "$0" pr diff 2>/dev/null`
-- Diff (GitLab): !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/glab.sh" "$0" mr diff 2>/dev/null`
+- Diff (GitHub): !`[ "$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts")" = github ] && "${CLAUDE_PLUGIN_ROOT}/scripts/worktree/gh.sh" "$0" pr diff 2>/dev/null || true`
+- Diff (GitLab): !`[ "$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts")" = gitlab ] && "${CLAUDE_PLUGIN_ROOT}/scripts/worktree/glab.sh" "$0" mr diff 2>/dev/null || true`
 
 ## Workflow
 


### PR DESCRIPTION
The `pull-request:update` skill's context commands for `gh pr diff` and `glab mr diff` ran unconditionally. On GitLab repos, `gh pr diff` exits non-zero, which fails the `!` backtick expansion and breaks the entire skill.

## Changes

- Guard each diff context command with a `detect-provider.ts` check so only the matching CLI runs
- Add `|| true` fallback so the context command always exits 0 even if the diff itself fails
