### PR TITLE
perf: cut wasteful per-session token overhead

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@types/bun": "^1.3.12",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
+        "gray-matter": "^4.0.3",
       },
     },
     "packages/claude-tool": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "@constellos/claude-code-kit": "^0.4.0",
     "@types/bun": "^1.3.12",
     "ajv": "^8.17.1",
-    "ajv-formats": "^3.0.1"
+    "ajv-formats": "^3.0.1",
+    "gray-matter": "^4.0.3"
   },
   "dependencies": {
     "typescript": "^5.9.3",

--- a/plugins/bun/skills/bun/SKILL.md
+++ b/plugins/bun/skills/bun/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: bun
-description: >-
-  Bun runtime patterns and best practices. Use when running bun commands (bun run, bun test, bunx),
-  working with package.json or bun.lock, writing TypeScript scripts that run under Bun,
-  developing Claude Code skills/hooks/scripts (which use Bun as their runtime),
-  or working in projects that use Bun as their package manager.
-  Covers bunx execution, lockfile handling, module resolution, shell scripting with Bun.$,
-  subprocess spawning, file I/O, and testing with bun test.
+description: Bun runtime patterns. Use when running bun commands, working with package.json/bun.lock, writing TypeScript scripts under Bun, or developing Claude Code plugins.
 user-invocable: false
 ---
 

--- a/plugins/claude-code/skills/skill-creator/SKILL.md
+++ b/plugins/claude-code/skills/skill-creator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: claude-code:skill-creator
 description: Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, update or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.
+disable-model-invocation: true
 ---
 
 # Skill Creator

--- a/plugins/github/skills/actions-monitor/SKILL.md
+++ b/plugins/github/skills/actions-monitor/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: github:actions-monitor
-description: |
-  Monitor GitHub Actions workflow runs for a PR, a branch, or a specific run (including `workflow_dispatch` triggers) and extract failure diagnostics. Use when watching PR CI, main-branch build-and-deploy, or a specific workflow run (including `workflow_dispatch` triggers). Identifies failing jobs, extracts relevant error output, and returns a concise summary.
+description: Monitor GitHub Actions runs and extract failure diagnostics. Use when watching PR CI, branch builds, or specific workflow runs.
 allowed-tools:
   - Monitor
   - TaskStop

--- a/plugins/gitlab/skills/ci-monitor/SKILL.md
+++ b/plugins/gitlab/skills/ci-monitor/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: gitlab:ci-monitor
-description: |
-  Investigate GitLab CI pipeline failures and extract diagnostic information. Use when watching MR CI, main-branch build-and-deploy, or a specific pipeline (including manually-triggered pipelines). Identifies failing jobs, extracts relevant error output, and returns a concise summary.
+description: Investigate GitLab CI pipeline failures and extract diagnostics. Use when watching MR CI, branch builds, or specific pipelines.
 allowed-tools:
   - Monitor
   - TaskStop

--- a/plugins/opentelemetry/skills/opentelemetry/SKILL.md
+++ b/plugins/opentelemetry/skills/opentelemetry/SKILL.md
@@ -3,7 +3,8 @@ name: opentelemetry
 description: >-
   OpenTelemetry instrumentation conventions. Use when instrumenting code with
   spans, setting up tracing, or writing trace tests.
-user-invocable: false
+user-invocable: true
+disable-model-invocation: true
 ---
 
 # OpenTelemetry

--- a/plugins/plan/skills/guidelines/SKILL.md
+++ b/plugins/plan/skills/guidelines/SKILL.md
@@ -2,6 +2,7 @@
 name: plan:guidelines
 description: |
   Detailed planning guidelines and best practices. Use when you want explicit guidance on creating high-quality implementation plans, or when a plan was rejected and you need to understand why.
+disable-model-invocation: true
 ---
 
 # Planning Guidelines

--- a/plugins/raycast/skills/raycast/SKILL.md
+++ b/plugins/raycast/skills/raycast/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: raycast
-description: >-
-  Raycast extension development patterns and API. Use when working with @raycast/api imports,
-  package.json files with Raycast commands/tools, npx ray commands, or building Raycast extensions
-  with React and TypeScript.
+description: Raycast extension development. Use when working with @raycast/api imports, Raycast commands/tools, or building extensions.
 user-invocable: false
 ---
 

--- a/plugins/raycast/skills/raycast/SKILL.md
+++ b/plugins/raycast/skills/raycast/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: raycast
 description: Raycast extension development. Use when working with @raycast/api imports, Raycast commands/tools, or building extensions.
-user-invocable: false
+user-invocable: true
+disable-model-invocation: true
 ---
 
 # Raycast

--- a/plugins/review/skills/dashboard/SKILL.md
+++ b/plugins/review/skills/dashboard/SKILL.md
@@ -3,6 +3,7 @@ name: review:dashboard
 description: >
   Live tmux dashboard for reviewing inbound pull requests across GitHub and GitLab.
   Use when reviewing multiple PRs, checking review queue, batch reviews, or managing a review dashboard.
+disable-model-invocation: true
 allowed-tools:
   - Bash(gh:*)
   - Bash(glab:*)

--- a/plugins/review/skills/self/SKILL.md
+++ b/plugins/review/skills/self/SKILL.md
@@ -2,6 +2,7 @@
 name: review:self
 description: |
   Self-review your own code changes using a visual diff viewer. Opens a GitHub-style web UI where you can add comments on changed lines. Comments are returned to Claude for action.
+disable-model-invocation: true
 allowed-tools:
   - "Bash(bunx difit:*)"
   - "Bash(git diff:*)"

--- a/plugins/shortcuts/skills/cli/SKILL.md
+++ b/plugins/shortcuts/skills/cli/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: shortcuts:cli
 description: Running and managing Apple Shortcuts via the macOS shortcuts CLI. Use when the user wants to run, list, or inspect shortcuts.
+disable-model-invocation: true
 allowed-tools:
   - Bash(shortcuts:*)
   - Bash(open:*)

--- a/plugins/shortcuts/skills/shortcut/SKILL.md
+++ b/plugins/shortcuts/skills/shortcut/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: shortcuts:shortcut
 description: Creating Apple Shortcuts programmatically as plist XML files. Use when the user wants to build, generate, or author Apple Shortcuts without the GUI app.
+disable-model-invocation: true
 allowed-tools:
   - Read
   - Write

--- a/plugins/terraform/skills/terraform/SKILL.md
+++ b/plugins/terraform/skills/terraform/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Terraform Cloud workspace management, run monitoring, and log retrieval. Use when
   listing workspaces, checking run status, fetching plan/apply logs, or looking up
   providers and modules in the Terraform Registry.
+disable-model-invocation: true
 allowed-tools:
   - mcp__terraform
   - Bash(curl:*)

--- a/plugins/tmux/hooks/hooks.json
+++ b/plugins/tmux/hooks/hooks.json
@@ -13,6 +13,7 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "Bash|Edit|Write|MultiEdit|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/plugins/tmux/skills/tmux/SKILL.md
+++ b/plugins/tmux/skills/tmux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tmux
-description: Tmux session, window, and pane awareness. Use when the user asks about tmux panes, wants to capture terminal output, send keys to another pane, open a process in a pane, organize panes, navigate windows/sessions, or check for bell/activity notifications.
+description: Tmux session, window, and pane management. Use when capturing output, sending keys, opening processes in panes, or checking notifications.
 allowed-tools:
   - "Bash(bash ${CLAUDE_SKILL_DIR}/scripts/layout.sh)"
 hooks:

--- a/plugins/type-ignore/skills/fix/SKILL.md
+++ b/plugins/type-ignore/skills/fix/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: type-ignore:fix
-description: |
-  Fixes type ignores in a file, directory, or codebase by discovering ignores and dispatching parallel fixer agents. Use when cleaning up type ignores across multiple files, eliminating ignores before a release, or batch-fixing type errors.
+description: Fix type errors instead of ignoring them. Use when cleaning up type ignores across files or batch-fixing type errors.
 context: fork
 agent: general-purpose
 allowed-tools:

--- a/plugins/vscode/skills/edit/SKILL.md
+++ b/plugins/vscode/skills/edit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vscode:edit
 description: Open content in VS Code for interactive editing before using it in the next step.
+disable-model-invocation: true
 user-invocable: true
 allowed-tools:
   - "Bash(bun ${CLAUDE_SKILL_DIR}/scripts/edit.ts:*)"

--- a/plugins/writing/hooks/hooks.json
+++ b/plugins/writing/hooks/hooks.json
@@ -7,11 +7,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts write"
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts write"
           },
           {
             "type": "command",
-            "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts",
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts",
             "if": "Write(**/*.md)"
           },
           {
@@ -25,11 +25,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts edit"
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts edit"
           },
           {
             "type": "command",
-            "command": "bun install --cwd ${CLAUDE_PLUGIN_ROOT} 2>/dev/null; bun ${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts",
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts",
             "if": "Edit(**/*.md)"
           },
           {

--- a/plugins/x-callback-url/skills/xcall/SKILL.md
+++ b/plugins/x-callback-url/skills/xcall/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: x-callback-url:xcall
-description: Call x-callback-url schemes from the CLI and receive responses synchronously. Use when invoking macOS app URL schemes that have no CLI but support x-callback-url (Things, Bear, OmniFocus, etc.) and you need to capture the result.
+description: Call x-callback-url schemes from the CLI synchronously. Use when invoking macOS app URL schemes (Things, Bear, OmniFocus, etc.).
 allowed-tools:
   - Bash
   - Read

--- a/scripts/audit-descriptions.ts
+++ b/scripts/audit-descriptions.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env bun
+
+import { globSync } from "node:fs";
+import { join } from "node:path";
+import matter from "gray-matter";
+
+const root = join(import.meta.dirname, "..");
+
+interface SkillEntry {
+  path: string;
+  name: string;
+  description: string;
+  chars: number;
+  tokens: number;
+  userInvocable: boolean | undefined;
+  disableModelInvocation: boolean | undefined;
+  flags: string[];
+}
+
+const files = globSync("plugins/*/skills/*/SKILL.md", { cwd: root });
+const entries: SkillEntry[] = [];
+
+for (const file of files) {
+  if (file.includes("/test/")) continue;
+
+  const raw = await Bun.file(join(root, file)).text();
+  const { data } = matter(raw);
+  const name = (data.name as string) ?? "(unnamed)";
+  const description = String(data.description ?? "").trim();
+  const chars = description.length;
+  const tokens = Math.ceil(chars / 4);
+  const userInvocable = data["user-invocable"] as boolean | undefined;
+  const disableModelInvocation = data["disable-model-invocation"] as boolean | undefined;
+
+  const flags: string[] = [];
+
+  if (userInvocable === false && !disableModelInvocation) {
+    flags.push("hidden-but-model-invocable");
+  }
+
+  if (disableModelInvocation && userInvocable === false) {
+    flags.push("fully-hidden");
+  }
+
+  if (!disableModelInvocation && chars > 200) {
+    flags.push("verbose");
+  }
+
+  entries.push({
+    path: file,
+    name,
+    description,
+    chars,
+    tokens,
+    userInvocable,
+    disableModelInvocation,
+    flags,
+  });
+}
+
+entries.sort((a, b) => b.chars - a.chars);
+
+const modelInvocable = entries.filter((e) => !e.disableModelInvocation);
+const totalChars = modelInvocable.reduce((sum, e) => sum + e.chars, 0);
+const totalTokens = modelInvocable.reduce((sum, e) => sum + e.tokens, 0);
+
+console.log(`## Description Budget: ${totalChars} chars (~${totalTokens} tokens)\n`);
+console.log(
+  `${modelInvocable.length} skills with model-invocable descriptions (${entries.length} total)\n`,
+);
+
+console.log("| Chars | Tokens | Skill | Flags |");
+console.log("|------:|-------:|-------|-------|");
+
+for (const entry of modelInvocable) {
+  const flags = entry.flags.length > 0 ? entry.flags.join(", ") : "";
+  console.log(`| ${entry.chars} | ${entry.tokens} | ${entry.name} | ${flags} |`);
+}
+
+const flagged = entries.filter((e) => e.flags.length > 0);
+if (flagged.length > 0) {
+  console.log(`\n## Flagged (${flagged.length})\n`);
+  for (const entry of flagged) {
+    console.log(`- **${entry.name}** (${entry.path}): ${entry.flags.join(", ")}`);
+  }
+}

--- a/user/settings.json
+++ b/user/settings.json
@@ -79,7 +79,6 @@
     ]
   },
   "enabledPlugins": {
-    "pr-review-toolkit@claude-plugins-official": true,
     "go@bendrucker": true,
     "mac@bendrucker": true,
     "git@bendrucker": true,
@@ -109,7 +108,6 @@
     "playground@claude-plugins-official": true,
     "linear-cli@linear-cli": true,
     "tmux@bendrucker": true,
-    "agent-browser@agent-browser": true,
     "bun@bendrucker": true,
     "git-town@bendrucker": true,
     "mermaid@bendrucker": true,


### PR DESCRIPTION
Reduces per-session description budget from ~10,500 chars (~2,645 tokens) to ~9,200 chars (~2,316 tokens), plus eliminates plugin description overhead (~8,200 chars) and hook execution waste.

- Disable `agent-browser` and `pr-review-toolkit` plugins that inject ~8,200 chars of skill/agent descriptions without matching usage patterns
- Disable model invocation on 10 skills that are slash-only workflows (command-oriented tools, domain-specific references, niche macOS tools)
- Trim 7 verbose descriptions by ~40%, cutting redundant trigger examples
- Remove redundant `bun install` prefix from writing hooks (saves ~200-500ms per Write/Edit)
- Add matcher to tmux `notification.ts --clear` so it only fires for permission-gated tools
- Add `scripts/audit-descriptions.ts` for continuous token budget measurement

## Skills with `disable-model-invocation: true`

| Skill | Rationale |
|-------|-----------|
| `review:self` | Launches external diff viewer |
| `vscode:edit` | Opens VS Code |
| `raycast` | Domain-specific to Raycast extension monorepo |
| `claude-code:skill-creator` | Structured eval workflow |
| `terraform` | Domain-specific to Terraform repos |
| `plan:guidelines` | Reference material |
| `review:dashboard` | Launches tmux dashboard |
| `shortcuts:shortcut` | Niche macOS tool |
| `shortcuts:cli` | Niche macOS tool |
| `opentelemetry` | Domain-specific, now user-invocable via `/opentelemetry` |

## Future work

When `skillOverrides: "name-only"` gains plugin skill support, infrastructure skills like `mac:jxa`, `mac:jxa-run`, and `x-callback-url:xcall` can be downgraded to name-only (keeping model invocation while dropping descriptions). These are called transitively by other skills and don't need descriptions for detection, but currently can't be fully disabled without breaking the invocation chain.

## Testing

- Run `bun scripts/audit-descriptions.ts` to verify budget reduction
- Confirm disabled skills still work via `/slash-command`
- Verify tmux notification clears after Bash permission prompts
- Confirm writing hooks fire correctly without `bun install` prefix
