### PR TITLE
settings: enable bun, git-town, webfetch-auth, mermaid, tech-spec plugins

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -86,7 +86,12 @@
     "playground@claude-plugins-official": true,
     "linear-cli@schpet": true,
     "tmux@bendrucker": true,
-    "agent-browser@agent-browser": true
+    "agent-browser@agent-browser": true,
+    "bun@bendrucker": true,
+    "git-town@bendrucker": true,
+    "webfetch-auth@bendrucker": true,
+    "mermaid@bendrucker": true,
+    "tech-spec@bendrucker": true
   },
   "extraKnownMarketplaces": {
     "bendrucker": {


### PR DESCRIPTION
Enable plugins that are useful in every session but were missing from `enabledPlugins`: `bun`, `git-town`, `webfetch-auth`, `mermaid`, and `tech-spec`.
