### PR TITLE
feat(gitlab): detect glab OAuth token expiration and guide recovery

### DIFF
--- a/plugins/gitlab/README.md
+++ b/plugins/gitlab/README.md
@@ -20,9 +20,10 @@ GitLab workflow best practices and glab CLI usage for Claude Code.
 ### Hooks
 
 - Transforms GitLab URLs into API requests for better content fetching
+- Detects glab OAuth token expiration and provides recovery guidance
 
 ## Testing
 
 ```bash
-npm test -- plugins/gitlab
+bun test plugins/gitlab
 ```

--- a/plugins/gitlab/hooks/auth.test.ts
+++ b/plugins/gitlab/hooks/auth.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import type { PostToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { processInput } from "./auth";
+
+function mockInput(command: string, toolResponse: unknown = {}): PostToolUseHookInput {
+  return {
+    session_id: "test",
+    hook_event_name: "PostToolUse",
+    tool_name: "Bash",
+    tool_input: { command },
+    tool_response: toolResponse,
+    transcript_path: "/tmp/transcript.json",
+    cwd: process.cwd(),
+    tool_use_id: "test",
+  };
+}
+
+describe("glab auth hook", () => {
+  it("returns recovery guidance for invalid_grant error", () => {
+    const input = mockInput("glab mr view 112", {
+      stdout: "",
+      stderr: 'oauth2: "invalid_grant" "The provided authorization grant is invalid"',
+    });
+    const result = processInput(input);
+    expect(result).not.toBeNull();
+    expect(
+      (result?.hookSpecificOutput as { additionalContext: string }).additionalContext,
+    ).toContain("glab auth login");
+  });
+
+  it("ignores glab commands without auth errors", () => {
+    const input = mockInput("glab mr list", { stdout: "No merge requests" });
+    expect(processInput(input)).toBeNull();
+  });
+
+  it("ignores non-glab commands", () => {
+    const input = mockInput("git status", {
+      stderr: 'oauth2: "invalid_grant"',
+    });
+    expect(processInput(input)).toBeNull();
+  });
+
+  it("ignores commands with no response", () => {
+    const input = mockInput("glab mr view 1");
+    expect(processInput(input)).toBeNull();
+  });
+});

--- a/plugins/gitlab/hooks/auth.ts
+++ b/plugins/gitlab/hooks/auth.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env bun
+
+import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+
+export function processInput(input: PostToolUseHookInput): SyncHookJSONOutput | null {
+  const command = (input.tool_input as { command?: string }).command;
+  if (!command || !command.includes("glab")) return null;
+
+  const response = JSON.stringify(input.tool_response ?? "");
+  if (!response.includes("invalid_grant")) return null;
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      additionalContext:
+        "glab OAuth token expired. Run: glab auth login --hostname gitlab.com --git-protocol ssh (requires dangerouslyDisableSandbox: true for browser OAuth flow)",
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  let input: PostToolUseHookInput;
+  try {
+    input = await readStdinJson<PostToolUseHookInput>();
+  } catch {
+    return;
+  }
+
+  if (input.hook_event_name !== "PostToolUse") return;
+
+  const output = processInput(input);
+  if (output) {
+    writeStdoutJson(output);
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/plugins/gitlab/hooks/hooks.json
+++ b/plugins/gitlab/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Transforms GitLab URLs into API requests for better content fetching",
+  "description": "GitLab URL transforms and auth expiration recovery",
   "hooks": {
     "PreToolUse": [
       {
@@ -8,6 +8,17 @@
           {
             "type": "command",
             "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/auth.ts"
           }
         ]
       }


### PR DESCRIPTION
Adds a PostToolUse hook to the GitLab plugin that detects `glab` OAuth token expiration (`invalid_grant` errors) and provides `additionalContext` guiding Claude to re-authenticate with `glab auth login --hostname gitlab.com --git-protocol ssh`.

## Changes

- Adds `PostToolUse` Bash matcher in `hooks.json` pointing to `hooks/auth.ts`
- `auth.ts` checks if a Bash command contains `glab` and the response includes `invalid_grant`, returning recovery guidance via `additionalContext`
- Updates README to document the new hook and fix the test command (`bun test` instead of `npm test`)

## Testing

- Tests cover the key cases: `invalid_grant` in glab output triggers guidance, non-glab commands and other errors are ignored
