### PR TITLE
enable typescript and gopls LSP plugins

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -91,7 +91,9 @@
     "git-town@bendrucker": true,
     "webfetch-auth@bendrucker": true,
     "mermaid@bendrucker": true,
-    "tech-spec@bendrucker": true
+    "tech-spec@bendrucker": true,
+    "typescript-lsp@claude-plugins-official": true,
+    "gopls-lsp@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "bendrucker": {


### PR DESCRIPTION
Enables `typescript-lsp` and `gopls-lsp` from `claude-plugins-official` for TypeScript and Go LSP support in Claude Code.
