### PR TITLE
feat(things): add Today list triage skill

### DIFF
--- a/plugins/things/README.md
+++ b/plugins/things/README.md
@@ -11,6 +11,7 @@ Uses only **public APIs** from Cultured Code — URL scheme (`things:///`) for w
 - **inbox** — Quick inbox capture for delegating tasks from a coding session
 - **url** — Full URL scheme operations (add, update, json, show, search, reorder) with xcall verification
 - **jxa** — JXA/AppleScript read operations, queries, filtering, logbook analysis
+- **triage** — Today list triage: group, prioritize, defer, reorder
 
 ### Scripts
 

--- a/plugins/things/scripts/query-list.ts
+++ b/plugins/things/scripts/query-list.ts
@@ -29,6 +29,7 @@ interface Todo {
   tags: string;
   project: string | null;
   area: string | null;
+  creationDate: string | null;
 }
 
 debug(`querying list: ${argv._.listId}`);
@@ -55,6 +56,7 @@ const items: Todo[] = await runJxa(
         tags: props.tagNames || "",
         project: project ? project.name() : null,
         area: area ? area.name() : null,
+        creationDate: props.creationDate ? props.creationDate.toISOString() : null,
       });
     }
 

--- a/plugins/things/skills/triage/SKILL.md
+++ b/plugins/things/skills/triage/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: triage
+description: Triage and prioritize the Things Today list. Use when the user wants to review, prioritize, or reorder their Today list.
+---
+
+# Today List Triage
+
+Group, prioritize, defer, and reorder the Things Today list.
+
+## Query
+
+Load the `things:jxa` skill. Run `query-list.ts TMTodayListSource --json` to get all Today items. Filter to open items.
+
+## Repeating Task Detection
+
+Apply the midnight heuristic: a task is a repeating instance if `creationDate` ends with `T00:00:00` (midnight local time in ISO). Manually created tasks have non-zero hours/minutes/seconds.
+
+Overdue repeating tasks (where `dueDate` or `activationDate` is before today) should be batched for a single "Defer all overdue repeating tasks to tomorrow?" prompt. Load the `things:url` skill for batch defer via URL scheme.
+
+## Grouping
+
+Group remaining items by area (primary) and tag (secondary) for batch triage. This is a presentation strategy — read the JSON and form logical groups.
+
+## Triage Questions
+
+Per group, use `AskUserQuestion`:
+
+- **Keep** — stays on Today for prioritization
+- **Defer** — to tomorrow, next week, someday, or a specific date
+- **Complete** — mark done
+- **Drop** — move to Someday
+
+## Ordering
+
+After triage, propose an order for kept items:
+- Salaried/work items first
+- Deadline items high priority
+- Personal items toward end
+
+Present proposed order for user confirmation.
+
+## Reorder
+
+Load the `things:url` skill. Use the reorder script:
+
+```bash
+osascript ${PLUGIN_ROOT}/scripts/reorder.js <id1> <id2> <id3> ...
+```
+
+Pass IDs in the confirmed priority order.
+
+## Batch Operations
+
+Group deferred items by target date. Use Things URL scheme for batch updates. Load `things:url` for syntax.
+
+## Summary
+
+Present final counts:
+- Kept on Today: N
+- Deferred: N (by date)
+- Completed: N
+- Final Today order (numbered list)


### PR DESCRIPTION
Add `things:triage` skill for grouping, prioritizing, deferring, and reordering the Today list. Add `creationDate` to `query-list.ts` to enable repeating task detection via the midnight heuristic.

## Changes

- Triage workflow: query Today → detect overdue repeating tasks → group by area/tag → batch triage questions → preference-based ordering → reorder
- `creationDate` field added to `query-list.ts` Todo interface and JXA output

## Original Task

[Create Today list triage skill](things:///show?id=DG9mzcXmTNomAJGjCfgXey)