### PR TITLE
user: route status line through vibe-island chain

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -332,7 +332,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "~/.claude/scripts/statusline.ts"
+    "command": "/Users/ben/.vibe-island/bin/vibe-island-statusline-chain"
   },
   "subagentStatusLine": {
     "type": "command",


### PR DESCRIPTION
Routes the `statusLine` command through `vibe-island-statusline-chain`, matching what the vibe-island installer wrote to the live `~/.claude/settings.json`. This completes capturing vibe-island's config footprint in the repo (the bridge hooks landed in #723).

The chain is a transparent wrapper: it reads the status line stdin, caches `rate_limits` to `~/.vibe-island/cache/rl.json` (only when the app's `showUsage` is enabled), then forwards the identical stdin to my original command, which it stores in `~/.vibe-island/cache/statusline-chain-original-command` (still `statusline.ts`). The visible status line is unchanged.

## Caveats

- Unlike the bridge hooks, the chain has no `[ -x ]` guard, so on a machine without vibe-island installed the status line command won't exist and renders blank. The hooks fail safe; this does not.
- The chain forwards to a vibe-island-managed cache file that isn't tracked here, so the display isn't fully reproducible from this repo alone.
- The path is absolute (`/Users/ben/...`) to mirror what the installer wrote; it's not portable across usernames.
