### PR TITLE
feat(gitlab): improve MR review draft note positioning

### DIFF
--- a/plugins/gitlab/skills/merge-request/discussions.md
+++ b/plugins/gitlab/skills/merge-request/discussions.md
@@ -55,23 +55,20 @@ bun ${CLAUDE_SKILL_ROOT}/scripts/discussions.ts summary <iid>
 
 ### Create
 
-Write body to a file or pipe via stdin:
+Always use `--body-file` for comment bodies. Piping through echo breaks backtick-heavy markdown due to shell expansion.
 
 ```bash
 # General discussion (no position)
-echo "Looks good overall" | bun ${CLAUDE_SKILL_ROOT}/scripts/discussions.ts create <iid>
+bun ${CLAUDE_SKILL_ROOT}/scripts/discussions.ts create <iid> --body-file tmp/note.md
 
-# Inline comment on a new line
+# Inline comment on a new line (validated against diff hunks)
 bun ${CLAUDE_SKILL_ROOT}/scripts/discussions.ts create <iid> --file src/app.ts --line 42 --body-file tmp/note.md
 
 # Comment on a deleted line
 bun ${CLAUDE_SKILL_ROOT}/scripts/discussions.ts create <iid> --file src/app.ts --old-line 10 --body-file tmp/note.md
-
-# Multi-line comment (range)
-bun ${CLAUDE_SKILL_ROOT}/scripts/discussions.ts create <iid> --file src/app.ts --line-start 10 --line-end 15 --body-file tmp/note.md
 ```
 
-Diff refs are fetched automatically — no manual SHA management needed.
+Diff refs are fetched automatically. Positioned comments are validated against diff hunks before posting — if a line is not in the diff, the command exits with valid line ranges.
 
 ### Suggestions
 
@@ -93,12 +90,10 @@ third line
 ```
 ````
 
-Combine with the `create` command:
+Combine with the `create` command by writing the suggestion to a file first:
 
 ```bash
-echo '```suggestion:-0+0
-new code here
-```' | bun ${CLAUDE_SKILL_ROOT}/scripts/discussions.ts create <iid> --file src/app.ts --line 42
+bun ${CLAUDE_SKILL_ROOT}/scripts/discussions.ts create <iid> --file src/app.ts --line 42 --body-file tmp/suggestion.md
 ```
 
 ## Pitfalls

--- a/plugins/gitlab/skills/merge-request/review.md
+++ b/plugins/gitlab/skills/merge-request/review.md
@@ -8,20 +8,17 @@ Submit review feedback as draft notes that accumulate before publishing. Comment
 
 ### Create
 
-Write body to a file, then pipe or pass via `--body-file`:
+Always use `--body-file` for comment bodies. Piping through echo breaks backtick-heavy markdown due to shell expansion.
 
 ```bash
 # General comment
-echo "Looks good overall" | bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts create <iid>
+bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts create <iid> --body-file tmp/note.md
 
-# Inline comment on a new line
+# Inline comment on a new line (validated against diff hunks)
 bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts create <iid> --file src/app.go --line 42 --body-file tmp/note.md
 
 # Comment on a deleted line
 bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts create <iid> --file src/app.go --old-line 10 --body-file tmp/note.md
-
-# Multi-line comment
-bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts create <iid> --file src/app.go --line-start 10 --line-end 15 --body-file tmp/note.md
 
 # Reply to existing discussion
 bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts create <iid> --reply-to <discussion-id> --body-file tmp/note.md
@@ -29,6 +26,31 @@ bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts create <iid> --reply-to <discussi
 # Reply and resolve
 bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts create <iid> --reply-to <discussion-id> --resolve --body-file tmp/note.md
 ```
+
+Positioned comments are validated against the MR diff before posting. If a line is not within a diff hunk, the command exits with an error showing valid line ranges.
+
+### Batch Review
+
+Create multiple draft notes from a JSON file:
+
+```bash
+bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts review <iid> --input tmp/review.json
+
+# Create, publish, and approve
+bun ${CLAUDE_SKILL_ROOT}/scripts/draft-note.ts review <iid> --input tmp/review.json --submit --approve
+```
+
+Input JSON format:
+
+```json
+[
+  { "file": "src/app.ts", "line": 42, "body": "Consider extracting this." },
+  { "file": "src/db.ts", "oldLine": 10, "body": "This was handling errors." },
+  { "body": "Overall the approach looks good." }
+]
+```
+
+Each positioned entry is validated against diff hunks. Failures are reported per-entry without aborting the batch.
 
 ### List
 

--- a/plugins/gitlab/skills/merge-request/scripts/diff.test.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/diff.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "bun:test";
+import { buildPosition, isLineInDiff, parseDiffHunks, validateLineInDiff } from "./diff";
+
+describe("parseDiffHunks", () => {
+  it("parses a single hunk", () => {
+    const diff = "@@ -10,5 +12,8 @@ function foo() {";
+    expect(parseDiffHunks(diff)).toEqual([
+      { oldStart: 10, oldCount: 5, newStart: 12, newCount: 8 },
+    ]);
+  });
+
+  it("parses multiple hunks", () => {
+    const diff = [
+      "@@ -1,3 +1,4 @@",
+      " line1",
+      "+added",
+      " line2",
+      "@@ -20,5 +21,6 @@ context",
+      " line20",
+    ].join("\n");
+    expect(parseDiffHunks(diff)).toEqual([
+      { oldStart: 1, oldCount: 3, newStart: 1, newCount: 4 },
+      { oldStart: 20, oldCount: 5, newStart: 21, newCount: 6 },
+    ]);
+  });
+
+  it("handles single-line hunks (no count)", () => {
+    const diff = "@@ -5 +5 @@";
+    expect(parseDiffHunks(diff)).toEqual([{ oldStart: 5, oldCount: 1, newStart: 5, newCount: 1 }]);
+  });
+
+  it("handles deletion-only hunks", () => {
+    const diff = "@@ -10,3 +9,0 @@";
+    expect(parseDiffHunks(diff)).toEqual([{ oldStart: 10, oldCount: 3, newStart: 9, newCount: 0 }]);
+  });
+
+  it("returns empty for binary files", () => {
+    expect(parseDiffHunks("Binary files differ")).toEqual([]);
+  });
+});
+
+describe("isLineInDiff", () => {
+  const hunks = [
+    { oldStart: 10, oldCount: 5, newStart: 12, newCount: 8 },
+    { oldStart: 30, oldCount: 3, newStart: 35, newCount: 4 },
+  ];
+
+  it("returns true for line at hunk start", () => {
+    expect(isLineInDiff(hunks, 12, "new")).toBe(true);
+  });
+
+  it("returns true for line at hunk end", () => {
+    expect(isLineInDiff(hunks, 19, "new")).toBe(true);
+  });
+
+  it("returns true for line in middle of hunk", () => {
+    expect(isLineInDiff(hunks, 15, "new")).toBe(true);
+  });
+
+  it("returns false for line outside hunks", () => {
+    expect(isLineInDiff(hunks, 25, "new")).toBe(false);
+  });
+
+  it("returns false for line between hunks", () => {
+    expect(isLineInDiff(hunks, 22, "new")).toBe(false);
+  });
+
+  it("checks old side correctly", () => {
+    expect(isLineInDiff(hunks, 10, "old")).toBe(true);
+    expect(isLineInDiff(hunks, 14, "old")).toBe(true);
+    expect(isLineInDiff(hunks, 15, "old")).toBe(false);
+  });
+
+  it("works with second hunk", () => {
+    expect(isLineInDiff(hunks, 35, "new")).toBe(true);
+    expect(isLineInDiff(hunks, 38, "new")).toBe(true);
+    expect(isLineInDiff(hunks, 39, "new")).toBe(false);
+  });
+});
+
+describe("validateLineInDiff", () => {
+  const diffs = [
+    {
+      old_path: "src/app.ts",
+      new_path: "src/app.ts",
+      diff: "@@ -10,5 +12,8 @@\n context\n+added\n",
+    },
+  ];
+
+  it("passes for valid new line", () => {
+    expect(() => validateLineInDiff(diffs, "src/app.ts", { line: 15 })).not.toThrow();
+  });
+
+  it("passes for valid old line", () => {
+    expect(() => validateLineInDiff(diffs, "src/app.ts", { oldLine: 12 })).not.toThrow();
+  });
+
+  it("throws for line outside diff", () => {
+    expect(() => validateLineInDiff(diffs, "src/app.ts", { line: 50 })).toThrow(
+      "not within a diff hunk",
+    );
+  });
+
+  it("throws for unknown file", () => {
+    expect(() => validateLineInDiff(diffs, "unknown.ts", { line: 1 })).toThrow(
+      "not found in MR diff",
+    );
+  });
+});
+
+describe("buildPosition", () => {
+  const refs = { base_sha: "aaa", head_sha: "bbb", start_sha: "ccc" };
+
+  it("builds position with new line", () => {
+    const pos = buildPosition(refs, "src/app.ts", { line: 42 });
+    expect(pos).toEqual({
+      base_sha: "aaa",
+      head_sha: "bbb",
+      start_sha: "ccc",
+      old_path: "src/app.ts",
+      new_path: "src/app.ts",
+      position_type: "text",
+      new_line: 42,
+    });
+  });
+
+  it("builds position with old line", () => {
+    const pos = buildPosition(refs, "src/app.ts", { oldLine: 10 });
+    expect(pos).toEqual({
+      base_sha: "aaa",
+      head_sha: "bbb",
+      start_sha: "ccc",
+      old_path: "src/app.ts",
+      new_path: "src/app.ts",
+      position_type: "text",
+      old_line: 10,
+    });
+  });
+
+  it("builds position without line (general file comment)", () => {
+    const pos = buildPosition(refs, "src/app.ts", {});
+    expect(pos).toEqual({
+      base_sha: "aaa",
+      head_sha: "bbb",
+      start_sha: "ccc",
+      old_path: "src/app.ts",
+      new_path: "src/app.ts",
+      position_type: "text",
+    });
+  });
+});

--- a/plugins/gitlab/skills/merge-request/scripts/diff.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/diff.ts
@@ -1,0 +1,132 @@
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { $ } from "bun";
+
+export type DiffRefs = { base_sha: string; head_sha: string; start_sha: string };
+
+export async function getDiffRefs(iid: number | string): Promise<DiffRefs> {
+  const result = await $`glab api projects/:id/merge_requests/${iid} | jq '.diff_refs'`.json();
+  return result as DiffRefs;
+}
+
+export type Hunk = {
+  oldStart: number;
+  oldCount: number;
+  newStart: number;
+  newCount: number;
+};
+
+export function parseDiffHunks(diff: string): Hunk[] {
+  const hunks: Hunk[] = [];
+  const regex = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/gm;
+  for (const match of diff.matchAll(regex)) {
+    hunks.push({
+      oldStart: Number(match[1]),
+      oldCount: match[2] !== undefined ? Number(match[2]) : 1,
+      newStart: Number(match[3]),
+      newCount: match[4] !== undefined ? Number(match[4]) : 1,
+    });
+  }
+  return hunks;
+}
+
+export function isLineInDiff(hunks: Hunk[], line: number, side: "new" | "old"): boolean {
+  for (const hunk of hunks) {
+    const start = side === "new" ? hunk.newStart : hunk.oldStart;
+    const count = side === "new" ? hunk.newCount : hunk.oldCount;
+    if (line >= start && line < start + count) return true;
+  }
+  return false;
+}
+
+type MrDiff = {
+  old_path: string;
+  new_path: string;
+  diff: string;
+};
+
+export async function fetchMrDiffs(iid: number | string): Promise<MrDiff[]> {
+  const result = await $`glab api projects/:id/merge_requests/${iid}/diffs`.json();
+  return result as MrDiff[];
+}
+
+export function validateLineInDiff(
+  diffs: MrDiff[],
+  file: string,
+  opts: { line?: number | undefined; oldLine?: number | undefined },
+): void {
+  const fileDiff = diffs.find((d) => d.new_path === file || d.old_path === file);
+  if (!fileDiff) {
+    throw new Error(`File ${file} not found in MR diff`);
+  }
+
+  const hunks = parseDiffHunks(fileDiff.diff);
+
+  if (opts.oldLine !== undefined) {
+    if (!isLineInDiff(hunks, opts.oldLine, "old")) {
+      const ranges = hunks.map((h) => `${h.oldStart}-${h.oldStart + h.oldCount - 1}`).join(", ");
+      throw new Error(
+        `Old line ${opts.oldLine} of ${file} is not within a diff hunk. Valid old-line ranges: ${ranges}`,
+      );
+    }
+  } else if (opts.line !== undefined) {
+    if (!isLineInDiff(hunks, opts.line, "new")) {
+      const ranges = hunks.map((h) => `${h.newStart}-${h.newStart + h.newCount - 1}`).join(", ");
+      throw new Error(
+        `Line ${opts.line} of ${file} is not within a diff hunk. Valid new-line ranges: ${ranges}`,
+      );
+    }
+  }
+}
+
+export type Position = {
+  base_sha: string;
+  head_sha: string;
+  start_sha: string;
+  old_path: string;
+  new_path: string;
+  position_type: "text";
+  old_line?: number;
+  new_line?: number;
+};
+
+export function buildPosition(
+  refs: DiffRefs,
+  path: string,
+  opts: { line?: number | undefined; oldLine?: number | undefined },
+): Position {
+  const position: Position = {
+    ...refs,
+    old_path: path,
+    new_path: path,
+    position_type: "text",
+  };
+
+  if (opts.oldLine !== undefined) {
+    position.old_line = opts.oldLine;
+  } else if (opts.line !== undefined) {
+    position.new_line = opts.line;
+  }
+
+  return position;
+}
+
+export async function readBody(file: string | undefined): Promise<string> {
+  if (file === "-" || !file) {
+    return await Bun.stdin.text();
+  }
+  return await Bun.file(file).text();
+}
+
+export async function glabApiPost(path: string, payload: Record<string, unknown>): Promise<void> {
+  const tmpFile = join(tmpdir(), `glab-api-${randomUUID()}.json`);
+  await Bun.write(tmpFile, JSON.stringify(payload));
+  try {
+    const result =
+      await $`glab api ${path} -X POST -H "Content-Type: application/json" --input ${tmpFile}`.text();
+    console.log(result);
+  } finally {
+    await Bun.file(tmpFile).unlink();
+  }
+}

--- a/plugins/gitlab/skills/merge-request/scripts/discussions.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/discussions.ts
@@ -1,10 +1,16 @@
 #!/usr/bin/env bun
 
-import { randomUUID } from "node:crypto";
-import { tmpdir } from "node:os";
 import { $ } from "bun";
 import { cli, command } from "cleye";
 import { table } from "table";
+import {
+  buildPosition,
+  fetchMrDiffs,
+  getDiffRefs,
+  glabApiPost,
+  readBody,
+  validateLineInDiff,
+} from "./diff";
 
 type LineRange = {
   start: { type: "new" | "old"; new_line?: number; old_line?: number };
@@ -117,78 +123,6 @@ function buildFilterOptions(flags: {
   return opts;
 }
 
-type DiffRefs = { base_sha: string; head_sha: string; start_sha: string };
-
-async function getDiffRefs(iid: string): Promise<DiffRefs> {
-  const result = await $`glab api projects/:id/merge_requests/${iid} | jq '.diff_refs'`.json();
-  return result as DiffRefs;
-}
-
-type CreatePosition = {
-  base_sha: string;
-  head_sha: string;
-  start_sha: string;
-  old_path: string;
-  new_path: string;
-  position_type: "text";
-  old_line?: number;
-  new_line?: number;
-  line_range?: {
-    start: { new_line: number; type: "new" };
-    end: { new_line: number; type: "new" };
-  };
-};
-
-function buildPosition(
-  refs: DiffRefs,
-  path: string,
-  opts: {
-    line?: number | undefined;
-    oldLine?: number | undefined;
-    lineStart?: number | undefined;
-    lineEnd?: number | undefined;
-  },
-): CreatePosition {
-  const position: CreatePosition = {
-    ...refs,
-    old_path: path,
-    new_path: path,
-    position_type: "text",
-  };
-
-  if (opts.lineStart !== undefined && opts.lineEnd !== undefined) {
-    position.line_range = {
-      start: { new_line: opts.lineStart, type: "new" },
-      end: { new_line: opts.lineEnd, type: "new" },
-    };
-  } else if (opts.oldLine !== undefined) {
-    position.old_line = opts.oldLine;
-  } else if (opts.line !== undefined) {
-    position.new_line = opts.line;
-  }
-
-  return position;
-}
-
-async function readBody(file: string | undefined): Promise<string> {
-  if (file === "-" || !file) {
-    return await Bun.stdin.text();
-  }
-  return await Bun.file(file).text();
-}
-
-async function glabApiPost(path: string, payload: Record<string, unknown>): Promise<void> {
-  const tmpFile = `${tmpdir()}/discussions-${randomUUID()}.json`;
-  await Bun.write(tmpFile, JSON.stringify(payload));
-  try {
-    const result =
-      await $`glab api ${path} -X POST -H "Content-Type: application/json" --input ${tmpFile}`.text();
-    console.log(result);
-  } finally {
-    await Bun.file(tmpFile).unlink();
-  }
-}
-
 const createCmd = command(
   {
     name: "create",
@@ -199,14 +133,6 @@ const createCmd = command(
       oldLine: {
         type: Number,
         description: "Old line number (deleted lines)",
-      },
-      lineStart: {
-        type: Number,
-        description: "Multi-line range start",
-      },
-      lineEnd: {
-        type: Number,
-        description: "Multi-line range end",
       },
       bodyFile: {
         type: String,
@@ -221,12 +147,14 @@ const createCmd = command(
     const payload: Record<string, unknown> = { body };
 
     if (parsed.flags.file) {
-      const refs = await getDiffRefs(iid);
+      const [refs, diffs] = await Promise.all([getDiffRefs(iid), fetchMrDiffs(iid)]);
+      validateLineInDiff(diffs, parsed.flags.file, {
+        line: parsed.flags.line,
+        oldLine: parsed.flags.oldLine,
+      });
       payload.position = buildPosition(refs, parsed.flags.file, {
         line: parsed.flags.line,
         oldLine: parsed.flags.oldLine,
-        lineStart: parsed.flags.lineStart,
-        lineEnd: parsed.flags.lineEnd,
       });
     }
 

--- a/plugins/gitlab/skills/merge-request/scripts/draft-note.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/draft-note.ts
@@ -1,85 +1,18 @@
 #!/usr/bin/env bun
 
-import { randomUUID } from "node:crypto";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { $ } from "bun";
 import { cli, command } from "cleye";
+import {
+  buildPosition,
+  fetchMrDiffs,
+  getDiffRefs,
+  glabApiPost,
+  readBody,
+  validateLineInDiff,
+} from "./diff";
 
 function apiPath(mr: number): string {
   return `projects/:id/merge_requests/${mr}/draft_notes`;
-}
-
-async function readBody(file: string | undefined): Promise<string> {
-  if (file === "-" || !file) {
-    return await Bun.stdin.text();
-  }
-  return await Bun.file(file).text();
-}
-
-type DiffRefs = { base_sha: string; head_sha: string; start_sha: string };
-
-async function getDiffRefs(mr: number): Promise<DiffRefs> {
-  const result = await $`glab api projects/:id/merge_requests/${mr} | jq '.diff_refs'`.json();
-  return result as DiffRefs;
-}
-
-type Position = {
-  base_sha: string;
-  head_sha: string;
-  start_sha: string;
-  old_path: string;
-  new_path: string;
-  position_type: "text";
-  old_line?: number;
-  new_line?: number;
-  line_range?: {
-    start: { new_line: number; type: "new" };
-    end: { new_line: number; type: "new" };
-  };
-};
-
-function buildPosition(
-  refs: { base_sha: string; head_sha: string; start_sha: string },
-  path: string,
-  opts: {
-    line?: number | undefined;
-    oldLine?: number | undefined;
-    lineStart?: number | undefined;
-    lineEnd?: number | undefined;
-  },
-): Position {
-  const position: Position = {
-    ...refs,
-    old_path: path,
-    new_path: path,
-    position_type: "text",
-  };
-
-  if (opts.lineStart !== undefined && opts.lineEnd !== undefined) {
-    position.line_range = {
-      start: { new_line: opts.lineStart, type: "new" },
-      end: { new_line: opts.lineEnd, type: "new" },
-    };
-  } else if (opts.oldLine !== undefined) {
-    position.old_line = opts.oldLine;
-  } else if (opts.line !== undefined) {
-    position.new_line = opts.line;
-  }
-
-  return position;
-}
-
-async function glabApiPost(path: string, payload: Record<string, unknown>): Promise<void> {
-  const tmpFile = join(tmpdir(), `draft-note-${randomUUID()}.json`);
-  await Bun.write(tmpFile, JSON.stringify(payload));
-  try {
-    const result =
-      await $`glab api ${path} -X POST -H "Content-Type: application/json" --input ${tmpFile}`.text();
-    console.log(result);
-  } finally {
-    await Bun.file(tmpFile).unlink();
-  }
 }
 
 const createCmd = command(
@@ -92,14 +25,6 @@ const createCmd = command(
       oldLine: {
         type: Number,
         description: "Old line number (deleted lines)",
-      },
-      lineStart: {
-        type: Number,
-        description: "Multi-line range start",
-      },
-      lineEnd: {
-        type: Number,
-        description: "Multi-line range end",
       },
       replyTo: {
         type: String,
@@ -128,12 +53,14 @@ const createCmd = command(
         payload.resolve_discussion = true;
       }
     } else if (parsed.flags.file) {
-      const refs = await getDiffRefs(mr);
+      const [refs, diffs] = await Promise.all([getDiffRefs(mr), fetchMrDiffs(mr)]);
+      validateLineInDiff(diffs, parsed.flags.file, {
+        line: parsed.flags.line,
+        oldLine: parsed.flags.oldLine,
+      });
       payload.position = buildPosition(refs, parsed.flags.file, {
         line: parsed.flags.line,
         oldLine: parsed.flags.oldLine,
-        lineStart: parsed.flags.lineStart,
-        lineEnd: parsed.flags.lineEnd,
       });
     }
 
@@ -236,10 +163,96 @@ const listCmd = command(
   },
 );
 
+type ReviewEntry = {
+  file?: string;
+  line?: number;
+  oldLine?: number;
+  body: string;
+};
+
+const reviewCmd = command(
+  {
+    name: "review",
+    parameters: ["<mr>"],
+    flags: {
+      input: {
+        type: String,
+        description: "JSON file with review entries",
+      },
+      submit: {
+        type: Boolean,
+        default: false,
+        description: "Publish draft notes after creating",
+      },
+      approve: {
+        type: Boolean,
+        default: false,
+        description: "Approve MR after publishing",
+      },
+    },
+  },
+  async (parsed) => {
+    const mr = Number(parsed._.mr);
+
+    if (!parsed.flags.input) {
+      console.error("--input is required");
+      process.exit(1);
+    }
+
+    const entries: ReviewEntry[] = JSON.parse(await Bun.file(parsed.flags.input).text());
+    const hasPositioned = entries.some((e) => e.file);
+
+    const [refs, diffs] = hasPositioned
+      ? await Promise.all([getDiffRefs(mr), fetchMrDiffs(mr)])
+      : [null, null];
+
+    let created = 0;
+    let failed = 0;
+
+    for (const entry of entries) {
+      try {
+        const payload: Record<string, unknown> = { note: entry.body };
+
+        if (entry.file && refs && diffs) {
+          validateLineInDiff(diffs, entry.file, {
+            line: entry.line,
+            oldLine: entry.oldLine,
+          });
+          payload.position = buildPosition(refs, entry.file, {
+            line: entry.line,
+            oldLine: entry.oldLine,
+          });
+        }
+
+        await glabApiPost(apiPath(mr), payload);
+        created++;
+      } catch (err) {
+        console.error(
+          `Failed: ${entry.file ?? "general"}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        failed++;
+      }
+    }
+
+    console.error(`Created ${created} draft notes (${failed} failed)`);
+
+    if (parsed.flags.submit) {
+      await $`glab api ${apiPath(mr)}/bulk_publish -X POST`.text();
+      console.error("Published draft notes");
+
+      if (parsed.flags.approve) {
+        const approveRefs = refs ?? (await getDiffRefs(mr));
+        await $`glab api projects/:id/merge_requests/${mr}/approve -X POST -f sha=${approveRefs.head_sha}`.text();
+        console.error("Approved MR");
+      }
+    }
+  },
+);
+
 cli(
   {
     name: "draft-note",
-    commands: [createCmd, publishCmd, submitCmd, listCmd],
+    commands: [createCmd, publishCmd, submitCmd, listCmd, reviewCmd],
   },
   (parsed) => {
     parsed.showHelp();


### PR DESCRIPTION
Extracts a shared diff module from duplicated code in `draft-note.ts` and `discussions.ts`, adds diff-hunk validation for positioned comments, drops `line_range` support (which silently fails in GitLab UI when spanning non-diff lines), and adds a batch `review` subcommand for multi-comment reviews.

## Changes

- **Shared `diff.ts` module**: `getDiffRefs`, `fetchMrDiffs`, `parseDiffHunks`, `isLineInDiff`, `validateLineInDiff`, `buildPosition`, `readBody`, `glabApiPost` — extracted from both scripts
- **Diff-hunk validation**: Positioned comments are validated against MR diffs before posting. Invalid lines produce a clear error with valid ranges
- **Drop `line_range`**: Removed `--line-start`/`--line-end` flags and `line_range` field. Single `--line` anchors with `suggestion:-N+M` offsets are more reliable
- **Batch review command**: `draft-note.ts review <iid> --input review.json [--submit] [--approve]` creates multiple draft notes from a JSON file with per-entry validation and failure reporting
- **Docs**: All examples use `--body-file` instead of echo/pipe (backtick-heavy markdown breaks when piped through the shell)

## Testing

- 19 new tests in `diff.test.ts` covering `parseDiffHunks`, `isLineInDiff`, `validateLineInDiff`, and `buildPosition`
- All 65 gitlab plugin tests pass

## References

Original Task: [Improve GitLab MR review skill: draft note positioning](https://things.bendrucker.me/show?id=3fQGQG7c9cHfbRakYTLacL)
