### PR TITLE
fix(zsh): disable bang history expansion in Claude Code sessions

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -34,6 +34,16 @@
     "deny": []
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$CLAUDE_ENV_FILE\" ] && echo 'setopt nobanghist' >> \"$CLAUDE_ENV_FILE\""
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
Adds a `SessionStart` hook that writes `setopt nobanghist` to `CLAUDE_ENV_FILE`, disabling zsh's `!`-triggered history expansion only in Claude Code sessions. This fixes issues where `!` in markdown image syntax (`![alt](url)`) and jq expressions (`!=`) gets incorrectly escaped by zsh.

## Original Task

- [Investigate zsh history expansion escaping ! in shell strings passed to curl/APIs](https://things.bendrucker.me/show?id=WiX6Vra3G3Frtks1uxMwkT)
- [Investigate zsh bang history escaping for Claude Code](https://things.bendrucker.me/show?id=VmqqRunSfuC5wGmuLA7yQC)
