### PR TITLE
fix(worktree): allow throwaway worktrees under tmp/

### DIFF
--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -8,6 +8,8 @@ paths:
 
 See the `claude-code:hook` skill for hook documentation. Plugin hooks are defined in `hooks/hooks.json`. This repository includes a Biome PostToolUse hook (`.claude/hooks/biome/`) that runs after file edits to check for lint errors.
 
+Raw `git worktree add` is denied in favor of the `worktrunk` skill, except when the target is under `tmp/`, which is allowed for disposable scripted verification checkouts.
+
 Wrap `${CLAUDE_PLUGIN_ROOT}` in double quotes in shell-form hook commands: `bun "${CLAUDE_PLUGIN_ROOT}/scripts/foo.ts"`. Matcher fields are not shell commands and should not be quoted. Run `bun scripts/check-hook-quoting.ts` to validate.
 
 ## MCP Matchers

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -41,6 +41,7 @@ I use Worktrunk (the `wt` CLI) for git worktrees, exposed through two skills:
 
 - For creating or entering a worktree, use the `worktrunk:wt-switch-create` skill. It re-roots the session into a new worktree (optionally in another repo), runs an optional task, and acts as a targeted command for the common case. Prefer it over the generic skill whenever the task is worktree creation, including anywhere you would otherwise delegate worktree creation to Worktrunk.
 - For everything else (pruning, listing, removing, running hooks, editing config, and general `wt` questions), use the generic `worktrunk:worktrunk` skill.
+- Disposable verification worktrees may be created with `git worktree add tmp/<name>`; everything persistent goes through the worktrunk skills.
 
 ## Stacked PRs
 

--- a/user/hooks/worktree/index.test.ts
+++ b/user/hooks/worktree/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { formatAskOutput, formatDenyOutput, processInput } from "./index";
+import { formatAskOutput, formatDenyOutput, isThrowawayAdd, processInput } from "./index";
 
 function bashInput(command: string): PreToolUseHookInput {
   return {
@@ -18,6 +18,45 @@ describe("processInput", () => {
 
   it("allows git worktree list", () => {
     expect(processInput(bashInput("git worktree list"))).toBeNull();
+  });
+
+  it("allows git worktree add under tmp/", () => {
+    expect(processInput(bashInput("git worktree add tmp/verify"))).toBeNull();
+  });
+
+  it("allows git worktree add under ./tmp/ with a commit-ish", () => {
+    expect(processInput(bashInput("git worktree add ./tmp/verify HEAD"))).toBeNull();
+  });
+
+  it("allows git worktree add --detach under tmp/", () => {
+    expect(processInput(bashInput("git worktree add --detach tmp/verify"))).toBeNull();
+  });
+
+  it("allows git worktree add with a flag value before the tmp path", () => {
+    expect(processInput(bashInput("git worktree add -b throwaway tmp/verify"))).toBeNull();
+  });
+
+  it("denies git worktree add outside tmp/", () => {
+    expect(processInput(bashInput("git worktree add ../path -b branch"))).toEqual(
+      formatDenyOutput("add"),
+    );
+  });
+
+  it("denies git worktree add to a path that merely contains tmp/", () => {
+    expect(processInput(bashInput("git worktree add notmp/foo"))).toEqual(formatDenyOutput("add"));
+    expect(processInput(bashInput("git worktree add a/tmp/foo"))).toEqual(formatDenyOutput("add"));
+  });
+
+  it("denies git worktree add under .worktrees/", () => {
+    expect(processInput(bashInput("git worktree add .worktrees/foo"))).toEqual(
+      formatDenyOutput("add"),
+    );
+  });
+
+  it("denies git worktree remove under tmp/", () => {
+    expect(processInput(bashInput("git worktree remove tmp/verify"))).toEqual(
+      formatDenyOutput("remove"),
+    );
   });
 
   it("denies git worktree remove", () => {
@@ -47,5 +86,23 @@ describe("processInput", () => {
   it("returns null when command is missing", () => {
     const input = { tool_name: "Bash", tool_input: {} } as PreToolUseHookInput;
     expect(processInput(input)).toBeNull();
+  });
+});
+
+describe("isThrowawayAdd", () => {
+  it("matches a tmp/ target", () => {
+    expect(isThrowawayAdd("git worktree add tmp/x")).toBe(true);
+  });
+
+  it("matches a ./tmp/ target", () => {
+    expect(isThrowawayAdd("git worktree add ./tmp/x")).toBe(true);
+  });
+
+  it("does not match a tmp-prefixed sibling directory", () => {
+    expect(isThrowawayAdd("git worktree add tmpfoo/x")).toBe(false);
+  });
+
+  it("does not match tmp/ nested below another directory", () => {
+    expect(isThrowawayAdd("git worktree add a/tmp/x")).toBe(false);
   });
 });

--- a/user/hooks/worktree/index.ts
+++ b/user/hooks/worktree/index.ts
@@ -9,13 +9,25 @@ export type BashInput = {
 
 const READ_ONLY_SUBCOMMANDS = new Set(["list"]);
 const REPLACED_SUBCOMMANDS = new Set(["add", "remove"]);
+const TMP_TARGET = /^(\.\/)?tmp\//;
+
+export function isThrowawayAdd(command: string): boolean {
+  const after = command.split(/\bgit\s+worktree\s+add\b/)[1];
+  if (after === undefined) return false;
+  return after.split(/\s+/).some((tok) => TMP_TARGET.test(tok));
+}
 
 export function formatDenyOutput(subcommand: string): SyncHookJSONOutput {
+  const base = `Use the worktrunk skill (/worktrunk) instead of \`git worktree ${subcommand}\`.`;
+  const reason =
+    subcommand === "add"
+      ? `${base} For a throwaway verification checkout, add it under \`tmp/\`.`
+      : base;
   return {
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       permissionDecision: "deny",
-      permissionDecisionReason: `Use the worktrunk skill (/worktrunk) instead of \`git worktree ${subcommand}\`.`,
+      permissionDecisionReason: reason,
     },
   };
 }
@@ -43,6 +55,9 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
     return null;
   }
   if (READ_ONLY_SUBCOMMANDS.has(subcommand)) {
+    return null;
+  }
+  if (subcommand === "add" && isThrowawayAdd(command)) {
     return null;
   }
   if (REPLACED_SUBCOMMANDS.has(subcommand)) {


### PR DESCRIPTION
Allows `git worktree add` when the target path is under `tmp/`. The `PreToolUse` hook in `user/hooks/worktree/index.ts` previously redirected every `git worktree add` to the worktrunk skill, with no way to spin up a disposable, scripted verification worktree. That left `git archive | tar -x` into a temp dir as the only workaround.

`tmp/` is the repo's documented throwaway location (`user/CLAUDE.md`), so a worktree under it reads as disposable and won't collide with worktrunk's `.worktrees/` paths or be picked up by `wt sync`. Persistent worktrees still go through worktrunk.

## Changes

- `isThrowawayAdd` scans the tokens after `git worktree add` for a `tmp/`-prefixed path. I scan all tokens rather than just the first positional so a flag-with-value (`-b branch tmp/foo`) still resolves correctly; the tradeoff is that a `tmp/`-prefixed branch name also passes, which is acceptable for a self-permission gate.
- `remove` stays fully redirected (cleanup of a `tmp/` worktree is just `rm -rf`).
- The `add` denial message now points at the `tmp/` path for throwaway checkouts; `.claude/rules/hooks.md` and `user/CLAUDE.md` document it.
- I rejected allowing all `--detach` worktrees: detached checkouts are a legitimate way to do real multi-branch work, so that would be too broad.

## Testing

`bun test ./user/hooks/worktree`. New cases cover `tmp/` and `./tmp/` allows, a flag-with-value before the path, and denials for look-alike paths (`notmp/`, `a/tmp/`, `.worktrees/`) and `remove` under `tmp/`.

Original Task: [[bug] git worktree add hook lacks escape hatch for throwaway worktrees](https://things.bendrucker.me/show?id=Wq4TMmRtqN5MQJy8SLUaux)
