### PR TITLE
fix: set TMPPREFIX for zsh heredocs in sandbox

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -176,6 +176,7 @@
   },
   "alwaysThinkingEnabled": true,
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "TMPPREFIX": "/tmp/claude/zsh"
   }
 }


### PR DESCRIPTION
zsh uses TMPPREFIX (default /tmp/zsh) for heredoc temp files, not TMPDIR. The sandbox allows /tmp/claude/ but not /tmp/zsh*, causing heredocs to fail with 'can't create temp file for here document: operation not permitted'. Set TMPPREFIX=/tmp/claude/zsh in env settings to fix.