### PR TITLE
gitlab: compact triage formats for discussions list

### DIFF
--- a/plugins/gitlab/skills/merge-request/discussions.md
+++ b/plugins/gitlab/skills/merge-request/discussions.md
@@ -25,6 +25,40 @@ bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts list <iid> --dedupe
 bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts list <iid> --format table
 ```
 
+JSON and table are the two supported output formats.
+
+#### JSON output schema
+
+The default (`--format json`) is a flat array of summary objects, one per discussion (the first note of each thread). It is not the raw GitLab `{ notes: [...] }` shape, so query the top-level fields directly.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | string | Discussion id, pass to `resolve` |
+| `author` | string | Username of the first note's author |
+| `body` | string | Full body of the first note |
+| `resolved` | boolean | Flattened from `notes[0].resolved` (see Resolution status location) |
+| `resolvable` | boolean | Whether the thread can be resolved |
+| `file` | string (optional) | Present only for positioned (inline) comments |
+| `line` | number (optional) | Present only for positioned (inline) comments |
+| `lineRange` | `{ start, end }` or `null` | `null` for single-line and non-positioned comments |
+
+`file` and `line` are omitted entirely for general (non-inline) discussions, so handle them as optional. `lineRange` is always present but is `null` unless the comment spans multiple lines.
+
+#### jq triage
+
+Print `id`, `file:line`, resolution state, and a truncated body per discussion:
+
+```bash
+bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts list <iid> | \
+  jq -r '.[] | "\(.id[0:12])  \(.file // "-"):\(.line // "-")  [\(if .resolved then "resolved" else "open" end)]  \(.body[0:60] | gsub("\n";" "))"'
+```
+
+`--format table` is the compact one-shot triage view. It prints ID, Author, Resolved, Location (`file:line` or `file:start-end` for ranges), and a truncated body without any jq:
+
+```bash
+bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts list <iid> --format table
+```
+
 ### Resolve
 
 ```bash

--- a/plugins/gitlab/skills/merge-request/discussions.md
+++ b/plugins/gitlab/skills/merge-request/discussions.md
@@ -21,11 +21,12 @@ bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts list <iid> --resolvable --unresol
 # Deduplicate threads across diff versions
 bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts list <iid> --dedupe
 
-# Table output
+# Compact triage views
+bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts list <iid> --format digest
 bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts list <iid> --format table
 ```
 
-JSON and table are the two supported output formats.
+Three output formats are supported: `json` (default), `digest`, and `table`.
 
 #### JSON output schema
 
@@ -44,16 +45,18 @@ The default (`--format json`) is a flat array of summary objects, one per discus
 
 `file` and `line` are omitted entirely for general (non-inline) discussions, so handle them as optional. `lineRange` is always present but is `null` unless the comment spans multiple lines.
 
-#### jq triage
+#### Compact triage
 
-Print `id`, `file:line`, resolution state, and a truncated body per discussion:
+For triage, prefer a compact format over the full JSON. Both truncate each body to `--truncate` characters (default 80); raise it when bodies are clipped too aggressively.
+
+`--format digest` prints one line per discussion: id, location (`file:line`, `file:start-end` for ranges, or `-` when not positioned), resolution state, and a truncated body.
 
 ```bash
-bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts list <iid> | \
-  jq -r '.[] | "\(.id[0:12])  \(.file // "-"):\(.line // "-")  [\(if .resolved then "resolved" else "open" end)]  \(.body[0:60] | gsub("\n";" "))"'
+bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts list <iid> --format digest
+bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts list <iid> --format digest --truncate 120
 ```
 
-`--format table` is the compact one-shot triage view. It prints ID, Author, Resolved, Location (`file:line` or `file:start-end` for ranges), and a truncated body without any jq:
+`--format table` shows the same fields as bordered columns, plus the author.
 
 ```bash
 bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts list <iid> --format table

--- a/plugins/gitlab/skills/merge-request/scripts/discussions.test.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/discussions.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import type { Discussion } from "./discussions";
-import { deduplicateDiscussions, filterDiscussions } from "./discussions";
+import type { Discussion, DiscussionSummary } from "./discussions";
+import {
+  deduplicateDiscussions,
+  filterDiscussions,
+  formatDigest,
+  formatLocation,
+  truncateBody,
+} from "./discussions";
 
 function makeNote(overrides: Record<string, unknown> = {}) {
   return {
@@ -129,5 +135,79 @@ describe("deduplicateDiscussions", () => {
     const discussions: Discussion[] = [{ id: "1", notes: [] }];
     const result = deduplicateDiscussions(discussions);
     expect(result).toHaveLength(0);
+  });
+});
+
+function makeSummary(overrides: Partial<DiscussionSummary> = {}): DiscussionSummary {
+  return {
+    id: "abcdef0123456789",
+    author: "reviewer",
+    body: "Needs work",
+    resolved: false,
+    resolvable: true,
+    lineRange: null,
+    ...overrides,
+  };
+}
+
+describe("truncateBody", () => {
+  it("collapses whitespace and newlines to single spaces", () => {
+    expect(truncateBody("a\n  b\t c", 80)).toBe("a b c");
+  });
+
+  it("truncates with an ellipsis past the max", () => {
+    const result = truncateBody("abcdefghij", 5);
+    expect(result).toBe("abcd…");
+    expect(result).toHaveLength(5);
+  });
+
+  it("leaves short bodies untouched", () => {
+    expect(truncateBody("short", 80)).toBe("short");
+  });
+});
+
+describe("formatLocation", () => {
+  it("returns empty string for non-positioned discussions", () => {
+    expect(formatLocation(makeSummary())).toBe("");
+  });
+
+  it("renders file:line for single-line comments", () => {
+    expect(formatLocation(makeSummary({ file: "src/app.ts", line: 42 }))).toBe("src/app.ts:42");
+  });
+
+  it("renders file:start-end for ranges", () => {
+    expect(
+      formatLocation(makeSummary({ file: "src/app.ts", lineRange: { start: 10, end: 14 } })),
+    ).toBe("src/app.ts:10-14");
+  });
+});
+
+describe("formatDigest", () => {
+  it("emits one line per discussion with id, location, state, and body", () => {
+    const out = formatDigest(
+      [
+        makeSummary({ id: "111111111111aaaa", file: "src/app.ts", line: 42, body: "Extract this" }),
+        makeSummary({ id: "222222222222bbbb", resolved: true, body: "Nit: typo" }),
+      ],
+      80,
+    );
+    const lines = out.split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain("111111111111");
+    expect(lines[0]).toContain("src/app.ts:42");
+    expect(lines[0]).toContain("[open]");
+    expect(lines[0]).toContain("Extract this");
+    expect(lines[1]).toContain("[resolved]");
+    expect(lines[1]).toContain("-");
+  });
+
+  it("truncates bodies to the given width", () => {
+    const out = formatDigest([makeSummary({ body: "x".repeat(200) })], 20);
+    expect(out).toContain(`${"x".repeat(19)}…`);
+    expect(out).not.toContain("x".repeat(21));
+  });
+
+  it("returns an empty string with no discussions", () => {
+    expect(formatDigest([], 80)).toBe("");
   });
 });

--- a/plugins/gitlab/skills/merge-request/scripts/discussions.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/discussions.ts
@@ -43,7 +43,7 @@ export type Discussion = {
   notes: Note[];
 };
 
-type DiscussionSummary = {
+export type DiscussionSummary = {
   id: string;
   author: string;
   body: string;
@@ -53,6 +53,8 @@ type DiscussionSummary = {
   line?: number;
   lineRange?: { start: number; end: number } | null;
 };
+
+export const DEFAULT_BODY_TRUNCATE = 80;
 
 function summarize(d: Discussion): DiscussionSummary | null {
   const note = d.notes[0];
@@ -76,6 +78,45 @@ function summarize(d: Discussion): DiscussionSummary | null {
   const line = note.position?.new_line ?? note.position?.old_line;
   if (line) result.line = line;
   return result;
+}
+
+export function truncateBody(body: string, max: number): string {
+  const collapsed = body.replace(/\s+/g, " ").trim();
+  if (max <= 0 || collapsed.length <= max) return collapsed;
+  return `${collapsed.slice(0, max - 1)}…`;
+}
+
+export function formatLocation(s: DiscussionSummary): string {
+  if (!s.file) return "";
+  const loc = s.lineRange ? `${s.lineRange.start}-${s.lineRange.end}` : String(s.line ?? "");
+  return loc ? `${s.file}:${loc}` : s.file;
+}
+
+const LOCATION_MAX_WIDTH = 40;
+
+export function formatDigest(summaries: DiscussionSummary[], truncate: number): string {
+  const rows = summaries.map((s) => ({
+    id: s.id.slice(0, 12),
+    location: formatLocation(s) || "-",
+    state: s.resolved ? "[resolved]" : "[open]",
+    body: truncateBody(s.body, truncate),
+  }));
+  const locWidth = Math.min(Math.max(0, ...rows.map((r) => r.location.length)), LOCATION_MAX_WIDTH);
+  const stateWidth = Math.max(0, ...rows.map((r) => r.state.length));
+  return rows
+    .map((r) => `${r.id}  ${r.location.padEnd(locWidth)}  ${r.state.padEnd(stateWidth)}  ${r.body}`)
+    .join("\n");
+}
+
+export function formatTable(summaries: DiscussionSummary[], truncate: number): string {
+  const rows = summaries.map((s) => [
+    s.id.slice(0, 12),
+    s.author,
+    s.resolved ? "yes" : "no",
+    formatLocation(s),
+    truncateBody(s.body, truncate),
+  ]);
+  return table([["ID", "Author", "Resolved", "Location", "Body"], ...rows]);
 }
 
 export type FilterOptions = {
@@ -190,8 +231,13 @@ const listCmd = command(
       },
       format: {
         type: String,
-        description: "Output format: json or table",
+        description: "Output format: json, table, or digest",
         default: "json",
+      },
+      truncate: {
+        type: Number,
+        description: "Max body length for table and digest output",
+        default: DEFAULT_BODY_TRUNCATE,
       },
     },
   },
@@ -209,19 +255,9 @@ const listCmd = command(
     const summaries = discussions.map(summarize).filter((s): s is DiscussionSummary => s !== null);
 
     if (parsed.flags.format === "table") {
-      const formatLocation = (s: DiscussionSummary) => {
-        if (!s.file) return "";
-        const loc = s.lineRange ? `${s.lineRange.start}-${s.lineRange.end}` : String(s.line ?? "");
-        return loc ? `${s.file}:${loc}` : s.file;
-      };
-      const rows = summaries.map((s) => [
-        s.id.slice(0, 12),
-        s.author,
-        s.resolved ? "yes" : "no",
-        formatLocation(s),
-        s.body.slice(0, 60),
-      ]);
-      console.log(table([["ID", "Author", "Resolved", "Location", "Body"], ...rows]));
+      console.log(formatTable(summaries, parsed.flags.truncate));
+    } else if (parsed.flags.format === "digest") {
+      console.log(formatDigest(summaries, parsed.flags.truncate));
     } else {
       console.log(JSON.stringify(summaries, null, 2));
     }


### PR DESCRIPTION
Adds a compact triage view to `discussions.ts list` in the `gitlab:merge-request` skill and documents the output schema.

During MR review triage, Claude assumed the raw GitLab nested `{ notes: [...] }` shape for the `list` output and burned several failed jq passes, then reached for a jq one-liner to get a compact view. That workaround was the script's gap showing through: there was no compact format built in for triage.

## Changes

- Add `--format digest`: one line per discussion (id, location, resolution state, truncated body).
- Add `--truncate <n>` (default 80), shared by `digest` and `table`, replacing the table's hardcoded 60. No terminal-width detection, since the CLI commonly runs piped or non-TTY.
- Document the `list` JSON schema (`id`, `author`, `body`, `resolved`, `resolvable`, optional `file`/`line`, `lineRange`), noting `file`/`line` appear only for positioned comments, `lineRange` is `null` for single-line and non-positioned comments, and `resolved` is flattened from `notes[0].resolved`.
- Document the two compact formats; drop the jq one-liner.

## Testing

- `bun test plugins/gitlab` (153 pass), `biome check` on the changed scripts, and `skill-lint` on the merge-request skill all clean.
- Rendered `digest` and `table` against a sample with positioned, ranged, and general discussions.

Original Task: [gitlab:merge-request: document discussions.ts list output schema](https://things.bendrucker.me/show?id=8PhqyPkDuXjaw8pEo5AaPZ)
