### PR TITLE
feat: expand style enforcement to Bash and MCP tools

### DIFF
--- a/plugins/style/hooks/headings.test.ts
+++ b/plugins/style/hooks/headings.test.ts
@@ -17,8 +17,8 @@ function mockWriteInput(filePath: string, content: string): PreToolUseHookInput 
   };
 }
 
-function getOutput(input: PreToolUseHookInput): PreToolUseHookSpecificOutput | null {
-  const result = processInput(input);
+async function getOutput(input: PreToolUseHookInput): Promise<PreToolUseHookSpecificOutput | null> {
+  const result = await processInput(input);
   if (!result) return null;
   return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
 }
@@ -50,7 +50,7 @@ const titleCaseCases: { description: string; content: string; match: boolean }[]
 
 describe("checkTitleCase", () => {
   for (const { description, content, match } of titleCaseCases) {
-    it(description, () => {
+    it(description, async () => {
       const result = checkTitleCase(content);
       if (match) {
         expect(result).not.toBeNull();
@@ -79,7 +79,7 @@ const boldAsHeadingCases: { description: string; content: string; match: boolean
 
 describe("checkBoldAsHeading", () => {
   for (const { description, content, match } of boldAsHeadingCases) {
-    it(description, () => {
+    it(description, async () => {
       const result = checkBoldAsHeading(content);
       if (match) {
         expect(result).not.toBeNull();
@@ -91,21 +91,49 @@ describe("checkBoldAsHeading", () => {
 });
 
 describe("processInput", () => {
-  it("returns title case guidance", () => {
-    const output = getOutput(mockWriteInput("README.md", "# introduction"));
+  it("returns title case guidance", async () => {
+    const output = await getOutput(mockWriteInput("README.md", "# introduction"));
     expect(output?.additionalContext).toContain("AP-style title case");
   });
 
-  it("returns bold-as-heading guidance", () => {
-    const output = getOutput(mockWriteInput("README.md", "**Configuration:**\nSome text"));
+  it("returns bold-as-heading guidance", async () => {
+    const output = await getOutput(mockWriteInput("README.md", "**Configuration:**\nSome text"));
     expect(output?.additionalContext).toContain("markdown heading");
   });
 
-  it("skips non-markdown files", () => {
-    expect(getOutput(mockWriteInput("app.ts", "# introduction"))).toBeNull();
+  it("skips non-markdown files", async () => {
+    expect(await getOutput(mockWriteInput("app.ts", "# introduction"))).toBeNull();
   });
 
-  it("returns null for unknown tool", () => {
+  it("detects title case issue from MCP body", async () => {
+    const input: PreToolUseHookInput = {
+      hook_event_name: "PreToolUse",
+      session_id: "test",
+      transcript_path: "/tmp/test",
+      cwd: "/tmp",
+      tool_name: "mcp__plugin_github_github__create_pull_request",
+      tool_input: { body: "# introduction" },
+      tool_use_id: "test",
+    };
+    const output = await getOutput(input);
+    expect(output?.additionalContext).toContain("AP-style title case");
+  });
+
+  it("allows correct title case from MCP body", async () => {
+    const input: PreToolUseHookInput = {
+      hook_event_name: "PreToolUse",
+      session_id: "test",
+      transcript_path: "/tmp/test",
+      cwd: "/tmp",
+      tool_name: "mcp__plugin_github_github__create_pull_request",
+      tool_input: { body: "# Introduction" },
+      tool_use_id: "test",
+    };
+    const output = await getOutput(input);
+    expect(output).toBeNull();
+  });
+
+  it("returns null for non-PR Bash command", async () => {
     const input: PreToolUseHookInput = {
       hook_event_name: "PreToolUse",
       session_id: "test",
@@ -115,6 +143,6 @@ describe("processInput", () => {
       tool_input: { command: "echo hello" },
       tool_use_id: "test",
     };
-    expect(getOutput(input)).toBeNull();
+    expect(await getOutput(input)).toBeNull();
   });
 });

--- a/plugins/style/hooks/headings.ts
+++ b/plugins/style/hooks/headings.ts
@@ -8,8 +8,11 @@ import { fromMarkdown } from "mdast-util-from-markdown";
 import { visit } from "unist-util-visit";
 import {
   type EditInput,
+  extractMarkdownFromBash,
+  extractMarkdownFromMcp,
   formatContext,
   getExtension,
+  hasBashCommand,
   isMarkdownFile,
   type SyncHookJSONOutput,
   type WriteInput,
@@ -81,26 +84,26 @@ export function checkBoldAsHeading(content: string): string | null {
   return result;
 }
 
-export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {
+export async function processInput(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
   const toolName = input.tool_name;
 
-  let content: string;
-  let filePath: string;
+  let content: string | null = null;
 
   if (toolName === "Write") {
     const toolInput = input.tool_input as WriteInput;
+    if (!isMarkdownFile(getExtension(toolInput.file_path))) return null;
     content = toolInput.content;
-    filePath = toolInput.file_path;
   } else if (toolName === "Edit") {
     const toolInput = input.tool_input as EditInput;
+    if (!isMarkdownFile(getExtension(toolInput.file_path))) return null;
     content = toolInput.new_string;
-    filePath = toolInput.file_path;
+  } else if (hasBashCommand(input.tool_input)) {
+    content = await extractMarkdownFromBash(input.tool_input.command, "style/headings");
   } else {
-    return null;
+    content = extractMarkdownFromMcp(input.tool_input);
   }
 
-  const ext = getExtension(filePath);
-  if (!isMarkdownFile(ext)) return null;
+  if (!content) return null;
 
   const titleCase = checkTitleCase(content);
   if (titleCase) {
@@ -130,7 +133,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const output = processInput(input);
+  const output = await processInput(input);
   if (output) {
     writeStdoutJson(output);
   }

--- a/plugins/style/hooks/hooks.json
+++ b/plugins/style/hooks/hooks.json
@@ -12,6 +12,10 @@
           {
             "type": "command",
             "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts"
+          },
+          {
+            "type": "command",
+            "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/test-counts.ts"
           }
         ]
       },
@@ -25,6 +29,44 @@
           {
             "type": "command",
             "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts"
+          },
+          {
+            "type": "command",
+            "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/test-counts.ts"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash(gh pr create:*)|Bash(gh pr edit:*)|Bash(glab mr create:*)|Bash(glab mr update:*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts external"
+          },
+          {
+            "type": "command",
+            "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts"
+          },
+          {
+            "type": "command",
+            "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/test-counts.ts"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__plugin_github_github__create_pull_request|mcp__plugin_github_github__update_pull_request|mcp__claude_ai_Linear__create_issue|mcp__claude_ai_Linear__create_comment|mcp__claude_ai_Linear__create_document",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts external"
+          },
+          {
+            "type": "command",
+            "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts"
+          },
+          {
+            "type": "command",
+            "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/test-counts.ts"
           }
         ]
       }

--- a/plugins/style/hooks/markdown.ts
+++ b/plugins/style/hooks/markdown.ts
@@ -1,5 +1,10 @@
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 export type { SyncHookJSONOutput };
+export {
+  extractMarkdownFromBash,
+  extractMarkdownFromMcp,
+  hasBashCommand,
+} from "@bendrucker/shell-extract";
 
 export type WriteInput = { file_path: string; content: string };
 export type EditInput = { file_path: string; new_string: string };

--- a/plugins/style/hooks/numbering.test.ts
+++ b/plugins/style/hooks/numbering.test.ts
@@ -41,17 +41,17 @@ function mockEditInput(filePath: string, newString: string): PreToolUseHookInput
   };
 }
 
-function getOutput(
+async function getOutput(
   input: PreToolUseHookInput,
-  mode: "write" | "edit" = "write",
-): PreToolUseHookSpecificOutput | null {
-  const result = processInput(input, mode);
+  mode: "write" | "edit" | "external" = "write",
+): Promise<PreToolUseHookSpecificOutput | null> {
+  const result = await processInput(input, mode);
   if (!result) return null;
   return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
 }
 
 describe("formatDecision", () => {
-  it("formats deny decision", () => {
+  it("formats deny decision", async () => {
     const output = formatDecision("deny", "Test reason");
     expect(output).toEqual({
       hookSpecificOutput: {
@@ -62,7 +62,7 @@ describe("formatDecision", () => {
     });
   });
 
-  it("formats ask decision", () => {
+  it("formats ask decision", async () => {
     const output = formatDecision("ask", "Test reason");
     expect(output).toEqual({
       hookSpecificOutput: {
@@ -75,79 +75,79 @@ describe("formatDecision", () => {
 });
 
 describe("checkMarkdown", () => {
-  it('detects "# 1. Introduction"', () => {
+  it('detects "# 1. Introduction"', async () => {
     const match = checkMarkdown("# 1. Introduction");
     expect(match).toContain("1. Introduction");
   });
 
-  it('detects "## Step 2: Setup"', () => {
+  it('detects "## Step 2: Setup"', async () => {
     const match = checkMarkdown("## Step 2: Setup");
     expect(match).toContain("Step 2");
   });
 
-  it('detects "### Phase 3"', () => {
+  it('detects "### Phase 3"', async () => {
     const match = checkMarkdown("### Phase 3");
     expect(match).toContain("Phase 3");
   });
 
-  it("allows descriptive headings", () => {
+  it("allows descriptive headings", async () => {
     const match = checkMarkdown("# Introduction");
     expect(match).toBeNull();
   });
 
-  it("allows headings with numbers mid-text", () => {
+  it("allows headings with numbers mid-text", async () => {
     const match = checkMarkdown("# Using OAuth2 for Authentication");
     expect(match).toBeNull();
   });
 });
 
 describe.skipIf(!hasSg())("checkCode (requires sg)", () => {
-  it("detects Go func step1()", () => {
+  it("detects Go func step1()", async () => {
     const match = checkCode('package main\nfunc step1() { fmt.Println("test") }', "go");
     expect(match).toContain("step1");
   });
 
-  it("detects Go func phase2()", () => {
+  it("detects Go func phase2()", async () => {
     const match = checkCode("package main\nfunc phase2() {}", "go");
     expect(match).toContain("phase2");
   });
 
-  it("allows descriptive Go function names", () => {
+  it("allows descriptive Go function names", async () => {
     const match = checkCode('package main\nfunc processItems() { fmt.Println("test") }', "go");
     expect(match).toBeNull();
   });
 
-  it("detects JavaScript function step1()", () => {
+  it("detects JavaScript function step1()", async () => {
     const match = checkCode('function step1() { console.log("test"); }', "js");
     expect(match).toContain("step1");
   });
 
-  it("detects JavaScript const part3", () => {
+  it("detects JavaScript const part3", async () => {
     const match = checkCode("const part3 = () => {};", "js");
     expect(match).toContain("part3");
   });
 
-  it("allows descriptive JavaScript names", () => {
+  it("allows descriptive JavaScript names", async () => {
     const match = checkCode('function handleSubmit() { console.log("test"); }', "js");
     expect(match).toBeNull();
   });
 
-  it("detects Python def step1()", () => {
+  it("detects Python def step1()", async () => {
     const match = checkCode("def step1():\n    pass", "py");
     expect(match).toContain("step1");
   });
 
-  it("detects Python class Phase2", () => {
+  it("detects Python class Phase2", async () => {
     const match = checkCode("class Phase2:\n    pass", "py");
     expect(match).toContain("Phase2");
   });
 
-  it("allows descriptive Python names", () => {
+  it("allows descriptive Python names", async () => {
     const match = checkCode("def process_items():\n    pass", "py");
     expect(match).toBeNull();
   });
 
-  it("detects TypeScript function step1()", () => {
+  it("detects TypeScript function step1()", async () => {
     const match = checkCode("function step1() {}", "ts");
     expect(match).toContain("step1");
   });
@@ -155,8 +155,8 @@ describe.skipIf(!hasSg())("checkCode (requires sg)", () => {
 
 describe.skipIf(!hasSg())("processInput with code (requires sg)", () => {
   describe("Go numbered identifiers", () => {
-    it("detects func step1()", () => {
-      const output = getOutput(
+    it("detects func step1()", async () => {
+      const output = await getOutput(
         mockWriteInput("main.go", 'package main\nfunc step1() { fmt.Println("test") }'),
         "write",
       );
@@ -164,8 +164,8 @@ describe.skipIf(!hasSg())("processInput with code (requires sg)", () => {
       expect(output?.permissionDecisionReason).toContain("step1");
     });
 
-    it("detects func phase2()", () => {
-      const output = getOutput(
+    it("detects func phase2()", async () => {
+      const output = await getOutput(
         mockWriteInput("main.go", "package main\nfunc phase2() {}"),
         "write",
       );
@@ -173,8 +173,8 @@ describe.skipIf(!hasSg())("processInput with code (requires sg)", () => {
       expect(output?.permissionDecisionReason).toContain("phase2");
     });
 
-    it("allows descriptive function names", () => {
-      const output = getOutput(
+    it("allows descriptive function names", async () => {
+      const output = await getOutput(
         mockWriteInput("main.go", 'package main\nfunc processItems() { fmt.Println("test") }'),
         "write",
       );
@@ -183,21 +183,21 @@ describe.skipIf(!hasSg())("processInput with code (requires sg)", () => {
   });
 
   describe("JavaScript numbered identifiers", () => {
-    it("detects function step1()", () => {
-      const output = getOutput(
+    it("detects function step1()", async () => {
+      const output = await getOutput(
         mockWriteInput("app.js", 'function step1() { console.log("test"); }'),
         "write",
       );
       expect(output?.permissionDecision).toBe("deny");
     });
 
-    it("detects const part3", () => {
-      const output = getOutput(mockWriteInput("app.js", "const part3 = () => {};"), "write");
+    it("detects const part3", async () => {
+      const output = await getOutput(mockWriteInput("app.js", "const part3 = () => {};"), "write");
       expect(output?.permissionDecision).toBe("deny");
     });
 
-    it("allows descriptive names", () => {
-      const output = getOutput(
+    it("allows descriptive names", async () => {
+      const output = await getOutput(
         mockWriteInput("app.js", 'function handleSubmit() { console.log("test"); }'),
         "write",
       );
@@ -206,18 +206,24 @@ describe.skipIf(!hasSg())("processInput with code (requires sg)", () => {
   });
 
   describe("Python numbered identifiers", () => {
-    it("detects def step1()", () => {
-      const output = getOutput(mockWriteInput("script.py", "def step1():\n    pass"), "write");
+    it("detects def step1()", async () => {
+      const output = await getOutput(
+        mockWriteInput("script.py", "def step1():\n    pass"),
+        "write",
+      );
       expect(output?.permissionDecision).toBe("deny");
     });
 
-    it("detects class Phase2", () => {
-      const output = getOutput(mockWriteInput("script.py", "class Phase2:\n    pass"), "write");
+    it("detects class Phase2", async () => {
+      const output = await getOutput(
+        mockWriteInput("script.py", "class Phase2:\n    pass"),
+        "write",
+      );
       expect(output?.permissionDecision).toBe("deny");
     });
 
-    it("allows descriptive names", () => {
-      const output = getOutput(
+    it("allows descriptive names", async () => {
+      const output = await getOutput(
         mockWriteInput("script.py", "def process_items():\n    pass"),
         "write",
       );
@@ -226,78 +232,84 @@ describe.skipIf(!hasSg())("processInput with code (requires sg)", () => {
   });
 
   describe("Write vs Edit mode", () => {
-    it("blocks Write tool with deny", () => {
-      const output = getOutput(mockWriteInput("main.go", "package main\nfunc step1() {}"), "write");
+    it("blocks Write tool with deny", async () => {
+      const output = await getOutput(
+        mockWriteInput("main.go", "package main\nfunc step1() {}"),
+        "write",
+      );
       expect(output?.permissionDecision).toBe("deny");
     });
 
-    it("asks for Edit tool instead of deny", () => {
-      const output = getOutput(mockEditInput("main.go", "func step1() {}"), "edit");
+    it("asks for Edit tool instead of deny", async () => {
+      const output = await getOutput(mockEditInput("main.go", "func step1() {}"), "edit");
       expect(output?.permissionDecision).toBe("ask");
     });
   });
 
   describe("File type filtering", () => {
-    it("checks Go files", () => {
-      const output = getOutput(mockWriteInput("main.go", "func step1() {}"), "write");
+    it("checks Go files", async () => {
+      const output = await getOutput(mockWriteInput("main.go", "func step1() {}"), "write");
       expect(output?.permissionDecision).toBe("deny");
     });
 
-    it("checks TypeScript files", () => {
-      const output = getOutput(mockWriteInput("app.ts", "function step1() {}"), "write");
+    it("checks TypeScript files", async () => {
+      const output = await getOutput(mockWriteInput("app.ts", "function step1() {}"), "write");
       expect(output?.permissionDecision).toBe("deny");
     });
 
-    it("skips unsupported file types (JSON)", () => {
-      const output = getOutput(mockWriteInput("config.json", '{"step1": "value"}'), "write");
+    it("skips unsupported file types (JSON)", async () => {
+      const output = await getOutput(mockWriteInput("config.json", '{"step1": "value"}'), "write");
       expect(output).toBeNull();
     });
   });
 
   describe("Test files are NOT excluded", () => {
-    it("checks *_test.go files", () => {
-      const output = getOutput(mockWriteInput("main_test.go", "func step1() {}"), "write");
+    it("checks *_test.go files", async () => {
+      const output = await getOutput(mockWriteInput("main_test.go", "func step1() {}"), "write");
       expect(output?.permissionDecision).toBe("deny");
     });
 
-    it("checks *.spec.ts files", () => {
-      const output = getOutput(mockWriteInput("app.spec.ts", "function step1() {}"), "write");
+    it("checks *.spec.ts files", async () => {
+      const output = await getOutput(mockWriteInput("app.spec.ts", "function step1() {}"), "write");
       expect(output?.permissionDecision).toBe("deny");
     });
 
-    it("checks test_*.py files", () => {
-      const output = getOutput(mockWriteInput("test_utils.py", "def step1():\n    pass"), "write");
+    it("checks test_*.py files", async () => {
+      const output = await getOutput(
+        mockWriteInput("test_utils.py", "def step1():\n    pass"),
+        "write",
+      );
       expect(output?.permissionDecision).toBe("deny");
     });
   });
 });
 
 describe("processInput with markdown", () => {
-  it('detects "# 1. Introduction"', () => {
-    const output = getOutput(mockWriteInput("README.md", "# 1. Introduction"), "write");
+  it('detects "# 1. Introduction"', async () => {
+    const output = await getOutput(mockWriteInput("README.md", "# 1. Introduction"), "write");
     expect(output?.permissionDecision).toBe("deny");
     expect(output?.permissionDecisionReason).toContain("1. Introduction");
   });
 
-  it('detects "## Step 2: Setup"', () => {
-    const output = getOutput(mockWriteInput("docs.md", "## Step 2: Setup"), "write");
+  it('detects "## Step 2: Setup"', async () => {
+    const output = await getOutput(mockWriteInput("docs.md", "## Step 2: Setup"), "write");
     expect(output?.permissionDecision).toBe("deny");
     expect(output?.permissionDecisionReason).toContain("Step 2");
   });
 
-  it('detects "### Phase 3"', () => {
-    const output = getOutput(mockWriteInput("guide.markdown", "### Phase 3"), "write");
+  it('detects "### Phase 3"', async () => {
+    const output = await getOutput(mockWriteInput("guide.markdown", "### Phase 3"), "write");
     expect(output?.permissionDecision).toBe("deny");
     expect(output?.permissionDecisionReason).toContain("Phase 3");
   });
 
-  it("allows descriptive headings", () => {
-    const output = getOutput(mockWriteInput("README.md", "# Introduction"), "write");
+  it("allows descriptive headings", async () => {
+    const output = await getOutput(mockWriteInput("README.md", "# Introduction"), "write");
     expect(output).toBeNull();
   });
 
-  it("allows headings with numbers mid-text", () => {
-    const output = getOutput(
+  it("allows headings with numbers mid-text", async () => {
+    const output = await getOutput(
       mockWriteInput("README.md", "# Using OAuth2 for Authentication"),
       "write",
     );
@@ -305,8 +317,52 @@ describe("processInput with markdown", () => {
   });
 });
 
+describe("processInput with external mode", () => {
+  it("detects numbered heading from MCP body", async () => {
+    const input: PreToolUseHookInput = {
+      hook_event_name: "PreToolUse",
+      session_id: "test",
+      transcript_path: "/tmp/test",
+      cwd: "/tmp",
+      tool_name: "mcp__plugin_github_github__create_pull_request",
+      tool_input: { body: "## Step 1: Setup\nContent here" },
+      tool_use_id: "test",
+    };
+    const output = await getOutput(input, "external");
+    expect(output?.permissionDecision).toBe("ask");
+  });
+
+  it("allows clean MCP body", async () => {
+    const input: PreToolUseHookInput = {
+      hook_event_name: "PreToolUse",
+      session_id: "test",
+      transcript_path: "/tmp/test",
+      cwd: "/tmp",
+      tool_name: "mcp__plugin_github_github__create_pull_request",
+      tool_input: { body: "## Summary\nClean content" },
+      tool_use_id: "test",
+    };
+    const output = await getOutput(input, "external");
+    expect(output).toBeNull();
+  });
+
+  it("uses ask instead of deny for external mode", async () => {
+    const input: PreToolUseHookInput = {
+      hook_event_name: "PreToolUse",
+      session_id: "test",
+      transcript_path: "/tmp/test",
+      cwd: "/tmp",
+      tool_name: "mcp__plugin_github_github__create_pull_request",
+      tool_input: { body: "# 1. First Step" },
+      tool_use_id: "test",
+    };
+    const output = await getOutput(input, "external");
+    expect(output?.permissionDecision).toBe("ask");
+  });
+});
+
 describe("processInput edge cases", () => {
-  it("returns null for unknown tool", () => {
+  it("returns null for Bash tool in write mode", async () => {
     const input: PreToolUseHookInput = {
       hook_event_name: "PreToolUse",
       session_id: "test",
@@ -316,10 +372,10 @@ describe("processInput edge cases", () => {
       tool_input: { command: "echo hello" },
       tool_use_id: "test",
     };
-    expect(getOutput(input, "write")).toBeNull();
+    expect(await getOutput(input, "write")).toBeNull();
   });
 
-  it("returns null for missing content", () => {
+  it("returns null for missing content", async () => {
     const input: PreToolUseHookInput = {
       hook_event_name: "PreToolUse",
       session_id: "test",
@@ -329,6 +385,6 @@ describe("processInput edge cases", () => {
       tool_input: { file_path: "test.go" },
       tool_use_id: "test",
     };
-    expect(getOutput(input, "write")).toBeNull();
+    expect(await getOutput(input, "write")).toBeNull();
   });
 });

--- a/plugins/style/hooks/numbering.ts
+++ b/plugins/style/hooks/numbering.ts
@@ -12,14 +12,17 @@ import { fromMarkdown } from "mdast-util-from-markdown";
 import { visit } from "unist-util-visit";
 import {
   type EditInput,
+  extractMarkdownFromBash,
+  extractMarkdownFromMcp,
   formatDecision,
   getExtension,
+  hasBashCommand,
   isMarkdownFile,
   type SyncHookJSONOutput,
   type WriteInput,
 } from "./markdown";
 
-type Mode = "write" | "edit";
+type Mode = "write" | "edit" | "external";
 
 type MarkdownMatch = {
   text: string;
@@ -106,11 +109,14 @@ export function checkCode(content: string, ext: string): string | null {
   return null;
 }
 
-export function processInput(input: PreToolUseHookInput, mode: Mode): SyncHookJSONOutput | null {
+export async function processInput(
+  input: PreToolUseHookInput,
+  mode: Mode,
+): Promise<SyncHookJSONOutput | null> {
   const toolName = input.tool_name;
 
-  let content: string;
-  let filePath: string;
+  let content: string | null = null;
+  let filePath: string | undefined;
 
   if (toolName === "Write") {
     const toolInput = input.tool_input as WriteInput;
@@ -120,22 +126,25 @@ export function processInput(input: PreToolUseHookInput, mode: Mode): SyncHookJS
     const toolInput = input.tool_input as EditInput;
     content = toolInput.new_string;
     filePath = toolInput.file_path;
-  } else {
-    return null;
+  } else if (mode === "external") {
+    if (hasBashCommand(input.tool_input)) {
+      content = await extractMarkdownFromBash(input.tool_input.command, "style/numbering");
+    } else {
+      content = extractMarkdownFromMcp(input.tool_input);
+    }
   }
 
-  const ext = getExtension(filePath);
+  if (!content) return null;
+
   let match: string | null = null;
 
-  if (isMarkdownFile(ext)) {
+  if (mode === "external" || (filePath && isMarkdownFile(getExtension(filePath)))) {
     match = checkMarkdown(content);
-  } else {
-    match = checkCode(content, ext);
+  } else if (filePath) {
+    match = checkCode(content, getExtension(filePath));
   }
 
-  if (!match) {
-    return null;
-  }
+  if (!match) return null;
 
   const reason = `Detected numbered sequences that create tight coupling.
 ${match}
@@ -144,9 +153,8 @@ Use descriptive names instead. See CLAUDE.md Organization guidelines.`;
 
   if (mode === "write") {
     return formatDecision("deny", reason);
-  } else {
-    return formatDecision("ask", `This edit introduces numbered sequences. ${reason}`);
   }
+  return formatDecision("ask", `This edit introduces numbered sequences. ${reason}`);
 }
 
 async function main(): Promise<void> {
@@ -162,7 +170,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const output = processInput(input, mode);
+  const output = await processInput(input, mode);
   if (output) {
     writeStdoutJson(output);
   }

--- a/plugins/style/hooks/test-counts.test.ts
+++ b/plugins/style/hooks/test-counts.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
+import { unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  PreToolUseHookInput,
+  PreToolUseHookSpecificOutput,
+} from "@anthropic-ai/claude-agent-sdk";
+import { processInput } from "./test-counts";
+
+function mockWriteInput(
+  filePath: string,
+  content: string,
+  sessionId = "test-session",
+): PreToolUseHookInput {
+  return {
+    hook_event_name: "PreToolUse",
+    session_id: sessionId,
+    transcript_path: "/tmp/test",
+    cwd: "/tmp",
+    tool_name: "Write",
+    tool_input: { file_path: filePath, content },
+    tool_use_id: "test-use-id",
+  };
+}
+
+function mockEditInput(
+  filePath: string,
+  newString: string,
+  sessionId = "test-session",
+): PreToolUseHookInput {
+  return {
+    hook_event_name: "PreToolUse",
+    session_id: sessionId,
+    transcript_path: "/tmp/test",
+    cwd: "/tmp",
+    tool_name: "Edit",
+    tool_input: { file_path: filePath, new_string: newString },
+    tool_use_id: "test-use-id",
+  };
+}
+
+function markerPath(sessionId: string, key: string): string {
+  const hash = createHash("sha256").update(key).digest("hex").slice(0, 12);
+  return join(tmpdir(), `style-counts-${sessionId}-${hash}`);
+}
+
+function getContext(result: Awaited<ReturnType<typeof processInput>>): string | undefined {
+  const output = result?.hookSpecificOutput as PreToolUseHookSpecificOutput | undefined;
+  if (output && "additionalContext" in output) {
+    return output.additionalContext;
+  }
+  return undefined;
+}
+
+const markers: string[] = [];
+afterEach(() => {
+  for (const m of markers) {
+    try {
+      unlinkSync(m);
+    } catch {}
+  }
+  markers.length = 0;
+});
+
+function trackMarker(sessionId: string, key: string) {
+  markers.push(markerPath(sessionId, key));
+}
+
+describe("processInput", () => {
+  it("injects context for markdown Write with digits", async () => {
+    const sid = `tc-${Date.now()}-1`;
+    trackMarker(sid, "README.md");
+    const result = await processInput(mockWriteInput("README.md", "Added 5 endpoints", sid));
+    expect(getContext(result)).toContain("counting");
+  });
+
+  it("returns null for markdown Write without digits", async () => {
+    const result = await processInput(
+      mockWriteInput("README.md", "No numbers here", `tc-${Date.now()}-2`),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null for non-markdown files", async () => {
+    const result = await processInput(
+      mockWriteInput("app.ts", "Added 5 tests", `tc-${Date.now()}-3`),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("injects context for markdown Edit with digits", async () => {
+    const sid = `tc-${Date.now()}-4`;
+    trackMarker(sid, "docs.md");
+    const result = await processInput(mockEditInput("docs.md", "3 new features", sid));
+    expect(getContext(result)).toContain("counting");
+  });
+
+  it("skips injection on second call for same file", async () => {
+    const sid = `tc-${Date.now()}-5`;
+    trackMarker(sid, "README.md");
+    const first = await processInput(mockWriteInput("README.md", "5 items", sid));
+    expect(first).not.toBeNull();
+    const second = await processInput(mockWriteInput("README.md", "10 items", sid));
+    expect(second).toBeNull();
+  });
+
+  it("injects again for different session", async () => {
+    const sid1 = `tc-${Date.now()}-6a`;
+    const sid2 = `tc-${Date.now()}-6b`;
+    trackMarker(sid1, "README.md");
+    trackMarker(sid2, "README.md");
+    const first = await processInput(mockWriteInput("README.md", "5 items", sid1));
+    expect(first).not.toBeNull();
+    const second = await processInput(mockWriteInput("README.md", "5 items", sid2));
+    expect(second).not.toBeNull();
+  });
+
+  it("injects context for MCP tool with body containing digits", async () => {
+    const sid = `tc-${Date.now()}-7`;
+    const input: PreToolUseHookInput = {
+      hook_event_name: "PreToolUse",
+      session_id: sid,
+      transcript_path: "/tmp/test",
+      cwd: "/tmp",
+      tool_name: "mcp__plugin_github_github__create_pull_request",
+      tool_input: { body: "Added 5 endpoints" },
+      tool_use_id: "mcp-test-id",
+    };
+    trackMarker(sid, "mcp:mcp-test-id");
+    const result = await processInput(input);
+    expect(getContext(result)).toContain("counting");
+  });
+
+  it("returns null for MCP tool with body without digits", async () => {
+    const input: PreToolUseHookInput = {
+      hook_event_name: "PreToolUse",
+      session_id: `tc-${Date.now()}-8`,
+      transcript_path: "/tmp/test",
+      cwd: "/tmp",
+      tool_name: "mcp__plugin_github_github__create_pull_request",
+      tool_input: { body: "No numbers here" },
+      tool_use_id: "mcp-test-id",
+    };
+    expect(await processInput(input)).toBeNull();
+  });
+});

--- a/plugins/style/hooks/test-counts.ts
+++ b/plugins/style/hooks/test-counts.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import {
+  type EditInput,
+  extractMarkdownFromBash,
+  extractMarkdownFromMcp,
+  formatContext,
+  getExtension,
+  hasBashCommand,
+  isMarkdownFile,
+  type SyncHookJSONOutput,
+  type WriteInput,
+} from "./markdown";
+
+const CONTEXT_MESSAGE =
+  "Do not summarize by counting items (e.g. 'Added 5 tests', '3 new endpoints'). " +
+  "Either list the items individually or provide a qualitative summary of what was added and why it matters.";
+
+function markerPath(sessionId: string, key: string): string {
+  const hash = createHash("sha256").update(key).digest("hex").slice(0, 12);
+  return join(tmpdir(), `style-counts-${sessionId}-${hash}`);
+}
+
+function alreadyInjected(sessionId: string, key: string): boolean {
+  return existsSync(markerPath(sessionId, key));
+}
+
+function markInjected(sessionId: string, key: string): void {
+  try {
+    mkdirSync(tmpdir(), { recursive: true });
+    writeFileSync(markerPath(sessionId, key), "");
+  } catch (error) {
+    console.error(
+      `[style/test-counts] Failed to write cooldown marker: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+export async function processInput(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
+  const toolName = input.tool_name;
+
+  let content: string | null = null;
+  let key: string;
+
+  if (toolName === "Write") {
+    const toolInput = input.tool_input as WriteInput;
+    if (!isMarkdownFile(getExtension(toolInput.file_path))) return null;
+    content = toolInput.content;
+    key = toolInput.file_path;
+  } else if (toolName === "Edit") {
+    const toolInput = input.tool_input as EditInput;
+    if (!isMarkdownFile(getExtension(toolInput.file_path))) return null;
+    content = toolInput.new_string;
+    key = toolInput.file_path;
+  } else if (hasBashCommand(input.tool_input)) {
+    content = await extractMarkdownFromBash(input.tool_input.command, "style/test-counts");
+    key = `bash:${input.tool_use_id}`;
+  } else {
+    content = extractMarkdownFromMcp(input.tool_input);
+    key = `mcp:${input.tool_use_id}`;
+  }
+
+  if (!content) return null;
+  if (!/\d/.test(content)) return null;
+  if (alreadyInjected(input.session_id, key)) return null;
+
+  markInjected(input.session_id, key);
+  return formatContext(CONTEXT_MESSAGE);
+}
+
+async function main(): Promise<void> {
+  let input: PreToolUseHookInput;
+  try {
+    input = await readStdinJson<PreToolUseHookInput>();
+  } catch (error) {
+    console.error(
+      `[style/test-counts] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  const output = await processInput(input);
+  if (output) {
+    writeStdoutJson(output);
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/plugins/style/package.json
+++ b/plugins/style/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@bendrucker/shell-extract": "workspace:*",
     "@constellos/claude-code-kit": "^0.4.0",
     "ap-style-title-case": "^2.0.0",
     "mdast-util-from-markdown": "^2.0.2",


### PR DESCRIPTION
Extends style plugin hooks to fire on Bash PR/MR commands (\`gh pr create\`, \`glab mr create\`) and MCP tools (GitHub PR, Linear issue/comment/document). Previously hooks only ran on \`Write\` and \`Edit\` — PR bodies created via Bash heredocs or MCP tools bypassed enforcement entirely.

Depends on #437.

## Changes

- \`hooks.json\`: new matchers for Bash PR/MR commands and MCP content tools
- \`numbering.ts\`: new \`external\` mode (covers Bash + MCP) using \`ask\` instead of \`deny\`, async \`processInput\`
- \`headings.ts\`: Bash/MCP extraction branches, async \`processInput\`
- \`markdown.ts\`: simplified to re-exports from \`@bendrucker/shell-extract\`
- New \`test-counts.ts\` hook: injects context reminding Claude not to summarize by counting items, with digit pre-check and per-file cooldown

## Test plan

- External mode tests verify MCP body extraction triggers numbered heading detection with \`ask\` decision
- Heading tests verify MCP body title case detection and clean pass-through
- Test-counts tests cover Write/Edit/MCP paths, digit pre-check, cooldown deduplication, and cross-session injection