### PR TITLE
fix: add worktree sandbox permissions and agent team docs

### DIFF
--- a/plugins/claude-code/skills/agent-team/SKILL.md
+++ b/plugins/claude-code/skills/agent-team/SKILL.md
@@ -47,6 +47,10 @@ Teammates inherit the lead's permission settings at spawn. Each teammate loads p
 - One team per session, no nested teams
 - Lead is fixed for the team's lifetime
 
+## Known Issues
+
+- **tmux backend**: teammates spawned in tmux panes may never receive their initial prompt or poll their inbox, causing them to idle indefinitely ([#23415](https://github.com/anthropics/claude-code/issues/23415)). A separate race condition between pane creation and shell initialization can prevent the `claude` command from executing at all ([#25315](https://github.com/anthropics/claude-code/issues/25315)). Use `in-process` backend (the default) as a workaround.
+
 ## References
 
 - [references/hooks.md](references/hooks.md) — `TeammateIdle` and `TaskCompleted` quality gate hooks

--- a/plugins/claude-code/skills/agent-team/references/practices.md
+++ b/plugins/claude-code/skills/agent-team/references/practices.md
@@ -95,3 +95,15 @@ Assigning tests to the same agent that writes the feature creates tight coupling
 - **Post-completion verification**: Lead runs tests and verification after feature agents complete.
 
 This is an evolving area — no single approach dominates yet.
+
+## Worktree Dispatch
+
+When teammates need isolated worktrees, use `WORKTRUNK_WORKTREE_PATH` to place them under the project directory:
+
+```bash
+WORKTRUNK_WORKTREE_PATH='.worktrees/{{ branch | sanitize }}' wt switch --create feature/foo
+```
+
+This keeps worktrees within the sandbox's `.` write scope. Requires `Edit(.worktrees/**)` in `permissions.allow`.
+
+Create all worktrees and spawn all agents from the project root before switching into any worktree. If the lead switches into a worktree first, agents spawned afterward inherit that worktree as their sandbox root — they won't be able to write to other worktrees.

--- a/user/settings.json
+++ b/user/settings.json
@@ -27,6 +27,7 @@
       "Edit(tmp/**)",
       "Edit(.git/config)",
       "Edit(.git/config.lock)",
+      "Edit(.worktrees/**)",
       "Edit(~/.npm/**)",
       "Edit(~/.terraform.d/plugin-cache/**)",
       "Edit(~/.cache/uv/**)",


### PR DESCRIPTION
Adds `Edit(.worktrees/**)` permission so agents in project-local worktrees can write files when sandbox is re-enabled. Documents worktree dispatch best practices and known tmux backend issues in the agent team skill.

## Changes

- `user/settings.json`: add `Edit(.worktrees/**)` to `permissions.allow`
- `practices.md`: add Worktree Dispatch section covering `WORKTRUNK_WORKTREE_PATH`, sandbox permissions, and the requirement to create all worktrees from project root before switching
- `SKILL.md`: add Known Issues section documenting tmux backend prompt delivery and shell initialization race conditions ([#23415](https://github.com/anthropics/claude-code/issues/23415), [#25315](https://github.com/anthropics/claude-code/issues/25315))
