### PR TITLE
writing: fix skill trigger to use writing:writing

### DIFF
--- a/plugins/writing/commands/writing.md
+++ b/plugins/writing/commands/writing.md
@@ -2,4 +2,4 @@
 description: Inject writing style rules into the current context
 ---
 
-Invoke the `writing` skill with: $ARGUMENTS
+Invoke the `writing:writing` skill with: $ARGUMENTS

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -10,7 +10,7 @@
 - Prefer meaningful anchor text over raw URLs.
 - Use bullet points for lists, checklists if I ask for tasks.
 - Use code comments ONLY to clarify code that is not self-explanatory to OTHER readers. If you need to explain the code, do so in a separate message before editing.
-- Load the `writing` skill before writing any long-form prose for others (PR comments, review feedback, documents, issue descriptions, Slack messages). The skill enforces tone and style rules that must be followed.
+- Load the `writing:writing` skill before writing any long-form prose for others (PR comments, review feedback, documents, issue descriptions, Slack messages). The skill enforces tone and style rules that must be followed.
 
 ## Organization
 

--- a/user/rules/markdown.md
+++ b/user/rules/markdown.md
@@ -8,7 +8,7 @@ paths:
 
 ## Prose
 
-Load the `writing` skill for tone and style rules (AI trope avoidance, em dashes, vocabulary, voice). Follow those rules rather than duplicating them here.
+Load the `writing:writing` skill for tone and style rules (AI trope avoidance, em dashes, vocabulary, voice). Follow those rules rather than duplicating them here.
 
 ## Structure
 


### PR DESCRIPTION
Fixes the `writing` skill load instruction, which fails with "Unknown skill" because the plugin system auto-prefixes the bare name to `writing:writing`. This failure was observed 5 times across sessions. The fix updates `user/CLAUDE.md`, `user/rules/markdown.md`, and `plugins/writing/commands/writing.md` so all prose-work load instructions use the qualified name, covering every repo where these files are active.
