### PR TITLE
tmux: rely on allowUnixSockets instead of sandbox bypass

### DIFF
--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -13,4 +13,22 @@ Tmux session, window, and pane awareness for Claude Code.
 
 A SessionStart hook detects whether Claude is running inside tmux and writes session/window/pane identifiers to `CLAUDE_ENV_FILE`. These env vars are available in all subsequent Bash calls.
 
-The skill provides a PreToolUse hook that auto-allows safe tmux commands (read-only, navigation, layout) and disables the sandbox for all tmux calls. The safe command list is maintained in [`safe-commands.json`](skills/tmux/resources/safe-commands.json).
+The skill provides a PreToolUse hook that auto-allows safe tmux commands (read-only, navigation, layout). The safe command list is maintained in [`safe-commands.json`](skills/tmux/resources/safe-commands.json).
+
+## Sandbox
+
+Claude Code's Bash sandbox blocks Unix socket connections, including tmux's control socket. The skill's scripts run sandboxed, so without an exception they fail with `pane lookup failed`.
+
+Allow the socket's directory in your user settings (`~/.claude/settings.json`):
+
+```json
+{
+  "sandbox": {
+    "network": {
+      "allowUnixSockets": ["~/.tmux"]
+    }
+  }
+}
+```
+
+An `allowUnixSockets` entry matches a path and everything beneath it, so allowing the directory covers every socket regardless of the server's per-user socket name. Find yours with `tmux display-message -p '#{socket_path}'`. The default location varies by platform (often under `$TMPDIR`); set `TMUX_TMPDIR` to pin it somewhere stable like `~/.tmux`.

--- a/plugins/tmux/skills/tmux/SKILL.md
+++ b/plugins/tmux/skills/tmux/SKILL.md
@@ -16,7 +16,7 @@ hooks:
       hooks:
         - type: command
           command: |
-            cat | jq '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow", updatedInput: (.tool_input + {dangerouslyDisableSandbox: true})}}'
+            cat | jq '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"}}'
 ---
 
 # tmux

--- a/plugins/tmux/skills/tmux/scripts/lib.sh
+++ b/plugins/tmux/skills/tmux/scripts/lib.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Print an actionable tmux-lookup failure and exit. $1 is the noun (pane/window/session).
+lookup_failed() {
+  echo "$1 lookup failed: cannot reach tmux${TMUX:+ at ${TMUX%%,*}}. If Claude Code's Bash sandbox is enabled, allow the tmux socket's directory under sandbox.network.allowUnixSockets (see the tmux plugin README)." >&2
+  exit 1
+}

--- a/plugins/tmux/skills/tmux/scripts/pane.sh
+++ b/plugins/tmux/skills/tmux/scripts/pane.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
 target="${1:-${TMUX_PANE:-}}"
 [ -z "$target" ] && { echo 'no pane target' >&2; exit 1; }
 
 tmux display-message -t "$target" -p -- '- Session: #{session_name}
 - Window: #{window_index} (#{window_name})
-- Pane: #{pane_index} (#{pane_id})' 2>/dev/null || { echo 'pane lookup failed' >&2; exit 1; }
+- Pane: #{pane_index} (#{pane_id})' 2>/dev/null || lookup_failed pane

--- a/plugins/tmux/skills/tmux/scripts/safe-command.sh
+++ b/plugins/tmux/skills/tmux/scripts/safe-command.sh
@@ -6,6 +6,6 @@ pattern=$(jq -r 'join("|")' "$dir/../resources/safe-commands.json")
 
 cat | jq --arg pattern "$pattern" '
   if (.tool_input.command | test("^tmux\\s+(" + $pattern + ")\\b"))
-  then {hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow", updatedInput: {dangerouslyDisableSandbox: true}}}
-  else {hookSpecificOutput: {hookEventName: "PreToolUse", updatedInput: {dangerouslyDisableSandbox: true}}}
+  then {hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"}}
+  else empty
   end'

--- a/plugins/tmux/skills/tmux/scripts/session.sh
+++ b/plugins/tmux/skills/tmux/scripts/session.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
 MAX_TITLE=48
 
 trunc() {
@@ -18,7 +20,7 @@ target="${1:-}"
 current_window=""
 if [ -z "$target" ]; then
   [ -z "${TMUX_PANE:-}" ] && { echo 'no session target' >&2; exit 1; }
-  info=$(tmux display-message -t "$TMUX_PANE" -p "#{session_name}${TAB}#{window_index}" 2>/dev/null) || { echo 'session lookup failed' >&2; exit 1; }
+  info=$(tmux display-message -t "$TMUX_PANE" -p "#{session_name}${TAB}#{window_index}" 2>/dev/null) || lookup_failed session
   IFS=$'\t' read -r target current_window <<< "$info"
 fi
 

--- a/plugins/tmux/skills/tmux/scripts/window.sh
+++ b/plugins/tmux/skills/tmux/scripts/window.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
 MAX_TITLE=48
 
 trunc() {
@@ -15,7 +17,7 @@ trunc() {
 target="${1:-}"
 if [ -z "$target" ]; then
   [ -z "${TMUX_PANE:-}" ] && { echo 'no window target' >&2; exit 1; }
-  target=$(tmux display-message -t "$TMUX_PANE" -p '#{session_name}:#{window_index}' 2>/dev/null) || { echo 'window lookup failed' >&2; exit 1; }
+  target=$(tmux display-message -t "$TMUX_PANE" -p '#{session_name}:#{window_index}' 2>/dev/null) || lookup_failed window
 fi
 
 TAB=$'\t'

--- a/user/settings.json
+++ b/user/settings.json
@@ -171,7 +171,8 @@
     "network": {
       "allowLocalBinding": true,
       "allowUnixSockets": [
-        "~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+        "~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh",
+        "~/.tmux"
       ]
     },
     "filesystem": {


### PR DESCRIPTION
Loading the `tmux` skill failed at the `!`-block context injection with `pane lookup failed`. This drops the skill's sandbox bypass and instead grants tmux socket access through the `allowUnixSockets` user setting, which fixes both the load-time and tool-call paths uniformly.

## Issue

Claude Code's Bash sandbox blocks Unix-socket connections, including tmux's control socket. The skill tried to work around this by injecting `dangerouslyDisableSandbox` from PreToolUse hooks, but those hooks only fire for Bash-*tool* invocations. The `!` blocks in `SKILL.md` run `bash scripts/*.sh` at skill-load time, which stays sandboxed and can't reach the socket. My `tmux:*` `excludedCommands` entry is why bare `tmux …` calls work (they run unsandboxed) while `bash pane.sh` does not: its command starts with `bash`, not `tmux`. So the bypass never covered the path that actually failed.

I confirmed the mechanism with `sandbox-exec`: Claude Code renders each `allowUnixSockets` entry as a seatbelt `(remote unix-socket (subpath "…"))` rule. `subpath` matches a directory and everything beneath it, so allowing the socket *directory* covers every socket regardless of UID or socket name. A wrong path reproduced the exact `Operation not permitted` failure; `~/.tmux` succeeded.

## Changes

- **Drop the sandbox bypass from the skill.** Removed `dangerouslyDisableSandbox` from the `SKILL.md` inline hook and both branches of `safe-command.sh`; the permission auto-allow for safe commands stays.
- **Self-documenting failures.** New `scripts/lib.sh` exposes `lookup_failed`, used by `pane.sh`, `window.sh`, and `session.sh`. On failure it names the exact socket and points at the fix, so a misconfigured installer sees what to do rather than a bare `pane lookup failed`.
- **README.** Documented the required `allowUnixSockets` setting and the directory-subtree matching behavior.
- **`user/settings.json`.** Allowed `~/.tmux` so the skill keeps working here once the bypass is gone.

## Testing

- Ran each script under `sandbox-exec` with the socket directory allowed (correct context output) and blocked (the new actionable hint, exit 1).
- Verified the hook JSON for `safe-command.sh` (allow on safe commands, empty otherwise) and the `SKILL.md` inline hook.
- `bun run skill-lint` and `biome` pass; `shellcheck` reports only `SC1091` for the dynamic `source`.

Live effect needs merge + plugin sync + restart, since sandbox config loads at startup.
