### PR TITLE
fix(mac): drop forked context from jxa-run skill

### DIFF
--- a/plugins/mac/skills/jxa-run/SKILL.md
+++ b/plugins/mac/skills/jxa-run/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mac:jxa-run
 description: Execute JXA scripts scoped to a macOS application. Use when running JXA expressions or script files against an app via osascript. Validates Application() scope via AST.
-context: fork
 allowed-tools:
   - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/jxa.ts:*)"
 hooks:


### PR DESCRIPTION
Removes `context: fork` from the `mac:jxa-run` skill so it runs in the parent agent's process tree. The forked subagent received a separate TCC responsible-process attribution, causing every `osascript` invocation to return `-600 Application isn't running.` even when the target app was running.

## Issue

The failing path was: forked subagent → `Bash` → `bun jxa.ts` → `Bun.spawn(osascript)`. AppleEvents sent from that chain lacked authority for the target app. Direct `osascript` from the parent agent's `Bash` succeeded, isolating the failure to the forked context. Possible follow-up if `Bun.spawn` itself proves problematic: move validation into a `PreToolUse` hook so `bash` invokes `osascript` directly without a `bun` parent.

## Testing

Ran `mac:jxa-run` against a running Things3 via `claude --plugin-dir ./plugins/mac --setting-sources local`. `bun jxa.ts Things3 -e 'Application("Things3").lists.byId("TMInboxListSource").toDos().length'` returns the inbox count; previously it returned `-600`.
