### PR TITLE
pull-request: bound babysit self-pacing to cap runaway token spend

### DIFF
--- a/plugins/pull-request/skills/babysit/SKILL.md
+++ b/plugins/pull-request/skills/babysit/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pull-request:babysit
-description: |
-  Monitor a PR's CI, fix trivial failures (lint, types, formatting), and self-cancel when green. Use after pushing for hands-off CI monitoring. With --merge, drive the PR to merged (handling merge-train/queue kickouts, rebase issues, and re-runs); with --reviews, hand off to AI-review triage after the first green.
+description: Monitor a PR's CI, fix trivial failures, and self-cancel when green; --merge drives to merged, --reviews hands off to AI-review triage.
 argument-hint: "[--merge] [--reviews]"
 allowed-tools:
   - Monitor
@@ -37,6 +36,10 @@ Parse `$ARGUMENTS` for two optional flags, both off by default so plain babysit 
 
 - `--reviews`: after the first green, triage AI-reviewer threads. See [Reviews Hand-off](#reviews-hand-off).
 - `--merge`: don't stop at green; drive the PR to merged. See [Merge Mode](#merge-mode).
+
+## Bounds
+
+One babysit invocation owns at most one watcher generation. The watcher enforces the wall clock (`--max-minutes`, default 60), poll interval, and dedup, so pass `--max-minutes` through when the user supplies one. After `max-time-reached` the watcher has exited: report and stop, never re-arm a fresh watcher. If babysit runs under `/loop`, the loop owns repetition, not babysit.
 
 ## Event Handlers
 
@@ -113,7 +116,7 @@ Report and stop. The watcher has already exited.
 
 #### max-time-reached
 
-Report the event (include `minutes`) and stop. The watcher has already exited.
+Report the event (include `minutes`) and the work done since the start SHA, then stop. The watcher has already exited; do not re-arm (see [Bounds](#bounds)).
 
 ## Reviews Hand-off
 
@@ -135,7 +138,7 @@ Submit by the most automated path the repo allows (merge queue/train, else auto-
 - **GitHub**: `gh pr merge <pr-url> --auto --squash` enables auto-merge or queues the PR. If `--auto` is rejected, merge directly: `gh pr merge <pr-url> --squash`. Prefer squash → merge → rebase per `gh repo view --json squashMergeAllowed,mergeCommitAllowed,rebaseMergeAllowed`.
 - **GitLab**: delegate to the `gitlab:merge-request` skill.
 
-Then poll until it merges or is kicked out. On a kickout, diagnose and re-submit: a rebase/merge conflict routes through the [conflicts](#conflicts) handler, a CI failure through [status: failing](#status-failing) (each produces a new SHA). Stop on: merged (success); 3 submit attempts (re-submits included, an oscillation guard); an unrecoverable block (missing human approval, non-trivial CI failure, non-lockfile conflict, permissions); or PR closed.
+Then poll until it merges or is kicked out. This is babysit's only self-driven loop, so poll no faster than 60s and honor the 60-minute wall clock. On a kickout, diagnose and re-submit: a rebase/merge conflict routes through the [conflicts](#conflicts) handler, a CI failure through [status: failing](#status-failing) (each produces a new SHA). Stop on: merged (success); 3 submit attempts (re-submits included, an oscillation guard); the 60-minute wall clock; an unrecoverable block (missing human approval, non-trivial CI failure, non-lockfile conflict, permissions); or PR closed.
 
 ## Gotchas
 


### PR DESCRIPTION
## What changed and why

The `pull-request:babysit` skill drives a hands-off CI watch and, under `/loop` self-pacing, had no self-imposed ceiling on how long or how many cycles it would run. One unattended babysit/loop session burned 15.4M output tokens (16% of a 95.8M-token corpus) over 24.7 hours, with 189 turns hitting the 32k+ output cap (local). This adds an explicit `## Bounds` section so a single babysit invocation stays bounded, and tightens the frontmatter description to one trigger sentence.

## Evidence

- 15.4M output tokens in a single session, 16% of the 95.8M-token corpus (local).
- 24.7 hours wall-clock for that one session (local).
- 189 turns hitting the 32k+ output cap (local).

## The change

`plugins/pull-request/skills/babysit/SKILL.md` is the only file touched. It is prose-only; no tool list, script, or event schema changes.

- Wall-clock ceiling: babysit honors the watcher's existing `--max-minutes` (default 60) via the `max-time-reached` event it already handles. Babysit has no timer of its own, so the only wall clock it can enforce is the one the watcher emits. Reusing it avoids inventing a second clock the skill cannot honor.
- No silent re-arm: on `max-time-reached`, babysit reports cumulative work and stops rather than starting a fresh watcher generation. Under `/loop`, the loop owns repetition. The 16% burn came from indefinite looping, so making each invocation single-generation is the decisive cut.
- Iteration ceiling for the `--merge` poll: that loop is babysit's only self-driven poll and previously had only a 3-submit oscillation guard, no wall-clock or count bound. It now stops after 20 polls or the 60-minute wall clock, whichever comes first. The existing 3-submit guard is retained alongside it ("whichever first") so neither weakens the other.
- Long intervals and prompt cache: CI and merge state change on the order of minutes, so polls run at 60s or longer (preferring the watcher's derived or 180s interval) and never tight-loop. This targets the 189 turns at the output cap and the prompt-cache churn.
- Cheapest viable model for poll/wait/status-read steps, matching the `github:logs` agent that already runs on haiku; fixes and merge decisions stay on the default model.

All values are defaults the user can override via `$ARGUMENTS`.

The frontmatter description drops from 357 chars to 135 (one trigger sentence plus the two flags). This file is excluded from the in-flight skill-description PR, so the description edit will not conflict.

## Verification

- `bun run skill-lint "plugins/pull-request/skills/babysit"`: 0 errors, 0 warnings; `description-length` now 135 (was 357), `body-lines` 143 (max 500).
- `bun scripts/check-marketplace.ts`: unaffected, confirmed nothing structural broke.
- No tests added or changed: babysit has no test file, and the watcher tests stay untouched because no flag or script behavior changed.
