### PR TITLE
fix(sandbox): bypass via wrapper matcher for nested open calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,3 +173,16 @@ Permission patterns starting with `/` are relative to the settings file, not abs
 - `Edit(tmp/**)` → `<cwd>/tmp/**` (relative to current directory)
 - `Edit(//tmp/**)` → `/tmp/**` (absolute)
 - `Edit(~/.config/**)` → home directory (tilde expansion works)
+
+### Sandbox and Nested Commands
+
+`excludedCommands` matches only the top-level command of a Bash invocation. Nested commands (e.g., `open` spawned from a `bun scripts/foo.ts` wrapper) inherit the parent's sandbox profile, so adding `open:*` to `excludedCommands` does not exempt nested calls. The convention is a per-plugin PreToolUse hook scoped to the wrapping `bun ${CLAUDE_PLUGIN_ROOT}/scripts/...:*` matcher that emits `dangerouslyDisableSandbox: true`. See [`plugins/things/hooks/`](plugins/things/hooks/) and [`plugins/x-callback-url/hooks/`](plugins/x-callback-url/hooks/) for canonical examples:
+
+```json
+{
+  "matcher": "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/:*)",
+  "hooks": [
+    { "type": "command", "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/sandbox.ts" }
+  ]
+}
+```

--- a/plugins/mac/hooks/disable-sandbox.test.ts
+++ b/plugins/mac/hooks/disable-sandbox.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { processInput } from "./disable-sandbox";
+
+function makeInput(command: string): PreToolUseHookInput {
+  return {
+    tool_name: "Bash",
+    tool_input: { command },
+  } as PreToolUseHookInput;
+}
+
+describe("processInput", () => {
+  test("sets dangerouslyDisableSandbox on tool input", () => {
+    const result = processInput(makeInput("bun scripts/open-url.ts things things:///add"));
+    expect(result).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        updatedInput: {
+          command: "bun scripts/open-url.ts things things:///add",
+          dangerouslyDisableSandbox: true,
+        },
+      },
+    });
+  });
+});

--- a/plugins/mac/hooks/disable-sandbox.ts
+++ b/plugins/mac/hooks/disable-sandbox.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env bun
+
+import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+
+export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput {
+  const toolInput = input.tool_input as Record<string, unknown>;
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      updatedInput: { ...toolInput, dangerouslyDisableSandbox: true },
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  let input: PreToolUseHookInput;
+  try {
+    input = await readStdinJson<PreToolUseHookInput>();
+  } catch {
+    return;
+  }
+
+  writeStdoutJson(processInput(input));
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/plugins/mac/hooks/hooks.json
+++ b/plugins/mac/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Detects Go binaries and disables sandbox for TLS cert verification",
+  "description": "Disables sandbox for Go binaries (TLS cert verification) and for plugin scripts that invoke macOS automation",
   "hooks": {
     "PreToolUse": [
       {
@@ -8,6 +8,15 @@
           {
             "type": "command",
             "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/sandbox.ts"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/open-url.ts:*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/disable-sandbox.ts"
           }
         ]
       }

--- a/plugins/things/CLAUDE.md
+++ b/plugins/things/CLAUDE.md
@@ -10,7 +10,7 @@ JXA scripts run via `osascript`, which requires Apple Events mach-lookup service
 - Formatter (`scripts/format-output.ts`): reads JSON from stdin, outputs tables or passes through `--json`
 - JXA execution: invoke the `mac:jxa-run` skill, which validates `Application("Things3")` scope via AST
 
-Sandbox bypass is handled by a PreToolUse hook in `hooks/hooks.json`. The matcher is `"Bash"` with an `if` condition that narrows to plugin scripts (`Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/:*)`). The `if` field uses permission rule syntax where `|` is literal, avoiding the conflict with piped commands that the matcher's OR operator causes.
+Sandbox bypass is handled by a PreToolUse hook in `hooks/hooks.json`. The matcher narrows to plugin scripts via `Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/:*)`.
 
 ## JXA Script Conventions
 
@@ -27,7 +27,7 @@ Biome linting is disabled for `scripts/jxa/` files via the root `biome.json` ove
 
 ## Reorder Script
 
-`scripts/reorder.ts` is a bun TypeScript script that reuses `url.ts` exports (`getAuthToken`, `buildUrl`). It opens Things URLs via `open -g` to reorder items. Unlike the JXA scripts, it does not use `osascript` — sandbox bypass comes from the `things:url` skill's inline hook.
+`scripts/reorder.ts` is a bun TypeScript script that reuses `url.ts` exports (`getAuthToken`, `buildUrl`). It opens Things URLs via `open -g` to reorder items. Unlike the JXA scripts, it does not use `osascript` — sandbox bypass comes from the plugin PreToolUse hook in `hooks/hooks.json`.
 
 ## What NOT to Do
 

--- a/plugins/things/hooks/hooks.json
+++ b/plugins/things/hooks/hooks.json
@@ -3,12 +3,11 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash",
+        "matcher": "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/:*)",
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/sandbox.ts",
-            "if": "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/:*)"
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/sandbox.ts"
           }
         ]
       }


### PR DESCRIPTION
`excludedCommands` matches only the top-level Bash command, so adding `open:*` does not exempt nested `open` calls spawned from `bun scripts/*.ts` wrappers. The convention in this repo is a per-plugin PreToolUse hook scoped to the wrapping script that emits `dangerouslyDisableSandbox: true`.

## Changes

- Tightens `plugins/things/hooks/hooks.json` to use a direct `Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/:*)` matcher instead of `matcher: "Bash"` + `if:`.
- Adds an analogous PreToolUse hook in `plugins/mac` for `scripts/open-url.ts`, backed by a new `hooks/disable-sandbox.ts` (mirrors the `things` and `x-callback-url` shape).
- Documents the invariant in the root `CLAUDE.md` under a new `Sandbox and Nested Commands` subsection, pointing at `plugins/things/hooks/` and `plugins/x-callback-url/hooks/` as the canonical examples.
- Updates `plugins/things/CLAUDE.md` to reflect the simplified matcher and to point at `hooks/hooks.json` as the source of truth for `reorder.ts` sandbox bypass.

## Testing

- New unit test for `disable-sandbox.ts` covers the `dangerouslyDisableSandbox` injection on tool input.
- Manual end-to-end invocation of both hooks confirms they emit the expected `updatedInput` envelope for representative wrapper script commands.

## References

Original Task: [Sandbox blocks Things inbox script via nested `open` despite `open:*` in excludedCommands](https://things.bendrucker.me/show?id=AaVMDzwMMkLyNRWRauoUJN)
