### PR TITLE
user: use description and type in subagent status line

### DIFF
--- a/user/scripts/subagent-statusline.sh
+++ b/user/scripts/subagent-statusline.sh
@@ -27,9 +27,12 @@ format_tokens() {
 
 render_task() {
   local task=$1
-  local id name status start_time token_count icon meta content
+  local columns=$2
+  local id description type name status start_time token_count icon meta label content
   id=$(echo "$task" | jq -r '.id')
-  name=$(echo "$task" | jq -r '.name // "agent"')
+  description=$(echo "$task" | jq -r '.description // empty')
+  type=$(echo "$task" | jq -r '.type // empty')
+  name=$(echo "$task" | jq -r '.name // empty')
   status=$(echo "$task" | jq -r '.status // "running"')
   start_time=$(echo "$task" | jq -r '.startTime // empty')
   token_count=$(echo "$task" | jq -r '.tokenCount // 0')
@@ -40,6 +43,18 @@ render_task() {
     *)         icon="${yellow}▸${reset}" ;;
   esac
 
+  if [ -n "$description" ] && [ -n "$type" ]; then
+    label="${dim}${type}${reset}  ${description}"
+  elif [ -n "$description" ]; then
+    label="$description"
+  elif [ -n "$type" ]; then
+    label="$type"
+  elif [ -n "$name" ]; then
+    label="$name"
+  else
+    label="agent"
+  fi
+
   meta=""
   if [ -n "$start_time" ]; then
     meta+="· $(format_elapsed "$start_time") "
@@ -48,14 +63,37 @@ render_task() {
     meta+="· $(format_tokens "$token_count")"
   fi
 
-  content="${icon} ${name}"
+  content="${icon} ${label}"
   if [ -n "$meta" ]; then
     content+=" ${dim}${meta}${reset}"
+  fi
+
+  if [ -n "$columns" ]; then
+    local visible
+    visible=$(printf '%s' "$content" | sed $'s/\033\\[[0-9;]*m//g')
+    if [ "${#visible}" -gt "$columns" ]; then
+      local overflow=$(( ${#visible} - columns ))
+      local desc_max=$(( ${#description} - overflow - 1 ))
+      if [ "$desc_max" -gt 0 ]; then
+        description="${description:0:$desc_max}…"
+        if [ -n "$type" ]; then
+          label="${dim}${type}${reset}  ${description}"
+        else
+          label="$description"
+        fi
+        content="${icon} ${label}"
+        if [ -n "$meta" ]; then
+          content+=" ${dim}${meta}${reset}"
+        fi
+      fi
+    fi
   fi
 
   jq -c --null-input --arg id "$id" --rawfile content <(printf '%s' "$content") '{id: $id, content: $content}'
 }
 
+columns=$(echo "$input" | jq -r '.columns // empty')
+
 echo "$input" | jq -c '.tasks[]' | while IFS= read -r task; do
-  render_task "$task"
+  render_task "$task" "$columns"
 done


### PR DESCRIPTION
The subagent status line rendered "agent" for every subagent because it displayed `name` (the optional `Agent` tool parameter for `SendMessage` addressing), which most agents don't set. I switched `render_task` to prefer `description` (always populated, concise) with `type` as a dim prefix, falling back through `type`, `name`, and finally `"agent"`. Long descriptions are truncated to fit `columns`.

Before:
```
▸ agent · 1m 23s · 4.2k
▸ agent · 0m 45s · 2.1k
```

After:
```
▸ Explore  find status line files · 1m 23s · 4.2k
▸ Plan  design implementation · 0m 45s · 2.1k
```
