### PR TITLE
skills: disable model invocation on never-auto-invoked skills

### DIFF
--- a/plugins/calendar/skills/calendar/SKILL.md
+++ b/plugins/calendar/skills/calendar/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: calendar
+disable-model-invocation: true
 description: Reading and managing macOS Calendar events. Use when checking schedules, finding events, creating meetings, or answering questions about availability.
 allowed-tools: [Bash(swift:*)]
 hooks:

--- a/plugins/claude-code/skills/changelog/SKILL.md
+++ b/plugins/claude-code/skills/changelog/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: claude-code:changelog
+disable-model-invocation: true
 description: Review Claude Code release notes for changes relevant to the user's skills, plugins, and tool usage. Use when the user asks "what's new in Claude Code?", "check for updates", "release notes", "new features", "what changed recently?", or wants to stay current with Claude Code.
 allowed-tools:
   - Bash(gh api graphql:*)

--- a/plugins/github/skills/notifications/SKILL.md
+++ b/plugins/github/skills/notifications/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: github:notifications
+disable-model-invocation: true
 description: Managing GitHub notifications inbox. Use when listing, filtering, or triaging notifications (mark read, done, unsubscribe).
 ---
 

--- a/plugins/interview/skills/clarify/SKILL.md
+++ b/plugins/interview/skills/clarify/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: interview:clarify
+disable-model-invocation: true
 description: |
   Targeted interview for execution-time clarification. Use when you hit an ambiguity or decision point during implementation that needs user input before proceeding.
 context: fork

--- a/plugins/linear/skills/notifications/SKILL.md
+++ b/plugins/linear/skills/notifications/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: linear:notifications
+disable-model-invocation: true
 description: Managing Linear notifications inbox. Use when listing, filtering, or triaging Linear notifications.
 allowed-tools:
   - mcp__linear

--- a/plugins/review/skills/hunk/SKILL.md
+++ b/plugins/review/skills/hunk/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: review:hunk
+disable-model-invocation: true
 description: >
   Drive Hunk, the terminal diff viewer, as a live local review surface in tmux. Use when
   reviewing changes through Hunk: launching a session, seeding agent notes, collecting inline

--- a/plugins/tech-spec/skills/create/SKILL.md
+++ b/plugins/tech-spec/skills/create/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: tech-spec:create
+disable-model-invocation: true
 description: |
   Create a technical specification through interactive planning and expert review. Use when starting a new feature or project that needs documented architecture, implementation approach, and design decisions. Invoke with product requirements (PRD, brief, or similar).
 ---

--- a/plugins/tech-spec/skills/review/SKILL.md
+++ b/plugins/tech-spec/skills/review/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: tech-spec:review
+disable-model-invocation: true
 description: |
   Review a technical specification through expert lenses. Use to identify gaps, risks, and missing considerations in an existing spec. Works on any tech spec, not just those created with tech-spec:create.
 ---

--- a/plugins/type-ignore/skills/fix/SKILL.md
+++ b/plugins/type-ignore/skills/fix/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: type-ignore:fix
+disable-model-invocation: true
 description: Fix type errors instead of ignoring them. Use when cleaning up type ignores across files or batch-fixing type errors.
 context: fork
 agent: general-purpose

--- a/plugins/x-callback-url/skills/xcall/SKILL.md
+++ b/plugins/x-callback-url/skills/xcall/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: x-callback-url:xcall
+disable-model-invocation: true
 description: Call x-callback-url schemes from the CLI synchronously. Use when invoking macOS app URL schemes (Things, Bear, OmniFocus, etc.).
 allowed-tools:
   - Bash

--- a/user/skills/doc-coauthoring/SKILL.md
+++ b/user/skills/doc-coauthoring/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: doc-coauthoring
+disable-model-invocation: true
 description: Guide users through a structured workflow for co-authoring documentation. Use when user wants to write documentation, proposals, technical specs, decision docs, or similar structured content. This workflow helps users efficiently transfer context, refine content through iteration, and verify the doc works for readers. Trigger when user mentions writing docs, creating proposals, drafting specs, or similar documentation tasks.
 ---
 

--- a/user/skills/improve-claude-code/SKILL.md
+++ b/user/skills/improve-claude-code/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: improve-claude-code
+disable-model-invocation: true
 description: |
   Triage and batch-implement Claude-tagged Things todos as PRs for the claude config repo.
   Use when the user wants to work on their Claude Code improvement backlog, process Things todos tagged claude-code, or batch-implement configuration changes.

--- a/user/skills/improve-codebase-architecture/SKILL.md
+++ b/user/skills/improve-codebase-architecture/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: improve-codebase-architecture
+disable-model-invocation: true
 description: Find deepening opportunities in a codebase. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more testable and AI-navigable.
 ---
 


### PR DESCRIPTION
## What and Why

Every model-visible skill ships its full description in the `skill_listing` attachment, re-injected on every turn. Skills that the model never autonomously routes to still pay that recurring roster cost. This sets `disable-model-invocation: true` on 13 skills that the session index shows the model auto-invoked zero times over the indexed window, removing them from the roster while keeping them fully usable by slash command and by explicit `Skill()` calls from parent skills.

## Evidence

From the read-only session index (`session.duckdb`, local = personal machine), 51 distinct skills were invoked over the window. Every skill below is absent from that set, so each had 0 model-auto invocations. 27 skills in the repo already carry `disable-model-invocation: true`, so the key and pattern are established.

Demoted (all 0 invocations):

- `improve-claude-code` (0)
- `claude-code:changelog` (0)
- `doc-coauthoring` (0)
- `review:hunk` (0, loaded on demand by `review:self` and `review:peer`, which list `Skill(review:hunk)` and instruct "Load `review:hunk`")
- `tech-spec:create` (0)
- `tech-spec:review` (0)
- `interview:clarify` (0)
- `improve-codebase-architecture` (0)
- `type-ignore:fix` (0)
- `x-callback-url:xcall` (0)
- `linear:notifications` (0, loaded on demand by `personal-review:review`)
- `github:notifications` (0, loaded on demand by `personal-review:review`)
- `calendar:calendar` (0, loaded on demand by `personal-review:review`)

## Change

Each file gets one frontmatter line, `disable-model-invocation: true`, placed after `name:`. No body or behavior edits. The workhorses the index confirms the model routes to (`git:conflicts`, `tmux:tmux`, `claude-code:skill`, `git:fix-conflicts`, `bun:bun`, `claude-code:hook`) are untouched.

Dropped from the original candidate list:

- `mail:mail`: the `mail` plugin is not in `enabledPlugins`, out of scope.
- `mac:jxa`, `github:gh`, `gitlab:glab`: the finding claimed a sibling loads each. A grep for any `Skill(...)` load directive or "load the X skill" instruction found none. `mac:jxa-run` references the `jxa.ts` script, not the `mac:jxa` skill. Demoting these would remove the model's only discovery path for that reference guidance, a behavior change the verification protocol guards against, so they need a deliberate decision rather than this batch.
- `ui-design/wireframe`: `ui-design` is not in `enabledPlugins`.
- `pull-request:babysit`: owned by another PR.

## Verification

- `bun run skill-lint` on all 13 touched skills: clean. The lint confirms `disable-model-invocation` is a recognized key and the YAML still parses.
- `bun scripts/check-marketplace.ts`: confirms no plugin-listing regression.
- Cross-referenced every demoted skill for callers. The only references are explicit load-by-name directives from parent skills (`review:self`/`review:peer` to `hunk`, `personal-review:review` to the notifications and calendar skills), which survive demotion, plus README and agent-doc mentions that are not auto-routing dependencies.

No tests added. There is no test asserting which skills are model-visible, and one enumerating `disable-model-invocation` skills would be brittle. The `skill-lint` schema check is the coverage.
