### PR TITLE
fix: use stdin mode for all uncommitted changes in review:self skill

### DIFF
--- a/plugins/review/skills/self/SKILL.md
+++ b/plugins/review/skills/self/SKILL.md
@@ -29,7 +29,6 @@ bunx difit $ARGUMENTS
 ```
 
 Common arguments:
-- `.` — All uncommitted changes (staged + unstaged)
 - `staged` — Staged changes only
 - `working` — Unstaged changes only
 - `@ main` — Compare HEAD with main branch
@@ -42,7 +41,11 @@ Pipe a git diff for full control over the diff content:
 git diff $ARGUMENTS | bunx difit
 ```
 
-Use stdin mode when `$ARGUMENTS` contains git diff flags (e.g., `--merge-base`, revision ranges).
+Common arguments:
+- `HEAD` — All uncommitted changes (staged + unstaged)
+- `--merge-base main` — Changes since diverging from main
+
+Use stdin mode for all uncommitted changes (`git diff HEAD`) or when using git diff flags (e.g., `--merge-base`, revision ranges).
 
 ## Workflow
 


### PR DESCRIPTION
`bunx difit .` delegates diff generation to difit's internal `simple-git` handling, which is unreliable when both staged and unstaged changes exist. This replaces the `.` direct mode argument with `git diff HEAD | bunx difit` via stdin mode for explicit control over the diff.

## Changes

- Remove `.` from direct mode common arguments
- Add `HEAD` and `--merge-base main` as stdin mode common arguments
- Update guidance to recommend stdin mode for all uncommitted changes

## Original Task

[Update review:self skill](https://things.bendrucker.me/show?id=JppH9gWEkvDNg6f6naVv4f)
