### PR TITLE
user: responsive status line and subagent origins

### DIFF
--- a/user/scripts/statusline.sh
+++ b/user/scripts/statusline.sh
@@ -2,6 +2,18 @@
 input=$(cat)
 segments=()
 
+# Strip ANSI SGR and OSC 8 hyperlink sequences so width math counts only
+# visible glyphs.
+strip_escapes() {
+  printf '%s' "$1" | sed -e $'s/\033\\[[0-9;]*m//g' -e $'s/\033\\]8;;[^\033]*\033\\\\//g'
+}
+
+visible_width() {
+  local stripped
+  stripped=$(strip_escapes "$1")
+  printf '%s' "${#stripped}"
+}
+
 render_dial() {
   local pct
   pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
@@ -63,7 +75,62 @@ render_lines() {
   segments+=("$parts")
 }
 
+# Middle-elide an ordered list of styled spans to a visible-width budget,
+# preserving the start of the first span and the end of the last. Each span is
+# emitted with its own escape wrapper intact, so OSC 8 hyperlinks and colors stay
+# valid even when their anchor text is shortened. Reads parallel arrays
+# span_text / span_pre / span_suf; prints the rendered label.
+elide_spans() {
+  local budget=$1
+  local i total=0
+  for i in "${!span_text[@]}"; do total=$(( total + ${#span_text[$i]} )); done
+
+  if [ "$total" -le "$budget" ]; then
+    for i in "${!span_text[@]}"; do
+      printf '%s%s%s' "${span_pre[$i]}" "${span_text[$i]}" "${span_suf[$i]}"
+    done
+    return
+  fi
+
+  local keep=$(( budget - 1 ))
+  if [ "$keep" -lt 1 ]; then keep=1; fi
+  local head=$(( (keep + 1) / 2 ))
+  local tail=$(( keep - head ))
+  local tail_start=$(( total - tail ))
+
+  local pos=0 out="" ellipsis_done=0
+  for i in "${!span_text[@]}"; do
+    local t="${span_text[$i]}"
+    local len=${#t}
+    local span_start=$pos
+    local span_end=$(( pos + len ))
+    local piece=""
+
+    if [ "$span_start" -lt "$head" ]; then
+      local h_end=$head
+      if [ "$span_end" -lt "$h_end" ]; then h_end=$span_end; fi
+      piece+="${t:0:$(( h_end - span_start ))}"
+    fi
+
+    if [ "$span_end" -gt "$tail_start" ]; then
+      local t_begin=$tail_start
+      if [ "$t_begin" -lt "$span_start" ]; then t_begin=$span_start; fi
+      if [ "$ellipsis_done" -eq 0 ]; then piece+="…"; ellipsis_done=1; fi
+      piece+="${t:$(( t_begin - span_start )):$(( span_end - t_begin ))}"
+    fi
+
+    if [ -n "$piece" ]; then
+      out+="${span_pre[$i]}${piece}${span_suf[$i]}"
+    fi
+    pos=$span_end
+  done
+
+  if [ "$ellipsis_done" -eq 0 ]; then out+="…"; fi
+  printf '%s' "$out"
+}
+
 render_worktree() {
+  local budget=$1
   local wt_json repo branch ahead
   wt_json=$(wt list statusline --format=json 2>/dev/null | jq -c '.[] | select(.is_current)') || return
   if [ -z "$wt_json" ]; then
@@ -93,34 +160,91 @@ render_worktree() {
   local is_main
   is_main=$(echo "$wt_json" | jq -r '.is_main')
 
-  local repo_display="$repo"
-  if [ -n "$repo_url" ]; then
-    repo_display=$(printf '\033]8;;%s\033\\%s\033]8;;\033\\' "$repo_url" "$repo")
+  # Collapse the repo≈branch redundancy: when the repo name is a prefix or
+  # suffix of the sanitized branch, the branch already carries the repo, so show
+  # the branch alone. Worktrunk names branches worktree-<id> against a <id>
+  # worktree, so the repo is a suffix, not a prefix.
+  local show_repo=true
+  if [ "$is_main" = "false" ] && [ -n "$repo" ]; then
+    if [[ "$sanitized_branch" == "$repo"* || "$sanitized_branch" == *"$repo" ]]; then
+      show_repo=false
+    fi
   fi
 
-  local label="$repo_display"
-  if [ "$is_main" = "false" ]; then
-    local branch_display="${cyan}${branch}${reset}"
-    if [ -n "$ci_url" ]; then
-      branch_display=$(printf '%s\033]8;;%s\033\\%s\033]8;;\033\\%s' "$cyan" "$ci_url" "$branch" "$reset")
+  # Build styled spans in visible order.
+  span_text=()
+  span_pre=()
+  span_suf=()
+
+  local repo_pre="" repo_suf=""
+  if [ -n "$repo_url" ]; then
+    repo_pre=$(printf '\033]8;;%s\033\\' "$repo_url")
+    repo_suf=$(printf '\033]8;;\033\\')
+  fi
+
+  if [ "$is_main" = "true" ]; then
+    span_text+=("$repo"); span_pre+=("$repo_pre"); span_suf+=("$repo_suf")
+  else
+    if [ "$show_repo" = "true" ]; then
+      span_text+=("$repo"); span_pre+=("$repo_pre"); span_suf+=("$repo_suf")
+      span_text+=("/"); span_pre+=("$dim"); span_suf+=("$reset")
     fi
-    label+="${dim}/${reset}${branch_display}"
+    local branch_pre="$cyan" branch_suf="$reset"
+    if [ -n "$ci_url" ]; then
+      branch_pre=$(printf '%s\033]8;;%s\033\\' "$cyan" "$ci_url")
+      branch_suf=$(printf '\033]8;;\033\\%s' "$reset")
+    fi
+    span_text+=("$branch"); span_pre+=("$branch_pre"); span_suf+=("$branch_suf")
   fi
 
   ahead=$(echo "$wt_json" | jq -r '.main.ahead // 0')
+  local ahead_seg=""
   if [ "$ahead" -gt 0 ]; then
-    segments+=("$label")
-    segments+=("${dim}↑${ahead}${reset}")
-  else
-    segments+=("$label")
+    ahead_seg="${dim}↑${ahead}${reset}"
+  fi
+
+  # Reserve room for the ahead segment (and its separator) before eliding.
+  local label_budget=$budget
+  if [ -n "$ahead_seg" ]; then
+    label_budget=$(( budget - $(visible_width "$ahead_seg") - 2 ))
+  fi
+
+  if [ "$label_budget" -lt 3 ]; then
+    if [ -n "$ahead_seg" ]; then
+      segments+=("$ahead_seg")
+    fi
+    return
+  fi
+
+  local label
+  label=$(elide_spans "$label_budget")
+  segments+=("$label")
+  if [ -n "$ahead_seg" ]; then
+    segments+=("$ahead_seg")
   fi
 }
 
-render_worktree
+sep="  "
+
 render_dial
 render_lines
 
-sep="  "
+# Fixed segments (dials) are rendered first and never elided; the worktree label
+# takes whatever width remains so the dial stays visible at any terminal width.
+fixed_width=0
+for i in "${!segments[@]}"; do
+  if [ "$i" -gt 0 ]; then
+    fixed_width=$(( fixed_width + ${#sep} ))
+  fi
+  fixed_width=$(( fixed_width + $(visible_width "${segments[$i]}") ))
+done
+
+columns=${COLUMNS:-80}
+if ! [ "$columns" -gt 0 ] 2>/dev/null; then columns=80; fi
+worktree_budget=$(( columns - fixed_width - ${#sep} - 1 ))
+
+render_worktree "$worktree_budget"
+
 output=""
 for i in "${!segments[@]}"; do
   if [ "$i" -gt 0 ]; then

--- a/user/scripts/subagent-statusline.sh
+++ b/user/scripts/subagent-statusline.sh
@@ -7,6 +7,10 @@ red=$'\033[31m'
 dim=$'\033[2m'
 reset=$'\033[0m'
 
+# Origin glyphs: desktop for local agents, cloud for remote agents.
+# Generated via python3 because macOS bash 3.2 lacks \u escapes.
+read -r local_glyph remote_glyph < <(python3 -c "print(chr(0xF108), chr(0xF0C2))")
+
 format_elapsed() {
   local start_ms=$1 now_ms elapsed_s mins secs
   now_ms=$(date +%s)000
@@ -25,10 +29,20 @@ format_tokens() {
   fi
 }
 
+# Reads status_icon, origin_glyph, text, and meta from the calling render_task
+# scope (bash dynamic scoping).
+build_content() {
+  local body="${status_icon} ${origin_glyph} ${text}"
+  if [ -n "$meta" ]; then
+    body+=" ${dim}${meta}${reset}"
+  fi
+  printf '%s' "$body"
+}
+
 render_task() {
   local task=$1
   local columns=$2
-  local id description type name status start_time token_count icon meta label content
+  local id description type name status start_time token_count status_icon origin_glyph text meta content
   id=$(echo "$task" | jq -r '.id')
   description=$(echo "$task" | jq -r '.description // empty')
   type=$(echo "$task" | jq -r '.type // empty')
@@ -38,22 +52,18 @@ render_task() {
   token_count=$(echo "$task" | jq -r '.tokenCount // 0')
 
   case "$status" in
-    completed) icon="${green}✓${reset}" ;;
-    failed)    icon="${red}✗${reset}" ;;
-    *)         icon="${yellow}▸${reset}" ;;
+    completed) status_icon="${green}✓${reset}" ;;
+    failed)    status_icon="${red}✗${reset}" ;;
+    *)         status_icon="${yellow}▶${reset}" ;;
   esac
 
-  if [ -n "$description" ] && [ -n "$type" ]; then
-    label="${dim}${type}${reset}  ${description}"
-  elif [ -n "$description" ]; then
-    label="$description"
-  elif [ -n "$type" ]; then
-    label="$type"
-  elif [ -n "$name" ]; then
-    label="$name"
-  else
-    label="agent"
-  fi
+  # .type is the agent origin (local_agent or remote_agent), not the agent kind.
+  case "$type" in
+    remote_agent) origin_glyph="${dim}${remote_glyph}${reset}" ;;
+    *)            origin_glyph="${dim}${local_glyph}${reset}" ;;
+  esac
+
+  text="${description:-${name:-agent}}"
 
   meta=""
   if [ -n "$start_time" ]; then
@@ -63,28 +73,17 @@ render_task() {
     meta+="· $(format_tokens "$token_count")"
   fi
 
-  content="${icon} ${label}"
-  if [ -n "$meta" ]; then
-    content+=" ${dim}${meta}${reset}"
-  fi
+  content=$(build_content)
 
   if [ -n "$columns" ]; then
     local visible
     visible=$(printf '%s' "$content" | sed $'s/\033\\[[0-9;]*m//g')
     if [ "${#visible}" -gt "$columns" ]; then
       local overflow=$(( ${#visible} - columns ))
-      local desc_max=$(( ${#description} - overflow - 1 ))
-      if [ "$desc_max" -gt 0 ]; then
-        description="${description:0:$desc_max}…"
-        if [ -n "$type" ]; then
-          label="${dim}${type}${reset}  ${description}"
-        else
-          label="$description"
-        fi
-        content="${icon} ${label}"
-        if [ -n "$meta" ]; then
-          content+=" ${dim}${meta}${reset}"
-        fi
+      local text_max=$(( ${#text} - overflow - 1 ))
+      if [ "$text_max" -gt 0 ]; then
+        text="${text:0:$text_max}…"
+        content=$(build_content)
       fi
     fi
   fi


### PR DESCRIPTION
Reorders the main status line so the fixed context dial stays visible at any terminal width, and replaces the misused agent-`type` text in subagent rows with local/remote origin glyphs.

The old `statusline.sh` printed the worktree label first, so on a narrow terminal the long `repo/branch` name filled the line and the terminal clipped the always-relevant context dial. I moved the dial and line-count segments to the front (never elided) and gave the worktree label only the leftover width budget, derived from the `COLUMNS` env var that Claude Code sets (2.1.153+).

For subagent rows, I captured real `subagentStatusLine` input from a throwaway logging session and found that `.type` is an origin tag (`local_agent` / `remote_agent`), not the agent kind. The previous code rendered it as a dim text prefix, so rows read `local_agent  Run sleep command`. I replaced that with a nerd-font glyph (desktop for local, cloud for remote) and use the description as the row text.

## Changes

`statusline.sh`:
- Render `render_dial` and `render_lines` first; the worktree label is rendered last and elided to the remaining width.
- Add `strip_escapes` / `visible_width` (strips ANSI SGR **and** OSC 8) for width math.
- Add `elide_spans`: a middle-elide over styled spans that preserves the start of the first span and the end of the last, keeping each span's OSC 8 hyperlink and color wrapper valid even when its anchor text is shortened or the span is dropped entirely.
- Collapse the `repo`≈`branch` redundancy: when the repo name is a prefix **or** suffix of the sanitized branch (the Worktrunk `worktree-<id>` / `<id>` case), show the branch alone.

`subagent-statusline.sh`:
- Map `.type` to an origin glyph (`U+F108` desktop / `U+F0C2` cloud) placed with the status icon, instead of printing the raw type text.
- Row text comes from `description`, falling back to `name` then `agent`.
- Restore the larger `▶` (`U+25B6`) running icon to match the weight of `✓` / `✗`.

## Testing

Verified both scripts under the real runtime (`/bin/bash` 3.2.57, `en_US.UTF-8`) against captured fixtures at `COLUMNS` of 40 / 60 / 80 / 120: the dial is always visible, labels elide cleanly, and OSC 8 hyperlinks stay balanced (including when the `/` separator span is fully elided). Confirmed the collapse fires on the `worktree-agent-…` / `agent-…` redundancy while keeping genuinely distinct `repo/branch` pairs intact, and that non-numeric or unset `COLUMNS` falls back to 80 without error.

A follow-up will port both scripts to TypeScript/bun (the repo's convention) once bun cold-start latency is measured against the refresh cadence.
