### PR TITLE
feat: add reminders plugin for Apple Reminders integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -175,6 +175,11 @@
       "name": "terraform",
       "description": "Terraform Cloud workspace management, run monitoring, and registry lookups",
       "source": "./plugins/terraform"
+    },
+    {
+      "name": "reminders",
+      "description": "Apple Reminders integration for reading and managing via JXA",
+      "source": "./plugins/reminders"
     }
   ]
 }

--- a/plugins/reminders/.claude-plugin/plugin.json
+++ b/plugins/reminders/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "reminders",
+  "description": "Apple Reminders integration for reading and managing via JXA",
+  "author": {
+    "name": "Ben Drucker",
+    "email": "bvdrucker@gmail.com"
+  }
+}

--- a/plugins/reminders/README.md
+++ b/plugins/reminders/README.md
@@ -1,0 +1,18 @@
+# Reminders
+
+Apple Reminders integration for reading and managing via JXA.
+
+## Contents
+
+### Skills
+
+- **reminders** — Read and manage the Reminders inbox
+
+### Scripts
+
+- `scripts/jxa/read-default-list.js` — Read incomplete reminders from the default list
+- `scripts/jxa/delete-reminders.js` — Delete reminders by ID
+
+## Testing
+
+JXA scripts require Reminders.app and cannot be tested in CI.

--- a/plugins/reminders/scripts/jxa/delete-reminders.js
+++ b/plugins/reminders/scripts/jxa/delete-reminders.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env osascript -l JavaScript
+
+function run(argv) {
+  var app = Application("Reminders");
+  var list = app.defaultList();
+  var deleted = 0;
+
+  for (var i = argv.length - 1; i >= 0; i--) {
+    var targetId = argv[i];
+    var reminders = list.reminders();
+    for (var j = reminders.length - 1; j >= 0; j--) {
+      if (reminders[j].id() === targetId) {
+        app.delete(reminders[j]);
+        deleted++;
+        break;
+      }
+    }
+  }
+
+  return JSON.stringify({ deleted: deleted });
+}

--- a/plugins/reminders/scripts/jxa/read-default-list.js
+++ b/plugins/reminders/scripts/jxa/read-default-list.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env osascript -l JavaScript
+
+function run(argv) {
+  var app = Application("Reminders");
+  var list = app.defaultList();
+  var reminders = list.reminders.whose({ completed: false })();
+  var items = [];
+  for (var i = 0; i < reminders.length; i++) {
+    var r = reminders[i];
+    items.push({
+      id: r.id(),
+      name: r.name(),
+      body: r.body() || "",
+      dueDate: r.dueDate() ? r.dueDate().toISOString() : null,
+      priority: r.priority(),
+      flagged: r.flagged(),
+      creationDate: r.creationDate().toISOString(),
+    });
+  }
+  return JSON.stringify(items);
+}

--- a/plugins/reminders/skills/reminders/SKILL.md
+++ b/plugins/reminders/skills/reminders/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: reminders
+description: Apple Reminders integration — read and manage the inbox. Use when the user wants to check reminders or work with Reminders.app.
+---
+
+# Reminders
+
+Read and manage Apple Reminders via JXA (`osascript -l JavaScript`).
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `${CLAUDE_PLUGIN_ROOT}/scripts/jxa/read-default-list.js` | Read incomplete reminders from the default list |
+| `${CLAUDE_PLUGIN_ROOT}/scripts/jxa/delete-reminders.js` | Delete reminders by ID (pass IDs as arguments) |
+
+## Notes
+
+- Launch Reminders first if not running: `open -g -a "Reminders"`
+- JXA arrays from Reminders lack `.map()/.filter()` — use for-loops
+- `.whose()` works for filtering reminders by `completed` status
+- The default list is where Siri dictation creates items


### PR DESCRIPTION
New plugin with JXA scripts to read and manage the Apple Reminders default list. Includes a skill for reading inbox items and deleting by ID.

## Test plan

- [ ] Run `osascript -l JavaScript plugins/reminders/scripts/jxa/read-default-list.js` with items in Reminders inbox
- [ ] Verify the skill activates when asking about reminders
- [ ] Verify `check-marketplace.sh` passes with the new plugin entry

Original Task: [Build Reminders → Things import script](https://things.bendrucker.me/show?id=CGPeQo1zgPwS6wonRwP8fo)
