### PR TITLE
user: trim agent type prefix from subagent status line

### DIFF
--- a/user/scripts/__snapshots__/subagent-statusline.test.ts.snap
+++ b/user/scripts/__snapshots__/subagent-statusline.test.ts.snap
@@ -2,18 +2,18 @@
 
 exports[`rendered content running 1`] = `"\x1B[90m\x1B[2m󰚩\x1B[22m\x1B[39m  builder"`;
 
-exports[`rendered content completed-tokens 1`] = `"\x1B[32m󰚩\x1B[39m  deploy to prod \x1B[2m· 1.5k\x1B[22m"`;
+exports[`rendered content completed-tokens 1`] = `"\x1B[32m󰚩\x1B[39m  Deploy to prod \x1B[2m· 1.5k\x1B[22m"`;
 
 exports[`rendered content failed 1`] = `"\x1B[31m󰚩\x1B[39m  reviewer"`;
 
-exports[`rendered content remote 1`] = `"\x1B[90m\x1B[2m󰚩\x1B[22m\x1B[39m \x1B[2m\x1B[22m  remote build"`;
+exports[`rendered content remote 1`] = `"\x1B[90m\x1B[2m󰚩\x1B[22m\x1B[39m \x1B[2m\x1B[22m  Remote build"`;
 
-exports[`rendered content explore-glyph 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m  search \x1B[2m· Explore\x1B[22m"`;
+exports[`rendered content explore-glyph 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m  Search \x1B[2m· Explore\x1B[22m"`;
 
-exports[`rendered content plan-glyph 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m  design \x1B[2m· Plan\x1B[22m"`;
+exports[`rendered content plan-glyph 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m  Design \x1B[2m· Plan\x1B[22m"`;
 
-exports[`rendered content guide-glyph 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m  docs \x1B[2m· claude-code-guide\x1B[22m"`;
+exports[`rendered content guide-glyph 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m  Docs \x1B[2m· claude-code-guide\x1B[22m"`;
 
-exports[`rendered content full-meta-remote-explore 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m \x1B[2m\x1B[22m  build the parser \x1B[2m· 1m 5s · 2.3k · Explore\x1B[22m"`;
+exports[`rendered content full-meta-remote-explore 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m \x1B[2m\x1B[22m  Build the parser \x1B[2m· 1m 5s · 2.3k · Explore\x1B[22m"`;
 
-exports[`rendered content truncated 1`] = `"\x1B[90m\x1B[2m󰚩\x1B[22m\x1B[39m  a really long description …"`;
+exports[`rendered content truncated 1`] = `"\x1B[90m\x1B[2m󰚩\x1B[22m\x1B[39m  A really long description …"`;

--- a/user/scripts/subagent-statusline.test.ts
+++ b/user/scripts/subagent-statusline.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import { styleText } from "node:util";
 import { genericGlyph, purposeGlyphs } from "./glyphs";
-import { formatElapsed, formatTokens, renderTask, type Task } from "./subagent-statusline";
+import {
+  formatDescription,
+  formatElapsed,
+  formatTokens,
+  renderTask,
+  type Task,
+} from "./subagent-statusline";
 
 function strip(s: string): string {
   // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping terminal escapes
@@ -29,6 +35,28 @@ describe("formatTokens", () => {
   });
 });
 
+describe("formatDescription", () => {
+  test("strips the agent-type prefix and sentence-cases the rest", () => {
+    expect(formatDescription("Plan: review:self comprehension variant", "Plan")).toBe(
+      "Review:self comprehension variant",
+    );
+    expect(formatDescription("Plan: worktree hook escape hatch", "Plan")).toBe(
+      "Worktree hook escape hatch",
+    );
+  });
+
+  test("sentence-cases even when no prefix is present", () => {
+    expect(formatDescription("search the parser", "Explore")).toBe("Search the parser");
+    expect(formatDescription("deploy to prod", null)).toBe("Deploy to prod");
+  });
+
+  test("only strips a leading prefix matching the agent type", () => {
+    expect(formatDescription("review:self comprehension variant", "Plan")).toBe(
+      "Review:self comprehension variant",
+    );
+  });
+});
+
 describe("renderTask", () => {
   const now = 65_000;
 
@@ -53,7 +81,7 @@ describe("renderTask", () => {
 
   test("description preferred over name", () => {
     const out = renderTask({ id: "a", description: "do thing", name: "builder" }, null, now, null);
-    expect(strip(out.content)).toContain("do thing");
+    expect(strip(out.content)).toContain("Do thing");
     expect(strip(out.content)).not.toContain("builder");
   });
 
@@ -96,7 +124,7 @@ describe("renderTask", () => {
   test("type name drops on narrow terminals while the description survives", () => {
     const out = renderTask({ id: "a", description: "search the parser" }, 24, now, "Explore");
     expect(Bun.stringWidth(out.content)).toBeLessThanOrEqual(24);
-    expect(strip(out.content)).toContain("search the parser");
+    expect(strip(out.content)).toContain("Search the parser");
     expect(strip(out.content)).not.toContain("Explore");
   });
 

--- a/user/scripts/subagent-statusline.ts
+++ b/user/scripts/subagent-statusline.ts
@@ -71,6 +71,18 @@ function remoteMarker(type: string | undefined): string {
   return type === "remote_agent" ? styleText(["dim"], remoteGlyph) : "";
 }
 
+// Descriptions arrive prefixed with the agent type (e.g. "Plan: design the
+// API"), which the trailing dim type name already conveys. Drop the redundant
+// prefix and sentence-case what remains so the title reads cleanly.
+export function formatDescription(description: string, agentType: string | null): string {
+  let text = description;
+  if (agentType) {
+    const prefix = `${agentType}: `;
+    if (text.toLowerCase().startsWith(prefix.toLowerCase())) text = text.slice(prefix.length);
+  }
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
 // The status-colored type glyph leads, the cloud marker follows, so origin
 // stays visible without displacing the kind.
 export function renderTask(
@@ -100,7 +112,9 @@ export function renderTask(
     return body;
   };
 
-  let text = task.description || task.name || "agent";
+  let text = task.description
+    ? formatDescription(task.description, agentType)
+    : task.name || "agent";
   let content = build(text, true);
 
   if (columns != null && Bun.stringWidth(content) > columns) {


### PR DESCRIPTION
Strips the redundant `<AgentType>: ` prefix from subagent descriptions in the status line and sentence-cases what remains. The trailing dim type name (`· Plan`) already conveys the agent type, so `Plan: review:self comprehension variant` rendered the kind twice.

## Changes

- Adds `formatDescription` to `subagent-statusline.ts`: drops a leading prefix matching the known agent type, then uppercases the first letter.
- The prefix strip matches against the agent type specifically rather than the first colon, so an embedded colon (`review:self`) survives.
- I apply the first-letter capitalization to all descriptions, not only ones where a prefix was stripped, so untyped descriptions read consistently (`deploy to prod` → `Deploy to prod`).

## Testing

- Added a `formatDescription` test block covering prefix stripping, the no-prefix case, and the embedded-colon case.
- Updated two `renderTask` assertions and the rendered-content snapshots for the new casing.
