### PR TITLE
settings: enable theme auto-detection

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "theme": "auto",
   "attribution": {
     "commit": "",
     "pr": ""


### PR DESCRIPTION
Sets `theme` to `auto` so Claude Code follows the terminal's light/dark appearance natively. Pairs with a dotfiles change that retires the third-party `claude-theme-sync` daemon.
