### PR TITLE
Clarify peer review tone guidance on author addressing

### DIFF
--- a/plugins/review/skills/peer/tone.md
+++ b/plugins/review/skills/peer/tone.md
@@ -4,7 +4,7 @@ Comments should be concise and instructive. Help the author understand why a sug
 
 Write in a natural, conversational tone. Avoid stiff or over-punctuated prose. Read the reviewer's actual comment history to match their voice.
 
-Don't address the author by name or with greetings ("Hey Arya,", "Hi @alice"). Comments are already targeted at the author — open with the substance.
+Don't address the author by name or with greetings ("Hey Alice,", "Hi @bob"). Comments are already targeted at the author, so open with the substance.
 
 ## Severity
 

--- a/plugins/review/skills/peer/tone.md
+++ b/plugins/review/skills/peer/tone.md
@@ -4,6 +4,8 @@ Comments should be concise and instructive. Help the author understand why a sug
 
 Write in a natural, conversational tone. Avoid stiff or over-punctuated prose. Read the reviewer's actual comment history to match their voice.
 
+Don't address the author by name or with greetings ("Hey Arya,", "Hi @alice"). Comments are already targeted at the author — open with the substance.
+
 ## Severity
 
 Use RFC keywords (must, should, may) naturally within sentences to convey importance. Do not use them as labels or prefixes.


### PR DESCRIPTION
Update the peer review tone skill to clarify that reviewers should not address the author by name or with greetings in code review comments.

**Changes:**
- Added guidance to avoid opening comments with direct address ("Hey Alice,", "Hi @bob") since comments are already targeted at the author
- Reviewers should open with the substance of the comment instead

This clarification helps maintain a more professional and efficient review tone by eliminating unnecessary pleasantries that add no value in the code review context.

https://claude.ai/code/session_01U9Xj9GD1CMN9bWMFWpKt9m