### PR TITLE
biome hook: run checks from the file's git working tree

### DIFF
--- a/.claude/hooks/biome/index.test.ts
+++ b/.claude/hooks/biome/index.test.ts
@@ -8,6 +8,7 @@ import type {
   StopHookInput,
 } from "@anthropic-ai/claude-agent-sdk";
 import {
+  isConfigurationError,
   parseTranscript,
   processInput,
   processPostToolUse,
@@ -113,6 +114,29 @@ describe("biome hook", () => {
       const result = await runBiomeCheck(filePath);
       expect(result).not.toBeNull();
       expect(result).toContain("noDuplicateObjectKeys");
+    });
+  });
+
+  describe("isConfigurationError", () => {
+    it("detects a nested root configuration error", () => {
+      expect(
+        isConfigurationError(
+          "× Found a nested root configuration, but there's already a root configuration.",
+        ),
+      ).toBe(true);
+    });
+
+    it("detects a generic configuration error", () => {
+      expect(
+        isConfigurationError("× Biome exited because the configuration resulted in errors."),
+      ).toBe(true);
+    });
+
+    it("does not treat lint findings as configuration errors", () => {
+      expect(isConfigurationError("lint/suspicious/noDuplicateObjectKeys")).toBe(false);
+      expect(isConfigurationError("Formatter would have printed the following content")).toBe(
+        false,
+      );
     });
   });
 

--- a/.claude/hooks/biome/index.test.ts
+++ b/.claude/hooks/biome/index.test.ts
@@ -8,7 +8,6 @@ import type {
   StopHookInput,
 } from "@anthropic-ai/claude-agent-sdk";
 import {
-  isConfigurationError,
   parseTranscript,
   processInput,
   processPostToolUse,
@@ -114,29 +113,6 @@ describe("biome hook", () => {
       const result = await runBiomeCheck(filePath);
       expect(result).not.toBeNull();
       expect(result).toContain("noDuplicateObjectKeys");
-    });
-  });
-
-  describe("isConfigurationError", () => {
-    it("detects a nested root configuration error", () => {
-      expect(
-        isConfigurationError(
-          "× Found a nested root configuration, but there's already a root configuration.",
-        ),
-      ).toBe(true);
-    });
-
-    it("detects a generic configuration error", () => {
-      expect(
-        isConfigurationError("× Biome exited because the configuration resulted in errors."),
-      ).toBe(true);
-    });
-
-    it("does not treat lint findings as configuration errors", () => {
-      expect(isConfigurationError("lint/suspicious/noDuplicateObjectKeys")).toBe(false);
-      expect(isConfigurationError("Formatter would have printed the following content")).toBe(
-        false,
-      );
     });
   });
 

--- a/.claude/hooks/biome/index.ts
+++ b/.claude/hooks/biome/index.ts
@@ -106,16 +106,6 @@ async function biomeWorkingTree(filePath: string): Promise<string | undefined> {
   }
 }
 
-// A non-zero exit can mean Biome could not resolve its configuration rather than
-// that the file has lint findings. That is an environment problem, not a code
-// issue, so the hook reports nothing instead of blocking on it.
-export function isConfigurationError(output: string): boolean {
-  return (
-    output.includes("Found a nested root configuration") ||
-    output.includes("configuration resulted in errors")
-  );
-}
-
 export async function runBiomeCheck(filePath: string): Promise<string | null> {
   const cwd = await biomeWorkingTree(filePath);
   try {
@@ -124,10 +114,6 @@ export async function runBiomeCheck(filePath: string): Promise<string | null> {
   } catch (error) {
     const execError = error as { stdout?: string; stderr?: string };
     const output = (execError.stdout || "") + (execError.stderr || "");
-    if (isConfigurationError(output)) {
-      console.error(`[biome] Skipping ${filePath}: could not resolve Biome configuration.`);
-      return null;
-    }
     return output.trim() || null;
   }
 }

--- a/.claude/hooks/biome/index.ts
+++ b/.claude/hooks/biome/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { exec } from "node:child_process";
+import { dirname } from "node:path";
 import { promisify } from "node:util";
 import type {
   PostToolUseHookInput,
@@ -88,20 +89,53 @@ export async function parseTranscript(transcriptPath: string): Promise<string[]>
   return [...files];
 }
 
-export async function runBiomeCheck(filePath: string): Promise<string | null> {
+// Biome derives its project root from the working directory. Running from an
+// ancestor of a nested git worktree makes Biome discover that worktree's own
+// root biome.json and reject the pair as a nested root configuration, so it
+// never lints the file. Running from inside the file's own working tree scopes
+// Biome to the config that governs the file and avoids the collision. Files
+// outside any git repository fall back to Biome's default resolution.
+async function biomeWorkingTree(filePath: string): Promise<string | undefined> {
   try {
-    await execAsync(`biome check "${filePath}"`);
+    const { stdout } = await execAsync("git rev-parse --show-toplevel", {
+      cwd: dirname(filePath),
+    });
+    return stdout.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// A non-zero exit can mean Biome could not resolve its configuration rather than
+// that the file has lint findings. That is an environment problem, not a code
+// issue, so the hook reports nothing instead of blocking on it.
+export function isConfigurationError(output: string): boolean {
+  return (
+    output.includes("Found a nested root configuration") ||
+    output.includes("configuration resulted in errors")
+  );
+}
+
+export async function runBiomeCheck(filePath: string): Promise<string | null> {
+  const cwd = await biomeWorkingTree(filePath);
+  try {
+    await execAsync(`biome check "${filePath}"`, cwd ? { cwd } : undefined);
     return null;
   } catch (error) {
     const execError = error as { stdout?: string; stderr?: string };
     const output = (execError.stdout || "") + (execError.stderr || "");
+    if (isConfigurationError(output)) {
+      console.error(`[biome] Skipping ${filePath}: could not resolve Biome configuration.`);
+      return null;
+    }
     return output.trim() || null;
   }
 }
 
 export async function runBiomeFix(filePath: string): Promise<void> {
+  const cwd = await biomeWorkingTree(filePath);
   try {
-    await execAsync(`biome check --write "${filePath}"`);
+    await execAsync(`biome check --write "${filePath}"`, cwd ? { cwd } : undefined);
   } catch {
     // biome check --write exits non-zero if there are unfixable issues
   }


### PR DESCRIPTION
Runs Biome from the working tree that owns each checked file instead of from the hook process's directory. When a session works inside a nested git worktree (each carries its own root `biome.json`), running Biome from an ancestor made it discover that config as a nested root under the main repo's config and reject the pair, so it never linted the file and the Stop hook blocked with a configuration error.

The hook resolves each file's working tree with `git rev-parse --show-toplevel` and runs Biome there, scoping it to the config that governs the file. Files outside any repository fall back to Biome's default resolution.

## Why This Happens

`biome check <path>` derives its project root from the working directory. From an ancestor of `.claude/worktrees/<wt>/`, Biome's scan reaches the worktree's `biome.json` (a `root` config) and errors with `Found a nested root configuration`. The error is specific to paths that live inside a worktree: an explicitly passed path scopes Biome's scan to that file's subtree, so a main-repo file checked from the main root never descends into the worktree dirs. Running from inside the file's own working tree makes that tree's config the project root, so no ancestor config sits above it.

Ignoring the worktree directories in the root config does not fix this. Biome then reports `No files were processed` (also a non-zero exit the hook cannot distinguish from real findings) and stops linting files inside worktrees entirely. `.gitignore` does not help either: Biome's config discovery ignores it.

## Testing

`bun test ./.claude/hooks/biome/index.test.ts` passes with Biome on `PATH`. I verified the fix end-to-end against the real file that was failing inside a worktree: run from the main repo root it errors with the nested-root config, and run from the file's working tree it lints clean.
