### PR TITLE
pull-request: add plain-prose style guidance for PR bodies

### DIFF
--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -48,7 +48,7 @@ allowed-tools:
 
 #### Voice
 
-Write plainly. Technical precision is good; marketing is not. Match the author's own voice: a developer explaining the change to a reviewer, not selling it.
+Write plainly. Technical precision is good, marketing is not. Match the author's own voice: a developer explaining the change to a reviewer, not selling it.
 
 - Open with a bare present-tense verb: "Adds", "Fixes", "Changes", "Updates". State the mechanism first, then the motivation
 - Use a concrete noun where one exists. Don't reach for a metaphor when the real name is shorter

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -45,6 +45,18 @@ allowed-tools:
   - Design decisions and judgment calls: use "I" so it's clear you made the call ("I chose X over Y because…", "I kept the old endpoint to avoid a breaking change")
 - If the PR is directly motivated by an issue, reference it at the end of the opening summary (`Closes #N`, `Fixes #N`, or just `#N` if not closing). Related issues mentioned for context belong in a `## References` section. Never drop issue refs at the bottom of the body without a section
 - **Wrap all code identifiers with backticks**: function names, class names, file paths, endpoints, status codes, etc.
+
+#### Voice
+
+Write plainly. Technical precision is good; marketing is not. Match the author's own voice: a developer explaining the change to a reviewer, not selling it.
+
+- Open with a bare present-tense verb: "Adds", "Fixes", "Changes", "Updates". State the mechanism first, then the motivation
+- Use a concrete noun where one exists. Don't reach for a metaphor when the real name is shorter
+- Length tracks substance. A one-line change gets a one-line body. Don't pad
+- Hedge and name rejected alternatives honestly ("I doubt anyone has hit this", "I chose X over Y because…", "unrelated, required to run tests")
+- Avoid model flourishes: "source of truth", "fail loudly", "escape hatch", "wires up", "cleanly". The antithesis construction ("X instead of Y") is usually padding
+- Load the `writing` skill for the full set of tropes to avoid
+
 - Use `##` sections for larger changes. See [`sections.md`](sections.md) for detailed guidance on:
   - `## Issue` - Root cause analysis and issue linking
   - `## Changes` - High-level description of changes

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -45,23 +45,22 @@ allowed-tools:
   - Design decisions and judgment calls: use "I" so it's clear you made the call ("I chose X over Y because…", "I kept the old endpoint to avoid a breaking change")
 - If the PR is directly motivated by an issue, reference it at the end of the opening summary (`Closes #N`, `Fixes #N`, or just `#N` if not closing). Related issues mentioned for context belong in a `## References` section. Never drop issue refs at the bottom of the body without a section
 - **Wrap all code identifiers with backticks**: function names, class names, file paths, endpoints, status codes, etc.
+- Use `##` sections for larger changes. See [`sections.md`](sections.md) for detailed guidance on:
+  - `## Issue` - Root cause analysis and issue linking
+  - `## Changes` - High-level description of changes
+  - `## Testing` - Test coverage insights
+  - `## References` - Related links and issues
 
 #### Voice
 
 Write plainly. Technical precision is good, marketing is not. Match the author's own voice: a developer explaining the change to a reviewer, not selling it.
 
 - Open with a bare present-tense verb: "Adds", "Fixes", "Changes", "Updates". State the mechanism first, then the motivation
-- Use a concrete noun where one exists. Don't reach for a metaphor when the real name is shorter
+- Use a concrete noun where one exists. A metaphor is rarely shorter than the real name
 - Length tracks substance. A one-line change gets a one-line body. Don't pad
 - Hedge and name rejected alternatives honestly ("I doubt anyone has hit this", "I chose X over Y because…", "unrelated, required to run tests")
-- Avoid model flourishes: "source of truth", "fail loudly", "escape hatch", "wires up", "cleanly". The antithesis construction ("X instead of Y") is usually padding
+- Avoid model flourishes: `source of truth`, `fail loudly`, `escape hatch`, `wires up`, `cleanly`. The antithesis construction (`X instead of Y`) is usually padding
 - Load the `writing` skill for the full set of tropes to avoid
-
-- Use `##` sections for larger changes. See [`sections.md`](sections.md) for detailed guidance on:
-  - `## Issue` - Root cause analysis and issue linking
-  - `## Changes` - High-level description of changes
-  - `## Testing` - Test coverage insights
-  - `## References` - Related links and issues
 
 ## Template
 

--- a/plugins/pull-request/skills/create/sections.md
+++ b/plugins/pull-request/skills/create/sections.md
@@ -7,7 +7,7 @@ Stick to active voice. Don't use passive ("X was added"). Rewrite so something i
 - Self-evident description of what the PR does: PR-as-subject is fine ("Adds retry logic") or subject-elided in bullets ("Added retry logic", "Extracted the helper")
 - Design decisions and judgment calls: use "I" so it's clear you made the call ("I chose X over Y because…")
 
-Keep the prose plain. Technical terms are fine. Marketing phrasing and model flourishes ("source of truth", "fail loudly", "escape hatch", "cleanly") are not. Load the `writing` skill for the full set of tropes to avoid.
+Keep the prose plain. Technical terms are fine. Marketing phrasing and model flourishes (`source of truth`, `fail loudly`, `escape hatch`, `cleanly`) are not. Load the `writing` skill for the full set of tropes to avoid.
 
 ## Issue
 

--- a/plugins/pull-request/skills/create/sections.md
+++ b/plugins/pull-request/skills/create/sections.md
@@ -7,7 +7,7 @@ Stick to active voice. Don't use passive ("X was added"). Rewrite so something i
 - Self-evident description of what the PR does: PR-as-subject is fine ("Adds retry logic") or subject-elided in bullets ("Added retry logic", "Extracted the helper")
 - Design decisions and judgment calls: use "I" so it's clear you made the call ("I chose X over Y because…")
 
-Keep the prose plain. Technical terms are fine; marketing phrasing and model flourishes ("source of truth", "fail loudly", "escape hatch", "cleanly") are not. Load the `writing` skill for the full set of tropes to avoid.
+Keep the prose plain. Technical terms are fine. Marketing phrasing and model flourishes ("source of truth", "fail loudly", "escape hatch", "cleanly") are not. Load the `writing` skill for the full set of tropes to avoid.
 
 ## Issue
 

--- a/plugins/pull-request/skills/create/sections.md
+++ b/plugins/pull-request/skills/create/sections.md
@@ -7,6 +7,8 @@ Stick to active voice. Don't use passive ("X was added"). Rewrite so something i
 - Self-evident description of what the PR does: PR-as-subject is fine ("Adds retry logic") or subject-elided in bullets ("Added retry logic", "Extracted the helper")
 - Design decisions and judgment calls: use "I" so it's clear you made the call ("I chose X over Y because…")
 
+Keep the prose plain. Technical terms are fine; marketing phrasing and model flourishes ("source of truth", "fail loudly", "escape hatch", "cleanly") are not. Load the `writing` skill for the full set of tropes to avoid.
+
 ## Issue
 
 Use for bug fixes, which should include a related issue.

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -45,7 +45,7 @@ The PR body documents what will happen when merged, not the journey. Don't echo 
 
 ## Writing
 
-1. Rewrite the PR body following the same title and body rules as the create skill, including its plain-voice guidance. Keep the prose plain and free of marketing or model flourishes; load the `writing` skill for the full set of tropes to avoid. If a PR template is provided in context, preserve its structure. See [`sections.md`](../create/sections.md) for section guidance.
+1. Rewrite the PR body following the same title and body rules as the create skill, including its plain-voice guidance. Load the `writing` skill for the full set of tropes to avoid. If a PR template is provided in context, preserve its structure. See [`sections.md`](../create/sections.md) for section guidance.
 2. Write the updated body to a temp file (e.g., `tmp/pr-body-<branch>.md`) and apply:
    - **GitHub**: `gh pr edit --body-file tmp/pr-body-<branch>.md`
    - **GitLab**: `glab mr update --description "$(cat tmp/pr-body-<branch>.md)"`

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -45,7 +45,7 @@ The PR body documents what will happen when merged, not the journey. Don't echo 
 
 ## Writing
 
-1. Rewrite the PR body following the same title and body rules as the create skill. If a PR template is provided in context, preserve its structure. See [`sections.md`](sections.md) for section guidance.
+1. Rewrite the PR body following the same title and body rules as the create skill, including its plain-voice guidance. Keep the prose plain and free of marketing or model flourishes; load the `writing` skill for the full set of tropes to avoid. If a PR template is provided in context, preserve its structure. See [`sections.md`](../create/sections.md) for section guidance.
 2. Write the updated body to a temp file (e.g., `tmp/pr-body-<branch>.md`) and apply:
    - **GitHub**: `gh pr edit --body-file tmp/pr-body-<branch>.md`
    - **GitLab**: `glab mr update --description "$(cat tmp/pr-body-<branch>.md)"`


### PR DESCRIPTION
Adds a Voice subsection to the `pull-request:create` skill, with matching notes in `sections.md` and the `pull-request:update` skill, so generated PR bodies read like a developer explaining a change rather than selling it. The rules come from the repo owner's hand-written PR bodies: bare present-tense openers, mechanism before motivation, concrete nouns over metaphor, honest hedging, and length that tracks substance. Each note cross-references the `writing` skill instead of duplicating its vocabulary.

## Changes

- Added a `#### Voice` subsection to the create skill's Body section with the positive rules and a short list of model flourishes to avoid ("source of truth", "fail loudly", "escape hatch", "wires up", "cleanly")
- Added a one-line plain-prose note to `sections.md` covering the same flourishes
- Added a plain-voice reminder to the update skill's Writing step
- Repointed the update skill's `sections.md` link to `../create/sections.md`, where the file actually lives (the link was previously dangling)

## Notes

The cited flourishes were checked against the owner's hand-written PR corpus and appear zero times, so the guidance bans model habits rather than the author's own vocabulary. The additions follow the `writing` skill themselves: no em dashes, no marketing language, no semicolon-heavy sentences.
