### PR TITLE
feat: add OpenTelemetry plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -165,6 +165,11 @@
       "name": "mail",
       "description": "Apple Mail integration for reading and managing email via JXA",
       "source": "./plugins/mail"
+    },
+    {
+      "name": "opentelemetry",
+      "description": "OpenTelemetry instrumentation patterns, semantic conventions, and testing",
+      "source": "./plugins/opentelemetry"
     }
   ]
 }

--- a/plugins/opentelemetry/.claude-plugin/plugin.json
+++ b/plugins/opentelemetry/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "opentelemetry",
+  "description": "OpenTelemetry instrumentation patterns, semantic conventions, and testing",
+  "author": {
+    "name": "Ben Drucker",
+    "email": "bvdrucker@gmail.com"
+  }
+}

--- a/plugins/opentelemetry/README.md
+++ b/plugins/opentelemetry/README.md
@@ -1,0 +1,7 @@
+# OpenTelemetry Plugin
+
+OpenTelemetry instrumentation patterns, semantic conventions, and testing.
+
+## Contents
+
+- **Skill**: Guidance on span naming, attributes, status, testing, and instrumentation boundaries

--- a/plugins/opentelemetry/skills/opentelemetry/SKILL.md
+++ b/plugins/opentelemetry/skills/opentelemetry/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: opentelemetry
+description: >-
+  OpenTelemetry instrumentation conventions. Use when instrumenting code with
+  spans, setting up tracing, or writing trace tests.
+user-invocable: false
+---
+
+# OpenTelemetry
+
+## Span Naming
+
+Use short, low-cardinality names from semantic conventions:
+
+- HTTP: `GET /users/{id}` (method + route template, never full URL path)
+- DB: `SELECT users` (operation + table)
+- RPC: `grpc.health.v1.Health/Check`
+- Messaging: `orders process` (destination + operation)
+
+## Attributes
+
+Use [semantic convention](https://opentelemetry.io/docs/specs/semconv/) attribute names — never invent your own:
+
+- HTTP: `http.request.method`, `url.full`, `http.response.status_code`, `server.address`
+- DB: `db.system`, `db.statement`, `db.namespace`
+- General: `error.type`, `service.name`
+
+Import from the versioned semconv package (e.g., `go.opentelemetry.io/otel/semconv/v1.x`).
+
+## Status
+
+Only set status on errors: `span.SetStatus(codes.Error, err.Error())`. Never set `Ok` — unset is the success state. Call `RecordError` alongside `SetStatus` (it only adds a span event, doesn't change status).
+
+For HTTP: 4xx is `Error` on client spans, `Unset` on server spans. 5xx is always `Error`.
+
+## Testing
+
+Use in-memory exporters with `SimpleSpanProcessor` (not batch — batch introduces timing). Assert on exported spans' names, attributes, and status. No mocking needed.
+
+## Boundaries
+
+Instrument network calls, I/O, and queue operations — not every function. Use span events (`AddEvent`) instead of separate log statements for events within a traced operation.


### PR DESCRIPTION
Adds an OpenTelemetry plugin with a single skill focused on what Claude gets wrong by default: span naming conventions, semantic convention attribute names, status handling, and testing with in-memory exporters.

## Changes

- Adds `plugins/opentelemetry/` with `plugin.json`, `SKILL.md`, and `README.md`
- Skill activates contextually (not user-invocable) when working with OTel instrumentation
- Covers span naming (low-cardinality, route templates), attributes (semconv names only), status (never set `Ok`), testing (`SimpleSpanProcessor` + in-memory exporter), and instrumentation boundaries
- Registers plugin in `marketplace.json`
