### PR TITLE
interview: mandate AskUserQuestion over inline prose

### DIFF
--- a/plugins/interview/skills/clarify/SKILL.md
+++ b/plugins/interview/skills/clarify/SKILL.md
@@ -7,21 +7,19 @@ context: fork
 
 # Clarification Interview
 
-Ask targeted questions using `AskUserQuestion` to resolve a specific blocker.
+Resolve a specific blocker via the `AskUserQuestion` tool.
 
-## When to Use
+## Rules
 
-- Implementation detail is ambiguous
-- Multiple valid approaches exist
-- Edge case behavior is undefined
-- User preference affects the solution
+- Every question goes through `AskUserQuestion`. Never list questions in chat prose.
+- One blocker at a time. 1-2 questions per call; 4 is the cap.
+- If the answer would not change your next action, do not ask.
 
-## Interview Style
+## Open-Ended Questions
 
-- **Focused** - Address the immediate blocker, not comprehensive coverage
-- **Targeted** - Usually 1-2 questions at a time
-- **Actionable** - Each question should unblock progress
-- **Context-rich** - Explain why you're asking and what the options mean
+Even when the answer space feels open, sketch 2-4 plausible options. The user gets "Other" automatically (do not add it). If you cannot name two distinct options, read more code first.
+
+When you have a recommendation, put it first and append "(Recommended)" to the label.
 
 ## Output
 

--- a/plugins/interview/skills/plan/SKILL.md
+++ b/plugins/interview/skills/plan/SKILL.md
@@ -8,27 +8,30 @@ agent: Plan
 
 # Planning Interview
 
-Interview the user comprehensively about their requested change using `AskUserQuestion`.
+Interview the user about their requested change via the `AskUserQuestion` tool.
 
-## Interview Topics
+## Rules
 
-Cover these areas, adapting to context:
+- Every question goes through `AskUserQuestion`. Never list questions in chat prose.
+- Up to 4 questions per call, batched by topic. The cap is per call, not per interview: chain calls until the plan is solid.
+- Refine the next batch based on prior answers. Do not pre-plan all questions.
 
-- **Requirements** - What exactly should this do? What shouldn't it do?
-- **Technical implementation** - Architecture, data flow, dependencies, APIs
-- **UI/UX** - User interactions, feedback, error states, edge cases
-- **Constraints** - Performance, compatibility, security, accessibility
-- **Tradeoffs** - What are you willing to sacrifice? What's non-negotiable?
-- **Scope boundaries** - What's explicitly out of scope for this change?
-- **Validation** - How will we know it works? What does success look like?
+## Open-Ended Questions
 
-## Interview Style
+Even when the answer space feels open, sketch 2-4 plausible options. The user gets "Other" automatically (do not add it). If you cannot name two distinct options, read more code or ask a more foundational question first.
 
-- **Non-obvious questions** - Skip questions with obvious answers
-- **In-depth** - Dig into specifics, follow interesting threads
-- **Batch questions** - Use up to 4 questions per `AskUserQuestion` call
-- **Continue until complete** - Keep interviewing until the plan feels solid
-- **Challenge assumptions** - Surface implicit decisions that deserve explicit consideration
+When you have a recommendation, put it first and append "(Recommended)". For visual or code comparisons, use the `preview` field on options.
+
+## Topics
+
+Adapt to context. Skip questions with obvious answers. Challenge implicit decisions.
+
+- Requirements: what it should and shouldn't do
+- Technical implementation: architecture, data flow, dependencies
+- UI/UX: interactions, feedback, error states
+- Constraints: performance, compatibility, security, accessibility
+- Tradeoffs and scope boundaries
+- Validation: how we know it works
 
 ## Output
 


### PR DESCRIPTION
Mandates `AskUserQuestion` in both `interview:clarify` and `interview:plan` skills, since each one mentioned the tool but did not require it. Interviews routinely degraded into walls of numbered questions in chat prose, which forces the user to scroll, track, and compose multi-part replies.

## Changes

- New "Rules" section in each skill makes `AskUserQuestion` mandatory and bans inline question lists.
- New "Open-Ended Questions" section explains how to fit free-form questions into the structured format: sketch 2-4 plausible options and rely on the auto-added "Other" for fallback.
- `interview:plan` clarifies that the 4-question cap is per call, not per interview, so long interviews chain multiple calls.
- Trimmed the topics list and dropped redundant style guidance. Token counts dropped from 381 → 229 (clarify) and 664 → 385 (plan).
