### PR TITLE
user: skip workflow usage warning

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -227,6 +227,7 @@
     "command": "~/.claude/scripts/subagent-statusline.ts"
   },
   "skipAutoPermissionPrompt": true,
+  "skipWorkflowUsageWarning": true,
   "alwaysThinkingEnabled": true,
   "spinnerTipsEnabled": false,
   "showClearContextOnPlanAccept": true,


### PR DESCRIPTION
Sets `skipWorkflowUsageWarning` to `true` in `user/settings.json` to suppress the workflow usage warning prompt.
