### PR TITLE
user: allow sandbox writes for tmux sockets and agent worktrees

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -33,7 +33,7 @@ The sandbox is egress control, not filesystem lockdown. Credentials stay outside
 
 ### Sockets and Writes
 
-`allowUnixSockets`: the Secretive SSH agent is a signing channel (keys stay in the Secure Enclave), `~/.tmux` is local IPC. `allowLocalBinding` is loopback-only. `filesystem.allowWrite` covers caches and scratch, not credential stores: `/tmp`, `~/.cache`, `~/.terraform.d/plugin-cache`, `~/Library/Caches/go-build`, `~/src/go/pkg/{mod,sumdb}`, `~/.bun/install`, `~/.local/share/uv`, `~/.local/share/graphite`.
+`allowUnixSockets`: the Secretive SSH agent is a signing channel (keys stay in the Secure Enclave), `~/.tmux` is local IPC. `allowLocalBinding` is loopback-only. `filesystem.allowWrite` covers caches and scratch, not credential stores: `/tmp`, `~/.tmux` (tmux creates response sockets under `~/.tmux/tmux-$UID/`, a filesystem write that `allowUnixSockets` does not grant), `.claude/worktrees` (relative to the repo root, so agent worktrees the harness checks out under `<repo>/.claude/worktrees/agent-*` are writable from their own cwd), `~/.cache`, `~/.terraform.d/plugin-cache`, `~/Library/Caches/go-build`, `~/src/go/pkg/{mod,sumdb}`, `~/.bun/install`, `~/.local/share/uv`, `~/.local/share/graphite`.
 
 ### Escaped Commands (`excludedCommands`)
 

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -33,26 +33,11 @@ The sandbox is egress control, not filesystem lockdown. Credentials stay outside
 
 ### Sockets and Writes
 
-These settings allow local IPC plus safe scratch/cache writes without opening credential stores.
+Treat this section as a trust model, not an exhaustive mirror of `settings.json`.
 
-- `allowUnixSockets`
-  - Secretive SSH agent is a signing channel (keys stay in the Secure Enclave).
-  - `~/.tmux` is local IPC.
-- `allowLocalBinding`
-  - Loopback-only.
-- `filesystem.allowWrite` (caches and scratch, not credential stores)
-  - `/tmp`
-  - `~/.tmux`
-    - tmux creates response sockets under `~/.tmux/tmux-$UID/`, a filesystem write that `allowUnixSockets` does not grant.
-  - `.claude/worktrees`
-    - Relative to the repo root, so agent worktrees under `<repo>/.claude/worktrees/agent-*` are writable from their own cwd.
-  - `~/.cache`
-  - `~/.terraform.d/plugin-cache`
-  - `~/Library/Caches/go-build`
-  - `~/src/go/pkg/{mod,sumdb}`
-  - `~/.bun/install`
-  - `~/.local/share/uv`
-  - `~/.local/share/graphite`
+- `allowUnixSockets` should be local IPC endpoints where secret material never leaves a dedicated agent (for example, signing daemons or tmux sockets).
+- `allowLocalBinding` should stay loopback-only.
+- `filesystem.allowWrite` should allow only scratch/cache/worktree paths that tools must mutate, and never credential stores or broad home-directory globs.
 
 ### Escaped Commands (`excludedCommands`)
 

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -33,7 +33,26 @@ The sandbox is egress control, not filesystem lockdown. Credentials stay outside
 
 ### Sockets and Writes
 
-`allowUnixSockets`: the Secretive SSH agent is a signing channel (keys stay in the Secure Enclave), `~/.tmux` is local IPC. `allowLocalBinding` is loopback-only. `filesystem.allowWrite` covers caches and scratch, not credential stores: `/tmp`, `~/.tmux` (tmux creates response sockets under `~/.tmux/tmux-$UID/`, a filesystem write that `allowUnixSockets` does not grant), `.claude/worktrees` (relative to the repo root, so agent worktrees the harness checks out under `<repo>/.claude/worktrees/agent-*` are writable from their own cwd), `~/.cache`, `~/.terraform.d/plugin-cache`, `~/Library/Caches/go-build`, `~/src/go/pkg/{mod,sumdb}`, `~/.bun/install`, `~/.local/share/uv`, `~/.local/share/graphite`.
+These settings allow local IPC plus safe scratch/cache writes without opening credential stores.
+
+- `allowUnixSockets`
+  - Secretive SSH agent is a signing channel (keys stay in the Secure Enclave).
+  - `~/.tmux` is local IPC.
+- `allowLocalBinding`
+  - Loopback-only.
+- `filesystem.allowWrite` (caches and scratch, not credential stores)
+  - `/tmp`
+  - `~/.tmux`
+    - tmux creates response sockets under `~/.tmux/tmux-$UID/`, a filesystem write that `allowUnixSockets` does not grant.
+  - `.claude/worktrees`
+    - Relative to the repo root, so agent worktrees under `<repo>/.claude/worktrees/agent-*` are writable from their own cwd.
+  - `~/.cache`
+  - `~/.terraform.d/plugin-cache`
+  - `~/Library/Caches/go-build`
+  - `~/src/go/pkg/{mod,sumdb}`
+  - `~/.bun/install`
+  - `~/.local/share/uv`
+  - `~/.local/share/graphite`
 
 ### Escaped Commands (`excludedCommands`)
 

--- a/user/settings.json
+++ b/user/settings.json
@@ -290,6 +290,8 @@
     "filesystem": {
       "allowWrite": [
         "/tmp",
+        "~/.tmux",
+        ".claude/worktrees",
         "~/.terraform.d/plugin-cache",
         "~/.cache",
         "~/Library/Caches/go-build",


### PR DESCRIPTION
## What and why

The sandbox config in `user/settings.json` blocked two filesystem writes that show up as recurring friction in session history. tmux response-socket creation and agent-worktree writes both failed under the default writable root, so any flow that touched them stalled until a sandbox bypass. Both are concrete gaps in `sandbox.filesystem.allowWrite`, fixed by adding two scoped entries.

## Evidence

Grounded in session history (local = personal machine):

- tmux response-socket creation denied: 8 failures (local). `network.allowUnixSockets` already lists `~/.tmux`, which covers connecting to an existing socket, but tmux creates new response sockets under `~/.tmux/tmux-501/`, which is a filesystem write the socket allowlist does not grant.
- Agent-worktree writes denied: 9 failures (local), e.g. `mkdir: /Users/ben/src/bendrucker/claude/.claude/worktrees/agent-.../plugins/writing/skills/rewrite: Operation not permitted`. The agent worktree the harness checks out becomes the model cwd, and that tree sits outside the writable root.

I confirmed the agent-worktree path against the failures and the session project index: worktrees land at `<repo>/.claude/worktrees/agent-*` across multiple repos (`bendrucker/claude`, `bendrucker/bendrucker.me`, `terraform-linters/setup-tflint`), all relative to the repo root.

## Change

Two entries added to `sandbox.filesystem.allowWrite`:

- `~/.tmux` so tmux can create response sockets under `~/.tmux/tmux-$UID/`. This is consistent with `~/.tmux` already being in `allowUnixSockets`; it does not widen network egress.
- `.claude/worktrees`, relative to the repo root, so agent worktrees under `<repo>/.claude/worktrees/agent-*` are writable from their own cwd in any repo. Scoped to the worktree subtree rather than a broad home-directory grant.

The `.claude/rules/settings.md` "Sockets and Writes" section is updated to document both entries and their rationale.

## Verification

- `jq empty user/settings.json` passes; JSON is valid and existing entries are intact.
- No plugin hook or skill code changed, so no `bun test` or `skill-lint` target applies. The diff is config plus the matching rule doc.

## Note for the reviewer

I could not verify from docs whether `allowWrite` resolves a relative entry like `.claude/worktrees` against the agent worktree cwd as intended. The live sandbox profile does resolve relative entries (it already includes `.worktrees` from `WORKTRUNK_WORKTREE_PATH`), which is the basis for this form. If a relative entry does not take effect in practice, the alternative is a per-repo absolute path or a broader `~/src/**` glob; confirm before relying on it.
