### PR TITLE
user: prefer wt-switch-create skill for worktree creation

### DIFF
--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -54,6 +54,13 @@ I use git-town for stacked branch workflows:
 
 Ship branches oldest-first. After a stack branch merges, `git town sync` rebases remaining branches.
 
+## Worktrees
+
+I use Worktrunk (the `wt` CLI) for git worktrees, exposed through two skills:
+
+- For creating or entering a worktree, use the `worktrunk:wt-switch-create` skill. It re-roots the session into a new worktree (optionally in another repo), runs an optional task, and acts as a targeted command for the common case. Prefer it over the generic skill whenever the task is worktree creation, including anywhere you would otherwise delegate worktree creation to Worktrunk.
+- For everything else (pruning, listing, removing, running hooks, editing config, and general `wt` questions), use the generic `worktrunk:worktrunk` skill.
+
 ## Personal Details
 
 - Standard username: `@bendrucker`. Refer to any actions performed by this user as "you."


### PR DESCRIPTION
Adds a Worktrees section to my user-level `CLAUDE.md` directing worktree work to the two Worktrunk skills. The `worktrunk:wt-switch-create` skill is a targeted command for the common case (create or enter a worktree, optionally in another repo, then run a task), so I route worktree creation there. Everything else (pruning, listing, removing, hooks, config) goes to the generic `worktrunk:worktrunk` skill.

The preference is explicit: prefer `worktrunk:wt-switch-create` over the generic skill anywhere the task is worktree creation.
