### PR TITLE
user: tighten status line spacing for narrow-glyph fonts

### DIFF
--- a/user/scripts/__snapshots__/statusline.test.ts.snap
+++ b/user/scripts/__snapshots__/statusline.test.ts.snap
@@ -40,20 +40,20 @@ exports[`rendered output wt-main-80 1`] = `"myrepo"`;
 
 exports[`rendered output wt-main-120 1`] = `"myrepo"`;
 
-exports[`rendered output wt-feature-40 1`] = `"\x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/l…iding-eventually\x1B]8;;\x1B\\\x1B[39m  \x1B[2m↑3\x1B[22m"`;
+exports[`rendered output wt-feature-40 1`] = `"\x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/lo…liding-eventually\x1B]8;;\x1B\\\x1B[39m \x1B[2m↑3\x1B[22m"`;
 
-exports[`rendered output wt-feature-60 1`] = `"\x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/long-branch…t-needs-eliding-eventually\x1B]8;;\x1B\\\x1B[39m  \x1B[2m↑3\x1B[22m"`;
+exports[`rendered output wt-feature-60 1`] = `"\x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/long-branch-…at-needs-eliding-eventually\x1B]8;;\x1B\\\x1B[39m \x1B[2m↑3\x1B[22m"`;
 
-exports[`rendered output wt-feature-80 1`] = `"\x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/long-branch-name-that-needs-eliding-eventually\x1B]8;;\x1B\\\x1B[39m  \x1B[2m↑3\x1B[22m"`;
+exports[`rendered output wt-feature-80 1`] = `"\x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/long-branch-name-that-needs-eliding-eventually\x1B]8;;\x1B\\\x1B[39m \x1B[2m↑3\x1B[22m"`;
 
-exports[`rendered output wt-feature-120 1`] = `"\x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/long-branch-name-that-needs-eliding-eventually\x1B]8;;\x1B\\\x1B[39m  \x1B[2m↑3\x1B[22m"`;
+exports[`rendered output wt-feature-120 1`] = `"\x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/long-branch-name-that-needs-eliding-eventually\x1B]8;;\x1B\\\x1B[39m \x1B[2m↑3\x1B[22m"`;
 
 exports[`rendered output wt-redundant 1`] = `"\x1B[36mworktree-abc123\x1B[39m"`;
 
-exports[`rendered output combined-40 1`] = `"\x1B[91m󰪣\x1B[39m  \x1B[32m+120\x1B[39m \x1B[31m-45\x1B[39m  \x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feat…eventually\x1B]8;;\x1B\\\x1B[39m  \x1B[2m↑2\x1B[22m"`;
+exports[`rendered output combined-40 1`] = `"\x1B[91m󰪣\x1B[39m \x1B[32m+120\x1B[39m \x1B[31m-45\x1B[39m \x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\featu…g-eventually\x1B]8;;\x1B\\\x1B[39m \x1B[2m↑2\x1B[22m"`;
 
-exports[`rendered output combined-60 1`] = `"\x1B[91m󰪣\x1B[39m  \x1B[32m+120\x1B[39m \x1B[31m-45\x1B[39m  \x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/long-b…s-eliding-eventually\x1B]8;;\x1B\\\x1B[39m  \x1B[2m↑2\x1B[22m"`;
+exports[`rendered output combined-60 1`] = `"\x1B[91m󰪣\x1B[39m \x1B[32m+120\x1B[39m \x1B[31m-45\x1B[39m \x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/long-br…eds-eliding-eventually\x1B]8;;\x1B\\\x1B[39m \x1B[2m↑2\x1B[22m"`;
 
-exports[`rendered output combined-80 1`] = `"\x1B[91m󰪣\x1B[39m  \x1B[32m+120\x1B[39m \x1B[31m-45\x1B[39m  \x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/long-branch-name-that-needs-eliding-eventually\x1B]8;;\x1B\\\x1B[39m  \x1B[2m↑2\x1B[22m"`;
+exports[`rendered output combined-80 1`] = `"\x1B[91m󰪣\x1B[39m \x1B[32m+120\x1B[39m \x1B[31m-45\x1B[39m \x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/long-branch-name-that-needs-eliding-eventually\x1B]8;;\x1B\\\x1B[39m \x1B[2m↑2\x1B[22m"`;
 
-exports[`rendered output combined-120 1`] = `"\x1B[91m󰪣\x1B[39m  \x1B[32m+120\x1B[39m \x1B[31m-45\x1B[39m  \x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/long-branch-name-that-needs-eliding-eventually\x1B]8;;\x1B\\\x1B[39m  \x1B[2m↑2\x1B[22m"`;
+exports[`rendered output combined-120 1`] = `"\x1B[91m󰪣\x1B[39m \x1B[32m+120\x1B[39m \x1B[31m-45\x1B[39m \x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/long-branch-name-that-needs-eliding-eventually\x1B]8;;\x1B\\\x1B[39m \x1B[2m↑2\x1B[22m"`;

--- a/user/scripts/__snapshots__/subagent-statusline.test.ts.snap
+++ b/user/scripts/__snapshots__/subagent-statusline.test.ts.snap
@@ -1,19 +1,19 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`rendered content running 1`] = `"\x1B[90m\x1B[2m󰚩\x1B[22m\x1B[39m  builder"`;
+exports[`rendered content running 1`] = `"\x1B[90m\x1B[2m󰚩\x1B[22m\x1B[39m builder"`;
 
-exports[`rendered content completed-tokens 1`] = `"\x1B[32m󰚩\x1B[39m  Deploy to prod \x1B[2m· 1.5k\x1B[22m"`;
+exports[`rendered content completed-tokens 1`] = `"\x1B[32m󰚩\x1B[39m Deploy to prod \x1B[2m· 1.5k\x1B[22m"`;
 
-exports[`rendered content failed 1`] = `"\x1B[31m󰚩\x1B[39m  reviewer"`;
+exports[`rendered content failed 1`] = `"\x1B[31m󰚩\x1B[39m reviewer"`;
 
-exports[`rendered content remote 1`] = `"\x1B[90m\x1B[2m󰚩\x1B[22m\x1B[39m \x1B[2m\x1B[22m  Remote build"`;
+exports[`rendered content remote 1`] = `"\x1B[90m\x1B[2m󰚩\x1B[22m\x1B[39m \x1B[2m\x1B[22m Remote build"`;
 
-exports[`rendered content explore-glyph 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m  Search \x1B[2m· Explore\x1B[22m"`;
+exports[`rendered content explore-glyph 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m Search \x1B[2m· Explore\x1B[22m"`;
 
-exports[`rendered content plan-glyph 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m  Design \x1B[2m· Plan\x1B[22m"`;
+exports[`rendered content plan-glyph 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m Design \x1B[2m· Plan\x1B[22m"`;
 
-exports[`rendered content guide-glyph 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m  Docs \x1B[2m· claude-code-guide\x1B[22m"`;
+exports[`rendered content guide-glyph 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m Docs \x1B[2m· claude-code-guide\x1B[22m"`;
 
-exports[`rendered content full-meta-remote-explore 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m \x1B[2m\x1B[22m  Build the parser \x1B[2m· 1m 5s · 2.3k · Explore\x1B[22m"`;
+exports[`rendered content full-meta-remote-explore 1`] = `"\x1B[90m\x1B[2m\x1B[22m\x1B[39m \x1B[2m\x1B[22m Build the parser \x1B[2m· 1m 5s · 2.3k · Explore\x1B[22m"`;
 
-exports[`rendered content truncated 1`] = `"\x1B[90m\x1B[2m󰚩\x1B[22m\x1B[39m  A really long description …"`;
+exports[`rendered content truncated 1`] = `"\x1B[90m\x1B[2m󰚩\x1B[22m\x1B[39m A really long description t…"`;

--- a/user/scripts/statusline.ts
+++ b/user/scripts/statusline.ts
@@ -48,7 +48,7 @@ export interface WorktreeData {
 
 type DialColor = "green" | "yellow" | "redBright" | "red";
 
-const SEP = "  ";
+const SEP = " ";
 
 // OSC 8 hyperlink open/close. Emitted unconditionally: the status line's stdout
 // is piped while still rendered, so TTY-gated link helpers would drop the link.

--- a/user/scripts/subagent-statusline.ts
+++ b/user/scripts/subagent-statusline.ts
@@ -103,7 +103,7 @@ export function renderTask(
   const build = (text: string, withType: boolean): string => {
     let body = icon;
     if (marker) body += ` ${marker}`;
-    body += `  ${text}`;
+    body += ` ${text}`;
     const trailing = [...metaParts];
     if (withType && agentType) trailing.push(agentType);
     if (trailing.length) {


### PR DESCRIPTION
Tightens the spacing in both status lines from two spaces to one. GitHub's monospace font renders the Nerd Font glyphs narrower, so the old double gaps read as too wide.

- Subagent line: the icon-to-title gap (`subagent-statusline.ts`)
- Main line: the `SEP` separator between every segment, including dial-to-diff (`statusline.ts`)

The `SEP` change applies to all segment joins on the main line, not just dial-to-diff, since the wider spacing isn't needed anywhere with these glyphs.
