### PR TITLE
agent-ideas: add local triage phase to the skill

### DIFF
--- a/.claude/skills/agent-ideas/SKILL.md
+++ b/.claude/skills/agent-ideas/SKILL.md
@@ -11,11 +11,15 @@ allowed-tools:
   - Write
   - Skill(things:inbox)
   - mcp__claude_ai_Zapier__things_create_to-do
+  - mcp__claude-in-chrome__tabs_context_mcp
+  - mcp__claude-in-chrome__tabs_create_mcp
+  - mcp__claude-in-chrome__navigate
+  - mcp__claude-in-chrome__get_page_text
 ---
 
 # Agent Ideas
 
-Harvest agent-tooling ideas from a curated list of thinkers and map them to concrete artifacts in this repo (a skill, hook, setting, or rule). The harvest runs in two phases: a headless weekly pass that fetches feeds, mines them, and delivers a digest, and a local pass after teleport that fills the gaps and files the keepers.
+Harvest agent-tooling ideas from a curated list of thinkers and map them to concrete artifacts in this repo (a skill, hook, setting, or rule). The harvest runs in two phases: a feed pass that fetches, mines, and delivers a digest, and a local pass that fills the X-only gap and files the keepers. As the weekly routine these run headless-then-local, bridged by a teleport doorway item. Run on-demand at your own terminal, they collapse into one pass with no doorway (see [Deliver the Doorway Item](#deliver-the-doorway-item)).
 
 ## Sources
 
@@ -51,11 +55,13 @@ Write the digest to `tmp/agent-ideas-digest-<YYYY-Www>.md`:
 - Per-idea cards in full (the schema fields), grouped high → low actionability.
 - A short "repo overlaps" note listing cards that refine existing surfaces.
 
-Keep the digest in this session's context as well. After teleport, the local phase reads it from here.
+Keep the digest in this session's context as well. The local phase reads it from here.
 
 ## Deliver the Doorway Item
 
-Create exactly one Things inbox item. It is the routine's only notification, so make its notes self-sufficient:
+Skip this section on a local on-demand run. The doorway exists only to bridge the headless weekly routine to a local terminal; `claude --teleport ${CLAUDE_SESSION_ID}` minted from a session you are already in points at itself. When the browser and Things are reachable (you invoked the skill yourself), go straight from Synthesize to [Fill the X-Only Gap](#fill-the-x-only-gap). The doorway is the remote routine's handoff, nothing more.
+
+For the weekly routine, create exactly one Things inbox item. It is the routine's only notification, so make its notes self-sufficient:
 
 - **Title**: `[agent-ideas] Weekly digest: N ideas (YYYY-Www)`
 - **Notes**: the top-line summary, then the teleport command on its own line so it's tappable:
@@ -71,8 +77,33 @@ Pick the delivery path by environment:
 
 Do not tag the doorway item `claude-code`. Tagging happens per keeper in the local phase, so the whole digest doesn't land in the `improve-claude-code` backlog as one blob.
 
+## Local Phase
+
+The local phase fills the X-only gap and files the keepers. You reach it two ways. The weekly routine gets here when you tap the doorway item: `claude --teleport` pulls the cloud session into a local terminal where the browser and Things are reachable. A local on-demand run flows straight here from Synthesize, with no doorway in between.
+
+The digest is already in this session's context. After a teleport into a fresh terminal it may not be, so read the latest `tmp/agent-ideas-digest-*.md` to recover the feed-derived cards.
+
+## Fill the X-Only Gap
+
+`x-only` sources were skipped in the remote fetch. Read their recent timelines in the browser and mine them into cards with the same bar as the feed path. See [references/browser.md](references/browser.md) for the tool-loading sequence, the per-author flow, and the failure modes (extension not connected, logged-out wall). If the browser is unavailable, note which authors went unread and proceed with the feed cards.
+
+## Capture Keepers
+
+For each keeper card, create one Things todo via the `things:inbox` skill, tagged `claude-code` so `improve-claude-code` picks it up:
+
+- **Title**: `[agent-idea] <card title>`
+- **Notes**: the pitch, then the source URL, then the suggested `artifactType`. This is the shape `improve-claude-code` consumes (short title, full notes).
+- Pass `--tag claude-code` and `--session-id ${CLAUDE_SESSION_ID}` so the capture carries the right tag and session attribution.
+
+Capture one todo per keeper, not one blob. Each becomes an independently triageable backlog item. Don't re-capture the feed cards as new ideas; the digest already framed them. The local phase adds the X-only cards and tags everything.
+
+## Hand Off
+
+Once the keepers are captured, the work belongs to `improve-claude-code`: it triages the `claude-code` backlog into batched PRs. Tell the user how many todos landed and that they can run `improve-claude-code` to process them.
+
 ## Gotchas
 
 - **No completion notification exists for routines.** The doorway item _is_ the signal. If its creation fails, say so loudly in the run output rather than ending silently.
-- **Teleport, not resume.** The handoff is `claude --teleport <session>`, which pulls the cloud session into a local terminal with local tools. `--resume` does not do this.
-- **Thin weeks are normal.** Low-frequency blogs often post nothing in an 8-day window. A digest of 0-2 ideas is a valid outcome, not a failure. Still drop the doorway item so the cadence is visible.
+- **Teleport, not resume.** The handoff is `claude --teleport <session>`, which pulls the cloud session into a local terminal with local tools. `--resume` does not do this. If the browser or Things isn't reachable after teleport, you may not actually be in a local session. Confirm before assuming the fallback is broken.
+- **Thin weeks are normal.** Low-frequency blogs often post nothing in an 8-day window. A digest of 0-2 ideas is a valid outcome, not a failure. On the weekly routine, still drop the doorway item so the cadence is visible.
+- **One tag, one backlog.** The `claude-code` tag is the contract with `improve-claude-code`. Without it, the todo won't surface there.

--- a/.claude/skills/agent-ideas/references/browser.md
+++ b/.claude/skills/agent-ideas/references/browser.md
@@ -1,0 +1,36 @@
+# X Browser Fallback
+
+`x-only` sources have no usable feed (RSS mirrors are dead or gated, proven this
+session). After teleport, the local session has the Claude-in-Chrome extension,
+so read these authors' recent posts directly from the browser.
+
+## Which Authors
+
+Read the `x-only` entries from `sources.ts` (their `xHandle` is the timeline to
+open). As of this writing: Boris Cherny (`bcherny`), Dillon Mulroy
+(`dillon_mulroy`), Dex Horthy (`dexhorthy`).
+
+## Flow
+
+1. Load the browser tools you need via `ToolSearch` (they are deferred):
+   `select:mcp__claude-in-chrome__tabs_context_mcp,mcp__claude-in-chrome__tabs_create_mcp,mcp__claude-in-chrome__navigate,mcp__claude-in-chrome__get_page_text`.
+2. Call `tabs_context_mcp` first to see the live browser state. Don't reuse tab
+   IDs from another session.
+3. For each handle, open `https://x.com/<handle>` in a new tab and read the page
+   text. Pull the recent posts: text, permalink, and timestamp. Stay within the
+   last ~8 days to match the feed window.
+4. Mine the posts with the same bar and schema as the feed path (see the mining
+   heuristics in [mining.md](mining.md)). Append the resulting cards to the
+   keepers.
+
+## Gotchas
+
+- **The extension may not be connected.** If `tabs_context_mcp` errors or returns
+  nothing, the browser isn't available. Skip the fallback, note which `x-only`
+  authors went unread, and proceed with the feed-derived cards. Don't retry a
+  dead extension in a loop.
+- **No login, no timeline.** If x.com shows a logged-out wall, the timeline may
+  be truncated or empty. Capture what's visible and note the gap rather than
+  forcing it.
+- **Don't trigger dialogs.** Avoid clicking anything that opens a browser modal;
+  it blocks all further extension commands.


### PR DESCRIPTION
Third in the `agent-ideas` stack. Completes the skill with the local half of the harvest, entered after teleporting the routine session into a terminal where the browser and Things are reachable. It fills the X-only gap from the browser, then files each keeper as a `claude-code`-tagged Things todo, handing the backlog to `improve-claude-code`. Builds on the digest from #689.

## Changes

- `SKILL.md`: adds the After Teleport, Fill the X-Only Gap, Capture Keepers, and Hand Off sections, plus the browser tools in `allowed-tools`. Each keeper becomes its own `claude-code`-tagged todo via `things:inbox` (title `[agent-idea] <title>`, notes carrying the pitch, source URL, and suggested `artifactType`), so `improve-claude-code` triages them independently.
- `references/browser.md`: the Claude-in-Chrome fallback for `x-only` authors (Boris Cherny, Dillon Mulroy, Dex Horthy): the tool-loading sequence, the per-author timeline flow, and the failure modes (extension not connected, logged-out wall).

## Decisions

- The browser fallback degrades gracefully. If the extension isn't connected, the skill notes which authors went unread and proceeds with the feed cards rather than blocking triage.
- The X-only path reuses the feed path's mining heuristics (`references/mining.md`) instead of duplicating them, keeping one bar for what counts as a repo-mappable idea.

## Testing

- `skill-lint` covers the full `SKILL.md` and both references, and biome covers formatting and lint.
- The browser fallback and Things tagging are local-only runtime paths (the extension was not connected this session). They need a live teleport-simulated run to validate end-to-end.
