### PR TITLE
fix(things:inbox): print on success and surface sandbox errors

### DIFF
--- a/plugins/things/scripts/inbox.test.ts
+++ b/plugins/things/scripts/inbox.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { printCaptured } from "./inbox";
+
+describe("printCaptured", () => {
+  test("prints title when present", () => {
+    const log = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      printCaptured(new Map([["title", "Buy milk"]]));
+      expect(log).toHaveBeenCalledWith("captured: Buy milk");
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  test("prints first line and count for multi-line titles", () => {
+    const log = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      printCaptured(new Map([["titles", "Buy milk\nWalk dog\nCall mom"]]));
+      expect(log).toHaveBeenCalledWith("captured: Buy milk (+2 more)");
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  test("prints titles without suffix when only one line", () => {
+    const log = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      printCaptured(new Map([["titles", "Just one"]]));
+      expect(log).toHaveBeenCalledWith("captured: Just one");
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  test("ignores blank lines in titles count", () => {
+    const log = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      printCaptured(new Map([["titles", "Buy milk\n\n  \nWalk dog"]]));
+      expect(log).toHaveBeenCalledWith("captured: Buy milk (+1 more)");
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  test("falls back to (untitled) when neither title nor titles present", () => {
+    const log = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      printCaptured(new Map([["notes", "just notes"]]));
+      expect(log).toHaveBeenCalledWith("captured: (untitled)");
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  test("prefers title over titles when both present", () => {
+    const log = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      printCaptured(
+        new Map([
+          ["title", "Primary"],
+          ["titles", "Secondary"],
+        ]),
+      );
+      expect(log).toHaveBeenCalledWith("captured: Primary");
+    } finally {
+      log.mockRestore();
+    }
+  });
+});

--- a/plugins/things/scripts/inbox.ts
+++ b/plugins/things/scripts/inbox.ts
@@ -7,22 +7,6 @@ import { buildUrl, findXcallRunner, openUrl, xcall } from "./url";
 
 const INBOX_PARAMS = new Set(["title", "titles", "notes", "tags", "checklist-items"]);
 
-const argv = cli({
-  name: "inbox",
-  parameters: ["[params...]"],
-  flags: {
-    sessionId: {
-      type: String,
-      description: "Claude session ID for attribution",
-      alias: "s",
-    },
-    tag: {
-      type: [String],
-      description: "Extra tags to add (repeatable)",
-    },
-  },
-});
-
 function buildAttribution(sessionId: string): string {
   const dir = process.cwd();
   return `---\n\n🤖 Created via Claude Code (Session: ${sessionId})\n\n\`\`\`sh\ncd ${dir} && claude --resume ${sessionId}\n\`\`\``;
@@ -33,43 +17,90 @@ function parseThingsId(xcallOutput: string): string | null {
   return match?.[1] ?? null;
 }
 
-if (!argv.flags.sessionId) {
-  console.error("--session-id is required for session attribution");
-  process.exit(1);
-}
-
-const params = new Map<string, string>();
-
-for (const arg of argv._.params) {
-  const eqIndex = arg.indexOf("=");
-  if (eqIndex === -1) continue;
-  const key = arg.substring(0, eqIndex);
-  const value = arg.substring(eqIndex + 1);
-  if (INBOX_PARAMS.has(key)) {
-    params.set(key, value);
+export function printCaptured(params: Map<string, string>): void {
+  const title = params.get("title");
+  if (title) {
+    console.log(`captured: ${title}`);
+    return;
   }
+  const titles = params.get("titles");
+  if (titles) {
+    const lines = titles.split("\n").filter((line) => line.trim());
+    const first = lines[0] ?? "(untitled)";
+    const suffix = lines.length > 1 ? ` (+${lines.length - 1} more)` : "";
+    console.log(`captured: ${first}${suffix}`);
+    return;
+  }
+  console.log("captured: (untitled)");
 }
 
-const tags = mergeTags(["Claude"], argv.flags.tag ?? [], parseTags(params.get("tags")));
-params.set("tags", tags.join(","));
-
-const attribution = buildAttribution(argv.flags.sessionId);
-const existing = params.get("notes");
-params.set("notes", existing ? `${existing}\n\n${attribution}` : attribution);
-
-await ensureThingsRunning();
-
-if (await findXcallRunner()) {
-  const url = await buildUrl("add", params);
+async function captureViaOpen(params: Map<string, string>): Promise<void> {
   try {
-    const result = await xcall(url);
-    const id = parseThingsId(result);
-    if (id) {
-      console.log(`https://things.bendrucker.me/show?id=${id}`);
-    }
-  } catch {
     await openUrl("add", params);
+    printCaptured(params);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
   }
-} else {
-  await openUrl("add", params);
+}
+
+if (import.meta.main) {
+  const argv = cli({
+    name: "inbox",
+    parameters: ["[params...]"],
+    flags: {
+      sessionId: {
+        type: String,
+        description: "Claude session ID for attribution",
+        alias: "s",
+      },
+      tag: {
+        type: [String],
+        description: "Extra tags to add (repeatable)",
+      },
+    },
+  });
+
+  if (!argv.flags.sessionId) {
+    console.error("--session-id is required for session attribution");
+    process.exit(1);
+  }
+
+  const params = new Map<string, string>();
+
+  for (const arg of argv._.params) {
+    const eqIndex = arg.indexOf("=");
+    if (eqIndex === -1) continue;
+    const key = arg.substring(0, eqIndex);
+    const value = arg.substring(eqIndex + 1);
+    if (INBOX_PARAMS.has(key)) {
+      params.set(key, value);
+    }
+  }
+
+  const tags = mergeTags(["Claude"], argv.flags.tag ?? [], parseTags(params.get("tags")));
+  params.set("tags", tags.join(","));
+
+  const attribution = buildAttribution(argv.flags.sessionId);
+  const existing = params.get("notes");
+  params.set("notes", existing ? `${existing}\n\n${attribution}` : attribution);
+
+  await ensureThingsRunning();
+
+  if (await findXcallRunner()) {
+    const url = await buildUrl("add", params);
+    try {
+      const result = await xcall(url);
+      const id = parseThingsId(result);
+      if (id) {
+        console.log(`https://things.bendrucker.me/show?id=${id}`);
+      } else {
+        printCaptured(params);
+      }
+    } catch {
+      await captureViaOpen(params);
+    }
+  } else {
+    await captureViaOpen(params);
+  }
 }

--- a/plugins/things/scripts/url.test.ts
+++ b/plugins/things/scripts/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildJsonPayload, coerceAttributes } from "./url";
+import { buildJsonPayload, coerceAttributes, isSandboxBlockedHandoff } from "./url";
 
 describe("buildJsonPayload", () => {
   test("single ID produces correct structure", () => {
@@ -110,5 +110,36 @@ describe("coerceAttributes", () => {
         { type: "checklist-item", attributes: { title: "Item 2" } },
       ],
     });
+  });
+});
+
+describe("isSandboxBlockedHandoff", () => {
+  test("matches procNotFound message", () => {
+    expect(
+      isSandboxBlockedHandoff(
+        "LSOpenURLsWithRole() failed for the application /Applications/Things3.app with error -10810.\nprocNotFound: no eligible process with specified descriptor",
+      ),
+    ).toBe(true);
+  });
+
+  test("matches bare -10810 code", () => {
+    expect(isSandboxBlockedHandoff("kLSApplicationNotFoundErr (-10810)")).toBe(true);
+  });
+
+  test("matches LSOpenURLsWithRole line on its own", () => {
+    expect(isSandboxBlockedHandoff("LSOpenURLsWithRole failed")).toBe(true);
+  });
+
+  test("does not match unrelated stderr", () => {
+    expect(isSandboxBlockedHandoff("some other error from open")).toBe(false);
+  });
+
+  test("does not match empty stderr", () => {
+    expect(isSandboxBlockedHandoff("")).toBe(false);
+  });
+
+  test("does not match -10810 embedded in a larger number", () => {
+    expect(isSandboxBlockedHandoff("some unrelated number 999-108100 here")).toBe(false);
+    expect(isSandboxBlockedHandoff("error -108101 something else")).toBe(false);
   });
 });

--- a/plugins/things/scripts/url.ts
+++ b/plugins/things/scripts/url.ts
@@ -68,6 +68,10 @@ export async function buildUrl(command: string, params: Map<string, string>): Pr
   return url;
 }
 
+export function isSandboxBlockedHandoff(stderr: string): boolean {
+  return /procNotFound|LSOpenURLsWithRole|(?<![\d-])-10810(?!\d)/i.test(stderr);
+}
+
 export async function openUrl(
   command: string,
   params: Map<string, string>,
@@ -76,10 +80,22 @@ export async function openUrl(
   const url = await buildUrl(command, params);
   const background = options?.background ?? (command !== "show" && command !== "search");
 
-  if (background) {
-    await $`open -g ${url}`;
-  } else {
-    await $`open ${url}`;
+  try {
+    if (background) {
+      await $`open -g ${url}`;
+    } else {
+      await $`open ${url}`;
+    }
+  } catch (error) {
+    if (error instanceof $.ShellError) {
+      const stderr = error.stderr.toString();
+      if (isSandboxBlockedHandoff(stderr)) {
+        throw new Error(
+          `Things URL handoff was blocked by the Claude Code sandbox (LaunchServices procNotFound / -10810). The things plugin's PreToolUse hook should disable the sandbox for this script; verify the hook is registered, or rerun the calling tool with sandbox disabled. Original stderr: ${stderr.trim()}`,
+        );
+      }
+    }
+    throw error;
   }
 }
 

--- a/plugins/things/skills/inbox/SKILL.md
+++ b/plugins/things/skills/inbox/SKILL.md
@@ -16,7 +16,7 @@ bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts --session-id ${CLAUDE_SESSION_ID} tit
 
 The script handles URL encoding, session attribution, and the `Claude` tag automatically. Extra tags can be added via the `--tag` flag (repeatable). For example, `--tag claude-code` adds the `claude-code` tag to all captured todos. Multiple tags: `--tag foo --tag bar`.
 
-When the `x-callback-url` plugin is installed, the script uses xcall to get the todo ID back from Things and outputs a `https://things.bendrucker.me/show?id=...` URL. Present this URL to the user so they can click to open the todo. If xcall is unavailable, the script falls back to fire-and-forget.
+The script always prints a confirmation to stdout on success. When the `x-callback-url` plugin is installed, xcall returns the todo ID and the script outputs `https://things.bendrucker.me/show?id=...`. Present this URL to the user so they can click to open the todo. Without xcall (or when xcall succeeds but returns no ID), the script prints `captured: <title>`. No stdout output means the call failed; read stderr and surface the cause to the user rather than retrying.
 
 ## Parameters
 
@@ -55,3 +55,13 @@ Things supports [Markdown in notes](https://culturedcode.com/things/support/arti
 - **Code**: backticks for inline, triple backticks for blocks
 - **Links**: `[title](url)`
 - **Lists**: `-` or `1.`
+
+## Gotchas
+
+#### Never retry on silent output
+
+The script always prints to stdout on success. If you see no output, the call failed. Read stderr, surface the cause to the user, and only retry once the root cause is understood. Silent retries have historically created duplicate todos.
+
+#### Sandbox-blocked URL handoff
+
+If stderr mentions `procNotFound`, `-10810`, or `LSOpenURLsWithRole`, the macOS sandbox blocked the URL handoff to Things. The plugin's PreToolUse hook should disable the sandbox for `bun ${CLAUDE_PLUGIN_ROOT}/scripts/...` invocations. If this still happens, the hook is not firing for the invocation form being used. Investigate the invocation rather than disabling the sandbox manually.


### PR DESCRIPTION
Makes the `things:inbox` script print a confirmation on every success path and surfaces a clear remediation message when the macOS sandbox blocks the `open` handoff to Things. The old behavior fire-and-forgot on the `openUrl` fallback and on xcall successes that returned no parseable ID; combined with the cryptic LaunchServices error on sandbox blocks, this led to duplicate todos when callers retried on perceived failure.

## Changes

- `plugins/things/scripts/inbox.ts`: added `printCaptured(params)` (exported for tests) that prints `captured: <title>` to stdout, with a multi-line `titles` truncation (first line + `(+N more)`). Wired it into every success branch and wrapped the fallback `openUrl` calls in a `captureViaOpen` helper that prints the script error to stderr and exits non-zero. Wrapped the script body in `if (import.meta.main)` so `printCaptured` can be imported without executing the CLI.
- `plugins/things/scripts/url.ts`: added `isSandboxBlockedHandoff(stderr)` and wrapped the `open` shell calls in a `$.ShellError` catch. When stderr matches `procNotFound`, `LSOpenURLsWithRole`, or an isolated `-10810`, the script throws a clear message naming the plugin's PreToolUse hook as the likely missing piece. Other shell errors re-throw unchanged.
- `plugins/things/skills/inbox/SKILL.md`: rewrote the xcall paragraph to state the script always prints on success, and added a `## Gotchas` section covering the silent-retry trap and the sandbox-blocked handoff signature.

I anchored the `-10810` part of the regex with lookbehind/lookahead so it doesn't match inside larger numbers like `-108100`. I kept the friendly error in `url.ts` as a plain `Error` rather than a typed subclass since there's exactly one caller and the message is the entire contract.

## Testing

- New `plugins/things/scripts/inbox.test.ts` covers `printCaptured` for `title`, multi-line `titles` with count suffix, single-line `titles`, blank-line filtering, `(untitled)` fallback when neither key is present, and the precedence of `title` over `titles`.
- Extended `plugins/things/scripts/url.test.ts` covers `isSandboxBlockedHandoff` against the `procNotFound` message, an isolated `-10810` code, an `LSOpenURLsWithRole` line, unrelated stderr, empty stderr, and `-10810` embedded inside a larger number (to confirm the anchoring).
- Verified end-to-end by running `bun plugins/things/scripts/inbox.ts --session-id ... title="..."` and observing `captured: <title>` on the fallthrough path when xcall returned without a parseable id.

Original Task: [things:inbox skill: silent success on retry creates duplicate todos](https://things.bendrucker.me/show?id=828H8dABshkqSG8e2M7XrN)
