### PR TITLE
fix(mac): add sandbox bypass marker to jxa.ts

### DIFF
--- a/plugins/mac/hooks/sandbox.integration.ts
+++ b/plugins/mac/hooks/sandbox.integration.ts
@@ -29,6 +29,7 @@ const gitlabWatchScript = join(
   "scripts",
   "watch.ts",
 );
+const jxaScript = join(repoRoot, "plugins", "mac", "scripts", "jxa.ts");
 
 describe("isGoBinary", () => {
   test("gh is a Go binary", async () => {
@@ -51,6 +52,10 @@ describe("hasBypassMarker", () => {
 
   test("gitlab ci-monitor watch.ts carries the marker", async () => {
     expect(await hasBypassMarker(gitlabWatchScript)).toBe(true);
+  });
+
+  test("mac jxa.ts carries the marker", async () => {
+    expect(await hasBypassMarker(jxaScript)).toBe(true);
   });
 });
 
@@ -100,5 +105,14 @@ describe("processInput", () => {
       "darwin",
     );
     expect(result).not.toBeNull();
+  });
+
+  test("disables sandbox for mac jxa.ts", async () => {
+    const result = await processInput(makeInput(`bun ${jxaScript} Finder 'app.name()'`), "darwin");
+    expect(result).not.toBeNull();
+    expect(result?.hookSpecificOutput).toMatchObject({
+      hookEventName: "PreToolUse",
+      updatedInput: { dangerouslyDisableSandbox: true },
+    });
   });
 });

--- a/plugins/mac/scripts/jxa.ts
+++ b/plugins/mac/scripts/jxa.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: osascript hands off to LaunchServices/Apple Events, which the command sandbox blocks
 
 import * as acorn from "acorn";
 


### PR DESCRIPTION
Adds the `claude:dangerouslyDisableSandbox` marker to `plugins/mac/scripts/jxa.ts` so the first JXA call in a session no longer fails with `-600 Application isn't running`.

## Issue

`jxa.ts` spawns `osascript` via `Bun.spawn`, but the top-level `bun` wrapper runs sandboxed. The nested `osascript` inherits that sandbox, so the LaunchServices/Apple Events handoff is blocked and the call returns `-600`. `excludedCommands` does not help because it only matches the top-level command, not nested spawns.

The `mac` sandbox hook (`plugins/mac/hooks/sandbox.ts`) already solves this: it reads the head of an invoked `bun`/`node` script and injects `dangerouslyDisableSandbox: true` when it finds the marker comment. `jxa.ts` was missing the marker, so the hook never fired for it.

## Changes

- Added the marker after the shebang in `jxa.ts`.
- Added regression tests in `sandbox.integration.ts`: `hasBypassMarker` returns true for the real `jxa.ts`, and `processInput` disables the sandbox for a `bun .../jxa.ts ...` command.

## Testing

The new tests cover the real `jxa.ts` carrying the marker and the hook disabling the sandbox for a `bun .../jxa.ts ...` command, so the marker can't silently disappear. I could not reproduce the live `osascript` handoff from the agent environment (process spawn of `osascript` is blocked there regardless of the marker), but the CLI logic runs up to the spawn and the marker is a comment, so it cannot change runtime behavior beyond letting the hook fire.
