### PR TITLE
feat: add read-only allow rules for wt subcommands

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -4,11 +4,17 @@
   "permissions": {
     "allow": [
       "Bash(mkdir:*)",
+      "Bash(man:*)",
+      "Bash(pbcopy:*)",
+      "Bash(pbpaste:*)",
+      "Bash(wt list:*)",
+      "Bash(wt --help:*)",
+      "Bash(wt --version:*)",
+      "Bash(wt config:*)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)",
       "WebFetch(domain:modelcontextprotocol.io)",
       "WebFetch(domain:docs.anthropic.com)",
-      "Bash(man:*)",
       "WebFetch(domain:proxy.golang.org)",
       "WebFetch(domain:sum.golang.org)",
       "WebFetch(domain:api.github.com)",


### PR DESCRIPTION
Add permission allow rules for commands that are excluded from the sandbox and currently prompt the user each time, but are safe to auto-approve.

## Analysis

Analyzed 23,293 Bash tool uses across 30 days of session history.

**Excluded commands by usage volume:**

| Command | Uses | Coverage |
|---------|------|----------|
| `osascript` | 356 | Skill `allowed-tools` (things, shortcuts) |
| `wt` | 343 | `parallel-prs` skill only — ad-hoc usage prompts |
| `open` | 207 | Skill `allowed-tools` (things, shortcuts) + hook |
| `ssh` | 6 | Appropriately prompts |
| `pbcopy` | 4 | Prompted — now auto-allowed |
| `pbpaste` | 0 | Prompted — now auto-allowed |
| `security` | 1 | Covered by things skill scripts |

## Changes

**`pbcopy` and `pbpaste`**: Both are already excluded from the sandbox (they need real pasteboard access). Auto-allowing removes unnecessary prompts for a core workflow tool referenced in `CLAUDE.md`. The security risk of pasteboard access is tractable and the user's responsibility to manage.

**`wt` read-only subcommands** (`list`, `--help`, `--version`, `config`): 74 of 343 total `wt` uses are read-only and happen ad-hoc outside any skill context. The `parallel-prs` skill covers `Bash(wt:*)` but only when active.

| Subcommand | Uses | Nature |
|------------|------|--------|
| `wt switch` | 219 | Write (creates/switches worktrees) |
| `wt list` | 45 | **Read-only** — now auto-allowed |
| `wt remove` | 23 | Destructive — still prompts |
| `wt --help` | 22 | **Read-only** — now auto-allowed |
| `wt new` | 10 | Write — still prompts |
| `wt --version` | 5 | **Read-only** — now auto-allowed |
| `wt config` | 2 | **Read-only** — now auto-allowed |

## What this does NOT add

- **`osascript`**, **`open`**, **`security`** — already covered by `allowed-tools` in plugins. User settings should be a stable baseline, not the union of all plugin permissions.
- **Write `wt` subcommands** (`switch`, `new`, `remove`) — appropriately continue to prompt.