### PR TITLE
user: downweight subagent type name in status line

### DIFF
--- a/user/scripts/__snapshots__/subagent-statusline.test.ts.snap
+++ b/user/scripts/__snapshots__/subagent-statusline.test.ts.snap
@@ -1,19 +1,19 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`rendered content running 1`] = `"\x1B[90m󰚩\x1B[39m builder"`;
+exports[`rendered content running 1`] = `"\x1B[90m\x1B[2m󰚩\x1B[22m\x1B[39m  builder"`;
 
-exports[`rendered content completed-tokens 1`] = `"\x1B[32m󰚩\x1B[39m deploy to prod \x1B[2m· 1.5k\x1B[22m"`;
+exports[`rendered content completed-tokens 1`] = `"\x1B[32m󰚩\x1B[39m  deploy to prod \x1B[2m· 1.5k\x1B[22m"`;
 
-exports[`rendered content failed 1`] = `"\x1B[31m󰚩\x1B[39m reviewer"`;
+exports[`rendered content failed 1`] = `"\x1B[31m󰚩\x1B[39m  reviewer"`;
 
-exports[`rendered content remote 1`] = `"\x1B[90m󰚩\x1B[39m \x1B[2m\x1B[22m remote build"`;
+exports[`rendered content remote 1`] = `"\x1B[90m\x1B[2m󰚩\x1B[22m\x1B[39m \x1B[2m\x1B[22m  remote build"`;
 
-exports[`rendered content explore-glyph 1`] = `"\x1B[90m\x1B[39m search"`;
+exports[`rendered content explore-glyph 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m  search \x1B[2m· Explore\x1B[22m"`;
 
-exports[`rendered content plan-glyph 1`] = `"\x1B[90m\x1B[39m design"`;
+exports[`rendered content plan-glyph 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m  design \x1B[2m· Plan\x1B[22m"`;
 
-exports[`rendered content guide-glyph 1`] = `"\x1B[90m\x1B[39m docs"`;
+exports[`rendered content guide-glyph 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m  docs \x1B[2m· claude-code-guide\x1B[22m"`;
 
-exports[`rendered content full-meta-remote-explore 1`] = `"\x1B[90m\x1B[39m \x1B[2m\x1B[22m build the parser \x1B[2m· 1m 5s · 2.3k\x1B[22m"`;
+exports[`rendered content full-meta-remote-explore 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m \x1B[2m\x1B[22m  build the parser \x1B[2m· 1m 5s · 2.3k · Explore\x1B[22m"`;
 
-exports[`rendered content truncated 1`] = `"\x1B[90m󰚩\x1B[39m a really long description t…"`;
+exports[`rendered content truncated 1`] = `"\x1B[90m\x1B[2m󰚩\x1B[22m\x1B[39m  a really long description …"`;

--- a/user/scripts/subagent-statusline.test.ts
+++ b/user/scripts/subagent-statusline.test.ts
@@ -32,9 +32,9 @@ describe("formatTokens", () => {
 describe("renderTask", () => {
   const now = 65_000;
 
-  test("status colors the type glyph: gray running, green done, red failed", () => {
+  test("dims the in-progress gray glyph; finished green/red stay vivid", () => {
     expect(renderTask({ id: "a", status: "running" }, null, now, null).content).toContain(
-      styleText("gray", genericGlyph),
+      styleText(["gray", "dim"], genericGlyph),
     );
     expect(renderTask({ id: "a", status: "completed" }, null, now, null).content).toContain(
       styleText("green", genericGlyph),
@@ -80,6 +80,24 @@ describe("renderTask", () => {
   test("meta combines elapsed and tokens", () => {
     const out = renderTask({ id: "a", name: "x", startTime: 0, tokenCount: 1500 }, null, now, null);
     expect(strip(out.content)).toContain("· 1m 5s · 1.5k");
+  });
+
+  test("type name trails after the meta as dim text", () => {
+    const out = renderTask(
+      { id: "a", description: "search", startTime: 0, tokenCount: 1500 },
+      null,
+      now,
+      "Explore",
+    );
+    expect(strip(out.content)).toContain("· 1m 5s · 1.5k · Explore");
+    expect(out.content).toContain(styleText(["dim"], "· 1m 5s · 1.5k · Explore"));
+  });
+
+  test("type name drops on narrow terminals while the description survives", () => {
+    const out = renderTask({ id: "a", description: "search the parser" }, 24, now, "Explore");
+    expect(Bun.stringWidth(out.content)).toBeLessThanOrEqual(24);
+    expect(strip(out.content)).toContain("search the parser");
+    expect(strip(out.content)).not.toContain("Explore");
   });
 
   test("truncates text to columns", () => {

--- a/user/scripts/subagent-statusline.ts
+++ b/user/scripts/subagent-statusline.ts
@@ -56,10 +56,13 @@ function statusColor(status: string): "gray" | "green" | "red" {
 }
 
 // The agent kind drives the glyph; untyped kinds (general-purpose, unknown)
-// fall back to the generic robot. Its color carries the run status.
+// fall back to the generic robot. Color carries the run status. The in-progress
+// gray dims to recede behind the title; finished green/red stay vivid so a
+// terminal state reads at a glance.
 function typeIcon(agentType: string | null, status: string): string {
   const glyph = (agentType ? purposeGlyphs.get(agentType) : undefined) ?? genericGlyph;
-  return styleText(statusColor(status), glyph);
+  const color = statusColor(status);
+  return styleText(color === "gray" ? [color, "dim"] : color, glyph);
 }
 
 // .type is the agent origin. Cloud always marks remote agents; local agents
@@ -79,29 +82,37 @@ export function renderTask(
   const icon = typeIcon(agentType, task.status ?? "running");
   const marker = remoteMarker(task.type);
 
-  let meta = "";
-  if (task.startTime != null) meta += `· ${formatElapsed(task.startTime, now)} `;
-  if ((task.tokenCount ?? 0) > 0) meta += `· ${formatTokens(task.tokenCount ?? 0)}`;
+  const metaParts: string[] = [];
+  if (task.startTime != null) metaParts.push(formatElapsed(task.startTime, now));
+  if ((task.tokenCount ?? 0) > 0) metaParts.push(formatTokens(task.tokenCount ?? 0));
 
-  const build = (text: string): string => {
+  // The type name trails as dim text after the meta. The icon already conveys
+  // the kind, so a narrow terminal can drop the name without losing it.
+  const build = (text: string, withType: boolean): string => {
     let body = icon;
     if (marker) body += ` ${marker}`;
-    body += ` ${text}`;
-    if (meta) body += ` ${styleText(["dim"], meta)}`;
+    body += `  ${text}`;
+    const trailing = [...metaParts];
+    if (withType && agentType) trailing.push(agentType);
+    if (trailing.length) {
+      body += ` ${styleText(["dim"], trailing.map((part) => `· ${part}`).join(" "))}`;
+    }
     return body;
   };
 
   let text = task.description || task.name || "agent";
-  let content = build(text);
+  let content = build(text, true);
 
-  if (columns != null) {
+  if (columns != null && Bun.stringWidth(content) > columns) {
+    // Shed the optional type name first; the icon keeps the kind visible.
+    if (agentType) content = build(text, false);
     const visible = Bun.stringWidth(content);
     if (visible > columns) {
       const overflow = visible - columns;
       const textMax = Bun.stringWidth(text) - overflow - 1;
       if (textMax > 0) {
         text = `${sliceToWidth(text, textMax)}…`;
-        content = build(text);
+        content = build(text, false);
       }
     }
   }


### PR DESCRIPTION
Demotes the subagent type name in the subagent status line now that the icon carries the type. The spelled-out type moves to a dim trailing run after the meta, and the icon dims while in progress so it recedes behind the title.

## Changes

- Moves the agent type name to the end of the dim trailing run: `icon  description · 1m 5s · 2.3k · Explore`. The icon already conveys the kind, so the name is secondary.
- Drops the type name first on overflow, before truncating the description. A narrow terminal sheds the name and keeps the icon, which still communicates the type.
- Dims the in-progress gray glyph so it recedes behind the title, with two spaces between the icon and the title. Finished `green`/`red` glyphs stay vivid so a terminal state reads at a glance.

## Testing

Covers the trailing type name and its dim styling, the narrow-terminal drop that preserves the description, and the per-status icon treatment (dim gray while running, full-strength green/red when finished). Snapshot fixtures updated for the new spacing, dim glyph, and trailing name.
