### PR TITLE
user: trim CLAUDE.md by collapsing how-to sections to skill pointers

### DIFF
--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -20,7 +20,7 @@
 
 ## Curation
 
-Customizations (skills, hooks, wordlists, agents, rules, permissions) cost tokens on every session that touches them. Before adding one, define how it gets removed: what tells you it's working, what tells you it isn't, and where that signal surfaces. If you can't answer all three, design the prune mechanism before adding.
+Every customization costs tokens on every session. Before adding one, define how it gets removed: what shows it's working, what shows it isn't, and where that signal surfaces.
 
 ## Workflow
 
@@ -33,26 +33,11 @@ Customizations (skills, hooks, wordlists, agents, rules, permissions) cost token
 
 ### Bash `!` Escaping Bug
 
-Claude Code's Bash tool incorrectly escapes `!` to `\!` at the JS level, breaking operators like jq `!=` and awk `!~` ([#2941](https://github.com/anthropics/claude-code/issues/2941), [#10335](https://github.com/anthropics/claude-code/issues/10335)). Workarounds:
-
-- **jq**: Use `| not` instead of `!=` (e.g., `select(.x == null | not)` instead of `select(.x != null)`)
-- **General**: Use heredoc syntax to pass scripts, bypassing inline escaping:
-  ```sh
-  jq "$(cat <<'JQ'
-  select(.x != null)
-  JQ
-  )"
-  ```
+The Bash tool escapes `!` to `\!`, breaking `jq !=`, `awk !~`, and similar operators ([#2941](https://github.com/anthropics/claude-code/issues/2941), [#10335](https://github.com/anthropics/claude-code/issues/10335)). For `jq`, use `| not` instead of `!=`. For any script, pass it via heredoc to bypass inline escaping.
 
 ## Stacked PRs
 
-I use git-town for stacked branch workflows:
-
-- Append a child branch: `git town append child-name`
-- Sync the stack: `git town sync --stack`
-- Propose all PRs: `git town propose --stack`
-
-Ship branches oldest-first. After a stack branch merges, `git town sync` rebases remaining branches.
+Stacked branches use git-town. See the `git-town:git-town` skill for commands (`append`, `sync --stack`, `propose --stack`) and shipping order.
 
 ## Personal Details
 


### PR DESCRIPTION
Trims `user/CLAUDE.md`, which loads on every session across every machine and repo, by collapsing how-to sections into pointers to on-demand sources. The file drops from ~817 tokens to roughly 500.

## Changes

- **Bash `!` Escaping Bug**: Collapsed the multi-bullet/code-block section to a single sentence. `user/rules/json.md` already covers the `jq | not` workaround for `*.json` files; this line retains coverage for `awk !~` and other contexts not in that rule.
- **Stacked PRs**: Replaced the three `git town` command bullets and shipping-order note with a one-line pointer to the `git-town:git-town` skill. The skill's `stacking.md` reference covers all three commands and explicitly states "Ship branches bottom-first."
- **Curation**: Shortened the paragraph. The full elaboration lives in the project `CLAUDE.md`; the user-level file needs only the principle and the three-question gate.
