### PR TITLE
writing: exempt plan files from the numbering hook

### DIFF
--- a/plugins/writing/hooks/markdown.ts
+++ b/plugins/writing/hooks/markdown.ts
@@ -17,6 +17,12 @@ export function isMemoryPath(filePath: string): boolean {
   return MEMORY_PATH_PATTERN.test(resolve(filePath));
 }
 
+const PLAN_PATH_PATTERN = /\/\.claude\/plans\//;
+
+export function isPlanPath(filePath: string): boolean {
+  return PLAN_PATH_PATTERN.test(resolve(filePath));
+}
+
 export function isMarkdownFile(ext: string): boolean {
   return ext === "md" || ext === "markdown";
 }

--- a/plugins/writing/hooks/numbering.test.ts
+++ b/plugins/writing/hooks/numbering.test.ts
@@ -366,3 +366,25 @@ describe("memory files", () => {
     expect(output?.permissionDecision).toBe("deny");
   });
 });
+
+describe("plan files", () => {
+  const planPath = `${process.env.HOME}/.claude/plans/some-plan.md`;
+
+  it("skips Write to a plan with numbered heading", async () => {
+    const output = await getOutput(mockWriteInput(planPath, "# Phase 1: Setup"), "write");
+    expect(output).toBeNull();
+  });
+
+  it("skips Edit to a plan with numbered heading", async () => {
+    const output = await getOutput(mockEditInput(planPath, "## Step 2: Build"), "edit");
+    expect(output).toBeNull();
+  });
+
+  it("still denies a numbered heading staged in a project tmp directory", async () => {
+    const output = await getOutput(
+      mockWriteInput(`${process.cwd()}/tmp/pr-body.md`, "# 1. Summary"),
+      "write",
+    );
+    expect(output?.permissionDecision).toBe("deny");
+  });
+});

--- a/plugins/writing/hooks/numbering.ts
+++ b/plugins/writing/hooks/numbering.ts
@@ -17,6 +17,7 @@ import {
   getExtension,
   isMarkdownFile,
   isMemoryPath,
+  isPlanPath,
   type SyncHookJSONOutput,
   type WriteInput,
 } from "./markdown";
@@ -126,7 +127,7 @@ export async function processInput(
     return null;
   }
 
-  if (isMemoryPath(filePath)) return null;
+  if (isMemoryPath(filePath) || isPlanPath(filePath)) return null;
 
   const ext = getExtension(filePath);
   let match: string | null = null;


### PR DESCRIPTION
The numbering hook fires on numbered markdown headings and numbered code identifiers (`step1`, `phaseN`). Across the full session history every block came from markdown headings, and 82% of those were plan-mode files in `~/.claude/plans/`, where an ordered list of steps is expected. The code-identifier path has never fired.

Gating the hook to markdown (the original approach) would have left every plan-file block in place and disabled the never-firing code path, so it reduced no friction and dropped coverage.

Instead, exempt plan files the way memory files are already exempted. Deliverables staged in project `tmp/` directories, like PR bodies passed to `gh`, still get validated on write.

#### Changes

- `isPlanPath()` in `markdown.ts`, matching `~/.claude/plans/`
- `numbering.ts` skips plan files alongside memory files
- Reverts the markdown gate on the numbering hook; `headings.ts` stays markdown-gated
- Tests covering plan-file exemption and a numbered heading in `tmp/` still denying
