### PR TITLE
feat: add ntfy plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -183,6 +183,11 @@
       "name": "raycast",
       "description": "Raycast extension development patterns, API, and Store publishing",
       "source": "./plugins/raycast"
+    },
+    {
+      "name": "ntfy",
+      "description": "Push notifications via ntfy for remote Claude Code sessions",
+      "source": "./plugins/ntfy"
     }
   ]
 }

--- a/plugins/ntfy/.claude-plugin/plugin.json
+++ b/plugins/ntfy/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "ntfy",
+  "description": "Push notifications via ntfy for remote Claude Code sessions",
+  "author": { "name": "Ben Drucker", "email": "bvdrucker@gmail.com" }
+}

--- a/plugins/ntfy/README.md
+++ b/plugins/ntfy/README.md
@@ -1,0 +1,27 @@
+# ntfy
+
+Push notifications via ntfy for remote Claude Code sessions.
+
+## Configuration
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `SSH_CONNECTION` | Yes | Set automatically by SSH; notifications only fire in remote sessions |
+| `NTFY_URL` | Yes | Full ntfy topic URL (e.g., `https://ntfy.sh/my-topic`) |
+| `NTFY_TOKEN` | Yes | Bearer token for ntfy authentication |
+| `CLAUDE_TMUX_SESSION` | No | Session name for title prefix; falls back to hostname |
+
+## Hooks
+
+- **Notification**: Sends notification title and message to ntfy
+- **Stop**: Notifies when Claude finishes responding (low priority)
+- **PermissionRequest**: Notifies when Claude is blocked waiting for approval (high priority)
+- **TaskCompleted**: Notifies when a task is marked complete
+
+All hooks exit silently when `$SSH_CONNECTION`, `$NTFY_URL`, or `$NTFY_TOKEN` is not set.
+
+## Testing
+
+```sh
+bun test plugins/ntfy
+```

--- a/plugins/ntfy/hooks/hooks.json
+++ b/plugins/ntfy/hooks/hooks.json
@@ -1,0 +1,45 @@
+{
+  "description": "Push notifications via ntfy for remote sessions",
+  "hooks": {
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/notify.ts"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/notify.ts"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/notify.ts"
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/notify.ts"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/ntfy/hooks/notify.test.ts
+++ b/plugins/ntfy/hooks/notify.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "bun:test";
+import type {
+  NotificationHookInput,
+  PermissionRequestHookInput,
+  StopHookInput,
+  TaskCompletedHookInput,
+} from "@anthropic-ai/claude-agent-sdk";
+import { buildRequest, buildTitle, mapPriority, sessionContext, shouldNotify } from "./notify";
+
+const baseInput = {
+  session_id: "test",
+  transcript_path: "/tmp/transcript",
+  cwd: "/home/user",
+};
+
+describe("shouldNotify", () => {
+  it("returns false without SSH_CONNECTION", () => {
+    expect(shouldNotify({ NTFY_URL: "https://ntfy.sh/topic", NTFY_TOKEN: "tok" })).toBe(false);
+  });
+
+  it("returns false without NTFY_URL", () => {
+    expect(shouldNotify({ SSH_CONNECTION: "1.2.3.4 5678 5.6.7.8 22", NTFY_TOKEN: "tok" })).toBe(
+      false,
+    );
+  });
+
+  it("returns false without NTFY_TOKEN", () => {
+    expect(
+      shouldNotify({
+        SSH_CONNECTION: "1.2.3.4 5678 5.6.7.8 22",
+        NTFY_URL: "https://ntfy.sh/topic",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when all required vars are set", () => {
+    expect(
+      shouldNotify({
+        SSH_CONNECTION: "1.2.3.4 5678 5.6.7.8 22",
+        NTFY_URL: "https://ntfy.sh/topic",
+        NTFY_TOKEN: "tok",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("sessionContext", () => {
+  it("uses CLAUDE_TMUX_SESSION when set", () => {
+    expect(sessionContext({ CLAUDE_TMUX_SESSION: "dev" })).toBe("dev");
+  });
+
+  it("falls back to hostname", () => {
+    const result = sessionContext({});
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+describe("buildTitle", () => {
+  it("formats with session context prefix", () => {
+    expect(buildTitle("dev", "Task complete")).toBe("[dev] Task complete");
+  });
+});
+
+describe("mapPriority", () => {
+  it("returns high for PermissionRequest events", () => {
+    const input: PermissionRequestHookInput = {
+      ...baseInput,
+      hook_event_name: "PermissionRequest",
+      tool_name: "Bash",
+      tool_input: { command: "rm -rf /" },
+    };
+    expect(mapPriority(input)).toBe("high");
+  });
+
+  it("returns low for Stop events", () => {
+    const input: StopHookInput = {
+      ...baseInput,
+      hook_event_name: "Stop",
+      stop_hook_active: false,
+    };
+    expect(mapPriority(input)).toBe("low");
+  });
+
+  it("returns default for Notification events", () => {
+    const input: NotificationHookInput = {
+      ...baseInput,
+      hook_event_name: "Notification",
+      message: "Done",
+      notification_type: "info",
+    };
+    expect(mapPriority(input)).toBe("default");
+  });
+
+  it("returns default for TaskCompleted events", () => {
+    const input: TaskCompletedHookInput = {
+      ...baseInput,
+      hook_event_name: "TaskCompleted",
+      task_id: "1",
+      task_subject: "Fix bug",
+    };
+    expect(mapPriority(input)).toBe("default");
+  });
+});
+
+describe("buildRequest", () => {
+  const env = {
+    NTFY_URL: "https://ntfy.sh/topic",
+    NTFY_TOKEN: "tok",
+    CLAUDE_TMUX_SESSION: "dev",
+  };
+
+  it("builds request for Notification event", () => {
+    const input: NotificationHookInput = {
+      ...baseInput,
+      hook_event_name: "Notification",
+      message: "Build succeeded",
+      title: "CI",
+      notification_type: "info",
+    };
+
+    const req = buildRequest(input, env);
+    expect(req.url).toBe("https://ntfy.sh/topic");
+    expect(req.title).toBe("[dev] CI");
+    expect(req.body).toBe("Build succeeded");
+    expect(req.priority).toBe("default");
+  });
+
+  it("uses fallback title for Notification without title", () => {
+    const input: NotificationHookInput = {
+      ...baseInput,
+      hook_event_name: "Notification",
+      message: "Something happened",
+      notification_type: "info",
+    };
+
+    const req = buildRequest(input, env);
+    expect(req.title).toBe("[dev] Claude Code");
+  });
+
+  it("builds request for Stop event", () => {
+    const input: StopHookInput = {
+      ...baseInput,
+      hook_event_name: "Stop",
+      stop_hook_active: false,
+    };
+
+    const req = buildRequest(input, env);
+    expect(req.title).toBe("[dev] Claude Code stopped");
+    expect(req.body).toBe("Session ended");
+    expect(req.priority).toBe("low");
+  });
+
+  it("indicates active stop hook in body", () => {
+    const input: StopHookInput = {
+      ...baseInput,
+      hook_event_name: "Stop",
+      stop_hook_active: true,
+    };
+
+    const req = buildRequest(input, env);
+    expect(req.body).toBe("Session ended (stop hook active)");
+  });
+
+  it("builds request for PermissionRequest with Bash command", () => {
+    const input: PermissionRequestHookInput = {
+      ...baseInput,
+      hook_event_name: "PermissionRequest",
+      tool_name: "Bash",
+      tool_input: { command: "rm -rf node_modules" },
+    };
+
+    const req = buildRequest(input, env);
+    expect(req.title).toBe("[dev] Permission needed: Bash");
+    expect(req.body).toBe("rm -rf node_modules");
+    expect(req.priority).toBe("high");
+  });
+
+  it("builds request for PermissionRequest with non-Bash tool", () => {
+    const input: PermissionRequestHookInput = {
+      ...baseInput,
+      hook_event_name: "PermissionRequest",
+      tool_name: "Write",
+      tool_input: { file_path: "/etc/passwd", content: "x" },
+    };
+
+    const req = buildRequest(input, env);
+    expect(req.title).toBe("[dev] Permission needed: Write");
+    expect(req.body).toBe("Write tool call");
+  });
+
+  it("builds request for TaskCompleted event", () => {
+    const input: TaskCompletedHookInput = {
+      ...baseInput,
+      hook_event_name: "TaskCompleted",
+      task_id: "task-001",
+      task_subject: "Implement user authentication",
+    };
+
+    const req = buildRequest(input, env);
+    expect(req.title).toBe("[dev] Task completed");
+    expect(req.body).toBe("Implement user authentication");
+    expect(req.priority).toBe("default");
+  });
+});

--- a/plugins/ntfy/hooks/notify.ts
+++ b/plugins/ntfy/hooks/notify.ts
@@ -1,0 +1,119 @@
+#!/usr/bin/env bun
+
+import { hostname } from "node:os";
+import type {
+  NotificationHookInput,
+  PermissionRequestHookInput,
+  StopHookInput,
+  TaskCompletedHookInput,
+} from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson } from "@constellos/claude-code-kit/runners";
+
+type HookInput =
+  | NotificationHookInput
+  | StopHookInput
+  | PermissionRequestHookInput
+  | TaskCompletedHookInput;
+
+type Env = Record<string, string | undefined>;
+
+export function shouldNotify(env: Env): boolean {
+  return !!(env.SSH_CONNECTION && env.NTFY_URL && env.NTFY_TOKEN);
+}
+
+export function sessionContext(env: Env): string {
+  return env.CLAUDE_TMUX_SESSION || hostname();
+}
+
+export function buildTitle(context: string, title: string): string {
+  return `[${context}] ${title}`;
+}
+
+export function mapPriority(input: HookInput): string {
+  switch (input.hook_event_name) {
+    case "PermissionRequest":
+      return "high";
+    case "Stop":
+      return "low";
+    default:
+      return "default";
+  }
+}
+
+export function buildRequest(
+  input: HookInput,
+  env: Env,
+): { url: string; title: string; body: string; priority: string } {
+  const url = env.NTFY_URL as string;
+  const context = sessionContext(env);
+  const priority = mapPriority(input);
+
+  switch (input.hook_event_name) {
+    case "Notification":
+      return {
+        url,
+        title: buildTitle(context, input.title || "Claude Code"),
+        body: input.message,
+        priority,
+      };
+
+    case "Stop":
+      return {
+        url,
+        title: buildTitle(context, "Claude Code stopped"),
+        body: input.stop_hook_active ? "Session ended (stop hook active)" : "Session ended",
+        priority,
+      };
+
+    case "PermissionRequest":
+      return {
+        url,
+        title: buildTitle(context, `Permission needed: ${input.tool_name}`),
+        body: formatToolInput(input.tool_name, input.tool_input),
+        priority,
+      };
+
+    case "TaskCompleted":
+      return {
+        url,
+        title: buildTitle(context, "Task completed"),
+        body: input.task_subject,
+        priority,
+      };
+  }
+}
+
+function formatToolInput(toolName: string, toolInput: unknown): string {
+  if (toolName === "Bash" && typeof toolInput === "object" && toolInput !== null) {
+    const command = (toolInput as Record<string, unknown>).command;
+    if (typeof command === "string") return command;
+  }
+  return `${toolName} tool call`;
+}
+
+async function main(): Promise<void> {
+  if (!shouldNotify(process.env)) return;
+
+  let input: HookInput;
+  try {
+    input = await readStdinJson<HookInput>();
+  } catch {
+    return;
+  }
+
+  const req = buildRequest(input, process.env);
+
+  fetch(req.url, {
+    method: "POST",
+    body: req.body,
+    headers: {
+      Authorization: `Bearer ${process.env.NTFY_TOKEN}`,
+      Title: req.title,
+      Priority: req.priority,
+    },
+  }).catch(() => {});
+}
+
+if (import.meta.main) {
+  main().catch(() => {});
+}


### PR DESCRIPTION
Push notifications via ntfy for remote Claude Code sessions. Designed for the "away from keyboard" workflow — you're SSH'd into a remote machine and want to know when Claude needs attention or finishes work.

## Hooks

- **Notification**: Forwards notification title and message (default priority)
- **Stop**: Notifies when Claude finishes responding (low priority)
- **PermissionRequest**: Notifies when Claude is blocked waiting for approval, with tool name and command details (high priority)
- **TaskCompleted**: Notifies when a task is marked complete with the task subject (default priority)

All hooks exit silently when `$SSH_CONNECTION`, `$NTFY_URL`, or `$NTFY_TOKEN` is not set.

## Testing

- `bun test plugins/ntfy`
- Validate hooks: `bun packages/validate/hooks.ts plugins/ntfy`
