### PR TITLE
review: make dashboard poll platform-agnostic

### DIFF
--- a/plugins/review/skills/dashboard/SKILL.md
+++ b/plugins/review/skills/dashboard/SKILL.md
@@ -116,26 +116,32 @@ Periodically run `state.ts sync` to detect completed reviews. When all reviews a
 
 The interactive flow above is the default: fetch once, present, ask, spawn. The loop is the opt-in hands-off mode. It polls the UNREVIEWED queues on an interval and spawns a session for each newly-arrived review without prompting, so the queue drains itself while you work elsewhere.
 
-The `Monitor` command does the polling itself and emits one line per newly-arrived review; you react to each event by spawning. `poll.ts` owns the fetch-and-diff: it reads the tracked URLs from state, queries both platforms' UNREVIEWED queues, and prints the URLs not already tracked. `Monitor` is not a bare metronome.
+The `Monitor` command does the polling itself and emits one line per newly-arrived review; you react to each event by spawning. `poll.ts` owns the fetch-and-diff: it reads the tracked URLs from state, runs each `--queue` source command, and prints the URLs not already tracked. `Monitor` is not a bare metronome.
 
-#### Resolve the GitLab Queue Script
+#### Wire the Review-Queue Sources
 
-`poll.ts` runs the gitlab plugin's own `review-queue.ts` directly, so resolve its path once before arming the monitor: load `gitlab:merge-request` and note the absolute path of its `scripts/review-queue.ts` (its `${CLAUDE_SKILL_DIR}/scripts/review-queue.ts`). Pass that path as `--gitlab-queue` below. This keeps the queue's GraphQL owned by the gitlab plugin; the dashboard only invokes the resolved script. Omit `--gitlab-queue` to poll GitHub only.
+`poll.ts` knows no platforms. Each `--queue` is a command that emits an UNREVIEWED queue as `[{ url }]` JSON, one flag per source:
+
+- GitHub: `gh search prs --review-requested=@me --state=open --json url`.
+- A platform plugin that owns its own queue: load its skill and pass the command it documents. For GitLab, load `gitlab:merge-request` and pass `bun <its review-queue.ts path>` (its `${CLAUDE_SKILL_DIR}/scripts/review-queue.ts`). The query stays owned by that plugin; the dashboard only invokes the command it hands back.
+
+Pass a `--queue` for each platform you want polled, and omit the ones you don't.
 
 #### Arm the Monitor
 
 Pass this command to `Monitor` with `persistent: true` and a descriptive label. Each iteration prunes finished reviews (`sync`), then `poll.ts` prints the URLs of UNREVIEWED reviews not already tracked. Each printed URL is one event:
 
 ```bash
-GLQ=/abs/path/to/gitlab/skills/merge-request/scripts/review-queue.ts
 while true; do
   bun ${CLAUDE_SKILL_DIR}/scripts/state.ts sync --data-dir ${CLAUDE_PLUGIN_DATA} >/dev/null || true
-  bun ${CLAUDE_SKILL_DIR}/scripts/poll.ts --data-dir ${CLAUDE_PLUGIN_DATA} --gitlab-queue "$GLQ" || true
+  bun ${CLAUDE_SKILL_DIR}/scripts/poll.ts --data-dir ${CLAUDE_PLUGIN_DATA} \
+    --queue "gh search prs --review-requested=@me --state=open --json url" \
+    --queue "bun /abs/path/to/gitlab/skills/merge-request/scripts/review-queue.ts" || true
   sleep 300
 done
 ```
 
-`sync`'s output is suppressed so that only new-review URLs become events. Its worktree-removal failures flow to the monitor's output file, readable with `Read` if a prune fails. `poll.ts` treats a failed fetch as an empty queue, so one platform's outage never stalls the loop.
+`sync`'s output is suppressed so that only new-review URLs become events. Its worktree-removal failures flow to the monitor's output file, readable with `Read` if a prune fails. `poll.ts` treats a failed source as an empty queue, so one source's outage never stalls the loop.
 
 #### React to Each Event
 
@@ -143,6 +149,6 @@ For each emitted URL, spawn a session without prompting, reusing [Resolve the Lo
 
 #### Pacing and Stopping
 
-- A 300s interval is a reasonable floor. Reviews arrive over minutes-to-hours, and both queues hit rate-limited remote APIs. Shorten only when you expect a burst.
+- A 300s interval is a reasonable floor. Reviews arrive over minutes-to-hours, and the queue sources hit rate-limited remote APIs. Shorten only when you expect a burst.
 - Call `TaskStop` on the `Monitor` task to stop early.
 - The loop runs until you stop it. Surface a summary when the queue is empty across several consecutive intervals, but keep polling unless told otherwise (a re-request can re-add a review at any time).

--- a/plugins/review/skills/dashboard/SKILL.md
+++ b/plugins/review/skills/dashboard/SKILL.md
@@ -120,23 +120,25 @@ The `Monitor` command does the polling itself and emits one line per newly-arriv
 
 #### Wire the Review-Queue Sources
 
-`poll.ts` knows no platforms. Each `--queue` is a command that emits an UNREVIEWED queue as `[{ url }]` JSON, one flag per source:
+`poll.ts` knows no platforms. Each `--queue` is a command that emits an UNREVIEWED queue as `[{ url }]` JSON. Pass one per platform you want polled, and omit the rest:
 
 - GitHub: `gh search prs --review-requested=@me --state=open --json url`.
-- A platform plugin that owns its own queue: load its skill and pass the command it documents. For GitLab, load `gitlab:merge-request` and pass `bun <its review-queue.ts path>` (its `${CLAUDE_SKILL_DIR}/scripts/review-queue.ts`). The query stays owned by that plugin; the dashboard only invokes the command it hands back.
+- GitLab: load `gitlab:merge-request` and pass `bun <ABS>`, where `<ABS>` is the absolute path the gitlab docs resolve to for `scripts/review-queue.ts` (for example `/Users/you/.claude/plugins/cache/.../gitlab/skills/merge-request/scripts/review-queue.ts`). Write the resolved path out in full. Do not reuse `${CLAUDE_SKILL_DIR}` from the examples below: it points at this dashboard skill, not gitlab, so it would resolve to the wrong directory.
 
-Pass a `--queue` for each platform you want polled, and omit the ones you don't.
+A platform plugin that owns its queue keeps the query; the dashboard only runs the command it hands back.
 
 #### Arm the Monitor
 
-Pass this command to `Monitor` with `persistent: true` and a descriptive label. Each iteration prunes finished reviews (`sync`), then `poll.ts` prints the URLs of UNREVIEWED reviews not already tracked. Each printed URL is one event:
+Pass this command to `Monitor` with `persistent: true` and a descriptive label. Each iteration prunes finished reviews (`sync`), then `poll.ts` prints the URLs of UNREVIEWED reviews not already tracked. Each printed URL is one event.
+
+`${CLAUDE_SKILL_DIR}` below is the dashboard's own directory (where `poll.ts` and `state.ts` live). The GitLab `--queue` uses a full absolute path instead, since it points into a different skill:
 
 ```bash
 while true; do
   bun ${CLAUDE_SKILL_DIR}/scripts/state.ts sync --data-dir ${CLAUDE_PLUGIN_DATA} >/dev/null || true
   bun ${CLAUDE_SKILL_DIR}/scripts/poll.ts --data-dir ${CLAUDE_PLUGIN_DATA} \
     --queue "gh search prs --review-requested=@me --state=open --json url" \
-    --queue "bun /abs/path/to/gitlab/skills/merge-request/scripts/review-queue.ts" || true
+    --queue "bun <ABS>" || true
   sleep 300
 done
 ```

--- a/plugins/review/skills/dashboard/scripts/poll.ts
+++ b/plugins/review/skills/dashboard/scripts/poll.ts
@@ -5,11 +5,13 @@ import { readState } from "./store";
 
 type QueueEntry = { url: string };
 
-// Run a command that prints a JSON array of `{ url }` and return the URLs. A
-// failed fetch (network, auth, an unconfigured platform) yields an empty list
-// so one platform's outage never stalls the poll.
-async function fetchUrls(cmd: string[]): Promise<string[]> {
-  const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
+// Run a review-queue command that prints a JSON array of `{ url }` and return
+// the URLs. The dashboard knows nothing about any platform: each source is just
+// a command supplied by the caller. A failed command (network, auth, an
+// unconfigured source) yields an empty list, so one source's outage never
+// stalls the poll.
+async function fetchUrls(command: string): Promise<string[]> {
+  const proc = Bun.spawn(["sh", "-c", command], { stdout: "pipe", stderr: "pipe" });
   if ((await proc.exited) !== 0) {
     return [];
   }
@@ -21,7 +23,7 @@ async function fetchUrls(cmd: string[]): Promise<string[]> {
   }
 }
 
-// New reviews are the fetched URLs not already tracked, deduped across platforms
+// New reviews are the fetched URLs not already tracked, deduped across sources
 // and kept in fetch order.
 export function newUrls(fetched: string[], tracked: ReadonlySet<string>): string[] {
   const result: string[] = [];
@@ -39,9 +41,10 @@ if (import.meta.main) {
     name: "poll",
     flags: {
       dataDir: { type: String, description: "Data directory (defaults to CLAUDE_PLUGIN_DATA)" },
-      gitlabQueue: {
-        type: String,
-        description: "Path to the gitlab plugin's review-queue.ts (omit to poll GitHub only)",
+      queue: {
+        type: [String],
+        description:
+          "Review-queue command emitting [{ url }] JSON; repeat once per platform source",
       },
     },
   });
@@ -49,18 +52,9 @@ if (import.meta.main) {
   const tracked = new Set(
     (await readState(argv.flags.dataDir)).reviews.map((review) => review.url),
   );
-  const github = await fetchUrls([
-    "gh",
-    "search",
-    "prs",
-    "--review-requested=@me",
-    "--state=open",
-    "--json",
-    "url",
-  ]);
-  const gitlab = argv.flags.gitlabQueue ? await fetchUrls(["bun", argv.flags.gitlabQueue]) : [];
+  const fetched = (await Promise.all(argv.flags.queue.map(fetchUrls))).flat();
 
-  for (const url of newUrls([...github, ...gitlab], tracked)) {
+  for (const url of newUrls(fetched, tracked)) {
     console.log(url);
   }
 }


### PR DESCRIPTION
Follow-up to #706. `poll.ts` carried a `--gitlab-queue` flag, which put a GitLab-named knob inside the platform-agnostic `review` plugin. A platform-specific flag in a plugin that isn't that platform's is the tell that a plugin boundary leaked.

Makes the dashboard's queue polling platform-agnostic. `poll.ts` no longer names any platform: it takes a repeatable `--queue <command>` flag, runs each source command (anything that emits `[{ url }]` JSON), and prints the untracked URLs deduped across sources. GitHub and GitLab are wired identically from `SKILL.md` as two `--queue` commands, with GitLab as one example rather than a built-in.

## Changes

- `poll.ts`: replaced the `--gitlab-queue` path flag and the hardcoded GitHub `gh` call with a single repeatable `--queue` flag. `fetchUrls` now runs an arbitrary command string via `sh -c` instead of a fixed argv, so every source is uniform. The script names no platform.
- `SKILL.md`: the monitor loop passes `--queue` once per platform (`gh search prs …` for GitHub, `bun <gitlab review-queue.ts>` for GitLab). Renamed "Resolve the GitLab Queue Script" to "Wire the Review-Queue Sources" and framed GitLab as an example source.

The GitLab GraphQL query and its review-state filter stay owned by the `gitlab` plugin (`gitlab:merge-request`'s `review-queue.ts`). The dashboard still reaches it only through skill-delegation, never an import or a hardcoded cache path.

## Testing

- Covers the `newUrls` dedup-and-diff (untracked-only, cross-source dedup, fetch-order) through the existing dashboard unit tests, unchanged by this refactor.
- Ran `poll.ts` with no `--queue` (prints nothing, exits cleanly) and confirmed no `gitlab`/`glab` identifiers remain in the dashboard scripts.
