### PR TITLE
fix(gitlab): add missing claude-code-kit dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -78,6 +78,7 @@
       "name": "gitlab",
       "version": "1.0.0",
       "dependencies": {
+        "@constellos/claude-code-kit": "^0.4.0",
         "cleye": "^1.3.2",
         "table": "^6.9.0",
       },

--- a/plugins/gitlab/package.json
+++ b/plugins/gitlab/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@constellos/claude-code-kit": "^0.4.0",
     "cleye": "^1.3.2",
     "table": "^6.9.0"
   }


### PR DESCRIPTION
The gitlab plugin's `PostToolUse:Bash` hook imports from `@constellos/claude-code-kit` but didn't declare it as a dependency in `plugins/gitlab/package.json`, causing hook execution failures.

Original Task: [Fix gitlab plugin PostToolUse:Bash hook error](https://things.bendrucker.me/show?id=2GJmbo7Tn5DwhU9aZNgbic)
