### PR TITLE
skills: scope descriptions to eliminate routing collisions

### DIFF
--- a/plugins/git/skills/git/SKILL.md
+++ b/plugins/git/skills/git/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: git
-description: Git workflow and branching best practices. Use when working with git commands, creating branches, or pushing changes.
+description: >-
+  Core git usage (commit messages, topic branches, push safety rules).
+  For stacked branch workflows use git-town; for merge/rebase conflicts use git:conflicts.
 ---
 
 # Git

--- a/plugins/github/skills/actions/SKILL.md
+++ b/plugins/github/skills/actions/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: github:actions
 description: >-
-  GitHub Actions CI/CD workflow development and run monitoring. Use when creating
-  or editing .github/workflows YAML files, configuring triggers, jobs, matrix strategies,
-  caching, or artifacts. Also covers gh CLI for monitoring runs, viewing logs, and debugging failures.
+  Authoring GitHub Actions workflows. Use when creating or editing .github/workflows
+  YAML files, configuring triggers, jobs, matrix strategies, caching, or artifacts.
+  For monitoring runs and debugging failures, use github:actions-monitor.
 user-invocable: true
 ---
 

--- a/plugins/gitlab/skills/ci/SKILL.md
+++ b/plugins/gitlab/skills/ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gitlab:ci
-description: Working with GitLab CI/CD pipelines and jobs. Use when viewing pipelines, debugging jobs, or validating CI configuration.
+description: Authoring and validating GitLab CI configuration. Use when editing `.gitlab-ci.yml`, structuring pipeline stages and jobs, or running `glab ci lint`. For pipeline/job failure investigation, use gitlab:ci-monitor.
 ---
 # GitLab CI/CD
 


### PR DESCRIPTION
Scopes the `description` frontmatter of three skills to eliminate routing collisions where sibling skills own overlapping trigger phrases. `github:actions` previously claimed both authoring and run monitoring, colliding with `github:actions-monitor`. It now covers authoring `.github/workflows` YAML only. `gitlab:ci` claimed pipeline debugging alongside config authoring, colliding with `gitlab:ci-monitor`. It now routes failure investigation to that skill. `git:git` used broad branching language that overlapped `git-town:git-town` and `git:conflicts`. It now narrows to commit messages and push safety rules.

The audit flagged `gitlab:ci` and `git:git` as outright removal candidates (0 personal invocations, redundant with their siblings and the git PreToolUse hook). This PR scopes their descriptions instead of removing the published skills, leaving deletion as your call.
