### PR TITLE
settings: pre-allow common skills

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,21 @@
   "env": {
     "THINGS_EXTRA_TAGS": "claude-code"
   },
+  "permissions": {
+    "allow": [
+      "Skill(claude-code:*)",
+      "Skill(pr-review-toolkit:*)",
+      "Skill(pull-request:*)",
+      "Skill(review:*)",
+      "Skill(github:*)",
+      "Skill(git:*)",
+      "Skill(bun:bun)",
+      "Skill(writing:*)",
+      "Skill(plan:guidelines)",
+      "Skill(update-config)",
+      "Skill(simplify)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
Pre-allows `Skill(...)` invocations in `.claude/settings.json` for skills regularly used while editing this repo, avoiding permission prompts for routine work.

## Changes

Adds a `permissions.allow` block to `.claude/settings.json` covering:

- `Skill(claude-code:*)` for editing skills, hooks, agent teams
- `Skill(pr-review-toolkit:*)`, `Skill(pull-request:*)`, `Skill(review:*)` for PR creation and review
- `Skill(github:*)`, `Skill(git:*)` for git/GitHub workflows
- `Skill(bun:bun)` since the repo runs scripts and tests with Bun
- `Skill(writing:*)` per the global rule to load it for long-form prose
- `Skill(plan:guidelines)`, `Skill(update-config)`, `Skill(simplify)` for common authoring workflows

List is intentionally scoped to skills demonstrably used here. Personal skills (`things:*`, `linear:*`, etc.) stay in user settings.
