### PR TITLE
Clarify active voice and perspective in PR writing guidance

### DIFF
--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -40,7 +40,7 @@ allowed-tools:
 
 ## Body
 
-- Start with 1-3 sentences summarizing the change (no preceding header). Stick to active voice. Don't use passive ("Retry logic was added") — rewrite so something is actually doing the verb
+- Start with 1-3 sentences summarizing the change (no preceding header). Stick to active voice. Don't use passive ("Retry logic was added"); rewrite so something is actually doing the verb
   - Self-evident description of what the PR does: PR-as-subject is fine ("Adds retry logic to the HTTP client") or subject-elided in bullets ("Added retry logic")
   - Design decisions and judgment calls: use "I" so it's clear you made the call ("I chose X over Y because…", "I kept the old endpoint to avoid a breaking change")
 - If the PR is directly motivated by an issue, reference it at the end of the opening summary (`Closes #N`, `Fixes #N`, or just `#N` if not closing). Related issues mentioned for context belong in a `## References` section. Never drop issue refs at the bottom of the body without a section

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -40,11 +40,12 @@ allowed-tools:
 
 ## Body
 
-- Start with 1-3 sentences summarizing the change (no preceding header). Write in **first-person active voice** as the author reflecting on the decisions you made
-  - Good: "I added retry logic to the HTTP client and capped maximum attempts at 3 to avoid hammering downstream services."
-  - Bad (passive): "Retry logic is added to the HTTP client and maximum attempts are limited to 3."
-  - Bad (third-person/subject-elided): "Adds retry logic to the HTTP client and limits maximum attempts to 3."
-- Throughout the body, prefer "I" over "we", "this PR", or subject-elided imperatives. The PR is your work; describe the choices you made and why
+- Start with 1-3 sentences summarizing the change (no preceding header). Write as the author reflecting on the decisions you made — **first-person active voice**, with passive voice as the cardinal sin
+  - Best: "I added retry logic to the HTTP client and capped maximum attempts at 3 to avoid hammering downstream services."
+  - Acceptable shorthand: "Added retry logic to the HTTP client and capped maximum attempts at 3." (past-tense "Added" reads as first-person with the "I" elided)
+  - Avoid (third-person): "Adds retry logic to the HTTP client and limits maximum attempts to 3." (present-tense "Adds" implies the PR is the actor, not you)
+  - Worst (passive): "Retry logic is added to the HTTP client and maximum attempts are limited to 3."
+- Prefer "I" over "we" or "this PR". You can drop the "I" for brevity, but keep the verb in past tense so it still reads as your action ("Refactored…", "Chose…") rather than the PR's ("Refactors…", "Chooses…")
 - If the PR is directly motivated by an issue, reference it at the end of the opening summary (`Closes #N`, `Fixes #N`, or just `#N` if not closing). Related issues mentioned for context belong in a `## References` section. Never drop issue refs at the bottom of the body without a section
 - **Wrap all code identifiers with backticks**: function names, class names, file paths, endpoints, status codes, etc.
 - Use `##` sections for larger changes. See [`sections.md`](sections.md) for detailed guidance on:

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -40,12 +40,10 @@ allowed-tools:
 
 ## Body
 
-- Start with 1-3 sentences summarizing the change (no preceding header). Write as the author reflecting on the decisions you made — **first-person active voice**, with passive voice as the cardinal sin
-  - Best: "I added retry logic to the HTTP client and capped maximum attempts at 3 to avoid hammering downstream services."
-  - Acceptable shorthand: "Added retry logic to the HTTP client and capped maximum attempts at 3." (past-tense "Added" reads as first-person with the "I" elided)
-  - Avoid (third-person): "Adds retry logic to the HTTP client and limits maximum attempts to 3." (present-tense "Adds" implies the PR is the actor, not you)
-  - Worst (passive): "Retry logic is added to the HTTP client and maximum attempts are limited to 3."
-- Prefer "I" over "we" or "this PR". You can drop the "I" for brevity, but keep the verb in past tense so it still reads as your action ("Refactored…", "Chose…") rather than the PR's ("Refactors…", "Chooses…")
+- Start with 1-3 sentences summarizing the change (no preceding header). Write as the author, in past tense. Don't use passive voice ("Retry logic was added") — rewrite so the actor (you) is doing the verb
+  - Bullets: drop the "I" ("Added retry logic", "Capped attempts at 3")
+  - Prose: use "I" where a subject helps, especially for judgment calls ("I chose X over Y because…")
+  - Avoid present-tense "Adds X" — it reads as third-person, with the PR as the actor
 - If the PR is directly motivated by an issue, reference it at the end of the opening summary (`Closes #N`, `Fixes #N`, or just `#N` if not closing). Related issues mentioned for context belong in a `## References` section. Never drop issue refs at the bottom of the body without a section
 - **Wrap all code identifiers with backticks**: function names, class names, file paths, endpoints, status codes, etc.
 - Use `##` sections for larger changes. See [`sections.md`](sections.md) for detailed guidance on:

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -40,9 +40,11 @@ allowed-tools:
 
 ## Body
 
-- Start with 1-3 sentences summarizing the change (no preceding header). Use active voice and direct language
-  - Good: "Adds retry logic to the HTTP client and limits maximum attempts to 3."
-  - Bad: "Retry logic is added to the HTTP client and maximum attempts are limited to 3."
+- Start with 1-3 sentences summarizing the change (no preceding header). Write in **first-person active voice** as the author reflecting on the decisions you made
+  - Good: "I added retry logic to the HTTP client and capped maximum attempts at 3 to avoid hammering downstream services."
+  - Bad (passive): "Retry logic is added to the HTTP client and maximum attempts are limited to 3."
+  - Bad (third-person/subject-elided): "Adds retry logic to the HTTP client and limits maximum attempts to 3."
+- Throughout the body, prefer "I" over "we", "this PR", or subject-elided imperatives. The PR is your work; describe the choices you made and why
 - If the PR is directly motivated by an issue, reference it at the end of the opening summary (`Closes #N`, `Fixes #N`, or just `#N` if not closing). Related issues mentioned for context belong in a `## References` section. Never drop issue refs at the bottom of the body without a section
 - **Wrap all code identifiers with backticks**: function names, class names, file paths, endpoints, status codes, etc.
 - Use `##` sections for larger changes. See [`sections.md`](sections.md) for detailed guidance on:

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -40,10 +40,9 @@ allowed-tools:
 
 ## Body
 
-- Start with 1-3 sentences summarizing the change (no preceding header). Write as the author, in past tense. Don't use passive voice ("Retry logic was added") — rewrite so the actor (you) is doing the verb
-  - Bullets: drop the "I" ("Added retry logic", "Capped attempts at 3")
-  - Prose: use "I" where a subject helps, especially for judgment calls ("I chose X over Y because…")
-  - Avoid present-tense "Adds X" — it reads as third-person, with the PR as the actor
+- Start with 1-3 sentences summarizing the change (no preceding header). Stick to active voice. Don't use passive ("Retry logic was added") — rewrite so something is actually doing the verb
+  - Self-evident description of what the PR does: PR-as-subject is fine ("Adds retry logic to the HTTP client") or subject-elided in bullets ("Added retry logic")
+  - Design decisions and judgment calls: use "I" so it's clear you made the call ("I chose X over Y because…", "I kept the old endpoint to avoid a breaking change")
 - If the PR is directly motivated by an issue, reference it at the end of the opening summary (`Closes #N`, `Fixes #N`, or just `#N` if not closing). Related issues mentioned for context belong in a `## References` section. Never drop issue refs at the bottom of the body without a section
 - **Wrap all code identifiers with backticks**: function names, class names, file paths, endpoints, status codes, etc.
 - Use `##` sections for larger changes. See [`sections.md`](sections.md) for detailed guidance on:

--- a/plugins/pull-request/skills/create/sections.md
+++ b/plugins/pull-request/skills/create/sections.md
@@ -2,7 +2,14 @@
 
 Detailed guidance for optional PR body sections.
 
-All sections are written by the PR author (you, on behalf of the user). Use **first-person active voice** ("I added…", "I chose…", "I split…") rather than passive ("X was added") or subject-elided imperative ("Adds X"). The body should read as the author reflecting on the decisions they made, not a neutral changelog.
+All sections are written by the PR author (you, on behalf of the user). The cardinal sin is **passive voice** ("X was added", "is handled by…") — the body should read as the author reflecting on the decisions they made, not a neutral changelog.
+
+Voice ranking, best to worst:
+
+1. **First-person active**: "I added retry logic", "I chose to extract this into a helper"
+2. **Subject-elided past tense** (acceptable shorthand for first-person): "Added retry logic", "Chose to extract…"
+3. **Third-person/PR-as-actor**: "Adds retry logic", "Refactors the client" — avoid; the present-tense verb makes the PR the subject instead of you
+4. **Passive**: "Retry logic was added", "The client is refactored" — never use this
 
 ## Issue
 
@@ -15,7 +22,7 @@ Use for bug fixes, which should include a related issue.
 
 Organize by concept, not by file. Each bullet should describe a single conceptual shift, even when it spans multiple files. The reviewer reads this to understand *what's different and why*, not to get a tour of modified files.
 
-- Lead with the conceptual change, not the file location. Phrase bullets in first-person active voice ("I extracted…", "I replaced X with Y because…") rather than "Adds X" or "X was added"
+- Lead with the conceptual change, not the file location. Phrase bullets in active voice — first-person ("I extracted…") or past-tense subject-elided ("Extracted…") both work. Avoid present-tense "Adds X" (third-person) and never use passive "X was added"
 - Omit cleanup that follows naturally from the main change (e.g. removing dead imports). The diff shows this
 - Never structure bullets as `**path**: description`
 - Reference code identifiers only when they add information beyond what the diff shows. Use the shortest unambiguous name (module, filename, or component, not full paths)

--- a/plugins/pull-request/skills/create/sections.md
+++ b/plugins/pull-request/skills/create/sections.md
@@ -2,11 +2,10 @@
 
 Detailed guidance for optional PR body sections.
 
-Write as the PR author, in past tense. Don't use passive voice ("X was added") — rewrite so you're the actor.
+Stick to active voice. Don't use passive ("X was added") — rewrite so something is doing the verb.
 
-- Bullets: drop the "I" ("Added retry logic", "Extracted the helper")
-- Prose: use "I" where a subject helps, especially for judgment calls ("I chose X over Y because…")
-- Avoid present-tense "Adds X" — it reads as third-person, with the PR as the actor
+- Self-evident description of what the PR does: PR-as-subject is fine ("Adds retry logic") or subject-elided in bullets ("Added retry logic", "Extracted the helper")
+- Design decisions and judgment calls: use "I" so it's clear you made the call ("I chose X over Y because…")
 
 ## Issue
 
@@ -19,7 +18,7 @@ Use for bug fixes, which should include a related issue.
 
 Organize by concept, not by file. Each bullet should describe a single conceptual shift, even when it spans multiple files. The reviewer reads this to understand *what's different and why*, not to get a tour of modified files.
 
-- Lead with the conceptual change, not the file location. Use past-tense subject-elided phrasing ("Extracted the helper", "Replaced X with Y"); avoid present-tense "Adds X" and passive "X was added"
+- Lead with the conceptual change, not the file location. Subject-elided phrasing works for plain description ("Extracted the helper", "Replaced X with Y"); use "I" when a bullet explains a judgment call. Don't use passive ("X was added")
 - Omit cleanup that follows naturally from the main change (e.g. removing dead imports). The diff shows this
 - Never structure bullets as `**path**: description`
 - Reference code identifiers only when they add information beyond what the diff shows. Use the shortest unambiguous name (module, filename, or component, not full paths)

--- a/plugins/pull-request/skills/create/sections.md
+++ b/plugins/pull-request/skills/create/sections.md
@@ -2,27 +2,24 @@
 
 Detailed guidance for optional PR body sections.
 
-All sections are written by the PR author (you, on behalf of the user). The cardinal sin is **passive voice** ("X was added", "is handled by…") — the body should read as the author reflecting on the decisions they made, not a neutral changelog.
+Write as the PR author, in past tense. Don't use passive voice ("X was added") — rewrite so you're the actor.
 
-Voice ranking, best to worst:
-
-1. **First-person active**: "I added retry logic", "I chose to extract this into a helper"
-2. **Subject-elided past tense** (acceptable shorthand for first-person): "Added retry logic", "Chose to extract…"
-3. **Third-person/PR-as-actor**: "Adds retry logic", "Refactors the client" — avoid; the present-tense verb makes the PR the subject instead of you
-4. **Passive**: "Retry logic was added", "The client is refactored" — never use this
+- Bullets: drop the "I" ("Added retry logic", "Extracted the helper")
+- Prose: use "I" where a subject helps, especially for judgment calls ("I chose X over Y because…")
+- Avoid present-tense "Adds X" — it reads as third-person, with the PR as the actor
 
 ## Issue
 
 Use for bug fixes, which should include a related issue.
 
-- Describe the root cause in first person ("I traced this to…", "I found that…")
+- Describe the root cause as the author ("I traced this to…", "I found that…"). Avoid passive writeups ("the bug was caused by…")
 - Link existing issues with `Closes #123` or `Fixes #456`
 
 ## Changes
 
 Organize by concept, not by file. Each bullet should describe a single conceptual shift, even when it spans multiple files. The reviewer reads this to understand *what's different and why*, not to get a tour of modified files.
 
-- Lead with the conceptual change, not the file location. Phrase bullets in active voice — first-person ("I extracted…") or past-tense subject-elided ("Extracted…") both work. Avoid present-tense "Adds X" (third-person) and never use passive "X was added"
+- Lead with the conceptual change, not the file location. Use past-tense subject-elided phrasing ("Extracted the helper", "Replaced X with Y"); avoid present-tense "Adds X" and passive "X was added"
 - Omit cleanup that follows naturally from the main change (e.g. removing dead imports). The diff shows this
 - Never structure bullets as `**path**: description`
 - Reference code identifiers only when they add information beyond what the diff shows. Use the shortest unambiguous name (module, filename, or component, not full paths)
@@ -37,14 +34,14 @@ Only include if tests were added/modified or manual testing was performed. Omit 
 Focus on **what** is covered and **why** it matters:
 
 **Good examples:**
-- "I added tests covering error handling for malformed JSON responses"
-- "I added integration tests for the full request/response cycle"
-- "I extended the auth tests to cover the new OAuth flow"
-- "I verified edge cases: empty input, null values, and Unicode handling"
+- "Added tests covering error handling for malformed JSON responses"
+- "Added integration tests for the full request/response cycle"
+- "Extended the auth tests to cover the new OAuth flow"
+- "Verified edge cases: empty input, null values, and Unicode handling"
 
 **Coverage gaps**: Note anything that merited testing but was difficult to automate:
-- "I left rate-limiting behavior for manual verification against the live API"
-- "I verified visual layout changes in the browser but didn't add snapshot coverage"
+- "Left rate-limiting behavior for manual verification against the live API"
+- "Verified visual layout changes in the browser but didn't add snapshot coverage"
 
 **Manual verification**: Include any testing done outside of automated tests—running commands, checking output, verifying behavior in a browser or tool. This counts whether performed by the user or by Claude during the session.
 

--- a/plugins/pull-request/skills/create/sections.md
+++ b/plugins/pull-request/skills/create/sections.md
@@ -2,18 +2,20 @@
 
 Detailed guidance for optional PR body sections.
 
+All sections are written by the PR author (you, on behalf of the user). Use **first-person active voice** ("I added…", "I chose…", "I split…") rather than passive ("X was added") or subject-elided imperative ("Adds X"). The body should read as the author reflecting on the decisions they made, not a neutral changelog.
+
 ## Issue
 
 Use for bug fixes, which should include a related issue.
 
-- Provide root cause analysis
+- Describe the root cause in first person ("I traced this to…", "I found that…")
 - Link existing issues with `Closes #123` or `Fixes #456`
 
 ## Changes
 
 Organize by concept, not by file. Each bullet should describe a single conceptual shift, even when it spans multiple files. The reviewer reads this to understand *what's different and why*, not to get a tour of modified files.
 
-- Lead with the conceptual change, not the file location
+- Lead with the conceptual change, not the file location. Phrase bullets in first-person active voice ("I extracted…", "I replaced X with Y because…") rather than "Adds X" or "X was added"
 - Omit cleanup that follows naturally from the main change (e.g. removing dead imports). The diff shows this
 - Never structure bullets as `**path**: description`
 - Reference code identifiers only when they add information beyond what the diff shows. Use the shortest unambiguous name (module, filename, or component, not full paths)
@@ -28,14 +30,14 @@ Only include if tests were added/modified or manual testing was performed. Omit 
 Focus on **what** is covered and **why** it matters:
 
 **Good examples:**
-- "Tests cover error handling for malformed JSON responses"
-- "Added integration tests for the full request/response cycle"
-- "Extended auth tests to cover the new OAuth flow"
-- "Verified edge cases: empty input, null values, and Unicode handling"
+- "I added tests covering error handling for malformed JSON responses"
+- "I added integration tests for the full request/response cycle"
+- "I extended the auth tests to cover the new OAuth flow"
+- "I verified edge cases: empty input, null values, and Unicode handling"
 
 **Coverage gaps**: Note anything that merited testing but was difficult to automate:
-- "Rate limiting behavior requires manual verification against live API"
-- "Visual layout changes verified in browser but not covered by snapshot tests"
+- "I left rate-limiting behavior for manual verification against the live API"
+- "I verified visual layout changes in the browser but didn't add snapshot coverage"
 
 **Manual verification**: Include any testing done outside of automated tests—running commands, checking output, verifying behavior in a browser or tool. This counts whether performed by the user or by Claude during the session.
 

--- a/plugins/pull-request/skills/create/sections.md
+++ b/plugins/pull-request/skills/create/sections.md
@@ -2,7 +2,7 @@
 
 Detailed guidance for optional PR body sections.
 
-Stick to active voice. Don't use passive ("X was added") — rewrite so something is doing the verb.
+Stick to active voice. Don't use passive ("X was added"). Rewrite so something is doing the verb.
 
 - Self-evident description of what the PR does: PR-as-subject is fine ("Adds retry logic") or subject-elided in bullets ("Added retry logic", "Extracted the helper")
 - Design decisions and judgment calls: use "I" so it's clear you made the call ("I chose X over Y because…")


### PR DESCRIPTION
Refines the PR body writing guidance to emphasize active voice and appropriate use of perspective (PR-as-subject vs. first-person "I") depending on context.

**Changes:**

- Added explicit guidance at the top of `sections.md` distinguishing between self-evident descriptions (where PR-as-subject or subject-elided phrasing works) and design decisions (where "I" clarifies authorship)
- Updated the Issue section to encourage first-person language when describing root cause analysis ("I traced this to…" instead of passive "the bug was caused by…")
- Expanded the Changes section guidance to clarify when subject-elided phrasing is appropriate vs. when "I" should be used for judgment calls
- Revised Testing section examples to use consistent active voice:
  - Changed "Tests cover" to "Added tests covering" for clarity
  - Changed "Extended auth tests" to "Extended the auth tests" for consistency
  - Rewrote coverage gap examples to use active voice ("Left rate-limiting behavior for manual verification" and "Verified visual layout changes in the browser but didn't add snapshot coverage")
- Updated `SKILL.md` to align with the refined guidance, replacing the passive example with clearer explanations of when to use PR-as-subject vs. first-person perspective

These changes make the guidance more actionable by explicitly teaching authors when each voice/perspective is appropriate, rather than just showing good vs. bad examples.

https://claude.ai/code/session_012m7KCJHqasgVkLekyyyuy5