### PR TITLE
review: review changes through live Hunk sessions

### DIFF
--- a/plugins/review/README.md
+++ b/plugins/review/README.md
@@ -6,7 +6,14 @@ Code review workflows for Claude Code.
 
 ### Skills
 
-- **`peer`**: Review PRs when requested by a peer (GitHub or GitLab)
-- **`self`**: Self-review your own changes using difit's visual diff viewer
+- **`hunk`**: Core layer for reviewing changes through a live [Hunk](https://github.com/modem-dev/hunk) session in tmux. Launches and drives the session, seeds and reads back inline comments, and ships the watcher, line-mapping, and resolution-ledger helpers. `self` and `peer` delegate to it.
+- **`peer`**: Review PRs when requested by a peer (GitHub or GitLab). Stages comments in Hunk for local revision, then maps and posts them as a batch.
+- **`self`**: Self-review your own changes in a live Hunk session before committing. Your inline comments come back to Claude as edits to apply.
 - **`follow-up`**: Follow up on a PR/MR you reviewed: check if your comments were addressed, find silent resolves, decide whether to re-approve
 - **`dashboard`**: Live tmux dashboard for reviewing inbound PRs across GitHub and GitLab
+
+## Testing
+
+```sh
+bun test plugins/review
+```

--- a/plugins/review/skills/hunk/SKILL.md
+++ b/plugins/review/skills/hunk/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: review:hunk
+description: >
+  Drive Hunk, the terminal diff viewer, as a live local review surface in tmux. Use when
+  reviewing changes through Hunk: launching a session, seeding agent notes, collecting inline
+  comments to act on, or watching comments arrive live. The shared core that review:self
+  (inbound) and review:peer (outbound) delegate to. Triggers on "review in Hunk", "hunk
+  session", "open the diff in Hunk", "watch my comments".
+allowed-tools:
+  - Bash(hunk:*)
+  - Bash(tmux:*)
+  - Bash(jq:*)
+  - Bash(git:*)
+  - "Bash(bun ${CLAUDE_SKILL_DIR}/scripts/:*)"
+---
+
+# Hunk Review Surface
+
+Core layer for reviewing changes through a live [Hunk](https://github.com/modem-dev/hunk)
+session. You launch and drive it in a sibling pane; the TUI is the user's. `review:self`
+(inbound) and `review:peer` (outbound) build on this.
+
+## Live Sessions
+
+!`hunk session list`
+
+## Launching
+
+Launch detached in a sibling tmux pane, never your own pane (the TUI would seize your tty):
+
+```bash
+tmux split-window -h -d -c "<repo>" "cd '<repo>' && hunk diff --watch --agent-notes"
+```
+
+- `--agent-notes` is required to render notes you seed; the default hides them.
+- `--watch` reloads the diff on file changes, which drives the inbound loop.
+- Swap the inner command for other targets (`hunk diff --staged`, `hunk diff main...HEAD`,
+  `hunk show HEAD`), keeping `--watch --agent-notes`.
+
+After ~3s, `hunk session list` confirms the `sessionId` and `repoRoot`, and `git rev-parse HEAD`
+captures the head SHA for outbound mapping. `repoRoot` is canonical (`/private/tmp/...`). A
+single session auto-resolves `--repo .`.
+
+## Command Reference
+
+For the full `hunk session *` contract (`get`, `context`, `review`, `navigate`, `reload`,
+`comment`), run `hunk skill path` and read that file. It is the bundled reference, version
+matched to the installed Hunk.
+
+## Surface Notes
+
+#### Seeding
+Batch with `comment apply`, fed from a temp file so the command starts with `hunk session` and
+matches the permission rule:
+
+```bash
+hunk session comment apply --repo . --stdin < "$TMPDIR/notes.json"
+```
+
+Validation is all-or-nothing. Omit fields rather than nulling them. Anchors are single-line or
+whole-hunk, never ranges.
+
+#### Reading Back
+`comment list --type user --json` returns JSON. Tell the authors apart by `source` (`user` vs
+`agent`), `noteId` prefix (`user:` vs `mcp:`), or `editable` (`true` vs `false`).
+
+## Reconciliation
+
+`--watch` reloads the diff but never moves or resolves comments, so a note on a line you fixed
+orphans silently (no staleness field). `noteId` is stable across reloads, so track state by it.
+Inbound: Hunk has no native resolution, so mark notes resolved in the ledger rather than
+deleting them. Outbound: resolve natively on the platform.
+
+## Monitor Mode
+
+To act on comments as they arrive instead of in a batch, pass this as a `Monitor` command:
+
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/watch.sh <session-id>
+```
+
+It emits one event per new user comment and exits when the session closes. Accumulate drafted
+responses and gate the apply or post on the user's go.
+
+## Scripts
+
+Run each with `--help` for flags.
+
+- `scripts/watch.sh <session-id>`: per-comment events for `Monitor`.
+- `scripts/mapping.ts map`: notes to GitHub/GitLab payloads with an in-diff pre-check, dropping
+  off-diff anchors GitHub would reject with 422.
+- `scripts/ledger.ts`: resolution ledger keyed by `noteId`; repo and branch default to the git
+  checkout.

--- a/plugins/review/skills/hunk/scripts/ledger.test.ts
+++ b/plugins/review/skills/hunk/scripts/ledger.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { type HunkNote, Ledger, defaultLedgerDir } from "./ledger";
+import { defaultLedgerDir, type HunkNote, Ledger } from "./ledger";
 
 function makeNote(overrides: Partial<HunkNote> = {}): HunkNote {
   return {

--- a/plugins/review/skills/hunk/scripts/ledger.test.ts
+++ b/plugins/review/skills/hunk/scripts/ledger.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type HunkNote, Ledger, defaultLedgerDir } from "./ledger";
+
+function makeNote(overrides: Partial<HunkNote> = {}): HunkNote {
+  return {
+    noteId: "user:1",
+    source: "user",
+    filePath: "src/index.ts",
+    newRange: [10, 12],
+    oldRange: null,
+    body: "needs a guard clause",
+    ...overrides,
+  };
+}
+
+describe("Ledger", () => {
+  let dir: string;
+  const now = () => "2026-06-01T00:00:00.000Z";
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ledger-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  function ledger(branch = "feature") {
+    return new Ledger({ dir, repo: "owner/repo", branch, now });
+  }
+
+  test("round-trips records through persistence", () => {
+    const writer = ledger();
+    writer.upsert(makeNote());
+
+    const reader = ledger();
+    const record = reader.get("user:1");
+    expect(record).toEqual({
+      noteId: "user:1",
+      filePath: "src/index.ts",
+      anchor: { side: "new", line: 10 },
+      body: "needs a guard clause",
+      resolved: false,
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    });
+  });
+
+  test("upsert, markResolved, isResolved", () => {
+    const led = ledger();
+    led.upsert(makeNote());
+    expect(led.isResolved("user:1")).toBe(false);
+
+    led.markResolved("user:1", { action: "applied", ref: "abc123" });
+    expect(led.isResolved("user:1")).toBe(true);
+
+    const record = led.get("user:1");
+    expect(record?.action).toBe("applied");
+    expect(record?.ref).toBe("abc123");
+  });
+
+  test("upsert does not un-resolve an already-resolved note", () => {
+    const led = ledger();
+    led.upsert(makeNote());
+    led.markResolved("user:1");
+    expect(led.isResolved("user:1")).toBe(true);
+
+    led.upsert(makeNote({ body: "edited body" }));
+    expect(led.isResolved("user:1")).toBe(true);
+    expect(led.get("user:1")?.body).toBe("edited body");
+  });
+
+  test("first sight defaults resolved=false", () => {
+    const led = ledger();
+    led.upsert(makeNote());
+    expect(led.open()).toHaveLength(1);
+    expect(led.resolved()).toHaveLength(0);
+  });
+
+  test("open and resolved partition records", () => {
+    const led = ledger();
+    led.upsert(makeNote({ noteId: "user:1" }));
+    led.upsert(makeNote({ noteId: "user:2" }));
+    led.markResolved("user:2");
+
+    expect(led.open().map((r) => r.noteId)).toEqual(["user:1"]);
+    expect(led.resolved().map((r) => r.noteId)).toEqual(["user:2"]);
+  });
+
+  test("reconcile detects an orphaned entry", () => {
+    const led = ledger();
+    led.upsert(makeNote({ noteId: "user:1" }));
+    led.upsert(makeNote({ noteId: "user:2" }));
+
+    const { orphaned } = led.reconcile(["user:1"]);
+    expect(orphaned.map((r) => r.noteId)).toEqual(["user:2"]);
+  });
+
+  test("reconcile reports nothing when all notes are present", () => {
+    const led = ledger();
+    led.upsert(makeNote({ noteId: "user:1" }));
+    expect(led.reconcile(["user:1", "user:99"]).orphaned).toEqual([]);
+  });
+
+  test("different branches use different files", () => {
+    const a = ledger("feature-a");
+    const b = ledger("feature-b");
+    a.upsert(makeNote({ noteId: "user:1" }));
+
+    expect(a.filePath).not.toBe(b.filePath);
+    expect(b.get("user:1")).toBeUndefined();
+    expect(b.all()).toHaveLength(0);
+  });
+
+  test("anchors to old side when newRange is null", () => {
+    const led = ledger();
+    led.upsert(makeNote({ noteId: "user:1", newRange: null, oldRange: [5, 8] }));
+    expect(led.get("user:1")?.anchor).toEqual({ side: "old", line: 5 });
+  });
+
+  test("upsert throws when note has neither range", () => {
+    const led = ledger();
+    expect(() => led.upsert(makeNote({ newRange: null, oldRange: null }))).toThrow(
+      "note has no anchor",
+    );
+  });
+
+  test("markResolved throws for unknown note", () => {
+    const led = ledger();
+    expect(() => led.markResolved("user:404")).toThrow("No ledger record");
+  });
+
+  test("loads tolerantly when file is missing", () => {
+    const led = ledger();
+    expect(led.all()).toEqual([]);
+  });
+
+  test("sanitizes repo and branch into the filename", () => {
+    const led = new Ledger({
+      dir,
+      repo: "owner/repo",
+      branch: "feature/foo bar",
+      now,
+    });
+    led.upsert(makeNote());
+    const name = led.filePath.slice(dir.length + 1);
+    expect(name).toBe("owner-repo__feature-foo-bar.json");
+  });
+
+  test("persists pretty-printed JSON with trailing newline", () => {
+    const led = ledger();
+    led.upsert(makeNote());
+    const raw = readFileSync(led.filePath, "utf8");
+    expect(raw.endsWith("\n")).toBe(true);
+    expect(raw).toContain('  "records"');
+  });
+
+  test("defaultLedgerDir points under the plugin data dir", () => {
+    expect(defaultLedgerDir()).toContain(
+      join(".claude", "plugins", "data", "claude-review", "hunk-ledger"),
+    );
+  });
+});

--- a/plugins/review/skills/hunk/scripts/ledger.test.ts
+++ b/plugins/review/skills/hunk/scripts/ledger.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -30,14 +30,14 @@ describe("Ledger", () => {
   });
 
   function ledger(branch = "feature") {
-    return new Ledger({ dir, repo: "owner/repo", branch, now });
+    return Ledger.open({ dir, repo: "owner/repo", branch, now });
   }
 
-  test("round-trips records through persistence", () => {
-    const writer = ledger();
-    writer.upsert(makeNote());
+  test("round-trips records through persistence", async () => {
+    const writer = await ledger();
+    await writer.upsert(makeNote());
 
-    const reader = ledger();
+    const reader = await ledger();
     const record = reader.get("user:1");
     expect(record).toEqual({
       noteId: "user:1",
@@ -49,12 +49,12 @@ describe("Ledger", () => {
     });
   });
 
-  test("upsert, markResolved, isResolved", () => {
-    const led = ledger();
-    led.upsert(makeNote());
+  test("upsert, markResolved, isResolved", async () => {
+    const led = await ledger();
+    await led.upsert(makeNote());
     expect(led.isResolved("user:1")).toBe(false);
 
-    led.markResolved("user:1", { action: "applied", ref: "abc123" });
+    await led.markResolved("user:1", { action: "applied", ref: "abc123" });
     expect(led.isResolved("user:1")).toBe(true);
 
     const record = led.get("user:1");
@@ -62,98 +62,98 @@ describe("Ledger", () => {
     expect(record?.ref).toBe("abc123");
   });
 
-  test("upsert does not un-resolve an already-resolved note", () => {
-    const led = ledger();
-    led.upsert(makeNote());
-    led.markResolved("user:1");
+  test("upsert does not un-resolve an already-resolved note", async () => {
+    const led = await ledger();
+    await led.upsert(makeNote());
+    await led.markResolved("user:1");
     expect(led.isResolved("user:1")).toBe(true);
 
-    led.upsert(makeNote({ body: "edited body" }));
+    await led.upsert(makeNote({ body: "edited body" }));
     expect(led.isResolved("user:1")).toBe(true);
     expect(led.get("user:1")?.body).toBe("edited body");
   });
 
-  test("first sight defaults resolved=false", () => {
-    const led = ledger();
-    led.upsert(makeNote());
+  test("first sight defaults resolved=false", async () => {
+    const led = await ledger();
+    await led.upsert(makeNote());
     expect(led.open()).toHaveLength(1);
     expect(led.resolved()).toHaveLength(0);
   });
 
-  test("open and resolved partition records", () => {
-    const led = ledger();
-    led.upsert(makeNote({ noteId: "user:1" }));
-    led.upsert(makeNote({ noteId: "user:2" }));
-    led.markResolved("user:2");
+  test("open and resolved partition records", async () => {
+    const led = await ledger();
+    await led.upsert(makeNote({ noteId: "user:1" }));
+    await led.upsert(makeNote({ noteId: "user:2" }));
+    await led.markResolved("user:2");
 
     expect(led.open().map((r) => r.noteId)).toEqual(["user:1"]);
     expect(led.resolved().map((r) => r.noteId)).toEqual(["user:2"]);
   });
 
-  test("reconcile detects an orphaned entry", () => {
-    const led = ledger();
-    led.upsert(makeNote({ noteId: "user:1" }));
-    led.upsert(makeNote({ noteId: "user:2" }));
+  test("reconcile detects an orphaned entry", async () => {
+    const led = await ledger();
+    await led.upsert(makeNote({ noteId: "user:1" }));
+    await led.upsert(makeNote({ noteId: "user:2" }));
 
     const { orphaned } = led.reconcile(["user:1"]);
     expect(orphaned.map((r) => r.noteId)).toEqual(["user:2"]);
   });
 
-  test("reconcile reports nothing when all notes are present", () => {
-    const led = ledger();
-    led.upsert(makeNote({ noteId: "user:1" }));
+  test("reconcile reports nothing when all notes are present", async () => {
+    const led = await ledger();
+    await led.upsert(makeNote({ noteId: "user:1" }));
     expect(led.reconcile(["user:1", "user:99"]).orphaned).toEqual([]);
   });
 
-  test("different branches use different files", () => {
-    const a = ledger("feature-a");
-    const b = ledger("feature-b");
-    a.upsert(makeNote({ noteId: "user:1" }));
+  test("different branches use different files", async () => {
+    const a = await ledger("feature-a");
+    const b = await ledger("feature-b");
+    await a.upsert(makeNote({ noteId: "user:1" }));
 
     expect(a.filePath).not.toBe(b.filePath);
     expect(b.get("user:1")).toBeUndefined();
     expect(b.all()).toHaveLength(0);
   });
 
-  test("anchors to old side when newRange is null", () => {
-    const led = ledger();
-    led.upsert(makeNote({ noteId: "user:1", newRange: null, oldRange: [5, 8] }));
+  test("anchors to old side when newRange is null", async () => {
+    const led = await ledger();
+    await led.upsert(makeNote({ noteId: "user:1", newRange: null, oldRange: [5, 8] }));
     expect(led.get("user:1")?.anchor).toEqual({ side: "old", line: 5 });
   });
 
-  test("upsert throws when note has neither range", () => {
-    const led = ledger();
-    expect(() => led.upsert(makeNote({ newRange: null, oldRange: null }))).toThrow(
+  test("upsert throws when note has neither range", async () => {
+    const led = await ledger();
+    expect(led.upsert(makeNote({ newRange: null, oldRange: null }))).rejects.toThrow(
       "note has no anchor",
     );
   });
 
-  test("markResolved throws for unknown note", () => {
-    const led = ledger();
-    expect(() => led.markResolved("user:404")).toThrow("No ledger record");
+  test("markResolved throws for unknown note", async () => {
+    const led = await ledger();
+    expect(led.markResolved("user:404")).rejects.toThrow("No ledger record");
   });
 
-  test("loads tolerantly when file is missing", () => {
-    const led = ledger();
+  test("loads tolerantly when file is missing", async () => {
+    const led = await ledger();
     expect(led.all()).toEqual([]);
   });
 
-  test("sanitizes repo and branch into the filename", () => {
-    const led = new Ledger({
+  test("sanitizes repo and branch into the filename", async () => {
+    const led = await Ledger.open({
       dir,
       repo: "owner/repo",
       branch: "feature/foo bar",
       now,
     });
-    led.upsert(makeNote());
+    await led.upsert(makeNote());
     const name = led.filePath.slice(dir.length + 1);
     expect(name).toBe("owner-repo__feature-foo-bar.json");
   });
 
-  test("persists pretty-printed JSON with trailing newline", () => {
-    const led = ledger();
-    led.upsert(makeNote());
-    const raw = readFileSync(led.filePath, "utf8");
+  test("persists pretty-printed JSON with trailing newline", async () => {
+    const led = await ledger();
+    await led.upsert(makeNote());
+    const raw = await Bun.file(led.filePath).text();
     expect(raw.endsWith("\n")).toBe(true);
     expect(raw).toContain('  "records"');
   });

--- a/plugins/review/skills/hunk/scripts/ledger.ts
+++ b/plugins/review/skills/hunk/scripts/ledger.ts
@@ -1,5 +1,5 @@
 import { cli, command } from "cleye";
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { table } from "table";
@@ -57,40 +57,44 @@ export class Ledger {
     this.branch = opts.branch;
     this.now = opts.now ?? (() => new Date().toISOString());
     this.path = join(this.dir, `${sanitize(opts.repo)}__${sanitize(opts.branch)}.json`);
-    this.records = this.load();
+    this.records = new Map();
+  }
+
+  static async open(opts: LedgerOptions): Promise<Ledger> {
+    const ledger = new Ledger(opts);
+    ledger.records = await ledger.load();
+    return ledger;
   }
 
   get filePath(): string {
     return this.path;
   }
 
-  private load(): Map<string, LedgerRecord> {
-    let raw: string;
-    try {
-      raw = readFileSync(this.path, "utf8");
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-        return new Map();
-      }
-      throw error;
+  private async load(): Promise<Map<string, LedgerRecord>> {
+    const file = Bun.file(this.path);
+    if (!(await file.exists())) {
+      return new Map();
     }
-    const data = JSON.parse(raw) as LedgerFile;
+    const data = JSON.parse(await file.text()) as LedgerFile;
     return new Map(data.records.map((record) => [record.noteId, record]));
   }
 
-  private persist(): void {
-    mkdirSync(this.dir, { recursive: true });
+  private async persist(): Promise<void> {
+    await mkdir(this.dir, { recursive: true });
     const data: LedgerFile = {
       repo: this.repo,
       branch: this.branch,
       records: [...this.records.values()],
     };
     const tmp = `${this.path}.${process.pid}.tmp`;
-    writeFileSync(tmp, `${JSON.stringify(data, null, 2)}\n`);
-    renameSync(tmp, this.path);
+    await Bun.write(tmp, `${JSON.stringify(data, null, 2)}\n`);
+    const moved = Bun.spawnSync(["mv", tmp, this.path]);
+    if (moved.exitCode !== 0) {
+      throw new Error(`Failed to move ${tmp} to ${this.path}: ${moved.stderr.toString()}`);
+    }
   }
 
-  upsert(note: HunkNote): LedgerRecord {
+  async upsert(note: HunkNote): Promise<LedgerRecord> {
     const existing = this.records.get(note.noteId);
     const anchor = deriveAnchor(note);
     const record: LedgerRecord = {
@@ -108,11 +112,14 @@ export class Ledger {
       record.ref = existing.ref;
     }
     this.records.set(note.noteId, record);
-    this.persist();
+    await this.persist();
     return record;
   }
 
-  markResolved(noteId: string, info?: { action?: string; ref?: string }): LedgerRecord {
+  async markResolved(
+    noteId: string,
+    info?: { action?: string; ref?: string },
+  ): Promise<LedgerRecord> {
     const record = this.records.get(noteId);
     if (!record) {
       throw new Error(`No ledger record for note ${noteId}`);
@@ -125,7 +132,7 @@ export class Ledger {
       record.ref = info.ref;
     }
     record.updatedAt = this.now();
-    this.persist();
+    await this.persist();
     return record;
   }
 
@@ -163,19 +170,23 @@ function git(args: string[]): string | undefined {
   return out === "" ? undefined : out;
 }
 
-function resolveLedger(flags: { repo?: string; branch?: string; dir?: string }): Ledger {
+function resolveLedger(flags: {
+  repo?: string | undefined;
+  branch?: string | undefined;
+  dir?: string | undefined;
+}): Promise<Ledger> {
   const repo = flags.repo ?? git(["rev-parse", "--show-toplevel"]);
   const branch = flags.branch ?? git(["branch", "--show-current"]);
   const dir = flags.dir ?? defaultLedgerDir();
   if (!repo) {
     console.error("Could not determine repo; pass --repo");
-    process.exit(1);
+    return process.exit(1);
   }
   if (!branch) {
     console.error("Could not determine branch; pass --branch");
-    process.exit(1);
+    return process.exit(1);
   }
-  return new Ledger({ dir, repo, branch });
+  return Ledger.open({ dir, repo, branch });
 }
 
 function parseNotes(raw: string): HunkNote[] {
@@ -222,12 +233,12 @@ const resolveCmd = command(
       ref: { type: String, description: "Reference (e.g. commit sha)" },
     },
   },
-  (parsed) => {
-    const ledger = resolveLedger(parsed.flags);
-    const record = ledger.markResolved(parsed._.noteId, {
-      action: parsed.flags.action,
-      ref: parsed.flags.ref,
-    });
+  async (parsed) => {
+    const ledger = await resolveLedger(parsed.flags);
+    const info: { action?: string; ref?: string } = {};
+    if (parsed.flags.action !== undefined) info.action = parsed.flags.action;
+    if (parsed.flags.ref !== undefined) info.ref = parsed.flags.ref;
+    const record = await ledger.markResolved(parsed._.noteId, info);
     console.error(`Resolved ${record.noteId}`);
   },
 );
@@ -238,10 +249,10 @@ const upsertCmd = command(
     flags: { ...storageFlags },
   },
   async (parsed) => {
-    const ledger = resolveLedger(parsed.flags);
+    const ledger = await resolveLedger(parsed.flags);
     const notes = parseNotes(await Bun.stdin.text());
     for (const note of notes) {
-      ledger.upsert(note);
+      await ledger.upsert(note);
     }
     console.error(`Upserted ${notes.length} note(s)`);
   },
@@ -257,8 +268,8 @@ const listCmd = command(
       json: { type: Boolean, description: "Emit JSON", default: false },
     },
   },
-  (parsed) => {
-    const ledger = resolveLedger(parsed.flags);
+  async (parsed) => {
+    const ledger = await resolveLedger(parsed.flags);
     let records = ledger.all();
     if (parsed.flags.open) records = records.filter((r) => !r.resolved);
     if (parsed.flags.resolved) records = records.filter((r) => r.resolved);
@@ -272,7 +283,7 @@ const reconcileCmd = command(
     flags: { ...storageFlags },
   },
   async (parsed) => {
-    const ledger = resolveLedger(parsed.flags);
+    const ledger = await resolveLedger(parsed.flags);
     const raw = (await Bun.stdin.text()).trim();
     let noteIds: string[];
     if (raw.startsWith("[") || raw.startsWith("{")) {

--- a/plugins/review/skills/hunk/scripts/ledger.ts
+++ b/plugins/review/skills/hunk/scripts/ledger.ts
@@ -1,0 +1,296 @@
+import { cli, command } from "cleye";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { table } from "table";
+import { type AnchorSide, type HunkNote, deriveAnchor } from "./note";
+
+export type { AnchorSide, HunkNote, NoteSource } from "./note";
+
+export interface LedgerRecord {
+  noteId: string;
+  filePath: string;
+  anchor: { side: AnchorSide; line: number };
+  body: string;
+  resolved: boolean;
+  action?: string;
+  ref?: string;
+  updatedAt: string;
+}
+
+export interface LedgerOptions {
+  dir: string;
+  repo: string;
+  branch: string;
+  now?: () => string;
+}
+
+export interface ReconcileResult {
+  orphaned: LedgerRecord[];
+}
+
+export function defaultLedgerDir(): string {
+  return join(homedir(), ".claude", "plugins", "data", "claude-review", "hunk-ledger");
+}
+
+function sanitize(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+interface LedgerFile {
+  repo: string;
+  branch: string;
+  records: LedgerRecord[];
+}
+
+export class Ledger {
+  private readonly dir: string;
+  private readonly repo: string;
+  private readonly branch: string;
+  private readonly now: () => string;
+  private readonly path: string;
+  private records: Map<string, LedgerRecord>;
+
+  constructor(opts: LedgerOptions) {
+    this.dir = opts.dir;
+    this.repo = opts.repo;
+    this.branch = opts.branch;
+    this.now = opts.now ?? (() => new Date().toISOString());
+    this.path = join(this.dir, `${sanitize(opts.repo)}__${sanitize(opts.branch)}.json`);
+    this.records = this.load();
+  }
+
+  get filePath(): string {
+    return this.path;
+  }
+
+  private load(): Map<string, LedgerRecord> {
+    let raw: string;
+    try {
+      raw = readFileSync(this.path, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return new Map();
+      }
+      throw error;
+    }
+    const data = JSON.parse(raw) as LedgerFile;
+    return new Map(data.records.map((record) => [record.noteId, record]));
+  }
+
+  private persist(): void {
+    mkdirSync(this.dir, { recursive: true });
+    const data: LedgerFile = {
+      repo: this.repo,
+      branch: this.branch,
+      records: [...this.records.values()],
+    };
+    const tmp = `${this.path}.${process.pid}.tmp`;
+    writeFileSync(tmp, `${JSON.stringify(data, null, 2)}\n`);
+    renameSync(tmp, this.path);
+  }
+
+  upsert(note: HunkNote): LedgerRecord {
+    const existing = this.records.get(note.noteId);
+    const anchor = deriveAnchor(note);
+    const record: LedgerRecord = {
+      noteId: note.noteId,
+      filePath: note.filePath,
+      anchor: { side: anchor.side, line: anchor.line },
+      body: note.body,
+      resolved: existing?.resolved ?? false,
+      updatedAt: this.now(),
+    };
+    if (existing?.action !== undefined) {
+      record.action = existing.action;
+    }
+    if (existing?.ref !== undefined) {
+      record.ref = existing.ref;
+    }
+    this.records.set(note.noteId, record);
+    this.persist();
+    return record;
+  }
+
+  markResolved(noteId: string, info?: { action?: string; ref?: string }): LedgerRecord {
+    const record = this.records.get(noteId);
+    if (!record) {
+      throw new Error(`No ledger record for note ${noteId}`);
+    }
+    record.resolved = true;
+    if (info?.action !== undefined) {
+      record.action = info.action;
+    }
+    if (info?.ref !== undefined) {
+      record.ref = info.ref;
+    }
+    record.updatedAt = this.now();
+    this.persist();
+    return record;
+  }
+
+  isResolved(noteId: string): boolean {
+    return this.records.get(noteId)?.resolved ?? false;
+  }
+
+  get(noteId: string): LedgerRecord | undefined {
+    return this.records.get(noteId);
+  }
+
+  all(): LedgerRecord[] {
+    return [...this.records.values()];
+  }
+
+  open(): LedgerRecord[] {
+    return this.all().filter((record) => !record.resolved);
+  }
+
+  resolved(): LedgerRecord[] {
+    return this.all().filter((record) => record.resolved);
+  }
+
+  reconcile(currentNoteIds: string[]): ReconcileResult {
+    const present = new Set(currentNoteIds);
+    const orphaned = this.all().filter((record) => !present.has(record.noteId));
+    return { orphaned };
+  }
+}
+
+function git(args: string[]): string | undefined {
+  const result = Bun.spawnSync(["git", ...args]);
+  if (result.exitCode !== 0) return undefined;
+  const out = result.stdout.toString().trim();
+  return out === "" ? undefined : out;
+}
+
+function resolveLedger(flags: { repo?: string; branch?: string; dir?: string }): Ledger {
+  const repo = flags.repo ?? git(["rev-parse", "--show-toplevel"]);
+  const branch = flags.branch ?? git(["branch", "--show-current"]);
+  const dir = flags.dir ?? defaultLedgerDir();
+  if (!repo) {
+    console.error("Could not determine repo; pass --repo");
+    process.exit(1);
+  }
+  if (!branch) {
+    console.error("Could not determine branch; pass --branch");
+    process.exit(1);
+  }
+  return new Ledger({ dir, repo, branch });
+}
+
+function parseNotes(raw: string): HunkNote[] {
+  const data = JSON.parse(raw) as { comments: HunkNote[] } | HunkNote[];
+  return Array.isArray(data) ? data : data.comments;
+}
+
+function printRecords(records: LedgerRecord[], asJson: boolean): void {
+  if (asJson) {
+    console.log(JSON.stringify(records, null, 2));
+    return;
+  }
+  if (records.length === 0) {
+    console.error("No records");
+    return;
+  }
+  const rows = [
+    ["noteId", "file", "anchor", "status", "action", "ref"],
+    ...records.map((r) => [
+      r.noteId,
+      r.filePath,
+      `${r.anchor.side}:${r.anchor.line}`,
+      r.resolved ? "resolved" : "open",
+      r.action ?? "",
+      r.ref ?? "",
+    ]),
+  ];
+  console.log(table(rows));
+}
+
+const storageFlags = {
+  repo: { type: String, description: "Repo identifier (default: git toplevel)" },
+  branch: { type: String, description: "Branch name (default: current branch)" },
+  dir: { type: String, description: "Ledger storage dir (default: plugin data dir)" },
+} as const;
+
+const resolveCmd = command(
+  {
+    name: "resolve",
+    parameters: ["<noteId>"],
+    flags: {
+      ...storageFlags,
+      action: { type: String, description: "Action taken (e.g. applied)" },
+      ref: { type: String, description: "Reference (e.g. commit sha)" },
+    },
+  },
+  (parsed) => {
+    const ledger = resolveLedger(parsed.flags);
+    const record = ledger.markResolved(parsed._.noteId, {
+      action: parsed.flags.action,
+      ref: parsed.flags.ref,
+    });
+    console.error(`Resolved ${record.noteId}`);
+  },
+);
+
+const upsertCmd = command(
+  {
+    name: "upsert",
+    flags: { ...storageFlags },
+  },
+  async (parsed) => {
+    const ledger = resolveLedger(parsed.flags);
+    const notes = parseNotes(await Bun.stdin.text());
+    for (const note of notes) {
+      ledger.upsert(note);
+    }
+    console.error(`Upserted ${notes.length} note(s)`);
+  },
+);
+
+const listCmd = command(
+  {
+    name: "list",
+    flags: {
+      ...storageFlags,
+      open: { type: Boolean, description: "Only open records", default: false },
+      resolved: { type: Boolean, description: "Only resolved records", default: false },
+      json: { type: Boolean, description: "Emit JSON", default: false },
+    },
+  },
+  (parsed) => {
+    const ledger = resolveLedger(parsed.flags);
+    let records = ledger.all();
+    if (parsed.flags.open) records = records.filter((r) => !r.resolved);
+    if (parsed.flags.resolved) records = records.filter((r) => r.resolved);
+    printRecords(records, parsed.flags.json);
+  },
+);
+
+const reconcileCmd = command(
+  {
+    name: "reconcile",
+    flags: { ...storageFlags },
+  },
+  async (parsed) => {
+    const ledger = resolveLedger(parsed.flags);
+    const raw = (await Bun.stdin.text()).trim();
+    let noteIds: string[];
+    if (raw.startsWith("[") || raw.startsWith("{")) {
+      noteIds = parseNotes(raw).map((n) => n.noteId);
+    } else {
+      noteIds = raw
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line !== "");
+    }
+    const { orphaned } = ledger.reconcile(noteIds);
+    console.log(JSON.stringify(orphaned, null, 2));
+  },
+);
+
+if (import.meta.main) {
+  cli({
+    name: "ledger",
+    commands: [resolveCmd, upsertCmd, listCmd, reconcileCmd],
+  });
+}

--- a/plugins/review/skills/hunk/scripts/ledger.ts
+++ b/plugins/review/skills/hunk/scripts/ledger.ts
@@ -86,12 +86,7 @@ export class Ledger {
       branch: this.branch,
       records: [...this.records.values()],
     };
-    const tmp = `${this.path}.${process.pid}.tmp`;
-    await Bun.write(tmp, `${JSON.stringify(data, null, 2)}\n`);
-    const moved = Bun.spawnSync(["mv", tmp, this.path]);
-    if (moved.exitCode !== 0) {
-      throw new Error(`Failed to move ${tmp} to ${this.path}: ${moved.stderr.toString()}`);
-    }
+    await Bun.write(this.path, `${JSON.stringify(data, null, 2)}\n`);
   }
 
   async upsert(note: HunkNote): Promise<LedgerRecord> {

--- a/plugins/review/skills/hunk/scripts/ledger.ts
+++ b/plugins/review/skills/hunk/scripts/ledger.ts
@@ -1,9 +1,9 @@
-import { cli, command } from "cleye";
 import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { cli, command } from "cleye";
 import { table } from "table";
-import { type AnchorSide, type HunkNote, deriveAnchor } from "./note";
+import { type AnchorSide, deriveAnchor, type HunkNote } from "./note";
 
 export type { AnchorSide, HunkNote, NoteSource } from "./note";
 

--- a/plugins/review/skills/hunk/scripts/mapping.test.ts
+++ b/plugins/review/skills/hunk/scripts/mapping.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type HunkNote,
+  noteAnchor,
+  parseDiff,
+  toGitHubComment,
+  toGitLabPosition,
+  validateInDiff,
+} from "./mapping";
+
+const SETTINGS_DIFF = `diff --git a/user/settings.json b/user/settings.json
+index af2993b3..eb5273d5 100644
+--- a/user/settings.json
++++ b/user/settings.json
+@@ -147,7 +147,7 @@
+       "source": {
+         "source": "github",
+         "repo": "max-sixty/worktrunk",
+-        "ref": "v0.52.0"
++        "ref": "v0.55.0"
+       }
+     },
+     "linear-cli": {`;
+
+const DELETION_DIFF = `diff --git a/old.txt b/old.txt
+index 1111111..2222222 100644
+--- a/old.txt
++++ b/old.txt
+@@ -10,4 +10,3 @@ context
+ keep one
+-removed line
+ keep two
+ keep three`;
+
+const RENAME_DIFF = `diff --git a/src/old-name.ts b/src/new-name.ts
+similarity index 90%
+rename from src/old-name.ts
+rename to src/new-name.ts
+index 3333333..4444444 100644
+--- a/src/old-name.ts
++++ b/src/new-name.ts
+@@ -5,3 +5,3 @@ export function foo() {
+   const a = 1;
+-  return a;
++  return a + 1;
+ }`;
+
+function note(overrides: Partial<HunkNote>): HunkNote {
+  return {
+    noteId: "user:1",
+    source: "user",
+    filePath: "user/settings.json",
+    hunkIndex: 0,
+    newRange: null,
+    oldRange: null,
+    body: "comment",
+    ...overrides,
+  };
+}
+
+describe("parseDiff", () => {
+  test("collects new-side and old-side line sets for a modification", () => {
+    const parsed = parseDiff(SETTINGS_DIFF);
+    const file = parsed.get("user/settings.json");
+    expect(file).toBeDefined();
+    expect(file?.newLines.has(150)).toBe(true);
+    expect(file?.oldLines.has(150)).toBe(true);
+    expect(file?.newLines.has(147)).toBe(true);
+    expect(file?.newLines.has(1)).toBe(false);
+    expect(file?.oldPath).toBeUndefined();
+  });
+
+  test("records old-side line for a deletion", () => {
+    const parsed = parseDiff(DELETION_DIFF);
+    const file = parsed.get("old.txt");
+    expect(file?.oldLines.has(11)).toBe(true);
+    expect(file?.oldLines.has(13)).toBe(true);
+    expect(file?.newLines.has(13)).toBe(false);
+  });
+
+  test("tracks rename old/new paths", () => {
+    const parsed = parseDiff(RENAME_DIFF);
+    expect(parsed.has("src/new-name.ts")).toBe(true);
+    expect(parsed.has("src/old-name.ts")).toBe(false);
+    expect(parsed.get("src/new-name.ts")?.oldPath).toBe("src/old-name.ts");
+  });
+
+  test("classifies an added line that looks like a +++ header as new-side content", () => {
+    const diff = `diff --git a/a.txt b/a.txt
+index 1111111..2222222 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1,2 +1,3 @@
+ context
++++ still added
+ trailing
+`;
+    const file = parseDiff(diff).get("a.txt");
+    // context=1, "+++ still added"=new 2, trailing=new 3 / old 2.
+    expect(file?.newLines.has(1)).toBe(true);
+    expect(file?.newLines.has(2)).toBe(true);
+    expect(file?.newLines.has(3)).toBe(true);
+    expect(file?.oldLines.has(2)).toBe(true);
+    expect(file?.oldLines.has(3)).toBe(false);
+  });
+
+  test("classifies a deleted line that looks like a --- header as old-side content", () => {
+    const diff = `diff --git a/b.txt b/b.txt
+index 1111111..2222222 100644
+--- a/b.txt
++++ b/b.txt
+@@ -1,3 +1,2 @@
+ context
+--- still removed
+ trailing
+`;
+    const file = parseDiff(diff).get("b.txt");
+    // context=old 1, "--- still removed"=old 2, trailing=old 3 / new 2.
+    expect(file?.oldLines.has(1)).toBe(true);
+    expect(file?.oldLines.has(2)).toBe(true);
+    expect(file?.oldLines.has(3)).toBe(true);
+    expect(file?.newLines.has(2)).toBe(true);
+    expect(file?.newLines.has(3)).toBe(false);
+  });
+
+  test("a newline-terminated diff does not create a phantom line past the hunk", () => {
+    const parsed = parseDiff(`${SETTINGS_DIFF}\n`);
+    const file = parsed.get("user/settings.json");
+    // Last new-side line in the hunk is 153 (147..153). 154 is past the hunk.
+    expect(file?.newLines.has(153)).toBe(true);
+    expect(file?.newLines.has(154)).toBe(false);
+  });
+});
+
+describe("noteAnchor", () => {
+  test("prefers new-side when newRange is present", () => {
+    expect(noteAnchor(note({ newRange: [150, 150] }))).toEqual({
+      side: "new",
+      line: 150,
+      path: "user/settings.json",
+    });
+  });
+
+  test("falls back to old-side when only oldRange is present", () => {
+    expect(noteAnchor(note({ filePath: "old.txt", oldRange: [11, 11] }))).toEqual({
+      side: "old",
+      line: 11,
+      path: "old.txt",
+    });
+  });
+});
+
+describe("validateInDiff", () => {
+  test("accepts a note on a changed new-side line", () => {
+    const parsed = parseDiff(SETTINGS_DIFF);
+    expect(validateInDiff(note({ newRange: [150, 150] }), parsed)).toEqual({ ok: true });
+  });
+
+  test("rejects an off-diff anchor", () => {
+    const parsed = parseDiff(SETTINGS_DIFF);
+    const result = validateInDiff(note({ newRange: [1, 1] }), parsed);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toContain("line 1");
+  });
+
+  test("accepts an old-side deletion anchor", () => {
+    const parsed = parseDiff(DELETION_DIFF);
+    expect(
+      validateInDiff(note({ filePath: "old.txt", oldRange: [11, 11] }), parsed),
+    ).toEqual({ ok: true });
+  });
+
+  test("rejects a file not present in the diff", () => {
+    const parsed = parseDiff(SETTINGS_DIFF);
+    const result = validateInDiff(note({ filePath: "missing.ts", newRange: [5, 5] }), parsed);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toContain("not in the diff");
+  });
+
+  test("rejects an anchor one line past a newline-terminated hunk", () => {
+    const parsed = parseDiff(`${SETTINGS_DIFF}\n`);
+    const result = validateInDiff(note({ newRange: [154, 154] }), parsed);
+    expect(result.ok).toBe(false);
+  });
+
+  test("accepts an added line whose text starts with +++", () => {
+    const diff = `diff --git a/a.txt b/a.txt
+index 1111111..2222222 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1,2 +1,3 @@
+ context
++++ still added
+ trailing
+`;
+    const parsed = parseDiff(diff);
+    expect(validateInDiff(note({ filePath: "a.txt", newRange: [2, 2] }), parsed)).toEqual({
+      ok: true,
+    });
+  });
+
+  test("accepts a deleted line whose text starts with ---", () => {
+    const diff = `diff --git a/b.txt b/b.txt
+index 1111111..2222222 100644
+--- a/b.txt
++++ b/b.txt
+@@ -1,3 +1,2 @@
+ context
+--- still removed
+ trailing
+`;
+    const parsed = parseDiff(diff);
+    expect(validateInDiff(note({ filePath: "b.txt", oldRange: [2, 2] }), parsed)).toEqual({
+      ok: true,
+    });
+  });
+});
+
+describe("toGitHubComment", () => {
+  test("maps a new-side note to RIGHT", () => {
+    expect(toGitHubComment(note({ newRange: [150, 150] }), { commitId: "abc123" })).toEqual({
+      path: "user/settings.json",
+      line: 150,
+      side: "RIGHT",
+      commit_id: "abc123",
+      body: "comment",
+    });
+  });
+
+  test("maps an old-side deletion to LEFT", () => {
+    expect(
+      toGitHubComment(note({ filePath: "old.txt", oldRange: [11, 11] }), { commitId: "abc123" }),
+    ).toEqual({
+      path: "old.txt",
+      line: 11,
+      side: "LEFT",
+      commit_id: "abc123",
+      body: "comment",
+    });
+  });
+});
+
+describe("toGitLabPosition", () => {
+  const refs = { base_sha: "base", head_sha: "head", start_sha: "start" };
+
+  test("sets new_line for a new-side note and defaults old_path to new_path", () => {
+    expect(
+      toGitLabPosition(note({ newRange: [150, 150] }), refs, { newPath: "user/settings.json" }),
+    ).toEqual({
+      position_type: "text",
+      base_sha: "base",
+      head_sha: "head",
+      start_sha: "start",
+      new_path: "user/settings.json",
+      old_path: "user/settings.json",
+      new_line: 150,
+    });
+  });
+
+  test("sets old_line for an old-side deletion", () => {
+    expect(
+      toGitLabPosition(note({ filePath: "old.txt", oldRange: [11, 11] }), refs, {
+        newPath: "old.txt",
+      }),
+    ).toEqual({
+      position_type: "text",
+      base_sha: "base",
+      head_sha: "head",
+      start_sha: "start",
+      new_path: "old.txt",
+      old_path: "old.txt",
+      old_line: 11,
+    });
+  });
+
+  test("carries distinct old_path for a rename", () => {
+    expect(
+      toGitLabPosition(note({ filePath: "src/new-name.ts", newRange: [7, 7] }), refs, {
+        newPath: "src/new-name.ts",
+        oldPath: "src/old-name.ts",
+      }),
+    ).toEqual({
+      position_type: "text",
+      base_sha: "base",
+      head_sha: "head",
+      start_sha: "start",
+      new_path: "src/new-name.ts",
+      old_path: "src/old-name.ts",
+      new_line: 7,
+    });
+  });
+});

--- a/plugins/review/skills/hunk/scripts/mapping.test.ts
+++ b/plugins/review/skills/hunk/scripts/mapping.test.ts
@@ -165,9 +165,9 @@ describe("validateInDiff", () => {
 
   test("accepts an old-side deletion anchor", () => {
     const parsed = parseDiff(DELETION_DIFF);
-    expect(
-      validateInDiff(note({ filePath: "old.txt", oldRange: [11, 11] }), parsed),
-    ).toEqual({ ok: true });
+    expect(validateInDiff(note({ filePath: "old.txt", oldRange: [11, 11] }), parsed)).toEqual({
+      ok: true,
+    });
   });
 
   test("rejects a file not present in the diff", () => {

--- a/plugins/review/skills/hunk/scripts/mapping.ts
+++ b/plugins/review/skills/hunk/scripts/mapping.ts
@@ -93,32 +93,36 @@ export function parseDiff(diffText: string): ParsedDiff {
 
     const gitMatch = GIT_HEADER.exec(line);
     if (gitMatch) {
+      const oldFromHeader = gitMatch[1];
       const newPath = gitMatch[2];
-      currentKey = newPath;
-      current = { newLines: new Set(), oldLines: new Set() };
-      if (gitMatch[1] !== gitMatch[2]) current.oldPath = gitMatch[1];
-      files.set(currentKey, current);
-      renameFrom = undefined;
+      if (oldFromHeader !== undefined && newPath !== undefined) {
+        currentKey = newPath;
+        current = { newLines: new Set(), oldLines: new Set() };
+        if (oldFromHeader !== newPath) current.oldPath = oldFromHeader;
+        files.set(currentKey, current);
+        renameFrom = undefined;
+      }
       continue;
     }
 
     const renameFromMatch = RENAME_FROM.exec(line);
     if (renameFromMatch) {
       renameFrom = renameFromMatch[1];
-      if (current) current.oldPath = renameFrom;
+      if (current && renameFrom !== undefined) current.oldPath = renameFrom;
       continue;
     }
 
     const renameToMatch = RENAME_TO.exec(line);
     if (renameToMatch && current) {
-      rename(renameToMatch[1]);
-      if (renameFrom) current.oldPath = renameFrom;
+      const toPath = renameToMatch[1];
+      if (toPath !== undefined) rename(toPath);
+      if (renameFrom !== undefined) current.oldPath = renameFrom;
       continue;
     }
 
     if (line.startsWith("--- ")) {
       const oldMatch = OLD_PATH.exec(line);
-      if (oldMatch && current) {
+      if (oldMatch && oldMatch[1] !== undefined && current) {
         const oldPath = stripDevNull(oldMatch[1]);
         if (oldPath && currentKey && oldPath !== currentKey) current.oldPath = oldPath;
       }
@@ -127,7 +131,7 @@ export function parseDiff(diffText: string): ParsedDiff {
 
     if (line.startsWith("+++ ")) {
       const newMatch = NEW_PATH.exec(line);
-      if (newMatch && current) {
+      if (newMatch && newMatch[1] !== undefined && current) {
         const newPath = stripDevNull(newMatch[1]);
         if (newPath && currentKey && newPath !== currentKey) {
           if (current.oldPath === undefined) {
@@ -144,7 +148,6 @@ export function parseDiff(diffText: string): ParsedDiff {
       oldLine = Number(hunkMatch[1]);
       newLine = Number(hunkMatch[3]);
       inHunk = true;
-      continue;
     }
   }
 
@@ -272,15 +275,15 @@ const mapCmd = command(
 
     if (platform !== "github" && platform !== "gitlab") {
       console.error("--platform must be github or gitlab");
-      process.exit(1);
+      return process.exit(1);
     }
-    if (!notes || !diff || !commit) {
+    if (notes === undefined || diff === undefined || commit === undefined) {
       console.error("--notes, --diff, and --commit are required");
-      process.exit(1);
+      return process.exit(1);
     }
-    if (platform === "gitlab" && (!base || !start)) {
+    if (platform === "gitlab" && (base === undefined || start === undefined)) {
       console.error("gitlab requires --base and --start");
-      process.exit(1);
+      return process.exit(1);
     }
 
     let noteList: HunkNote[];
@@ -290,7 +293,7 @@ const mapCmd = command(
       diffText = await Bun.file(diff).text();
     } catch (error) {
       console.error((error as Error).message);
-      process.exit(1);
+      return process.exit(1);
     }
 
     const parsedDiff = parseDiff(diffText);
@@ -305,12 +308,14 @@ const mapCmd = command(
       }
       if (platform === "github") {
         payloads.push(toGitHubComment(note, { commitId: commit }));
-      } else {
+      } else if (base !== undefined && start !== undefined) {
         const fileDiff = parsedDiff.get(note.filePath);
+        const opts: { newPath: string; oldPath?: string } = { newPath: note.filePath };
+        if (fileDiff?.oldPath !== undefined) opts.oldPath = fileDiff.oldPath;
         const position = toGitLabPosition(
           note,
-          { base_sha: base as string, head_sha: commit, start_sha: start as string },
-          { newPath: note.filePath, oldPath: fileDiff?.oldPath },
+          { base_sha: base, head_sha: commit, start_sha: start },
+          opts,
         );
         payloads.push({ body: note.body, position });
       }

--- a/plugins/review/skills/hunk/scripts/mapping.ts
+++ b/plugins/review/skills/hunk/scripts/mapping.ts
@@ -1,5 +1,5 @@
 import { cli, command } from "cleye";
-import { type Anchor, type HunkNote, deriveAnchor } from "./note";
+import { type Anchor, deriveAnchor, type HunkNote } from "./note";
 
 export type { Anchor, HunkNote } from "./note";
 

--- a/plugins/review/skills/hunk/scripts/mapping.ts
+++ b/plugins/review/skills/hunk/scripts/mapping.ts
@@ -1,0 +1,328 @@
+import { cli, command } from "cleye";
+import { type Anchor, type HunkNote, deriveAnchor } from "./note";
+
+export type { Anchor, HunkNote } from "./note";
+
+export type FileDiff = {
+  newLines: Set<number>;
+  oldLines: Set<number>;
+  oldPath?: string;
+};
+
+export type ParsedDiff = Map<string, FileDiff>;
+
+const GIT_HEADER = /^diff --git a\/(.+) b\/(.+)$/;
+const RENAME_FROM = /^rename from (.+)$/;
+const RENAME_TO = /^rename to (.+)$/;
+const OLD_PATH = /^--- (?:a\/)?(.+)$/;
+const NEW_PATH = /^\+\+\+ (?:b\/)?(.+)$/;
+const HUNK_HEADER = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
+function stripDevNull(path: string): string | undefined {
+  return path === "/dev/null" ? undefined : path;
+}
+
+/**
+ * Parse a standard unified diff into per-file line sets.
+ *
+ * `newLines` holds every new-side line number present within a hunk (added or
+ * context); `oldLines` holds every old-side line number present within a hunk
+ * (removed or context). These sets are the source of truth for the in-diff
+ * pre-check that prevents GitHub's 422 "Line could not be resolved".
+ *
+ * The parser tracks an explicit `inHunk` flag so that header-shaped body lines
+ * (an added `+++ foo` or a deleted `--- foo`) are classified by their leading
+ * character rather than mistaken for file headers.
+ */
+export function parseDiff(diffText: string): ParsedDiff {
+  const files: ParsedDiff = new Map();
+  let current: FileDiff | undefined;
+  let currentKey: string | undefined;
+  let renameFrom: string | undefined;
+  let inHunk = false;
+  let newLine = 0;
+  let oldLine = 0;
+
+  const lines = diffText.split("\n");
+  if (lines.length > 0 && lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+
+  function rename(toPath: string): void {
+    if (!current) return;
+    if (currentKey && currentKey !== toPath) {
+      files.delete(currentKey);
+      files.set(toPath, current);
+      currentKey = toPath;
+    }
+  }
+
+  for (const line of lines) {
+    if (inHunk) {
+      const firstChar = line[0];
+      if (firstChar === "+") {
+        current?.newLines.add(newLine);
+        newLine++;
+        continue;
+      }
+      if (firstChar === "-") {
+        current?.oldLines.add(oldLine);
+        oldLine++;
+        continue;
+      }
+      if (firstChar === " ") {
+        current?.newLines.add(newLine);
+        current?.oldLines.add(oldLine);
+        newLine++;
+        oldLine++;
+        continue;
+      }
+      if (firstChar === "\\") {
+        // "\ No newline at end of file" marker; not a real line.
+        continue;
+      }
+      if (line === "") {
+        // Trailing split artifact from a newline-terminated diff. A real empty
+        // context line is " " (leading space) and is handled above.
+        continue;
+      }
+      // Anything else (diff --git, @@, ---/+++ of the next file) ends the hunk
+      // and falls through to the header logic below.
+      inHunk = false;
+    }
+
+    const gitMatch = GIT_HEADER.exec(line);
+    if (gitMatch) {
+      const newPath = gitMatch[2];
+      currentKey = newPath;
+      current = { newLines: new Set(), oldLines: new Set() };
+      if (gitMatch[1] !== gitMatch[2]) current.oldPath = gitMatch[1];
+      files.set(currentKey, current);
+      renameFrom = undefined;
+      continue;
+    }
+
+    const renameFromMatch = RENAME_FROM.exec(line);
+    if (renameFromMatch) {
+      renameFrom = renameFromMatch[1];
+      if (current) current.oldPath = renameFrom;
+      continue;
+    }
+
+    const renameToMatch = RENAME_TO.exec(line);
+    if (renameToMatch && current) {
+      rename(renameToMatch[1]);
+      if (renameFrom) current.oldPath = renameFrom;
+      continue;
+    }
+
+    if (line.startsWith("--- ")) {
+      const oldMatch = OLD_PATH.exec(line);
+      if (oldMatch && current) {
+        const oldPath = stripDevNull(oldMatch[1]);
+        if (oldPath && currentKey && oldPath !== currentKey) current.oldPath = oldPath;
+      }
+      continue;
+    }
+
+    if (line.startsWith("+++ ")) {
+      const newMatch = NEW_PATH.exec(line);
+      if (newMatch && current) {
+        const newPath = stripDevNull(newMatch[1]);
+        if (newPath && currentKey && newPath !== currentKey) {
+          if (current.oldPath === undefined) {
+            current.oldPath = currentKey;
+          }
+          rename(newPath);
+        }
+      }
+      continue;
+    }
+
+    const hunkMatch = HUNK_HEADER.exec(line);
+    if (hunkMatch) {
+      oldLine = Number(hunkMatch[1]);
+      newLine = Number(hunkMatch[3]);
+      inHunk = true;
+      continue;
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Resolve a note's anchor. Thin wrapper over the shared `deriveAnchor` so
+ * existing imports of `noteAnchor` keep working.
+ */
+export function noteAnchor(note: HunkNote): Anchor {
+  return deriveAnchor(note);
+}
+
+export type ValidationResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Pre-check that a note's anchor lands on a line the platform will accept.
+ * Hunk allows anchoring on unchanged context lines outside the diff, which
+ * GitHub rejects with 422 "Line could not be resolved".
+ */
+export function validateInDiff(note: HunkNote, parsed: ParsedDiff): ValidationResult {
+  const anchor = noteAnchor(note);
+  const fileDiff = parsed.get(anchor.path);
+  if (!fileDiff) {
+    return { ok: false, reason: `File ${anchor.path} is not in the diff` };
+  }
+
+  const lineSet = anchor.side === "new" ? fileDiff.newLines : fileDiff.oldLines;
+  if (!lineSet.has(anchor.line)) {
+    return {
+      ok: false,
+      reason: `${anchor.side === "new" ? "New" : "Old"}-side line ${anchor.line} of ${anchor.path} is not within a diff hunk`,
+    };
+  }
+
+  return { ok: true };
+}
+
+export type GitHubComment = {
+  path: string;
+  line: number;
+  side: "RIGHT" | "LEFT";
+  commit_id: string;
+  body: string;
+};
+
+/** Map a note to a GitHub review-comment payload. new-side -> RIGHT, old-side -> LEFT. */
+export function toGitHubComment(note: HunkNote, opts: { commitId: string }): GitHubComment {
+  const anchor = noteAnchor(note);
+  return {
+    path: anchor.path,
+    line: anchor.line,
+    side: anchor.side === "new" ? "RIGHT" : "LEFT",
+    commit_id: opts.commitId,
+    body: note.body,
+  };
+}
+
+export type GitLabRefs = {
+  base_sha: string;
+  head_sha: string;
+  start_sha: string;
+};
+
+export type GitLabPosition = {
+  position_type: "text";
+  base_sha: string;
+  head_sha: string;
+  start_sha: string;
+  new_path: string;
+  old_path: string;
+  new_line?: number;
+  old_line?: number;
+};
+
+/**
+ * Map a note to a GitLab discussion `position`. Sets `new_line` for new-side
+ * anchors and `old_line` for old-side. `old_path` defaults to `new_path` when
+ * the file is not a rename.
+ */
+export function toGitLabPosition(
+  note: HunkNote,
+  refs: GitLabRefs,
+  opts: { newPath: string; oldPath?: string },
+): GitLabPosition {
+  const anchor = noteAnchor(note);
+  const position: GitLabPosition = {
+    position_type: "text",
+    base_sha: refs.base_sha,
+    head_sha: refs.head_sha,
+    start_sha: refs.start_sha,
+    new_path: opts.newPath,
+    old_path: opts.oldPath ?? opts.newPath,
+  };
+
+  if (anchor.side === "new") {
+    position.new_line = anchor.line;
+  } else {
+    position.old_line = anchor.line;
+  }
+
+  return position;
+}
+
+function readNotes(raw: string): HunkNote[] {
+  const data = JSON.parse(raw) as { comments: HunkNote[] } | HunkNote[];
+  return Array.isArray(data) ? data : data.comments;
+}
+
+const mapCmd = command(
+  {
+    name: "map",
+    flags: {
+      platform: { type: String, description: "Target platform: github or gitlab" },
+      notes: { type: String, description: "Path to notes JSON ({comments:[...]} or [...])" },
+      diff: { type: String, description: "Path to unified diff text" },
+      commit: { type: String, description: "Head commit SHA" },
+      base: { type: String, description: "Base SHA (gitlab)" },
+      start: { type: String, description: "Start SHA (gitlab)" },
+    },
+  },
+  async (parsed) => {
+    const { platform, notes, diff, commit, base, start } = parsed.flags;
+
+    if (platform !== "github" && platform !== "gitlab") {
+      console.error("--platform must be github or gitlab");
+      process.exit(1);
+    }
+    if (!notes || !diff || !commit) {
+      console.error("--notes, --diff, and --commit are required");
+      process.exit(1);
+    }
+    if (platform === "gitlab" && (!base || !start)) {
+      console.error("gitlab requires --base and --start");
+      process.exit(1);
+    }
+
+    let noteList: HunkNote[];
+    let diffText: string;
+    try {
+      noteList = readNotes(await Bun.file(notes).text());
+      diffText = await Bun.file(diff).text();
+    } catch (error) {
+      console.error((error as Error).message);
+      process.exit(1);
+    }
+
+    const parsedDiff = parseDiff(diffText);
+    const payloads: unknown[] = [];
+    const dropped: { noteId: string; reason: string }[] = [];
+
+    for (const note of noteList) {
+      const result = validateInDiff(note, parsedDiff);
+      if (!result.ok) {
+        dropped.push({ noteId: note.noteId, reason: result.reason });
+        continue;
+      }
+      if (platform === "github") {
+        payloads.push(toGitHubComment(note, { commitId: commit }));
+      } else {
+        const fileDiff = parsedDiff.get(note.filePath);
+        const position = toGitLabPosition(
+          note,
+          { base_sha: base as string, head_sha: commit, start_sha: start as string },
+          { newPath: note.filePath, oldPath: fileDiff?.oldPath },
+        );
+        payloads.push({ body: note.body, position });
+      }
+    }
+
+    console.log(JSON.stringify({ platform, payloads, dropped }, null, 2));
+  },
+);
+
+if (import.meta.main) {
+  cli({
+    name: "mapping",
+    commands: [mapCmd],
+  });
+}

--- a/plugins/review/skills/hunk/scripts/note.ts
+++ b/plugins/review/skills/hunk/scripts/note.ts
@@ -1,0 +1,33 @@
+export type NoteSource = "user" | "agent" | "ai";
+export type AnchorSide = "new" | "old";
+
+export interface HunkNote {
+  noteId: string;
+  source?: NoteSource;
+  filePath: string;
+  hunkIndex?: number;
+  newRange: [number, number] | null;
+  oldRange: [number, number] | null;
+  body: string;
+  createdAt?: string;
+}
+
+export interface Anchor {
+  side: AnchorSide;
+  line: number;
+  path: string;
+}
+
+/**
+ * Resolve a note's anchor: the new-side line when `newRange` is present
+ * (side = new/RIGHT), otherwise the old-side line (side = old/LEFT).
+ */
+export function deriveAnchor(note: HunkNote): Anchor {
+  if (note.newRange) {
+    return { side: "new", line: note.newRange[0], path: note.filePath };
+  }
+  if (note.oldRange) {
+    return { side: "old", line: note.oldRange[0], path: note.filePath };
+  }
+  throw new Error("note has no anchor");
+}

--- a/plugins/review/skills/hunk/scripts/watch.sh
+++ b/plugins/review/skills/hunk/scripts/watch.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Emit one event line per new user comment in a Hunk session; exit when the session closes.
+# Designed to run under the Monitor tool. Each poll spawns short-lived commands that flush on
+# exit, so events reach the monitor without buffering delay.
+#
+# Tracks seen noteIds (Hunk's stable per-note key, which survives --watch reloads) rather than a
+# timestamp, so it never drops or re-fires a comment, even two created in the same millisecond.
+#
+# Usage: watch.sh <session-id> [poll-seconds]
+set -uo pipefail
+
+SID="${1:?usage: watch.sh <session-id> [poll-seconds]}"
+SLEEP="${2:-2}"
+
+seen=" " # space-delimited set of noteIds already handled (noteIds never contain spaces)
+
+# One TSV row per user comment: noteId, file, line, one-line body.
+jqfilter='.comments[]? | [.noteId, .filePath, (.newRange[0] // .oldRange[0] // "?"), (.body | gsub("\\s+"; " "))] | @tsv'
+
+# Read TSV rows on stdin; record unseen noteIds, and announce them unless mode is "silent".
+# Called with process substitution so the loop runs in this shell and `seen` persists.
+scan() {
+  local mode="$1" id file line body
+  while IFS=$'\t' read -r id file line body; do
+    [ -z "$id" ] && continue
+    case "$seen" in
+      *" $id "*) : ;;
+      *)
+        seen="$seen$id "
+        [ "$mode" = announce ] && printf 'NEW %s:%s | %s\n' "$file" "$line" "$body"
+        ;;
+    esac
+  done
+}
+
+# Arm: mark existing comments seen without announcing them.
+scan silent < <(hunk session comment list "$SID" --type user --json 2>/dev/null | jq -r "$jqfilter")
+echo "WATCHING $SID"
+
+while true; do
+  if ! hunk session get "$SID" >/dev/null 2>&1; then
+    echo "SESSION CLOSED"
+    exit 0
+  fi
+  scan announce < <(hunk session comment list "$SID" --type user --json 2>/dev/null | jq -r "$jqfilter")
+  sleep "$SLEEP"
+done

--- a/plugins/review/skills/peer/SKILL.md
+++ b/plugins/review/skills/peer/SKILL.md
@@ -4,8 +4,10 @@ description: |
   Review a pull request when requested by a peer. Use when reviewing PRs, providing code review feedback, or analyzing proposed changes. Supports GitHub and GitLab.
 allowed-tools:
   - Bash(gh:*)
+  - Bash(glab:*)
   - mcp__github
   - Skill(code-review)
+  - Skill(review:hunk)
 ---
 
 # Peer Review
@@ -33,12 +35,15 @@ If not on the branch, first run `gh pr checkout` to switch.
    - **xhigh**: security-sensitive (auth, payments, data access), breaking changes, migrations
    - **max**: rare — incident hotfix or change with extreme blast radius
 5. **Think** - Evaluate against priorities (see [priorities.md](priorities.md)), incorporating `/code-review` findings
-6. **Suggest** - Propose comments with revisions or issues
-7. **Comment** - Add approved comments to PR review
-8. **Submit** - Approve / Comment / Request Changes based on severity
+6. **Stage** - Open the PR diff in Hunk via `review:hunk` and seed proposed comments as agent notes. Capture the PR head SHA (and base/start SHAs for GitLab, from the MR `diff_refs`) for mapping. Skip staging entirely when approving with no comments.
+7. **Revise** - I curate in the Hunk pane: delete notes I reject, reword, and add my own at any line. The surviving set is what gets posted.
+8. **Map** - Read back the final set (`hunk session comment list --type all --json`) and map each note to a platform position with `review:hunk`'s mapping CLI (`mapping.ts map --platform <github|gitlab> --notes ... --diff ... --commit <sha>`). It runs the in-diff pre-check and returns `{ payloads, dropped }`; off-diff anchors land in `dropped` (GitHub rejects them with `422 "Line could not be resolved"`), so surface those to me rather than silently losing them.
+9. **Submit** - Show me the mapped set, then on my go post as one batch and choose Approve / Comment / Request Changes based on severity. GitHub: a pending review submitted as a batch. GitLab: draft notes published together.
 
 See [tone.md](tone.md) for comment style guidelines.
 
 ## Service Support
 
-This skill assumes GitHub. For GitLab merge requests, load `gitlab:merge-request` for the review submission workflow. Use `draft-note.ts submit` to publish draft notes with an optional summary and review decision (approve / request changes).
+This skill assumes GitHub. For GitLab merge requests, load `gitlab:merge-request` for the submission workflow; use `draft-note.ts submit` to publish draft notes with an optional summary and review decision.
+
+When Hunk is not running or I prefer to skip it, fall back to posting directly via `mcp__github` / `gh` / `glab`. On follow-up, resolution is native: resolve addressed threads on the platform (`review-threads.ts` for GitHub, the resolve flow in `gitlab:merge-request` for GitLab), not in Hunk.

--- a/plugins/review/skills/self/SKILL.md
+++ b/plugins/review/skills/self/SKILL.md
@@ -1,82 +1,54 @@
 ---
 name: review:self
 description: |
-  Self-review your own code changes using a visual diff viewer. Opens a GitHub-style web UI where you can add comments on changed lines. Comments are returned to Claude for action.
+  Self-review your own changes in a live Hunk session before committing or opening a PR. You annotate changed lines in the terminal and your comments come back to Claude as edits to apply. Replaces the difit web UI. Use for "review my changes", "self review", "let me look at the diff before committing".
 disable-model-invocation: true
 allowed-tools:
-  - "Bash(bunx difit:*)"
-  - "Bash(git diff:*)"
-hooks:
-  PreToolUse:
-    - matcher: "Bash(bunx difit:*)|Bash(git diff:*)"
-      hooks:
-        - type: command
-          command: |
-            cat | jq '
-              if (.tool_input.command | test("bunx difit"))
-              then {hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow", updatedInput: {dangerouslyDisableSandbox: true}}}
-              else {}
-              end'
+  - Skill(review:hunk)
+  - Read
+  - Edit
+  - Bash(hunk:*)
+  - Bash(git:*)
+  - Bash(jq:*)
 ---
 
 # Self Review
 
-Review your own code changes before committing or requesting peer review.
+I review my own changes in Hunk; you read my comments back and apply them. The live session is
+the buffer: I annotate lines, you edit. Nothing lives in a hand-edited JSON file.
 
-## Usage
+Load `review:hunk` for all session mechanics (launch, seeding, read-back, the ledger). This
+skill is the inbound loop on top of it.
 
-### Direct mode
+## Target
 
-```bash
-bunx difit $ARGUMENTS
-```
+Default to the working tree. Override with $ARGUMENTS (`staged`, `main...HEAD`, `HEAD`).
 
-Common arguments:
-- `staged` — Staged changes only
-- `working` — Unstaged changes only
-- `@ main` — Compare HEAD with main branch
+## Loop
 
-### Stdin mode
+1. **Launch** via `review:hunk`: open the target diff in a sibling tmux pane with
+   `--watch --agent-notes`.
+2. **Self-critique (optional)**: offer to flag your own concerns as agent notes first, so I see
+   your read alongside mine. Skip if I decline.
+3. **Hand off**: I add comments at lines (the `c` key) in the Hunk pane.
+   - **Batch**: I tell you when I am done.
+   - **Live**: if I ask to work as I go, arm monitor mode (`review:hunk` Monitor section) and
+     act on each comment as it lands, holding the applied edits for my review.
+4. **Collect**: `hunk session comment list --type user --json`.
+5. **Apply**: for each comment, read the referenced file and lines, then make the edit.
+   `--watch` reloads the diff as you go.
+6. **Resolve, don't delete**: mark each applied note resolved with `review:hunk`'s ledger CLI
+   (`ledger.ts resolve <noteId> --action ...`), keyed by `noteId`. The note stays visible and
+   nothing is lost. The ledger is the source of truth for open vs resolved, since `--watch`
+   orphans rather than resolves. Sync the current notes with `ledger.ts upsert` first, and use
+   `ledger.ts list --open` to report what remains.
+7. **Repeat** until I say done, then summarize what changed and what is still open (from the
+   ledger).
 
-Pipe a git diff for full control over the diff content:
+## Guidelines
 
-```bash
-git diff $ARGUMENTS | bunx difit
-```
-
-Common arguments:
-- `HEAD` — All uncommitted changes (staged + unstaged)
-- `--merge-base main` — Changes since diverging from main
-
-Use stdin mode for all uncommitted changes (`git diff HEAD`) or when using git diff flags (e.g., `--merge-base`, revision ranges).
-
-## Workflow
-
-1. Run `difit` with the target diff
-2. User reviews in the browser and adds comments on specific lines
-3. When the user closes the browser tab, comments are output to stdout
-4. Parse the comments and apply the requested changes
-
-## Comment Format
-
-Comments are output in this format:
-
-```
-📝 Comments from review session:
-==================================================
-path/to/file.ts:L42
-Comment text here
-=====
-path/to/other.ts:L10-L20
-Comment on a range of lines
-==================================================
-Total comments: 2
-```
-
-## Applying Feedback
-
-For each comment:
-1. Read the referenced file and lines
-2. Understand the requested change
-3. Apply the edit using the Edit tool
-4. Confirm the change was made correctly
+- Apply comments in file order, but ask before any change that is ambiguous or that you would
+  push back on.
+- A note you disagree with stays open: leave it and tell me why rather than silently resolving
+  it.
+- When done, offer next steps (commit, peer review, PR) without taking them unprompted.


### PR DESCRIPTION
Adds `review:hunk`, a core skill that drives a live [Hunk](https://github.com/modem-dev/hunk) terminal diff session as a local review surface, and ports `review:self` and `review:peer` to delegate to it. Comments live in the session instead of a hand-edited JSON file: I annotate lines in the TUI, and Claude reads them back to apply as edits (self) or post to the platform (peer). Closes #685.

## Changes

- `review:hunk` (new): launches Hunk in a sibling tmux pane, seeds agent notes, reads back inline comments partitioned by author, and reconciles state across `--watch` reloads. Loads the bundled `hunk-review` command reference on demand via `hunk skill path`, so it stays version-matched without re-encoding the commands.
- `review:self`: replaces the difit web UI with a live Hunk loop. Applies my inline comments as edits and records resolution in a ledger keyed by the stable `noteId` rather than deleting notes, since `--watch` orphans notes instead of resolving them.
- `review:peer`: stages proposed comments in Hunk for local revision, then maps the final set to GitHub/GitLab review positions. An in-diff pre-check drops anchors GitHub would reject with `422 "Line could not be resolved"` and surfaces them to me rather than losing them. Falls back to posting directly via `gh`/`glab` when no session is running.
- Helpers under `review:hunk/scripts`: `watch.sh` (one event per new comment, for monitor mode under the `Monitor` tool), `mapping.ts` (note to platform payload, with the in-diff pre-check), and `ledger.ts` (resolution ledger), sharing a `note.ts` module.

## Why This Supersedes #685

#685 ported both skills to Hunk but was written without the Hunk CLI installed and validated only against the docs. It concluded that `comment list --json` is unsupported and parsed text output; the flag works, so this parses JSON. It also deleted notes after applying; this resolves them in a ledger so feedback is preserved. This branch also adds the shared core skill, monitor mode, and the line-mapping pre-check that #685 did not cover.

## Testing

- Unit tests for the diff parser, the note-to-position mapping, and the ledger, covering the off-diff anchor case and parser edge cases (added and deleted lines whose content begins with `+++`/`---`, and newline-terminated diffs).
- Exercised both CLIs end to end and validated the live flow (launch, seed, read-back, monitor events, GitHub position acceptance) against Hunk 0.14.1.
