### PR TITLE
feat(git): add worktrunk permissions overlay skill

### DIFF
--- a/plugins/git/skills/worktrunk/SKILL.md
+++ b/plugins/git/skills/worktrunk/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: worktrunk
+description: Managing git worktrees with the wt CLI. Use when creating, switching, listing, or removing worktrees, running wt commands, or managing worktree-based workflows. Activate this skill for any wt CLI interaction.
+allowed-tools: [Bash(wt:*)]
+---
+
+# Worktrunk
+
+This skill grants permissions for the `wt` CLI. For usage documentation, configuration guides, and hook setup, also load the `worktrunk:worktrunk` skill.


### PR DESCRIPTION
Adds a thin overlay skill that grants `Bash(wt:*)` when wt CLI interaction is detected.

The upstream worktrunk plugin is a documentation/guidance skill with no `allowed-tools`. Its hooks run `wt config state marker` commands outside the tool permission system, but actual `wt` CLI usage from Bash tool calls (343/month) prompts every time unless `parallel-prs` happens to be active.

This overlay activates on wt CLI triggers and provides the missing `allowed-tools` declaration, avoiding the need to fork the upstream plugin or add a blanket allow rule to user settings.

## Alternatives

A PreToolUse hook matching `Bash(wt:*)` could enforce skill activation before any wt command runs. Combined with a `!<cmd>` directive in the skill content (which runs a command on skill load to create a session marker), the hook could check for the marker and block or inject context if the skill has not been loaded yet. This would catch cases where Claude runs `wt` without the skill system activating the overlay.

Deferring this approach — the overlay skill activation criteria should be sufficient in practice. If there is a pattern where `wt` commands run without skill activation, that is signal to revisit.