### PR TITLE
docs: centralize worktree dispatch guidance

### DIFF
--- a/.claude/commands/improve-claude-code.md
+++ b/.claude/commands/improve-claude-code.md
@@ -44,18 +44,7 @@ Derive `{slug}` from the todo title: lowercase, replace spaces/special chars wit
 
 ### Implement in Parallel
 
-Task tool subagents cannot write to worktree directories (permissions are scoped to the orchestrator's cwd). Use `claude -p` CLI processes instead — each gets the worktree as its cwd with full local file access.
-
-For each worktree, write the implementation plan to a temp file, then dispatch:
-
-```bash
-cd <worktree-path> && claude -p \
-  --allowedTools "Read Write Edit Glob Grep Bash(git:*) Bash(bun:*) Bash(bunx:*)" \
-  --output-format text \
-  "<implementation-plan>" 2>&1
-```
-
-Run all dispatches as background Bash commands for parallelism. The prompt should include:
+Dispatch a `claude -p` CLI subprocess to each worktree (see "Worktree Dispatch" in user CLAUDE.md). Each subprocess receives:
 
 - The full approved implementation plan
 - Instruction to commit changes with a descriptive message
@@ -63,16 +52,9 @@ Run all dispatches as background Bash commands for parallelism. The prompt shoul
 
 ### Create PRs
 
-After all implementations complete, dispatch `claude -p` from each worktree to create PRs:
+After all implementations complete, dispatch `claude -p` from each worktree to create PRs using the `pull-request:create` skill.
 
-```bash
-cd <worktree-path> && claude -p \
-  --allowedTools "Bash Read Write Edit Glob Grep Skill" \
-  --output-format text \
-  "Use the pull-request:create skill to create a PR. <context about the changes>" 2>&1
-```
-
-PR body includes a `Original Task` section:
+PR body includes an `Original Task` section:
 
 ```
 Original Task: [<todo-title>](things:///show?id=<todo-id>)
@@ -94,11 +76,3 @@ Output a final bulleted list — one entry per todo:
 - Things URL: `things:///show?id=<todo-id>`
 - Todo title
 
-## Dispatching CLI Agents
-
-When using `claude -p` for worktree work:
-
-- **Least privilege**: Use `--allowedTools` to scope to exactly the tools needed. Never use `--dangerously-skip-permissions`.
-- **No model override**: Let the user's default model apply. Do not pass `--model`.
-- **Background execution**: Run via `Bash(run_in_background: true)` and poll with `TaskOutput` for parallelism.
-- **Error handling**: Check exit codes and read output files. If an agent fails, report the error rather than retrying blindly.

--- a/plugins/parallel-prs/skills/parallel-prs/workflow.md
+++ b/plugins/parallel-prs/skills/parallel-prs/workflow.md
@@ -24,9 +24,9 @@ Worktrunk handles branch creation and worktree placement automatically based on 
 
 ## Implement in Parallel
 
-Implementation agents work in assigned worktree, then:
-1. Commit and push
-2. Load `pull-request:create` skill and create PR (write body to `tmp/{branch}/pr-body.md` first)
+Dispatch a `claude -p` CLI subprocess to each worktree (see "Worktree Dispatch" in user CLAUDE.md). Each agent:
+1. Implements the plan, commits, and pushes
+2. Loads `pull-request:create` skill and creates PR (writes body to `tmp/{branch}/pr-body.md` first)
 
 ## Monitor CI
 

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -38,6 +38,20 @@ I use git-town for stacked branch workflows combined with worktrunk:
 
 Ship branches oldest-first. After a stack branch merges, `git town sync` rebases remaining branches.
 
+## Worktree Dispatch
+
+Task tool subagents can't write to worktree directories — the sandbox scopes `.` to the orchestrator's cwd, not the worktree path. Two approaches depending on context:
+
+- **Parallel work**: Dispatch `claude -p` CLI subprocesses with the worktree as cwd. Run as background Bash commands and poll with `TaskOutput`.
+- **Single task**: Ask the user to start a new Claude session in the worktree directory.
+
+Best practices for `claude -p` dispatch:
+
+- Scope `--allowedTools` to exactly the tools needed. Never use `--dangerously-skip-permissions`.
+- Do not pass `--model` — let the user's default apply.
+- Run via `Bash(run_in_background: true)` for parallelism.
+- Check exit codes and output. Report errors rather than retrying blindly.
+
 ## Personal Details
 
 - Standard username: `@bendrucker`. Refer to any actions performed by this user as "you."


### PR DESCRIPTION
Centralizes worktree dispatch guidance into `user/CLAUDE.md` instead of duplicating the sandbox workaround inline in each skill that dispatches work to worktrees.

## Changes

- **`user/CLAUDE.md`**: New "Worktree Dispatch" section documenting the two approaches (CLI subprocesses for parallel work, new user session for single tasks) and best practices
- **`improve-claude-code.md`**: Removes inline sandbox explanation and `claude -p` code blocks, references centralized docs
- **`parallel-prs/workflow.md`**: Same simplification

Original Task: [Fix sandbox blocking subagent writes to worktree directories](things:///show?id=8oqro5E82RfTAud9RcJa5o)
