### PR TITLE
feat: add tmux status bar notifications for permission prompts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -115,6 +115,12 @@
         "typescript": "^5.7.3",
       },
     },
+    "plugins/tmux": {
+      "name": "@bendrucker/claude-tmux",
+      "dependencies": {
+        "cleye": "^1.3.2",
+      },
+    },
     "plugins/type-ignore": {
       "name": "@bendrucker/type-ignore",
     },
@@ -159,6 +165,8 @@
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "@bendrucker/claude-style": ["@bendrucker/claude-style@workspace:plugins/style"],
+
+    "@bendrucker/claude-tmux": ["@bendrucker/claude-tmux@workspace:plugins/tmux"],
 
     "@bendrucker/claude-validate": ["@bendrucker/claude-validate@workspace:packages/validate"],
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "plugins/ui-design",
     "plugins/gitlab",
     "plugins/vscode",
-    "packages/validate"
+    "packages/validate",
+    "plugins/tmux"
   ],
   "scripts": {
     "build": "tsc --noEmit",

--- a/plugins/tmux/hooks/hooks.json
+++ b/plugins/tmux/hooks/hooks.json
@@ -11,12 +11,23 @@
         ]
       }
     ],
-    "Notification": [
+    "PreToolUse": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "printf '\\a' > /dev/tty"
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/notification.ts --clear"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "permission_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/notification.ts"
           }
         ]
       }
@@ -26,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "printf '\\a' > /dev/tty"
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/notification.ts --background-only"
           }
         ]
       }

--- a/plugins/tmux/hooks/notification.ts
+++ b/plugins/tmux/hooks/notification.ts
@@ -1,0 +1,162 @@
+#!/usr/bin/env bun
+
+import { writeFileSync } from "node:fs";
+import { cli } from "cleye";
+
+const argv = cli({
+  name: "notification",
+  flags: {
+    backgroundOnly: {
+      type: Boolean,
+      description: "Only ring when the tmux window is in the background",
+      default: false,
+    },
+    clear: {
+      type: Boolean,
+      description: "Clear the notification from the status bar",
+      default: false,
+    },
+  },
+});
+
+function tmux(...args: string[]): void {
+  Bun.spawnSync(["tmux", ...args], { stderr: "inherit" });
+}
+
+function tmuxQuery(...args: string[]): string | null {
+  const proc = Bun.spawnSync(["tmux", ...args], { stdout: "pipe", stderr: "inherit" });
+  if (proc.exitCode !== 0) return null;
+  return proc.stdout.toString().trim();
+}
+
+function paneOptionKey(pane: string): string {
+  return `@claude_notification_${pane.replace("%", "")}`;
+}
+
+interface NotificationEntry {
+  window: string;
+  tool: string;
+}
+
+function parseEntry(raw: string): NotificationEntry | null {
+  const [window, tool] = raw.split(":");
+  if (!window || !tool) return null;
+  return { window, tool };
+}
+
+function maxToolLength(): number {
+  const width = Number(tmuxQuery("display-message", "-p", "#{client_width}") ?? "120");
+  return Math.max(4, Math.min(12, Math.floor(width / 16)));
+}
+
+function truncate(str: string, max: number): string {
+  return str.length <= max ? str : `${str.slice(0, max - 1)}…`;
+}
+
+function updateSummary(): void {
+  const output = tmuxQuery("show-options", "-g");
+  if (!output) return;
+
+  const entries: NotificationEntry[] = [];
+  for (const line of output.split("\n")) {
+    const match = line.match(/^@claude_notification_\d+ "?(.+?)"?$/);
+    if (match) {
+      const entry = parseEntry(match[1]!);
+      if (entry) entries.push(entry);
+    }
+  }
+
+  if (entries.length === 0) {
+    tmux("set-option", "-gu", "@claude_notification");
+    return;
+  }
+
+  const toolMax = maxToolLength();
+  const first = entries[0]!;
+  let text = `${first.window}:${truncate(first.tool, toolMax)}`;
+  if (entries.length > 1) {
+    text += ` (+${entries.length - 1})`;
+  }
+
+  const color = "#d97757";
+  const crust = "#11111b";
+  const fg = "#cdd6f4";
+  const surface = "#313244";
+  const sep = "\uE0B6";
+
+  const styled = [
+    `#[fg=${color}]${sep}`,
+    `#[fg=${crust},bg=${color}]󰂞 `,
+    `#[fg=${fg},bg=${surface}] ${text}`,
+    `#[fg=${surface}] `,
+  ].join("");
+
+  tmux("set-option", "-g", "@claude_notification", styled);
+}
+
+interface HookInput {
+  notification_type?: string;
+  message?: string;
+}
+
+async function readHookInput(): Promise<HookInput | null> {
+  const text = await Bun.stdin.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    console.error(
+      `[tmux/notification] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
+}
+
+async function main(): Promise<void> {
+  const pane = process.env.TMUX_PANE;
+  if (!process.env.TMUX || !pane) return;
+
+  if (argv.flags.clear) {
+    tmux("set-option", "-gu", paneOptionKey(pane));
+    updateSummary();
+    return;
+  }
+
+  const paneInfo = tmuxQuery(
+    "display-message",
+    "-p",
+    "-t",
+    pane,
+    "#{pane_tty}\n#{window_index}\n#{window_active}",
+  );
+  if (!paneInfo) return;
+
+  const [tty, window, active] = paneInfo.split("\n");
+  if (!tty || !window || !active) return;
+
+  if (argv.flags.backgroundOnly && active === "1") return;
+
+  if (argv.flags.backgroundOnly) {
+    tmux("set-option", "-gu", paneOptionKey(pane));
+    updateSummary();
+  } else {
+    const input = await readHookInput();
+    if (input?.notification_type === "permission_prompt") {
+      const tool = input.message?.match(/use (\w+)/)?.[1] ?? "input";
+      tmux("set-option", "-g", paneOptionKey(pane), `${window}:${tool}`);
+      updateSummary();
+    }
+  }
+
+  try {
+    writeFileSync(tty, "\x07");
+  } catch (error) {
+    console.error(
+      `[tmux/notification] Failed to write bell to ${tty}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/plugins/tmux/package.json
+++ b/plugins/tmux/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@bendrucker/claude-tmux",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "cleye": "^1.3.2"
+  }
+}


### PR DESCRIPTION
Replace the `printf '\a' > /dev/tty` hooks with a `notification.ts` script that writes bells to the tmux pane tty and sets `@claude_notification` in the tmux status bar for cross-session visibility.

## Changes

- `notification.ts` reads hook JSON from stdin, writes bell to pane tty via `#{pane_tty}`, and manages per-pane `@claude_notification_*` tmux options that aggregate into a styled `@claude_notification` summary for the status bar
- `Notification` hook now uses `matcher: "permission_prompt"` to only fire for permission requests
- `Stop` hook uses `--background-only` to skip when the window is active, and clears stale notifications
- `PreToolUse` hook clears the notification when the session resumes
- Status bar module uses catppuccin rounded pill style with Claude brand color (`#d97757`)
- Per-pane storage (`window:tool`) supports multiple concurrent notifications, showing the first with `(+N)` suffix
- Tool name length scales to `client_width`

## tmux config

Add to `~/.tmux.conf` after TPM loads:

```tmux
set -g status-right "#{E:@claude_notification}#{E:@catppuccin_status_directory}"
```
