### PR TITLE
docs(rules): document the sandbox trust model

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -21,42 +21,26 @@ Permission patterns starting with `/` are relative to the settings file, not abs
 
 ## Sandbox Trust Model
 
-The sandbox's primary job is egress control, not filesystem lockdown. The guarantee is that credentials never enter the sandbox, so a model (or an attacker steering it) cannot exfiltrate them no matter how creative the path. Broad filesystem writes are therefore tolerable, but any widening of the egress surface (a new host, socket, or network-reaching escaped command) opens a channel data can leave through and needs a reason. The groupings below exist so a routine addition (one more cache, one more `gh`-class tool) lands in an existing bucket, while a genuinely new kind of allowance forces a fresh decision.
+The sandbox is egress control, not filesystem lockdown: credentials stay outside it, so they cannot be exfiltrated. Broad filesystem writes are fine, but a new host, socket, or network-reaching escaped command widens the egress surface and needs justification.
 
-#### Egress allowances (the surface to guard)
+#### Hosts (`network`, mirrored by `WebFetch(domain:...)`)
 
-`network` (mirrored by the `WebFetch(domain:...)` permission list) is where data can leave. The allowed hosts fall into three trust groups:
+- Package registries: `registry.npmjs.org`, `www.npmjs.com`, `pypi.org`, `rubygems.org`, `proxy.golang.org`, `sum.golang.org`.
+- Docs and source: `docs.anthropic.com`, `code.claude.com`, `modelcontextprotocol.io`, `pkg.go.dev`, `bun.sh`, `bun.com`, `github.com`, `raw.githubusercontent.com`.
+- Credentialed APIs: `api.github.com`, `api.linear.app`, `api.anthropic.com`, `claude.ai`. Trusted only because each secret lives outside the sandbox.
 
-- Package registries: `registry.npmjs.org`, `www.npmjs.com`, `pypi.org`, `rubygems.org`, `proxy.golang.org`, `sum.golang.org`. Read-mostly public infrastructure with no credential attached.
-- Docs and source: `docs.anthropic.com`, `code.claude.com`, `modelcontextprotocol.io`, `pkg.go.dev`, `bun.sh`, `bun.com`, `github.com`, `raw.githubusercontent.com`. Public read endpoints.
-- Credentialed APIs: `api.github.com`, `api.linear.app`, `api.anthropic.com`, `claude.ai`. Each is trusted because its secret lives outside the sandbox (the host tool authenticates), not because the host itself is safe.
+`api.anthropic.com` is the known exfil-capable host (it accepts uploads). It stays because the agent needs the model API.
 
-`api.anthropic.com` is the known exfil-relevant host: it accepts uploads and has served as an unintended exfiltration vector before. It stays (the agent needs the model API), but it is the reason egress control is not a complete guarantee. Treat it as the standing exception, not a precedent for adding more upload-capable hosts.
+#### Sockets and writes
 
-`allowUnixSockets` grants two local channels:
-
-- The Secretive SSH agent socket (`~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/...`) is a signing channel only. Keys stay in the Secure Enclave. The sandbox can request signatures but never sees private key material.
-- `~/.tmux` is local IPC to the running tmux server. It reaches nothing off the machine.
-
-`allowLocalBinding` permits binding local ports for loopback servers. Local-only, no egress.
-
-#### Local-only allowances (cannot exfiltrate)
-
-`filesystem.allowWrite` covers scratch and toolchain or dependency caches: `/tmp`, `~/.cache`, `~/.terraform.d/plugin-cache`, `~/Library/Caches/go-build`, `~/src/go/pkg/{mod,sumdb}`, `~/.bun/install`, `~/.local/share/uv`, `~/.local/share/graphite`. None is a credential store. Writing here cannot move data off the machine, so the bar for adding a write path is low: confirm it is genuinely a cache or scratch directory and not somewhere secrets live.
+`allowUnixSockets`: the Secretive SSH agent is a signing channel (keys stay in the Secure Enclave), `~/.tmux` is local IPC. `allowLocalBinding` is loopback-only. `filesystem.allowWrite` covers caches and scratch, not credential stores: `/tmp`, `~/.cache`, `~/.terraform.d/plugin-cache`, `~/Library/Caches/go-build`, `~/src/go/pkg/{mod,sumdb}`, `~/.bun/install`, `~/.local/share/uv`, `~/.local/share/graphite`.
 
 #### Escaped commands (`excludedCommands`)
 
-These run outside the sandbox. `excludedCommands` matches only the top-level command (see [Sandbox and Nested Commands](#sandbox-and-nested-commands) above), so escaping a wrapper does not escape what it spawns. They group by why escaping is acceptable:
+Run outside the sandbox; only the top-level command matches (see [Sandbox and Nested Commands](#sandbox-and-nested-commands)).
 
-- Self-authenticating network tools: `git`, `gh`, `linear`, `aws`, `gcloud`, `az`, `ssh`, `scp`, `rsync`, `docker`. Each carries its own out-of-sandbox auth and already reaches the network on its own terms. Sandboxing them only breaks their credential handling without closing a channel they don't already have.
-- macOS host integration (the `mac` plugin): `open`, `osascript`, `shortcuts`, `pbcopy`, `pbpaste`, `security`, `defaults`, `screencapture`, `say`, `afplay`, `diskutil`, `networksetup`, `dscl`. Host APIs the sandbox cannot model.
-- Local agent and session tooling: `wt`, `claude`, `agent-browser`, `code`. Worktree, session, and editor control that operates locally.
+- Self-authenticating network tools: `git`, `gh`, `linear`, `aws`, `gcloud`, `az`, `ssh`, `scp`, `rsync`, `docker`. Each carries its own auth and already reaches the network.
+- macOS host integration (`mac` plugin): `open`, `osascript`, `shortcuts`, `pbcopy`, `pbpaste`, `security`, `defaults`, `screencapture`, `say`, `afplay`, `diskutil`, `networksetup`, `dscl`. Host APIs the sandbox cannot model.
+- Local session tooling: `wt`, `claude`, `agent-browser`, `code`. Worktree, session, and editor control that stays local.
 
-#### Editing guidance
-
-Before adding an allowance, place it in the right group and apply that group's test:
-
-- New host: which trust group does it belong to? Public read infra is low-risk. A credentialed API is acceptable only when its secret stays outside the sandbox. An upload-capable host is an egress risk, so do not add one casually.
-- New socket: confirm it is a signing or local-IPC channel that reaches nothing off-machine, like the two already listed.
-- New write path: confirm it is scratch or a cache, never a credential store.
-- New escaped command: confirm it fits an existing rationale (self-authenticating tool, host integration, or local tooling). A network-reaching command that does not carry its own auth widens egress and should stay sandboxed.
+A new host needs its secret kept outside the sandbox, and never add an upload-capable one casually. A new escaped command must fit a group above, or stay sandboxed if it reaches the network without its own auth.

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -21,9 +21,9 @@ Permission patterns starting with `/` are relative to the settings file, not abs
 
 ## Sandbox Trust Model
 
-The sandbox is egress control, not filesystem lockdown: credentials stay outside it, so they cannot be exfiltrated. Broad filesystem writes are fine, but a new host, socket, or network-reaching escaped command widens the egress surface and needs justification.
+The sandbox is egress control, not filesystem lockdown. Credentials stay outside its reach, so a sandboxed process cannot exfiltrate them. Broad filesystem writes are fine, but a new host, socket, or network-reaching escaped command widens the egress surface and needs justification.
 
-#### Hosts (`network`, mirrored by `WebFetch(domain:...)`)
+### Hosts (`WebFetch(domain:...)` Permissions)
 
 - Package registries: `registry.npmjs.org`, `www.npmjs.com`, `pypi.org`, `rubygems.org`, `proxy.golang.org`, `sum.golang.org`.
 - Docs and source: `docs.anthropic.com`, `code.claude.com`, `modelcontextprotocol.io`, `pkg.go.dev`, `bun.sh`, `bun.com`, `github.com`, `raw.githubusercontent.com`.
@@ -31,11 +31,11 @@ The sandbox is egress control, not filesystem lockdown: credentials stay outside
 
 `api.anthropic.com` is the known exfil-capable host (it accepts uploads). It stays because the agent needs the model API.
 
-#### Sockets and writes
+### Sockets and Writes
 
 `allowUnixSockets`: the Secretive SSH agent is a signing channel (keys stay in the Secure Enclave), `~/.tmux` is local IPC. `allowLocalBinding` is loopback-only. `filesystem.allowWrite` covers caches and scratch, not credential stores: `/tmp`, `~/.cache`, `~/.terraform.d/plugin-cache`, `~/Library/Caches/go-build`, `~/src/go/pkg/{mod,sumdb}`, `~/.bun/install`, `~/.local/share/uv`, `~/.local/share/graphite`.
 
-#### Escaped commands (`excludedCommands`)
+### Escaped Commands (`excludedCommands`)
 
 Run outside the sandbox; only the top-level command matches (see [Sandbox and Nested Commands](#sandbox-and-nested-commands)).
 
@@ -43,4 +43,4 @@ Run outside the sandbox; only the top-level command matches (see [Sandbox and Ne
 - macOS host integration (`mac` plugin): `open`, `osascript`, `shortcuts`, `pbcopy`, `pbpaste`, `security`, `defaults`, `screencapture`, `say`, `afplay`, `diskutil`, `networksetup`, `dscl`. Host APIs the sandbox cannot model.
 - Local session tooling: `wt`, `claude`, `agent-browser`, `code`. Worktree, session, and editor control that stays local.
 
-A new host needs its secret kept outside the sandbox, and never add an upload-capable one casually. A new escaped command must fit a group above, or stay sandboxed if it reaches the network without its own auth.
+A new host needs its secret kept outside the sandbox, and never add an upload-capable one casually. A new escaped command must fit a group above. If it reaches the network without its own auth, keep it sandboxed.

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -18,3 +18,45 @@ Permission patterns starting with `/` are relative to the settings file, not abs
 ## Sandbox and Nested Commands
 
 `excludedCommands` matches only the top-level command of a Bash invocation. Nested commands (e.g., `open` spawned from a `bun scripts/foo.ts` wrapper) inherit the parent's sandbox profile, so adding `open:*` to `excludedCommands` does not exempt nested calls. The working mechanism is the `mac` plugin's marker-based sandbox hook, which reads a `claude:dangerouslyDisableSandbox` comment from the invoked script. See [`scripts.md`](scripts.md) for the mechanism and canonical examples.
+
+## Sandbox Trust Model
+
+The sandbox's primary job is egress control, not filesystem lockdown. The guarantee is that credentials never enter the sandbox, so a model (or an attacker steering it) cannot exfiltrate them no matter how creative the path. Broad filesystem writes are therefore tolerable, but any widening of the egress surface (a new host, socket, or network-reaching escaped command) opens a channel data can leave through and needs a reason. The groupings below exist so a routine addition (one more cache, one more `gh`-class tool) lands in an existing bucket, while a genuinely new kind of allowance forces a fresh decision.
+
+#### Egress allowances (the surface to guard)
+
+`network` (mirrored by the `WebFetch(domain:...)` permission list) is where data can leave. The allowed hosts fall into three trust groups:
+
+- Package registries: `registry.npmjs.org`, `www.npmjs.com`, `pypi.org`, `rubygems.org`, `proxy.golang.org`, `sum.golang.org`. Read-mostly public infrastructure with no credential attached.
+- Docs and source: `docs.anthropic.com`, `code.claude.com`, `modelcontextprotocol.io`, `pkg.go.dev`, `bun.sh`, `bun.com`, `github.com`, `raw.githubusercontent.com`. Public read endpoints.
+- Credentialed APIs: `api.github.com`, `api.linear.app`, `api.anthropic.com`, `claude.ai`. Each is trusted because its secret lives outside the sandbox (the host tool authenticates), not because the host itself is safe.
+
+`api.anthropic.com` is the known exfil-relevant host: it accepts uploads and has served as an unintended exfiltration vector before. It stays (the agent needs the model API), but it is the reason egress control is not a complete guarantee. Treat it as the standing exception, not a precedent for adding more upload-capable hosts.
+
+`allowUnixSockets` grants two local channels:
+
+- The Secretive SSH agent socket (`~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/...`) is a signing channel only. Keys stay in the Secure Enclave. The sandbox can request signatures but never sees private key material.
+- `~/.tmux` is local IPC to the running tmux server. It reaches nothing off the machine.
+
+`allowLocalBinding` permits binding local ports for loopback servers. Local-only, no egress.
+
+#### Local-only allowances (cannot exfiltrate)
+
+`filesystem.allowWrite` covers scratch and toolchain or dependency caches: `/tmp`, `~/.cache`, `~/.terraform.d/plugin-cache`, `~/Library/Caches/go-build`, `~/src/go/pkg/{mod,sumdb}`, `~/.bun/install`, `~/.local/share/uv`, `~/.local/share/graphite`. None is a credential store. Writing here cannot move data off the machine, so the bar for adding a write path is low: confirm it is genuinely a cache or scratch directory and not somewhere secrets live.
+
+#### Escaped commands (`excludedCommands`)
+
+These run outside the sandbox. `excludedCommands` matches only the top-level command (see [Sandbox and Nested Commands](#sandbox-and-nested-commands) above), so escaping a wrapper does not escape what it spawns. They group by why escaping is acceptable:
+
+- Self-authenticating network tools: `git`, `gh`, `linear`, `aws`, `gcloud`, `az`, `ssh`, `scp`, `rsync`, `docker`. Each carries its own out-of-sandbox auth and already reaches the network on its own terms. Sandboxing them only breaks their credential handling without closing a channel they don't already have.
+- macOS host integration (the `mac` plugin): `open`, `osascript`, `shortcuts`, `pbcopy`, `pbpaste`, `security`, `defaults`, `screencapture`, `say`, `afplay`, `diskutil`, `networksetup`, `dscl`. Host APIs the sandbox cannot model.
+- Local agent and session tooling: `wt`, `claude`, `agent-browser`, `code`. Worktree, session, and editor control that operates locally.
+
+#### Editing guidance
+
+Before adding an allowance, place it in the right group and apply that group's test:
+
+- New host: which trust group does it belong to? Public read infra is low-risk. A credentialed API is acceptable only when its secret stays outside the sandbox. An upload-capable host is an egress risk, so do not add one casually.
+- New socket: confirm it is a signing or local-IPC channel that reaches nothing off-machine, like the two already listed.
+- New write path: confirm it is scratch or a cache, never a credential store.
+- New escaped command: confirm it fits an existing rationale (self-authenticating tool, host integration, or local tooling). A network-reaching command that does not carry its own auth widens egress and should stay sandboxed.


### PR DESCRIPTION
Adds a `## Sandbox Trust Model` section to `.claude/rules/settings.md`, the rule that auto-injects when editing `settings.json`. The section frames the sandbox as egress control rather than filesystem lockdown: the guarantee is that credentials never enter the sandbox, so broad filesystem writes are tolerable while any new host, socket, or network-reaching escaped command widens the surface data can leave through.

I grouped the real config values from `user/settings.json` by trust rationale so routine additions (one more cache, one more `gh`-class tool) land in an existing bucket while a genuinely new kind of allowance forces a fresh decision:

- Egress allowances: `allowedHosts` split into package registries, docs/source, and credentialed APIs, plus `allowUnixSockets` (Secretive signing socket, tmux IPC) and `allowLocalBinding`. I flagged `api.anthropic.com` as the standing exfil-relevant exception (it accepts uploads) rather than a precedent for more upload-capable hosts.
- Local-only allowances: the `filesystem.allowWrite` cache and scratch paths, which cannot move data off-machine.
- Escaped commands: `excludedCommands` grouped into self-authenticating network tools, macOS host integration, and local agent tooling, cross-linked to the existing `## Sandbox and Nested Commands` section for the top-level-match mechanics.

The section closes with a short checklist for vetting a new host, socket, write path, or escaped command before adding it.

Original Task: [[agent-idea] Document the sandbox trust model in the settings rule](https://things.bendrucker.me/show?id=HpQ3Bsq4tcweoddSVVYmnZ)
