### PR TITLE
fix: use things.bendrucker.me URLs in GitHub-visible contexts

### DIFF
--- a/.claude/commands/improve-claude-code.md
+++ b/.claude/commands/improve-claude-code.md
@@ -57,7 +57,7 @@ After all implementations complete, dispatch `claude -p` from each worktree to c
 PR body includes an `Original Task` section:
 
 ```
-Original Task: [<todo-title>](things:///show?id=<todo-id>)
+Original Task: [<todo-title>](https://things.bendrucker.me/show?id=<todo-id>)
 ```
 
 ### Monitor CI
@@ -73,6 +73,6 @@ For each passing PR, update the Things todo notes with the PR link and mark the 
 Output a final bulleted list — one entry per todo:
 
 - PR link (with pass/fail status)
-- Things URL: `things:///show?id=<todo-id>`
+- Things URL: `https://things.bendrucker.me/show?id=<todo-id>`
 - Todo title
 

--- a/plugins/things/scripts/inbox.ts
+++ b/plugins/things/scripts/inbox.ts
@@ -63,7 +63,7 @@ if (findXcallRunner()) {
     const result = await xcall(url);
     const id = parseThingsId(result);
     if (id) {
-      console.log(`things:///show?id=${id}`);
+      console.log(`https://things.bendrucker.me/show?id=${id}`);
     }
   } catch {
     await openUrl("add", params);

--- a/plugins/things/skills/inbox/SKILL.md
+++ b/plugins/things/skills/inbox/SKILL.md
@@ -29,7 +29,7 @@ bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts --session-id ${CLAUDE_SESSION_ID} tit
 
 The script handles URL encoding, session attribution, and the `Claude` tag automatically.
 
-When the `x-callback-url` plugin is installed, the script uses xcall to get the todo ID back from Things and outputs a `things:///show?id=...` URL. Present this URL to the user so they can click to open the todo. If xcall is unavailable, the script falls back to fire-and-forget.
+When the `x-callback-url` plugin is installed, the script uses xcall to get the todo ID back from Things and outputs a `https://things.bendrucker.me/show?id=...` URL. Present this URL to the user so they can click to open the todo. If xcall is unavailable, the script falls back to fire-and-forget.
 
 ## Parameters
 

--- a/plugins/things/skills/url/SKILL.md
+++ b/plugins/things/skills/url/SKILL.md
@@ -60,7 +60,7 @@ Items appear at the top of the list in the order specified. Default list is `tod
 
 ## Callback
 
-When the `x-callback-url` plugin is installed, `url.ts` automatically uses xcall to get a response from Things on stdout. Present the result to the user as clickable `things:///show?id=<id>` links:
+When the `x-callback-url` plugin is installed, `url.ts` automatically uses xcall to get a response from Things on stdout. Present the result to the user as clickable `https://things.bendrucker.me/show?id=<id>` links:
 
 - **Single todo** (`add`, `update`): returns `x-things-id=<id>` — present one link
 - **Batch** (`json`): returns `x-things-ids=["id1","id2"]` — present a bulleted list with each todo's title and link


### PR DESCRIPTION
GitHub strips `things:///` protocol URLs from markdown, rendering them as plain text. This updates all GitHub-visible contexts to use `https://things.bendrucker.me/show?id=...` which redirects to the Things app URL.

## Changes

- `.claude/commands/improve-claude-code.md` — PR body template and summary output
- `plugins/things/scripts/inbox.ts` — stdout URL output
- `plugins/things/skills/inbox/SKILL.md` — skill documentation
- `plugins/things/skills/url/SKILL.md` — callback presentation instructions

Runtime URLs for `open` commands and reference documentation remain unchanged.

## Original Task

[Update Things skills to use things.bendrucker.me for URLs in GitHub contexts](https://things.bendrucker.me/show?id=JzrHjb4iwmRpnNLY7TLBrz)