### PR TITLE
chore: remove statusLine from user settings

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -55,10 +55,6 @@
       }
     ]
   },
-  "statusLine": {
-    "type": "command",
-    "command": "wt list statusline --claude-code"
-  },
   "enabledPlugins": {
     "pr-review-toolkit@claude-plugins-official": true,
     "go@bendrucker": true,


### PR DESCRIPTION
Removes the `statusLine` configuration from user settings. The worktrunk statusline command is no longer needed.
