### PR TITLE
fix(tmux): target Claude's pane in context hook

### DIFF
--- a/plugins/tmux/hooks/context.ts
+++ b/plugins/tmux/hooks/context.ts
@@ -9,9 +9,10 @@ const FORMAT = [
 ].join("\n");
 
 async function main(): Promise<void> {
-  if (!process.env.TMUX || !process.env.CLAUDE_ENV_FILE) return;
+  const pane = process.env.TMUX_PANE;
+  if (!process.env.TMUX || !pane || !process.env.CLAUDE_ENV_FILE) return;
 
-  const proc = Bun.spawn(["tmux", "display-message", "-p", FORMAT], {
+  const proc = Bun.spawn(["tmux", "display-message", "-t", pane, "-p", FORMAT], {
     stdout: "pipe",
     stderr: "ignore",
   });


### PR DESCRIPTION
Targets Claude's actual pane when capturing tmux context at `SessionStart`, instead of whatever pane is active at hook-fire time.

## Issue

The `context.ts` hook calls `tmux display-message -p FORMAT` without a `-t` target. `display-message` without `-t` reports the **active** pane, not the pane the calling process runs in. When Claude launches in a background window (e.g., via `tmux new-window -d 'claude'`) or the user switches windows before the hook fires, the hook captures the user's active pane and overwrites `TMUX_PANE` in `$CLAUDE_ENV_FILE` with the wrong pane ID. Every later skill script that targets `$TMUX_PANE` (`pane.sh`, `layout.sh`) then queries the wrong pane and reports the wrong window.

Tmux exports `TMUX_PANE` natively into each pane's shell env, so Claude's own process already has the correct pane ID at hook-fire time. The hook just needs to use it.

## Changes

- Read `TMUX_PANE` from `process.env` and guard on its presence alongside `TMUX` and `CLAUDE_ENV_FILE`.
- Pass `-t "$TMUX_PANE"` to `tmux display-message` so the captured session/window/pane info matches Claude's pane, not the active one.

`pane.sh` and `layout.sh` already use `-t "$TMUX_PANE"` correctly; once the env file holds the right pane ID, downstream scripts follow.

## Testing

- Launch Claude in a background window with `tmux new-window -d 'claude'` while focused elsewhere, then confirm `TMUX_PANE` in the env file matches Claude's pane rather than the active one.
- Trigger the skill load and confirm `pane.sh` reports the correct session/window/pane.
- Switch windows mid-session and re-invoke the skill to confirm the captured value is stable (set once at `SessionStart`).
