### PR TITLE
Add submit command and API pitfalls to GitLab draft notes

### DIFF
--- a/plugins/gitlab/skills/merge-request/review.md
+++ b/plugins/gitlab/skills/merge-request/review.md
@@ -30,10 +30,36 @@ bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts create <iid> --reply-to <discussi
 bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts create <iid> --reply-to <discussion-id> --resolve --body-file tmp/note.md
 ```
 
-### List and Publish
+### List
 
 ```bash
 bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts list <iid>
+```
+
+### Submit Review
+
+Publish all draft notes and optionally set a review decision. GitLab's REST API has no atomic "submit review" endpoint, so this runs up to three sequential calls: bulk publish, summary comment, and decision.
+
+```bash
+# Publish only (equivalent to "Comment" in web UI)
+bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts submit <iid>
+
+# Publish with summary comment
+bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts submit <iid> --summary "LGTM, minor nits"
+
+# Publish and approve
+bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts submit <iid> --approve
+
+# Publish and request changes (Premium+, uses GraphQL)
+bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts submit <iid> --request-changes
+
+# Full review: summary + approve
+bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts submit <iid> --approve --summary-file tmp/review-summary.md
+```
+
+The older `publish` command is still available for quick draft publishing without a review decision:
+
+```bash
 bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts publish <iid>
 ```
 
@@ -56,6 +82,15 @@ second line
 third line
 ```
 ````
+
+## API Pitfalls
+
+- **Content-Type required**: `glab api --input <file>` requires `-H "Content-Type: application/json"`. Without it, GitLab returns HTTP 415.
+- **No nested `-f` fields**: `glab api -f "position[base_sha]=..."` silently fails. Nested objects must be sent as JSON via `--input`.
+- **Reply field**: Use `in_reply_to_discussion_id`, not `discussion_id`.
+- **Don't update positioned notes**: PUT to update a draft note strips the position. Delete and recreate instead.
+- **No atomic review submit**: The REST API's `bulk_publish` only publishes drafts — no summary comment or review decision. The web UI uses an internal controller that combines all three, but it's session-authenticated only. The `submit` command above sequences the calls separately.
+- **Request changes is GraphQL-only**: `mergeRequestRequestChanges` mutation, requires Premium/Ultimate.
 
 ## Discussions
 

--- a/plugins/gitlab/skills/merge-request/scripts/draft-note.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/draft-note.ts
@@ -74,7 +74,8 @@ async function glabApiPost(path: string, payload: Record<string, unknown>): Prom
   const tmpFile = join(tmpdir(), `draft-note-${randomUUID()}.json`);
   await Bun.write(tmpFile, JSON.stringify(payload));
   try {
-    const result = await $`glab api ${path} -X POST --input ${tmpFile}`.text();
+    const result =
+      await $`glab api ${path} -X POST -H "Content-Type: application/json" --input ${tmpFile}`.text();
     console.log(result);
   } finally {
     await Bun.file(tmpFile).unlink();
@@ -157,6 +158,79 @@ const publishCmd = command(
   },
 );
 
+const submitCmd = command(
+  {
+    name: "submit",
+    parameters: ["<mr>"],
+    flags: {
+      approve: {
+        type: Boolean,
+        default: false,
+        description: "Approve the MR after publishing",
+      },
+      requestChanges: {
+        type: Boolean,
+        alias: "request-changes",
+        default: false,
+        description: "Request changes after publishing (Premium+, GraphQL)",
+      },
+      summary: {
+        type: String,
+        description: "Review summary comment text",
+      },
+      summaryFile: {
+        type: String,
+        alias: "summary-file",
+        description: "Read review summary from file",
+      },
+    },
+  },
+  async (parsed) => {
+    const mr = Number(parsed._.mr);
+
+    if (parsed.flags.approve && parsed.flags.requestChanges) {
+      console.error("Cannot both --approve and --request-changes");
+      process.exit(1);
+    }
+
+    const summaryText = parsed.flags.summaryFile
+      ? await Bun.file(parsed.flags.summaryFile).text()
+      : parsed.flags.summary;
+
+    const result = await $`glab api ${apiPath(mr)}/bulk_publish -X POST`.text();
+    console.log(result);
+    console.error("Published draft notes");
+
+    if (summaryText) {
+      const notePath = `projects/:id/merge_requests/${mr}/notes`;
+      await glabApiPost(notePath, { body: summaryText });
+      console.error("Posted summary comment");
+    }
+
+    if (parsed.flags.approve) {
+      const refs = await getDiffRefs(mr);
+      await $`glab api projects/:id/merge_requests/${mr}/approve -X POST -f sha=${refs.head_sha}`.text();
+      console.error("Approved MR");
+    } else if (parsed.flags.requestChanges) {
+      const projectPath = (await $`glab repo view --output json | jq -r '.fullPath'`.text()).trim();
+      const query = `mutation($projectPath: String!, $iid: String!) {
+        mergeRequestRequestChanges(input: { projectPath: $projectPath, iid: $iid }) {
+          mergeRequest { iid }
+          errors
+        }
+      }`;
+      const gqlResult =
+        await $`glab api graphql -f query=${query} -F projectPath=${projectPath} -F iid=${String(mr)}`.json();
+      const payload = gqlResult?.data?.mergeRequestRequestChanges;
+      if (payload?.errors?.length) {
+        console.error(`Request changes failed: ${payload.errors.join(", ")}`);
+        process.exit(1);
+      }
+      console.error("Requested changes");
+    }
+  },
+);
+
 const listCmd = command(
   {
     name: "list",
@@ -172,7 +246,7 @@ const listCmd = command(
 cli(
   {
     name: "draft-note",
-    commands: [createCmd, publishCmd, listCmd],
+    commands: [createCmd, publishCmd, submitCmd, listCmd],
   },
   (parsed) => {
     parsed.showHelp();

--- a/plugins/review/skills/peer/SKILL.md
+++ b/plugins/review/skills/peer/SKILL.md
@@ -31,4 +31,4 @@ See [tone.md](tone.md) for comment style guidelines.
 
 ## Service Support
 
-This skill assumes GitHub. For GitLab merge requests, load `gitlab:merge-request` for the review submission workflow (draft notes + bulk publish).
+This skill assumes GitHub. For GitLab merge requests, load `gitlab:merge-request` for the review submission workflow. Use `draft-note.ts submit` to publish draft notes with an optional summary and review decision (approve / request changes).


### PR DESCRIPTION
Fixes the Content-Type header bug in `glabApiPost` and adds a `submit` subcommand to `draft-note.ts` that orchestrates GitLab's review submission flow.

GitLab has no atomic "submit review" REST endpoint — the web UI uses an internal session-authenticated controller. The `submit` command sequences the three separate API calls: bulk publish, summary comment, and review decision (approve via REST, request changes via GraphQL).

Also documents the API pitfalls discovered during MR reviews: missing Content-Type, broken bracket notation for nested fields, reply field naming, and positioned note update behavior.

## Test plan

- [ ] Run `draft-note.ts submit <iid>` to publish drafts without a decision
- [ ] Run `draft-note.ts submit <iid> --approve` to publish and approve
- [ ] Run `draft-note.ts submit <iid> --request-changes` to publish and request changes (Premium+)
- [ ] Verify `--summary` and `--summary-file` create a standalone comment

Original Task: [Improve GitLab MR review skill: draft notes workflow](https://things.bendrucker.me/show?id=XXFurSnWYaAiQU9eVbERZD)