### PR TITLE
feat(rules): add typescript and markdown rules

### DIFF
--- a/user/rules/markdown.md
+++ b/user/rules/markdown.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "**/*.md"
+  - "**/*.mdx"
+---
+
+# Markdown
+
+## Prose
+
+Load the `writing` skill for tone and style rules (AI trope avoidance, em dashes, vocabulary, voice). Follow those rules rather than duplicating them here.
+
+## Structure
+
+- Prefer `####` (or deeper) headers over `**Label**:` for labeled subsections. Headers give clearer visual hierarchy and document outline.
+- Earn the heading. A section present only to match a template is filler. Delete it.

--- a/user/rules/typescript.md
+++ b/user/rules/typescript.md
@@ -7,3 +7,5 @@ paths:
 # TypeScript
 
 - Avoid using `any` type. Use specific types or `unknown` if necessary.
+- Never use double type assertions (`as unknown as T`). Cast to `Record<string, unknown>` once, then assert individual values with `as string` etc., or fix the underlying type.
+- Prefer static `import` statements over dynamic `await import()`. There is no reason to defer loading a built-in or first-party module.


### PR DESCRIPTION
Adds TypeScript rules for avoiding double type assertions and dynamic imports, and introduces a `markdown.md` rule that defers prose guidance to the `writing` skill while documenting header-over-bold-labels structure.

## Changes

- `user/rules/typescript.md`: forbid `as unknown as T` double assertions; prefer static `import` over dynamic `await import()`.
- `user/rules/markdown.md` (new): points to the `writing` skill for tone/trope rules; adds header-over-bold-label structure guidance.
