### PR TITLE
feat(gitlab): add stack-merge script and skill docs

### DIFF
--- a/plugins/gitlab/scripts/stack-merge.ts
+++ b/plugins/gitlab/scripts/stack-merge.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env bun
+
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+
+interface StackRef {
+  prev: string;
+  branch: string;
+  sha: string;
+  next: string;
+  mr: string;
+  description: string;
+}
+
+async function stackTitle(): Promise<string> {
+  const title = await $`git config glab.currentstack`.text();
+  return title.trim();
+}
+
+async function readStackRefs(title: string): Promise<StackRef[]> {
+  const topLevel = (await $`git rev-parse --show-toplevel`.text()).trim();
+  const stackDir = join(topLevel, ".git", "stacked", title);
+  const entries = await readdir(stackDir);
+
+  const refs = new Map<string, StackRef>();
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) continue;
+    const ref: StackRef = await Bun.file(join(stackDir, entry)).json();
+    refs.set(ref.sha, ref);
+  }
+
+  const first = [...refs.values()].find((r) => r.prev === "");
+  if (!first) throw new Error("No first ref found in stack");
+
+  const ordered: StackRef[] = [];
+  let current: StackRef | undefined = first;
+  while (current) {
+    ordered.push(current);
+    current = current.next ? refs.get(current.next) : undefined;
+  }
+
+  return ordered;
+}
+
+interface ApprovalConfig {
+  reset_approvals_on_push: boolean;
+}
+
+async function checkApprovalSettings(): Promise<void> {
+  const config: ApprovalConfig = await $`glab api projects/:id/approvals`.json();
+
+  if (config.reset_approvals_on_push) {
+    console.warn("warn: reset_approvals_on_push is enabled.");
+    console.warn("The cascade relies on GitLab 16.7+ smart patch-id reset to preserve approvals.");
+    console.warn("Avoid squash merge on individual stack MRs — squash changes the patch-id.");
+  }
+}
+
+await checkApprovalSettings();
+
+const title = await stackTitle();
+const refs = await readStackRefs(title);
+
+if (refs.length === 0) {
+  console.error("No stack entries found");
+  process.exit(1);
+}
+
+for (const ref of refs) {
+  try {
+    await $`glab mr merge ${ref.branch} --auto-merge -y`;
+    console.log(`auto-merge enabled: ${ref.branch}`);
+  } catch {
+    console.error(`failed: ${ref.branch}`);
+  }
+}

--- a/plugins/gitlab/skills/merge-request/stack.md
+++ b/plugins/gitlab/skills/merge-request/stack.md
@@ -29,4 +29,26 @@ glab stack reorder         # Rearrange commit sequence
 glab stack amend           # Modify existing stack commits
 ```
 
+## Merging a Stack
+
+`glab stack` has no merge subcommand. Use the [stack-merge](../../scripts/stack-merge.ts) script to enable auto-merge on every MR in the stack:
+
+```bash
+bun plugins/gitlab/scripts/stack-merge.ts
+```
+
+The script reads stack refs from `.git/stacked/<title>/*.json`, checks project approval settings, and runs `glab mr merge <branch> --auto-merge -y` for each entry.
+
+### How the cascade works
+
+1. MR1 merges when its pipeline passes
+2. GitLab auto-retargets MR2 to the base branch
+3. MR2's pipeline runs — since the logical diff is unchanged, the smart patch-id reset (GitLab 16.7+) preserves approvals
+4. MR2 auto-merges, triggering the same cascade for MR3, etc.
+
+### Requirements
+
+- **GitLab 16.7+** for smart `git patch-id` approval reset. When `reset_approvals_on_push` is enabled (the default), GitLab compares patch-ids before and after a rebase. If the logical diff is unchanged, approvals are preserved. The script checks this setting via `glab api projects/:id/approvals`.
+- **Don't squash** individual stack MRs. Squash replaces the original commits with a single commit, changing the patch-id when the next MR is retargeted. This resets approvals and breaks the cascade.
+
 Use `glab stack --help` for full options. This feature is experimental.


### PR DESCRIPTION
Adds a script and skill documentation for merging an entire `glab stack` in one go, without requiring re-approval of each MR as it cascades.

## Issue

`glab stack` has no merge subcommand. To merge an approved stack today, you must manually merge each MR bottom-up. Worse, when MR1 merges and GitLab auto-retargets MR2, the target branch change can reset approvals — forcing reviewers to re-approve work they've already reviewed. This is the core problem described in [gitlab-org/gitlab#372602](https://gitlab.com/gitlab-org/gitlab/-/issues/372602), which remains open.

Squashing all stack MRs into a single MR to merge is a workaround, but it defeats the purpose of stacking (incremental review, parallel development) and still requires a final approval on the combined change.

## Changes

**`plugins/gitlab/scripts/stack-merge.ts`** — Script that enables auto-merge on every MR in the current stack:

- Reads stack refs directly from `.git/stacked/<title>/*.json` (the same linked-list JSON files `glab stack` uses internally) rather than parsing `glab stack list` CLI output
- Walks refs first-to-last and runs `glab mr merge <branch> --auto-merge -y` for each
- Checks `reset_approvals_on_push` via `glab api projects/:id/approvals` and warns when the cascade depends on the GitLab 16.7+ smart `git patch-id` reset

**`plugins/gitlab/skills/merge-request/stack.md`** — New "Merging a Stack" section documenting:

- The auto-merge cascade: MR1 merges → GitLab retargets MR2 → approvals preserved via patch-id → pipeline passes → auto-merge triggers → repeat
- Requirements: GitLab 16.7+ for smart patch-id approval reset, no squash merge on individual stack MRs (squash changes commit structure, altering the patch-id and resetting approvals)

## References

- [gitlab-org/gitlab#372602](https://gitlab.com/gitlab-org/gitlab/-/issues/372602) — Keep approvals in stacked MRs (open)
- [gitlab-org/gitlab#337888](https://gitlab.com/gitlab-org/gitlab/-/issues/337888) — Smart patch-id approval reset (shipped in 16.7)
- [gitlab-org/gitlab#337265](https://gitlab.com/gitlab-org/gitlab/-/issues/337265) — Auto-retarget stacked MRs (shipped)
