### PR TITLE
settings: bake in default values that Claude Code writes back

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -233,6 +233,9 @@
   "alwaysThinkingEnabled": true,
   "spinnerTipsEnabled": false,
   "showClearContextOnPlanAccept": true,
+  "autoCompactEnabled": false,
+  "preferredNotifChannel": "terminal_bell",
+  "teammateMode": "auto",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "TMPDIR": "/tmp",


### PR DESCRIPTION
Claude Code persists `autoCompactEnabled`, `preferredNotifChannel`, and `teammateMode` to `user/settings.json` with their default values, producing a diff against the checked-in file on every run. The `claude-upgrade` sync then refuses to pull because of the local changes.

Bake the defaults in so the upgrade sync stays clean.
