### PR TITLE
feat(personal-review): add gather/triage two-phase architecture

### DIFF
--- a/plugins/personal-review/README.md
+++ b/plugins/personal-review/README.md
@@ -6,4 +6,4 @@ Cross-tool daily review workflow for Calendar, Things, GitHub, and Linear.
 
 ### Skills
 
-- **review** — Interactive daily/weekly review orchestrating five inboxes: Calendar → Things → GitHub → GitLab → Linear
+- **review** — Daily review: gather data from five inboxes (Calendar, Things, GitHub, GitLab, Linear), then triage interactively

--- a/plugins/personal-review/skills/review/SKILL.md
+++ b/plugins/personal-review/skills/review/SKILL.md
@@ -5,7 +5,7 @@ description: Interactive daily review workflow across Calendar, Things, GitHub, 
 
 # Daily Review
 
-Process five inboxes in fixed order: Calendar → Things → GitHub → GitLab → Linear.
+Two-phase workflow: **gather** data from all inboxes, then **triage** interactively.
 
 ## Variants
 
@@ -16,16 +16,29 @@ Process five inboxes in fixed order: Calendar → Things → GitHub → GitLab �
 
 Ask which variant if not specified.
 
-## Workflow
+## Gather Phase
 
-### Calendar Scan
+Dispatch read-only sub-agents (via the Task tool) to collect data from each inbox in parallel. Each agent returns structured output — no writes, no user interaction.
 
-See [calendar.md](calendar.md).
+### Sub-Agents
 
-Calculate time budget:
-- Available hours (workday minus meetings)
-- Focus windows (90+ min gaps)
-- Meetings needing prep tasks
+**Calendar:** Load `calendar:calendar`. Query today's events. Return event list, time budget (available hours, focus windows, meetings needing prep).
+
+**Things Inbox:** Load `things:jxa`. Run `query-list.ts TMInboxListSource --json`. Return inbox items with names, notes (first line), tags, project.
+
+**GitHub Notifications:** Load `github:notifications`. Query active notifications (not done). Return notifications grouped by reason with summaryId, URL, title, isUnread.
+
+**GitLab Todos:** Load `gitlab:todos`. Query pending todos. Return todos grouped by action_name with id, target URL, title, project.
+
+**Linear Inbox:** Load `linear:notifications`. Query unread notifications. Return notifications with type, issue identifier, title, URL.
+
+### Output
+
+Combine all sub-agent results into a single gathering summary. Present to the user before starting triage.
+
+## Triage Phase
+
+Work through each inbox interactively using the gathered data. No need to re-query — all data is already available.
 
 ### Things Inbox
 
@@ -81,7 +94,7 @@ Present progress:
 - Things items processed (inbox now at 0)
 - GitHub notifications triaged (done/deferred)
 - Linear issues reviewed
-- Today's plan in priority order
+- Suggest `things:triage` in a fresh session for Today list prioritization
 
 ## Defer-to-Things Format
 

--- a/plugins/personal-review/skills/review/calendar.md
+++ b/plugins/personal-review/skills/review/calendar.md
@@ -34,6 +34,15 @@ Present:
 - Focus windows (start time and duration)
 - Meetings needing prep → suggest creating Things tasks
 
+## Re-Check (Post-Inbox)
+
+After Things inbox processing, re-query today's events:
+
+- Use the same query as the initial scan
+- Compare with the initial results
+- Note any new events (e.g., work calendar additions during personal triage)
+- Update the time budget if new meetings were added
+
 ## Evening Variant
 
 Preview tomorrow only:


### PR DESCRIPTION
Restructure the daily review into a two-phase workflow: a parallel read-only gather phase that dispatches sub-agents to collect data from all inboxes, followed by an interactive triage phase using the gathered data. Add a calendar re-check after inbox processing to catch events added during triage.

## Changes

- Gather phase dispatches sub-agents for Calendar, Things, GitHub, and Linear in parallel
- Sub-agents are read-only — no writes, no user interaction
- Triage phase works through collected data interactively
- Calendar re-check section added to `calendar.md`
- References `things:triage` for post-gathering Today list prioritization

## Original Task

[Daily review context management with plan mode phases](things:///show?id=DdWEUofWGCyR1JdsaeQdK7)