### PR TITLE
settings: allow writes to uv data dir

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -184,7 +184,8 @@
         "~/Library/Caches/go-build",
         "~/src/go/pkg/mod",
         "~/src/go/pkg/sumdb",
-        "~/.bun/install"
+        "~/.bun/install",
+        "~/.local/share/uv"
       ]
     },
     "excludedCommands": [


### PR DESCRIPTION
Allows the sandbox to write under `~/.local/share/uv`, where `uv` stores installed tools and other managed state. Scoped to the `uv/` parent rather than `uv/tools/` so cache and python installs are covered too.
