### PR TITLE
fix(ci): use official installer for claude cli instead of bun

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,8 +155,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Install Claude Code CLI
+        run: curl -fsSL https://claude.ai/install.sh | bash
+
       - name: Validate plugin
-        run: npx -y @anthropic-ai/claude-code@latest plugin validate "plugins/${{ matrix.plugin.name }}"
+        run: claude plugin validate "plugins/${{ matrix.plugin.name }}"
 
       - name: Check for hardcoded version
         if: steps.inspect.outputs.has_plugin_json == 'true'
@@ -251,6 +254,9 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
+      - name: Install Claude Code CLI
+        run: curl -fsSL https://claude.ai/install.sh | bash
+
       - name: Setup Claude configuration
         run: |
           mkdir -p "$HOME/.claude"
@@ -264,5 +270,5 @@ jobs:
           echo '## Claude Code Context Usage' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          npx -y @anthropic-ai/claude-code@latest --print '/context' --output-format json --verbose | jq -r '.[-1].result' >> $GITHUB_STEP_SUMMARY
+          claude --print '/context' --output-format json --verbose | jq -r '.[-1].result' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Validate plugin
-        run: bunx @anthropic-ai/claude-code plugin validate "plugins/${{ matrix.plugin.name }}"
+        run: npx -y @anthropic-ai/claude-code@latest plugin validate "plugins/${{ matrix.plugin.name }}"
 
       - name: Check for hardcoded version
         if: steps.inspect.outputs.has_plugin_json == 'true'
@@ -264,5 +264,5 @@ jobs:
           echo '## Claude Code Context Usage' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          bunx @anthropic-ai/claude-code --print '/context' --output-format json --verbose | jq -r '.[-1].result' >> $GITHUB_STEP_SUMMARY
+          npx -y @anthropic-ai/claude-code@latest --print '/context' --output-format json --verbose | jq -r '.[-1].result' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,11 +155,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Install Claude Code CLI
-        run: bun install -g @anthropic-ai/claude-code@latest
-
       - name: Validate plugin
-        run: claude plugin validate "plugins/${{ matrix.plugin.name }}"
+        run: bunx @anthropic-ai/claude-code plugin validate "plugins/${{ matrix.plugin.name }}"
 
       - name: Check for hardcoded version
         if: steps.inspect.outputs.has_plugin_json == 'true'
@@ -254,9 +251,6 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Install Claude Code CLI
-        run: bun install -g @anthropic-ai/claude-code@latest
-
       - name: Setup Claude configuration
         run: |
           mkdir -p "$HOME/.claude"
@@ -270,5 +264,5 @@ jobs:
           echo '## Claude Code Context Usage' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          claude --print '/context' --output-format json --verbose | jq -r '.[-1].result' >> $GITHUB_STEP_SUMMARY
+          bunx @anthropic-ai/claude-code --print '/context' --output-format json --verbose | jq -r '.[-1].result' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Installs the Claude Code CLI via the official installer (`curl -fsSL https://claude.ai/install.sh | bash`) in both the plugin-matrix and `context` jobs, replacing `bun install -g @anthropic-ai/claude-code@latest`.

## Issue

The [plugin validation job](https://github.com/bendrucker/claude/actions/runs/24421413622/job/71344385078) started failing with `claude: command not found` (exit 127). Bun 1.3.12 (released 2026-04-10) regressed `bun install -g`: although the install reports success and `bun pm bin -g` still returns `$HOME/.bun/bin`, the binary shim is not created there. Last green `main` run used bun 1.3.11; the first failing run matched the 1.3.12 bump.

## Changes

- Replace the `bun install -g @anthropic-ai/claude-code@latest` step with `curl -fsSL https://claude.ai/install.sh | bash` in the `plugin` matrix job and the `context` job
- `claude` and `claude --print '/context' ...` calls remain unchanged; the installer puts the binary on `$PATH`
