### PR TITLE
feat(claude-code): add agent-team skill

### DIFF
--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -4,8 +4,10 @@ Meta-tools for Claude Code configuration and customization.
 
 ## Skills
 
-- **skills**: Creating and optimizing Claude Code Skills including activation patterns, content structure, and development workflows
+- **agent-team**: Orchestrating teams of Claude Code sessions with shared tasks, messaging, and coordination
+- **hook**: Configuring, creating, and troubleshooting Claude Code hooks
 - **session**: View current session information including ID, duration, tool usage stats, and log file path
+- **skill**: Creating and optimizing Claude Code Skills including activation patterns, content structure, and development workflows
 
 ## Testing
 

--- a/plugins/claude-code/skills/agent-team/SKILL.md
+++ b/plugins/claude-code/skills/agent-team/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: claude-code:agent-team
+description: Orchestrating Claude Code agent teams. Use when creating teams, spawning teammates, assigning tasks, configuring teammate modes, or setting up team quality gate hooks.
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, WebFetch(domain:code.claude.com)]
+---
+
+# Agent Teams
+
+## Team Lifecycle
+
+Describe the task and team structure in natural language. Claude creates the team, spawns teammates, and coordinates work.
+
+- **Delegate mode** (Shift+Tab): restricts the lead to coordination-only tools — no direct implementation
+- **Plan approval**: require teammates to plan before implementing. The teammate works read-only until the lead approves.
+- **Shutdown**: ask the lead to shut down teammates individually, then clean up the team. Always clean up via the lead.
+
+## Task Management
+
+Tasks: pending, in progress, completed. Tasks can depend on other tasks — blocked tasks unlock automatically when dependencies complete.
+
+- **Lead assigns**: tell the lead which task to assign
+- **Self-claim**: teammates pick up unassigned, unblocked tasks after finishing
+- File locking prevents race conditions on simultaneous claims
+
+## Communication
+
+- **message**: send to one specific teammate
+- **broadcast**: send to all teammates (use sparingly — costs scale with team size)
+- Messages deliver automatically; the lead doesn't need to poll
+- Idle notifications are automatic when a teammate finishes a turn
+
+## Architecture
+
+Teams are stored locally:
+
+- **Team config**: `~/.claude/teams/{team-name}/config.json`
+- **Task list**: `~/.claude/tasks/{team-name}/`
+
+The config contains a `members` array with each teammate's name, agent ID, and type. Teammates read this file to discover each other.
+
+Teammates inherit the lead's permission settings at spawn. Each teammate loads project context (CLAUDE.md, MCP servers, skills) plus the spawn prompt — the lead's conversation history does not carry over.
+
+## Limitations
+
+- No session resumption for in-process teammates (`/resume` won't restore them)
+- Task status can lag — check and nudge if stuck
+- One team per session, no nested teams
+- Lead is fixed for the team's lifetime
+
+## References
+
+- [references/hooks.md](references/hooks.md) — `TeammateIdle` and `TaskCompleted` quality gate hooks
+- [references/practices.md](references/practices.md) — task sizing, spawn prompts, file conflicts, team structures
+- [references/interaction.md](references/interaction.md) — display modes, keyboard shortcuts, direct teammate interaction
+- [Agent Teams Documentation](https://code.claude.com/docs/en/agent-teams)

--- a/plugins/claude-code/skills/agent-team/references/hooks.md
+++ b/plugins/claude-code/skills/agent-team/references/hooks.md
@@ -1,0 +1,57 @@
+# Team Quality Gate Hooks
+
+Two hook types enforce quality when teammates finish work or complete tasks.
+
+## TeammateIdle
+
+Runs when a teammate is about to go idle. Exit with code 2 to send feedback and keep the teammate working.
+
+Use this to verify a teammate's output before letting them stop — check that tests pass, lint is clean, or deliverables exist.
+
+```json
+{
+  "hooks": {
+    "TeammateIdle": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun ./hooks/check-teammate-output.ts"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## TaskCompleted
+
+Runs when a task is being marked complete. Exit with code 2 to prevent completion and send feedback.
+
+Use this to enforce acceptance criteria — verify the task deliverable matches expectations before allowing the status change.
+
+```json
+{
+  "hooks": {
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun ./hooks/validate-task.ts"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Exit Code Behavior
+
+| Code | Effect |
+|---|---|
+| 0 | Allow (teammate goes idle / task completes) |
+| 2 | Block with feedback (stdout sent back to the agent) |
+| Other | Hook error, operation continues |

--- a/plugins/claude-code/skills/agent-team/references/interaction.md
+++ b/plugins/claude-code/skills/agent-team/references/interaction.md
@@ -1,0 +1,27 @@
+# Display Modes and Interaction
+
+## Display Modes
+
+Set `teammateMode` in settings or pass `--teammate-mode`:
+
+| Mode | Behavior |
+|---|---|
+| `auto` (default) | Split panes inside tmux, in-process otherwise |
+| `in-process` | All teammates in main terminal |
+| `tmux` | Each teammate in its own pane. Auto-detects tmux vs iTerm2. |
+
+Split panes require tmux or iTerm2 with the `it2` CLI.
+
+## Keyboard Shortcuts
+
+**In-process mode**:
+
+| Key | Action |
+|---|---|
+| Shift+Up/Down | Select a teammate |
+| Enter | View teammate's session |
+| Escape | Interrupt teammate's current turn |
+| Ctrl+T | Toggle task list |
+| Shift+Tab | Cycle to delegate mode |
+
+**Split-pane mode**: click into a teammate's pane to interact directly.

--- a/plugins/claude-code/skills/agent-team/references/practices.md
+++ b/plugins/claude-code/skills/agent-team/references/practices.md
@@ -1,0 +1,51 @@
+# Agent Team Best Practices
+
+## Give Teammates Enough Context
+
+Teammates don't inherit the lead's conversation history. Include task-specific details in spawn prompts:
+
+> Spawn a security reviewer with the prompt: "Review the authentication module at src/auth/ for vulnerabilities. Focus on token handling, session management, and input validation. The app uses JWT tokens in httpOnly cookies. Report issues with severity ratings."
+
+## Size Tasks Appropriately
+
+| Size | Problem |
+|---|---|
+| Too small | Coordination overhead exceeds the benefit |
+| Too large | Teammates work too long without check-ins, risking wasted effort |
+| Right | Self-contained units producing a clear deliverable (a function, test file, or review) |
+
+Aim for 5-6 tasks per teammate.
+
+## Avoid File Conflicts
+
+Two teammates editing the same file leads to overwrites. Break work so each teammate owns a different set of files.
+
+## Wait for Teammates
+
+If the lead starts implementing instead of delegating:
+
+> Wait for your teammates to complete their tasks before proceeding
+
+Or enable delegate mode (Shift+Tab) to restrict the lead to coordination tools.
+
+## Start with Research
+
+If new to agent teams, start with read-only tasks: reviewing a PR, researching a library, investigating a bug. These show the value of parallel exploration without coordination challenges.
+
+## Monitor and Steer
+
+Check in on progress, redirect failing approaches, synthesize findings as they come in. Unattended teams risk wasted effort.
+
+## Effective Team Structures
+
+**Parallel review** — split review criteria into independent domains:
+
+> Create a team to review PR #142. Three reviewers: security implications, performance impact, test coverage.
+
+**Competing hypotheses** — make teammates adversarial:
+
+> Spawn 5 teammates to investigate different hypotheses. Have them talk to each other to disprove theories, like a scientific debate.
+
+**Cross-layer implementation** — one teammate per layer:
+
+> Create a team: one for the API endpoint, one for the React component, one for integration tests.


### PR DESCRIPTION
Adds a `claude-code:agent-team` skill covering agent team orchestration — lifecycle, task management, communication, architecture, and limitations.

The main `SKILL.md` (~650 tokens) focuses on operational details Claude wouldn't already know. Conceptual context (when to use teams, teams vs subagents) is omitted since Claude already has that knowledge. Display modes, keyboard shortcuts, quality gate hooks, and best practices are split into references for progressive disclosure.