### PR TITLE
user: enable input-needed and agent push notifications

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -238,6 +238,8 @@
   "showClearContextOnPlanAccept": true,
   "autoCompactEnabled": false,
   "preferredNotifChannel": "terminal_bell",
+  "inputNeededNotifEnabled": true,
+  "agentPushNotifEnabled": true,
   "teammateMode": "auto",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",


### PR DESCRIPTION
Opts in to both push notification toggles for the Remote Control channel. These mirror the toggles under `/config` and feed the mobile push integration.

## Changes

- `inputNeededNotifEnabled` ("Push when actions required"): pushes a notification when Claude pauses for user input (a prompt, a permission request, or a dialog).
- `agentPushNotifEnabled` ("Push when Claude decides"): pushes a notification when Claude itself sends one via the `PushNotification` tool, for events worth surfacing mid-task.

Both only reach a device when Remote Control is connected; otherwise they fall back to the existing `preferredNotifChannel` (`terminal_bell`). I placed them next to `preferredNotifChannel` to keep the notification settings together.
