### PR TITLE
feat(skills): namespace plugin skill names with colon prefix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,11 @@ Each plugin in `plugins/` contains:
 
 ### Naming
 
-The plugin name forms a namespace for its contents (e.g., `gitlab:ci-monitor`). Avoid repeating the plugin name in skill, agent, or command names to prevent stuttering like `gitlab:gitlab-ci`.
+The plugin name forms a namespace for its contents (e.g., `gitlab:ci-monitor`). Commands and agents are auto-namespaced by the plugin system — the filename becomes the qualified name (e.g., `ci-monitor.md` in the `gitlab` plugin becomes `gitlab:ci-monitor`). Skills are **not** auto-namespaced — the `name` in YAML frontmatter is used as-is.
+
+Skills where the name differs from the plugin name must include the `plugin-name:` prefix in frontmatter (e.g., `gitlab:ci`, `things:inbox`). Skip the prefix when name equals plugin name (the primary skill) — `bun:bun` adds no information.
+
+Anti-stuttering applies to the part after the colon: `gitlab:gitlab-ci` is wrong, `gitlab:ci` is right.
 
 ### Plugin READMEs
 

--- a/packages/skill-lint/rules/frontmatter.ts
+++ b/packages/skill-lint/rules/frontmatter.ts
@@ -2,7 +2,7 @@ import type { Rule, RuleResult, SkillContent } from "../types";
 
 const SPEC_URL = "https://agentskills.io/specification";
 
-const NAME_PATTERN = /^[a-z0-9-]+$/;
+const NAME_PATTERN = /^([a-z0-9-]+:)?[a-z0-9-]+$/;
 const MAX_NAME_LENGTH = 64;
 const MAX_DESCRIPTION_LENGTH = 1024;
 
@@ -87,7 +87,8 @@ export const nameEdgeHyphens: Rule = {
       };
     }
 
-    if (name.startsWith("-") || name.endsWith("-")) {
+    const segments = name.split(":");
+    if (segments.some((s) => s.startsWith("-") || s.endsWith("-"))) {
       return {
         rule: "name-edge-hyphens",
         severity: "error",
@@ -120,7 +121,8 @@ export const nameConsecutiveHyphens: Rule = {
       };
     }
 
-    if (name.includes("--")) {
+    const segments = name.split(":");
+    if (segments.some((s) => s.includes("--"))) {
       return {
         rule: "name-consecutive-hyphens",
         severity: "error",

--- a/packages/skill-lint/test/rules.test.ts
+++ b/packages/skill-lint/test/rules.test.ts
@@ -70,6 +70,18 @@ describe("frontmatter rules", () => {
       const result = single(nameFormat.check(content, ""));
       expect(result.passed).toBe(true);
     });
+
+    it("allows namespaced names", () => {
+      const content = parseSkill("---\nname: github:actions\n---\n");
+      const result = single(nameFormat.check(content, ""));
+      expect(result.passed).toBe(true);
+    });
+
+    it("allows same-name namespace", () => {
+      const content = parseSkill("---\nname: git:git\n---\n");
+      const result = single(nameFormat.check(content, ""));
+      expect(result.passed).toBe(true);
+    });
   });
 
   describe("nameLength", () => {
@@ -104,6 +116,24 @@ describe("frontmatter rules", () => {
       const content = parseSkill("---\nname: invalid-\n---\n");
       const result = single(nameEdgeHyphens.check(content, ""));
       expect(result.passed).toBe(false);
+    });
+
+    it("fails for leading hyphen in namespace prefix", () => {
+      const content = parseSkill("---\nname: -github:actions\n---\n");
+      const result = single(nameEdgeHyphens.check(content, ""));
+      expect(result.passed).toBe(false);
+    });
+
+    it("fails for trailing hyphen in namespaced part", () => {
+      const content = parseSkill("---\nname: github:actions-\n---\n");
+      const result = single(nameEdgeHyphens.check(content, ""));
+      expect(result.passed).toBe(false);
+    });
+
+    it("passes for valid namespaced names", () => {
+      const content = parseSkill("---\nname: github:actions\n---\n");
+      const result = single(nameEdgeHyphens.check(content, ""));
+      expect(result.passed).toBe(true);
     });
   });
 

--- a/plugins/claude-code/skills/hook/SKILL.md
+++ b/plugins/claude-code/skills/hook/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: hook
+name: claude-code:hook
 description: Use this skill when you need to configure, create, or troubleshoot Claude Code hooks. This includes setting up PreToolUse hooks, PostToolUse hooks, UserPromptSubmit hooks, debugging hook failures, or any automation within Claude Code. Examples include "I want to run tests before every file edit", "My hook isn't firing", "1 out of 2 hooks ran", or "How do I create a hook that formats JSON output with jq?"
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, WebFetch(domain:docs.anthropic.com)]
 ---

--- a/plugins/claude-code/skills/session/SKILL.md
+++ b/plugins/claude-code/skills/session/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: session
+name: claude-code:session
 description: View current session info or search conversation history. Use when debugging sessions, reviewing activity, finding past discussions, or summarizing recent work.
 allowed-tools: [Bash, Read]
 ---

--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: skill
+name: claude-code:skill
 description: Creating and optimizing Claude Code Skills including activation patterns, content structure, and development workflows. Use when creating new skills, converting memory files to skills, debugging skill activation, or understanding skill architecture and best practices.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, WebFetch(domain:docs.claude.com)]
 hooks:
@@ -26,7 +26,7 @@ Reference for developing effective skills. The context window is a public good -
 
 ```yaml
 ---
-name: skill-name
+name: plugin-name:skill-name
 description: Third-person capability description with trigger terms
 allowed-tools: [Read, Grep, Glob]         # Optional: tool restrictions
 model: claude-sonnet-4-20250514           # Optional: override model
@@ -44,7 +44,7 @@ hooks:                                    # Optional: skill-scoped hooks
 ```
 
 **Required Fields**:
-- `name`: Lowercase letters, numbers, hyphens only (max 64 chars). Match directory name.
+- `name`: Lowercase letters, numbers, hyphens only (max 64 chars). Plugin skills use `plugin-name:skill-name` prefix for disambiguation. Skip the prefix when name equals plugin name.
 - `description`: Third-person, includes trigger terms and use cases (max 1024 chars).
 
 **Optional Fields**:
@@ -56,7 +56,7 @@ hooks:                                    # Optional: skill-scoped hooks
 - `disable-model-invocation`: Block programmatic invocation via Skill tool
 - `hooks`: Skill-scoped hooks (`PreToolUse`, `PostToolUse`, `Stop`)
 
-**Naming**: Use gerund form (verb + -ing): `processing-pdfs`, `analyzing-data`, `managing-databases`. Avoid vague names like `helper`, `utils`.
+**Naming**: Plugin skills use `plugin-name:skill-name` with a colon namespace (e.g., `gitlab:ci`, `things:inbox`). The part after the colon should not repeat the plugin name. For standalone skills, use gerund form (verb + -ing): `processing-pdfs`, `analyzing-data`. Avoid vague names like `helper`, `utils`.
 
 **Storage**: `~/.claude/skills/` (personal), `.claude/skills/` (project), plugins (bundled)
 

--- a/plugins/claude-code/skills/skill/scripts/check-namespace.test.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-namespace.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PostToolUseInput } from "@constellos/claude-code-kit";
 import {
+  checkSkillNamespace,
   checkStuttering,
   extractPluginName,
   getResourceName,
@@ -111,6 +112,38 @@ describe("checkStuttering", () => {
   });
 });
 
+describe("checkSkillNamespace", () => {
+  it("allows name matching plugin name (primary skill)", () => {
+    expect(checkSkillNamespace("git", "git")).toEqual([]);
+  });
+
+  it("allows properly prefixed names", () => {
+    expect(checkSkillNamespace("gitlab:ci", "gitlab")).toEqual([]);
+    expect(checkSkillNamespace("claude-code:hook", "claude-code")).toEqual([]);
+  });
+
+  it("allows plugin:plugin (primary skill with prefix)", () => {
+    expect(checkSkillNamespace("git:git", "git")).toEqual([]);
+  });
+
+  it("warns on missing prefix", () => {
+    const warnings = checkSkillNamespace("ci", "gitlab");
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain("should be prefixed");
+    expect(warnings[1]).toContain("gitlab:ci");
+  });
+
+  it("detects stuttering after prefix", () => {
+    const warnings = checkSkillNamespace("gitlab:gitlab-ci", "gitlab");
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain("stutters");
+  });
+
+  it("allows plugin:plugin without stuttering warning", () => {
+    expect(checkSkillNamespace("gitlab:gitlab", "gitlab")).toEqual([]);
+  });
+});
+
 describe("processHookInput", () => {
   let testDir: string;
 
@@ -125,14 +158,23 @@ describe("processHookInput", () => {
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  it("warns on stuttering skill name", () => {
+  it("warns on missing skill prefix", () => {
     const skillPath = join(testDir, "plugins/gitlab/skills/ci/SKILL.md");
-    writeFileSync(skillPath, "name: gitlab-ci\n");
+    writeFileSync(skillPath, "name: ci\n");
 
     const warnings = processHookInput(mockWriteInput(skillPath));
     expect(warnings.length).toBeGreaterThan(0);
     expect(warnings[0]).toContain("Warning");
-    expect(warnings[0]).toContain("skill name");
+    expect(warnings[0]).toContain("should be prefixed");
+  });
+
+  it("warns on stuttering skill name after prefix", () => {
+    const skillPath = join(testDir, "plugins/gitlab/skills/ci/SKILL.md");
+    writeFileSync(skillPath, "name: gitlab:gitlab-ci\n");
+
+    const warnings = processHookInput(mockWriteInput(skillPath));
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain("stutters");
   });
 
   it("warns on stuttering agent name", () => {
@@ -153,9 +195,17 @@ describe("processHookInput", () => {
     expect(warnings[0]).toContain("command name");
   });
 
-  it("returns empty for proper names", () => {
+  it("returns empty for properly namespaced skill", () => {
     const skillPath = join(testDir, "plugins/gitlab/skills/ci/SKILL.md");
-    writeFileSync(skillPath, "name: ci\n");
+    writeFileSync(skillPath, "name: gitlab:ci\n");
+
+    const warnings = processHookInput(mockWriteInput(skillPath));
+    expect(warnings).toEqual([]);
+  });
+
+  it("returns empty for primary skill (name matches plugin)", () => {
+    const skillPath = join(testDir, "plugins/gitlab/skills/ci/SKILL.md");
+    writeFileSync(skillPath, "name: gitlab\n");
 
     const warnings = processHookInput(mockWriteInput(skillPath));
     expect(warnings).toEqual([]);

--- a/plugins/claude-code/skills/skill/scripts/check-namespace.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-namespace.ts
@@ -40,6 +40,34 @@ export function checkStuttering(name: string, pluginName: string): string | null
   return null;
 }
 
+export function checkSkillNamespace(name: string, pluginName: string): string[] {
+  const warnings: string[] = [];
+
+  if (name === pluginName) return warnings;
+
+  const prefix = `${pluginName}:`;
+  if (!name.startsWith(prefix)) {
+    warnings.push(
+      `Warning: skill name '${name}' should be prefixed with '${prefix}' for disambiguation`,
+    );
+    warnings.push(`  Expected: '${prefix}${name}'`);
+    return warnings;
+  }
+
+  const localName = name.slice(prefix.length);
+  if (localName === pluginName) return warnings;
+
+  const stutterWarning = checkStuttering(localName, pluginName);
+  if (stutterWarning) {
+    warnings.push(`Warning: skill name after prefix ${stutterWarning}`);
+    warnings.push(
+      `  Consider renaming to avoid repetition (e.g., ${prefix}${pluginName}-foo -> ${prefix}foo)`,
+    );
+  }
+
+  return warnings;
+}
+
 export function processHookInput(input: PostToolUseInput): string[] {
   const warnings: string[] = [];
 
@@ -53,6 +81,10 @@ export function processHookInput(input: PostToolUseInput): string[] {
   const type = getResourceType(filePath);
   const name = getResourceName(filePath, type);
   if (!name) return warnings;
+
+  if (type === "skill") {
+    return checkSkillNamespace(name, pluginName);
+  }
 
   const stutterWarning = checkStuttering(name, pluginName);
   if (stutterWarning) {

--- a/plugins/git/skills/conflicts/SKILL.md
+++ b/plugins/git/skills/conflicts/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: conflicts
+name: git:conflicts
 description: Resolving git merge conflicts. Use when rebasing, merging, or cherry-picking results in conflicts.
 allowed-tools:
   - Read

--- a/plugins/github/skills/actions/SKILL.md
+++ b/plugins/github/skills/actions/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: github-actions
+name: github:actions
 description: >-
   GitHub Actions CI/CD workflow development and run monitoring. Use when creating
   or editing .github/workflows YAML files, configuring triggers, jobs, matrix strategies,

--- a/plugins/github/skills/notifications/SKILL.md
+++ b/plugins/github/skills/notifications/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: notifications
+name: github:notifications
 description: Managing GitHub notifications inbox. Use when listing, filtering, or triaging notifications (mark read, done, unsubscribe).
 ---
 

--- a/plugins/github/skills/pr-comments/SKILL.md
+++ b/plugins/github/skills/pr-comments/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: pr-comments
+name: github:pr-comments
 description: Fetch unresolved review comments from a GitHub pull request. Use when checking what review feedback needs to be addressed, whether review comments have been resolved, or resuming work on a PR with outstanding feedback.
 allowed-tools: ["Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/pr-comments.ts:*)"]
 hooks:

--- a/plugins/gitlab/skills/api/SKILL.md
+++ b/plugins/gitlab/skills/api/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: api
+name: gitlab:api
 description: GitLab REST and GraphQL API access via glab. Use when making API requests, querying project data, or automating GitLab operations.
 ---
 # GitLab API

--- a/plugins/gitlab/skills/ci/SKILL.md
+++ b/plugins/gitlab/skills/ci/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ci
+name: gitlab:ci
 description: Working with GitLab CI/CD pipelines and jobs. Use when viewing pipelines, debugging jobs, or validating CI configuration.
 ---
 # GitLab CI/CD

--- a/plugins/gitlab/skills/docs/SKILL.md
+++ b/plugins/gitlab/skills/docs/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: docs
+name: gitlab:docs
 description: Browsing GitLab documentation efficiently. Use when you need to look up GitLab features, configuration, API details, or CI/CD syntax.
 ---
 # GitLab Docs

--- a/plugins/gitlab/skills/glab/SKILL.md
+++ b/plugins/gitlab/skills/glab/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: glab
+name: gitlab:glab
 description: glab CLI basics and GitLab workflow overview. Use when working with GitLab repositories or adapting GitHub patterns to GitLab.
 ---
 # glab

--- a/plugins/gitlab/skills/merge-request/SKILL.md
+++ b/plugins/gitlab/skills/merge-request/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: merge-request
+name: gitlab:merge-request
 description: Working with GitLab merge requests via glab. Use when creating, updating, reviewing, or merging MRs.
 ---
 # Merge Requests

--- a/plugins/gitlab/skills/todos/SKILL.md
+++ b/plugins/gitlab/skills/todos/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: todos
+name: gitlab:todos
 description: Managing GitLab todos inbox. Use when listing, filtering, or triaging GitLab todos (mark done, mark pending).
 ---
 

--- a/plugins/implement-issue/skills/implement-issue/SKILL.md
+++ b/plugins/implement-issue/skills/implement-issue/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: implement-issue
+name: issue:implement
 description: |
   Implement a feature or fix based on an issue. Use when given an issue URL to work on, or when implementing changes described in a tracked issue. Supports GitHub, Linear, and GitLab.
 allowed-tools: Bash(gh:*), Bash(git:*), mcp__github, mcp__plugin_github_github__issue_read

--- a/plugins/interview/skills/clarify/SKILL.md
+++ b/plugins/interview/skills/clarify/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: clarify
+name: interview:clarify
 description: |
   Targeted interview for execution-time clarification. Use when you hit an ambiguity or decision point during implementation that needs user input before proceeding.
 context: fork

--- a/plugins/interview/skills/plan/SKILL.md
+++ b/plugins/interview/skills/plan/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: plan
+name: interview:plan
 description: |
   Comprehensive interview for planning new features or changes. Use when the user wants thorough upfront planning before implementation, or when starting work on a complex feature.
 context: fork

--- a/plugins/linear/skills/notifications/SKILL.md
+++ b/plugins/linear/skills/notifications/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: notifications
+name: linear:notifications
 description: Managing Linear notifications inbox. Use when listing, filtering, or triaging Linear notifications.
 allowed-tools:
   - mcp__linear

--- a/plugins/mermaid/skills/diagram/SKILL.md
+++ b/plugins/mermaid/skills/diagram/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: diagram
+name: mermaid
 description: Create and validate Mermaid diagrams. Use when creating, editing, or reviewing Mermaid diagrams in markdown files.
 user-invocable: true
 ---

--- a/plugins/personal-review/skills/review/SKILL.md
+++ b/plugins/personal-review/skills/review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: review
+name: personal-review:review
 description: Interactive daily review workflow across Calendar, Things, GitHub, and Linear. Use when the user asks for a daily review, morning review, evening review, or weekly review.
 ---
 

--- a/plugins/plan/skills/guidelines/SKILL.md
+++ b/plugins/plan/skills/guidelines/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: guidelines
+name: plan:guidelines
 description: |
   Detailed planning guidelines and best practices. Use when you want explicit guidance on creating high-quality implementation plans, or when a plan was rejected and you need to understand why.
 ---

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: create
+name: pull-request:create
 description: |
   Create a pull request, merge request, or change request with proper formatting and content guidelines.
   Invoke when the user wants to create, open, or submit a PR, MR, or CR—including after committing changes.

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: update
+name: pull-request:update
 description: |
   Update a pull request or merge request body to reflect the current state of changes.
   Use when a PR/MR has evolved through additional commits and the body needs to reflect what will be merged.

--- a/plugins/refine-issue/skills/refine-issue/SKILL.md
+++ b/plugins/refine-issue/skills/refine-issue/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: refine-issue
+name: issue:refine
 description: Refining issues with technical context and structured details. Use when expanding a brief bug, feature, or refactor description into a detailed issue suitable for developers and AI agents.
 ---
 

--- a/plugins/research/skills/prior-art/SKILL.md
+++ b/plugins/research/skills/prior-art/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: prior-art
+name: research:prior-art
 description: |
   Research existing solutions when exploring a new problem space. Use when the user mentions "prior art", "existing solutions", "what libraries exist for", or wants to understand the landscape before building.
 ---

--- a/plugins/review/skills/peer/SKILL.md
+++ b/plugins/review/skills/peer/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: peer
+name: review:peer
 description: |
   Review a pull request when requested by a peer. Use when reviewing PRs, providing code review feedback, or analyzing proposed changes. Supports GitHub and GitLab.
 allowed-tools: Bash(gh:*), mcp__github

--- a/plugins/review/skills/self/SKILL.md
+++ b/plugins/review/skills/self/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: self
+name: review:self
 description: |
   Self-review your own code changes using a visual diff viewer. Opens a GitHub-style web UI where you can add comments on changed lines. Comments are returned to Claude for action.
 allowed-tools: Bash(npx:*)

--- a/plugins/shortcuts/skills/cli/SKILL.md
+++ b/plugins/shortcuts/skills/cli/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: cli
+name: shortcuts:cli
 description: Running and managing Apple Shortcuts via the macOS shortcuts CLI. Use when the user wants to run, list, or inspect shortcuts.
 allowed-tools: [Bash(shortcuts:*), Bash(open:*)]
 hooks:

--- a/plugins/shortcuts/skills/shortcut/SKILL.md
+++ b/plugins/shortcuts/skills/shortcut/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: shortcut
+name: shortcuts:shortcut
 description: Creating Apple Shortcuts programmatically as plist XML files. Use when the user wants to build, generate, or author Apple Shortcuts without the GUI app.
 allowed-tools: [Read, Write, Edit, "Bash(swift ${CLAUDE_SKILL_ROOT}/scripts/discover.swift:*)", Bash(plutil:*), Bash(shortcuts:*), Bash(open:*), Bash(jq:*), Bash(uname:*), Bash(which:*), Glob, Grep]
 hooks:

--- a/plugins/tech-spec/skills/create/SKILL.md
+++ b/plugins/tech-spec/skills/create/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: create
+name: tech-spec:create
 description: |
   Create a technical specification through interactive planning and expert review. Use when starting a new feature or project that needs documented architecture, implementation approach, and design decisions. Invoke with product requirements (PRD, brief, or similar).
 ---

--- a/plugins/tech-spec/skills/review/SKILL.md
+++ b/plugins/tech-spec/skills/review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: review
+name: tech-spec:review
 description: |
   Review a technical specification through expert lenses. Use to identify gaps, risks, and missing considerations in an existing spec. Works on any tech spec, not just those created with tech-spec:create.
 ---

--- a/plugins/things/skills/inbox/SKILL.md
+++ b/plugins/things/skills/inbox/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: inbox
+name: things:inbox
 description: Quick captures to the Things 3 inbox. Not for reads (things:jxa), scheduled tasks, updates, or projects (things:url).
 allowed-tools: ["Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts:*)"]
 hooks:

--- a/plugins/things/skills/jxa/SKILL.md
+++ b/plugins/things/skills/jxa/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: jxa
+name: things:jxa
 description: Read and query Things 3 data (lists, todos, projects, tags, logbook). Not for writes — use things:url to create/update, things:inbox for quick captures.
 allowed-tools: ["Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/query-*:*)", "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/find-*:*)", "Bash(osascript:*)", Read]
 hooks:

--- a/plugins/things/skills/triage/SKILL.md
+++ b/plugins/things/skills/triage/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: triage
+name: things:triage
 description: Triage and prioritize the Things Today list. Use when the user wants to review, prioritize, or reorder their Today list.
 ---
 

--- a/plugins/things/skills/url/SKILL.md
+++ b/plugins/things/skills/url/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: url
+name: things:url
 description: Create, update, and manage Things 3 tasks and projects. Not for reads — use things:jxa to query data. For simple inbox captures, use things:inbox.
 allowed-tools: ["Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts:*)", Bash(osascript:*), Bash(open:*), Bash, Read]
 hooks:

--- a/plugins/type-ignore/skills/fix/SKILL.md
+++ b/plugins/type-ignore/skills/fix/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: fix
+name: type-ignore:fix
 description: |
   Fixes type ignores in a file, directory, or codebase by discovering ignores and dispatching parallel fixer agents. Use when cleaning up type ignores across multiple files, eliminating ignores before a release, or batch-fixing type errors.
 context: fork

--- a/plugins/vscode/skills/edit/SKILL.md
+++ b/plugins/vscode/skills/edit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: edit
+name: vscode:edit
 description: Open content in VS Code for interactive editing before using it in the next step.
 user-invocable: true
 allowed-tools:

--- a/plugins/x-callback-url/skills/xcall/SKILL.md
+++ b/plugins/x-callback-url/skills/xcall/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: xcall
+name: x-callback-url:xcall
 description: Call x-callback-url schemes from the CLI and receive responses synchronously. Use when invoking macOS app URL schemes that have no CLI but support x-callback-url (Things, Bear, OmniFocus, etc.) and you need to capture the result.
 allowed-tools: [Bash, Read]
 ---


### PR DESCRIPTION
Skills are not auto-namespaced by the plugin system like commands and agents are. This adds a `plugin-name:` colon prefix convention to skill names in frontmatter for disambiguation, along with tooling to enforce it.

## Changes

- Update `skill-lint` `NAME_PATTERN` to allow optional `prefix:` colon syntax, with per-segment validation for edge hyphens and consecutive hyphens
- Add `checkSkillNamespace()` to the `check-namespace` hook that validates skill names have the `plugin-name:` prefix (warns if missing, unless name == plugin name for primary skills)
- Rename 37 plugin skill `name` fields to use colon-prefixed format (e.g., `ci` → `gitlab:ci`, `hook` → `claude-code:hook`)
- Primary skills where name already matches plugin name are unchanged (`bun`, `calendar`, `git`, `linear`, etc.)
- Special renames: `diagram` → `mermaid`, `implement-issue` → `issue:implement`, `refine-issue` → `issue:refine`
- Update `CLAUDE.md` naming section and skill authoring guide with namespace documentation
