### PR TITLE
user: extend status line and add subagent rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,10 @@ When resolving `bun.lock` conflicts, regenerate from scratch:
 
 Unlike npm's `package-lock.json`, bun populates integrity hashes for all platforms from the registry, even for packages not downloaded locally. Regenerating from scratch is safe and avoids stale or empty hashes. Do **not** use `git checkout origin/main -- bun.lock && bun install` — this produces empty integrity hashes for platform-specific packages (e.g., `@img/sharp-libvips-linux-x64`), breaking CI on Linux.
 
+### Terminal Colors
+
+Use ANSI colors (0-15) in scripts that produce terminal output. These are remapped by the terminal theme (Catppuccin), so they adapt to both light and dark mode. Avoid 256-color or truecolor escapes for foreground text.
+
 ### Scripts
 
 When writing scripts (hooks, skill CLIs, etc.) that accept arguments:

--- a/user/scripts/statusline.sh
+++ b/user/scripts/statusline.sh
@@ -63,6 +63,58 @@ render_lines() {
   segments+=("$parts")
 }
 
+render_worktree() {
+  local wt_json repo branch ahead
+  wt_json=$(wt list statusline --format=json 2>/dev/null | jq -c '.[] | select(.is_current)') || return
+  if [ -z "$wt_json" ]; then
+    return
+  fi
+
+  local dim=$'\033[2m'
+  local reset=$'\033[0m'
+  local cyan=$'\033[36m'
+
+  branch=$(echo "$wt_json" | jq -r '.branch')
+  local path ci_url repo_url
+  path=$(echo "$wt_json" | jq -r '.path')
+  repo=$(basename "$path")
+  repo=${repo%%."$branch"}
+
+  ci_url=$(echo "$wt_json" | jq -r '.ci.url // empty')
+  local repo_url=""
+  if [ -n "$ci_url" ]; then
+    local remote_name
+    remote_name=$(echo "$wt_json" | jq -r '.remote.name // "origin"')
+    repo_url=$(git remote get-url "$remote_name" 2>/dev/null | sed -e 's|^git@\([^:]*\):|https://\1/|' -e 's|\.git$||')
+  fi
+
+  local is_main
+  is_main=$(echo "$wt_json" | jq -r '.is_main')
+
+  local repo_display="$repo"
+  if [ -n "$repo_url" ]; then
+    repo_display=$(printf '\033]8;;%s\033\\%s\033]8;;\033\\' "$repo_url" "$repo")
+  fi
+
+  local label="$repo_display"
+  if [ "$is_main" = "false" ]; then
+    local branch_display="${cyan}${branch}${reset}"
+    if [ -n "$ci_url" ]; then
+      branch_display=$(printf '%s\033]8;;%s\033\\%s\033]8;;\033\\%s' "$cyan" "$ci_url" "$branch" "$reset")
+    fi
+    label+="${dim}/${reset}${branch_display}"
+  fi
+
+  ahead=$(echo "$wt_json" | jq -r '.main.ahead // 0')
+  if [ "$ahead" -gt 0 ]; then
+    segments+=("$label")
+    segments+=("${dim}↑${ahead}${reset}")
+  else
+    segments+=("$label")
+  fi
+}
+
+render_worktree
 render_dial
 render_lines
 

--- a/user/scripts/statusline.sh
+++ b/user/scripts/statusline.sh
@@ -1,26 +1,101 @@
 #!/bin/bash
 input=$(cat)
-pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+segments=()
 
-if [ -z "$pct" ]; then
-  exit 0
-fi
+render_dial() {
+  local pct
+  pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+  if [ -z "$pct" ]; then
+    return
+  fi
 
-int_pct=$(printf '%.0f' "$pct")
+  local int_pct color idx icon
+  int_pct=$(printf '%.0f' "$pct")
 
-if [ "$int_pct" -lt 40 ]; then
-  color="\033[32m"
-elif [ "$int_pct" -lt 65 ]; then
-  color="\033[33m"
-elif [ "$int_pct" -lt 80 ]; then
-  color="\033[38;5;208m"
-else
-  color="\033[31m"
-fi
+  local exceeds_200k
+  exceeds_200k=$(echo "$input" | jq -r '.exceeds_200k_tokens // false')
 
-# nf-md-circle_slice 1-8 (U+F0ABE..U+F0AC5) as a filling dial
-idx=$(( int_pct * 7 / 100 ))
-if [ "$idx" -gt 7 ]; then idx=7; fi
-icon=$(python3 -c "print(chr(0xF0A9E + $idx), end='')")
+  if [ "$int_pct" -lt 40 ]; then
+    color="\033[32m"
+  elif [ "$int_pct" -lt 65 ]; then
+    color="\033[33m"
+  elif [ "$int_pct" -lt 80 ]; then
+    color="\033[91m"
+  else
+    color="\033[31m"
+  fi
 
-printf "${color}%s\033[0m" "$icon"
+  if [ "$exceeds_200k" = "true" ]; then
+    if [ "$color" = "\033[32m" ]; then
+      color="\033[33m"
+    elif [ "$color" = "\033[33m" ] && [ "$int_pct" -ge 45 ]; then
+      color="\033[31m"
+    fi
+  fi
+
+  idx=$(( int_pct * 7 / 100 ))
+  if [ "$idx" -gt 7 ]; then idx=7; fi
+  icon=$(python3 -c "print(chr(0xF0A9E + $idx), end='')")
+
+  segments+=("$(printf "${color}%s\033[0m" "$icon")")
+}
+
+render_lines() {
+  local added removed
+  added=$(echo "$input" | jq -r '.cost.total_lines_added // 0')
+  removed=$(echo "$input" | jq -r '.cost.total_lines_removed // 0')
+
+  if [ "$added" -eq 0 ] && [ "$removed" -eq 0 ]; then
+    return
+  fi
+
+  local parts=""
+  if [ "$added" -gt 0 ]; then
+    parts=$(printf "\033[32m+%d\033[0m" "$added")
+  fi
+  if [ "$removed" -gt 0 ]; then
+    if [ -n "$parts" ]; then
+      parts+=" "
+    fi
+    parts+=$(printf "\033[31m-%d\033[0m" "$removed")
+  fi
+
+  segments+=("$parts")
+}
+
+render_pr() {
+  local number url
+  number=$(echo "$input" | jq -r '.pr.number // empty')
+  if [ -z "$number" ]; then
+    return
+  fi
+
+  url=$(echo "$input" | jq -r '.pr.url // empty')
+
+  local link_color=$'\033[36m'
+  local reset=$'\033[0m'
+
+  if [ -n "$url" ]; then
+    local osc_open osc_close
+    osc_open=$(printf '\033]8;;%s\033\\' "$url")
+    osc_close=$(printf '\033]8;;\033\\')
+    segments+=("${link_color}${osc_open}#${number}${osc_close}${reset}")
+  else
+    segments+=("${link_color}#${number}${reset}")
+  fi
+}
+
+render_dial
+render_lines
+render_pr
+
+sep="  "
+output=""
+for i in "${!segments[@]}"; do
+  if [ "$i" -gt 0 ]; then
+    output+="$sep"
+  fi
+  output+="${segments[$i]}"
+done
+
+printf "%s" "$output"

--- a/user/scripts/statusline.sh
+++ b/user/scripts/statusline.sh
@@ -78,7 +78,9 @@ render_worktree() {
   local path ci_url repo_url
   path=$(echo "$wt_json" | jq -r '.path')
   repo=$(basename "$path")
-  repo=${repo%%."$branch"}
+  local sanitized_branch
+  sanitized_branch=$(echo "$branch" | tr '/\\' '-')
+  repo=${repo%%."$sanitized_branch"}
 
   ci_url=$(echo "$wt_json" | jq -r '.ci.url // empty')
   local repo_url=""

--- a/user/scripts/statusline.sh
+++ b/user/scripts/statusline.sh
@@ -63,31 +63,8 @@ render_lines() {
   segments+=("$parts")
 }
 
-render_pr() {
-  local number url
-  number=$(echo "$input" | jq -r '.pr.number // empty')
-  if [ -z "$number" ]; then
-    return
-  fi
-
-  url=$(echo "$input" | jq -r '.pr.url // empty')
-
-  local link_color=$'\033[36m'
-  local reset=$'\033[0m'
-
-  if [ -n "$url" ]; then
-    local osc_open osc_close
-    osc_open=$(printf '\033]8;;%s\033\\' "$url")
-    osc_close=$(printf '\033]8;;\033\\')
-    segments+=("${link_color}${osc_open}#${number}${osc_close}${reset}")
-  else
-    segments+=("${link_color}#${number}${reset}")
-  fi
-}
-
 render_dial
 render_lines
-render_pr
 
 sep="  "
 output=""

--- a/user/scripts/subagent-statusline.sh
+++ b/user/scripts/subagent-statusline.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+input=$(cat)
+
+yellow=$'\033[33m'
+green=$'\033[32m'
+red=$'\033[31m'
+dim=$'\033[2m'
+reset=$'\033[0m'
+
+format_elapsed() {
+  local start_ms=$1 now_ms elapsed_s mins secs
+  now_ms=$(date +%s)000
+  elapsed_s=$(( (now_ms - start_ms) / 1000 ))
+  mins=$(( elapsed_s / 60 ))
+  secs=$(( elapsed_s % 60 ))
+  printf "%dm %ds" "$mins" "$secs"
+}
+
+format_tokens() {
+  local count=$1
+  if [ "$count" -ge 1000 ]; then
+    printf "%.1fk" "$(echo "$count / 1000" | bc -l)"
+  else
+    printf "%d" "$count"
+  fi
+}
+
+render_task() {
+  local task=$1
+  local id name status start_time token_count icon meta content
+  id=$(echo "$task" | jq -r '.id')
+  name=$(echo "$task" | jq -r '.name // "agent"')
+  status=$(echo "$task" | jq -r '.status // "running"')
+  start_time=$(echo "$task" | jq -r '.startTime // empty')
+  token_count=$(echo "$task" | jq -r '.tokenCount // 0')
+
+  case "$status" in
+    completed) icon="${green}✓${reset}" ;;
+    failed)    icon="${red}✗${reset}" ;;
+    *)         icon="${yellow}▸${reset}" ;;
+  esac
+
+  meta=""
+  if [ -n "$start_time" ]; then
+    meta+="· $(format_elapsed "$start_time") "
+  fi
+  if [ "$token_count" -gt 0 ]; then
+    meta+="· $(format_tokens "$token_count")"
+  fi
+
+  content="${icon} ${name}"
+  if [ -n "$meta" ]; then
+    content+=" ${dim}${meta}${reset}"
+  fi
+
+  jq -c --null-input --arg id "$id" --rawfile content <(printf '%s' "$content") '{id: $id, content: $content}'
+}
+
+echo "$input" | jq -c '.tasks[]' | while IFS= read -r task; do
+  render_task "$task"
+done

--- a/user/settings.json
+++ b/user/settings.json
@@ -228,6 +228,10 @@
     "type": "command",
     "command": "~/.claude/scripts/statusline.sh"
   },
+  "subagentStatusLine": {
+    "type": "command",
+    "command": "~/.claude/scripts/subagent-statusline.sh"
+  },
   "skipAutoPermissionPrompt": true,
   "alwaysThinkingEnabled": true,
   "spinnerTipsEnabled": false,


### PR DESCRIPTION
Extends the main status line with repo/branch identity, lines changed, and context-aware coloring. Adds a subagent status line and documents ANSI color conventions.

## Changes

#### Main status line (`user/scripts/statusline.sh`)

- Refactored into segment-based rendering with `render_worktree`, `render_dial`, and `render_lines`
- Repo/branch identity from Worktrunk JSON: `claude/status` with the repo linking to the repository and the branch linking to the PR (both via OSC 8, only when a CI URL exists)
- Ahead-of-main count (`↑N`) as a separate segment
- Lines changed: green `+N` / red `-N`, hidden when zero, omitting the zero side for add-only or delete-only sessions
- Context dial uses ANSI colors throughout (replacing 256-color orange) for Catppuccin theme compatibility
- `exceeds_200k_tokens` floors the dial to yellow and switches to red at 45%

#### Subagent status line (`user/scripts/subagent-statusline.sh`)

- New event-driven script rendering each subagent as `▸ name · Xm Ys · Nk`
- Colored status icons: yellow `▸` (running), green `✓` (completed), red `✗` (failed)
- Dimmed metadata (elapsed time, token count) for visual hierarchy
- Uses `jq --rawfile` for clean JSON output with embedded ANSI escapes

#### Documentation

- Added Terminal Colors section to `CLAUDE.md`: use ANSI 0-15 only for dark mode support
