### PR TITLE
feat: add magic number detection to review:peer

### DIFF
--- a/plugins/review/skills/peer/magic-numbers.md
+++ b/plugins/review/skills/peer/magic-numbers.md
@@ -31,4 +31,4 @@ For Go, suggest package-level constants. For Python, suggest module-level consta
 
 ## Severity
 
-Magic numbers are a **Style** concern. Use `Nit:` prefix for isolated cases. Escalate to **Should** when multiple unexplained literals appear in the same function or when the value is non-obvious (e.g., `if size > 8192`).
+Magic numbers are an **Anti-pattern**. Use `Nit:` prefix for isolated cases. Escalate to **Should** when multiple unexplained literals appear in the same function or when the value is non-obvious (e.g., `if size > 8192`).

--- a/plugins/review/skills/peer/priorities.md
+++ b/plugins/review/skills/peer/priorities.md
@@ -5,6 +5,7 @@ Prioritize in order when making comments:
 1. **Bugs** - Issues that could cause unexpected behavior or crashes
 2. **Performance** - Inefficient approaches consuming excess resources or adding latency
 3. **Architecture** - Module organization, interface design, separation of concerns. Avoid "utils" packages.
-4. **Style** - Note deviations from project/language style, but limit these. Prefer automated linting. Suggest enforcement to *me* instead of commenting on PR. Flag magic numbers (see [magic-numbers.md](magic-numbers.md)).
+4. **Anti-patterns** - Flag magic numbers (see [magic-numbers.md](magic-numbers.md)) and other code smells that hurt readability or maintainability.
+5. **Style** - Note deviations from project/language style, but limit these. Prefer automated linting. Suggest enforcement to *me* instead of commenting on PR.
 
 Think hard about the problem the PR solves and whether the approach is optimal.


### PR DESCRIPTION
Adds magic number detection to the peer review skill. Reviews now flag unexplained numeric literals while skipping common acceptable values (0, 1, HTTP status codes, test assertions).

## Changes

- Add `magic-numbers.md` reference with guidance on what to flag, what to skip, and how to suggest fixes
- Add **Anti-patterns** priority to `priorities.md` (between Architecture and Style) for magic numbers and other code smells

## Test plan

- [ ] Verify `bun run skill-lint "plugins/review/skills/*"` passes
- [ ] Test peer review on a PR containing magic numbers

Original Task: [/review:peer: magic number detection](https://things.bendrucker.me/show?id=BdNeG4uaQGRWUsa13vmbCB)
