### PR TITLE
fix(hooks): skip writing and newline hooks on memory files

### DIFF
--- a/plugins/newline/scripts/check.ts
+++ b/plugins/newline/scripts/check.ts
@@ -2,6 +2,7 @@
 
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson } from "@constellos/claude-code-kit/runners";
+import { isMemoryPath } from "./memory-path";
 import { setState } from "./state";
 
 type ToolInput = {
@@ -25,6 +26,7 @@ export async function hasTrailingNewline(filePath: string): Promise<boolean | nu
 export async function processInput(input: PreToolUseHookInput): Promise<void> {
   const { file_path: filePath } = input.tool_input as ToolInput;
   if (!filePath) return;
+  if (isMemoryPath(filePath)) return;
 
   const hasNewline = await hasTrailingNewline(filePath);
 

--- a/plugins/newline/scripts/ensure.ts
+++ b/plugins/newline/scripts/ensure.ts
@@ -2,6 +2,7 @@
 
 import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { isMemoryPath } from "./memory-path";
 
 type ToolInput = {
   file_path?: string;
@@ -31,6 +32,7 @@ export async function processInput(
 ): Promise<SyncHookJSONOutput | null> {
   const { file_path: filePath } = input.tool_input as ToolInput;
   if (!filePath) return null;
+  if (isMemoryPath(filePath)) return null;
 
   const message = await ensureTrailingNewline(filePath);
 

--- a/plugins/newline/scripts/memory-path.ts
+++ b/plugins/newline/scripts/memory-path.ts
@@ -1,0 +1,7 @@
+import { resolve } from "node:path";
+
+const MEMORY_PATH_PATTERN = /\/\.claude\/projects\/[^/]+\/memory\//;
+
+export function isMemoryPath(filePath: string): boolean {
+  return MEMORY_PATH_PATTERN.test(resolve(filePath));
+}

--- a/plugins/newline/scripts/newline.test.ts
+++ b/plugins/newline/scripts/newline.test.ts
@@ -238,3 +238,30 @@ describe("integration", () => {
     expect(await getState("newline", filePath)).toBe("");
   });
 });
+
+describe("memory files", () => {
+  const memoryPath = `${process.env.HOME}/.claude/projects/-Users-ben-test/memory/MEMORY.md`;
+
+  it("check skips memory files without touching state", async () => {
+    await checkInput(mockPreToolInput(memoryPath));
+    expect(await getState("newline", memoryPath)).toBe("");
+  });
+
+  it("ensure skips memory files", async () => {
+    const output = await ensureInput(mockPostToolInput(memoryPath));
+    expect(output).toBeNull();
+  });
+
+  it("preserve skips memory files", async () => {
+    const output = await preserveInput(mockPostToolInput(memoryPath));
+    expect(output).toBeNull();
+  });
+
+  it("ensure still processes non-memory files", async () => {
+    const filePath = join(testDir, "non_memory.txt");
+    await Bun.write(filePath, "no newline");
+    const output = await ensureInput(mockPostToolInput(filePath));
+    expect(output).not.toBeNull();
+    expect(await hasNewline(filePath)).toBe(true);
+  });
+});

--- a/plugins/newline/scripts/preserve.ts
+++ b/plugins/newline/scripts/preserve.ts
@@ -2,6 +2,7 @@
 
 import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { isMemoryPath } from "./memory-path";
 import { clearState, getState } from "./state";
 
 type ToolInput = {
@@ -42,6 +43,7 @@ export async function processInput(
 ): Promise<SyncHookJSONOutput | null> {
   const { file_path: filePath } = input.tool_input as ToolInput;
   if (!filePath) return null;
+  if (isMemoryPath(filePath)) return null;
 
   const hadNewline = await getState("newline", filePath);
   const message = await preserveNewlineState(filePath, hadNewline);

--- a/plugins/writing/hooks/check-tropes.test.ts
+++ b/plugins/writing/hooks/check-tropes.test.ts
@@ -86,6 +86,22 @@ describe("plan files", () => {
   });
 });
 
+describe("memory files", () => {
+  const memoryPath = `${process.env.HOME}/.claude/projects/-Users-ben-test/memory/MEMORY.md`;
+
+  it("skips Write to memory file with spaced em dash", async () => {
+    const input = mockWrite("This \u2014 is bad");
+    (input.tool_input as Record<string, unknown>).file_path = memoryPath;
+    expect(await processInput(input)).toBeNull();
+  });
+
+  it("skips Edit to memory file with spaced em dash", async () => {
+    const input = mockEdit("This \u2014 is bad");
+    (input.tool_input as Record<string, unknown>).file_path = memoryPath;
+    expect(await processInput(input)).toBeNull();
+  });
+});
+
 describe("semicolon file scoping", () => {
   const semicolonText = "First point; second point; third point; fourth";
 

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -2,7 +2,7 @@
 
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
-import { formatContext, formatDecision, type SyncHookJSONOutput } from "./markdown";
+import { formatContext, formatDecision, isMemoryPath, type SyncHookJSONOutput } from "./markdown";
 import { firstByTier, scan } from "./tropes";
 
 const MIN_PROSE_LENGTH = 20;
@@ -78,8 +78,15 @@ function isPlanFile(input: PreToolUseHookInput): boolean {
   return home !== "" && filePath.startsWith(`${home}/.claude/plans/`);
 }
 
+function isMemoryFile(input: PreToolUseHookInput): boolean {
+  const filePath = (input.tool_input as Record<string, unknown>).file_path;
+  if (typeof filePath !== "string") return false;
+  return isMemoryPath(filePath);
+}
+
 export async function processInput(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
   if (isPlanFile(input)) return null;
+  if (isMemoryFile(input)) return null;
 
   const texts = await collectText(input);
   if (texts.length === 0) return null;

--- a/plugins/writing/hooks/headings.test.ts
+++ b/plugins/writing/hooks/headings.test.ts
@@ -117,4 +117,9 @@ describe("processInput", () => {
     };
     expect(getOutput(input)).toBeNull();
   });
+
+  it("skips memory markdown files", () => {
+    const memoryPath = `${process.env.HOME}/.claude/projects/-Users-ben-test/memory/MEMORY.md`;
+    expect(getOutput(mockWriteInput(memoryPath, "# introduction"))).toBeNull();
+  });
 });

--- a/plugins/writing/hooks/headings.ts
+++ b/plugins/writing/hooks/headings.ts
@@ -11,6 +11,7 @@ import {
   formatContext,
   getExtension,
   isMarkdownFile,
+  isMemoryPath,
   type SyncHookJSONOutput,
   type WriteInput,
 } from "./markdown";
@@ -98,6 +99,8 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
   } else {
     return null;
   }
+
+  if (isMemoryPath(filePath)) return null;
 
   const ext = getExtension(filePath);
   if (!isMarkdownFile(ext)) return null;

--- a/plugins/writing/hooks/markdown.ts
+++ b/plugins/writing/hooks/markdown.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 
 export type { SyncHookJSONOutput };
@@ -8,6 +9,12 @@ export type EditInput = { file_path: string; new_string: string };
 export function getExtension(filePath: string): string {
   const parts = filePath.split(".");
   return parts.length > 1 ? (parts.at(-1) ?? "") : "";
+}
+
+const MEMORY_PATH_PATTERN = /\/\.claude\/projects\/[^/]+\/memory\//;
+
+export function isMemoryPath(filePath: string): boolean {
+  return MEMORY_PATH_PATTERN.test(resolve(filePath));
 }
 
 export function isMarkdownFile(ext: string): boolean {

--- a/plugins/writing/hooks/numbering.test.ts
+++ b/plugins/writing/hooks/numbering.test.ts
@@ -347,3 +347,22 @@ describe("processInput edge cases", () => {
     expect(await getOutput(input, "write")).toBeNull();
   });
 });
+
+describe("memory files", () => {
+  const memoryPath = `${process.env.HOME}/.claude/projects/-Users-ben-test/memory/MEMORY.md`;
+
+  it("skips Write to memory markdown with numbered heading", async () => {
+    const output = await getOutput(mockWriteInput(memoryPath, "# 1. Introduction"), "write");
+    expect(output).toBeNull();
+  });
+
+  it("skips Edit to memory markdown with numbered heading", async () => {
+    const output = await getOutput(mockEditInput(memoryPath, "# 1. Introduction"), "edit");
+    expect(output).toBeNull();
+  });
+
+  it("still denies non-memory markdown with numbered heading", async () => {
+    const output = await getOutput(mockWriteInput("README.md", "# 1. Introduction"), "write");
+    expect(output?.permissionDecision).toBe("deny");
+  });
+});

--- a/plugins/writing/hooks/numbering.ts
+++ b/plugins/writing/hooks/numbering.ts
@@ -16,6 +16,7 @@ import {
   formatDecision,
   getExtension,
   isMarkdownFile,
+  isMemoryPath,
   type SyncHookJSONOutput,
   type WriteInput,
 } from "./markdown";
@@ -124,6 +125,8 @@ export async function processInput(
   } else {
     return null;
   }
+
+  if (isMemoryPath(filePath)) return null;
 
   const ext = getExtension(filePath);
   let match: string | null = null;


### PR DESCRIPTION
The auto-memory system writes files under `~/.claude/projects/<project>/memory/` and should not trigger any style or formatting hooks. Each `writing` and `newline` hook script now returns early when the target `file_path` matches the memory directory pattern.

## Changes

- Add an `isMemoryPath` helper to `plugins/writing/hooks/markdown.ts` and a matching `plugins/newline/scripts/memory-path.ts`. Both match `/\.claude/projects/[^/]+/memory/` against the resolved absolute path.
- Skip memory paths in `numbering.ts`, `headings.ts`, and `check-tropes.ts` (alongside the existing `isPlanFile` check).
- Skip memory paths in `check.ts`, `ensure.ts`, and `preserve.ts`.
- `check-tropes.ts` still processes Bash and MCP payloads normally when there is no `file_path`.

## Testing

- `bun test plugins/writing plugins/newline`: 202 pass.
- Manually invoked each hook with a memory-path payload and confirmed exit 0 with no blocking output. Non-memory payloads still trigger normal behavior.

---
Original Task: [Exclude memory files from writing and newline hooks](https://things.bendrucker.me/show?id=SKTwf5zTeXu7NJWuDktHJB)
