### PR TITLE
feat(portless): add skill for .localhost dev URLs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -163,6 +163,11 @@
       "name": "tmux",
       "description": "Tmux session awareness and pane interaction",
       "source": "./plugins/tmux"
+    },
+    {
+      "name": "portless",
+      "description": "Portless-managed dev servers and stable .localhost URLs",
+      "source": "./plugins/portless"
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 node_modules/
 .DS_Store
 **/fixtures/
+**/evals-workspace/
 
 # Generated coverage output (bun test --coverage)
 /coverage/

--- a/plugins/portless/.claude-plugin/plugin.json
+++ b/plugins/portless/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "portless",
+  "description": "Portless-managed dev servers and stable .localhost URLs",
+  "author": {
+    "name": "Ben Drucker",
+    "email": "bvdrucker@gmail.com"
+  }
+}

--- a/plugins/portless/README.md
+++ b/plugins/portless/README.md
@@ -1,7 +1,3 @@
 # Portless Plugin
 
 Guidance for working with [portless](https://github.com/vercel-labs/portless): stable `.localhost` URLs for local dev servers.
-
-## Contents
-
-- **Skill**: URL contract, worktree subdomain prefix, `PORTLESS_URL`, browser automation, and the `PORTLESS=0` bypass

--- a/plugins/portless/README.md
+++ b/plugins/portless/README.md
@@ -1,0 +1,7 @@
+# Portless Plugin
+
+Guidance for working with [portless](https://github.com/vercel-labs/portless): stable `.localhost` URLs for local dev servers.
+
+## Contents
+
+- **Skill**: URL contract, worktree subdomain prefix, `PORTLESS_URL`, browser automation, and the `PORTLESS=0` bypass

--- a/plugins/portless/skills/portless/SKILL.md
+++ b/plugins/portless/skills/portless/SKILL.md
@@ -3,30 +3,19 @@ name: portless
 description: >-
   Portless-managed dev servers and stable .localhost URLs. Use when starting
   a dev server, navigating to a local URL in a browser, testing UI changes,
-  or debugging why a port-based URL isn't reachable. Covers the
-  <name>.localhost URL contract, worktree subdomain prefix, PORTLESS_URL env
-  var, and the PORTLESS=0 bypass.
+  or debugging why a port-based URL isn't reachable.
 ---
 
 # Portless
 
-[portless](https://github.com/vercel-labs/portless) fronts local dev servers with stable `https://<name>.localhost` URLs instead of random ports.
-
-## Detecting portless
-
-A repo uses portless when `package.json` scripts invoke `portless run` or `portless <name>`. For active routes:
-
-```sh
-portless list
-```
+[portless](https://github.com/vercel-labs/portless) fronts local dev servers with stable `https://<name>.localhost` URLs instead of random ports. A repo uses it when `package.json` scripts invoke `portless run`. Don't prepend `portless run` yourself unless those scripts already do.
 
 ## URL contract
 
 - Inside a process spawned by `portless run`, `PORTLESS_URL` is authoritative.
-- From outside the process, `portless get <name>` prints the URL (use `--no-worktree` to skip the branch prefix).
-- Otherwise the URL is `https://<name>.localhost`. `<name>` comes from (in order): `--name <name>`, the first positional arg to `portless`, or the `package.json` name.
+- From outside, `portless get <name>` prints the URL (use `--no-worktree` to skip the branch prefix), or run `portless list` for all active routes.
+- Otherwise the URL is `https://<name>.localhost`, where `<name>` is the `package.json` name (or `--name` / first positional arg to `portless`).
 - `PORT` / `HOST` in the child env are the ephemeral upstream. Browsers hit the `.localhost` URL, not those.
-- When driving `mcp__claude-in-chrome__navigate` or any browser tool, use the portless URL, not `localhost:<port>`.
 
 ## Worktrees
 
@@ -39,16 +28,6 @@ fix-ui worktree: https://fix-ui.myapp.localhost
 
 Don't assume the bare name. If unsure, check `PORTLESS_URL` or `portless list`.
 
-## Running commands
-
-- Prepend `portless run` only when the repo's scripts already do. Don't add it otherwise.
-- `PORTLESS=0 <cmd>` bypasses the proxy (useful for debugging portless itself).
-- HTTPS is on by default; `NODE_EXTRA_CA_CERTS` is injected into children so Node trusts the portless CA.
-
-## Reserved names
-
-`run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, and `proxy` are subcommands and can't be used as app names. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force it.
-
 ## Full docs
 
-Installation, LAN mode, framework notes, HTTPS/CA trust, and the complete CLI reference live in the upstream skill: [vercel-labs/portless SKILL.md](https://github.com/vercel-labs/portless/blob/main/skills/portless/SKILL.md).
+Installation, LAN mode, framework notes, HTTPS/CA trust, reserved names, and the complete CLI reference live in the upstream skill: [vercel-labs/portless SKILL.md](https://github.com/vercel-labs/portless/blob/main/skills/portless/SKILL.md).

--- a/plugins/portless/skills/portless/SKILL.md
+++ b/plugins/portless/skills/portless/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: portless
+description: >-
+  Portless-managed dev servers and stable .localhost URLs. Use when starting
+  a dev server, navigating to a local URL in a browser, testing UI changes,
+  or debugging why a port-based URL isn't reachable. Covers the
+  <name>.localhost URL contract, worktree subdomain prefix, PORTLESS_URL env
+  var, and the PORTLESS=0 bypass.
+---
+
+# Portless
+
+[portless](https://github.com/vercel-labs/portless) fronts local dev servers with stable `https://<name>.localhost` URLs instead of random ports.
+
+## Detecting portless
+
+A repo uses portless when `package.json` scripts invoke `portless run` or `portless <name>`. For active routes:
+
+```sh
+portless list
+```
+
+## URL contract
+
+- Inside a process spawned by `portless run`, `PORTLESS_URL` is authoritative.
+- Otherwise the URL is `https://<name>.localhost`. `<name>` comes from (in order): `--name <name>`, the first positional arg to `portless`, or the `package.json` name.
+- `PORT` / `HOST` in the child env are the ephemeral upstream. Browsers hit the `.localhost` URL, not those.
+- When driving `mcp__claude-in-chrome__navigate` or any browser tool, use the portless URL, not `localhost:<port>`.
+
+## Worktrees
+
+In a linked git worktree, portless prepends the branch as a subdomain:
+
+```
+main worktree:   https://myapp.localhost
+fix-ui worktree: https://fix-ui.myapp.localhost
+```
+
+Don't assume the bare name. If unsure, check `PORTLESS_URL` or `portless list`.
+
+## Running commands
+
+- Prepend `portless run` only when the repo's scripts already do. Don't add it otherwise.
+- `PORTLESS=0 <cmd>` bypasses the proxy (useful for debugging portless itself).
+- HTTPS is on by default; `NODE_EXTRA_CA_CERTS` is injected into children so Node trusts the portless CA.
+
+## Reserved names
+
+`run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, and `proxy` are subcommands and can't be used as app names. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force it.

--- a/plugins/portless/skills/portless/SKILL.md
+++ b/plugins/portless/skills/portless/SKILL.md
@@ -16,6 +16,7 @@ description: >-
 - From outside, `portless get <name>` prints the URL (use `--no-worktree` to skip the branch prefix), or run `portless list` for all active routes.
 - Otherwise the URL is `https://<name>.localhost`, where `<name>` is the `package.json` name (or `--name` / first positional arg to `portless`).
 - `PORT` / `HOST` in the child env are the ephemeral upstream. Browsers hit the `.localhost` URL, not those.
+- With `PORTLESS=0`, portless is bypassed: the dev server binds directly to `PORT`/`HOST`, no `.localhost` URL is routed, and `PORTLESS_URL` / `portless list` shouldn't be treated as authoritative. Use the port-based URL from the dev server's own output.
 
 ## Worktrees
 

--- a/plugins/portless/skills/portless/SKILL.md
+++ b/plugins/portless/skills/portless/SKILL.md
@@ -23,6 +23,7 @@ portless list
 ## URL contract
 
 - Inside a process spawned by `portless run`, `PORTLESS_URL` is authoritative.
+- From outside the process, `portless get <name>` prints the URL (use `--no-worktree` to skip the branch prefix).
 - Otherwise the URL is `https://<name>.localhost`. `<name>` comes from (in order): `--name <name>`, the first positional arg to `portless`, or the `package.json` name.
 - `PORT` / `HOST` in the child env are the ephemeral upstream. Browsers hit the `.localhost` URL, not those.
 - When driving `mcp__claude-in-chrome__navigate` or any browser tool, use the portless URL, not `localhost:<port>`.
@@ -47,3 +48,7 @@ Don't assume the bare name. If unsure, check `PORTLESS_URL` or `portless list`.
 ## Reserved names
 
 `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, and `proxy` are subcommands and can't be used as app names. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force it.
+
+## Full docs
+
+Installation, LAN mode, framework notes, HTTPS/CA trust, and the complete CLI reference live in the upstream skill: [vercel-labs/portless SKILL.md](https://github.com/vercel-labs/portless/blob/main/skills/portless/SKILL.md).

--- a/plugins/portless/skills/portless/evals/evals.json
+++ b/plugins/portless/skills/portless/evals/evals.json
@@ -1,0 +1,33 @@
+{
+  "skill_name": "portless",
+  "evals": [
+    {
+      "id": 1,
+      "name": "main-worktree-start-and-browse",
+      "prompt": "I just tweaked the Header component in my Next.js app. Start the dev server and open it in Chrome so I can eyeball the change. Investigate the repo and explain exactly what you would do: the commands you would run, and the URL you would navigate to in Chrome. Do not actually spawn servers or open a browser. Save your complete response to outputs/response.md.",
+      "mock_repo": "eval-1-main",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "worktree-branch-prefix",
+      "prompt": "This checkout is a linked git worktree on branch fix-auth-redirect (the main checkout lives elsewhere). Bring up the app and verify the login page still works. Investigate the repo and explain exactly what you would do: the commands you would run, and the URL you would navigate to in Chrome. Do not actually spawn servers or open a browser. Save your complete response to outputs/response.md.",
+      "mock_repo": "eval-2-worktree",
+      "files": []
+    },
+    {
+      "id": 3,
+      "name": "debug-port-url-not-loading",
+      "prompt": "The dev server started fine (I ran npm run dev and it didn't error out) but http://localhost:3000 is not loading in my browser. What am I doing wrong? Investigate the repo and diagnose. Save your complete response to outputs/response.md.",
+      "mock_repo": "eval-3-debug",
+      "files": []
+    },
+    {
+      "id": 4,
+      "name": "negative-non-portless-repo",
+      "prompt": "Start the dev server and open localhost in Chrome to check the homepage. Investigate the repo and explain exactly what you would do: the commands you would run, and the URL you would navigate to in Chrome. Do not actually spawn servers or open a browser. Save your complete response to outputs/response.md.",
+      "mock_repo": "eval-4-plain",
+      "files": []
+    }
+  ]
+}

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -29,7 +29,7 @@ Every customization costs tokens on every session. Before adding one, define how
 - For questions about Claude Code features or usage, use the Task tool with `subagent_type='claude-code-guide'` to consult official documentation.
 - Always use the `pull-request:create` skill to create pull requests. If the skill is unavailable, create the PR with an empty body.
 - When executing build commands, output to `/dev/null` to avoid creating binaries.
-- Dev servers: if a repo's `package.json` uses `portless run`, dev URLs are `https://<name>.localhost` (worktrees prepend branch). Load the `portless` skill for details.
+- Dev servers: load the `portless` skill when a repo's scripts invoke `portless run`.
 - Store temporary files in `tmp/` directory.
 - Use `pbcopy` and `pbpaste` for clipboard interaction.
 

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -29,7 +29,7 @@ Every customization costs tokens on every session. Before adding one, define how
 - For questions about Claude Code features or usage, use the Task tool with `subagent_type='claude-code-guide'` to consult official documentation.
 - Always use the `pull-request:create` skill to create pull requests. If the skill is unavailable, create the PR with an empty body.
 - When executing build commands, output to `/dev/null` to avoid creating binaries.
-- Dev servers: load the `portless` skill when a repo's scripts invoke `portless run`.
+- Dev servers: load the `portless` skill when a repo's scripts invoke `portless run`. Skip it if `PORTLESS=0` is set, since portless is bypassed and `.localhost` URLs don't apply.
 - Store temporary files in `tmp/` directory.
 - Use `pbcopy` and `pbpaste` for clipboard interaction.
 

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -29,6 +29,7 @@ Every customization costs tokens on every session. Before adding one, define how
 - For questions about Claude Code features or usage, use the Task tool with `subagent_type='claude-code-guide'` to consult official documentation.
 - Always use the `pull-request:create` skill to create pull requests. If the skill is unavailable, create the PR with an empty body.
 - When executing build commands, output to `/dev/null` to avoid creating binaries.
+- Dev servers: if a repo's `package.json` uses `portless run`, dev URLs are `https://<name>.localhost` (worktrees prepend branch). Load the `portless` skill for details.
 - Store temporary files in `tmp/` directory.
 - Use `pbcopy` and `pbpaste` for clipboard interaction.
 


### PR DESCRIPTION
Adds a `portless` plugin so Claude uses the stable `https://<name>.localhost` URL contract from [portless](https://github.com/vercel-labs/portless) instead of scraping dev-server ports from stdout. Covers the worktree branch-prefix subdomain, `PORTLESS_URL` / `portless list` as sources of truth, browser automation, and the `PORTLESS=0` bypass.

## Changes

- New plugin `plugins/portless/` with a single primary skill (`portless`), `plugin.json`, and `README.md`.
- Marketplace entry in `.claude-plugin/marketplace.json`.
- One dev-server bullet in `user/CLAUDE.md` pointing at the skill.
- `.gitignore` entry for `**/evals-workspace/` so skill-creator eval artifacts stay local.

## Testing

Evaluated via `claude-code:skill-creator` with four scenarios, each run with and without the skill:

- Starting a dev server in a main-worktree portless repo and navigating to it.
- Same, inside a linked worktree (verifying the branch-prefix subdomain).
- Diagnosing a stuck `http://localhost:3000` in a portless-using repo.
- Negative control in a plain Next.js repo that does not use portless.

Key observation: without the skill, the baseline guessed the wrong TLD (`.test`) for the main-worktree case. The skill fixes that and standardizes the contract across the other scenarios.
