### PR TITLE
hooks: keep bun install banner out of hook stdout

### DIFF
--- a/.claude/hooks/run.sh
+++ b/.claude/hooks/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Run a bun hook so only its decision payload reaches stdout.
+#
+# bun's install summary ("bun install v...", "Checked N installs") prints to
+# stdout, the same stream Claude Code captures as a hook's additionalContext.
+# When a package's dependencies are missing, install them silently off stdout,
+# then run with auto-install disabled so no install banner can reach fd1.
+unset CDPATH
+target=$1
+if [ -d "$target" ]; then
+  start=$target
+else
+  start=$(dirname -- "$target")
+fi
+root=$(cd -- "$start" && pwd)
+while [ ! -f "$root/package.json" ] && [ "$root" != "/" ]; do
+  root=$(dirname -- "$root")
+done
+if [ -f "$root/package.json" ] && [ ! -d "$root/node_modules" ]; then
+  (cd "$root" && bun install --silent >/dev/null 2>&1)
+fi
+exec bun --no-install "$@"

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -10,7 +10,11 @@ See the `claude-code:hook` skill for hook documentation. Plugin hooks are define
 
 Raw `git worktree add` is denied in favor of the `worktrunk` skill, except when the target is under `tmp/`, which is allowed for disposable scripted verification checkouts.
 
-Wrap `${CLAUDE_PLUGIN_ROOT}` in double quotes in shell-form hook commands: `bun "${CLAUDE_PLUGIN_ROOT}/scripts/foo.ts"`. Matcher fields are not shell commands and should not be quoted. Run `bun scripts/check-hook-quoting.ts` to validate.
+Wrap `${CLAUDE_PLUGIN_ROOT}` in double quotes in shell-form hook commands: `sh "${CLAUDE_PLUGIN_ROOT}/hooks/run.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/foo.ts"`. Matcher fields are not shell commands and should not be quoted. Run `bun scripts/check-hook-quoting.ts` to validate.
+
+## Stdout Is Context
+
+A hook's stdout is injected into the model as `additionalContext` (PreToolUse) or appended to the transcript. It must carry only the decision payload. `bun`'s install banner (`bun install v…`, `Checked N installs (no changes)`) prints to stdout and leaks into context when `node_modules` is stale, so a bun hook must never run as a bare `bun "<script>"`. Invoke it through the plugin's `hooks/run.sh`, which installs deps silently off stdout and runs the script with `--no-install`, so only the decision JSON reaches stdout regardless of bun version. New plugins with bun hooks need their own copy of `hooks/run.sh`, since plugins are distributed independently and cannot share a repo-level script. Run `bun scripts/check-hook-stdout.ts` to validate. Never write extra logging to stdout from a hook.
 
 ## MCP Matchers
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/biome\""
+            "command": "sh \"$CLAUDE_PROJECT_DIR/.claude/hooks/run.sh\" \"$CLAUDE_PROJECT_DIR/.claude/hooks/biome\""
           }
         ]
       }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/biome\"",
+            "command": "sh \"$CLAUDE_PROJECT_DIR/.claude/hooks/run.sh\" \"$CLAUDE_PROJECT_DIR/.claude/hooks/biome\"",
             "if": "Edit(**/*.ts)|Edit(**/*.tsx)|Edit(**/*.js)|Edit(**/*.jsx)|Edit(**/*.json)|Edit(**/*.jsonc)|Write(**/*.ts)|Write(**/*.tsx)|Write(**/*.js)|Write(**/*.jsx)|Write(**/*.json)|Write(**/*.jsonc)"
           }
         ]
@@ -69,15 +69,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/biome\""
+            "command": "sh \"$CLAUDE_PROJECT_DIR/.claude/hooks/run.sh\" \"$CLAUDE_PROJECT_DIR/.claude/hooks/biome\""
           },
           {
             "type": "command",
-            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/plugin-imports\""
+            "command": "sh \"$CLAUDE_PROJECT_DIR/.claude/hooks/run.sh\" \"$CLAUDE_PROJECT_DIR/.claude/hooks/plugin-imports\""
           },
           {
             "type": "command",
-            "command": "PREK_HOME=\"$CLAUDE_PROJECT_DIR/.prek\" bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop\""
+            "command": "PREK_HOME=\"$CLAUDE_PROJECT_DIR/.prek\" sh \"$CLAUDE_PROJECT_DIR/.claude/hooks/run.sh\" \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop\""
           }
         ]
       }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Check hook quoting
         run: bun scripts/check-hook-quoting.ts
 
+      - name: Check hook stdout
+        run: bun scripts/check-hook-stdout.ts
+
       - name: Check for unenabled plugins
         if: github.event_name == 'pull_request'
         env:

--- a/plugins/git/hooks/hooks.json
+++ b/plugins/git/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/block-default-branch-commit.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/block-default-branch-commit.ts\""
           }
         ]
       }

--- a/plugins/git/hooks/run.sh
+++ b/plugins/git/hooks/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Run a bun hook so only its decision payload reaches stdout.
+#
+# bun's install summary ("bun install v...", "Checked N installs") prints to
+# stdout, the same stream Claude Code captures as a hook's additionalContext.
+# When a package's dependencies are missing, install them silently off stdout,
+# then run with auto-install disabled so no install banner can reach fd1.
+unset CDPATH
+target=$1
+if [ -d "$target" ]; then
+  start=$target
+else
+  start=$(dirname -- "$target")
+fi
+root=$(cd -- "$start" && pwd)
+while [ ! -f "$root/package.json" ] && [ "$root" != "/" ]; do
+  root=$(dirname -- "$root")
+done
+if [ -f "$root/package.json" ] && [ ! -d "$root/node_modules" ]; then
+  (cd "$root" && bun install --silent >/dev/null 2>&1)
+fi
+exec bun --no-install "$@"

--- a/plugins/github/hooks/hooks.json
+++ b/plugins/github/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts\"",
             "if": "WebFetch(https://github.com/*)"
           }
         ]

--- a/plugins/github/hooks/run.sh
+++ b/plugins/github/hooks/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Run a bun hook so only its decision payload reaches stdout.
+#
+# bun's install summary ("bun install v...", "Checked N installs") prints to
+# stdout, the same stream Claude Code captures as a hook's additionalContext.
+# When a package's dependencies are missing, install them silently off stdout,
+# then run with auto-install disabled so no install banner can reach fd1.
+unset CDPATH
+target=$1
+if [ -d "$target" ]; then
+  start=$target
+else
+  start=$(dirname -- "$target")
+fi
+root=$(cd -- "$start" && pwd)
+while [ ! -f "$root/package.json" ] && [ "$root" != "/" ]; do
+  root=$(dirname -- "$root")
+done
+if [ -f "$root/package.json" ] && [ ! -d "$root/node_modules" ]; then
+  (cd "$root" && bun install --silent >/dev/null 2>&1)
+fi
+exec bun --no-install "$@"

--- a/plugins/gitlab/hooks/hooks.json
+++ b/plugins/gitlab/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts\"",
             "if": "WebFetch(https://gitlab.com/*)"
           }
         ]
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/auth.ts\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/auth.ts\"",
             "if": "Bash(glab *)"
           }
         ]

--- a/plugins/gitlab/hooks/run.sh
+++ b/plugins/gitlab/hooks/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Run a bun hook so only its decision payload reaches stdout.
+#
+# bun's install summary ("bun install v...", "Checked N installs") prints to
+# stdout, the same stream Claude Code captures as a hook's additionalContext.
+# When a package's dependencies are missing, install them silently off stdout,
+# then run with auto-install disabled so no install banner can reach fd1.
+unset CDPATH
+target=$1
+if [ -d "$target" ]; then
+  start=$target
+else
+  start=$(dirname -- "$target")
+fi
+root=$(cd -- "$start" && pwd)
+while [ ! -f "$root/package.json" ] && [ "$root" != "/" ]; do
+  root=$(dirname -- "$root")
+done
+if [ -f "$root/package.json" ] && [ ! -d "$root/node_modules" ]; then
+  (cd "$root" && bun install --silent >/dev/null 2>&1)
+fi
+exec bun --no-install "$@"

--- a/plugins/go/hooks/hooks.json
+++ b/plugins/go/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/check.ts\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/check.ts\"",
             "if": "Edit(**/*.go)|MultiEdit(**/*.go)|Write(**/*.go)"
           }
         ]

--- a/plugins/go/hooks/run.sh
+++ b/plugins/go/hooks/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Run a bun hook so only its decision payload reaches stdout.
+#
+# bun's install summary ("bun install v...", "Checked N installs") prints to
+# stdout, the same stream Claude Code captures as a hook's additionalContext.
+# When a package's dependencies are missing, install them silently off stdout,
+# then run with auto-install disabled so no install banner can reach fd1.
+unset CDPATH
+target=$1
+if [ -d "$target" ]; then
+  start=$target
+else
+  start=$(dirname -- "$target")
+fi
+root=$(cd -- "$start" && pwd)
+while [ ! -f "$root/package.json" ] && [ "$root" != "/" ]; do
+  root=$(dirname -- "$root")
+done
+if [ -f "$root/package.json" ] && [ ! -d "$root/node_modules" ]; then
+  (cd "$root" && bun install --silent >/dev/null 2>&1)
+fi
+exec bun --no-install "$@"

--- a/plugins/issue/hooks/hooks.json
+++ b/plugins/issue/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/approve-read.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/approve-read.ts\""
           }
         ]
       }

--- a/plugins/issue/hooks/run.sh
+++ b/plugins/issue/hooks/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Run a bun hook so only its decision payload reaches stdout.
+#
+# bun's install summary ("bun install v...", "Checked N installs") prints to
+# stdout, the same stream Claude Code captures as a hook's additionalContext.
+# When a package's dependencies are missing, install them silently off stdout,
+# then run with auto-install disabled so no install banner can reach fd1.
+unset CDPATH
+target=$1
+if [ -d "$target" ]; then
+  start=$target
+else
+  start=$(dirname -- "$target")
+fi
+root=$(cd -- "$start" && pwd)
+while [ ! -f "$root/package.json" ] && [ "$root" != "/" ]; do
+  root=$(dirname -- "$root")
+done
+if [ -f "$root/package.json" ] && [ ! -d "$root/node_modules" ]; then
+  (cd "$root" && bun install --silent >/dev/null 2>&1)
+fi
+exec bun --no-install "$@"

--- a/plugins/linear/hooks/hooks.json
+++ b/plugins/linear/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts\""
           }
         ]
       },
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/default-state.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/default-state.ts\""
           }
         ]
       }

--- a/plugins/linear/hooks/run.sh
+++ b/plugins/linear/hooks/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Run a bun hook so only its decision payload reaches stdout.
+#
+# bun's install summary ("bun install v...", "Checked N installs") prints to
+# stdout, the same stream Claude Code captures as a hook's additionalContext.
+# When a package's dependencies are missing, install them silently off stdout,
+# then run with auto-install disabled so no install banner can reach fd1.
+unset CDPATH
+target=$1
+if [ -d "$target" ]; then
+  start=$target
+else
+  start=$(dirname -- "$target")
+fi
+root=$(cd -- "$start" && pwd)
+while [ ! -f "$root/package.json" ] && [ "$root" != "/" ]; do
+  root=$(dirname -- "$root")
+done
+if [ -f "$root/package.json" ] && [ ! -d "$root/node_modules" ]; then
+  (cd "$root" && bun install --silent >/dev/null 2>&1)
+fi
+exec bun --no-install "$@"

--- a/plugins/mac/hooks/hooks.json
+++ b/plugins/mac/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/sandbox.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/sandbox.ts\""
           }
         ]
       },
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/disable-sandbox.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/disable-sandbox.ts\""
           }
         ]
       }

--- a/plugins/mac/hooks/run.sh
+++ b/plugins/mac/hooks/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Run a bun hook so only its decision payload reaches stdout.
+#
+# bun's install summary ("bun install v...", "Checked N installs") prints to
+# stdout, the same stream Claude Code captures as a hook's additionalContext.
+# When a package's dependencies are missing, install them silently off stdout,
+# then run with auto-install disabled so no install banner can reach fd1.
+unset CDPATH
+target=$1
+if [ -d "$target" ]; then
+  start=$target
+else
+  start=$(dirname -- "$target")
+fi
+root=$(cd -- "$start" && pwd)
+while [ ! -f "$root/package.json" ] && [ "$root" != "/" ]; do
+  root=$(dirname -- "$root")
+done
+if [ -f "$root/package.json" ] && [ ! -d "$root/node_modules" ]; then
+  (cd "$root" && bun install --silent >/dev/null 2>&1)
+fi
+exec bun --no-install "$@"

--- a/plugins/newline/hooks/hooks.json
+++ b/plugins/newline/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/check.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/check.ts\""
           }
         ]
       }
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/ensure.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/ensure.ts\""
           }
         ]
       },
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/preserve.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/preserve.ts\""
           }
         ]
       }

--- a/plugins/newline/hooks/run.sh
+++ b/plugins/newline/hooks/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Run a bun hook so only its decision payload reaches stdout.
+#
+# bun's install summary ("bun install v...", "Checked N installs") prints to
+# stdout, the same stream Claude Code captures as a hook's additionalContext.
+# When a package's dependencies are missing, install them silently off stdout,
+# then run with auto-install disabled so no install banner can reach fd1.
+unset CDPATH
+target=$1
+if [ -d "$target" ]; then
+  start=$target
+else
+  start=$(dirname -- "$target")
+fi
+root=$(cd -- "$start" && pwd)
+while [ ! -f "$root/package.json" ] && [ "$root" != "/" ]; do
+  root=$(dirname -- "$root")
+done
+if [ -f "$root/package.json" ] && [ ! -d "$root/node_modules" ]; then
+  (cd "$root" && bun install --silent >/dev/null 2>&1)
+fi
+exec bun --no-install "$@"

--- a/plugins/pull-request/hooks/hooks.json
+++ b/plugins/pull-request/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/validate.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/validate.ts\""
           }
         ]
       }

--- a/plugins/pull-request/hooks/run.sh
+++ b/plugins/pull-request/hooks/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Run a bun hook so only its decision payload reaches stdout.
+#
+# bun's install summary ("bun install v...", "Checked N installs") prints to
+# stdout, the same stream Claude Code captures as a hook's additionalContext.
+# When a package's dependencies are missing, install them silently off stdout,
+# then run with auto-install disabled so no install banner can reach fd1.
+unset CDPATH
+target=$1
+if [ -d "$target" ]; then
+  start=$target
+else
+  start=$(dirname -- "$target")
+fi
+root=$(cd -- "$start" && pwd)
+while [ ! -f "$root/package.json" ] && [ "$root" != "/" ]; do
+  root=$(dirname -- "$root")
+done
+if [ -f "$root/package.json" ] && [ ! -d "$root/node_modules" ]; then
+  (cd "$root" && bun install --silent >/dev/null 2>&1)
+fi
+exec bun --no-install "$@"

--- a/plugins/shortcuts/hooks/hooks.json
+++ b/plugins/shortcuts/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/open.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/open.ts\""
           }
         ]
       }

--- a/plugins/shortcuts/hooks/run.sh
+++ b/plugins/shortcuts/hooks/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Run a bun hook so only its decision payload reaches stdout.
+#
+# bun's install summary ("bun install v...", "Checked N installs") prints to
+# stdout, the same stream Claude Code captures as a hook's additionalContext.
+# When a package's dependencies are missing, install them silently off stdout,
+# then run with auto-install disabled so no install banner can reach fd1.
+unset CDPATH
+target=$1
+if [ -d "$target" ]; then
+  start=$target
+else
+  start=$(dirname -- "$target")
+fi
+root=$(cd -- "$start" && pwd)
+while [ ! -f "$root/package.json" ] && [ "$root" != "/" ]; do
+  root=$(dirname -- "$root")
+done
+if [ -f "$root/package.json" ] && [ ! -d "$root/node_modules" ]; then
+  (cd "$root" && bun install --silent >/dev/null 2>&1)
+fi
+exec bun --no-install "$@"

--- a/plugins/tmux/hooks/hooks.json
+++ b/plugins/tmux/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/context.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/context.ts\""
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/notification.ts\" --clear"
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/notification.ts\" --clear"
           }
         ]
       },
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/target.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/target.ts\""
           }
         ]
       },
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/team-workaround.ts\" --setup"
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/team-workaround.ts\" --setup"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/notification.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/notification.ts\""
           }
         ]
       }
@@ -56,11 +56,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/notification.ts\" --background-only"
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/notification.ts\" --background-only"
           },
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/team-workaround.ts\" --teardown"
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/team-workaround.ts\" --teardown"
           }
         ]
       }

--- a/plugins/tmux/hooks/run.sh
+++ b/plugins/tmux/hooks/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Run a bun hook so only its decision payload reaches stdout.
+#
+# bun's install summary ("bun install v...", "Checked N installs") prints to
+# stdout, the same stream Claude Code captures as a hook's additionalContext.
+# When a package's dependencies are missing, install them silently off stdout,
+# then run with auto-install disabled so no install banner can reach fd1.
+unset CDPATH
+target=$1
+if [ -d "$target" ]; then
+  start=$target
+else
+  start=$(dirname -- "$target")
+fi
+root=$(cd -- "$start" && pwd)
+while [ ! -f "$root/package.json" ] && [ "$root" != "/" ]; do
+  root=$(dirname -- "$root")
+done
+if [ -f "$root/package.json" ] && [ ! -d "$root/node_modules" ]; then
+  (cd "$root" && bun install --silent >/dev/null 2>&1)
+fi
+exec bun --no-install "$@"

--- a/plugins/type-ignore/hooks/hooks.json
+++ b/plugins/type-ignore/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/detect.ts\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/detect.ts\"",
             "if": "Edit(**/*.ts)|Edit(**/*.tsx)|Write(**/*.ts)|Write(**/*.tsx)"
           }
         ]

--- a/plugins/type-ignore/hooks/run.sh
+++ b/plugins/type-ignore/hooks/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Run a bun hook so only its decision payload reaches stdout.
+#
+# bun's install summary ("bun install v...", "Checked N installs") prints to
+# stdout, the same stream Claude Code captures as a hook's additionalContext.
+# When a package's dependencies are missing, install them silently off stdout,
+# then run with auto-install disabled so no install banner can reach fd1.
+unset CDPATH
+target=$1
+if [ -d "$target" ]; then
+  start=$target
+else
+  start=$(dirname -- "$target")
+fi
+root=$(cd -- "$start" && pwd)
+while [ ! -f "$root/package.json" ] && [ "$root" != "/" ]; do
+  root=$(dirname -- "$root")
+done
+if [ -f "$root/package.json" ] && [ ! -d "$root/node_modules" ]; then
+  (cd "$root" && bun install --silent >/dev/null 2>&1)
+fi
+exec bun --no-install "$@"

--- a/plugins/writing/hooks/hooks.json
+++ b/plugins/writing/hooks/hooks.json
@@ -7,16 +7,16 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts\" write"
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts\" write"
           },
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts\"",
             "if": "Write(**/*.md)"
           },
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\""
           }
         ]
       },
@@ -25,16 +25,16 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts\" edit"
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts\" edit"
           },
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts\"",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts\"",
             "if": "Edit(**/*.md)"
           },
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\""
           }
         ]
       },
@@ -43,7 +43,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\""
           }
         ]
       },
@@ -52,7 +52,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\""
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\""
           }
         ]
       }

--- a/plugins/writing/hooks/run.sh
+++ b/plugins/writing/hooks/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Run a bun hook so only its decision payload reaches stdout.
+#
+# bun's install summary ("bun install v...", "Checked N installs") prints to
+# stdout, the same stream Claude Code captures as a hook's additionalContext.
+# When a package's dependencies are missing, install them silently off stdout,
+# then run with auto-install disabled so no install banner can reach fd1.
+unset CDPATH
+target=$1
+if [ -d "$target" ]; then
+  start=$target
+else
+  start=$(dirname -- "$target")
+fi
+root=$(cd -- "$start" && pwd)
+while [ ! -f "$root/package.json" ] && [ "$root" != "/" ]; do
+  root=$(dirname -- "$root")
+done
+if [ -f "$root/package.json" ] && [ ! -d "$root/node_modules" ]; then
+  (cd "$root" && bun install --silent >/dev/null 2>&1)
+fi
+exec bun --no-install "$@"

--- a/scripts/check-hook-stdout.test.ts
+++ b/scripts/check-hook-stdout.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { invokesBunDirectly } from "./check-hook-stdout";
+
+// Hook command strings embed bare ${CLAUDE_PLUGIN_ROOT}; build it here so the
+// fixtures read like real commands without tripping noTemplateCurlyInString.
+const ROOT = `$\{CLAUDE_PLUGIN_ROOT}`;
+const PREK = 'PREK_HOME="$CLAUDE_PROJECT_DIR/.prek"';
+const STOP = '"$CLAUDE_PROJECT_DIR/.claude/hooks/stop"';
+
+describe("invokesBunDirectly", () => {
+  const direct = [
+    `bun "${ROOT}/scripts/check.ts"`,
+    `bun "${ROOT}/hooks/numbering.ts" write`,
+    "bun ~/.claude/hooks/worktree",
+    `${PREK} bun ${STOP}`,
+  ];
+  for (const command of direct) {
+    it(`flags bare bun: ${command}`, () => {
+      expect(invokesBunDirectly(command)).toBe(true);
+    });
+  }
+
+  const wrapped = [
+    `sh "${ROOT}/hooks/run.sh" "${ROOT}/scripts/check.ts"`,
+    `sh "${ROOT}/hooks/run.sh" "${ROOT}/hooks/numbering.ts" write`,
+    "sh ~/.claude/hooks/run.sh ~/.claude/hooks/worktree",
+    `${PREK} sh "$CLAUDE_PROJECT_DIR/.claude/hooks/run.sh" ${STOP}`,
+    "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ]'",
+  ];
+  for (const command of wrapped) {
+    it(`allows run.sh wrapper: ${command}`, () => {
+      expect(invokesBunDirectly(command)).toBe(false);
+    });
+  }
+
+  it("ignores undefined commands", () => {
+    expect(invokesBunDirectly(undefined)).toBe(false);
+  });
+});

--- a/scripts/check-hook-stdout.ts
+++ b/scripts/check-hook-stdout.ts
@@ -1,0 +1,67 @@
+#!/usr/bin/env bun
+
+import { join } from "node:path";
+import { loadPlugins } from "@bendrucker/claude-marketplace";
+
+// A hook's stdout is injected into the model as context, so it must carry only
+// the decision payload. bun's install/lockfile banner prints to stdout and
+// leaks in when node_modules is stale. Every bun hook must run through
+// hooks/run.sh, which installs deps silently off stdout and runs the script
+// with --no-install. Flag any hook command that still invokes bun directly.
+
+const BARE_BUN = /(^|\s|=)bun\s/;
+
+/** True when a hook command invokes bun directly instead of through run.sh. */
+export function invokesBunDirectly(command: string | undefined): boolean {
+  if (!command) return false;
+  return BARE_BUN.test(command);
+}
+
+interface SettingsHooks {
+  hooks?: Record<string, Array<{ hooks?: Array<{ command?: string }> }>>;
+}
+
+if (import.meta.main) {
+  const root = join(import.meta.dirname, "..");
+  const violations: string[] = [];
+
+  const plugins = await loadPlugins();
+  for (const plugin of plugins) {
+    if (!plugin.hooks) continue;
+    const file = `plugins/${plugin.name}/hooks/hooks.json`;
+    for (const entries of Object.values(plugin.hooks.hooks)) {
+      for (const entry of entries) {
+        for (const hook of entry.hooks) {
+          if (invokesBunDirectly(hook.command)) {
+            violations.push(`${file}: ${hook.command}`);
+          }
+        }
+      }
+    }
+  }
+
+  for (const relative of ["user/settings.json", ".claude/settings.json"]) {
+    const file = Bun.file(join(root, relative));
+    if (!(await file.exists())) continue;
+    const settings = (await file.json()) as SettingsHooks;
+    for (const entries of Object.values(settings.hooks ?? {})) {
+      for (const entry of entries) {
+        for (const hook of entry.hooks ?? []) {
+          if (invokesBunDirectly(hook.command)) {
+            violations.push(`${relative}: ${hook.command}`);
+          }
+        }
+      }
+    }
+  }
+
+  if (violations.length > 0) {
+    console.log("Hook commands that invoke bun directly instead of hooks/run.sh:");
+    for (const v of violations) console.log(`  ${v}`);
+    console.log("\nbun's install banner prints to stdout and leaks into hook context.");
+    console.log('Wrap each command as: sh "<base>/hooks/run.sh" "<script>" <args>');
+    process.exit(1);
+  }
+
+  console.log("All bun hook commands run through hooks/run.sh");
+}

--- a/user/hooks/run.sh
+++ b/user/hooks/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Run a bun hook so only its decision payload reaches stdout.
+#
+# bun's install summary ("bun install v...", "Checked N installs") prints to
+# stdout, the same stream Claude Code captures as a hook's additionalContext.
+# When a package's dependencies are missing, install them silently off stdout,
+# then run with auto-install disabled so no install banner can reach fd1.
+unset CDPATH
+target=$1
+if [ -d "$target" ]; then
+  start=$target
+else
+  start=$(dirname -- "$target")
+fi
+root=$(cd -- "$start" && pwd)
+while [ ! -f "$root/package.json" ] && [ "$root" != "/" ]; do
+  root=$(dirname -- "$root")
+done
+if [ -f "$root/package.json" ] && [ ! -d "$root/node_modules" ]; then
+  (cd "$root" && bun install --silent >/dev/null 2>&1)
+fi
+exec bun --no-install "$@"

--- a/user/settings.json
+++ b/user/settings.json
@@ -106,7 +106,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ~/.claude/hooks/worktree",
+            "command": "sh ~/.claude/hooks/run.sh ~/.claude/hooks/worktree",
             "if": "Bash(git worktree *)"
           }
         ]
@@ -116,7 +116,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun ~/.claude/hooks/webfetch-block"
+            "command": "sh ~/.claude/hooks/run.sh ~/.claude/hooks/webfetch-block"
           }
         ]
       },


### PR DESCRIPTION
## What and Why

A hook's stdout is injected into the model as context, but `bun` prints its install/lockfile banner (`bun install v...`, `Checked N installs (no changes)`) to that same stream when `node_modules` is stale. Every in-repo hook invoked as a bare `bun "<script>"` can leak that no-op preamble into context. This routes all in-repo bun hooks through a small `hooks/run.sh` wrapper that installs deps silently off stdout and runs the script with `--no-install`, so only the decision JSON reaches stdout regardless of bun version.

## Evidence

From the session-history analysis (local = personal machine): 92% of `PreToolUse:Edit` and 66% of `PreToolUse:Write` `hook_success` context injections carried the bun install banner as a no-op preamble. The Edit/Write injectors are primarily the `writing`, `newline`, `go`, and `tmux` hooks. The banner is a real, version-dependent leak: on bun 1.3.14 the `bun <script>` path is quiet, but the install phase still prints the banner to stdout, and earlier versions leaked it on the script run too. The fix cannot rely on current quiet behavior.

Reproduced locally on bun 1.3.14:

- `bun install` (default) prints the banner to stdout.
- `bun install --silent` suppresses it entirely.
- `bun --no-install <script>` with missing deps fails on stderr (not stdout), so no banner can reach the decision stream.

## The Change

`hooks/run.sh` walks up from the script (or hook directory) to the nearest `package.json`, runs `bun install --silent` redirected to `/dev/null` only when `node_modules` is absent, then `exec bun --no-install` so the install phase can never reach fd1. Because plugins are distributed independently and cannot share a repo-level script, each plugin with bun hooks carries its own identical copy.

- Added `hooks/run.sh` to the 13 plugins with bun hooks, plus `.claude/hooks/` and `user/hooks/`.
- Rewrote all 31 bare `bun "<script>"` commands across `plugins/*/hooks/hooks.json`, `.claude/settings.json`, and `user/settings.json` to `sh "<base>/hooks/run.sh" "<script>" <args>`, preserving args, `if` fields, and the `PREK_HOME=` prefix on the stop hook.
- Added `scripts/check-hook-stdout.ts` (with a unit test) and wired it into the test workflow, so any future bare-`bun` hook command fails CI.
- Documented the stdout-is-context guardrail in `.claude/rules/hooks.md`.

## Verification

- `bun scripts/check-hook-stdout.ts` and `bun scripts/check-hook-quoting.ts` pass; the new check rejects a command reverted to bare `bun`.
- The test suite covers the touched plugins and the new check. Existing per-hook tests invoke the `.ts` directly and are unaffected.
- Ran each rewritten hook through the wrapper with a realistic payload (writing, newline, go, tmux, mac sandbox, biome, plugin-imports, user worktree/webfetch-block); all emit a valid decision with empty stderr.
- Banner check: an isolated package with missing deps emits the banner under bare `bun install`, but through `run.sh` stdout carries only the decision JSON. Stale deps with a newly added package fail identically to bare `bun` on 1.3.14 (error on stderr only), so the wrapper adds no new failure surface.
- `run.sh` is shellcheck-clean (`-s sh`) and handles file args, directory args, paths with spaces, and symlinked user-hook paths.

Pre-existing biome errors on `main` (in files this PR does not touch) are out of scope.
