### PR TITLE
ci: lint skills

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -252,6 +252,21 @@ jobs:
           folder-path: '.claude/'
           file-path: './CLAUDE.md'
 
+  skills:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint skills
+        run: bun run skill-lint "user/skills/*"
+
   context:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
CI runs `skill-lint` only inside the per-plugin matrix job, so skills under `user/skills/` (`doc-coauthoring`, `improve-claude-code`, `improve-codebase-architecture`) were never linted. This adds a root-level `skills` job that runs `bun run skill-lint "user/skills/*"`, closing the gap. The name parallels the existing `hooks` job, which covers the user and `.claude` hook locations generically.

The job mirrors the other root-level jobs (`checkout`, `setup-bun`, `bun install --frozen-lockfile`) and keeps the glob quoted, since `skill-lint` expands it itself.
