### PR TITLE
fix: remove fallback expressions from git:conflicts backtick commands

### DIFF
--- a/plugins/git/skills/conflicts/SKILL.md
+++ b/plugins/git/skills/conflicts/SKILL.md
@@ -32,15 +32,15 @@ hooks:
 
 ## Status
 
-!`bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/status.ts 2>/dev/null || echo "Run status.ts manually"`
+!`bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/status.ts 2>/dev/null`
 
 ## Context
 
-!`bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/context.ts 2>/dev/null || echo "Run context.ts manually"`
+!`bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/context.ts 2>/dev/null`
 
 ## Upstream
 
-!`bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/upstream.ts 2>/dev/null || echo "Run upstream.ts manually"`
+!`bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/upstream.ts 2>/dev/null`
 
 ## Three-Way Access
 


### PR DESCRIPTION
The `|| echo "..."` fallback in backtick commands triggers permission checks because Claude sees them as compound shell commands. The `2>/dev/null` redirect already suppresses errors, making the fallback unnecessary.

## Test plan

- [ ] Verify `bun run skill-lint "plugins/git/skills/*"` passes
- [ ] Load the `git:conflicts` skill and confirm backtick commands execute without permission prompts