### PR TITLE
user: fold subagent status into a colored type glyph

### DIFF
--- a/user/scripts/__snapshots__/subagent-statusline.test.ts.snap
+++ b/user/scripts/__snapshots__/subagent-statusline.test.ts.snap
@@ -1,19 +1,19 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`rendered content running 1`] = `"\x1B[33m▶\x1B[39m builder"`;
+exports[`rendered content running 1`] = `"\x1B[90m󰚩\x1B[39m builder"`;
 
-exports[`rendered content completed-tokens 1`] = `"\x1B[32m✓\x1B[39m deploy to prod \x1B[2m· 1.5k\x1B[22m"`;
+exports[`rendered content completed-tokens 1`] = `"\x1B[32m󰚩\x1B[39m deploy to prod \x1B[2m· 1.5k\x1B[22m"`;
 
-exports[`rendered content failed 1`] = `"\x1B[31m✗\x1B[39m reviewer"`;
+exports[`rendered content failed 1`] = `"\x1B[31m󰚩\x1B[39m reviewer"`;
 
-exports[`rendered content remote 1`] = `"\x1B[33m▶\x1B[39m \x1B[2m\x1B[22m remote build"`;
+exports[`rendered content remote 1`] = `"\x1B[90m󰚩\x1B[39m \x1B[2m\x1B[22m remote build"`;
 
-exports[`rendered content explore-glyph 1`] = `"\x1B[33m▶\x1B[39m \x1B[2m\x1B[22m search"`;
+exports[`rendered content explore-glyph 1`] = `"\x1B[90m\x1B[39m search"`;
 
-exports[`rendered content plan-glyph 1`] = `"\x1B[33m▶\x1B[39m \x1B[2m\x1B[22m design"`;
+exports[`rendered content plan-glyph 1`] = `"\x1B[90m\x1B[39m design"`;
 
-exports[`rendered content guide-glyph 1`] = `"\x1B[33m▶\x1B[39m \x1B[2m\x1B[22m docs"`;
+exports[`rendered content guide-glyph 1`] = `"\x1B[90m\x1B[39m docs"`;
 
-exports[`rendered content full-meta-remote-explore 1`] = `"\x1B[33m▶\x1B[39m \x1B[2m\x1B[22m \x1B[2m\x1B[22m build the parser \x1B[2m· 1m 5s · 2.3k\x1B[22m"`;
+exports[`rendered content full-meta-remote-explore 1`] = `"\x1B[90m\x1B[39m \x1B[2m\x1B[22m build the parser \x1B[2m· 1m 5s · 2.3k\x1B[22m"`;
 
-exports[`rendered content truncated 1`] = `"\x1B[33m▶\x1B[39m a really long description t…"`;
+exports[`rendered content truncated 1`] = `"\x1B[90m󰚩\x1B[39m a really long description t…"`;

--- a/user/scripts/glyphs.ts
+++ b/user/scripts/glyphs.ts
@@ -7,12 +7,15 @@ export function dialGlyph(idx: number): string {
   return String.fromCodePoint(DIAL_BASE + idx);
 }
 
-// Purpose glyphs mark the agent kind. Untyped kinds get no glyph.
+// Purpose glyphs mark the agent kind. Untyped kinds fall back to genericGlyph.
 export const purposeGlyphs = new Map<string, string>([
   ["Explore", String.fromCodePoint(0xf002)],
   ["Plan", String.fromCodePoint(0xf0ea)],
   ["claude-code-guide", String.fromCodePoint(0xf02d)],
 ]);
+
+// Fallback glyph (robot) for agents with no typed purpose.
+export const genericGlyph = String.fromCodePoint(0xf06a9);
 
 // Cloud marker for remote agents.
 export const remoteGlyph = String.fromCodePoint(0xf0c2);

--- a/user/scripts/subagent-statusline.test.ts
+++ b/user/scripts/subagent-statusline.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { styleText } from "node:util";
+import { genericGlyph, purposeGlyphs } from "./glyphs";
 import { formatElapsed, formatTokens, renderTask, type Task } from "./subagent-statusline";
 
 function strip(s: string): string {
@@ -30,15 +32,15 @@ describe("formatTokens", () => {
 describe("renderTask", () => {
   const now = 65_000;
 
-  test("status icons", () => {
-    expect(strip(renderTask({ id: "a", status: "completed" }, null, now, null).content)).toContain(
-      "✓",
+  test("status colors the type glyph: gray running, green done, red failed", () => {
+    expect(renderTask({ id: "a", status: "running" }, null, now, null).content).toContain(
+      styleText("gray", genericGlyph),
     );
-    expect(strip(renderTask({ id: "a", status: "failed" }, null, now, null).content)).toContain(
-      "✗",
+    expect(renderTask({ id: "a", status: "completed" }, null, now, null).content).toContain(
+      styleText("green", genericGlyph),
     );
-    expect(strip(renderTask({ id: "a", status: "running" }, null, now, null).content)).toContain(
-      "▶",
+    expect(renderTask({ id: "a", status: "failed" }, null, now, null).content).toContain(
+      styleText("red", genericGlyph),
     );
   });
 
@@ -55,11 +57,13 @@ describe("renderTask", () => {
     expect(strip(out.content)).not.toContain("builder");
   });
 
-  test("purpose glyph from agent type, none when untyped", () => {
+  test("type glyph from agent type, generic fallback when untyped", () => {
     const explore = strip(renderTask({ id: "a", name: "x" }, null, now, "Explore").content);
-    expect(explore).toContain(String.fromCodePoint(0xf002));
+    expect(explore).toContain(purposeGlyphs.get("Explore") ?? "");
+    expect(explore).not.toContain(genericGlyph);
     const untyped = strip(renderTask({ id: "a", name: "x" }, null, now, "general-purpose").content);
-    expect(untyped).not.toContain(String.fromCodePoint(0xf002));
+    expect(untyped).toContain(genericGlyph);
+    expect(untyped).not.toContain(purposeGlyphs.get("Explore") ?? "");
   });
 
   test("remote marker only for remote_agent", () => {

--- a/user/scripts/subagent-statusline.ts
+++ b/user/scripts/subagent-statusline.ts
@@ -2,7 +2,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { styleText } from "node:util";
-import { purposeGlyphs, remoteGlyph } from "./glyphs";
+import { genericGlyph, purposeGlyphs, remoteGlyph } from "./glyphs";
 
 export interface Task {
   id: string;
@@ -42,22 +42,24 @@ function sliceToWidth(s: string, maxWidth: number): string {
   return out;
 }
 
-function statusIcon(status: string): string {
+// Status drives the icon color: gray while running, green on success, red on
+// failure. Folding status into the type glyph drops the separate status column.
+function statusColor(status: string): "gray" | "green" | "red" {
   switch (status) {
     case "completed":
-      return styleText("green", "✓");
+      return "green";
     case "failed":
-      return styleText("red", "✗");
+      return "red";
     default:
-      return styleText("yellow", "▶");
+      return "gray";
   }
 }
 
-// The agent kind drives the purpose glyph; untyped kinds (general-purpose,
-// unknown) get none.
-function purposeGlyph(agentType: string | null): string {
-  const glyph = agentType ? purposeGlyphs.get(agentType) : undefined;
-  return glyph ? styleText(["dim"], glyph) : "";
+// The agent kind drives the glyph; untyped kinds (general-purpose, unknown)
+// fall back to the generic robot. Its color carries the run status.
+function typeIcon(agentType: string | null, status: string): string {
+  const glyph = (agentType ? purposeGlyphs.get(agentType) : undefined) ?? genericGlyph;
+  return styleText(statusColor(status), glyph);
 }
 
 // .type is the agent origin. Cloud always marks remote agents; local agents
@@ -66,16 +68,15 @@ function remoteMarker(type: string | undefined): string {
   return type === "remote_agent" ? styleText(["dim"], remoteGlyph) : "";
 }
 
-// The purpose glyph leads, the cloud marker follows, so origin stays visible
-// without displacing the kind.
+// The status-colored type glyph leads, the cloud marker follows, so origin
+// stays visible without displacing the kind.
 export function renderTask(
   task: Task,
   columns: number | null,
   now: number,
   agentType: string | null,
 ): { id: string; content: string } {
-  const icon = statusIcon(task.status ?? "running");
-  const glyph = purposeGlyph(agentType);
+  const icon = typeIcon(agentType, task.status ?? "running");
   const marker = remoteMarker(task.type);
 
   let meta = "";
@@ -84,7 +85,6 @@ export function renderTask(
 
   const build = (text: string): string => {
     let body = icon;
-    if (glyph) body += ` ${glyph}`;
     if (marker) body += ` ${marker}`;
     body += ` ${text}`;
     if (meta) body += ` ${styleText(["dim"], meta)}`;


### PR DESCRIPTION
Compresses the subagent status line by dropping the dedicated status-icon column. Previously each row led with a status icon (`▶`/`✓`/`✗`) followed by a separate, dimmed type glyph. Now the type glyph leads and carries status through its color, freeing a column for the description, which matters most on narrow screens.

## Changes

- The agent-type glyph leads each row, colored by run status: gray while running, green on success, red on failure.
- Untyped agents (`general-purpose`, unknown) fall back to a generic robot glyph instead of rendering no glyph. Every row now shows an icon.
- Replaced `statusIcon` (which returned a styled glyph) with `statusColor`, and `purposeGlyph` with `typeIcon`, which resolves the type-or-fallback glyph and applies the status color.
- The remote cloud marker and the dim `· elapsed · tokens` meta are unchanged.

Status colors use ANSI 8/2/1 (gray maps to `\x1b[90m`), keeping them within the 0-15 range the terminal theme remaps.

## Testing

Snapshots regenerated for the new layout. Coverage asserts the glyph color per status and the generic fallback for untyped agents.
