### PR TITLE
docs(gitlab): document mergeRequestReviewerRereview mutation

### DIFF
--- a/plugins/gitlab/skills/merge-request/discussions.md
+++ b/plugins/gitlab/skills/merge-request/discussions.md
@@ -68,7 +68,7 @@ bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts create <iid> --file src/app.ts --
 bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts create <iid> --file src/app.ts --old-line 10 --body-file tmp/note.md
 ```
 
-Diff refs are fetched automatically. Positioned comments are validated against diff hunks before posting — if a line is not in the diff, the command exits with valid line ranges.
+Diff refs are fetched automatically. Positioned comments are validated against diff hunks before posting. If a line is not in the diff, the command exits with valid line ranges.
 
 ### Suggestions
 

--- a/plugins/gitlab/skills/merge-request/review-state.md
+++ b/plugins/gitlab/skills/merge-request/review-state.md
@@ -37,9 +37,9 @@ mutation($projectPath: ID!, $iid: String!) {
 }
 ```
 
-## Re-request Review
+## Re-Request Review
 
-Fires the same mutation as the web UI's "re-request review" button. Re-requests review from a specific reviewer after you've pushed changes addressing their feedback.
+Fires the same mutation as the web UI's "re-request review" button.
 
 ```graphql
 mutation($projectPath: ID!, $iid: String!, $userId: UserID!) {
@@ -53,7 +53,7 @@ mutation($projectPath: ID!, $iid: String!, $userId: UserID!) {
 }
 ```
 
-The `userId` must be a global ID (`gid://gitlab/User/<id>`), not a username. Look up the numeric ID first:
+Look up the numeric user ID first, then pass it as the full `gid://gitlab/User/<id>`:
 
 ```bash
 user_id=$(glab api "users?username=<username>" | jq -r '.[0].id')
@@ -65,13 +65,10 @@ glab api graphql \
   -F userId="gid://gitlab/User/$user_id"
 ```
 
-**Requirements:**
-- Target user must already be a reviewer on the MR
-- Caller needs permission to update the MR
-
 **Gotchas:**
-- `userId` is typed `UserID!` and expects the full `gid://gitlab/User/<id>` form. Bare numeric IDs or usernames fail with a type error.
-- This is a mutation; probing the schema by running it will actually fire the re-request. Use the documented form, don't explore.
+- Target user must already be a reviewer on the MR
+- `userId` is typed `UserID!` — bare numeric IDs or usernames fail with a type error
+- Probing the schema fires the mutation. Use the documented form, don't explore.
 
 ## Read Review State
 

--- a/plugins/gitlab/skills/merge-request/review-state.md
+++ b/plugins/gitlab/skills/merge-request/review-state.md
@@ -67,7 +67,7 @@ glab api graphql \
 
 **Gotchas:**
 - Target user must already be a reviewer on the MR
-- `userId` is typed `UserID!` — bare numeric IDs or usernames fail with a type error
+- `userId` is typed `UserID!`, so bare numeric IDs or usernames fail with a type error
 - Probing the schema fires the mutation. Use the documented form, don't explore.
 
 ## Read Review State

--- a/plugins/gitlab/skills/merge-request/review-state.md
+++ b/plugins/gitlab/skills/merge-request/review-state.md
@@ -37,6 +37,42 @@ mutation($projectPath: ID!, $iid: String!) {
 }
 ```
 
+## Re-request Review
+
+Fires the same mutation as the web UI's "re-request review" button. Re-requests review from a specific reviewer after you've pushed changes addressing their feedback.
+
+```graphql
+mutation($projectPath: ID!, $iid: String!, $userId: UserID!) {
+  mergeRequestReviewerRereview(input: {
+    projectPath: $projectPath,
+    iid: $iid,
+    userId: $userId
+  }) {
+    errors
+  }
+}
+```
+
+The `userId` must be a global ID (`gid://gitlab/User/<id>`), not a username. Look up the numeric ID first:
+
+```bash
+user_id=$(glab api "users?username=<username>" | jq -r '.[0].id')
+
+glab api graphql \
+  -f query='mutation($projectPath: ID!, $iid: String!, $userId: UserID!) { mergeRequestReviewerRereview(input: { projectPath: $projectPath, iid: $iid, userId: $userId }) { errors } }' \
+  -F projectPath=$(glab repo view --output json | jq -r '.fullPath') \
+  -F iid=<iid> \
+  -F userId="gid://gitlab/User/$user_id"
+```
+
+**Requirements:**
+- Target user must already be a reviewer on the MR
+- Caller needs permission to update the MR
+
+**Gotchas:**
+- `userId` is typed `UserID!` and expects the full `gid://gitlab/User/<id>` form. Bare numeric IDs or usernames fail with a type error.
+- This is a mutation; probing the schema by running it will actually fire the re-request. Use the documented form, don't explore.
+
 ## Read Review State
 
 REST `reviewers[].state` only returns `"active"`. Use GraphQL:

--- a/plugins/gitlab/skills/merge-request/review.md
+++ b/plugins/gitlab/skills/merge-request/review.md
@@ -129,6 +129,6 @@ glab api projects/:id/merge_requests/<iid>/approve -X POST -f sha="<head_sha>"
 glab api projects/:id/merge_requests/<iid>/unapprove -X POST
 ```
 
-## Re-request Review
+## Re-Request Review
 
-After addressing reviewer feedback, re-request review via GraphQL (no REST or `glab mr` equivalent). See [review-state.md](review-state.md#re-request-review).
+No REST or `glab mr` equivalent — GraphQL only. See [review-state.md](review-state.md#re-request-review).

--- a/plugins/gitlab/skills/merge-request/review.md
+++ b/plugins/gitlab/skills/merge-request/review.md
@@ -128,3 +128,7 @@ glab api projects/:id/merge_requests/<iid>/approve -X POST -f sha="<head_sha>"
 # Unapprove
 glab api projects/:id/merge_requests/<iid>/unapprove -X POST
 ```
+
+## Re-request Review
+
+After addressing reviewer feedback, re-request review via GraphQL (no REST or `glab mr` equivalent). See [review-state.md](review-state.md#re-request-review).

--- a/plugins/gitlab/skills/merge-request/review.md
+++ b/plugins/gitlab/skills/merge-request/review.md
@@ -1,6 +1,6 @@
 # MR Reviews
 
-Submit review feedback as draft notes that accumulate before publishing. Comments stay private until bulk-published — mirrors GitHub's pending review workflow.
+Submit review feedback as draft notes that accumulate before publishing. Comments stay private until bulk-published, mirroring GitHub's pending review workflow.
 
 ## Draft Notes Script
 
@@ -111,9 +111,9 @@ third line
 - **No nested `-f` fields**: `glab api -f "position[base_sha]=..."` silently fails. Nested objects must be sent as JSON via `--input`.
 - **Reply field**: Use `in_reply_to_discussion_id`, not `discussion_id`.
 - **Don't update positioned notes**: PUT to update a draft note strips the position. Delete and recreate instead.
-- **No atomic review submit**: The REST API's `bulk_publish` only publishes drafts — no summary comment or review decision. The web UI uses an internal controller that combines all three, but it's session-authenticated only. The `submit` command above sequences the calls separately.
+- **No atomic review submit**: The REST API's `bulk_publish` only publishes drafts (no summary comment or review decision). The web UI uses an internal controller that combines all three, but it's session-authenticated only. The `submit` command above sequences the calls separately.
 - **Review state is GraphQL-only**: See [review-state.md](review-state.md) for mutations (`mergeRequestRequestChanges`, `mergeRequestDestroyRequestedChanges`) and querying review state. Key: `projectPath` is `ID!` not `String!`, caller must be assigned as reviewer, requires Premium/Ultimate.
-- **Range comments need `new_line`**: `line_range` alone is rejected ("position is incomplete"). Always set `new_line` to the range end line — the comment anchors at this line in the UI.
+- **Range comments need `new_line`**: `line_range` alone is rejected ("position is incomplete"). Always set `new_line` to the range end line. The comment anchors at this line in the UI.
 
 ## Discussions
 
@@ -122,7 +122,7 @@ See [discussions.md](discussions.md) for fetching, filtering, resolving, and sum
 ## Approvals
 
 ```bash
-# Approve (with SHA safety check — returns 409 if MR updated)
+# Approve with SHA safety check (returns 409 if MR updated)
 glab api projects/:id/merge_requests/<iid>/approve -X POST -f sha="<head_sha>"
 
 # Unapprove
@@ -131,4 +131,4 @@ glab api projects/:id/merge_requests/<iid>/unapprove -X POST
 
 ## Re-Request Review
 
-No REST or `glab mr` equivalent — GraphQL only. See [review-state.md](review-state.md#re-request-review).
+GraphQL only (no REST or `glab mr` equivalent). See [review-state.md](review-state.md#re-request-review).

--- a/plugins/gitlab/skills/merge-request/stack.md
+++ b/plugins/gitlab/skills/merge-request/stack.md
@@ -43,7 +43,7 @@ The script reads stack refs from `.git/stacked/<title>/*.json`, checks project a
 
 1. MR1 merges when its pipeline passes
 2. GitLab auto-retargets MR2 to the base branch
-3. MR2's pipeline runs — since the logical diff is unchanged, the smart patch-id reset (GitLab 16.7+) preserves approvals
+3. MR2's pipeline runs; since the logical diff is unchanged, the smart patch-id reset (GitLab 16.7+) preserves approvals
 4. MR2 auto-merges, triggering the same cascade for MR3, etc.
 
 ### Requirements


### PR DESCRIPTION
Adds a "Re-request Review" section to the `gitlab:merge-request` skill covering the `mergeRequestReviewerRereview` GraphQL mutation behind the web UI's "re-request review" button. Documenting the mutation prevents future automation from probing the schema, which fires the mutation as a side effect. The sibling `review.md` gets a short cross-reference so the reviewer workflow doc surfaces the capability.

## Changes

- `plugins/gitlab/skills/merge-request/review-state.md`: new `## Re-request Review` section between `## Remove Request Changes` and `## Read Review State`, including the GraphQL mutation, a `glab api graphql` invocation, requirements, and gotchas (`userId` must be a `gid://gitlab/User/<id>` global ID; probing the schema fires the mutation).
- `plugins/gitlab/skills/merge-request/review.md`: appended a short `## Re-request Review` pointer at the end linking to the full doc.

Original Task: [Add re-request review support to gitlab:merge-request skill](https://things.bendrucker.me/show?id=3PxoDpY6Dc1v6bVR14uzMT)
