### PR TITLE
docs: add workarounds for Bash tool bang escaping bug

### DIFF
--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -26,6 +26,19 @@
 - Store temporary files in `tmp/` directory.
 - Use `pbcopy` and `pbpaste` for clipboard interaction.
 
+### Bash `!` Escaping Bug
+
+Claude Code's Bash tool incorrectly escapes `!` to `\!` at the JS level, breaking operators like jq `!=` and awk `!~` ([#2941](https://github.com/anthropics/claude-code/issues/2941), [#10335](https://github.com/anthropics/claude-code/issues/10335)). Workarounds:
+
+- **jq**: Use `| not` instead of `!=` (e.g., `select(.x == null | not)` instead of `select(.x != null)`)
+- **General**: Use heredoc syntax to pass scripts, bypassing inline escaping:
+  ```sh
+  jq "$(cat <<'JQ'
+  select(.x != null)
+  JQ
+  )"
+  ```
+
 ## Stacked PRs
 
 I use git-town for stacked branch workflows:

--- a/user/rules/json.md
+++ b/user/rules/json.md
@@ -9,3 +9,4 @@ paths:
 - Use `jq` to parse JSON input. If you know the structure, use `jq` filters to extract specific fields. JSON is often token-heavy, so optimizing for size is important.
   - Use `jq` filters like `keys`, `type`, and length to inspect JSON structures.
   - When fetching from the internet, output JSON to temporary files in `tmp/` directory to allow for inspection.
+- The Bash tool escapes `!` to `\!`, breaking jq `!=`. Use `| not` instead (e.g., `select(.x == null | not)`) or pass the filter via heredoc.

--- a/user/settings.json
+++ b/user/settings.json
@@ -32,16 +32,6 @@
     "deny": []
   },
   "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "[ -n \"$CLAUDE_ENV_FILE\" ] && echo 'setopt nobanghist' >> \"$CLAUDE_ENV_FILE\""
-          }
-        ]
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "Bash",
@@ -168,7 +158,8 @@
       "az:*",
       "wt:*",
       "claude:*",
-      "agent-browser:*"
+      "agent-browser:*",
+      "bun link:*"
     ]
   },
   "alwaysThinkingEnabled": true,


### PR DESCRIPTION
Add instructional workarounds for Claude Code's Bash tool `!` escaping bug, which breaks jq `!=`, awk `!~`, and similar operators. Document `| not` and heredoc workarounds in `user/CLAUDE.md` and `user/rules/json.md`, and remove the ineffective `SessionStart` hook that attempted to fix this via `setopt nobanghist`.

## Issue

Claude Code escapes `!` to `\!` at the JS level before the command reaches the shell ([#2941](https://github.com/anthropics/claude-code/issues/2941), [#10335](https://github.com/anthropics/claude-code/issues/10335)). The previous `setopt nobanghist` hook targeted zsh history expansion, which is not the actual cause.

## References

- Original Task: [Claude Code: jq != escaping in zsh](https://things.bendrucker.me/show?id=Sub3d99kQeaJ7P7cmBCRVF)
