### PR TITLE
linear: document save_issue create/update preconditions

### DIFF
--- a/plugins/linear/skills/linear/SKILL.md
+++ b/plugins/linear/skills/linear/SKILL.md
@@ -21,6 +21,15 @@ Choose the right tool for the task:
 
 ## Conventions
 
+#### Creating vs Updating
+
+The Claude.ai Linear connector exposes a single tool, `save_issue`, for both creating and updating issues:
+
+- **Create**: omit the issue id. `title` is **required** (omitting it produces "title is required when creating an issue").
+- **Update**: supply the issue id. `title` is optional.
+
+The local and plugin variants use separate tools (`create_issue` and `update_issue`). The examples below use those names. When connected via the Claude.ai connector, substitute `save_issue` and apply the preconditions above.
+
 ### Issue References
 
 When writing text that references other issues (descriptions, comments, updates), never use bare identifiers like `ENG-123`. Linear auto-renders issue URLs as inline preview components, so use the full URL:


### PR DESCRIPTION
The Claude.ai Linear connector exposes a single `save_issue` tool for both creating and updating issues, unlike the local/plugin variants which use separate `create_issue` and `update_issue` tools. Omitting `title` on create causes a "title is required when creating an issue" error, which accounted for 161 of 263 `save_issue` calls (72% failure rate). This adds a `#### Creating vs Updating` subsection to the linear skill documenting the preconditions, an on-demand content change with no always-on token cost.
