### PR TITLE
writing: rewrite skill, analyze fixes, wordlist curation

### DIFF
--- a/plugins/writing/README.md
+++ b/plugins/writing/README.md
@@ -5,7 +5,7 @@ Writing style enforcement and slop detection for prose output (PR descriptions, 
 ## Contents
 
 - **Hooks**: Numbered heading detection, heading style enforcement, AI writing trope detection (em dashes, vocabulary, copula avoidance, promotional language, parallelism, semicolons)
-- **Skills**: `writing` system reminder for prose writing guidelines, `writing:analyze` session-history-based trope ruleset curation, `writing:review` multi-agent document review
+- **Skills**: `writing` system reminder for prose writing guidelines, `writing:analyze` session-history-based trope ruleset curation, `writing:rewrite` user-invoked text rewriter, `writing:review` multi-agent document review
 - **Agents**: `content`, `style`, `artifacts` (conditional review lenses)
 
 ## Wordlists

--- a/plugins/writing/hooks/check-tropes.test.ts
+++ b/plugins/writing/hooks/check-tropes.test.ts
@@ -258,7 +258,7 @@ describe("diff-aware filtering", () => {
   });
 
   it("skips sycophantic opener in file Edit (sideEffectOnly)", async () => {
-    const input = mockEdit("Perfect. Let me proceed.\nNext line.", "Next line.");
+    const input = mockEdit("Excellent. Let me proceed.\nNext line.", "Next line.");
     expect(await processInput(input)).toBeNull();
   });
 });

--- a/plugins/writing/hooks/tropes.test.ts
+++ b/plugins/writing/hooks/tropes.test.ts
@@ -34,17 +34,15 @@ describe("scan", () => {
     const words = [
       "delve",
       "tapestry",
-      "landscape",
       "meticulous",
       "meticulously",
-      "pivotal",
-      "testament",
-      "underscored",
-      "interplay",
-      "intricacies",
-      "bolstered",
-      "garnered",
-      "fostering",
+      "leverage",
+      "leveraged",
+      "robust",
+      "comprehensive",
+      "comprehensively",
+      "nuance",
+      "nuanced",
     ];
 
     for (const word of words) {
@@ -219,12 +217,7 @@ describe("scan", () => {
   });
 
   describe("sycophantic opener", () => {
-    const flag = [
-      "Perfect. That works.",
-      "Excellent! Moving on.",
-      "Great, the build passes.",
-      "Absolutely, the design holds up.",
-    ];
+    const flag = ["Perfect. That works.", "Excellent! Moving on."];
     const allow = [
       "This was a perfect example of the issue.",
       "An excellent question to consider.",
@@ -467,24 +460,22 @@ describe("scan", () => {
   });
 
   describe("marketing verbs (weighted)", () => {
-    it("does not flag single low-weight hit", () => {
+    it("does not flag a single low-weight hit", () => {
       expect(
-        scan("This change enables the new flag.").find((m) => m.category === "marketing verbs"),
+        scan("This change simplifies the workflow.").find((m) => m.category === "marketing verbs"),
       ).toBeUndefined();
     });
 
-    it("does not flag stack below threshold", () => {
+    it("does not flag a single mid-weight hit below threshold", () => {
+      // empower is 2.5, below the 3.0 threshold on its own.
       expect(
-        scan("This enables and simplifies the workflow.").find(
-          (m) => m.category === "marketing verbs",
-        ),
+        scan("This release empowers users.").find((m) => m.category === "marketing verbs"),
       ).toBeUndefined();
     });
 
-    it("flags when a single high-weight hit clears threshold alone", () => {
-      // Three independent matches: each empower(s|ed|ing) is weight 2.5.
-      // Need to clear 3.0 by stacking with one more.
-      const text = "This release empowers users and streamlines deploys.";
+    it("flags when stacked verbs clear the threshold", () => {
+      // empower (2.5) + simplify (0.8) = 3.3, above 3.0.
+      const text = "This release empowers users and simplifies deploys.";
       expect(firstByTier(scan(text), "context")?.category).toBe("marketing verbs");
     });
 

--- a/plugins/writing/hooks/tropes.test.ts
+++ b/plugins/writing/hooks/tropes.test.ts
@@ -486,6 +486,70 @@ describe("scan", () => {
       expect(firstByTier(scan(text), "context")?.category).toBe("marketing verbs");
     });
   });
+
+  describe("flowery phrasing", () => {
+    const flag = [
+      "this keeps a single source of truth",
+      "the canonical sources of truth live here",
+      "stored as source-of-truth metadata",
+      "treat it as the Source Of Truth",
+      "added an escape hatch for power users",
+      "two escape hatches remain",
+      "the module is fully self-sufficient",
+      "the fixture is self sufficient",
+      "the assertion fails loudly on drift",
+      "it failed loudly during CI",
+    ];
+    const allow = [
+      "the truth about the data source is unclear",
+      "a hatch you can escape through",
+      "loudly proclaimed the failure",
+    ];
+    for (const text of flag) {
+      it(`flags ${JSON.stringify(text)}`, () => {
+        expect(firstByTier(scan(text), "context")?.category).toBe("flowery phrasing");
+      });
+    }
+    for (const text of allow) {
+      it(`allows ${JSON.stringify(text)}`, () => {
+        expect(scan(text).find((m) => m.category === "flowery phrasing")).toBeUndefined();
+      });
+    }
+    it("does not fire in non-prose file context", () => {
+      expect(
+        scan("a single source of truth", "module.ts", "file").find(
+          (m) => m.category === "flowery phrasing",
+        ),
+      ).toBeUndefined();
+    });
+    it("fires in prose file context", () => {
+      expect(
+        firstByTier(scan("a single source of truth", "README.md", "file"), "context")?.category,
+      ).toBe("flowery phrasing");
+    });
+  });
+
+  describe("soft phrasing (weighted)", () => {
+    it("does not flag a lone soft word", () => {
+      // cleanly is 1.5, below the 3.0 threshold on its own.
+      expect(
+        scan("the fixtures strip cleanly").find((m) => m.category === "soft phrasing"),
+      ).toBeUndefined();
+    });
+
+    it("flags when soft words stack", () => {
+      // Two occurrences of cleanly (1.5 each) = 3.0, at the threshold.
+      const text = "the migration runs cleanly and the tests strip cleanly";
+      expect(firstByTier(scan(text), "context")?.category).toBe("soft phrasing");
+    });
+
+    it("does not fire in non-prose file context", () => {
+      const text = "the migration runs cleanly and the tests strip cleanly";
+      expect(
+        scan(text, "module.ts", "file").find((m) => m.category === "soft phrasing"),
+      ).toBeUndefined();
+    });
+  });
 });
 
 describe("firstByTier", () => {

--- a/plugins/writing/hooks/tropes.test.ts
+++ b/plugins/writing/hooks/tropes.test.ts
@@ -217,7 +217,7 @@ describe("scan", () => {
   });
 
   describe("sycophantic opener", () => {
-    const flag = ["Perfect. That works.", "Excellent! Moving on."];
+    const flag = ["Excellent. That works.", "Excellent! Moving on."];
     const allow = [
       "This was a perfect example of the issue.",
       "An excellent question to consider.",
@@ -429,7 +429,7 @@ describe("scan", () => {
 
   describe("sideEffectOnly scoping", () => {
     const conversational = [
-      { text: "Perfect. That works.", category: "sycophantic opener" },
+      { text: "Excellent. That works.", category: "sycophantic opener" },
       { text: "You're right about that.", category: "sycophantic acknowledgment" },
       { text: "Want me to fix the bug?", category: "permission-seeking" },
       { text: "Would you like me to retry?", category: "hedging close" },
@@ -461,8 +461,9 @@ describe("scan", () => {
 
   describe("marketing verbs (weighted)", () => {
     it("does not flag a single low-weight hit", () => {
+      // enhance is 1.5, below the 3.0 threshold on its own.
       expect(
-        scan("This change simplifies the workflow.").find((m) => m.category === "marketing verbs"),
+        scan("This change enhances the workflow.").find((m) => m.category === "marketing verbs"),
       ).toBeUndefined();
     });
 
@@ -474,8 +475,8 @@ describe("scan", () => {
     });
 
     it("flags when stacked verbs clear the threshold", () => {
-      // empower (2.5) + simplify (0.8) = 3.3, above 3.0.
-      const text = "This release empowers users and simplifies deploys.";
+      // empower (2.5) + streamline (1.5) = 4.0, above 3.0.
+      const text = "This release empowers users and streamlines deploys.";
       expect(firstByTier(scan(text), "context")?.category).toBe("marketing verbs");
     });
 

--- a/plugins/writing/hooks/tropes.ts
+++ b/plugins/writing/hooks/tropes.ts
@@ -1,5 +1,11 @@
 import { isProseFile } from "./markdown";
-import { type Hits, type StemmedWeight, WORDLISTS, weightedStemHits } from "./wordlists";
+import {
+  type Hits,
+  type StemmedWeight,
+  stemmedPhraseHits,
+  WORDLISTS,
+  weightedStemHits,
+} from "./wordlists";
 
 export type PatternTier = "deny" | "context";
 
@@ -136,6 +142,14 @@ export const PATTERNS: PatternDef[] = [
   },
   {
     tier: "context",
+    category: "flowery phrasing",
+    test: (text) => stemmedPhraseHits(text, WORDLISTS.floweryPhrases),
+    fileOnly: true,
+    message: (matched) =>
+      `"${matched}" is stock phrasing the model reaches for. State the mechanism plainly.`,
+  },
+  {
+    tier: "context",
     category: "parallelism",
     test: /\bnot (?:just|only) .{1,50}, but (?:also )?/gi,
     message: () =>
@@ -218,6 +232,7 @@ export const PATTERNS: PatternDef[] = [
 ];
 
 const MARKETING_VERB_THRESHOLD = 3.0;
+const SOFT_PHRASING_THRESHOLD = 3.0;
 
 const WEIGHTED_PATTERNS: WeightedPatternGroup[] = [
   {
@@ -227,6 +242,15 @@ const WEIGHTED_PATTERNS: WeightedPatternGroup[] = [
     threshold: MARKETING_VERB_THRESHOLD,
     message: (examples) =>
       `Marketing verbs stack up (${examples.join(", ")}). Describe concretely what changed instead of promotional framing.`,
+  },
+  {
+    tier: "context",
+    category: "soft phrasing",
+    entries: WORDLISTS.softPhrasing,
+    threshold: SOFT_PHRASING_THRESHOLD,
+    fileOnly: true,
+    message: (examples) =>
+      `Soft phrasing piles up (${examples.join(", ")}). These read as filler. Describe what the code does plainly.`,
   },
 ];
 

--- a/plugins/writing/hooks/tropes.ts
+++ b/plugins/writing/hooks/tropes.ts
@@ -12,7 +12,7 @@ export type PatternMatch = {
   message: string;
 };
 
-type PatternDef = {
+export type PatternDef = {
   tier: PatternTier;
   category: string;
   test: RegExp | ((text: string) => Hits);
@@ -62,7 +62,7 @@ function testResultHits(text: string): Hits {
 const CROSS_SENTENCE_NOT =
   /\b(it|this|that|he|she|they|we|you)\s+(?:is|are|was|were)(?:n't|\s+not)\s+[^.!?]{1,80}[.!?]\s+\1\s+(?:is|are|was|were)\b/gi;
 
-const PATTERNS: PatternDef[] = [
+export const PATTERNS: PatternDef[] = [
   {
     tier: "deny",
     category: "spaced em dash",

--- a/plugins/writing/hooks/wordlists.test.ts
+++ b/plugins/writing/hooks/wordlists.test.ts
@@ -145,9 +145,9 @@ describe("loaded WORDLISTS", () => {
   });
 
   it("loads openers", () => {
-    expect("Perfect.".match(WORDLISTS.openers)).not.toBeNull();
+    expect("Excellent.".match(WORDLISTS.openers)).not.toBeNull();
     expect("Excellent! Moving on.".match(WORDLISTS.openers)).not.toBeNull();
-    expect("this was a perfect example".match(WORDLISTS.openers)).toBeNull();
+    expect("an excellent example here".match(WORDLISTS.openers)).toBeNull();
   });
 
   it("loads marketing verbs as weighted stems", () => {

--- a/plugins/writing/hooks/wordlists.test.ts
+++ b/plugins/writing/hooks/wordlists.test.ts
@@ -135,13 +135,13 @@ describe("weightedStemHits", () => {
 describe("loaded WORDLISTS", () => {
   it("loads vocabulary as stemmed matcher", () => {
     expect(WORDLISTS.vocabulary("we delve into the data").count).toBeGreaterThan(0);
-    expect(WORDLISTS.vocabulary("the myriad options").count).toBeGreaterThan(0);
+    expect(WORDLISTS.vocabulary("a robust solution").count).toBeGreaterThan(0);
   });
 
   it("matches inflected vocabulary via stemming", () => {
     expect(WORDLISTS.vocabulary("done meticulously").count).toBeGreaterThan(0);
-    expect(WORDLISTS.vocabulary("she garnered support").count).toBeGreaterThan(0);
-    expect(WORDLISTS.vocabulary("by fostering growth").count).toBeGreaterThan(0);
+    expect(WORDLISTS.vocabulary("she leveraged the data").count).toBeGreaterThan(0);
+    expect(WORDLISTS.vocabulary("a nuanced take").count).toBeGreaterThan(0);
   });
 
   it("loads openers", () => {

--- a/plugins/writing/hooks/wordlists.test.ts
+++ b/plugins/writing/hooks/wordlists.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import {
   compilePlainWordlist,
+  compileStemmedPhrases,
   compileStemmedWordlist,
   compileWeightedStems,
+  stemmedPhraseHits,
   WORDLISTS,
   weightedStemHits,
 } from "./wordlists";
@@ -132,6 +134,35 @@ describe("weightedStemHits", () => {
   });
 });
 
+describe("compileStemmedPhrases / stemmedPhraseHits", () => {
+  const phrases = compileStemmedPhrases("source of truth\nescape hatch\nfail loudly\n");
+
+  it("matches the exact phrase", () => {
+    expect(stemmedPhraseHits("a single source of truth here", phrases).count).toBe(1);
+  });
+
+  it("matches inflected, hyphenated, and cased variants via stemming", () => {
+    expect(stemmedPhraseHits("the canonical sources of truth", phrases).count).toBe(1);
+    expect(stemmedPhraseHits("stored as source-of-truth metadata", phrases).count).toBe(1);
+    expect(stemmedPhraseHits("treat it as the Source Of Truth", phrases).count).toBe(1);
+    expect(stemmedPhraseHits("the test fails loudly", phrases).count).toBe(1);
+  });
+
+  it("requires contiguous order, not scattered words", () => {
+    expect(stemmedPhraseHits("the truth about the data source", phrases).count).toBe(0);
+    expect(stemmedPhraseHits("a hatch you can escape through", phrases).count).toBe(0);
+  });
+
+  it("reports the original phrase as the sample", () => {
+    expect(stemmedPhraseHits("added an escape hatch", phrases).sample).toBe("escape hatch");
+  });
+
+  it("ignores comments and blank lines", () => {
+    const compiled = compileStemmedPhrases("# header\n\nsource of truth\n");
+    expect(compiled.length).toBe(1);
+  });
+});
+
 describe("loaded WORDLISTS", () => {
   it("loads vocabulary as stemmed matcher", () => {
     expect(WORDLISTS.vocabulary("we delve into the data").count).toBeGreaterThan(0);
@@ -154,5 +185,16 @@ describe("loaded WORDLISTS", () => {
     expect(WORDLISTS.marketingVerbs.length).toBeGreaterThan(0);
     const result = weightedStemHits("this empowers users", WORDLISTS.marketingVerbs);
     expect(result.totalWeight).toBeGreaterThan(2);
+  });
+
+  it("loads soft phrasing as weighted stems", () => {
+    expect(WORDLISTS.softPhrasing.length).toBeGreaterThan(0);
+    const result = weightedStemHits("this runs cleanly and exits cleanly", WORDLISTS.softPhrasing);
+    expect(result.totalWeight).toBeGreaterThan(2);
+  });
+
+  it("loads flowery phrases as stemmed token sequences", () => {
+    expect(WORDLISTS.floweryPhrases.map((p) => p.original)).toContain("source of truth");
+    expect(WORDLISTS.floweryPhrases.every((p) => p.stems.length > 0)).toBe(true);
   });
 });

--- a/plugins/writing/hooks/wordlists.ts
+++ b/plugins/writing/hooks/wordlists.ts
@@ -86,6 +86,50 @@ export function compileWeightedStems(content: string): StemmedWeight[] {
   return entries;
 }
 
+export type StemmedPhrase = { stems: string[]; original: string };
+
+export function compileStemmedPhrases(content: string): StemmedPhrase[] {
+  const phrases: StemmedPhrase[] = [];
+  for (const line of parseLines(content)) {
+    const stems = (line.toLowerCase().match(WORD_TOKEN) ?? []).map((word) => stemmer(word));
+    if (stems.length > 0) phrases.push({ stems, original: line });
+  }
+  return phrases;
+}
+
+// Count contiguous occurrences of `needle` within `haystack` (non-overlapping).
+function countSubsequence(haystack: string[], needle: string[]): number {
+  if (needle.length === 0) return 0;
+  let count = 0;
+  for (let i = 0; i + needle.length <= haystack.length; i++) {
+    let matched = true;
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) {
+      count++;
+      i += needle.length - 1;
+    }
+  }
+  return count;
+}
+
+export function stemmedPhraseHits(text: string, phrases: StemmedPhrase[]): Hits {
+  const tokens = (text.toLowerCase().match(WORD_TOKEN) ?? []).map((word) => stemmer(word));
+  let count = 0;
+  let sample = "";
+  for (const phrase of phrases) {
+    const occurrences = countSubsequence(tokens, phrase.stems);
+    if (occurrences === 0) continue;
+    count += occurrences;
+    if (!sample) sample = phrase.original;
+  }
+  return { count, sample };
+}
+
 export function weightedStemHits(text: string, entries: StemmedWeight[]): WeightedHits {
   const words = text.match(WORD_TOKEN) ?? [];
   const stemCounts = new Map<string, number>();
@@ -115,13 +159,17 @@ export type LoadedWordlists = {
   vocabulary: (text: string) => Hits;
   openers: RegExp;
   marketingVerbs: StemmedWeight[];
+  softPhrasing: StemmedWeight[];
+  floweryPhrases: StemmedPhrase[];
 };
 
 async function load(): Promise<LoadedWordlists> {
-  const [vocabularySrc, openersSrc, marketingSrc] = await Promise.all([
+  const [vocabularySrc, openersSrc, marketingSrc, softSrc, flowerySrc] = await Promise.all([
     readWordlist("vocabulary.txt"),
     readWordlist("openers.txt"),
     readWordlist("marketing-verbs.txt"),
+    readWordlist("soft-phrasing.txt"),
+    readWordlist("flowery-phrases.txt"),
   ]);
 
   const vocabulary = compileStemmedWordlist(vocabularySrc);
@@ -134,8 +182,10 @@ async function load(): Promise<LoadedWordlists> {
   if (!openers) throw new Error("openers.txt produced no entries");
 
   const marketingVerbs = compileWeightedStems(marketingSrc);
+  const softPhrasing = compileWeightedStems(softSrc);
+  const floweryPhrases = compileStemmedPhrases(flowerySrc);
 
-  return { vocabulary, openers, marketingVerbs };
+  return { vocabulary, openers, marketingVerbs, softPhrasing, floweryPhrases };
 }
 
 export const WORDLISTS: LoadedWordlists = await load();

--- a/plugins/writing/skills/analyze/SKILL.md
+++ b/plugins/writing/skills/analyze/SKILL.md
@@ -53,7 +53,7 @@ Run with `--help` for all flags. Writes a markdown report to `tmp/trope-analysis
 - Structural pattern audit (the hook's regex patterns, hit counts across sessions)
 - Correction candidates (long-assistant, short-user pairs suggesting prose pushback)
 
-A rule the model uses far more than the user is **kept** even when its lift reads low. Lift is not used for removal decisions because the smoothed user baseline (see methodology) compresses it for any word the user never types, which would flag the model's strongest tells (`delve`, `Perfect`, `robust`) for removal.
+A rule the model uses far more than the user is **kept** even when its lift reads low. Lift is not used for removal decisions because the smoothed user baseline (see methodology) compresses it for any word the user never types, which would flag the model's strongest tells (`delve`, `comprehensive`, `robust`) for removal.
 
 ## Corpora
 

--- a/plugins/writing/skills/analyze/SKILL.md
+++ b/plugins/writing/skills/analyze/SKILL.md
@@ -40,18 +40,20 @@ Run with `--help` for all flags. Writes a markdown report to `tmp/trope-analysis
 
 ## Metrics
 
-**Lift**: how distinctive a phrase is to assistant output vs. user text. `lift = rate_assistant / rate_user_smoothed`, where rates are per-million-token frequencies. A lift of 10.0 means the assistant uses the phrase 10x more per token than the user. The `--min-lift` threshold (default 5.0) decides rule health and candidate inclusion.
+**Lift**: how distinctive a phrase is to assistant output vs. user text. `lift = rate_assistant / rate_user_smoothed`, where rates are per-million-token frequencies. A lift of 10.0 means the assistant uses the phrase 10x more per token than the user. The `--min-lift` threshold (default 5.0) gates new candidate phrases only. Rule keep/remove uses a direct rate comparison plus `--min-count`, not lift (see methodology for why).
 
 **Session count**: number of distinct sessions containing a phrase. Candidates require session count >= 3 to filter project-specific jargon that dominates a single session.
 
 ## Output
 
 - Summary stats (corpus sizes, rule count, model breakdown)
-- Proposed removals (rules whose lift collapsed below `--min-lift`)
+- Proposed removals, each tagged **dead** (model produced it fewer than `--min-count` times) or **not distinctive** (user uses it at least as often as the model)
 - Proposed additions (high-lift n-grams not already covered)
-- Rule health table (every entry with type, `keep` / `remove` / `no data`)
-- Structural pattern audit (regex-based hook patterns, hit counts across sessions)
+- Rule health table (every entry with type and `keep` / `remove (reason)`)
+- Structural pattern audit (the hook's regex patterns, hit counts across sessions)
 - Correction candidates (long-assistant, short-user pairs suggesting prose pushback)
+
+A rule the model uses far more than the user is **kept** even when its lift reads low. Lift is not used for removal decisions because the smoothed user baseline (see methodology) compresses it for any word the user never types, which would flag the model's strongest tells (`delve`, `Perfect`, `robust`) for removal.
 
 ## Corpora
 

--- a/plugins/writing/skills/analyze/references/methodology.md
+++ b/plugins/writing/skills/analyze/references/methodology.md
@@ -48,6 +48,8 @@ Removal does **not** use lift. The user baseline is small (often tens of thousan
 
 The audit measures each term in `text_content` (conversational assistant and user text). This is a proxy surface: most wordlist rules fire on deliverables and side-effect inputs, not chat, but the model's chat usage of a term tracks its overall habit closely enough to judge distinctiveness. A consequence: a term both the model and the user say conversationally (`Perfect` as an acknowledgment) reads as not distinctive and is dropped even if it might still open a deliverable.
 
+The proxy breaks entirely for tells that live *only* in deliverables and never in chat. The flowery phrases (`flowery-phrases.txt`) and the soft group (`soft-phrasing.txt`) were curated from PR-body evidence, so the chat-surface audit reports them as `dead` (zero chat hits) or as `not distinctive`. Those verdicts are not authoritative for deliverable-surface rules. Auditing wordlist health against the deliverable corpus directly (not just chat) is the fix, tracked with the rest of the deliverable-aware analyze work.
+
 Because removed single words are no longer in the wordlist, a later audit cannot resurface them (the additions pipeline only mines multi-word n-grams). If the model regresses to a removed word, add it back by hand.
 
 ## Surface Candidate Phrases

--- a/plugins/writing/skills/analyze/references/methodology.md
+++ b/plugins/writing/skills/analyze/references/methodology.md
@@ -25,7 +25,7 @@ Where rates are per-million-token frequencies and the user rate uses Laplace smo
 - `lift = 1.0` means the phrase appears at equal rates in both corpora.
 - `lift = 10.0` means the assistant uses the phrase 10x more often per token than the user.
 
-The `--min-lift` threshold (default 5.0) decides both rule health (keep vs. remove) and new candidate inclusion.
+The `--min-lift` threshold (default 5.0) gates new candidate phrases. It does **not** decide rule keep/remove (see "Audit Current Wordlists" for why lift is unreliable there).
 
 #### Session count
 
@@ -39,9 +39,16 @@ Installs DuckDB's FTS extension and materializes per-role corpus tables (`fts_as
 
 Wordlist entries are batch-audited via `fts-phrase-audit.sql`. The query stems each entry with Porter stemming, then looks up term frequencies in both FTS indexes. Returns per-term assistant/user counts, per-million rates, and lift.
 
-A phrase with `lift >= --min-lift` keeps its rule. Below that threshold, the report proposes removal.
+A rule is **kept** when the model uses it strictly more per token than the user (`assistant_per_m > user_per_m`) and it appears at least `--min-count` times (default 5). Otherwise the report proposes removal with one of two reasons:
+
+- **dead**: fewer than `--min-count` assistant occurrences. The rule rarely fires regardless of distinctiveness.
+- **not distinctive**: the user uses it at least as often per token. The rule would flag the user's own voice.
+
+Removal does **not** use lift. The user baseline is small (often ~10K tokens), so the Laplace smoothing floor (`1/user_total`, ~99 per million) dominates: any word the user never types needs ~500 per million in assistant text just to reach a lift of 5.0. That gate is nearly unreachable for single words, so a pure lift threshold flags the model's strongest surviving tells (`delve`, `Perfect`, `robust`) for removal. The direct rate comparison is smoothing-free and keeps them.
 
 The audit uses `text_content` (all assistant text, including conversational messages) because wordlist rules fire on all prose surfaces, not just deliverables.
+
+Because removed single words are no longer in the wordlist, a later audit cannot resurface them (the additions pipeline only mines multi-word n-grams). If the model regresses to a removed word, add it back by hand.
 
 ## Surface Candidate Phrases
 
@@ -82,7 +89,9 @@ Without this filtering, roughly half the user corpus by character count is machi
 
 ## Structural Pattern Audit
 
-Runs the regex-based patterns from `tropes.ts` against all assistant text (not just deliverables). Each pattern reports total hits, number of rows containing hits, and session spread. Patterns are labeled by their hook scope (all, file-only, side-effect-only).
+`structural.ts` imports the hook's `PATTERNS` directly from `hooks/tropes.ts` rather than re-declaring them, so the audit cannot drift from what the hook enforces. It keeps only the regex patterns whose source is not a wordlist (stemmed vocabulary and weighted verbs are covered by the FTS pass; `WORDLISTS.openers` is too) and normalizes each to the global flag for accurate counting. Function-based tests (e.g. test-result reporting) are excluded because they cannot be counted by a single regex match.
+
+The patterns run against all assistant text (not just deliverables). Each reports total hits, number of rows containing hits, and session spread. Patterns are labeled by their hook scope (all, file-only, side-effect-only).
 
 This catches structural tropes (semicolons, passive voice, hedging, parallelism) that the n-gram pipeline cannot detect.
 
@@ -131,4 +140,4 @@ Stratify by sampling sessions first, then rows within those sessions. Without th
 
 ## Tuning
 
-Raise `--min-lift` (default 5.0) if the report is too noisy. Lower it if too quiet. N-grams larger than 4 tokens are not currently considered.
+Raise `--min-lift` (default 5.0) if the candidate list is too noisy. Lower it if too quiet. Raise `--min-count` (default 5) to be stricter about what counts as a live rule (more removals tagged dead); lower it to keep rarer rules. N-grams larger than 4 tokens are not currently considered.

--- a/plugins/writing/skills/analyze/references/methodology.md
+++ b/plugins/writing/skills/analyze/references/methodology.md
@@ -54,8 +54,8 @@ Because removed single words are no longer in the wordlist, a later audit cannot
 
 Pulls two corpora:
 
-- **All model-generated text**: conversational assistant text from `text-export` (filtered by `--model`) combined with deliverable prose from `deliverable-prose.sql`. The `text_content` view only captures `type='text'` content items (conversational output), not `type='tool_use'` (Write/Edit/Bash tool inputs). The deliverable-prose query fills this gap. The combined corpus is used for n-gram candidates. The structural pattern audit runs against conversational text only.
-- **Human-only user text** (`text-export` with `role=user`, filtered): the baseline corpus for lift calculation. Excludes system-injected content that arrives as user-role messages: skill injections, context compaction summaries, task notifications, system reminders, and CLAUDE.md context.
+- **Deliverable prose** (`deliverable-prose.sql`): the model's file writes (`.md`/`.txt`/`.rst`/`.adoc`) and Bash commit/PR/MR bodies. This is the n-gram candidate corpus, because these are the surfaces the hook scans. Conversational assistant text is deliberately excluded: the hook never sees the model's chat, so mining it floods the candidate list with narration (`now let me`, `let me check`) at enormous lift that no rule can act on. Scoping to deliverables surfaces only phrasing that could become an enforceable rule.
+- **Human-only user text** (`text-export` with `role=user`, filtered): the baseline for lift. The human doesn't write via Write/Edit, so this is their chat voice; lift therefore contrasts the model's deliverable phrasing against the human's natural voice. Excludes system-injected user-role content: skill injections, context compaction summaries, task notifications, system reminders, and CLAUDE.md context.
 
 The n-gram code in `ngram.ts` strips markdown/code artifacts, URLs, table lines, headers, and code-shaped identifiers from both corpora.
 
@@ -65,7 +65,7 @@ Minimum assistant counts per n-gram size (3-grams: 5, 4-grams: 3) are hardcoded 
 
 #### Deliverable prose
 
-The `deliverable-prose.sql` query extracts text from Write/Edit to prose files (`.md`, `.txt`, `.rst`, `.adoc`) and Bash commands with `--body`/`--message`/`--description`/`--title`/`-m`. It excludes paths the hook skips (memory, plan, wordlist files). For Bash, it extracts heredoc content and quoted flag values via regex. This corpus is reported in the summary for sizing context but is not used for n-gram candidates.
+The `deliverable-prose.sql` query extracts text from Write/Edit to prose files (`.md`, `.txt`, `.rst`, `.adoc`) and Bash commands with `--body`/`--message`/`--description`/`--title`/`-m`. It excludes paths the hook skips (memory, plan, wordlist files). For Bash, it extracts heredoc content and quoted flag values via regex. This is the corpus the n-gram candidate miner runs on (see above); the all-assistant `text-export` corpus is still pulled for the structural audit and summary sizing.
 
 #### User text filtering
 

--- a/plugins/writing/skills/analyze/references/methodology.md
+++ b/plugins/writing/skills/analyze/references/methodology.md
@@ -44,9 +44,9 @@ A rule is **kept** when the model uses it strictly more per token than the user 
 - **dead**: fewer than `--min-count` assistant occurrences. The rule rarely fires regardless of distinctiveness.
 - **not distinctive**: the user uses it at least as often per token. The rule would flag the user's own voice.
 
-Removal does **not** use lift. The user baseline is small (often ~10K tokens), so the Laplace smoothing floor (`1/user_total`, ~99 per million) dominates: any word the user never types needs ~500 per million in assistant text just to reach a lift of 5.0. That gate is nearly unreachable for single words, so a pure lift threshold flags the model's strongest surviving tells (`delve`, `Perfect`, `robust`) for removal. The direct rate comparison is smoothing-free and keeps them.
+Removal does **not** use lift. The user baseline is small (often tens of thousands of tokens, even with cross-machine history merged in), so the Laplace smoothing floor (`1/user_total`) dominates: any word the user never types needs a high per-million rate in assistant text just to reach a lift of 5.0. That gate is nearly unreachable for single words, so a pure lift threshold flags the model's strongest surviving tells (`delve`, `comprehensive`, `robust`) for removal. The direct rate comparison is smoothing-free and keeps them.
 
-The audit uses `text_content` (all assistant text, including conversational messages) because wordlist rules fire on all prose surfaces, not just deliverables.
+The audit measures each term in `text_content` (conversational assistant and user text). This is a proxy surface: most wordlist rules fire on deliverables and side-effect inputs, not chat, but the model's chat usage of a term tracks its overall habit closely enough to judge distinctiveness. A consequence: a term both the model and the user say conversationally (`Perfect` as an acknowledgment) reads as not distinctive and is dropped even if it might still open a deliverable.
 
 Because removed single words are no longer in the wordlist, a later audit cannot resurface them (the additions pipeline only mines multi-word n-grams). If the model regresses to a removed word, add it back by hand.
 

--- a/plugins/writing/skills/analyze/scripts/analyze.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.ts
@@ -141,15 +141,22 @@ async function main(): Promise<void> {
     );
 
     const allModelText = [...assistantRows, ...deliverableRows];
-    const totalSessions = new Set(allModelText.map((r) => r.session_id)).size;
     const ngramSizes = [3, 4];
+    // Mine candidates from deliverable prose only (file writes and Bash
+    // commit/PR/MR bodies), not conversational assistant text. The hook scans
+    // deliverables and side-effect inputs, never the model's chat, so chat
+    // narration ("now let me", "let me check") would otherwise dominate the
+    // candidate list with phrases the hook can never act on.
     const { stats: assistantCorpus, sessionSpread: sessionCounts } = processRows(
-      allModelText,
+      deliverableRows,
       ngramSizes,
     );
     const userCorpus = processCorpus(serializeCorpus(userRows), ngramSizes);
-    const minSessions = Math.max(3, Math.round(totalSessions * 0.05));
-    console.error(`Session threshold: ${minSessions} (${totalSessions} sessions in window)`);
+    const candidateSessions = new Set(deliverableRows.map((r) => r.session_id)).size;
+    const minSessions = Math.max(3, Math.round(candidateSessions * 0.05));
+    console.error(
+      `Session threshold: ${minSessions} (${candidateSessions} deliverable sessions in window)`,
+    );
 
     const allLifts = computeLift({
       assistant: assistantCorpus,

--- a/plugins/writing/skills/analyze/scripts/analyze.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.ts
@@ -39,8 +39,14 @@ const argv = cli({
     },
     minLift: {
       type: Number,
-      description: "Minimum lift threshold for keep/include decisions",
+      description: "Minimum lift threshold for surfacing new candidate phrases",
       default: 5.0,
+    },
+    minCount: {
+      type: Number,
+      description:
+        "Minimum assistant occurrences for a rule to count as alive (below this is 'dead')",
+      default: 5,
     },
     top: {
       type: Number,
@@ -69,6 +75,7 @@ const until = argv.flags.until ?? today;
 const modelFilter = argv.flags.model;
 const projectFilter = argv.flags.project ?? null;
 const minLift = argv.flags.minLift;
+const minCount = argv.flags.minCount;
 const topN = argv.flags.top;
 const dbPath = path.resolve(argv.flags.sessionDb ?? "");
 const wordlistsDir =
@@ -162,7 +169,7 @@ async function main(): Promise<void> {
     console.error("Auditing structural patterns against all model-generated text");
     const structuralAudit = auditStructuralPatterns(allModelText, userRows);
 
-    const ruleHealth = buildRuleHealth(wordlistEntries, auditByTerm, minLift);
+    const ruleHealth = buildRuleHealth(wordlistEntries, auditByTerm, minCount);
 
     const report = renderReport({
       generatedAt: today,
@@ -171,6 +178,7 @@ async function main(): Promise<void> {
       modelFilter,
       projectFilter,
       minLift,
+      minCount,
       topN,
       modelSummary,
       assistantTotalChars: totalChars(assistantRows),

--- a/plugins/writing/skills/analyze/scripts/report.test.ts
+++ b/plugins/writing/skills/analyze/scripts/report.test.ts
@@ -11,6 +11,7 @@ const baseInput = {
   modelFilter: "*opus*",
   projectFilter: null,
   minLift: 5,
+  minCount: 5,
   topN: 10,
   modelSummary: [] as ModelSummaryRow[],
   assistantTotalChars: 0,
@@ -28,13 +29,14 @@ describe("buildRuleHealth", () => {
     { phrase: "missing entry", source: "openers.txt" },
   ];
 
-  test("marks an entry with no data when audit row is missing", () => {
+  test("marks a missing audit row as dead (no occurrences)", () => {
     const result = buildRuleHealth(entries, new Map(), 5);
     expect(result[1]?.noData).toBe(true);
-    expect(result[1]?.stillDistinctive).toBe(false);
+    expect(result[1]?.status).toBe("remove");
+    expect(result[1]?.removeReason).toBe("dead");
   });
 
-  test("marks an entry with no data when counts are zero", () => {
+  test("marks an entry with zero counts as dead", () => {
     const audit = new Map<string, FtsAuditRow>();
     audit.set("let me", {
       term: "let me",
@@ -46,10 +48,11 @@ describe("buildRuleHealth", () => {
     });
     const result = buildRuleHealth(entries, audit, 5);
     expect(result[0]?.noData).toBe(true);
-    expect(result[0]?.stillDistinctive).toBe(false);
+    expect(result[0]?.status).toBe("remove");
+    expect(result[0]?.removeReason).toBe("dead");
   });
 
-  test("computes lift from FTS audit and decides distinctiveness", () => {
+  test("keeps a rule the model uses more than the user", () => {
     const audit = new Map<string, FtsAuditRow>();
     audit.set("let me", {
       term: "let me",
@@ -60,23 +63,55 @@ describe("buildRuleHealth", () => {
       lift: 10,
     });
     const result = buildRuleHealth(entries, audit, 5);
-    expect(result[0]?.noData).toBe(false);
-    expect(result[0]?.stillDistinctive).toBe(true);
+    expect(result[0]?.status).toBe("keep");
+    expect(result[0]?.removeReason).toBeNull();
     expect(result[0]?.lift).toBeCloseTo(10, 0);
   });
 
-  test("proposes removal when lift drops below threshold", () => {
+  test("keeps a rare-but-distinctive rule even when lift reads low", () => {
+    // The model uses it, the user never does, but the smoothed baseline
+    // compresses lift below the additions threshold. It must still be kept.
+    const audit = new Map<string, FtsAuditRow>();
+    audit.set("let me", {
+      term: "let me",
+      assistant_count: 32,
+      user_count: 0,
+      assistant_per_m: 296.8,
+      user_per_m: 0,
+      lift: 3.0,
+    });
+    const result = buildRuleHealth(entries, audit, 5);
+    expect(result[0]?.status).toBe("keep");
+  });
+
+  test("removes a rule the user uses at least as much (not distinctive)", () => {
     const audit = new Map<string, FtsAuditRow>();
     audit.set("let me", {
       term: "let me",
       assistant_count: 10,
-      user_count: 5,
-      assistant_per_m: 1000,
-      user_per_m: 500,
-      lift: 2,
+      user_count: 40,
+      assistant_per_m: 100,
+      user_per_m: 200,
+      lift: 0.5,
     });
     const result = buildRuleHealth(entries, audit, 5);
-    expect(result[0]?.stillDistinctive).toBe(false);
+    expect(result[0]?.status).toBe("remove");
+    expect(result[0]?.removeReason).toBe("not distinctive");
+  });
+
+  test("removes a rule below the occurrence floor (dead)", () => {
+    const audit = new Map<string, FtsAuditRow>();
+    audit.set("let me", {
+      term: "let me",
+      assistant_count: 2,
+      user_count: 0,
+      assistant_per_m: 18.5,
+      user_per_m: 0,
+      lift: 0.2,
+    });
+    const result = buildRuleHealth(entries, audit, 5);
+    expect(result[0]?.status).toBe("remove");
+    expect(result[0]?.removeReason).toBe("dead");
   });
 });
 
@@ -103,7 +138,8 @@ describe("renderReport", () => {
           assistantPerM: 50,
           userPerM: 100,
           lift: 0.5,
-          stillDistinctive: false,
+          status: "remove",
+          removeReason: "not distinctive",
           noData: false,
         },
       ],
@@ -163,24 +199,26 @@ describe("renderReport", () => {
           assistantPerM: 100,
           userPerM: 20,
           lift: 5,
-          stillDistinctive: true,
+          status: "keep",
+          removeReason: null,
           noData: false,
         },
         {
-          entry: { phrase: "delve into", source: "vocabulary.txt" },
+          entry: { phrase: "tapestry", source: "vocabulary.txt" },
           assistantCount: 5,
           userCount: 1,
           assistantPerM: 50,
           userPerM: 10,
           lift: 5,
-          stillDistinctive: true,
+          status: "keep",
+          removeReason: null,
           noData: false,
         },
       ],
     });
     expect(output).toContain("| type |");
     expect(output).toMatch(/Perfect.*opener/);
-    expect(output).toMatch(/delve into.*vocabulary/);
+    expect(output).toMatch(/tapestry.*vocabulary/);
   });
 
   test("orders sections: summary, removals, additions, health", () => {

--- a/plugins/writing/skills/analyze/scripts/report.ts
+++ b/plugins/writing/skills/analyze/scripts/report.ts
@@ -12,6 +12,8 @@ export interface FtsAuditRow {
   lift: number | null;
 }
 
+export type RemoveReason = "dead" | "not distinctive";
+
 export interface CurrentRuleHealth {
   entry: WordlistEntry;
   assistantCount: number;
@@ -19,7 +21,8 @@ export interface CurrentRuleHealth {
   assistantPerM: number | null;
   userPerM: number | null;
   lift: number | null;
-  stillDistinctive: boolean;
+  status: "keep" | "remove";
+  removeReason: RemoveReason | null;
   noData: boolean;
 }
 
@@ -30,6 +33,7 @@ export interface ReportInput {
   modelFilter: string;
   projectFilter: string | null;
   minLift: number;
+  minCount: number;
   topN: number;
   modelSummary: ModelSummaryRow[];
   assistantTotalChars: number;
@@ -62,13 +66,17 @@ function renderHeader(input: ReportInput): string {
     `Window: ${input.since} to ${input.until}`,
     `Model filter: \`${input.modelFilter}\``,
     `Project filter: ${project}`,
-    `Min lift threshold: ${fmtLift(input.minLift)}`,
+    `Min lift threshold (additions): ${fmtLift(input.minLift)}`,
+    `Min occurrences to count as alive: ${input.minCount}`,
     `Top N candidates: ${input.topN}`,
   ].join("\n");
 }
 
 function renderSummary(input: ReportInput): string {
-  const removals = input.ruleHealth.filter((r) => !r.noData && !r.stillDistinctive).length;
+  const removable = input.ruleHealth.filter((r) => r.status === "remove");
+  const dead = removable.filter((r) => r.removeReason === "dead").length;
+  const notDistinctive = removable.filter((r) => r.removeReason === "not distinctive").length;
+  const keep = input.ruleHealth.length - removable.length;
   const lines = [
     "## Summary",
     "",
@@ -76,7 +84,8 @@ function renderSummary(input: ReportInput): string {
     `- Deliverable prose (Write/Edit/Bash): ${fmtNum(input.deliverableTotalChars)} chars`,
     `- User text (human only): ${fmtNum(input.userTotalChars)} chars`,
     `- Current wordlist entries audited: ${input.ruleHealth.length}`,
-    `- Proposed removals (collapsed lift): ${removals}`,
+    `- Rules kept (distinctive and alive): ${keep}`,
+    `- Proposed removals: ${removable.length} (dead: ${dead}, not distinctive: ${notDistinctive})`,
     `- Proposed additions (new candidates above threshold): ${input.candidatePhrases.length}`,
     `- Correction candidates surfaced: ${input.corrections.length}`,
   ];
@@ -97,26 +106,35 @@ function renderProposedRemovals(input: ReportInput): string {
   const lines = [
     "## Proposed Wordlist Removals",
     "",
-    "Rules whose assistant-vs-user lift dropped below the threshold.",
+    "Two reasons a rule earns removal:",
+    "",
+    `- **dead**: the model produced it fewer than ${input.minCount} times in the window, so the rule rarely fires.`,
+    "- **not distinctive**: the user uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.",
+    "",
+    "A rule the model uses far more than the user is **kept** even when its lift reads low, because the smoothed user baseline (see methodology) compresses lift for any word the user never types.",
     "",
   ];
   const removable = input.ruleHealth
-    .filter((r) => !r.noData && !r.stillDistinctive)
-    .sort((a, b) => (a.lift ?? 0) - (b.lift ?? 0));
+    .filter((r) => r.status === "remove")
+    .sort(
+      (a, b) =>
+        reasonRank(a.removeReason) - reasonRank(b.removeReason) ||
+        (a.assistantPerM ?? 0) - (b.assistantPerM ?? 0),
+    );
   if (removable.length === 0) {
     lines.push("_No removals proposed._");
     return lines.join("\n");
   }
-  lines.push("| phrase | source | assistant/M | user/M | lift |");
-  lines.push("| --- | --- | --- | --- | --- |");
+  lines.push("| phrase | source | reason | assistant/M | user/M | lift |");
+  lines.push("| --- | --- | --- | --- | --- | --- |");
   for (const r of removable) {
     lines.push(
-      `| \`${esc(r.entry.phrase)}\` | ${r.entry.source} | ${fmtPerM(r.assistantPerM)} | ${fmtPerM(r.userPerM)} | ${fmtLift(r.lift)} |`,
+      `| \`${esc(r.entry.phrase)}\` | ${r.entry.source} | ${r.removeReason} | ${fmtPerM(r.assistantPerM)} | ${fmtPerM(r.userPerM)} | ${fmtLift(r.lift)} |`,
     );
   }
   lines.push("", "```diff");
   for (const r of removable) {
-    lines.push(`- ${r.entry.phrase}  # was lift=${fmtLift(r.lift)}, source=${r.entry.source}`);
+    lines.push(`- ${r.entry.phrase}  # ${r.removeReason}, source=${r.entry.source}`);
   }
   lines.push("```");
   return lines.join("\n");
@@ -152,7 +170,7 @@ function renderRuleHealthTable(input: ReportInput): string {
   const lines = [
     "## Current Rule Health",
     "",
-    "Full audit of every wordlist entry. Check phrases with marginal lift.",
+    "Full audit of every wordlist entry. `remove` rules are either dead or not distinctive (see Proposed Removals).",
     "",
   ];
   if (input.ruleHealth.length === 0) {
@@ -162,7 +180,7 @@ function renderRuleHealthTable(input: ReportInput): string {
   lines.push("| phrase | source | type | assistant/M | user/M | lift | status |");
   lines.push("| --- | --- | --- | --- | --- | --- | --- |");
   for (const r of input.ruleHealth) {
-    const status = r.noData ? "no data" : r.stillDistinctive ? "keep" : "remove";
+    const status = r.status === "keep" ? "keep" : `remove (${r.removeReason})`;
     const ruleType = ruleTypeLabel(r.entry.source);
     lines.push(
       `| \`${esc(r.entry.phrase)}\` | ${r.entry.source} | ${ruleType} | ${fmtPerM(r.assistantPerM)} | ${fmtPerM(r.userPerM)} | ${fmtLift(r.lift)} | ${status} |`,
@@ -219,33 +237,48 @@ function renderCorrections(input: ReportInput): string {
 export function buildRuleHealth(
   entries: WordlistEntry[],
   auditByTerm: Map<string, FtsAuditRow>,
-  minLift: number,
+  minCount: number,
 ): CurrentRuleHealth[] {
   return entries.map((entry) => {
     const row = auditByTerm.get(entry.phrase.toLowerCase());
-    if (!row || (row.assistant_count === 0 && row.user_count === 0)) {
-      return {
-        entry,
-        assistantCount: 0,
-        userCount: 0,
-        assistantPerM: null,
-        userPerM: null,
-        lift: null,
-        stillDistinctive: false,
-        noData: true,
-      };
+    const assistantCount = row?.assistant_count ?? 0;
+    const userCount = row?.user_count ?? 0;
+    const assistantPerM = row?.assistant_per_m ?? null;
+    const userPerM = row?.user_per_m ?? null;
+    const lift = row?.lift ?? null;
+    const noData = !row || (assistantCount === 0 && userCount === 0);
+
+    const alive = assistantCount >= minCount;
+    const distinctive = (assistantPerM ?? 0) > (userPerM ?? 0);
+
+    let status: "keep" | "remove" = "keep";
+    let removeReason: RemoveReason | null = null;
+    if (!alive) {
+      status = "remove";
+      removeReason = "dead";
+    } else if (!distinctive) {
+      status = "remove";
+      removeReason = "not distinctive";
     }
+
     return {
       entry,
-      assistantCount: row.assistant_count,
-      userCount: row.user_count,
-      assistantPerM: row.assistant_per_m,
-      userPerM: row.user_per_m,
-      lift: row.lift,
-      stillDistinctive: row.lift !== null && row.lift >= minLift,
-      noData: false,
+      assistantCount,
+      userCount,
+      assistantPerM,
+      userPerM,
+      lift,
+      status,
+      removeReason,
+      noData,
     };
   });
+}
+
+function reasonRank(reason: RemoveReason | null): number {
+  if (reason === "dead") return 0;
+  if (reason === "not distinctive") return 1;
+  return 2;
 }
 
 function fmtNum(value: number | null): string {

--- a/plugins/writing/skills/analyze/scripts/report.ts
+++ b/plugins/writing/skills/analyze/scripts/report.ts
@@ -298,7 +298,8 @@ function fmtLift(value: number | null): string {
 
 function ruleTypeLabel(source: string): string {
   if (source === "openers.txt") return "opener";
-  if (source === "marketing-verbs.txt") return "weighted";
+  if (source === "marketing-verbs.txt" || source === "soft-phrasing.txt") return "weighted";
+  if (source === "flowery-phrases.txt") return "phrase";
   return "vocabulary";
 }
 

--- a/plugins/writing/skills/analyze/scripts/structural.ts
+++ b/plugins/writing/skills/analyze/scripts/structural.ts
@@ -9,7 +9,10 @@ export interface StructuralPattern {
 }
 
 function globalize(pattern: RegExp): RegExp {
-  return pattern.flags.includes("g") ? pattern : new RegExp(pattern.source, `${pattern.flags}g`);
+  return new RegExp(
+    pattern.source,
+    pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`,
+  );
 }
 
 // Derived from the hook's regex patterns so the audit cannot drift from what

--- a/plugins/writing/skills/analyze/scripts/structural.ts
+++ b/plugins/writing/skills/analyze/scripts/structural.ts
@@ -1,5 +1,5 @@
-const FENCED_CODE = /```[\s\S]*?```/g;
-const INLINE_CODE = /`[^`]+`/g;
+import { PATTERNS, stripCode } from "../../../hooks/tropes";
+import { WORDLISTS } from "../../../hooks/wordlists";
 
 export interface StructuralPattern {
   category: string;
@@ -8,50 +8,24 @@ export interface StructuralPattern {
   sideEffectOnly?: boolean;
 }
 
-export const STRUCTURAL_PATTERNS: StructuralPattern[] = [
-  { category: "spaced em dash", pattern: / — /g },
-  { category: "copula avoidance", pattern: /\b(?:serves|stands) as\b/gi },
-  { category: "reaching for", pattern: /\breach(?:ing|es|ed)?\s+for\b/gi },
-  {
-    category: "promotional language",
-    pattern: /\b(boasts|vibrant|showcasing|nestled|groundbreaking|renowned|diverse array)\b/gi,
-  },
-  { category: "parallelism", pattern: /\bnot (?:just|only) .{1,50}, but (?:also )?/gi },
-  {
-    category: "cross-sentence not-X",
-    pattern:
-      /\b(it|this|that|he|she|they|we|you)\s+(?:is|are|was|were)(?:n't|\s+not)\s+[^.!?]{1,80}[.!?]\s+\1\s+(?:is|are|was|were)\b/gi,
-  },
-  { category: "semicolon overuse", pattern: /;[^;]*;[^;]*;/g, fileOnly: true },
-  {
-    category: "passive PR summary",
-    pattern:
-      /\b(?:is|was|are|were)\s+(?:added|updated|removed|refactored|introduced|created|deleted|modified|improved)\b/gi,
-    fileOnly: true,
-  },
-  { category: "tests cover preamble", pattern: /^Tests\s+(?:cover|verify|ensure|validate)\b/gm },
-  { category: "path bullet", pattern: /^\s*-\s*\*\*[^*\n]+\*\*\s*:\s*/gm, fileOnly: true },
-  {
-    category: "trailing hedge",
-    pattern: /\b(?:regardless|nonetheless|anyway)\.\s*(?:$|\n)/gim,
-    fileOnly: true,
-  },
-  { category: "label bold", pattern: /^\s*\*\*[A-Z][A-Za-z ]+(?::\*\*|\*\*:)\s/gm, fileOnly: true },
-  { category: "dig into", pattern: /\b(?:dig|dive|wade)\s+into\b/gi },
-  { category: "hedging observation", pattern: /\b(?:looks|appears|seems)\s+(?:like|to)\b/gi },
-  {
-    category: "sycophantic acknowledgment",
-    pattern: /\byou(?:'re|\s+are)\s+(?:absolutely\s+|completely\s+)?right\b/gi,
-    sideEffectOnly: true,
-  },
-  { category: "permission-seeking", pattern: /\bwant\s+me\s+to\s+\w+/gi, sideEffectOnly: true },
-  { category: "hedging close", pattern: /\bwould\s+you\s+like\b/gi, sideEffectOnly: true },
-  { category: "I understand", pattern: /\bi\s+understand\b/gi, sideEffectOnly: true },
-];
-
-function stripCode(text: string): string {
-  return text.replace(FENCED_CODE, "").replace(INLINE_CODE, "");
+function globalize(pattern: RegExp): RegExp {
+  return pattern.flags.includes("g") ? pattern : new RegExp(pattern.source, `${pattern.flags}g`);
 }
+
+// Derived from the hook's regex patterns so the audit cannot drift from what
+// the hook enforces. Wordlist-backed and function tests are excluded: stemmed
+// vocabulary and weighted verbs are covered by the FTS pass, openers compile to
+// WORDLISTS.openers (also FTS-covered), and function tests cannot be counted by
+// a single regex match.
+export const STRUCTURAL_PATTERNS: StructuralPattern[] = PATTERNS.filter(
+  (def): def is typeof def & { test: RegExp } =>
+    def.test instanceof RegExp && def.test !== WORDLISTS.openers,
+).map((def) => ({
+  category: def.category,
+  pattern: globalize(def.test),
+  fileOnly: def.fileOnly ?? false,
+  sideEffectOnly: def.sideEffectOnly ?? false,
+}));
 
 function countHits(text: string, pattern: RegExp): number {
   pattern.lastIndex = 0;

--- a/plugins/writing/skills/rewrite/SKILL.md
+++ b/plugins/writing/skills/rewrite/SKILL.md
@@ -6,6 +6,9 @@ description: >-
   before sending. Strips AI voice, slop, and filler while preserving meaning.
 user-invocable: true
 context: fork
+allowed-tools:
+  - Bash
+  - Read
 ---
 
 # Rewrite
@@ -18,11 +21,11 @@ $ARGUMENTS
 
 Read input from one of these sources, checked in order:
 
-#### File path
+#### File Path
 
 If `$ARGUMENTS` is a path to an existing file, read the file contents.
 
-#### Inline text
+#### Inline Text
 
 If `$ARGUMENTS` contains text, use it directly.
 
@@ -30,16 +33,30 @@ If `$ARGUMENTS` contains text, use it directly.
 
 If `$ARGUMENTS` is empty, read from the clipboard with `pbpaste`.
 
+## Lint
+
+Before and after rewriting, run the lint script to find violations:
+
+```bash
+echo "<text>" | bun ${CLAUDE_SKILL_DIR}/scripts/lint.ts
+```
+
+Or pass a file path directly:
+
+```bash
+bun ${CLAUDE_SKILL_DIR}/scripts/lint.ts path/to/file.md
+```
+
+The script outputs one violation per line (`line:col: category: message`). Fix every reported violation. Re-run until the output is clean.
+
 ## Rewriting
 
-Read the wordlist files referenced in [references/style-rules.md](references/style-rules.md), then apply every rule. Focus on:
+Fix all lint violations, then apply the structural rules from [references/style-rules.md](references/style-rules.md):
 
-- Replacing banned vocabulary and promotional language with natural alternatives
-- Removing filler phrases and hedging
 - Breaking long compound sentences into shorter ones
 - Converting passive voice to active
 - Cutting sentences that restate previous ones
-- Removing sycophantic openers
+- Removing filler phrases and hedging
 
 Do not add, remove, or restructure the content's meaning. The output should convey the same information in fewer, clearer words.
 

--- a/plugins/writing/skills/rewrite/SKILL.md
+++ b/plugins/writing/skills/rewrite/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: writing:rewrite
+description: >-
+  Rewrite text in direct, concise style. Use when you have functional content
+  (an explanation, a draft message, notes) that needs to read as polished prose
+  before sending. Strips AI voice, slop, and filler while preserving meaning.
+user-invocable: true
+context: fork
+---
+
+# Rewrite
+
+Rewrite input text to match the style rules in [references/style-rules.md](references/style-rules.md). Preserve all functional information. Change only voice, word choice, and sentence structure.
+
+## Input
+
+$ARGUMENTS
+
+Read input from one of these sources, checked in order:
+
+#### File path
+
+If `$ARGUMENTS` is a path to an existing file, read the file contents.
+
+#### Inline text
+
+If `$ARGUMENTS` contains text, use it directly.
+
+#### Clipboard
+
+If `$ARGUMENTS` is empty, read from the clipboard with `pbpaste`.
+
+## Rewriting
+
+Apply every rule in [references/style-rules.md](references/style-rules.md). Focus on:
+
+- Replacing banned vocabulary and promotional language with natural alternatives
+- Removing filler phrases and hedging
+- Breaking long compound sentences into shorter ones
+- Converting passive voice to active
+- Cutting sentences that restate previous ones
+- Removing sycophantic openers
+
+Do not add, remove, or restructure the content's meaning. The output should convey the same information in fewer, clearer words.
+
+## Output
+
+Display the rewritten text directly. Do not wrap it in a code block unless the input was code.
+
+If the user asks, copy the result to the clipboard with `pbcopy`.

--- a/plugins/writing/skills/rewrite/SKILL.md
+++ b/plugins/writing/skills/rewrite/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: writing:rewrite
 description: >-
-  Rewrite text in direct, concise style. Use when you have functional content
-  (an explanation, a draft message, notes) that needs to read as polished prose
-  before sending. Strips AI voice, slop, and filler while preserving meaning.
+  Rewrite a draft message, explanation, or note to strip AI voice, slop, and
+  filler while preserving meaning. Use to polish functional prose before
+  sending.
+argument-hint: "[file path or text; omit to read input from the clipboard]"
 user-invocable: true
 context: fork
 allowed-tools:
@@ -19,7 +20,7 @@ Rewrite input text to match the style rules in [references/style-rules.md](refer
 
 $ARGUMENTS
 
-Read input from one of these sources, checked in order:
+Read input from one of these sources:
 
 #### File Path
 
@@ -29,9 +30,7 @@ If `$ARGUMENTS` is a path to an existing file, read the file contents.
 
 If `$ARGUMENTS` contains text, use it directly.
 
-#### Clipboard
-
-If `$ARGUMENTS` is empty, read from the clipboard with `pbpaste`.
+If `$ARGUMENTS` is empty, ask for the text to rewrite. You may offer to read it from the clipboard.
 
 ## Lint
 
@@ -64,4 +63,4 @@ Do not add, remove, or restructure the content's meaning. The output should conv
 
 Display the rewritten text directly. Do not wrap it in a code block unless the input was code.
 
-If the user asks, copy the result to the clipboard with `pbcopy`.
+If the user asks, copy the result to the clipboard.

--- a/plugins/writing/skills/rewrite/SKILL.md
+++ b/plugins/writing/skills/rewrite/SKILL.md
@@ -32,7 +32,7 @@ If `$ARGUMENTS` is empty, read from the clipboard with `pbpaste`.
 
 ## Rewriting
 
-Apply every rule in [references/style-rules.md](references/style-rules.md). Focus on:
+Read the wordlist files referenced in [references/style-rules.md](references/style-rules.md), then apply every rule. Focus on:
 
 - Replacing banned vocabulary and promotional language with natural alternatives
 - Removing filler phrases and hedging

--- a/plugins/writing/skills/rewrite/SKILL.md
+++ b/plugins/writing/skills/rewrite/SKILL.md
@@ -46,11 +46,15 @@ Or pass a file path directly:
 bun ${CLAUDE_SKILL_DIR}/scripts/lint.ts path/to/file.md
 ```
 
-The script outputs one violation per line (`line:col: category: message`). Fix every reported violation. Re-run until the output is clean.
+The script outputs one finding per line (`line:col: category: message`).
+
+Fix every hard tell (em dash, copula avoidance, hedging, filler, vocabulary, and the other fixed-phrase categories), then re-run until those are clean.
+
+Treat `marketing verb` findings as advisory. The script flags each one, but the live hook only objects when their weighted sum is high enough, so a lone marketing verb may be fine. Consider each in context and replace the ones that read as promotional rather than driving the count to zero.
 
 ## Rewriting
 
-Fix all lint violations, then apply the structural rules from [references/style-rules.md](references/style-rules.md):
+Clear the lint findings as described above, then apply the structural rules from [references/style-rules.md](references/style-rules.md):
 
 - Breaking long compound sentences into shorter ones
 - Converting passive voice to active

--- a/plugins/writing/skills/rewrite/references/style-rules.md
+++ b/plugins/writing/skills/rewrite/references/style-rules.md
@@ -9,17 +9,11 @@ Rules for rewriting text in direct, concise style. Rewritten text must pass all 
 - Specific verbs over vague ones. "Generates a report" not "handles report generation."
 - Every sentence teaches the reader something new. Cut sentences that restate what came before.
 
-## Banned Vocabulary
+## Vocabulary
 
-These words are AI tells. Replace them with natural alternatives:
+Read `plugins/writing/wordlists/vocabulary.txt` for the full banned word list. These are AI tells. Replace every occurrence with a natural alternative.
 
-- delve, tapestry, landscape (figurative), meticulous/meticulously
-- pivotal, testament, underscore (figurative), interplay, intricacies
-- bolstered, garner/garnered, foster/fostering
-
-## Banned Promotional Language
-
-- boasts, vibrant, showcasing, nestled, groundbreaking, renowned, diverse array
+Read `plugins/writing/wordlists/marketing-verbs.txt` for promotional verbs to avoid. These are weighted by severity. Replace with concrete, specific verbs.
 
 ## Copula Avoidance
 
@@ -30,7 +24,7 @@ Do not replace "is" or "are" with fancier constructions:
 
 ## Em Dashes
 
-Never use spaced em dashes (` — `). Rewrite with commas, colons, parentheses, or periods. Unspaced em dashes are acceptable but less common in natural writing.
+Never use spaced em dashes (` — `). Rewrite with commas, colons, parentheses, or periods.
 
 ## Parallelism
 
@@ -57,14 +51,7 @@ Cut filler phrases that add no information:
 
 ## Openers
 
-Do not start with sycophantic or formulaic openers:
-
-- "Great question"
-- "Absolutely"
-- "That's a great point"
-- "Sure thing"
-
-Start with the substance.
+Do not start with sycophantic or formulaic openers. Read `plugins/writing/wordlists/openers.txt` for the full list. Start with the substance.
 
 ## Tone
 

--- a/plugins/writing/skills/rewrite/references/style-rules.md
+++ b/plugins/writing/skills/rewrite/references/style-rules.md
@@ -1,6 +1,6 @@
 # Style Rules
 
-Rules for rewriting text in direct, concise style. Rewritten text must pass all of these.
+Structural rules for rewriting text. Vocabulary and pattern violations are caught by the lint script. These rules cover sentence-level concerns the linter cannot check.
 
 ## Sentence Structure
 
@@ -9,34 +9,9 @@ Rules for rewriting text in direct, concise style. Rewritten text must pass all 
 - Specific verbs over vague ones. "Generates a report" not "handles report generation."
 - Every sentence teaches the reader something new. Cut sentences that restate what came before.
 
-## Vocabulary
-
-Read `plugins/writing/wordlists/vocabulary.txt` for the full banned word list. These are AI tells. Replace every occurrence with a natural alternative.
-
-Read `plugins/writing/wordlists/marketing-verbs.txt` for promotional verbs to avoid. These are weighted by severity. Replace with concrete, specific verbs.
-
-## Copula Avoidance
-
-Do not replace "is" or "are" with fancier constructions:
-
-- "serves as" -> "is"
-- "stands as" -> "is"
-
-## Em Dashes
-
-Never use spaced em dashes (` — `). Rewrite with commas, colons, parentheses, or periods.
-
-## Parallelism
-
-Avoid "not just X, but also Y" and similar constructions. State both things directly.
-
 ## Semicolons
 
 Limit to one per paragraph at most. Prefer splitting into separate sentences.
-
-## Hedging
-
-Do not hedge. "Looks like", "appears to", "seems to", "might be" all weaken the statement. State directly, or name the specific uncertainty.
 
 ## Filler
 
@@ -48,10 +23,6 @@ Cut filler phrases that add no information:
 - "It should be noted"
 - "As mentioned"
 - "In terms of"
-
-## Openers
-
-Do not start with sycophantic or formulaic openers. Read `plugins/writing/wordlists/openers.txt` for the full list. Start with the substance.
 
 ## Tone
 

--- a/plugins/writing/skills/rewrite/references/style-rules.md
+++ b/plugins/writing/skills/rewrite/references/style-rules.md
@@ -1,0 +1,71 @@
+# Style Rules
+
+Rules for rewriting text in direct, concise style. Rewritten text must pass all of these.
+
+## Sentence Structure
+
+- Short sentences. One idea per sentence.
+- Active voice. Name the subject and verb.
+- Specific verbs over vague ones. "Generates a report" not "handles report generation."
+- Every sentence teaches the reader something new. Cut sentences that restate what came before.
+
+## Banned Vocabulary
+
+These words are AI tells. Replace them with natural alternatives:
+
+- delve, tapestry, landscape (figurative), meticulous/meticulously
+- pivotal, testament, underscore (figurative), interplay, intricacies
+- bolstered, garner/garnered, foster/fostering
+
+## Banned Promotional Language
+
+- boasts, vibrant, showcasing, nestled, groundbreaking, renowned, diverse array
+
+## Copula Avoidance
+
+Do not replace "is" or "are" with fancier constructions:
+
+- "serves as" -> "is"
+- "stands as" -> "is"
+
+## Em Dashes
+
+Never use spaced em dashes (` — `). Rewrite with commas, colons, parentheses, or periods. Unspaced em dashes are acceptable but less common in natural writing.
+
+## Parallelism
+
+Avoid "not just X, but also Y" and similar constructions. State both things directly.
+
+## Semicolons
+
+Limit to one per paragraph at most. Prefer splitting into separate sentences.
+
+## Hedging
+
+Do not hedge. "Looks like", "appears to", "seems to", "might be" all weaken the statement. State directly, or name the specific uncertainty.
+
+## Filler
+
+Cut filler phrases that add no information:
+
+- "It's worth noting that"
+- "Importantly"
+- "Interestingly"
+- "It should be noted"
+- "As mentioned"
+- "In terms of"
+
+## Openers
+
+Do not start with sycophantic or formulaic openers:
+
+- "Great question"
+- "Absolutely"
+- "That's a great point"
+- "Sure thing"
+
+Start with the substance.
+
+## Tone
+
+Write as if the reader is a peer. Conversational, not formal. No marketing language. No excessive enthusiasm.

--- a/plugins/writing/skills/rewrite/scripts/lint.ts
+++ b/plugins/writing/skills/rewrite/scripts/lint.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env bun
+import { stemmer } from "stemmer";
+import { WORDLISTS, weightedStemHits } from "../../../hooks/wordlists";
+
+const WORD_TOKEN = /[a-zA-Z]+/g;
+
+type Violation = {
+  line: number;
+  col: number;
+  category: string;
+  matched: string;
+  message: string;
+};
+
+type InlinePattern = {
+  category: string;
+  pattern: RegExp;
+  message: (matched: string) => string;
+};
+
+const INLINE_PATTERNS: InlinePattern[] = [
+  {
+    category: "spaced em dash",
+    pattern: / — /g,
+    message: () => "Use commas, colons, or parentheses instead of spaced em dashes.",
+  },
+  {
+    category: "copula avoidance",
+    pattern: /\b(?:serves|stands) as\b/gi,
+    message: (m) => `Replace "${m}" with "is" or "are".`,
+  },
+  {
+    category: "reaching for",
+    pattern: /\breach(?:ing|es|ed)?\s+for\b/gi,
+    message: () => `Use "use" or "prefer X over Y" instead.`,
+  },
+  {
+    category: "parallelism",
+    pattern: /\bnot (?:just|only) .{1,50}, but (?:also )?/gi,
+    message: () => "State both things directly.",
+  },
+  {
+    category: "hedging",
+    pattern: /\b(?:looks|appears|seems)\s+(?:like|to)\b/gi,
+    message: (m) => `"${m}" hedges. State directly or name the uncertainty.`,
+  },
+  {
+    category: "dig into",
+    pattern: /\b(?:dig|dive|wade)\s+into\b/gi,
+    message: () => "Describe what you're looking at.",
+  },
+  {
+    category: "promotional",
+    pattern: /\b(boasts|vibrant|showcasing|nestled|groundbreaking|renowned|diverse array)\b/gi,
+    message: (m) => `"${m}" is promotional. Use a neutral alternative.`,
+  },
+  {
+    category: "trailing hedge",
+    pattern: /\b(?:regardless|nonetheless|anyway)\.\s*$/gim,
+    message: (m) => `"${m.trim()}" dangles. Drop it or rewrite.`,
+  },
+  {
+    category: "filler",
+    pattern:
+      /\b(?:it's worth noting that|importantly|interestingly|it should be noted|as mentioned|in terms of)\b/gi,
+    message: (m) => `"${m}" is filler. Cut it.`,
+  },
+];
+
+function lintLine(line: string, lineNum: number, stripped: string): Violation[] {
+  const violations: Violation[] = [];
+
+  for (const { category, pattern, message } of INLINE_PATTERNS) {
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(stripped)) !== null) {
+      violations.push({
+        line: lineNum,
+        col: match.index + 1,
+        category,
+        matched: match[0],
+        message: message(match[0]),
+      });
+    }
+  }
+
+  return violations;
+}
+
+async function lintVocabulary(lines: string[], strippedLines: string[]): Promise<Violation[]> {
+  const violations: Violation[] = [];
+  const vocabStems = new Set<string>();
+  const vocabFile = Bun.file(
+    `${import.meta.dirname}/../../../wordlists/vocabulary.txt`,
+  );
+
+  const content = await vocabFile.text();
+  for (const raw of content.split(/\r?\n/)) {
+    const trimmed = raw.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    for (const word of trimmed.toLowerCase().match(WORD_TOKEN) ?? []) {
+      vocabStems.add(stemmer(word));
+    }
+  }
+
+  for (let i = 0; i < strippedLines.length; i++) {
+    const words = strippedLines[i].match(WORD_TOKEN) ?? [];
+    let col = 0;
+    for (const word of words) {
+      const idx = strippedLines[i].indexOf(word, col);
+      if (vocabStems.has(stemmer(word.toLowerCase()))) {
+        violations.push({
+          line: i + 1,
+          col: idx + 1,
+          category: "vocabulary",
+          matched: word,
+          message: `"${word}" is AI-typical vocabulary. Use a natural alternative.`,
+        });
+      }
+      col = idx + word.length;
+    }
+  }
+
+  return violations;
+}
+
+function lintMarketingVerbs(strippedLines: string[]): Violation[] {
+  const violations: Violation[] = [];
+
+  for (let i = 0; i < strippedLines.length; i++) {
+    const words = strippedLines[i].match(WORD_TOKEN) ?? [];
+    let col = 0;
+    for (const word of words) {
+      const idx = strippedLines[i].indexOf(word, col);
+      const stem = stemmer(word.toLowerCase());
+      const entry = WORDLISTS.marketingVerbs.find((e) => e.stem === stem);
+      if (entry) {
+        violations.push({
+          line: i + 1,
+          col: idx + 1,
+          category: "marketing verb",
+          matched: word,
+          message: `"${word}" is a marketing verb (weight ${entry.weight}). Use a concrete alternative.`,
+        });
+      }
+      col = idx + word.length;
+    }
+  }
+
+  return violations;
+}
+
+const FENCED_CODE = /```[\s\S]*?```/g;
+const INLINE_CODE = /`[^`]+`/g;
+
+function stripCode(text: string): string {
+  return text
+    .replace(FENCED_CODE, (m) => "\n".repeat(m.split("\n").length - 1))
+    .replace(INLINE_CODE, (m) => " ".repeat(m.length));
+}
+
+async function main(): Promise<void> {
+  let input: string;
+  const arg = process.argv[2];
+
+  if (arg && (await Bun.file(arg).exists())) {
+    input = await Bun.file(arg).text();
+  } else if (arg) {
+    input = arg;
+  } else {
+    input = await new Response(Bun.stdin.stream()).text();
+  }
+
+  const stripped = stripCode(input);
+  const lines = input.split("\n");
+  const strippedLines = stripped.split("\n");
+
+  const violations: Violation[] = [];
+
+  for (let i = 0; i < strippedLines.length; i++) {
+    violations.push(...lintLine(lines[i], i + 1, strippedLines[i]));
+  }
+
+  violations.push(...(await lintVocabulary(lines, strippedLines)));
+  violations.push(...lintMarketingVerbs(strippedLines));
+
+  violations.sort((a, b) => a.line - b.line || a.col - b.col);
+
+  if (violations.length === 0) {
+    console.log("No violations found.");
+    process.exit(0);
+  }
+
+  for (const v of violations) {
+    console.log(`${v.line}:${v.col}: ${v.category}: ${v.message}`);
+  }
+
+  process.exit(1);
+}
+
+await main();

--- a/plugins/writing/skills/rewrite/scripts/lint.ts
+++ b/plugins/writing/skills/rewrite/scripts/lint.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env bun
+import { join } from "node:path";
 import { stemmer } from "stemmer";
+
+const WORDLISTS_DIR = join(import.meta.dirname, "..", "..", "..", "wordlists");
 
 const WORD_TOKEN = /[a-zA-Z]+/g;
 
@@ -50,7 +53,7 @@ const INLINE_PATTERNS: InlinePattern[] = [
   },
   {
     category: "promotional",
-    pattern: /\b(boasts|vibrant|showcasing|nestled|groundbreaking|renowned|diverse array)\b/gi,
+    pattern: /\b(?:boasts|vibrant|showcasing|nestled|groundbreaking|renowned|diverse array)\b/gi,
     message: (m) => `"${m}" is promotional. Use a neutral alternative.`,
   },
   {
@@ -88,7 +91,7 @@ function lintLine(lineNum: number, stripped: string): Violation[] {
 async function lintVocabulary(strippedLines: string[]): Promise<Violation[]> {
   const violations: Violation[] = [];
   const vocabStems = new Set<string>();
-  const vocabFile = Bun.file(`${import.meta.dirname}/../../../wordlists/vocabulary.txt`);
+  const vocabFile = Bun.file(join(WORDLISTS_DIR, "vocabulary.txt"));
 
   const content = await vocabFile.text();
   for (const raw of content.split(/\r?\n/)) {
@@ -125,9 +128,7 @@ type WeightedEntry = { stem: string; weight: number };
 const WEIGHTED_LINE = /^(\S+)\s+([0-9]+(?:\.[0-9]+)?)$/;
 
 async function loadMarketingVerbs(): Promise<WeightedEntry[]> {
-  const content = await Bun.file(
-    `${import.meta.dirname}/../../../wordlists/marketing-verbs.txt`,
-  ).text();
+  const content = await Bun.file(join(WORDLISTS_DIR, "marketing-verbs.txt")).text();
   const entries: WeightedEntry[] = [];
   for (const raw of content.split(/\r?\n/)) {
     const trimmed = raw.trim();

--- a/plugins/writing/skills/rewrite/scripts/lint.ts
+++ b/plugins/writing/skills/rewrite/scripts/lint.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env bun
 import { stemmer } from "stemmer";
-import { WORDLISTS, weightedStemHits } from "../../../hooks/wordlists";
 
 const WORD_TOKEN = /[a-zA-Z]+/g;
 
@@ -67,13 +66,12 @@ const INLINE_PATTERNS: InlinePattern[] = [
   },
 ];
 
-function lintLine(line: string, lineNum: number, stripped: string): Violation[] {
+function lintLine(lineNum: number, stripped: string): Violation[] {
   const violations: Violation[] = [];
 
   for (const { category, pattern, message } of INLINE_PATTERNS) {
     pattern.lastIndex = 0;
-    let match: RegExpExecArray | null;
-    while ((match = pattern.exec(stripped)) !== null) {
+    for (let match = pattern.exec(stripped); match !== null; match = pattern.exec(stripped)) {
       violations.push({
         line: lineNum,
         col: match.index + 1,
@@ -87,12 +85,10 @@ function lintLine(line: string, lineNum: number, stripped: string): Violation[] 
   return violations;
 }
 
-async function lintVocabulary(lines: string[], strippedLines: string[]): Promise<Violation[]> {
+async function lintVocabulary(strippedLines: string[]): Promise<Violation[]> {
   const violations: Violation[] = [];
   const vocabStems = new Set<string>();
-  const vocabFile = Bun.file(
-    `${import.meta.dirname}/../../../wordlists/vocabulary.txt`,
-  );
+  const vocabFile = Bun.file(`${import.meta.dirname}/../../../wordlists/vocabulary.txt`);
 
   const content = await vocabFile.text();
   for (const raw of content.split(/\r?\n/)) {
@@ -124,7 +120,30 @@ async function lintVocabulary(lines: string[], strippedLines: string[]): Promise
   return violations;
 }
 
-function lintMarketingVerbs(strippedLines: string[]): Violation[] {
+type WeightedEntry = { stem: string; weight: number };
+
+const WEIGHTED_LINE = /^(\S+)\s+([0-9]+(?:\.[0-9]+)?)$/;
+
+async function loadMarketingVerbs(): Promise<WeightedEntry[]> {
+  const content = await Bun.file(
+    `${import.meta.dirname}/../../../wordlists/marketing-verbs.txt`,
+  ).text();
+  const entries: WeightedEntry[] = [];
+  for (const raw of content.split(/\r?\n/)) {
+    const trimmed = raw.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const match = WEIGHTED_LINE.exec(trimmed);
+    if (!match) continue;
+    entries.push({
+      stem: stemmer((match[1] ?? "").toLowerCase()),
+      weight: Number.parseFloat(match[2] ?? "0"),
+    });
+  }
+  return entries;
+}
+
+async function lintMarketingVerbs(strippedLines: string[]): Promise<Violation[]> {
+  const entries = await loadMarketingVerbs();
   const violations: Violation[] = [];
 
   for (let i = 0; i < strippedLines.length; i++) {
@@ -133,7 +152,7 @@ function lintMarketingVerbs(strippedLines: string[]): Violation[] {
     for (const word of words) {
       const idx = strippedLines[i].indexOf(word, col);
       const stem = stemmer(word.toLowerCase());
-      const entry = WORDLISTS.marketingVerbs.find((e) => e.stem === stem);
+      const entry = entries.find((e) => e.stem === stem);
       if (entry) {
         violations.push({
           line: i + 1,
@@ -171,18 +190,19 @@ async function main(): Promise<void> {
     input = await new Response(Bun.stdin.stream()).text();
   }
 
-  const stripped = stripCode(input);
-  const lines = input.split("\n");
-  const strippedLines = stripped.split("\n");
+  const strippedLines = stripCode(input).split("\n");
 
   const violations: Violation[] = [];
 
   for (let i = 0; i < strippedLines.length; i++) {
-    violations.push(...lintLine(lines[i], i + 1, strippedLines[i]));
+    violations.push(...lintLine(i + 1, strippedLines[i]));
   }
 
-  violations.push(...(await lintVocabulary(lines, strippedLines)));
-  violations.push(...lintMarketingVerbs(strippedLines));
+  const [vocabViolations, marketingViolations] = await Promise.all([
+    lintVocabulary(strippedLines),
+    lintMarketingVerbs(strippedLines),
+  ]);
+  violations.push(...vocabViolations, ...marketingViolations);
 
   violations.sort((a, b) => a.line - b.line || a.col - b.col);
 

--- a/plugins/writing/skills/rewrite/scripts/lint.ts
+++ b/plugins/writing/skills/rewrite/scripts/lint.ts
@@ -103,10 +103,11 @@ async function lintVocabulary(strippedLines: string[]): Promise<Violation[]> {
   }
 
   for (let i = 0; i < strippedLines.length; i++) {
-    const words = strippedLines[i].match(WORD_TOKEN) ?? [];
+    const line = strippedLines[i] ?? "";
+    const words = line.match(WORD_TOKEN) ?? [];
     let col = 0;
     for (const word of words) {
-      const idx = strippedLines[i].indexOf(word, col);
+      const idx = line.indexOf(word, col);
       if (vocabStems.has(stemmer(word.toLowerCase()))) {
         violations.push({
           line: i + 1,
@@ -148,10 +149,11 @@ async function lintMarketingVerbs(strippedLines: string[]): Promise<Violation[]>
   const violations: Violation[] = [];
 
   for (let i = 0; i < strippedLines.length; i++) {
-    const words = strippedLines[i].match(WORD_TOKEN) ?? [];
+    const line = strippedLines[i] ?? "";
+    const words = line.match(WORD_TOKEN) ?? [];
     let col = 0;
     for (const word of words) {
-      const idx = strippedLines[i].indexOf(word, col);
+      const idx = line.indexOf(word, col);
       const stem = stemmer(word.toLowerCase());
       const entry = entries.find((e) => e.stem === stem);
       if (entry) {
@@ -196,7 +198,7 @@ async function main(): Promise<void> {
   const violations: Violation[] = [];
 
   for (let i = 0; i < strippedLines.length; i++) {
-    violations.push(...lintLine(i + 1, strippedLines[i]));
+    violations.push(...lintLine(i + 1, strippedLines[i] ?? ""));
   }
 
   const [vocabViolations, marketingViolations] = await Promise.all([

--- a/plugins/writing/skills/rewrite/scripts/lint.ts
+++ b/plugins/writing/skills/rewrite/scripts/lint.ts
@@ -2,7 +2,10 @@
 import { join } from "node:path";
 import { stemmer } from "stemmer";
 
-const WORDLISTS_DIR = join(import.meta.dirname, "..", "..", "..", "wordlists");
+const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+const WORDLISTS_DIR = pluginRoot
+  ? join(pluginRoot, "wordlists")
+  : join(import.meta.dirname, "..", "..", "..", "wordlists");
 
 const WORD_TOKEN = /[a-zA-Z]+/g;
 

--- a/plugins/writing/wordlists/flowery-phrases.txt
+++ b/plugins/writing/wordlists/flowery-phrases.txt
@@ -1,20 +1,4 @@
-# Flowery multi-word phrases the model reaches for in deliverable prose.
-# One phrase per line. Matching stems each word (Porter) and looks for the
-# stemmed token sequence, so inflection, spacing, and hyphenation are caught
-# automatically. "sources of truth", "source-of-truth", and "Source Of Truth"
-# all match "source of truth". "fails loudly" matches "fail loudly". A
-# context-tier reminder fires on the first occurrence in introduced prose.
-#
-# Added from the hand-written PR-body baseline (writing:analyze). Each phrase
-# appears in the model's PR/MR/commit bodies and zero times across the user's
-# 209 pre-AI pull requests. These are distinctive enough to flag on a single
-# use. The softer single-word tells live in soft-phrasing.txt.
-#
-# Matching is a stemmed subsequence scan: robust, exact, no false positives in
-# benchmarking. If this list ever grows into the thousands via mining, the
-# documented word-interior n-gram prefilter (see references/methodology.md) is a
-# transparent accelerator. At present scale the per-invocation process floor
-# dwarfs match time, so the plain scan is preferred.
+# Flowery multi-word phrases, one per line. Stemmed subsequence match catches inflection, spacing, and hyphenation.
 source of truth
 escape hatch
 self-sufficient

--- a/plugins/writing/wordlists/flowery-phrases.txt
+++ b/plugins/writing/wordlists/flowery-phrases.txt
@@ -1,0 +1,21 @@
+# Flowery multi-word phrases the model reaches for in deliverable prose.
+# One phrase per line. Matching stems each word (Porter) and looks for the
+# stemmed token sequence, so inflection, spacing, and hyphenation are caught
+# automatically. "sources of truth", "source-of-truth", and "Source Of Truth"
+# all match "source of truth". "fails loudly" matches "fail loudly". A
+# context-tier reminder fires on the first occurrence in introduced prose.
+#
+# Added from the hand-written PR-body baseline (writing:analyze). Each phrase
+# appears in the model's PR/MR/commit bodies and zero times across the user's
+# 209 pre-AI pull requests. These are distinctive enough to flag on a single
+# use. The softer single-word tells live in soft-phrasing.txt.
+#
+# Matching is a stemmed subsequence scan: robust, exact, no false positives in
+# benchmarking. If this list ever grows into the thousands via mining, the
+# documented word-interior n-gram prefilter (see references/methodology.md) is a
+# transparent accelerator. At present scale the per-invocation process floor
+# dwarfs match time, so the plain scan is preferred.
+source of truth
+escape hatch
+self-sufficient
+fail loudly

--- a/plugins/writing/wordlists/marketing-verbs.txt
+++ b/plugins/writing/wordlists/marketing-verbs.txt
@@ -1,16 +1,5 @@
-# Marketing/promotional verbs, weighted by promotional intensity.
-# Format: <word> <weight>
-# Matching uses a Porter stemmer, so inflected forms are caught automatically.
-# A context-tier reminder fires when the sum of weighted hits in the
-# introduced text reaches the threshold defined in tropes.ts.
-#
-# Curated against session history by writing:analyze. Every verb here is one the
-# model writes in deliverables and the user never does. `simplify` was dropped
-# because the user writes it far more than the model (normal engineering
-# vocabulary, not promotional). `enhance` and `streamline` were resurfaced once a
-# larger cross-machine corpus showed the model still produces them. Weights are
-# tuned so any two marketing verbs in one passage clear the threshold; a lone
-# verb does not.
+# Marketing/promotional verbs, weighted by intensity. Format: <word> <weight>
+# Stemmed; fires when weighted hits reach the threshold in tropes.ts.
 empower 2.5
 enhance 1.5
 streamline 1.5

--- a/plugins/writing/wordlists/marketing-verbs.txt
+++ b/plugins/writing/wordlists/marketing-verbs.txt
@@ -4,21 +4,10 @@
 # A context-tier reminder fires when the sum of weighted hits in the
 # introduced text reaches the threshold defined in tropes.ts.
 #
-# Promotional and vague verbs (high weight).
+# Curated against session history by writing:analyze. Removed verbs the user
+# uses as much as the model (enable, transform, optimize, unlock, generalize)
+# and verbs the model rarely produces now (streamline, elevate, enhance). With
+# only two entries the list fires only when both stack; revisit the mechanism
+# if it stays inert.
 empower 2.5
-streamline 2.5
-generalize 2.5
-#
-# Figurative motion verbs (medium-high weight).
-unlock 2.0
-elevate 2.0
-#
-# Borderline figurative; commonly legitimate but worth counting.
-transform 1.5
-enhance 1.5
-optimize 1.2
-#
-# Often legitimate technical usage; low weight so they accumulate only
-# when stacked with stronger entries.
-enable 0.8
 simplify 0.8

--- a/plugins/writing/wordlists/marketing-verbs.txt
+++ b/plugins/writing/wordlists/marketing-verbs.txt
@@ -4,10 +4,13 @@
 # A context-tier reminder fires when the sum of weighted hits in the
 # introduced text reaches the threshold defined in tropes.ts.
 #
-# Curated against session history by writing:analyze. Removed verbs the user
-# uses as much as the model (enable, transform, optimize, unlock, generalize)
-# and verbs the model rarely produces now (streamline, elevate, enhance). With
-# only two entries the list fires only when both stack; revisit the mechanism
-# if it stays inert.
+# Curated against session history by writing:analyze. Every verb here is one the
+# model writes in deliverables and the user never does. `simplify` was dropped
+# because the user writes it far more than the model (normal engineering
+# vocabulary, not promotional). `enhance` and `streamline` were resurfaced once a
+# larger cross-machine corpus showed the model still produces them. Weights are
+# tuned so any two marketing verbs in one passage clear the threshold; a lone
+# verb does not.
 empower 2.5
-simplify 0.8
+enhance 1.5
+streamline 1.5

--- a/plugins/writing/wordlists/openers.txt
+++ b/plugins/writing/wordlists/openers.txt
@@ -3,7 +3,6 @@
 # punctuation or comma. See wordlists.ts loader for compilation rules.
 #
 # Curated against session history by writing:analyze. Entries the user uses as
-# much as the model (Great, Absolutely) or that the model has stopped producing
-# (Wonderful, Fantastic, Amazing, Awesome, Brilliant) were removed.
-Perfect
+# much as the model (Great, Absolutely, Perfect) or that the model has stopped
+# producing (Wonderful, Fantastic, Amazing, Awesome, Brilliant) were removed.
 Excellent

--- a/plugins/writing/wordlists/openers.txt
+++ b/plugins/writing/wordlists/openers.txt
@@ -1,12 +1,9 @@
 # Sycophantic affirmation openers at line/sentence start.
 # Matched at the start of a line (or after a newline) followed by terminal
 # punctuation or comma. See wordlists.ts loader for compilation rules.
+#
+# Curated against session history by writing:analyze. Entries the user uses as
+# much as the model (Great, Absolutely) or that the model has stopped producing
+# (Wonderful, Fantastic, Amazing, Awesome, Brilliant) were removed.
 Perfect
 Excellent
-Great
-Wonderful
-Absolutely
-Fantastic
-Amazing
-Awesome
-Brilliant

--- a/plugins/writing/wordlists/soft-phrasing.txt
+++ b/plugins/writing/wordlists/soft-phrasing.txt
@@ -1,0 +1,19 @@
+# Soft phrasing tells, weighted by how strongly they read as filler.
+# Format: <word> <weight>
+# Matching uses a Porter stemmer, so inflected forms are caught automatically.
+# A context-tier reminder fires when the sum of weighted hits in the introduced
+# text reaches the threshold defined in tropes.ts, so a lone benign use never
+# fires.
+#
+# Added from the hand-written PR-body baseline (writing:analyze): the model
+# writes `cleanly` far more than the user (0 of the user's 209 pre-AI PRs) and
+# it has legitimate uses ("strips cleanly"), so it is weighted to fire only when
+# it stacks rather than on a single occurrence.
+#
+# `owns` and `carries` were considered and rejected: the verb forms are absent
+# from the user's PRs, but the stem `own` also matches the possessive "its own"
+# (14 uses in the baseline), so the bare stem would flag the user's own voice.
+# The audit agrees (not distinctive). The ownership metaphor ("code owns its X")
+# is a real deliverable tell but needs a precise matcher, deferred to the
+# deliverable-aware audit work.
+cleanly 1.5

--- a/plugins/writing/wordlists/soft-phrasing.txt
+++ b/plugins/writing/wordlists/soft-phrasing.txt
@@ -1,19 +1,3 @@
-# Soft phrasing tells, weighted by how strongly they read as filler.
-# Format: <word> <weight>
-# Matching uses a Porter stemmer, so inflected forms are caught automatically.
-# A context-tier reminder fires when the sum of weighted hits in the introduced
-# text reaches the threshold defined in tropes.ts, so a lone benign use never
-# fires.
-#
-# Added from the hand-written PR-body baseline (writing:analyze): the model
-# writes `cleanly` far more than the user (0 of the user's 209 pre-AI PRs) and
-# it has legitimate uses ("strips cleanly"), so it is weighted to fire only when
-# it stacks rather than on a single occurrence.
-#
-# `owns` and `carries` were considered and rejected: the verb forms are absent
-# from the user's PRs, but the stem `own` also matches the possessive "its own"
-# (14 uses in the baseline), so the bare stem would flag the user's own voice.
-# The audit agrees (not distinctive). The ownership metaphor ("code owns its X")
-# is a real deliverable tell but needs a precise matcher, deferred to the
-# deliverable-aware audit work.
+# Soft phrasing filler tells, weighted by strength. Format: <word> <weight>
+# Stemmed; fires when weighted hits reach the threshold in tropes.ts.
 cleanly 1.5

--- a/plugins/writing/wordlists/vocabulary.txt
+++ b/plugins/writing/wordlists/vocabulary.txt
@@ -1,43 +1,16 @@
 # Single-word AI vocabulary deny list.
 # One entry per line. Matching uses a Porter stemmer, so inflected forms
-# (e.g., "meticulously", "garnered") are caught automatically.
+# (e.g., "meticulously", "leveraged") are caught automatically.
 #
-# Original deny list.
+# Curated against session history by writing:analyze. Each entry below is one
+# the model uses far more than the user and still produces regularly. Words the
+# model has stopped using (landscape, paradigm, synergy, myriad, ...) were
+# removed as dead weight. The additions pipeline only surfaces multi-word
+# phrases, so a single word that regresses must be re-added by hand.
 delve
 tapestry
-landscape
 meticulous
-pivotal
-testament
-underscore
-interplay
-intricacies
-bolstered
-garner
-foster
-#
-# High-confidence additions sourced from sam-paech/slop-forensics
-# (https://github.com/sam-paech/slop-forensics). Filtered to entries that
-# match the user's correction history and avoid ambiguous technical terms.
-myriad
-plethora
-seamless
-revolutionary
-paradigm
-holistic
-synergy
 leverage
 robust
 comprehensive
 nuance
-realm
-resonate
-embrace
-unveil
-intricate
-embark
-elucidate
-multifaceted
-quintessential
-mosaic
-beacon

--- a/plugins/writing/wordlists/vocabulary.txt
+++ b/plugins/writing/wordlists/vocabulary.txt
@@ -1,12 +1,5 @@
-# Single-word AI vocabulary deny list.
-# One entry per line. Matching uses a Porter stemmer, so inflected forms
-# (e.g., "meticulously", "leveraged") are caught automatically.
-#
-# Curated against session history by writing:analyze. Each entry below is one
-# the model uses far more than the user and still produces regularly. Words the
-# model has stopped using (landscape, paradigm, synergy, myriad, ...) were
-# removed as dead weight. The additions pipeline only surfaces multi-word
-# phrases, so a single word that regresses must be re-added by hand.
+# Single-word AI vocabulary deny list, one entry per line.
+# Stemmed, so inflected forms (e.g., "meticulously", "leveraged") are caught.
 delve
 tapestry
 meticulous


### PR DESCRIPTION
Extends the writing plugin: a user-invoked `writing:rewrite` skill, fixes to `writing:analyze` so its curation is trustworthy and its candidate miner scans the surface the hook actually enforces, and a round of wordlist curation against a larger combined corpus that both prunes stale entries and adds PR-body tells.

## Rewrite skill

A user-invocable `writing:rewrite` skill that rewrites input text in direct, concise style. It accepts text from a file path, inline arguments, or the clipboard, and detects violations programmatically rather than loading wordlists into context.

#### Lint script (`scripts/lint.ts`)

A programmatic linter that intersects input text against the writing plugin's vocabulary, marketing verbs, and inline patterns (em dashes, copula avoidance, hedging). It reuses the Porter stemmer from `hooks/wordlists.ts` for vocabulary matching and outputs one violation per line as `line:col: category: message`, exiting non-zero when it finds any. The agent runs it before and after rewriting.

#### Skill definition (`SKILL.md`)

Input resolution (file path, inline text, clipboard via `pbpaste`), instructions to run the lint script, and structural rewriting guidance. The skill runs in `context: fork` so it operates in a sidechain.

#### Style rules (`references/style-rules.md`)

Trimmed to structural rules only: sentence structure, semicolons, filler phrases, tone. Anything the lint script detects programmatically is gone from the reference file.

<details>
<summary>Why programmatic linting instead of loading the wordlists</summary>

Having the agent read `wordlists/*.txt` to learn what to avoid wastes tokens on a full vocabulary dump and shows the model the exact words we want it to avoid, which risks steering it toward them. The lint script runs the same stemmer-based matching as the hook but reports only the violations present in the input, so the agent sees `line 3: vocabulary: 'delve' is AI-typical` and fixes it without ever reading the list.
</details>

## Analyze fixes

Three changes so `writing:analyze` recommends the right edits against the surface the hook enforces.

#### Keep/remove no longer uses lift

A rule is kept when the model uses it more per token than the user and it clears a `--min-count` floor (new flag, default 5). Otherwise the report removes it as **dead** (too rare to fire) or **not distinctive** (the user uses it as often). Lift drove this before, but the human baseline is small, so Laplace smoothing puts a high floor on the lift denominator: any word the user never types reads as low lift regardless of how often the model writes it. That gate flagged `delve`, `Perfect`, and `robust` for removal. The direct rate comparison keeps them.

#### Structural audit sourced from the hook

`structural.ts` now imports the hook's `PATTERNS` from `hooks/tropes.ts` and filters to the non-wordlist regexes, instead of a hand-copied list that had already drifted and under-reported. The audit can no longer diverge from what the hook enforces.

#### Candidate miner scoped to deliverable prose

The n-gram candidate miner now reads only deliverable prose (file writes and Bash commit/PR/MR bodies), not conversational assistant text. The hook scans deliverables and side-effect inputs, never chat, so mining chat flooded the candidate list with narration ("now let me", "let me check") at high lift that no rule can act on.

## Wordlist curation

Re-runs the corrected audit against a larger combined corpus (cross-machine history merged in #662) and curates in both directions.

#### Prune and refine

The earlier prune (53 entries to 11) holds against the larger baseline: every surviving entry audits as distinctive. Two refinements fell out. `Perfect` left the openers list because the user says it as an acknowledgment about as often as the model. In the marketing verbs, `simplify` left (normal engineering vocabulary the user writes more than the model) and `enhance`/`streamline` came back once the larger corpus showed the model still produces them.

#### PR-body tells

Adds tells found by comparing the model's PR bodies against the user's hand-written, pre-AI pull requests, where each phrase appears zero times:

- `flowery-phrases.txt`: distinctive multi-word phrasing (`source of truth`, `escape hatch`, `self-sufficient`, `fail loudly`). Matching stems each word and looks for the stemmed token sequence, so inflection, hyphenation, and case are caught (`sources of truth`, `source-of-truth`, `fails loudly`). A context-tier reminder fires on the first match.
- `soft-phrasing.txt`: `cleanly`, weighted so it fires only when it stacks rather than on a single legitimate use.

Both rules are `fileOnly`, so code is never flagged. The verbs `owns`/`carries` were considered and rejected: the bare stem also matches the possessive "its own", which the baseline uses, so the rule would flag the user's own voice. Matching is a plain stemmed subsequence scan, which benchmarks at full recall with no false positives. A word-interior n-gram prefilter is documented as the scaling lever for if a mined list ever reaches thousands of entries.

#### Known limitation

The audit measures `text_content` (chat), so it cannot see tells that live only in deliverables. It reports the new phrase tells as `dead` (zero chat hits). The methodology reference notes this. Auditing wordlist health against the deliverable corpus directly is follow-up work.

## Test plan

- [ ] `echo "delve into the intricacies" | bun plugins/writing/skills/rewrite/scripts/lint.ts` reports violations
- [ ] Clean text exits 0 with "No violations found."
- [ ] Code blocks are excluded from scanning
- [ ] `/writing:rewrite` with inline text runs the linter, fixes violations, and re-lints clean
- [ ] `/writing:rewrite path/to/file.md` reads and rewrites file contents
- [ ] `/writing:rewrite` with no args reads from the clipboard
- [ ] `bun test plugins/writing` exercises the removal logic, pruned wordlists, and new matchers
- [ ] `writing:analyze` proposes no removals against the kept entries
