### PR TITLE
fix(deps): consolidate Renovate config into json5

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "schedule:weekly", ":preserveSemverRanges"]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:recommended"],
+  extends: ["config:recommended", "schedule:weekly", ":preserveSemverRanges"],
   enabledManagers: ["custom.regex"],
   customManagers: [
     {


### PR DESCRIPTION
Renovate's onboarding PR created `renovate.json5` with custom regex managers for tracking marketplace plugin versions in `user/settings.json`. This consolidates the presets from `renovate.json` (`schedule:weekly`, `:preserveSemverRanges`) into `renovate.json5` and deletes the duplicate file.
