### PR TITLE
fix: remove 2>/dev/null from git:conflicts backtick commands

### DIFF
--- a/plugins/git/skills/conflicts/SKILL.md
+++ b/plugins/git/skills/conflicts/SKILL.md
@@ -32,15 +32,15 @@ hooks:
 
 ## Status
 
-!`bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/status.ts 2>/dev/null`
+!`bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/status.ts`
 
 ## Context
 
-!`bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/context.ts 2>/dev/null`
+!`bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/context.ts`
 
 ## Upstream
 
-!`bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/upstream.ts 2>/dev/null`
+!`bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/upstream.ts`
 
 ## Three-Way Access
 


### PR DESCRIPTION
Shell redirections in bang-backtick commands cause "multiple operations" permission check failures when the sandbox is disabled. All three scripts (`status.ts`, `context.ts`, `upstream.ts`) already handle errors gracefully with informative exit-0 messages, so the `2>/dev/null` suppression was unnecessary.

## Original Task

[/git:conflicts error](https://things.bendrucker.me/show?id=X43gSwjBRJGoWUUqea7q3d)