### PR TITLE
settings: allowlist read-only commands to reduce prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,15 @@
   "env": {
     "THINGS_EXTRA_TAGS": "claude-code"
   },
+  "permissions": {
+    "allow": [
+      "Bash(gh extension list)",
+      "Bash(gh search prs:*)",
+      "Bash(npm view:*)",
+      "Bash(shellcheck:*)",
+      "Bash(brew info:*)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
Allowlists read-only commands observed across recent sessions that were still triggering permission prompts. Skips patterns Claude Code already auto-allows (`git status`, `gh pr view`, `grep`, etc.) and anything that mutates state or enables arbitrary code execution.

## Changes

Adds a `permissions.allow` block to `.claude/settings.json` with:

- `Bash(gh extension list)` (exact match; other `gh extension` subcommands mutate)
- `Bash(gh search prs:*)`
- `Bash(npm view:*)`
- `Bash(shellcheck:*)`
- `Bash(brew info:*)`
