### PR TITLE
fix: exclude claude CLI from sandbox

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -169,7 +169,8 @@
       "diskutil:*",
       "networksetup:*",
       "wt:*",
-      "gh:*"
+      "gh:*",
+      "claude:*"
     ]
   },
   "alwaysThinkingEnabled": true,


### PR DESCRIPTION
The sandbox blocks `claude -p` subprocesses from creating `session-env/` directories through the `~/.claude` symlink, causing dispatched worktree work to fail silently. Adding `claude:*` to `excludedCommands` fixes this.

## Changes

- `user/settings.json` — added `claude:*` to `sandbox.excludedCommands`