### PR TITLE
feat(bun): expand skill with subprocess, file-io, improved activation

### DIFF
--- a/plugins/bun/skills/bun/SKILL.md
+++ b/plugins/bun/skills/bun/SKILL.md
@@ -1,8 +1,12 @@
 ---
 name: bun
 description: >-
-  Bun runtime patterns and best practices. Use when running scripts with bun,
-  using bunx, writing Bun shell scripts, managing bun.lock, or running bun test.
+  Bun runtime patterns and best practices. Use when running bun commands (bun run, bun test, bunx),
+  working with package.json or bun.lock, writing TypeScript scripts that run under Bun,
+  developing Claude Code skills/hooks/scripts (which use Bun as their runtime),
+  or working in projects that use Bun as their package manager.
+  Covers bunx execution, lockfile handling, module resolution, shell scripting with Bun.$,
+  subprocess spawning, file I/O, and testing with bun test.
 user-invocable: false
 ---
 
@@ -28,12 +32,24 @@ See [references/resolution.md](references/resolution.md)
 
 ## Shell
 
-`Bun.$` is a tagged template for shell execution. Use `.text()` for string output, `.nothrow()` to handle failures without exceptions.
+`Bun.$` is a tagged template for shell execution. Use response methods (`.text()`, `.json()`, `.lines()`) to extract output, `.nothrow()` to handle failures without exceptions, and pipe/redirect syntax for composing commands.
 
 See [references/shell.md](references/shell.md)
 
+## Subprocess
+
+`Bun.spawn` spawns subprocesses with streaming I/O. Use `Bun.spawnSync` for synchronous execution. Configure stdin/stdout/stderr, environment variables, and working directory. Check `exitCode` for error handling.
+
+See [references/spawn.md](references/spawn.md)
+
+## File I/O
+
+`Bun.file()` creates file handles with `.text()`, `.json()`, `.arrayBuffer()`, and `.stream()` methods. `Bun.write()` writes content to files or stdout/stderr. Both support streaming for large files.
+
+See [references/file-io.md](references/file-io.md)
+
 ## Testing
 
-Bun runs tests in a single process. Set `AGENT=1` to suppress passing test output. Use `--bail` to stop after first failure, `-t` for name filtering.
+Bun runs tests in a single process. Use `describe`/`it`/`test` for structure, `expect` matchers for assertions, lifecycle hooks (`beforeEach`, `afterEach`) for setup/teardown, `mock()` for function mocking, and `.toMatchSnapshot()` for snapshot testing. Set `AGENT=1` to suppress passing test output.
 
 See [references/testing.md](references/testing.md)

--- a/plugins/bun/skills/bun/references/file-io.md
+++ b/plugins/bun/skills/bun/references/file-io.md
@@ -1,0 +1,81 @@
+# File I/O
+
+## Bun.file()
+
+`Bun.file()` returns a `BunFile` representing a file on disk. It does not read the file immediately:
+
+```ts
+const file = Bun.file("path.txt");
+const content = await file.text();
+```
+
+Common methods:
+
+```ts
+// Read as text
+const text = await Bun.file("file.txt").text();
+
+// Read as JSON
+const data = await Bun.file("data.json").json();
+
+// Read as ArrayBuffer
+const buffer = await Bun.file("binary.dat").arrayBuffer();
+
+// Read as stream
+const stream = Bun.file("large.txt").stream();
+```
+
+Check if a file exists:
+
+```ts
+const file = Bun.file("path.txt");
+const exists = await file.exists();
+```
+
+MIME type detection:
+
+```ts
+const file = Bun.file("image.png");
+console.log(file.type); // "image/png"
+```
+
+## Bun.write()
+
+`Bun.write()` writes content to a file, creating it if it doesn't exist:
+
+```ts
+await Bun.write("output.txt", "content");
+```
+
+Write JSON:
+
+```ts
+await Bun.write("data.json", JSON.stringify(data, null, 2));
+```
+
+Write from a stream or Response:
+
+```ts
+const response = await fetch("https://example.com/data.json");
+await Bun.write("data.json", response);
+```
+
+Write to stdout or stderr:
+
+```ts
+await Bun.write(Bun.stdout, "message\n");
+await Bun.write(Bun.stderr, "error\n");
+```
+
+## Streaming
+
+For large files, stream instead of loading into memory:
+
+```ts
+const file = Bun.file("large.txt");
+const stream = file.stream();
+
+for await (const chunk of stream) {
+  // Process chunk
+}
+```

--- a/plugins/bun/skills/bun/references/shell.md
+++ b/plugins/bun/skills/bun/references/shell.md
@@ -7,11 +7,67 @@ import { $ } from "bun";
 const text = await $`echo hello`.text();
 ```
 
-Use `.nothrow()` to suppress exceptions on non-zero exit codes:
+## Response Methods
+
+Extract output in different formats:
+
+```ts
+// As string
+const text = await $`echo hello`.text();
+
+// As JSON
+const data = await $`echo '{"key":"value"}'`.json();
+
+// As array of lines
+const lines = await $`ls`.lines();
+
+// As Blob
+const blob = await $`cat file.txt`.blob();
+```
+
+## Error Handling
+
+By default, `$` throws on non-zero exit codes. Use `.nothrow()` to handle failures manually:
+
+```ts
+const result = await $`false`.nothrow();
+if (result.exitCode !== 0) {
+  console.error("Command failed:", result.stderr.toString());
+}
+```
+
+Combine with `.quiet()` to suppress stdout/stderr:
 
 ```ts
 const { exitCode, stdout } = await $`cmd`.nothrow().quiet();
 ```
+
+## Piping
+
+Pipe output between commands:
+
+```ts
+const text = await $`echo hello | tr a-z A-Z`.text();
+console.log(text); // "HELLO"
+```
+
+## Redirection
+
+Redirect output to files:
+
+```ts
+await $`echo hello > /tmp/output.txt`;
+await $`echo world >> /tmp/output.txt`; // append
+```
+
+Redirect stderr:
+
+```ts
+await $`cmd 2> /tmp/errors.txt`;
+await $`cmd 2>&1`; // stderr to stdout
+```
+
+## Configuration
 
 Per-command configuration:
 

--- a/plugins/bun/skills/bun/references/spawn.md
+++ b/plugins/bun/skills/bun/references/spawn.md
@@ -1,0 +1,74 @@
+# Subprocess
+
+## Bun.spawn
+
+Spawn a subprocess and stream its output:
+
+```ts
+const proc = Bun.spawn(["echo", "hello"]);
+const text = await new Response(proc.stdout).text();
+console.log(text); // "hello\n"
+```
+
+Stdin, stdout, and stderr are `ReadableStream` or `WritableStream` depending on the option:
+
+```ts
+const proc = Bun.spawn(["cat"], {
+  stdin: "pipe",
+  stdout: "pipe",
+});
+
+const writer = proc.stdin.getWriter();
+writer.write(new TextEncoder().encode("hello\n"));
+writer.close();
+
+const output = await new Response(proc.stdout).text();
+```
+
+Set environment variables and working directory:
+
+```ts
+const proc = Bun.spawn(["pwd"], {
+  cwd: "/tmp",
+  env: { ...process.env, FOO: "bar" },
+});
+```
+
+Check exit code:
+
+```ts
+const proc = Bun.spawn(["false"]);
+await proc.exited;
+console.log(proc.exitCode); // 1
+```
+
+## Bun.spawnSync
+
+For synchronous execution, use `Bun.spawnSync`:
+
+```ts
+const result = Bun.spawnSync(["echo", "hello"]);
+console.log(result.stdout.toString()); // "hello\n"
+console.log(result.exitCode); // 0
+```
+
+## Error Handling
+
+`Bun.spawn` does not throw on non-zero exit codes. Check `exitCode` explicitly:
+
+```ts
+const proc = Bun.spawn(["false"]);
+await proc.exited;
+if (proc.exitCode !== 0) {
+  throw new Error(`Command failed with exit code ${proc.exitCode}`);
+}
+```
+
+For `spawnSync`, check the returned `exitCode`:
+
+```ts
+const result = Bun.spawnSync(["false"]);
+if (result.exitCode !== 0) {
+  throw new Error(`Command failed: ${result.stderr.toString()}`);
+}
+```

--- a/plugins/bun/skills/bun/references/testing.md
+++ b/plugins/bun/skills/bun/references/testing.md
@@ -2,12 +2,127 @@
 
 Bun's test runner executes all tests in a single process, not worker-per-file like Vitest or Jest.
 
+## Test Structure
+
+Use `describe`, `it`, or `test` to define tests:
+
+```ts
+import { describe, it, test, expect } from "bun:test";
+
+describe("math", () => {
+  it("adds numbers", () => {
+    expect(1 + 1).toBe(2);
+  });
+
+  test("multiplies numbers", () => {
+    expect(2 * 3).toBe(6);
+  });
+});
+```
+
+## Matchers
+
+Common `expect` matchers:
+
+```ts
+// Equality
+expect(value).toBe(expected); // strict equality (===)
+expect(obj).toEqual(expected); // deep equality
+
+// Truthiness
+expect(value).toBeTruthy();
+expect(value).toBeFalsy();
+
+// Strings
+expect(str).toMatch(/pattern/);
+expect(str).toContain("substring");
+
+// Numbers
+expect(num).toBeGreaterThan(5);
+expect(num).toBeLessThanOrEqual(10);
+
+// Arrays/Objects
+expect(arr).toContain(item);
+expect(arr).toHaveLength(3);
+
+// Exceptions
+expect(() => fn()).toThrow();
+expect(() => fn()).toThrow("error message");
+expect(() => fn()).toThrow(ErrorClass);
+
+// Negation
+expect(value).not.toBe(other);
+```
+
+## Lifecycle Hooks
+
+Run setup/teardown code:
+
+```ts
+import { beforeEach, afterEach, beforeAll, afterAll } from "bun:test";
+
+beforeAll(() => {
+  // Runs once before all tests
+});
+
+beforeEach(() => {
+  // Runs before each test
+});
+
+afterEach(() => {
+  // Runs after each test
+});
+
+afterAll(() => {
+  // Runs once after all tests
+});
+```
+
+## Mocking
+
+Use `mock()` to create function mocks:
+
+```ts
+import { mock } from "bun:test";
+
+const fn = mock((a: number, b: number) => a + b);
+fn(1, 2);
+
+expect(fn).toHaveBeenCalled();
+expect(fn).toHaveBeenCalledWith(1, 2);
+expect(fn).toHaveBeenCalledTimes(1);
+
+// Clear call history
+fn.mockClear();
+
+// Change implementation
+fn.mockImplementation((a, b) => a * b);
+
+// Return specific value
+fn.mockReturnValue(42);
+```
+
+## Snapshot Testing
+
+Compare output to saved snapshots:
+
+```ts
+expect(value).toMatchSnapshot();
+```
+
+Update snapshots with `--update-snapshots`:
+
+```bash
+bun test --update-snapshots
+```
+
 ## Key Flags
 
 | Flag | Description |
 |------|-------------|
 | `--bail` / `--bail=N` | Stop after N failures (default: 1) |
 | `-t` / `--test-name-pattern` | Filter by name (regex, not globs) |
+| `--update-snapshots` | Update snapshot files |
 
 ## Agent Output
 


### PR DESCRIPTION
Expands the Bun skill with new reference docs and improved activation patterns.

## Changes

- **Activation**: Broadened skill description to trigger for Claude Code skill/hook development contexts and projects using Bun as a package manager
- **`references/shell.md`**: Added response methods (`.json()`, `.lines()`, `.blob()`), piping, redirection, and error handling patterns
- **`references/spawn.md`**: New reference for `Bun.spawn`/`Bun.spawnSync` covering streaming I/O, environment configuration, and exit code handling
- **`references/file-io.md`**: New reference for `Bun.file()`/`Bun.write()` covering reading, writing, MIME detection, and streaming
- **`references/testing.md`**: Expanded with test structure, matchers, lifecycle hooks, mocking, and snapshot testing
