### PR TITLE
tmux: add per-pane branch, worktree, and geometry

### DIFF
--- a/plugins/tmux/skills/tmux/SKILL.md
+++ b/plugins/tmux/skills/tmux/SKILL.md
@@ -31,7 +31,11 @@ Use `$TMUX_PANE` to identify the current pane and target adjacent ones.
 
 !`bash ${CLAUDE_SKILL_DIR}/scripts/window.sh`
 
-Use `left`/`top` coordinates to resolve spatial references within the current window (LHS = lowest `left`, RHS = highest `left`, top = lowest `top`, bottom = highest `top`). When describing layouts, draw ASCII box diagrams showing pane positions and sizes.
+Each pane line ends with its geometry as `@<left>,<top> <width>x<height>`, in cell coordinates from the window's top-left. Resolve spatial references from these: LHS = lowest `left`, RHS = highest `left`, top = lowest `top`, bottom = highest `top`. When describing layouts, draw ASCII box diagrams from the positions and sizes.
+
+### Worktrees and Parallel Panes
+
+Panes in a git repo show their branch and whether the checkout is a linked `(worktree)` or the primary `(main)` one. When the user refers to work by branch or worktree ("the pane on the X branch", "the worktree for Y", "the other pane, which is ready"), match the reference to a pane's branch and dispatch to it with `send-keys` (or treat it as already running) rather than entering a worktree of your own. A pane already sitting in a worktree is set up for parallel work; hand off to it instead of duplicating the checkout.
 
 ## Session
 

--- a/plugins/tmux/skills/tmux/scripts/window.sh
+++ b/plugins/tmux/skills/tmux/scripts/window.sh
@@ -14,6 +14,18 @@ trunc() {
   fi
 }
 
+# Print "<branch> (worktree|main)" for a pane's path, or nothing outside a repo.
+git_segment() {
+  local path=$1 branch gdir cdir kind
+  { read -r branch || true; read -r gdir || true; read -r cdir || true; } \
+    < <(git -C "$path" rev-parse --abbrev-ref HEAD --git-dir --git-common-dir 2>/dev/null)
+  [ -z "$branch" ] && return 0
+  [ "$branch" = "HEAD" ] && branch="detached"
+  kind="main"
+  [ -n "$cdir" ] && [ "$cdir" != "$gdir" ] && kind="worktree"
+  printf '%s (%s)' "$branch" "$kind"
+}
+
 target="${1:-}"
 if [ -z "$target" ]; then
   [ -z "${TMUX_PANE:-}" ] && { echo 'no window target' >&2; exit 1; }
@@ -21,9 +33,9 @@ if [ -z "$target" ]; then
 fi
 
 TAB=$'\t'
-fmt="#{pane_id}${TAB}#{pane_current_command}${TAB}#{pane_title}${TAB}#{pane_current_path}"
+fmt="#{pane_id}${TAB}#{pane_current_command}${TAB}#{pane_title}${TAB}#{pane_current_path}${TAB}#{pane_left}${TAB}#{pane_top}${TAB}#{pane_width}${TAB}#{pane_height}"
 
-tmux list-panes -t "$target" -F "$fmt" 2>/dev/null | while IFS=$'\t' read -r id cmd title path; do
+tmux list-panes -t "$target" -F "$fmt" 2>/dev/null | while IFS=$'\t' read -r id cmd title path left top width height; do
   tag=""
   [ "$id" = "${TMUX_PANE:-}" ] && tag=" (you)"
 
@@ -37,6 +49,11 @@ tmux list-panes -t "$target" -F "$fmt" 2>/dev/null | while IFS=$'\t' read -r id 
     short="${path/#"$HOME"/~}"
     line="${line} [${short}]"
   fi
+
+  seg=$(git_segment "$path")
+  [ -n "$seg" ] && line="${line} ${seg}"
+
+  line="${line} @${left},${top} ${width}x${height}"
 
   echo "$line"
 done


### PR DESCRIPTION
Adds each pane's git branch, worktree/main status, and screen geometry to `window.sh`, which feeds the `SessionStart` context hook. Claude can now tell when a sibling pane is already sitting on a branch or in a linked worktree.

## Changes

- `window.sh` appends `<branch> (worktree|main)` per pane (one `git rev-parse`, bash builtins only, prints nothing outside a repo) and ends each line with `@<left>,<top> <width>x<height>`.
- `SKILL.md` gains a *Worktrees and Parallel Panes* note: when the user points at work by branch or worktree ("the pane on the X branch", "the other pane, which is ready"), match it to a pane and `send-keys` instead of entering a worktree of your own.

The geometry change also fixes a stale doc: the Window section told Claude to "use `left`/`top` coordinates," but `window.sh` never emitted any. The skill text now describes the format the script actually prints.

## Motivation

Session history showed the handoff-to-worktree-pane pattern recurring without the context to act on it: "I created a new pane in a new worktree, send keys to that to dispatch it", "dispatch to pane 3, which is waiting to work on that". The branch is now the dispatch key, and `(worktree)` signals the pane is already isolated for parallel work.

I scoped this to `window.sh` (current window) rather than also enriching cross-session drilldown; the handoff cases in history were all same-window, and `session.sh` lists windows rather than pane paths, so cross-session would be a larger change.

## Testing

Ran `window.sh` against live layouts: a vertical stack (shared `left`, differing `top`), horizontal splits (differing `left`, shared `top`), a repo with a primary checkout plus two linked worktrees, and a non-repo path (empty git segment, clean exit under `set -euo pipefail`). `skill-lint` clean.
