### PR TITLE
fix: use bun run for workspace skill-lint command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,13 +126,13 @@ Run `scripts/check-marketplace.sh` to verify all plugin directories are listed i
 
 ### Skill Linting
 
-Skills are validated with `bunx skill-lint`:
+Skills are validated with `bun run skill-lint`:
 
 ```bash
-bunx skill-lint "plugins/<name>/skills/*"
+bun run skill-lint "plugins/<name>/skills/*"
 ```
 
-This validates SKILL.md frontmatter (name, description) and checks reference depth. There is no `@constellos/skill-linter` or similar package—use `skill-lint` only.
+This validates SKILL.md frontmatter (name, description) and checks reference depth. `skill-lint` is a workspace package in `packages/skill-lint`, not an npm registry package.
 
 ## Workflow
 

--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -117,7 +117,7 @@ Reserve ALL CAPS for files with special meaning (`SKILL.md`, `README.md`). Use l
 
 ## Validation
 
-Run `bunx skill-lint path/to/skill/` to check for issues before committing. CI runs this automatically.
+Run `bun run skill-lint path/to/skill/` to check for issues before committing. CI runs this automatically.
 
 ## References
 


### PR DESCRIPTION
`skill-lint` is a workspace package in `packages/skill-lint`, not published to npm. `bunx` tries to fetch from the registry and fails. Replace with `bun run skill-lint` which resolves via the root `package.json` script.
