### PR TITLE
user: emit rate limits from the status line for external readers

### DIFF
--- a/user/scripts/statusline.test.ts
+++ b/user/scripts/statusline.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   buildStatusLine,
   dialColor,
   dialIndex,
   dialSegment,
   elideSpans,
+  emitRateLimits,
   exceeds200k,
   formatWorktree,
   type Span,
@@ -266,5 +271,34 @@ describe("formatWorktree redundancy collapse", () => {
   test("budget too small with no ahead yields nothing", () => {
     const out = formatWorktree({ ...base, isMain: true, branch: "main", path: "/x/myrepo" }, 2);
     expect(out).toEqual([]);
+  });
+});
+
+describe("emitRateLimits", () => {
+  const limits = {
+    five_hour: { used_percentage: 0, resets_at: 1780524600 },
+    seven_day: { used_percentage: 33, resets_at: 1780898400 },
+  };
+
+  test("writes rate_limits to a nested path, creating dirs", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "rl-"));
+    try {
+      const target = join(dir, "nested", "rl.json");
+      await emitRateLimits({ rate_limits: limits }, target);
+      expect(await Bun.file(target).json()).toEqual(limits);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("no rate_limits is a no-op", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "rl-"));
+    try {
+      const target = join(dir, "rl.json");
+      await emitRateLimits({}, target);
+      expect(await Bun.file(target).exists()).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/user/scripts/statusline.ts
+++ b/user/scripts/statusline.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
-import { basename } from "node:path";
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join } from "node:path";
 import { styleText } from "node:util";
 import { dialGlyph } from "./glyphs";
 
@@ -10,9 +12,20 @@ interface CurrentUsage {
   cache_read_input_tokens?: number;
 }
 
+interface RateLimitWindow {
+  used_percentage?: number;
+  resets_at?: number;
+}
+
+interface RateLimits {
+  five_hour?: RateLimitWindow;
+  seven_day?: RateLimitWindow;
+}
+
 interface StatusInput {
   context_window?: { used_percentage?: number | null; current_usage?: CurrentUsage | null };
   cost?: { total_lines_added?: number; total_lines_removed?: number };
+  rate_limits?: RateLimits | null;
 }
 
 // A styled, ordered piece of the worktree label. `text` is the visible content
@@ -201,6 +214,18 @@ export function formatWorktree(data: WorktreeData, budget: number): string[] {
   return segments;
 }
 
+// Mirror the live `rate_limits` to a file so external readers (the menu-bar app)
+// can show usage without wrapping the status line command. Claude Code only pipes
+// rate limits through the status line, so this is the single place they surface.
+export async function emitRateLimits(input: StatusInput, target: string): Promise<void> {
+  const limits = input.rate_limits;
+  if (!limits) return;
+
+  const path = target.startsWith("~/") ? join(homedir(), target.slice(2)) : target;
+  mkdirSync(dirname(path), { recursive: true });
+  await Bun.write(path, `${JSON.stringify(limits)}\n`);
+}
+
 export function buildStatusLine(
   input: StatusInput,
   columns: number,
@@ -276,6 +301,15 @@ if (import.meta.main) {
     input = null;
   }
   if (input) {
+    const rateLimitsPath = process.env.CLAUDE_STATUSLINE_RATE_LIMITS_PATH;
+    if (rateLimitsPath) {
+      try {
+        await emitRateLimits(input, rateLimitsPath);
+      } catch {
+        // Emitting usage is best-effort; rendering the line takes priority.
+      }
+    }
+
     const parsed = Number(process.env.COLUMNS);
     const columns = Number.isInteger(parsed) && parsed > 0 ? parsed : 80;
     process.stdout.write(buildStatusLine(input, columns, resolveWorktree()));

--- a/user/settings.json
+++ b/user/settings.json
@@ -351,6 +351,7 @@
   "env": {
     "CLAUDE_CODE_DISABLE_TERMINAL_TITLE": "1",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_STATUSLINE_RATE_LIMITS_PATH": "~/.vibe-island/cache/rl.json",
     "TMPDIR": "/tmp",
     "TMPPREFIX": "/tmp/claude/zsh",
     "WORKTRUNK_WORKTREE_PATH": ".worktrees/{{ branch | sanitize }}",


### PR DESCRIPTION
Teaches `statusline.ts` to optionally write the `rate_limits` object Claude Code pipes into it to a file, so an external reader (the Vibe Island menu-bar app) can show usage without wrapping my status line command.

Vibe Island's "usage bridge" works by rewriting `statusLine` to point at its own `vibe-island-statusline-chain` wrapper, which extracts `.rate_limits` from the status line stdin, writes it to `~/.vibe-island/cache/rl.json`, then forwards stdin to the original command. That wrapper is an absolute, app-managed path the installer writes directly into `~/.claude/settings.json`, which diverges from my version-controlled copy and breaks `claude-upgrade`'s sync. The integration is really just file IPC through `rl.json`, and my status line already receives the same stdin, so I can produce that file myself and skip the wrapper.

## Changes

- `emitRateLimits(input, target)` writes `input.rate_limits` to `target` (expanding a leading `~/`), creating parent dirs. It's a no-op when rate limits are absent, and the call site swallows errors so a failed write never blanks the line.
- Gated on `CLAUDE_STATUSLINE_RATE_LIMITS_PATH`. Unset means nothing runs, so this costs nothing for anyone not opting in.
- Wired that env var to `~/.vibe-island/cache/rl.json` in `user/settings.json`. `statusLine` stays pointed at my own script.

## Testing

`emitRateLimits` writes the expected JSON (verified byte-for-byte against the live `rl.json` shape) and no-ops without rate limits. Piping a real payload through the script confirms the file lands and the line still renders.

## Caveat

I can't verify from here whether the app shows usage when its bridge isn't installed. The app reads `rl.json`, but its usage feature may be gated on the bridge being present, not just on the file existing. Confirming that needs a live check: remove the bridge, enable usage in the app, and see if it reads the file I write. If it does, the wrapper is fully avoidable; if not, the feature is tied to the bridge and this can't replace it.
