### PR TITLE
testing: prefix dotdir paths with ./ in bun test

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -14,6 +14,7 @@ After making changes to plugin scripts, run them directly to verify they work en
 ## Conventions
 
 - **`bun test` runs all unit tests**: Bun auto-discovers `*.test.ts` files. Integration tests (`*.integration.ts`) are not auto-discovered and can be run by passing paths explicitly (e.g., `bun test plugins/<name>/tests/file.integration.ts`).
+- **Prefix dotdir paths with `./` in `bun test`**: A positional arg is a *filter* (substring match against discovered test paths), not a path. Discovery skips dotdirs, so `bun test .claude/hooks` matches nothing and silently runs 0 tests. Writing `bun test ./.claude/hooks` makes bun read it as a path and run the tests under it. Always use a `./` prefix for hidden-dir paths in CI and local test commands.
 - **No `.js` imports in TypeScript**: Import from `./module` not `./module.js`. The bundler/runtime handles resolution.
 - **Prefer skills over agents**: Skills are invocable via the Skill tool. Agents require the Task tool. If something should be directly invocable, make it a skill.
 


### PR DESCRIPTION
Documents that a positional arg to `bun test` is a filter (substring match against discovered test paths), not a path, and that discovery skips dotdirs. So `bun test .claude/hooks` matches nothing and silently runs 0 tests, while `bun test ./.claude/hooks` is read as a path and runs the tests under it.

The CI fix already shipped in #709, which switched the workflow to `./.claude/hooks`. This PR only adds the convention to `.claude/rules/testing.md` so the gotcha is documented next to the existing `bun test` invocation guidance.

Original Task: [[bug] CI test job skips hidden .claude/ dirs (bun test needs ./ prefix)](https://things.bendrucker.me/show?id=6Heecznka8mk2deVsekRpZ)
