### PR TITLE
user: reset status line dial color after compaction

### DIFF
--- a/user/scripts/statusline.test.ts
+++ b/user/scripts/statusline.test.ts
@@ -3,7 +3,9 @@ import {
   buildStatusLine,
   dialColor,
   dialIndex,
+  dialSegment,
   elideSpans,
+  exceeds200k,
   formatWorktree,
   type Span,
   type WorktreeData,
@@ -60,11 +62,13 @@ const cases: RenderCase[] = [
     stdin: { context_window: { used_percentage: pct } },
     worktree: null,
   })),
-  // exceeds_200k color escalation.
+  // exceeds_200k color escalation, driven by live current_usage.
   ...[30, 44, 45, 70].map((pct) => ({
     name: `dial-exceeds-${pct}`,
     columns: 80,
-    stdin: { context_window: { used_percentage: pct }, exceeds_200k_tokens: true },
+    stdin: {
+      context_window: { used_percentage: pct, current_usage: { input_tokens: 250_000 } },
+    },
     worktree: null,
   })),
   { name: "no-dial", columns: 80, stdin: {}, worktree: null },
@@ -138,6 +142,45 @@ describe("dialColor", () => {
     expect(dialColor(45, true)).toBe("red"); // yellow -> red (>= 45)
     expect(dialColor(70, true)).toBe("redBright"); // redBright unaffected
     expect(dialColor(85, true)).toBe("red"); // red unaffected
+  });
+});
+
+describe("exceeds200k", () => {
+  test("sums the live current_usage token breakdown", () => {
+    expect(exceeds200k({ context_window: { current_usage: { input_tokens: 250_000 } } })).toBe(
+      true,
+    );
+    expect(
+      exceeds200k({
+        context_window: {
+          current_usage: {
+            input_tokens: 100_000,
+            cache_read_input_tokens: 90_000,
+            output_tokens: 20_000,
+          },
+        },
+      }),
+    ).toBe(true);
+    expect(exceeds200k({ context_window: { current_usage: { input_tokens: 150_000 } } })).toBe(
+      false,
+    );
+    expect(exceeds200k({ context_window: {} })).toBe(false);
+    expect(exceeds200k({})).toBe(false);
+  });
+
+  test("color de-escalates with position after compaction shrinks the context", () => {
+    // Before compaction: large context, escalated color.
+    const before = dialSegment({
+      context_window: { used_percentage: 85, current_usage: { input_tokens: 850_000 } },
+    });
+    // After compaction: used_percentage drops and current_usage shrinks together,
+    // so both the glyph (position) and its color reset.
+    const after = dialSegment({
+      context_window: { used_percentage: 10, current_usage: { input_tokens: 100_000 } },
+    });
+    expect(strip(before ?? "")).not.toBe(strip(after ?? ""));
+    // The post-compaction dial uses the un-escalated color for its low percentage.
+    expect(after).toBe(dialSegment({ context_window: { used_percentage: 10 } }));
   });
 });
 

--- a/user/scripts/statusline.ts
+++ b/user/scripts/statusline.ts
@@ -3,9 +3,15 @@ import { basename } from "node:path";
 import { styleText } from "node:util";
 import { dialGlyph } from "./glyphs";
 
+interface CurrentUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
 interface StatusInput {
-  context_window?: { used_percentage?: number | null };
-  exceeds_200k_tokens?: boolean;
+  context_window?: { used_percentage?: number | null; current_usage?: CurrentUsage | null };
   cost?: { total_lines_added?: number; total_lines_removed?: number };
 }
 
@@ -67,12 +73,27 @@ export function dialIndex(pct: number): number {
   return idx > 7 ? 7 : idx;
 }
 
+// Claude Code's top-level `exceeds_200k_tokens` reflects the most recent API
+// response and is not recomputed on compaction, so it stays true after the
+// context shrinks. Derive it from the live `current_usage` instead, the same
+// source as `used_percentage`, so the dial's color and position reset together.
+export function exceeds200k(input: StatusInput): boolean {
+  const usage = input.context_window?.current_usage;
+  if (!usage) return false;
+  const total =
+    (usage.input_tokens ?? 0) +
+    (usage.output_tokens ?? 0) +
+    (usage.cache_creation_input_tokens ?? 0) +
+    (usage.cache_read_input_tokens ?? 0);
+  return total > 200_000;
+}
+
 export function dialSegment(input: StatusInput): string | null {
   const pct = input.context_window?.used_percentage;
   if (pct == null) return null;
 
   const intPct = Math.round(pct);
-  const color = dialColor(intPct, input.exceeds_200k_tokens === true);
+  const color = dialColor(intPct, exceeds200k(input));
   return styleText(color, dialGlyph(dialIndex(intPct)));
 }
 


### PR DESCRIPTION
Colors the context-window dial from the live `current_usage` token total instead of the top-level `exceeds_200k_tokens` flag, so the dial's color resets along with its position after compaction.

## Issue

Claude Code computes `exceeds_200k_tokens` from the most recent API response and does not recompute it on compaction, so it stays `true` after the context shrinks. `dialSegment` colored the dial from that sticky flag while positioning the glyph from `used_percentage` (which does reset), so a freshly compacted, low dial kept its escalated color.

## Changes

- Added `exceeds200k()`, which sums the live `context_window.current_usage` token breakdown (the same source that drives `used_percentage`) and compares it against the 200k threshold.
- `dialSegment` now derives escalation from `exceeds200k()`, so color and position de-escalate together.
- Dropped the unused `exceeds_200k_tokens` field from `StatusInput` and added `current_usage`.

## Testing

Added a unit test for `exceeds200k()` and a regression test asserting the dial color de-escalates with its position when the context shrinks. Existing render snapshots are unchanged (the escalation cases now supply `current_usage` and produce identical output).
