### PR TITLE
fix(things): add 10s timeout to xcall to prevent hangs

### DIFF
--- a/plugins/things/scripts/url.ts
+++ b/plugins/things/scripts/url.ts
@@ -106,7 +106,11 @@ export async function xcall(url: string): Promise<string> {
   if (!runner) {
     throw new Error("xcall not found — x-callback-url plugin not installed");
   }
-  return (await $`${runner} ${url}`.text()).trim();
+  const proc = Bun.spawn([runner, url], { stdout: "pipe", timeout: 10_000 });
+  const text = await new Response(proc.stdout).text();
+  const code = await proc.exited;
+  if (code !== 0) throw new Error(`xcall failed (exit ${code})`);
+  return text.trim();
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
The xcall binary can block indefinitely when Things doesn't respond to the x-callback-url callback. This adds a 10-second timeout using `Promise.race` that kills the process and rejects. The existing `catch` block in the CLI entry point falls back to fire-and-forget `open -g`.