### PR TITLE
writing:analyze: deliverable-aware audit + local voice baseline

### DIFF
--- a/plugins/writing/skills/analyze/SKILL.md
+++ b/plugins/writing/skills/analyze/SKILL.md
@@ -26,6 +26,19 @@ DB_PATH=$(<session-skill-dir>/scripts/refresh.ts --refresh)
 
 The refresh script prints the resolved DB path to stdout.
 
+Build the local voice baseline once (and refresh it as new writing accumulates). It is the comparison surface for deliverable-aware rule health. The baseline is local-only and never committed; it lives at `CLAUDE_PLUGIN_DATA` (else `~/.claude/plugins/data/writing-bendrucker`).
+
+```bash
+# Seed from the already-present delimited corpus (no re-fetch needed)
+${CLAUDE_SKILL_DIR}/scripts/ingest-voice.ts --source file --file <data-dir>/voice-baseline/github-prs.txt
+# Or fetch fresh merged PRs (designed to add more sources later)
+${CLAUDE_SKILL_DIR}/scripts/ingest-voice.ts --source github --author <user> --created 2019-01-01..2025-01-01
+# Build the profile the audit reads
+${CLAUDE_SKILL_DIR}/scripts/voice-profile.ts
+```
+
+If no profile exists, analyze still runs: deliverable-surface rules fall back to the chat audit and the report flags the baseline as not loaded.
+
 ## Run
 
 Pass the DB path via `--session-db`:
@@ -36,7 +49,7 @@ ${CLAUDE_SKILL_DIR}/scripts/analyze.ts --session-db "$DB_PATH" --since 2026-04-0
 ${CLAUDE_SKILL_DIR}/scripts/analyze.ts --session-db "$DB_PATH" --project bendrucker.me --min-lift 7
 ```
 
-Run with `--help` for all flags. Writes a markdown report to `tmp/trope-analysis-<date>.md` (override with `--out`).
+Run with `--help` for all flags. `--data-dir` overrides where the voice baseline is read from (default: `CLAUDE_PLUGIN_DATA` or `~/.claude/plugins/data/writing-bendrucker`). Writes a markdown report to `tmp/trope-analysis-<date>.md` (override with `--out`). The report may quote any host in the combined index, so keep it under `tmp/` and never paste host-specific content into committed work.
 
 ## Metrics
 
@@ -46,24 +59,26 @@ Run with `--help` for all flags. Writes a markdown report to `tmp/trope-analysis
 
 ## Output
 
-- Summary stats (corpus sizes, rule count, model breakdown)
-- Proposed removals, each tagged **dead** (model produced it fewer than `--min-count` times) or **not distinctive** (user uses it at least as often as the model)
-- Proposed additions (high-lift n-grams not already covered)
-- Rule health table (every entry with type and `keep` / `remove (reason)`)
+- Summary stats (corpus sizes, voice-baseline size, rule count, model breakdown)
+- Proposed removals, each tagged **dead** (model produced it fewer than `--min-count` times on its firing surface) or **not distinctive** (baseline uses it at least as often as the model)
+- Proposed additions (high-lift n-grams not already covered), each with its voice-baseline rate and a spot-checkable quote
+- Rule health table (every entry with type, audit surface, and `keep` / `remove (reason)`), plus deliverable quotes for the deliverable-surface tells
 - Structural pattern audit (the hook's regex patterns, hit counts across sessions)
+- Corrective feedback (short human messages naming a writing problem, with the preceding model output)
 - Correction candidates (long-assistant, short-user pairs suggesting prose pushback)
 
-A rule the model uses far more than the user is **kept** even when its lift reads low. Lift is not used for removal decisions because the smoothed user baseline (see methodology) compresses it for any word the user never types, which would flag the model's strongest tells (`delve`, `comprehensive`, `robust`) for removal.
+Each rule is judged on the surface where the hook fires it. Chat-surface rules (openers, sycophantic patterns, conversational vocabulary) compare the model's chat against the user's chat. Deliverable-surface rules (`flowery-phrases.txt`, `soft-phrasing.txt`) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as **keep**, not dead. A rule the model uses far more than the baseline is kept even when its lift reads low. Lift is not used for removal decisions because the smoothed user baseline (see methodology) compresses it for any word the user never types, which would flag the model's strongest tells (`delve`, `comprehensive`, `robust`) for removal.
 
 ## Corpora
 
-Three corpora, each serving a different purpose:
+Four corpora, each serving a different purpose:
 
 - **All model-generated text**: conversational assistant text (`text-export`, role=assistant) combined with deliverable prose (`deliverable-prose.sql`). The session DB's `text_content` view only captures conversational text blocks, not tool inputs (Write/Edit/Bash). The deliverable query fills this gap. The combined corpus is used for n-gram candidates.
-- **Deliverable prose** (`deliverable-prose.sql`): Write/Edit to prose files, Bash commands with `--body`/`--message`/`-m`. Reported in the summary for context.
-- **Human-only user text** (`text-export`, role=user, filtered): the baseline for lift calculation. Filters out system-injected content (skill injections, context compaction summaries, task notifications, system reminders) that arrives as user-role messages but is machine-generated.
+- **Deliverable prose** (`deliverable-prose.sql`): Write/Edit to prose files, Bash commands with `--body`/`--message`/`-m`. The candidate-mining corpus and the model side of the deliverable-aware rule audit.
+- **Human-only user text** (`text-export`, role=user, filtered): the baseline for lift calculation. Filters out system-injected content (skill injections, context compaction summaries, task notifications, system reminders) and pasted model output (see methodology) that arrives as user-role messages but is machine-generated.
+- **Voice baseline** (local-only, `voice-profile.ts`): the user's hand-written, pre-AI pull requests. The baseline side of the deliverable-aware rule audit and the "absent from my baseline" signal for additions.
 
-The FTS rule health audit uses `text_content` (a view covering both roles) with its own FTS indexes.
+The FTS rule health audit uses `text_content` (a view covering both roles) with its own FTS indexes for chat-surface rules. Deliverable-surface rules compare deliverable prose against the voice baseline.
 
 ## Workflow
 

--- a/plugins/writing/skills/analyze/SKILL.md
+++ b/plugins/writing/skills/analyze/SKILL.md
@@ -30,11 +30,11 @@ Build the local voice baseline once (and refresh it as new writing accumulates).
 
 ```bash
 # Seed from the already-present delimited corpus (no re-fetch needed)
-${CLAUDE_SKILL_DIR}/scripts/ingest-voice.ts --source file --file <data-dir>/voice-baseline/github-prs.txt
+bun ${CLAUDE_SKILL_DIR}/scripts/ingest-voice.ts --source file --file <data-dir>/voice-baseline/github-prs.txt
 # Or fetch fresh merged PRs (designed to add more sources later)
-${CLAUDE_SKILL_DIR}/scripts/ingest-voice.ts --source github --author <user> --created 2019-01-01..2025-01-01
+bun ${CLAUDE_SKILL_DIR}/scripts/ingest-voice.ts --source github --author <user> --created 2019-01-01..2025-01-01
 # Build the profile the audit reads
-${CLAUDE_SKILL_DIR}/scripts/voice-profile.ts
+bun ${CLAUDE_SKILL_DIR}/scripts/voice-profile.ts
 ```
 
 If no profile exists, analyze still runs: deliverable-surface rules fall back to the chat audit and the report flags the baseline as not loaded.
@@ -44,9 +44,9 @@ If no profile exists, analyze still runs: deliverable-surface rules fall back to
 Pass the DB path via `--session-db`:
 
 ```bash
-${CLAUDE_SKILL_DIR}/scripts/analyze.ts --session-db "$DB_PATH"
-${CLAUDE_SKILL_DIR}/scripts/analyze.ts --session-db "$DB_PATH" --since 2026-04-01 --model '*opus*' --top 50
-${CLAUDE_SKILL_DIR}/scripts/analyze.ts --session-db "$DB_PATH" --project bendrucker.me --min-lift 7
+bun ${CLAUDE_SKILL_DIR}/scripts/analyze.ts --session-db "$DB_PATH"
+bun ${CLAUDE_SKILL_DIR}/scripts/analyze.ts --session-db "$DB_PATH" --since 2026-04-01 --model '*opus*' --top 50
+bun ${CLAUDE_SKILL_DIR}/scripts/analyze.ts --session-db "$DB_PATH" --project bendrucker.me --min-lift 7
 ```
 
 Run with `--help` for all flags. `--data-dir` overrides where the voice baseline is read from (default: `CLAUDE_PLUGIN_DATA` or `~/.claude/plugins/data/writing-bendrucker`). Writes a markdown report to `tmp/trope-analysis-<date>.md` (override with `--out`). The report may quote any host in the combined index, so keep it under `tmp/` and never paste host-specific content into committed work.

--- a/plugins/writing/skills/analyze/SKILL.md
+++ b/plugins/writing/skills/analyze/SKILL.md
@@ -26,7 +26,7 @@ DB_PATH=$(<session-skill-dir>/scripts/refresh.ts --refresh)
 
 The refresh script prints the resolved DB path to stdout.
 
-Build the local voice baseline once (and refresh it as new writing accumulates). It is the comparison surface for deliverable-aware rule health. The baseline is local-only and never committed; it lives at `CLAUDE_PLUGIN_DATA` (else `~/.claude/plugins/data/writing-bendrucker`).
+Build the local voice baseline once (and refresh it as new writing accumulates). It is the comparison surface for deliverable-aware rule health. The baseline is local-only and never committed. It is stored in the plugin data directory (`CLAUDE_PLUGIN_DATA`, else `~/.claude/plugins/data/writing-bendrucker`).
 
 ```bash
 # Seed from the already-present delimited corpus (no re-fetch needed)
@@ -60,7 +60,7 @@ Run with `--help` for all flags. `--data-dir` overrides where the voice baseline
 ## Output
 
 - Summary stats (corpus sizes, voice-baseline size, rule count, model breakdown)
-- Proposed removals, each tagged **dead** (model produced it fewer than `--min-count` times on its firing surface) or **not distinctive** (baseline uses it at least as often as the model)
+- Proposed removals, each tagged **dead** (model produced it fewer than `--min-count` times on the surface where the hook fires it) or **not distinctive** (baseline uses it at least as often as the model)
 - Proposed additions (high-lift n-grams not already covered), each with its voice-baseline rate and a spot-checkable quote
 - Rule health table (every entry with type, audit surface, and `keep` / `remove (reason)`), plus deliverable quotes for the deliverable-surface tells
 - Structural pattern audit (the hook's regex patterns, hit counts across sessions)

--- a/plugins/writing/skills/analyze/references/methodology.md
+++ b/plugins/writing/skills/analyze/references/methodology.md
@@ -39,18 +39,52 @@ Installs DuckDB's FTS extension and materializes per-role corpus tables (`fts_as
 
 Wordlist entries are batch-audited via `fts-phrase-audit.sql`. The query stems each entry with Porter stemming, then looks up term frequencies in both FTS indexes. Returns per-term assistant/user counts, per-million rates, and lift.
 
-A rule is **kept** when the model uses it strictly more per token than the user (`assistant_per_m > user_per_m`) and it appears at least `--min-count` times (default 5). Otherwise the report proposes removal with one of two reasons:
+A rule is **kept** when the model uses it strictly more per token than the comparison baseline (`model_per_m > baseline_per_m`) and it appears at least `--min-count` times (default 5) on its firing surface. Otherwise the report proposes removal with one of two reasons:
 
-- **dead**: fewer than `--min-count` assistant occurrences. The rule rarely fires regardless of distinctiveness.
-- **not distinctive**: the user uses it at least as often per token. The rule would flag the user's own voice.
+- **dead**: fewer than `--min-count` model occurrences on the firing surface. The rule rarely fires regardless of distinctiveness.
+- **not distinctive**: the baseline uses it at least as often per token. The rule would flag the user's own voice.
 
 Removal does **not** use lift. The user baseline is small (often tens of thousands of tokens, even with cross-machine history merged in), so the Laplace smoothing floor (`1/user_total`) dominates: any word the user never types needs a high per-million rate in assistant text just to reach a lift of 5.0. That gate is nearly unreachable for single words, so a pure lift threshold flags the model's strongest surviving tells (`delve`, `comprehensive`, `robust`) for removal. The direct rate comparison is smoothing-free and keeps them.
 
-The audit measures each term in `text_content` (conversational assistant and user text). This is a proxy surface: most wordlist rules fire on deliverables and side-effect inputs, not chat, but the model's chat usage of a term tracks its overall habit closely enough to judge distinctiveness. A consequence: a term both the model and the user say conversationally (`Perfect` as an acknowledgment) reads as not distinctive and is dropped even if it might still open a deliverable.
+#### Per-surface auditing
 
-The proxy breaks entirely for tells that live *only* in deliverables and never in chat. The flowery phrases (`flowery-phrases.txt`) and the soft group (`soft-phrasing.txt`) were curated from PR-body evidence, so the chat-surface audit reports them as `dead` (zero chat hits) or as `not distinctive`. Those verdicts are not authoritative for deliverable-surface rules. Auditing wordlist health against the deliverable corpus directly (not just chat) is the fix, tracked with the rest of the deliverable-aware analyze work.
+Each rule is judged on the surface where the hook fires it, so the audit measures the rule against the corpus it actually polices.
+
+- **Chat-surface rules** (`openers.txt`, the conversational vocabulary, the sycophantic patterns) compare the model's chat assistant text against the user's chat text in `text_content`, via the FTS pass. The model's chat usage of these terms tracks its overall habit. A consequence: a term both the model and the user say conversationally (`Perfect` as an acknowledgment) reads as not distinctive and is dropped even if it might still open a deliverable.
+- **Deliverable-surface rules** (`flowery-phrases.txt` and `soft-phrasing.txt`, both `fileOnly` in the hook) compare the model's deliverable-prose rate against the user's voice-baseline rate. Each entry is stem-matched against the deliverable corpus (the same Porter-stemmed subsequence scan the hook uses) and looked up in the voice profile (`voice-profile.ts`). A phrase frequent in the model's PR bodies and absent from the user's hand-written baseline reads as **keep**, which is the correct verdict: `source of truth`, `escape hatch`, `self-sufficient`, and `fail loudly` each occur dozens of times in deliverable prose and zero times across the 209 pre-AI baseline PRs.
+
+`marketing-verbs.txt` stays on the chat audit even though it reads as deliverable phrasing: its hook group is not `fileOnly`, so it fires on Bash side-effect inputs too, and auditing it against deliverables alone undercounts it (the few deliverable hits are often the user's own meta-discussion of the wordlist file). See `deliverable-audit.ts` for the surface assignment.
+
+When no voice profile is loaded (the local baseline has not been built), deliverable-surface rules fall back to the chat audit so the script still runs. Build the baseline with `ingest-voice.ts` then `voice-profile.ts` (see "Voice baseline" below) to get the deliverable-aware verdicts.
 
 Because removed single words are no longer in the wordlist, a later audit cannot resurface them (the additions pipeline only mines multi-word n-grams). If the model regresses to a removed word, add it back by hand.
+
+## Voice baseline
+
+The user's true deliverable voice is their hand-written, pre-AI pull requests, not their chat. A tell is real if it is frequent in the model's deliverables and absent from this baseline. The baseline is **local-only and never committed**: it lives outside the repository at the plugin data dir (`CLAUDE_PLUGIN_DATA`, else `~/.claude/plugins/data/writing-bendrucker`), resolved by `data-dir.ts`. It is local-only by design because it will grow to include private writing.
+
+#### Ingesting sources
+
+`ingest-voice.ts` normalizes one or more document sources into `voice-baseline/github-prs.txt`, a delimited corpus (`===== <source> (<meta>) =====` per document). Two sources:
+
+- **github**: `gh search prs --author=<user> --merged --json url,body,createdAt`, optionally scoped with `--created`. Designed to add more sources later.
+- **file**: merges an existing delimited corpus (the already-present seed) so the 209-PR baseline does not need re-fetching.
+
+Merging de-duplicates by source pointer, so re-ingesting a range is idempotent.
+
+#### Building the profile
+
+`voice-profile.ts` reads the corpus and writes `voice-baseline/profile.json`: unigram, bigram, and trigram word n-gram counts plus the total token count, built with the same tokenizer (`ngram.ts`) the candidate miner uses. `phraseProfileStat` looks a phrase up in the profile, and phrases longer than a trigram match by their leading trigram. A count of 0 is the strongest "absent from my baseline" signal.
+
+Both the corpus and the profile stay in the local data dir. `analyze.ts` loads the profile read-only via `--data-dir`. Nothing baseline-derived is ever written into the repository.
+
+## Corrective feedback
+
+`corrective-feedback.sql` surfaces labeled-slop moments: short, human-authored user messages that match a frustration lexicon (`frustration.ts`: `wtf`, `ugh`, `flowery`, `verbose`, `cut the`, `reads like`, and similar), paired with the preceding model output as context. These are higher-signal than the inferred long-assistant/short-user correction candidates because the user named a writing problem directly. The lexicon is compiled to a boundary-anchored regex alternation and passed to the query as the `lexicon` variable. Pasted model output is excluded by the same `is_system`/`is_subagent` flags and length ceiling used elsewhere.
+
+## Quote in context
+
+Every candidate phrase and every audited deliverable-surface tell ships with a context window and a source pointer (`quote-context.ts`), so a curation decision is spot-checkable without a separate query. `deliverable-prose.sql` carries `source_file`, `source_line`, and the written `file_path`. `findQuote` locates the first occurrence (exact for n-gram candidates, stemmed fallback for inflected tells) and returns a trimmed window plus the pointer. Quotes can reflect any host in the combined index, so they appear only in the local report under `tmp/`, never in committed content.
 
 ## Surface Candidate Phrases
 

--- a/plugins/writing/skills/analyze/references/methodology.md
+++ b/plugins/writing/skills/analyze/references/methodology.md
@@ -4,47 +4,44 @@ How each pass of `analyze.ts` works and how to read the report.
 
 ## Dependencies
 
-The analyze script opens the session DuckDB database directly via `@duckdb/node-api`. The DB path is passed via `--session-db`. The session skill's refresh script must run first to ensure the index is current. All SQL queries live in `resources/queries/` within the analyze skill.
+`analyze.ts` opens the session DuckDB database directly via `@duckdb/node-api`, reading the path from `--session-db`. SQL queries live in `resources/queries/`.
 
 ## Refresh
 
-The agent runs the session skill's `refresh.ts --refresh` before invoking analyze. This forces a rescan of `~/.claude/projects/**/*.jsonl`. The refresh script prints the DB path to stdout, which the agent captures and passes as `--session-db`.
+Run the session skill's `refresh.ts --refresh` before analyze. It rescans `~/.claude/projects/**/*.jsonl` and prints the DB path to stdout, which the agent passes as `--session-db`.
 
 ## Metrics
 
 #### Lift
 
-Lift measures how distinctive a phrase is to assistant output compared to the user's voice. Borrowed from association rule mining:
+How distinctive a phrase is to assistant output versus the user's voice, borrowed from association rule mining:
 
 ```
 lift = rate_assistant / rate_user_smoothed
 ```
 
-Where rates are per-million-token frequencies and the user rate uses Laplace smoothing (`+1 pseudo-count`) to avoid division by zero for phrases absent from user text.
+Rates are per-million-token frequencies; the user rate uses Laplace smoothing (`+1 pseudo-count`) to avoid dividing by zero for phrases absent from user text. A lift of 1.0 means equal rates; 10.0 means the assistant uses the phrase 10x more often per token.
 
-- `lift = 1.0` means the phrase appears at equal rates in both corpora.
-- `lift = 10.0` means the assistant uses the phrase 10x more often per token than the user.
-
-The `--min-lift` threshold (default 5.0) gates new candidate phrases. It does **not** decide rule keep/remove (see "Audit Current Wordlists" for why lift is unreliable there).
+The `--min-lift` threshold (default 5.0) gates new candidate phrases. It does **not** decide rule keep/remove (see "Audit current wordlists" for why lift is unreliable there).
 
 #### Session count
 
-The number of distinct sessions in which a phrase appears. Filters project-specific jargon that dominates a single long session but doesn't represent a model-wide habit. Candidates require a session count of 3+ to be surfaced.
+Distinct sessions containing a phrase. Filters project-specific jargon that dominates a single long session without representing a model-wide habit. Candidates require a session count of 3+.
 
-## FTS Setup
+## FTS setup
 
 Installs DuckDB's FTS extension and materializes per-role corpus tables (`fts_assistant_corpus`, `fts_user_corpus`) from `text_content`, filtered by date, model, project, and minimum length. Creates Porter-stemmed FTS indexes with English stopwords. These ephemeral tables are cleaned up in a `finally` block.
 
-## Audit Current Wordlists
+## Audit current wordlists
 
-Wordlist entries are batch-audited via `fts-phrase-audit.sql`. The query stems each entry with Porter stemming, then looks up term frequencies in both FTS indexes. Returns per-term assistant/user counts, per-million rates, and lift.
+`fts-phrase-audit.sql` batch-audits wordlist entries: it Porter-stems each entry, looks up term frequencies in both FTS indexes, and returns per-term assistant/user counts, per-million rates, and lift.
 
 A rule is **kept** when the model uses it strictly more per token than the comparison baseline (`model_per_m > baseline_per_m`) and it appears at least `--min-count` times (default 5) on its firing surface. Otherwise the report proposes removal with one of two reasons:
 
 - **dead**: fewer than `--min-count` model occurrences on the firing surface. The rule rarely fires regardless of distinctiveness.
 - **not distinctive**: the baseline uses it at least as often per token. The rule would flag the user's own voice.
 
-Removal does **not** use lift. The user baseline is small (often tens of thousands of tokens, even with cross-machine history merged in), so the Laplace smoothing floor (`1/user_total`) dominates: any word the user never types needs a high per-million rate in assistant text just to reach a lift of 5.0. That gate is nearly unreachable for single words, so a pure lift threshold flags the model's strongest surviving tells (`delve`, `comprehensive`, `robust`) for removal. The direct rate comparison is smoothing-free and keeps them.
+Removal does **not** use lift. The user baseline is small (often tens of thousands of tokens, even with cross-machine history merged in), so the Laplace smoothing floor (`1/user_total`) dominates: any word the user never types needs a high per-million rate in assistant text just to reach a lift of 5.0. That gate is nearly unreachable for single words, so a pure lift threshold would flag the model's strongest surviving tells (`delve`, `comprehensive`, `robust`) for removal. The direct rate comparison is smoothing-free and keeps them.
 
 #### Per-surface auditing
 
@@ -55,13 +52,13 @@ Each rule is judged on the surface where the hook fires it, so the audit measure
 
 `marketing-verbs.txt` stays on the chat audit even though it reads as deliverable phrasing: its hook group is not `fileOnly`, so it fires on Bash side-effect inputs too, and auditing it against deliverables alone undercounts it (the few deliverable hits are often the user's own meta-discussion of the wordlist file). See `deliverable-audit.ts` for the surface assignment.
 
-When no voice profile is loaded (the local baseline has not been built), deliverable-surface rules are still measured on the deliverable corpus, not the chat audit. The chat audit cannot score them: it stems each entry and joins against single-word FTS tokens, so a multi-word phrase never matches and would read as a false `dead`. Without a baseline the distinctiveness check is skipped, so an alive rule is reported `keep (no baseline)` rather than proposed for removal. Build the baseline with `ingest-voice.ts` then `voice-profile.ts` (see "Voice baseline" below) to get the full deliverable-aware verdicts.
+When no voice profile is loaded, deliverable-surface rules are still measured on the deliverable corpus, not the chat audit. The chat audit cannot score them: it stems each entry and joins against single-word FTS tokens, so a multi-word phrase never matches and would read as a false `dead`. Without a baseline the distinctiveness check is skipped, so an alive rule is reported `keep (no baseline)` rather than proposed for removal. Build the baseline with `ingest-voice.ts` then `voice-profile.ts` (see "Voice baseline") for the full deliverable-aware verdicts.
 
 Because removed single words are no longer in the wordlist, a later audit cannot resurface them (the additions pipeline only mines multi-word n-grams). If the model regresses to a removed word, add it back by hand.
 
 ## Voice baseline
 
-The user's true deliverable voice is their hand-written, pre-AI pull requests, not their chat. A tell is real if it is frequent in the model's deliverables and absent from this baseline. The baseline is **local-only and never committed**: it lives outside the repository at the plugin data dir (`CLAUDE_PLUGIN_DATA`, else `~/.claude/plugins/data/writing-bendrucker`), resolved by `data-dir.ts`. It is local-only by design because it will grow to include private writing.
+The user's true deliverable voice is their hand-written, pre-AI pull requests, not their chat. A tell is real if it is frequent in the model's deliverables and absent from this baseline. The baseline is **local-only and never committed**, since it will grow to include private writing. It is stored in the plugin data directory (`CLAUDE_PLUGIN_DATA`, else `~/.claude/plugins/data/writing-bendrucker`), resolved by `data-dir.ts`.
 
 #### Ingesting sources
 
@@ -80,74 +77,55 @@ Both the corpus and the profile stay in the local data dir. `analyze.ts` loads t
 
 ## Corrective feedback
 
-`corrective-feedback.sql` surfaces labeled-slop moments: short, human-authored user messages that match a frustration lexicon (`frustration.ts`: `wtf`, `ugh`, `flowery`, `verbose`, `cut the`, `reads like`, and similar), paired with the preceding model output as context. These are higher-signal than the inferred long-assistant/short-user correction candidates because the user named a writing problem directly. The lexicon is compiled to a boundary-anchored regex alternation and passed to the query as the `lexicon` variable. Pasted model output is excluded by the same `is_system`/`is_subagent` flags and length ceiling used elsewhere.
+`corrective-feedback.sql` surfaces labeled-slop moments: short, human-authored user messages matching a frustration lexicon (`frustration.ts`: `wtf`, `ugh`, `flowery`, `verbose`, `cut the`, `reads like`, and similar), paired with the preceding model output. These are higher-signal than the inferred long-assistant/short-user candidates because the user named a writing problem directly. The lexicon compiles to a boundary-anchored regex alternation passed as the `lexicon` variable. Pasted model output is excluded by the same `is_system`/`is_subagent` flags and length ceiling used elsewhere.
 
 ## Quote in context
 
-Every candidate phrase and every audited deliverable-surface tell ships with a context window and a source pointer (`quote-context.ts`), so a curation decision is spot-checkable without a separate query. `deliverable-prose.sql` carries `source_file`, `source_line`, and the written `file_path`. `findQuote` locates the first occurrence (exact for n-gram candidates, stemmed fallback for inflected tells) and returns a trimmed window plus the pointer. Quotes can reflect any host in the combined index, so they appear only in the local report under `tmp/`, never in committed content.
+Every candidate phrase and audited deliverable-surface tell ships with a context window and source pointer (`quote-context.ts`), so a curation decision is spot-checkable without a separate query. `deliverable-prose.sql` carries `source_file`, `source_line`, and the written `file_path`. `findQuote` locates the first occurrence (exact for n-gram candidates, stemmed fallback for inflected tells) and returns a trimmed window plus the pointer. Quotes can reflect any host in the combined index, so they appear only in the local report under `tmp/`, never in committed content.
 
-## Surface Candidate Phrases
+## Surface candidate phrases
 
 Pulls two corpora:
 
-- **Deliverable prose** (`deliverable-prose.sql`): the model's file writes (`.md`/`.txt`/`.rst`/`.adoc`) and Bash commit/PR/MR bodies. This is the n-gram candidate corpus, because these are the surfaces the hook scans. Conversational assistant text is deliberately excluded: the hook never sees the model's chat, so mining it floods the candidate list with narration (`now let me`, `let me check`) at enormous lift that no rule can act on. Scoping to deliverables surfaces only phrasing that could become an enforceable rule.
-- **Human-only user text** (`text-export` with `role=user`, filtered): the baseline for lift. The human doesn't write via Write/Edit, so this is their chat voice; lift therefore contrasts the model's deliverable phrasing against the human's natural voice. Excludes system-injected user-role content: skill injections, context compaction summaries, task notifications, system reminders, and CLAUDE.md context.
+- **Deliverable prose** (`deliverable-prose.sql`): the model's file writes (`.md`/`.txt`/`.rst`/`.adoc`) and Bash commit/PR/MR bodies, the surfaces the hook scans. Conversational assistant text is excluded: the hook never sees the model's chat, so mining it floods the candidate list with narration (`now let me`, `let me check`) at enormous lift that no rule can act on.
+- **Human-only user text** (`text-export` with `role=user`, filtered): the baseline for lift. The human doesn't write via Write/Edit, so this is their chat voice, contrasting the model's deliverable phrasing against the human's natural voice. Excludes system-injected user-role content (see "User text filtering").
 
-The n-gram code in `ngram.ts` strips markdown/code artifacts, URLs, table lines, headers, and code-shaped identifiers from both corpora.
-
-For each cleaned sentence, accumulates 3- and 4-gram counts. Builds rows with assistant count, user count, per-million-token rates, and lift. Excludes phrases already covered by the wordlists (substring match). Filters to `lift >= --min-lift` and `session count >= 3`, then returns the top N.
-
-Minimum assistant counts per n-gram size (3-grams: 5, 4-grams: 3) are hardcoded to suppress noise.
+`ngram.ts` strips markdown/code artifacts, URLs, table lines, headers, and code-shaped identifiers from both corpora, then accumulates 3- and 4-gram counts per cleaned sentence. It builds rows with assistant count, user count, per-million-token rates, and lift, excludes phrases already covered by the wordlists (substring match), filters to `lift >= --min-lift` and `session count >= 3`, and returns the top N. Minimum assistant counts per n-gram size (3-grams: 5, 4-grams: 3) are hardcoded to suppress noise.
 
 #### Deliverable prose
 
-The `deliverable-prose.sql` query extracts text from Write/Edit to prose files (`.md`, `.txt`, `.rst`, `.adoc`) and Bash commands with `--body`/`--message`/`--description`/`--title`/`-m`. It excludes paths the hook skips (memory, plan, wordlist files). For Bash, it extracts heredoc content and quoted flag values via regex. This is the corpus the n-gram candidate miner runs on (see above); the all-assistant `text-export` corpus is still pulled for the structural audit and summary sizing.
+`deliverable-prose.sql` extracts text from Write/Edit to prose files (`.md`, `.txt`, `.rst`, `.adoc`) and Bash commands with `--body`/`--message`/`--description`/`--title`/`-m`, pulling heredoc content and quoted flag values via regex. It excludes paths the hook skips (memory, plan, wordlist files). The all-assistant `text-export` corpus is still pulled for the structural audit and summary sizing.
 
 #### User text filtering
 
 User-role messages in Claude Code contain a mix of human input and machine-generated content. The `text_content` view classifies these with two boolean columns:
 
 - `is_subagent`: `source_file` contains `/subagents/` (subagent prompts, task dispatches)
-- `is_system`: prefix-based heuristics for system-injected content
+- `is_system`: prefix-based heuristics covering XML-tagged injections (`<task-notification>`, `<command-name>`, `<system-reminder>`), context compaction summaries (`This session is being continued from a previous conversation`), plan injections (`Implement the following plan:`), interruption markers (`[Request interrupted by user]`), ultraplan/ultrareview UI (`◇ `, `◆ `, `Ultraplan `), and goal injections (`Goal set:`)
 
-The `is_system` patterns cover:
+Skill injections and hook feedback are excluded earlier by `is_meta=true` in the WHERE clause. Without this filtering, roughly half the user corpus by character count is machine-generated, inflating the baseline and suppressing real lift signals.
 
-- XML-tagged injections (`<task-notification>`, `<command-name>`, `<system-reminder>`, etc.)
-- Context compaction summaries (`This session is being continued from a previous conversation`)
-- Plan injections (`Implement the following plan:`)
-- Interruption markers (`[Request interrupted by user]`)
-- Ultraplan/ultrareview UI (`◇ `, `◆ `, `Ultraplan `)
-- Goal injections (`Goal set:`)
+## Structural pattern audit
 
-Skill injections and hook feedback are excluded earlier by `is_meta=true` in the WHERE clause (787+ messages in a typical 30-day window).
+`structural.ts` imports the hook's `PATTERNS` directly from `hooks/tropes.ts` rather than re-declaring them, so the audit cannot drift from what the hook enforces. It keeps only the regex patterns whose source is not a wordlist (the FTS pass covers stemmed vocabulary, weighted verbs, and `WORDLISTS.openers`) and normalizes each to the global flag for counting. Function-based tests (e.g. test-result reporting) are excluded because a single regex match cannot count them.
 
-Without this filtering, roughly half the user corpus by character count is machine-generated, which inflates the baseline and suppresses real lift signals.
-
-## Structural Pattern Audit
-
-`structural.ts` imports the hook's `PATTERNS` directly from `hooks/tropes.ts` rather than re-declaring them, so the audit cannot drift from what the hook enforces. It keeps only the regex patterns whose source is not a wordlist (stemmed vocabulary and weighted verbs are covered by the FTS pass; `WORDLISTS.openers` is too) and normalizes each to the global flag for accurate counting. Function-based tests (e.g. test-result reporting) are excluded because they cannot be counted by a single regex match.
-
-The patterns run against all assistant text (not just deliverables). Each reports total hits, number of rows containing hits, and session spread. Patterns are labeled by their hook scope (all, file-only, side-effect-only).
-
-This catches structural tropes (semicolons, passive voice, hedging, parallelism) that the n-gram pipeline cannot detect.
+The patterns run against all assistant text (not just deliverables). Each reports total hits, rows containing hits, and session spread, labeled by hook scope (all, file-only, side-effect-only). This catches structural tropes (semicolons, passive voice, hedging, parallelism) that the n-gram pipeline cannot detect.
 
 ## Rule health table
 
-#### Type column
-
-Each rule in the health table is labeled by how the hook enforces it:
+Each rule is labeled in the **type** column by how the hook enforces it:
 
 - **vocabulary**: stemmed word match, fires on all prose (file writes, Bash args, MCP inputs)
 - **opener**: sideEffectOnly pattern, fires only on Bash/MCP inputs (not file writes)
 - **weighted**: accumulates a weighted score across matches, fires at a threshold
 
-## Surface Corrections
+## Surface corrections
 
-Runs `correction-candidates` with `min_assistant_chars=300`, `max_user_chars=250`, `limit=--corrections-limit`. The query finds adjacent message pairs where a long assistant message is followed by a short user reply. Short replies often indicate corrections or pushback.
+Runs `correction-candidates` with `min_assistant_chars=300`, `max_user_chars=250`, `limit=--corrections-limit`. It finds adjacent pairs where a long assistant message is followed by a short user reply, which often indicates a correction or pushback.
 
-## Spot-checking with DuckDB sampling
+## Spot-checking with DuckDB samples
 
-When auditing corpus quality (verifying `is_system`/`is_subagent` classification, checking for pasted machine content in user text), use DuckDB's `USING SAMPLE` clause for stratified random sampling across sessions:
+When auditing corpus quality (verifying `is_system`/`is_subagent` classification, checking for pasted machine content), use DuckDB's `USING SAMPLE` clause for stratified random sampling across sessions:
 
 ```sql
 -- Sample 20 sessions, then 40 rows within those sessions
@@ -170,9 +148,9 @@ USING SAMPLE reservoir(40 ROWS) REPEATABLE(42)
 ORDER BY h.session_id, h.timestamp
 ```
 
-`USING SAMPLE reservoir(N ROWS) REPEATABLE(seed)` gives deterministic reservoir sampling. The sample size and seed must be integer literals (expressions and `getvariable()` are not supported in the `SAMPLE` clause). To vary sample sizes, edit the query inline rather than parameterizing.
+`USING SAMPLE reservoir(N ROWS) REPEATABLE(seed)` gives deterministic reservoir sampling. The size and seed must be integer literals (expressions and `getvariable()` are unsupported in the `SAMPLE` clause), so vary sample sizes by editing the query inline.
 
-Stratify by sampling sessions first, then rows within those sessions. Without the session pool step, high-volume sessions dominate the sample and patterns from quieter sessions go unexamined.
+Sample sessions first, then rows within them. Without the session pool step, high-volume sessions dominate the sample and quieter sessions go unexamined.
 
 ## Tuning
 

--- a/plugins/writing/skills/analyze/references/methodology.md
+++ b/plugins/writing/skills/analyze/references/methodology.md
@@ -55,7 +55,7 @@ Each rule is judged on the surface where the hook fires it, so the audit measure
 
 `marketing-verbs.txt` stays on the chat audit even though it reads as deliverable phrasing: its hook group is not `fileOnly`, so it fires on Bash side-effect inputs too, and auditing it against deliverables alone undercounts it (the few deliverable hits are often the user's own meta-discussion of the wordlist file). See `deliverable-audit.ts` for the surface assignment.
 
-When no voice profile is loaded (the local baseline has not been built), deliverable-surface rules fall back to the chat audit so the script still runs. Build the baseline with `ingest-voice.ts` then `voice-profile.ts` (see "Voice baseline" below) to get the deliverable-aware verdicts.
+When no voice profile is loaded (the local baseline has not been built), deliverable-surface rules are still measured on the deliverable corpus, not the chat audit. The chat audit cannot score them: it stems each entry and joins against single-word FTS tokens, so a multi-word phrase never matches and would read as a false `dead`. Without a baseline the distinctiveness check is skipped, so an alive rule is reported `keep (no baseline)` rather than proposed for removal. Build the baseline with `ingest-voice.ts` then `voice-profile.ts` (see "Voice baseline" below) to get the full deliverable-aware verdicts.
 
 Because removed single words are no longer in the wordlist, a later audit cannot resurface them (the additions pipeline only mines multi-word n-grams). If the model regresses to a removed word, add it back by hand.
 

--- a/plugins/writing/skills/analyze/resources/queries/corrective-feedback.sql
+++ b/plugins/writing/skills/analyze/resources/queries/corrective-feedback.sql
@@ -1,0 +1,55 @@
+-- Surface labeled-slop moments: short, human-authored user messages that
+-- express frustration about writing quality, paired with the preceding model
+-- output as context. The frustration lexicon is passed as a regex alternation
+-- via the 'lexicon' variable. Pasted model output is excluded by length and by
+-- the is_system/is_subagent flags already on text_content.
+WITH per_message AS (
+  SELECT
+    tc.host,
+    tc.session_id,
+    s.project_path AS session_project_path,
+    tc.source_file,
+    tc.source_line,
+    tc.timestamp,
+    tc.role,
+    tc.is_system,
+    tc.is_subagent,
+    string_agg(tc.text, E'\n' ORDER BY tc.source_line) AS message_text,
+    SUM(length(tc.text)) AS chars
+  FROM text_content tc
+  JOIN sessions s USING (host, session_id)
+  WHERE date_filter(tc.timestamp, getvariable('after_date'), getvariable('before_date'))
+    AND project_filter(s.project_path, getvariable('project'))
+  GROUP BY tc.host, tc.session_id, s.project_path, tc.source_file, tc.source_line,
+           tc.timestamp, tc.role, tc.is_system, tc.is_subagent
+),
+paired AS (
+  SELECT
+    *,
+    LAG(role)         OVER w AS prev_role,
+    LAG(message_text) OVER w AS prev_text,
+    LAG(chars)        OVER w AS prev_chars,
+    LAG(source_file)  OVER w AS prev_source_file,
+    LAG(source_line)  OVER w AS prev_source_line
+  FROM per_message
+  WINDOW w AS (PARTITION BY host, session_id ORDER BY timestamp, source_file, source_line)
+)
+SELECT
+  session_id,
+  SPLIT_PART(session_project_path, '/', -1) AS project,
+  timestamp,
+  chars AS user_chars,
+  message_text AS user_text,
+  source_file AS user_source_file,
+  source_line AS user_source_line,
+  regexp_extract(lower(message_text), getvariable('lexicon')::VARCHAR) AS matched_term,
+  prev_chars AS context_chars,
+  LEFT(prev_text, 400) AS context_snippet
+FROM paired
+WHERE role = 'user'
+  AND NOT is_system
+  AND NOT is_subagent
+  AND chars <= COALESCE(getvariable('max_user_chars')::BIGINT, 400)
+  AND regexp_matches(lower(message_text), getvariable('lexicon')::VARCHAR)
+ORDER BY timestamp DESC
+LIMIT COALESCE(getvariable('limit')::BIGINT, 25);

--- a/plugins/writing/skills/analyze/resources/queries/corrective-feedback.sql
+++ b/plugins/writing/skills/analyze/resources/queries/corrective-feedback.sql
@@ -47,6 +47,7 @@ SELECT
   LEFT(prev_text, 400) AS context_snippet
 FROM paired
 WHERE role = 'user'
+  AND prev_role = 'assistant'
   AND NOT is_system
   AND NOT is_subagent
   AND chars <= COALESCE(getvariable('max_user_chars')::BIGINT, 400)

--- a/plugins/writing/skills/analyze/resources/queries/deliverable-prose.sql
+++ b/plugins/writing/skills/analyze/resources/queries/deliverable-prose.sql
@@ -9,6 +9,9 @@ WITH hook_excluded AS (
 write_prose AS (
   SELECT
     ci.session_id,
+    ci.source_file,
+    ci.source_line,
+    (ci.data->>'$.input.file_path') AS file_path,
     (ci.data->>'$.input.content') AS text
   FROM content_items ci
   JOIN sessions s USING (host, session_id)
@@ -26,6 +29,9 @@ write_prose AS (
 edit_prose AS (
   SELECT
     ci.session_id,
+    ci.source_file,
+    ci.source_line,
+    (ci.data->>'$.input.file_path') AS file_path,
     (ci.data->>'$.input.new_string') AS text
   FROM content_items ci
   JOIN sessions s USING (host, session_id)
@@ -43,6 +49,9 @@ edit_prose AS (
 bash_prose AS (
   SELECT
     ci.session_id,
+    ci.source_file,
+    ci.source_line,
+    NULL AS file_path,
     COALESCE(
       NULLIF(regexp_extract((ci.data->>'$.input.command'), '<<''?\w+''?\n([\s\S]+)\n\w+', 1), ''),
       NULLIF(regexp_extract((ci.data->>'$.input.command'), '(?:-m|--(?:body|message|description|title))\s+"([^"]+)"', 1), ''),
@@ -61,18 +70,18 @@ bash_prose AS (
     AND project_filter(s.project_path, getvariable('project'))
 )
 
-SELECT session_id, text
+SELECT session_id, source_file, source_line, file_path, text
 FROM write_prose
 WHERE text IS NOT NULL AND length(trim(text)) >= 30
 
 UNION ALL
 
-SELECT session_id, text
+SELECT session_id, source_file, source_line, file_path, text
 FROM edit_prose
 WHERE text IS NOT NULL AND length(trim(text)) >= 30
 
 UNION ALL
 
-SELECT session_id, text
+SELECT session_id, source_file, source_line, file_path, text
 FROM bash_prose
 WHERE text IS NOT NULL AND length(trim(text)) >= 30;

--- a/plugins/writing/skills/analyze/resources/queries/fts-setup.sql
+++ b/plugins/writing/skills/analyze/resources/queries/fts-setup.sql
@@ -21,6 +21,7 @@ CREATE TABLE fts_user_corpus AS
   WHERE tc.role = 'user'
     AND NOT tc.is_subagent
     AND NOT tc.is_system
+    AND not_pasted_model(tc.text, COALESCE(getvariable('paste_max_chars')::BIGINT, 2000))
     AND date_filter(tc.timestamp, getvariable('after_date'), getvariable('before_date'))
     AND project_filter(s.project_path, getvariable('project'))
     AND length(tc.text) >= 50;

--- a/plugins/writing/skills/analyze/resources/queries/paste-filter.sql
+++ b/plugins/writing/skills/analyze/resources/queries/paste-filter.sql
@@ -1,0 +1,22 @@
+-- Heuristic to exclude pasted model output from the human user baseline.
+-- User-role messages sometimes contain text the user copied from the model
+-- (PR bodies, docs, prior assistant turns) and pasted back for review. Counting
+-- that text as the user's own voice inflates the lift baseline and suppresses
+-- real tells, because the model's phrasing then appears on both sides of the
+-- ratio. is_system/is_subagent already drop machine-injected content. This
+-- macro additionally drops human-pasted machine prose by shape:
+--
+--   * very long messages (pasted blocks dwarf a typed reply)
+--   * third-person self-reference (the literal name "Ben": the user types "I",
+--     so "Ben" in a user message is almost always quoted/pasted prose)
+--   * document structure (markdown headers or table rows: the user writes chat
+--     prose, not formatted documents, in their turns)
+--
+-- The length ceiling is passed via the 'paste_max_chars' variable so it can be
+-- tuned without editing the macro.
+CREATE OR REPLACE MACRO not_pasted_model(txt, max_chars) AS (
+  length(txt) <= max_chars
+  AND NOT regexp_matches(txt, '\bBen\b')
+  AND NOT regexp_matches(txt, '(?m)^\s*#{1,6}\s')
+  AND NOT regexp_matches(txt, '(?m)^\s*\|.*\|')
+);

--- a/plugins/writing/skills/analyze/resources/queries/paste-filter.sql
+++ b/plugins/writing/skills/analyze/resources/queries/paste-filter.sql
@@ -7,8 +7,11 @@
 -- macro additionally drops human-pasted machine prose by shape:
 --
 --   * very long messages (pasted blocks dwarf a typed reply)
---   * third-person self-reference (the literal name "Ben": the user types "I",
---     so "Ben" in a user message is almost always quoted/pasted prose)
+--   * third-person self-reference (the user types "I", so their own name in a
+--     user message is almost always quoted or pasted prose). The name comes
+--     from the 'self_name' variable and the check is case-insensitive. An empty
+--     'self_name' disables this signal, which keeps the macro host-agnostic for
+--     anyone who has not set their name.
 --   * document structure (markdown headers or table rows: the user writes chat
 --     prose, not formatted documents, in their turns)
 --
@@ -16,7 +19,10 @@
 -- tuned without editing the macro.
 CREATE OR REPLACE MACRO not_pasted_model(txt, max_chars) AS (
   length(txt) <= max_chars
-  AND NOT regexp_matches(txt, '\bBen\b')
+  AND (
+    getvariable('self_name') = ''
+    OR NOT regexp_matches(txt, '(?i)\b' || getvariable('self_name') || '\b')
+  )
   AND NOT regexp_matches(txt, '(?m)^\s*#{1,6}\s')
   AND NOT regexp_matches(txt, '(?m)^\s*\|.*\|')
 );

--- a/plugins/writing/skills/analyze/resources/queries/text-export.sql
+++ b/plugins/writing/skills/analyze/resources/queries/text-export.sql
@@ -8,4 +8,7 @@ WHERE (getvariable('role') IS NULL OR tc.role = getvariable('role'))
   AND date_filter(tc.timestamp, getvariable('after_date'), getvariable('before_date'))
   AND project_filter(s.project_path, getvariable('project'))
   AND (getvariable('min_chars') IS NULL OR length(tc.text) >= getvariable('min_chars')::BIGINT)
-  AND (getvariable('human_only') IS NULL OR getvariable('human_only')::VARCHAR = 'false' OR (NOT tc.is_subagent AND NOT tc.is_system));
+  AND (getvariable('human_only') IS NULL OR getvariable('human_only')::VARCHAR = 'false' OR (
+    NOT tc.is_subagent AND NOT tc.is_system
+    AND not_pasted_model(tc.text, COALESCE(getvariable('paste_max_chars')::BIGINT, 2000))
+  ));

--- a/plugins/writing/skills/analyze/scripts/analyze.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.ts
@@ -83,6 +83,12 @@ const argv = cli({
       description: "Length ceiling for human-authored user messages (paste filter)",
       default: 2000,
     },
+    selfName: {
+      type: String,
+      description:
+        "Your name, used to drop pasted prose that refers to you in the third person from the user baseline (case-insensitive; empty disables this signal)",
+      default: "",
+    },
     correctiveLimit: {
       type: Number,
       description: "Max corrective-feedback moments to surface",
@@ -111,6 +117,7 @@ const baseParams: Record<string, string | null> = {
   before_date: until,
   project: projectFilter,
   paste_max_chars: pasteMaxChars,
+  self_name: argv.flags.selfName ?? "",
 };
 
 await main();
@@ -138,13 +145,13 @@ async function main(): Promise<void> {
     );
   } else {
     console.error(
-      `No voice profile found. Run ingest-voice.ts (seed: ${corpusPath(dataDir)}) then voice-profile.ts. Deliverable-surface rules fall back to the chat audit.`,
+      `No voice profile found. Run ingest-voice.ts (seed: ${corpusPath(dataDir)}) then voice-profile.ts. Deliverable-surface rules are kept pending a baseline (distinctiveness unverified) instead of falling back to the chat audit.`,
     );
   }
 
   try {
     console.error("Creating paste filter for the user baseline");
-    await db.execQuery("paste-filter");
+    await db.execQuery("paste-filter", baseParams);
 
     console.error("Building FTS indexes");
     await db.execQuery("fts-setup", { ...baseParams, model: modelFilter });

--- a/plugins/writing/skills/analyze/scripts/analyze.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.ts
@@ -3,18 +3,25 @@ import { mkdirSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import * as path from "node:path";
 import { cli } from "cleye";
+import { corpusPath, profilePath, resolveDataDir } from "./data-dir";
 import { openSessionDb } from "./db";
+import { auditDeliverableCorpus } from "./deliverable-audit";
 import {
   type CorrectionRow,
+  type CorrectiveRow,
   type DeliverableRow,
   type ModelSummaryRow,
   serializeCorpus,
   type TextRow,
   totalChars,
 } from "./dump";
+import { frustrationRegex } from "./frustration";
 import { computeLift, excludePhrases, processCorpus, processRows } from "./ngram";
-import { buildRuleHealth, type FtsAuditRow, renderReport } from "./report";
+import { findQuote } from "./quote-context";
+import { buildRuleHealth, type CandidatePhrase, type FtsAuditRow, renderReport } from "./report";
 import { auditStructuralPatterns } from "./structural";
+import { loadProfile, phraseProfileStat } from "./voice-profile";
+import type { WordlistEntry } from "./wordlists";
 import { loadWordlists } from "./wordlists";
 
 const argv = cli({
@@ -66,6 +73,21 @@ const argv = cli({
       type: String,
       description: "Wordlists directory (defaults to plugins/writing/wordlists)",
     },
+    dataDir: {
+      type: String,
+      description:
+        "Local data dir for the voice baseline (default: CLAUDE_PLUGIN_DATA or ~/.claude/plugins/data/writing-bendrucker)",
+    },
+    pasteMaxChars: {
+      type: Number,
+      description: "Length ceiling for human-authored user messages (paste filter)",
+      default: 2000,
+    },
+    correctiveLimit: {
+      type: Number,
+      description: "Max corrective-feedback moments to surface",
+      default: 25,
+    },
   },
 });
 
@@ -81,10 +103,14 @@ const dbPath = path.resolve(argv.flags.sessionDb ?? "");
 const wordlistsDir =
   argv.flags.wordlistsDir ?? path.join(import.meta.dirname, "..", "..", "..", "wordlists");
 const outPath = argv.flags.out ?? path.join("tmp", `trope-analysis-${today}.md`);
+const dataDir = resolveDataDir(argv.flags.dataDir);
+const pasteMaxChars = String(argv.flags.pasteMaxChars);
+const correctiveLimit = String(argv.flags.correctiveLimit);
 const baseParams: Record<string, string | null> = {
   after_date: since,
   before_date: until,
   project: projectFilter,
+  paste_max_chars: pasteMaxChars,
 };
 
 await main();
@@ -104,7 +130,22 @@ async function main(): Promise<void> {
   const wordlistEntries = await loadWordlists(wordlistsDir);
   console.error(`Loaded ${wordlistEntries.length} wordlist entries from ${wordlistsDir}`);
 
+  console.error(`Loading voice profile from ${profilePath(dataDir)}`);
+  const voiceProfile = await loadProfile(profilePath(dataDir));
+  if (voiceProfile) {
+    console.error(
+      `Voice baseline: ${voiceProfile.documentCount} documents, ${voiceProfile.totalTokens.toLocaleString()} tokens`,
+    );
+  } else {
+    console.error(
+      `No voice profile found. Run ingest-voice.ts (seed: ${corpusPath(dataDir)}) then voice-profile.ts. Deliverable-surface rules fall back to the chat audit.`,
+    );
+  }
+
   try {
+    console.error("Creating paste filter for the user baseline");
+    await db.execQuery("paste-filter");
+
     console.error("Building FTS indexes");
     await db.execQuery("fts-setup", { ...baseParams, model: modelFilter });
 
@@ -164,19 +205,49 @@ async function main(): Promise<void> {
       minAssistantCount: { 3: 5, 4: 3 },
     });
     const exclusionSet = new Set(wordlistEntries.map((e) => e.phrase));
-    const candidatePhrases = excludePhrases(allLifts, exclusionSet)
+    const candidatePhrases: CandidatePhrase[] = excludePhrases(allLifts, exclusionSet)
       .filter((r) => r.lift >= minLift)
       .filter((r) => (sessionCounts.get(r.phrase) ?? 0) >= minSessions)
-      .map((r) => ({ ...r, sessions: sessionCounts.get(r.phrase) ?? 0 }))
-      .slice(0, topN);
+      .slice(0, topN)
+      .map((r) => {
+        const baseline = voiceProfile
+          ? phraseProfileStat(voiceProfile, r.phrase)
+          : { count: 0, perMillion: 0 };
+        return {
+          ...r,
+          sessions: sessionCounts.get(r.phrase) ?? 0,
+          baselineCount: baseline.count,
+          baselinePerM: baseline.perMillion,
+          quote: findQuote(r.phrase, deliverableRows),
+        };
+      });
+
+    console.error("Auditing deliverable corpus for wordlist rules");
+    const deliverableAudit = auditDeliverableCorpus(wordlistEntries, deliverableRows);
 
     console.error("Fetching correction candidates");
     const corrections = await db.runQuery<CorrectionRow>("correction-candidates", baseParams);
 
+    console.error("Fetching corrective feedback (frustration lexicon)");
+    const corrective = await db.runQuery<CorrectiveRow>("corrective-feedback", {
+      ...baseParams,
+      lexicon: frustrationRegex(),
+      max_user_chars: "400",
+      limit: correctiveLimit,
+    });
+
     console.error("Auditing structural patterns against all model-generated text");
     const structuralAudit = auditStructuralPatterns(allModelText, userRows);
 
-    const ruleHealth = buildRuleHealth(wordlistEntries, auditByTerm, minCount);
+    const ruleHealth = buildRuleHealth({
+      entries: wordlistEntries,
+      chatAudit: auditByTerm,
+      deliverableAudit,
+      voiceProfile,
+      minCount,
+      findQuote: (entry: WordlistEntry, surface) =>
+        surface === "deliverable" ? findQuote(entry.phrase, deliverableRows) : null,
+    });
 
     const report = renderReport({
       generatedAt: today,
@@ -191,10 +262,12 @@ async function main(): Promise<void> {
       assistantTotalChars: totalChars(assistantRows),
       deliverableTotalChars: totalChars(deliverableRows),
       userTotalChars: totalChars(userRows),
+      voiceProfile,
       ruleHealth,
       structuralAudit,
       candidatePhrases,
       corrections,
+      corrective,
     });
 
     mkdirSync(path.dirname(outPath), { recursive: true });

--- a/plugins/writing/skills/analyze/scripts/analyze.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.ts
@@ -15,7 +15,7 @@ import {
   type TextRow,
   totalChars,
 } from "./dump";
-import { frustrationRegex } from "./frustration";
+import { escapeRegex, frustrationRegex } from "./frustration";
 import { computeLift, excludePhrases, processCorpus, processRows } from "./ngram";
 import { findQuote } from "./quote-context";
 import { buildRuleHealth, type CandidatePhrase, type FtsAuditRow, renderReport } from "./report";
@@ -117,7 +117,9 @@ const baseParams: Record<string, string | null> = {
   before_date: until,
   project: projectFilter,
   paste_max_chars: pasteMaxChars,
-  self_name: argv.flags.selfName ?? "",
+  // Escape regex metacharacters: the paste filter interpolates this into an RE2
+  // pattern (\b...\b), so a literal name with metachars must match literally.
+  self_name: escapeRegex(argv.flags.selfName ?? ""),
 };
 
 await main();

--- a/plugins/writing/skills/analyze/scripts/data-dir.ts
+++ b/plugins/writing/skills/analyze/scripts/data-dir.ts
@@ -1,0 +1,25 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// The voice baseline is local-only and never committed. It lives outside the
+// repository at the plugin data dir so it can later grow to include private
+// writing. Resolve CLAUDE_PLUGIN_DATA if set, else the conventional default.
+export function resolveDataDir(override?: string): string {
+  if (override) return override;
+  if (process.env.CLAUDE_PLUGIN_DATA) return process.env.CLAUDE_PLUGIN_DATA;
+  return join(homedir(), ".claude", "plugins", "data", "writing-bendrucker");
+}
+
+export function voiceBaselineDir(dataDir: string): string {
+  return join(dataDir, "voice-baseline");
+}
+
+// The seed corpus shipped with the data dir: one normalized text file with
+// per-document delimiter lines. ingest-voice.ts appends new sources here.
+export function corpusPath(dataDir: string): string {
+  return join(voiceBaselineDir(dataDir), "github-prs.txt");
+}
+
+export function profilePath(dataDir: string): string {
+  return join(voiceBaselineDir(dataDir), "profile.json");
+}

--- a/plugins/writing/skills/analyze/scripts/deliverable-audit.test.ts
+++ b/plugins/writing/skills/analyze/scripts/deliverable-audit.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { auditDeliverableCorpus, isDeliverableSurface } from "./deliverable-audit";
+import type { WordlistEntry } from "./wordlists";
+
+describe("isDeliverableSurface", () => {
+  test("flowery phrases and soft phrasing are deliverable-surface", () => {
+    expect(isDeliverableSurface("flowery-phrases.txt")).toBe(true);
+    expect(isDeliverableSurface("soft-phrasing.txt")).toBe(true);
+  });
+
+  test("openers, vocabulary, and marketing verbs are not deliverable-surface", () => {
+    expect(isDeliverableSurface("openers.txt")).toBe(false);
+    expect(isDeliverableSurface("vocabulary.txt")).toBe(false);
+    expect(isDeliverableSurface("marketing-verbs.txt")).toBe(false);
+  });
+});
+
+describe("auditDeliverableCorpus", () => {
+  const entries: WordlistEntry[] = [
+    { phrase: "source of truth", source: "flowery-phrases.txt" },
+    { phrase: "fail loudly", source: "flowery-phrases.txt" },
+    { phrase: "cleanly", source: "soft-phrasing.txt" },
+  ];
+
+  test("counts stemmed phrase occurrences across rows", () => {
+    const rows = [
+      { text: "This is the source of truth for the cache." },
+      { text: "The sources of truth diverge. It fails loudly on error." },
+      { text: "It strips cleanly and loads cleanly." },
+    ];
+    const audit = auditDeliverableCorpus(entries, rows);
+    expect(audit.byPhrase.get("source of truth")?.count).toBe(2);
+    expect(audit.byPhrase.get("fail loudly")?.count).toBe(1);
+    expect(audit.byPhrase.get("cleanly")?.count).toBe(2);
+    expect(audit.totalTokens).toBeGreaterThan(0);
+  });
+
+  test("reports per-million rates against the corpus token total", () => {
+    const audit = auditDeliverableCorpus(
+      [{ phrase: "cleanly", source: "soft-phrasing.txt" }],
+      [{ text: "loads cleanly" }],
+    );
+    const row = audit.byPhrase.get("cleanly");
+    expect(row?.count).toBe(1);
+    expect(row?.perMillion).toBeCloseTo((1 / audit.totalTokens) * 1_000_000, 1);
+  });
+
+  test("ignores code-shaped artifacts via cleanText", () => {
+    const audit = auditDeliverableCorpus(
+      [{ phrase: "cleanly", source: "soft-phrasing.txt" }],
+      [{ text: "Run `cleanly()` then describe it." }],
+    );
+    expect(audit.byPhrase.get("cleanly")?.count).toBe(0);
+  });
+});

--- a/plugins/writing/skills/analyze/scripts/deliverable-audit.ts
+++ b/plugins/writing/skills/analyze/scripts/deliverable-audit.ts
@@ -2,7 +2,7 @@ import { stemmer } from "stemmer";
 import { cleanText } from "./ngram";
 import type { WordlistEntry } from "./wordlists";
 
-const WORD_TOKEN = /[a-zA-Z]+/g;
+export const WORD_TOKEN = /[a-zA-Z]+/g;
 
 // Rules the hook fires *exclusively* on deliverable prose (file writes and
 // PR/MR/commit bodies): the flowery-phrase phrase group and the soft-phrasing
@@ -22,14 +22,21 @@ export function isDeliverableSurface(source: string): boolean {
   return DELIVERABLE_SOURCES.has(source);
 }
 
-function stemTokens(text: string): string[] {
+export function stemTokens(text: string): string[] {
   return (cleanText(text).toLowerCase().match(WORD_TOKEN) ?? []).map((w) => stemmer(w));
+}
+
+// Stem a wordlist phrase into its needle tokens. Unlike stemTokens it does not
+// run cleanText, because a wordlist entry is already clean prose, matching how
+// auditDeliverableCorpus builds its needles.
+export function stemPhrase(phrase: string): string[] {
+  return (phrase.toLowerCase().match(WORD_TOKEN) ?? []).map((w) => stemmer(w));
 }
 
 // Count non-overlapping occurrences of a stemmed token subsequence, matching
 // how the hook's stemmedPhraseHits / compileStemmedWordlist scan deliverable
 // text. Single-word entries reduce to a token-membership count.
-function countSubsequence(haystack: string[], needle: string[]): number {
+export function countSubsequence(haystack: string[], needle: string[]): number {
   if (needle.length === 0) return 0;
   let count = 0;
   for (let i = 0; i + needle.length <= haystack.length; i++) {
@@ -68,7 +75,7 @@ export function auditDeliverableCorpus(
 ): DeliverableAudit {
   const needles = entries.map((e) => ({
     phrase: e.phrase,
-    stems: (e.phrase.toLowerCase().match(WORD_TOKEN) ?? []).map((w) => stemmer(w)),
+    stems: stemPhrase(e.phrase),
   }));
   const counts = new Map<string, number>();
   for (const n of needles) counts.set(n.phrase, 0);

--- a/plugins/writing/skills/analyze/scripts/deliverable-audit.ts
+++ b/plugins/writing/skills/analyze/scripts/deliverable-audit.ts
@@ -1,0 +1,96 @@
+import { stemmer } from "stemmer";
+import { cleanText } from "./ngram";
+import type { WordlistEntry } from "./wordlists";
+
+const WORD_TOKEN = /[a-zA-Z]+/g;
+
+// Rules the hook fires *exclusively* on deliverable prose (file writes and
+// PR/MR/commit bodies): the flowery-phrase phrase group and the soft-phrasing
+// weighted group are both fileOnly in tropes.ts. These are audited against the
+// model's deliverable corpus and the user's voice baseline, not chat
+// text_content, because the chat surface barely contains them and would report
+// them as dead.
+//
+// marketing-verbs.txt is deliberately excluded: its hook group is not fileOnly,
+// so it fires on chat side-effect inputs too. Auditing it against deliverables
+// alone undercounts it (and the few deliverable hits are often the user's own
+// meta-discussion of the wordlist file). It stays on the chat audit, where its
+// usage tracks the model's overall habit.
+const DELIVERABLE_SOURCES = new Set(["flowery-phrases.txt", "soft-phrasing.txt"]);
+
+export function isDeliverableSurface(source: string): boolean {
+  return DELIVERABLE_SOURCES.has(source);
+}
+
+function stemTokens(text: string): string[] {
+  return (cleanText(text).toLowerCase().match(WORD_TOKEN) ?? []).map((w) => stemmer(w));
+}
+
+// Count non-overlapping occurrences of a stemmed token subsequence, matching
+// how the hook's stemmedPhraseHits / compileStemmedWordlist scan deliverable
+// text. Single-word entries reduce to a token-membership count.
+function countSubsequence(haystack: string[], needle: string[]): number {
+  if (needle.length === 0) return 0;
+  let count = 0;
+  for (let i = 0; i + needle.length <= haystack.length; i++) {
+    let matched = true;
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) {
+      count++;
+      i += needle.length - 1;
+    }
+  }
+  return count;
+}
+
+export interface DeliverableAuditRow {
+  count: number;
+  perMillion: number;
+}
+
+export interface DeliverableAudit {
+  totalTokens: number;
+  byPhrase: Map<string, DeliverableAuditRow>;
+}
+
+// Audit each entry against the deliverable corpus, returning per-entry counts
+// and per-million rates. Phrases are stemmed the same way the hook stems them,
+// so inflection and hyphenation match (e.g. "fails loudly" counts for "fail
+// loudly").
+export function auditDeliverableCorpus(
+  entries: WordlistEntry[],
+  rows: Array<{ text?: string }>,
+): DeliverableAudit {
+  const needles = entries.map((e) => ({
+    phrase: e.phrase,
+    stems: (e.phrase.toLowerCase().match(WORD_TOKEN) ?? []).map((w) => stemmer(w)),
+  }));
+  const counts = new Map<string, number>();
+  for (const n of needles) counts.set(n.phrase, 0);
+
+  let totalTokens = 0;
+  for (const row of rows) {
+    if (!row.text) continue;
+    const tokens = stemTokens(row.text);
+    totalTokens += tokens.length;
+    for (const n of needles) {
+      if (n.stems.length === 0) continue;
+      const hits = countSubsequence(tokens, n.stems);
+      if (hits > 0) counts.set(n.phrase, (counts.get(n.phrase) ?? 0) + hits);
+    }
+  }
+
+  const byPhrase = new Map<string, DeliverableAuditRow>();
+  for (const [phrase, count] of counts) {
+    byPhrase.set(phrase, {
+      count,
+      perMillion: totalTokens > 0 ? (count / totalTokens) * 1_000_000 : 0,
+    });
+  }
+  return { totalTokens, byPhrase };
+}

--- a/plugins/writing/skills/analyze/scripts/dump.ts
+++ b/plugins/writing/skills/analyze/scripts/dump.ts
@@ -5,7 +5,23 @@ export interface TextRow {
 
 export interface DeliverableRow {
   session_id: string;
+  source_file: string | null;
+  source_line: number | null;
+  file_path: string | null;
   text: string;
+}
+
+export interface CorrectiveRow {
+  session_id: string;
+  project: string | null;
+  timestamp: string;
+  user_chars: number;
+  user_text: string;
+  user_source_file: string | null;
+  user_source_line: number | null;
+  matched_term: string;
+  context_chars: number | null;
+  context_snippet: string | null;
 }
 
 export interface CorrectionRow {

--- a/plugins/writing/skills/analyze/scripts/frustration.test.ts
+++ b/plugins/writing/skills/analyze/scripts/frustration.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { FRUSTRATION_TERMS, frustrationRegex } from "./frustration";
+
+describe("frustrationRegex", () => {
+  test("matches single-word and multi-word terms with boundaries", () => {
+    const re = new RegExp(frustrationRegex(), "i");
+    expect(re.test("ugh this is gross")).toBe(true);
+    expect(re.test("that reads like marketing copy")).toBe(true);
+    expect(re.test("cut the fluff please")).toBe(true);
+  });
+
+  test("does not match terms embedded in larger words", () => {
+    const re = new RegExp(frustrationRegex(["stop"]), "i");
+    expect(re.test("the build stopped")).toBe(false);
+    expect(re.test("please stop")).toBe(true);
+  });
+
+  test("escapes regex metacharacters in custom terms", () => {
+    const re = new RegExp(frustrationRegex(["a.b"]), "i");
+    expect(re.test("axb")).toBe(false);
+    expect(re.test("a.b")).toBe(true);
+  });
+
+  test("the default lexicon is non-empty and covers known gripes", () => {
+    expect(FRUSTRATION_TERMS).toContain("flowery");
+    expect(FRUSTRATION_TERMS).toContain("clanker");
+    expect(FRUSTRATION_TERMS).toContain("reads like");
+  });
+});

--- a/plugins/writing/skills/analyze/scripts/frustration.ts
+++ b/plugins/writing/skills/analyze/scripts/frustration.ts
@@ -1,0 +1,36 @@
+// Frustration lexicon: terms that, in a short human-authored message, signal
+// the user pushing back on writing quality. Multi-word entries are matched as
+// phrases. Used to surface labeled-slop moments where the user named a problem
+// in the model's prose, which are higher-signal than inferred corrections.
+export const FRUSTRATION_TERMS = [
+  "wtf",
+  "ugh",
+  "gross",
+  "stop",
+  "cut the",
+  "tighten",
+  "jargon",
+  "marketing",
+  "fluff",
+  "buzzword",
+  "flowery",
+  "verbose",
+  "wordy",
+  "dramatic",
+  "clanker",
+  "reads like",
+  "sounds like",
+];
+
+function escapeRegex(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// A DuckDB-compatible regex alternation with word boundaries. DuckDB's regexp
+// engine (RE2) supports \b, so short terms like "stop" do not match inside
+// "stopped" is acceptable here (we want the standalone gripe), and "ugh" will
+// not fire on "tough".
+export function frustrationRegex(terms: string[] = FRUSTRATION_TERMS): string {
+  const fragments = terms.map(escapeRegex).join("|");
+  return `\\b(?:${fragments})\\b`;
+}

--- a/plugins/writing/skills/analyze/scripts/frustration.ts
+++ b/plugins/writing/skills/analyze/scripts/frustration.ts
@@ -22,7 +22,7 @@ export const FRUSTRATION_TERMS = [
   "sounds like",
 ];
 
-function escapeRegex(literal: string): string {
+export function escapeRegex(literal: string): string {
   return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 

--- a/plugins/writing/skills/analyze/scripts/ingest-voice.ts
+++ b/plugins/writing/skills/analyze/scripts/ingest-voice.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env bun
+import { mkdirSync } from "node:fs";
+import { cli } from "cleye";
+import { corpusPath, resolveDataDir, voiceBaselineDir } from "./data-dir";
+import { mergeDocuments, parseCorpus, serializeCorpus, type VoiceDocument } from "./voice-corpus";
+
+const argv = cli({
+  name: "ingest-voice",
+  flags: {
+    dataDir: {
+      type: String,
+      description:
+        "Local data dir for the voice baseline (default: CLAUDE_PLUGIN_DATA or ~/.claude/plugins/data/writing-bendrucker)",
+    },
+    source: {
+      type: String,
+      description: "Source to ingest: 'github' (via gh search prs) or 'file' (a delimited corpus)",
+      default: "github",
+    },
+    author: {
+      type: String,
+      description: "GitHub author to fetch merged PRs for (github source)",
+    },
+    created: {
+      type: String,
+      description: "gh search date range, e.g. 2019-01-01..2024-01-01 (github source)",
+    },
+    limit: {
+      type: Number,
+      description: "Max PRs to fetch (github source)",
+      default: 200,
+    },
+    file: {
+      type: String,
+      description: "Path to a delimited corpus file to merge in (file source)",
+    },
+  },
+});
+
+const dataDir = resolveDataDir(argv.flags.dataDir);
+const target = corpusPath(dataDir);
+
+await main();
+
+async function main(): Promise<void> {
+  mkdirSync(voiceBaselineDir(dataDir), { recursive: true });
+
+  const existing = await readExisting(target);
+  const incoming = await collectIncoming();
+  if (incoming.length === 0) {
+    console.error("No documents to ingest.");
+    return;
+  }
+
+  const merged = mergeDocuments(existing, incoming);
+  const added = merged.length - existing.length;
+  await Bun.write(target, serializeCorpus(merged));
+  console.error(
+    `Ingested ${incoming.length} document(s) from '${argv.flags.source}'; ${added} new, ${merged.length} total.`,
+  );
+  process.stdout.write(`${target}\n`);
+}
+
+async function collectIncoming(): Promise<VoiceDocument[]> {
+  if (argv.flags.source === "github") return fetchGithub();
+  if (argv.flags.source === "file") return readFileSource();
+  throw new Error(`Unknown source: ${argv.flags.source}. Use 'github' or 'file'.`);
+}
+
+async function fetchGithub(): Promise<VoiceDocument[]> {
+  const author = argv.flags.author;
+  if (!author) {
+    throw new Error("--author is required for the github source");
+  }
+  // gh search prs does not expose diff sizes, so the meta line carries the
+  // creation date only. The seed corpus retains its richer +x/-y metadata; new
+  // fetches simply omit it. Metadata is provenance, not counted as prose.
+  const args = [
+    "search",
+    "prs",
+    `--author=${author}`,
+    "--merged",
+    `--limit=${argv.flags.limit}`,
+    "--json",
+    "url,body,createdAt",
+  ];
+  if (argv.flags.created) args.push(`--created=${argv.flags.created}`);
+
+  console.error(`Running: gh ${args.join(" ")}`);
+  const proc = Bun.spawn(["gh", ...args], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`gh search prs failed (exit ${exitCode}): ${stderr.trim()}`);
+  }
+
+  const results = JSON.parse(stdout) as Array<{
+    url: string;
+    body: string;
+    createdAt: string;
+  }>;
+
+  return results
+    .filter((pr) => pr.body && pr.body.trim().length >= 30)
+    .map((pr) => ({
+      source: pr.url,
+      meta: pr.createdAt,
+      body: pr.body.trim(),
+    }));
+}
+
+async function readFileSource(): Promise<VoiceDocument[]> {
+  const file = argv.flags.file;
+  if (!file) {
+    throw new Error("--file is required for the file source");
+  }
+  const text = await Bun.file(file).text();
+  return parseCorpus(text);
+}
+
+async function readExisting(path: string): Promise<VoiceDocument[]> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) return [];
+  return parseCorpus(await file.text());
+}

--- a/plugins/writing/skills/analyze/scripts/quote-context.test.ts
+++ b/plugins/writing/skills/analyze/scripts/quote-context.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { findQuote } from "./quote-context";
+
+describe("findQuote", () => {
+  const rows = [
+    {
+      session_id: "s1",
+      source_file: "a.jsonl",
+      source_line: 5,
+      file_path: "tmp/pr-body.md",
+      text: "The auto-instrumented spans are the source of truth for tracing.",
+    },
+    {
+      session_id: "s2",
+      source_file: "b.jsonl",
+      source_line: 9,
+      file_path: null,
+      text: "We should make the loader fail loudly on partial input.",
+    },
+  ];
+
+  test("finds an exact phrase and returns a context window plus pointer", () => {
+    const quote = findQuote("source of truth", rows);
+    expect(quote?.window).toContain("source of truth");
+    expect(quote?.filePath).toBe("tmp/pr-body.md");
+    expect(quote?.sourceFile).toBe("a.jsonl");
+    expect(quote?.sourceLine).toBe(5);
+  });
+
+  test("finds an inflected phrase via stemmed fallback", () => {
+    const quote = findQuote("fails loudly", [
+      {
+        session_id: "s3",
+        source_file: "c.jsonl",
+        source_line: 1,
+        file_path: null,
+        text: "The loader fail loudly here.",
+      },
+    ]);
+    expect(quote?.window).toContain("fail loudly");
+    expect(quote?.sourceFile).toBe("c.jsonl");
+  });
+
+  test("falls back to source_file pointer when file_path is absent", () => {
+    const quote = findQuote("fail loudly", rows);
+    expect(quote?.filePath).toBeNull();
+    expect(quote?.sourceFile).toBe("b.jsonl");
+  });
+
+  test("returns null when the phrase is not found", () => {
+    expect(findQuote("nonexistent phrase", rows)).toBeNull();
+  });
+
+  test("truncates the window with ellipses for long text", () => {
+    const long = `${"x ".repeat(100)}source of truth${" y".repeat(100)}`;
+    const quote = findQuote("source of truth", [{ session_id: "s", text: long }]);
+    expect(quote?.window.startsWith("...")).toBe(true);
+    expect(quote?.window.endsWith("...")).toBe(true);
+  });
+});

--- a/plugins/writing/skills/analyze/scripts/quote-context.ts
+++ b/plugins/writing/skills/analyze/scripts/quote-context.ts
@@ -1,0 +1,86 @@
+import { stemmer } from "stemmer";
+
+export interface SourceRow {
+  session_id: string;
+  source_file?: string | null;
+  source_line?: number | null;
+  file_path?: string | null;
+  text?: string;
+}
+
+export interface QuoteContext {
+  window: string;
+  sourceFile: string | null;
+  sourceLine: number | null;
+  filePath: string | null;
+}
+
+const WORD_TOKEN = /[a-zA-Z]+/g;
+
+// Find the first deliverable occurrence of a phrase and return a context window
+// plus a source pointer, so every candidate and audited tell is spot-checkable.
+// Tries an exact case-insensitive match first (n-gram candidates), then a
+// stemmed-subsequence scan (wordlist tells with inflection like "fails loudly").
+export function findQuote(phrase: string, rows: SourceRow[], radius = 60): QuoteContext | null {
+  const lowered = phrase.toLowerCase();
+  for (const row of rows) {
+    if (!row.text) continue;
+    const idx = row.text.toLowerCase().indexOf(lowered);
+    if (idx >= 0) return makeContext(row, idx, idx + phrase.length, radius);
+  }
+
+  const needle = (lowered.match(WORD_TOKEN) ?? []).map((w) => stemmer(w));
+  if (needle.length === 0) return null;
+  for (const row of rows) {
+    if (!row.text) continue;
+    const span = findStemmedSpan(row.text, needle);
+    if (span) return makeContext(row, span.start, span.end, radius);
+  }
+  return null;
+}
+
+interface Span {
+  start: number;
+  end: number;
+}
+
+function findStemmedSpan(text: string, needle: string[]): Span | null {
+  const tokens: Array<{ stem: string; start: number; end: number }> = [];
+  for (const match of text.matchAll(WORD_TOKEN)) {
+    const word = match[0];
+    tokens.push({
+      stem: stemmer(word.toLowerCase()),
+      start: match.index,
+      end: match.index + word.length,
+    });
+  }
+  for (let i = 0; i + needle.length <= tokens.length; i++) {
+    let matched = true;
+    for (let j = 0; j < needle.length; j++) {
+      if (tokens[i + j]?.stem !== needle[j]) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) {
+      const first = tokens[i];
+      const last = tokens[i + needle.length - 1];
+      if (first && last) return { start: first.start, end: last.end };
+    }
+  }
+  return null;
+}
+
+function makeContext(row: SourceRow, start: number, end: number, radius: number): QuoteContext {
+  const from = Math.max(0, start - radius);
+  const to = Math.min(row.text?.length ?? 0, end + radius);
+  const prefix = from > 0 ? "..." : "";
+  const suffix = to < (row.text?.length ?? 0) ? "..." : "";
+  const window = `${prefix}${(row.text ?? "").slice(from, to).replace(/\s+/g, " ").trim()}${suffix}`;
+  return {
+    window,
+    sourceFile: row.source_file ?? null,
+    sourceLine: row.source_line ?? null,
+    filePath: row.file_path ?? null,
+  };
+}

--- a/plugins/writing/skills/analyze/scripts/report.test.ts
+++ b/plugins/writing/skills/analyze/scripts/report.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import type { CorrectionRow, ModelSummaryRow } from "./dump";
-import type { FtsAuditRow } from "./report";
+import type { DeliverableAudit } from "./deliverable-audit";
+import type { CorrectionRow, CorrectiveRow, ModelSummaryRow } from "./dump";
+import type { CandidatePhrase, FtsAuditRow } from "./report";
 import { buildRuleHealth, renderReport } from "./report";
+import type { VoiceProfile } from "./voice-profile";
 import type { WordlistEntry } from "./wordlists";
 
 const baseInput = {
@@ -17,101 +19,181 @@ const baseInput = {
   assistantTotalChars: 0,
   deliverableTotalChars: 0,
   userTotalChars: 0,
+  voiceProfile: null,
   ruleHealth: [],
   structuralAudit: [],
-  candidatePhrases: [],
+  candidatePhrases: [] as CandidatePhrase[],
   corrections: [] as CorrectionRow[],
+  corrective: [] as CorrectiveRow[],
 };
 
-describe("buildRuleHealth", () => {
+function chatAudit(entry: string, row: Omit<FtsAuditRow, "term">): Map<string, FtsAuditRow> {
+  return new Map([[entry, { term: entry, ...row }]]);
+}
+
+describe("buildRuleHealth (chat surface)", () => {
   const entries: WordlistEntry[] = [
     { phrase: "let me", source: "openers.txt" },
     { phrase: "missing entry", source: "openers.txt" },
   ];
 
   test("marks a missing audit row as dead (no occurrences)", () => {
-    const result = buildRuleHealth(entries, new Map(), 5);
+    const result = buildRuleHealth({
+      entries,
+      chatAudit: new Map(),
+      deliverableAudit: null,
+      voiceProfile: null,
+      minCount: 5,
+    });
     expect(result[1]?.noData).toBe(true);
     expect(result[1]?.status).toBe("remove");
     expect(result[1]?.removeReason).toBe("dead");
   });
 
-  test("marks an entry with zero counts as dead", () => {
-    const audit = new Map<string, FtsAuditRow>();
-    audit.set("let me", {
-      term: "let me",
-      assistant_count: 0,
-      user_count: 0,
-      assistant_per_m: null,
-      user_per_m: null,
-      lift: null,
-    });
-    const result = buildRuleHealth(entries, audit, 5);
-    expect(result[0]?.noData).toBe(true);
-    expect(result[0]?.status).toBe("remove");
-    expect(result[0]?.removeReason).toBe("dead");
-  });
-
   test("keeps a rule the model uses more than the user", () => {
-    const audit = new Map<string, FtsAuditRow>();
-    audit.set("let me", {
-      term: "let me",
-      assistant_count: 50,
-      user_count: 5,
-      assistant_per_m: 5000,
-      user_per_m: 500,
-      lift: 10,
+    const result = buildRuleHealth({
+      entries,
+      chatAudit: chatAudit("let me", {
+        assistant_count: 50,
+        user_count: 5,
+        assistant_per_m: 5000,
+        user_per_m: 500,
+        lift: 10,
+      }),
+      deliverableAudit: null,
+      voiceProfile: null,
+      minCount: 5,
     });
-    const result = buildRuleHealth(entries, audit, 5);
     expect(result[0]?.status).toBe("keep");
+    expect(result[0]?.surface).toBe("chat");
     expect(result[0]?.removeReason).toBeNull();
     expect(result[0]?.lift).toBeCloseTo(10, 0);
   });
 
   test("keeps a rare-but-distinctive rule even when lift reads low", () => {
-    // The model uses it, the user never does, but the smoothed baseline
-    // compresses lift below the additions threshold. It must still be kept.
-    const audit = new Map<string, FtsAuditRow>();
-    audit.set("let me", {
-      term: "let me",
-      assistant_count: 32,
-      user_count: 0,
-      assistant_per_m: 296.8,
-      user_per_m: 0,
-      lift: 3.0,
+    const result = buildRuleHealth({
+      entries,
+      chatAudit: chatAudit("let me", {
+        assistant_count: 32,
+        user_count: 0,
+        assistant_per_m: 296.8,
+        user_per_m: 0,
+        lift: 3.0,
+      }),
+      deliverableAudit: null,
+      voiceProfile: null,
+      minCount: 5,
     });
-    const result = buildRuleHealth(entries, audit, 5);
     expect(result[0]?.status).toBe("keep");
   });
 
   test("removes a rule the user uses at least as much (not distinctive)", () => {
-    const audit = new Map<string, FtsAuditRow>();
-    audit.set("let me", {
-      term: "let me",
-      assistant_count: 10,
-      user_count: 40,
-      assistant_per_m: 100,
-      user_per_m: 200,
-      lift: 0.5,
+    const result = buildRuleHealth({
+      entries,
+      chatAudit: chatAudit("let me", {
+        assistant_count: 10,
+        user_count: 40,
+        assistant_per_m: 100,
+        user_per_m: 200,
+        lift: 0.5,
+      }),
+      deliverableAudit: null,
+      voiceProfile: null,
+      minCount: 5,
     });
-    const result = buildRuleHealth(entries, audit, 5);
     expect(result[0]?.status).toBe("remove");
     expect(result[0]?.removeReason).toBe("not distinctive");
   });
 
   test("removes a rule below the occurrence floor (dead)", () => {
-    const audit = new Map<string, FtsAuditRow>();
-    audit.set("let me", {
-      term: "let me",
-      assistant_count: 2,
-      user_count: 0,
-      assistant_per_m: 18.5,
-      user_per_m: 0,
-      lift: 0.2,
+    const result = buildRuleHealth({
+      entries,
+      chatAudit: chatAudit("let me", {
+        assistant_count: 2,
+        user_count: 0,
+        assistant_per_m: 18.5,
+        user_per_m: 0,
+        lift: 0.2,
+      }),
+      deliverableAudit: null,
+      voiceProfile: null,
+      minCount: 5,
     });
-    const result = buildRuleHealth(entries, audit, 5);
     expect(result[0]?.status).toBe("remove");
     expect(result[0]?.removeReason).toBe("dead");
+  });
+});
+
+describe("buildRuleHealth (deliverable surface)", () => {
+  const entries: WordlistEntry[] = [{ phrase: "source of truth", source: "flowery-phrases.txt" }];
+
+  const profile: VoiceProfile = {
+    documentCount: 1,
+    totalTokens: 1000,
+    ngrams: { "1": {}, "2": {}, "3": {} },
+    generatedAt: "2026-05-24",
+    sources: ["github"],
+  };
+
+  function deliverableAudit(count: number, perMillion: number): DeliverableAudit {
+    return { totalTokens: 100000, byPhrase: new Map([["source of truth", { count, perMillion }]]) };
+  }
+
+  test("keeps a deliverable tell frequent in deliverables and absent from baseline", () => {
+    // The chat audit would call this dead (0 chat hits). The deliverable audit
+    // sees it 78 times in deliverable prose and never in the voice baseline.
+    const result = buildRuleHealth({
+      entries,
+      chatAudit: chatAudit("source of truth", {
+        assistant_count: 0,
+        user_count: 0,
+        assistant_per_m: 0,
+        user_per_m: 0,
+        lift: null,
+      }),
+      deliverableAudit: deliverableAudit(78, 122.7),
+      voiceProfile: profile,
+      minCount: 5,
+    });
+    expect(result[0]?.surface).toBe("deliverable");
+    expect(result[0]?.status).toBe("keep");
+    expect(result[0]?.modelCount).toBe(78);
+    expect(result[0]?.baselinePerM).toBe(0);
+  });
+
+  test("removes a deliverable tell present in the baseline (not distinctive)", () => {
+    const baselineProfile: VoiceProfile = {
+      ...profile,
+      ngrams: { "1": {}, "2": {}, "3": { "source of truth": 200 } },
+    };
+    const result = buildRuleHealth({
+      entries,
+      chatAudit: new Map(),
+      deliverableAudit: deliverableAudit(78, 122.7),
+      voiceProfile: baselineProfile,
+      minCount: 5,
+    });
+    expect(result[0]?.surface).toBe("deliverable");
+    expect(result[0]?.status).toBe("remove");
+    expect(result[0]?.removeReason).toBe("not distinctive");
+  });
+
+  test("falls back to chat audit when no voice profile is loaded", () => {
+    const result = buildRuleHealth({
+      entries,
+      chatAudit: chatAudit("source of truth", {
+        assistant_count: 0,
+        user_count: 0,
+        assistant_per_m: 0,
+        user_per_m: 0,
+        lift: null,
+      }),
+      deliverableAudit: deliverableAudit(78, 122.7),
+      voiceProfile: null,
+      minCount: 5,
+    });
+    expect(result[0]?.surface).toBe("chat");
+    expect(result[0]?.status).toBe("remove");
   });
 });
 
@@ -133,14 +215,15 @@ describe("renderReport", () => {
       ruleHealth: [
         {
           entry,
-          assistantCount: 5,
-          userCount: 10,
-          assistantPerM: 50,
-          userPerM: 100,
+          surface: "chat",
+          modelCount: 5,
+          modelPerM: 50,
+          baselinePerM: 100,
           lift: 0.5,
           status: "remove",
           removeReason: "not distinctive",
           noData: false,
+          quote: null,
         },
       ],
     });
@@ -161,11 +244,38 @@ describe("renderReport", () => {
           assistantPerM: 80,
           userPerM: 5,
           lift: 16,
+          baselineCount: 0,
+          baselinePerM: 0,
+          quote: null,
         },
       ],
     });
     expect(output).toContain("+ reaching for");
     expect(output).toContain("lift=16.0");
+    expect(output).toContain("baseline=0");
+  });
+
+  test("renders corrective-feedback moments with matched term", () => {
+    const output = renderReport({
+      ...baseInput,
+      corrective: [
+        {
+          session_id: "s1",
+          project: "myproject",
+          timestamp: "2026-05-20T10:01:00Z",
+          user_chars: 40,
+          user_text: "ugh this reads like marketing fluff",
+          user_source_file: "f.jsonl",
+          user_source_line: 12,
+          matched_term: "fluff",
+          context_chars: 300,
+          context_snippet: "the model wrote a flowery paragraph",
+        },
+      ],
+    });
+    expect(output).toContain("## Corrective Feedback");
+    expect(output).toContain("matched `fluff`");
+    expect(output).toContain("reads like marketing fluff");
   });
 
   test("renders correction snippets in their own subsections", () => {
@@ -194,25 +304,27 @@ describe("renderReport", () => {
       ruleHealth: [
         {
           entry: { phrase: "Perfect", source: "openers.txt" },
-          assistantCount: 10,
-          userCount: 2,
-          assistantPerM: 100,
-          userPerM: 20,
+          surface: "chat",
+          modelCount: 10,
+          modelPerM: 100,
+          baselinePerM: 20,
           lift: 5,
           status: "keep",
           removeReason: null,
           noData: false,
+          quote: null,
         },
         {
           entry: { phrase: "tapestry", source: "vocabulary.txt" },
-          assistantCount: 5,
-          userCount: 1,
-          assistantPerM: 50,
-          userPerM: 10,
+          surface: "chat",
+          modelCount: 5,
+          modelPerM: 50,
+          baselinePerM: 10,
           lift: 5,
           status: "keep",
           removeReason: null,
           noData: false,
+          quote: null,
         },
       ],
     });

--- a/plugins/writing/skills/analyze/scripts/report.test.ts
+++ b/plugins/writing/skills/analyze/scripts/report.test.ts
@@ -131,6 +131,8 @@ describe("buildRuleHealth (deliverable surface)", () => {
     documentCount: 1,
     totalTokens: 1000,
     ngrams: { "1": {}, "2": {}, "3": {} },
+    stemmedNgrams: { "1": {}, "2": {}, "3": {} },
+    totalStemmedTokens: 1000,
     generatedAt: "2026-05-24",
     sources: ["github"],
   };
@@ -164,7 +166,7 @@ describe("buildRuleHealth (deliverable surface)", () => {
   test("removes a deliverable tell present in the baseline (not distinctive)", () => {
     const baselineProfile: VoiceProfile = {
       ...profile,
-      ngrams: { "1": {}, "2": {}, "3": { "source of truth": 200 } },
+      stemmedNgrams: { "1": {}, "2": {}, "3": { "sourc of truth": 200 } },
     };
     const result = buildRuleHealth({
       entries,

--- a/plugins/writing/skills/analyze/scripts/report.test.ts
+++ b/plugins/writing/skills/analyze/scripts/report.test.ts
@@ -178,7 +178,10 @@ describe("buildRuleHealth (deliverable surface)", () => {
     expect(result[0]?.removeReason).toBe("not distinctive");
   });
 
-  test("falls back to chat audit when no voice profile is loaded", () => {
+  test("keeps a deliverable tell pending a baseline when no profile is loaded", () => {
+    // No profile: the multi-word phrase must NOT fall back to the chat audit
+    // (which can't match it and would call it dead). It stays on the deliverable
+    // surface and, being alive there, is kept with distinctiveness unverified.
     const result = buildRuleHealth({
       entries,
       chatAudit: chatAudit("source of truth", {
@@ -192,8 +195,24 @@ describe("buildRuleHealth (deliverable surface)", () => {
       voiceProfile: null,
       minCount: 5,
     });
-    expect(result[0]?.surface).toBe("chat");
+    expect(result[0]?.surface).toBe("deliverable");
+    expect(result[0]?.status).toBe("keep");
+    expect(result[0]?.removeReason).toBeNull();
+    expect(result[0]?.baselinePerM).toBeNull();
+    expect(result[0]?.noData).toBe(true);
+  });
+
+  test("marks a deliverable rule dead when it rarely fires on its own surface (no profile)", () => {
+    const result = buildRuleHealth({
+      entries,
+      chatAudit: new Map(),
+      deliverableAudit: deliverableAudit(0, 0),
+      voiceProfile: null,
+      minCount: 5,
+    });
+    expect(result[0]?.surface).toBe("deliverable");
     expect(result[0]?.status).toBe("remove");
+    expect(result[0]?.removeReason).toBe("dead");
   });
 });
 

--- a/plugins/writing/skills/analyze/scripts/report.ts
+++ b/plugins/writing/skills/analyze/scripts/report.ts
@@ -4,7 +4,7 @@ import type { LiftRow } from "./ngram";
 import type { QuoteContext } from "./quote-context";
 import type { StructuralAuditRow } from "./structural";
 import type { VoiceProfile } from "./voice-profile";
-import { phraseProfileStat } from "./voice-profile";
+import { phraseProfileStatStemmed } from "./voice-profile";
 import type { WordlistEntry } from "./wordlists";
 
 export interface FtsAuditRow {
@@ -131,7 +131,7 @@ function renderProposedRemovals(input: ReportInput): string {
     `- **dead**: the model produced it fewer than ${input.minCount} times in the window on the surface where the rule fires, so the rule rarely fires.`,
     "- **not distinctive**: the comparison baseline uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.",
     "",
-    "Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing, marketing verbs) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.",
+    "Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.",
     "",
   ];
   const removable = input.ruleHealth
@@ -394,7 +394,7 @@ function buildDeliverableHealth(
     };
   }
 
-  const baseline = phraseProfileStat(voiceProfile, entry.phrase);
+  const baseline = phraseProfileStatStemmed(voiceProfile, entry.phrase);
   const baselinePerM = baseline.perMillion;
   const lift = baselinePerM > 0 ? modelPerM / baselinePerM : null;
   const noData = modelCount === 0 && baseline.count === 0;

--- a/plugins/writing/skills/analyze/scripts/report.ts
+++ b/plugins/writing/skills/analyze/scripts/report.ts
@@ -1,6 +1,10 @@
-import type { CorrectionRow, ModelSummaryRow } from "./dump";
+import { type DeliverableAudit, isDeliverableSurface } from "./deliverable-audit";
+import type { CorrectionRow, CorrectiveRow, ModelSummaryRow } from "./dump";
 import type { LiftRow } from "./ngram";
+import type { QuoteContext } from "./quote-context";
 import type { StructuralAuditRow } from "./structural";
+import type { VoiceProfile } from "./voice-profile";
+import { phraseProfileStat } from "./voice-profile";
 import type { WordlistEntry } from "./wordlists";
 
 export interface FtsAuditRow {
@@ -13,17 +17,21 @@ export interface FtsAuditRow {
 }
 
 export type RemoveReason = "dead" | "not distinctive";
+export type AuditSurface = "chat" | "deliverable";
 
 export interface CurrentRuleHealth {
   entry: WordlistEntry;
-  assistantCount: number;
-  userCount: number;
-  assistantPerM: number | null;
-  userPerM: number | null;
+  surface: AuditSurface;
+  // Model rate on the audited surface (chat assistant text, or deliverable
+  // prose) and the comparison baseline (chat user text, or voice baseline).
+  modelCount: number;
+  modelPerM: number | null;
+  baselinePerM: number | null;
   lift: number | null;
   status: "keep" | "remove";
   removeReason: RemoveReason | null;
   noData: boolean;
+  quote: QuoteContext | null;
 }
 
 export interface ReportInput {
@@ -39,10 +47,19 @@ export interface ReportInput {
   assistantTotalChars: number;
   deliverableTotalChars: number;
   userTotalChars: number;
+  voiceProfile: VoiceProfile | null;
   ruleHealth: CurrentRuleHealth[];
   structuralAudit: StructuralAuditRow[];
-  candidatePhrases: LiftRow[];
+  candidatePhrases: CandidatePhrase[];
   corrections: CorrectionRow[];
+  corrective: CorrectiveRow[];
+}
+
+// A candidate phrase plus its baseline rate and a spot-checkable quote.
+export interface CandidatePhrase extends LiftRow {
+  baselineCount: number;
+  baselinePerM: number;
+  quote: QuoteContext | null;
 }
 
 export function renderReport(input: ReportInput): string {
@@ -53,6 +70,7 @@ export function renderReport(input: ReportInput): string {
     renderProposedAdditions(input),
     renderRuleHealthTable(input),
     renderStructuralAudit(input),
+    renderCorrectiveFeedback(input),
     renderCorrections(input),
   ];
   return `${sections.join("\n\n")}\n`;
@@ -83,11 +101,13 @@ function renderSummary(input: ReportInput): string {
     `- All assistant text: ${fmtNum(input.assistantTotalChars)} chars`,
     `- Deliverable prose (Write/Edit/Bash): ${fmtNum(input.deliverableTotalChars)} chars`,
     `- User text (human only): ${fmtNum(input.userTotalChars)} chars`,
+    `- Voice baseline: ${voiceBaselineSummary(input.voiceProfile)}`,
     `- Current wordlist entries audited: ${input.ruleHealth.length}`,
     `- Rules kept (distinctive and alive): ${keep}`,
     `- Proposed removals: ${removable.length} (dead: ${dead}, not distinctive: ${notDistinctive})`,
     `- Proposed additions (new candidates above threshold): ${input.candidatePhrases.length}`,
     `- Correction candidates surfaced: ${input.corrections.length}`,
+    `- Corrective-feedback moments surfaced: ${input.corrective.length}`,
   ];
   if (input.modelSummary.length > 0) {
     lines.push("", "### Models Seen in Window", "");
@@ -108,10 +128,10 @@ function renderProposedRemovals(input: ReportInput): string {
     "",
     "Two reasons a rule earns removal:",
     "",
-    `- **dead**: the model produced it fewer than ${input.minCount} times in the window, so the rule rarely fires.`,
-    "- **not distinctive**: the user uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.",
+    `- **dead**: the model produced it fewer than ${input.minCount} times in the window on the surface where the rule fires, so the rule rarely fires.`,
+    "- **not distinctive**: the comparison baseline uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.",
     "",
-    "A rule the model uses far more than the user is **kept** even when its lift reads low, because the smoothed user baseline (see methodology) compresses lift for any word the user never types.",
+    "Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing, marketing verbs) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.",
     "",
   ];
   const removable = input.ruleHealth
@@ -119,17 +139,17 @@ function renderProposedRemovals(input: ReportInput): string {
     .sort(
       (a, b) =>
         reasonRank(a.removeReason) - reasonRank(b.removeReason) ||
-        (a.assistantPerM ?? 0) - (b.assistantPerM ?? 0),
+        (a.modelPerM ?? 0) - (b.modelPerM ?? 0),
     );
   if (removable.length === 0) {
     lines.push("_No removals proposed._");
     return lines.join("\n");
   }
-  lines.push("| phrase | source | reason | assistant/M | user/M | lift |");
-  lines.push("| --- | --- | --- | --- | --- | --- |");
+  lines.push("| phrase | source | surface | reason | model/M | baseline/M | lift |");
+  lines.push("| --- | --- | --- | --- | --- | --- | --- |");
   for (const r of removable) {
     lines.push(
-      `| \`${esc(r.entry.phrase)}\` | ${r.entry.source} | ${r.removeReason} | ${fmtPerM(r.assistantPerM)} | ${fmtPerM(r.userPerM)} | ${fmtLift(r.lift)} |`,
+      `| \`${esc(r.entry.phrase)}\` | ${r.entry.source} | ${r.surface} | ${r.removeReason} | ${fmtPerM(r.modelPerM)} | ${fmtPerM(r.baselinePerM)} | ${fmtLift(r.lift)} |`,
     );
   }
   lines.push("", "```diff");
@@ -144,23 +164,29 @@ function renderProposedAdditions(input: ReportInput): string {
   const lines = [
     "## Proposed Wordlist Additions",
     "",
-    `Phrases distinctive to the assistant (lift >= ${input.minLift.toFixed(1)}x) not yet in the wordlists.`,
+    `Phrases distinctive to the assistant (lift >= ${input.minLift.toFixed(1)}x) not yet in the wordlists. The baseline columns report the phrase's rate in the user's voice baseline; a count of 0 is the strongest "absent from my baseline" signal.`,
     "",
   ];
   if (input.candidatePhrases.length === 0) {
     lines.push("_No additions proposed._");
     return lines.join("\n");
   }
-  lines.push("| phrase | n | assistant count | user count | sessions | lift |");
-  lines.push("| --- | --- | --- | --- | --- | --- |");
+  lines.push(
+    "| phrase | n | assistant count | user count | sessions | baseline count | baseline/M | lift |",
+  );
+  lines.push("| --- | --- | --- | --- | --- | --- | --- | --- |");
   for (const r of input.candidatePhrases) {
     lines.push(
-      `| \`${esc(r.phrase)}\` | ${r.n} | ${r.assistantCount} | ${r.userCount} | ${r.sessions ?? "-"} | ${r.lift.toFixed(1)} |`,
+      `| \`${esc(r.phrase)}\` | ${r.n} | ${r.assistantCount} | ${r.userCount} | ${r.sessions ?? "-"} | ${r.baselineCount} | ${fmtPerM(r.baselinePerM)} | ${r.lift.toFixed(1)} |`,
     );
+  }
+  lines.push("", "Context for each candidate (spot-check before adding):", "");
+  for (const r of input.candidatePhrases) {
+    lines.push(`- \`${esc(r.phrase)}\` ${formatQuote(r.quote)}`);
   }
   lines.push("", "```diff");
   for (const r of input.candidatePhrases) {
-    lines.push(`+ ${r.phrase}  # lift=${r.lift.toFixed(1)}, n=${r.n}`);
+    lines.push(`+ ${r.phrase}  # lift=${r.lift.toFixed(1)}, n=${r.n}, baseline=${r.baselineCount}`);
   }
   lines.push("```");
   return lines.join("\n");
@@ -170,21 +196,28 @@ function renderRuleHealthTable(input: ReportInput): string {
   const lines = [
     "## Current Rule Health",
     "",
-    "Full audit of every wordlist entry. `remove` rules are either dead or not distinctive (see Proposed Removals).",
+    "Full audit of every wordlist entry on its firing surface. `remove` rules are either dead or not distinctive (see Proposed Removals). The surface column shows which corpora the model/baseline rates come from.",
     "",
   ];
   if (input.ruleHealth.length === 0) {
     lines.push("_No wordlists found at `plugins/writing/wordlists/`._");
     return lines.join("\n");
   }
-  lines.push("| phrase | source | type | assistant/M | user/M | lift | status |");
-  lines.push("| --- | --- | --- | --- | --- | --- | --- |");
+  lines.push("| phrase | source | type | surface | model/M | baseline/M | lift | status |");
+  lines.push("| --- | --- | --- | --- | --- | --- | --- | --- |");
   for (const r of input.ruleHealth) {
     const status = r.status === "keep" ? "keep" : `remove (${r.removeReason})`;
     const ruleType = ruleTypeLabel(r.entry.source);
     lines.push(
-      `| \`${esc(r.entry.phrase)}\` | ${r.entry.source} | ${ruleType} | ${fmtPerM(r.assistantPerM)} | ${fmtPerM(r.userPerM)} | ${fmtLift(r.lift)} | ${status} |`,
+      `| \`${esc(r.entry.phrase)}\` | ${r.entry.source} | ${ruleType} | ${r.surface} | ${fmtPerM(r.modelPerM)} | ${fmtPerM(r.baselinePerM)} | ${fmtLift(r.lift)} | ${status} |`,
     );
+  }
+  const withQuotes = input.ruleHealth.filter((r) => r.quote);
+  if (withQuotes.length > 0) {
+    lines.push("", "Deliverable context for audited tells (spot-check verdicts):", "");
+    for (const r of withQuotes) {
+      lines.push(`- \`${esc(r.entry.phrase)}\` ${formatQuote(r.quote)}`);
+    }
   }
   return lines.join("\n");
 }
@@ -234,45 +267,132 @@ function renderCorrections(input: ReportInput): string {
   return lines.join("\n").trimEnd();
 }
 
-export function buildRuleHealth(
-  entries: WordlistEntry[],
-  auditByTerm: Map<string, FtsAuditRow>,
-  minCount: number,
-): CurrentRuleHealth[] {
-  return entries.map((entry) => {
-    const row = auditByTerm.get(entry.phrase.toLowerCase());
-    const assistantCount = row?.assistant_count ?? 0;
-    const userCount = row?.user_count ?? 0;
-    const assistantPerM = row?.assistant_per_m ?? null;
-    const userPerM = row?.user_per_m ?? null;
-    const lift = row?.lift ?? null;
-    const noData = !row || (assistantCount === 0 && userCount === 0);
-
-    const alive = assistantCount >= minCount;
-    const distinctive = (assistantPerM ?? 0) > (userPerM ?? 0);
-
-    let status: "keep" | "remove" = "keep";
-    let removeReason: RemoveReason | null = null;
-    if (!alive) {
-      status = "remove";
-      removeReason = "dead";
-    } else if (!distinctive) {
-      status = "remove";
-      removeReason = "not distinctive";
+function renderCorrectiveFeedback(input: ReportInput): string {
+  const lines = [
+    "## Corrective Feedback",
+    "",
+    "Short, human-authored user messages that name a writing problem (frustration lexicon match), paired with the preceding model output. These are labeled-slop moments: the user explicitly called out prose the model produced.",
+    "",
+  ];
+  if (input.corrective.length === 0) {
+    lines.push("_No corrective-feedback moments in window._");
+    return lines.join("\n");
+  }
+  for (const c of input.corrective) {
+    lines.push(`### ${c.timestamp} (${c.project ?? "unknown"}) — matched \`${c.matched_term}\``);
+    lines.push("");
+    if (c.context_snippet) {
+      lines.push(`Preceding model output (${fmtNum(c.context_chars)} chars):`);
+      lines.push("", "```", c.context_snippet, "```", "");
     }
+    lines.push(`User feedback (${c.user_chars} chars):`);
+    lines.push("", "```", c.user_text, "```", "");
+  }
+  return lines.join("\n").trimEnd();
+}
 
-    return {
-      entry,
-      assistantCount,
-      userCount,
-      assistantPerM,
-      userPerM,
-      lift,
-      status,
-      removeReason,
-      noData,
-    };
+export interface RuleHealthInput {
+  entries: WordlistEntry[];
+  chatAudit: Map<string, FtsAuditRow>;
+  deliverableAudit: DeliverableAudit | null;
+  voiceProfile: VoiceProfile | null;
+  minCount: number;
+  findQuote?: (entry: WordlistEntry, surface: AuditSurface) => QuoteContext | null;
+}
+
+// Audit each rule against the surface where it actually fires. Chat-surface
+// rules (openers, sycophantic patterns, conversational vocabulary) keep the
+// FTS chat comparison: the model's chat usage of a term tracks its habit.
+// Deliverable-surface rules (flowery phrases, soft phrasing, marketing verbs)
+// are judged on the model's deliverable-prose rate versus the user's voice
+// baseline, because those tells live in PR bodies and barely appear in chat.
+// Without the voice baseline, deliverable-surface rules fall back to the chat
+// audit so the script still runs.
+export function buildRuleHealth(input: RuleHealthInput): CurrentRuleHealth[] {
+  const { entries, chatAudit, deliverableAudit, voiceProfile, minCount, findQuote } = input;
+  const useDeliverable = deliverableAudit !== null && voiceProfile !== null;
+
+  return entries.map((entry) => {
+    const onDeliverable = useDeliverable && isDeliverableSurface(entry.source);
+    const surface: AuditSurface = onDeliverable ? "deliverable" : "chat";
+    const quote = findQuote ? findQuote(entry, surface) : null;
+
+    if (onDeliverable && deliverableAudit && voiceProfile) {
+      return buildDeliverableHealth(entry, deliverableAudit, voiceProfile, minCount, quote);
+    }
+    return buildChatHealth(entry, chatAudit, minCount, quote);
   });
+}
+
+function buildChatHealth(
+  entry: WordlistEntry,
+  chatAudit: Map<string, FtsAuditRow>,
+  minCount: number,
+  quote: QuoteContext | null,
+): CurrentRuleHealth {
+  const row = chatAudit.get(entry.phrase.toLowerCase());
+  const modelCount = row?.assistant_count ?? 0;
+  const baselinePerM = row?.user_per_m ?? null;
+  const modelPerM = row?.assistant_per_m ?? null;
+  const lift = row?.lift ?? null;
+  const noData = !row || (modelCount === 0 && (row?.user_count ?? 0) === 0);
+
+  const { status, removeReason } = verdict(modelCount, modelPerM, baselinePerM, minCount);
+  return {
+    entry,
+    surface: "chat",
+    modelCount,
+    modelPerM,
+    baselinePerM,
+    lift,
+    status,
+    removeReason,
+    noData,
+    quote,
+  };
+}
+
+function buildDeliverableHealth(
+  entry: WordlistEntry,
+  deliverableAudit: DeliverableAudit,
+  voiceProfile: VoiceProfile,
+  minCount: number,
+  quote: QuoteContext | null,
+): CurrentRuleHealth {
+  const audit = deliverableAudit.byPhrase.get(entry.phrase);
+  const modelCount = audit?.count ?? 0;
+  const modelPerM = audit?.perMillion ?? 0;
+  const baseline = phraseProfileStat(voiceProfile, entry.phrase);
+  const baselinePerM = baseline.perMillion;
+  const lift = baselinePerM > 0 ? modelPerM / baselinePerM : null;
+  const noData = modelCount === 0 && baseline.count === 0;
+
+  const { status, removeReason } = verdict(modelCount, modelPerM, baselinePerM, minCount);
+  return {
+    entry,
+    surface: "deliverable",
+    modelCount,
+    modelPerM,
+    baselinePerM,
+    lift,
+    status,
+    removeReason,
+    noData,
+    quote,
+  };
+}
+
+function verdict(
+  modelCount: number,
+  modelPerM: number | null,
+  baselinePerM: number | null,
+  minCount: number,
+): { status: "keep" | "remove"; removeReason: RemoveReason | null } {
+  const alive = modelCount >= minCount;
+  const distinctive = (modelPerM ?? 0) > (baselinePerM ?? 0);
+  if (!alive) return { status: "remove", removeReason: "dead" };
+  if (!distinctive) return { status: "remove", removeReason: "not distinctive" };
+  return { status: "keep", removeReason: null };
 }
 
 function reasonRank(reason: RemoveReason | null): number {
@@ -305,4 +425,19 @@ function ruleTypeLabel(source: string): string {
 
 function esc(s: string): string {
   return s.replace(/\|/g, "\\|");
+}
+
+function voiceBaselineSummary(profile: VoiceProfile | null): string {
+  if (!profile) return "not loaded (run ingest-voice.ts + voice-profile.ts)";
+  return `${fmtNum(profile.documentCount)} documents, ${fmtNum(profile.totalTokens)} tokens (sources: ${profile.sources.join("+") || "none"})`;
+}
+
+function formatQuote(quote: QuoteContext | null): string {
+  if (!quote) return "(no deliverable occurrence found)";
+  const pointer = quote.filePath
+    ? `${quote.filePath}`
+    : quote.sourceFile
+      ? `${quote.sourceFile}:${quote.sourceLine ?? "?"}`
+      : "(no source pointer)";
+  return `"${quote.window}" — ${pointer}`;
 }

--- a/plugins/writing/skills/analyze/scripts/report.ts
+++ b/plugins/writing/skills/analyze/scripts/report.ts
@@ -203,10 +203,21 @@ function renderRuleHealthTable(input: ReportInput): string {
     lines.push("_No wordlists found at `plugins/writing/wordlists/`._");
     return lines.join("\n");
   }
+  if (!input.voiceProfile && input.ruleHealth.some((r) => r.surface === "deliverable")) {
+    lines.push(
+      "Voice profile not loaded: deliverable-surface rules are kept pending a baseline (run `ingest-voice.ts` then `voice-profile.ts` to verify distinctiveness). Their baseline/M reads `-`.",
+      "",
+    );
+  }
   lines.push("| phrase | source | type | surface | model/M | baseline/M | lift | status |");
   lines.push("| --- | --- | --- | --- | --- | --- | --- | --- |");
   for (const r of input.ruleHealth) {
-    const status = r.status === "keep" ? "keep" : `remove (${r.removeReason})`;
+    const status =
+      r.status === "keep"
+        ? r.noData && r.surface === "deliverable"
+          ? "keep (no baseline)"
+          : "keep"
+        : `remove (${r.removeReason})`;
     const ruleType = ruleTypeLabel(r.entry.source);
     lines.push(
       `| \`${esc(r.entry.phrase)}\` | ${r.entry.source} | ${ruleType} | ${r.surface} | ${fmtPerM(r.modelPerM)} | ${fmtPerM(r.baselinePerM)} | ${fmtLift(r.lift)} | ${status} |`,
@@ -279,7 +290,7 @@ function renderCorrectiveFeedback(input: ReportInput): string {
     return lines.join("\n");
   }
   for (const c of input.corrective) {
-    lines.push(`### ${c.timestamp} (${c.project ?? "unknown"}) — matched \`${c.matched_term}\``);
+    lines.push(`### ${c.timestamp} (${c.project ?? "unknown"}): matched \`${c.matched_term}\``);
     lines.push("");
     if (c.context_snippet) {
       lines.push(`Preceding model output (${fmtNum(c.context_chars)} chars):`);
@@ -303,21 +314,23 @@ export interface RuleHealthInput {
 // Audit each rule against the surface where it actually fires. Chat-surface
 // rules (openers, sycophantic patterns, conversational vocabulary) keep the
 // FTS chat comparison: the model's chat usage of a term tracks its habit.
-// Deliverable-surface rules (flowery phrases, soft phrasing, marketing verbs)
-// are judged on the model's deliverable-prose rate versus the user's voice
-// baseline, because those tells live in PR bodies and barely appear in chat.
-// Without the voice baseline, deliverable-surface rules fall back to the chat
-// audit so the script still runs.
+// Deliverable-surface rules (flowery phrases, soft phrasing) are judged on the
+// model's deliverable-prose rate. The chat audit cannot measure them: it stems
+// each entry and joins against single-word FTS tokens, so a multi-word phrase
+// never matches and would read as a false "dead". They are always routed to
+// the deliverable audit. With the voice baseline loaded they also get a
+// distinctiveness check against the user's hand-written voice. Without it the
+// baseline is unknown, so an alive rule is kept rather than proposed for
+// removal (we never recommend dropping a rule we cannot measure).
 export function buildRuleHealth(input: RuleHealthInput): CurrentRuleHealth[] {
   const { entries, chatAudit, deliverableAudit, voiceProfile, minCount, findQuote } = input;
-  const useDeliverable = deliverableAudit !== null && voiceProfile !== null;
 
   return entries.map((entry) => {
-    const onDeliverable = useDeliverable && isDeliverableSurface(entry.source);
+    const onDeliverable = deliverableAudit !== null && isDeliverableSurface(entry.source);
     const surface: AuditSurface = onDeliverable ? "deliverable" : "chat";
     const quote = findQuote ? findQuote(entry, surface) : null;
 
-    if (onDeliverable && deliverableAudit && voiceProfile) {
+    if (onDeliverable && deliverableAudit) {
       return buildDeliverableHealth(entry, deliverableAudit, voiceProfile, minCount, quote);
     }
     return buildChatHealth(entry, chatAudit, minCount, quote);
@@ -355,13 +368,32 @@ function buildChatHealth(
 function buildDeliverableHealth(
   entry: WordlistEntry,
   deliverableAudit: DeliverableAudit,
-  voiceProfile: VoiceProfile,
+  voiceProfile: VoiceProfile | null,
   minCount: number,
   quote: QuoteContext | null,
 ): CurrentRuleHealth {
   const audit = deliverableAudit.byPhrase.get(entry.phrase);
   const modelCount = audit?.count ?? 0;
   const modelPerM = audit?.perMillion ?? 0;
+
+  if (!voiceProfile) {
+    // No baseline loaded. Judge only whether the rule fires on its deliverable
+    // surface; distinctiveness is unmeasurable, so an alive rule is kept.
+    const alive = modelCount >= minCount;
+    return {
+      entry,
+      surface: "deliverable",
+      modelCount,
+      modelPerM,
+      baselinePerM: null,
+      lift: null,
+      status: alive ? "keep" : "remove",
+      removeReason: alive ? null : "dead",
+      noData: true,
+      quote,
+    };
+  }
+
   const baseline = phraseProfileStat(voiceProfile, entry.phrase);
   const baselinePerM = baseline.perMillion;
   const lift = baselinePerM > 0 ? modelPerM / baselinePerM : null;
@@ -439,5 +471,5 @@ function formatQuote(quote: QuoteContext | null): string {
     : quote.sourceFile
       ? `${quote.sourceFile}:${quote.sourceLine ?? "?"}`
       : "(no source pointer)";
-  return `"${quote.window}" — ${pointer}`;
+  return `"${quote.window}" (${pointer})`;
 }

--- a/plugins/writing/skills/analyze/scripts/voice-corpus.test.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-corpus.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { mergeDocuments, parseCorpus, serializeCorpus } from "./voice-corpus";
+
+const sample = `===== https://github.com/o/r/pull/1 (2020-01-01T00:00:00Z, +10/-2) =====
+First PR body.
+Second line.
+
+
+===== https://github.com/o/r/pull/2 (2020-02-01T00:00:00Z, +1/-0) =====
+Another body.
+`;
+
+describe("parseCorpus", () => {
+  test("splits documents on delimiter lines", () => {
+    const docs = parseCorpus(sample);
+    expect(docs).toHaveLength(2);
+    expect(docs[0]?.source).toBe("https://github.com/o/r/pull/1");
+    expect(docs[0]?.meta).toBe("2020-01-01T00:00:00Z, +10/-2");
+    expect(docs[0]?.body).toBe("First PR body.\nSecond line.");
+    expect(docs[1]?.body).toBe("Another body.");
+  });
+
+  test("returns no documents for text without delimiters", () => {
+    expect(parseCorpus("just some text\nno delimiters")).toHaveLength(0);
+  });
+});
+
+describe("serializeCorpus", () => {
+  test("round-trips through parse", () => {
+    const docs = parseCorpus(sample);
+    const reparsed = parseCorpus(serializeCorpus(docs));
+    expect(reparsed.map((d) => d.source)).toEqual(docs.map((d) => d.source));
+    expect(reparsed.map((d) => d.body)).toEqual(docs.map((d) => d.body));
+  });
+});
+
+describe("mergeDocuments", () => {
+  test("de-duplicates by source pointer, existing wins", () => {
+    const existing = [{ source: "u/1", meta: "a", body: "old" }];
+    const incoming = [
+      { source: "u/1", meta: "b", body: "new" },
+      { source: "u/2", meta: "c", body: "fresh" },
+    ];
+    const merged = mergeDocuments(existing, incoming);
+    expect(merged).toHaveLength(2);
+    expect(merged.find((d) => d.source === "u/1")?.body).toBe("old");
+    expect(merged.find((d) => d.source === "u/2")?.body).toBe("fresh");
+  });
+});

--- a/plugins/writing/skills/analyze/scripts/voice-corpus.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-corpus.ts
@@ -1,0 +1,58 @@
+export interface VoiceDocument {
+  source: string;
+  meta: string;
+  body: string;
+}
+
+// A delimiter line marks the start of a document. The captured group is the
+// source pointer (a URL for GitHub PRs); the trailing parenthetical is metadata
+// (date and diff size) kept for provenance but not counted as prose.
+const DELIMITER = /^=====\s+(\S+)\s+\(([^)]*)\)\s+=====$/;
+
+export function parseCorpus(text: string): VoiceDocument[] {
+  const docs: VoiceDocument[] = [];
+  let current: VoiceDocument | null = null;
+  const lines: string[] = [];
+
+  const flush = (): void => {
+    if (!current) return;
+    docs.push({ ...current, body: lines.join("\n").trim() });
+    lines.length = 0;
+  };
+
+  for (const line of text.split("\n")) {
+    const match = DELIMITER.exec(line);
+    if (match) {
+      flush();
+      current = { source: match[1] ?? "", meta: match[2] ?? "", body: "" };
+      continue;
+    }
+    if (current) lines.push(line);
+  }
+  flush();
+  return docs;
+}
+
+export function formatDocument(doc: VoiceDocument): string {
+  return `===== ${doc.source} (${doc.meta}) =====\n${doc.body.trim()}\n`;
+}
+
+// Serialize a set of documents back to the on-disk corpus format. Documents are
+// separated by a blank line so the file stays human-readable.
+export function serializeCorpus(docs: VoiceDocument[]): string {
+  return `${docs.map(formatDocument).join("\n\n")}\n`;
+}
+
+// Merge new documents into an existing corpus, de-duplicating by source pointer
+// so re-ingesting the same range is idempotent. Existing entries win.
+export function mergeDocuments(
+  existing: VoiceDocument[],
+  incoming: VoiceDocument[],
+): VoiceDocument[] {
+  const bySource = new Map<string, VoiceDocument>();
+  for (const doc of existing) bySource.set(doc.source, doc);
+  for (const doc of incoming) {
+    if (!bySource.has(doc.source)) bySource.set(doc.source, doc);
+  }
+  return Array.from(bySource.values());
+}

--- a/plugins/writing/skills/analyze/scripts/voice-profile.test.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-profile.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { buildProfileFromCorpus, phraseProfileStat } from "./voice-profile";
+import {
+  buildProfileFromCorpus,
+  phraseProfileStat,
+  phraseProfileStatStemmed,
+} from "./voice-profile";
 
 const corpus = `===== https://github.com/o/r/pull/1 (2020-01-01, +1/-0) =====
 The change updates the cache layer. It updates the cache layer twice.
@@ -45,5 +49,30 @@ describe("phraseProfileStat", () => {
   test("returns zero against an empty profile", () => {
     const empty = buildProfileFromCorpus("", "2026-05-24");
     expect(phraseProfileStat(empty, "anything").count).toBe(0);
+  });
+});
+
+describe("phraseProfileStatStemmed", () => {
+  const inflected = `===== https://github.com/o/r/pull/1 (2020-01-01, +1/-0) =====
+The handler fails loudly on bad input. A second guard also fails loudly.
+`;
+  const profile = buildProfileFromCorpus(inflected, "2026-05-24");
+
+  test("matches an inflected baseline phrase against the rule stem", () => {
+    // The baseline says "fails loudly" twice; the wordlist rule is "fail
+    // loudly". Stemming both sides makes them match, so the rule is correctly
+    // seen as present in the voice baseline (count 2), not absent.
+    const stat = phraseProfileStatStemmed(profile, "fail loudly");
+    expect(stat.count).toBe(2);
+    expect(stat.perMillion).toBeGreaterThan(0);
+  });
+
+  test("returns zero for a phrase absent from the stemmed baseline", () => {
+    expect(phraseProfileStatStemmed(profile, "source of truth").count).toBe(0);
+  });
+
+  test("returns zero against an empty profile", () => {
+    const empty = buildProfileFromCorpus("", "2026-05-24");
+    expect(phraseProfileStatStemmed(empty, "fail loudly").count).toBe(0);
   });
 });

--- a/plugins/writing/skills/analyze/scripts/voice-profile.test.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-profile.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { buildProfileFromCorpus, phraseProfileStat } from "./voice-profile";
+
+const corpus = `===== https://github.com/o/r/pull/1 (2020-01-01, +1/-0) =====
+The change updates the cache layer. It updates the cache layer twice.
+
+===== https://github.com/o/r/pull/2 (2020-02-01, +1/-0) =====
+Refactors the loader for clarity.
+`;
+
+describe("buildProfileFromCorpus", () => {
+  test("counts documents, tokens, and word n-grams", () => {
+    const profile = buildProfileFromCorpus(corpus, "2026-05-24");
+    expect(profile.documentCount).toBe(2);
+    expect(profile.totalTokens).toBeGreaterThan(0);
+    expect(profile.ngrams["1"]?.updates).toBe(2);
+    expect(profile.ngrams["2"]?.["the cache"]).toBe(2);
+    expect(profile.ngrams["3"]?.["updates the cache"]).toBe(2);
+    expect(profile.sources).toEqual(["github"]);
+  });
+});
+
+describe("phraseProfileStat", () => {
+  const profile = buildProfileFromCorpus(corpus, "2026-05-24");
+
+  test("returns count and per-million for a present bigram", () => {
+    const stat = phraseProfileStat(profile, "the cache");
+    expect(stat.count).toBe(2);
+    expect(stat.perMillion).toBeGreaterThan(0);
+  });
+
+  test("returns zero for an absent phrase (the tell signal)", () => {
+    const stat = phraseProfileStat(profile, "source of truth");
+    expect(stat.count).toBe(0);
+    expect(stat.perMillion).toBe(0);
+  });
+
+  test("matches a phrase longer than the max profile size by its leading trigram", () => {
+    // "updates the cache layer" is 4 tokens; the profile stores up to trigrams,
+    // so the lookup uses the leading trigram "updates the cache" (count 2).
+    const stat = phraseProfileStat(profile, "updates the cache layer");
+    expect(stat.count).toBe(2);
+  });
+
+  test("returns zero against an empty profile", () => {
+    const empty = buildProfileFromCorpus("", "2026-05-24");
+    expect(phraseProfileStat(empty, "anything").count).toBe(0);
+  });
+});

--- a/plugins/writing/skills/analyze/scripts/voice-profile.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-profile.ts
@@ -1,0 +1,124 @@
+import { mkdirSync } from "node:fs";
+import { cli } from "cleye";
+import { corpusPath, profilePath, resolveDataDir, voiceBaselineDir } from "./data-dir";
+import { cleanText, splitSentences, tokenizeSentence } from "./ngram";
+import { parseCorpus, type VoiceDocument } from "./voice-corpus";
+
+// Word n-gram sizes the profile records. Unigrams cover single-word tells
+// (e.g. "cleanly"); bigrams and trigrams cover phrase tells (e.g. "source of
+// truth", up to 3 words). Phrases longer than 3 words are matched by their
+// leading trigram (see phraseProfileMatch).
+export const PROFILE_SIZES = [1, 2, 3] as const;
+
+export interface VoiceProfile {
+  documentCount: number;
+  totalTokens: number;
+  // n-gram size -> phrase -> count. Stored as plain objects for JSON.
+  ngrams: Record<string, Record<string, number>>;
+  generatedAt: string;
+  sources: string[];
+}
+
+export function buildProfile(docs: VoiceDocument[], generatedAt: string): VoiceProfile {
+  const ngrams = new Map<number, Map<string, number>>(PROFILE_SIZES.map((n) => [n, new Map()]));
+  let totalTokens = 0;
+  const sources = new Set<string>();
+
+  for (const doc of docs) {
+    sources.add(hostOf(doc.source));
+    for (const sentence of splitSentences(cleanText(doc.body))) {
+      const tokens = tokenizeSentence(sentence);
+      if (tokens.length === 0) continue;
+      totalTokens += tokens.length;
+      for (const n of PROFILE_SIZES) {
+        const counts = ngrams.get(n);
+        if (!counts) continue;
+        for (let i = 0; i + n <= tokens.length; i++) {
+          const key = tokens.slice(i, i + n).join(" ");
+          counts.set(key, (counts.get(key) ?? 0) + 1);
+        }
+      }
+    }
+  }
+
+  const serializedNgrams: Record<string, Record<string, number>> = {};
+  for (const [n, counts] of ngrams) {
+    serializedNgrams[String(n)] = Object.fromEntries(counts);
+  }
+
+  return {
+    documentCount: docs.length,
+    totalTokens,
+    ngrams: serializedNgrams,
+    generatedAt,
+    sources: Array.from(sources).sort(),
+  };
+}
+
+export function buildProfileFromCorpus(corpusText: string, generatedAt: string): VoiceProfile {
+  return buildProfile(parseCorpus(corpusText), generatedAt);
+}
+
+export async function loadProfile(path: string): Promise<VoiceProfile | null> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) return null;
+  return (await file.json()) as VoiceProfile;
+}
+
+export interface PhraseProfileStat {
+  count: number;
+  perMillion: number;
+}
+
+// Look up how often a phrase appears in the voice profile. The phrase is
+// tokenized the same way the profile was built. Phrases up to PROFILE_SIZES.max
+// are looked up directly; longer phrases use their leading trigram as a proxy
+// (the profile only stores up to trigrams). A count of 0 is the strong
+// "absent from my baseline" tell signal.
+export function phraseProfileStat(profile: VoiceProfile, phrase: string): PhraseProfileStat {
+  const tokens = tokenizeSentence(cleanText(phrase));
+  if (tokens.length === 0 || profile.totalTokens === 0) {
+    return { count: 0, perMillion: 0 };
+  }
+  const maxSize = Math.max(...PROFILE_SIZES);
+  const size = Math.min(tokens.length, maxSize);
+  const key = tokens.slice(0, size).join(" ");
+  const count = profile.ngrams[String(size)]?.[key] ?? 0;
+  return { count, perMillion: (count / profile.totalTokens) * 1_000_000 };
+}
+
+// Derive a coarse source label from a document pointer for the profile's
+// provenance list. A GitHub PR URL becomes "github"; anything else is "other".
+function hostOf(source: string): string {
+  if (/github\.com/.test(source)) return "github";
+  return "other";
+}
+
+if (import.meta.main) {
+  const argv = cli({
+    name: "voice-profile",
+    flags: {
+      dataDir: {
+        type: String,
+        description:
+          "Local data dir for the voice baseline (default: CLAUDE_PLUGIN_DATA or ~/.claude/plugins/data/writing-bendrucker)",
+      },
+    },
+  });
+
+  const dataDir = resolveDataDir(argv.flags.dataDir);
+  const corpus = corpusPath(dataDir);
+  if (!(await Bun.file(corpus).exists())) {
+    throw new Error(`No voice corpus at ${corpus}. Run ingest-voice.ts first.`);
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+  const profile = buildProfileFromCorpus(await Bun.file(corpus).text(), today);
+  mkdirSync(voiceBaselineDir(dataDir), { recursive: true });
+  const out = profilePath(dataDir);
+  await Bun.write(out, `${JSON.stringify(profile, null, 2)}\n`);
+  console.error(
+    `Built profile: ${profile.documentCount} documents, ${profile.totalTokens.toLocaleString()} tokens, sources=${profile.sources.join("+")}`,
+  );
+  process.stdout.write(`${out}\n`);
+}

--- a/plugins/writing/skills/analyze/scripts/voice-profile.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-profile.ts
@@ -1,6 +1,8 @@
+#!/usr/bin/env bun
 import { mkdirSync } from "node:fs";
 import { cli } from "cleye";
 import { corpusPath, profilePath, resolveDataDir, voiceBaselineDir } from "./data-dir";
+import { stemPhrase, stemTokens } from "./deliverable-audit";
 import { cleanText, splitSentences, tokenizeSentence } from "./ngram";
 import { parseCorpus, type VoiceDocument } from "./voice-corpus";
 
@@ -13,15 +15,28 @@ export const PROFILE_SIZES = [1, 2, 3] as const;
 export interface VoiceProfile {
   documentCount: number;
   totalTokens: number;
-  // n-gram size -> phrase -> count. Stored as plain objects for JSON.
+  // n-gram size -> phrase -> count. Stored as plain objects for JSON. Built from
+  // unstemmed tokens; the candidate-additions path looks these up directly.
   ngrams: Record<string, Record<string, number>>;
+  // Same shape, but built from Porter-stemmed tokens via the deliverable-audit
+  // stemming. The deliverable rule-health path looks these up so an inflected
+  // baseline phrase ("fails loudly") matches the rule's stem ("fail loudli"),
+  // mirroring how auditDeliverableCorpus stems the model's deliverable corpus.
+  stemmedNgrams: Record<string, Record<string, number>>;
+  // Stemmed token count, the denominator for stemmed per-million rates. Differs
+  // from totalTokens because the two tokenizers split prose differently.
+  totalStemmedTokens: number;
   generatedAt: string;
   sources: string[];
 }
 
 export function buildProfile(docs: VoiceDocument[], generatedAt: string): VoiceProfile {
   const ngrams = new Map<number, Map<string, number>>(PROFILE_SIZES.map((n) => [n, new Map()]));
+  const stemmedNgrams = new Map<number, Map<string, number>>(
+    PROFILE_SIZES.map((n) => [n, new Map()]),
+  );
   let totalTokens = 0;
+  let totalStemmedTokens = 0;
   const sources = new Set<string>();
 
   for (const doc of docs) {
@@ -30,29 +45,43 @@ export function buildProfile(docs: VoiceDocument[], generatedAt: string): VoiceP
       const tokens = tokenizeSentence(sentence);
       if (tokens.length === 0) continue;
       totalTokens += tokens.length;
-      for (const n of PROFILE_SIZES) {
-        const counts = ngrams.get(n);
-        if (!counts) continue;
-        for (let i = 0; i + n <= tokens.length; i++) {
-          const key = tokens.slice(i, i + n).join(" ");
-          counts.set(key, (counts.get(key) ?? 0) + 1);
-        }
-      }
+      addNgramCounts(ngrams, tokens);
     }
-  }
-
-  const serializedNgrams: Record<string, Record<string, number>> = {};
-  for (const [n, counts] of ngrams) {
-    serializedNgrams[String(n)] = Object.fromEntries(counts);
+    const stemmed = stemTokens(doc.body);
+    totalStemmedTokens += stemmed.length;
+    addNgramCounts(stemmedNgrams, stemmed);
   }
 
   return {
     documentCount: docs.length,
     totalTokens,
-    ngrams: serializedNgrams,
+    ngrams: serializeNgrams(ngrams),
+    stemmedNgrams: serializeNgrams(stemmedNgrams),
+    totalStemmedTokens,
     generatedAt,
     sources: Array.from(sources).sort(),
   };
+}
+
+function addNgramCounts(ngrams: Map<number, Map<string, number>>, tokens: string[]): void {
+  for (const n of PROFILE_SIZES) {
+    const counts = ngrams.get(n);
+    if (!counts) continue;
+    for (let i = 0; i + n <= tokens.length; i++) {
+      const key = tokens.slice(i, i + n).join(" ");
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  }
+}
+
+function serializeNgrams(
+  ngrams: Map<number, Map<string, number>>,
+): Record<string, Record<string, number>> {
+  const serialized: Record<string, Record<string, number>> = {};
+  for (const [n, counts] of ngrams) {
+    serialized[String(n)] = Object.fromEntries(counts);
+  }
+  return serialized;
 }
 
 export function buildProfileFromCorpus(corpusText: string, generatedAt: string): VoiceProfile {
@@ -70,21 +99,43 @@ export interface PhraseProfileStat {
   perMillion: number;
 }
 
-// Look up how often a phrase appears in the voice profile. The phrase is
-// tokenized the same way the profile was built. Phrases up to PROFILE_SIZES.max
-// are looked up directly; longer phrases use their leading trigram as a proxy
-// (the profile only stores up to trigrams). A count of 0 is the strong
-// "absent from my baseline" tell signal.
+// Look up how often a phrase appears in the voice profile (UNstemmed). The
+// phrase is tokenized the same way the unstemmed profile was built. Phrases up
+// to PROFILE_SIZES.max are looked up directly; longer phrases use their leading
+// trigram as a proxy (the profile only stores up to trigrams). A count of 0 is
+// the strong "absent from my baseline" tell signal. This feeds the
+// candidate-additions path, which is intentionally unstemmed.
 export function phraseProfileStat(profile: VoiceProfile, phrase: string): PhraseProfileStat {
   const tokens = tokenizeSentence(cleanText(phrase));
   if (tokens.length === 0 || profile.totalTokens === 0) {
     return { count: 0, perMillion: 0 };
   }
+  return lookupNgram(profile.ngrams, tokens, profile.totalTokens);
+}
+
+// Stemmed variant of phraseProfileStat. The phrase is stemmed the same way
+// auditDeliverableCorpus stems its needles, and looked up against the profile's
+// stemmed n-grams, so an inflected baseline phrase ("fails loudly") matches the
+// rule's stem. This feeds the deliverable rule-health comparison, keeping the
+// model and baseline sides stem-consistent.
+export function phraseProfileStatStemmed(profile: VoiceProfile, phrase: string): PhraseProfileStat {
+  const tokens = stemPhrase(phrase);
+  if (tokens.length === 0 || profile.totalStemmedTokens === 0) {
+    return { count: 0, perMillion: 0 };
+  }
+  return lookupNgram(profile.stemmedNgrams, tokens, profile.totalStemmedTokens);
+}
+
+function lookupNgram(
+  ngrams: Record<string, Record<string, number>>,
+  tokens: string[],
+  totalTokens: number,
+): PhraseProfileStat {
   const maxSize = Math.max(...PROFILE_SIZES);
   const size = Math.min(tokens.length, maxSize);
   const key = tokens.slice(0, size).join(" ");
-  const count = profile.ngrams[String(size)]?.[key] ?? 0;
-  return { count, perMillion: (count / profile.totalTokens) * 1_000_000 };
+  const count = ngrams[String(size)]?.[key] ?? 0;
+  return { count, perMillion: (count / totalTokens) * 1_000_000 };
 }
 
 // Derive a coarse source label from a document pointer for the profile's


### PR DESCRIPTION
Audits `writing:analyze` rules against the surface where the hook actually fires them, so deliverable-only tells stop reading as dead. Adds a local-only voice baseline (the user's hand-written pull requests) as the comparison surface, a corrective-feedback extractor, quote-in-context for every candidate and tell, and a paste filter for the user baseline.

Stacks on #642.

#### The blind spot this fixes

The rule-health audit measured every wordlist entry against chat text. Most rules fire on deliverables, not chat, and the model's chat usage tracks its habit closely enough for chat-surface rules. It breaks for tells that live only in deliverables. The flowery phrases (`source of truth`, `escape hatch`, `self-sufficient`, `fail loudly`) and the soft `cleanly` were curated from PR-body evidence, so the chat audit reported all four flowery phrases as dead and proposed them for removal.

Each rule is now judged on its firing surface. Chat-surface rules (openers, sycophantic patterns, conversational vocabulary) keep the chat comparison. The `fileOnly` deliverable rules compare the model's deliverable-prose rate against the user's voice baseline. A phrase frequent in deliverables and absent from the baseline now reads as keep:

| phrase | before | after | deliverable/M | baseline/M |
| --- | --- | --- | --- | --- |
| `source of truth` | remove (dead) | keep | 169.2 | 0.0 |
| `fail loudly` | remove (dead) | keep | 76.0 | 0.0 |
| `escape hatch` | remove (dead) | keep | 44.1 | 0.0 |
| `self-sufficient` | remove (dead) | keep | 17.2 | 0.0 |
| `cleanly` | keep | keep | 215.7 | 0.0 |

`marketing-verbs.txt` stays on the chat audit because its hook group is not `fileOnly`, so it fires on side-effect inputs too and a deliverable-only count undercounts it.

#### Voice baseline

The user's true deliverable voice is their hand-written, pre-AI pull requests, not their chat. A tell is real if it is frequent in the model's deliverables and absent from this baseline. The baseline is local-only and never committed: it lives outside the repository at the plugin data dir and will grow to include private writing. `ingest-voice.ts` normalizes sources (a `gh search prs` source and the already-present seed corpus) into the data dir. `voice-profile.ts` builds a word n-gram profile from it. A configurable `--self-name` drops pasted prose that refers to the user in the third person from the baseline. Without a profile, deliverable rules are still measured on the deliverable corpus (never the chat audit, which cannot match a multi-word phrase) and an alive rule reads `keep (no baseline)` rather than being proposed for removal.

#### Also in this change

- Corrective-feedback extractor: short, human-authored messages that name a writing problem (a frustration lexicon), paired with the preceding model output. These are higher-signal than the inferred long-assistant/short-user correction candidates.
- Quote-in-context: every candidate and audited deliverable tell ships with a context window and a source pointer, so a curation decision is spot-checkable.
- Paste-aware user baseline: a heuristic drops human-pasted model output (very long messages, third-person self-reference, document structure) so the model's phrasing does not appear on both sides of the lift ratio. On the combined index this trims the human user corpus by more than half.

#### Verification

Type checking, the writing test suite, and skill linting all run clean. New unit tests cover the corpus parser, the profile lookup (including the absent-phrase signal), the frustration regex, the deliverable phrase audit, and the quote finder. Each new script was exercised end-to-end against the session index and the existing baseline corpus, including both `ingest-voice` sources. The profile and corpus write only to the local data dir, and no baseline files are staged for commit.
