### PR TITLE
settings: enable clear context on plan accept

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -213,6 +213,7 @@
     "command": "~/.claude/scripts/statusline.sh"
   },
   "alwaysThinkingEnabled": true,
+  "showClearContextOnPlanAccept": true,
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "TMPDIR": "/tmp",


### PR DESCRIPTION
Enables `showClearContextOnPlanAccept` so the plan accept screen offers clearing the session context before executing the plan.
