### PR TITLE
fix(mac): bypass sandbox for Monitor and marked wrappers

### DIFF
--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -17,7 +17,7 @@ GitHub workflow, Actions monitoring, and rulesets management for Claude Code.
 
 ## macOS
 
-The `actions-monitor` watch script shells out to `gh`, which fails with `OSStatus -26276` TLS errors under macOS Seatbelt. On macOS, install the `mac` plugin alongside this one. Its sandbox hook recognizes the `claude:dangerouslyDisableSandbox` marker at the top of the watch script and disables Seatbelt for that invocation. Linux users do not need the `mac` plugin.
+The `actions-monitor` watch script shells out to `gh`, which fails with `OSStatus -26276` TLS errors under macOS Seatbelt. On macOS, install the `mac` plugin alongside this one. Its sandbox hook recognizes the `claude:dangerouslyDisableSandbox` marker at the top of the watch script and disables Seatbelt for that invocation.
 
 ## Testing
 

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -17,7 +17,7 @@ GitHub workflow, Actions monitoring, and rulesets management for Claude Code.
 
 ## macOS
 
-The `actions-monitor` watch script shells out to `gh`, which fails with `OSStatus -26276` TLS errors under macOS Seatbelt. On macOS, install the `mac` plugin alongside this one. Its sandbox hook recognizes the `claude:sandbox-bypass` marker at the top of the watch script and disables Seatbelt for that invocation. Linux users do not need the `mac` plugin.
+The `actions-monitor` watch script shells out to `gh`, which fails with `OSStatus -26276` TLS errors under macOS Seatbelt. On macOS, install the `mac` plugin alongside this one. Its sandbox hook recognizes the `claude:dangerouslyDisableSandbox` marker at the top of the watch script and disables Seatbelt for that invocation. Linux users do not need the `mac` plugin.
 
 ## Testing
 

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -15,6 +15,10 @@ GitHub workflow, Actions monitoring, and rulesets management for Claude Code.
   - `logs`: Extracts relevant lines from failing-job logs (invoked by `actions-monitor`)
 - **Hook**: Intercepts WebFetch for efficient GitHub data access
 
+## macOS
+
+The `actions-monitor` watch script shells out to `gh`, which fails with `OSStatus -26276` TLS errors under macOS Seatbelt. On macOS, install the `mac` plugin alongside this one. Its sandbox hook recognizes the `claude:sandbox-bypass` marker at the top of the watch script and disables Seatbelt for that invocation. Linux users do not need the `mac` plugin.
+
 ## Testing
 
 ```bash

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// claude:sandbox-bypass: shells out to gh (Go binary) for TLS-bearing API calls
 
 import { type ExecSyncOptions, execSync } from "node:child_process";
 import { cli } from "cleye";

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-// claude:sandbox-bypass: shells out to gh (Go binary) for TLS-bearing API calls
+// claude:dangerouslyDisableSandbox: shells out to gh (Go binary) for TLS-bearing API calls
 
 import { type ExecSyncOptions, execSync } from "node:child_process";
 import { cli } from "cleye";

--- a/plugins/gitlab/README.md
+++ b/plugins/gitlab/README.md
@@ -25,7 +25,7 @@ GitLab workflow best practices and glab CLI usage for Claude Code.
 
 ## macOS
 
-The `ci-monitor` watch script shells out to `glab`, which fails with `OSStatus -26276` TLS errors under macOS Seatbelt. On macOS, install the `mac` plugin alongside this one. Its sandbox hook recognizes the `claude:dangerouslyDisableSandbox` marker at the top of the watch script and disables Seatbelt for that invocation. Linux users do not need the `mac` plugin.
+The `ci-monitor` watch script shells out to `glab`, which fails with `OSStatus -26276` TLS errors under macOS Seatbelt. On macOS, install the `mac` plugin alongside this one. Its sandbox hook recognizes the `claude:dangerouslyDisableSandbox` marker at the top of the watch script and disables Seatbelt for that invocation.
 
 ## Testing
 

--- a/plugins/gitlab/README.md
+++ b/plugins/gitlab/README.md
@@ -23,6 +23,10 @@ GitLab workflow best practices and glab CLI usage for Claude Code.
 - Transforms GitLab URLs into API requests for better content fetching
 - Detects glab OAuth token expiration and provides recovery guidance
 
+## macOS
+
+The `ci-monitor` watch script shells out to `glab`, which fails with `OSStatus -26276` TLS errors under macOS Seatbelt. On macOS, install the `mac` plugin alongside this one. Its sandbox hook recognizes the `claude:sandbox-bypass` marker at the top of the watch script and disables Seatbelt for that invocation. Linux users do not need the `mac` plugin.
+
 ## Testing
 
 ```bash

--- a/plugins/gitlab/README.md
+++ b/plugins/gitlab/README.md
@@ -25,7 +25,7 @@ GitLab workflow best practices and glab CLI usage for Claude Code.
 
 ## macOS
 
-The `ci-monitor` watch script shells out to `glab`, which fails with `OSStatus -26276` TLS errors under macOS Seatbelt. On macOS, install the `mac` plugin alongside this one. Its sandbox hook recognizes the `claude:sandbox-bypass` marker at the top of the watch script and disables Seatbelt for that invocation. Linux users do not need the `mac` plugin.
+The `ci-monitor` watch script shells out to `glab`, which fails with `OSStatus -26276` TLS errors under macOS Seatbelt. On macOS, install the `mac` plugin alongside this one. Its sandbox hook recognizes the `claude:dangerouslyDisableSandbox` marker at the top of the watch script and disables Seatbelt for that invocation. Linux users do not need the `mac` plugin.
 
 ## Testing
 

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-// claude:sandbox-bypass: shells out to glab (Go binary) for TLS-bearing API calls
+// claude:dangerouslyDisableSandbox: shells out to glab (Go binary) for TLS-bearing API calls
 
 import { type ExecSyncOptions, execSync } from "node:child_process";
 import { cli } from "cleye";

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// claude:sandbox-bypass: shells out to glab (Go binary) for TLS-bearing API calls
 
 import { type ExecSyncOptions, execSync } from "node:child_process";
 import { cli } from "cleye";

--- a/plugins/mac/README.md
+++ b/plugins/mac/README.md
@@ -23,13 +23,13 @@ macOS-specific automation, sandbox workarounds, and system integration.
 The sandbox hook auto-disables Seatbelt for two cases:
 
 1. The invoked executable is a Go binary (detected by the `__go_buildinfo` byte marker in the first 64KB of the binary).
-2. A `bun <script>` or `node <script>` invocation, where the script's first 64KB contains the literal string `claude:sandbox-bypass`.
+2. A `bun <script>` or `node <script>` invocation, where the script's first 64KB contains the literal string `claude:dangerouslyDisableSandbox`.
 
 The second mechanism is opt-in. Plugins that ship a wrapper script which shells out to Go binaries (`gh`, `glab`, `terraform`, etc.) can add a comment near the top of the script:
 
 ```ts
 #!/usr/bin/env bun
-// claude:sandbox-bypass: shells out to gh for TLS-bearing API calls
+// claude:dangerouslyDisableSandbox: shells out to gh for TLS-bearing API calls
 ```
 
 The marker is inert on Linux and inert when the `mac` plugin is not installed. It only activates when this hook is running on macOS.

--- a/plugins/mac/README.md
+++ b/plugins/mac/README.md
@@ -11,12 +11,28 @@ macOS-specific automation, sandbox workarounds, and system integration.
 
 ### Hooks
 
-- **sandbox** — Detects Go binaries and disables sandbox for TLS cert verification
+- **sandbox** — Detects Go binaries and disables sandbox for TLS cert verification. Matches both `Bash` and `Monitor` tool calls.
 
 ### Scripts
 
 - `scripts/jxa.ts` — App-scoped JXA runner with AST-based `Application()` validation
 - `scripts/open-url.ts` — Scheme-scoped URL opener with scheme validation
+
+## Sandbox bypass marker
+
+The sandbox hook auto-disables Seatbelt for two cases:
+
+1. The invoked executable is a Go binary (detected by the `__go_buildinfo` byte marker in the first 64KB of the binary).
+2. A `bun <script>` or `node <script>` invocation, where the script's first 64KB contains the literal string `claude:sandbox-bypass`.
+
+The second mechanism is opt-in. Plugins that ship a wrapper script which shells out to Go binaries (`gh`, `glab`, `terraform`, etc.) can add a comment near the top of the script:
+
+```ts
+#!/usr/bin/env bun
+// claude:sandbox-bypass: shells out to gh for TLS-bearing API calls
+```
+
+The marker is inert on Linux and inert when the `mac` plugin is not installed. It only activates when this hook is running on macOS.
 
 ## Testing
 

--- a/plugins/mac/hooks/hooks.json
+++ b/plugins/mac/hooks/hooks.json
@@ -3,7 +3,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash",
+        "matcher": "Bash|Monitor",
         "hooks": [
           {
             "type": "command",

--- a/plugins/mac/hooks/sandbox.integration.ts
+++ b/plugins/mac/hooks/sandbox.integration.ts
@@ -1,13 +1,34 @@
 import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { isGoBinary, processInput } from "./sandbox";
+import { hasBypassMarker, isGoBinary, processInput } from "./sandbox";
 
-function makeInput(command: string): PreToolUseHookInput {
+function makeInput(command: string, toolName = "Bash"): PreToolUseHookInput {
   return {
-    tool_name: "Bash",
+    tool_name: toolName,
     tool_input: { command },
   } as PreToolUseHookInput;
 }
+
+const repoRoot = join(import.meta.dirname, "..", "..", "..");
+const githubWatchScript = join(
+  repoRoot,
+  "plugins",
+  "github",
+  "skills",
+  "actions-monitor",
+  "scripts",
+  "watch.ts",
+);
+const gitlabWatchScript = join(
+  repoRoot,
+  "plugins",
+  "gitlab",
+  "skills",
+  "ci-monitor",
+  "scripts",
+  "watch.ts",
+);
 
 describe("isGoBinary", () => {
   test("gh is a Go binary", async () => {
@@ -20,6 +41,16 @@ describe("isGoBinary", () => {
 
   test("nonexistent binary returns false", async () => {
     expect(await isGoBinary("nonexistent-binary-12345")).toBe(false);
+  });
+});
+
+describe("hasBypassMarker", () => {
+  test("github actions-monitor watch.ts carries the marker", async () => {
+    expect(await hasBypassMarker(githubWatchScript)).toBe(true);
+  });
+
+  test("gitlab ci-monitor watch.ts carries the marker", async () => {
+    expect(await hasBypassMarker(gitlabWatchScript)).toBe(true);
   });
 });
 
@@ -45,6 +76,29 @@ describe("processInput", () => {
 
   test("detects Go binary through &&", async () => {
     const result = await processInput(makeInput("echo start && gh api /rate_limit"), "darwin");
+    expect(result).not.toBeNull();
+  });
+
+  test("disables sandbox for github watch.ts under Monitor", async () => {
+    const result = await processInput(
+      makeInput(`bun ${githubWatchScript} --pr https://github.com/o/r/pull/1`, "Monitor"),
+      "darwin",
+    );
+    expect(result).not.toBeNull();
+    expect(result?.hookSpecificOutput).toMatchObject({
+      hookEventName: "PreToolUse",
+      updatedInput: { dangerouslyDisableSandbox: true },
+    });
+  });
+
+  test("disables sandbox for gitlab watch.ts under Monitor", async () => {
+    const result = await processInput(
+      makeInput(
+        `bun ${gitlabWatchScript} --mr https://gitlab.com/o/r/-/merge_requests/1`,
+        "Monitor",
+      ),
+      "darwin",
+    );
     expect(result).not.toBeNull();
   });
 });

--- a/plugins/mac/hooks/sandbox.test.ts
+++ b/plugins/mac/hooks/sandbox.test.ts
@@ -1,13 +1,15 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdtemp } from "node:fs/promises";
-import { join, sep } from "node:path";
 import { tmpdir } from "node:os";
+import { join, sep } from "node:path";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { extractCommands, hasGoBuildInfo, processInput } from "./sandbox";
+import { extractCommands, hasBypassMarker, hasGoBuildInfo, processInput } from "./sandbox";
 
 let fixtureDir: string;
 let goBinaryPath: string;
 let plainBinaryPath: string;
+let markedScriptPath: string;
+let unmarkedScriptPath: string;
 
 beforeAll(async () => {
   fixtureDir = await mkdtemp(`${tmpdir()}${sep}sandbox-test-`);
@@ -17,6 +19,15 @@ beforeAll(async () => {
 
   plainBinaryPath = join(fixtureDir, "fake-plain");
   await Bun.write(plainBinaryPath, `\x7fELF\x00\x00\x00\x00`);
+
+  markedScriptPath = join(fixtureDir, "marked.ts");
+  await Bun.write(
+    markedScriptPath,
+    `#!/usr/bin/env bun\n// claude:sandbox-bypass: calls a Go binary\nconsole.log("hi");\n`,
+  );
+
+  unmarkedScriptPath = join(fixtureDir, "unmarked.ts");
+  await Bun.write(unmarkedScriptPath, `#!/usr/bin/env bun\nconsole.log("hi");\n`);
 });
 
 afterAll(async () => {
@@ -24,52 +35,82 @@ afterAll(async () => {
   await rm(fixtureDir, { recursive: true, force: true });
 });
 
-function makeInput(command: string): PreToolUseHookInput {
+function makeInput(command: string, toolName = "Bash"): PreToolUseHookInput {
   return {
-    tool_name: "Bash",
+    tool_name: toolName,
     tool_input: { command },
   } as PreToolUseHookInput;
 }
 
 describe("extractCommands", () => {
   test("simple command", () => {
-    expect(extractCommands("gh api /rate_limit")).toEqual(["gh"]);
+    expect(extractCommands("gh api /rate_limit")).toEqual([{ cmd: "gh" }]);
   });
 
   test("pipe", () => {
-    expect(extractCommands("gh api /rate_limit | jq .rate")).toEqual(["gh", "jq"]);
+    expect(extractCommands("gh api /rate_limit | jq .rate")).toEqual([
+      { cmd: "gh" },
+      { cmd: "jq" },
+    ]);
   });
 
   test("&& chain", () => {
-    expect(extractCommands("terraform init && terraform plan")).toEqual(["terraform"]);
+    expect(extractCommands("terraform init && terraform plan")).toEqual([{ cmd: "terraform" }]);
   });
 
   test("|| chain", () => {
-    expect(extractCommands("gh pr view || echo not found")).toEqual(["gh", "echo"]);
+    expect(extractCommands("gh pr view || echo not found")).toEqual([
+      { cmd: "gh" },
+      { cmd: "echo" },
+    ]);
   });
 
   test("; separator", () => {
-    expect(extractCommands("git status; gh pr list")).toEqual(["git", "gh"]);
+    expect(extractCommands("git status; gh pr list")).toEqual([{ cmd: "git" }, { cmd: "gh" }]);
   });
 
   test("env var prefixes", () => {
-    expect(extractCommands("GOFLAGS=-mod=vendor go test ./...")).toEqual(["go"]);
+    expect(extractCommands("GOFLAGS=-mod=vendor go test ./...")).toEqual([{ cmd: "go" }]);
   });
 
   test("absolute path", () => {
-    expect(extractCommands("/usr/local/bin/gh api /rate_limit")).toEqual(["/usr/local/bin/gh"]);
+    expect(extractCommands("/usr/local/bin/gh api /rate_limit")).toEqual([
+      { cmd: "/usr/local/bin/gh" },
+    ]);
   });
 
   test("subshell parens", () => {
-    expect(extractCommands("(gh api /rate_limit)")).toEqual(["gh"]);
+    expect(extractCommands("(gh api /rate_limit)")).toEqual([{ cmd: "gh" }]);
   });
 
   test("deduplication", () => {
-    expect(extractCommands("gh pr list && gh pr view 1")).toEqual(["gh"]);
+    expect(extractCommands("gh pr list && gh pr view 1")).toEqual([{ cmd: "gh" }]);
   });
 
   test("empty input", () => {
     expect(extractCommands("")).toEqual([]);
+  });
+
+  test("captures bun script arg", () => {
+    expect(extractCommands("bun watch.ts --pr 42")).toEqual([
+      { cmd: "bun", scriptArg: "watch.ts" },
+    ]);
+  });
+
+  test("captures node script arg", () => {
+    expect(extractCommands("node ./scripts/run.js")).toEqual([
+      { cmd: "node", scriptArg: "./scripts/run.js" },
+    ]);
+  });
+
+  test("skips bun flag-bearing invocation", () => {
+    expect(extractCommands("bun --silent watch.ts")).toEqual([{ cmd: "bun" }]);
+  });
+
+  test("absolute bun script path", () => {
+    expect(extractCommands("bun /abs/path/watch.ts")).toEqual([
+      { cmd: "bun", scriptArg: "/abs/path/watch.ts" },
+    ]);
   });
 });
 
@@ -84,6 +125,20 @@ describe("hasGoBuildInfo", () => {
 
   test("returns false for nonexistent path", async () => {
     expect(await hasGoBuildInfo("/nonexistent/path")).toBe(false);
+  });
+});
+
+describe("hasBypassMarker", () => {
+  test("detects bypass marker in script", async () => {
+    expect(await hasBypassMarker(markedScriptPath)).toBe(true);
+  });
+
+  test("returns false for script without marker", async () => {
+    expect(await hasBypassMarker(unmarkedScriptPath)).toBe(false);
+  });
+
+  test("returns false for nonexistent path", async () => {
+    expect(await hasBypassMarker("/nonexistent/path")).toBe(false);
   });
 });
 
@@ -132,5 +187,30 @@ describe("processInput", () => {
       "darwin",
     );
     expect(result).not.toBeNull();
+  });
+
+  test("disables sandbox for marked bun script", async () => {
+    const input = makeInput(`bun ${markedScriptPath} --pr 42`);
+    const result = await processInput(input, "darwin");
+    expect(result).not.toBeNull();
+    expect(result?.hookSpecificOutput).toMatchObject({
+      hookEventName: "PreToolUse",
+      updatedInput: { dangerouslyDisableSandbox: true },
+    });
+  });
+
+  test("does not disable sandbox for unmarked bun script", async () => {
+    const result = await processInput(makeInput(`bun ${unmarkedScriptPath}`), "darwin");
+    expect(result).toBeNull();
+  });
+
+  test("processes Monitor tool input the same as Bash", async () => {
+    const input = makeInput(`bun ${markedScriptPath}`, "Monitor");
+    const result = await processInput(input, "darwin");
+    expect(result).not.toBeNull();
+    expect(result?.hookSpecificOutput).toMatchObject({
+      hookEventName: "PreToolUse",
+      updatedInput: { dangerouslyDisableSandbox: true },
+    });
   });
 });

--- a/plugins/mac/hooks/sandbox.test.ts
+++ b/plugins/mac/hooks/sandbox.test.ts
@@ -23,7 +23,7 @@ beforeAll(async () => {
   markedScriptPath = join(fixtureDir, "marked.ts");
   await Bun.write(
     markedScriptPath,
-    `#!/usr/bin/env bun\n// claude:sandbox-bypass: calls a Go binary\nconsole.log("hi");\n`,
+    `#!/usr/bin/env bun\n// claude:dangerouslyDisableSandbox: calls a Go binary\nconsole.log("hi");\n`,
   );
 
   unmarkedScriptPath = join(fixtureDir, "unmarked.ts");

--- a/plugins/mac/hooks/sandbox.ts
+++ b/plugins/mac/hooks/sandbox.ts
@@ -8,7 +8,7 @@ type ToolInput = { command: string };
 
 const SHELL_OPERATORS = /\s*(?:&&|\|\||[|;])\s*/;
 const SCRIPT_INTERPRETERS = new Set(["bun", "node"]);
-const SCRIPT_MARKER = "claude:sandbox-bypass";
+const SCRIPT_MARKER = "claude:dangerouslyDisableSandbox";
 
 export type Invocation = { cmd: string; scriptArg?: string };
 

--- a/plugins/mac/hooks/sandbox.ts
+++ b/plugins/mac/hooks/sandbox.ts
@@ -4,14 +4,18 @@ import { basename } from "node:path";
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
-type BashInput = { command: string };
+type ToolInput = { command: string };
 
 const SHELL_OPERATORS = /\s*(?:&&|\|\||[|;])\s*/;
+const SCRIPT_INTERPRETERS = new Set(["bun", "node"]);
+const SCRIPT_MARKER = "claude:sandbox-bypass";
 
-export function extractCommands(command: string): string[] {
+export type Invocation = { cmd: string; scriptArg?: string };
+
+export function extractCommands(command: string): Invocation[] {
   const segments = command.split(SHELL_OPERATORS);
   const seen = new Set<string>();
-  const result: string[] = [];
+  const result: Invocation[] = [];
 
   for (const segment of segments) {
     const trimmed = segment.trim().replace(/^[()]+|[()]+$/g, "");
@@ -29,24 +33,40 @@ export function extractCommands(command: string): string[] {
     if (!cmd) continue;
 
     const name = basename(cmd);
-    if (!seen.has(name)) {
-      seen.add(name);
-      result.push(cmd);
+    if (seen.has(name)) continue;
+    seen.add(name);
+
+    const invocation: Invocation = { cmd };
+    if (SCRIPT_INTERPRETERS.has(name)) {
+      const next = tokens[i + 1];
+      if (next && !next.startsWith("-")) {
+        invocation.scriptArg = next;
+      }
     }
+    result.push(invocation);
   }
 
   return result;
 }
 
-export async function hasGoBuildInfo(path: string): Promise<boolean> {
+async function readHead(path: string, length = 65536): Promise<Buffer | null> {
   try {
     const file = Bun.file(path);
-    const slice = file.slice(0, 65536);
-    const bytes = Buffer.from(await slice.arrayBuffer());
-    return bytes.includes("__go_buildinfo");
+    const slice = file.slice(0, length);
+    return Buffer.from(await slice.arrayBuffer());
   } catch {
-    return false;
+    return null;
   }
+}
+
+export async function hasGoBuildInfo(path: string): Promise<boolean> {
+  const head = await readHead(path);
+  return head ? head.includes("__go_buildinfo") : false;
+}
+
+export async function hasBypassMarker(path: string): Promise<boolean> {
+  const head = await readHead(path);
+  return head ? head.includes(SCRIPT_MARKER) : false;
 }
 
 export async function isGoBinary(command: string): Promise<boolean> {
@@ -71,13 +91,16 @@ export async function processInput(
   if (platform !== "darwin") return null;
 
   const toolInput = input.tool_input as Record<string, unknown>;
-  const { command } = toolInput as BashInput;
+  const { command } = toolInput as ToolInput;
   if (!command) return null;
 
-  const commands = extractCommands(command);
+  const invocations = extractCommands(command);
 
-  for (const cmd of commands) {
+  for (const { cmd, scriptArg } of invocations) {
     if (await isGoBinary(cmd)) {
+      return disableSandbox(toolInput);
+    }
+    if (scriptArg && (await hasBypassMarker(scriptArg))) {
       return disableSandbox(toolInput);
     }
   }


### PR DESCRIPTION
Fixes a regression where `pull-request:babysit` and the underlying `github:actions-monitor` / `gitlab:ci-monitor` watchers fail with macOS keychain TLS errors (`OSStatus -26276`, i.e. `errSecInteractionNotAllowed`). After the move to the `Monitor` tool, the watch scripts run as `bun .../watch.ts` under Seatbelt, and the nested `gh`/`glab` calls cannot reach the macOS keychain to verify TLS certs.

The `mac` plugin's sandbox hook already auto-disabled Seatbelt when the top-level Bash command was a Go binary (`gh`, `glab`, `terraform`, …), but it never fired for `Monitor`, and the top-level command here is `bun`, not `gh`.

## Changes

- `plugins/mac/hooks/hooks.json`: matcher widened from `Bash` to `Bash|Monitor`. `Monitor`'s `tool_input.command` shape matches `Bash`, so the existing processor works unchanged.
- `plugins/mac/hooks/sandbox.ts`: added a `claude:sandbox-bypass` marker check. For a `bun <script>` or `node <script>` invocation, the hook reads the first 64 KB of the script and disables sandbox if the marker is present. Mirrors the existing `__go_buildinfo` byte-marker pattern, but for transitively-Go wrapper scripts. `extractCommands` now returns `Invocation[]` (capturing the script argument when the executable is a known interpreter); flag-bearing forms like `bun --silent foo.ts` fall back to no script arg.
- `plugins/github/skills/actions-monitor/scripts/watch.ts`, `plugins/gitlab/skills/ci-monitor/scripts/watch.ts`: added the marker comment near the top of each script. Inert on Linux and inert when the `mac` plugin is not installed.

I chose a marker-based opt-in over copying the hook into each plugin because the `mac` plugin should remain optional for Linux users. This keeps the bypass mechanism a single source of truth in `mac/sandbox.ts` and lets other plugins opt in by adding a one-line comment.

## Testing

Unit tests cover the new `Invocation` return shape from `extractCommands` (including `bun <script>`, `node <script>`, flag-bearing forms, and absolute script paths), marker detection on a fixture script, the unmarked-script control case, and a `Monitor` tool-name input. Integration tests resolve the real watcher scripts in `plugins/github` and `plugins/gitlab` and exercise them through `processInput` under both `Bash` and `Monitor` inputs.

Empirical verification that `Monitor` honors `dangerouslyDisableSandbox` from a PreToolUse hook depends on running the watcher against this branch. The babysit on this PR is itself the live test.

## Documentation

- `plugins/mac/README.md`: documents the marker convention so other plugin authors can opt in.
- `plugins/github/README.md`, `plugins/gitlab/README.md`: short macOS soft-dependency note pointing to the `mac` plugin.
