### PR TITLE
ci: run biome check to catch import-organization issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Check formatting
-        run: bun run format:check
-
-      - name: Lint
-        run: bun run lint
+      - name: Check
+        run: bun run check
 
   build:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "scripts": {
     "build": "tsc --noEmit",
+    "check": "biome check",
     "format": "biome format --write",
     "format:check": "biome format",
     "lint": "biome lint",

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
@@ -7,9 +7,9 @@ import {
   initialState,
   isNotFoundError,
   normalizePipelineStatus,
+  type Probe,
   parseMrUrl,
   parseProject,
-  type Probe,
   registerApiError,
 } from "./watch";
 

--- a/plugins/review/skills/dashboard/scripts/layout.test.ts
+++ b/plugins/review/skills/dashboard/scripts/layout.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { layoutArgs } from "./layout";
 
 describe("layoutArgs", () => {


### PR DESCRIPTION
CI ran `bun run format:check` (`biome format`) and `bun run lint` (`biome lint`), but neither runs biome's assist action (`organizeImports`). The local pre-commit hook runs `biome check`, which does organize imports, so import-order issues passed CI yet failed pre-commit.

This change adds a `check` script (`biome check`) and replaces the separate `format:check` and `lint` CI steps with `bun run check`. `biome check` runs format, lint, and assist together, matching the hook's command so CI and pre-commit cannot drift.

It also fixes two pre-existing import-order issues in `watch.test.ts` and `layout.test.ts` that the new check surfaced.

Verification:
- `bun run check` passes on this branch.
- Temporarily disordering imports makes `bun run check` fail with an `organizeImports` error; reverting restores a pass.
- `bun run build` and `bun test` on the edited files pass.
