### PR TITLE
fix(gitlab): paginate MR diffs fetch

### DIFF
--- a/plugins/gitlab/skills/merge-request/scripts/diff.test.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/diff.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, it } from "bun:test";
-import { buildPosition, isLineInDiff, parseDiffHunks, validateLineInDiff } from "./diff";
+import {
+  buildPosition,
+  isLineInDiff,
+  parseDiffHunks,
+  parseGlabPaginated,
+  validateLineInDiff,
+} from "./diff";
+
+describe("parseGlabPaginated", () => {
+  it("parses a single page", () => {
+    const result = parseGlabPaginated('[{"id": 1}]');
+    expect(result).toEqual([{ id: 1 }]);
+  });
+
+  it("fixes concatenated pages", () => {
+    const result = parseGlabPaginated('[{"id": 1}][{"id": 2}]');
+    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it("handles whitespace between pages", () => {
+    const result = parseGlabPaginated('[{"id": 1}]\n[{"id": 2}]');
+    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it("handles three concatenated pages", () => {
+    const result = parseGlabPaginated('[{"a":1}][{"b":2}][{"c":3}]');
+    expect(result).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
+  });
+
+  it("preserves arrays inside objects", () => {
+    const result = parseGlabPaginated('[{"notes": [1, 2]}]');
+    expect(result).toEqual([{ notes: [1, 2] }]);
+  });
+});
 
 describe("parseDiffHunks", () => {
   it("parses a single hunk", () => {

--- a/plugins/gitlab/skills/merge-request/scripts/diff.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/diff.ts
@@ -46,9 +46,14 @@ type MrDiff = {
   diff: string;
 };
 
+export function parseGlabPaginated(raw: string): unknown[] {
+  const fixed = raw.replace(/\]\s*\[/g, ",");
+  return JSON.parse(fixed);
+}
+
 export async function fetchMrDiffs(iid: number | string): Promise<MrDiff[]> {
-  const result = await $`glab api projects/:id/merge_requests/${iid}/diffs`.json();
-  return result as MrDiff[];
+  const raw = await $`glab api projects/:id/merge_requests/${iid}/diffs --paginate`.text();
+  return parseGlabPaginated(raw) as MrDiff[];
 }
 
 export function validateLineInDiff(

--- a/plugins/gitlab/skills/merge-request/scripts/discussions.test.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/discussions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { Discussion } from "./discussions";
-import { deduplicateDiscussions, filterDiscussions, parseGlabPaginated } from "./discussions";
+import { deduplicateDiscussions, filterDiscussions } from "./discussions";
 
 function makeNote(overrides: Record<string, unknown> = {}) {
   return {
@@ -15,33 +15,6 @@ function makeNote(overrides: Record<string, unknown> = {}) {
 function makeDiscussion(id: string, noteOverrides: Record<string, unknown> = {}): Discussion {
   return { id, notes: [makeNote(noteOverrides)] };
 }
-
-describe("parseGlabPaginated", () => {
-  it("parses a single page", () => {
-    const result = parseGlabPaginated('[{"id": 1}]');
-    expect(result).toEqual([{ id: 1 }]);
-  });
-
-  it("fixes concatenated pages", () => {
-    const result = parseGlabPaginated('[{"id": 1}][{"id": 2}]');
-    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
-  });
-
-  it("handles whitespace between pages", () => {
-    const result = parseGlabPaginated('[{"id": 1}]\n[{"id": 2}]');
-    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
-  });
-
-  it("handles three concatenated pages", () => {
-    const result = parseGlabPaginated('[{"a":1}][{"b":2}][{"c":3}]');
-    expect(result).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
-  });
-
-  it("preserves arrays inside objects", () => {
-    const result = parseGlabPaginated('[{"notes": [1, 2]}]');
-    expect(result).toEqual([{ notes: [1, 2] }]);
-  });
-});
 
 describe("filterDiscussions", () => {
   it("filters by author", () => {

--- a/plugins/gitlab/skills/merge-request/scripts/discussions.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/discussions.ts
@@ -8,9 +8,12 @@ import {
   fetchMrDiffs,
   getDiffRefs,
   glabApiPost,
+  parseGlabPaginated,
   readBody,
   validateLineInDiff,
 } from "./diff";
+
+export { parseGlabPaginated } from "./diff";
 
 type LineRange = {
   start: { type: "new" | "old"; new_line?: number; old_line?: number };
@@ -49,11 +52,6 @@ type DiscussionSummary = {
   line?: number;
   lineRange?: { start: number; end: number } | null;
 };
-
-export function parseGlabPaginated(raw: string): unknown[] {
-  const fixed = raw.replace(/\]\s*\[/g, ",");
-  return JSON.parse(fixed);
-}
 
 function summarize(d: Discussion): DiscussionSummary | null {
   const note = d.notes[0];


### PR DESCRIPTION
Fetches all pages when loading MR diffs so file validation works on MRs with more than 20 files. Without `--paginate`, `fetchMrDiffs` only sees page 1, and `draft-note.ts` batch fails with "File X not found in MR diff" for any file past the first page (hit on MR !426 with 30+ files).

## Changes

- Move `parseGlabPaginated` from `discussions.ts` into `diff.ts` (the lower-level module) so `fetchMrDiffs` can reuse it
- Update `fetchMrDiffs` to pass `--paginate` and parse with `parseGlabPaginated` (switching from `.json()` to `.text()` since paginated output concatenates arrays as `][`)
- Re-export `parseGlabPaginated` from `discussions.ts` to preserve the external import surface
- Move the `parseGlabPaginated` tests to `diff.test.ts`

## References

Original Task: [review: draft-note.ts batch skips files past diff page 1](https://things.bendrucker.me/show?id=38FAahi1hdQzs3GoYLRnTg)
