### PR TITLE
fix(hooks): allow git worktree list

### DIFF
--- a/user/hooks/worktree/index.test.ts
+++ b/user/hooks/worktree/index.test.ts
@@ -16,8 +16,8 @@ describe("processInput", () => {
     );
   });
 
-  it("denies git worktree list", () => {
-    expect(processInput(bashInput("git worktree list"))).toEqual(formatDenyOutput("list"));
+  it("allows git worktree list", () => {
+    expect(processInput(bashInput("git worktree list"))).toBeNull();
   });
 
   it("denies git worktree remove", () => {

--- a/user/hooks/worktree/index.ts
+++ b/user/hooks/worktree/index.ts
@@ -7,7 +7,8 @@ export type BashInput = {
   command?: string;
 };
 
-const REPLACED_SUBCOMMANDS = new Set(["add", "list", "remove"]);
+const READ_ONLY_SUBCOMMANDS = new Set(["list"]);
+const REPLACED_SUBCOMMANDS = new Set(["add", "remove"]);
 
 export function formatDenyOutput(subcommand: string): SyncHookJSONOutput {
   return {
@@ -39,6 +40,9 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
   const match = command.match(/\bgit\s+worktree\s+(\w+)/);
   const subcommand = match?.[1];
   if (!subcommand) {
+    return null;
+  }
+  if (READ_ONLY_SUBCOMMANDS.has(subcommand)) {
     return null;
   }
   if (REPLACED_SUBCOMMANDS.has(subcommand)) {


### PR DESCRIPTION
Lets `git worktree list` pass through the worktree hook instead of denying it. Worktrunk's value is its hooks for write operations like `add`/`remove`; routing read-only listing through the skill is just friction without a payoff.

## Changes

- Split worktree subcommands into `READ_ONLY_SUBCOMMANDS` (allowed) and `REPLACED_SUBCOMMANDS` (denied)
- `list` now returns `null` from the hook, allowing the native command
- `add` and `remove` still deny with the worktrunk nudge; other subcommands still ask
