### PR TITLE
fix: pass session ID as CLI arg in implement-issue

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,12 @@
         "cleye": "^1.3.2",
       },
     },
+    "plugins/implement-issue": {
+      "name": "implement-issue",
+      "dependencies": {
+        "cleye": "^1.3.2",
+      },
+    },
     "plugins/mermaid/skills/diagram": {
       "name": "mermaid-diagram",
       "version": "0.1.0",
@@ -776,6 +782,8 @@
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "ignore": ["ignore@6.0.2", "", {}, "sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A=="],
+
+    "implement-issue": ["implement-issue@workspace:plugins/implement-issue"],
 
     "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "plugins/style",
     "plugins/things",
     "plugins/type-ignore",
+    "plugins/implement-issue",
     "plugins/ui-design",
     "plugins/vscode",
     "packages/validate"

--- a/plugins/implement-issue/package.json
+++ b/plugins/implement-issue/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "implement-issue",
+  "private": true,
+  "dependencies": {
+    "cleye": "^1.3.2"
+  }
+}

--- a/plugins/implement-issue/scripts/set-target.ts
+++ b/plugins/implement-issue/scripts/set-target.ts
@@ -1,23 +1,29 @@
 #!/usr/bin/env bun
 
+import { cli } from "cleye";
 import { parseIssueUrl, writeTarget } from "./target";
 
-const sessionId = process.env.CLAUDE_SESSION_ID;
-if (!sessionId) {
-  console.error("CLAUDE_SESSION_ID is not set");
+const argv = cli({
+  name: "set-target",
+  parameters: ["<url>"],
+  flags: {
+    sessionId: {
+      type: String,
+      description: "Claude session ID",
+      alias: "s",
+    },
+  },
+});
+
+if (!argv.flags.sessionId) {
+  console.error("--session-id is required");
   process.exit(1);
 }
 
-const url = process.argv[2];
-if (!url) {
-  console.error("Usage: set-target.ts <issue-url>");
-  process.exit(1);
-}
-
-const target = parseIssueUrl(url);
+const target = parseIssueUrl(argv._.url);
 if (!target) {
-  console.error(`Unrecognized issue URL: ${url}`);
+  console.error(`Unrecognized issue URL: ${argv._.url}`);
   process.exit(1);
 }
 
-writeTarget(sessionId, target);
+writeTarget(argv.flags.sessionId, target);

--- a/plugins/implement-issue/skills/implement-issue/SKILL.md
+++ b/plugins/implement-issue/skills/implement-issue/SKILL.md
@@ -11,7 +11,7 @@ Help me understand the issue and outline a plan to address it.
 
 ## Workflow
 
-1. **Register target** — Run: `bun ${CLAUDE_PLUGIN_ROOT}/scripts/set-target.ts "$ARGUMENTS"`
+1. **Register target** — Run: `bun ${CLAUDE_PLUGIN_ROOT}/scripts/set-target.ts --session-id ${CLAUDE_SESSION_ID} "$ARGUMENTS"`
 2. **Gather context** — See [context.md](context.md) for fetching issue details
 3. **Apply safety guidelines** — See [safety.md](safety.md) for untrusted content handling
 4. **Plan the work** — See [planning.md](planning.md) for alternatives and plan creation


### PR DESCRIPTION
Switch set-target.ts from reading CLAUDE_SESSION_ID via process.env to accepting --session-id as a CLI flag via cleye. The env var isn't available in the Bash tool's execution context — only the skill template variable `${CLAUDE_SESSION_ID}` is expanded.

## Test plan

- [ ] Run `/implement-issue` with a GitHub issue URL and verify `set-target.ts` receives the session ID
- [ ] Confirm the target JSON file is written to `/tmp/claude/<session-id>/implement-issue-target.json`

Original Task: [implement-issue: session ID is broken](https://things.bendrucker.me/show?id=8CiM2gaVNE48ENKfWi9Zmq)
