### PR TITLE
feat: set WORKTRUNK_WORKTREE_PATH in user env settings

### DIFF
--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -38,16 +38,6 @@ I use git-town for stacked branch workflows combined with worktrunk:
 
 Ship branches oldest-first. After a stack branch merges, `git town sync` rebases remaining branches.
 
-## Worktree Dispatch
-
-When creating worktrees that Task subagents will work in, set `WORKTRUNK_WORKTREE_PATH` so worktrees land under the project directory. This keeps them within the sandbox's `.` write scope, allowing subagents to write directly:
-
-```bash
-WORKTRUNK_WORKTREE_PATH='.worktrees/{{ branch | sanitize }}' wt switch --create feature/foo
-```
-
-Only use this override when dispatching work to subagents. For worktrees the user will work in manually, let Worktrunk use its default location.
-
 ## Personal Details
 
 - Standard username: `@bendrucker`. Refer to any actions performed by this user as "you."

--- a/user/settings.json
+++ b/user/settings.json
@@ -177,6 +177,7 @@
   "alwaysThinkingEnabled": true,
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "TMPPREFIX": "/tmp/claude/zsh"
+    "TMPPREFIX": "/tmp/claude/zsh",
+    "WORKTRUNK_WORKTREE_PATH": ".worktrees/{{ branch | sanitize }}"
   }
 }


### PR DESCRIPTION
## Summary

- Adds `WORKTRUNK_WORKTREE_PATH` to `user/settings.json` env so all `wt` invocations automatically create worktrees under `.worktrees/`
- Removes the "Worktree Dispatch" section from `user/CLAUDE.md` — no longer need compound commands or special instructions

## Test plan

- [ ] Verify `wt switch --create` creates worktrees under `.worktrees/` without explicit env var prefix
- [ ] Confirm subagents can write to worktrees created this way