### PR TITLE
feat(issue): prune tautological sections in refine skill

### DIFF
--- a/plugins/issue/skills/refine/SKILL.md
+++ b/plugins/issue/skills/refine/SKILL.md
@@ -24,14 +24,14 @@ Expand brief issue descriptions into structured issues for developers and AI age
 
 ## Output Structure
 
-All issues share this skeleton. Type guides add sections in between.
+Every issue opens with Summary and closes with Context. Type guides offer a menu of middle sections. Include only those that earn their place.
 
 ```markdown
 ## Summary
 
 One to two sentences.
 
-[Type-specific sections from guide]
+[Type-specific sections from guide (select, don't fill)]
 
 ## Context
 
@@ -44,11 +44,18 @@ Files that need changes or inform the work.
 Links to related issues, prior attempts, upstream work.
 ```
 
+## Section Selection
+
+Every section must tell the reader something they couldn't have guessed. Cut sections whose content is tautological ("tests must pass"), template residue ("no behavior change"), or obvious given the issue's size.
+
+Minimum: Summary plus one type section plus Context. Grow only when content demands.
+
 ## Style
 
 - **Direct** - Facts, not hedging
 - **Specific** - Name the function, file, behavior
 - **Concise** - Every sentence adds information
+- **Earn the heading** - A section present only to match the template is filler
 - **Link to code** - Permalinks for GitHub (`https://github.com/{owner}/{repo}/blob/{sha}/path#L10-L20`), file paths elsewhere (`path/to/file:10-20`)
 
 ## Issue Trackers

--- a/plugins/issue/skills/refine/bug.md
+++ b/plugins/issue/skills/refine/bug.md
@@ -1,6 +1,6 @@
 # Bug
 
-## Sections
+## Sections (menu: include only those that earn their place)
 
 ### Symptoms
 
@@ -8,15 +8,15 @@ What the user or system observes. Error messages, unexpected behavior, failed op
 
 ### Root Cause
 
-Why this happens. Link to the responsible code.
+Why this happens. Link to the responsible code. Skip when unknown or self-evident from Symptoms plus a code link.
 
 ### Reproduction
 
-Steps to trigger the bug. Include inputs, environment, state.
+Steps to trigger the bug. Include inputs, environment, state. Skip when Symptoms already contain a minimal trigger.
 
 ### Requirements
 
-What the fix must accomplish. Behavioral changes, edge cases, constraints.
+What the fix must accomplish. Behavioral changes, edge cases, constraints. Skip when "match expected behavior from Symptoms" says it all.
 
 ## Key Questions
 

--- a/plugins/issue/skills/refine/feature.md
+++ b/plugins/issue/skills/refine/feature.md
@@ -1,6 +1,6 @@
 # Feature
 
-## Sections
+## Sections (menu: include only those that earn their place)
 
 ### Goal
 
@@ -12,21 +12,23 @@ Specific behaviors, inputs/outputs, error handling.
 
 #### Out of Scope
 
-What this does not include.
+What this does not include. Skip unless there's an adjacent thing a reasonable reader would assume is included.
 
 ### Design
 
+Include subsections selectively.
+
 #### Approach
 
-High-level implementation. Reference existing patterns.
+High-level implementation. Reference existing patterns. Skip for trivially-designed features.
 
 #### Changes
 
-Files and components to modify.
+Files and components to modify. Skip when Related Code already names the files.
 
 #### Open Questions
 
-Decisions needed before or during implementation.
+Decisions needed before or during implementation. Skip when there are none.
 
 ## Key Questions
 

--- a/plugins/issue/skills/refine/refactor.md
+++ b/plugins/issue/skills/refine/refactor.md
@@ -1,10 +1,10 @@
 # Refactor
 
-## Sections
+## Sections (menu: include only those that earn their place)
 
 ### Motivation
 
-Why now. Pain points, what it unblocks, cost of inaction.
+Why now. Pain points, what it unblocks, cost of inaction. Skip when title/summary convey why.
 
 ### Scope
 
@@ -12,11 +12,11 @@ What changes, what doesn't. State behavior changes explicitly (usually none).
 
 ### Approach
 
-Strategy (incremental vs. big bang), key transformations, risks.
+Strategy (incremental vs. big bang), key transformations, risks. Skip for single-file or atomic refactors; include when strategy, migration, or rollback matters.
 
 ### Validation
 
-How to verify correctness. Test coverage, manual checks, metrics.
+How to verify correctness. Test coverage, manual checks, metrics. Skip when the default test/lint/typecheck suite is the whole answer. Fold any added test into Scope.
 
 ## Key Questions
 


### PR DESCRIPTION
Teaches the `issue:refine` skill to omit sections by judgment instead of filling every template slot. Adds a Section Selection rule to `SKILL.md`, reframes each type guide (`bug.md`, `feature.md`, `refactor.md`) as a menu, and annotates each section with a one-line skip hint.

## Changes

- `SKILL.md`: reframed Output Structure as Summary plus a menu plus Context, added a terse Section Selection block, and added an "Earn the heading" bullet to Style.
- `bug.md`, `feature.md`, `refactor.md`: headers now say "Sections (menu: include only those that earn their place)". Each section gained a skip hint covering the common tautological case.

Original Task: [issue:refine skill—prune spurious sections by judgment, not template](https://things.bendrucker.me/show?id=3X56xrZyDDesR7cr6hvA1X)
