### PR TITLE
writing: stop hard-denying prose tropes on command and MCP inputs

### DIFF
--- a/plugins/writing/hooks/check-tropes.test.ts
+++ b/plugins/writing/hooks/check-tropes.test.ts
@@ -363,15 +363,23 @@ describe("collectText", () => {
 });
 
 describe("Bash/MCP processInput", () => {
-  it("flags MCP tool input with spaced em dash as context", async () => {
+  it("denies MCP tool input with spaced em dash", async () => {
     const result = await processInput(
       mockMcp("mcp__linear__save_issue", {
         title: "Fix the bug",
         description: "This feature \u2014 which was added last week \u2014 is broken",
       }),
     );
-    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
-    expect(result?.hookSpecificOutput).not.toHaveProperty("permissionDecision");
+    expect(result?.hookSpecificOutput).toHaveProperty("permissionDecision", "deny");
+  });
+
+  it("denies a spaced em dash even on a non-prose tool", async () => {
+    const result = await processInput(
+      mockMcp("mcp__db__execute", {
+        statement: "Filter the rows \u2014 the pending ones \u2014 before the update runs",
+      }),
+    );
+    expect(result?.hookSpecificOutput).toHaveProperty("permissionDecision", "deny");
   });
 
   it("flags Bash body-file with AI vocabulary as context", async () => {
@@ -389,6 +397,36 @@ describe("Bash/MCP processInput", () => {
     if (result) {
       expect(result.hookSpecificOutput).not.toHaveProperty("permissionDecision");
     }
+  });
+
+  it("flags AI vocabulary on a prose-bearing tool as context", async () => {
+    const result = await processInput(
+      mockMcp("mcp__linear__save_issue", {
+        title: "Login fails",
+        summary: "We delve into the intricacies of the auth flow here",
+      }),
+    );
+    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
+    expect(result?.hookSpecificOutput).not.toHaveProperty("permissionDecision");
+  });
+
+  it("ignores AI vocabulary on a non-prose tool with a non-prose key", async () => {
+    const result = await processInput(
+      mockMcp("mcp__db__execute", {
+        statement: "We delve into the rows and underscore the totals here",
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("flags AI vocabulary on a non-prose tool with a prose key", async () => {
+    const result = await processInput(
+      mockMcp("mcp__db__execute", {
+        description: "We delve into the rows and underscore the totals here",
+      }),
+    );
+    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
+    expect(result?.hookSpecificOutput).not.toHaveProperty("permissionDecision");
   });
 
   it("returns null for clean MCP input", async () => {

--- a/plugins/writing/hooks/check-tropes.test.ts
+++ b/plugins/writing/hooks/check-tropes.test.ts
@@ -363,23 +363,32 @@ describe("collectText", () => {
 });
 
 describe("Bash/MCP processInput", () => {
-  it("denies MCP tool input with spaced em dash", async () => {
+  it("flags MCP tool input with spaced em dash as context", async () => {
     const result = await processInput(
       mockMcp("mcp__linear__save_issue", {
         title: "Fix the bug",
         description: "This feature \u2014 which was added last week \u2014 is broken",
       }),
     );
-    expect(result?.hookSpecificOutput).toHaveProperty("permissionDecision", "deny");
+    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
+    expect(result?.hookSpecificOutput).not.toHaveProperty("permissionDecision");
   });
 
-  it("denies Bash body-file with AI vocabulary", async () => {
+  it("flags Bash body-file with AI vocabulary as context", async () => {
     const dir = mkdtempSync(join(tmpdir(), "trope-test-"));
     const file = join(dir, "body.md");
     await Bun.write(file, "We must delve into the issue");
     const result = await processInput(mockBash(`gh pr create --body-file ${file}`));
     await rm(dir, { recursive: true, force: true });
-    expect(result?.hookSpecificOutput).toHaveProperty("permissionDecision", "deny");
+    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
+    expect(result?.hookSpecificOutput).not.toHaveProperty("permissionDecision");
+  });
+
+  it("does not deny Bash commands containing flagged tokens as literals", async () => {
+    const result = await processInput(mockBash('gh pr create --title "Rename underscore field"'));
+    if (result) {
+      expect(result.hookSpecificOutput).not.toHaveProperty("permissionDecision");
+    }
   });
 
   it("returns null for clean MCP input", async () => {
@@ -422,6 +431,7 @@ describe("Bash/MCP processInput", () => {
         payload: { body: "We delve into the system for a while longer" },
       }),
     );
-    expect(result?.hookSpecificOutput).toHaveProperty("permissionDecision", "deny");
+    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
+    expect(result?.hookSpecificOutput).not.toHaveProperty("permissionDecision");
   });
 });

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -34,7 +34,7 @@ function isProse(value: string): boolean {
   return /\s/.test(value);
 }
 
-type ProseEntry = { key?: string; value: string };
+type ProseEntry = { key: string | undefined; value: string };
 
 function extractProseEntries(value: unknown, key?: string): ProseEntry[] {
   if (shouldSkipKey(key)) return [];

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -2,7 +2,7 @@
 
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
-import { formatContext, isMemoryPath, type SyncHookJSONOutput } from "./markdown";
+import { formatContext, formatDecision, isMemoryPath, type SyncHookJSONOutput } from "./markdown";
 import { firstByTier, type PatternMatch, type ScanContext, scan, scanIntroduced } from "./tropes";
 
 const FILE_OP_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
@@ -34,16 +34,40 @@ function isProse(value: string): boolean {
   return /\s/.test(value);
 }
 
-function extractProse(value: unknown, key?: string): string[] {
+type ProseEntry = { key?: string; value: string };
+
+function extractProseEntries(value: unknown, key?: string): ProseEntry[] {
   if (shouldSkipKey(key)) return [];
-  if (typeof value === "string") return isProse(value) ? [value] : [];
-  if (Array.isArray(value)) return value.flatMap((item) => extractProse(item, key));
+  if (typeof value === "string") return isProse(value) ? [{ key, value }] : [];
+  if (Array.isArray(value)) return value.flatMap((item) => extractProseEntries(item, key));
   if (typeof value === "object" && value !== null) {
     return Object.entries(value).flatMap(([childKey, childValue]) =>
-      extractProse(childValue, childKey),
+      extractProseEntries(childValue, childKey),
     );
   }
   return [];
+}
+
+function extractProse(value: unknown, key?: string): string[] {
+  return extractProseEntries(value, key).map((entry) => entry.value);
+}
+
+const PROSE_TOOL_PATTERN =
+  /\b(?:issue|ticket|story|epic|document|doc|page|wiki|note|comment|message|post|reply|thread|discussion|review|article|memo)\b/;
+
+const PROSE_KEY_PATTERN =
+  /\b(?:description|body|content|text|title|summary|comment|message|note|details)\b/;
+
+function tokenize(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, " ");
+}
+
+function isProseTool(toolName: string): boolean {
+  return PROSE_TOOL_PATTERN.test(tokenize(toolName));
+}
+
+function isProseKey(key: string | undefined): boolean {
+  return key !== undefined && PROSE_KEY_PATTERN.test(tokenize(key));
 }
 
 function extractBodyFilePath(command: string): string | null {
@@ -140,6 +164,17 @@ export async function collectText(input: PreToolUseHookInput): Promise<string[]>
   return extractProse(toolInput);
 }
 
+async function collectLexicalText(input: PreToolUseHookInput): Promise<string[]> {
+  const toolName = input.tool_name;
+
+  if (toolName === "Bash") return collectText(input);
+
+  const toolInput = input.tool_input as Record<string, unknown>;
+  const entries = extractProseEntries(toolInput);
+  if (isProseTool(toolName)) return entries.map((entry) => entry.value);
+  return entries.filter((entry) => isProseKey(entry.key)).map((entry) => entry.value);
+}
+
 function isPlanFile(input: PreToolUseHookInput): boolean {
   const filePath = (input.tool_input as Record<string, unknown>).file_path;
   if (typeof filePath !== "string") return false;
@@ -193,9 +228,13 @@ async function processFileOp(input: PreToolUseHookInput): Promise<SyncHookJSONOu
 async function processSideEffect(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
   const texts = await collectText(input);
   if (texts.length === 0) return null;
-  const combined = texts.join("\n");
-  const matches = scan(combined, undefined, "sideEffect");
 
+  const structural = firstByTier(scan(texts.join("\n"), undefined, "sideEffect"), "deny");
+  if (structural?.structural) return formatDecision("deny", structural.message);
+
+  const lexical = await collectLexicalText(input);
+  if (lexical.length === 0) return null;
+  const matches = scan(lexical.join("\n"), undefined, "sideEffect");
   const match = firstByTier(matches, "deny") ?? firstByTier(matches, "context");
   if (match) return formatContext(match.message);
 

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -2,7 +2,7 @@
 
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
-import { formatContext, formatDecision, isMemoryPath, type SyncHookJSONOutput } from "./markdown";
+import { formatContext, isMemoryPath, type SyncHookJSONOutput } from "./markdown";
 import { firstByTier, type PatternMatch, type ScanContext, scan, scanIntroduced } from "./tropes";
 
 const FILE_OP_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
@@ -196,11 +196,8 @@ async function processSideEffect(input: PreToolUseHookInput): Promise<SyncHookJS
   const combined = texts.join("\n");
   const matches = scan(combined, undefined, "sideEffect");
 
-  const deny = firstByTier(matches, "deny");
-  if (deny) return formatDecision("deny", deny.message);
-
-  const context = firstByTier(matches, "context");
-  if (context) return formatContext(context.message);
+  const match = firstByTier(matches, "deny") ?? firstByTier(matches, "context");
+  if (match) return formatContext(match.message);
 
   return null;
 }

--- a/plugins/writing/hooks/tropes.test.ts
+++ b/plugins/writing/hooks/tropes.test.ts
@@ -499,15 +499,15 @@ describe("scan", () => {
 describe("firstByTier", () => {
   it("finds first deny match", () => {
     const matches: PatternMatch[] = [
-      { tier: "context", category: "test", matched: "x", message: "x" },
-      { tier: "deny", category: "test", matched: "y", message: "y" },
+      { tier: "context", category: "test", matched: "x", message: "x", structural: false },
+      { tier: "deny", category: "test", matched: "y", message: "y", structural: false },
     ];
     expect(firstByTier(matches, "deny")?.matched).toBe("y");
   });
 
   it("returns undefined when tier not found", () => {
     const matches: PatternMatch[] = [
-      { tier: "context", category: "test", matched: "x", message: "x" },
+      { tier: "context", category: "test", matched: "x", message: "x", structural: false },
     ];
     expect(firstByTier(matches, "deny")).toBeUndefined();
   });

--- a/plugins/writing/hooks/tropes.ts
+++ b/plugins/writing/hooks/tropes.ts
@@ -10,6 +10,7 @@ export type PatternMatch = {
   category: string;
   matched: string;
   message: string;
+  structural: boolean;
 };
 
 type PatternDef = {
@@ -19,6 +20,7 @@ type PatternDef = {
   message: (matched: string) => string;
   fileOnly?: boolean;
   sideEffectOnly?: boolean;
+  structural?: boolean;
 };
 
 type WeightedPatternGroup = {
@@ -66,6 +68,7 @@ const PATTERNS: PatternDef[] = [
   {
     tier: "deny",
     category: "spaced em dash",
+    structural: true,
     test: / — /g,
     message: () =>
       "Spaced em dashes ( — ) are an AI writing tell. Use unspaced em dashes (—), commas, colons, or parentheses instead.",
@@ -273,6 +276,7 @@ export function scanIntroduced(
       category: def.category,
       matched: newHits.sample,
       message: def.message(newHits.sample),
+      structural: def.structural ?? false,
     });
     seenTiers.add(def.tier);
   }
@@ -291,6 +295,7 @@ export function scanIntroduced(
       category: group.category,
       matched: newWeighted.samples[0] ?? "",
       message: group.message(newWeighted.samples, newWeighted.totalWeight),
+      structural: false,
     });
     seenTiers.add(group.tier);
   }


### PR DESCRIPTION
## What and Why

The trope hook (`plugins/writing/hooks/check-tropes.ts`) runs on the `Bash|mcp__.*` matcher, and its side-effect path called `formatDecision("deny", ...)` for any deny-tier match. Deny-tier entries include both the spaced em dash and AI-vocabulary words such as `underscore`. On command strings and MCP tool inputs, those vocabulary matches are usually literal identifiers or data rather than authored prose, so the hook hard-blocked legitimate commands.

This splits deny-tier tropes into two kinds and handles each by what it actually signals:

- **Structural** tropes (currently the spaced em dash) are unambiguous regardless of input shape. They still hard-deny on every side-effect input.
- **Lexical** tropes (AI vocabulary, marketing verbs) only mean something in prose. They are scoped to prose-shaped inputs and downgraded to a non-blocking reminder, never a deny.

## Evidence

Confirmed false positives on host=work: technical command strings containing the literal token `underscore` (a deny-tier vocabulary entry) tripped the hook and blocked the command. The side-effect path was the only path that escalated these lexical matches to a hard `deny`.

## Change

- `PatternMatch` and `PatternDef` gain a `structural` flag. The spaced em dash pattern sets `structural: true`; every other pattern defaults to `false`.
- `processSideEffect` scans for a structural deny first and keeps the hard `formatDecision("deny", ...)` for it. Lexical matches go through a separate prose-scoped pass and render as `formatContext` (a reminder), collapsing the deny and context tiers on that path.
- `collectLexicalText` decides which inputs count as prose:
  - `Bash`: all extracted prose, same as before.
  - Prose-bearing MCP tools (name matches `issue|ticket|doc|comment|...`): all extracted prose.
  - Other tools: only values whose key looks prose-bearing (`description|body|title|...`); everything else is ignored.
- `extractProse` now builds on `extractProseEntries`, which retains each value's key so the lexical pass can filter by key.
- Tests cover the matrix: a spaced em dash denies even on a non-prose tool; AI vocabulary flags as context on Bash body-files and prose-bearing tools/keys; the reported `underscore` false positive and non-prose keys no longer fire.

No change to `hooks.json` (the `Bash|mcp__.*` block is untouched) or the `underscore` wordlist entry. Lexical slop coverage of `underscore` and other deny-tier words is preserved wherever the input is actually prose.

## Verification

- `bun test plugins/writing` covers the full plugin suite, including the new structural-vs-lexical cases.
- `bunx tsc --noEmit` passes (the `structural` flag is threaded through `PatternMatch` and its construction sites).
