### PR TITLE
fix(sandbox): allow writes to plugin cache node_modules

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -27,7 +27,8 @@
       "Edit(~/src/go/pkg/mod/**)",
       "Edit(~/src/go/pkg/sumdb/**)",
       "Edit(~/.bun/**)",
-      "Read(~/.claude/plugins/**)"
+      "Read(~/.claude/plugins/**)",
+      "Edit(~/.claude/plugins/cache/**/node_modules/**)"
     ],
     "deny": []
   },


### PR DESCRIPTION
Bun auto-install creates `node_modules` inside plugin cache directories when scripts import packages like `acorn` or `cleye`. The sandbox was blocking `mkdir` with EPERM, causing bun to hang indefinitely at "Resolving dependencies" instead of failing fast.

Adds a scoped sandbox write permission for `node_modules` directories within the plugin cache, keeping plugin source files read-only.
