### PR TITLE
fix(hooks): strip \! → ! in Bash commands

### DIFF
--- a/user/hooks/bang-escape/index.test.ts
+++ b/user/hooks/bang-escape/index.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { processInput } from "./index";
+
+function bashInput(command: string): PreToolUseHookInput {
+  return {
+    tool_name: "Bash",
+    tool_input: { command },
+  } as PreToolUseHookInput;
+}
+
+describe("processInput", () => {
+  it("replaces \\! with ! in jq expressions", () => {
+    const result = processInput(bashInput("jq 'select(.x \\!= null)' file.json"));
+    expect(result).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        updatedInput: { command: "jq 'select(.x != null)' file.json" },
+      },
+    });
+  });
+
+  it("replaces \\! with ! in awk expressions", () => {
+    const result = processInput(bashInput("awk '$1 \\!~ /pattern/' file.txt"));
+    expect(result).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        updatedInput: { command: "awk '$1 !~ /pattern/' file.txt" },
+      },
+    });
+  });
+
+  it("replaces multiple occurrences", () => {
+    const result = processInput(bashInput("jq 'select(.a \\!= null and .b \\!= null)'"));
+    expect(result).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        updatedInput: { command: "jq 'select(.a != null and .b != null)'" },
+      },
+    });
+  });
+
+  it("returns null when command has no escaped bangs", () => {
+    expect(processInput(bashInput("ls -la"))).toBeNull();
+    expect(processInput(bashInput("echo hello"))).toBeNull();
+  });
+
+  it("returns null when command contains unescaped bangs", () => {
+    expect(processInput(bashInput("echo 'hello!'"))).toBeNull();
+  });
+
+  it("returns null when command is missing", () => {
+    const input = { tool_name: "Bash", tool_input: {} } as PreToolUseHookInput;
+    expect(processInput(input)).toBeNull();
+  });
+
+  it("preserves other tool_input fields", () => {
+    const input = {
+      tool_name: "Bash",
+      tool_input: { command: "echo \\!done", timeout: 5000 },
+    } as PreToolUseHookInput;
+    const result = processInput(input);
+    expect(result).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        updatedInput: { command: "echo !done", timeout: 5000 },
+      },
+    });
+  });
+});

--- a/user/hooks/bang-escape/index.ts
+++ b/user/hooks/bang-escape/index.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env bun
+
+import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+
+type BashInput = { command: string };
+
+export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {
+  const toolInput = input.tool_input as Record<string, unknown>;
+  const { command } = toolInput as BashInput;
+  if (!command || !command.includes("\\!")) {
+    return null;
+  }
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      updatedInput: { ...toolInput, command: command.replaceAll("\\!", "!") },
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  let input: PreToolUseHookInput;
+  try {
+    input = await readStdinJson<PreToolUseHookInput>();
+  } catch (error) {
+    console.error(
+      `[bang-escape] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  const output = processInput(input);
+  if (output) {
+    writeStdoutJson(output);
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/user/settings.json
+++ b/user/settings.json
@@ -32,20 +32,14 @@
     "deny": []
   },
   "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "[ -n \"$CLAUDE_ENV_FILE\" ] && echo 'setopt nobanghist' >> \"$CLAUDE_ENV_FILE\""
-          }
-        ]
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "Bash",
         "hooks": [
+          {
+            "type": "command",
+            "command": "bun ~/.claude/hooks/bang-escape"
+          },
           {
             "type": "command",
             "command": "bun ~/.claude/hooks/worktree"


### PR DESCRIPTION
Claude Code's `shell-quote` library incorrectly escapes `!` to `\!` in non-interactive shells, breaking operators like jq `!=` and awk `!~`. The previous `SessionStart` hook (`setopt nobanghist`) was ineffective since the escaping happens in JS before the shell sees the command. This adds a `PreToolUse` hook that rewrites `\!` back to `!` in Bash commands before execution.

## Changes

- Add `user/hooks/bang-escape/` with a `PreToolUse:Bash` hook that strips `\!` to `!` via `updatedInput`
- Remove the ineffective `SessionStart` `nobanghist` hook from `user/settings.json`
- Register the new hook in the existing `PreToolUse` Bash matcher

## Testing

- 7 unit tests covering jq, awk, multiple occurrences, passthrough for clean commands, missing commands, and preservation of other `tool_input` fields

## References

- Original Task: [Claude Code: jq != escaping in zsh](https://things.bendrucker.me/show?id=Sub3d99kQeaJ7P7cmBCRVF)
- [shell-quote escaping bug #2941](https://github.com/anthropics/claude-code/issues/2941)
- [shell-quote escaping bug #10335](https://github.com/anthropics/claude-code/issues/10335)
