### PR TITLE
git: remove worktrunk skill, simplify stacked PRs

### DIFF
--- a/plugins/git/skills/worktrunk/SKILL.md
+++ b/plugins/git/skills/worktrunk/SKILL.md
@@ -1,9 +1,0 @@
----
-name: worktrunk
-description: Managing git worktrees with the wt CLI. Use when creating, switching, listing, or removing worktrees, running wt commands, or managing worktree-based workflows. Activate this skill for any wt CLI interaction.
-allowed-tools: [Bash(wt:*)]
----
-
-# Worktrunk
-
-This skill grants permissions for the `wt` CLI. For usage documentation, configuration guides, and hook setup, also load the `worktrunk:worktrunk` skill.

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -28,13 +28,11 @@
 
 ## Stacked PRs
 
-I use git-town for stacked branch workflows combined with worktrunk:
+I use git-town for stacked branch workflows:
 
-1. Create base branch: `wt switch --create feature/base`
-2. Work, commit, then append: `git town append child-name`
-3. Create worktree for child: `wt switch child-name`
-4. Sync entire stack: `git town sync --stack`
-5. Propose all PRs: `git town propose --stack`
+- Append a child branch: `git town append child-name`
+- Sync the stack: `git town sync --stack`
+- Propose all PRs: `git town propose --stack`
 
 Ship branches oldest-first. After a stack branch merges, `git town sync` rebases remaining branches.
 


### PR DESCRIPTION
Removes the `git:worktrunk` skill and updates the stacked PRs section in `user/CLAUDE.md` to use only git-town commands. The built-in `EnterWorktree` tool and `Task(isolation: "worktree")` handle worktree management natively — the `wt` permission grant from the git plugin is no longer needed.

The `worktrunk:worktrunk` plugin skill is unchanged.
