### PR TITLE
tmux: enrich layout with title, pid, and cross-window panes

### DIFF
--- a/plugins/tmux/skills/tmux/SKILL.md
+++ b/plugins/tmux/skills/tmux/SKILL.md
@@ -28,9 +28,9 @@ Use `$TMUX_PANE` to identify the current pane and target adjacent ones.
 
 !`bash ${CLAUDE_SKILL_DIR}/scripts/layout.sh`
 
-Use `left`/`top` coordinates to resolve spatial references (LHS = lowest `left`, RHS = highest `left`, top = lowest `top`, bottom = highest `top`). When describing layouts, draw ASCII box diagrams showing pane positions and sizes.
+Use `left`/`top` coordinates to resolve spatial references within the current window (LHS = lowest `left`, RHS = highest `left`, top = lowest `top`, bottom = highest `top`). When describing layouts, draw ASCII box diagrams showing pane positions and sizes.
 
-Target panes across windows and sessions with `<session>:<window>.<pane>` (e.g., `dotfiles:1.%42`). Use `tmux list-panes -t <session>:<window>` to discover pane IDs in other windows.
+The `Other Panes` section lists panes in other windows and sessions. Its `TARGET` column is ready to use with `-t` (e.g., `tmux capture-pane -t website:1.%7 -p`). The `TITLE` column shows app-set context — Claude sessions advertise their current task there, which is usually enough to identify a pane without capturing its content.
 
 ### Notifications
 

--- a/plugins/tmux/skills/tmux/scripts/layout.sh
+++ b/plugins/tmux/skills/tmux/scripts/layout.sh
@@ -6,14 +6,30 @@ set -euo pipefail
 info=$(tmux display-message -t "$TMUX_PANE" -p '#{session_name} #{window_index}' 2>/dev/null) || exit 0
 read -r session current_window <<< "$info"
 
-echo "## Panes"
+TAB=$'\t'
+
+echo "## Panes (current window)"
 echo ""
-printf '%-14s  %-5s %-5s %-12s %-10s %s\n' "ID" "LEFT" "TOP" "SIZE" "CMD" "PATH"
-tmux list-panes -t "$session:$current_window" -F '#{pane_id} #{pane_left} #{pane_top} #{pane_width}x#{pane_height} #{pane_current_command} #{pane_current_path}' 2>/dev/null | while read -r id left top size cmd path; do
+printf '%-14s %-5s %-5s %-10s %-9s %-7s %-44s %s\n' "ID" "LEFT" "TOP" "SIZE" "CMD" "PID" "PATH" "TITLE"
+current_fmt="#{pane_id}${TAB}#{pane_left}${TAB}#{pane_top}${TAB}#{pane_width}x#{pane_height}${TAB}#{pane_current_command}${TAB}#{pane_pid}${TAB}#{pane_current_path}${TAB}#{pane_title}"
+tmux list-panes -t "$session:$current_window" -F "$current_fmt" 2>/dev/null | while IFS=$'\t' read -r id left top size cmd pid path title; do
   tag=""
   [ "$id" = "$TMUX_PANE" ] && tag=" (you)"
-  printf '%-14s  %-5s %-5s %-12s %-10s %s\n' "${id}${tag}" "$left" "$top" "$size" "$cmd" "$path"
+  printf '%-14s %-5s %-5s %-10s %-9s %-7s %-44s %s\n' "${id}${tag}" "$left" "$top" "$size" "$cmd" "$pid" "$path" "$title"
 done
+
+other_fmt="#{session_name}:#{window_index}.#{pane_id}${TAB}#{pane_current_command}${TAB}#{pane_pid}${TAB}#{pane_current_path}${TAB}#{pane_title}"
+others=$(tmux list-panes -a -F "$other_fmt" 2>/dev/null | awk -F'\t' -v prefix="$session:$current_window." 'index($1, prefix) != 1')
+
+if [ -n "$others" ]; then
+  echo ""
+  echo "## Other Panes"
+  echo ""
+  printf '%-25s %-9s %-7s %-44s %s\n' "TARGET" "CMD" "PID" "PATH" "TITLE"
+  printf '%s\n' "$others" | while IFS=$'\t' read -r target cmd pid path title; do
+    printf '%-25s %-9s %-7s %-44s %s\n' "$target" "$cmd" "$pid" "$path" "$title"
+  done
+fi
 
 echo ""
 echo "## Windows"


### PR DESCRIPTION
Expands the tmux skill's `layout.sh` so it surfaces more identifying context up front. The current-window pane table now includes `PID`, `PATH`, and `TITLE` columns, and a new `Other Panes` section flat-lists panes from other windows and sessions with `<session>:<window>.<pane>` targets that drop straight into `-t` arguments.

Claude sessions advertise their current task as the pane title, so the `TITLE` column usually identifies a pane without a `capture-pane` round-trip. I stopped short of pre-capturing pane content tails. That would inflate the skill load on every invocation, and a benchmark should decide whether it's worth it before going further.

## Testing

Ran `bash plugins/tmux/skills/tmux/scripts/layout.sh` against a setup with four Claude sessions in the current window plus a `zsh` pane in another session. Confirmed Claude session titles surface their current task, `TARGET` values work directly with `tmux -t`, and the `Other Panes` section is suppressed when no cross-window panes exist.
