### PR TITLE
fix: eliminate command substitution in pull-request skill context

### DIFF
--- a/plugins/pull-request/scripts/detect-provider.ts
+++ b/plugins/pull-request/scripts/detect-provider.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env bun
 // Detect git hosting provider from remote URL
+// Args: [branch] — resolves worktree path for branch if provided
 // Outputs: github, gitlab, or unknown
 
 import { execSync } from "node:child_process";
+import { resolveWorktree } from "./worktree/resolve";
 
 export type Provider = "github" | "gitlab" | "unknown";
 
@@ -44,5 +46,7 @@ export function detectProvider(cwd?: string): Provider {
 
 // Run as CLI
 if (import.meta.main) {
-  console.log(detectProvider());
+  const branch = process.argv[2];
+  const worktreePath = branch ? await resolveWorktree(branch) : null;
+  console.log(detectProvider(worktreePath ?? undefined));
 }

--- a/plugins/pull-request/scripts/pr-diff.ts
+++ b/plugins/pull-request/scripts/pr-diff.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env bun
+// Fetch PR/MR diff for the current branch
+// Args: [branch]
+// Detects provider and runs gh pr diff or glab mr diff
+
+import { $ } from "bun";
+import { detectProvider } from "./detect-provider";
+import { resolveWorktree } from "./worktree/resolve";
+
+const [branch = ""] = process.argv.slice(2);
+const cwd = (await resolveWorktree(branch)) || undefined;
+const provider = detectProvider(cwd);
+const shell = cwd ? $.cwd(cwd) : $;
+
+if (provider === "github") {
+  const result = await shell`gh pr diff`.nothrow().quiet();
+  process.stdout.write(result.stdout);
+} else if (provider === "gitlab") {
+  const result = await shell`glab mr diff`.nothrow().quiet();
+  process.stdout.write(result.stdout);
+}

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: Bash(bun:${CLAUDE_PLUGIN_ROOT}/scripts/*), Bash(${CLAUDE_PLUGIN_R
 
 ## Context
 
-- Provider: !`wt_path=$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/worktree/resolve.ts" "$0"); bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts" ${wt_path:+"$wt_path"}`
+- Provider: !`bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts" "$0"`
 - Branch: !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" branch --show-current`
 - Status: !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" status --short`
 - Log: !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" log --oneline -20`

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -13,11 +13,10 @@ The PR body documents what will happen when merged, not the journey. Don't echo 
 
 ## Context
 
-- Provider: !`wt_path=$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/worktree/resolve.ts" "$0"); bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts" ${wt_path:+"$wt_path"}`
+- Provider: !`bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts" "$0"`
 - Branch: !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" branch --show-current`
 - PR: !`bun "${CLAUDE_PLUGIN_ROOT}/scripts/pr-context.ts" "$0" 2>/dev/null || echo "No PR found for current branch"`
-- Diff (GitHub): !`wt_path=$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/worktree/resolve.ts" "$0"); [ "$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts" ${wt_path:+"$wt_path"})" = github ] && "${CLAUDE_PLUGIN_ROOT}/scripts/worktree/gh.sh" "$0" pr diff 2>/dev/null || true`
-- Diff (GitLab): !`wt_path=$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/worktree/resolve.ts" "$0"); [ "$(bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts" ${wt_path:+"$wt_path"})" = gitlab ] && "${CLAUDE_PLUGIN_ROOT}/scripts/worktree/glab.sh" "$0" mr diff 2>/dev/null || true`
+- Diff: !`bun "${CLAUDE_PLUGIN_ROOT}/scripts/pr-diff.ts" "$0"`
 
 ## Workflow
 


### PR DESCRIPTION
Skill context commands in `pull-request:create` and `pull-request:update` used `$()` command substitution to resolve worktree paths before passing them to `detect-provider.ts`. Claude Code rejects commands containing `$()` substitution during permission checks, causing the skills to fail on initialization.

## Changes

- `detect-provider.ts` now accepts an optional branch argument and resolves the worktree path internally via `resolveWorktree()`, eliminating the shell-level `$()` pipe
- New `pr-diff.ts` script combines provider detection and diff fetching into a single command, replacing the two conditional `$()` context lines in the update skill

## Testing

`bun test plugins/pull-request/`
