### PR TITLE
fix(writing): non-blocking reminders, diff-aware scanning

### DIFF
--- a/plugins/writing/hooks/check-tropes.test.ts
+++ b/plugins/writing/hooks/check-tropes.test.ts
@@ -99,9 +99,9 @@ describe("plan files", () => {
     expect(await processInput(input)).toBeNull();
   });
 
-  it("still denies non-plan files with spaced em dash", async () => {
-    const output = await getDecision(mockWrite("This \u2014 is bad"));
-    expect(output?.permissionDecision).toBe("deny");
+  it("returns reminder for non-plan files with spaced em dash", async () => {
+    const result = await processInput(mockWrite("This \u2014 is bad"));
+    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
   });
 });
 
@@ -144,14 +144,16 @@ describe("semicolon file scoping", () => {
 });
 
 describe("Write/Edit", () => {
-  it("denies Write with spaced em dash", async () => {
-    const output = await getDecision(mockWrite("This \u2014 is bad"));
-    expect(output?.permissionDecision).toBe("deny");
+  it("returns reminder for Write with spaced em dash", async () => {
+    const result = await processInput(mockWrite("This \u2014 is bad"));
+    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
+    const ctx = (result?.hookSpecificOutput as { additionalContext: string }).additionalContext;
+    expect(ctx).toContain("follow-up Edit");
   });
 
-  it("asks on Edit with spaced em dash", async () => {
-    const output = await getDecision(mockEdit("This \u2014 is bad"));
-    expect(output?.permissionDecision).toBe("ask");
+  it("returns reminder for Edit with spaced em dash", async () => {
+    const result = await processInput(mockEdit("This \u2014 is bad"));
+    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
   });
 
   it("ignores flagged content in Edit old_string", async () => {
@@ -162,10 +164,10 @@ describe("Write/Edit", () => {
     expect(await processInput(input)).toBeNull();
   });
 
-  it("asks on Edit when old_string is clean but new_string has em dash", async () => {
+  it("returns reminder when old_string is clean but new_string has em dash", async () => {
     const input = mockEdit("This \u2014 is bad", "clean original text here");
-    const output = await getDecision(input);
-    expect(output?.permissionDecision).toBe("ask");
+    const result = await processInput(input);
+    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
   });
 
   it("returns context for promotional language", async () => {
@@ -182,6 +184,57 @@ describe("Write/Edit", () => {
   });
 });
 
+describe("diff-aware filtering", () => {
+  it("ignores Edit that preserves a pre-existing em dash", async () => {
+    const input = mockEdit(
+      "Title \u2014 kept verbatim, with extra detail added.",
+      "Title \u2014 kept verbatim.",
+    );
+    expect(await processInput(input)).toBeNull();
+  });
+
+  it("flags Edit that adds a second em dash beyond what old_string had", async () => {
+    const input = mockEdit(
+      "Title \u2014 kept, and now another \u2014 added phrase.",
+      "Title \u2014 kept verbatim.",
+    );
+    const result = await processInput(input);
+    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
+  });
+
+  it("ignores MultiEdit that preserves pre-existing AI vocabulary", async () => {
+    const input = mockMultiEdit([
+      {
+        old_string: "We delve into the intricacies of the system.",
+        new_string: "We delve into the intricacies of the new system, with examples.",
+      },
+    ]);
+    expect(await processInput(input)).toBeNull();
+  });
+
+  it("ignores Write that preserves an em dash already in the file", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "trope-diff-"));
+    const file = join(dir, "doc.md");
+    await Bun.write(file, "Title \u2014 already here in the existing file.\n");
+    const input = mockWrite("Title \u2014 already here in the existing file.\nAdded line.\n");
+    (input.tool_input as Record<string, unknown>).file_path = file;
+    const result = await processInput(input);
+    await rm(dir, { recursive: true, force: true });
+    expect(result).toBeNull();
+  });
+
+  it("flags Write that adds a new em dash beyond what file had", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "trope-diff-"));
+    const file = join(dir, "doc.md");
+    await Bun.write(file, "Title \u2014 already here.\n");
+    const input = mockWrite("Title \u2014 already here.\nNow another \u2014 line.\n");
+    (input.tool_input as Record<string, unknown>).file_path = file;
+    const result = await processInput(input);
+    await rm(dir, { recursive: true, force: true });
+    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
+  });
+});
+
 describe("MultiEdit", () => {
   it("returns null when all old_string values are flagged but new_string values are clean", async () => {
     const input = mockMultiEdit([
@@ -191,13 +244,13 @@ describe("MultiEdit", () => {
     expect(await processInput(input)).toBeNull();
   });
 
-  it("asks when any new_string contains a spaced em dash", async () => {
+  it("returns reminder when any new_string contains a spaced em dash", async () => {
     const input = mockMultiEdit([
       { old_string: "clean original text here", new_string: "clean replacement text here" },
       { old_string: "more clean original content", new_string: "bad \u2014 replacement here" },
     ]);
-    const output = await getDecision(input);
-    expect(output?.permissionDecision).toBe("ask");
+    const result = await processInput(input);
+    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
   });
 
   it("returns null for fully clean MultiEdit", async () => {

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -3,7 +3,9 @@
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import { formatContext, formatDecision, isMemoryPath, type SyncHookJSONOutput } from "./markdown";
-import { firstByTier, scan } from "./tropes";
+import { firstByTier, type PatternMatch, scan, scanIntroduced } from "./tropes";
+
+const FILE_OP_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
 
 const MIN_PROSE_LENGTH = 20;
 
@@ -62,35 +64,64 @@ function extractInlineArg(command: string, flag: string): string | null {
   return match?.[1] ?? match?.[2] ?? null;
 }
 
-function collectMultiEditText(toolInput: Record<string, unknown>): string[] {
+function collectMultiEditPairs(toolInput: Record<string, unknown>): {
+  newText: string;
+  oldText: string;
+} {
   const edits = toolInput.edits;
-  if (!Array.isArray(edits)) return [];
-  const texts: string[] = [];
+  if (!Array.isArray(edits)) return { newText: "", oldText: "" };
+  const newParts: string[] = [];
+  const oldParts: string[] = [];
   for (const edit of edits) {
-    if (edit && typeof edit === "object") {
-      const newString = (edit as Record<string, unknown>).new_string;
-      if (typeof newString === "string") texts.push(newString);
-    }
+    if (!edit || typeof edit !== "object") continue;
+    const fields = edit as Record<string, unknown>;
+    if (typeof fields.new_string === "string") newParts.push(fields.new_string);
+    if (typeof fields.old_string === "string") oldParts.push(fields.old_string);
   }
-  return texts;
+  return { newText: newParts.join("\n"), oldText: oldParts.join("\n") };
+}
+
+async function collectFileOpPair(
+  input: PreToolUseHookInput,
+): Promise<{ newText: string; oldText: string } | null> {
+  const toolInput = input.tool_input as Record<string, unknown>;
+  const toolName = input.tool_name;
+
+  if (toolName === "Write") {
+    const content = toolInput.content;
+    if (typeof content !== "string" || content.length === 0) return null;
+    const filePath = toolInput.file_path;
+    let oldText = "";
+    if (typeof filePath === "string") {
+      const file = Bun.file(filePath);
+      if (await file.exists()) oldText = await file.text();
+    }
+    return { newText: content, oldText };
+  }
+
+  if (toolName === "Edit") {
+    const newString = toolInput.new_string;
+    if (typeof newString !== "string" || newString.length === 0) return null;
+    const oldString = toolInput.old_string;
+    return { newText: newString, oldText: typeof oldString === "string" ? oldString : "" };
+  }
+
+  if (toolName === "MultiEdit") {
+    const pair = collectMultiEditPairs(toolInput);
+    if (pair.newText.length === 0) return null;
+    return pair;
+  }
+
+  return null;
 }
 
 export async function collectText(input: PreToolUseHookInput): Promise<string[]> {
   const toolInput = input.tool_input as Record<string, unknown>;
   const toolName = input.tool_name;
 
-  if (toolName === "Write") {
-    const content = toolInput.content as string | undefined;
-    return content ? [content] : [];
-  }
-
-  if (toolName === "Edit") {
-    const content = toolInput.new_string as string | undefined;
-    return content ? [content] : [];
-  }
-
-  if (toolName === "MultiEdit") {
-    return collectMultiEditText(toolInput);
+  if (FILE_OP_TOOLS.has(toolName)) {
+    const pair = await collectFileOpPair(input);
+    return pair ? [pair.newText] : [];
   }
 
   if (toolName === "Bash" && typeof toolInput.command === "string") {
@@ -122,31 +153,56 @@ function isMemoryFile(input: PreToolUseHookInput): boolean {
   return isMemoryPath(filePath);
 }
 
+function buildFileOpReminder(
+  toolName: string,
+  filePath: string | undefined,
+  deny: PatternMatch,
+): string {
+  const target = filePath ? `\`${filePath}\`` : "the file";
+  if (toolName === "Write") {
+    return `${deny.message} You wrote ${target} introducing this. Issue a follow-up Edit that fixes only the trope you just introduced. Do not modify unrelated parts of the file.`;
+  }
+  return `${deny.message} You introduced this in your edit to ${target}. Issue a follow-up Edit that targets only the text you just changed. Do not modify unrelated parts of the file, including other pre-existing tropes.`;
+}
+
+async function processFileOp(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
+  const pair = await collectFileOpPair(input);
+  if (!pair) return null;
+  const filePath = (input.tool_input as Record<string, unknown>).file_path as string | undefined;
+  const matches = scanIntroduced(pair.newText, pair.oldText, filePath);
+
+  const deny = firstByTier(matches, "deny");
+  if (deny) {
+    return formatContext(buildFileOpReminder(input.tool_name, filePath, deny));
+  }
+
+  const context = firstByTier(matches, "context");
+  if (context) return formatContext(context.message);
+
+  return null;
+}
+
+async function processSideEffect(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
+  const texts = await collectText(input);
+  if (texts.length === 0) return null;
+  const combined = texts.join("\n");
+  const matches = scan(combined);
+
+  const deny = firstByTier(matches, "deny");
+  if (deny) return formatDecision("deny", deny.message);
+
+  const context = firstByTier(matches, "context");
+  if (context) return formatContext(context.message);
+
+  return null;
+}
+
 export async function processInput(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
   if (isPlanFile(input)) return null;
   if (isMemoryFile(input)) return null;
 
-  const texts = await collectText(input);
-  if (texts.length === 0) return null;
-
-  const combined = texts.join("\n");
-  const filePath = (input.tool_input as Record<string, unknown>).file_path as string | undefined;
-  const matches = scan(combined, filePath);
-  const deny = firstByTier(matches, "deny");
-
-  if (deny) {
-    if (input.tool_name === "Edit" || input.tool_name === "MultiEdit") {
-      return formatDecision("ask", deny.message);
-    }
-    return formatDecision("deny", deny.message);
-  }
-
-  const context = firstByTier(matches, "context");
-  if (context) {
-    return formatContext(context.message);
-  }
-
-  return null;
+  if (FILE_OP_TOOLS.has(input.tool_name)) return processFileOp(input);
+  return processSideEffect(input);
 }
 
 async function main(): Promise<void> {

--- a/plugins/writing/hooks/tropes.ts
+++ b/plugins/writing/hooks/tropes.ts
@@ -102,8 +102,28 @@ export function stripCode(text: string): string {
   return text.replace(FENCED_CODE_BLOCK, "").replace(INLINE_CODE, "");
 }
 
+type Hits = { count: number; sample: string };
+
+function patternHits(stripped: string, def: PatternDef): Hits {
+  if (typeof def.test === "function") {
+    return { count: def.test(stripped) ? 1 : 0, sample: "" };
+  }
+  def.test.lastIndex = 0;
+  const all = stripped.match(def.test);
+  return { count: all?.length ?? 0, sample: all?.[0] ?? "" };
+}
+
 export function scan(text: string, filePath?: string): PatternMatch[] {
-  const stripped = stripCode(text);
+  return scanIntroduced(text, "", filePath);
+}
+
+export function scanIntroduced(
+  newText: string,
+  oldText: string,
+  filePath?: string,
+): PatternMatch[] {
+  const newStripped = stripCode(newText);
+  const oldStripped = stripCode(oldText);
   const matches: PatternMatch[] = [];
   const seenTiers = new Set<PatternTier>();
 
@@ -111,24 +131,18 @@ export function scan(text: string, filePath?: string): PatternMatch[] {
     if (seenTiers.has(def.tier)) continue;
     if (def.fileOnly && filePath && !isProseFile(filePath)) continue;
 
-    let matched: string | null = null;
-    if (typeof def.test === "function") {
-      if (def.test(stripped)) matched = "";
-    } else {
-      def.test.lastIndex = 0;
-      const result = def.test.exec(stripped);
-      if (result) matched = result[0];
-    }
+    const newHits = patternHits(newStripped, def);
+    if (newHits.count === 0) continue;
+    const oldHits = patternHits(oldStripped, def);
+    if (newHits.count <= oldHits.count) continue;
 
-    if (matched !== null) {
-      matches.push({
-        tier: def.tier,
-        category: def.category,
-        matched,
-        message: def.message(matched),
-      });
-      seenTiers.add(def.tier);
-    }
+    matches.push({
+      tier: def.tier,
+      category: def.category,
+      matched: newHits.sample,
+      message: def.message(newHits.sample),
+    });
+    seenTiers.add(def.tier);
   }
 
   return matches;


### PR DESCRIPTION
Two papercuts on the writing hook. First, blocking a `Write` that contains a single AI trope wastes tokens because Claude has to re-emit the whole file just to fix one phrase. Second, when Claude edits a file someone else littered with em dashes, the hook fires on those pre-existing tropes even when the change Claude made is unrelated.

## Changes

- For `Write`/`Edit`/`MultiEdit`, deny matches now return `additionalContext` instead of blocking. The reminder tells Claude to issue a follow-up `Edit` that targets only the trope it just introduced and not unrelated parts of the file.
- `Bash` and MCP tools keep the `deny` behavior because their side effects (sent messages, created issues, pushed commits) cannot be undone with a follow-up edit.
- Added `scanIntroduced(newText, oldText, filePath?)` in `tropes.ts`. It counts pattern hits in both texts and only flags when the new count exceeds the old count.
- `processFileOp` reads the existing file from disk for `Write`, uses `old_string` for `Edit`, and aggregates `old_string`/`new_string` for `MultiEdit`. Pre-existing tropes drop out of the comparison.

## Testing

- Updated existing assertions: Write/Edit/MultiEdit em dash inputs now expect `additionalContext`.
- Added five tests covering diff-aware filtering: Edit preserving an em dash, Edit adding a second em dash beyond the original count, MultiEdit preserving pre-existing AI vocabulary, Write to a file that already contains an em dash, and Write that adds a new em dash on top of an existing one.
