### PR TITLE
plugin best practices: quote hook paths, add namespace lint, remove empty settings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,9 @@ jobs:
       - name: Check plugin imports
         run: bun scripts/check-plugin-imports.ts
 
+      - name: Check hook quoting
+        run: bun scripts/check-hook-quoting.ts
+
       - name: Check for unenabled plugins
         if: github.event_name == 'pull_request'
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,11 +39,9 @@ When creating or modifying skills, load the `claude-code:skill` skill for author
 
 ### Naming
 
-The plugin name forms a namespace for its contents (e.g., `gitlab:ci-monitor`). Commands and agents are auto-namespaced by the plugin system — the filename becomes the qualified name (e.g., `ci-monitor.md` in the `gitlab` plugin becomes `gitlab:ci-monitor`). Skills are **not** auto-namespaced — the `name` in YAML frontmatter is used as-is.
+The plugin name forms a namespace for its contents (e.g., `gitlab:ci-monitor`). Commands and agents are auto-namespaced by the plugin system — the filename becomes the qualified name (e.g., `ci-monitor.md` in the `gitlab` plugin becomes `gitlab:ci-monitor`). Skills are auto-prefixed with `plugin-name:` when the frontmatter `name` doesn't already start with that prefix. Including the prefix explicitly is optional but harmless (avoids double-prefixing).
 
-Skills where the name differs from the plugin name must include the `plugin-name:` prefix in frontmatter (e.g., `gitlab:ci`, `things:inbox`). Skip the prefix when name equals plugin name (the primary skill) — `bun:bun` adds no information.
-
-Anti-stuttering applies to the part after the colon: `gitlab:gitlab-ci` is wrong, `gitlab:ci` is right.
+Anti-stuttering applies to the part after the colon: `gitlab:gitlab-ci` is wrong, `gitlab:ci` is right. Run `bun run skill-lint` to catch namespace mismatches and stuttering.
 
 ### MCP Tool Naming
 
@@ -73,6 +71,10 @@ Each plugin should have a `README.md` with consistent sections:
 - **Testing**: How to run tests (if the plugin has tests)
 
 Do not include installation instructions or skill activation details—the README is an index, not documentation. Users can read the skill files directly for activation patterns.
+
+### Plugin Metadata
+
+Plugin `settings.json` only supports `agent` and `subagentStatusLine` keys. Don't create schema-only placeholder files. `plugin.json` supports an optional `"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json"` for editor autocomplete, and `displayName` for human-readable names in the UI.
 
 ### Dependencies
 
@@ -116,6 +118,8 @@ Use rules for language/file-type guidance that Claude should always have when wo
 ## Hooks
 
 See the `claude-code:hook` skill for hook documentation. Plugin hooks are defined in `hooks/hooks.json`. This repository includes a Biome PostToolUse hook (`.claude/hooks/biome/`) that runs after file edits to check for lint errors.
+
+Wrap `${CLAUDE_PLUGIN_ROOT}` in double quotes in shell-form hook commands: `bun "${CLAUDE_PLUGIN_ROOT}/scripts/foo.ts"`. Matcher fields are not shell commands and should not be quoted. Run `bun scripts/check-hook-quoting.ts` to validate.
 
 ## Testing
 
@@ -196,7 +200,7 @@ Permission patterns starting with `/` are relative to the settings file, not abs
 {
   "matcher": "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/:*)",
   "hooks": [
-    { "type": "command", "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/sandbox.ts" }
+    { "type": "command", "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/sandbox.ts\"" }
   ]
 }
 ```

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/rules/index.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/rules/index.ts
@@ -1,8 +1,14 @@
 import type { Rule } from "../types";
 import { bodyRules } from "./body";
 import { frontmatterRules } from "./frontmatter";
+import { namespaceRules } from "./namespace";
 import { tokenRules } from "./tokens";
 
-export const allRules: Rule[] = [...frontmatterRules, ...bodyRules, ...tokenRules];
+export const allRules: Rule[] = [
+  ...frontmatterRules,
+  ...namespaceRules,
+  ...bodyRules,
+  ...tokenRules,
+];
 
 export { findReferences, lintReference } from "./references";

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/rules/namespace.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/rules/namespace.ts
@@ -1,0 +1,98 @@
+import type { Rule, RuleResult, SkillContent } from "../types";
+
+function pluginName(skillPath: string): string | null {
+  const match = skillPath.match(/plugins\/([^/]+)\/skills\//);
+  return match?.[1] ?? null;
+}
+
+export const namespaceMismatch: Rule = {
+  name: "namespace-mismatch",
+  severity: "error",
+  check(content: SkillContent, path: string): RuleResult {
+    const name = content.frontmatter.name;
+    const plugin = pluginName(path);
+
+    if (typeof name !== "string" || !plugin) {
+      return {
+        rule: "namespace-mismatch",
+        severity: "error",
+        passed: true,
+        message: "skipped (no name or not in a plugin)",
+      };
+    }
+
+    const colonIndex = name.indexOf(":");
+    if (colonIndex === -1) {
+      return {
+        rule: "namespace-mismatch",
+        severity: "error",
+        passed: true,
+        message: "no namespace prefix",
+      };
+    }
+
+    const prefix = name.slice(0, colonIndex);
+    if (prefix !== plugin) {
+      return {
+        rule: "namespace-mismatch",
+        severity: "error",
+        passed: false,
+        message: `prefix "${prefix}:" does not match plugin "${plugin}"`,
+      };
+    }
+
+    return {
+      rule: "namespace-mismatch",
+      severity: "error",
+      passed: true,
+      message: `prefix matches plugin "${plugin}"`,
+    };
+  },
+};
+
+export const namespaceStutter: Rule = {
+  name: "namespace-stutter",
+  severity: "warn",
+  check(content: SkillContent, path: string): RuleResult {
+    const name = content.frontmatter.name;
+    const plugin = pluginName(path);
+
+    if (typeof name !== "string" || !plugin) {
+      return {
+        rule: "namespace-stutter",
+        severity: "warn",
+        passed: true,
+        message: "skipped (no name or not in a plugin)",
+      };
+    }
+
+    const colonIndex = name.indexOf(":");
+    if (colonIndex === -1) {
+      return {
+        rule: "namespace-stutter",
+        severity: "warn",
+        passed: true,
+        message: "no namespace prefix",
+      };
+    }
+
+    const suffix = name.slice(colonIndex + 1);
+    if (suffix.startsWith(`${plugin}-`)) {
+      return {
+        rule: "namespace-stutter",
+        severity: "warn",
+        passed: false,
+        message: `"${name}" stutters — "${suffix}" repeats the plugin name as a prefix`,
+      };
+    }
+
+    return {
+      rule: "namespace-stutter",
+      severity: "warn",
+      passed: true,
+      message: "no stuttering",
+    };
+  },
+};
+
+export const namespaceRules: Rule[] = [namespaceMismatch, namespaceStutter];

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
@@ -11,6 +11,7 @@ import {
   nameFormat,
   nameLength,
 } from "../rules/frontmatter";
+import { namespaceMismatch, namespaceStutter } from "../rules/namespace";
 import type { RuleResult } from "../types";
 
 const fixturesDir = path.join(import.meta.dirname, "fixtures");
@@ -210,6 +211,63 @@ describe("frontmatter rules", () => {
       const content = parseSkill("---\nallowed-tools: Bash(gh:*), mcp__github\n---\n");
       const result = single(allowedToolsFormat.check(content, ""));
       expect(result.passed).toBe(false);
+    });
+  });
+});
+
+describe("namespace rules", () => {
+  const pluginPath = (plugin: string) => `plugins/${plugin}/skills/some-skill`;
+
+  describe("namespaceMismatch", () => {
+    it("passes when prefix matches plugin", () => {
+      const content = parseSkill("---\nname: github:actions\n---\n");
+      const result = single(namespaceMismatch.check(content, pluginPath("github")));
+      expect(result.passed).toBe(true);
+    });
+
+    it("passes when no prefix", () => {
+      const content = parseSkill("---\nname: actions\n---\n");
+      const result = single(namespaceMismatch.check(content, pluginPath("github")));
+      expect(result.passed).toBe(true);
+    });
+
+    it("fails when prefix mismatches plugin", () => {
+      const content = parseSkill("---\nname: gitlab:foo\n---\n");
+      const result = single(namespaceMismatch.check(content, pluginPath("github")));
+      expect(result.passed).toBe(false);
+    });
+
+    it("skips when not in a plugin directory", () => {
+      const content = parseSkill("---\nname: gitlab:foo\n---\n");
+      const result = single(namespaceMismatch.check(content, "/some/other/path"));
+      expect(result.passed).toBe(true);
+    });
+  });
+
+  describe("namespaceStutter", () => {
+    it("passes for non-stuttering names", () => {
+      const content = parseSkill("---\nname: gitlab:ci\n---\n");
+      const result = single(namespaceStutter.check(content, pluginPath("gitlab")));
+      expect(result.passed).toBe(true);
+    });
+
+    it("warns on stuttering suffix", () => {
+      const content = parseSkill("---\nname: gitlab:gitlab-ci\n---\n");
+      const result = single(namespaceStutter.check(content, pluginPath("gitlab")));
+      expect(result.passed).toBe(false);
+      expect(result.severity).toBe("warn");
+    });
+
+    it("passes when suffix equals plugin name", () => {
+      const content = parseSkill("---\nname: git:git\n---\n");
+      const result = single(namespaceStutter.check(content, pluginPath("git")));
+      expect(result.passed).toBe(true);
+    });
+
+    it("passes when no prefix", () => {
+      const content = parseSkill("---\nname: actions\n---\n");
+      const result = single(namespaceStutter.check(content, pluginPath("github")));
+      expect(result.passed).toBe(true);
     });
   });
 });

--- a/plugins/git/hooks/hooks.json
+++ b/plugins/git/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/block-default-branch-commit.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/block-default-branch-commit.ts\""
           }
         ]
       }

--- a/plugins/github/hooks/hooks.json
+++ b/plugins/github/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts\"",
             "if": "WebFetch(https://github.com/*)"
           }
         ]

--- a/plugins/github/settings.json
+++ b/plugins/github/settings.json
@@ -1,3 +1,0 @@
-{
-  "$schema": "https://json.schemastore.org/claude-code-settings.json"
-}

--- a/plugins/gitlab/hooks/hooks.json
+++ b/plugins/gitlab/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts\"",
             "if": "WebFetch(https://gitlab.com/*)"
           }
         ]
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/auth.ts",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/auth.ts\"",
             "if": "Bash(glab *)"
           }
         ]

--- a/plugins/go/hooks/hooks.json
+++ b/plugins/go/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/check.ts",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/check.ts\"",
             "if": "Edit(**/*.go)|MultiEdit(**/*.go)|Write(**/*.go)"
           }
         ]

--- a/plugins/go/settings.json
+++ b/plugins/go/settings.json
@@ -1,3 +1,0 @@
-{
-  "$schema": "https://json.schemastore.org/claude-code-settings.json"
-}

--- a/plugins/issue/hooks/hooks.json
+++ b/plugins/issue/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/approve-read.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/approve-read.ts\""
           }
         ]
       }

--- a/plugins/linear/hooks/hooks.json
+++ b/plugins/linear/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts\""
           }
         ]
       },
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/default-state.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/default-state.ts\""
           }
         ]
       }

--- a/plugins/mac/hooks/hooks.json
+++ b/plugins/mac/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/sandbox.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/sandbox.ts\""
           }
         ]
       },
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/disable-sandbox.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/disable-sandbox.ts\""
           }
         ]
       }

--- a/plugins/mac/settings.json
+++ b/plugins/mac/settings.json
@@ -1,3 +1,0 @@
-{
-  "$schema": "https://json.schemastore.org/claude-code-settings.json"
-}

--- a/plugins/newline/hooks/hooks.json
+++ b/plugins/newline/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/check.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/check.ts\""
           }
         ]
       }
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/ensure.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/ensure.ts\""
           }
         ]
       },
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/preserve.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/preserve.ts\""
           }
         ]
       }

--- a/plugins/plan/hooks/hooks.json
+++ b/plugins/plan/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/context.sh"
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/context.sh\""
           }
         ]
       }

--- a/plugins/pull-request/hooks/hooks.json
+++ b/plugins/pull-request/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/validate.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/validate.ts\""
           }
         ]
       }

--- a/plugins/shortcuts/hooks/hooks.json
+++ b/plugins/shortcuts/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/open.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/open.ts\""
           }
         ]
       }

--- a/plugins/shortcuts/settings.json
+++ b/plugins/shortcuts/settings.json
@@ -1,3 +1,0 @@
-{
-  "$schema": "https://json.schemastore.org/claude-code-settings.json"
-}

--- a/plugins/things/hooks/hooks.json
+++ b/plugins/things/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/sandbox.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/sandbox.ts\""
           }
         ]
       }

--- a/plugins/tmux/hooks/hooks.json
+++ b/plugins/tmux/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/context.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/context.ts\""
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/notification.ts --clear"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/notification.ts\" --clear"
           }
         ]
       },
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/team-workaround.ts --setup"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/team-workaround.ts\" --setup"
           }
         ]
       }
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/notification.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/notification.ts\""
           }
         ]
       }
@@ -47,11 +47,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/notification.ts --background-only"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/notification.ts\" --background-only"
           },
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/team-workaround.ts --teardown"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/team-workaround.ts\" --teardown"
           }
         ]
       }

--- a/plugins/type-ignore/hooks/hooks.json
+++ b/plugins/type-ignore/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/detect.ts",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/detect.ts\"",
             "if": "Edit(**/*.ts)|Edit(**/*.tsx)|Write(**/*.ts)|Write(**/*.tsx)"
           }
         ]

--- a/plugins/vscode/settings.json
+++ b/plugins/vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "$schema": "https://json.schemastore.org/claude-code-settings.json"
-}

--- a/plugins/writing/hooks/hooks.json
+++ b/plugins/writing/hooks/hooks.json
@@ -7,16 +7,16 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts write"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts\" write"
           },
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts\"",
             "if": "Write(**/*.md)"
           },
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\""
           }
         ]
       },
@@ -25,16 +25,16 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts edit"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts\" edit"
           },
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts\"",
             "if": "Edit(**/*.md)"
           },
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\""
           }
         ]
       },
@@ -43,7 +43,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\""
           }
         ]
       },
@@ -52,7 +52,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\""
           }
         ]
       }

--- a/plugins/x-callback-url/hooks/hooks.json
+++ b/plugins/x-callback-url/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/sandbox.ts"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/sandbox.ts\""
           }
         ]
       }

--- a/scripts/check-hook-quoting.ts
+++ b/scripts/check-hook-quoting.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env bun
+
+import { globSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dirname, "..");
+
+interface HookEntry {
+  type: string;
+  command: string;
+}
+
+interface MatcherEntry {
+  matcher?: string;
+  hooks: HookEntry[];
+}
+
+interface HooksFile {
+  hooks: Record<string, MatcherEntry[]>;
+}
+
+// Matches an unquoted ${CLAUDE_PLUGIN_ROOT}/... path segment in a command string.
+// The path is unquoted if it is NOT preceded by a double quote.
+const UNQUOTED_PATH = /(?<!")(\$\{CLAUDE_PLUGIN_ROOT\}\/\S+)/g;
+
+const files = globSync("plugins/*/hooks/hooks.json", { cwd: root });
+const violations: string[] = [];
+
+for (const file of files) {
+  const content: HooksFile = await Bun.file(join(root, file)).json();
+
+  for (const entries of Object.values(content.hooks)) {
+    for (const entry of entries) {
+      for (const hook of entry.hooks) {
+        if (!hook.command?.includes("${CLAUDE_PLUGIN_ROOT}")) continue;
+
+        for (const match of hook.command.matchAll(UNQUOTED_PATH)) {
+          violations.push(`${file}: ${hook.command}`);
+          break;
+        }
+      }
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.log("Hook commands with unquoted ${CLAUDE_PLUGIN_ROOT} paths:");
+  for (const v of violations) {
+    console.log(`  ${v}`);
+  }
+  process.exit(1);
+}
+
+console.log("All hook commands have properly quoted ${CLAUDE_PLUGIN_ROOT} paths");


### PR DESCRIPTION
Audited the repo against the plugin reference docs and fixed violations and enforcement gaps. I dropped the dead `CLAUDE.md` detection from the original plan since plugin-root `CLAUDE.md` files serve a legitimate purpose as developer context.

## Changes

- Quoted all `${CLAUDE_PLUGIN_ROOT}` paths in hook `command` fields across 16 `hooks.json` files, with flags kept outside the quotes
- Added `scripts/check-hook-quoting.ts` to enforce quoting in CI
- Added `namespace-mismatch` (error) and `namespace-stutter` (warn) rules to `skill-lint` with tests
- Deleted 5 schema-only `settings.json` files from plugins that had no functional settings
- Updated `CLAUDE.md`: corrected skill namespacing docs (skills are auto-prefixed), added plugin metadata and hook quoting guidance
