### PR TITLE
hook: centralize hook stdin/stdout plumbing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,12 @@
         "gray-matter": "^4.0.3",
       },
     },
+    "packages/hook": {
+      "name": "@bendrucker/claude-hook",
+      "dependencies": {
+        "@constellos/claude-code-kit": "^0.4.0",
+      },
+    },
     "packages/marketplace": {
       "name": "@bendrucker/claude-marketplace",
     },
@@ -64,6 +70,7 @@
       "name": "git",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.25",
+        "@bendrucker/claude-hook": "workspace:*",
         "@constellos/claude-code-kit": "^0.4.0",
       },
     },
@@ -99,6 +106,7 @@
       "name": "issue",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.25",
+        "@bendrucker/claude-hook": "workspace:*",
         "cleye": "^1.3.2",
       },
     },
@@ -106,6 +114,7 @@
       "name": "linear",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.25",
+        "@bendrucker/claude-hook": "workspace:*",
         "@constellos/claude-code-kit": "^0.4.0",
       },
     },
@@ -113,6 +122,7 @@
       "name": "mac",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.25",
+        "@bendrucker/claude-hook": "workspace:*",
         "@constellos/claude-code-kit": "^0.4.0",
         "acorn": "^8.15.0",
         "cleye": "^1.3.2",
@@ -155,7 +165,7 @@
       "name": "shortcuts",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.25",
-        "@constellos/claude-code-kit": "^0.4.0",
+        "@bendrucker/claude-hook": "workspace:*",
       },
     },
     "plugins/things": {
@@ -180,7 +190,7 @@
       "name": "@bendrucker/claude-tmux",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.25",
-        "@constellos/claude-code-kit": "^0.4.0",
+        "@bendrucker/claude-hook": "workspace:*",
         "cleye": "^1.3.2",
         "table": "^6.9.0",
       },
@@ -189,7 +199,7 @@
       "name": "@bendrucker/type-ignore",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.25",
-        "@constellos/claude-code-kit": "^0.4.0",
+        "@bendrucker/claude-hook": "workspace:*",
       },
     },
     "plugins/ui-design": {
@@ -215,7 +225,7 @@
       "name": "@bendrucker/claude-writing",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.25",
-        "@constellos/claude-code-kit": "^0.4.0",
+        "@bendrucker/claude-hook": "workspace:*",
         "@duckdb/node-api": "1.5.0-r.1",
         "ap-style-title-case": "^2.0.0",
         "cleye": "^2.2.1",
@@ -274,6 +284,8 @@
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@bendrucker/claude-hook": ["@bendrucker/claude-hook@workspace:packages/hook"],
 
     "@bendrucker/claude-marketplace": ["@bendrucker/claude-marketplace@workspace:packages/marketplace"],
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "plugins/vscode",
     "packages/validate",
     "packages/marketplace",
+    "packages/hook",
     "plugins/tmux",
     "plugins/mac",
     "plugins/x-callback-url",

--- a/packages/hook/hook.test.ts
+++ b/packages/hook/hook.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, mock, test } from "bun:test";
+
+let stdinValue: unknown = {};
+let stdinError: Error | null = null;
+const writes: unknown[] = [];
+
+mock.module("@constellos/claude-code-kit/runners", () => ({
+  readStdinJson: async () => {
+    if (stdinError) throw stdinError;
+    return stdinValue;
+  },
+  writeStdoutJson: (output: unknown) => {
+    writes.push(output);
+  },
+}));
+
+const { runHook } = await import("./index");
+
+describe("runHook", () => {
+  test("writes JSON when the handler returns an object", async () => {
+    writes.length = 0;
+    stdinError = null;
+    stdinValue = { tool_name: "Bash" };
+
+    const output = { decision: "allow" };
+    await runHook(() => output, "test/object");
+
+    expect(writes).toEqual([output]);
+  });
+
+  test("writes nothing when the handler returns null", async () => {
+    writes.length = 0;
+    stdinError = null;
+    stdinValue = {};
+
+    await runHook(() => null, "test/null");
+
+    expect(writes).toEqual([]);
+  });
+
+  test("awaits async handlers", async () => {
+    writes.length = 0;
+    stdinError = null;
+    stdinValue = {};
+
+    const output = { ok: true };
+    await runHook(async () => output, "test/async");
+
+    expect(writes).toEqual([output]);
+  });
+
+  test("logs and writes nothing on parse error", async () => {
+    writes.length = 0;
+    stdinError = new Error("bad json");
+    const errors: string[] = [];
+    const original = console.error;
+    console.error = (message: string) => {
+      errors.push(message);
+    };
+
+    try {
+      await runHook(() => ({ ok: true }), "test/parse-error");
+    } finally {
+      console.error = original;
+    }
+
+    expect(writes).toEqual([]);
+    expect(errors[0]).toBe("[test/parse-error] Failed to parse hook input: bad json");
+  });
+});

--- a/packages/hook/index.ts
+++ b/packages/hook/index.ts
@@ -1,0 +1,21 @@
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+
+export async function runHook<I, O>(
+  handler: (input: I) => O | null | Promise<O | null>,
+  label: string,
+): Promise<void> {
+  let input: I;
+  try {
+    input = await readStdinJson<I>();
+  } catch (error) {
+    console.error(
+      `[${label}] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  const result = await handler(input);
+  if (result) {
+    writeStdoutJson(result);
+  }
+}

--- a/packages/hook/package.json
+++ b/packages/hook/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@bendrucker/claude-hook",
+  "private": true,
+  "type": "module",
+  "main": "./index.ts",
+  "dependencies": {
+    "@constellos/claude-code-kit": "^0.4.0"
+  }
+}

--- a/plugins/git/package.json
+++ b/plugins/git/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.25",
+    "@bendrucker/claude-hook": "workspace:*",
     "@constellos/claude-code-kit": "^0.4.0"
   }
 }

--- a/plugins/git/scripts/block-default-branch-commit.ts
+++ b/plugins/git/scripts/block-default-branch-commit.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { runHook } from "@bendrucker/claude-hook";
 import { $ } from "bun";
 import { getDefaultBranch } from "./default-branch";
 
@@ -44,23 +44,6 @@ export async function processInput(
   return null;
 }
 
-async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
-  try {
-    input = await readStdinJson<PreToolUseHookInput>();
-  } catch (error) {
-    console.error(
-      `[git/block-default-branch-commit] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return;
-  }
-
-  const output = await processInput(input);
-  if (output) {
-    writeStdoutJson(output);
-  }
-}
-
 if (import.meta.main) {
-  main().catch(console.error);
+  runHook(processInput, "git/block-default-branch-commit");
 }

--- a/plugins/issue/hooks/approve-read.ts
+++ b/plugins/issue/hooks/approve-read.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { runHook } from "@bendrucker/claude-hook";
 import { type IssueTarget, readTarget } from "../scripts/target";
 
 type IssueReadInput = {
@@ -35,21 +36,5 @@ export async function processInput(input: PreToolUseHookInput): Promise<SyncHook
 }
 
 if (import.meta.main) {
-  (async () => {
-    const { readStdinJson, writeStdoutJson } = await import("@constellos/claude-code-kit/runners");
-    let input: PreToolUseHookInput;
-    try {
-      input = await readStdinJson<PreToolUseHookInput>();
-    } catch (error) {
-      console.error(
-        `[issue/approve-read] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return;
-    }
-
-    const output = await processInput(input);
-    if (output) {
-      writeStdoutJson(output);
-    }
-  })().catch(console.error);
+  runHook(processInput, "issue/approve-read");
 }

--- a/plugins/issue/package.json
+++ b/plugins/issue/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.25",
+    "@bendrucker/claude-hook": "workspace:*",
     "cleye": "^1.3.2"
   }
 }

--- a/plugins/linear/hooks/default-state.ts
+++ b/plugins/linear/hooks/default-state.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { runHook } from "@bendrucker/claude-hook";
 
 export type CreateIssueInput = {
   title?: string;
@@ -33,23 +33,6 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
   };
 }
 
-async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
-  try {
-    input = await readStdinJson<PreToolUseHookInput>();
-  } catch (error) {
-    console.error(
-      `[linear/default-state] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return;
-  }
-
-  const output = processInput(input);
-  if (output) {
-    writeStdoutJson(output);
-  }
-}
-
 if (import.meta.main) {
-  main().catch(console.error);
+  runHook(processInput, "linear/default-state");
 }

--- a/plugins/linear/package.json
+++ b/plugins/linear/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.25",
+    "@bendrucker/claude-hook": "workspace:*",
     "@constellos/claude-code-kit": "^0.4.0"
   }
 }

--- a/plugins/mac/hooks/sandbox.ts
+++ b/plugins/mac/hooks/sandbox.ts
@@ -2,7 +2,7 @@
 
 import { basename } from "node:path";
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { runHook } from "@bendrucker/claude-hook";
 
 type ToolInput = { command: string };
 
@@ -108,23 +108,6 @@ export async function processInput(
   return null;
 }
 
-async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
-  try {
-    input = await readStdinJson<PreToolUseHookInput>();
-  } catch (error) {
-    console.error(
-      `[mac/sandbox] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return;
-  }
-
-  const output = await processInput(input);
-  if (output) {
-    writeStdoutJson(output);
-  }
-}
-
 if (import.meta.main) {
-  main().catch(console.error);
+  runHook(processInput, "mac/sandbox");
 }

--- a/plugins/mac/package.json
+++ b/plugins/mac/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.25",
+    "@bendrucker/claude-hook": "workspace:*",
     "@constellos/claude-code-kit": "^0.4.0",
     "acorn": "^8.15.0",
     "cleye": "^1.3.2"

--- a/plugins/shortcuts/hooks/open.ts
+++ b/plugins/shortcuts/hooks/open.ts
@@ -2,7 +2,7 @@
 
 import { extname } from "node:path";
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { runHook } from "@bendrucker/claude-hook";
 
 type BashInput = { command: string };
 
@@ -58,23 +58,6 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
   };
 }
 
-async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
-  try {
-    input = await readStdinJson<PreToolUseHookInput>();
-  } catch (error) {
-    console.error(
-      `[shortcuts/open] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return;
-  }
-
-  const output = processInput(input);
-  if (output) {
-    writeStdoutJson(output);
-  }
-}
-
 if (import.meta.main) {
-  main().catch(console.error);
+  runHook(processInput, "shortcuts/open");
 }

--- a/plugins/shortcuts/package.json
+++ b/plugins/shortcuts/package.json
@@ -4,6 +4,6 @@
   "type": "module",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.25",
-    "@constellos/claude-code-kit": "^0.4.0"
+    "@bendrucker/claude-hook": "workspace:*"
   }
 }

--- a/plugins/tmux/hooks/target.ts
+++ b/plugins/tmux/hooks/target.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { runHook } from "@bendrucker/claude-hook";
 
 const targetableCommands = new Set([
   "split-window",
@@ -69,23 +69,9 @@ export function processInput(input: PreToolUseHookInput, pane?: string): SyncHoo
   };
 }
 
-async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
-  try {
-    input = await readStdinJson<PreToolUseHookInput>();
-  } catch (error) {
-    console.error(
-      `[tmux/target] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return;
-  }
-
-  const output = processInput(input, process.env.TMUX_PANE);
-  if (output) {
-    writeStdoutJson(output);
-  }
-}
-
 if (import.meta.main) {
-  main().catch(console.error);
+  runHook(
+    (input: PreToolUseHookInput) => processInput(input, process.env.TMUX_PANE),
+    "tmux/target",
+  );
 }

--- a/plugins/tmux/package.json
+++ b/plugins/tmux/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.25",
-    "@constellos/claude-code-kit": "^0.4.0",
+    "@bendrucker/claude-hook": "workspace:*",
     "cleye": "^1.3.2",
     "table": "^6.9.0"
   }

--- a/plugins/type-ignore/hooks/detect.ts
+++ b/plugins/type-ignore/hooks/detect.ts
@@ -3,7 +3,7 @@
 import { mkdirSync } from "node:fs";
 import * as path from "node:path";
 import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { runHook } from "@bendrucker/claude-hook";
 import { EXTENSION_MAP, LANGUAGES, TARGET_EXTENSIONS } from "./languages";
 
 export type WriteInput = { file_path: string; content: string };
@@ -155,23 +155,6 @@ export async function processInput(
   return formatOutput(filePath, lineNumber, pattern.label);
 }
 
-async function main(): Promise<void> {
-  let input: PostToolUseHookInput;
-  try {
-    input = await readStdinJson<PostToolUseHookInput>();
-  } catch (error) {
-    console.error(
-      `[type-ignore] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return;
-  }
-
-  const output = await processInput(input);
-  if (output) {
-    writeStdoutJson(output);
-  }
-}
-
 if (import.meta.main) {
-  main().catch(console.error);
+  runHook(processInput, "type-ignore");
 }

--- a/plugins/type-ignore/package.json
+++ b/plugins/type-ignore/package.json
@@ -4,6 +4,6 @@
   "type": "module",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.25",
-    "@constellos/claude-code-kit": "^0.4.0"
+    "@bendrucker/claude-hook": "workspace:*"
   }
 }

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { runHook } from "@bendrucker/claude-hook";
 import { formatContext, formatDecision, isMemoryPath, type SyncHookJSONOutput } from "./markdown";
 import { firstByTier, type PatternMatch, type ScanContext, scan, scanIntroduced } from "./tropes";
 
@@ -214,23 +214,6 @@ export async function processInput(input: PreToolUseHookInput): Promise<SyncHook
   return processSideEffect(input);
 }
 
-async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
-  try {
-    input = await readStdinJson<PreToolUseHookInput>();
-  } catch (error) {
-    console.error(
-      `[writing/tropes] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return;
-  }
-
-  const output = await processInput(input);
-  if (output) {
-    writeStdoutJson(output);
-  }
-}
-
 if (import.meta.main) {
-  main().catch(console.error);
+  runHook(processInput, "writing/tropes");
 }

--- a/plugins/writing/hooks/headings.ts
+++ b/plugins/writing/hooks/headings.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { runHook } from "@bendrucker/claude-hook";
 import { apStyleTitleCase } from "ap-style-title-case";
 import type { Heading, Paragraph, Strong, Text } from "mdast";
 import { fromMarkdown } from "mdast-util-from-markdown";
@@ -122,23 +122,6 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
   return null;
 }
 
-async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
-  try {
-    input = await readStdinJson<PreToolUseHookInput>();
-  } catch (error) {
-    console.error(
-      `[style/headings] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return;
-  }
-
-  const output = processInput(input);
-  if (output) {
-    writeStdoutJson(output);
-  }
-}
-
 if (import.meta.main) {
-  main().catch(console.error);
+  runHook(processInput, "style/headings");
 }

--- a/plugins/writing/hooks/numbering.ts
+++ b/plugins/writing/hooks/numbering.ts
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { runHook } from "@bendrucker/claude-hook";
 import type { Heading, Text } from "mdast";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { visit } from "unist-util-visit";
@@ -153,25 +153,7 @@ Use descriptive names instead. See CLAUDE.md Organization guidelines.`;
   }
 }
 
-async function main(): Promise<void> {
-  const mode = (process.argv[2] || "write") as Mode;
-
-  let input: PreToolUseHookInput;
-  try {
-    input = await readStdinJson<PreToolUseHookInput>();
-  } catch (error) {
-    console.error(
-      `[style/numbering] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return;
-  }
-
-  const output = await processInput(input, mode);
-  if (output) {
-    writeStdoutJson(output);
-  }
-}
-
 if (import.meta.main) {
-  main().catch(console.error);
+  const mode = (process.argv[2] || "write") as Mode;
+  runHook((input: PreToolUseHookInput) => processInput(input, mode), "style/numbering");
 }

--- a/plugins/writing/package.json
+++ b/plugins/writing/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.25",
-    "@constellos/claude-code-kit": "^0.4.0",
+    "@bendrucker/claude-hook": "workspace:*",
     "ap-style-title-case": "^2.0.0",
     "@duckdb/node-api": "1.5.0-r.1",
     "cleye": "^2.2.1",


### PR DESCRIPTION
Centralizes the stdin/stdout plumbing that every hook hand-rolled around its transform. Each converted hook reduces to a pure `(input) => output | null` function plus a one-line `runHook` call.

## Changes

Adds `@bendrucker/claude-hook` at `packages/hook/`, exporting `runHook(handler, label)`. It reads stdin via the kit's `readStdinJson`, logs `[${label}] Failed to parse hook input: ...` and returns on parse error, awaits the handler, and writes the result with `writeStdoutJson` when truthy. This matches the previous per-hook behavior exactly.

Converted these hooks to export their transform and delegate to `runHook`:

- `linear/default-state`
- `mac/sandbox`
- `type-ignore` (`detect.ts`)
- `issue/approve-read` (also drops a dynamic `import()` of the runners)
- `shortcuts/open`
- `tmux/target` (wrapped in a closure to pass `process.env.TMUX_PANE`)
- `style/numbering` (wrapped in a closure to pass the CLI `mode` arg)
- `style/headings`
- `writing/tropes` (`check-tropes.ts`)
- `git/block-default-branch-commit`

Each plugin declares `@bendrucker/claude-hook` as a workspace dependency. For `type-ignore`, `shortcuts`, `tmux`, and `writing` the direct `@constellos/claude-code-kit` dependency is now unused (the kit comes transitively through the hook package), so I dropped it.

#### Skipped

- `tmux/notification`: a `cleye` CLI with tmux side effects, not a stdin/stdout transform.
- `user/hooks/webfetch-block` and `user/hooks/worktree`: `user/` has no `package.json`, so they cannot declare a workspace dependency. Left on the old pattern per the constraint to skip rather than force-fit.
- The remaining `grep` matches (`scripts/fetch.ts`, `scripts/check.ts`, `newline/scripts/*`, `pull-request/scripts/validate.ts`, etc.) are CLI scripts, not hook entry points, and do not follow the canonical shape.

## Testing

Added `packages/hook/hook.test.ts` covering the four `runHook` behaviors: an object result writes JSON, `null` writes nothing, async handlers are awaited, and a parse error logs the labeled message and writes nothing. I mocked `@constellos/claude-code-kit/runners` to control `readStdinJson` and capture `writeStdoutJson`, since mocking real stdin under `bun test` is impractical.

Also exercised converted hooks end-to-end with real piped stdin to confirm output and the parse-error path. Verified the existing test suite, `bun run build`, `bun run lint`, and the `check-plugin-imports`, `check-plugin-deps`, `check-hook-quoting`, `check-mcp-matchers`, and `check-marketplace` scripts.
