### PR TITLE
ci: consolidate hooks-job test dirs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run tests
-        run: bun test ./.claude/hooks ./.claude/skills user/hooks user/scripts user/skills
+        run: bun test ./.claude ./user
 
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Changes the `hooks` job to `bun test ./.claude ./user` instead of enumerating each subdirectory. `bun test` treats a dotdir argument without a `./` prefix as a no-match filter, so the per-subdir list was fragile: each `.claude/*` arg needed the `./`, and every new test directory needed a CI edit. Pointing at the two top-level trees runs the same 121 tests across 7 files and auto-covers any new test dir.

## Testing

Verified locally that `bun test ./.claude ./user` and the previous enumerated list both run 121 tests across 7 files (same coverage, no tests dropped).
