### PR TITLE
improve-claude-code: rewrite command for reliability

### DIFF
--- a/.claude/commands/improve-claude-code.md
+++ b/.claude/commands/improve-claude-code.md
@@ -63,7 +63,7 @@ For failing PRs, dispatch `general-purpose` agents to the worktree branch to fix
 
 ### Annotate and Complete
 
-Load the `things:url` skill. For each passing PR, update the Things todo notes with the PR link and mark the todo complete.
+Load the `things:url` skill. For each passing PR, update the Things todo notes with the PR link and tag the todo with `review`. Move the todo to Anytime.
 
 ### Present Summary
 


### PR DESCRIPTION
Replace `claude -p` subprocesses and manual worktrees with Agent tool
`isolation: "worktree"` which handles worktree lifecycle automatically.
Merge implementation and PR creation into a single agent dispatch, add
explicit rules against inline JXA and direct `gh pr create`, and lower
max batch size from 5 to 3.
