### PR TITLE
Switch peer review and improve workflow to /code-review

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
       "Skill(claude-code:session)",
       "Skill(claude-code:skill)",
       "Skill(claude-code:skill-creator)",
-      "Skill(code-review *)",
+      "Skill(code-review)",
       "Skill(git:conflicts)",
       "Skill(git:fix-conflicts)",
       "Skill(git:git)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,7 @@
       "Skill(claude-code:session)",
       "Skill(claude-code:skill)",
       "Skill(claude-code:skill-creator)",
+      "Skill(code-review *)",
       "Skill(git:conflicts)",
       "Skill(git:fix-conflicts)",
       "Skill(git:git)",
@@ -26,7 +27,6 @@
       "Skill(github:notifications)",
       "Skill(github:pr-comments)",
       "Skill(plan:guidelines)",
-      "Skill(pr-review-toolkit:review-pr)",
       "Skill(pull-request:babysit)",
       "Skill(pull-request:create)",
       "Skill(pull-request:follow-up)",
@@ -35,7 +35,6 @@
       "Skill(review:follow-up)",
       "Skill(review:peer)",
       "Skill(review:self)",
-      "Skill(simplify)",
       "Skill(update-config)",
       "Skill(writing:review)",
       "Skill(writing:writing)"

--- a/plugins/review/skills/peer/SKILL.md
+++ b/plugins/review/skills/peer/SKILL.md
@@ -5,7 +5,7 @@ description: |
 allowed-tools:
   - Bash(gh:*)
   - mcp__github
-  - Skill(code-review *)
+  - Skill(code-review)
 ---
 
 # Peer Review

--- a/plugins/review/skills/peer/SKILL.md
+++ b/plugins/review/skills/peer/SKILL.md
@@ -5,6 +5,7 @@ description: |
 allowed-tools:
   - Bash(gh:*)
   - mcp__github
+  - Skill(code-review *)
 ---
 
 # Peer Review
@@ -25,12 +26,13 @@ If not on the branch, first run `gh pr checkout` to switch.
 1. **Research** - Gather context (see [research.md](research.md))
 2. **Context** - Determine review context using repository visibility. Private repositories use [corporate](references/corporate.md) defaults. Public repositories use [open-source](references/open-source.md) defaults. Check visibility via the platform API (`gh api repos/OWNER/REPO --jq .visibility` or `glab api projects/ENCODED_PATH | jq .visibility`). If ambiguous, ask me.
 3. **Review** - Examine changed files and existing comments
-4. **Delegate** - Selectively dispatch PR review toolkit agents in parallel based on what the diff touches:
-   - Error handling, catch blocks, fallback logic: `silent-failure-hunter`
-   - New type definitions: `type-design-analyzer`
-   - New or modified tests: `pr-test-analyzer`
-   - Skip delegation for trivial PRs (docs-only, config changes, dependency bumps).
-5. **Think** - Evaluate against priorities (see [priorities.md](priorities.md)), incorporating toolkit agent findings
+4. **Delegate** - Run `/code-review` for code-quality analysis. Summarize the diff (rough line count, files touched, sensitive areas) and signals from the PR body, propose an effort level with one-line reasoning, and confirm via `AskUserQuestion` before invoking. Skip the call entirely for trivial PRs (docs-only, dep bumps). Effort heuristics:
+   - **low**: docs-only, dep bumps, config tweaks, trivial fixes (<50 lines)
+   - **medium**: typical features or fixes, single module, ~50–500 lines
+   - **high**: large refactors, multi-module, public API or schema changes, ~500–2000 lines
+   - **xhigh**: security-sensitive (auth, payments, data access), breaking changes, migrations
+   - **max**: rare — incident hotfix or change with extreme blast radius
+5. **Think** - Evaluate against priorities (see [priorities.md](priorities.md)), incorporating `/code-review` findings
 6. **Suggest** - Propose comments with revisions or issues
 7. **Comment** - Add approved comments to PR review
 8. **Submit** - Approve / Comment / Request Changes based on severity

--- a/user/skills/improve-claude-code/SKILL.md
+++ b/user/skills/improve-claude-code/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools:
   - Skill(things:jxa)
   - Skill(things:url)
   - Skill(pull-request:create)
-  - Skill(simplify)
+  - Skill(code-review *)
   - Skill(github:actions-monitor)
 ---
 
@@ -32,11 +32,17 @@ Launch parallel `Plan` agents (one per todo). Give each the todo title, full not
 
 Point agents to relevant domain skills: `claude-code:skill` for skill changes, `claude-code:hook` for hooks, `bun:bun` for scripts.
 
-Present all plans. The user approves or rejects each before implementation begins.
+Present all plans. For each, propose a `/code-review` effort level based on the planned changes with one-line reasoning and confirm via `AskUserQuestion`. The user approves the plan and effort together before implementation begins. Effort heuristics:
+
+- **low**: docs-only, dep bumps, config tweaks, trivial fixes (<50 lines)
+- **medium**: typical features or fixes, single module, ~50–500 lines
+- **high**: large refactors, multi-module, public API or schema changes, ~500–2000 lines
+- **xhigh**: security-sensitive (auth, payments, data access), breaking changes, migrations
+- **max**: rare — incident hotfix or change with extreme blast radius
 
 ## Implement
 
-For each approved plan, launch a background `general-purpose` agent with `isolation: "worktree"`. Each agent implements the plan, runs `bun test`, runs `/simplify`, commits, and creates the PR via `pull-request:create`. Pass the same domain skills from the planning step.
+For each approved plan, launch a background `general-purpose` agent with `isolation: "worktree"`. Each agent implements the plan, runs `bun test`, runs `/code-review <effort>` with the level chosen during planning, commits, and creates the PR via `pull-request:create`. Pass the same domain skills from the planning step.
 
 #### PR body
 

--- a/user/skills/improve-claude-code/SKILL.md
+++ b/user/skills/improve-claude-code/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools:
   - Skill(things:jxa)
   - Skill(things:url)
   - Skill(pull-request:create)
-  - Skill(code-review *)
+  - Skill(code-review)
   - Skill(github:actions-monitor)
 ---
 
@@ -32,13 +32,7 @@ Launch parallel `Plan` agents (one per todo). Give each the todo title, full not
 
 Point agents to relevant domain skills: `claude-code:skill` for skill changes, `claude-code:hook` for hooks, `bun:bun` for scripts.
 
-Present all plans. For each, propose a `/code-review` effort level based on the planned changes with one-line reasoning and confirm via `AskUserQuestion`. The user approves the plan and effort together before implementation begins. Effort heuristics:
-
-- **low**: docs-only, dep bumps, config tweaks, trivial fixes (<50 lines)
-- **medium**: typical features or fixes, single module, ~50–500 lines
-- **high**: large refactors, multi-module, public API or schema changes, ~500–2000 lines
-- **xhigh**: security-sensitive (auth, payments, data access), breaking changes, migrations
-- **max**: rare — incident hotfix or change with extreme blast radius
+Present all plans. For each, propose a `/code-review` effort (typically `low`; `medium` for changes touching multiple plugins) and confirm via `AskUserQuestion` alongside plan approval.
 
 ## Implement
 


### PR DESCRIPTION
Replace /simplify with /code-review (renamed in v2.1.146 with optional
effort parameter) and drop pr-review-toolkit as a delegation target.

In review:peer, replace the toolkit agent dispatch with a propose-and-
confirm step: summarize the diff and PR body, pick an effort level
(low/medium/high/xhigh/max) with one-line reasoning, confirm via
AskUserQuestion, then invoke /code-review. Same pattern in improve-
claude-code, run during planning so each background agent receives a
fixed effort. Update .claude/settings.json permissions to match.