### PR TITLE
feat: add vendor notification delegation to daily review

### DIFF
--- a/plugins/gitlab/README.md
+++ b/plugins/gitlab/README.md
@@ -11,6 +11,7 @@ GitLab workflow best practices and glab CLI usage for Claude Code.
 - **ci**: CI/CD pipelines and jobs
 - **api**: REST and GraphQL API access
 - **docs**: Navigating GitLab documentation
+- **todos**: Managing GitLab todos inbox (notifications)
 
 ### Agents
 

--- a/plugins/gitlab/skills/todos/SKILL.md
+++ b/plugins/gitlab/skills/todos/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: todos
+description: Managing GitLab todos inbox. Use when listing, filtering, or triaging GitLab todos (mark done, mark pending).
+---
+
+# GitLab Todos
+
+Manage the GitLab todos inbox via `glab api`.
+
+## Listing
+
+```bash
+glab api /todos --paginate | jq '[.[] | select(.state == "pending")]'
+```
+
+### Fields
+
+| Field | Description |
+|-------|-------------|
+| `id` | Todo ID for actions |
+| `action_name` | `assigned`, `mentioned`, `build_failed`, `approval_required`, `review_requested`, `directly_addressed` |
+| `target_type` | `MergeRequest`, `Issue` |
+| `target.title` | Target title |
+| `target.web_url` | Browser URL |
+| `state` | `pending`, `done` |
+| `project.path_with_namespace` | Full project path |
+
+## Actions
+
+```bash
+glab api -X POST /todos/{id}/mark_as_done        # Mark single done
+glab api -X POST /todos/mark_as_done              # Mark all done
+```
+
+## Filtering
+
+Filter in jq after the API call:
+
+```bash
+# By action
+... | jq '[.[] | select(.state == "pending" and .action_name == "review_requested")]'
+
+# MRs only
+... | jq '[.[] | select(.state == "pending" and .target_type == "MergeRequest")]'
+```
+
+## Bulk Mark Done
+
+```bash
+glab api /todos --paginate | \
+  jq -r '[.[] | select(.state == "pending")] | .[].id' | \
+  xargs -I {} glab api -X POST /todos/{}/mark_as_done
+```

--- a/plugins/linear/README.md
+++ b/plugins/linear/README.md
@@ -4,8 +4,14 @@ Managing Linear issues, projects, and teams for Claude Code.
 
 ## Contents
 
-- **Skill**: Guidance on Linear workflows, issue management, and API usage
-- **Hook**: Sets default state for new issues based on assignee
+### Skills
+
+- **linear** — Workflows, issue management, and API usage
+- **notifications** — Notifications inbox triage
+
+### Hooks
+
+- Sets default state for new issues based on assignee
 
 ## Testing
 

--- a/plugins/linear/skills/notifications/SKILL.md
+++ b/plugins/linear/skills/notifications/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: notifications
+description: Managing Linear notifications inbox. Use when listing, filtering, or triaging Linear notifications.
+allowed-tools:
+  - mcp__linear
+  - Bash
+---
+
+# Linear Notifications
+
+<!-- TODO: Switch to `linear api` when the CLI api subcommand lands (https://github.com/bendrucker/claude/issues/353) -->
+
+Manage the Linear notifications inbox via GraphQL. Use `query.ts` from the `linear:linear` skill for ad-hoc queries until the Linear CLI gains an `api` subcommand.
+
+## Listing
+
+```bash
+bun ${SCRIPTS}/query.ts 'query {
+  notifications(first: 50, filter: { readAt: { null: true } }) {
+    nodes {
+      id type readAt archivedAt
+      ... on IssueNotification {
+        issue { identifier title url state { name } }
+        comment { body }
+      }
+    }
+  }
+}'
+```
+
+Where `${SCRIPTS}` is the `scripts/` directory from the `linear:linear` skill.
+
+### Notification Types
+
+| Type | Description |
+|------|-------------|
+| `IssueAssignedToYou` | Issue assigned to you |
+| `IssueCommentMention` | Mentioned in a comment |
+| `IssueStatusChanged` | Status change on subscribed issue |
+| `IssuePriorityUrgent` | Issue marked urgent |
+
+## Actions
+
+Archive:
+
+```graphql
+mutation { notificationArchive(input: { id: "..." }) { success } }
+```
+
+Mark all read:
+
+```graphql
+mutation { notificationMarkAllAsRead(input: {}) { success } }
+```
+
+## Filtering
+
+Add filters to the query:
+
+```graphql
+notifications(first: 50, filter: { type: { eq: "IssueAssignedToYou" } })
+notifications(first: 50, filter: { archivedAt: { null: true } })
+```

--- a/plugins/personal-review/README.md
+++ b/plugins/personal-review/README.md
@@ -6,4 +6,4 @@ Cross-tool daily review workflow for Calendar, Things, GitHub, and Linear.
 
 ### Skills
 
-- **review** — Interactive daily/weekly review orchestrating four inboxes in fixed order: Calendar → Things → GitHub → Linear
+- **review** — Interactive daily/weekly review orchestrating five inboxes: Calendar → Things → GitHub → GitLab → Linear

--- a/plugins/personal-review/skills/review/SKILL.md
+++ b/plugins/personal-review/skills/review/SKILL.md
@@ -5,20 +5,20 @@ description: Interactive daily review workflow across Calendar, Things, GitHub, 
 
 # Daily Review
 
-Process four inboxes in fixed order: Calendar → Things → GitHub → Linear.
+Process five inboxes in fixed order: Calendar → Things → GitHub → GitLab → Linear.
 
 ## Variants
 
-| Variant | Calendar | Things | GitHub | Linear |
-|---------|----------|--------|--------|--------|
-| Morning | Full scan + prep | Full processing | Full triage | Full review |
-| Evening | Tomorrow preview | Quick triage | Mark read, defer | Skip |
+| Variant | Calendar | Things | GitHub | GitLab | Linear |
+|---------|----------|--------|--------|--------|--------|
+| Morning | Full scan + prep | Full processing | Full triage | Full triage | Full review |
+| Evening | Tomorrow preview | Quick triage | Mark read, defer | Defer reviews | Skip |
 
 Ask which variant if not specified.
 
 ## Workflow
 
-### 1. Calendar Scan
+### Calendar Scan
 
 See [calendar.md](calendar.md).
 
@@ -27,7 +27,7 @@ Calculate time budget:
 - Focus windows (90+ min gaps)
 - Meetings needing prep tasks
 
-### 2. Things Inbox
+### Things Inbox
 
 See [things.md](things.md).
 
@@ -39,7 +39,7 @@ Batch items by pattern, ask user for each batch:
 
 Goal: inbox count = 0
 
-### 3. GitHub Notifications
+### GitHub Notifications
 
 See [github.md](github.md).
 
@@ -52,15 +52,29 @@ Group by reason, typical actions:
 | `CI_ACTIVITY` | Check status, mark done |
 | `MENTION`/`COMMENT` | Read, respond, mark done |
 
-### 4. Linear Inbox
+### GitLab Todos
+
+See [gitlab.md](gitlab.md).
+
+Group by action, typical actions:
+
+| Action | Actions |
+|--------|---------|
+| `review_requested` / `approval_required` | Review now, defer to Things |
+| `assigned` | Review now, defer to Things |
+| `mentioned` | Read, respond, mark done |
+| `build_failed` | Check CI, mark done |
+
+### Linear Notifications
 
 See [linear.md](linear.md).
 
-Review assigned issues:
-- **Todo** — start now, keep on radar, defer to Things
-- **In Progress** — check for blockers
+Review unread notifications:
+- **Assignments** — start now, keep on radar, defer to Things
+- **Mentions** — read, respond, archive
+- **Status changes** — acknowledge, archive
 
-### 5. Summary
+### Summary
 
 Present progress:
 - Time budget from Calendar
@@ -75,7 +89,7 @@ Items deferred from GitHub/Linear:
 
 - **Title**: `{Source}: {identifier} - {summary}`
 - **Notes**: Markdown link to source
-- **Tags**: Source name (GitHub, Linear)
+- **Tags**: Source name (GitHub, GitLab, Linear)
 
 ## Skills Used
 
@@ -84,7 +98,8 @@ Items deferred from GitHub/Linear:
 - `things:url` — Update Things items
 - `things:inbox` — Quick captures
 - `github:notifications` — Notification triage
-- `linear:linear` — Issue queries
+- `gitlab:todos` — Todo triage
+- `linear:notifications` — Notification triage
 
 ## Future
 

--- a/plugins/personal-review/skills/review/automation.md
+++ b/plugins/personal-review/skills/review/automation.md
@@ -12,10 +12,15 @@ Patterns that could be handled without user input:
 - **PR merged**: Mark done automatically
 - **Stale subscription**: Auto-unsubscribe after N ignores
 
+### GitLab
+
+- **Build passed on my MR**: Mark todo done automatically
+- **MR merged**: Mark todo done automatically
+
 ### Linear
 
-- **Blocked issues**: Auto-defer to Things with blocker context
-- **Stale in-progress**: Flag for review if no activity in N days
+- **Stale assignments**: Auto-defer to Things if unread for N days
+- **Resolved status changes**: Auto-archive when issue is done/canceled
 
 ### Things
 

--- a/plugins/personal-review/skills/review/gitlab.md
+++ b/plugins/personal-review/skills/review/gitlab.md
@@ -1,0 +1,44 @@
+# GitLab Todos
+
+Triage GitLab todos inbox by action type.
+
+## Query
+
+Load the `gitlab:todos` skill. Query pending todos.
+
+## Group by Action
+
+Present groups in priority order:
+
+| Priority | Action | Typical Actions |
+|----------|--------|-----------------|
+| 1 | `review_requested` / `approval_required` | Review now, defer to Things |
+| 2 | `assigned` / `directly_addressed` | Review now, defer to Things |
+| 3 | `mentioned` | Read, respond, mark done |
+| 4 | `build_failed` | Check CI, mark done |
+
+## Actions
+
+For each todo, use `AskUserQuestion`:
+
+| Action | API |
+|--------|-----|
+| Mark done | `POST /todos/{id}/mark_as_done` |
+| Defer to Things | Create task, then mark done |
+
+## Defer to Things
+
+Load the `things:inbox` skill. Create task with:
+
+- **Title**: `GitLab: {project}!{iid} - {title}`
+- **Notes**: Markdown link to `target.web_url`
+- **Tags**: `GitLab`
+
+Example: `GitLab: team/project!456 - Update CI pipeline config`
+
+## Evening Variant
+
+Simplified triage:
+- Defer review requests and approvals to Things
+- Mark done completed build notifications
+- Skip mentions

--- a/plugins/personal-review/skills/review/linear.md
+++ b/plugins/personal-review/skills/review/linear.md
@@ -1,36 +1,42 @@
-# Linear Inbox
+# Linear Notifications
 
-Review issues assigned to me.
+Triage Linear notifications inbox by type.
 
 ## Query
 
-Load the `linear:linear` skill. Query issues with `assignee: "me"`.
+Load the `linear:notifications` skill. Query unread notifications.
 
-Filter by state:
-- **Todo** — Ready to start
-- **In Progress** — Check for blockers
+## Group by Type
 
-## Review
+Present groups in priority order:
 
-For each issue, use `AskUserQuestion`:
+| Priority | Type | Typical Actions |
+|----------|------|-----------------|
+| 1 | `IssueAssignedToYou` | Review issue, start now, defer to Things |
+| 2 | `IssueCommentMention` | Read, respond, archive |
+| 3 | `IssueStatusChanged` | Acknowledge, archive |
+| 4 | `IssuePriorityUrgent` | Review urgency, start now, defer to Things |
 
-| Action | Description |
-|--------|-------------|
-| Start now | Begin working on this issue |
-| Keep on radar | Leave in current state, no action needed |
-| Defer to Things | Create tracking task in Things |
-| Unassign | Remove self, return to backlog |
+## Actions
+
+For each notification, use `AskUserQuestion`:
+
+| Action | GraphQL |
+|--------|---------|
+| Archive | `notificationArchive(input: { id: "..." })` |
+| Mark read | `notificationMarkAsRead(input: { id: "..." })` |
+| Defer to Things | Create task, then archive |
 
 ## Defer to Things
 
 Load the `things:inbox` skill. Create task with:
 
 - **Title**: `Linear: {identifier} - {title}`
-- **Notes**: Markdown link (MCP tools return full URLs)
+- **Notes**: Markdown link to issue URL
 - **Tags**: `Linear`
 
 Example: `Linear: ENG-123 - Implement user authentication`
 
 ## Evening Variant
 
-Skip entirely. Linear issues are for focused work, not evening triage.
+Skip entirely. Linear notifications are for focused work, not evening triage.


### PR DESCRIPTION
Add `gitlab:todos` skill for GitLab todo triage via `glab api` and `linear:notifications` skill for Linear notification triage. Add GitLab as fifth inbox in the daily review workflow. Rewrite the Linear step from assigned-issues to a notifications-first approach.

## Changes

- `gitlab:todos` covers listing, filtering, and marking done via `glab api /todos`
- `linear:notifications` uses existing `query.ts` for GraphQL until the Linear CLI gains an `api` subcommand (#353)
- Daily review gains a GitLab Todos step between GitHub and Linear
- `linear.md` rewritten to triage by notification type instead of querying assigned issues
- Numbered step headings removed from workflow

## Original Task

[Add vendor notification delegation to daily review](things:///show?id=KqT38H6KMiKSZZ5Xc56YKJ)