### PR TITLE
feat: auto-allow safe wt commands in permissions

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -27,7 +27,13 @@
       "Edit(~/Library/Caches/go-build/**)",
       "Edit(~/src/go/pkg/mod/**)",
       "Edit(~/src/go/pkg/sumdb/**)",
-      "Edit(~/.bun/**)"
+      "Edit(~/.bun/**)",
+      "Bash(wt list:*)",
+      "Bash(wt switch:*)",
+      "Bash(wt config:*)",
+      "Bash(wt hook:*)",
+      "Bash(wt step commit:*)",
+      "Bash(wt step copy-ignored:*)"
     ],
     "deny": []
   },


### PR DESCRIPTION
Adds non-destructive `wt` subcommands to the permissions allow list so they auto-approve without prompting. Destructive commands (`remove`, `merge`, `step squash`, `step push`, `step rebase`, `step for-each`, `step relocate`) remain unlisted and will prompt for approval.

## Changes

Auto-allowed (safe, read-only or standard workflow):
- `wt list` — read-only listing
- `wt switch` — create/switch worktrees
- `wt config` — configuration management
- `wt hook` — hook management and execution
- `wt step commit` — stage and commit
- `wt step copy-ignored` — copy gitignored files between worktrees
