### PR TITLE
feat(review:self): add by-hand mode

### DIFF
--- a/plugins/review/README.md
+++ b/plugins/review/README.md
@@ -8,7 +8,7 @@ Code review workflows for Claude Code.
 
 - **`hunk`**: Core layer for reviewing changes through a live [Hunk](https://github.com/modem-dev/hunk) session in tmux. Launches and drives the session, seeds and reads back inline comments, and ships the watcher, line-mapping, and resolution-ledger helpers. `self` and `peer` delegate to it.
 - **`peer`**: Review PRs when requested by a peer (GitHub or GitLab). Stages comments in Hunk for local revision, then maps and posts them as a batch.
-- **`self`**: Self-review your own changes in a live Hunk session before committing. Your inline comments come back to Claude as edits to apply.
+- **`self`**: Self-review your own changes in a live Hunk session before committing. Your inline comments come back to Claude as edits to apply, or in by-hand mode Claude hands each one back and you apply it yourself.
 - **`follow-up`**: Follow up on a PR/MR you reviewed: check if your comments were addressed, find silent resolves, decide whether to re-approve
 - **`dashboard`**: Live tmux dashboard for reviewing inbound PRs across GitHub and GitLab
 

--- a/plugins/review/skills/self/SKILL.md
+++ b/plugins/review/skills/self/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review:self
 description: |
-  Self-review your own changes in a live Hunk session before committing or opening a PR. You annotate changed lines in the terminal and your comments come back to Claude as edits to apply. Replaces the difit web UI. Use for "review my changes", "self review", "let me look at the diff before committing".
+  Self-review your own changes in a live Hunk session before committing or opening a PR. You annotate changed lines in the terminal and your comments come back to Claude as edits to apply. Replaces the difit web UI. Use for "review my changes", "self review", "let me look at the diff before committing". Supports a by-hand mode where Claude hands each comment back as an instruction and you apply the edits yourself, for changes you want to understand and remember ("guide me through the changes", "I'll apply the edits myself", "let me make the changes").
 disable-model-invocation: true
 allowed-tools:
   - Skill(review:hunk)
@@ -14,8 +14,9 @@ allowed-tools:
 
 # Self Review
 
-I review my own changes in Hunk; you read my comments back and apply them. The live session is
-the buffer: I annotate lines, you edit. Nothing lives in a hand-edited JSON file.
+I review my own changes in Hunk; you read my comments back. The live session is the buffer: I
+annotate lines, the comments come back as edits. Nothing lives in a hand-edited JSON file. By
+default you apply the edits; in by-hand mode you guide me and I apply them myself.
 
 Load `review:hunk` for all session mechanics (launch, seeding, read-back, the ledger). This
 skill is the inbound loop on top of it.
@@ -24,7 +25,10 @@ skill is the inbound loop on top of it.
 
 Default to the working tree. Override with $ARGUMENTS (`staged`, `main...HEAD`, `HEAD`).
 
-## Loop
+## Modes
+
+Two loops over the same Hunk session. The setup is identical: target the diff, launch the
+session, hand off, collect the comments, and keep the ledger. They differ only at apply time.
 
 1. **Launch** via `review:hunk`: open the target diff in a sibling tmux pane with
    `--watch --agent-notes`.
@@ -35,15 +39,32 @@ Default to the working tree. Override with $ARGUMENTS (`staged`, `main...HEAD`, 
    - **Live**: if I ask to work as I go, arm monitor mode (`review:hunk` Monitor section) and
      act on each comment as it lands, holding the applied edits for my review.
 4. **Collect**: `hunk session comment list --type user --json`.
-5. **Apply**: for each comment, read the referenced file and lines, then make the edit.
-   `--watch` reloads the diff as you go.
-6. **Resolve, don't delete**: mark each applied note resolved with `review:hunk`'s ledger CLI
-   (`ledger.ts resolve <noteId> --action ...`), keyed by `noteId`. The note stays visible and
-   nothing is lost. The ledger is the source of truth for open vs resolved, since `--watch`
-   orphans rather than resolves. Sync the current notes with `ledger.ts upsert` first, and use
-   `ledger.ts list --open` to report what remains.
-7. **Repeat** until I say done, then summarize what changed and what is still open (from the
-   ledger).
+
+Then apply, in one of two modes:
+
+#### Apply (default)
+
+For each comment, read the referenced file and lines, then make the edit. `--watch` reloads the
+diff as you go.
+
+#### By-hand
+
+I make the edits; you guide me. For each comment, in file order, tell me the file, the lines,
+what to change, and why, as one concrete instruction. Then stop and wait. I make the edit; you
+confirm it landed (the `--watch` reload shows it) before moving to the next. One comment at a
+time. The friction is the point: I want to understand and remember each change, so never use
+`Edit` here.
+
+#### Resolve, don't delete
+
+Mark each handled note resolved with `review:hunk`'s ledger CLI
+(`ledger.ts resolve <noteId> --action ...`), keyed by `noteId`. The note stays visible and
+nothing is lost. The ledger is the source of truth for open vs resolved, since `--watch`
+orphans rather than resolves. Sync the current notes with `ledger.ts upsert` first, and use
+`ledger.ts list --open` to report what remains. In by-hand mode, resolve only after I confirm I
+applied the edit, recording "applied by hand".
+
+Repeat until I say done, then summarize what changed and what is still open (from the ledger).
 
 ## Guidelines
 
@@ -51,4 +72,7 @@ Default to the working tree. Override with $ARGUMENTS (`staged`, `main...HEAD`, 
   push back on.
 - A note you disagree with stays open: leave it and tell me why rather than silently resolving
   it.
+- In by-hand mode, never use `Edit`. If I stall, explain more, but do not apply the change for
+  me.
+- In by-hand mode, give me one comment at a time. Do not dump the full list.
 - When done, offer next steps (commit, peer review, PR) without taking them unprompted.


### PR DESCRIPTION
Adds a by-hand mode to `review:self` where Claude reads each Hunk comment back as one concrete instruction (file, lines, what to change, and why), then stops and waits for me to make the edit. Claude confirms each edit landed before handing me the next, one comment at a time. Default mode, where Claude applies the edits, is unchanged.

Both modes run the same loop over a single Hunk session. Targeting the diff, launching, handing off, collecting comments, and the resolution ledger are identical; they fork only at apply time. In by-hand mode Claude never uses `Edit` and resolves a note only after I confirm I applied the change, recording "applied by hand".

I added the mode inside the existing `self` skill rather than a new skill or a flag. It is a second loop over the same machinery, so a separate skill would duplicate the setup and the ledger handling. Triggering is description-driven ("guide me through the changes", "I'll apply the edits myself", "let me make the changes").

## Changes

- `plugins/review/skills/self/SKILL.md`: replace the single Loop section with a Modes frame covering shared setup, the default Apply path, the new By-hand path, and ledger resolution; extend the frontmatter `description` with by-hand triggers; add two Guidelines lines.
- `plugins/review/README.md`: note the by-hand mode in the `self` bullet.

Original Task: [[agent-idea] Add a comprehension-preserving variant to review:self where the human applies edits](https://things.bendrucker.me/show?id=Soaf6uSghXvkFYsuJ21pdw)
