### PR TITLE
settings: use sandbox filesystem allowWrite for cache dirs

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -24,20 +24,11 @@
       "WebFetch(domain:proxy.golang.org)",
       "WebFetch(domain:sum.golang.org)",
       "WebFetch(domain:pkg.go.dev)",
-      "Edit(//tmp/**)",
       "Edit(tmp/**)",
       "Edit(.git/config)",
       "Edit(.git/config.lock)",
       "Edit(.worktrees/**)",
-      "Edit(~/.npm/**)",
-      "Edit(~/.terraform.d/plugin-cache/**)",
-      "Edit(~/.cache/uv/**)",
-      "Edit(~/Library/Caches/go-build/**)",
-      "Edit(~/src/go/pkg/mod/**)",
-      "Edit(~/src/go/pkg/sumdb/**)",
-      "Edit(~/.bun/**)",
       "Read(~/.claude/plugins/**)",
-      "Edit(~/.claude/plugins/cache/**/node_modules/**)",
       "Bash(tmux display-message:*)",
       "Bash(tmux list-panes:*)",
       "Bash(tmux list-windows:*)",
@@ -171,6 +162,17 @@
         "~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
       ]
     },
+    "filesystem": {
+      "allowWrite": [
+        "/tmp",
+        "~/.terraform.d/plugin-cache",
+        "~/.cache",
+        "~/Library/Caches/go-build",
+        "~/src/go/pkg/mod",
+        "~/src/go/pkg/sumdb",
+        "~/.bun/install"
+      ]
+    },
     "excludedCommands": [
       "docker:*",
       "ssh:*",
@@ -204,6 +206,7 @@
       "dscl:*",
       "plutil:*",
       "tmux:*",
+      "git:*",
       "gh:*",
       "code:*"
     ]


### PR DESCRIPTION
Moves cache and package-manager write paths out of `permissions.allow` Edit rules and into `sandbox.filesystem.allowWrite`, which is the dedicated setting for sandbox filesystem access. Edit permissions now only cover project-related paths (`tmp/**`, `.git/config`, `.worktrees/**`).

## Changes

- Cache directories (`/tmp`, `~/.cache`, `~/.terraform.d/plugin-cache`, `~/Library/Caches/go-build`, `~/src/go/pkg/mod`, `~/src/go/pkg/sumdb`, `~/.bun/install`) moved to `sandbox.filesystem.allowWrite`
- Broadened `~/.cache/uv` to `~/.cache` to cover all XDG cache entries
- Removed `~/.npm` and `~/.claude/plugins` since plugin installation runs outside the sandbox via the Claude CLI
- Added `git:*` to `excludedCommands` since git needs to write to the main repo's `.git/` directory, which is outside the worktree's working directory and can't be scoped in the sandbox
