### PR TITLE
agent-ideas: scaffold skill with curated sources and RSS fetch

### DIFF
--- a/.claude/skills/agent-ideas/SKILL.md
+++ b/.claude/skills/agent-ideas/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: agent-ideas
+description: Harvest agent-tooling ideas from prominent developers.
+allowed-tools:
+  - Bash(bun ${CLAUDE_SKILL_DIR}/scripts/fetch.ts:*)
+  - Read
+  - Grep
+  - Glob
+---
+
+# Agent Ideas
+
+Harvest agent-tooling ideas from a curated list of thinkers and map them to concrete artifacts in this repo (a skill, hook, setting, or rule). The harvest runs in two phases: a headless weekly pass that fetches feeds and delivers a digest, and a local pass after teleport that fills the gaps and files the keepers.
+
+This is the foundation: the curated source list and the deterministic fetch.
+
+## Sources
+
+`sources.ts` is the prunable core: a version-controlled list of thinkers, each with a feed URL, or marked `x-only` when no usable feed exists. Edit it directly to add, drop, or retune sources. Keep it small and high-signal; a source earns its place by regularly producing ideas that map to artifacts in this repo.
+
+## Fetch
+
+Pull the last 8 days of posts across all feed sources:
+
+```bash
+bun ${CLAUDE_SKILL_DIR}/scripts/fetch.ts > tmp/agent-ideas-posts.json
+```
+
+Each result is `{source, sourceType, feedUrl, posts:[{title,url,date,excerpt}], error?}`. Sources with `error` set could not be fetched; note them but don't block. `x-only` sources are absent here by design (the local phase handles them after teleport).
+
+Narrow to specific sources or widen the window with flags:
+
+```bash
+bun ${CLAUDE_SKILL_DIR}/scripts/fetch.ts --days 14 --source simon --source mario
+```

--- a/.claude/skills/agent-ideas/package.json
+++ b/.claude/skills/agent-ideas/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "agent-ideas",
+  "version": "1.0.0",
+  "description": "Weekly harvest of agent-tooling ideas from curated thinkers",
+  "type": "module",
+  "dependencies": {
+    "cleye": "^1.3.2",
+    "fast-xml-parser": "^4.5.0"
+  }
+}

--- a/.claude/skills/agent-ideas/scripts/fetch.test.ts
+++ b/.claude/skills/agent-ideas/scripts/fetch.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { parseFeed } from "./fetch";
+
+const atom = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example</title>
+  <entry>
+    <title>Agentic coding with Claude</title>
+    <link rel="alternate" href="https://example.com/post-1"/>
+    <published>2026-05-28T12:00:00Z</published>
+    <summary>A &lt;b&gt;post&lt;/b&gt; about &amp; MCP tooling.</summary>
+  </entry>
+  <entry>
+    <title>Second post</title>
+    <link href="https://example.com/post-2"/>
+    <updated>2026-05-20T08:00:00Z</updated>
+    <content type="html">Body content here.</content>
+  </entry>
+</feed>`;
+
+const rss = `<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>Example RSS</title>
+    <item>
+      <title>RSS item one</title>
+      <link>https://example.com/rss-1</link>
+      <pubDate>Wed, 28 May 2026 12:00:00 GMT</pubDate>
+      <description>&lt;p&gt;HTML stripped&lt;/p&gt; description.</description>
+    </item>
+  </channel>
+</rss>`;
+
+describe("parseFeed", () => {
+  test("parses Atom entries with alternate links and HTML-stripped excerpts", () => {
+    const posts = parseFeed(atom);
+    expect(posts).toHaveLength(2);
+    expect(posts[0]).toMatchObject({
+      title: "Agentic coding with Claude",
+      url: "https://example.com/post-1",
+      date: "2026-05-28T12:00:00.000Z",
+    });
+    expect(posts[0]?.excerpt).toBe("A post about & MCP tooling.");
+    expect(posts[1]?.url).toBe("https://example.com/post-2");
+  });
+
+  test("parses RSS items and normalizes pubDate to ISO", () => {
+    const posts = parseFeed(rss);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toMatchObject({
+      title: "RSS item one",
+      url: "https://example.com/rss-1",
+      date: "2026-05-28T12:00:00.000Z",
+    });
+    expect(posts[0]?.excerpt).toBe("HTML stripped description.");
+  });
+
+  test("returns no posts for an unrecognized document", () => {
+    expect(parseFeed("<html><body>not a feed</body></html>")).toEqual([]);
+  });
+
+  test("handles a single-entry feed without an array wrapper", () => {
+    const single = `<rss version="2.0"><channel><item>
+      <title>Lone item</title><link>https://example.com/x</link>
+    </item></channel></rss>`;
+    const posts = parseFeed(single);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]?.title).toBe("Lone item");
+  });
+});

--- a/.claude/skills/agent-ideas/scripts/fetch.ts
+++ b/.claude/skills/agent-ideas/scripts/fetch.ts
@@ -1,0 +1,209 @@
+#!/usr/bin/env bun
+
+import { cli } from "cleye";
+import { XMLParser } from "fast-xml-parser";
+import { type Source, sources } from "../sources";
+
+export interface Post {
+  title: string;
+  url: string;
+  /** ISO 8601 date string, or null when the feed omits one. */
+  date: string | null;
+  excerpt: string;
+}
+
+export interface FetchResult {
+  source: string;
+  sourceType: Source["sourceType"];
+  feedUrl: string | null;
+  posts: Post[];
+  /** Populated when the feed could not be fetched or parsed. */
+  error?: string;
+}
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: "@_",
+  // Large full-content feeds (e.g. Simon Willison's "everything") trip the
+  // built-in entity-expansion DoS guard. Skip parser-side entity decoding and
+  // let stripHtml handle the common entities when building excerpts.
+  processEntities: false,
+});
+
+/** Normalize a parser value that may be a string, object, or array into a string. */
+function text(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  if (Array.isArray(value)) return text(value[0]);
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    if ("#text" in record) return text(record["#text"]);
+  }
+  return "";
+}
+
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&nbsp;/g, " ")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&#0*39;|&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number.parseInt(dec, 10)))
+    .replace(/&amp;/g, "&");
+}
+
+function stripHtml(html: string): string {
+  // Decode entities before stripping tags so escaped markup (e.g. &lt;b&gt;)
+  // becomes real tags and gets removed rather than leaking into the excerpt.
+  return decodeEntities(html)
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function excerpt(html: string, limit = 320): string {
+  const clean = stripHtml(html);
+  return clean.length > limit ? `${clean.slice(0, limit).trimEnd()}…` : clean;
+}
+
+function asArray<T>(value: T | T[] | undefined): T[] {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+/** Resolve the alternate link from an Atom entry's `link` field. */
+function atomLink(link: unknown): string {
+  const links = asArray(link as Record<string, unknown> | Record<string, unknown>[]);
+  if (links.length === 0) return "";
+  const alternate = links.find((l) => l?.["@_rel"] === "alternate" || l?.["@_rel"] == null);
+  const chosen = alternate ?? links[0];
+  return typeof chosen === "string" ? chosen : text(chosen?.["@_href"]);
+}
+
+function parseAtom(feed: Record<string, unknown>): Post[] {
+  return asArray(feed.entry as Record<string, unknown> | Record<string, unknown>[]).map(
+    (entry) => ({
+      title: stripHtml(text(entry.title)),
+      url: atomLink(entry.link),
+      date: normalizeDate(text(entry.published) || text(entry.updated)),
+      excerpt: excerpt(text(entry.summary) || text(entry.content)),
+    }),
+  );
+}
+
+function parseRss(channel: Record<string, unknown>): Post[] {
+  return asArray(channel.item as Record<string, unknown> | Record<string, unknown>[]).map(
+    (item) => ({
+      title: stripHtml(text(item.title)),
+      url: text(item.link),
+      date: normalizeDate(text(item.pubDate) || text(item["dc:date"])),
+      excerpt: excerpt(text(item.description) || text(item["content:encoded"])),
+    }),
+  );
+}
+
+function normalizeDate(raw: string): string | null {
+  if (!raw) return null;
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+export function parseFeed(xml: string): Post[] {
+  const doc = parser.parse(xml) as Record<string, unknown>;
+  if (doc.feed) return parseAtom(doc.feed as Record<string, unknown>);
+  const rss = doc.rss as Record<string, unknown> | undefined;
+  if (rss?.channel) return parseRss(rss.channel as Record<string, unknown>);
+  // Some RSS 1.0 (RDF) feeds put items at the top level.
+  if (doc["rdf:RDF"]) {
+    const rdf = doc["rdf:RDF"] as Record<string, unknown>;
+    return parseRss(rdf);
+  }
+  return [];
+}
+
+function matchesTopic(post: Post, topicHint: string): boolean {
+  const keywords = topicHint
+    .split(",")
+    .map((k) => k.trim().toLowerCase())
+    .filter(Boolean);
+  if (keywords.length === 0) return true;
+  const haystack = `${post.title} ${post.excerpt}`.toLowerCase();
+  return keywords.some((keyword) => haystack.includes(keyword));
+}
+
+function withinDays(post: Post, days: number, now: number): boolean {
+  if (!post.date) return false;
+  const age = now - new Date(post.date).getTime();
+  return age >= 0 && age <= days * 24 * 60 * 60 * 1000;
+}
+
+export async function fetchSource(source: Source, days: number, now: number): Promise<FetchResult> {
+  const base: FetchResult = {
+    source: source.name,
+    sourceType: source.sourceType,
+    feedUrl: source.feedUrl,
+    posts: [],
+  };
+
+  if (!source.feedUrl) return base;
+
+  try {
+    const response = await fetch(source.feedUrl, {
+      headers: { "User-Agent": "agent-ideas/1.0 (+https://github.com/bendrucker/claude)" },
+      signal: AbortSignal.timeout(20_000),
+    });
+    if (!response.ok) {
+      return { ...base, error: `HTTP ${response.status}` };
+    }
+    const xml = await response.text();
+    const posts = parseFeed(xml)
+      .filter((post) => withinDays(post, days, now))
+      .filter((post) => (source.topicHint ? matchesTopic(post, source.topicHint) : true));
+    return { ...base, posts };
+  } catch (error) {
+    return { ...base, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export async function fetchAll(
+  selected: Source[],
+  days: number,
+  now: number,
+): Promise<FetchResult[]> {
+  return Promise.all(selected.map((source) => fetchSource(source, days, now)));
+}
+
+if (import.meta.main) {
+  const argv = cli({
+    name: "fetch",
+    flags: {
+      days: {
+        type: Number,
+        description: "Look back this many days for posts",
+        default: 8,
+      },
+      source: {
+        type: [String],
+        description: "Only fetch sources whose name contains this (repeatable, case-insensitive)",
+      },
+      includeXOnly: {
+        type: Boolean,
+        description: "Include x-only sources in the output (they have no feed and yield no posts)",
+        default: false,
+      },
+    },
+  });
+
+  const filters = argv.flags.source.map((s) => s.toLowerCase());
+  const selected = sources.filter((source) => {
+    if (source.sourceType === "x-only" && !argv.flags.includeXOnly) return false;
+    if (filters.length === 0) return true;
+    return filters.some((filter) => source.name.toLowerCase().includes(filter));
+  });
+
+  const results = await fetchAll(selected, argv.flags.days, Date.now());
+  console.log(JSON.stringify(results, null, 2));
+}

--- a/.claude/skills/agent-ideas/sources.ts
+++ b/.claude/skills/agent-ideas/sources.ts
@@ -1,0 +1,119 @@
+/**
+ * Curated source list for the weekly agent-tooling idea harvest.
+ *
+ * This is the prunable core of the skill: edit it directly to add, drop, or
+ * retune sources. Keep it small and high-signal. A source earns its place by
+ * regularly producing ideas that map to concrete artifacts in this repo.
+ *
+ * - `rss` / `blog` / `newsletter`: fetched automatically by `scripts/fetch.ts`.
+ *   Set `feedUrl` to a working Atom/RSS URL.
+ * - `x-only`: no usable feed; handled by the local triage phase via the
+ *   browser fallback after teleport. Leave `feedUrl` null.
+ * - `topicHint`: comma-separated keywords. Set it for large org feeds so the
+ *   fetch only keeps agent/tooling-relevant posts. Omit for personal blogs
+ *   where every post is already on-topic.
+ */
+
+export type SourceType = "rss" | "blog" | "newsletter" | "x-only";
+
+export interface Source {
+  /** Display name, used in the digest and as the `--source` filter key. */
+  name: string;
+  /** Atom/RSS feed URL, or null for `x-only` sources. */
+  feedUrl: string | null;
+  sourceType: SourceType;
+  /** X handle without the `@`, or null. Used by the browser fallback. */
+  xHandle: string | null;
+  /** Comma-separated keywords to topic-filter large org feeds. */
+  topicHint?: string;
+}
+
+export const sources: Source[] = [
+  // --- Seeds (confirmed this session) ---
+  {
+    name: "Simon Willison",
+    feedUrl: "https://simonwillison.net/atom/everything/",
+    sourceType: "rss",
+    xHandle: "simonw",
+  },
+  {
+    name: "Mario Zechner",
+    feedUrl: "https://mariozechner.at/rss.xml",
+    sourceType: "blog",
+    xHandle: "badlogicgames",
+  },
+  {
+    name: "Matt Pocock",
+    feedUrl: "https://www.aihero.dev/rss.xml",
+    sourceType: "newsletter",
+    xHandle: "mattpocockuk",
+  },
+  {
+    name: "Thariq Shihipar",
+    feedUrl: "https://thariq.io/rss.xml",
+    sourceType: "blog",
+    xHandle: "trq212",
+  },
+  {
+    name: "Cloudflare Blog",
+    feedUrl: "https://blog.cloudflare.com/rss/",
+    sourceType: "rss",
+    xHandle: "CloudflareDev",
+    topicHint: "agent,claude,mcp,llm,ai,tooling,coding,model context protocol",
+  },
+  {
+    name: "Boris Cherny",
+    feedUrl: null,
+    sourceType: "x-only",
+    xHandle: "bcherny",
+  },
+  {
+    name: "Dillon Mulroy",
+    feedUrl: null,
+    sourceType: "x-only",
+    xHandle: "dillon_mulroy",
+  },
+
+  // --- Discovered: confirmed feed (citation-graph run) ---
+  {
+    name: "Armin Ronacher",
+    feedUrl: "https://lucumr.pocoo.org/feed.atom",
+    sourceType: "blog",
+    xHandle: "mitsuhiko",
+  },
+
+  // --- Discovered: high/medium relevance, feeds resolved during the foundation pass ---
+  {
+    // humanlayer.dev is a Next.js app with no discoverable RSS feed as of the
+    // foundation pass; handled via the browser fallback until a feed surfaces.
+    name: "Dex Horthy",
+    feedUrl: null,
+    sourceType: "x-only",
+    xHandle: "dexhorthy",
+  },
+  {
+    name: "Mitchell Hashimoto",
+    feedUrl: "https://mitchellh.com/feed.xml",
+    sourceType: "blog",
+    xHandle: "mitchellh",
+  },
+  {
+    name: "Thomas Ptacek",
+    feedUrl: "https://fly.io/blog/feed.xml",
+    sourceType: "rss",
+    xHandle: "tqbf",
+    topicHint: "agent,claude,mcp,llm,ai,tooling,coding,model context protocol",
+  },
+  {
+    name: "Vicki Boykis",
+    feedUrl: "https://vickiboykis.com/index.xml",
+    sourceType: "blog",
+    xHandle: "vboykis",
+  },
+  {
+    name: "Michael Ramos",
+    feedUrl: "https://backnotprop.com/rss.xml",
+    sourceType: "blog",
+    xHandle: "backnotprop",
+  },
+];

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,14 @@
         "gray-matter": "^4.0.3",
       },
     },
+    ".claude/skills/agent-ideas": {
+      "name": "agent-ideas",
+      "version": "1.0.0",
+      "dependencies": {
+        "cleye": "^1.3.2",
+        "fast-xml-parser": "^4.5.0",
+      },
+    },
     "packages/marketplace": {
       "name": "@bendrucker/claude-marketplace",
     },
@@ -573,6 +581,8 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
+    "agent-ideas": ["agent-ideas@workspace:.claude/skills/agent-ideas"],
+
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
@@ -649,7 +659,7 @@
 
     "cssstyle": ["cssstyle@5.3.7", "", { "dependencies": { "@asamuzakjp/css-color": "^4.1.1", "@csstools/css-syntax-patches-for-csstree": "^1.0.21", "css-tree": "^3.1.0", "lru-cache": "^11.2.4" } }, "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ=="],
 
-    "cytoscape": ["cytoscape@3.33.4", "", {}, "sha512-HIN5Pmd9MrX9BkV7tDwnOcEJCSFvCpc8X97h3f508J6I5FsqAY65wKOCvgH2CuP42CaahWaz4tuh32SOOIH7ww=="],
+    "cytoscape": ["cytoscape@3.34.0", "", {}, "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg=="],
 
     "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
 
@@ -808,6 +818,8 @@
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "fast-xml-parser": ["fast-xml-parser@4.5.6", "", { "dependencies": { "strnum": "^1.0.5" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
@@ -1197,6 +1209,8 @@
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
+    "strnum": ["strnum@1.1.2", "", {}, "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA=="],
+
     "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
@@ -1215,7 +1229,7 @@
 
     "timers-ext": ["timers-ext@0.1.8", "", { "dependencies": { "es5-ext": "^0.10.64", "next-tick": "^1.1.0" } }, "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww=="],
 
-    "tinyexec": ["tinyexec@1.2.3", "", {}, "sha512-g62dB+w1/OEFnPvmX0yd/HnetYITOL+1nJW7kitOycOeAvmbWC/nu0fwmmQ/kupNojqExzyC/T++pST/jRJ2mQ=="],
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "tldts": ["tldts@7.4.2", "", { "dependencies": { "tldts-core": "^7.4.2" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "plugins/tmux",
     "plugins/mac",
     "plugins/x-callback-url",
-    "plugins/review"
+    "plugins/review",
+    ".claude/skills/agent-ideas"
   ],
   "scripts": {
     "build": "tsc --noEmit",


### PR DESCRIPTION
Opens the `agent-ideas` stack: a weekly routine that harvests agent-tooling ideas from curated thinkers (Simon Willison, Mario Zechner, Matt Pocock, and others) and maps them to concrete artifacts in this repo, feeding the keepers into `improve-claude-code` triage.

The harvest is one skill, not a plugin. This PR lays its foundation at `user/skills/agent-ideas`: the curated source list and the deterministic RSS fetch. The next two PRs grow the same `SKILL.md` with the mining/digest phase (#689) and the local triage phase (#690).

## Changes

- `SKILL.md`: the skill scaffold. Frames the two-phase harvest (remote fetch, mine, and deliver, then local triage after teleport) and documents the fetch step. It grows over the stack.
- `sources.ts`: a typed, version-controlled source list. This is the prunable core. Each entry carries a `feedUrl`, `sourceType`, optional `xHandle`, and an optional `topicHint` for filtering large org feeds. X-only authors (no usable feed) are marked `x-only` and deferred to the local browser fallback.
- `scripts/fetch.ts`: a deterministic `fetch()` + `fast-xml-parser` fetcher (no `WebFetch` or agents). For each feed source it pulls posts from the last N days (default 8), topic-filters large org feeds, and emits JSON. Standalone-testable via a `cleye` CLI.

## Decisions

- This is a user skill, not a plugin, so it needs no marketplace entry or `plugin.json`. It carries its own `package.json` (a workspace) declaring the fetch script's dependencies (`cleye`, `fast-xml-parser`), and `user/skills` joins the `user/scripts` test job in CI so `fetch.test.ts` runs.
- I disabled `fast-xml-parser`'s entity expansion (`processEntities: false`) because full-content feeds like Simon Willison's "everything" feed trip its built-in DoS guard. `stripHtml` decodes the common entities itself when building excerpts.
- Feed URLs were resolved against the live sources. Mario Zechner publishes at `/rss.xml` (not `/feed.xml`), and Dex Horthy's `humanlayer.dev` has no discoverable feed, so it is marked `x-only`. Thariq, Michael Ramos, Fly.io, and Mitchell Hashimoto have valid feeds that were simply quiet inside the default window.

## Testing

- Unit tests cover `parseFeed` across Atom, RSS, single-entry (no array wrapper), and unrecognized documents, including HTML-entity decoding.
- The `fetch.ts` parsing logic is unchanged from the verified original. The `cleye` CLI exposes `--days`, `--source`, and `--include-x-only`.
- The repo typecheck covers `sources.ts` and `fetch.ts`. The marketplace, plugin-import, and hook-quoting validators cover the structural changes, and `skill-lint` covers the scaffolded skill.
