### PR TITLE
fix: pull-request skill permission patterns for non-sandboxed environments

### DIFF
--- a/plugins/pull-request/scripts/pr-context.ts
+++ b/plugins/pull-request/scripts/pr-context.ts
@@ -85,7 +85,7 @@ if (import.meta.main) {
 
     console.log(JSON.stringify(context, null, 2));
   } catch (error) {
-    console.error(error instanceof Error ? error.message : error);
-    process.exit(1);
+    console.log("No PR found for current branch");
+    process.exit(0);
   }
 }

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -4,18 +4,18 @@ description: |
   Create a pull request, merge request, or change request with proper formatting and content guidelines.
   Invoke when the user wants to create, open, or submit a PR, MR, or CR—including after committing changes.
 
-allowed-tools: Bash(bun:${CLAUDE_PLUGIN_ROOT}/scripts/*), Bash(${CLAUDE_PLUGIN_ROOT}/scripts/worktree/*), Bash(gh:*), Bash(git:*), Bash(glab:*), mcp__github
+allowed-tools: Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/*:*), Bash(${CLAUDE_PLUGIN_ROOT}/scripts/worktree/*:*), Bash(gh:*), Bash(git:*), Bash(glab:*), mcp__github
 ---
 
 # Create Pull Request
 
 ## Context
 
-- Provider: !`bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts" "$0"`
-- Branch: !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" branch --show-current`
-- Status: !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" status --short`
-- Log: !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" log --oneline -20`
-- Diff: !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" diff HEAD`
+- Provider: !`bun ${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts $0`
+- Branch: !`${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh $0 branch --show-current`
+- Status: !`${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh $0 status --short`
+- Log: !`${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh $0 log --oneline -20`
+- Diff: !`${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh $0 diff HEAD`
 
 ## Title
 

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Update a pull request or merge request body to reflect the current state of changes.
   Use when a PR/MR has evolved through additional commits and the body needs to reflect what will be merged.
 
-allowed-tools: Bash(bun:${CLAUDE_PLUGIN_ROOT}/scripts/*), Bash(${CLAUDE_PLUGIN_ROOT}/scripts/worktree/*), Bash(gh:*), Bash(git:*), Bash(glab:*), mcp__github
+allowed-tools: Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/*:*), Bash(${CLAUDE_PLUGIN_ROOT}/scripts/worktree/*:*), Bash(gh:*), Bash(git:*), Bash(glab:*), mcp__github
 ---
 
 # Update Pull Request
@@ -13,10 +13,10 @@ The PR body documents what will happen when merged, not the journey. Don't echo 
 
 ## Context
 
-- Provider: !`bun "${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts" "$0"`
-- Branch: !`"${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh" "$0" branch --show-current`
-- PR: !`bun "${CLAUDE_PLUGIN_ROOT}/scripts/pr-context.ts" "$0" 2>/dev/null || echo "No PR found for current branch"`
-- Diff: !`bun "${CLAUDE_PLUGIN_ROOT}/scripts/pr-diff.ts" "$0"`
+- Provider: !`bun ${CLAUDE_PLUGIN_ROOT}/scripts/detect-provider.ts $0`
+- Branch: !`${CLAUDE_PLUGIN_ROOT}/scripts/worktree/git.sh $0 branch --show-current`
+- PR: !`bun ${CLAUDE_PLUGIN_ROOT}/scripts/pr-context.ts $0`
+- Diff: !`bun ${CLAUDE_PLUGIN_ROOT}/scripts/pr-diff.ts $0`
 
 ## Workflow
 


### PR DESCRIPTION
Fix `allowed-tools` patterns and bang-backtick commands in the pull-request plugin that fail permission checks when the sandbox is disabled.

## Changes

- Fix `allowed-tools` pattern from `Bash(bun:path)` to `Bash(bun path:*)` — colon after `bun` is treated as a literal character, not a glob separator
- Remove shell quotes from bang-backtick commands — quoted paths prevent pattern matching against `allowed-tools`
- Update `pr-context.ts` to exit 0 with a fallback message on failure, eliminating `2>/dev/null || echo` compound expressions

## Original Task

[/pull-request:create fails outside of sandbox](https://things.bendrucker.me/show?id=Hoo8Jm1GWLJtqzhZckYUAs)