### PR TITLE
settings: exclude agent-browser from sandbox

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -157,7 +157,8 @@
       "gcloud:*",
       "az:*",
       "wt:*",
-      "claude:*"
+      "claude:*",
+      "agent-browser:*"
     ]
   },
   "alwaysThinkingEnabled": true,


### PR DESCRIPTION
Exclude `agent-browser` from the sandbox. The CLI requires cross-process access to communicate with Chrome, which the sandbox blocks.
