### PR TITLE
review:peer: rewrite guidelines from actual review patterns

### DIFF
--- a/plugins/review/skills/peer/SKILL.md
+++ b/plugins/review/skills/peer/SKILL.md
@@ -21,12 +21,17 @@ If not on the branch, first run `gh pr checkout` to switch.
 ## Workflow
 
 1. **Research** - Gather context (see [research.md](research.md))
-2. **Context** - Determine review context by checking the repository type. Apply [corporate](references/corporate.md) defaults for internal/company repos or [open-source](references/open-source.md) defaults for public community projects.
+2. **Context** - Determine review context using repository visibility. Private repositories use [corporate](references/corporate.md) defaults. Public repositories use [open-source](references/open-source.md) defaults. Check visibility via the platform API (`gh api repos/OWNER/REPO --jq .visibility` or `glab api projects/ENCODED_PATH | jq .visibility`). If ambiguous, ask me.
 3. **Review** - Examine changed files and existing comments
-4. **Think** - Evaluate against priorities (see [priorities.md](priorities.md))
-5. **Suggest** - Propose comments with revisions or issues
-6. **Comment** - Add approved comments to PR review
-7. **Submit** - Approve / Comment / Request Changes based on severity
+4. **Delegate** - Selectively dispatch PR review toolkit agents in parallel based on what the diff touches:
+   - Error handling, catch blocks, fallback logic: `silent-failure-hunter`
+   - New type definitions: `type-design-analyzer`
+   - New or modified tests: `pr-test-analyzer`
+   - Skip delegation for trivial PRs (docs-only, config changes, dependency bumps).
+5. **Think** - Evaluate against priorities (see [priorities.md](priorities.md)), incorporating toolkit agent findings
+6. **Suggest** - Propose comments with revisions or issues
+7. **Comment** - Add approved comments to PR review
+8. **Submit** - Approve / Comment / Request Changes based on severity
 
 See [tone.md](tone.md) for comment style guidelines.
 

--- a/plugins/review/skills/peer/magic-numbers.md
+++ b/plugins/review/skills/peer/magic-numbers.md
@@ -16,7 +16,7 @@ Flag unexplained numeric literals in changed lines. A magic number is a bare num
 - **Exit codes** (0, 1) in process exit calls
 - **Math constants** (100 for percentages, 1000 for ms conversion) when the intent is clear from context
 - **Test assertions** where the literal is the expected value being verified
-- **Enum-like definitions** — the constant is being named, not used anonymously
+- **Enum-like definitions** where the constant is being named, not used anonymously
 
 ## Suggesting Fixes
 

--- a/plugins/review/skills/peer/priorities.md
+++ b/plugins/review/skills/peer/priorities.md
@@ -6,7 +6,7 @@ Prioritize in order when making comments:
 2. **Performance** - Inefficient approaches consuming excess resources or adding latency
 3. **Architecture** - Module organization, interface design, separation of concerns. Avoid "utils" packages.
 4. **Anti-patterns** - Flag magic numbers (see [magic-numbers.md](magic-numbers.md)) and other code smells that hurt readability or maintainability.
-5. **Style** - Note deviations from project/language style, but limit these. Prefer automated linting. Suggest enforcement to *me* instead of commenting on PR.
+5. **Style** - Note deviations from project/language style, but limit these. Prefer automated linting. When you spot something automatable, file an issue in the project tracker to add the lint rule or CI check and link it in the review comment.
 
 Priority weighting shifts by context. See [corporate](references/corporate.md) and [open-source](references/open-source.md) references for how disposition and thresholds differ.
 

--- a/plugins/review/skills/peer/references/corporate.md
+++ b/plugins/review/skills/peer/references/corporate.md
@@ -1,7 +1,17 @@
 # Corporate Review Context
 
-- Default disposition: approve. Most PRs from teammates should be approved, possibly with minor suggestions.
-- Priority: production reliability, correctness, observability. Flag issues that could cause outages or data loss.
-- Avoid deep code quality nitpicks on working code. The team has shared ownership and can iterate.
-- Tone: collaborative. Phrase suggestions as "what about..." or "have you considered..." rather than directives.
-- Threshold for "Request Changes": reserve for bugs that would break production, security issues, or data integrity risks. Style and architecture comments should not block.
+## Disposition
+
+- Default to approve. Most PRs from teammates should be approved, possibly with minor suggestions.
+- Blocking threshold: production reliability (unbounded queries, new failure points for existing users), correctness bugs, security issues, or acceptance criteria gaps. Consider labeling critical comments as "Blocking" to signal severity.
+
+## What to Review
+
+- Verify the code delivers on the linked ticket's acceptance criteria, not just that it compiles and passes tests.
+- Focus on subjective qualities: architecture decisions, naming, edge case reasoning, failure mode analysis. Anything detectable by a linter or static analysis should be automated instead of commented on. File an issue in the project tracker and link it (e.g., "This variable is unused. Issue for detecting this automatically: <link>").
+- Code quality, type safety, PR body accuracy, and documentation gaps fall under a general quality umbrella. Flag them but they should not block unless they mask a correctness issue.
+
+## How to Comment
+
+- Use code snippets when they communicate the idea more clearly than prose. The goal is actionable advice, not necessarily a complete fix.
+- See [tone.md](../tone.md) for general comment style. Corporate-specific additions: blocking comments should be matter-of-fact about the risk, non-blocking suggestions should be collaborative ("what about...", "have you considered...", "worth adding").

--- a/plugins/review/skills/peer/references/open-source.md
+++ b/plugins/review/skills/peer/references/open-source.md
@@ -1,7 +1,18 @@
 # Open Source Review Context
 
-- Default disposition: request changes when code quality issues exist. Maintainers carry long-term maintenance burden, so the bar is higher.
-- Priority: code quality, API design, documentation, test coverage. The PR becomes the maintainer's responsibility after merge.
-- Maintainer happiness matters: suggest improvements that reduce future maintenance burden even if the code "works."
-- Tone: appreciative but direct. Thank contributors for their work, then clearly explain what needs to change and why.
-- Threshold for "Request Changes": code quality issues, missing tests, unclear naming, incomplete documentation are all valid reasons.
+## Disposition
+
+- Default to request changes when code quality issues exist. Maintainers carry the long-term maintenance burden, so the bar is higher.
+- Request changes for: code quality issues, missing tests, unclear naming, incomplete documentation, scope creep, and security concerns.
+- Security is always blocking. Prefer mechanisms that make unsafe behavior impossible (data passed as data, not code) over detection-based approaches.
+
+## What to Review
+
+- Enforce minimal PR scope. Push back on unrelated changes (dependency bumps, formatting, contributor additions) that aren't part of the stated goal. Be persistent if unrelated changes reappear after feedback.
+- Focus on subjective qualities. When you spot something automatable (lint rule, CI check), file an issue to automate it and link it in the review comment rather than just requesting the manual fix.
+
+## How to Comment
+
+- See [tone.md](../tone.md) for general comment style. Open-source additions: thank contributors for their work, then clearly explain what needs to change and why.
+- Scale teaching depth with contributor experience. Newer contributors benefit from enumerated edge cases, alternative approaches, and links to relevant documentation. Experienced contributors get terser feedback.
+- Cite authoritative sources (official docs, upstream source code, specs) when requesting changes so contributors can verify the reasoning themselves.

--- a/plugins/review/skills/peer/research.md
+++ b/plugins/review/skills/peer/research.md
@@ -2,6 +2,7 @@
 
 Gather context before reviewing:
 
-- [ ] If issues are referenced in the body, fetch content and comments with `mcp__github__get_issue`
+- [ ] Read the project's CLAUDE.md to understand conventions, coding standards, and project-specific guidelines
+- [ ] If issues are referenced in the body, fetch their content and comments from the platform API
 - [ ] If URLs are referenced, fetch with `WebFetch`
 - [ ] If insufficient context about motivation or implementation, ask me for additional information

--- a/plugins/review/skills/peer/tone.md
+++ b/plugins/review/skills/peer/tone.md
@@ -1,22 +1,30 @@
 # Tone Guidelines
 
-Comments should be friendly, concise, and instructive. Help the author understand why a suggestion was made. Provide inline links to relevant sources.
+Comments should be concise and instructive. Help the author understand why a suggestion was made. Provide inline links to relevant sources.
+
+Write in a natural, conversational tone. Avoid stiff or over-punctuated prose. Read the reviewer's actual comment history to match their voice.
 
 ## Severity
 
 Use RFC keywords (must, should, may) naturally within sentences to convey importance. Do not use them as labels or prefixes.
 
-**Good** — keywords flow naturally in the sentence:
+**Good**, keywords flow naturally in the sentence:
 - "The error response should include the status code so callers can distinguish transient failures."
 - "This must validate the input before writing to the database."
 - "You may want to extract this into a helper if it gets reused."
 
-**Bad** — keywords used as formal labels:
+**Bad**, keywords used as formal labels:
 - "**Must**: Add input validation"
 - "**Should**: Include error codes in response"
-- "Must — required change for functionality"
+- "Must: required change for functionality"
 
 The keyword conveys severity without drawing attention to itself.
+
+## Blocking vs Suggestions
+
+Blocking comments should be matter-of-fact about the risk. State the problem and its impact directly without hedging.
+
+Non-blocking suggestions should be collaborative. Use phrasing like "what about...", "have you considered...", or "worth adding" to invite discussion rather than direct.
 
 ## Nitpicks
 


### PR DESCRIPTION
Rewrote the `review:peer` skill guidelines based on patterns distilled from actual review comments across GitLab MRs and GitHub PRs.

## Changes

- Add `references/corporate.md` and `references/open-source.md` with structured Disposition / What to Review / How to Comment sections
- Detect corporate vs open-source context via repository visibility API
- Add toolkit agent delegation step with selection criteria per diff content
- Rewrite `tone.md` with natural RFC keyword examples, blocking vs suggestions guidance, and natural writing style direction
- Add CLAUDE.md reading as first research step, make research platform-agnostic
- Style priority now files automation issues instead of suggesting to reviewer
- Remove em dashes throughout

## Test Plan

- [ ] Structural review of skill file hierarchy and cross-references
- [ ] Verify no duplicated guidance across files
