### PR TITLE
fix(ui-design): share browser instance across render-html tests

### DIFF
--- a/plugins/ui-design/skills/wireframe/scripts/render-html.integration.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/render-html.integration.ts
@@ -2,17 +2,23 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 
+import { type Browser, chromium } from "playwright";
+
 import { renderFile } from "./render-html";
 
 const fixturesDir = path.join(import.meta.dirname, "fixtures");
 const tmpDir = path.join(import.meta.dirname, "..", "tmp");
 
 describe("render-html", () => {
+  let browser: Browser;
+
   beforeAll(async () => {
     await mkdir(tmpDir, { recursive: true });
+    browser = await chromium.launch();
   });
 
   afterAll(async () => {
+    await browser?.close();
     await rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -20,7 +26,7 @@ describe("render-html", () => {
     const inputPath = path.join(fixturesDir, "simple-wireframe.html");
     const outputPath = path.join(tmpDir, "simple-wireframe.png");
 
-    const result = await renderFile(inputPath, outputPath);
+    const result = await renderFile(inputPath, outputPath, { browser });
 
     expect(result.input).toContain(".html");
     expect(result.output).toContain(".png");
@@ -34,7 +40,7 @@ describe("render-html", () => {
     const inputPath = path.join(fixturesDir, "simple-wireframe.html");
     const outputPath = path.join(tmpDir, "simple-wireframe@2x.png");
 
-    const result = await renderFile(inputPath, outputPath, { scale: 2 });
+    const result = await renderFile(inputPath, outputPath, { scale: 2, browser });
 
     expect(result.scale).toBe(2);
     expect(result.output).toContain("@2x.png");
@@ -47,13 +53,17 @@ describe("render-html", () => {
     const inputPath = path.join(fixturesDir, "no-root-div.html");
     const outputPath = path.join(tmpDir, "no-root-div.png");
 
-    await expect(renderFile(inputPath, outputPath)).rejects.toThrow("No root div found in HTML");
+    await expect(renderFile(inputPath, outputPath, { browser })).rejects.toThrow(
+      "No root div found in HTML",
+    );
   });
 
   it("throws when bounding box is null", async () => {
     const inputPath = path.join(fixturesDir, "hidden-div.html");
     const outputPath = path.join(tmpDir, "hidden-div.png");
 
-    await expect(renderFile(inputPath, outputPath)).rejects.toThrow("Could not get bounding box");
+    await expect(renderFile(inputPath, outputPath, { browser })).rejects.toThrow(
+      "Could not get bounding box",
+    );
   });
 });

--- a/plugins/ui-design/skills/wireframe/scripts/render-html.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/render-html.ts
@@ -1,10 +1,11 @@
 import { extname, resolve } from "node:path";
 
 import { cli } from "cleye";
-import { chromium } from "playwright";
+import { type Browser, chromium } from "playwright";
 
 export interface RenderOptions {
   scale?: number;
+  browser?: Browser;
 }
 
 export interface RenderResult {
@@ -23,7 +24,8 @@ export async function renderFile(
   const absInput = resolve(inputPath);
   const output = outputPath ?? absInput.replace(/\.html$/, `${suffix}.png`);
 
-  const browser = await chromium.launch();
+  const owned = !options.browser;
+  const browser = options.browser ?? (await chromium.launch());
   try {
     const page = await browser.newPage();
     await page.goto(`file://${absInput}`, { waitUntil: "domcontentloaded" });
@@ -50,7 +52,9 @@ export async function renderFile(
 
     return { input: inputPath, output, scale };
   } finally {
-    await browser.close();
+    if (owned) {
+      await browser.close();
+    }
   }
 }
 


### PR DESCRIPTION
Each `renderFile` call launched a separate Chromium process. The 2x scale test launched a second browser, which under CI load pushed past the 5s default timeout.

- Add optional `browser` field to `RenderOptions` so callers can pass in a shared instance
- When `browser` is provided, `renderFile` reuses it and skips closing it
- When omitted, behavior is unchanged (launch and close per call)
- Tests now share a single browser via `beforeAll`/`afterAll`

## Test plan
- [ ] CI passes (integration tests run in the `ui-design` matrix job)

Closes #646