### PR TITLE
feat: use Bun.markdown.ansi() for terminal markdown rendering

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.2.25",
         "@biomejs/biome": "^2.3.13",
         "@constellos/claude-code-kit": "^0.4.0",
-        "@types/bun": "^1.3.8",
+        "@types/bun": "^1.3.12",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
       },
@@ -461,7 +461,7 @@
 
     "@rgrove/parse-xml": ["@rgrove/parse-xml@1.1.1", "", { "dependencies": { "babel-runtime": "^6.23.0" } }, "sha512-3wFRoPyAnb7w5oLdUuiXoMN5s19RZjTmdN7pz4G8XDVgjpXFCP6gUvb5k/GtzZwwFRNCYpBFxCEykcYdeWLiPQ=="],
 
-    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/camelcase": ["@types/camelcase@4.1.0", "", {}, "sha512-nsaprOtNLvUrLyFX5+mRpE9h2Q0d5YzQRr+Lav3fxdYtc1/E/U7G+Ld861NWBDDtWY3MnwKoUOhCrE1nrVxUQA=="],
 
@@ -597,7 +597,7 @@
 
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
-    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.25",
     "@biomejs/biome": "^2.3.13",
     "@constellos/claude-code-kit": "^0.4.0",
-    "@types/bun": "^1.3.8",
+    "@types/bun": "^1.3.12",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1"
   },

--- a/plugins/pull-request/scripts/contributing.ts
+++ b/plugins/pull-request/scripts/contributing.ts
@@ -2,6 +2,7 @@
 
 import { type ExecSyncOptions, execSync } from "node:child_process";
 import { join } from "node:path";
+import { markdown } from "bun";
 
 const CANDIDATES = ["CONTRIBUTING.md", "contributing.md", ".github/CONTRIBUTING.md"];
 
@@ -27,6 +28,6 @@ if (import.meta.main) {
   const result = await findContributing(getRepoRoot());
   if (result) {
     console.log(`Contributing Guidelines (${result.path}):\n`);
-    console.log(result.content.trim());
+    console.log(markdown.ansi(result.content.trim()));
   }
 }

--- a/plugins/pull-request/scripts/pr-template.ts
+++ b/plugins/pull-request/scripts/pr-template.ts
@@ -4,6 +4,7 @@
 
 import { execSync } from "node:child_process";
 import { join } from "node:path";
+import { markdown } from "bun";
 export type Provider = "github" | "gitlab";
 
 const TEMPLATE_PATHS: Record<Provider, string[]> = {
@@ -44,6 +45,6 @@ if (import.meta.main) {
   const provider = (process.argv[2] as Provider) || "github";
   const template = await findTemplate(provider, repoRoot);
   if (template) {
-    process.stdout.write(template);
+    process.stdout.write(markdown.ansi(template));
   }
 }

--- a/plugins/tmux/skills/tmux/SKILL.md
+++ b/plugins/tmux/skills/tmux/SKILL.md
@@ -93,7 +93,7 @@ Prefer a terminal markdown renderer with file watching. Tools in preference orde
 
 | Tool | Command | Notes |
 |---|---|---|
-| markless | `markless --watch file.md` | Rendered markdown with live reload |
+| bun | `bun --watch file.md` | Rendered markdown with live reload |
 | glow | `glow -w 0 file.md` | Rendered, no watch (reopen on change) |
 | batwatch | `batwatch --watcher poll file.md` | Syntax-highlighted with file watching |
 | bat | `bat --paging always file.md` | Syntax-highlighted source, no watch |

--- a/plugins/tmux/skills/tmux/scripts/tools.sh
+++ b/plugins/tmux/skills/tmux/scripts/tools.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-for tool in markless batwatch bat; do
+for tool in batwatch bat; do
   path=$(which "$tool" 2>/dev/null || true)
   if [ -n "$path" ]; then
     echo "- $tool: $path"


### PR DESCRIPTION
Use Bun's built-in `markdown.ansi()` API to render markdown with ANSI formatting in the terminal, replacing raw output and external tools.

- Render CONTRIBUTING.md and PR templates with ANSI formatting in pull-request scripts
- Replace `markless` with `bun --watch` in tmux skill's markdown viewer table

Blocked on [oven-sh/bun#28833](https://github.com/oven-sh/bun/pull/28833) shipping in a stable Bun release.

## Test plan

- [ ] Verify `Bun.markdown.ansi()` is available after Bun upgrade
- [ ] Run `contributing.ts` against a repo with CONTRIBUTING.md
- [ ] Run `pr-template.ts` against a repo with a PR template
- [ ] Run `bun --watch file.md` in a tmux pane