### PR TITLE
docs: add Curation principle to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Before adding a customization, define how it gets removed:
 - What evidence will show it isn't?
 - Where does that evidence surface?
 
-Detectors of model behavior need particular care. Models drift, and a ruleset that doesn't evolve with them stops earning its cost. Pair detection with a path to evolve or retire.
+Detectors of model behavior need particular care. Models drift and rules lose value. Pair detection with a path to evolve or retire.
 
 ## Plugin Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,18 @@ This repository contains my personal Claude Code configuration and a plugin mark
 
 The [`user/`](user/) directory contains user-level Claude Code configuration that gets symlinked to `~/.claude`. This includes global instructions (`CLAUDE.md`), settings (plugins, permissions, sandbox), and hooks that apply across all projects. Symlinks and other system setup are managed by the [claude topic](https://github.com/bendrucker/dotfiles/tree/main/claude) in dotfiles.
 
+## Curation
+
+Every customization (skill, hook, wordlist entry, agent, rule, permission) costs tokens on every session that touches it. Adding is cheap, accumulation is silent, and removal has no natural trigger. Without one, the configuration only grows, and sessions pay tokens for things that may no longer matter.
+
+Before adding a customization, define how it gets removed:
+
+- What evidence will show it's earning its cost?
+- What evidence will show it isn't?
+- Where does that evidence surface?
+
+Detectors of model behavior need particular care. Models drift; a frozen ruleset chasing a moving target is whack-a-mole, not progress. Pair detection with a path to evolve or retire.
+
 ## Plugin Architecture
 
 Each plugin in `plugins/` contains:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Before adding a customization, define how it gets removed:
 - What evidence will show it isn't?
 - Where does that evidence surface?
 
-Detectors of model behavior need particular care. Models drift; a frozen ruleset chasing a moving target is whack-a-mole, not progress. Pair detection with a path to evolve or retire.
+Detectors of model behavior need particular care. Models drift, and a ruleset that doesn't evolve with them stops earning its cost. Pair detection with a path to evolve or retire.
 
 ## Plugin Architecture
 

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -18,6 +18,10 @@
 - Break code into multiple files where appropriate first before splitting across directories.
 - Do not number steps or phases in code (e.g., "Phase 1:", "Step 2:"). Use descriptive function names and call them in sequence. Numbering creates tight coupling, obscures whether order matters, and impedes inserting new steps.
 
+## Curation
+
+Customizations (skills, hooks, wordlists, agents, rules, permissions) cost tokens on every session that touches them. Before adding one, define how it gets removed: what tells you it's working, what tells you it isn't, and where that signal surfaces. If you can't answer all three, design the prune mechanism before adding.
+
 ## Workflow
 
 - The user has carefully curated skills for their common workflows. Load skills when possible to adhere to the user's preferences and navigate their projects efficiently.


### PR DESCRIPTION
Adds a `Curation` section to the project `CLAUDE.md` and a one-paragraph counterpart to `user/CLAUDE.md`. The principle: every customization (skill, hook, wordlist entry, agent, rule, permission) costs tokens on every session that touches its surface, and the configuration only grows because removal has no natural trigger. The new section asks contributors to define the prune mechanism before adding.

## Motivation

This principle came up during a long working session that produced the writing-plugin overhaul stack (#636, #638, #639). Two of the user's exact framings from that conversation:

> "When we do add content, we need to ensure that we're not creating monotonic growing context cost. Otherwise, that's how customizations end up causing worse performance, because you only accumulate tools and never remove them."

> "Frequently we can have the illusion of progress against some sort of AI pattern because we create a specific detection mechanism, but then we have no means to support evolving that over time. We're basically playing whack-a-mole with various different patterns that are emergent in the models to some extent, inevitable, and unfixable."

The principle had been at work implicitly for months. Naming it makes the cost-benefit visible at the moment of addition rather than retroactively at cleanup time.

## What This Adds

### Project `CLAUDE.md`

A new top-level `Curation` section placed between `User` and `Plugin Architecture`. It names the cost (tokens on every session), the failure mode (silent monotonic growth), and the discipline (three evidence questions about how the customization gets removed). It also includes a corollary specifically for detectors of model behavior, since model drift makes frozen rulesets the canonical failure case.

### User `CLAUDE.md`

A single-paragraph version of the same principle, placed in the `Organization` section. The user file gets the short form because the principle applies broadly across every project, while this repo gets the longer form because most customizations live here.

## Design Decisions

<details>
<summary>Why `CLAUDE.md`, Not Memory</summary>

Memory is per-user, drifts between machines, and applies only to my own sessions. This principle binds every contributor (and every Claude session running in this repo) without depending on an auto-loaded memory file being present. `CLAUDE.md` is the durable surface that gets read whether someone is editing locally, reviewing a PR, or working in a fresh worktree.

The matching memory file (`feedback_customizations_cost_context.md`) still exists for personal-context emphasis, but the canonical source moves to `CLAUDE.md`.

</details>

<details>
<summary>Why Prose Plus Questions, Not Just Checklist</summary>

The agent's draft iterations included a pure-checklist version (three questions, no preamble). It read as generic without grounding in the actual failure mode. The chosen form names the cost legibly first, then asks the three questions. The questions are concrete enough to act on, but the preamble makes a reader who hasn't absorbed the conversation understand *why* the questions matter.

</details>

<details>
<summary>Why the Whack-A-Mole Corollary</summary>

Detection mechanisms (the writing-plugin trope hook, for example) are the highest-risk customization category for this failure mode. Adding one detector feels like progress, but models drift and a frozen ruleset chasing a moving target is theater. Including the corollary directly in `CLAUDE.md` points at this case explicitly so a future addition to a detector triggers the right thinking.

</details>

<details>
<summary>Section Placement</summary>

Between `User` and `Plugin Architecture` was deliberate. Earlier in the doc reads as foundational rather than mid-document procedure. The principle is meant to color every section below it, not be one section among many.

</details>

## Prior Art In Git History

This principle has been firing implicitly for months. Concrete recent examples:

- **[#443](https://github.com/bendrucker/claude/pull/443)** (`git: remove worktrunk skill, simplify stacked PRs`). Collapsed a numbered five-step workflow into a three-bullet one once `wt switch --create` stopped being needed.
- **[#440](https://github.com/bendrucker/claude/pull/440)** (`refactor: consolidate implement-issue and refine-issue into issue plugin`). Merged two plugins into one when their surface areas overlapped.
- **[#395](https://github.com/bendrucker/claude/pull/395)** (`chore: remove parallel-prs plugin`). Deleted a formalized skill once ad-hoc task agents covered the same workflow with better visibility.
- **[#269](https://github.com/bendrucker/claude/pull/269)** (`chore: remove redundant plugins (code-simplifier, ralph-wiggum)`). Dropped enabled plugins whose value had eroded.

Each of these came late, after the customization had been accumulating cost for a while. The new section is aimed at making that decision earlier.

## Suspect Cases (Follow-Up Issues, Not Part of This PR)

While investigating prior art, the implementing agent surveyed the current customization surface and flagged **15 specific suspect cases** worth follow-up issues. Notes live at `tmp/curation-suspect-cases.md` in the worktree.

<details>
<summary>Categories Covered (Read the Notes for Full Detail)</summary>

- **MCP servers**: ~10 connected, only 4 calls total in the last 60 days; most candidates for disconnection (Cloudflare, Monarch, Gmail, Calendar, Drive, Slack, Zapier, Chrome).
- **Plugins / skills with zero recorded invocations**: 30+ declared skills with zero `Skill` calls in 536 sessions, plus several entire stale plugins (`mail`, `opentelemetry`, `raycast`, `terraform`, `ui-design`).
- **`pr-review-toolkit`**: 5 sub-agents and a skill used once on a single day; overlaps with `code-review` and `review:peer`.
- **Settings rot**: `excludedCommands` entries that haven't fired in 90+ days, `wt`-prefixed allow-list entries that are no-ops because `wt` is sandbox-bypassed.
- **Hook dead code**: `tropes.ts` has 7 patterns gated behind a `seenTiers` guard so the 4th–7th in each tier may never reach the user (worth auditing now that PR #638 adds more patterns).
- **Naming inconsistency**: `writing` vs `writing:writing` showing up as two separate names in `skill_calls`.

</details>

The intent is that I file each of these as a separate issue rather than bundling them into this PR. The notes are sized so each entry maps cleanly to one issue.

## Items Worth a Careful Look

1. **Section placement.** I think between `User` and `Plugin Architecture` is right, but it's a judgment call.
2. **User `CLAUDE.md` length.** The user-level version is one paragraph by design. If you'd rather have the three-question structure there too, easy change.
3. **Whack-a-mole corollary.** It's specific to detectors. Worth deciding whether that specificity helps or whether it should be a general "evolve customizations as the underlying patterns change" statement.

## Related Work

- #636: session-plugin trope-analysis queries that underwrite the analyze skill's curation loop.
- #638: writing-plugin wordlists and new patterns. The most direct application of the principle this PR documents.
- #639: `writing:analyze` skill. The mechanism by which the writing-plugin ruleset evolves over time.
- Memory file `feedback_customizations_cost_context.md`: same principle in my personal memory, kept for personal-context emphasis.
- Branch `session-cross-machine-design`: design doc for multi-machine session corpus (out-of-stack).
