### PR TITLE
fix(x-callback-url): drop LSBackgroundOnly, install to plugin data

### DIFF
--- a/plugins/x-callback-url/scripts/build.sh
+++ b/plugins/x-callback-url/scripts/build.sh
@@ -6,19 +6,23 @@ set -euo pipefail
 # The .app bundle is required because macOS only delivers URL scheme
 # callbacks to registered applications with CFBundleURLTypes in Info.plist.
 #
-# Installs into ${CLAUDE_PLUGIN_DATA} so the bundle survives plugin cache
-# invalidation. Builds inside the plugin's cache directory would otherwise
-# go stale whenever the plugin's content hash rotates, leaving Launch
-# Services pointing at a deleted path.
+# Installs into ${CLAUDE_PLUGIN_DATA}. Marketplace installs put plugin
+# sources in a content-addressed cache directory whose hash rotates per
+# plugin version; building xcall.app there would leave Launch Services
+# pointing at a deleted path after any plugin update.
 #
 # Output (stdout): path to the compiled binary inside the .app bundle.
 # Cached: only recompiles if main.swift is newer than the existing binary.
 
+if [[ -z "${CLAUDE_PLUGIN_DATA:-}" ]]; then
+  echo "CLAUDE_PLUGIN_DATA is not set; this script must be invoked from a Claude Code plugin context" >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SOURCE="$SCRIPT_DIR/main.swift"
 
-INSTALL_DIR="${CLAUDE_PLUGIN_DATA:-$HOME/.claude/plugins/data/x-callback-url-bendrucker}"
-APP_DIR="$INSTALL_DIR/xcall.app"
+APP_DIR="$CLAUDE_PLUGIN_DATA/xcall.app"
 CONTENTS_DIR="$APP_DIR/Contents"
 MACOS_DIR="$CONTENTS_DIR/MacOS"
 BINARY="$MACOS_DIR/xcall"

--- a/plugins/x-callback-url/scripts/build.sh
+++ b/plugins/x-callback-url/scripts/build.sh
@@ -1,35 +1,56 @@
 #!/bin/bash
 set -euo pipefail
 
-# Build xcall.app — a macOS .app bundle for x-callback-url bridging
+# Build xcall.app — a macOS .app bundle for x-callback-url bridging.
 #
 # The .app bundle is required because macOS only delivers URL scheme
 # callbacks to registered applications with CFBundleURLTypes in Info.plist.
 #
-# Output: <script_dir>/xcall.app/Contents/MacOS/xcall
-# The build is cached — only rebuilds if main.swift is newer than the binary.
+# Installs into ${CLAUDE_PLUGIN_DATA} so the bundle survives plugin cache
+# invalidation. Builds inside the plugin's cache directory would otherwise
+# go stale whenever the plugin's content hash rotates, leaving Launch
+# Services pointing at a deleted path.
+#
+# Output (stdout): path to the compiled binary inside the .app bundle.
+# Cached: only recompiles if main.swift is newer than the existing binary.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-APP_DIR="$SCRIPT_DIR/xcall.app"
+SOURCE="$SCRIPT_DIR/main.swift"
+
+INSTALL_DIR="${CLAUDE_PLUGIN_DATA:-$HOME/.claude/plugins/data/x-callback-url-bendrucker}"
+APP_DIR="$INSTALL_DIR/xcall.app"
 CONTENTS_DIR="$APP_DIR/Contents"
 MACOS_DIR="$CONTENTS_DIR/MacOS"
 BINARY="$MACOS_DIR/xcall"
-SOURCE="$SCRIPT_DIR/main.swift"
-CALLBACK_SCHEME="xcall-claude"
 
-if [[ -x "$BINARY" && "$BINARY" -nt "$SOURCE" ]]; then
-  echo "$BINARY"
-  exit 0
-fi
+LEGACY_APP_DIR="$SCRIPT_DIR/xcall.app"
+LSREGISTER=/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister
 
-mkdir -p "$MACOS_DIR"
+scheme_handler_path() {
+  "$LSREGISTER" -dump 2>/dev/null \
+    | awk 'BEGIN { RS = "--------------------------------------------------------------------------------" } /com\.bendrucker\.xcall-claude/' \
+    | awk '/^path:/ { sub(/^path:[[:space:]]+/, ""); sub(/[[:space:]]+\([^)]+\)$/, ""); print; exit }'
+}
 
-swiftc "$SOURCE" -o "$BINARY"
+unregister_legacy_bundle() {
+  if [[ -d "$LEGACY_APP_DIR" && "$LEGACY_APP_DIR" != "$APP_DIR" ]]; then
+    "$LSREGISTER" -u "$LEGACY_APP_DIR" >/dev/null 2>&1 || true
+    rm -rf "$LEGACY_APP_DIR"
+  fi
+}
 
-# Info.plist registers the callback URL scheme and keeps the app out of the Dock.
-# CFBundleTypeRole is Editor (not Viewer) to ensure macOS delivers URL events.
-# LSUIElement hides the app from the Dock and Cmd-Tab switcher.
-cat > "$CONTENTS_DIR/Info.plist" << 'PLIST'
+needs_rebuild() {
+  [[ ! -x "$BINARY" ]] || [[ "$SOURCE" -nt "$BINARY" ]]
+}
+
+build_bundle() {
+  mkdir -p "$MACOS_DIR"
+  swiftc "$SOURCE" -o "$BINARY"
+
+  # CFBundleTypeRole=Editor ensures macOS delivers GetURL Apple Events to this app.
+  # LSUIElement hides from Dock and Cmd-Tab without disabling URL scheme handling
+  # (which LSBackgroundOnly would do — kept that out deliberately).
+  cat > "$CONTENTS_DIR/Info.plist" << 'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -59,13 +80,27 @@ cat > "$CONTENTS_DIR/Info.plist" << 'PLIST'
   </array>
   <key>LSUIElement</key>
   <true/>
-  <key>LSBackgroundOnly</key>
-  <true/>
 </dict>
 </plist>
 PLIST
+}
 
-# Register the URL scheme with Launch Services
-/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -f "$APP_DIR" 2>/dev/null || true
+register_bundle() {
+  "$LSREGISTER" -f "$APP_DIR"
+
+  local handler
+  handler="$(scheme_handler_path)"
+  if [[ "$handler" != "$APP_DIR" ]]; then
+    echo "lsregister did not bind xcall-claude:// to $APP_DIR (got: ${handler:-<none>})" >&2
+    exit 1
+  fi
+}
+
+unregister_legacy_bundle
+
+if needs_rebuild; then
+  build_bundle
+  register_bundle
+fi
 
 echo "$BINARY"

--- a/plugins/x-callback-url/skills/xcall/SKILL.md
+++ b/plugins/x-callback-url/skills/xcall/SKILL.md
@@ -12,7 +12,7 @@ Send [x-callback-url](https://x-callback-url.com/) requests from the command lin
 
 ## How It Works
 
-`xcall` is a Swift CLI that builds into a macOS `.app` bundle. The `.app` is required because macOS only delivers URL scheme callbacks to registered applications. On first use, `run.sh` compiles the source into `${CLAUDE_PLUGIN_DATA}/xcall.app` and registers the callback scheme (`xcall-claude://`) with Launch Services. The bundle lives in the persistent plugin data directory so it survives plugin cache invalidation.
+`xcall` is a Swift CLI that builds into a macOS `.app` bundle. The `.app` is required because macOS only delivers URL scheme callbacks to registered applications. On first use, `run.sh` compiles the source into `${CLAUDE_PLUGIN_DATA}/xcall.app` and registers the callback scheme (`xcall-claude://`) with Launch Services. Installing into the plugin's data directory (instead of the plugin source/cache tree) keeps the registered path stable across plugin updates: the marketplace cache is content-addressed, so building xcall.app inside it would orphan the Launch Services registration on the next update.
 
 ## Usage
 
@@ -74,7 +74,7 @@ Apps with their own CLI (e.g., Shortcuts via `shortcuts run`) don't need xcall â
 ## Build Details
 
 - Source: `scripts/main.swift` (~100 lines)
-- Build: `scripts/build.sh` compiles to `${CLAUDE_PLUGIN_DATA}/xcall.app/` (falls back to `~/.claude/plugins/data/x-callback-url-bendrucker/xcall.app/`)
+- Build: `scripts/build.sh` compiles to `${CLAUDE_PLUGIN_DATA}/xcall.app/`. The script exits non-zero if `CLAUDE_PLUGIN_DATA` is unset.
 - Bundle ID: `com.bendrucker.xcall-claude`
 - Callback scheme: `xcall-claude://`
 - `Info.plist`: `CFBundleTypeRole=Editor`, `LSUIElement=true`. `LSBackgroundOnly` is intentionally not set: combining it with `LSUIElement` causes macOS to refuse to route URL scheme callbacks to the app, surfacing as a "no application set" dialog.

--- a/plugins/x-callback-url/skills/xcall/SKILL.md
+++ b/plugins/x-callback-url/skills/xcall/SKILL.md
@@ -12,7 +12,7 @@ Send [x-callback-url](https://x-callback-url.com/) requests from the command lin
 
 ## How It Works
 
-`xcall` is a Swift CLI that builds into a macOS `.app` bundle. The `.app` is required because macOS only delivers URL scheme callbacks to registered applications. On first use, `run.sh` compiles the source and registers the callback scheme (`xcall-claude://`) with Launch Services.
+`xcall` is a Swift CLI that builds into a macOS `.app` bundle. The `.app` is required because macOS only delivers URL scheme callbacks to registered applications. On first use, `run.sh` compiles the source into `${CLAUDE_PLUGIN_DATA}/xcall.app` and registers the callback scheme (`xcall-claude://`) with Launch Services. The bundle lives in the persistent plugin data directory so it survives plugin cache invalidation.
 
 ## Usage
 
@@ -74,9 +74,10 @@ Apps with their own CLI (e.g., Shortcuts via `shortcuts run`) don't need xcall â
 ## Build Details
 
 - Source: `scripts/main.swift` (~100 lines)
-- Build: `scripts/build.sh` compiles to `scripts/xcall.app/`
+- Build: `scripts/build.sh` compiles to `${CLAUDE_PLUGIN_DATA}/xcall.app/` (falls back to `~/.claude/plugins/data/x-callback-url-bendrucker/xcall.app/`)
 - Bundle ID: `com.bendrucker.xcall-claude`
 - Callback scheme: `xcall-claude://`
-- `Info.plist`: `CFBundleTypeRole=Editor`, `LSUIElement=true`, `LSBackgroundOnly=true`
+- `Info.plist`: `CFBundleTypeRole=Editor`, `LSUIElement=true`. `LSBackgroundOnly` is intentionally not set: combining it with `LSUIElement` causes macOS to refuse to route URL scheme callbacks to the app, surfacing as a "no application set" dialog.
+- After building, `build.sh` calls `lsregister -f` and verifies the scheme handler is the freshly built bundle. If verification fails it exits non-zero.
 - Build is cached â€” only recompiles if `main.swift` is newer than the binary
 - Timeout: 10 seconds


### PR DESCRIPTION
Drops `LSBackgroundOnly` from the xcall.app Info.plist and moves the install path to `${CLAUDE_PLUGIN_DATA}`. The Info.plist change is the actual bug fix: combining `LSBackgroundOnly` with `LSUIElement` kept the app out of Launch Services' URL handler list, so callbacks from Things to `xcall-claude://x-callback-url/success?...` surfaced a "no application set to open the URL" dialog even though the bundle was technically registered. The path move is housekeeping for marketplace consumers (whose plugin source lives in a content-addressed cache directory that rotates per version).

## Changes

- `plugins/x-callback-url/scripts/build.sh`:
  - Builds and registers `${CLAUDE_PLUGIN_DATA}/xcall.app` instead of `${SCRIPT_DIR}/xcall.app`. Exits non-zero if `CLAUDE_PLUGIN_DATA` is unset rather than silently picking a fallback location.
  - Drops `LSBackgroundOnly` from `Info.plist`. `LSUIElement` alone hides the app from the Dock and `Cmd-Tab` without disabling URL scheme handling.
  - After `lsregister -f`, parses the dump and confirms the `xcall-claude://` scheme handler is the freshly built bundle. Exits non-zero on mismatch instead of swallowing failures with `|| true`.
  - Unregisters and removes any legacy `${SCRIPT_DIR}/xcall.app` from prior installs.
- `plugins/x-callback-url/skills/xcall/SKILL.md`: documents the new install path, the rationale (marketplace cache stability), and the Info.plist choice (why `LSBackgroundOnly` is intentionally absent).

I tried other diagnoses first (stale plugin cache pointing at a deleted xcall.app) but Launch Services confirmed the registered path matched the live dev bundle, so the dialog wasn't a stale-handler issue for this user. The Info.plist flag combination is the real cause; the path move only helps marketplace installers.

## Testing

- Ran `build.sh` with `CLAUDE_PLUGIN_DATA` set: produced an `xcall.app` under the data directory, registered the scheme handler, and printed the binary path.
- Ran `build.sh` without `CLAUDE_PLUGIN_DATA`: exited non-zero with a clear message naming the plugin contract.
- Re-ran `build.sh` against a fresh binary: the cache short-circuit prints the binary path in under 20 ms.
- Invoked the freshly built `xcall` against `things:///version` and `things:///add?...`. Both round-tripped synchronously with the expected stdout (`x-things-client-version=...` and `x-things-id=...` respectively) and no "no application set" dialog appeared.
- Confirmed Launch Services no longer references the in-source `xcall.app` after build (legacy unregister + `rm -rf` cleared it).
