### PR TITLE
fix(mac): only disable sandbox for Go binaries, don't bypass permissions

### DIFF
--- a/plugins/mac/hooks/sandbox.test.ts
+++ b/plugins/mac/hooks/sandbox.test.ts
@@ -100,8 +100,6 @@ describe("processInput", () => {
     expect(result).toEqual({
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
-        permissionDecision: "allow",
-        permissionDecisionReason: expect.stringContaining("fake-go"),
         updatedInput: { dangerouslyDisableSandbox: true },
       },
     });

--- a/plugins/mac/hooks/sandbox.ts
+++ b/plugins/mac/hooks/sandbox.ts
@@ -55,12 +55,10 @@ export async function isGoBinary(command: string): Promise<boolean> {
   return hasGoBuildInfo(resolved);
 }
 
-function allow(reason: string): SyncHookJSONOutput {
+function disableSandbox(): SyncHookJSONOutput {
   return {
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
-      permissionDecision: "allow",
-      permissionDecisionReason: reason,
       updatedInput: { dangerouslyDisableSandbox: true },
     },
   };
@@ -77,9 +75,7 @@ export async function processInput(
 
   for (const cmd of commands) {
     if (await isGoBinary(cmd)) {
-      return allow(
-        `Go binary "${basename(cmd)}" needs unsandboxed access for TLS cert verification on macOS`,
-      );
+      return disableSandbox();
     }
   }
 


### PR DESCRIPTION
The mac sandbox hook was setting `permissionDecision: "allow"`, bypassing permissions entirely for Go binaries. Now it only sets `dangerouslyDisableSandbox: true`, letting the normal permission system handle authorization — commands are allowed only if declared in settings and prompt the user otherwise.
