### PR TITLE
feat: add terminal bell hooks to tmux plugin

### DIFF
--- a/plugins/tmux/hooks/hooks.json
+++ b/plugins/tmux/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Inject tmux context at session start",
+  "description": "Inject tmux context and ring terminal bell for notifications",
   "hooks": {
     "SessionStart": [
       {
@@ -7,6 +7,26 @@
           {
             "type": "command",
             "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/context.ts"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "printf '\\a' > /dev/tty"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "printf '\\a' > /dev/tty"
           }
         ]
       }


### PR DESCRIPTION
Adds `Notification` and `Stop` hooks to the tmux plugin that write BEL (`\a`) to `/dev/tty`. This ensures the terminal bell rings when Claude finishes responding or needs user attention (permission prompts, idle prompts, auth dialogs), allowing tmux to flag background windows with activity.
