### PR TITLE
feat: use shared shell-extract for PR validation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -93,6 +93,12 @@
         "@types/jsdom": "^27.0.0",
       },
     },
+    "plugins/pull-request": {
+      "name": "@bendrucker/claude-pull-request",
+      "dependencies": {
+        "@bendrucker/shell-extract": "workspace:*",
+      },
+    },
     "plugins/style": {
       "name": "@bendrucker/claude-style",
       "dependencies": {
@@ -164,6 +170,8 @@
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@bendrucker/claude-pull-request": ["@bendrucker/claude-pull-request@workspace:plugins/pull-request"],
 
     "@bendrucker/claude-style": ["@bendrucker/claude-style@workspace:plugins/style"],
 
@@ -807,7 +815,7 @@
 
     "ini": ["ini@4.1.3", "", {}, "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg=="],
 
-    "internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
@@ -1436,6 +1444,8 @@
     "@npmcli/promise-spawn/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
 
     "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "plugins/gitlab",
     "plugins/vscode",
     "packages/shell-extract",
-    "packages/validate"
+    "packages/validate",
+    "plugins/pull-request"
   ],
   "scripts": {
     "build": "tsc --noEmit",

--- a/plugins/pull-request/package.json
+++ b/plugins/pull-request/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@bendrucker/claude-pull-request",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@bendrucker/shell-extract": "workspace:*"
+  }
+}

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { extractBodyFilePath, processInput, validateBody } from "./validate";
+import { extractBody, processInput, validateBody } from "./validate";
 
 function getPermissionDecision(result: Awaited<ReturnType<typeof validateBody>>) {
   const output = result?.hookSpecificOutput;
@@ -13,27 +13,52 @@ function getPermissionDecision(result: Awaited<ReturnType<typeof validateBody>>)
   return undefined;
 }
 
-describe("extractBodyFilePath", () => {
-  it("returns null when command has no --body-file", () => {
-    expect(extractBodyFilePath("gh pr create --title 'Test'")).toBeNull();
+describe("extractBody", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "extract-body-test-"));
   });
 
-  it("extracts path with space separator", () => {
-    expect(extractBodyFilePath("gh pr create --body-file /tmp/body.md")).toBe("/tmp/body.md");
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("extracts path with equals separator", () => {
-    expect(extractBodyFilePath("gh pr create --body-file=/tmp/body.md")).toBe("/tmp/body.md");
+  it("returns null when command has no body", async () => {
+    expect(await extractBody("gh pr create --title 'Test'")).toBeNull();
   });
 
-  it("handles path with spaces in quotes", () => {
-    expect(extractBodyFilePath('gh pr create --body-file "/tmp/my file.md"')).toBe('"/tmp/my');
+  it("reads --body-file with space separator", async () => {
+    const file = path.join(tempDir, "body.md");
+    fs.writeFileSync(file, "## Summary\nHello");
+    expect(await extractBody(`gh pr create --body-file ${file}`)).toBe("## Summary\nHello");
   });
 
-  it("extracts path when --body-file is not at end", () => {
-    expect(extractBodyFilePath("gh pr create --body-file /tmp/body.md --draft")).toBe(
-      "/tmp/body.md",
-    );
+  it("reads --body-file with equals separator", async () => {
+    const file = path.join(tempDir, "body.md");
+    fs.writeFileSync(file, "content");
+    expect(await extractBody(`gh pr create --body-file=${file}`)).toBe("content");
+  });
+
+  it("returns null when --body-file path does not exist", async () => {
+    expect(await extractBody("gh pr create --body-file /nonexistent.md")).toBeNull();
+  });
+
+  it("extracts heredoc body", async () => {
+    const cmd = `gh pr create --title "test" --body "$(cat <<'EOF'
+## Summary
+Hello world
+EOF
+)"`;
+    expect(await extractBody(cmd)).toBe("## Summary\nHello world\n");
+  });
+
+  it("extracts heredoc with unquoted delimiter", async () => {
+    const cmd = `gh pr create --body "$(cat <<EOF
+content here
+EOF
+)"`;
+    expect(await extractBody(cmd)).toBe("content here\n");
   });
 });
 
@@ -93,7 +118,7 @@ describe("processInput", () => {
     } as PreToolUseHookInput;
   }
 
-  it("returns null when command has no --body-file", async () => {
+  it("returns null when command has no body", async () => {
     const result = await processInput(createInput("gh pr create --title 'Test'"));
     expect(result).toBeNull();
   });
@@ -111,18 +136,39 @@ describe("processInput", () => {
     expect(result).toBeNull();
   });
 
-  it("returns null for valid body", async () => {
+  it("returns null for valid body via --body-file", async () => {
     const bodyFile = path.join(tempDir, "body.md");
     fs.writeFileSync(bodyFile, "## Summary\nFixes a bug");
     const result = await processInput(createInput(`gh pr create --body-file ${bodyFile}`));
     expect(result).toBeNull();
   });
 
-  it("denies body with test count", async () => {
+  it("denies body with test count via --body-file", async () => {
     const bodyFile = path.join(tempDir, "body.md");
     fs.writeFileSync(bodyFile, "## Test plan\nAdded 5 tests");
     const result = await processInput(createInput(`gh pr create --body-file ${bodyFile}`));
     expect(result).not.toBeNull();
     expect(getPermissionDecision(result)).toBe("deny");
+  });
+
+  it("denies body with test count via heredoc", async () => {
+    const cmd = `gh pr create --title "test" --body "$(cat <<'EOF'
+## Test plan
+Added 5 tests
+EOF
+)"`;
+    const result = await processInput(createInput(cmd));
+    expect(result).not.toBeNull();
+    expect(getPermissionDecision(result)).toBe("deny");
+  });
+
+  it("returns null for valid heredoc body", async () => {
+    const cmd = `gh pr create --title "test" --body "$(cat <<'EOF'
+## Summary
+Fixes a bug
+EOF
+)"`;
+    const result = await processInput(createInput(cmd));
+    expect(result).toBeNull();
   });
 });

--- a/plugins/pull-request/scripts/validate.ts
+++ b/plugins/pull-request/scripts/validate.ts
@@ -1,25 +1,13 @@
 #!/usr/bin/env bun
 
-import { existsSync, readFileSync } from "node:fs";
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { extractMarkdownFromBash, hasBashCommand } from "@bendrucker/shell-extract";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
-
-function hasBashCommand(input: unknown): input is { command: string } {
-  return (
-    typeof input === "object" &&
-    input !== null &&
-    "command" in input &&
-    typeof (input as { command: unknown }).command === "string"
-  );
-}
 
 const TEST_COUNT_PATTERN =
   /[Aa]dded [0-9]+ (unit |integration )?tests|[0-9]+ (unit |integration )?tests/;
 
-export function extractBodyFilePath(command: string): string | null {
-  const match = command.match(/--body-file[=\s]([^\s]+)/);
-  return match?.[1] ?? null;
-}
+export { extractMarkdownFromBash as extractBody };
 
 export function validateBody(body: string): SyncHookJSONOutput | null {
   if (TEST_COUNT_PATTERN.test(body)) {
@@ -40,18 +28,10 @@ export async function processInput(input: PreToolUseHookInput): Promise<SyncHook
   if (!hasBashCommand(input.tool_input)) {
     return null;
   }
-  const { command } = input.tool_input;
 
-  const bodyFilePath = extractBodyFilePath(command);
-  if (!bodyFilePath) {
-    return null;
-  }
+  const body = await extractMarkdownFromBash(input.tool_input.command, "pull-request/validate");
+  if (!body) return null;
 
-  if (!existsSync(bodyFilePath)) {
-    return null;
-  }
-
-  const body = readFileSync(bodyFilePath, "utf-8");
   return validateBody(body);
 }
 

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -27,6 +27,7 @@ allowed-tools: Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/*:*), Bash(bun ${CLAUDE_PL
 
 - Start with 1-3 sentences summarizing the change (no preceding header)
 - **Wrap all code identifiers with backticks**: function names, class names, file paths, endpoints, status codes, etc.
+- **Testing section**: Describe _what_ is tested, not _how many_. Never mention test counts or summarize by counting items.
 - Use `##` sections for larger changes. See [`sections.md`](sections.md) for detailed guidance on:
   - `## Issue` - Root cause analysis and issue linking
   - `## Changes` - High-level description of changes

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -28,7 +28,7 @@ The PR body documents what will happen when merged, not the journey. Don't echo 
 
 ## Writing
 
-1. Rewrite the PR body following the same title and body rules as the create skill. See [`sections.md`](sections.md) for section guidance.
+1. Rewrite the PR body following the same title and body rules as the create skill. Describe _what_ is tested, not _how many_ — never mention test counts or summarize by counting items. See [`sections.md`](sections.md) for section guidance.
 2. Write the updated body to a temp file (e.g., `tmp/pr-body-<branch>.md`) and apply:
    - **GitHub**: `gh pr edit --body-file tmp/pr-body-<branch>.md`
    - **GitLab**: `glab mr update --description "$(cat tmp/pr-body-<branch>.md)"`


### PR DESCRIPTION
Replaces duplicated shell parsing logic in the pull-request plugin with the shared \`@bendrucker/shell-extract\` package. Adds heredoc body extraction support and inline testing guidance to PR skills.

Depends on #438.

## Changes

- \`validate.ts\`: imports \`extractMarkdownFromBash\` and \`hasBashCommand\` from shared package instead of maintaining its own extraction logic
- \`package.json\`: new workspace package with \`@bendrucker/shell-extract\` dependency
- \`create/SKILL.md\` and \`update/SKILL.md\`: inline reminder to describe what is tested, not how many
- Root \`package.json\`: adds \`packages/shell-extract\` and \`plugins/pull-request\` to workspaces

## Test plan

- Existing \`extractBody\` tests validate \`--body-file\`, heredoc (quoted/unquoted delimiters), and no-body cases
- \`processInput\` integration tests cover heredoc body validation through the full pipeline