### PR TITLE
session: broaden description to route direct transcript access to skill

### DIFF
--- a/plugins/claude-code/skills/session/SKILL.md
+++ b/plugins/claude-code/skills/session/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-code:session
-description: Introspect on your own Claude Code usage and history (session ID, duration, tokens consumed, tool usage patterns, time per project, recent activity summaries, or searching past conversations). Use whenever the user asks about their Claude Code activity ("what's my session ID?", "how many tokens today?", "what did I work on this week?", "find that conversation where I set up X", "am I overusing Bash?"). Do NOT use for general codebase search, git log queries, or arbitrary databases.
+description: Query Claude Code session history via a DuckDB index over `~/.claude/projects/**/*.jsonl`. Use when the user asks about Claude Code activity ("how many tokens today?", "what did I work on this week?"), or when you would otherwise read, grep, or jq session transcripts directly from `~/.claude/projects/`. Do NOT use for general codebase search, git log queries, or arbitrary databases.
 allowed-tools:
   - Bash
   - Read


### PR DESCRIPTION
Across 65 sessions, the model read Claude Code transcripts by hand 259 times (jq/grep over `~/.claude/projects/**/*.jsonl`) while the `claude-code:session` skill loaded only 5 times. The skill description did not mention direct transcript access, so the model hand-rolled instead. This trims the quoted example list from 5 to 2 and adds an explicit trigger for hand-rolled `.jsonl` access, bringing the description from 499 to 385 chars.
