### PR TITLE
feat: add honeycomb plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -170,6 +170,14 @@
       "name": "terraform",
       "description": "Terraform Cloud workspace management, run monitoring, and registry lookups",
       "source": "./plugins/terraform"
+    },
+    {
+      "name": "honeycomb",
+      "description": "Honeycomb CLI and MCP server for observability",
+      "source": {
+        "source": "github",
+        "repo": "bendrucker/honeycomb-cli"
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds the `honeycomb` plugin to the marketplace, sourced from `bendrucker/honeycomb-cli`. This is an external GitHub-sourced plugin (like `agents-md`) providing a skill for the Honeycomb CLI and MCP server.
