### PR TITLE
fix(pull-request): use worktree wrappers in workflow instructions

### DIFF
--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: Bash(bun:${CLAUDE_PLUGIN_ROOT}/scripts/*), Bash(${CLAUDE_PLUGIN_R
 
 ## Context
 
-- Provider: !`bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts"`
+- Provider: !`wt_path=$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/worktree/resolve.ts" "$0"); bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts" ${wt_path:+"$wt_path"}`
 - Branch: !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" branch --show-current`
 - Status: !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" status --short`
 - Log: !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" log --oneline -20`
@@ -44,15 +44,23 @@ When an issue is referenced:
 
 ## Workflow
 
-1. **Branch validation**: If the context shows you're on a default branch (main/master) and no `$0` argument was provided, stop and tell the user to specify the target branch: `/pull-request:create <branch>`. When a branch argument is provided, all git/gh commands must run in that branch's worktree using the wrapper scripts.
-2. Stage changes if not already staged.
-3. Commit if there are no commits yet on the branch. Follow the same format for the commit message as for the pull request title (conventional or subject-oriented based on repo standard).
-4. Push the branch to remote.
+1. **Branch validation**: If the context shows you're on a default branch (main/master) and no `$0` argument was provided, stop and tell the user to specify the target branch: `/pull-request:create <branch>`. When a branch argument is provided, all git/gh/glab commands must run in that branch's worktree using the wrapper scripts.
+2. Stage changes if not already staged:
+   - With `$0`: `"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" add .`
+   - Without `$0`: `git add .`
+3. Commit if there are no commits yet on the branch. Follow the same format for the commit message as for the pull request title (conventional or subject-oriented based on repo standard):
+   - With `$0`: `"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" commit -m "..."`
+   - Without `$0`: `git commit -m "..."`
+4. Push the branch to remote:
+   - With `$0`: `"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" push -u origin "$0"`
+   - Without `$0`: `git push -u origin HEAD`
 5. Create the PR/MR:
    - Write the body to a temp file first (e.g., `tmp/pr-body-<branch>.md`)
    - Include the branch name in the filename to avoid conflicts with concurrent agents
-   - **GitHub**: `gh pr create --title "..." --body-file tmp/pr-body-<branch>.md`
-   - **GitLab**: `glab mr create --title "..." --description "$(cat tmp/pr-body-<branch>.md)"`
+   - **GitHub with `$0`**: `"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/gh.sh" "$0" pr create --title "..." --body-file tmp/pr-body-<branch>.md`
+   - **GitHub without `$0`**: `gh pr create --title "..." --body-file tmp/pr-body-<branch>.md`
+   - **GitLab with `$0`**: `"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/glab.sh" "$0" mr create --title "..." --description "$(cat tmp/pr-body-<branch>.md)"`
+   - **GitLab without `$0`**: `glab mr create --title "..." --description "$(cat tmp/pr-body-<branch>.md)"`
 
 ## GitLab Notes
 

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -13,11 +13,11 @@ The PR body documents what will happen when merged, not the journey. Don't echo 
 
 ## Context
 
-- Provider: !`bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts"`
+- Provider: !`wt_path=$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/worktree/resolve.ts" "$0"); bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts" ${wt_path:+"$wt_path"}`
 - Branch: !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" branch --show-current`
 - PR: !`bun "${CLAUDE_PLUGIN_ROOT}/scripts/pr-context.ts" "$0" "${CLAUDE_PLUGIN_ROOT}/skills/update/assets/pr-context.graphql" 2>/dev/null || echo "No PR found for current branch"`
-- Diff (GitHub): !`[ "$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts")" = github ] && "${CLAUDE_PLUGIN_ROOT}/scripts/worktree/gh.sh" "$0" pr diff 2>/dev/null || true`
-- Diff (GitLab): !`[ "$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts")" = gitlab ] && "${CLAUDE_PLUGIN_ROOT}/scripts/worktree/glab.sh" "$0" mr diff 2>/dev/null || true`
+- Diff (GitHub): !`wt_path=$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/worktree/resolve.ts" "$0"); [ "$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts" ${wt_path:+"$wt_path"})" = github ] && "${CLAUDE_PLUGIN_ROOT}/scripts/worktree/gh.sh" "$0" pr diff 2>/dev/null || true`
+- Diff (GitLab): !`wt_path=$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/worktree/resolve.ts" "$0"); [ "$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts" ${wt_path:+"$wt_path"})" = gitlab ] && "${CLAUDE_PLUGIN_ROOT}/scripts/worktree/glab.sh" "$0" mr diff 2>/dev/null || true`
 
 ## Workflow
 
@@ -32,8 +32,10 @@ The PR body documents what will happen when merged, not the journey. Don't echo 
 
 1. Rewrite the PR body following the same title and body rules as the create skill. See [`sections.md`](sections.md) for section guidance.
 2. Write the updated body to a temp file (e.g., `tmp/pr-body-<branch>.md`) and apply:
-   - **GitHub**: `gh pr edit --body-file tmp/pr-body-<branch>.md`
-   - **GitLab**: `glab mr update --description "$(cat tmp/pr-body-<branch>.md)"`
+   - **GitHub with `$0`**: `"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/gh.sh" "$0" pr edit --body-file tmp/pr-body-<branch>.md`
+   - **GitHub without `$0`**: `gh pr edit --body-file tmp/pr-body-<branch>.md`
+   - **GitLab with `$0`**: `"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/glab.sh" "$0" mr update --description "$(cat tmp/pr-body-<branch>.md)"`
+   - **GitLab without `$0`**: `glab mr update --description "$(cat tmp/pr-body-<branch>.md)"`
 
 ## GitLab Notes
 


### PR DESCRIPTION
The create and update pull-request skills use worktree wrapper scripts (`git.sh`, `gh.sh`, `glab.sh`) to resolve the correct working directory when a branch argument (`$0`) is provided. However, several context commands and workflow instructions were still calling tools directly (e.g., `bun detect-provider.ts`, `gh pr create`) instead of using the wrappers.

## Changes

- Update `detect-provider.ts` context commands in both skills to resolve the worktree path and pass it through
- Add explicit worktree wrapper variants for all workflow steps: staging, committing, pushing, and creating/editing PRs
- Apply the same pattern to the update skill's diff context commands
