### PR TITLE
pull-request: improve changelog readability guidance

### DIFF
--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -26,7 +26,9 @@ allowed-tools: Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/*:*), Bash(bun ${CLAUDE_PL
 
 ## Body
 
-- Start with 1-3 sentences summarizing the change (no preceding header)
+- Start with 1-3 sentences summarizing the change (no preceding header). Use active voice and direct language
+  - Good: "Adds retry logic to the HTTP client and limits maximum attempts to 3."
+  - Bad: "Retry logic is added to the HTTP client and maximum attempts are limited to 3."
 - **Wrap all code identifiers with backticks**: function names, class names, file paths, endpoints, status codes, etc.
 - Use `##` sections for larger changes. See [`sections.md`](sections.md) for detailed guidance on:
   - `## Issue` - Root cause analysis and issue linking

--- a/plugins/pull-request/skills/create/sections.md
+++ b/plugins/pull-request/skills/create/sections.md
@@ -11,17 +11,25 @@ Use for bug fixes, which should include a related issue.
 
 ## Changes
 
-High-level bulleted description of changes made.
+High-level bulleted description of changes made, written for human reviewers.
 
+- Summarize user impact, don't narrate code
 - Emphasize API and interface changes first:
   - Adds `POST /users` endpoint to create users
   - Updates `User.create` to accept `email` parameter
   - Handles `404` errors in `GET /users/{id}`
-- Do not list modified files by path or line number
-- Summarize user impact, don't narrate code
 - Include refactoring as separate bullets:
-  - Refactors `UserService` to use dependency injection
   - Extracts repeated logic into `UserRepository`
+  - Refactors `UserService` to use dependency injection
+
+### Referencing code
+
+- Use the shortest unambiguous name: module name, filename, or component, not full paths
+  - `UserService`, not `src/services/UserService.ts`
+  - `discussions.ts`, not `plugins/gitlab/skills/merge-request/scripts/discussions.ts`
+  - The `diff` module, not `plugins/gitlab/scripts/diff.ts`
+- Never structure bullets as `**path**: description`. This reads like a file manifest, not a changelog
+- Reference identifiers only when they clarify the change. "Add `email` parameter to `User.create`" is useful. "Update `handleRequest` in `server.ts` to call `validateInput`" is noise
 
 ## Testing
 


### PR DESCRIPTION
Improves the `pull-request:create` skill to produce more natural, human-readable changelogs instead of verbose file manifests.

## Changes

- Add "Referencing code" guidance to `sections.md` that directs Claude to use short, unambiguous names (module, filename, component) instead of full paths, and to avoid the `**path**: description` bullet pattern
- Add active voice guidance with good/bad examples to the summary sentence rules in `SKILL.md`
- Reorder existing bullets to lead with "summarize user impact" and remove the redundant "do not list modified files" rule (now covered by the new subsection)
