### PR TITLE
tmux: correct targeting guidance for metacharacter commands

### DIFF
--- a/plugins/tmux/hooks/prompt.md
+++ b/plugins/tmux/hooks/prompt.md
@@ -8,9 +8,12 @@ Load the `tmux` skill for split, capture, and send-keys commands.
 
 ## tmux targeting
 
-A hook auto-injects `-t` with your pane ID on tmux commands that
-accept a target. If `-t` is already present, the command passes
-through unchanged.
+A hook tries to auto-inject `-t` with your pane ID on tmux commands
+that accept a target. If `-t` is already present, the command passes
+through unchanged. Injection is best-effort: it does NOT fire when the
+command's argument contains shell metacharacters (`$(...)`, `;`,
+`&&`, etc.), so pass `-t "$TMUX_PANE"` explicitly in those cases to
+stay anchored to your own pane.
 
 To target the user's currently active pane, resolve it first:
 


### PR DESCRIPTION
Corrects the tmux plugin's injected targeting guidance, which overstated the `-t` auto-injection as reliable.

The hook in `plugins/tmux/hooks/target.ts` injects `-t "$TMUX_PANE"` into targetable tmux commands, gated by the matcher `Bash(tmux:*)`. That matcher does not fire when a tmux command's argument contains embedded shell metacharacters (`$(...)`, `;`, `&&`), confirmed on Claude Code 2.1.159 via session history. A `split-window` like `tmux split-window -v -l 18 "cd $(pwd) && bun tmp/x.ts; echo; read"` silently lands in the user's active window instead of Claude's pane.

`target.ts` is correct in isolation; the gap is the matcher gate, which is upstream Claude Code behavior. I fixed the misleading guidance rather than broadening the matcher, since broadening it would spawn the hook on every Bash, Edit, Write, and MCP call. The guidance now says injection is best-effort and tells Claude to pass `-t "$TMUX_PANE"` explicitly when the command contains metacharacters.

`SKILL.md` already instructs explicit `-t $TMUX_PANE` targeting, so it needed no caveat.

Original Task: [tmux target hook misses split-window when command contains $(...) / metacharacters](https://things.bendrucker.me/show?id=H95n3jm2Z3iDF2rASNCjaL)
