### PR TITLE
fix: use ref instead of sha for marketplace pins, exclude gh from sandbox

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -15,10 +15,10 @@
     },
     {
       customType: "regex",
-      description: "Third-party marketplaces pinned to commit digests via sha",
+      description: "Third-party marketplaces pinned to commit digests via ref",
       managerFilePatterns: ["user/settings.json"],
       matchStrings: [
-        '"repo":\\s*"(?<depName>[^"]+/[^"]+)"[^}]*"sha":\\s*"(?<currentDigest>[0-9a-f]{40})"',
+        '"repo":\\s*"(?<depName>[^"]+/[^"]+)"[^}]*"ref":\\s*"(?<currentDigest>[0-9a-f]{40})"',
       ],
       currentValueTemplate: "main",
       datasourceTemplate: "git-refs",

--- a/user/settings.json
+++ b/user/settings.json
@@ -107,21 +107,21 @@
       "source": {
         "source": "github",
         "repo": "anthropics/claude-plugins-official",
-        "sha": "27d2b86d72da27c64585150857cee8472ad47abb"
+        "ref": "27d2b86d72da27c64585150857cee8472ad47abb"
       }
     },
     "astral-sh": {
       "source": {
         "source": "github",
         "repo": "astral-sh/claude-code-plugins",
-        "sha": "f8034678a15ad751aae6a2b684daebac416267a1"
+        "ref": "f8034678a15ad751aae6a2b684daebac416267a1"
       }
     },
     "ast-grep": {
       "source": {
         "source": "github",
         "repo": "ast-grep/claude-skill",
-        "sha": "577f4d4507678f2c8cee150fae25e6ce309f70b1"
+        "ref": "577f4d4507678f2c8cee150fae25e6ce309f70b1"
       }
     },
     "worktrunk": {
@@ -168,7 +168,8 @@
       "afplay:*",
       "diskutil:*",
       "networksetup:*",
-      "wt:*"
+      "wt:*",
+      "gh:*"
     ]
   },
   "alwaysThinkingEnabled": true,


### PR DESCRIPTION
Work around two issues with user settings:

- **Marketplace `sha` → `ref`**: `sha` is not a documented property for marketplace sources. Rename to `ref` for the three commit-pinned marketplaces. Update the Renovate regex manager to match the new key.
- **Exclude `gh` from sandbox**: Go programs cannot verify TLS certificates inside the sandbox due to blocked `com.apple.trustd.agent` access. Adds `gh:*` to `excludedCommands` until [sandbox-runtime#120](https://github.com/anthropic-experimental/sandbox-runtime/pull/120) ships `enableWeakerNetworkIsolation`.
