### PR TITLE
scripts: link workspace deps in new worktrees

### DIFF
--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -5,7 +5,11 @@ paths:
 
 # Bun
 
-Hooks and scripts use [Bun](https://bun.sh) to run TypeScript. Bun auto-installs missing dependencies on first run, eliminating the need to run `bun install` before executing scripts. This simplifies hook execution since hooks run in isolated contexts where `node_modules` may not be readily available.
+Hooks and scripts use [Bun](https://bun.sh) to run TypeScript. Bun auto-installs missing registry dependencies on first run, so most scripts run without a prior `bun install`.
+
+#### Workspace Dependencies
+
+Auto-install does not cover `workspace:*` specifiers. Scripts that import workspace packages (`@bendrucker/*`) need `bun install` first to create the `node_modules` symlinks; without it they fail with `Cannot find module`. The project Worktrunk `post-start` hook (`.config/wt.toml`) runs `bun install` for new worktrees so this resolves automatically.
 
 # Script Conventions
 

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,5 @@
+# Link workspace deps (@bendrucker/*) so bun scripts and hooks resolve them
+# immediately. bun's auto-install only fetches registry packages, not
+# workspace:* specifiers, so a fresh worktree needs `bun install` to create the
+# node_modules symlinks. Runs in the background to avoid blocking session start.
+post-start = "bun install"


### PR DESCRIPTION
Adds a project Worktrunk `post-start` hook that runs `bun install` in new worktrees, and corrects a false claim about Bun auto-install in `scripts.md`.

Bun's on-demand auto-install only fetches missing registry packages. It does not satisfy `workspace:*` specifiers, so the `node_modules/@bendrucker/claude-marketplace` symlink only exists after `bun install` runs. Until then, scripts and the `plugin-imports` Stop hook that import `@bendrucker/claude-marketplace` fail with `Cannot find module`. Fresh worktrees hit this consistently because they start without that symlink. This is a setup gap, not a real import violation.

## Changes

- `.config/wt.toml`: new project config with a `post-start = "bun install"` hook so new worktrees link workspace deps. I chose `post-start` over a blocking `pre-start` to keep session start fast, accepting the brief race where a script could run before the install finishes.
- `.claude/rules/scripts.md`: the `# Bun` section claimed auto-install "eliminat[es] the need to run `bun install`". That holds for registry packages but not workspace packages. I scoped the claim to registry deps and added a note that `@bendrucker/*` imports require an install first, which the new hook handles for worktrees.

## Caveat

Project Worktrunk hooks require approval on first run. I did not bypass it (no `--yes`). To trust this hook, run `wt config approvals add`.

Original Task: [Fix transient plugin-imports Stop hook failure in fresh worktrees](https://things.bendrucker.me/show?id=GXtHZgxrpPBRVfjsBVZ95F)
