### PR TITLE
writing: flag journalistic cadence as an outbound-prose tell

### DIFF
--- a/plugins/writing/skills/writing/SKILL.md
+++ b/plugins/writing/skills/writing/SKILL.md
@@ -34,6 +34,10 @@ The hook enforces these automatically. Vocabulary and marketing-verb lists are i
 - No trailing hedge adverbs ("regardless.", "nonetheless.").
 - No cross-sentence negation ("It isn't X. It is Y."). Combine or drop the negation.
 
+#### Outbound Email and Messages
+
+- Don't write human-facing email in a punchy journalistic cadence: dramatic one-sentence paragraphs, rhetorical question then answer ("The result? X."), or escalating triads. Founders and colleagues don't write this way, so it reads as ghostwritten and therefore deceptive. Match the sender's plain voice.
+
 ## Voice
 
 Direct, conversational. Every sentence should teach something new. Cut words that restate the obvious.

--- a/plugins/writing/skills/writing/SKILL.md
+++ b/plugins/writing/skills/writing/SKILL.md
@@ -36,7 +36,7 @@ The hook enforces these automatically. Vocabulary and marketing-verb lists are i
 
 #### Outbound Email and Messages
 
-- Don't write human-facing email in a punchy journalistic cadence: dramatic one-sentence paragraphs, rhetorical question then answer ("The result? X."), or escalating triads. Founders and colleagues don't write this way, so it reads as ghostwritten and therefore deceptive. Match the sender's plain voice.
+- Don't write human-facing email in a punchy journalistic cadence: dramatic one-sentence paragraphs, rhetorical question then answer ("The result? X."), or escalating triads. Match the sender's plain voice.
 
 ## Voice
 


### PR DESCRIPTION
Adds a bullet to the `writing` skill that flags a punchy journalistic cadence as a tell in outbound, human-facing email and messages. It names the concrete sub-tells (dramatic one-sentence paragraphs, rhetorical question then answer, escalating triads) and the reason they matter: founders and colleagues don't write that way, so the cadence reads as ghostwritten and therefore deceptive. The corrective is to match the sender's plain voice.

This is prose-only. It lives under a new `#### Outbound Email and Messages` subsection alongside the existing `Structure`, `Word Choice`, and `PR and Review Prose` subsections. The hook (`tropes.ts`), wordlists, and tests are untouched.

## References

- [The cadence of AI-ghostwritten email](https://simonwillison.net/2026/May/26/paul-graham/)

Original Task: [[agent-idea] Flag hard-hitting journalistic cadence as an outbound-prose tell](https://things.bendrucker.me/show?id=NezyL1dwQ6VVsMXGfBvBXw)
