### PR TITLE
Fix GitLab API parameter flags and field names in merge request skills

### DIFF
--- a/plugins/gitlab/skills/merge-request/review-state.md
+++ b/plugins/gitlab/skills/merge-request/review-state.md
@@ -16,15 +16,18 @@ mutation($projectPath: ID!, $iid: String!) {
 ```bash
 glab api graphql \
   -f query='mutation($projectPath: ID!, $iid: String!) { mergeRequestRequestChanges(input: { projectPath: $projectPath, iid: $iid }) { mergeRequest { iid } errors } }' \
-  -F projectPath=$(glab repo view --output json | jq -r '.fullPath') \
-  -F iid=<iid>
+  -f projectPath=$(glab repo view --output json | jq -r '.path_with_namespace') \
+  -f iid=<iid>
 ```
 
 **Requirements:**
 - Premium/Ultimate tier
 - Caller must be assigned as a reviewer on the MR (fails with "Reviewer not found" otherwise)
 
-**Common mistake:** `projectPath` is typed `ID!`, not `String!`. Using `String!` causes a type mismatch error.
+**Common mistakes:**
+- `projectPath` is typed `ID!`, not `String!`. Using `String!` causes a type mismatch error.
+- Use `-f` (raw string) for `iid`, not `-F`. `-F` coerces numeric-looking values to int, which fails against `String!`.
+- `glab repo view --output json` returns `path_with_namespace`, not `fullPath`.
 
 ## Remove Request Changes
 
@@ -60,9 +63,9 @@ user_id=$(glab api "users?username=<username>" | jq -r '.[0].id')
 
 glab api graphql \
   -f query='mutation($projectPath: ID!, $iid: String!, $userId: UserID!) { mergeRequestReviewerRereview(input: { projectPath: $projectPath, iid: $iid, userId: $userId }) { errors } }' \
-  -F projectPath=$(glab repo view --output json | jq -r '.fullPath') \
-  -F iid=<iid> \
-  -F userId="gid://gitlab/User/$user_id"
+  -f projectPath=$(glab repo view --output json | jq -r '.path_with_namespace') \
+  -f iid=<iid> \
+  -f userId="gid://gitlab/User/$user_id"
 ```
 
 **Gotchas:**

--- a/plugins/gitlab/skills/merge-request/scripts/draft-note.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/draft-note.ts
@@ -132,7 +132,9 @@ const submitCmd = command(
       await $`glab api projects/:id/merge_requests/${mr}/approve -X POST -f sha=${refs.head_sha}`.text();
       console.error("Approved MR");
     } else if (parsed.flags.requestChanges) {
-      const projectPath = (await $`glab repo view --output json | jq -r '.fullPath'`.text()).trim();
+      const projectPath = (
+        await $`glab repo view --output json | jq -r '.path_with_namespace'`.text()
+      ).trim();
       const query = `mutation($projectPath: ID!, $iid: String!) {
         mergeRequestRequestChanges(input: { projectPath: $projectPath, iid: $iid }) {
           mergeRequest { iid }
@@ -140,7 +142,7 @@ const submitCmd = command(
         }
       }`;
       const gqlResult =
-        await $`glab api graphql -f query=${query} -F projectPath=${projectPath} -F iid=${String(mr)}`.json();
+        await $`glab api graphql -f query=${query} -f projectPath=${projectPath} -f iid=${String(mr)}`.json();
       const payload = gqlResult?.data?.mergeRequestRequestChanges;
       if (payload?.errors?.length) {
         console.error(`Request changes failed: ${payload.errors.join(", ")}`);


### PR DESCRIPTION
Corrects multiple issues in GitLab merge request review state documentation and implementation:

**Key changes:**
- Changed `-F` (coerce to int) to `-f` (raw string) flags for `iid` and `userId` parameters, which are typed as `String!` and `UserID!` respectively. The `-F` flag was causing type mismatches by coercing numeric-looking values to integers.
- Updated `glab repo view` field reference from `.fullPath` to `.path_with_namespace` to match the actual JSON output structure
- Updated both the markdown documentation and the TypeScript implementation in `draft-note.ts` to use the correct flags and field names

**Files affected:**
- `plugins/gitlab/skills/merge-request/review-state.md`: Updated command examples and added clarification to common mistakes section
- `plugins/gitlab/skills/merge-request/scripts/draft-note.ts`: Fixed the `requestChanges` mutation to use correct flags and field name

These changes ensure the GraphQL mutations execute successfully without type errors and correctly retrieve the project path from the GitLab API response.

https://claude.ai/code/session_01W51odgYq7gVPQyNeemUBV3