### PR TITLE
feat(tmux): add agent handoffs section for new-window and new-session

### DIFF
--- a/plugins/tmux/skills/tmux/SKILL.md
+++ b/plugins/tmux/skills/tmux/SKILL.md
@@ -52,3 +52,32 @@ tmux capture-pane -t $TARGET -p -S -100
 ```
 
 `-S -100` includes 100 lines of scrollback above the visible area.
+
+## Agent Handoffs
+
+Launch a `claude` CLI instance in a new tmux window or session to hand off work.
+
+### new-window
+
+Spawns a window in the current session. Visible in the status bar tab list.
+
+```bash
+tmux new-window -d -n task-name -t "$TMUX_SESSION_NAME" 'claude -p "prompt here"'
+```
+
+- `-d` keeps focus on the current window
+- `-n task-name` labels the window in the status bar
+- `-t "$TMUX_SESSION_NAME"` targets the current session
+
+This is the common case — the agent runs alongside the user's current work and is easy to switch to.
+
+### new-session
+
+Spawns a detached session. Use for isolated or long-lived tasks.
+
+```bash
+tmux new-session -d -s task-name 'claude -p "prompt here"'
+```
+
+- `-d` creates the session without attaching
+- `-s task-name` names the session for `tmux attach -t task-name`


### PR DESCRIPTION
Adds an Agent Handoffs section to the tmux skill documenting how to launch `claude` CLI instances in new tmux windows or sessions for parallel work.

- `new-window` pattern (preferred) — spawns in current session, visible in tab bar
- `new-session` pattern — detached, for isolated/long-lived tasks
- Flag explanations for `-d`, `-n`, `-t`, `-s`

## Test plan

- [x] `bun run skill-lint "plugins/tmux/skills/*"` — 0 errors
- [ ] Verify `tmux new-window -d -n test -t "$TMUX_SESSION_NAME" 'echo hello'` works

Original Task: [tmux skill: add new-window pattern to Agent Handoffs](https://things.bendrucker.me/show?id=8TyuWYAwWXUrV2RLeoYxA1)