### PR TITLE
gitlab: add next-actor triage to MR review-state

### DIFF
--- a/plugins/gitlab/skills/merge-request/SKILL.md
+++ b/plugins/gitlab/skills/merge-request/SKILL.md
@@ -78,6 +78,8 @@ bun ${CLAUDE_SKILL_DIR}/scripts/review-queue.ts
 
 See [review-state.md](review-state.md) for the underlying GraphQL query and filter.
 
+To group all your review-requested MRs by next actor (not just the `UNREVIEWED` slice), see [Review Inbox (Next-Actor Triage)](review-state.md#review-inbox-next-actor-triage) in review-state.md.
+
 ## Discussions
 
 Fetch, filter, resolve, and summarize MR discussion threads. See [discussions.md](discussions.md) for the discussions script, resolution workflow, and pagination pitfalls.
@@ -89,6 +91,6 @@ Fetch, filter, resolve, and summarize MR discussion threads. See [discussions.md
 ## Reference Files
 
 - [review.md](review.md) - Draft notes review workflow
-- [review-state.md](review-state.md) - GraphQL mutations for review decisions and the cross-project review queue
+- [review-state.md](review-state.md) - GraphQL mutations for review decisions, the cross-project review queue, and next-actor triage
 - [discussions.md](discussions.md) - Discussion threads and resolution
 - [stack.md](stack.md) - Stacked diff workflow

--- a/plugins/gitlab/skills/merge-request/review-state.md
+++ b/plugins/gitlab/skills/merge-request/review-state.md
@@ -128,3 +128,30 @@ Keep nodes where the reviewer whose `username` equals `currentUser.username` has
 ```bash
 bun ${CLAUDE_SKILL_DIR}/scripts/review-queue.ts
 ```
+
+## Review Inbox (Next-Actor Triage)
+
+The cross-project queue above filters to `UNREVIEWED` and answers "what awaits my first review." The triage read uses the same `reviewRequestedMergeRequests` query but keeps every entry where you are a reviewer, then groups by next actor so you can see what is on your plate versus the author's. Match your reviewer entry the same way the queue does: the reviewer whose `username` equals `currentUser.username`, then read its `reviewState`.
+
+#### Next Actor by Review State
+
+| `reviewState` | Next actor |
+|---------------|-----------|
+| `UNREVIEWED` | You. The true inbox: awaiting your first review. Maps to the dashboard "Review requests" and [`scripts/review-queue.ts`](scripts/review-queue.ts). |
+| `REVIEW_STARTED` | You, mid-review. In progress, not yet submitted. |
+| `REQUESTED_CHANGES` | Author's court until they re-request. |
+| `APPROVED` | Off your plate. |
+
+The API never returns `REVIEWED`. The web UI label "Reviewed" surfaces as `REVIEW_STARTED` or `REQUESTED_CHANGES` in the API, so a reader who saw "Reviewed" knows the API name.
+
+#### Re-Request Flip-Back
+
+Requesting changes or approving moves the MR out of your `UNREVIEWED` bucket. The author's re-request (the [`mergeRequestReviewerRereview`](#re-request-review) mutation) resets your entry to `UNREVIEWED` and re-surfaces it as a fresh inbox item.
+
+#### Why This Beats the Todos Inbox
+
+A dismissed todo records that you dismissed the notification, not that you handled the review. Re-requests do not reliably regenerate a todo, so the [todos inbox](../todos/SKILL.md) drifts out of sync with the actual review state. `reviewState` is the authoritative per-MR signal.
+
+#### Relation to `review:dashboard`
+
+The `review:dashboard` UNREVIEWED fetch is the spawn-a-session surface for the `UNREVIEWED` row. This triage read is the broader read-and-group view across every state.

--- a/plugins/gitlab/skills/merge-request/review-state.md
+++ b/plugins/gitlab/skills/merge-request/review-state.md
@@ -142,4 +142,4 @@ The cross-project queue above filters to `UNREVIEWED`. To triage everything you 
 
 The API never returns `REVIEWED`; the web UI's "Reviewed" label maps to `REVIEW_STARTED` or `REQUESTED_CHANGES`.
 
-A re-request ([`mergeRequestReviewerRereview`](#re-request-review)) resets your entry to `UNREVIEWED` and re-surfaces the MR. Triage off `reviewState` rather than the [todos inbox](../todos/SKILL.md): a dismissed todo does not mean the review is handled, and re-requests do not reliably regenerate one.
+A re-request ([`mergeRequestReviewerRereview`](#re-request-review)) resets your entry to `UNREVIEWED` and re-surfaces the MR. Triage off `reviewState` rather than the GitLab todos inbox: a dismissed todo does not mean the review is handled, and re-requests do not reliably regenerate one.

--- a/plugins/gitlab/skills/merge-request/review-state.md
+++ b/plugins/gitlab/skills/merge-request/review-state.md
@@ -131,27 +131,15 @@ bun ${CLAUDE_SKILL_DIR}/scripts/review-queue.ts
 
 ## Review Inbox (Next-Actor Triage)
 
-The cross-project queue above filters to `UNREVIEWED` and answers "what awaits my first review." The triage read uses the same `reviewRequestedMergeRequests` query but keeps every entry where you are a reviewer, then groups by next actor so you can see what is on your plate versus the author's. Match your reviewer entry the same way the queue does: the reviewer whose `username` equals `currentUser.username`, then read its `reviewState`.
-
-#### Next Actor by Review State
+The cross-project queue above filters to `UNREVIEWED`. To triage everything you are a reviewer on, run the same `reviewRequestedMergeRequests` query without that filter, match your `username` as the queue does, and group by `reviewState`:
 
 | `reviewState` | Next actor |
 |---------------|-----------|
-| `UNREVIEWED` | You. The true inbox: awaiting your first review. Maps to the dashboard "Review requests" and [`scripts/review-queue.ts`](scripts/review-queue.ts). |
-| `REVIEW_STARTED` | You, mid-review. In progress, not yet submitted. |
-| `REQUESTED_CHANGES` | Author's court until they re-request. |
-| `APPROVED` | Off your plate. |
+| `UNREVIEWED` | You. Awaiting your first review. |
+| `REVIEW_STARTED` | You. Review in progress, not yet submitted. |
+| `REQUESTED_CHANGES` | Author, until they re-request. |
+| `APPROVED` | Nobody. Off your plate. |
 
-The API never returns `REVIEWED`. The web UI label "Reviewed" surfaces as `REVIEW_STARTED` or `REQUESTED_CHANGES` in the API, so a reader who saw "Reviewed" knows the API name.
+The API never returns `REVIEWED`; the web UI's "Reviewed" label maps to `REVIEW_STARTED` or `REQUESTED_CHANGES`.
 
-#### Re-Request Flip-Back
-
-Requesting changes or approving moves the MR out of your `UNREVIEWED` bucket. The author's re-request (the [`mergeRequestReviewerRereview`](#re-request-review) mutation) resets your entry to `UNREVIEWED` and re-surfaces it as a fresh inbox item.
-
-#### Why This Beats the Todos Inbox
-
-A dismissed todo records that you dismissed the notification, not that you handled the review. Re-requests do not reliably regenerate a todo, so the [todos inbox](../todos/SKILL.md) drifts out of sync with the actual review state. `reviewState` is the authoritative per-MR signal.
-
-#### Relation to `review:dashboard`
-
-The `review:dashboard` UNREVIEWED fetch is the spawn-a-session surface for the `UNREVIEWED` row. This triage read is the broader read-and-group view across every state.
+A re-request ([`mergeRequestReviewerRereview`](#re-request-review)) resets your entry to `UNREVIEWED` and re-surfaces the MR. Triage off `reviewState` rather than the [todos inbox](../todos/SKILL.md): a dismissed todo does not mean the review is handled, and re-requests do not reliably regenerate one.


### PR DESCRIPTION
Adds a Review Inbox section to `plugins/gitlab/skills/merge-request/review-state.md` that groups every review-requested MR by next actor, not just the `UNREVIEWED` slice the existing cross-project queue covers.

The section reuses the `reviewRequestedMergeRequests` query already documented above, keeps all reviewer entries, and maps each `reviewState` to whose court the MR sits in: `UNREVIEWED` and `REVIEW_STARTED` are yours, `REQUESTED_CHANGES` is the author's until they re-request, and `APPROVED` is off your plate. It uses the actual API enum values from `scripts/review-queue.ts` and calls out that the web UI's "Reviewed" label surfaces as `REVIEW_STARTED`/`REQUESTED_CHANGES`, since the API never returns `REVIEWED`.

I documented why this read beats the `gitlab:todos` inbox: a dismissed todo records that you dismissed a notification, not that you handled the review, and re-requests do not reliably regenerate a todo, so `reviewState` is the authoritative per-MR signal. The re-request flip-back cross-links the existing `#re-request-review` mutation, and the dashboard relation points at `review:dashboard` as the spawn-a-session surface for the `UNREVIEWED` row.

`SKILL.md` gains a pointer to the new section under `## Reviews` and an updated `review-state.md` description in the reference list.

## References

`#705` tracks related gitlab review-inbox gaps.

Original Task: [gitlab skill: add "reviews awaiting me by status" triage workflow](https://things.bendrucker.me/show?id=3ym9r3HqBG8gg2DkBz3fjH)
