### PR TITLE
feat: move plugin-specific permissions to plugin settings.json

### DIFF
--- a/plugins/github/settings.json
+++ b/plugins/github/settings.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:api.github.com)"
+    ]
+  },
+  "sandbox": {
+    "excludedCommands": ["gh:*"]
+  }
+}

--- a/plugins/go/settings.json
+++ b/plugins/go/settings.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:proxy.golang.org)",
+      "WebFetch(domain:sum.golang.org)",
+      "WebFetch(domain:pkg.go.dev)"
+    ]
+  }
+}

--- a/plugins/shortcuts/settings.json
+++ b/plugins/shortcuts/settings.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "sandbox": {
+    "excludedCommands": ["open:*"]
+  }
+}

--- a/plugins/things/settings.json
+++ b/plugins/things/settings.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "sandbox": {
+    "excludedCommands": ["osascript:*"]
+  }
+}

--- a/plugins/vscode/settings.json
+++ b/plugins/vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "sandbox": {
+    "excludedCommands": ["code:*"]
+  }
+}

--- a/user/settings.json
+++ b/user/settings.json
@@ -11,17 +11,11 @@
       "Bash(wt --help:*)",
       "Bash(wt --version:*)",
       "Bash(wt config:*)",
-      "WebFetch(domain:github.com)",
-      "WebFetch(domain:raw.githubusercontent.com)",
       "WebFetch(domain:modelcontextprotocol.io)",
       "WebFetch(domain:docs.anthropic.com)",
-      "WebFetch(domain:proxy.golang.org)",
-      "WebFetch(domain:sum.golang.org)",
-      "WebFetch(domain:api.github.com)",
       "WebFetch(domain:registry.npmjs.org)",
       "WebFetch(domain:www.npmjs.com)",
       "WebFetch(domain:pypi.org)",
-      "WebFetch(domain:pkg.go.dev)",
       "WebFetch(domain:rubygems.org)",
       "Edit(//tmp/**)",
       "Edit(tmp/**)",
@@ -150,12 +144,9 @@
       ]
     },
     "excludedCommands": [
-      "code:*",
       "docker:*",
       "pbcopy:*",
       "pbpaste:*",
-      "open:*",
-      "osascript:*",
       "ssh:*",
       "scp:*",
       "security:*",
@@ -171,7 +162,6 @@
       "diskutil:*",
       "networksetup:*",
       "wt:*",
-      "gh:*",
       "claude:*"
     ]
   },


### PR DESCRIPTION
Moves plugin-specific `permissions.allow` and `sandbox.excludedCommands` entries from `user/settings.json` into each plugin's own `settings.json`, using the new plugin settings support added in Claude Code 2.1.49.

## Changes

- `github`: adds `settings.json` with `WebFetch` allow for `github.com`, `raw.githubusercontent.com`, `api.github.com` and sandbox exclusion for `gh:*`
- `go`: adds `settings.json` with `WebFetch` allow for `proxy.golang.org`, `sum.golang.org`, `pkg.go.dev`
- `things`: adds `settings.json` with sandbox exclusion for `osascript:*`
- `shortcuts`: adds `settings.json` with sandbox exclusion for `open:*`
- `vscode`: adds `settings.json` with sandbox exclusion for `code:*`
- `user/settings.json`: removes the above entries, now provided by the plugins themselves

Marketplace users who install these plugins will automatically get the appropriate permissions and sandbox exclusions without manual configuration.
