### PR TITLE
feat(tmux): inject current pane context via bang-backtick

### DIFF
--- a/plugins/tmux/skills/tmux/SKILL.md
+++ b/plugins/tmux/skills/tmux/SKILL.md
@@ -17,7 +17,13 @@ hooks:
 
 # tmux
 
-The SessionStart hook injects `TMUX_SESSION_NAME`, `TMUX_WINDOW_INDEX`, `TMUX_WINDOW_NAME`, `TMUX_PANE_INDEX`, and `TMUX_PANE_ID` into the environment. Use `$TMUX_PANE_ID` to identify the current pane and target adjacent ones.
+## Current Pane
+
+!`tmux display-message -p '- Session: #{session_name}
+- Window: #{window_index} (#{window_name})
+- Pane: #{pane_index} (#{pane_id})' 2>/dev/null || echo 'not running in tmux'`
+
+Use `$TMUX_PANE_ID` to identify the current pane and target adjacent ones.
 
 ## Opening Panes
 


### PR DESCRIPTION
Replaces the descriptive env var paragraph in the tmux skill with bang-backtick dynamic context injection using `tmux display-message`. Session, window, and pane info now render at skill load time, eliminating a wasted Bash turn to echo env vars.

- Replaced static description with `## Current Pane` using bang-backtick
- Values rendered as a bullet list (session, window, pane)
- Graceful fallback when not running in tmux
- `context.ts` SessionStart hook unchanged (still provides env vars for Bash commands)

## Test plan

- [x] `bun run skill-lint "plugins/tmux/skills/*"` — 0 errors
- [ ] Activate tmux skill inside tmux and verify pane info renders
- [ ] Activate outside tmux and verify fallback text appears

Original Task: [tmux skill: auto-inject env vars](https://things.bendrucker.me/show?id=86U8QfnFgRJwY2M4Yu5rid)