### PR TITLE
skills: align invocability with usage

### DIFF
--- a/plugins/bun/skills/bun/SKILL.md
+++ b/plugins/bun/skills/bun/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: bun
 description: Bun runtime patterns. Use when running bun commands, working with package.json/bun.lock, writing TypeScript scripts under Bun, or developing Claude Code plugins.
-user-invocable: false
 ---
 
 # Bun

--- a/plugins/personal-review/skills/review/SKILL.md
+++ b/plugins/personal-review/skills/review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: personal-review:review
 description: Interactive daily review workflow across Calendar, Things, GitHub, and Linear. Use when the user asks for a daily review, morning review, evening review, or weekly review.
+disable-model-invocation: true
 ---
 
 # Daily Review

--- a/plugins/things/skills/triage/SKILL.md
+++ b/plugins/things/skills/triage/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: things:triage
 description: Triage and prioritize the Things Today list. Use when the user wants to review, prioritize, or reorder their Today list.
+disable-model-invocation: true
 ---
 
 # Today List Triage

--- a/plugins/writing/skills/writing/SKILL.md
+++ b/plugins/writing/skills/writing/SKILL.md
@@ -4,7 +4,6 @@ description: >-
   Enforce direct, concise prose style and catch writing slop. Use when writing or editing PR descriptions,
   issue bodies, commit messages, documentation, Slack messages, or any human-facing text.
   Also use when asked to clean up, rewrite, or "de-AI" existing text.
-user-invocable: false
 ---
 
 # Writing


### PR DESCRIPTION
Audits skill invocability in both directions and aligns four skills with how they're actually used.

## Made user-invocable (added to the slash menu)

`bun` and `writing` were the only two skills carrying `user-invocable: false`. Both are reference/context-injection skills (Bun runtime patterns, prose style rules) that fit on-demand slash recall. I removed the flag rather than setting it to `true`, matching the convention of other invocable skills, which omit it (default is `true`).

## Made slash-only (`disable-model-invocation: true`)

`personal-review:review` and `things:triage` are interactive, multi-phase, checkpoint-driven workflows the user launches deliberately. They're the same shape as `review:dashboard` and `review:self`, which were already disabled. Disabling model invocation drops them from the per-session skill list (token savings) while keeping them invocable via the slash menu. The `things` primitives (`inbox`, `jxa`, `url`) stay model-invocable since the model uses them as building blocks.

## Stuttered names

None found. The linter only flags an explicit `plugin:plugin-x` prefix (like `gitlab:gitlab-ci`), and no skill has one. Single-skill plugins named `plugin:plugin` (`git:git`, `tmux:tmux`, `bun:bun`) are the canonical primary-skill convention, not stutters.
