### PR TITLE
session: add cross-machine session history

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,10 @@
     "plugins/claude-code/skills/session": {
       "name": "session",
       "version": "1.0.0",
+      "dependencies": {
+        "cleye": "^2.2.1",
+        "table": "^6.9.0",
+      },
       "devDependencies": {
         "@duckdb/node-api": "1.5.0-r.1",
       },
@@ -1382,6 +1386,8 @@
 
     "redent/indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
+    "session/cleye": ["cleye@2.3.0", "", { "dependencies": { "terminal-columns": "^2.0.0", "type-flag": "^4.1.0" } }, "sha512-hnROLVsAA8JQo8W65/khA90gPvZ0ymuZqWwQcBpHrrmpIDD2CLvB7HdqAeA0Odxf7RpJLS5Zor0ujlPOXx4IBQ=="],
+
     "ui-design/cleye": ["cleye@2.3.0", "", { "dependencies": { "terminal-columns": "^2.0.0", "type-flag": "^4.1.0" } }, "sha512-hnROLVsAA8JQo8W65/khA90gPvZ0ymuZqWwQcBpHrrmpIDD2CLvB7HdqAeA0Odxf7RpJLS5Zor0ujlPOXx4IBQ=="],
 
     "@bendrucker/claude-writing/cleye/terminal-columns": ["terminal-columns@2.0.0", "", {}, "sha512-6IByuUjyNZJXUtwDNm+OIe62zgwwaRbH+WMNTcx05O2G5V9WhvluAAHJY8OvUdwmzMPpqAD/7EUpGdI6ae1aiQ=="],
@@ -1413,6 +1419,10 @@
     "read-pkg/normalize-package-data/hosted-git-info": ["hosted-git-info@2.8.9", "", {}, "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="],
 
     "read-pkg/normalize-package-data/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
+
+    "session/cleye/terminal-columns": ["terminal-columns@2.0.0", "", {}, "sha512-6IByuUjyNZJXUtwDNm+OIe62zgwwaRbH+WMNTcx05O2G5V9WhvluAAHJY8OvUdwmzMPpqAD/7EUpGdI6ae1aiQ=="],
+
+    "session/cleye/type-flag": ["type-flag@4.1.0", "", {}, "sha512-I/K5a1jUhdFgzM3L7413akxQRzUYq4sCbef6bMAe6SrIvIdFxGZFJys5M1SiY0d0VrAjZjY4LQzppuTaLHMvSQ=="],
 
     "ui-design/cleye/terminal-columns": ["terminal-columns@2.0.0", "", {}, "sha512-6IByuUjyNZJXUtwDNm+OIe62zgwwaRbH+WMNTcx05O2G5V9WhvluAAHJY8OvUdwmzMPpqAD/7EUpGdI6ae1aiQ=="],
 

--- a/plugins/claude-code/skills/session/CLAUDE.md
+++ b/plugins/claude-code/skills/session/CLAUDE.md
@@ -2,18 +2,22 @@
 
 ## DuckDB Architecture
 
-JSONL files in `~/.claude/projects/` are the canonical data. The DuckDB database is a derived cache.
+JSONL files in `~/.claude/projects/` are the canonical data. The DuckDB database is a derived cache. Other machines' corpora, copied under `~/.claude/session-imports/<label>/projects/`, are indexed under a `host` label alongside `local` (see SKILL.md "Cross-Machine History").
 
 ### Schema
 
 `resources/schema/` runs on every startup:
 
-- `01_tables.sql`: `raw` with pinned columns plus a `data JSON` blob, and `meta` with `last_import`. The full pinned column set is declared upfront so the table type is stable across imports.
-- `03_macros.sql`: filter macros for date ranges and project paths.
+- `01_tables.sql`: `raw` with pinned columns (`host` first) plus a `data JSON` blob, and `meta(host, last_import)` holding a per-host import watermark. The full pinned column set is declared upfront so the table type is stable across imports.
+- `03_macros.sql`: filter macros for date ranges, project paths, and host, plus `project_id(host, path)`.
+
+### Host enumeration
+
+`db.ts` enumerates one entry per host: `local` (honoring `CLAUDE_PROJECTS_DIR` / the `projectsDir` option) plus one per `~/.claude/session-imports/*/manifest.json` (override the root with `CLAUDE_SESSION_IMPORTS_DIR` / the `importsDir` option). The filesystem is the registry; there is no host table. `ensureIndex` loops the hosts, setting `host` and `projects_glob` per iteration; `views.sql` runs once after the loop.
 
 ### Tables
 
-- **`raw`**: pinned scalar columns (`session_id`, `type`, `project_path`, `git_branch`, `is_meta`, `is_sidechain`, `duration_ms`, `timestamp`, `summary`, `input_tokens`, `output_tokens`, `source_file`, `source_line`) plus `data JSON` holding the full original JSONL line. Imports use `read_json_objects(...)` (no auto-detected types beyond `json` itself), so column types never drift between imports.
+- **`raw`**: pinned scalar columns (`host`, `session_id`, `type`, `project_path`, `git_branch`, `is_meta`, `is_sidechain`, `duration_ms`, `timestamp`, `summary`, `input_tokens`, `output_tokens`, `source_file`, `source_line`) plus `data JSON` holding the full original JSONL line. Imports use `read_json_objects(...)` (no auto-detected types beyond `json` itself), so column types never drift between imports.
 - **`messages`**: view over `raw` filtered to `type IN ('user', 'assistant')`, adding `content_text` (when message content is a string) and a joined `summary`.
 - **`content_items`**: built from `raw` via `unnest(json_extract(data, '$.message.content[*]'))`. Pinned columns plus the content item's full `data JSON` plus the parent's `tool_use_result JSON`. No temp file roundtrip.
 
@@ -21,13 +25,13 @@ Other views (`tool_calls`, `tool_errors`, `permission_requests`, `sandbox_bypass
 
 ### Import pipeline
 
-`refresh.sql` returns `changed_files` (those modified after `last_import`). `import.sql` runs `read_json_objects` on just those files, projects pinned columns with explicit casts, and updates `raw` via `UNION ALL BY NAME` against the cached rows from sessions not in `changed_sessions`. The pinned schema means the cached `raw` and the freshly-built `new_raw` always have identical column types, so the union cannot fail with conversion errors.
+`refresh.sql` returns `changed_files` for the current host (those modified after that host's `last_import`, keyed by `host`). The watermark is per-host because `rsync -a` preserves source mtimes, so an imported host's files can predate `local`'s watermark; a shared watermark would skip them. `import.sql` runs `read_json_objects` on just those files, projects pinned columns with explicit casts (including `getvariable('host') AS host`), and updates `raw` via `UNION ALL` against the cached rows, deduping host-scoped (`NOT (host = <host> AND session_id IN changed_sessions)`) so other hosts' rows survive. It then upserts that host's `meta` row. The pinned schema means the cached `raw` and the freshly-built `new_raw` always have identical column types, so the union cannot fail with conversion errors.
 
-After `import.sql`, `views.sql` rebuilds `content_items` and the views. No temp JSONL files, no `COPY TO` step.
+After the per-host loop, `views.sql` rebuilds `content_items` and the views. No temp JSONL files, no `COPY TO` step. Cross-host joins key on `(host, session_id)`; the `content_items`/`messages` join keys on `(source_file, source_line)`, which is host-unique because imported files have distinct absolute paths.
 
 ### Migration
 
-`db.ts` runs `migrateIfNeeded` after the warm-session marker check, before `applySchema`. If `raw.data` is missing (the old auto-detected schema), it drops `raw`, `meta`, `messages`, and `content_items`. The next `applySchema` recreates the pinned tables, and the empty `meta` forces a one-shot full reimport from JSONL. Warm sessions with a `.refreshed-<id>` marker skip migration entirely.
+`db.ts` runs `migrateIfNeeded` after the warm-session marker check, before `applySchema`. If `raw.data` or `raw.host` is missing (a pre-host schema), it drops `raw`, `meta`, and `content_items`. The next `applySchema` recreates the pinned tables, and the empty `meta` forces a one-shot full reimport from JSONL. Warm sessions with a `.refreshed-<id>` marker skip migration entirely.
 
 ### JSON path gotcha
 

--- a/plugins/claude-code/skills/session/README.md
+++ b/plugins/claude-code/skills/session/README.md
@@ -6,7 +6,10 @@ Search and analyze Claude Code conversation history using a DuckDB index over JS
 
 - `SKILL.md` - Skill definition with schema docs and usage examples
 - `scripts/refresh.ts` - CLI entry point; refreshes the index and prints the DB path
-- `scripts/db.ts` - DuckDB index, schema, and query logic
+- `scripts/import.ts` - Register an imported machine's corpus and index it under a host label
+- `scripts/hosts.ts` - List hosts with their egress policy and re-sync command
+- `scripts/forget.ts` - Remove an imported host's rows and synced files
+- `scripts/db.ts` - DuckDB index, schema, host enumeration, and query logic
 - `resources/schema/` - Table and view definitions (ordered, run on startup)
 - `resources/queries/` - Parameterized SQL for built-in queries
 - `resources/import.sql` - JSONL parsing and flattening

--- a/plugins/claude-code/skills/session/SKILL.md
+++ b/plugins/claude-code/skills/session/SKILL.md
@@ -41,6 +41,8 @@ Built-in queries in `resources/queries/` run by name with `SET VARIABLE` params.
 
 The `project` param matches against the directory name (last path component) using glob syntax: `project=myapp` matches exactly, `project=myapp*` matches the repo and its worktrees.
 
+Every query also takes an optional `host` param. Omit it to span every machine (including `local`); pass `host=work` to scope to one imported machine. See [Cross-Machine History](#cross-machine-history).
+
 - `search`: find sessions by keyword (ILIKE on `content_text` and `summary`). Params: `query`, `limit`, `after_date`, `before_date`, `project`
 - `stats`: tool usage breakdown with error rates and aggregate totals. Params: `after_date`, `before_date`, `project`
 - `errors`: recent tool errors with type filtering. Params: `error_type` (`rejection` or `failure`), `limit`, `after_date`, `before_date`, `project`
@@ -53,9 +55,61 @@ The `project` param matches against the directory name (last path component) usi
 - `schema`: list every column in every table/view. Use this first when you don't know what's available.
 - `keys`: sample which top-level JSON keys appear in `raw.data` (the unstructured part), with occurrence counts.
 
+## Cross-Machine History
+
+Session history copied from another machine is queryable alongside this machine's. Each machine is a `host`: this one is always `local`, and every imported machine gets a label you choose. With nothing imported, the index behaves exactly as the single-machine case.
+
+### Listing hosts
+
+```bash
+${CLAUDE_SKILL_DIR}/scripts/hosts.ts
+```
+
+Shows each host with its import time, egress policy, last index, rsync source, and a ready-to-run re-sync command.
+
+### Importing a machine
+
+Copy the source machine's `~/.claude/projects/` into the import root, then register it. The `!` prefix runs the commands in your own shell, so SSH host-key trust and any 2FA stay in your hands.
+
+```bash
+mkdir -p ~/.claude/session-imports/<label>/projects
+rsync -avn --update <user@host>:.claude/projects/ ~/.claude/session-imports/<label>/projects/   # dry run
+rsync -av  --update <user@host>:.claude/projects/ ~/.claude/session-imports/<label>/projects/   # real copy
+${CLAUDE_SKILL_DIR}/scripts/import.ts --host <label> --source '<user@host>:.claude/projects/'
+```
+
+`import.ts` writes a manifest (dirs `0700`, manifest `0600`) recording the label, `--source`, and egress policy, then re-indexes. The whole `projects/` tree is copied even though only `*.jsonl` is indexed, because that tree is also the re-sync unit.
+
+### Re-syncing
+
+The source stored in the manifest doubles as the re-sync input, so refreshing is the same rsync line followed by `import.ts`:
+
+```bash
+rsync -av --update <source> ~/.claude/session-imports/<label>/projects/
+${CLAUDE_SKILL_DIR}/scripts/import.ts --host <label>
+```
+
+Re-running `import.ts` on a registered host leaves its manifest intact and re-indexes only the files whose mtime advanced (the watermark is per-host, so `rsync -a` preserving source mtimes is not a problem). `hosts.ts` prints the exact line per host.
+
+### Forgetting a machine
+
+```bash
+${CLAUDE_SKILL_DIR}/scripts/forget.ts --host <label>
+```
+
+Deletes the host's rows from the index and removes its synced files. `local` cannot be forgotten.
+
+### Privacy
+
+Importing another machine's history is a data-ownership decision: raise it once, at import. The egress policy records the answer. A host imported without `--egress` is marked `block_egress`, meaning its rows must be excluded from any output that leaves this machine (PR descriptions, Slack, email, web requests, uploads) by adding `host != '<label>'` (or scoping to `local`). `hosts.ts` prints each host's policy so that filter is easy to build. Pass `--egress` at import only when the source machine's history may leave this machine.
+
+Imported corpora are a hot place for secrets in tool output and pasted text. Patterns worth watching before anything leaves the machine: `sk_live_`, `xoxb-`, `ghp_`, `AKIA`, `eyJhbGciOi`. This is a signal to review, not a redactor.
+
 ## Tables and Views
 
-- `raw`: one row per JSONL line. Pinned scalar columns (`session_id`, `type`, `project_path`, `git_branch`, `is_meta`, `is_sidechain`, `duration_ms`, `timestamp`, `summary`, `input_tokens`, `output_tokens`, `source_file`, `source_line`) plus a `data JSON` column that holds the full original line.
+Every table and view carries a `host` column (`local` for this machine, the label for imported ones). The `sessions` view adds `project_id` (`host || ':' || project_path`) for cross-host project identity.
+
+- `raw`: one row per JSONL line. Pinned scalar columns (`host`, `session_id`, `type`, `project_path`, `git_branch`, `is_meta`, `is_sidechain`, `duration_ms`, `timestamp`, `summary`, `input_tokens`, `output_tokens`, `source_file`, `source_line`) plus a `data JSON` column that holds the full original line.
 - `messages`: view over `raw` filtered to `type IN ('user', 'assistant')`, with a derived `content_text` (string-form messages only) and a `summary` joined from summary rows.
 - `content_items`: one row per element of `data->'$.message.content'`, with pinned columns (`type`, `name`, `id`, `tool_use_id`, `text`, `content`, `is_error`) plus `data JSON` (the content item) and `tool_use_result JSON` (merged from the parent message).
 - `text_content`: one row per prose text item across user and assistant messages. Columns: `session_id`, `timestamp`, `role`, `model` (NULL for user), `project_path`, `text` (fenced and inline-backtick code stripped), `raw_text`, `source_file`, `source_line`.
@@ -70,6 +124,8 @@ The `project` param matches against the directory name (last path component) usi
 
 - `date_filter(ts, after, before)`: filter a timestamp column by optional date bounds.
 - `project_filter(path, pattern)`: match the last path component against a glob pattern.
+- `host_filter(host_col, host_val)`: pass through when `host_val` is NULL, else match the host column.
+- `project_id(host, path)`: `host || ':' || path`, a cross-host project identity.
 
 ## Discovery
 

--- a/plugins/claude-code/skills/session/package.json
+++ b/plugins/claude-code/skills/session/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
+  "dependencies": {
+    "cleye": "^2.2.1",
+    "table": "^6.9.0"
+  },
   "devDependencies": {
     "@duckdb/node-api": "1.5.0-r.1"
   }

--- a/plugins/claude-code/skills/session/resources/import.sql
+++ b/plugins/claude-code/skills/session/resources/import.sql
@@ -1,5 +1,6 @@
 CREATE OR REPLACE TEMP TABLE new_raw AS
 SELECT
+  getvariable('host')                                 AS host,
   json->>'$.sessionId'                                AS session_id,
   json->>'$.type'                                     AS type,
   json->>'$.cwd'                                      AS project_path,
@@ -28,11 +29,14 @@ SET VARIABLE changed_sessions = (
 
 CREATE OR REPLACE TABLE raw AS
 SELECT * FROM raw
-WHERE session_id NOT IN (SELECT unnest(getvariable('changed_sessions'))::VARCHAR)
+WHERE NOT (
+  host = getvariable('host')
+  AND session_id IN (SELECT unnest(getvariable('changed_sessions'))::VARCHAR)
+)
 UNION ALL
 SELECT * FROM new_raw;
 
 DROP TABLE new_raw;
 
-DELETE FROM meta;
-INSERT INTO meta VALUES (CURRENT_TIMESTAMP);
+DELETE FROM meta WHERE host = getvariable('host');
+INSERT INTO meta VALUES (getvariable('host'), CURRENT_TIMESTAMP);

--- a/plugins/claude-code/skills/session/resources/queries/errors.sql
+++ b/plugins/claude-code/skills/session/resources/queries/errors.sql
@@ -1,8 +1,9 @@
 SELECT te.*
 FROM tool_errors te
-JOIN sessions s USING (session_id)
+JOIN sessions s USING (host, session_id)
 WHERE date_filter(s.start_time, getvariable('after_date'), getvariable('before_date'))
   AND project_filter(s.project_path, getvariable('project'))
+  AND host_filter(s.host, getvariable('host'))
   AND (getvariable('error_type') IS NULL OR te.error_type = getvariable('error_type'))
 ORDER BY te.timestamp DESC
 LIMIT getvariable('limit');

--- a/plugins/claude-code/skills/session/resources/queries/model-summary.sql
+++ b/plugins/claude-code/skills/session/resources/queries/model-summary.sql
@@ -1,16 +1,17 @@
 WITH scoped AS (
   SELECT tc.*
   FROM text_content tc
-  JOIN sessions s USING (session_id)
+  JOIN sessions s USING (host, session_id)
   WHERE tc.role = 'assistant'
     AND date_filter(tc.timestamp, getvariable('after_date'), getvariable('before_date'))
     AND project_filter(s.project_path, getvariable('project'))
+    AND host_filter(tc.host, getvariable('host'))
 )
 SELECT
   COALESCE(model, '(unknown)') AS model,
   COUNT(*) AS text_items,
   COUNT(DISTINCT (source_file, source_line)) AS messages,
-  COUNT(DISTINCT session_id) AS sessions,
+  COUNT(DISTINCT (host, session_id)) AS sessions,
   SUM(length(text)) AS total_chars,
   ROUND(AVG(length(text)), 1) AS avg_chars_per_item
 FROM scoped

--- a/plugins/claude-code/skills/session/resources/queries/permissions.sql
+++ b/plugins/claude-code/skills/session/resources/queries/permissions.sql
@@ -8,8 +8,9 @@ SELECT
   SPLIT_PART(pr.project_path, '/', -1) as project,
   strftime(pr.timestamp, '%Y-%m-%d %H:%M') as time
 FROM permission_requests pr
-JOIN sessions s USING (session_id)
+JOIN sessions s USING (host, session_id)
 WHERE date_filter(s.start_time, getvariable('after_date'), getvariable('before_date'))
   AND project_filter(s.project_path, getvariable('project'))
+  AND host_filter(s.host, getvariable('host'))
 ORDER BY pr.timestamp DESC
 LIMIT getvariable('limit');

--- a/plugins/claude-code/skills/session/resources/queries/phrase-lift.sql
+++ b/plugins/claude-code/skills/session/resources/queries/phrase-lift.sql
@@ -2,6 +2,7 @@ WITH scoped AS (
   SELECT role, model, text
   FROM text_content
   WHERE date_filter(timestamp, getvariable('after_date'), getvariable('before_date'))
+    AND host_filter(host, getvariable('host'))
     AND (role = 'assistant' OR (NOT is_subagent AND NOT is_system))
 ),
 counts AS (

--- a/plugins/claude-code/skills/session/resources/queries/sandbox.sql
+++ b/plugins/claude-code/skills/session/resources/queries/sandbox.sql
@@ -6,8 +6,9 @@ SELECT
   SPLIT_PART(sb.project_path, '/', -1) as project,
   strftime(sb.timestamp, '%Y-%m-%d %H:%M') as time
 FROM sandbox_bypasses sb
-JOIN sessions s USING (session_id)
+JOIN sessions s USING (host, session_id)
 WHERE date_filter(s.start_time, getvariable('after_date'), getvariable('before_date'))
   AND project_filter(s.project_path, getvariable('project'))
+  AND host_filter(s.host, getvariable('host'))
 ORDER BY sb.timestamp DESC
 LIMIT getvariable('limit');

--- a/plugins/claude-code/skills/session/resources/queries/search.sql
+++ b/plugins/claude-code/skills/session/resources/queries/search.sql
@@ -3,17 +3,18 @@ FROM sessions s
 WHERE (
   EXISTS (
     SELECT 1 FROM messages m
-    WHERE m.session_id = s.session_id
+    WHERE m.host = s.host AND m.session_id = s.session_id
       AND (m.content_text ILIKE '%' || getvariable('query') || '%'
         OR m.summary ILIKE '%' || getvariable('query') || '%')
   )
   OR EXISTS (
     SELECT 1 FROM content_items ci
-    WHERE ci.session_id = s.session_id
+    WHERE ci.host = s.host AND ci.session_id = s.session_id
       AND ci.text ILIKE '%' || getvariable('query') || '%'
   )
 )
   AND date_filter(s.start_time, getvariable('after_date'), getvariable('before_date'))
   AND project_filter(s.project_path, getvariable('project'))
+  AND host_filter(s.host, getvariable('host'))
 ORDER BY s.start_time DESC
 LIMIT getvariable('limit');

--- a/plugins/claude-code/skills/session/resources/queries/skills.sql
+++ b/plugins/claude-code/skills/session/resources/queries/skills.sql
@@ -1,16 +1,17 @@
 WITH filtered AS (
   SELECT sc.*
   FROM skill_calls sc
-  JOIN sessions s USING (session_id)
+  JOIN sessions s USING (host, session_id)
   WHERE date_filter(s.start_time, getvariable('after_date'), getvariable('before_date'))
     AND project_filter(s.project_path, getvariable('project'))
+    AND host_filter(s.host, getvariable('host'))
     AND (getvariable('skill') IS NULL OR sc.skill_name = getvariable('skill'))
 ),
 per_skill AS (
   SELECT
     skill_name,
     COUNT(*) as uses,
-    COUNT(DISTINCT session_id) as sessions
+    COUNT(DISTINCT (host, session_id)) as sessions
   FROM filtered
   GROUP BY skill_name
 )
@@ -18,7 +19,7 @@ SELECT
   skill_name,
   uses,
   sessions,
-  (SELECT COUNT(DISTINCT session_id) FROM filtered) as total_sessions,
+  (SELECT COUNT(DISTINCT (host, session_id)) FROM filtered) as total_sessions,
   (SELECT SUM(uses) FROM per_skill) as total_uses
 FROM per_skill
 ORDER BY uses DESC, skill_name;

--- a/plugins/claude-code/skills/session/resources/queries/stats.sql
+++ b/plugins/claude-code/skills/session/resources/queries/stats.sql
@@ -1,9 +1,10 @@
 WITH filtered_calls AS (
   SELECT tc.*
   FROM tool_calls tc
-  JOIN sessions s USING (session_id)
+  JOIN sessions s USING (host, session_id)
   WHERE date_filter(s.start_time, getvariable('after_date'), getvariable('before_date'))
     AND project_filter(s.project_path, getvariable('project'))
+    AND host_filter(s.host, getvariable('host'))
 ),
 per_tool AS (
   SELECT
@@ -11,7 +12,7 @@ per_tool AS (
     COUNT(*) as uses,
     COUNT(te.error_content) as errors
   FROM filtered_calls fc
-  LEFT JOIN tool_errors te ON fc.tool_id = te.tool_id
+  LEFT JOIN tool_errors te ON fc.tool_id = te.tool_id AND fc.host = te.host
   GROUP BY fc.tool_name
 )
 SELECT
@@ -19,7 +20,7 @@ SELECT
   uses,
   errors,
   ROUND(errors::DOUBLE / uses * 100, 1) as error_rate_pct,
-  (SELECT COUNT(DISTINCT session_id) FROM filtered_calls) as total_sessions,
+  (SELECT COUNT(DISTINCT (host, session_id)) FROM filtered_calls) as total_sessions,
   (SELECT SUM(uses) FROM per_tool) as total_tool_uses,
   (SELECT SUM(errors) FROM per_tool) as total_errors
 FROM per_tool

--- a/plugins/claude-code/skills/session/resources/queries/text-export.sql
+++ b/plugins/claude-code/skills/session/resources/queries/text-export.sql
@@ -9,10 +9,11 @@ SELECT
   tc.source_file,
   tc.source_line
 FROM text_content tc
-JOIN sessions s USING (session_id)
+JOIN sessions s USING (host, session_id)
 WHERE (getvariable('role') IS NULL OR tc.role = getvariable('role'))
   AND (getvariable('model') IS NULL OR (tc.model IS NOT NULL AND tc.model GLOB getvariable('model')::VARCHAR))
   AND date_filter(tc.timestamp, getvariable('after_date'), getvariable('before_date'))
   AND project_filter(s.project_path, getvariable('project'))
+  AND host_filter(tc.host, getvariable('host'))
   AND (getvariable('min_chars') IS NULL OR length(tc.text) >= getvariable('min_chars')::BIGINT)
 ORDER BY tc.timestamp, tc.source_file, tc.source_line;

--- a/plugins/claude-code/skills/session/resources/refresh.sql
+++ b/plugins/claude-code/skills/session/resources/refresh.sql
@@ -1,5 +1,5 @@
 SET VARIABLE last_import_time = COALESCE(
-  (SELECT last_import FROM meta LIMIT 1),
+  (SELECT last_import FROM meta WHERE host = getvariable('host') LIMIT 1),
   '1970-01-01'::TIMESTAMP
 );
 

--- a/plugins/claude-code/skills/session/resources/schema/01_tables.sql
+++ b/plugins/claude-code/skills/session/resources/schema/01_tables.sql
@@ -1,4 +1,5 @@
 CREATE TABLE IF NOT EXISTS raw (
+  host            VARCHAR,
   session_id      VARCHAR,
   type            VARCHAR,
   project_path    VARCHAR,
@@ -16,5 +17,6 @@ CREATE TABLE IF NOT EXISTS raw (
 );
 
 CREATE TABLE IF NOT EXISTS meta (
+  host            VARCHAR,
   last_import     TIMESTAMP
 );

--- a/plugins/claude-code/skills/session/resources/schema/03_macros.sql
+++ b/plugins/claude-code/skills/session/resources/schema/03_macros.sql
@@ -4,3 +4,8 @@ CREATE OR REPLACE MACRO date_filter(ts, after_val, before_val) AS
 
 CREATE OR REPLACE MACRO project_filter(path, project_val) AS
   (project_val IS NULL OR SPLIT_PART(path, '/', -1) GLOB project_val::VARCHAR);
+
+CREATE OR REPLACE MACRO host_filter(host_col, host_val) AS
+  (host_val IS NULL OR host_col = host_val::VARCHAR);
+
+CREATE OR REPLACE MACRO project_id(host, path) AS host || ':' || path;

--- a/plugins/claude-code/skills/session/resources/views.sql
+++ b/plugins/claude-code/skills/session/resources/views.sql
@@ -9,16 +9,17 @@ SELECT
   s.summary
 FROM raw r
 LEFT JOIN (
-  SELECT session_id, ANY_VALUE(summary) AS summary
+  SELECT host, session_id, ANY_VALUE(summary) AS summary
   FROM raw
   WHERE type = 'summary' AND summary IS NOT NULL
-  GROUP BY session_id
-) s USING (session_id)
+  GROUP BY host, session_id
+) s USING (host, session_id)
 WHERE r.type IN ('user', 'assistant');
 
 CREATE OR REPLACE TABLE content_items AS
 WITH src AS (
   SELECT
+    r.host,
     r.session_id,
     r.timestamp,
     r.project_path,
@@ -30,6 +31,7 @@ WITH src AS (
   WHERE r.type IN ('user', 'assistant')
 )
 SELECT
+  s.host,
   s.session_id,
   s.timestamp,
   s.project_path,
@@ -52,6 +54,7 @@ CREATE OR REPLACE VIEW tool_calls AS
 SELECT
   name AS tool_name,
   id   AS tool_id,
+  host,
   session_id,
   project_path,
   timestamp
@@ -63,13 +66,14 @@ SELECT
   er.tool_use_id   AS tool_id,
   er.content       AS error_content,
   COALESCE(tc.tool_name, 'unknown') AS tool_name,
+  er.host,
   er.session_id,
   tc.project_path,
   er.timestamp,
   CASE WHEN er.tool_use_result::VARCHAR = '"User rejected tool use"'
        THEN 'rejection' ELSE 'failure' END AS error_type
 FROM content_items er
-LEFT JOIN tool_calls tc ON er.tool_use_id = tc.tool_id
+LEFT JOIN tool_calls tc ON er.tool_use_id = tc.tool_id AND er.host = tc.host
 WHERE er.type = 'tool_result' AND er.is_error;
 
 CREATE OR REPLACE VIEW skill_calls AS
@@ -77,6 +81,7 @@ SELECT
   (data->>'$.input.skill') AS skill_name,
   NULLIF((data->>'$.input.args'), '') AS args,
   id AS tool_id,
+  host,
   session_id,
   project_path,
   timestamp
@@ -92,11 +97,12 @@ SELECT
   (tc.data->>'$.input.command')     AS command,
   (tc.data->>'$.input.file_path')   AS file_path,
   (tc.data->>'$.input.description') AS description,
+  tc.host,
   tc.session_id,
   tc.project_path,
   tc.timestamp
 FROM content_items er
-JOIN content_items tc ON er.tool_use_id = tc.id
+JOIN content_items tc ON er.tool_use_id = tc.id AND er.host = tc.host
 WHERE er.type = 'tool_result'
   AND er.tool_use_result::VARCHAR = '"User rejected tool use"';
 
@@ -106,6 +112,7 @@ WITH bypass AS (
     (data->>'$.input.command')     AS command,
     (data->>'$.input.description') AS description,
     id AS tool_id,
+    host,
     session_id,
     project_path,
     timestamp
@@ -118,6 +125,7 @@ SELECT
   b.command,
   b.description,
   b.tool_id,
+  b.host,
   b.session_id,
   b.project_path,
   b.timestamp,
@@ -128,10 +136,12 @@ LEFT JOIN LATERAL (
   SELECT tc.id AS tool_id, er.content AS error
   FROM content_items tc
   JOIN content_items er
-    ON er.tool_use_id = tc.id AND er.type = 'tool_result' AND er.is_error
+    ON er.tool_use_id = tc.id AND er.host = tc.host
+       AND er.type = 'tool_result' AND er.is_error
   WHERE tc.type = 'tool_use'
     AND tc.name = 'Bash'
     AND COALESCE((tc.data->>'$.input.dangerouslyDisableSandbox'), 'false') = 'false'
+    AND tc.host = b.host
     AND tc.session_id = b.session_id
     AND tc.timestamp  < b.timestamp
     AND (tc.data->>'$.input.command') = b.command
@@ -142,6 +152,7 @@ LEFT JOIN LATERAL (
 CREATE OR REPLACE VIEW text_content AS
 WITH unified AS (
   SELECT
+    ci.host,
     ci.session_id,
     ci.timestamp,
     ci.project_path,
@@ -155,7 +166,7 @@ WITH unified AS (
       OR ci.text LIKE '[Request interrupted%'
     AS is_system
   FROM content_items ci
-  JOIN messages m USING (source_file, source_line)
+  JOIN messages m USING (host, source_file, source_line)
   WHERE ci.type = 'text'
     AND ci.text IS NOT NULL
     AND length(trim(ci.text)) > 0
@@ -164,6 +175,7 @@ WITH unified AS (
   UNION ALL
 
   SELECT
+    m.host,
     m.session_id,
     m.timestamp,
     m.project_path,
@@ -189,6 +201,7 @@ WITH unified AS (
     AND NOT m.is_meta
 )
 SELECT
+  host,
   session_id,
   timestamp,
   project_path,
@@ -207,7 +220,9 @@ FROM unified;
 
 CREATE OR REPLACE VIEW sessions AS
 SELECT
+  host,
   session_id,
+  project_id(host, ANY_VALUE(project_path)) AS project_id,
   ANY_VALUE(summary) AS summary,
   MIN(timestamp) AS start_time,
   MAX(timestamp) AS end_time,
@@ -217,5 +232,5 @@ SELECT
   COUNT(*) FILTER (WHERE type = 'user' AND NOT is_meta) AS user_messages,
   COUNT(*) FILTER (WHERE type = 'assistant')            AS assistant_messages
 FROM messages
-GROUP BY session_id
+GROUP BY host, session_id
 HAVING COUNT(*) FILTER (WHERE type = 'user' AND NOT is_meta) > 0;

--- a/plugins/claude-code/skills/session/scripts/db.test.ts
+++ b/plugins/claude-code/skills/session/scripts/db.test.ts
@@ -1,13 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import * as path from "node:path";
-import { type Database, ensureIndex, getDb, runQuery } from "./db";
+import { $ } from "bun";
+import { type Database, dirExists, ensureIndex, getDb, rebuildViews, runQuery } from "./db";
 
 const fixturesDir = path.join(import.meta.dirname, "..", "fixtures", "sessions");
 
 function filterParams(overrides: Record<string, string | null> = {}) {
-  return { after_date: null, before_date: null, project: null, ...overrides };
+  return { after_date: null, before_date: null, project: null, host: null, ...overrides };
 }
 
 function queryParams(overrides: Record<string, string | null> = {}) {
@@ -16,11 +17,33 @@ function queryParams(overrides: Record<string, string | null> = {}) {
 
 let db: Database;
 let tmpDir: string;
+let importsDir: string;
+
+async function importFixtureHost(label: string, opts: { source?: string } = {}) {
+  const projects = path.join(importsDir, label, "projects");
+  mkdirSync(projects, { recursive: true });
+  await $`cp -R ${fixturesDir}/. ${projects}`.quiet();
+  await Bun.write(
+    path.join(importsDir, label, "manifest.json"),
+    `${JSON.stringify({
+      host: label,
+      source: opts.source ?? `${label}:.claude/projects/`,
+      imported_at: "2026-01-01T00:00:00Z",
+      policy: { block_egress: true },
+    })}\n`,
+  );
+}
+
+async function reindex() {
+  await ensureIndex(db, { projectsDir: fixturesDir, dataDir: tmpDir, importsDir, force: true });
+}
 
 beforeEach(async () => {
   tmpDir = mkdtempSync(path.join(process.env.TMPDIR || "/tmp", "session-test-"));
+  importsDir = path.join(tmpDir, "imports");
+  mkdirSync(importsDir, { recursive: true });
   db = await getDb(tmpDir);
-  await ensureIndex(db, { projectsDir: fixturesDir, dataDir: tmpDir });
+  await ensureIndex(db, { projectsDir: fixturesDir, dataDir: tmpDir, importsDir });
 });
 
 afterEach(async () => {
@@ -258,7 +281,7 @@ describe("incremental refresh", () => {
     const before = await db.query<{ session_id: string }>(
       "SELECT * FROM sessions ORDER BY session_id",
     );
-    await ensureIndex(db, { projectsDir: fixturesDir, dataDir: tmpDir });
+    await ensureIndex(db, { projectsDir: fixturesDir, dataDir: tmpDir, importsDir });
     const after = await db.query<{ session_id: string }>(
       "SELECT * FROM sessions ORDER BY session_id",
     );
@@ -311,7 +334,7 @@ describe("type drift across imports", () => {
     );
     await db.run("DELETE FROM meta");
 
-    await ensureIndex(db, { projectsDir: fixturesDir, dataDir: tmpDir, force: true });
+    await ensureIndex(db, { projectsDir: fixturesDir, dataDir: tmpDir, importsDir, force: true });
 
     const [typeRow] = await db.query<{ data_type: string }>(
       "SELECT data_type FROM information_schema.columns WHERE table_name = 'raw' AND column_name = 'data'",
@@ -445,6 +468,7 @@ describe("text-export query", () => {
       before_date: null,
       project: null,
       min_chars: null,
+      host: null,
       ...overrides,
     };
   }
@@ -481,7 +505,13 @@ describe("text-export query", () => {
 
 describe("phrase-lift query", () => {
   function liftParams(overrides: Record<string, string | null> = {}) {
-    return { phrase: "reaching for", after_date: null, before_date: null, ...overrides };
+    return {
+      phrase: "reaching for",
+      after_date: null,
+      before_date: null,
+      host: null,
+      ...overrides,
+    };
   }
 
   it("counts phrase occurrences per role and model", async () => {
@@ -535,12 +565,107 @@ describe("model-summary query", () => {
       model: string;
       messages: bigint;
       total_chars: bigint;
-    }>(db, "model-summary", { after_date: null, before_date: null, project: null });
+    }>(db, "model-summary", { after_date: null, before_date: null, project: null, host: null });
     expect(rows.length).toBeGreaterThan(0);
     for (const row of rows) {
       expect(row.model).toBeTruthy();
       expect(Number(row.messages)).toBeGreaterThan(0);
       expect(Number(row.total_chars)).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("cross-machine history", () => {
+  it("tags imported rows with the host across sessions, messages, and content_items", async () => {
+    await importFixtureHost("work");
+    await reindex();
+
+    for (const tbl of ["sessions", "messages", "content_items"]) {
+      const rows = await db.query<{ host: string }>(
+        `SELECT DISTINCT host FROM ${tbl} ORDER BY host`,
+      );
+      expect(rows.map((r) => r.host)).toEqual(["local", "work"]);
+    }
+  });
+
+  it("scopes to a host with host= and spans all hosts without it", async () => {
+    await importFixtureHost("work");
+    await reindex();
+
+    const scoped = await runQuery<{ host: string }>(
+      db,
+      "search",
+      queryParams({ host: "work", query: "error" }),
+    );
+    expect(scoped.length).toBeGreaterThan(0);
+    expect(scoped.every((r) => r.host === "work")).toBe(true);
+
+    const spanned = await runQuery<{ host: string }>(db, "search", queryParams({ query: "error" }));
+    expect(new Set(spanned.map((r) => r.host))).toEqual(new Set(["local", "work"]));
+
+    const scopedStats = await runQuery<{ total_sessions: number }>(
+      db,
+      "stats",
+      filterParams({ host: "work" }),
+    );
+    const allStats = await runQuery<{ total_sessions: number }>(db, "stats", filterParams());
+    expect(Number(allStats[0]?.total_sessions)).toBe(Number(scopedStats[0]?.total_sessions) * 2);
+  });
+
+  it("indexes a host whose files predate the local import (per-host watermark)", async () => {
+    // Push local's watermark past the imported files so they "predate" the local
+    // import. Only a per-host watermark (epoch for a new host) lets archive index;
+    // a shared watermark would skip its now-older files.
+    await db.run("UPDATE meta SET last_import = '2099-01-01'::TIMESTAMP WHERE host = 'local'");
+    await importFixtureHost("archive");
+    await reindex();
+
+    const [row] = await db.query<{ n: bigint }>(
+      "SELECT COUNT(*) AS n FROM sessions WHERE host = 'archive'",
+    );
+    expect(Number(row?.n)).toBeGreaterThan(0);
+  });
+
+  it("forget removes a host's rows and synced files", async () => {
+    await importFixtureHost("gone");
+    await reindex();
+    const [before] = await db.query<{ n: bigint }>(
+      "SELECT COUNT(*) AS n FROM raw WHERE host = 'gone'",
+    );
+    expect(Number(before?.n)).toBeGreaterThan(0);
+
+    await db.run("DELETE FROM raw WHERE host = $host", { host: "gone" });
+    await db.run("DELETE FROM meta WHERE host = $host", { host: "gone" });
+    await rebuildViews(db);
+    await rm(path.join(importsDir, "gone"), { recursive: true, force: true });
+
+    const [after] = await db.query<{ n: bigint }>(
+      "SELECT COUNT(*) AS n FROM raw WHERE host = 'gone'",
+    );
+    expect(Number(after?.n)).toBe(0);
+    const sessions = await db.query<{ host: string }>(
+      "SELECT DISTINCT host FROM sessions ORDER BY host",
+    );
+    expect(sessions.map((r) => r.host)).toEqual(["local"]);
+    expect(dirExists(path.join(importsDir, "gone"))).toBe(false);
+  });
+
+  it("keeps the same session distinct across hosts without merging or dropping", async () => {
+    await importFixtureHost("alpha");
+    await importFixtureHost("beta");
+    await reindex();
+
+    const hosts = await db.query<{ host: string }>(
+      "SELECT host FROM sessions WHERE session_id = 'basic-session' ORDER BY host",
+    );
+    expect(hosts.map((r) => r.host)).toEqual(["alpha", "beta", "local"]);
+
+    const counts = await db.query<{ host: string; n: bigint }>(
+      "SELECT host, COUNT(*) AS n FROM sessions GROUP BY host ORDER BY host",
+    );
+    expect(counts.map((r) => r.host)).toEqual(["alpha", "beta", "local"]);
+    const distinct = new Set(counts.map((r) => Number(r.n)));
+    expect(distinct.size).toBe(1);
+    expect([...distinct][0]).toBeGreaterThan(0);
   });
 });

--- a/plugins/claude-code/skills/session/scripts/db.ts
+++ b/plugins/claude-code/skills/session/scripts/db.ts
@@ -6,10 +6,29 @@ const RESOURCES_DIR = path.join(import.meta.dirname, "..", "resources");
 const SCHEMA_DIR = path.join(RESOURCES_DIR, "schema");
 const QUERIES_DIR = path.join(RESOURCES_DIR, "queries");
 
+export const LOCAL_HOST = "local";
+
 export interface Database {
   run(sql: string, params?: Record<string, string | null>): Promise<void>;
   query<T>(sql: string, params?: Record<string, string | null>): Promise<T[]>;
   close(): void;
+}
+
+export interface HostPolicy {
+  block_egress?: boolean;
+}
+
+export interface Manifest {
+  host: string;
+  source: string;
+  imported_at: string;
+  policy: HostPolicy;
+}
+
+export interface HostEntry {
+  host: string;
+  glob: string;
+  policy: HostPolicy;
 }
 
 async function createDatabase(dbPath: string): Promise<Database> {
@@ -40,7 +59,7 @@ async function readSql(dir: string, name: string): Promise<string> {
   return Bun.file(path.join(dir, `${name}.sql`)).text();
 }
 
-function getProjectsGlob(projectsDir?: string): string {
+function getLocalGlob(projectsDir?: string): string {
   const dir = projectsDir || process.env.CLAUDE_PROJECTS_DIR;
   if (dir) return path.join(dir, "**", "*.jsonl");
 
@@ -48,6 +67,96 @@ function getProjectsGlob(projectsDir?: string): string {
     throw new Error("Cannot locate projects directory: set CLAUDE_PROJECTS_DIR or HOME");
   }
   return path.join(process.env.HOME, ".claude", "projects", "**", "*.jsonl");
+}
+
+export function getImportsDir(importsDir?: string): string {
+  const dir = importsDir || process.env.CLAUDE_SESSION_IMPORTS_DIR;
+  if (dir) return dir;
+
+  if (!process.env.HOME) {
+    throw new Error("Cannot locate imports directory: set CLAUDE_SESSION_IMPORTS_DIR or HOME");
+  }
+  return path.join(process.env.HOME, ".claude", "session-imports");
+}
+
+export function importRoot(label: string, importsDir?: string): string {
+  return path.join(getImportsDir(importsDir), label);
+}
+
+export function getDataDir(): string {
+  return (
+    process.env.CLAUDE_PLUGIN_DATA || path.join(process.env.TMPDIR || "/tmp", "claude-session")
+  );
+}
+
+export function sessionDbPath(dataDir: string): string {
+  return path.join(dataDir, "session.duckdb");
+}
+
+export function dirExists(target: string): boolean {
+  try {
+    readdirSync(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface ImportedHost {
+  label: string;
+  root: string;
+  manifestPath: string;
+  manifest: Manifest;
+}
+
+function readDirEntries(dir: string) {
+  try {
+    return readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+export async function listImportedHosts(importsDir?: string): Promise<ImportedHost[]> {
+  const root = getImportsDir(importsDir);
+  const hosts: ImportedHost[] = [];
+  for (const entry of readDirEntries(root)) {
+    if (!entry.isDirectory()) continue;
+    const hostRoot = path.join(root, entry.name);
+    const manifestPath = path.join(hostRoot, "manifest.json");
+    try {
+      const manifest: unknown = await Bun.file(manifestPath).json();
+      hosts.push({
+        label: entry.name,
+        root: hostRoot,
+        manifestPath,
+        manifest: manifest as Manifest,
+      });
+    } catch {
+      // No manifest (or invalid JSON) means this directory is not a registered host.
+    }
+  }
+  return hosts;
+}
+
+export async function enumerateHosts(
+  options: { projectsDir?: string; importsDir?: string } = {},
+): Promise<HostEntry[]> {
+  const hosts: HostEntry[] = [
+    { host: LOCAL_HOST, glob: getLocalGlob(options.projectsDir), policy: {} },
+  ];
+
+  for (const imported of await listImportedHosts(options.importsDir)) {
+    // The directory name is the canonical label (forget.ts/hosts.ts/importRoot all
+    // key on it); the manifest's host field is informational and may be hand-edited.
+    hosts.push({
+      host: imported.label,
+      glob: path.join(imported.root, "projects", "**", "*.jsonl"),
+      policy: imported.manifest.policy ?? {},
+    });
+  }
+
+  return hosts;
 }
 
 async function applySchema(db: Database): Promise<void> {
@@ -61,56 +170,74 @@ async function applySchema(db: Database): Promise<void> {
 }
 
 async function migrateIfNeeded(db: Database): Promise<void> {
-  const [row] = await db.query<{ ok: boolean }>(`
-    SELECT EXISTS (
-      SELECT 1 FROM information_schema.columns
-      WHERE table_schema = 'main' AND table_name = 'raw' AND column_name = 'data'
-    ) AS ok
+  const [row] = await db.query<{ has_data: boolean; has_host: boolean }>(`
+    SELECT
+      EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'main' AND table_name = 'raw' AND column_name = 'data'
+      ) AS has_data,
+      EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'main' AND table_name = 'raw' AND column_name = 'host'
+      ) AS has_host
   `);
-  if (row?.ok) return;
-  await db.run("DROP TABLE IF EXISTS messages");
+  if (row?.has_data && row?.has_host) return;
   await db.run("DROP TABLE IF EXISTS content_items");
   await db.run("DROP TABLE IF EXISTS raw");
   await db.run("DROP TABLE IF EXISTS meta");
 }
 
 export async function getDb(dataDir: string): Promise<Database> {
-  const dbPath = path.join(dataDir, "session.duckdb");
-  return createDatabase(dbPath);
+  return createDatabase(sessionDbPath(dataDir));
+}
+
+export async function ensureSchema(db: Database): Promise<void> {
+  await migrateIfNeeded(db);
+  await applySchema(db);
+}
+
+export async function rebuildViews(db: Database): Promise<void> {
+  await db.run(await readSql(RESOURCES_DIR, "views"));
 }
 
 export async function ensureIndex(
   db: Database,
-  options: { projectsDir?: string; force?: boolean; dataDir?: string } = {},
+  options: { projectsDir?: string; importsDir?: string; force?: boolean; dataDir?: string } = {},
 ): Promise<void> {
-  if (!options.force && options.dataDir) {
-    const sessionId = process.env.CLAUDE_SESSION_ID;
-    if (sessionId) {
-      const marker = path.join(options.dataDir, `.refreshed-${sessionId}`);
-      if (await Bun.file(marker).exists()) return;
-    }
+  const sessionId = process.env.CLAUDE_SESSION_ID;
+  const marker =
+    options.dataDir && sessionId
+      ? path.join(options.dataDir, `.refreshed-${sessionId}`)
+      : undefined;
+
+  if (!options.force && marker && (await Bun.file(marker).exists())) return;
+
+  await ensureSchema(db);
+
+  let imported = false;
+  for (const entry of await enumerateHosts(options)) {
+    await db.run("SET VARIABLE host = $host", { host: entry.host });
+    await db.run("SET VARIABLE projects_glob = $glob", { glob: entry.glob });
+    await db.run(await readSql(RESOURCES_DIR, "refresh"));
+
+    const [row] = await db.query<{ n: bigint }>("SELECT LEN(getvariable('changed_files')) as n");
+    if (!row || row.n === 0n) continue;
+
+    await db.run("SET VARIABLE source = getvariable('changed_files')");
+    await db.run(await readSql(RESOURCES_DIR, "import"));
+    imported = true;
   }
 
-  await migrateIfNeeded(db);
-  await applySchema(db);
+  if (imported) {
+    await rebuildViews(db);
+  }
 
-  const glob = getProjectsGlob(options.projectsDir);
+  // Clear the per-host indexing variable so a query reusing this connection without
+  // an explicit host param spans all hosts rather than inheriting the last one.
+  await db.run("SET VARIABLE host = NULL");
 
-  await db.run("SET VARIABLE projects_glob = $glob", { glob });
-  await db.run(await readSql(RESOURCES_DIR, "refresh"));
-
-  const [row] = await db.query<{ n: bigint }>("SELECT LEN(getvariable('changed_files')) as n");
-  if (!row || row.n === 0n) return;
-
-  await db.run("SET VARIABLE source = getvariable('changed_files')");
-  await db.run(await readSql(RESOURCES_DIR, "import"));
-  await db.run(await readSql(RESOURCES_DIR, "views"));
-
-  if (options.dataDir) {
-    const sessionId = process.env.CLAUDE_SESSION_ID;
-    if (sessionId) {
-      await Bun.write(path.join(options.dataDir, `.refreshed-${sessionId}`), "");
-    }
+  if (marker) {
+    await Bun.write(marker, "");
   }
 }
 

--- a/plugins/claude-code/skills/session/scripts/forget.ts
+++ b/plugins/claude-code/skills/session/scripts/forget.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env bun
+import { rm } from "node:fs/promises";
+import { cli } from "cleye";
+import {
+  dirExists,
+  ensureSchema,
+  getDataDir,
+  getDb,
+  importRoot,
+  LOCAL_HOST,
+  rebuildViews,
+} from "./db";
+
+const argv = cli({
+  name: "forget",
+  flags: {
+    host: {
+      type: String,
+      description: "Imported host label to remove (rows and synced files)",
+      required: true as const,
+    },
+  },
+});
+
+const label = argv.flags.host;
+
+if (!label) {
+  console.error("--host is required.");
+  process.exit(1);
+}
+
+if (label === LOCAL_HOST) {
+  console.error(`"${LOCAL_HOST}" is this machine's own history and cannot be forgotten.`);
+  process.exit(1);
+}
+
+const db = await getDb(getDataDir());
+let deleted = 0;
+try {
+  await ensureSchema(db);
+  const [row] = await db.query<{ n: bigint }>("SELECT COUNT(*) AS n FROM raw WHERE host = $host", {
+    host: label,
+  });
+  deleted = Number(row?.n ?? 0n);
+  await db.run("DELETE FROM raw WHERE host = $host", { host: label });
+  await db.run("DELETE FROM meta WHERE host = $host", { host: label });
+  await rebuildViews(db);
+} finally {
+  db.close();
+}
+
+const root = importRoot(label);
+const removedFiles = dirExists(root);
+if (removedFiles) {
+  await rm(root, { recursive: true, force: true });
+}
+
+console.log(
+  `Forgot host "${label}": ${deleted} rows removed${removedFiles ? `, ${root} deleted` : ""}`,
+);

--- a/plugins/claude-code/skills/session/scripts/hosts.ts
+++ b/plugins/claude-code/skills/session/scripts/hosts.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env bun
+import * as path from "node:path";
+import { cli } from "cleye";
+import { table } from "table";
+import { getDataDir, getDb, LOCAL_HOST, listImportedHosts, sessionDbPath } from "./db";
+
+cli({ name: "hosts", flags: {} });
+
+const dataDir = getDataDir();
+
+async function lastImports(): Promise<Record<string, string>> {
+  if (!(await Bun.file(sessionDbPath(dataDir)).exists())) return {};
+  const db = await getDb(dataDir);
+  try {
+    const rows = await db.query<{ host: string; last_import: string | null }>(
+      "SELECT host, strftime(last_import, '%Y-%m-%d %H:%M') AS last_import FROM meta",
+    );
+    return Object.fromEntries(rows.map((r) => [r.host, r.last_import ?? "-"]));
+  } catch {
+    return {};
+  } finally {
+    db.close();
+  }
+}
+
+const imported = await listImportedHosts();
+const watermarks = await lastImports();
+
+const rows: string[][] = [["HOST", "IMPORTED", "EGRESS", "LAST IMPORT", "SOURCE"]];
+rows.push([LOCAL_HOST, "-", "allowed", watermarks[LOCAL_HOST] ?? "-", "(this machine)"]);
+for (const { label, manifest } of imported) {
+  rows.push([
+    label,
+    manifest.imported_at,
+    (manifest.policy?.block_egress ?? true) ? "blocked" : "allowed",
+    watermarks[label] ?? "-",
+    manifest.source || "-",
+  ]);
+}
+
+console.log(table(rows));
+
+if (imported.length > 0) {
+  console.log("Re-sync (copy, paste, run, then re-run import.ts):\n");
+  for (const { label, root, manifest } of imported) {
+    const source = manifest.source || "<source>";
+    console.log(`  ${label}:`);
+    console.log(`    rsync -av --update ${source} ${path.join(root, "projects")}/`);
+  }
+}

--- a/plugins/claude-code/skills/session/scripts/import.ts
+++ b/plugins/claude-code/skills/session/scripts/import.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+import { mkdir } from "node:fs/promises";
+import * as path from "node:path";
+import { $ } from "bun";
+import { cli } from "cleye";
+import {
+  dirExists,
+  ensureIndex,
+  getDataDir,
+  getDb,
+  getImportsDir,
+  importRoot,
+  LOCAL_HOST,
+  listImportedHosts,
+  type Manifest,
+} from "./db";
+
+const argv = cli({
+  name: "import",
+  flags: {
+    host: {
+      type: String,
+      description: "Label for the imported machine (lands in the host column)",
+      required: true as const,
+    },
+    source: {
+      type: String,
+      description:
+        "rsync source, recorded in the manifest for re-sync (e.g. work:.claude/projects/)",
+      default: "",
+    },
+    egress: {
+      type: Boolean,
+      description: "Allow this host's rows in output that leaves the machine (default: blocked)",
+      default: false,
+    },
+  },
+});
+
+const label = argv.flags.host;
+
+if (!label) {
+  console.error("--host is required.");
+  process.exit(1);
+}
+
+if (label === LOCAL_HOST) {
+  console.error(`"${LOCAL_HOST}" is reserved for this machine's own history.`);
+  process.exit(1);
+}
+
+if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(label)) {
+  console.error(`Invalid host label "${label}". Use letters, digits, "-" and "_".`);
+  process.exit(1);
+}
+
+const root = importRoot(label);
+const projectsDir = path.join(root, "projects");
+if (!dirExists(projectsDir)) {
+  console.error(`No corpus at ${projectsDir}.`);
+  console.error("Sync the source machine's ~/.claude/projects/ there first, then re-run:");
+  console.error(`  rsync -av --update ${argv.flags.source || "<source>"} ${projectsDir}/`);
+  process.exit(1);
+}
+
+// Re-running on a registered host is a re-sync: leave the manifest (source, policy,
+// imported_at) intact and just re-index the changed files.
+const existing = (await listImportedHosts()).find((h) => h.label === label)?.manifest;
+const manifestPath = path.join(root, "manifest.json");
+if (!existing) {
+  await mkdir(getImportsDir(), { recursive: true, mode: 0o700 });
+  const manifest: Manifest = {
+    host: label,
+    source: argv.flags.source,
+    imported_at: new Date().toISOString(),
+    policy: { block_egress: !argv.flags.egress },
+  };
+  await Bun.write(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  // Lock down the import tree: 0700 dirs, 0600 manifest (no Bun chmod API).
+  await $`chmod 700 ${getImportsDir()} ${root}`.quiet();
+  await $`chmod 600 ${manifestPath}`.quiet();
+}
+
+const dataDir = getDataDir();
+await mkdir(dataDir, { recursive: true });
+
+const db = await getDb(dataDir);
+try {
+  await ensureIndex(db, { dataDir, force: true });
+} finally {
+  db.close();
+}
+
+const blockEgress = existing ? (existing.policy?.block_egress ?? true) : !argv.flags.egress;
+console.log(`${existing ? "Re-indexed" : "Imported"} host "${label}" from ${projectsDir}`);
+console.log(`  egress: ${blockEgress ? "blocked" : "allowed"}`);

--- a/plugins/claude-code/skills/session/scripts/refresh.integration.ts
+++ b/plugins/claude-code/skills/session/scripts/refresh.integration.ts
@@ -21,6 +21,7 @@ function env() {
     ...process.env,
     CLAUDE_PLUGIN_DATA: tmpDir,
     CLAUDE_PROJECTS_DIR: fixturesDir,
+    CLAUDE_SESSION_IMPORTS_DIR: path.join(tmpDir, "imports"),
   };
 }
 

--- a/plugins/claude-code/skills/session/scripts/refresh.ts
+++ b/plugins/claude-code/skills/session/scripts/refresh.ts
@@ -1,10 +1,8 @@
 #!/usr/bin/env bun
 import { mkdirSync } from "node:fs";
-import * as path from "node:path";
-import { ensureIndex, getDb } from "./db";
+import { ensureIndex, getDataDir, getDb, sessionDbPath } from "./db";
 
-const dataDir =
-  process.env.CLAUDE_PLUGIN_DATA || path.join(process.env.TMPDIR || "/tmp", "claude-session");
+const dataDir = getDataDir();
 mkdirSync(dataDir, { recursive: true });
 
 const refresh = process.argv.includes("--refresh");
@@ -16,4 +14,4 @@ try {
   db.close();
 }
 
-process.stdout.write(`${path.join(dataDir, "session.duckdb")}\n`);
+process.stdout.write(`${sessionDbPath(dataDir)}\n`);

--- a/plugins/writing/skills/analyze/resources/queries/correction-candidates.sql
+++ b/plugins/writing/skills/analyze/resources/queries/correction-candidates.sql
@@ -1,5 +1,6 @@
 WITH per_message AS (
   SELECT
+    tc.host,
     tc.session_id,
     s.project_path AS session_project_path,
     tc.source_file,
@@ -9,12 +10,12 @@ WITH per_message AS (
     string_agg(tc.text, E'\n' ORDER BY tc.source_line) AS message_text,
     SUM(length(tc.text)) AS chars
   FROM text_content tc
-  JOIN sessions s USING (session_id)
+  JOIN sessions s USING (host, session_id)
   WHERE date_filter(tc.timestamp, getvariable('after_date'), getvariable('before_date'))
     AND project_filter(s.project_path, getvariable('project'))
     AND NOT tc.is_subagent
     AND (tc.role = 'assistant' OR NOT tc.is_system)
-  GROUP BY tc.session_id, s.project_path, tc.source_file, tc.source_line, tc.timestamp, tc.role
+  GROUP BY tc.host, tc.session_id, s.project_path, tc.source_file, tc.source_line, tc.timestamp, tc.role
 ),
 paired AS (
   SELECT
@@ -26,7 +27,7 @@ paired AS (
     LEAD(source_file) OVER w AS next_source_file,
     LEAD(source_line) OVER w AS next_source_line
   FROM per_message
-  WINDOW w AS (PARTITION BY session_id ORDER BY timestamp, source_file, source_line)
+  WINDOW w AS (PARTITION BY host, session_id ORDER BY timestamp, source_file, source_line)
 ),
 candidates AS (
   SELECT

--- a/plugins/writing/skills/analyze/resources/queries/deliverable-prose.sql
+++ b/plugins/writing/skills/analyze/resources/queries/deliverable-prose.sql
@@ -11,7 +11,7 @@ write_prose AS (
     ci.session_id,
     (ci.data->>'$.input.content') AS text
   FROM content_items ci
-  JOIN sessions s USING (session_id)
+  JOIN sessions s USING (host, session_id)
   WHERE ci.type = 'tool_use'
     AND ci.name = 'Write'
     AND regexp_matches((ci.data->>'$.input.file_path'), '\.(md|txt|rst|adoc)$')
@@ -28,7 +28,7 @@ edit_prose AS (
     ci.session_id,
     (ci.data->>'$.input.new_string') AS text
   FROM content_items ci
-  JOIN sessions s USING (session_id)
+  JOIN sessions s USING (host, session_id)
   WHERE ci.type = 'tool_use'
     AND ci.name = 'Edit'
     AND regexp_matches((ci.data->>'$.input.file_path'), '\.(md|txt|rst|adoc)$')
@@ -49,7 +49,7 @@ bash_prose AS (
       NULLIF(regexp_extract((ci.data->>'$.input.command'), '(?:-m|--(?:body|message|description|title))\s+''([^'']+)''', 1), '')
     ) AS text
   FROM content_items ci
-  JOIN sessions s USING (session_id)
+  JOIN sessions s USING (host, session_id)
   WHERE ci.type = 'tool_use'
     AND ci.name = 'Bash'
     AND regexp_matches(

--- a/plugins/writing/skills/analyze/resources/queries/fts-setup.sql
+++ b/plugins/writing/skills/analyze/resources/queries/fts-setup.sql
@@ -7,7 +7,7 @@ DROP TABLE IF EXISTS fts_user_corpus;
 CREATE TABLE fts_assistant_corpus AS
   SELECT row_number() OVER () AS id, text
   FROM text_content tc
-  JOIN sessions s USING (session_id)
+  JOIN sessions s USING (host, session_id)
   WHERE tc.role = 'assistant'
     AND date_filter(tc.timestamp, getvariable('after_date'), getvariable('before_date'))
     AND (tc.model IS NOT NULL AND tc.model GLOB getvariable('model')::VARCHAR)
@@ -17,7 +17,7 @@ CREATE TABLE fts_assistant_corpus AS
 CREATE TABLE fts_user_corpus AS
   SELECT row_number() OVER () AS id, text
   FROM text_content tc
-  JOIN sessions s USING (session_id)
+  JOIN sessions s USING (host, session_id)
   WHERE tc.role = 'user'
     AND NOT tc.is_subagent
     AND NOT tc.is_system

--- a/plugins/writing/skills/analyze/resources/queries/model-summary.sql
+++ b/plugins/writing/skills/analyze/resources/queries/model-summary.sql
@@ -1,7 +1,7 @@
 WITH scoped AS (
   SELECT tc.*
   FROM text_content tc
-  JOIN sessions s USING (session_id)
+  JOIN sessions s USING (host, session_id)
   WHERE tc.role = 'assistant'
     AND date_filter(tc.timestamp, getvariable('after_date'), getvariable('before_date'))
     AND project_filter(s.project_path, getvariable('project'))
@@ -10,7 +10,7 @@ SELECT
   COALESCE(model, '(unknown)') AS model,
   COUNT(*) AS text_items,
   COUNT(DISTINCT (source_file, source_line)) AS messages,
-  COUNT(DISTINCT session_id) AS sessions,
+  COUNT(DISTINCT (host, session_id)) AS sessions,
   SUM(length(text)) AS total_chars
 FROM scoped
 GROUP BY model

--- a/plugins/writing/skills/analyze/resources/queries/text-export.sql
+++ b/plugins/writing/skills/analyze/resources/queries/text-export.sql
@@ -2,7 +2,7 @@ SELECT
   tc.session_id,
   tc.text
 FROM text_content tc
-JOIN sessions s USING (session_id)
+JOIN sessions s USING (host, session_id)
 WHERE (getvariable('role') IS NULL OR tc.role = getvariable('role'))
   AND (getvariable('model') IS NULL OR (tc.model IS NOT NULL AND tc.model GLOB getvariable('model')::VARCHAR))
   AND date_filter(tc.timestamp, getvariable('after_date'), getvariable('before_date'))


### PR DESCRIPTION
Adds a cross-machine dimension to the `session` skill so another machine's history, copied locally, is queryable as one corpus. Each machine is a `host`, with `local` for this one and a chosen label for imported ones. With nothing imported, the index behaves exactly as the single-machine case. This unblocks `writing:analyze`, whose per-word lift needs a larger, writing-heavier user baseline than the local corpus alone provides.

## Changes

Session skill:

- Schema: `raw` gains `host` as its first column, and `meta` becomes `meta(host, last_import)`, a per-host import watermark. New macros `host_filter` (null pass-through) and `project_id(host, path)`.
- `db.ts` enumerates one entry per host (`local` plus each `~/.claude/session-imports/<label>/manifest.json`) and indexes them in a per-host loop. The watermark is keyed by host because `rsync -a` preserves source mtimes, so a freshly imported host's files predate `local`'s watermark. A shared watermark would skip them entirely.
- Every view and named query carries `host`. An optional `host=` param scopes a query to one machine, and omitting it spans all hosts. Cross-host joins key on `(host, session_id)`.
- New CLIs manage the lifecycle. `import.ts` registers a synced corpus and indexes it (dirs `0700`, manifest `0600`). `forget.ts` removes a host's rows and files. `hosts.ts` lists hosts with their egress policy and a ready-to-run re-sync command.

Consumer update:

- `writing:analyze` queries now join on `(host, session_id)` and count `DISTINCT (host, session_id)`. Without this, the combined corpus fans out, and session counts collapse, when a session id appears under more than one host.

## Decisions

- **Idempotent `import.ts`.** The plan asked both to reject an already-registered label and to re-run `import.ts` for re-sync. I reconciled these by making a re-run preserve the existing manifest (`source`, policy, `imported_at`) and re-index only the changed files, so one command covers both import and refresh without clobbering.
- **Directory name is the canonical host label.** `enumerateHosts` derives the label from the import directory, matching `forget.ts`, `hosts.ts`, and `importRoot`, rather than the manifest's `host` field. A hand-edited manifest then cannot orphan rows under a label the lifecycle commands cannot reach.
- **Privacy.** Imported data defaults to `block_egress`, and `--egress` opts in. `SKILL.md` documents excluding blocked hosts from anything that leaves the machine, and flags credential patterns as a review signal.
- **File I/O** uses Bun APIs and `node:fs/promises` per the repo's `noRestrictedImports` rule. Modes are set via `mkdir` and a `chmod` shell-out since Bun has no `chmod`.

## Testing

- Unit coverage for: `host` tagging across `sessions`, `messages`, and `content_items`, `host=` scoping versus spanning all hosts, a host whose files predate the `local` import still indexing (per-host watermark), `forget` removing both rows and files, and the same fixture under two labels neither merging nor dropping rows. Fixtures drive an isolated `session-imports` dir so the suite never reads the real corpus.
- The `import.ts`, `hosts.ts`, and `forget.ts` CLIs were exercised end-to-end against a temporary corpus (register, list with re-sync command, host-scoped query, forget), including the `local` and duplicate rejections and the `0700` / `0600` permissions.
- Verified on a real second machine's corpus: imported it under a `work` host and re-ran `writing:analyze` across the combined baseline. The larger user baseline confirms the provisional wordlist prune holds, since the single-word lists read as dead and the distinctive signal sits in multi-word phrases and the structural patterns. The wordlist edit itself is a curation decision left to a follow-up rather than changed here.
