### PR TITLE
fix(session): pin raw schema, keep full line as data JSON

### DIFF
--- a/plugins/claude-code/skills/session/CLAUDE.md
+++ b/plugins/claude-code/skills/session/CLAUDE.md
@@ -13,7 +13,7 @@ JSONL files in `~/.claude/projects/` are the canonical data. The DuckDB database
 
 ### Tables
 
-- **`raw`**: Incremental `UNION ALL BY NAME` — only changed JSONL files are re-read. `01_tables.sql` seeds sparse columns (`summary`).
+- **`raw`**: Rebuilt from disk on every import via a single `read_ndjson` over the full `projects_glob`. `refresh.sql` short-circuits the import when nothing has changed since `last_import`, but when it does run, `raw` is fully replaced — never `UNION`-ed with cached rows. This avoids cross-run column type drift (e.g., a column inferred as `VARCHAR` in one run and `JSON` in the next), which would fail the union cast.
 - **`messages`**: Built from `raw` via `* EXCLUDE` pass-through + snake_case renames. One row per message.
 - **`content_items`**: Built from a temp JSONL file via `read_ndjson` auto-detect. Each content array element is written with parent context merged in. Schema is fully auto-detected.
 
@@ -22,6 +22,8 @@ Views (`tool_calls`, `tool_errors`, `sessions`) query these tables.
 ### Import pipeline
 
 `import.sql` flattens `message.*` into `raw`. Only `message.content` is explicitly aliased to `message_content`; the rest of `message.*` expands via `EXCLUDE (content)`. When message fields collide with top-level fields (e.g., `type`, `id`, `container`), DuckDB auto-suffixes them (`type_1`, `id_1`, etc.). This avoids `EXCLUDE` on optional message fields, which fails when they're absent from the struct.
+
+`source_line` uses `ROW_NUMBER() OVER (PARTITION BY filename)` so it preserves per-file 1-based line numbers — needed by the `sed -n '<source_line>p' <source_file>` lookup pattern documented in `SKILL.md`.
 
 After rebuilding `raw`, `import.sql` creates a `content_items_export` temp table. Callers must COPY this to `${data_dir}/content_items.jsonl` and DROP it before running `views.sql`. DuckDB's `COPY TO` requires a literal path, so this step cannot live in SQL alone.
 

--- a/plugins/claude-code/skills/session/CLAUDE.md
+++ b/plugins/claude-code/skills/session/CLAUDE.md
@@ -6,30 +6,34 @@ JSONL files in `~/.claude/projects/` are the canonical data. The DuckDB database
 
 ### Schema
 
-`resources/schema/` contains ordered DDL files run on every startup:
+`resources/schema/` runs on every startup:
 
-- `01_tables.sql`: Bootstrap `raw` (minimal schema, replaced on import) and `meta` (import timestamps)
-- `03_macros.sql`: Filter macros for date ranges and project paths
+- `01_tables.sql`: `raw` with pinned columns plus a `data JSON` blob, and `meta` with `last_import`. The full pinned column set is declared upfront so the table type is stable across imports.
+- `03_macros.sql`: filter macros for date ranges and project paths.
 
 ### Tables
 
-- **`raw`**: Rebuilt from disk on every import via a single `read_ndjson` over the full `projects_glob`. `refresh.sql` short-circuits the import when nothing has changed since `last_import`, but when it does run, `raw` is fully replaced — never `UNION`-ed with cached rows. This avoids cross-run column type drift (e.g., a column inferred as `VARCHAR` in one run and `JSON` in the next), which would fail the union cast.
-- **`messages`**: Built from `raw` via `* EXCLUDE` pass-through + snake_case renames. One row per message.
-- **`content_items`**: Built from a temp JSONL file via `read_ndjson` auto-detect. Each content array element is written with parent context merged in. Schema is fully auto-detected.
+- **`raw`**: pinned scalar columns (`session_id`, `type`, `project_path`, `git_branch`, `is_meta`, `is_sidechain`, `duration_ms`, `timestamp`, `summary`, `input_tokens`, `output_tokens`, `source_file`, `source_line`) plus `data JSON` holding the full original JSONL line. Imports use `read_json_objects(...)` (no auto-detected types beyond `json` itself), so column types never drift between imports.
+- **`messages`**: view over `raw` filtered to `type IN ('user', 'assistant')`, adding `content_text` (when message content is a string) and a joined `summary`.
+- **`content_items`**: built from `raw` via `unnest(json_extract(data, '$.message.content[*]'))`. Pinned columns plus the content item's full `data JSON` plus the parent's `tool_use_result JSON`. No temp file roundtrip.
 
-Views (`tool_calls`, `tool_errors`, `sessions`) query these tables.
+Other views (`tool_calls`, `tool_errors`, `permission_requests`, `sandbox_bypasses`, `skill_calls`, `sessions`) read from `messages` / `content_items`.
 
 ### Import pipeline
 
-`import.sql` flattens `message.*` into `raw`. Only `message.content` is explicitly aliased to `message_content`; the rest of `message.*` expands via `EXCLUDE (content)`. When message fields collide with top-level fields (e.g., `type`, `id`, `container`), DuckDB auto-suffixes them (`type_1`, `id_1`, etc.). This avoids `EXCLUDE` on optional message fields, which fails when they're absent from the struct.
+`refresh.sql` returns `changed_files` (those modified after `last_import`). `import.sql` runs `read_json_objects` on just those files, projects pinned columns with explicit casts, and updates `raw` via `UNION ALL BY NAME` against the cached rows from sessions not in `changed_sessions`. The pinned schema means the cached `raw` and the freshly-built `new_raw` always have identical column types, so the union cannot fail with conversion errors.
 
-`source_line` uses `ROW_NUMBER() OVER (PARTITION BY filename)` so it preserves per-file 1-based line numbers — needed by the `sed -n '<source_line>p' <source_file>` lookup pattern documented in `SKILL.md`.
+After `import.sql`, `views.sql` rebuilds `content_items` and the views. No temp JSONL files, no `COPY TO` step.
 
-After rebuilding `raw`, `import.sql` creates a `content_items_export` temp table. Callers must COPY this to `${data_dir}/content_items.jsonl` and DROP it before running `views.sql`. DuckDB's `COPY TO` requires a literal path, so this step cannot live in SQL alone.
+### Migration
 
-`views.sql` reads the temp file back via `read_ndjson(getvariable('data_dir') || '/content_items.jsonl')` and creates `content_items`, `messages`, and downstream views.
+`db.ts` runs `migrateIfNeeded` after the warm-session marker check, before `applySchema`. If `raw.data` is missing (the old auto-detected schema), it drops `raw`, `meta`, `messages`, and `content_items`. The next `applySchema` recreates the pinned tables, and the empty `meta` forces a one-shot full reimport from JSONL. Warm sessions with a `.refreshed-<id>` marker skip migration entirely.
+
+### JSON path gotcha
+
+DuckDB parses `data->>'$.x' = 'y'` as `data->>('$.x' = 'y')` because `=` binds tighter than `->>`. Wrap `data->>'$.path'` in parens before any comparison or function call where this matters. The views in `views.sql` apply this convention; downstream queries in `resources/queries/` should too.
 
 ### Callers
 
-- `db.ts`: Sets `data_dir` variable, orchestrates import → COPY → views via separate `db.run()` calls
-- `query.ts`: CLI entry point, uses `db.ts` functions directly
+- `db.ts`: orchestrates migration, schema, refresh, import, views.
+- `query.ts`: CLI entry point.

--- a/plugins/claude-code/skills/session/SKILL.md
+++ b/plugins/claude-code/skills/session/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-code:session
-description: Introspect on your own Claude Code usage and history — session ID, duration, tokens consumed, tool usage patterns, time per project, recent activity summaries, or searching past conversations. Use whenever the user asks about their Claude Code activity ("what's my session ID?", "how many tokens today?", "what did I work on this week?", "find that conversation where I set up X", "am I overusing Bash?"). Do NOT use for general codebase search, git log queries, or arbitrary databases.
+description: Introspect on your own Claude Code usage and history (session ID, duration, tokens consumed, tool usage patterns, time per project, recent activity summaries, or searching past conversations). Use whenever the user asks about their Claude Code activity ("what's my session ID?", "how many tokens today?", "what did I work on this week?", "find that conversation where I set up X", "am I overusing Bash?"). Do NOT use for general codebase search, git log queries, or arbitrary databases.
 allowed-tools:
   - Bash
   - Read
@@ -14,16 +14,16 @@ Search and analyze Claude Code conversation history via a DuckDB index over JSON
 
 ## Running Queries
 
-The index refreshes automatically on first use per session. Subsequent queries skip the refresh for faster results. Pass `--refresh` to force a re-scan when the user asks for the latest data.
+The index refreshes automatically on first use per session. Subsequent queries skip the refresh for faster results. Pass `--refresh` to re-scan when the user asks for the latest data.
 
 ```bash
-${CLAUDE_SKILL_DIR}/scripts/query.ts "SELECT model, SUM(output_tokens) as tokens FROM messages WHERE type = 'assistant' GROUP BY model"
+${CLAUDE_SKILL_DIR}/scripts/query.ts "SELECT model, SUM(output_tokens) FROM messages WHERE type = 'assistant' GROUP BY model"
 ${CLAUDE_SKILL_DIR}/scripts/query.ts --refresh "SELECT * FROM sessions ORDER BY start_time DESC LIMIT 5"
 ```
 
-#### Named Queries
+## Named Queries
 
-Built-in queries in `resources/queries/` can be run by name with `key=value` params. Prefer these over writing SQL from scratch for common tasks:
+Built-in queries in `resources/queries/` run by name with `key=value` params. Prefer these over writing SQL from scratch.
 
 ```bash
 ${CLAUDE_SKILL_DIR}/scripts/query.ts search query=authentication limit=10
@@ -33,145 +33,61 @@ ${CLAUDE_SKILL_DIR}/scripts/query.ts permissions project=bendrucker.me limit=10
 ${CLAUDE_SKILL_DIR}/scripts/query.ts sandbox limit=10
 ```
 
-The `project` param matches against the directory name (last path component) using glob syntax. `project=myapp` matches exactly, `project=myapp*` matches the repo and its worktrees (`myapp.feature-branch`, `myapp.bugfix`, etc.).
+The `project` param matches against the directory name (last path component) using glob syntax: `project=myapp` matches exactly, `project=myapp*` matches the repo and its worktrees.
 
 - `search`: find sessions by keyword (ILIKE on `content_text` and `summary`). Params: `query`, `limit`, `after_date`, `before_date`, `project`
 - `stats`: tool usage breakdown with error rates and aggregate totals. Params: `after_date`, `before_date`, `project`
 - `errors`: recent tool errors with type filtering. Params: `error_type` (`rejection` or `failure`), `limit`, `after_date`, `before_date`, `project`
 - `permissions`: tool calls the user rejected. Params: `limit`, `after_date`, `before_date`, `project`
 - `sandbox`: Bash calls that bypassed the sandbox (`dangerouslyDisableSandbox`), with back-links to prior failed sandboxed calls of the same command. Params: `limit`, `after_date`, `before_date`, `project`
+- `skills`: skill invocation counts by name. Params: `skill`, `after_date`, `before_date`, `project`
+- `schema`: list every column in every table/view. Use this first when you don't know what's available.
+- `keys`: sample which top-level JSON keys appear in `raw.data` (the unstructured part), with occurrence counts.
 
-## Schema
+## Tables and Views
 
-### `messages` table
+- `raw`: one row per JSONL line. Pinned scalar columns (`session_id`, `type`, `project_path`, `git_branch`, `is_meta`, `is_sidechain`, `duration_ms`, `timestamp`, `summary`, `input_tokens`, `output_tokens`, `source_file`, `source_line`) plus a `data JSON` column that holds the full original line.
+- `messages`: view over `raw` filtered to `type IN ('user', 'assistant')`, with a derived `content_text` (string-form messages only) and a `summary` joined from summary rows.
+- `content_items`: one row per element of `data->'$.message.content'`, with pinned columns (`type`, `name`, `id`, `tool_use_id`, `text`, `content`, `is_error`) plus `data JSON` (the content item) and `tool_use_result JSON` (merged from the parent message).
+- `sessions`: aggregated session-level stats (start/end time, duration, message counts).
+- `tool_calls`: one row per tool use.
+- `tool_errors`: tool results where `is_error` is true, joined with the originating tool call. `error_type` is `rejection` or `failure`.
+- `permission_requests`: tool calls the user rejected.
+- `sandbox_bypasses`: Bash calls that used `dangerouslyDisableSandbox=true`, with back-links to retried failures.
+- `skill_calls`: one row per `Skill` tool invocation.
 
-One row per message. Schema is auto-detected from JSONL with snake_case renames for known fields.
+## Discovery
 
-| Column | Type | Description |
-|---|---|---|
-| `session_id` | VARCHAR | Session UUID |
-| `type` | VARCHAR | `user` or `assistant` |
-| `timestamp` | TIMESTAMP | Message timestamp |
-| `project_path` | VARCHAR | Absolute path to the project directory |
-| `git_branch` | VARCHAR | Branch at time of message |
-| `is_meta` | BOOLEAN | System-injected user message (not human input) |
-| `content_text` | VARCHAR | Raw text content (string-content messages only) |
-| `summary` | VARCHAR | Conversation summary (joined from summary rows) |
-| `input_tokens` | BIGINT | Input token count — assistant rows only |
-| `output_tokens` | BIGINT | Output token count — assistant rows only |
-| `duration_ms` | BIGINT | Message duration in milliseconds |
-| `is_sidechain` | BOOLEAN | Whether the message is on a sidechain |
-| `source_file` | VARCHAR | Absolute path to the source JSONL file |
-| `source_line` | BIGINT | Line number in the source file (1-based) |
+Don't memorize column lists. Ask DuckDB.
 
-Unknown fields from JSONL pass through automatically via `* EXCLUDE`.
+```bash
+${CLAUDE_SKILL_DIR}/scripts/query.ts schema
+${CLAUDE_SKILL_DIR}/scripts/query.ts keys
+${CLAUDE_SKILL_DIR}/scripts/query.ts "DESCRIBE messages"
+${CLAUDE_SKILL_DIR}/scripts/query.ts "DESCRIBE content_items"
+```
 
-### `content_items` table
+For fields not in the pinned columns, reach into `data` directly with JSON path operators.
 
-One row per content array element, with parent context merged in. Schema is fully auto-detected.
+```sql
+SELECT (data->>'$.message.model') AS model
+FROM messages
+WHERE type = 'assistant' AND (data->>'$.message.model') IS NOT NULL
+GROUP BY model;
+```
 
-| Column | Type | Description |
-|---|---|---|
-| `type` | VARCHAR | `text`, `tool_use`, `tool_result`, `thinking` |
-| `text` | VARCHAR | Text content |
-| `name` | VARCHAR | Tool name (for `tool_use`) |
-| `id` | VARCHAR | Tool use ID (for `tool_use`) |
-| `tool_use_id` | VARCHAR | Matching tool use ID (for `tool_result`) |
-| `content` | VARCHAR | Tool result text (for `tool_result`) |
-| `is_error` | BOOLEAN | Whether the tool result is an error |
-| `session_id` | VARCHAR | Session UUID (from parent message) |
-| `timestamp` | VARCHAR | Message timestamp (from parent message) |
-| `project_path` | VARCHAR | Project directory (from parent message) |
-
-Additional fields (`input`, `thinking`, `caller`, `signature`, etc.) are auto-detected from real data.
-
-### `sessions` view
-
-Aggregated session-level data.
-
-| Column | Type |
-|---|---|
-| `session_id` | VARCHAR |
-| `summary` | VARCHAR |
-| `start_time` | TIMESTAMP |
-| `end_time` | TIMESTAMP |
-| `duration` | INTERVAL |
-| `project_path` | VARCHAR |
-| `git_branch` | VARCHAR |
-| `user_messages` | BIGINT |
-| `assistant_messages` | BIGINT |
-
-### `tool_calls` view
-
-One row per tool use.
-
-| Column | Type |
-|---|---|
-| `tool_name` | VARCHAR |
-| `tool_id` | VARCHAR |
-| `session_id` | VARCHAR |
-| `project_path` | VARCHAR |
-| `timestamp` | TIMESTAMP |
-
-### `tool_errors` view
-
-Tool results where `is_error` is true, joined with the originating tool call.
-
-| Column | Type |
-|---|---|
-| `tool_id` | VARCHAR |
-| `error_content` | VARCHAR |
-| `tool_name` | VARCHAR |
-| `session_id` | VARCHAR |
-| `project_path` | VARCHAR |
-| `timestamp` | TIMESTAMP |
-| `error_type` | VARCHAR (`rejection` or `failure`) |
-
-### `permission_requests` view
-
-Tool calls the user rejected (denied the permission prompt).
-
-| Column | Type |
-|---|---|
-| `tool_name` | VARCHAR |
-| `tool_id` | VARCHAR |
-| `command` | VARCHAR (Bash only) |
-| `file_path` | VARCHAR (Edit/Write only) |
-| `description` | VARCHAR |
-| `session_id` | VARCHAR |
-| `project_path` | VARCHAR |
-| `timestamp` | TIMESTAMP |
-
-### `sandbox_bypasses` view
-
-Bash calls that used `dangerouslyDisableSandbox=true`. Includes a back-link to the most recent prior failed sandboxed call with the same command, identifying retry patterns where the sandbox caused the initial failure.
-
-| Column | Type | Description |
-|---|---|---|
-| `command` | VARCHAR | The Bash command |
-| `description` | VARCHAR | Command description |
-| `tool_id` | VARCHAR | Tool use ID |
-| `session_id` | VARCHAR | Session UUID |
-| `project_path` | VARCHAR | Project directory |
-| `timestamp` | TIMESTAMP | When the bypass was used |
-| `retried_tool_id` | VARCHAR | Tool ID of the prior failed sandboxed call (NULL if no match) |
-| `retried_error` | VARCHAR | Error from the prior failed call (NULL if no match) |
-
-### Macros
-
-Reusable filter helpers available in all queries:
-
-- `date_filter(ts, after_val, before_val)`: filters by timestamp range, NULL values bypass the check
-- `project_filter(path, project_val)`: ILIKE match on project path, NULL bypasses
+Wrap `data->>'$.path'` in parens before any comparison. DuckDB parses `data->>'$.x' = 'y'` as `data->>('$.x' = 'y')` (boolean array index) and fails.
 
 ## Source Lookup
 
-To retrieve the full JSONL line for a message (e.g., to inspect tool input):
+To retrieve the full JSONL line for a message:
 
 ```bash
 sed -n '<source_line>p' <source_file>
 ```
 
+`source_line` is 1-based and per-file (partitioned by `source_file`).
+
 ## Session File Structure
 
-Session logs are stored in `~/.claude/projects/<encoded-path>/<session-id>.jsonl` where the encoded path replaces `/` with `-`. The CLI maintains a DuckDB index at `$CLAUDE_PLUGIN_DATA/session.duckdb`, rebuilt incrementally on each invocation.
+Session logs live in `~/.claude/projects/<encoded-path>/<session-id>.jsonl` where the encoded path replaces `/` with `-`. The index lives at `$CLAUDE_PLUGIN_DATA/session.duckdb`, refreshed incrementally based on file mtime.

--- a/plugins/claude-code/skills/session/resources/import.sql
+++ b/plugins/claude-code/skills/session/resources/import.sql
@@ -1,40 +1,38 @@
-CREATE OR REPLACE TABLE raw AS
+CREATE OR REPLACE TEMP TABLE new_raw AS
 SELECT
-  * EXCLUDE (message, filename),
-  message.content as message_content,
-  message.* EXCLUDE (content),
-  filename as source_file,
-  ROW_NUMBER() OVER (PARTITION BY filename) as source_line
-FROM read_ndjson(
-  getvariable('projects_glob'),
+  json->>'$.sessionId'                                AS session_id,
+  json->>'$.type'                                     AS type,
+  json->>'$.cwd'                                      AS project_path,
+  json->>'$.gitBranch'                                AS git_branch,
+  COALESCE(CAST(json->>'$.isMeta'      AS BOOLEAN), false) AS is_meta,
+  COALESCE(CAST(json->>'$.isSidechain' AS BOOLEAN), false) AS is_sidechain,
+  CAST(json->>'$.durationMs' AS BIGINT)               AS duration_ms,
+  CAST(json->>'$.timestamp'  AS TIMESTAMP)            AS timestamp,
+  json->>'$.summary'                                  AS summary,
+  CAST(json->>'$.message.usage.input_tokens'  AS BIGINT) AS input_tokens,
+  CAST(json->>'$.message.usage.output_tokens' AS BIGINT) AS output_tokens,
+  filename                                            AS source_file,
+  ROW_NUMBER() OVER (PARTITION BY filename)           AS source_line,
+  json                                                AS data
+FROM read_json_objects(
+  getvariable('source'),
+  format='newline_delimited',
   ignore_errors=true,
-  union_by_name=true,
   filename=true
 )
-WHERE type IN ('user', 'assistant', 'summary');
+WHERE json->>'$.type' IN ('user', 'assistant', 'summary');
 
--- views.sql references `summary` directly; corpora without any summary-type
--- rows won't have the column auto-detected, so add it defensively.
-ALTER TABLE raw ADD COLUMN IF NOT EXISTS summary VARCHAR;
+SET VARIABLE changed_sessions = (
+  SELECT COALESCE(LIST(DISTINCT session_id), []) FROM new_raw
+);
 
-CREATE OR REPLACE TEMP TABLE content_items_export AS
-SELECT (
-  substr(item::VARCHAR, 1, length(item::VARCHAR) - 1) || ',' ||
-  ltrim(json_object(
-    'session_id', sessionId::VARCHAR,
-    'source_file', source_file,
-    'source_line', source_line,
-    'timestamp', timestamp,
-    'project_path', cwd,
-    'tool_use_result', toolUseResult
-  )::VARCHAR, '{')
-)::VARCHAR as line
-FROM raw,
-LATERAL (SELECT unnest(json_extract(message_content, '$[*]')) as item) t
-WHERE type IN ('user', 'assistant')
-  AND message_content IS NOT NULL
-  AND json_type(message_content) = 'ARRAY'
-  AND json_array_length(message_content) > 0;
+CREATE OR REPLACE TABLE raw AS
+SELECT * FROM raw
+WHERE session_id NOT IN (SELECT unnest(getvariable('changed_sessions'))::VARCHAR)
+UNION ALL
+SELECT * FROM new_raw;
+
+DROP TABLE new_raw;
 
 DELETE FROM meta;
 INSERT INTO meta VALUES (CURRENT_TIMESTAMP);

--- a/plugins/claude-code/skills/session/resources/import.sql
+++ b/plugins/claude-code/skills/session/resources/import.sql
@@ -1,29 +1,21 @@
-CREATE OR REPLACE TEMP TABLE new_raw AS
+CREATE OR REPLACE TABLE raw AS
 SELECT
   * EXCLUDE (message, filename),
   message.content as message_content,
   message.* EXCLUDE (content),
   filename as source_file,
-  ROW_NUMBER() OVER () as source_line
+  ROW_NUMBER() OVER (PARTITION BY filename) as source_line
 FROM read_ndjson(
-  getvariable('source'),
+  getvariable('projects_glob'),
   ignore_errors=true,
   union_by_name=true,
   filename=true
 )
 WHERE type IN ('user', 'assistant', 'summary');
 
-SET VARIABLE changed_sessions = (
-  SELECT COALESCE(LIST(DISTINCT sessionId), []) FROM new_raw
-);
-
-CREATE OR REPLACE TABLE raw AS
-SELECT * FROM raw
-WHERE sessionId::VARCHAR NOT IN (SELECT unnest(getvariable('changed_sessions'))::VARCHAR)
-UNION ALL BY NAME
-SELECT * FROM new_raw;
-
-DROP TABLE new_raw;
+-- views.sql references `summary` directly; corpora without any summary-type
+-- rows won't have the column auto-detected, so add it defensively.
+ALTER TABLE raw ADD COLUMN IF NOT EXISTS summary VARCHAR;
 
 CREATE OR REPLACE TEMP TABLE content_items_export AS
 SELECT (

--- a/plugins/claude-code/skills/session/resources/queries/keys.sql
+++ b/plugins/claude-code/skills/session/resources/queries/keys.sql
@@ -1,0 +1,12 @@
+WITH sampled AS (
+  SELECT data
+  FROM raw
+  WHERE type IN ('user', 'assistant')
+  USING SAMPLE 500 ROWS
+)
+SELECT
+  key,
+  COUNT(*) AS occurrences
+FROM sampled, LATERAL (SELECT unnest(json_keys(data)) AS key) k
+GROUP BY key
+ORDER BY occurrences DESC, key;

--- a/plugins/claude-code/skills/session/resources/queries/schema.sql
+++ b/plugins/claude-code/skills/session/resources/queries/schema.sql
@@ -1,0 +1,5 @@
+SELECT table_name, column_name, data_type
+FROM information_schema.columns
+WHERE table_schema = 'main'
+  AND table_name != 'meta'
+ORDER BY table_name, ordinal_position;

--- a/plugins/claude-code/skills/session/resources/schema/01_tables.sql
+++ b/plugins/claude-code/skills/session/resources/schema/01_tables.sql
@@ -1,8 +1,20 @@
 CREATE TABLE IF NOT EXISTS raw (
-  sessionId VARCHAR,
-  summary VARCHAR
+  session_id      VARCHAR,
+  type            VARCHAR,
+  project_path    VARCHAR,
+  git_branch      VARCHAR,
+  is_meta         BOOLEAN,
+  is_sidechain    BOOLEAN,
+  duration_ms     BIGINT,
+  timestamp       TIMESTAMP,
+  summary         VARCHAR,
+  input_tokens    BIGINT,
+  output_tokens   BIGINT,
+  source_file     VARCHAR,
+  source_line     BIGINT,
+  data            JSON
 );
 
 CREATE TABLE IF NOT EXISTS meta (
-  last_import TIMESTAMP
+  last_import     TIMESTAMP
 );

--- a/plugins/claude-code/skills/session/resources/views.sql
+++ b/plugins/claude-code/skills/session/resources/views.sql
@@ -1,138 +1,155 @@
-CREATE OR REPLACE TABLE content_items AS
-SELECT * FROM read_ndjson(
-  getvariable('data_dir') || '/content_items.jsonl',
-  auto_detect=true,
-  union_by_name=true
-);
-
-CREATE OR REPLACE TABLE messages AS
+CREATE OR REPLACE VIEW messages AS
 SELECT
-  e.* EXCLUDE (sessionId, cwd, gitBranch, isMeta, isSidechain, durationMs, message_content, toolUseResult, usage, timestamp, summary),
-  e.sessionId::VARCHAR as session_id,
-  e.timestamp::TIMESTAMP as timestamp,
-  e.cwd as project_path,
-  e.gitBranch as git_branch,
-  COALESCE(e.isMeta, false) as is_meta,
-  COALESCE(e.isSidechain, false) as is_sidechain,
-  e.durationMs as duration_ms,
-  e.usage.input_tokens as input_tokens,
-  e.usage.output_tokens as output_tokens,
-  CASE WHEN json_type(e.message_content) = 'VARCHAR' THEN e.message_content::VARCHAR END as content_text,
+  r.* EXCLUDE (data, summary),
+  r.data,
+  CASE
+    WHEN json_type(r.data->'$.message.content') = 'VARCHAR'
+    THEN r.data->>'$.message.content'
+  END AS content_text,
   s.summary
-FROM raw e
+FROM raw r
 LEFT JOIN (
-  SELECT sessionId, summary
+  SELECT session_id, ANY_VALUE(summary) AS summary
   FROM raw
   WHERE type = 'summary' AND summary IS NOT NULL
-) s USING (sessionId)
-WHERE e.type IN ('user', 'assistant');
+  GROUP BY session_id
+) s USING (session_id)
+WHERE r.type IN ('user', 'assistant');
+
+CREATE OR REPLACE TABLE content_items AS
+WITH src AS (
+  SELECT
+    r.session_id,
+    r.timestamp,
+    r.project_path,
+    r.source_file,
+    r.source_line,
+    r.data->'$.message.content' AS message_content,
+    r.data->'$.toolUseResult'   AS tool_use_result
+  FROM raw r
+  WHERE r.type IN ('user', 'assistant')
+)
+SELECT
+  s.session_id,
+  s.timestamp,
+  s.project_path,
+  s.source_file,
+  s.source_line,
+  (item->>'$.type')        AS type,
+  (item->>'$.name')        AS name,
+  (item->>'$.id')          AS id,
+  (item->>'$.tool_use_id') AS tool_use_id,
+  (item->>'$.text')        AS text,
+  (item->>'$.content')     AS content,
+  CAST(item->>'$.is_error' AS BOOLEAN) AS is_error,
+  item AS data,
+  s.tool_use_result
+FROM src s,
+LATERAL (SELECT unnest(json_extract(s.message_content, '$[*]')) AS item) t
+WHERE json_type(s.message_content) = 'ARRAY';
 
 CREATE OR REPLACE VIEW tool_calls AS
 SELECT
-  name as tool_name,
-  id as tool_id,
-  session_id::VARCHAR as session_id,
+  name AS tool_name,
+  id   AS tool_id,
+  session_id,
   project_path,
-  timestamp::TIMESTAMP as timestamp
+  timestamp
 FROM content_items
-WHERE type = 'tool_use'
-  AND name IS NOT NULL;
+WHERE type = 'tool_use' AND name IS NOT NULL;
 
 CREATE OR REPLACE VIEW tool_errors AS
 SELECT
-  er.tool_use_id as tool_id,
-  er.content as error_content,
-  COALESCE(tc.tool_name, 'unknown') as tool_name,
-  er.session_id::VARCHAR as session_id,
+  er.tool_use_id   AS tool_id,
+  er.content       AS error_content,
+  COALESCE(tc.tool_name, 'unknown') AS tool_name,
+  er.session_id,
   tc.project_path,
-  er.timestamp::TIMESTAMP as timestamp,
-  CASE WHEN TRIM(er.tool_use_result::VARCHAR, '"') = 'User rejected tool use' THEN 'rejection' ELSE 'failure' END as error_type
+  er.timestamp,
+  CASE WHEN er.tool_use_result::VARCHAR = '"User rejected tool use"'
+       THEN 'rejection' ELSE 'failure' END AS error_type
 FROM content_items er
 LEFT JOIN tool_calls tc ON er.tool_use_id = tc.tool_id
-WHERE er.type = 'tool_result'
-  AND er.is_error;
+WHERE er.type = 'tool_result' AND er.is_error;
 
 CREATE OR REPLACE VIEW skill_calls AS
 SELECT
-  TRIM(input.skill::VARCHAR, '"') as skill_name,
-  NULLIF(TRIM(input.args::VARCHAR, '"'), '') as args,
-  id as tool_id,
-  session_id::VARCHAR as session_id,
+  (data->>'$.input.skill') AS skill_name,
+  NULLIF((data->>'$.input.args'), '') AS args,
+  id AS tool_id,
+  session_id,
   project_path,
-  timestamp::TIMESTAMP as timestamp
+  timestamp
 FROM content_items
 WHERE type = 'tool_use'
   AND name = 'Skill'
-  AND input.skill IS NOT NULL;
+  AND (data->>'$.input.skill') IS NOT NULL;
 
 CREATE OR REPLACE VIEW permission_requests AS
 SELECT
-  tc.name as tool_name,
-  tc.id as tool_id,
-  TRIM(tc.input['command']::VARCHAR, '"') as command,
-  TRIM(tc.input['file_path']::VARCHAR, '"') as file_path,
-  TRIM(tc.input['description']::VARCHAR, '"') as description,
-  tc.session_id::VARCHAR as session_id,
+  tc.name AS tool_name,
+  tc.id   AS tool_id,
+  (tc.data->>'$.input.command')     AS command,
+  (tc.data->>'$.input.file_path')   AS file_path,
+  (tc.data->>'$.input.description') AS description,
+  tc.session_id,
   tc.project_path,
-  tc.timestamp::TIMESTAMP as timestamp
+  tc.timestamp
 FROM content_items er
 JOIN content_items tc ON er.tool_use_id = tc.id
 WHERE er.type = 'tool_result'
-  AND TRIM(er.tool_use_result::VARCHAR, '"') = 'User rejected tool use';
+  AND er.tool_use_result::VARCHAR = '"User rejected tool use"';
 
 CREATE OR REPLACE VIEW sandbox_bypasses AS
-SELECT
-  bypass.command,
-  bypass.description,
-  bypass.tool_id,
-  bypass.session_id,
-  bypass.project_path,
-  bypass.timestamp,
-  prior_fail.tool_id as retried_tool_id,
-  prior_fail.error as retried_error
-FROM (
+WITH bypass AS (
   SELECT
-    TRIM(input['command']::VARCHAR, '"') as command,
-    TRIM(input['description']::VARCHAR, '"') as description,
-    id as tool_id,
-    session_id::VARCHAR as session_id,
+    (data->>'$.input.command')     AS command,
+    (data->>'$.input.description') AS description,
+    id AS tool_id,
+    session_id,
     project_path,
-    timestamp::TIMESTAMP as timestamp
+    timestamp
   FROM content_items
   WHERE type = 'tool_use'
     AND name = 'Bash'
-    AND input['dangerouslyDisableSandbox']::VARCHAR = 'true'
-) bypass
+    AND (data->>'$.input.dangerouslyDisableSandbox') = 'true'
+)
+SELECT
+  b.command,
+  b.description,
+  b.tool_id,
+  b.session_id,
+  b.project_path,
+  b.timestamp,
+  prior.tool_id AS retried_tool_id,
+  prior.error   AS retried_error
+FROM bypass b
 LEFT JOIN LATERAL (
-  SELECT
-    tc.id as tool_id,
-    TRIM(er.content::VARCHAR, '"') as error
+  SELECT tc.id AS tool_id, er.content AS error
   FROM content_items tc
   JOIN content_items er
-    ON er.tool_use_id = tc.id
-    AND er.type = 'tool_result'
-    AND er.is_error
+    ON er.tool_use_id = tc.id AND er.type = 'tool_result' AND er.is_error
   WHERE tc.type = 'tool_use'
     AND tc.name = 'Bash'
-    AND COALESCE(tc.input['dangerouslyDisableSandbox']::VARCHAR, 'false') = 'false'
-    AND tc.session_id::VARCHAR = bypass.session_id
-    AND tc.timestamp::TIMESTAMP < bypass.timestamp
-    AND TRIM(tc.input['command']::VARCHAR, '"') = bypass.command
-  ORDER BY tc.timestamp::TIMESTAMP DESC
+    AND COALESCE((tc.data->>'$.input.dangerouslyDisableSandbox'), 'false') = 'false'
+    AND tc.session_id = b.session_id
+    AND tc.timestamp  < b.timestamp
+    AND (tc.data->>'$.input.command') = b.command
+  ORDER BY tc.timestamp DESC
   LIMIT 1
-) prior_fail ON true;
+) prior ON true;
 
 CREATE OR REPLACE VIEW sessions AS
 SELECT
   session_id,
-  ANY_VALUE(summary) as summary,
-  MIN(timestamp) as start_time,
-  MAX(timestamp) as end_time,
-  MAX(timestamp) - MIN(timestamp) as duration,
-  ANY_VALUE(project_path) as project_path,
-  ANY_VALUE(git_branch) as git_branch,
-  COUNT(*) FILTER (WHERE type = 'user' AND NOT is_meta) as user_messages,
-  COUNT(*) FILTER (WHERE type = 'assistant') as assistant_messages
+  ANY_VALUE(summary) AS summary,
+  MIN(timestamp) AS start_time,
+  MAX(timestamp) AS end_time,
+  MAX(timestamp) - MIN(timestamp) AS duration,
+  ANY_VALUE(project_path) AS project_path,
+  ANY_VALUE(git_branch)   AS git_branch,
+  COUNT(*) FILTER (WHERE type = 'user' AND NOT is_meta) AS user_messages,
+  COUNT(*) FILTER (WHERE type = 'assistant')            AS assistant_messages
 FROM messages
 GROUP BY session_id
 HAVING COUNT(*) FILTER (WHERE type = 'user' AND NOT is_meta) > 0;

--- a/plugins/claude-code/skills/session/scripts/db.test.ts
+++ b/plugins/claude-code/skills/session/scripts/db.test.ts
@@ -286,3 +286,22 @@ describe("malformed JSONL", () => {
     expect(Number(rows[0]?.assistant_messages)).toBe(1);
   });
 });
+
+describe("type drift across imports", () => {
+  it("recovers when a cached column type drifts from the freshly-detected one", async () => {
+    await db.run(
+      "ALTER TABLE raw ALTER COLUMN container_1 TYPE VARCHAR USING container_1::VARCHAR",
+    );
+    await db.run(
+      "INSERT INTO raw (sessionId, container_1) VALUES (gen_random_uuid()::VARCHAR, '')",
+    );
+    await db.run("DELETE FROM meta");
+
+    await ensureIndex(db, { projectsDir: fixturesDir, dataDir: tmpDir, force: true });
+
+    const [typeRow] = await db.query<{ data_type: string }>(
+      "SELECT data_type FROM information_schema.columns WHERE table_name = 'raw' AND column_name = 'container_1'",
+    );
+    expect(typeRow?.data_type).toBe("JSON");
+  });
+});

--- a/plugins/claude-code/skills/session/scripts/db.test.ts
+++ b/plugins/claude-code/skills/session/scripts/db.test.ts
@@ -288,20 +288,83 @@ describe("malformed JSONL", () => {
 });
 
 describe("type drift across imports", () => {
-  it("recovers when a cached column type drifts from the freshly-detected one", async () => {
+  it("absorbs heterogeneous nested shapes via the `data` JSON column", async () => {
+    const drifted = JSON.stringify({
+      type: "assistant",
+      sessionId: "drift-session",
+      cwd: "/Users/test/project",
+      timestamp: "2024-01-15T10:00:00.000Z",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "drifted" }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+        stop_sequence: { nested: "object" },
+      },
+    });
     await db.run(
-      "ALTER TABLE raw ALTER COLUMN container_1 TYPE VARCHAR USING container_1::VARCHAR",
-    );
-    await db.run(
-      "INSERT INTO raw (sessionId, container_1) VALUES (gen_random_uuid()::VARCHAR, '')",
+      `INSERT INTO raw (session_id, type, project_path, timestamp, data)
+                  VALUES ('drift-session', 'assistant', '/Users/test/project',
+                          '2024-01-15T10:00:00'::TIMESTAMP, $line::JSON)`,
+      {
+        line: drifted,
+      },
     );
     await db.run("DELETE FROM meta");
 
     await ensureIndex(db, { projectsDir: fixturesDir, dataDir: tmpDir, force: true });
 
     const [typeRow] = await db.query<{ data_type: string }>(
-      "SELECT data_type FROM information_schema.columns WHERE table_name = 'raw' AND column_name = 'container_1'",
+      "SELECT data_type FROM information_schema.columns WHERE table_name = 'raw' AND column_name = 'data'",
     );
     expect(typeRow?.data_type).toBe("JSON");
+
+    const rows = await db.query<{ session_id: string }>(
+      "SELECT session_id FROM sessions ORDER BY session_id",
+    );
+    expect(rows.length).toBeGreaterThan(0);
+  });
+});
+
+describe("discovery", () => {
+  it("returns column metadata via the schema query", async () => {
+    const rows = await runQuery<{ table_name: string; column_name: string }>(db, "schema");
+    const tables = new Set(rows.map((r) => r.table_name));
+    expect(tables.has("raw")).toBe(true);
+    expect(tables.has("messages")).toBe(true);
+    expect(tables.has("content_items")).toBe(true);
+    expect(rows.some((r) => r.table_name === "raw" && r.column_name === "data")).toBe(true);
+  });
+
+  it("samples JSON keys from raw.data via the keys query", async () => {
+    const rows = await runQuery<{ key: string; occurrences: number }>(db, "keys");
+    expect(rows.length).toBeGreaterThan(0);
+    const keys = new Set(rows.map((r) => r.key));
+    expect(keys.has("sessionId")).toBe(true);
+    expect(keys.has("type")).toBe(true);
+    expect(keys.has("message")).toBe(true);
+  });
+
+  it("describes messages with the expected pinned columns", async () => {
+    const rows = await db.query<{ column_name: string }>("DESCRIBE messages");
+    const cols = rows.map((r) => r.column_name);
+    expect(cols).toEqual(
+      expect.arrayContaining([
+        "session_id",
+        "type",
+        "project_path",
+        "git_branch",
+        "is_meta",
+        "is_sidechain",
+        "duration_ms",
+        "timestamp",
+        "input_tokens",
+        "output_tokens",
+        "source_file",
+        "source_line",
+        "data",
+        "content_text",
+        "summary",
+      ]),
+    );
   });
 });

--- a/plugins/claude-code/skills/session/scripts/db.ts
+++ b/plugins/claude-code/skills/session/scripts/db.ts
@@ -90,7 +90,6 @@ export async function ensureIndex(
   const dataDir = options.dataDir;
   if (!dataDir) throw new Error("dataDir is required for import");
   await db.run("SET VARIABLE data_dir = $dir", { dir: dataDir });
-  await db.run("SET VARIABLE source = getvariable('changed_files')");
   await db.run(await readSql(RESOURCES_DIR, "import"));
 
   const contentItemsPath = path.join(dataDir, "content_items.jsonl");

--- a/plugins/claude-code/skills/session/scripts/db.ts
+++ b/plugins/claude-code/skills/session/scripts/db.ts
@@ -60,6 +60,20 @@ async function applySchema(db: Database): Promise<void> {
   }
 }
 
+async function migrateIfNeeded(db: Database): Promise<void> {
+  const [row] = await db.query<{ ok: boolean }>(`
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'main' AND table_name = 'raw' AND column_name = 'data'
+    ) AS ok
+  `);
+  if (row?.ok) return;
+  await db.run("DROP TABLE IF EXISTS messages");
+  await db.run("DROP TABLE IF EXISTS content_items");
+  await db.run("DROP TABLE IF EXISTS raw");
+  await db.run("DROP TABLE IF EXISTS meta");
+}
+
 export async function getDb(dataDir: string): Promise<Database> {
   const dbPath = path.join(dataDir, "session.duckdb");
   return createDatabase(dbPath);
@@ -69,8 +83,6 @@ export async function ensureIndex(
   db: Database,
   options: { projectsDir?: string; force?: boolean; dataDir?: string } = {},
 ): Promise<void> {
-  await applySchema(db);
-
   if (!options.force && options.dataDir) {
     const sessionId = process.env.CLAUDE_SESSION_ID;
     if (sessionId) {
@@ -78,6 +90,9 @@ export async function ensureIndex(
       if (await Bun.file(marker).exists()) return;
     }
   }
+
+  await migrateIfNeeded(db);
+  await applySchema(db);
 
   const glob = getProjectsGlob(options.projectsDir);
 
@@ -87,17 +102,8 @@ export async function ensureIndex(
   const [row] = await db.query<{ n: bigint }>("SELECT LEN(getvariable('changed_files')) as n");
   if (!row || row.n === 0n) return;
 
-  const dataDir = options.dataDir;
-  if (!dataDir) throw new Error("dataDir is required for import");
-  await db.run("SET VARIABLE data_dir = $dir", { dir: dataDir });
+  await db.run("SET VARIABLE source = getvariable('changed_files')");
   await db.run(await readSql(RESOURCES_DIR, "import"));
-
-  const contentItemsPath = path.join(dataDir, "content_items.jsonl");
-  await db.run(
-    `COPY content_items_export TO '${contentItemsPath}' (FORMAT CSV, HEADER false, QUOTE '', ESCAPE '')`,
-  );
-  await db.run("DROP TABLE content_items_export");
-
   await db.run(await readSql(RESOURCES_DIR, "views"));
 
   if (options.dataDir) {


### PR DESCRIPTION
Replace the previous full-rebuild approach with a pinned `raw` schema plus a `data JSON` column holding the full original JSONL line. Cached and freshly-imported rows always have identical column types so `UNION ALL` cannot drift, and the incremental refresh path is preserved: subsequent sessions only re-parse files modified since `last_import` rather than the entire corpus.

Original Task: [Fix session skill DuckDB index, fails with malformed JSON on trivial queries](https://things.bendrucker.me/show?id=6gtTev1C17diA2XuBgQFG9)

## Issue

DuckDB's `read_ndjson` infers column types per call. The `stop_sequence` field cached as `VARCHAR` then re-detected as `JSON` (and the same drift hazard for `usage`, `hookErrors`, nested STRUCT fields) crashed `UNION ALL BY NAME` with `Conversion Error: Malformed JSON at byte 0`. The first attempt rebuilt `raw` from disk on every import, which fixed the crash but forced every fresh `CLAUDE_SESSION_ID` to re-parse every JSONL file in `~/.claude/projects/`.

## Changes

- `resources/schema/01_tables.sql`: pin the full 14-column `raw` schema upfront, including `data JSON`. `meta` keeps just `last_import`.
- `resources/import.sql`: read via `read_json_objects` (no auto-detection beyond `json` itself), project pinned scalars (`session_id`, `type`, `project_path`, `git_branch`, `is_meta`, `is_sidechain`, `duration_ms`, `timestamp`, `summary`, `input_tokens`, `output_tokens`) plus `source_file`/`source_line` plus the original line as `data`. Drops the `union_by_name` flag and the `message.* EXCLUDE (content)` flattening. `UNION ALL` is positional; column order matches the schema.
- `resources/views.sql`: `messages` becomes a view that derives `content_text` from `data->>'$.message.content'` and joins `summary` from summary rows. `content_items` is a table built directly from `raw` via `LATERAL unnest(json_extract(..., '$.message.content[*]'))` with a CTE that evaluates the JSON path once. The `COPY TO content_items.jsonl` temp-file shuffle is gone. All views reach into nested fields via `(data->>'$.path')` (parens required because DuckDB binds `=` tighter than `->>`).
- `scripts/db.ts`: `migrateIfNeeded` runs after the warm-session marker check. If `raw.data` is missing (any pre-existing schema), it drops `raw`/`meta`/`messages`/`content_items` so the next `applySchema` rebuilds correctly. Warm sessions skip migration and schema apply entirely.
- `resources/queries/schema.sql`, `resources/queries/keys.sql`: new discovery queries. `schema` returns `information_schema.columns` for the views; `keys` samples 500 rows of `raw.data` and counts top-level JSON keys.
- `SKILL.md`: replaces the static column tables with a Discovery section pointing at `query.ts schema`, `query.ts keys`, and `DESCRIBE`. Documents the `data->>'$.path'` parens gotcha.
- `CLAUDE.md`: rewrites the architecture section to describe the pinned-schema model, the migration trigger, and the per-import path.

## Testing

The type-drift regression test inserts a row whose nested `data` JSON shape differs from sibling rows and asserts that `ensureIndex` absorbs it without error and the views remain queryable. New tests cover the discovery surface: the `schema` query returns column metadata for known views, the `keys` query surfaces JSON keys from `raw.data`, and `DESCRIBE messages` exposes the pinned columns. The existing unit and integration tests for `sessions`, named queries, idempotent re-indexing, and malformed JSONL still apply.

Verified end-to-end against the real `~/.claude/projects/` corpus:

- Cold rebuild of an empty DB produces consistent counts across `messages`, `content_items`, and the named queries.
- A new `CLAUDE_SESSION_ID` against a cached DB only re-parses files newer than `last_import` rather than the whole corpus.
- The warm marker fast-path bypasses both `migrateIfNeeded` and `applySchema`.
- A simulated old-shape DB (pre-PR-608: `raw(sessionId VARCHAR, summary VARCHAR, foo_struct STRUCT(...))`) is dropped and rebuilt automatically on first run with new code.
