### PR TITLE
fix(writing): skip flagged content in search-pattern fields

### DIFF
--- a/plugins/writing/hooks/check-tropes.test.ts
+++ b/plugins/writing/hooks/check-tropes.test.ts
@@ -21,14 +21,33 @@ function mockWrite(content: string): PreToolUseHookInput {
   };
 }
 
-function mockEdit(newString: string): PreToolUseHookInput {
+function mockEdit(newString: string, oldString?: string): PreToolUseHookInput {
+  const toolInput: Record<string, unknown> = {
+    file_path: "test.md",
+    new_string: newString,
+  };
+  if (oldString !== undefined) toolInput.old_string = oldString;
   return {
     hook_event_name: "PreToolUse",
     session_id: "test",
     transcript_path: "/tmp/test",
     cwd: "/tmp",
     tool_name: "Edit",
-    tool_input: { file_path: "test.md", new_string: newString },
+    tool_input: toolInput,
+    tool_use_id: "test",
+  };
+}
+
+function mockMultiEdit(
+  edits: Array<{ old_string?: string; new_string: string }>,
+): PreToolUseHookInput {
+  return {
+    hook_event_name: "PreToolUse",
+    session_id: "test",
+    transcript_path: "/tmp/test",
+    cwd: "/tmp",
+    tool_name: "MultiEdit",
+    tool_input: { file_path: "test.md", edits },
     tool_use_id: "test",
   };
 }
@@ -119,6 +138,20 @@ describe("Write/Edit", () => {
     expect(output?.permissionDecision).toBe("ask");
   });
 
+  it("ignores flagged content in Edit old_string", async () => {
+    const input = mockEdit(
+      "clean replacement text here",
+      "old content with \u2014 spaced em dash inside",
+    );
+    expect(await processInput(input)).toBeNull();
+  });
+
+  it("asks on Edit when old_string is clean but new_string has em dash", async () => {
+    const input = mockEdit("This \u2014 is bad", "clean original text here");
+    const output = await getDecision(input);
+    expect(output?.permissionDecision).toBe("ask");
+  });
+
   it("returns context for promotional language", async () => {
     const result = await processInput(mockWrite("A groundbreaking approach"));
     expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
@@ -130,6 +163,32 @@ describe("Write/Edit", () => {
 
   it("returns null for empty content", async () => {
     expect(await processInput(mockWrite(""))).toBeNull();
+  });
+});
+
+describe("MultiEdit", () => {
+  it("returns null when all old_string values are flagged but new_string values are clean", async () => {
+    const input = mockMultiEdit([
+      { old_string: "text with \u2014 em dash", new_string: "clean replacement text here" },
+      { old_string: "delve into the codebase", new_string: "look at the code carefully" },
+    ]);
+    expect(await processInput(input)).toBeNull();
+  });
+
+  it("asks when any new_string contains a spaced em dash", async () => {
+    const input = mockMultiEdit([
+      { old_string: "clean original text here", new_string: "clean replacement text here" },
+      { old_string: "more clean original content", new_string: "bad \u2014 replacement here" },
+    ]);
+    const output = await getDecision(input);
+    expect(output?.permissionDecision).toBe("ask");
+  });
+
+  it("returns null for fully clean MultiEdit", async () => {
+    const input = mockMultiEdit([
+      { old_string: "original content here", new_string: "replacement content here" },
+    ]);
+    expect(await processInput(input)).toBeNull();
   });
 });
 describe("collectText", () => {
@@ -237,5 +296,35 @@ describe("Bash/MCP processInput", () => {
 
   it("returns null for non-text Bash commands", async () => {
     expect(await processInput(mockBash("git push origin main"))).toBeNull();
+  });
+
+  it("ignores flagged content in nested old_str fields", async () => {
+    const flagged = "text with; semicolons; everywhere; really; lots of them";
+    const result = await processInput(
+      mockMcp("mcp__example_tool", {
+        command: "update_content",
+        content_updates: [{ old_str: flagged, new_str: "Clean replacement text here." }],
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("ignores blocklisted query fields but scans remaining prose", async () => {
+    const result = await processInput(
+      mockMcp("mcp__search_tool", {
+        query: "delve into the codebase and find issues",
+        result_description: "A straightforward summary of the findings.",
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("still flags nested prose in non-blocklisted keys", async () => {
+    const result = await processInput(
+      mockMcp("mcp__some_tool", {
+        payload: { body: "We delve into the system for a while longer" },
+      }),
+    );
+    expect(result?.hookSpecificOutput).toHaveProperty("permissionDecision", "deny");
   });
 });

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -7,6 +7,24 @@ import { firstByTier, scan } from "./tropes";
 
 const MIN_PROSE_LENGTH = 20;
 
+const SKIPPED_KEYS = new Set([
+  "old_string",
+  "oldstring",
+  "old_str",
+  "pattern",
+  "match",
+  "search",
+  "search_query",
+  "query",
+]);
+
+function shouldSkipKey(key: string | undefined): boolean {
+  if (!key) return false;
+  const lower = key.toLowerCase();
+  if (SKIPPED_KEYS.has(lower)) return true;
+  return lower.startsWith("old_");
+}
+
 function isProse(value: string): boolean {
   if (value.length < MIN_PROSE_LENGTH) return false;
   if (/^https?:\/\//.test(value)) return false;
@@ -14,11 +32,14 @@ function isProse(value: string): boolean {
   return /\s/.test(value);
 }
 
-function extractProse(value: unknown): string[] {
+function extractProse(value: unknown, key?: string): string[] {
+  if (shouldSkipKey(key)) return [];
   if (typeof value === "string") return isProse(value) ? [value] : [];
-  if (Array.isArray(value)) return value.flatMap(extractProse);
+  if (Array.isArray(value)) return value.flatMap((item) => extractProse(item, key));
   if (typeof value === "object" && value !== null) {
-    return Object.values(value).flatMap(extractProse);
+    return Object.entries(value).flatMap(([childKey, childValue]) =>
+      extractProse(childValue, childKey),
+    );
   }
   return [];
 }
@@ -41,6 +62,19 @@ function extractInlineArg(command: string, flag: string): string | null {
   return match?.[1] ?? match?.[2] ?? null;
 }
 
+function collectMultiEditText(toolInput: Record<string, unknown>): string[] {
+  const edits = toolInput.edits;
+  if (!Array.isArray(edits)) return [];
+  const texts: string[] = [];
+  for (const edit of edits) {
+    if (edit && typeof edit === "object") {
+      const newString = (edit as Record<string, unknown>).new_string;
+      if (typeof newString === "string") texts.push(newString);
+    }
+  }
+  return texts;
+}
+
 export async function collectText(input: PreToolUseHookInput): Promise<string[]> {
   const toolInput = input.tool_input as Record<string, unknown>;
   const toolName = input.tool_name;
@@ -53,6 +87,10 @@ export async function collectText(input: PreToolUseHookInput): Promise<string[]>
   if (toolName === "Edit") {
     const content = toolInput.new_string as string | undefined;
     return content ? [content] : [];
+  }
+
+  if (toolName === "MultiEdit") {
+    return collectMultiEditText(toolInput);
   }
 
   if (toolName === "Bash" && typeof toolInput.command === "string") {
@@ -90,7 +128,7 @@ export async function processInput(input: PreToolUseHookInput): Promise<SyncHook
   const deny = firstByTier(matches, "deny");
 
   if (deny) {
-    if (input.tool_name === "Edit") {
+    if (input.tool_name === "Edit" || input.tool_name === "MultiEdit") {
       return formatDecision("ask", deny.message);
     }
     return formatDecision("deny", deny.message);

--- a/plugins/writing/hooks/hooks.json
+++ b/plugins/writing/hooks/hooks.json
@@ -21,7 +21,7 @@
         ]
       },
       {
-        "matcher": "Edit",
+        "matcher": "Edit|MultiEdit",
         "hooks": [
           {
             "type": "command",
@@ -30,7 +30,7 @@
           {
             "type": "command",
             "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts",
-            "if": "Edit(**/*.md)"
+            "if": "Edit(**/*.md)|MultiEdit(**/*.md)"
           },
           {
             "type": "command",

--- a/plugins/writing/hooks/hooks.json
+++ b/plugins/writing/hooks/hooks.json
@@ -21,7 +21,7 @@
         ]
       },
       {
-        "matcher": "Edit|MultiEdit",
+        "matcher": "Edit",
         "hooks": [
           {
             "type": "command",
@@ -30,8 +30,17 @@
           {
             "type": "command",
             "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts",
-            "if": "Edit(**/*.md)|MultiEdit(**/*.md)"
+            "if": "Edit(**/*.md)"
           },
+          {
+            "type": "command",
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts"
+          }
+        ]
+      },
+      {
+        "matcher": "MultiEdit",
+        "hooks": [
           {
             "type": "command",
             "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts"


### PR DESCRIPTION
Trope detection walked every string in `PreToolUse` inputs, so flagged prose that appeared only in removal fields (`old_string`, `old_str`) or search patterns (`query`, `search`) tripped the hook. Removing flagged content now passes through cleanly, and `MultiEdit` is scanned the same way as `Edit` (only `edits[].new_string` is inspected).

## Changes

- Recursive walker now tracks the parent key and skips a blocklist of keys (`old_string`, `oldstring`, `old_str`, `pattern`, `match`, `search`, `search_query`, `query`, plus any key starting with `old_`).
- New `collectMultiEditText` branch pulls only `new_string` values from `MultiEdit` inputs.
- `processInput` treats `MultiEdit` like `Edit` and issues `ask` rather than `deny`.
- `hooks.json` matcher expanded from `Edit` to `Edit|MultiEdit`; the `headings.ts` markdown filter updated to match both.

## Testing

Added cases in `check-tropes.test.ts`:

- `Edit` with flagged `old_string` and clean `new_string` → passes.
- `MultiEdit` with flagged `old_string` across all edits and clean `new_string` → passes; flipping any `new_string` to contain a spaced em dash → `ask`.
- Nested `content_updates[].old_str` (generic MCP shape) containing semicolons → passes, matching the original Notion repro without any Notion-specific code.
- Blocklisted `query` alongside clean `result_description` → passes.
- Non-blocklisted `body` under a `payload` wrapper with flagged prose → `deny` (confirms the blocklist does not over-block).

Original Task: [Writing hook: semicolon detection matches on old_str field](https://things.bendrucker.me/show?id=JFwGzkW7cKc7NFm4LkgAea)
