### PR TITLE
feat(mail): add mail plugin with account-aware archiving

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -160,6 +160,11 @@
       "name": "webfetch-auth",
       "description": "Blocks WebFetch for authenticated URLs and suggests MCP alternatives",
       "source": "./plugins/webfetch-auth"
+    },
+    {
+      "name": "mail",
+      "description": "Apple Mail integration for reading and managing email via JXA",
+      "source": "./plugins/mail"
     }
   ]
 }

--- a/plugins/mail/.claude-plugin/plugin.json
+++ b/plugins/mail/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mail",
+  "description": "Apple Mail integration for reading and managing email via JXA",
+  "author": {
+    "name": "Ben Drucker",
+    "email": "bvdrucker@gmail.com"
+  }
+}

--- a/plugins/mail/README.md
+++ b/plugins/mail/README.md
@@ -1,0 +1,9 @@
+# Mail
+
+Apple Mail integration for reading and managing email via JXA.
+
+## Contents
+
+### Skills
+
+- **mail** — Reading, archiving, and managing email with account-aware behavior

--- a/plugins/mail/skills/mail/SKILL.md
+++ b/plugins/mail/skills/mail/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: mail
+description: Reading and managing Apple Mail via JXA. Use when working with email, archiving messages, or processing the inbox.
+---
+
+# Mail
+
+Apple Mail automation via JXA (`osascript -l JavaScript`).
+
+## Archiving
+
+Mail.app `delete()` moves messages to Trash, not Archive. There is no `archiveMailbox` property — find the archive mailbox by name per account.
+
+See [archiving.md](archiving.md) for account detection, mailbox lookup, and batch archive patterns.
+
+## Reading
+
+```javascript
+var app = Application("Mail");
+var inbox = app.inbox();
+var messages = inbox.messages();
+```
+
+Key properties: `subject()`, `sender()`, `dateReceived()`, `content()`, `mailbox().account()`.
+
+## Notes
+
+- JXA arrays from Mail may lack `.map()/.filter()` — use `Array.from()` or for-loops
+- `.whose()` selectors fail on child mailbox arrays — use for-loops
+- Launch Mail first if not running: `open -g -a "Mail"`

--- a/plugins/mail/skills/mail/archiving.md
+++ b/plugins/mail/skills/mail/archiving.md
@@ -1,0 +1,60 @@
+# Archiving
+
+**Never use `delete()`** — it moves to Trash on all account types. Use `move()` to the correct mailbox.
+
+## Account Detection
+
+```javascript
+var account = msg.mailbox().account();
+var serverName = account.serverName();  // e.g., "imap.gmail.com"
+var accountType = account.accountType(); // e.g., "imap", "iCloud"
+```
+
+## Finding the Archive Mailbox
+
+| Account | Server Name | Target Mailbox |
+|---------|------------|----------------|
+| Gmail | contains `gmail.com` | `[Gmail]/All Mail` or `All Mail` |
+| iCloud | accountType `iCloud` | `Archive` |
+| Other | — | `Archive` (fallback) |
+
+```javascript
+function findArchiveMailbox(account) {
+  var mailboxes = account.mailboxes();
+  var isGmail = account.serverName().indexOf("gmail.com") !== -1;
+  var targets = isGmail
+    ? ["[Gmail]/All Mail", "All Mail"]
+    : ["Archive"];
+
+  for (var t = 0; t < targets.length; t++) {
+    for (var i = 0; i < mailboxes.length; i++) {
+      if (mailboxes[i].name() === targets[t]) return mailboxes[i];
+    }
+  }
+  return null;
+}
+```
+
+## Moving a Message
+
+```javascript
+var archiveBox = findArchiveMailbox(msg.mailbox().account());
+if (archiveBox) {
+  app.move(msg, { to: archiveBox });
+}
+```
+
+## Batch Archiving
+
+Process in reverse index order to avoid index shifting:
+
+```javascript
+for (var i = toArchive.length - 1; i >= 0; i--) {
+  app.move(messages[toArchive[i]], { to: archiveBox });
+}
+```
+
+## Gmail Notes
+
+- "All Mail" may appear as `[Gmail]/All Mail` or just `All Mail` depending on IMAP config
+- Test with a single message first before batch operations

--- a/plugins/personal-review/skills/review/SKILL.md
+++ b/plugins/personal-review/skills/review/SKILL.md
@@ -88,4 +88,5 @@ Items deferred from GitHub/Linear:
 
 ## Future
 
-See [automation.md](automation.md) for planned auto-handling patterns.
+- **Mail inbox**: Add `mail:archive` for account-aware email archiving
+- See [automation.md](automation.md) for planned auto-handling patterns.


### PR DESCRIPTION
New `mail` plugin with a single `mail:mail` skill covering reading and archiving email via JXA. Mail.app has no `archiveMailbox` property — the `archiving.md` reference documents finding the correct mailbox by name per account type (Gmail → All Mail, iCloud → Archive).

## Original Task

[Mail skill: proper Gmail archiving](things:///show?id=74Jfvca6ingtcpk1kdvcAi)