### PR TITLE
fix(things): coerce boolean attributes in JSON payload

### DIFF
--- a/plugins/things/scripts/url.test.ts
+++ b/plugins/things/scripts/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildJsonPayload } from "./url";
+import { buildJsonPayload, coerceBooleanAttributes } from "./url";
 
 describe("buildJsonPayload", () => {
   test("single ID produces correct structure", () => {
@@ -36,5 +36,42 @@ describe("buildJsonPayload", () => {
 
   test("empty attributes throws", () => {
     expect(() => buildJsonPayload(["ABC"], {})).toThrow("At least one attribute is required");
+  });
+
+  test("coerces boolean attributes to actual booleans", () => {
+    const result = JSON.parse(buildJsonPayload(["ABC"], { completed: "true", canceled: "false" }));
+    expect(result[0].attributes).toEqual({ completed: true, canceled: false });
+  });
+
+  test("leaves non-boolean attributes as strings", () => {
+    const result = JSON.parse(buildJsonPayload(["ABC"], { when: "today", completed: "true" }));
+    expect(result[0].attributes).toEqual({ when: "today", completed: true });
+  });
+});
+
+describe("coerceBooleanAttributes", () => {
+  test("coerces all known boolean attributes", () => {
+    const result = coerceBooleanAttributes({
+      completed: "true",
+      canceled: "false",
+      reveal: "true",
+      duplicate: "false",
+    });
+    expect(result).toEqual({
+      completed: true,
+      canceled: false,
+      reveal: true,
+      duplicate: false,
+    });
+  });
+
+  test("passes through string attributes unchanged", () => {
+    const result = coerceBooleanAttributes({ when: "today", "add-tags": "Urgent" });
+    expect(result).toEqual({ when: "today", "add-tags": "Urgent" });
+  });
+
+  test("does not coerce non-boolean values for boolean attributes", () => {
+    const result = coerceBooleanAttributes({ completed: "yes" });
+    expect(result).toEqual({ completed: "yes" });
   });
 });

--- a/plugins/things/scripts/url.ts
+++ b/plugins/things/scripts/url.ts
@@ -101,6 +101,25 @@ export function findXcallRunner(): string | null {
   return null;
 }
 
+const BOOLEAN_ATTRIBUTES = ["completed", "canceled", "reveal", "duplicate"] as const;
+
+export function coerceBooleanAttributes(
+  attributes: Record<string, string>,
+): Record<string, string | boolean> {
+  const result: Record<string, string | boolean> = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (
+      (BOOLEAN_ATTRIBUTES as readonly string[]).includes(key) &&
+      (value === "true" || value === "false")
+    ) {
+      result[key] = value === "true";
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
 export function buildJsonPayload(ids: string[], attributes: Record<string, string>): string {
   if (ids.length === 0) {
     throw new Error("At least one ID is required");
@@ -109,11 +128,12 @@ export function buildJsonPayload(ids: string[], attributes: Record<string, strin
     throw new Error("At least one attribute is required");
   }
 
+  const coerced = coerceBooleanAttributes(attributes);
   const data = ids.map((id) => ({
     type: "to-do" as const,
     operation: "update" as const,
     id,
-    attributes,
+    attributes: coerced,
   }));
 
   return JSON.stringify(data);
@@ -176,7 +196,8 @@ if (import.meta.main) {
       try {
         const result = await xcall(url);
         console.log(result);
-      } catch {
+      } catch (error) {
+        console.error("xcall failed, falling back to open", error);
         await openUrl("json", jsonParams);
       }
     } else {
@@ -192,7 +213,8 @@ if (import.meta.main) {
       try {
         const result = await xcall(url);
         console.log(result);
-      } catch {
+      } catch (error) {
+        console.error("xcall failed, falling back to open", error);
         await openUrl(command, params);
       }
     } else {


### PR DESCRIPTION
Multi-ID updates via the JSON command path passed boolean attributes as strings, which Things silently ignores. Also, xcall failures were silently swallowed with no feedback.

- Coerce known boolean attributes (`completed`, `canceled`, `reveal`, `duplicate`) from strings to actual JSON booleans in `buildJsonPayload`
- Log warning to stderr when falling back from xcall to `open -g`
- Add tests for boolean coercion logic

Original Task: Things url.ts: coerce boolean attributes in JSON payload + surface errors instead of silent fallback