### PR TITLE
feat: use claude -p for worktree implementation agents

### DIFF
--- a/.claude/commands/improve-claude-code.md
+++ b/.claude/commands/improve-claude-code.md
@@ -25,7 +25,7 @@ Ask the user which items to work on. Accept numbers, ranges (e.g. `1-3`), or `al
 
 ### Plan Each Todo
 
-Launch parallel `Plan` agents (one per selected todo). Each agent receives:
+Launch parallel `Plan` agents via the Task tool (one per selected todo). Each agent receives:
 
 - Todo title and full notes
 - Instruction to explore the repo, identify files to modify, and produce a concrete implementation plan
@@ -44,21 +44,43 @@ Derive `{slug}` from the todo title: lowercase, replace spaces/special chars wit
 
 ### Implement in Parallel
 
-Dispatch `general-purpose` Task agents, one per worktree. Each agent receives the approved implementation plan and the worktree path. Agent implements changes, commits, pushes, and creates a PR.
+Task tool subagents cannot write to worktree directories (permissions are scoped to the orchestrator's cwd). Use `claude -p` CLI processes instead — each gets the worktree as its cwd with full local file access.
 
-PR body includes a `☑️ Original Task` section:
+For each worktree, write the implementation plan to a temp file, then dispatch:
+
+```bash
+cd <worktree-path> && claude -p \
+  --allowedTools "Read Write Edit Glob Grep Bash(git:*) Bash(bun:*) Bash(bunx:*)" \
+  --output-format text \
+  "<implementation-plan>" 2>&1
+```
+
+Run all dispatches as background Bash commands for parallelism. The prompt should include:
+
+- The full approved implementation plan
+- Instruction to commit changes with a descriptive message
+- Relevant skill guidance (e.g., skill structure conventions from `claude-code:skill` when creating skills)
+
+### Create PRs
+
+After all implementations complete, dispatch `claude -p` from each worktree to create PRs:
+
+```bash
+cd <worktree-path> && claude -p \
+  --allowedTools "Bash Read Write Edit Glob Grep Skill" \
+  --output-format text \
+  "Use the pull-request:create skill to create a PR. <context about the changes>" 2>&1
+```
+
+PR body includes a `Original Task` section:
 
 ```
-☑️ Original Task: [<todo-title>](things:///show?id=<todo-id>)
+Original Task: [<todo-title>](things:///show?id=<todo-id>)
 ```
-
-### Local Review
-
-Launch `pr-review-toolkit:code-reviewer` agents for each PR. If issues are found, present them to the user for decision before proceeding.
 
 ### Monitor CI
 
-Launch `github:actions-monitor` agents for each PR. Wait for all to complete. Collect pass/fail status and failure logs.
+Launch `github:actions-monitor` agents (via Task tool) for each PR. Wait for all to complete. Collect pass/fail status and failure logs. Fix failures in each worktree using `claude -p` the same way as implementation.
 
 ### Annotate and Complete
 
@@ -72,13 +94,11 @@ Output a final bulleted list — one entry per todo:
 - Things URL: `things:///show?id=<todo-id>`
 - Todo title
 
-## Agents
+## Dispatching CLI Agents
 
-| Agent | Type | Purpose |
-|-------|------|---------|
-| Planning | `Plan` | Explore repo, create implementation plan for a single todo |
-| Implementation | `general-purpose` | Implement changes in worktree, commit, push, create PR |
-| Code Review | `pr-review-toolkit:code-reviewer` | Local review of PR changes |
-| CI Monitor | `github:actions-monitor` | Watch GitHub Actions, report pass/fail with logs |
+When using `claude -p` for worktree work:
 
-Planning and implementation agents run in parallel. Code review and CI monitoring run after PR creation, in parallel across all PRs.
+- **Least privilege**: Use `--allowedTools` to scope to exactly the tools needed. Never use `--dangerously-skip-permissions`.
+- **No model override**: Let the user's default model apply. Do not pass `--model`.
+- **Background execution**: Run via `Bash(run_in_background: true)` and poll with `TaskOutput` for parallelism.
+- **Error handling**: Check exit codes and read output files. If an agent fails, report the error rather than retrying blindly.


### PR DESCRIPTION
Update the `improve-claude-code` command to use `claude -p` CLI processes instead of Task tool subagents for worktree implementation and PR creation.

Task tool subagents cannot write to worktree directories because permissions are scoped to the orchestrator's cwd. `claude -p` processes get their own cwd, sandbox scope, and tool permissions — each runs from the worktree directory with `--allowedTools` for least-privilege access.

## Changes

- Replace `general-purpose` Task agents with `claude -p` dispatches for implementation
- Add separate PR creation step using `claude -p` with `pull-request:create` skill
- Add `Dispatching CLI Agents` section documenting conventions (least privilege, no model override, background execution, error handling)
- Remove the Agents summary table (no longer accurate with mixed dispatch methods)

## Testing

Validated in a live session: dispatched 3 parallel `claude -p` implementation agents and 4 parallel PR creation agents across worktrees. All completed successfully with commits, pushes, and PRs created.