### PR TITLE
feat(calendar): detect missing app bundle context for EventKit TCC

### DIFF
--- a/plugins/calendar/README.md
+++ b/plugins/calendar/README.md
@@ -14,7 +14,7 @@ A Claude Code plugin for reading and managing macOS Calendar events via EventKit
 
 Grant Calendar access to your terminal app in **System Settings → Privacy & Security → Calendars**.
 
-EventKit permissions don't work over SSH. Use a local terminal session.
+EventKit requires an app bundle context for TCC permissions. It does not work in tmux, SSH, or other environments where the responsible process lacks a bundle ID. Use a direct local terminal session.
 
 ## How It Works
 

--- a/plugins/calendar/skills/calendar/SKILL.md
+++ b/plugins/calendar/skills/calendar/SKILL.md
@@ -28,7 +28,7 @@ The CLI lives at `@skills/calendar/scripts/cal.swift` and is invoked via `swift 
 
 Calendar access must be granted to the terminal app (Ghostty, Terminal.app, etc.) in **System Settings → Privacy & Security → Calendars**.
 
-Over SSH, EventKit permissions don't apply. Use a local terminal session.
+EventKit requires TCC permissions tied to an app bundle. Over SSH, in tmux, or in any context where the responsible process has no app bundle, EventKit access is unavailable. Use a local terminal session launched directly from an app (not through a multiplexer).
 
 ## Read Operations
 
@@ -122,6 +122,8 @@ For calendars with duplicate names (e.g., "Personal" on both Google and iCloud),
 ## Troubleshooting
 
 **"Calendar access denied"**: Grant access in System Settings → Privacy & Security → Calendars for your terminal app.
+
+**"Calendar access denied" with `"reason": "no-app-bundle"`**: The responsible process has no app bundle context. This occurs in tmux, SSH, or similar environments where macOS cannot identify a bundled app to associate TCC permissions with. Switch to a direct terminal session (e.g., Ghostty or Terminal.app, not inside tmux).
 
 **"Event not found"**: Event IDs are EventKit identifiers returned by `list` and `create`. IDs from other tools (icalBuddy, JXA) are incompatible.
 

--- a/plugins/calendar/skills/calendar/scripts/cal.swift
+++ b/plugins/calendar/skills/calendar/scripts/cal.swift
@@ -1,5 +1,16 @@
+import Darwin
 import EventKit
 import Foundation
+
+@_silgen_name("responsibility_get_pid_responsible_for_pid")
+func responsibility_get_pid_responsible_for_pid(_ pid: pid_t) -> pid_t
+
+func hasAppBundleContext() -> Bool {
+    let pid = responsibility_get_pid_responsible_for_pid(getpid())
+    var buf = [CChar](repeating: 0, count: Int(PROC_PIDPATHINFO_MAXSIZE))
+    proc_pidpath(pid, &buf, UInt32(buf.count))
+    return String(cString: buf).contains(".app/")
+}
 
 let store = EKEventStore()
 
@@ -207,7 +218,11 @@ func deleteEvent(id: String) {
 }
 
 guard requestAccess() else {
-    print("{\"error\": \"Calendar access denied\"}")
+    if hasAppBundleContext() {
+        print("{\"error\": \"Calendar access denied\"}")
+    } else {
+        print("{\"error\": \"Calendar access denied\", \"reason\": \"no-app-bundle\", \"detail\": \"EventKit requires a bundle ID for TCC — the responsible process has no app bundle context.\"}")
+    }
     exit(1)
 }
 

--- a/plugins/personal-review/skills/review/SKILL.md
+++ b/plugins/personal-review/skills/review/SKILL.md
@@ -20,7 +20,9 @@ Ask which variant if not specified.
 
 Dispatch a read-only sub-agent (Task tool) to scan today's events. See [calendar.md](calendar.md).
 
-Present time budget (available hours, focus windows, meetings needing prep). Ask user to proceed.
+If the sub-agent reports calendar access denied (the `"reason": "no-app-bundle"` error), skip silently. Do not prompt to fix permissions. Note "Calendar: skipped (access denied)" and proceed to the next phase.
+
+Otherwise, present time budget (available hours, focus windows, meetings needing prep). Ask user to proceed.
 
 ## Phase: Things Inbox
 
@@ -34,7 +36,7 @@ Batch items by pattern, ask user for each batch:
 
 Goal: inbox count = 0.
 
-After inbox processing, re-query calendar (see Re-Check in [calendar.md](calendar.md)). Present any new events and updated time budget. Ask user to proceed.
+After inbox processing, re-query calendar (see Re-Check in [calendar.md](calendar.md)). If calendar was skipped due to access denied in the initial phase, skip the re-check too. Otherwise, present any new events and updated time budget. Ask user to proceed.
 
 ## Phase: Notifications
 
@@ -86,7 +88,7 @@ Group, prioritize, defer, and reorder the Today list. Present final order for co
 ## Summary
 
 Present progress across all phases:
-- Time budget from Calendar
+- Time budget from Calendar (or "skipped — access denied" if calendar was unavailable)
 - Things inbox processed (count = 0)
 - GitHub/GitLab/Linear notifications triaged (done/deferred counts)
 - Today list ordered (final count)

--- a/plugins/personal-review/skills/review/calendar.md
+++ b/plugins/personal-review/skills/review/calendar.md
@@ -43,6 +43,16 @@ After Things inbox processing, re-query today's events:
 - Note any new events (e.g., work calendar additions during personal triage)
 - Update the time budget if new meetings were added
 
+## Access Denied
+
+When the calendar sub-agent reports `"reason": "no-app-bundle"`, EventKit cannot obtain TCC permissions. This happens in tmux, SSH, or any context where the responsible process lacks an app bundle. The review workflow skips calendar silently:
+
+- Initial scan: note "Calendar: skipped (access denied)" and proceed
+- Post-inbox re-check: skip entirely
+- Summary: report calendar as skipped
+
+Do not prompt the user to fix permissions — the environment does not support EventKit.
+
 ## Evening Variant
 
 Preview tomorrow only:


### PR DESCRIPTION
EventKit requires a bundle ID for TCC permissions. Processes in tmux, SSH, or other non-app-bundle contexts are permanently blocked from calendar access. This change detects the condition and handles it gracefully.

- Add responsible-process detection in `cal.swift` using `responsibility_get_pid_responsible_for_pid`
- Personal-review skill silently skips calendar phase on access denied
- Document limitation in calendar plugin setup and troubleshooting

Original Task: [personal-review: document calendar unavailability from tmux](https://things.bendrucker.me/show?id=SbwFLuSVmq5z6HJtiQxvCd)