### PR TITLE
improve-claude-code: feed session context into planning

### DIFF
--- a/user/skills/improve-claude-code/SKILL.md
+++ b/user/skills/improve-claude-code/SKILL.md
@@ -6,6 +6,7 @@ description: |
 allowed-tools:
   - Skill(things:jxa)
   - Skill(things:url)
+  - Skill(claude-code:session)
   - Skill(pull-request:create)
   - Skill(code-review)
   - Skill(github:actions-monitor)
@@ -26,9 +27,21 @@ Use `things:jxa` to find all open todos tagged `claude-code`. Display a numbered
 
 Ask the user which items to work on (numbers, ranges like `1-3`, or `all`). Cap each batch at 3 to keep parallel agents manageable. Split larger selections automatically.
 
+## Session Context
+
+Each todo's notes embed the originating session as `Session: <uuid>`. For every selected todo, parse that UUID and use the `claude-code:session` skill to pull the original context: what you were doing, the commands that ran, and the errors that prompted the todo. This is richer than the todo's prose summary and grounds each plan in the real failure.
+
+Query `messages` / `content_items` / `text_content` filtered by `WHERE session_id = '<uuid>'`. Do not filter by `host`: many todos come from the work machine, whose corpus is imported as a separate host, and omitting the filter spans every machine. Distill the result to a few lines per todo and pass it to the matching `Plan` agent alongside the title and notes.
+
+If the UUID is absent from the index (not yet imported, or the index needs a refresh), proceed with notes only and say so for that todo.
+
+#### Egress
+
+Session context informs local planning only. Imported hosts may be marked `block_egress`, so never paste session-derived content into PR bodies or any other output that leaves the machine.
+
 ## Plan
 
-Launch parallel `Plan` agents (one per todo). Give each the todo title, full notes, and instruction to explore the repo and produce a concrete implementation plan.
+Launch parallel `Plan` agents (one per todo). Give each the todo title, full notes, the session context from the previous step, and instruction to explore the repo and produce a concrete implementation plan.
 
 Point agents to relevant domain skills: `claude-code:skill` for skill changes, `claude-code:hook` for hooks, `bun:bun` for scripts.
 


### PR DESCRIPTION
Feeds the originating Claude Code session into the planning step of the `improve-claude-code` skill, so each `Plan` agent works from the real failure (the commands that ran, the errors that prompted the todo) instead of only the todo's prose summary.

Every `claude-code` Things todo embeds a `Session: <uuid>` reference in its notes. The new Session Context step parses that UUID and queries the `claude-code:session` index for the original context, then passes it to the matching `Plan` agent alongside the title and notes.

## Changes

- Added `Skill(claude-code:session)` to `allowed-tools`.
- Added a Session Context step between triage and planning that looks up each selected todo's session and distills the originating context for its `Plan` agent.
- Specified the fallback: if the UUID is not in the index (not imported, or the index needs a refresh), proceed with notes only and say so.

I intentionally do not filter by `host` in the lookup. Many todos originate on the work machine, whose corpus is imported as a separate host, and omitting the filter spans every machine so those sessions still resolve. I also added an Egress note: imported hosts may be marked `block_egress`, so session-derived content must stay in local planning and never land in PR bodies or other output that leaves the machine.
