### PR TITLE
fix(github): use bucket field for gh pr checks classification

### DIFF
--- a/plugins/github/skills/actions-monitor/scripts/watch.test.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.test.ts
@@ -5,14 +5,52 @@ import {
   deriveChecksState,
   deriveEvents,
   deriveRunListState,
+  type Event,
+  type ExecFn,
+  type ExecResult,
   initialState,
+  type Probe,
   parsePrUrl,
   parseRepo,
+  probeBranch,
+  probePr,
+  probeRunId,
   registerApiError,
-  type Event,
-  type Probe,
   type WatcherState,
 } from "./watch";
+
+// Stub `exec` for probe* tests. Each entry maps a substring matcher (anything
+// the gh command line should contain) to a canned result. Tests assert that
+// commands are issued in the expected order by exhausting the array.
+function makeExec(scripted: Array<{ match: string; result: ExecResult }>): {
+  exec: ExecFn;
+  remaining: () => Array<{ match: string; result: ExecResult }>;
+} {
+  const queue = [...scripted];
+  return {
+    exec: (command: string): ExecResult => {
+      const next = queue.shift();
+      if (!next) {
+        throw new Error(`unexpected exec call: ${command}`);
+      }
+      if (!command.includes(next.match)) {
+        throw new Error(
+          `exec call did not match expected substring "${next.match}". got: ${command}`,
+        );
+      }
+      return next.result;
+    },
+    remaining: () => queue,
+  };
+}
+
+const ok = (stdout: string): ExecResult => ({ ok: true, stdout });
+const err = (stderr: string): ExecResult => ({
+  ok: false,
+  stderr,
+  rateLimited: false,
+  retryAfter: "",
+});
 
 function baseProbe(overrides: Partial<Probe> = {}): Probe {
   return {
@@ -59,16 +97,33 @@ describe("parsePrUrl", () => {
   });
 });
 
+// `gh pr checks --json state,bucket,name` shapes (verified against gh CLI):
+//   - completed pass:    { state: "SUCCESS",     bucket: "pass" }
+//   - completed skip:    { state: "SKIPPED",     bucket: "skipping" }
+//   - completed fail:    { state: "FAILURE",     bucket: "fail" }
+//   - cancelled:         { state: "CANCELLED",   bucket: "cancel" }
+//   - in flight:         { state: "IN_PROGRESS", bucket: "pending" }
+//   - queued (action):   { state: "QUEUED",      bucket: "pending" }
+//   - pending (status):  { state: "PENDING",     bucket: "pending" }
 describe("deriveChecksState", () => {
   it("returns running on empty checks", () => {
     expect(deriveChecksState([])).toBe("running");
   });
 
-  it("returns failing on any failure conclusion", () => {
+  it("returns failing when any check is in fail bucket", () => {
     expect(
       deriveChecksState([
-        { state: "COMPLETED", conclusion: "success", name: "a" },
-        { state: "COMPLETED", conclusion: "failure", name: "b" },
+        { state: "SUCCESS", bucket: "pass", name: "a" },
+        { state: "FAILURE", bucket: "fail", name: "b" },
+      ]),
+    ).toBe("failing");
+  });
+
+  it("returns failing when any check is in cancel bucket", () => {
+    expect(
+      deriveChecksState([
+        { state: "SUCCESS", bucket: "pass", name: "a" },
+        { state: "CANCELLED", bucket: "cancel", name: "b" },
       ]),
     ).toBe("failing");
   });
@@ -76,8 +131,8 @@ describe("deriveChecksState", () => {
   it("returns running when any check is IN_PROGRESS", () => {
     expect(
       deriveChecksState([
-        { state: "IN_PROGRESS", conclusion: "", name: "a" },
-        { state: "QUEUED", conclusion: "", name: "b" },
+        { state: "IN_PROGRESS", bucket: "pending", name: "a" },
+        { state: "QUEUED", bucket: "pending", name: "b" },
       ]),
     ).toBe("running");
   });
@@ -85,19 +140,43 @@ describe("deriveChecksState", () => {
   it("returns queued when all checks are queued", () => {
     expect(
       deriveChecksState([
-        { state: "QUEUED", conclusion: "", name: "a" },
-        { state: "QUEUED", conclusion: "", name: "b" },
+        { state: "QUEUED", bucket: "pending", name: "a" },
+        { state: "QUEUED", bucket: "pending", name: "b" },
       ]),
     ).toBe("queued");
   });
 
-  it("returns success when all checks pass", () => {
+  it("returns running when some checks are queued and others have completed", () => {
     expect(
       deriveChecksState([
-        { state: "COMPLETED", conclusion: "success", name: "a" },
-        { state: "COMPLETED", conclusion: "skipped", name: "b" },
+        { state: "QUEUED", bucket: "pending", name: "a" },
+        { state: "SUCCESS", bucket: "pass", name: "b" },
+      ]),
+    ).toBe("running");
+  });
+
+  it("returns success when all checks pass or skip", () => {
+    expect(
+      deriveChecksState([
+        { state: "SUCCESS", bucket: "pass", name: "a" },
+        { state: "SKIPPED", bucket: "skipping", name: "b" },
       ]),
     ).toBe("success");
+  });
+
+  it("returns success on the canonical all-green payload (regression: bucket+state schema)", () => {
+    // Exact shape captured from `gh pr checks <num> --json state,bucket,name`
+    // against a fully-green PR. If this assertion ever flips back to "running"
+    // it means deriveChecksState has drifted from gh's actual JSON schema —
+    // the same drift that caused the silent-hang on initial-green PRs.
+    const allGreen = [
+      { bucket: "pass", name: "plugins", state: "SUCCESS" },
+      { bucket: "pass", name: "lint", state: "SUCCESS" },
+      { bucket: "pass", name: "build", state: "SUCCESS" },
+      { bucket: "pass", name: "hooks", state: "SUCCESS" },
+      { bucket: "pass", name: "validate", state: "SUCCESS" },
+    ];
+    expect(deriveChecksState(allGreen)).toBe("success");
   });
 });
 
@@ -435,5 +514,202 @@ describe("deriveEvents run-id mode", () => {
     for (const s of statuses) {
       expect(s).toMatchObject({ run_id: "42" });
     }
+  });
+});
+
+// End-to-end probe* tests that exercise the full gh-output → probe pipeline.
+// These exist because the previous unit tests only fed hand-rolled fictional
+// payloads (`{ state: "COMPLETED", conclusion: "success" }`) to
+// deriveChecksState in isolation — they never validated that probe* actually
+// requested fields gh exposes, or that gh's real JSON shape parses cleanly
+// into the success/failing/queued/running classification. That blind spot
+// caused watch.ts to silently retry for ~15 minutes against any green PR
+// because it asked gh for a non-existent `conclusion` field.
+describe("probePr (gh schema integration)", () => {
+  const prJson = JSON.stringify({
+    headRefOid: "abc123",
+    headRefName: "feature/x",
+    state: "OPEN",
+    mergeable: "MERGEABLE",
+  });
+
+  it("emits state=success when gh pr checks reports all-pass buckets", () => {
+    const checksJson = JSON.stringify([
+      { state: "SUCCESS", bucket: "pass", name: "lint" },
+      { state: "SUCCESS", bucket: "pass", name: "build" },
+      { state: "SKIPPED", bucket: "skipping", name: "docs" },
+    ]);
+    const { exec, remaining } = makeExec([
+      { match: "gh pr view 42", result: ok(prJson) },
+      { match: "gh pr checks 42", result: ok(checksJson) },
+      { match: "gh run list --branch feature/x", result: ok("999") },
+    ]);
+    const result = probePr(42, exec);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.probe.state).toBe("success");
+    expect(result.probe.sha).toBe("abc123");
+    expect(result.probe.runId).toBe("999");
+    expect(result.branch).toBe("feature/x");
+    expect(remaining()).toEqual([]);
+  });
+
+  it("requests gh pr checks with --json state,bucket,name (regression)", () => {
+    // Pin the JSON field set the script asks for. If someone reintroduces
+    // `conclusion` (which gh rejects) or drops `bucket` (which gh's
+    // pass/fail/cancel categorization needs), this test will throw on the
+    // matcher mismatch.
+    const seen: string[] = [];
+    const recordingExec: ExecFn = (command) => {
+      seen.push(command);
+      if (command.startsWith("gh pr view")) return ok(prJson);
+      if (command.startsWith("gh pr checks")) {
+        return ok(JSON.stringify([{ state: "SUCCESS", bucket: "pass", name: "x" }]));
+      }
+      if (command.startsWith("gh run list")) return ok("");
+      throw new Error(`unexpected: ${command}`);
+    };
+    probePr(42, recordingExec);
+    const checksCall = seen.find((c) => c.startsWith("gh pr checks"));
+    expect(checksCall).toBeDefined();
+    expect(checksCall).toContain("--json state,bucket,name");
+    expect(checksCall).not.toContain("conclusion");
+  });
+
+  it("emits state=failing when any check is in fail bucket", () => {
+    const checksJson = JSON.stringify([
+      { state: "SUCCESS", bucket: "pass", name: "lint" },
+      { state: "FAILURE", bucket: "fail", name: "build" },
+    ]);
+    const { exec } = makeExec([
+      { match: "gh pr view", result: ok(prJson) },
+      { match: "gh pr checks", result: ok(checksJson) },
+      { match: "gh run list", result: ok("123") },
+    ]);
+    const result = probePr(42, exec);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.probe.state).toBe("failing");
+  });
+
+  it("emits state=queued when all checks pending in QUEUED state", () => {
+    const checksJson = JSON.stringify([
+      { state: "QUEUED", bucket: "pending", name: "lint" },
+      { state: "QUEUED", bucket: "pending", name: "build" },
+    ]);
+    const { exec } = makeExec([
+      { match: "gh pr view", result: ok(prJson) },
+      { match: "gh pr checks", result: ok(checksJson) },
+      { match: "gh run list", result: ok("123") },
+    ]);
+    const result = probePr(42, exec);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.probe.state).toBe("queued");
+  });
+
+  it("propagates stderr on gh exec failure so callers can surface it", () => {
+    // Covers the silent-hang root cause: when gh exits non-zero (e.g., schema
+    // drift, network blip, auth issue), the probe must carry stderr through
+    // to the caller so the loop can log it instead of swallowing the error
+    // and waiting for the api-error threshold to trip.
+    const ghError = err('Unknown JSON field: "conclusion"');
+    const { exec } = makeExec([
+      { match: "gh pr view", result: ok(prJson) },
+      { match: "gh pr checks", result: ghError },
+    ]);
+    const result = probePr(42, exec);
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") return;
+    expect(result.stderr).toContain("Unknown JSON field");
+    expect(result.rateLimited).toBe(false);
+  });
+
+  it("returns kind=error when gh pr view emits unparseable JSON", () => {
+    const { exec } = makeExec([{ match: "gh pr view", result: ok("not json") }]);
+    const result = probePr(42, exec);
+    expect(result.kind).toBe("error");
+  });
+
+  it("returns kind=error with stderr when headRefName is missing", () => {
+    const partialJson = JSON.stringify({
+      headRefOid: "abc",
+      state: "OPEN",
+      mergeable: "MERGEABLE",
+    });
+    const { exec } = makeExec([{ match: "gh pr view", result: ok(partialJson) }]);
+    const result = probePr(42, exec);
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") return;
+    expect(result.stderr).toContain("headRefName");
+  });
+});
+
+describe("probeBranch (gh schema integration)", () => {
+  it("returns kind=empty when gh run list returns []", () => {
+    const { exec } = makeExec([{ match: "gh run list", result: ok("[]") }]);
+    const result = probeBranch("owner/repo", "main", exec);
+    expect(result.kind).toBe("empty");
+  });
+
+  it("maps a successful run-list payload to state=success", () => {
+    const runJson = JSON.stringify([
+      {
+        databaseId: 12345,
+        headSha: "deadbeef",
+        status: "completed",
+        conclusion: "success",
+      },
+    ]);
+    const { exec } = makeExec([{ match: "gh run list", result: ok(runJson) }]);
+    const result = probeBranch("owner/repo", "main", exec);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.probe.state).toBe("success");
+    expect(result.probe.runId).toBe("12345");
+    expect(result.probe.sha).toBe("deadbeef");
+  });
+
+  it("propagates stderr on gh exec failure", () => {
+    const { exec } = makeExec([{ match: "gh run list", result: err("auth required") }]);
+    const result = probeBranch("owner/repo", "main", exec);
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") return;
+    expect(result.stderr).toContain("auth required");
+  });
+});
+
+describe("probeRunId (gh schema integration)", () => {
+  it("classifies kind=not-found from gh's 'could not resolve' stderr", () => {
+    const { exec } = makeExec([
+      { match: "gh run view", result: err("could not resolve to a Node") },
+    ]);
+    const result = probeRunId("999", "owner/repo", exec);
+    expect(result.kind).toBe("not-found");
+  });
+
+  it("maps a failed run-view payload to state=failing", () => {
+    const runJson = JSON.stringify({
+      databaseId: 555,
+      headSha: "cafebabe",
+      status: "completed",
+      conclusion: "failure",
+    });
+    const { exec } = makeExec([{ match: "gh run view", result: ok(runJson) }]);
+    const result = probeRunId("555", "owner/repo", exec);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.probe.state).toBe("failing");
+    expect(result.probe.runId).toBe("555");
+  });
+
+  it("propagates stderr on transient gh failure (non-not-found)", () => {
+    const { exec } = makeExec([
+      { match: "gh run view", result: err("network timeout reaching api.github.com") },
+    ]);
+    const result = probeRunId("555", "owner/repo", exec);
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") return;
+    expect(result.stderr).toContain("network timeout");
   });
 });

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -180,9 +180,11 @@ const execOptions: ExecSyncOptions = {
   stdio: ["pipe", "pipe", "pipe"],
 };
 
-type ExecResult =
+export type ExecResult =
   | { ok: true; stdout: string }
   | { ok: false; stderr: string; rateLimited: boolean; retryAfter: string };
+
+export type ExecFn = (command: string) => ExecResult;
 
 export function detectRateLimit(stderr: string): { rateLimited: boolean; retryAfter: string } {
   const lower = stderr.toLowerCase();
@@ -223,31 +225,30 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// `gh pr checks --json` exposes a unified `state` (status when in-flight,
+// conclusion when complete) and a normalized `bucket` ("pass" | "fail" |
+// "cancel" | "pending" | "skipping"). It does NOT expose `conclusion`. Use
+// `bucket` for terminal classification and `state` to distinguish running
+// from queued.
 export function deriveChecksState(
-  checks: Array<{ state?: string; conclusion?: string; name?: string }>,
+  checks: Array<{ state?: string; bucket?: string; name?: string }>,
 ): InternalState {
   if (checks.length === 0) {
     return "running";
   }
-  const anyFailure = checks.some(
-    (c) =>
-      (c.conclusion ?? "").toLowerCase() === "failure" ||
-      (c.conclusion ?? "").toLowerCase() === "cancelled" ||
-      (c.conclusion ?? "").toLowerCase() === "timed_out",
-  );
-  if (anyFailure) return "failing";
+  const buckets = checks.map((c) => (c.bucket ?? "").toLowerCase());
+  if (buckets.some((b) => b === "fail" || b === "cancel")) {
+    return "failing";
+  }
   const states = checks.map((c) => (c.state ?? "").toUpperCase());
-  const conclusions = checks.map((c) => (c.conclusion ?? "").toLowerCase());
-  const allQueued = states.every((s) => s === "QUEUED" || s === "PENDING");
-  const anyInProgress = states.some((s) => s === "IN_PROGRESS");
-  const anyQueued = states.some((s) => s === "QUEUED" || s === "PENDING");
-  if (anyInProgress) return "running";
+  if (states.some((s) => s === "IN_PROGRESS")) return "running";
+  const isQueuedState = (s: string): boolean =>
+    s === "QUEUED" || s === "PENDING" || s === "WAITING" || s === "REQUESTED" || s === "EXPECTED";
+  const anyQueued = states.some(isQueuedState);
+  const allQueued = states.every(isQueuedState);
   if (allQueued && anyQueued) return "queued";
   if (anyQueued) return "running";
-  const allSuccess = conclusions.every(
-    (c) => c === "success" || c === "neutral" || c === "skipped",
-  );
-  if (allSuccess) return "success";
+  if (buckets.every((b) => b === "pass" || b === "skipping")) return "success";
   return "running";
 }
 
@@ -268,16 +269,21 @@ export function deriveRunListState(run: { status?: string; conclusion?: string }
 // Probed uses a `kind` discriminator so callers narrow via switch rather than
 // brittle `"empty" in result` / `"notFound" in result` property checks. Only
 // probePr populates `branch`; the other probes leave it null.
-type Probed =
+export type Probed =
   | { kind: "ok"; probe: Probe; branch: string | null }
-  | { kind: "error"; rateLimited: boolean; retryAfter: string }
+  | { kind: "error"; rateLimited: boolean; retryAfter: string; stderr: string }
   | { kind: "empty" }
   | { kind: "not-found"; stderr: string };
 
-function probePr(prNumber: number): Probed {
-  const prResult = exec(`gh pr view ${prNumber} --json headRefOid,headRefName,state,mergeable`);
+export function probePr(prNumber: number, run: ExecFn = exec): Probed {
+  const prResult = run(`gh pr view ${prNumber} --json headRefOid,headRefName,state,mergeable`);
   if (!prResult.ok) {
-    return { kind: "error", rateLimited: prResult.rateLimited, retryAfter: prResult.retryAfter };
+    return {
+      kind: "error",
+      rateLimited: prResult.rateLimited,
+      retryAfter: prResult.retryAfter,
+      stderr: prResult.stderr,
+    };
   }
   let sha = "";
   let branch = "";
@@ -292,46 +298,41 @@ function probePr(prNumber: number): Probed {
       mergeable = parsed.mergeable as Probe["mergeable"];
     }
   } catch (err) {
-    console.error(
-      `gh pr view returned unparseable JSON for PR #${prNumber}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return { kind: "error", rateLimited: false, retryAfter: "" };
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`gh pr view returned unparseable JSON for PR #${prNumber}: ${message}`);
+    return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
   if (!branch) {
-    console.error(
-      `gh pr view did not include headRefName for PR #${prNumber}; treating as probe failure`,
-    );
-    return { kind: "error", rateLimited: false, retryAfter: "" };
+    const message = `gh pr view did not include headRefName for PR #${prNumber}`;
+    console.error(`${message}; treating as probe failure`);
+    return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
 
-  const checksResult = exec(
-    `gh pr checks ${prNumber} --required=false --json state,conclusion,name`,
-  );
+  const checksResult = run(`gh pr checks ${prNumber} --required=false --json state,bucket,name`);
   if (!checksResult.ok) {
     return {
       kind: "error",
       rateLimited: checksResult.rateLimited,
       retryAfter: checksResult.retryAfter,
+      stderr: checksResult.stderr,
     };
   }
   let state: InternalState;
   try {
     const parsed = JSON.parse(checksResult.stdout || "[]");
     if (!Array.isArray(parsed)) {
-      console.error(
-        `gh pr checks returned non-array JSON for PR #${prNumber}; treating as probe failure`,
-      );
-      return { kind: "error", rateLimited: false, retryAfter: "" };
+      const message = `gh pr checks returned non-array JSON for PR #${prNumber}`;
+      console.error(`${message}; treating as probe failure`);
+      return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
     }
     state = deriveChecksState(parsed as Record<string, unknown>[]);
   } catch (err) {
-    console.error(
-      `gh pr checks returned unparseable JSON for PR #${prNumber}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return { kind: "error", rateLimited: false, retryAfter: "" };
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`gh pr checks returned unparseable JSON for PR #${prNumber}: ${message}`);
+    return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
 
-  const runIdResult = exec(
+  const runIdResult = run(
     `gh run list --branch ${branch} --limit 1 --json databaseId --jq '.[0].databaseId // ""'`,
   );
   if (!runIdResult.ok) {
@@ -339,6 +340,7 @@ function probePr(prNumber: number): Probed {
       kind: "error",
       rateLimited: runIdResult.rateLimited,
       retryAfter: runIdResult.retryAfter,
+      stderr: runIdResult.stderr,
     };
   }
   const runId = runIdResult.stdout ? runIdResult.stdout : null;
@@ -373,21 +375,25 @@ function buildRunProbe(run: Record<string, unknown>, fallbackRunId: string | nul
 // Branch-mode probe: query the latest run for the branch. If no runs exist yet
 // (empty array), signal "empty" so the main loop can skip event emission and
 // keep polling without tripping the api-error threshold.
-function probeBranch(repo: string, branch: string): Probed {
-  const result = exec(
+export function probeBranch(repo: string, branch: string, run: ExecFn = exec): Probed {
+  const result = run(
     `gh run list --repo ${repo} --branch ${branch} --limit 1 --json databaseId,headSha,status,conclusion`,
   );
   if (!result.ok) {
-    return { kind: "error", rateLimited: result.rateLimited, retryAfter: result.retryAfter };
+    return {
+      kind: "error",
+      rateLimited: result.rateLimited,
+      retryAfter: result.retryAfter,
+      stderr: result.stderr,
+    };
   }
   let parsed: unknown;
   try {
     parsed = JSON.parse(result.stdout || "[]");
   } catch (err) {
-    console.error(
-      `gh run list returned unparseable JSON for ${repo}@${branch}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return { kind: "error", rateLimited: false, retryAfter: "" };
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`gh run list returned unparseable JSON for ${repo}@${branch}: ${message}`);
+    return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
   if (!Array.isArray(parsed) || parsed.length === 0) {
     return { kind: "empty" };
@@ -438,8 +444,8 @@ function fetchInterval(branch: string, repo: string | null): number {
   return DEFAULT_INTERVAL_SECONDS;
 }
 
-function probeRunId(runId: string, repo: string): Probed {
-  const result = exec(
+export function probeRunId(runId: string, repo: string, run: ExecFn = exec): Probed {
+  const result = run(
     `gh run view ${runId} --repo ${repo} --json databaseId,headSha,status,conclusion`,
   );
   if (!result.ok) {
@@ -449,22 +455,25 @@ function probeRunId(runId: string, repo: string): Probed {
     if (notFound) {
       return { kind: "not-found", stderr: result.stderr };
     }
-    return { kind: "error", rateLimited: result.rateLimited, retryAfter: result.retryAfter };
+    return {
+      kind: "error",
+      rateLimited: result.rateLimited,
+      retryAfter: result.retryAfter,
+      stderr: result.stderr,
+    };
   }
   let parsed: unknown;
   try {
     parsed = JSON.parse(result.stdout || "{}");
   } catch (err) {
-    console.error(
-      `gh run view returned unparseable JSON for run ${runId}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return { kind: "error", rateLimited: false, retryAfter: "" };
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`gh run view returned unparseable JSON for run ${runId}: ${message}`);
+    return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
   if (!parsed || typeof parsed !== "object") {
-    console.error(
-      `gh run view returned non-object JSON for run ${runId}; treating as probe failure`,
-    );
-    return { kind: "error", rateLimited: false, retryAfter: "" };
+    const message = `gh run view returned non-object JSON for run ${runId}`;
+    console.error(`${message}; treating as probe failure`);
+    return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
   return {
     kind: "ok",
@@ -536,6 +545,12 @@ async function run(options: RunOptions): Promise<void> {
     } else if (result.kind === "error") {
       if (result.rateLimited) {
         emit({ type: "rate-limited", retry_after: result.retryAfter });
+      } else if (result.stderr) {
+        // Surface the probe failure so callers see *something* before the
+        // api-error threshold is reached. Without this, a misshapen gh
+        // command (e.g., schema drift in --json fields) silently retries
+        // for ~threshold * interval seconds before emitting any event.
+        console.error(`probe failed: ${result.stderr.trim()}`);
       }
       const outcome = registerApiError(state, options.apiErrorThreshold);
       state = outcome.state;


### PR DESCRIPTION
The `actions-monitor` watch script asked `gh pr checks` for a `--json conclusion` field that `gh` does not expose, so every probe failed silently. The loop then waited for the api-error threshold (5) times the poll interval (180s) before emitting any event, leaving green PRs frozen with zero output for ~15 minutes.

## Issue

`gh pr checks --json` exposes `state`, `bucket`, `name` (and a few others), but not `conclusion`. The previous `deriveChecksState` derived terminal classification from `conclusion`, so every probe failed at the `gh` layer with `Unknown JSON field: "conclusion"`. Errors never surfaced because the main loop only logged probe failures via the `api-error` event, which requires the threshold count to be reached first.

The unit test for the initial-green path fed hand-rolled `{ state: "COMPLETED", conclusion: "success" }` payloads to `deriveChecksState` in isolation. That shape did not reflect `gh`'s actual JSON, so the test could not have caught the field mismatch.

## Changes

- Switch `gh pr checks` to `--json state,bucket,name` and rewrite `deriveChecksState` to classify by `bucket` (`fail`/`cancel` -> failing, `pass`/`skipping` -> success) and `state` (`IN_PROGRESS` -> running, `QUEUED`/`PENDING`/`WAITING`/`REQUESTED`/`EXPECTED` -> queued).
- Carry `gh` stderr through the `Probed` error variant and log `probe failed: <stderr>` from the main loop on non-rate-limit failures, so future schema drift surfaces immediately instead of after ~15 silent minutes.
- Make `probePr`, `probeBranch`, and `probeRunId` accept an injectable `ExecFn` so tests can feed real `gh` output shapes through the full pipeline.

## Testing

Closes the testing gap that allowed the regression:

- Updates existing `deriveChecksState` cases to use the real `gh` schema (`bucket` and `state`).
- Adds a regression case using a payload captured directly from `gh pr checks <num> --json state,bucket,name` against a green PR.
- Adds end-to-end probe tests for `probePr`, `probeBranch`, and `probeRunId` with a mocked `exec` returning realistic `gh` JSON, covering success/failing/queued paths.
- Pins the `gh pr checks` invocation: a dedicated test asserts the command contains `--json state,bucket,name` and does not contain `conclusion`. Reintroducing the bad field will fail the test.
- Adds coverage for stderr propagation on `gh` exec failures so silent-hang regressions stay detectable.

Verified end-to-end: `bun watch.ts --pr <green-PR>` now emits `status:success` and exits 0.
