### PR TITLE
ci: skip plugins gate on cancelled runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,7 +223,7 @@ jobs:
   plugins:
     needs: [validate, plugin]
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ !cancelled() }}
     steps:
       - name: Check plugin results
         run: |


### PR DESCRIPTION
Changes the `plugins` aggregator job's condition from `if: always()` to `if: ${{ !cancelled() }}`.

The `plugins` job is a fan-in gate over the `plugin` matrix. With `always()`, it also runs when `cancel-in-progress` concurrency cancels the run. In that case `needs.plugin.result` is `cancelled`, the `!= "success"` check trips, the job exits 1, and a phantom red `plugins` FAILURE check-run gets stamped on the commit even though a complete green run exists for the same SHA.

`!cancelled()` keeps the gate running on genuine `plugin` failures (so they still surface and exit 1) but skips it when the run is cancelled, so concurrency cancellation no longer produces a phantom failure.

## References

Observed on #690: two `pull_request` runs fired for one SHA, concurrency cancelled one, and its `plugins` aggregator reported a FAILURE despite a complete green run for the identical commit.
