### PR TITLE
user: note that git push must be top-level to reach SSH-signing socket

### DIFF
--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -30,6 +30,7 @@ Customizations (skills, hooks, wordlists, agents, rules, permissions) cost token
 - When executing build commands, output to `/dev/null` to avoid creating binaries.
 - Store temporary files in `tmp/` directory.
 - Use `pbcopy` and `pbpaste` for clipboard interaction.
+- Run `git push` (and other git commands that need SSH signing) as the top-level Bash command, not nested inside `cd … && git push` or a wrapper script. `excludedCommands` (`git:*`) matches only the top-level command, so nested git inherits the sandbox profile and cannot reach the Secretive SSH-signing socket.
 
 ### Bash `!` Escaping Bug
 


### PR DESCRIPTION
Adds a habit note to `user/CLAUDE.md` (loads machine-wide, every session and repo) explaining that `git push` and other SSH-signing git commands must be the top-level Bash command. `excludedCommands` (`git:*`) matches only the top-level command of a Bash invocation, so nested git (e.g. `cd … && git push`) inherits the sandbox profile and cannot reach the Secretive SSH-signing socket (the root cause of ~20 signing failures).

The note is placed at the end of the `## Workflow` bullet list, before the `### Bash ! Escaping Bug` subsection. This is a distinct location from the sections trimmed by `trim/user-claude-md`, so the two branches should rebase cleanly.
