### PR TITLE
fix: handle sandbox-protected dirty files in fix-conflicts

### DIFF
--- a/plugins/git/commands/fix-conflicts.md
+++ b/plugins/git/commands/fix-conflicts.md
@@ -29,9 +29,13 @@ Fix all merge conflicts in the working tree, then commit and push the result.
    - `git add` the resolved file.
    - For generated files (lockfiles, build artifacts), prefer deleting and regenerating over manual merge.
 
-4. **Continue the operation.** Run the appropriate continuation command (`git rebase --continue`, `git merge --continue`, or `git cherry-pick --continue`).
+4. **Stash unrelated dirty files.** Before continuing, check for unstaged changes unrelated to the conflicts via `git status --porcelain`.
+   - If dirty files exist beyond the resolved conflicts, try `git stash push -m "fix-conflicts: temp" -- <file1> <file2>` with all unrelated dirty files.
+   - If stash fails (the sandbox may block unlinking protected files like `.mcp.json`), stash files individually and skip failures. For files that cannot be stashed, hide them temporarily with `git update-index --assume-unchanged <file>`.
 
-5. **Push.** Run `git push` to update the remote branch.
+5. **Continue the operation.** Run the appropriate continuation command (`git rebase --continue`, `git merge --continue`, or `git cherry-pick --continue`).
+
+6. **Push and restore.** Run `git push` to update the remote branch. Then restore any hidden files with `git update-index --no-assume-unchanged <file>` and run `git stash pop` if anything was stashed.
 
 ## Notes
 

--- a/plugins/git/skills/conflicts/SKILL.md
+++ b/plugins/git/skills/conflicts/SKILL.md
@@ -15,6 +15,8 @@ allowed-tools:
   - Bash(git merge:*)
   - Bash(git cherry-pick:*)
   - Bash(git rerere:*)
+  - Bash(git stash:*)
+  - Bash(git update-index:*)
   - Bash(bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/*:*)
 hooks:
   PreToolUse:


### PR DESCRIPTION
The `git:fix-conflicts` command fails when the working tree has unstaged changes in sandbox-protected files (e.g., `.mcp.json`). This adds a stash-with-fallback step that uses `git update-index --assume-unchanged` for files the sandbox blocks from stashing.

## Changes

- `plugins/git/commands/fix-conflicts.md` — new step 4 to stash dirty files before continuing, with `--assume-unchanged` fallback for sandbox-protected files
- `plugins/git/skills/conflicts/SKILL.md` — added `git stash` and `git update-index` to allowed-tools

## Original Task

[Fix git:fix-conflicts skill: handle dirty working tree with sandbox-protected files](https://things.bendrucker.me/show?id=Eh4NAEddMkM2Rq2Fvp7hCT)