### PR TITLE
fix(ci-monitor): close poll-interval blind window that skips success on merge

### DIFF
--- a/plugins/github/skills/actions-monitor/scripts/watch.test.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.test.ts
@@ -330,11 +330,39 @@ describe("pr-closed", () => {
     const { events } = advance([{ probe: baseProbe({ prState: "CLOSED" }) }]);
     expect(events.find((e) => e.type === "pr-closed")).toBeDefined();
   });
+
+  it("emits status:success before pr-closed when merged with success checks and lastState not success", () => {
+    const { events } = advance([
+      { probe: baseProbe({ prState: "MERGED", state: "success", sha: "s1" }) },
+    ]);
+    const statusIdx = events.findIndex((e) => e.type === "status");
+    const closedIdx = events.findIndex((e) => e.type === "pr-closed");
+    expect(statusIdx).toBeGreaterThanOrEqual(0);
+    expect(events[statusIdx]).toMatchObject({ type: "status", state: "success", sha: "s1" });
+    expect(closedIdx).toBeGreaterThan(statusIdx);
+  });
+
+  it("emits only pr-closed when merged with success checks and lastState already success", () => {
+    const initial: WatcherState = { ...initialState(), lastState: "success", lastSha: "s1" };
+    const { events } = advance(
+      [{ probe: baseProbe({ prState: "MERGED", state: "success", sha: "s1" }) }],
+      { initial },
+    );
+    expect(events).toEqual([{ type: "pr-closed" }]);
+  });
+
+  it("emits only pr-closed when merged with failing checks (no false success)", () => {
+    const { events } = advance([
+      { probe: baseProbe({ prState: "MERGED", state: "failing", sha: "s1" }) },
+    ]);
+    expect(events.find((e) => e.type === "status")).toBeUndefined();
+    expect(events.find((e) => e.type === "pr-closed")).toBeDefined();
+  });
 });
 
 describe("computeInterval", () => {
-  it("returns default when no durations", () => {
-    expect(computeInterval([])).toBe(180);
+  it("returns fast poll floor when no durations (first PR on branch)", () => {
+    expect(computeInterval([])).toBe(30);
   });
 
   it("adds buffer and clamps to minimum", () => {

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -6,6 +6,7 @@ import { cli } from "cleye";
 import UrlPattern from "url-pattern";
 
 const DEFAULT_INTERVAL_SECONDS = 180;
+const NO_HISTORY_INTERVAL_SECONDS = 30;
 
 export type StatusState = "running" | "failing" | "success";
 export type InternalState = StatusState | "queued";
@@ -63,6 +64,16 @@ export function deriveEvents(
   let next: WatcherState = { ...state };
 
   if (probe.prState === "CLOSED" || probe.prState === "MERGED") {
+    const emitStateTerminal = mapToEmitState(probe.state);
+    if (emitStateTerminal === "success" && next.lastState !== "success") {
+      events.push({
+        type: "status",
+        state: "success",
+        sha: probe.sha,
+        run_id: probe.runId,
+      });
+      next = { ...next, lastSha: probe.sha, lastState: "success" };
+    }
     events.push({ type: "pr-closed" });
     return { events, state: next };
   }
@@ -411,7 +422,7 @@ export function probeBranch(repo: string, branch: string, run: ExecFn = exec): P
 }
 
 export function computeInterval(durationsSeconds: number[]): number {
-  if (durationsSeconds.length === 0) return DEFAULT_INTERVAL_SECONDS;
+  if (durationsSeconds.length === 0) return NO_HISTORY_INTERVAL_SECONDS;
   const avg = durationsSeconds.reduce((a, b) => a + b, 0) / durationsSeconds.length;
   const buffered = avg + 30;
   return Math.min(600, Math.max(30, Math.round(buffered)));

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
@@ -159,8 +159,8 @@ describe("isNotFoundError", () => {
 });
 
 describe("computeInterval", () => {
-  it("defaults to 180 when no data", () => {
-    expect(computeInterval([])).toBe(180);
+  it("returns fast poll floor when no data (first PR on branch)", () => {
+    expect(computeInterval([])).toBe(30);
   });
 
   it("adds a 30 second buffer to the average", () => {
@@ -285,14 +285,45 @@ describe("deriveEvents", () => {
     expect(events).toEqual([{ type: "pr-closed" }]);
   });
 
-  it("emits pr-closed when the MR is merged", () => {
+  it("emits pr-closed when the MR is merged (lastState already success)", () => {
+    const initial = { ...initialState(), lastState: "success" as const, lastSha: "sha1" };
     const { events } = deriveEvents(
       makeProbe({ mrState: "merged", state: "success" }),
-      initialState(),
+      initial,
       0,
       15,
     );
     expect(events).toEqual([{ type: "pr-closed" }]);
+  });
+
+  it("emits status:success before pr-closed when merged and lastState not success", () => {
+    const { events } = deriveEvents(
+      makeProbe({ mrState: "merged", state: "success", sha: "sha1", runId: "100" }),
+      initialState(),
+      0,
+      15,
+    );
+    const statusIdx = events.findIndex((e) => e.type === "status");
+    const closedIdx = events.findIndex((e) => e.type === "pr-closed");
+    expect(statusIdx).toBeGreaterThanOrEqual(0);
+    expect(events[statusIdx]).toEqual({
+      type: "status",
+      state: "success",
+      sha: "sha1",
+      run_id: "100",
+    });
+    expect(closedIdx).toBeGreaterThan(statusIdx);
+  });
+
+  it("emits only pr-closed when merged with failing checks (no false success)", () => {
+    const { events } = deriveEvents(
+      makeProbe({ mrState: "merged", state: "failing" }),
+      initialState(),
+      0,
+      15,
+    );
+    expect(events.find((e) => e.type === "status")).toBeUndefined();
+    expect(events.find((e) => e.type === "pr-closed")).toBeDefined();
   });
 });
 

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
@@ -6,6 +6,7 @@ import { cli } from "cleye";
 import UrlPattern from "url-pattern";
 
 const DEFAULT_INTERVAL_SECONDS = 180;
+const NO_HISTORY_INTERVAL_SECONDS = 30;
 
 export type StatusState = "running" | "failing" | "success";
 export type InternalState = StatusState | "queued";
@@ -64,6 +65,16 @@ export function deriveEvents(
   let next: WatcherState = { ...state };
 
   if (probe.mrState === "closed" || probe.mrState === "merged") {
+    const emitStateTerminal = mapToEmitState(probe.state);
+    if (emitStateTerminal === "success" && next.lastState !== "success") {
+      events.push({
+        type: "status",
+        state: "success",
+        sha: probe.sha,
+        run_id: probe.runId,
+      });
+      next = { ...next, lastSha: probe.sha, lastState: "success" };
+    }
     events.push({ type: "pr-closed" });
     return { events, state: next };
   }
@@ -209,7 +220,7 @@ export function normalizePipelineStatus(status: string): InternalState {
 }
 
 export function computeInterval(durationsSeconds: number[]): number {
-  if (durationsSeconds.length === 0) return DEFAULT_INTERVAL_SECONDS;
+  if (durationsSeconds.length === 0) return NO_HISTORY_INTERVAL_SECONDS;
   const avg = durationsSeconds.reduce((a, b) => a + b, 0) / durationsSeconds.length;
   const buffered = avg + 30;
   return Math.min(600, Math.max(30, Math.round(buffered)));


### PR DESCRIPTION
Fixes two defects in `github:actions-monitor` and `gitlab:ci-monitor` that cause a blind window where a poll straddling `running → success → merged` loses the `success` event and reports the merge late, breaking `babysit --merge`.

## Changes

**Emit `status:success` before `pr-closed` on merge**

`deriveEvents` returned early on `MERGED`/`CLOSED` emitting only `{type:"pr-closed"}`. If the first poll to observe the PR already merged, the intervening `success` was never emitted and `babysit --merge` never received the signal it waits on to confirm completion.

Now when `prState` is `MERGED` or `CLOSED`: if `mapToEmitState(probe.state) === "success"` and `lastState` is not already `"success"`, a `status:success` event is pushed first and `lastState` is updated, then `pr-closed` follows. Probes with failing or in-progress checks at merge time still emit only `pr-closed` (no false success on force-merges).

**Poll fast on branches with no run history**

`computeInterval([])` returned `DEFAULT_INTERVAL_SECONDS` (180s) when there were no prior successful runs. On a branch's first PR this is the common case, so the watcher spent three minutes between polls, leaving the merge window wide open.

`computeInterval([])` now returns `NO_HISTORY_INTERVAL_SECONDS` (30s). The fallbacks inside `fetchInterval` for API errors and non-array responses remain at 180s: those are "back off" signals, not "no history" signals.

Both fixes are mirrored identically in the GitHub and GitLab watchers.

## Testing

Updated the existing `computeInterval([])` assertion (180 → 30) in both test files. Added three `deriveEvents` cases in each:

- `prState:MERGED` + success checks + `lastState` not success → emits `status:success` then `pr-closed`
- `prState:MERGED` + success checks + `lastState` already success → emits only `pr-closed`
- `prState:MERGED` + failing checks → emits only `pr-closed` (no false success)

All 119 tests pass.

Original Task: [actions-monitor: poll-interval blind window skips success and reports merges late](https://things.bendrucker.me/show?id=5peNbsWaWLdPioucq4ywyR)
