### PR TITLE
fix: disable sandbox, add allowLocalBinding for re-enablement

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -139,9 +139,10 @@
     }
   },
   "sandbox": {
-    "enabled": true,
+    "enabled": false,
     "autoAllowBashIfSandboxed": true,
     "network": {
+      "allowLocalBinding": true,
       "allowUnixSockets": [
         "~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
       ]


### PR DESCRIPTION
Disable sandbox by default due to persistent Go TLS failures (Security.framework IPC blocked by Seatbelt) and port binding issues that cause constant `dangerouslyDisableSandbox` retries. Add `allowLocalBinding: true` for when sandbox is re-enabled upstream ([anthropics/claude-code#23416](https://github.com/anthropics/claude-code/issues/23416)).

## Issue

Closes #414

The sandbox blocks IPC to `com.apple.trustd.agent`, breaking TLS verification for all Go binaries (`gh`, `glab`, `go test`, etc.) with `x509: OSStatus -26276`. It also blocks `bind()` on localhost ports, failing `httptest.NewServer` and dev servers. The upstream fix (`enableWeakerNetworkIsolation`) exists in `sandbox-runtime@0.0.37` but isn't exposed in Claude Code settings yet.

## Changes

- Set `sandbox.enabled` to `false` — trades auto-allow for permission prompts, eliminating sandbox failure/retry noise
- Add `allowLocalBinding: true` — pre-configures localhost port binding for when sandbox is re-enabled
