### PR TITLE
shell: avoid zsh read-only status/state variable names

### DIFF
--- a/user/rules/shell.md
+++ b/user/rules/shell.md
@@ -9,3 +9,4 @@ paths:
 
 - Use `--long-flags` where available for human readability
 - Use macOS compatible commands, don't expect GNU tools
+- In zsh, avoid `status` and `state` as variable names. They are read-only, so assignment fails with `read-only variable`. Use `st` or a descriptive name. Matters for loop/poll snippets that track a status value.


### PR DESCRIPTION
Adds a shell rule guarding against `status` and `state` as zsh variable names. Both are read-only in zsh, so assigning to them fails with `read-only variable`. This bites poll/loop snippets that track a status value, where the assignment is silently fatal.

It lives in `user/rules/shell.md` because that is the existing always-relevant shell rule and the lowest-cost home for the guidance. The motivating case is inline Bash-tool usage, which has no file-based rule home in this repo.

Original Task: [Bug: zsh poll loops break on `status` loop variable](https://things.bendrucker.me/show?id=GAXN7Vnt45bnxCRLuFaU7r)
