### PR TITLE
claude-code: add tool-overlap and over-prescription anti-patterns

### DIFF
--- a/plugins/claude-code/skills/skill/references/patterns.md
+++ b/plugins/claude-code/skills/skill/references/patterns.md
@@ -332,6 +332,30 @@ hooks:
 - **Imperative Form**: Use "Run script" not "You should run"
 - **Avoid Time-Sensitive Info**: Use "Old Patterns" sections for deprecated methods
 
+## Anti-Patterns
+
+### Tool Overlap Confuses the Model
+
+Exposing several near-duplicate tools makes Claude pick the wrong one. Three "fetch" variants or two "search" tools force a choice the model often gets wrong. Consolidate overlapping capabilities into a single parameterized tool, where an argument selects behavior.
+
+```yaml
+# Avoid: near-duplicate tools competing for the same job
+allowed-tools: [Bash(fetch-url:*), Bash(fetch-json:*), Bash(fetch-html:*)]
+```
+
+```yaml
+# Preferred: one tool, an argument selects behavior
+allowed-tools: [Bash(fetch:*)]
+```
+
+The same overlap appears at the skill level. Two near-duplicate skills whose `description` fields overlap compete to trigger, the activation equivalent of tool overlap. Prefer one skill with a `$ARGUMENTS`-selected mode over splitting it into rivals that race to activate.
+
+### Over-Prescription Lowers Quality
+
+Prompts that micromanage the exact sequence of tool calls degrade output and become brittle. Spelling out every call ties the skill to one path, so any change upstream breaks it. Prefer high-level guidance that states the goal and the constraints, then trust the model to sequence the work.
+
+This is the operational elaboration of [Don't Railroad Claude](../SKILL.md) and the appropriate-freedom principle: give Claude the outcome and let it choose the steps. When a skill keeps accreting prescriptive steps to patch failures, the fix is usually a clearer goal or a helper script, not more steps.
+
 ## Executable Code
 
 - Handle errors explicitly (don't punt to Claude)


### PR DESCRIPTION
Adds an `## Anti-Patterns` section to `references/patterns.md` in the `claude-code:skill` guide. The skill's Quick Reference already names "too many options" as an anti-pattern, but `patterns.md` never elaborated it. This gives that pointer a home.

## Changes

- `### Tool Overlap Confuses the Model`: near-duplicate tools (three "fetch" variants, two "search" tools) make Claude pick the wrong one. Consolidate into a single parameterized tool, with `Avoid`/`Preferred` `allowed-tools` examples following the file's existing fenced-block idiom. Extends the point to skills: prefer one skill with a `$ARGUMENTS`-selected mode over near-duplicate skills whose `description` fields compete to trigger.
- `### Over-Prescription Lowers Quality`: prompts that micromanage the exact sequence of tool calls degrade output and become brittle. Prefer high-level guidance, linking back to `Don't Railroad Claude` in `SKILL.md` via a relative `../SKILL.md` link.

Verified with `bun run skill-lint` against the skill.

Original Task: [[agent-idea] Add a tool-overlap and over-prescription anti-pattern to the skill-authoring guide](https://things.bendrucker.me/show?id=U5AMchwN8ALdBgyTnF7Ev3)
