### PR TITLE
plugins: declare hard dependencies in plugin.json

### DIFF
--- a/plugins/issue/.claude-plugin/plugin.json
+++ b/plugins/issue/.claude-plugin/plugin.json
@@ -4,5 +4,6 @@
   "author": {
     "name": "Ben Drucker",
     "email": "bvdrucker@gmail.com"
-  }
+  },
+  "dependencies": ["pull-request"]
 }

--- a/plugins/personal-review/.claude-plugin/plugin.json
+++ b/plugins/personal-review/.claude-plugin/plugin.json
@@ -4,5 +4,6 @@
   "author": {
     "name": "Ben Drucker",
     "email": "bvdrucker@gmail.com"
-  }
+  },
+  "dependencies": ["things"]
 }

--- a/plugins/tech-spec/.claude-plugin/plugin.json
+++ b/plugins/tech-spec/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
   "name": "tech-spec",
-  "description": "Create technical specifications through interactive planning and expert review"
+  "description": "Create technical specifications through interactive planning and expert review",
+  "dependencies": ["interview"]
 }

--- a/plugins/things/.claude-plugin/plugin.json
+++ b/plugins/things/.claude-plugin/plugin.json
@@ -4,5 +4,6 @@
   "author": {
     "name": "Ben Drucker",
     "email": "bvdrucker@gmail.com"
-  }
+  },
+  "dependencies": ["mac"]
 }

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -69,6 +69,25 @@
     "lspServers": {
       "$ref": "#/$defs/pathOrObject",
       "description": "LSP config path or inline config"
+    },
+    "dependencies": {
+      "type": "array",
+      "description": "Plugins required by this plugin",
+      "items": {
+        "oneOf": [
+          { "type": "string" },
+          {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": { "type": "string" },
+              "version": { "type": "string" },
+              "marketplace": { "type": "string" }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
     }
   },
   "$defs": {


### PR DESCRIPTION
- things depends on mac (uses Skill(mac:jxa-run) for all JXA scripts)
- tech-spec depends on interview (uses Skill(interview:plan))
- personal-review depends on things (Things inbox processing is core
  to every variant)
- issue depends on pull-request (workflow ends in pull-request:create)

Extend plugin.schema.json with the dependencies field per the docs at
https://code.claude.com/docs/en/plugin-dependencies. No version
constraints — entries are bare plugin names. Soft deps (gitlab,
x-callback-url, calendar/github/linear in personal-review) are omitted
because they degrade gracefully or have alternative paths.