### PR TITLE
settings: disable spinner tips

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -217,6 +217,7 @@
   },
   "skipAutoPermissionPrompt": true,
   "alwaysThinkingEnabled": true,
+  "spinnerTipsEnabled": false,
   "showClearContextOnPlanAccept": true,
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",


### PR DESCRIPTION
Disables the spinner tips shown while Claude is working by setting `spinnerTipsEnabled` to `false` in `user/settings.json`.
