### PR TITLE
fix(review): address dashboard env, context, sandbox, and peer guardrails

### DIFF
--- a/plugins/review/skills/dashboard/SKILL.md
+++ b/plugins/review/skills/dashboard/SKILL.md
@@ -57,10 +57,10 @@ Ask the user where the repo is cloned locally. If it's not cloned, clone it firs
 #### Spawn
 
 ```bash
-bun ${CLAUDE_SKILL_DIR}/scripts/spawn.ts <pr-url> --repo-path <local-path>
+bun ${CLAUDE_SKILL_DIR}/scripts/spawn.ts <pr-url> --repo-path <local-path> --data-dir ${CLAUDE_PLUGIN_DATA} --context "<PR metadata: title, author, description summary>"
 ```
 
-`spawn.ts` handles `--worktree` for branch isolation, tmux layout computation, and state tracking. Panes cycle in groups of 3: one horizontal split (new column at 70% width for the first, equal width after), then two vertical splits stacking within the column.
+`spawn.ts` handles `--worktree` for branch isolation, tmux layout computation, and state tracking. Pass `--context` with PR metadata (title, author, description summary) so the spawned review session has immediate context. Panes cycle in groups of 3: one horizontal split (new column at 70% width for the first, equal width after), then two vertical splits stacking within the column.
 
 Before spawning the first pane, resize the orchestrator to a sidebar:
 
@@ -73,7 +73,7 @@ tmux resize-pane -t $TMUX_PANE -x 30%
 #### Summary
 
 ```bash
-bun ${CLAUDE_SKILL_DIR}/scripts/state.ts list
+bun ${CLAUDE_SKILL_DIR}/scripts/state.ts list --data-dir ${CLAUDE_PLUGIN_DATA}
 ```
 
 #### Sync Completed Reviews
@@ -81,7 +81,7 @@ bun ${CLAUDE_SKILL_DIR}/scripts/state.ts list
 Detect exited panes and mark them completed:
 
 ```bash
-bun ${CLAUDE_SKILL_DIR}/scripts/state.ts sync
+bun ${CLAUDE_SKILL_DIR}/scripts/state.ts sync --data-dir ${CLAUDE_PLUGIN_DATA}
 ```
 
 #### Quick Glance

--- a/plugins/review/skills/dashboard/scripts/spawn.ts
+++ b/plugins/review/skills/dashboard/scripts/spawn.ts
@@ -20,7 +20,7 @@ const argv = cli({
     },
     context: {
       type: String,
-      description: "Additional context to append as a system prompt to the spawned session",
+      description: "Additional context to pass as the initial prompt to the spawned session",
     },
   },
 });
@@ -42,11 +42,11 @@ const splitArgs = layoutArgs(activeReviews.length, activeReviews.at(-1)?.paneId)
 
 const claudeArgs = ["claude", "--worktree", "--session-id", sessionId, "--name", paneName];
 
-if (argv.flags.context) {
-  claudeArgs.push("--append-system-prompt", argv.flags.context);
-}
+const prompt = argv.flags.context
+  ? `${argv.flags.context}\n\n/review:peer ${url}`
+  : `/review:peer ${url}`;
 
-claudeArgs.push(`/review:peer ${url}`);
+claudeArgs.push(prompt);
 
 const claudeCmd = claudeArgs.map((arg) => Bun.$.escape(arg)).join(" ");
 

--- a/plugins/review/skills/dashboard/scripts/spawn.ts
+++ b/plugins/review/skills/dashboard/scripts/spawn.ts
@@ -40,14 +40,7 @@ const state = await readState(dataDir);
 const activeReviews = state.reviews.filter((r) => r.status === "active");
 const splitArgs = layoutArgs(activeReviews.length, activeReviews.at(-1)?.paneId);
 
-const claudeArgs = [
-  "claude",
-  "--worktree",
-  "--session-id",
-  sessionId,
-  "--name",
-  paneName,
-];
+const claudeArgs = ["claude", "--worktree", "--session-id", sessionId, "--name", paneName];
 
 if (argv.flags.context) {
   claudeArgs.push("--append-system-prompt", argv.flags.context);

--- a/plugins/review/skills/dashboard/scripts/spawn.ts
+++ b/plugins/review/skills/dashboard/scripts/spawn.ts
@@ -14,11 +14,20 @@ const argv = cli({
       alias: "C",
       description: "Local path to the repository",
     },
+    dataDir: {
+      type: String,
+      description: "Data directory for persistent state (defaults to CLAUDE_PLUGIN_DATA)",
+    },
+    context: {
+      type: String,
+      description: "Additional context to append as a system prompt to the spawned session",
+    },
   },
 });
 
 const url = argv._.url;
 const repoPath = argv.flags.repoPath;
+const dataDir = argv.flags.dataDir;
 
 if (!repoPath) {
   console.error("--repo-path (-C) is required: local path to the repository");
@@ -27,21 +36,26 @@ if (!repoPath) {
 
 const sessionId = crypto.randomUUID();
 const paneName = derivePaneName(url);
-const state = await readState();
+const state = await readState(dataDir);
 const activeReviews = state.reviews.filter((r) => r.status === "active");
 const splitArgs = layoutArgs(activeReviews.length, activeReviews.at(-1)?.paneId);
 
-const claudeCmd = [
+const claudeArgs = [
   "claude",
   "--worktree",
   "--session-id",
   sessionId,
   "--name",
   paneName,
-  `/review:peer ${url}`,
-]
-  .map((arg) => Bun.$.escape(arg))
-  .join(" ");
+];
+
+if (argv.flags.context) {
+  claudeArgs.push("--append-system-prompt", argv.flags.context);
+}
+
+claudeArgs.push(`/review:peer ${url}`);
+
+const claudeCmd = claudeArgs.map((arg) => Bun.$.escape(arg)).join(" ");
 
 const result = Bun.spawnSync(
   ["tmux", "split-window", ...splitArgs, "-c", repoPath, "-P", "-F", "#{pane_id}", claudeCmd],
@@ -59,7 +73,7 @@ const paneId = result.stdout.toString().trim();
 const review = createReview({ url, title: null, sessionId, paneId, repoPath });
 try {
   addReview(state, review);
-  await writeState(state);
+  await writeState(state, dataDir);
 } catch (error) {
   Bun.spawnSync(["tmux", "kill-pane", "-t", paneId]);
   throw error;

--- a/plugins/review/skills/dashboard/scripts/state.ts
+++ b/plugins/review/skills/dashboard/scripts/state.ts
@@ -22,20 +22,26 @@ const argv = cli({
   flags: {
     url: { type: String, description: "PR/MR URL" },
     json: { type: Boolean, description: "Output as JSON", default: false },
+    dataDir: {
+      type: String,
+      description: "Data directory for persistent state (defaults to CLAUDE_PLUGIN_DATA)",
+    },
   },
 });
+
+const dataDir = argv.flags.dataDir;
 
 const command = argv._.command;
 
 switch (command) {
   case "init": {
-    await writeState({ reviews: [] });
+    await writeState({ reviews: [] }, dataDir);
     console.log("State initialized");
     break;
   }
 
   case "list": {
-    const state = await readState();
+    const state = await readState(dataDir);
     if (argv.flags.json) {
       console.log(JSON.stringify(state.reviews, null, 2));
     } else if (state.reviews.length === 0) {
@@ -59,15 +65,15 @@ switch (command) {
       console.error("--url is required for remove");
       process.exit(1);
     }
-    const state = await readState();
+    const state = await readState(dataDir);
     const removed = removeReview(state, url);
-    await writeState(state);
+    await writeState(state, dataDir);
     console.log(`Removed ${removed} review(s)`);
     break;
   }
 
   case "sync": {
-    const state = await readState();
+    const state = await readState(dataDir);
     const livePanes = getLivePaneIds();
     let updated = 0;
     for (const review of state.reviews) {
@@ -76,7 +82,7 @@ switch (command) {
         updated++;
       }
     }
-    await writeState(state);
+    await writeState(state, dataDir);
     console.log(`Synced: ${updated} review(s) marked completed`);
     break;
   }

--- a/plugins/review/skills/dashboard/scripts/store.test.ts
+++ b/plugins/review/skills/dashboard/scripts/store.test.ts
@@ -31,25 +31,18 @@ function makeReview(overrides: Partial<Review> = {}): Review {
 
 describe("store", () => {
   let tmpDir: string;
-  const originalEnv = process.env.CLAUDE_PLUGIN_DATA;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "store-test-"));
-    process.env.CLAUDE_PLUGIN_DATA = tmpDir;
   });
 
   afterEach(async () => {
     await rm(tmpDir, { recursive: true });
-    if (originalEnv === undefined) {
-      delete process.env.CLAUDE_PLUGIN_DATA;
-    } else {
-      process.env.CLAUDE_PLUGIN_DATA = originalEnv;
-    }
   });
 
   describe("readState", () => {
     test("returns empty reviews when no file exists", async () => {
-      expect(await readState()).toEqual({ reviews: [] });
+      expect(await readState(tmpDir)).toEqual({ reviews: [] });
     });
 
     test("reads and parses valid state file", async () => {
@@ -58,7 +51,7 @@ describe("store", () => {
       mkdirSync(dir, { recursive: true });
       await Bun.write(join(dir, "state.json"), JSON.stringify(state));
 
-      expect(await readState()).toEqual(state);
+      expect(await readState(tmpDir)).toEqual(state);
     });
 
     test("throws on malformed JSON missing reviews array", async () => {
@@ -66,7 +59,7 @@ describe("store", () => {
       mkdirSync(dir, { recursive: true });
       await Bun.write(join(dir, "state.json"), JSON.stringify({ something: "else" }));
 
-      expect(readState()).rejects.toThrow("Invalid state file");
+      expect(readState(tmpDir)).rejects.toThrow("Invalid state file");
     });
   });
 
@@ -83,8 +76,8 @@ describe("store", () => {
         ],
       };
 
-      await writeState(state);
-      expect(await readState()).toEqual(state);
+      await writeState(state, tmpDir);
+      expect(await readState(tmpDir)).toEqual(state);
     });
   });
 
@@ -93,7 +86,7 @@ describe("store", () => {
       const dir = join(tmpDir, "review-dashboard");
       await expect(readdir(dir)).rejects.toThrow();
 
-      await writeState({ reviews: [] });
+      await writeState({ reviews: [] }, tmpDir);
 
       await expect(readdir(dir)).resolves.toBeDefined();
     });
@@ -187,15 +180,47 @@ describe("store", () => {
     });
   });
 
-  describe("CLAUDE_PLUGIN_DATA unset", () => {
-    test("readState throws", () => {
+  describe("no dataDir and no CLAUDE_PLUGIN_DATA", () => {
+    const originalEnv = process.env.CLAUDE_PLUGIN_DATA;
+
+    beforeEach(() => {
       delete process.env.CLAUDE_PLUGIN_DATA;
-      expect(readState()).rejects.toThrow("CLAUDE_PLUGIN_DATA is not set");
+    });
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.CLAUDE_PLUGIN_DATA;
+      } else {
+        process.env.CLAUDE_PLUGIN_DATA = originalEnv;
+      }
+    });
+
+    test("readState throws", () => {
+      expect(readState()).rejects.toThrow("dataDir is required");
     });
 
     test("writeState throws", () => {
-      delete process.env.CLAUDE_PLUGIN_DATA;
-      expect(writeState({ reviews: [] })).rejects.toThrow("CLAUDE_PLUGIN_DATA is not set");
+      expect(writeState({ reviews: [] })).rejects.toThrow("dataDir is required");
+    });
+  });
+
+  describe("falls back to CLAUDE_PLUGIN_DATA", () => {
+    const originalEnv = process.env.CLAUDE_PLUGIN_DATA;
+
+    beforeEach(() => {
+      process.env.CLAUDE_PLUGIN_DATA = tmpDir;
+    });
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.CLAUDE_PLUGIN_DATA;
+      } else {
+        process.env.CLAUDE_PLUGIN_DATA = originalEnv;
+      }
+    });
+
+    test("readState uses CLAUDE_PLUGIN_DATA when no dataDir provided", async () => {
+      expect(await readState()).toEqual({ reviews: [] });
     });
   });
 });

--- a/plugins/review/skills/dashboard/scripts/store.ts
+++ b/plugins/review/skills/dashboard/scripts/store.ts
@@ -34,20 +34,24 @@ export function createReview(params: {
   };
 }
 
-function stateDir(): string {
-  const base = process.env.CLAUDE_PLUGIN_DATA;
+function resolveDataDir(dataDir?: string): string {
+  const base = dataDir ?? process.env.CLAUDE_PLUGIN_DATA;
   if (!base) {
-    throw new Error("CLAUDE_PLUGIN_DATA is not set");
+    throw new Error("dataDir is required (or set CLAUDE_PLUGIN_DATA)");
   }
-  return join(base, "review-dashboard");
+  return base;
 }
 
-function statePath(): string {
-  return join(stateDir(), "state.json");
+function stateDir(dataDir?: string): string {
+  return join(resolveDataDir(dataDir), "review-dashboard");
 }
 
-export async function readState(): Promise<DashboardState> {
-  const file = Bun.file(statePath());
+function statePath(dataDir?: string): string {
+  return join(stateDir(dataDir), "state.json");
+}
+
+export async function readState(dataDir?: string): Promise<DashboardState> {
+  const file = Bun.file(statePath(dataDir));
   if (!(await file.exists())) {
     return { reviews: [] };
   }
@@ -83,8 +87,8 @@ export function completeReview(state: DashboardState, paneId: string): boolean {
   return true;
 }
 
-export async function writeState(state: DashboardState): Promise<void> {
-  await mkdir(stateDir(), { recursive: true });
-  const path = statePath();
+export async function writeState(state: DashboardState, dataDir?: string): Promise<void> {
+  await mkdir(stateDir(dataDir), { recursive: true });
+  const path = statePath(dataDir);
   await Bun.write(path, JSON.stringify(state, null, 2));
 }

--- a/plugins/review/skills/peer/SKILL.md
+++ b/plugins/review/skills/peer/SKILL.md
@@ -6,6 +6,7 @@ allowed-tools:
   - Bash(gh:*)
   - Bash(glab:*)
   - mcp__github
+  - WebFetch
   - Skill(code-review)
   - Skill(review:hunk)
 ---
@@ -20,6 +21,7 @@ If not on the branch, first run `gh pr checkout` to switch.
 
 - **Must** check with me before submitting. Show file comments and review comment.
 - **Don't** insist on commenting on every PR. Propose approving with no comment if everything looks good.
+- **Don't** run Python, Ruby, or other interpreters for library introspection. Use Read to examine source files or WebFetch to read documentation instead.
 - **Do** match my writing style. You're commenting as me, not a generic AI assistant.
 - **Do** present technical questions to me for ambiguous code. Don't proceed until you understand fully.
 


### PR DESCRIPTION
Fixes issues with the `review:dashboard` skill so its scripts run outside the plugin subprocess context, and tightens the `review:peer` guardrails.

## Dashboard State Directory

The dashboard scripts resolved their state directory from `CLAUDE_PLUGIN_DATA`, which is only set when a script runs inside the plugin subprocess. Invoking them directly (e.g. `Bash(bun .../spawn.ts)`) left them with nowhere to read or write state.

- `store.ts`: Accept an explicit `dataDir` parameter, falling back to `CLAUDE_PLUGIN_DATA`
- `spawn.ts`: Add `--data-dir` and `--context`. `--context` prepends PR metadata (title, author, description summary) to the spawned session's initial prompt so the review starts with context in hand
- `state.ts`: Add `--data-dir`, threaded through to every store call
- `store.test.ts`: Pass `dataDir` explicitly instead of mutating the environment, with added coverage for the `CLAUDE_PLUGIN_DATA` fallback

## Peer Review Guardrails

- Add a guardrail against running Python, Ruby, or other interpreters for library introspection (use `Read` on source or `WebFetch` on docs)
- Add `WebFetch` to `allowed-tools`
