### PR TITLE
agent-ideas: add mining and digest delivery to the skill

### DIFF
--- a/.claude/skills/agent-ideas/SKILL.md
+++ b/.claude/skills/agent-ideas/SKILL.md
@@ -6,13 +6,16 @@ allowed-tools:
   - Read
   - Grep
   - Glob
+  - WebFetch
+  - Task
+  - Write
+  - Skill(things:inbox)
+  - mcp__claude_ai_Zapier__things_create_to-do
 ---
 
 # Agent Ideas
 
-Harvest agent-tooling ideas from a curated list of thinkers and map them to concrete artifacts in this repo (a skill, hook, setting, or rule). The harvest runs in two phases: a headless weekly pass that fetches feeds and delivers a digest, and a local pass after teleport that fills the gaps and files the keepers.
-
-This is the foundation: the curated source list and the deterministic fetch.
+Harvest agent-tooling ideas from a curated list of thinkers and map them to concrete artifacts in this repo (a skill, hook, setting, or rule). The harvest runs in two phases: a headless weekly pass that fetches feeds, mines them, and delivers a digest, and a local pass after teleport that fills the gaps and files the keepers.
 
 ## Sources
 
@@ -33,3 +36,43 @@ Narrow to specific sources or widen the window with flags:
 ```bash
 bun ${CLAUDE_SKILL_DIR}/scripts/fetch.ts --days 14 --source simon --source mario
 ```
+
+## Mine
+
+Turn posts into repo-mappable idea cards. The bar is high: a card must name a real surface in this repo it would refine, or make a clear case for a net-new artifact. See [references/mining.md](references/mining.md) for the card schema, the proven heuristics (per-source cap by depth, auto-demote 404 sources, dedupe against existing repo surfaces), and the fan-out flow.
+
+Fan out one mining `Task` agent per source (batch thin sources together). Give each the source's posts, the schema, the heuristics, and a read-only view of the repo so it can fill `repoOverlap` and dedupe. Collect the cards, verify each `sourceUrl` resolves (demote 404s), then dedupe across agents.
+
+## Synthesize
+
+Write the digest to `tmp/agent-ideas-digest-<YYYY-Www>.md`:
+
+- A top-line summary: idea count, the standout cards, the low/medium/high split.
+- Per-idea cards in full (the schema fields), grouped high → low actionability.
+- A short "repo overlaps" note listing cards that refine existing surfaces.
+
+Keep the digest in this session's context as well. After teleport, the local phase reads it from here.
+
+## Deliver the Doorway Item
+
+Create exactly one Things inbox item. It is the routine's only notification, so make its notes self-sufficient:
+
+- **Title**: `[agent-ideas] Weekly digest: N ideas (YYYY-Www)`
+- **Notes**: the top-line summary, then the teleport command on its own line so it's tappable:
+
+  ```
+  claude --teleport ${CLAUDE_SESSION_ID}
+  ```
+
+Pick the delivery path by environment:
+
+- **Local** (Things reachable on this Mac): use the `things:inbox` skill. Leave it untagged, since the local phase adds `claude-code` per keeper later.
+- **Remote** (headless routine, no local MCPs): use the Zapier connector tool `mcp__claude_ai_Zapier__things_create_to-do`. It reaches Things through Anthropic's proxy. Tags aren't available remotely, which is fine: the doorway item is intentionally untagged.
+
+Do not tag the doorway item `claude-code`. Tagging happens per keeper in the local phase, so the whole digest doesn't land in the `improve-claude-code` backlog as one blob.
+
+## Gotchas
+
+- **No completion notification exists for routines.** The doorway item _is_ the signal. If its creation fails, say so loudly in the run output rather than ending silently.
+- **Teleport, not resume.** The handoff is `claude --teleport <session>`, which pulls the cloud session into a local terminal with local tools. `--resume` does not do this.
+- **Thin weeks are normal.** Low-frequency blogs often post nothing in an 8-day window. A digest of 0-2 ideas is a valid outcome, not a failure. Still drop the doorway item so the cadence is visible.

--- a/.claude/skills/agent-ideas/references/mining.md
+++ b/.claude/skills/agent-ideas/references/mining.md
@@ -1,0 +1,69 @@
+# Mining Posts Into Repo-Mappable Ideas
+
+The goal is not "summarize what these people wrote." It is: **which posts suggest a concrete artifact in _this_ repo** (a skill, hook, user setting, rule, or workflow), and what is the smallest version of that artifact.
+
+## Idea card schema
+
+Each surviving idea is a card with these fields:
+
+```
+title         short imperative phrase, becomes "[agent-idea] <title>"
+pitch         1-2 sentences: what the artifact is and why this post motivates it
+artifactType  skill | hook | setting | rule | workflow
+sourceName    the source's display name
+sourceUrl     the post URL
+actionability low | medium | high
+repoOverlap   existing surface it refines (path or name), or null if net-new
+```
+
+The local triage phase consumes these directly: `title` becomes the Things todo
+title, and the rest becomes the notes body.
+
+## Heuristics (proven in the proof run)
+
+- **Repo-aware is the bar.** A good card names a real surface in this repo it
+  would refine, or makes a clear case for a net-new artifact. Vague "you could
+  build a tool for X" with no repo hook is noise. Drop it. "Real" is literal:
+  a non-null `repoOverlap` must point at a path that exists, and the pitch must
+  not misstate what that surface already does. A card whose overlap is wrong is
+  as dead as one with a 404 source.
+- **Per-source cap by depth.** A long-form essay can yield 2-3 cards; a thin
+  link-blog entry or quote yields at most 1. Don't pad thin sources to hit a
+  quota.
+- **Expect a low/medium skew.** This is a mature repo. Refinements to existing
+  skills dominate. Net-new high-actionability artifacts are rare and notable.
+  Flag the rare one when it appears. Don't manufacture them.
+- **Auto-demote dead sources.** Before a card ships, confirm its `sourceUrl`
+  resolves. If it 404s, drop the card (the idea cannot be traced or verified).
+- **Dedupe against the repo.** Before a candidate becomes a card, check it
+  against existing surfaces (skills, hooks, settings, rules). If the repo
+  already has it, either set `repoOverlap` to that surface and reframe the card
+  as a refinement, or drop it if there is nothing to add.
+
+## Suggested flow
+
+1. Group the fetched posts by source. Skip sources with no posts.
+2. Fan out: one mining agent per source (or per small batch of thin sources).
+   Give each agent the posts plus this schema and the heuristics above, and a
+   read-only view of the repo so it can fill `repoOverlap` and dedupe. Feed
+   excerpts are often a single thin line; tell the agent to `WebFetch` the full
+   post when a title or excerpt looks promising, before judging it. That fetch
+   doubles as the 404 check in step 3.
+3. Collect cards. Verify each `sourceUrl` resolves (demote 404s) and each
+   non-null `repoOverlap` points at a path that exists (drop the card, or
+   reframe it as net-new, when the overlap doesn't resolve). Same bar both
+   ways: a claim you can't verify doesn't ship.
+4. Dedupe across agents (two sources can surface the same idea) and against the
+   repo. Keep the strongest framing of each.
+
+## Dedupe targets in this repo
+
+When checking `repoOverlap`, the surfaces that already exist:
+
+- Skills: `plugins/*/skills/*/SKILL.md`, `.claude/skills/*/SKILL.md`, and `user/skills/*`
+- Hooks: `plugins/*/hooks/`, plus hooks in `.claude/settings.json` and `user/settings.json`
+- Settings/permissions/sandbox: `.claude/settings.json` (project) and `user/settings.json` (user)
+- Rules: `.claude/rules/*.md` (project, path-scoped) and `user/rules/*.md` (user, all repos)
+
+Both `.claude/*` (project) and `user/*` (user-level, symlinked to `~/.claude`) are live;
+a card can land in either. Don't check only one tree.


### PR DESCRIPTION
Second in the `agent-ideas` stack. Grows the skill with the remote half of the harvest: mine fetched posts into repo-mappable idea cards, synthesize a weekly digest, and deliver one Things doorway item carrying a `claude --teleport` link. Builds on the scaffold and fetch from #687.

## Changes

- `SKILL.md`: adds the Mine, Synthesize, and Deliver sections to the skill scaffolded in #687, plus the tools those steps need (`Task`, `Write`, `things:inbox`, the Zapier connector). It picks `things:inbox` when Things is reachable locally, or the Zapier connector (`mcp__claude_ai_Zapier__things_create_to-do`) when running headless in the routine. The doorway item is intentionally untagged. Tagging happens per keeper in the local phase (#690).
- `references/mining.md`: the idea-card schema and the mining heuristics (per-source cap by depth, auto-demote 404 sources, dedupe against existing repo surfaces, expect a low/medium skew in a mature repo).

## Decisions

- The doorway item is the only signal. Routines have no built-in completion notification, so its notes are self-sufficient (summary plus teleport command) and the skill fails loudly if creation fails.
- The mining heuristics live in a reference file so the local triage phase can point at the same canonical bar for its X-only path, rather than duplicating it.

## Testing

- `skill-lint` covers the expanded `SKILL.md` and its reference, and biome covers formatting and lint.
- The mining fan-out and the live Things doorway item are a runtime path that creates a Things item and spawns agents. That side effect is left for an interactive run. The deterministic fetch it builds on is covered in #687.
