### PR TITLE
settings: skip auto permission prompt

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -212,6 +212,7 @@
     "type": "command",
     "command": "~/.claude/scripts/statusline.sh"
   },
+  "skipAutoPermissionPrompt": true,
   "alwaysThinkingEnabled": true,
   "showClearContextOnPlanAccept": true,
   "env": {


### PR DESCRIPTION
Enables `skipAutoPermissionPrompt` in user settings so sandboxed commands are auto-approved without prompting.
