### PR TITLE
tmux: auto-inject -t with Claude's pane ID

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -187,6 +187,8 @@
     "plugins/tmux": {
       "name": "@bendrucker/claude-tmux",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.25",
+        "@constellos/claude-code-kit": "^0.4.0",
         "cleye": "^1.3.2",
         "table": "^6.9.0",
       },

--- a/plugins/tmux/hooks/hooks.json
+++ b/plugins/tmux/hooks/hooks.json
@@ -22,6 +22,15 @@
         ]
       },
       {
+        "matcher": "Bash(tmux:*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/target.ts\""
+          }
+        ]
+      },
+      {
         "matcher": "TeamCreate",
         "hooks": [
           {

--- a/plugins/tmux/hooks/prompt.md
+++ b/plugins/tmux/hooks/prompt.md
@@ -5,3 +5,13 @@ log tails, builds, REPLs, interactive Claude sessions. Use
 `run_in_background` only for work the user does not need to see.
 
 Load the `tmux` skill for split, capture, and send-keys commands.
+
+## tmux targeting
+
+A hook auto-injects `-t` with your pane ID on tmux commands that
+accept a target. If `-t` is already present, the command passes
+through unchanged.
+
+To target the user's currently active pane, resolve it first:
+
+    target=$(tmux display-message -p '#{pane_id}') && tmux send-keys -t "$target" ...

--- a/plugins/tmux/hooks/target.test.ts
+++ b/plugins/tmux/hooks/target.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import {
-  hasExistingTarget,
-  injectTarget,
-  parseTmuxCommand,
-  processInput,
-} from "./target";
+import { hasExistingTarget, injectTarget, parseTmuxCommand, processInput } from "./target";
 
 function mockInput(command: string): PreToolUseHookInput {
   return {
@@ -75,15 +70,11 @@ describe("hasExistingTarget", () => {
 
 describe("injectTarget", () => {
   it("injects target after subcommand", () => {
-    expect(injectTarget("tmux split-window -h -d", "%5")).toBe(
-      'tmux split-window -t "%5" -h -d',
-    );
+    expect(injectTarget("tmux split-window -h -d", "%5")).toBe('tmux split-window -t "%5" -h -d');
   });
 
   it("injects target for alias", () => {
-    expect(injectTarget("tmux splitw -h", "%5")).toBe(
-      'tmux splitw -t "%5" -h',
-    );
+    expect(injectTarget("tmux splitw -h", "%5")).toBe('tmux splitw -t "%5" -h');
   });
 
   it("returns null for non-targetable command", () => {
@@ -99,21 +90,15 @@ describe("injectTarget", () => {
   });
 
   it("injects target for send-keys", () => {
-    expect(injectTarget("tmux send-keys C-c", "%5")).toBe(
-      'tmux send-keys -t "%5" C-c',
-    );
+    expect(injectTarget("tmux send-keys C-c", "%5")).toBe('tmux send-keys -t "%5" C-c');
   });
 
   it("injects target for capture-pane", () => {
-    expect(injectTarget("tmux capture-pane -p", "%5")).toBe(
-      'tmux capture-pane -t "%5" -p',
-    );
+    expect(injectTarget("tmux capture-pane -p", "%5")).toBe('tmux capture-pane -t "%5" -p');
   });
 
   it("does not inject target for display-message", () => {
-    expect(
-      injectTarget("tmux display-message -p '#{pane_id}'", "%5"),
-    ).toBeNull();
+    expect(injectTarget("tmux display-message -p '#{pane_id}'", "%5")).toBeNull();
   });
 
   it("returns null when -t has value attached (no space)", () => {
@@ -131,15 +116,11 @@ describe("processInput", () => {
   });
 
   it("returns null for non-targetable command", () => {
-    expect(
-      processInput(mockInput("tmux list-sessions"), "%5"),
-    ).toBeNull();
+    expect(processInput(mockInput("tmux list-sessions"), "%5")).toBeNull();
   });
 
   it("returns null when -t already present", () => {
-    expect(
-      processInput(mockInput("tmux split-window -t %3 -h"), "%5"),
-    ).toBeNull();
+    expect(processInput(mockInput("tmux split-window -t %3 -h"), "%5")).toBeNull();
   });
 
   it("returns updatedInput and additionalContext for targetable command", () => {
@@ -150,14 +131,15 @@ describe("processInput", () => {
         updatedInput: {
           command: 'tmux split-window -t "%5" -h -d',
         },
-        additionalContext: expect.stringContaining("-t \"%5\""),
+        additionalContext: expect.stringContaining('-t "%5"'),
       },
     });
   });
 
   it("updatedInput contains only command", () => {
     const result = processInput(mockInput("tmux send-keys C-c"), "%5");
-    const updatedInput = result?.hookSpecificOutput?.updatedInput as Record<string, unknown>;
+    const output = result?.hookSpecificOutput as Record<string, unknown>;
+    const updatedInput = output?.updatedInput as Record<string, unknown>;
     expect(Object.keys(updatedInput)).toEqual(["command"]);
   });
 });

--- a/plugins/tmux/hooks/target.test.ts
+++ b/plugins/tmux/hooks/target.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "bun:test";
+import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+import {
+  hasExistingTarget,
+  injectTarget,
+  parseTmuxCommand,
+  processInput,
+} from "./target";
+
+function mockInput(command: string): PreToolUseHookInput {
+  return {
+    hook_event_name: "PreToolUse",
+    session_id: "test",
+    transcript_path: "/tmp/test",
+    cwd: "/tmp",
+    tool_name: "Bash",
+    tool_input: { command },
+    tool_use_id: "test",
+  };
+}
+
+describe("parseTmuxCommand", () => {
+  it("extracts subcommand and rest", () => {
+    expect(parseTmuxCommand("tmux split-window -h -d")).toEqual({
+      subcommand: "split-window",
+      rest: " -h -d",
+    });
+  });
+
+  it("handles subcommand with no args", () => {
+    expect(parseTmuxCommand("tmux split-window")).toEqual({
+      subcommand: "split-window",
+      rest: "",
+    });
+  });
+
+  it("returns null for non-tmux command", () => {
+    expect(parseTmuxCommand("ls -la")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseTmuxCommand("")).toBeNull();
+  });
+});
+
+describe("hasExistingTarget", () => {
+  it("detects -t mid-args", () => {
+    expect(hasExistingTarget(" -t %5 -h")).toBe(true);
+  });
+
+  it("detects -t at end", () => {
+    expect(hasExistingTarget(" -h -t ")).toBe(true);
+  });
+
+  it("detects standalone -t", () => {
+    expect(hasExistingTarget(" -t ")).toBe(true);
+  });
+
+  it("returns false when absent", () => {
+    expect(hasExistingTarget(" -h -d")).toBe(false);
+  });
+
+  it("does not match -t inside another flag", () => {
+    expect(hasExistingTarget(" -target foo")).toBe(false);
+  });
+
+  it("detects -t with value attached (no space)", () => {
+    expect(hasExistingTarget(" -t%3 -h")).toBe(true);
+  });
+
+  it("detects -t with quoted value attached", () => {
+    expect(hasExistingTarget(' -t"%3" -h')).toBe(true);
+  });
+});
+
+describe("injectTarget", () => {
+  it("injects target after subcommand", () => {
+    expect(injectTarget("tmux split-window -h -d", "%5")).toBe(
+      'tmux split-window -t "%5" -h -d',
+    );
+  });
+
+  it("injects target for alias", () => {
+    expect(injectTarget("tmux splitw -h", "%5")).toBe(
+      'tmux splitw -t "%5" -h',
+    );
+  });
+
+  it("returns null for non-targetable command", () => {
+    expect(injectTarget("tmux list-sessions", "%5")).toBeNull();
+  });
+
+  it("returns null when -t already present", () => {
+    expect(injectTarget("tmux split-window -t %3 -h", "%5")).toBeNull();
+  });
+
+  it("returns null for non-tmux command", () => {
+    expect(injectTarget("ls -la", "%5")).toBeNull();
+  });
+
+  it("injects target for send-keys", () => {
+    expect(injectTarget("tmux send-keys C-c", "%5")).toBe(
+      'tmux send-keys -t "%5" C-c',
+    );
+  });
+
+  it("injects target for capture-pane", () => {
+    expect(injectTarget("tmux capture-pane -p", "%5")).toBe(
+      'tmux capture-pane -t "%5" -p',
+    );
+  });
+
+  it("does not inject target for display-message", () => {
+    expect(
+      injectTarget("tmux display-message -p '#{pane_id}'", "%5"),
+    ).toBeNull();
+  });
+
+  it("returns null when -t has value attached (no space)", () => {
+    expect(injectTarget("tmux split-window -t%3 -h", "%5")).toBeNull();
+  });
+});
+
+describe("processInput", () => {
+  it("returns null when pane is undefined", () => {
+    expect(processInput(mockInput("tmux split-window -h"))).toBeNull();
+  });
+
+  it("returns null when pane is empty", () => {
+    expect(processInput(mockInput("tmux split-window -h"), "")).toBeNull();
+  });
+
+  it("returns null for non-targetable command", () => {
+    expect(
+      processInput(mockInput("tmux list-sessions"), "%5"),
+    ).toBeNull();
+  });
+
+  it("returns null when -t already present", () => {
+    expect(
+      processInput(mockInput("tmux split-window -t %3 -h"), "%5"),
+    ).toBeNull();
+  });
+
+  it("returns updatedInput and additionalContext for targetable command", () => {
+    const result = processInput(mockInput("tmux split-window -h -d"), "%5");
+    expect(result).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        updatedInput: {
+          command: 'tmux split-window -t "%5" -h -d',
+        },
+        additionalContext: expect.stringContaining("-t \"%5\""),
+      },
+    });
+  });
+
+  it("updatedInput contains only command", () => {
+    const result = processInput(mockInput("tmux send-keys C-c"), "%5");
+    const updatedInput = result?.hookSpecificOutput?.updatedInput as Record<string, unknown>;
+    expect(Object.keys(updatedInput)).toEqual(["command"]);
+  });
+});

--- a/plugins/tmux/hooks/target.ts
+++ b/plugins/tmux/hooks/target.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+
+import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+
+const targetableCommands = new Set([
+  "split-window",
+  "splitw",
+  "send-keys",
+  "send",
+  "capture-pane",
+  "capturep",
+  "select-pane",
+  "selectp",
+  "resize-pane",
+  "resizep",
+  "kill-pane",
+  "killp",
+  "select-layout",
+  "selectl",
+  "rename-window",
+  "renamew",
+  "swap-pane",
+  "swapp",
+  "swap-window",
+  "swapw",
+  "move-pane",
+  "movep",
+  "move-window",
+  "movew",
+]);
+
+export function parseTmuxCommand(
+  command: string,
+): { subcommand: string; rest: string } | null {
+  const match = command.match(/^tmux\s+(\S+)(.*)/);
+  if (!match) return null;
+  return { subcommand: match[1], rest: match[2] };
+}
+
+export function hasExistingTarget(rest: string): boolean {
+  return /(?:^|\s)-t(?:[^a-zA-Z]|$)/.test(rest);
+}
+
+export function injectTarget(command: string, pane: string): string | null {
+  const parsed = parseTmuxCommand(command);
+  if (!parsed) return null;
+  if (!targetableCommands.has(parsed.subcommand)) return null;
+  if (hasExistingTarget(parsed.rest)) return null;
+
+  return `tmux ${parsed.subcommand} -t "${pane}"${parsed.rest}`;
+}
+
+export function processInput(
+  input: PreToolUseHookInput,
+  pane?: string,
+): SyncHookJSONOutput | null {
+  if (!pane) return null;
+
+  const { command } = input.tool_input as { command?: string };
+  if (!command) return null;
+
+  const rewritten = injectTarget(command, pane);
+  if (!rewritten) return null;
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      updatedInput: {
+        command: rewritten,
+      },
+      additionalContext: `tmux target auto-injected: -t "${pane}" (your pane). To target the user's active pane, resolve it explicitly:\n  target=$(tmux display-message -p '#{pane_id}') && tmux <cmd> -t "$target" ...`,
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  let input: PreToolUseHookInput;
+  try {
+    input = await readStdinJson<PreToolUseHookInput>();
+  } catch (error) {
+    console.error(
+      `[tmux/target] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  const output = processInput(input, process.env.TMUX_PANE);
+  if (output) {
+    writeStdoutJson(output);
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/plugins/tmux/hooks/target.ts
+++ b/plugins/tmux/hooks/target.ts
@@ -30,12 +30,10 @@ const targetableCommands = new Set([
   "movew",
 ]);
 
-export function parseTmuxCommand(
-  command: string,
-): { subcommand: string; rest: string } | null {
+export function parseTmuxCommand(command: string): { subcommand: string; rest: string } | null {
   const match = command.match(/^tmux\s+(\S+)(.*)/);
-  if (!match) return null;
-  return { subcommand: match[1], rest: match[2] };
+  if (!match?.[1]) return null;
+  return { subcommand: match[1], rest: match[2] ?? "" };
 }
 
 export function hasExistingTarget(rest: string): boolean {
@@ -51,10 +49,7 @@ export function injectTarget(command: string, pane: string): string | null {
   return `tmux ${parsed.subcommand} -t "${pane}"${parsed.rest}`;
 }
 
-export function processInput(
-  input: PreToolUseHookInput,
-  pane?: string,
-): SyncHookJSONOutput | null {
+export function processInput(input: PreToolUseHookInput, pane?: string): SyncHookJSONOutput | null {
   if (!pane) return null;
 
   const { command } = input.tool_input as { command?: string };

--- a/plugins/tmux/package.json
+++ b/plugins/tmux/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.25",
+    "@constellos/claude-code-kit": "^0.4.0",
     "cleye": "^1.3.2",
     "table": "^6.9.0"
   }

--- a/plugins/tmux/skills/tmux/scripts/safe-command.sh
+++ b/plugins/tmux/skills/tmux/scripts/safe-command.sh
@@ -6,6 +6,6 @@ pattern=$(jq -r 'join("|")' "$dir/../resources/safe-commands.json")
 
 cat | jq --arg pattern "$pattern" '
   if (.tool_input.command | test("^tmux\\s+(" + $pattern + ")\\b"))
-  then {hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow", updatedInput: (.tool_input + {dangerouslyDisableSandbox: true})}}
-  else {hookSpecificOutput: {hookEventName: "PreToolUse", updatedInput: (.tool_input + {dangerouslyDisableSandbox: true})}}
+  then {hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow", updatedInput: {dangerouslyDisableSandbox: true}}}
+  else {hookSpecificOutput: {hookEventName: "PreToolUse", updatedInput: {dangerouslyDisableSandbox: true}}}
   end'


### PR DESCRIPTION
Without `-t`, tmux resolves the target using the server's "current" client state (whatever pane the user is focused on), not Claude's pane. A PreToolUse hook now intercepts tmux commands and injects `-t` with `$TMUX_PANE` when the flag is missing.

## Changes

- New `plugins/tmux/hooks/target.ts`: parses tmux commands, checks if the subcommand is targetable, and injects `-t "<pane_id>"` when missing. Returns `additionalContext` explaining the rewrite and documenting the escape hatch for targeting the user's active pane.
- `safe-command.sh` stops spreading `tool_input` into `updatedInput` to avoid merge conflicts with `target.ts` (both hooks set `updatedInput` fields that Claude Code merges).
- `display-message`/`display` are intentionally excluded from the targetable set so the escape hatch (`tmux display-message -p '#{pane_id}'`) resolves the user's active pane via tmux's default resolution.
- `prompt.md` documents the targeting behavior and escape hatch.

## Testing

- `parseTmuxCommand`, `hasExistingTarget`, `injectTarget`, and `processInput` are tested directly as pure functions
- Edge cases covered: combined `-tVALUE` form (no space), aliases, non-targetable commands, missing pane env var, already-present `-t`
