### PR TITLE
fix(ci): prefix integration test paths for bun discovery

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,7 +220,7 @@ jobs:
 
       - name: Run integration tests
         if: steps.inspect.outputs.has_integration_tests == 'true'
-        run: find "plugins/${{ matrix.plugin.name }}" -name '*.integration.ts' -exec bun test {} +
+        run: find "plugins/${{ matrix.plugin.name }}" -name '*.integration.ts' -exec bun test ./{} +
 
   plugins:
     needs: [validate, plugin]


### PR DESCRIPTION
`bun test` requires `.test.` or `.spec.` in filenames for auto-discovery. When integration test files (`.integration.ts`) are passed as arguments via `find -exec`, they need a `./` prefix to be treated as file paths rather than filter patterns.

## Issue

The "Run integration tests" step added in 44592f86 fails across all plugins with integration tests because `bun test plugins/foo/bar.integration.ts` is interpreted as a filter pattern (no matches) rather than a file path.

## References

- https://github.com/bendrucker/claude/actions/runs/22683442506
