### PR TITLE
writing: stop numbering hook from blocking numbered prose in plans

### DIFF
--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -2,7 +2,13 @@
 
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
-import { formatContext, formatDecision, isMemoryPath, type SyncHookJSONOutput } from "./markdown";
+import {
+  formatContext,
+  formatDecision,
+  isMemoryPath,
+  isPlanPath,
+  type SyncHookJSONOutput,
+} from "./markdown";
 import { firstByTier, type PatternMatch, type ScanContext, scan, scanIntroduced } from "./tropes";
 
 const FILE_OP_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
@@ -143,8 +149,7 @@ export async function collectText(input: PreToolUseHookInput): Promise<string[]>
 function isPlanFile(input: PreToolUseHookInput): boolean {
   const filePath = (input.tool_input as Record<string, unknown>).file_path;
   if (typeof filePath !== "string") return false;
-  const home = process.env.HOME ?? "";
-  return home !== "" && filePath.startsWith(`${home}/.claude/plans/`);
+  return isPlanPath(filePath);
 }
 
 function isMemoryFile(input: PreToolUseHookInput): boolean {

--- a/plugins/writing/hooks/markdown.ts
+++ b/plugins/writing/hooks/markdown.ts
@@ -17,6 +17,11 @@ export function isMemoryPath(filePath: string): boolean {
   return MEMORY_PATH_PATTERN.test(resolve(filePath));
 }
 
+export function isPlanPath(filePath: string): boolean {
+  const home = process.env.HOME ?? "";
+  return home !== "" && filePath.startsWith(`${home}/.claude/plans/`);
+}
+
 export function isMarkdownFile(ext: string): boolean {
   return ext === "md" || ext === "markdown";
 }

--- a/plugins/writing/hooks/numbering.test.ts
+++ b/plugins/writing/hooks/numbering.test.ts
@@ -290,19 +290,19 @@ describe.skipIf(!hasSg())("processInput with code (requires sg)", () => {
 describe("processInput with markdown", () => {
   it('detects "# 1. Introduction"', async () => {
     const output = await getOutput(mockWriteInput("README.md", "# 1. Introduction"), "write");
-    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecision).toBe("ask");
     expect(output?.permissionDecisionReason).toContain("1. Introduction");
   });
 
   it('detects "## Step 2: Setup"', async () => {
     const output = await getOutput(mockWriteInput("docs.md", "## Step 2: Setup"), "write");
-    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecision).toBe("ask");
     expect(output?.permissionDecisionReason).toContain("Step 2");
   });
 
   it('detects "### Phase 3"', async () => {
     const output = await getOutput(mockWriteInput("guide.markdown", "### Phase 3"), "write");
-    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecision).toBe("ask");
     expect(output?.permissionDecisionReason).toContain("Phase 3");
   });
 
@@ -361,8 +361,50 @@ describe("memory files", () => {
     expect(output).toBeNull();
   });
 
-  it("still denies non-memory markdown with numbered heading", async () => {
+  it("still asks on non-memory markdown with numbered heading", async () => {
     const output = await getOutput(mockWriteInput("README.md", "# 1. Introduction"), "write");
-    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecision).toBe("ask");
+  });
+});
+
+describe("plan files", () => {
+  const planPath = `${process.env.HOME}/.claude/plans/feature.md`;
+
+  it("skips Write to plan markdown with numbered heading", async () => {
+    const output = await getOutput(mockWriteInput(planPath, "# 1. Introduction"), "write");
+    expect(output).toBeNull();
+  });
+
+  it("skips Edit to plan markdown with numbered heading", async () => {
+    const output = await getOutput(mockEditInput(planPath, "# 1. Introduction"), "edit");
+    expect(output).toBeNull();
+  });
+
+  it("still asks on non-plan markdown with numbered heading", async () => {
+    const output = await getOutput(mockWriteInput("README.md", "# 1. Introduction"), "write");
+    expect(output?.permissionDecision).toBe("ask");
+  });
+});
+
+describe("plan mode", () => {
+  function mockPlanModeWrite(filePath: string, content: string): PreToolUseHookInput {
+    return { ...mockWriteInput(filePath, content), permission_mode: "plan" };
+  }
+
+  it("skips Write with numbered heading when permission_mode is plan", async () => {
+    const output = await getOutput(mockPlanModeWrite("README.md", "# 1. Introduction"), "write");
+    expect(output).toBeNull();
+  });
+
+  it("still asks when permission_mode is not plan", async () => {
+    const output = await getOutput(mockWriteInput("README.md", "# 1. Introduction"), "write");
+    expect(output?.permissionDecision).toBe("ask");
+  });
+});
+
+describe("markdown ask tier", () => {
+  it("asks rather than denies on markdown Write", async () => {
+    const output = await getOutput(mockWriteInput("README.md", "# 1. Introduction"), "write");
+    expect(output?.permissionDecision).toBe("ask");
   });
 });

--- a/plugins/writing/hooks/numbering.ts
+++ b/plugins/writing/hooks/numbering.ts
@@ -17,6 +17,7 @@ import {
   getExtension,
   isMarkdownFile,
   isMemoryPath,
+  isPlanPath,
   type SyncHookJSONOutput,
   type WriteInput,
 } from "./markdown";
@@ -34,6 +35,10 @@ type AstGrepMatch = {
 };
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function isPlanMode(input: PreToolUseHookInput): boolean {
+  return input.permission_mode === "plan";
+}
 
 export function checkMarkdown(content: string): string | null {
   const ast = fromMarkdown(content);
@@ -127,6 +132,8 @@ export async function processInput(
   }
 
   if (isMemoryPath(filePath)) return null;
+  if (isPlanPath(filePath)) return null;
+  if (isPlanMode(input)) return null;
 
   const ext = getExtension(filePath);
   let match: string | null = null;
@@ -146,11 +153,12 @@ ${match}
 
 Use descriptive names instead. See CLAUDE.md Organization guidelines.`;
 
-  if (mode === "write") {
-    return formatDecision("deny", reason);
-  } else {
+  if (mode === "edit") {
     return formatDecision("ask", `This edit introduces numbered sequences. ${reason}`);
   }
+
+  const decision = isMarkdownFile(ext) ? "ask" : "deny";
+  return formatDecision(decision, reason);
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## What and why

`plugins/writing/hooks/numbering.ts` hard-denied legitimate numbered and Step/Phase/Part headings in plan and spec prose. The rule exists to flag coupling between sequenced code functions, not numbered lists in markdown, so prose headings should not be a hard block. This downgrades markdown writes to `ask` (matching edit mode) and exempts plan surfaces, while leaving the code path (the `sg` scan over real source) unchanged.

## Evidence

From the session-history analysis (local, personal machine): 42 of 60 numbering blocks were prose or plan headings, and the analysis report itself tripped the deny on its first write. Only 3 of 47 deny blocks were followed by a same-hook success within five minutes, so the friction was real, not self-correcting. The single exemption was `isMemoryPath`; there was no plan-surface guard.

## Change

- `checkMarkdown` matching is unchanged. The decision tier changes: edit mode stays `ask`; in write mode, markdown returns `ask` and code returns `deny` (gated on `isMarkdownFile(ext)`).
- Added a plan-surface guard in `processInput`: returns no decision when the path is under `~/.claude/plans/` or when `permission_mode` is `"plan"`.
- Hoisted `isPlanPath` into the shared `markdown.ts` module and pointed `check-tropes.ts` at it so both hooks share one definition rather than duplicating the plan-path logic.
- `numbering.test.ts`: updated the markdown and memory assertions from `deny` to `ask`, and added coverage for the plan-path exemption, the plan-mode exemption, and the markdown ask tier. The existing code-path `deny` tests serve as the regression guard.

## Verification

- `bun test plugins/writing`: 320 pass, 0 fail.
- Piped payloads through the hook: markdown write returns `ask`; a path under `~/.claude/plans/` returns no output; `permission_mode: "plan"` returns no output; a `.go` write with `func step1()` still returns `deny`.
- `bunx tsc --noEmit` clean; biome reports only a pre-existing unused-import warning in `check-tropes.ts` unrelated to this change.
