### PR TITLE
fix: auto-approve Read for plugin cache files

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -34,7 +34,8 @@
       "Edit(~/Library/Caches/go-build/**)",
       "Edit(~/src/go/pkg/mod/**)",
       "Edit(~/src/go/pkg/sumdb/**)",
-      "Edit(~/.bun/**)"
+      "Edit(~/.bun/**)",
+      "Read(~/.claude/plugins/**)"
     ],
     "deny": []
   },


### PR DESCRIPTION
Skills with reference files (e.g., `[context.md](context.md)`) trigger `Read` tool calls for files in `~/.claude/plugins/cache/`. These reads prompt for permission since the plugin cache is outside the project directory. Adding `Read(~/.claude/plugins/**)` to the allow list suppresses these prompts for all installed plugins.
