### PR TITLE
user: allow sandbox writes to graphite state dir

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -184,7 +184,8 @@
         "~/src/go/pkg/mod",
         "~/src/go/pkg/sumdb",
         "~/.bun/install",
-        "~/.local/share/uv"
+        "~/.local/share/uv",
+        "~/.local/share/graphite"
       ]
     },
     "excludedCommands": [


### PR DESCRIPTION
Graphite (`gt`) writes state to `~/.local/share/graphite/`, which the sandbox blocked. I added that directory to the sandbox `allowWrite` list alongside the other tool state dirs.
