### PR TITLE
fix(skills): use CLAUDE_PLUGIN_ROOT in skill hook commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Check hook quoting
         run: bun scripts/check-hook-quoting.ts
 
+      - name: Check skill hook path variables
+        run: bun scripts/check-skill-hook-vars.ts
+
       - name: Check for unenabled plugins
         if: github.event_name == 'pull_request'
         env:

--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -14,11 +14,11 @@ hooks:
     - matcher: "Write|Edit"
       hooks:
         - type: command
-          command: "bun ${CLAUDE_SKILL_DIR}/scripts/check-namespace.ts"
+          command: "bun ${CLAUDE_PLUGIN_ROOT}/skills/skill/scripts/check-namespace.ts"
         - type: command
-          command: "bun ${CLAUDE_SKILL_DIR}/scripts/check-structure.ts"
+          command: "bun ${CLAUDE_PLUGIN_ROOT}/skills/skill/scripts/check-structure.ts"
         - type: command
-          command: "bun ${CLAUDE_SKILL_DIR}/scripts/check-lint.ts"
+          command: "bun ${CLAUDE_PLUGIN_ROOT}/skills/skill/scripts/check-lint.ts"
 ---
 
 # Claude Code Skills Development
@@ -116,7 +116,9 @@ Skill-scoped hooks activate only when the skill is invoked and last for the sess
 | `$ARGUMENTS`           | All arguments passed when invoking the skill. Appended automatically if absent.  |
 | `$ARGUMENTS[N]` / `$N` | Access a specific argument by 0-based index.                                     |
 | `${CLAUDE_SESSION_ID}` | Current session ID.                                                              |
-| `${CLAUDE_SKILL_DIR}` | Absolute path to the skill's directory. Works in hooks and allowed-tools, but NOT in `!` context. |
+| `${CLAUDE_SKILL_DIR}` | Absolute path to the skill's directory. Substituted in skill content: the body, `!` injection commands, and `allowed-tools`. |
+
+These substitutions apply to skill content, not the frontmatter `hooks:` block. The hooks engine expands only `${CLAUDE_PROJECT_DIR}`, `${CLAUDE_PLUGIN_ROOT}`, and `${CLAUDE_PLUGIN_DATA}` ([hooks reference](https://code.claude.com/docs/en/hooks)); `${CLAUDE_SKILL_DIR}` there resolves to an empty string. In a hook command, reference a bundled script by plugin root instead: `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/scripts/check.ts`.
 
 ### Dynamic Context Injection
 

--- a/plugins/tmux/skills/tmux/SKILL.md
+++ b/plugins/tmux/skills/tmux/SKILL.md
@@ -11,7 +11,7 @@ hooks:
     - matcher: "Bash(tmux:*)"
       hooks:
         - type: command
-          command: "bash ${CLAUDE_SKILL_DIR}/scripts/safe-command.sh"
+          command: "bash ${CLAUDE_PLUGIN_ROOT}/skills/tmux/scripts/safe-command.sh"
     - matcher: "Bash(bash ${CLAUDE_SKILL_DIR}/scripts/:*)"
       hooks:
         - type: command

--- a/plugins/ui-design/skills/wireframe/SKILL.md
+++ b/plugins/ui-design/skills/wireframe/SKILL.md
@@ -9,7 +9,7 @@ hooks:
     - matcher: "Bash(bun ${CLAUDE_SKILL_DIR}/scripts/render.ts:*)|Bash(bun ${CLAUDE_SKILL_DIR}/scripts/render-html.ts:*)"
       hooks:
         - type: command
-          command: "bun ${CLAUDE_SKILL_DIR}/scripts/setup.ts"
+          command: "bun ${CLAUDE_PLUGIN_ROOT}/skills/wireframe/scripts/setup.ts"
           once: true
         - type: command
           command: |
@@ -18,7 +18,7 @@ hooks:
     - matcher: "Write|Edit"
       hooks:
         - type: command
-          command: "bun ${CLAUDE_SKILL_DIR}/scripts/validate-hook.ts"
+          command: "bun ${CLAUDE_PLUGIN_ROOT}/skills/wireframe/scripts/validate-hook.ts"
 ---
 
 # Wireframe

--- a/scripts/check-skill-hook-vars.ts
+++ b/scripts/check-skill-hook-vars.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env bun
+
+import { globSync } from "node:fs";
+import { join } from "node:path";
+import matter from "gray-matter";
+
+// The hooks engine substitutes only ${CLAUDE_PROJECT_DIR}, ${CLAUDE_PLUGIN_ROOT},
+// and ${CLAUDE_PLUGIN_DATA} in hook command strings. ${CLAUDE_SKILL_DIR} is a
+// skill-content substitution (body, ! injection, allowed-tools); inside a
+// frontmatter hooks: command it resolves to an empty string, so the path
+// collapses to /scripts/... and the hook fails with "Module not found".
+// Reference bundled scripts by ${CLAUDE_PLUGIN_ROOT}/skills/<skill>/... instead.
+const FORBIDDEN = /\$\{CLAUDE_SKILL_(?:DIR|ROOT)\}/;
+
+const root = join(import.meta.dirname, "..");
+const files = globSync("plugins/*/skills/*/SKILL.md", { cwd: root });
+
+interface MatcherEntry {
+  hooks?: Array<{ command?: string; args?: string[] }>;
+}
+
+const violations: string[] = [];
+
+for (const file of files) {
+  if (file.includes("/test/")) continue;
+
+  const raw = await Bun.file(join(root, file)).text();
+  const { data } = matter(raw);
+  const hooks = data.hooks as Record<string, MatcherEntry[]> | undefined;
+  if (!hooks) continue;
+
+  for (const entries of Object.values(hooks)) {
+    for (const entry of entries) {
+      for (const hook of entry.hooks ?? []) {
+        const command = hook.command ?? "";
+        const args = (hook.args ?? []).join(" ");
+        if (FORBIDDEN.test(command) || FORBIDDEN.test(args)) {
+          violations.push(`${file}: ${command || args}`);
+        }
+      }
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.log(
+    "Hook commands must not use CLAUDE_SKILL_DIR/CLAUDE_SKILL_ROOT (the hooks engine leaves them empty).",
+  );
+  console.log("Use CLAUDE_PLUGIN_ROOT/skills/<skill>/... instead:");
+  for (const v of violations) {
+    console.log(`  ${v}`);
+  }
+  process.exit(1);
+}
+
+console.log("All skill hook commands use supported path placeholders");


### PR DESCRIPTION
Fixes skill hook commands that referenced `${CLAUDE_SKILL_DIR}`, a variable the hooks engine does not substitute. The engine expands only `${CLAUDE_PROJECT_DIR}`, `${CLAUDE_PLUGIN_ROOT}`, and `${CLAUDE_PLUGIN_DATA}` ([hooks reference](https://code.claude.com/docs/en/hooks)); `${CLAUDE_SKILL_DIR}` is a skill-*content* substitution (body, `!` injection, `allowed-tools`). In a frontmatter `hooks:` command the shell then expands the unset variable to an empty string, so paths became `/scripts/<name>.ts` and every `Edit`/`Write` produced `PostToolUse:Edit hook error … Module not found "/scripts/check-namespace.ts"`.

## Changes

- Point hook commands at `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/...` in `claude-code:skill` (the three `check-*.ts` scripts that triggered this), `ui-design:wireframe` (`setup.ts`, `validate-hook.ts`), and `tmux:tmux` (`safe-command.sh`).
- Correct the string-substitution table in the `claude-code:skill` skill. It claimed `${CLAUDE_SKILL_DIR}` "Works in hooks", the opposite of reality. It now documents that the variable applies to skill content and that hook commands must use `${CLAUDE_PLUGIN_ROOT}`.
- Add `scripts/check-skill-hook-vars.ts` (plus a CI step) that scans `SKILL.md` frontmatter `hooks:` blocks and rejects `${CLAUDE_SKILL_DIR}`/`${CLAUDE_SKILL_ROOT}` in any hook `command`/`args`. The bug was silent because hooks are non-blocking, so it sat unnoticed since #528 renamed `CLAUDE_SKILL_ROOT` to `CLAUDE_SKILL_DIR`.

## Dead Matchers, Handled Separately

While confirming this, I found a larger, distinct bug: most skill `PreToolUse` hooks use `Bash(command:*)` matchers, which never fire. Hook matchers match the tool *name* only (`new RegExp(matcher).test("Bash")`), proven both in the 2.1.160 binary's matcher function and by an empirical test (a `Bash(echo:*)` matcher did not fire on an `echo` command; `Bash` did). That is a separate concern from this command-path bug and is addressed in a follow-up PR, so this one stays scoped to the `Module not found` errors.

## Testing

- `bun scripts/check-skill-hook-vars.ts` passes on the fixed tree and fails on a synthetic `${CLAUDE_SKILL_DIR}` command (verified both directions).
- `bun run check`, `bun run build`, and `skill-lint` pass on the changed skills.
