### PR TITLE
enforce plugin import boundaries in CI and Stop hook

### DIFF
--- a/.claude/hooks/plugin-imports/index.ts
+++ b/.claude/hooks/plugin-imports/index.ts
@@ -1,47 +1,31 @@
 #!/usr/bin/env bun
 
 import { join } from "node:path";
-import type { StopHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { StopHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
-export async function processInput(input: StopHookInput): Promise<SyncHookJSONOutput | null> {
-  if (input.hook_event_name !== "Stop" || input.stop_hook_active) return null;
+const input = await readStdinJson<StopHookInput>();
+if (input.hook_event_name !== "Stop" || input.stop_hook_active) process.exit(0);
 
-  const scriptPath = join(import.meta.dirname, "..", "..", "scripts", "check-plugin-imports.ts");
-  const proc = Bun.spawn(["bun", scriptPath], {
-    cwd: input.cwd,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+const scriptPath = join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "..",
+  "scripts",
+  "check-plugin-imports.ts",
+);
+const proc = Bun.spawn(["bun", scriptPath], {
+  cwd: input.cwd,
+  stdout: "pipe",
+  stderr: "pipe",
+});
 
-  const exitCode = await proc.exited;
-  if (exitCode === 0) return null;
+const exitCode = await proc.exited;
+if (exitCode === 0) process.exit(0);
 
-  const stderr = await new Response(proc.stderr).text();
-
-  return {
-    decision: "block",
-    reason: `Cross-plugin imports detected:\n\n${stderr}\n\nFix these imports before stopping. Plugins must not import from outside their own directory.`,
-  };
-}
-
-async function main(): Promise<void> {
-  let input: StopHookInput;
-  try {
-    input = await readStdinJson<StopHookInput>();
-  } catch (error) {
-    console.error(
-      `[plugin-imports] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return;
-  }
-
-  const output = await processInput(input);
-  if (output) {
-    writeStdoutJson(output);
-  }
-}
-
-if (import.meta.main) {
-  main().catch(console.error);
-}
+const stderr = await new Response(proc.stderr).text();
+writeStdoutJson({
+  decision: "block",
+  reason: `Cross-plugin imports detected:\n\n${stderr}\n\nFix these imports before stopping. Plugins must not import from outside their own directory.`,
+});

--- a/.claude/hooks/plugin-imports/index.ts
+++ b/.claude/hooks/plugin-imports/index.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env bun
+
+import { join } from "node:path";
+import type { StopHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+
+interface TranscriptEntry {
+  type?: string;
+  message?: {
+    content?: Array<{
+      type: string;
+      name?: string;
+      input?: { file_path?: string };
+    }>;
+  };
+}
+
+export function extractPluginDir(filePath: string, projectDir: string): string | null {
+  const prefix = `${join(projectDir, "plugins")}/`;
+  if (!filePath.startsWith(prefix)) return null;
+
+  const rest = filePath.slice(prefix.length);
+  const pluginName = rest.split("/")[0];
+  if (!pluginName) return null;
+
+  return join(projectDir, "plugins", pluginName);
+}
+
+export async function getAffectedPlugins(
+  input: StopHookInput,
+  projectDir: string,
+): Promise<string[]> {
+  const transcriptPath = input.transcript_path;
+  const file = Bun.file(transcriptPath);
+  if (!(await file.exists())) return [];
+
+  const content = await file.text();
+  const pluginDirs = new Set<string>();
+
+  for (const line of content.split("\n")) {
+    if (!line.trim()) continue;
+
+    try {
+      const entry = JSON.parse(line) as TranscriptEntry;
+      if (entry.type !== "assistant" || !entry.message?.content) continue;
+
+      for (const block of entry.message.content) {
+        if (block.type !== "tool_use") continue;
+        if (block.name !== "Edit" && block.name !== "Write") continue;
+
+        const filePath = block.input?.file_path;
+        if (!filePath?.endsWith(".ts")) continue;
+
+        const pluginDir = extractPluginDir(filePath, projectDir);
+        if (pluginDir) pluginDirs.add(pluginDir);
+      }
+    } catch {}
+  }
+
+  return [...pluginDirs];
+}
+
+export async function processInput(input: StopHookInput): Promise<SyncHookJSONOutput | null> {
+  if (input.hook_event_name !== "Stop" || input.stop_hook_active) return null;
+
+  const projectDir = input.cwd;
+  const pluginDirs = await getAffectedPlugins(input, projectDir);
+  if (pluginDirs.length === 0) return null;
+
+  const scriptPath = join(import.meta.dirname, "..", "..", "scripts", "check-plugin-imports.ts");
+  const proc = Bun.spawn(["bun", scriptPath, ...pluginDirs], {
+    cwd: projectDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const exitCode = await proc.exited;
+  if (exitCode === 0) return null;
+
+  const stderr = await new Response(proc.stderr).text();
+
+  return {
+    decision: "block",
+    reason: `Cross-plugin imports detected:\n\n${stderr}\n\nFix these imports before stopping. Plugins must not import from outside their own directory.`,
+  };
+}
+
+async function main(): Promise<void> {
+  let input: StopHookInput;
+  try {
+    input = await readStdinJson<StopHookInput>();
+  } catch (error) {
+    console.error(
+      `[plugin-imports] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  const output = await processInput(input);
+  if (output) {
+    writeStdoutJson(output);
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/.claude/hooks/plugin-imports/index.ts
+++ b/.claude/hooks/plugin-imports/index.ts
@@ -4,72 +4,12 @@ import { join } from "node:path";
 import type { StopHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
-interface TranscriptEntry {
-  type?: string;
-  message?: {
-    content?: Array<{
-      type: string;
-      name?: string;
-      input?: { file_path?: string };
-    }>;
-  };
-}
-
-export function extractPluginDir(filePath: string, projectDir: string): string | null {
-  const prefix = `${join(projectDir, "plugins")}/`;
-  if (!filePath.startsWith(prefix)) return null;
-
-  const rest = filePath.slice(prefix.length);
-  const pluginName = rest.split("/")[0];
-  if (!pluginName) return null;
-
-  return join(projectDir, "plugins", pluginName);
-}
-
-export async function getAffectedPlugins(
-  input: StopHookInput,
-  projectDir: string,
-): Promise<string[]> {
-  const transcriptPath = input.transcript_path;
-  const file = Bun.file(transcriptPath);
-  if (!(await file.exists())) return [];
-
-  const content = await file.text();
-  const pluginDirs = new Set<string>();
-
-  for (const line of content.split("\n")) {
-    if (!line.trim()) continue;
-
-    try {
-      const entry = JSON.parse(line) as TranscriptEntry;
-      if (entry.type !== "assistant" || !entry.message?.content) continue;
-
-      for (const block of entry.message.content) {
-        if (block.type !== "tool_use") continue;
-        if (block.name !== "Edit" && block.name !== "Write") continue;
-
-        const filePath = block.input?.file_path;
-        if (!filePath?.endsWith(".ts")) continue;
-
-        const pluginDir = extractPluginDir(filePath, projectDir);
-        if (pluginDir) pluginDirs.add(pluginDir);
-      }
-    } catch {}
-  }
-
-  return [...pluginDirs];
-}
-
 export async function processInput(input: StopHookInput): Promise<SyncHookJSONOutput | null> {
   if (input.hook_event_name !== "Stop" || input.stop_hook_active) return null;
 
-  const projectDir = input.cwd;
-  const pluginDirs = await getAffectedPlugins(input, projectDir);
-  if (pluginDirs.length === 0) return null;
-
   const scriptPath = join(import.meta.dirname, "..", "..", "scripts", "check-plugin-imports.ts");
-  const proc = Bun.spawn(["bun", scriptPath, ...pluginDirs], {
-    cwd: projectDir,
+  const proc = Bun.spawn(["bun", scriptPath], {
+    cwd: input.cwd,
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -73,6 +73,10 @@
           },
           {
             "type": "command",
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/plugin-imports\""
+          },
+          {
+            "type": "command",
             "command": "PREK_HOME=\"$CLAUDE_PROJECT_DIR/.prek\" bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop\""
           }
         ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Check plugin dependencies
         run: bun scripts/check-plugin-deps.ts
 
+      - name: Check plugin imports
+        run: bun scripts/check-plugin-imports.ts
+
       - name: Check for unenabled plugins
         if: github.event_name == 'pull_request'
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,8 @@ The root `package.json` contains shared tooling (typescript) and dependencies us
 
 Avoid collecting all dependencies in the root package.json. Each plugin should be self-contained where practical.
 
+Plugins must not import from outside their own directory. No cross-plugin imports, no reaching into `packages/` or root-level modules via relative paths. If two plugins need shared code, extract it to an npm workspace package and declare the dependency in each plugin's `package.json`. Run `bun scripts/check-plugin-imports.ts` to verify.
+
 ### Bun
 
 Hooks and scripts use [Bun](https://bun.sh) to run TypeScript. Bun auto-installs missing dependencies on first run, eliminating the need to run `bun install` before executing scripts. This simplifies hook execution since hooks run in isolated contexts where `node_modules` may not be readily available.

--- a/scripts/check-plugin-imports.ts
+++ b/scripts/check-plugin-imports.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env bun
+
+import { readdir } from "node:fs/promises";
+import { dirname, join, resolve, relative } from "node:path";
+import { Glob } from "bun";
+
+const rootDir = join(import.meta.dirname, "..");
+const pluginsDir = join(rootDir, "plugins");
+const transpiler = new Bun.Transpiler({ loader: "ts" });
+
+async function getPluginDirs(): Promise<string[]> {
+  const args = process.argv.slice(2);
+  if (args.length > 0) {
+    return args.map((arg) => resolve(arg));
+  }
+
+  const entries = await readdir(pluginsDir, { withFileTypes: true });
+  return entries.filter((e) => e.isDirectory()).map((e) => join(pluginsDir, e.name));
+}
+
+async function checkPlugin(pluginDir: string): Promise<string[]> {
+  const violations: string[] = [];
+  const pluginName = relative(pluginsDir, pluginDir);
+  const glob = new Glob("**/*.ts");
+
+  for await (const path of glob.scan({ cwd: pluginDir })) {
+    if (path.includes("node_modules") || path.includes(".bun-cache")) continue;
+
+    const filePath = join(pluginDir, path);
+    let content = await Bun.file(filePath).text();
+    if (content.startsWith("#!")) {
+      const newline = content.indexOf("\n");
+      content = newline === -1 ? "" : content.slice(newline + 1);
+    }
+    const imports = transpiler.scanImports(content);
+
+    for (const imp of imports) {
+      if (!imp.path.startsWith(".")) continue;
+
+      const resolved = resolve(dirname(filePath), imp.path);
+
+      if (!resolved.startsWith(`${pluginDir}/`) && resolved !== pluginDir) {
+        const target = relative(rootDir, resolved);
+        violations.push(
+          `${pluginName}: ${path} imports outside plugin boundary: ${imp.path} → ${target}`,
+        );
+      }
+    }
+  }
+
+  return violations;
+}
+
+const pluginDirs = await getPluginDirs();
+const results = await Promise.all(pluginDirs.map(checkPlugin));
+const violations = results.flat();
+
+for (const v of violations) {
+  console.error(v);
+}
+
+if (violations.length > 0) {
+  process.exit(1);
+}

--- a/scripts/check-plugin-imports.ts
+++ b/scripts/check-plugin-imports.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { readdir } from "node:fs/promises";
-import { dirname, join, resolve, relative } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { Glob } from "bun";
 
 const rootDir = join(import.meta.dirname, "..");


### PR DESCRIPTION
Plugins must be independent modules, but Claude frequently introduces relative imports that reach across plugin boundaries. This adds enforcement at two levels: a CI check that scans all plugins on every PR, and a Stop hook that runs the same check before ending a session.

## Changes

- `scripts/check-plugin-imports.ts`: Uses `Bun.Transpiler.scanImports()` (SWC-based AST parser) to extract imports from each plugin's `.ts` files, resolves relative paths, and reports any that escape the plugin boundary. Accepts optional plugin directory arguments for targeted checking.
- `.claude/hooks/plugin-imports/index.ts`: Stop hook that runs the check script and blocks if violations exist.
- `.github/workflows/test.yml`: Adds a `Check plugin imports` step to the `validate` job.
- `CLAUDE.md`: Documents the cross-plugin import rule under Dependencies.
- `.claude/settings.json`: Registers the Stop hook.

## Testing

- `bun scripts/check-plugin-imports.ts` passes on the current codebase (no existing violations)
- `bun scripts/check-plugin-imports.ts plugins/git` checks a single plugin
- Cross-plugin imports (e.g., `plugins/git/` importing from `plugins/github/`) are correctly detected, including prefix collisions (`git` vs `github`)
- Ancestor imports (e.g., reaching into `packages/`) are detected
