### PR TITLE
validate: extract shared validation harness

### DIFF
--- a/packages/validate/hooks.ts
+++ b/packages/validate/hooks.ts
@@ -2,7 +2,9 @@ import { pluginDirFile, runEntry, runValidation } from "./run";
 
 runEntry(() =>
   runValidation({
-    files: [pluginDirFile("Usage: bun packages/validate/hooks.ts <plugin-dir>", "hooks/hooks.json")],
+    files: [
+      pluginDirFile("Usage: bun packages/validate/hooks.ts <plugin-dir>", "hooks/hooks.json"),
+    ],
     schema: "schemas/plugin-hook.schema.json",
     extraSchemas: [{ schema: "schemas/hook.schema.json", key: "hook.schema.json" }],
   }),

--- a/packages/validate/hooks.ts
+++ b/packages/validate/hooks.ts
@@ -1,27 +1,9 @@
-import { join } from "node:path";
-import { createValidator, loadSchema, reportAndExit, validateFile } from "./validate";
+import { pluginDirFile, runEntry, runValidation } from "./run";
 
-async function main() {
-  const dir = process.argv[2];
-  if (!dir) {
-    console.error("Usage: bun packages/validate/hooks.ts <plugin-dir>");
-    process.exit(1);
-  }
-
-  const file = join(dir, "hooks/hooks.json");
-  console.log(`• ${file}`);
-
-  const ajv = createValidator();
-  const hookSchema = await loadSchema("schemas/hook.schema.json");
-  ajv.addSchema(hookSchema, "hook.schema.json");
-
-  const result = await validateFile(file, "schemas/plugin-hook.schema.json", { ajv });
-  console.log("");
-  reportAndExit(result);
-  console.log("Validation passed.");
-}
-
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+runEntry(() =>
+  runValidation({
+    files: [pluginDirFile("Usage: bun packages/validate/hooks.ts <plugin-dir>", "hooks/hooks.json")],
+    schema: "schemas/plugin-hook.schema.json",
+    extraSchemas: [{ schema: "schemas/hook.schema.json", key: "hook.schema.json" }],
+  }),
+);

--- a/packages/validate/marketplace.ts
+++ b/packages/validate/marketplace.ts
@@ -1,18 +1,8 @@
-import { reportAndExit, validateFile } from "./validate";
+import { runEntry, runValidation } from "./run";
 
-async function main() {
-  const file = ".claude-plugin/marketplace.json";
-
-  console.log(`• ${file}`);
-
-  const result = await validateFile(file, "schemas/marketplace.schema.json");
-
-  console.log("");
-  reportAndExit(result);
-  console.log("Validation passed.");
-}
-
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+runEntry(() =>
+  runValidation({
+    files: [".claude-plugin/marketplace.json"],
+    schema: "schemas/marketplace.schema.json",
+  }),
+);

--- a/packages/validate/plugin.ts
+++ b/packages/validate/plugin.ts
@@ -1,25 +1,14 @@
-import { join } from "node:path";
-import { reportAndExit, validateFile } from "./validate";
+import { pluginDirFile, runEntry, runValidation } from "./run";
 
-async function main() {
-  const dir = process.argv[2];
-  if (!dir) {
-    console.error("Usage: bun packages/validate/plugin.ts <plugin-dir>");
-    process.exit(1);
-  }
-
-  const file = join(dir, ".claude-plugin/plugin.json");
-  console.log(`• ${file}`);
-
-  const result = await validateFile(file, "schemas/plugin.schema.json", {
+runEntry(() =>
+  runValidation({
+    files: [
+      pluginDirFile(
+        "Usage: bun packages/validate/plugin.ts <plugin-dir>",
+        ".claude-plugin/plugin.json",
+      ),
+    ],
+    schema: "schemas/plugin.schema.json",
     warnAdditional: true,
-  });
-  console.log("");
-  reportAndExit(result);
-  console.log("Validation passed.");
-}
-
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+  }),
+);

--- a/packages/validate/run.test.ts
+++ b/packages/validate/run.test.ts
@@ -1,0 +1,83 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runValidation } from "./run";
+
+let tempDir: string;
+let schemaPath: string;
+
+const schema = {
+  type: "object",
+  properties: {
+    name: { type: "string" },
+  },
+  required: ["name"],
+};
+
+async function writeFixture(name: string, data: unknown): Promise<string> {
+  const file = join(tempDir, `${name}.json`);
+  await Bun.write(file, JSON.stringify(data));
+  return file;
+}
+
+beforeAll(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "run-test-"));
+  await mkdir(join(tempDir, "schemas"), { recursive: true });
+  schemaPath = join(tempDir, "schemas/run.json");
+  await Bun.write(schemaPath, JSON.stringify(schema));
+});
+
+afterAll(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+const logSpy = spyOn(console, "log").mockImplementation(() => {});
+
+afterEach(() => {
+  logSpy.mockClear();
+});
+
+describe("runValidation", () => {
+  it("logs each file, a blank line, and the success message", async () => {
+    const a = await writeFixture("valid-a", { name: "a" });
+    const b = await writeFixture("valid-b", { name: "b" });
+
+    await runValidation({ files: [a, b], schema: schemaPath });
+
+    const lines = logSpy.mock.calls.map((call) => call[0]);
+    expect(lines).toEqual([`• ${a}`, `• ${b}`, "", "Validation passed."]);
+  });
+
+  it("honors a custom success message", async () => {
+    const file = await writeFixture("valid-custom", { name: "ok" });
+
+    await runValidation({ files: [file], schema: schemaPath, successMessage: "All good." });
+
+    const lines = logSpy.mock.calls.map((call) => call[0]);
+    expect(lines.at(-1)).toBe("All good.");
+  });
+
+  it("emits warnings when warnAdditional is set", async () => {
+    const file = await writeFixture("warn-extra", { name: "ok", extra: true });
+
+    await runValidation({ files: [file], schema: schemaPath, warnAdditional: true });
+
+    const lines = logSpy.mock.calls.map((call) => call[0]);
+    expect(lines.some((line) => typeof line === "string" && line.includes("extra"))).toBe(true);
+  });
+
+  it("exits non-zero on validation errors", async () => {
+    const file = await writeFixture("invalid", { name: 123 });
+    const exitSpy = spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("exit");
+    }) as never);
+
+    try {
+      await expect(runValidation({ files: [file], schema: schemaPath })).rejects.toThrow("exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+});

--- a/packages/validate/run.ts
+++ b/packages/validate/run.ts
@@ -1,5 +1,5 @@
-import type Ajv from "ajv";
 import { join } from "node:path";
+import type Ajv from "ajv";
 import {
   createValidator,
   loadSchema,

--- a/packages/validate/run.ts
+++ b/packages/validate/run.ts
@@ -1,0 +1,59 @@
+import type Ajv from "ajv";
+import { join } from "node:path";
+import {
+  createValidator,
+  loadSchema,
+  reportAndExit,
+  type ValidationResult,
+  validateFile,
+} from "./validate";
+
+export interface ValidationTarget {
+  files: string[];
+  schema: string;
+  warnAdditional?: boolean;
+  extraSchemas?: { schema: string; key: string }[];
+  successMessage?: string;
+}
+
+export async function runValidation(target: ValidationTarget): Promise<void> {
+  let ajv: Ajv | undefined;
+  if (target.extraSchemas?.length) {
+    ajv = createValidator();
+    for (const extra of target.extraSchemas) {
+      ajv.addSchema(await loadSchema(extra.schema), extra.key);
+    }
+  }
+
+  const options: { ajv?: Ajv; warnAdditional?: boolean } = {};
+  if (ajv) options.ajv = ajv;
+  if (target.warnAdditional) options.warnAdditional = true;
+
+  const result: ValidationResult = { errors: [], warnings: [] };
+  for (const file of target.files) {
+    console.log(`• ${file}`);
+    const r = await validateFile(file, target.schema, options);
+    result.errors.push(...r.errors);
+    result.warnings.push(...r.warnings);
+  }
+
+  console.log("");
+  reportAndExit(result);
+  console.log(target.successMessage ?? "Validation passed.");
+}
+
+export function pluginDirFile(usage: string, file: string): string {
+  const dir = process.argv[2];
+  if (!dir) {
+    console.error(usage);
+    process.exit(1);
+  }
+  return join(dir, file);
+}
+
+export function runEntry(run: () => Promise<void>): void {
+  run().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/validate/settings.ts
+++ b/packages/validate/settings.ts
@@ -1,25 +1,10 @@
-import { reportAndExit, type ValidationResult, validateFile } from "./validate";
+import { runEntry, runValidation } from "./run";
 
-const schema = "https://www.schemastore.org/claude-code-settings.json";
-
-const files = [".claude/settings.json", "user/settings.json"];
-
-async function main() {
-  const result: ValidationResult = { errors: [], warnings: [] };
-
-  for (const file of files) {
-    console.log(`• ${file}`);
-    const r = await validateFile(file, schema, { warnAdditional: true });
-    result.errors.push(...r.errors);
-    result.warnings.push(...r.warnings);
-  }
-
-  console.log("");
-  reportAndExit(result);
-  console.log("All validations passed.");
-}
-
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+runEntry(() =>
+  runValidation({
+    files: [".claude/settings.json", "user/settings.json"],
+    schema: "https://www.schemastore.org/claude-code-settings.json",
+    warnAdditional: true,
+    successMessage: "All validations passed.",
+  }),
+);


### PR DESCRIPTION
Extracts the shared validation ritual from the four `packages/validate` entry points into a single `runValidation` harness. Each entry repeated the same steps: log `• <file>`, validate, accumulate errors and warnings, print a blank line, call `reportAndExit`, then print a success line. The only real differences were the files, the schema, the options, and (for `hooks.ts`) an extra schema to register.

## Changes

`run.ts` adds the harness and two small helpers:

- `runValidation(target)` owns the loop, logging, accumulation, `reportAndExit`, and success message. A `ValidationTarget` describes one job: `files`, `schema`, optional `warnAdditional`, optional `extraSchemas` to register on a fresh validator, and an optional `successMessage`.
- `pluginDirFile(usage, file)` reads `process.argv[2]`, prints the usage error and exits when it is missing, and otherwise joins the plugin dir with the target file.
- `runEntry(run)` wraps the top-level promise with the shared `catch`/`exit` handler.

Each entry file is now a thin delegation that declares only its target. `marketplace.ts` and `settings.ts` pass a fixed file list; `plugin.ts` and `hooks.ts` derive their file from the argv plugin dir. `hooks.ts` registers `schemas/hook.schema.json` as `hook.schema.json` via `extraSchemas` before validating against `schemas/plugin-hook.schema.json`.

The four filenames stay runnable entry points, so the invocations in `.github/workflows/test.yml` and `scripts/prek-check.sh` keep working unchanged. The `validate.ts` core API is untouched.

## Testing

Added `run.test.ts` covering `runValidation`: per-file logging plus blank line and success message, custom success message, `warnAdditional` warnings, and non-zero exit on validation errors.

Exercised each entry point against a real plugin to confirm it still reports success:

- `bun packages/validate/settings.ts`
- `bun packages/validate/marketplace.ts`
- `bun packages/validate/plugin.ts plugins/linear`
- `bun packages/validate/hooks.ts plugins/linear`
