### PR TITLE
session, improve-claude-code: history-discovery loop

### DIFF
--- a/plugins/claude-code/skills/session/SKILL.md
+++ b/plugins/claude-code/skills/session/SKILL.md
@@ -58,6 +58,8 @@ SQL
 
 Breadth-first leads come from the survey surfaces (`records` taxonomy, `fields` for schema inference, `activity`, `hooks`, `diagnostics`, `skill-activity`); a depth pass is then custom read-only SQL over whatever table or view the survey pointed at.
 
+For self-improvement discovery (fanning out over the whole corpus to mine config-change candidates, then grounding them against the live config), [`references/discovery.md`](references/discovery.md) carries the full recipe: the dimension-to-query cheat sheet, the mandatory grounding pass, the host-safety rules, and the Tier-2 query catalog (six discovery queries shipped as SQL but kept out of the catalog above).
+
 ## Named Queries
 
 Built-in queries in `resources/queries/` run by name with `SET VARIABLE` params. Prefer these over writing SQL from scratch.
@@ -84,6 +86,10 @@ Every query also takes an optional `host` param. Omit it to span every machine (
 - `files`: file hotspots, the files read and edited most across sessions. Params: `limit`, `after_date`, `before_date`, `project`.
 - `skill-activity`: work attributed to each skill (assistant turns, sessions, input/output/cache tokens). Swap `attribution_skill` for `attribution_plugin`/`attribution_agent` in the SQL to re-cut. Params: `after_date`, `before_date`, `project`.
 - `fields`: schema discovery by inference. Enumerates JSON keys at a path for records of a kind, with each value's JSON type and a count (divergent types appear as multiple rows). Params: `kind` (glob on `records.kind`, or null for all), `path` (JSON path, e.g. `$` or `$.attachment`), `after_date`, `before_date`, `project`.
+- `hook-block-then-retry-success`: per hook, blocks that were retried away by a same-hook success in the same session within N seconds (noise vs genuine redirect). Params: `hook` (glob on command/name), `within_seconds` (default 300), `after_date`, `before_date`, `project`, `host`.
+- `repeat-read-waste`: fraction of Reads that re-read an already-read file in the same session, and the char/token cost re-injected. Params: `after_date`, `before_date`, `project`, `host`.
+- `skill-auto-vs-explicit`: per skill, model-auto (empty args) vs explicit/slash invocations, the core `disable-model-invocation` lever. Params: `min_calls` (default 1), `after_date`, `before_date`, `project`, `host`.
+- `sandbox-bypass-effective-command`: top `dangerouslyDisableSandbox` commands normalized to their real verb after stripping a leading `cd <path>` wrapper (`excludedCommands` candidates). Params: `min_count` (default 5), `after_date`, `before_date`, `project`, `host`.
 
 ## Cross-Machine History
 

--- a/plugins/claude-code/skills/session/references/discovery.md
+++ b/plugins/claude-code/skills/session/references/discovery.md
@@ -29,14 +29,12 @@ Use `records`, `fields`, `schema`, and `keys` whenever a dimension needs a path 
 
 ## Grounding
 
-Grounding is mandatory, not optional. A prior run overturned four of its own headline findings at this step: the Stop-hook latency was a work-repo `make test-unit` hook rather than portable config, the permission prompts were already absorbed by the allowlist, the trope file-op block was already fixed, and the compactions were all manual. Raw query findings go stale within a week against a config that changes weekly.
+Grounding is required. Raw query findings can go stale if config changes.
 
 Re-check every candidate against the live files under `/Users/ben/src/bendrucker/claude`. Drop the candidate if the config already addresses it; downgrade it if the evidence is thin or host-skewed. Carry two fields per candidate:
 
 - `grounded` (boolean): the finding survived the re-check against live config.
 - `confidence` (high/medium/low): how strong the grounded evidence is.
-
-Two rules this step encodes, because the same mistakes recur:
 
 - Hooks run in parallel. Never sum hook durations as wall-clock; the cost the user waits on is the single slowest hook plus a fixed per-process overhead, not the sum across matching hooks. `hook-origin-split`'s `total_s` is aggregate process work, not latency.
 - Split friction into the part a setting can change and the part it cannot. `ExitPlanMode` and `AskUserQuestion` rejections are not allowlistable. Compound commands defeat `excludedCommands` prefix matching. Counting raw rejections without that split inflates the actionable set.
@@ -51,9 +49,9 @@ The index spans every machine. `local` is this machine; imported hosts carry the
 - Default to `host = 'local'` for any config-change candidate. The config you are changing is this machine's. Use other hosts only as corroborating aggregate ("this also shows up on `work`"), never as the sole evidence for a local change.
 - Never paste raw `content`, `command`, `stdout`, or `text` from an egress-blocked host verbatim into a digest, a todo, a PR, or anything else that leaves the machine. Quote `local` rows when you need a literal; cite imported hosts as counts only.
 
-## Tier-2 Catalog
+## Full Catalog
 
-Six discovery queries ship as SQL in `resources/queries/` but stay out of `SKILL.md`'s always-relevant catalog. They take the same `after_date`/`before_date`/`project`/`host` params as the rest.
+Additional queries available in `resources/queries/`:
 
 - `hook-origin-split`: split hook wall-clock between portable shared config and per-repo project hooks. Measure your config, not someone's `make test-unit`.
 - `already-allowed-still-prompting`: Bash prompts matching a `permissions.allow` pattern you pass as `allow_glob`. A non-empty result is an allowlist pattern mismatch, usually a compound command.
@@ -61,5 +59,3 @@ Six discovery queries ship as SQL in `resources/queries/` but stay out of `SKILL
 - `catalog-reinjection-thrash-sessions`: sessions re-injecting the full skill catalog and deferred-tools delta many times, with an estimated token total. The thrash detector. Tune via `min_injections`.
 - `top-sessions-by-output`: sessions ranked by total output tokens, the runaway or unattended-session detector. Tune via `limit`.
 - `stop-hook-noop-detector`: Stop hooks that never produce stdout, a decision, or a non-zero exit. Pure-overhead removal candidates.
-
-A Tier-2 query earns its file by being non-obvious or complex and likely to recur. If one goes unreferenced by any discovery run over a quarter, drop it back to inline.

--- a/plugins/claude-code/skills/session/references/discovery.md
+++ b/plugins/claude-code/skills/session/references/discovery.md
@@ -1,0 +1,65 @@
+# History-Discovery Recipe
+
+Fan out read-only analysts over the session index to mine config-change candidates, ground every candidate against the live config, then emit a ranked digest. This is the engine `improve-claude-code`'s Discover mode drives; the recipe lives here so the per-run prompt stays small.
+
+## Fan-Out
+
+Mirror the "Parallel Queries (Workflows)" pattern in [`SKILL.md`](../SKILL.md): refresh once, then every agent opens the index read-only.
+
+1. Refresh once, alone. `scripts/refresh.ts --refresh` takes an exclusive write lock, so it must finish before any agent starts. Capture the printed `$DB` path and hand it to the agents. Never let a fanned-out agent call `refresh.ts`.
+2. Fan out one agent per dimension below. Each runs its named queries (`duckdb -readonly "$DB" < resources/queries/<name>.sql`, scoped with `SET VARIABLE`) plus any inline rollups, all read-only, all against the one shared file. Read-only opens take no lock, so the agents never contend.
+3. Each agent returns structured candidate findings plus the exact SQL it ran. The SQL travels with the finding so the grounding pass and the digest can both cite it.
+4. One or more grounding agents re-check every candidate against the live config (see [Grounding](#grounding)). Drop or downgrade anything that does not hold.
+
+## Dimension Cheat Sheet
+
+Each dimension maps to the named queries that answer it (Tier-1 listed in `SKILL.md`'s catalog, Tier-2 documented in [Tier-2 Catalog](#tier-2-catalog) below) plus the survey surfaces to start from. Simple `GROUP BY ... COUNT/SUM` rollups (tokens by host, turns by project, hook time by event) stay inline; an agent writes them in seconds.
+
+| Dimension | Named queries | Survey surfaces |
+|-----------|---------------|-----------------|
+| Hook latency | `hook-origin-split` | `hooks` |
+| Hook blocks | `hook-block-then-retry-success` | `hook-blocks`, `hooks` |
+| Permissions and sandbox | `sandbox-bypass-effective-command`, `already-allowed-still-prompting`, `sandbox-path-deny-recurrence` | `permissions`, `sandbox` |
+| Context tax | `catalog-reinjection-thrash-sessions` | `activity`, `hooks` (additionalContext) |
+| Tokens | `repeat-read-waste`, `top-sessions-by-output` | `stats`, `model-summary`, `skill-activity` |
+| Turns and compaction | `stop-hook-noop-detector` | `activity` (compactions, API errors) |
+| Skill economy | `skill-auto-vs-explicit` | `skills`, `skill-activity` |
+
+Use `records`, `fields`, `schema`, and `keys` whenever a dimension needs a path that isn't pinned: `SELECT kind, COUNT(*) FROM records GROUP BY kind` is the full taxonomy, and `fields` infers the JSON keys under any path.
+
+## Grounding
+
+Grounding is mandatory, not optional. A prior run overturned four of its own headline findings at this step: the Stop-hook latency was a work-repo `make test-unit` hook rather than portable config, the permission prompts were already absorbed by the allowlist, the trope file-op block was already fixed, and the compactions were all manual. Raw query findings go stale within a week against a config that changes weekly.
+
+Re-check every candidate against the live files under `/Users/ben/src/bendrucker/claude`. Drop the candidate if the config already addresses it; downgrade it if the evidence is thin or host-skewed. Carry two fields per candidate:
+
+- `grounded` (boolean): the finding survived the re-check against live config.
+- `confidence` (high/medium/low): how strong the grounded evidence is.
+
+Two rules this step encodes, because the same mistakes recur:
+
+- Hooks run in parallel. Never sum hook durations as wall-clock; the cost the user waits on is the single slowest hook plus a fixed per-process overhead, not the sum across matching hooks. `hook-origin-split`'s `total_s` is aggregate process work, not latency.
+- Split friction into the part a setting can change and the part it cannot. `ExitPlanMode` and `AskUserQuestion` rejections are not allowlistable. Compound commands defeat `excludedCommands` prefix matching. Counting raw rejections without that split inflates the actionable set.
+
+Verify any claim about harness behavior against the primary Claude Code docs, not a paraphrase, before grounding a finding on it.
+
+## Host Safety
+
+The index spans every machine. `local` is this machine; imported hosts carry their own label and may be marked `block_egress` (see `SKILL.md` "Cross-Machine History").
+
+- Aggregate across hosts, but label the host on every row. The queries here already select `host`.
+- Default to `host = 'local'` for any config-change candidate. The config you are changing is this machine's. Use other hosts only as corroborating aggregate ("this also shows up on `work`"), never as the sole evidence for a local change.
+- Never paste raw `content`, `command`, `stdout`, or `text` from an egress-blocked host verbatim into a digest, a todo, a PR, or anything else that leaves the machine. Quote `local` rows when you need a literal; cite imported hosts as counts only.
+
+## Tier-2 Catalog
+
+Six discovery queries ship as SQL in `resources/queries/` but stay out of `SKILL.md`'s always-relevant catalog. They take the same `after_date`/`before_date`/`project`/`host` params as the rest.
+
+- `hook-origin-split`: split hook wall-clock between portable shared config and per-repo project hooks. Measure your config, not someone's `make test-unit`.
+- `already-allowed-still-prompting`: Bash prompts matching a `permissions.allow` pattern you pass as `allow_glob`. A non-empty result is an allowlist pattern mismatch, usually a compound command.
+- `sandbox-path-deny-recurrence`: `Operation not permitted` Bash failures bucketed into concrete config gaps (worktree writes, tmux sockets, process substitution, mktemp, TLS, SSH agent), with recurrence and date span.
+- `catalog-reinjection-thrash-sessions`: sessions re-injecting the full skill catalog and deferred-tools delta many times, with an estimated token total. The thrash detector. Tune via `min_injections`.
+- `top-sessions-by-output`: sessions ranked by total output tokens, the runaway or unattended-session detector. Tune via `limit`.
+- `stop-hook-noop-detector`: Stop hooks that never produce stdout, a decision, or a non-zero exit. Pure-overhead removal candidates.
+
+A Tier-2 query earns its file by being non-obvious or complex and likely to recur. If one goes unreferenced by any discovery run over a quarter, drop it back to inline.

--- a/plugins/claude-code/skills/session/resources/queries/already-allowed-still-prompting.sql
+++ b/plugins/claude-code/skills/session/resources/queries/already-allowed-still-prompting.sql
@@ -1,0 +1,27 @@
+-- Commands that prompted for permission even though an allow rule should cover them.
+-- Pass a permissions.allow pattern as `allow_glob`; this lists the Bash prompts whose
+-- command matches it. A non-empty result means the allow pattern isn't matching at the
+-- prompt (usually a compound command defeating prefix matching). The grounding step
+-- compares each row against the live permissions.allow list.
+-- Params: after_date, before_date, project, host, allow_glob (GLOB on command; required
+-- to be useful, e.g. 'gh pr *' or 'bun *').
+WITH pr AS (
+  SELECT p.host, p.command, p.session_id, p.timestamp
+  FROM permission_requests p
+  JOIN sessions s USING (host, session_id)
+  WHERE p.tool_name = 'Bash'
+    AND date_filter(s.start_time, getvariable('after_date'), getvariable('before_date'))
+    AND project_filter(s.project_path, getvariable('project'))
+    AND host_filter(s.host, getvariable('host'))
+    AND (getvariable('allow_glob') IS NULL OR p.command GLOB getvariable('allow_glob')::VARCHAR)
+)
+SELECT
+  host,
+  command,
+  COUNT(*)                   AS prompts,
+  COUNT(DISTINCT session_id) AS sessions,
+  MIN(timestamp)::DATE       AS first_seen,
+  MAX(timestamp)::DATE       AS last_seen
+FROM pr
+GROUP BY host, command
+ORDER BY prompts DESC, host;

--- a/plugins/claude-code/skills/session/resources/queries/catalog-reinjection-thrash-sessions.sql
+++ b/plugins/claude-code/skills/session/resources/queries/catalog-reinjection-thrash-sessions.sql
@@ -1,0 +1,36 @@
+-- Sessions that re-inject the full skill catalog and deferred-tools delta many times,
+-- cumulatively re-billing the same context (the token-thrash detector). Counts
+-- skill_listing and deferred_tools_delta injections per session with an estimated token
+-- total; tune the floor via min_injections.
+-- Params: after_date, before_date, project, host, min_injections (default 6).
+WITH att AS (
+  SELECT a.host, a.session_id, a.project_path, a.kind, a.attachment
+  FROM attachments a
+  JOIN sessions s USING (host, session_id)
+  WHERE a.kind IN ('skill_listing', 'deferred_tools_delta')
+    AND date_filter(s.start_time, getvariable('after_date'), getvariable('before_date'))
+    AND project_filter(s.project_path, getvariable('project'))
+    AND host_filter(s.host, getvariable('host'))
+),
+per AS (
+  SELECT
+    host,
+    session_id,
+    regexp_extract(project_path, '[^/]+$')                  AS repo,
+    COUNT(*) FILTER (WHERE kind = 'skill_listing')          AS skill_listings,
+    COUNT(*) FILTER (WHERE kind = 'deferred_tools_delta')   AS tool_deltas,
+    SUM(length(attachment::VARCHAR))                        AS chars
+  FROM att
+  GROUP BY host, session_id, project_path
+)
+SELECT
+  host,
+  session_id,
+  repo,
+  skill_listings,
+  tool_deltas,
+  ROUND(chars / 4.0 / 1000.0) AS est_ktokens
+FROM per
+WHERE skill_listings + tool_deltas > COALESCE(getvariable('min_injections'), 6)
+ORDER BY est_ktokens DESC
+LIMIT 20;

--- a/plugins/claude-code/skills/session/resources/queries/hook-block-then-retry-success.sql
+++ b/plugins/claude-code/skills/session/resources/queries/hook-block-then-retry-success.sql
@@ -1,0 +1,47 @@
+-- Hook blocks that were followed by a same-hook *success* in the same session within N
+-- seconds: a block the model simply retried away, which is noise rather than a genuine
+-- redirect. Groups by hook (command, or hook_name when no command) and reports total
+-- blocks against how many were retried away, with the retry rate. A high rate means the
+-- gate mostly annoys; a low rate means it actually stops work. The windowed
+-- self-correlation is the hard part to rewrite from memory.
+-- Params: after_date, before_date, project, host, hook (GLOB on command/name),
+-- within_seconds (window, default 300).
+WITH ev AS (
+  SELECT
+    he.host,
+    he.session_id,
+    he.timestamp AS ts,
+    COALESCE(he.command, he.hook_name) AS hook,
+    he.blocked
+  FROM hook_events he
+  JOIN sessions s USING (host, session_id)
+  WHERE date_filter(s.start_time, getvariable('after_date'), getvariable('before_date'))
+    AND project_filter(s.project_path, getvariable('project'))
+    AND host_filter(s.host, getvariable('host'))
+    AND (getvariable('hook') IS NULL OR COALESCE(he.command, he.hook_name) GLOB getvariable('hook')::VARCHAR)
+),
+blk AS (
+  SELECT
+    b.host,
+    b.hook,
+    EXISTS (
+      SELECT 1 FROM ev s
+      WHERE s.host = b.host
+        AND s.session_id = b.session_id
+        AND s.hook = b.hook
+        AND NOT s.blocked
+        AND epoch(s.ts) > epoch(b.ts)
+        AND epoch(s.ts) - epoch(b.ts) < COALESCE(getvariable('within_seconds'), 300)
+    ) AS retried_away
+  FROM ev b
+  WHERE b.blocked
+)
+SELECT
+  host,
+  hook,
+  COUNT(*)                                          AS total_blocks,
+  COUNT(*) FILTER (WHERE retried_away)              AS followed_by_success,
+  ROUND(100.0 * COUNT(*) FILTER (WHERE retried_away) / COUNT(*), 1) AS retry_pct
+FROM blk
+GROUP BY host, hook
+ORDER BY total_blocks DESC, hook;

--- a/plugins/claude-code/skills/session/resources/queries/hook-origin-split.sql
+++ b/plugins/claude-code/skills/session/resources/queries/hook-origin-split.sql
@@ -1,0 +1,28 @@
+-- Split hook wall-clock between portable shared config (CLAUDE_PLUGIN_ROOT/CLAUDE_SKILL_DIR
+-- and the symlinked ~/.claude hooks) and arbitrary per-repo project hooks. The central
+-- discovery lesson: measure your own config, not a project's `make test-unit`. Per-repo
+-- hooks dominating total_s means the latency isn't yours to fix. Hooks run in parallel,
+-- so read total_s as aggregate process work, not the wall-clock the user waits on.
+-- Params: after_date, before_date, project, host.
+WITH ev AS (
+  SELECT he.command, he.duration_ms
+  FROM hook_events he
+  JOIN sessions s USING (host, session_id)
+  WHERE date_filter(s.start_time, getvariable('after_date'), getvariable('before_date'))
+    AND project_filter(s.project_path, getvariable('project'))
+    AND host_filter(s.host, getvariable('host'))
+)
+SELECT
+  CASE
+    WHEN command LIKE '%CLAUDE_PLUGIN_ROOT%' OR command LIKE '%CLAUDE_SKILL_DIR%'
+      OR command LIKE '%/.claude/hooks/%' THEN 'shared_config'
+    WHEN command IS NULL THEN 'null'
+    ELSE 'project_local'
+  END AS origin,
+  COUNT(*)                                     AS fires,
+  ROUND(SUM(duration_ms) / 1000.0, 1)          AS total_s,
+  ROUND(AVG(duration_ms), 0)                   AS avg_ms,
+  CAST(quantile_cont(duration_ms, 0.95) AS BIGINT) AS p95_ms
+FROM ev
+GROUP BY origin
+ORDER BY total_s DESC NULLS LAST;

--- a/plugins/claude-code/skills/session/resources/queries/repeat-read-waste.sql
+++ b/plugins/claude-code/skills/session/resources/queries/repeat-read-waste.sql
@@ -1,0 +1,45 @@
+-- What fraction of Read calls re-read a file already read earlier in the same session,
+-- and how many characters those repeat reads re-injected into context. Self-joins each
+-- Read tool_use to its tool_result, ranks reads within (session, file) by time, and
+-- counts every read after the first as a repeat. Surfaces re-reading as a context-tax
+-- lever (the result is often surprisingly high).
+-- Params: after_date, before_date, project, host.
+WITH reads AS (
+  SELECT
+    tr.host,
+    tr.session_id,
+    tc.file_path,
+    length(tr.content)              AS chars,
+    tr.timestamp,
+    tr.source_line
+  FROM content_items tr
+  JOIN tool_calls tc
+    ON tr.tool_use_id = tc.tool_id AND tr.host = tc.host
+   AND tc.tool_name = 'Read'
+  JOIN sessions s ON s.host = tr.host AND s.session_id = tr.session_id
+  WHERE tr.type = 'tool_result'
+    AND tr.content IS NOT NULL
+    AND tc.file_path IS NOT NULL
+    AND date_filter(s.start_time, getvariable('after_date'), getvariable('before_date'))
+    AND project_filter(s.project_path, getvariable('project'))
+    AND host_filter(s.host, getvariable('host'))
+),
+ranked AS (
+  SELECT
+    *,
+    row_number() OVER (
+      PARTITION BY host, session_id, file_path
+      ORDER BY timestamp, source_line
+    ) AS rn
+  FROM reads
+)
+SELECT
+  host,
+  COUNT(*)                                       AS total_reads,
+  COUNT(*) FILTER (WHERE rn > 1)                 AS repeat_reads,
+  ROUND(100.0 * COUNT(*) FILTER (WHERE rn > 1) / COUNT(*), 1) AS repeat_pct,
+  SUM(chars) FILTER (WHERE rn > 1)               AS repeat_chars,
+  ROUND(SUM(chars) FILTER (WHERE rn > 1) / 4.0 / 1000.0, 1) AS repeat_ktokens
+FROM ranked
+GROUP BY host
+ORDER BY host;

--- a/plugins/claude-code/skills/session/resources/queries/sandbox-bypass-effective-command.sql
+++ b/plugins/claude-code/skills/session/resources/queries/sandbox-bypass-effective-command.sql
@@ -1,0 +1,28 @@
+-- Top commands that get dangerouslyDisableSandbox, normalized to their real verb by
+-- stripping a leading `cd <path>` wrapper (followed by `&&`, `;`, or a newline) so the
+-- actual tool (not `cd`) surfaces. The normalization is the reusable part: it recurs
+-- across every permission and sandbox question, because compound commands otherwise hide
+-- the verb that needs an exemption. Ranked by frequency; reveals `excludedCommands`
+-- candidates.
+-- Params: after_date, before_date, project, host, min_count (floor, default 5).
+WITH stripped AS (
+  SELECT
+    sb.host,
+    sb.session_id,
+    regexp_replace(trim(sb.command), '^cd [^&;]*?(&&|;|\n)\s*', '') AS eff
+  FROM sandbox_bypasses sb
+  JOIN sessions s USING (host, session_id)
+  WHERE date_filter(s.start_time, getvariable('after_date'), getvariable('before_date'))
+    AND project_filter(s.project_path, getvariable('project'))
+    AND host_filter(s.host, getvariable('host'))
+)
+SELECT
+  host,
+  regexp_extract(trim(eff), '^[A-Za-z0-9_./-]+', 0) AS cmd,
+  COUNT(*)                   AS n,
+  COUNT(DISTINCT session_id) AS sessions
+FROM stripped
+WHERE eff <> ''
+GROUP BY host, cmd
+HAVING COUNT(*) >= COALESCE(getvariable('min_count'), 5)
+ORDER BY n DESC, host;

--- a/plugins/claude-code/skills/session/resources/queries/sandbox-path-deny-recurrence.sql
+++ b/plugins/claude-code/skills/session/resources/queries/sandbox-path-deny-recurrence.sql
@@ -1,0 +1,32 @@
+-- Map `Operation not permitted` (and adjacent) Bash failures to concrete sandbox config
+-- gaps (worktree writes, tmux sockets, process substitution, mktemp, TLS, SSH agent),
+-- with session recurrence and date span, so each failure class becomes a settings diff.
+-- Params: after_date, before_date, project, host.
+WITH errs AS (
+  SELECT te.host, te.session_id, te.error_content, te.timestamp
+  FROM tool_errors te
+  JOIN sessions s USING (host, session_id)
+  WHERE te.error_type = 'failure'
+    AND date_filter(s.start_time, getvariable('after_date'), getvariable('before_date'))
+    AND project_filter(s.project_path, getvariable('project'))
+    AND host_filter(s.host, getvariable('host'))
+)
+SELECT
+  host,
+  CASE
+    WHEN error_content LIKE '%/worktrees/agent-%Operation not permitted%' THEN 'worktree-agent-write'
+    WHEN error_content LIKE '%/.tmux/%' THEN 'tmux-socket'
+    WHEN error_content LIKE '%/dev/fd/%' THEN 'process-substitution'
+    WHEN error_content LIKE '%mktemp%' OR error_content LIKE '%mkstemp%' OR error_content LIKE '%mkdtemp%' THEN 'mktemp'
+    WHEN error_content LIKE '%failed to verify certificate%' OR error_content LIKE '%OSStatus -26276%' THEN 'tls-github'
+    WHEN error_content LIKE '%signing failed for ECDSA%' OR error_content LIKE '%agent refused%'
+      OR error_content LIKE '%communication with agent failed%' THEN 'ssh-agent'
+  END AS cat,
+  COUNT(*)                   AS n,
+  COUNT(DISTINCT session_id) AS sessions,
+  MIN(timestamp)::DATE       AS first_d,
+  MAX(timestamp)::DATE       AS last_d
+FROM errs
+GROUP BY host, cat
+HAVING cat IS NOT NULL
+ORDER BY host, n DESC;

--- a/plugins/claude-code/skills/session/resources/queries/skill-auto-vs-explicit.sql
+++ b/plugins/claude-code/skills/session/resources/queries/skill-auto-vs-explicit.sql
@@ -1,0 +1,24 @@
+-- Per skill, how invocations split between model-auto (the model chose to load it, empty
+-- args) and explicit slash/args calls. A skill invoked only explicitly can go
+-- `disable-model-invocation` and stop paying for its always-on description; one invoked
+-- mostly model-auto is earning that description. The core skill-economy lever.
+-- `args` is already NULL when empty (the skill_calls view applies NULLIF), so model-auto
+-- is `args IS NULL`.
+-- Params: after_date, before_date, project, host, min_calls (floor on total, default 1).
+WITH sc AS (
+  SELECT c.*
+  FROM skill_calls c
+  JOIN sessions s USING (host, session_id)
+  WHERE date_filter(s.start_time, getvariable('after_date'), getvariable('before_date'))
+    AND project_filter(s.project_path, getvariable('project'))
+    AND host_filter(s.host, getvariable('host'))
+)
+SELECT
+  skill_name,
+  COUNT(*) FILTER (WHERE args IS NULL)     AS model_auto,
+  COUNT(*) FILTER (WHERE args IS NOT NULL)  AS explicit_args,
+  COUNT(*)                                  AS total
+FROM sc
+GROUP BY skill_name
+HAVING COUNT(*) >= COALESCE(getvariable('min_calls'), 1)
+ORDER BY total DESC, skill_name;

--- a/plugins/claude-code/skills/session/resources/queries/stop-hook-noop-detector.sql
+++ b/plugins/claude-code/skills/session/resources/queries/stop-hook-noop-detector.sql
@@ -1,0 +1,29 @@
+-- Stop hooks that never produce stdout, a decision, or a non-zero exit: pure-overhead
+-- automations that fire on every Stop and do nothing observable (removal candidates).
+-- Compare with_stdout/with_decision/nonzero_exit against fires: a hook all-zero across
+-- those three columns earns its latency back by being deleted.
+-- Params: after_date, before_date, project, host.
+WITH ev AS (
+  SELECT
+    he.host,
+    COALESCE(he.command, he.hook_name) AS command,
+    he.stdout,
+    he.decision,
+    he.exit_code
+  FROM hook_events he
+  JOIN sessions s USING (host, session_id)
+  WHERE he.hook_event = 'Stop'
+    AND date_filter(s.start_time, getvariable('after_date'), getvariable('before_date'))
+    AND project_filter(s.project_path, getvariable('project'))
+    AND host_filter(s.host, getvariable('host'))
+)
+SELECT
+  host,
+  command,
+  COUNT(*)                                                    AS fires,
+  COUNT(*) FILTER (WHERE stdout IS NOT NULL AND length(stdout) > 0) AS with_stdout,
+  COUNT(*) FILTER (WHERE decision IS NOT NULL)                AS with_decision,
+  COUNT(*) FILTER (WHERE exit_code <> 0)                      AS nonzero_exit
+FROM ev
+GROUP BY host, command
+ORDER BY fires DESC, host;

--- a/plugins/claude-code/skills/session/resources/queries/top-sessions-by-output.sql
+++ b/plugins/claude-code/skills/session/resources/queries/top-sessions-by-output.sql
@@ -1,0 +1,23 @@
+-- Rank sessions by total output tokens (with row count and per-row average) to surface
+-- runaway or unattended sessions: a huge output total spread over many rows is the
+-- signature of a loop left running.
+-- Params: after_date, before_date, project, host, limit (default 15).
+WITH a AS (
+  SELECT r.host, r.session_id, r.project_path, r.output_tokens
+  FROM raw r
+  WHERE r.type = 'assistant'
+    AND date_filter(r.timestamp, getvariable('after_date'), getvariable('before_date'))
+    AND project_filter(r.project_path, getvariable('project'))
+    AND host_filter(r.host, getvariable('host'))
+)
+SELECT
+  session_id,
+  host,
+  regexp_extract(project_path, '[^/]+$') AS repo,
+  SUM(output_tokens)        AS out_tokens,
+  COUNT(*)                  AS nrows,
+  ROUND(AVG(output_tokens), 0) AS avg_out
+FROM a
+GROUP BY session_id, host, repo
+ORDER BY out_tokens DESC NULLS LAST
+LIMIT COALESCE(getvariable('limit'), 15);

--- a/user/skills/improve-claude-code/SKILL.md
+++ b/user/skills/improve-claude-code/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: improve-claude-code
 description: |
-  Triage and batch-implement Claude-tagged Things todos as PRs for the claude config repo.
-  Use when the user wants to work on their Claude Code improvement backlog, process Things todos tagged claude-code, or batch-implement configuration changes.
+  Triage and batch-implement Claude-tagged Things todos as PRs for the claude config repo, or discover improvement candidates from session history.
+  Use when the user wants to work on their Claude Code improvement backlog, process Things todos tagged claude-code, batch-implement configuration changes, or mine session history for grounded config-change candidates (Discover mode).
 allowed-tools:
   - Skill(things:jxa)
   - Skill(things:url)
@@ -16,7 +16,69 @@ allowed-tools:
 
 Work through the `claude-code` Things backlog: fetch todos, triage with the user, then plan and implement each in parallel as separate PRs.
 
+The backlog has two sources. The user files todos tagged `claude-code` by hand (and `agent-ideas` files external-harvest ideas in the same shape). **Discover mode** adds a second source: it mines this machine's session history for config-change candidates, grounds them against the live config, and files the keepers as `claude-code` todos. Both sources feed the one implement loop below. Discover is upstream of triage, not a replacement for it.
+
 All Things interaction goes through the `things:jxa` and `things:url` skills (never inline JXA). PRs go through `pull-request:create` (never `gh pr create`).
+
+## Discover
+
+Mine session history for improvement candidates, ground them against the live config, write a digest, and file the keepers. Discover never auto-implements and never auto-files: filing is an explicit user choice, implementing is a separate run of the loop below. The engine is the `claude-code:session` skill's fan-out, whose `references/discovery.md` carries the full recipe (dimension cheat sheet, grounding mandate, host safety, Tier-2 catalog). Load that skill to read it.
+
+#### Refresh
+
+Run the session skill's `scripts/refresh.ts --refresh` once, alone (it takes an exclusive write lock), and capture the printed `$DB` path. Hand that path to every agent, and never let a fanned-out agent refresh.
+
+#### Fan-Out
+
+Launch one `Task` agent per dimension (hook latency, hook blocks, permissions and sandbox, context tax, tokens, turns and compaction, skill economy), the same mining fan-out `agent-ideas` uses. Give each agent the `$DB` path and point it at `references/discovery.md`. Each agent runs its dimension's named queries (by name, read-only) plus any inline rollups, and returns structured candidate findings **plus the exact SQL it ran**. Read-only opens take no lock, so the agents never contend.
+
+#### Grounding
+
+Mandatory. Launch one or more grounding agents that re-check every candidate against the live files under `/Users/ben/src/bendrucker/claude`. Drop anything the config already addresses. Downgrade anything thin or host-skewed. Carry `grounded` (boolean) and `confidence` (high/medium/low) per candidate. Raw query findings go stale within a week against a config that changes weekly: a prior run overturned four of its own headline findings here. See the grounding rules in `references/discovery.md` (hooks run in parallel, so never sum durations as wall-clock, and split friction into what a setting can fix and what it cannot).
+
+#### Dedup
+
+Fingerprint each candidate (see [Fingerprint](#fingerprint)). Then query Things via `things:jxa` for every `claude-code`-tagged todo and recently-completed (logbook) todo, and scan their notes for `Discovery: <fp>`. Mark each candidate:
+
+- `already-filed`: fingerprint found in an open `claude-code` todo.
+- `already-shipped`: fingerprint found in a completed todo (the annotate phase removes the `claude-code` tag on a shipped todo, so the marker persists in notes or the logbook).
+- `new`: fingerprint not found.
+
+Suppress `already-filed` and `already-shipped` from the actionable set; still count them in the digest tail. Things is the ledger: there is no separate dedup store.
+
+#### Digest
+
+The only guaranteed output. Write `tmp/claude-discovery-digest-<YYYY-Www>.md`, ranked and grouped high to low confidence. Each entry shows the finding, its grounding note, the SQL that produced it, and its dedup status. Default `host=local` for config-change candidates; cite imported hosts as corroborating counts only, never pasting raw `content`/`command`/`stdout` from an egress-blocked host (see host safety in `references/discovery.md`). **Never auto-file from this step.**
+
+#### File the Keepers
+
+Present the actionable (new, grounded) candidates and ask the user which to file (numbers, ranges like `1-3`, or `all`), mirroring the triage UX below. For each selected candidate, create one Things todo via `things:url`, tagged `claude-code`:
+
+- **Title**: `[discovery] <finding title>`
+- **Notes**: the pitch, then the SQL/evidence, then `Discovery: <fingerprint>` on its own line.
+
+One todo per candidate, not one blob. Filing lands findings in the same backlog the implement loop already drains.
+
+#### Hand Off
+
+Report how many todos landed. The existing triage, plan, implement, PR, CI, and annotate phases run on them later, unchanged. Filing is the default terminal action of Discover mode; implementing is a separate, explicit choice (run the loop below when ready).
+
+#### Cadence
+
+On-demand is primary: invoke this skill in Discover mode at your terminal. A weekly run is optional and must run **locally** (a `/loop` or `/schedule` trigger on this machine). The session DB and the `duckdb` CLI live here, so the `agent-ideas` headless-then-teleport bridge does not apply (that works only because RSS is public). This is a documented option, not built infrastructure.
+
+#### Fingerprint
+
+The dedup identity. Compute `sha256(finding_type + '|' + normalized_target)` truncated to 12 chars:
+
+```bash
+printf '%s' "hook-noop|team-workaround.ts" | shasum -a 256 | cut -c1-12
+```
+
+- `finding_type` is a stable slug for the class of finding (`hook-noop`, `permission-allowlist-miss`, `repeat-read`, `sandbox-deny`).
+- `normalized_target` is the specific config object the finding is about (a hook script basename, a permission pattern, a skill name), **never** a count or a date, so re-runs of the same underlying finding collapse to one identity.
+
+Filed todos carry `Discovery: <fingerprint>` in notes. The dedup step extracts those markers from Things and suppresses matches. Suppressing *dismissed* findings (surfaced but not filed) is deferred: dismissed findings reappear as `new` until filed.
 
 ## Fetch and Triage
 


### PR DESCRIPTION
Adds a second source to the `improve-claude-code` backlog: the session history itself. Today the backlog is fed by hand (Things todos tagged `claude-code`) plus `agent-ideas`. This closes a self-improvement loop, history then grounded digest then triaged filing then the existing implement loop.

The work splits along an existing seam. The `claude-code:session` skill owns the DuckDB index and all SQL, so the queries and the fan-out recipe live there. `improve-claude-code` owns the workflow, so the Discover mode, grounding, dedup, and filing live there. The implement, PR, CI, and annotate phases are untouched.

## Changes

#### `session` Skill

- Four queries promoted into the Named Queries catalog, the broadly-useful ones that are hardest to rewrite from memory: `hook-block-then-retry-success` (a block retried away within N seconds was noise), `repeat-read-waste` (a self-join showing ~50% of Reads re-read an already-read file), `skill-auto-vs-explicit` (the `disable-model-invocation` lever), and `sandbox-bypass-effective-command` (normalize a command to its real verb after stripping the `cd <path>` wrapper).
- Six discovery queries shipped as SQL but kept out of the always-relevant catalog, documented only in the new reference: `hook-origin-split`, `already-allowed-still-prompting`, `sandbox-path-deny-recurrence`, `catalog-reinjection-thrash-sessions`, `top-sessions-by-output`, `stop-hook-noop-detector`.
- `references/discovery.md`: the fan-out recipe, the dimension-to-query cheat sheet, the grounding mandate, and the host-safety rules.

I trimmed the source notes' 22-query proposal (and the 56 raw candidates) to these 10. A query earns a file only when it is non-obvious and likely to recur; the rest are simple `GROUP BY` rollups a dimension agent writes inline.

#### `improve-claude-code` Skill

- A Discover mode: refresh once, fan out one agent per dimension over the read-only index, ground every candidate against the live config, write a ranked digest to `tmp/`, and file selected keepers as `claude-code` todos.
- Grounding is mandatory. The prior manual run overturned four of its own headline findings at this step (a Stop-hook latency that was a work-repo `make test-unit`, permission prompts already absorbed, a trope block already fixed, compactions all manual). Raw query findings go stale within a week against a config that changes weekly.
- Dedup is explicit because discovery re-scans all history every run. Each finding carries a `Discovery: <fingerprint>` marker in its todo notes (`sha256(finding_type + '|' + normalized_target)`, 12 chars). Things is the ledger, so there is no new local store. I deferred suppressing dismissed-but-unfiled findings, which would need a small dismiss-ledger.
- Discover is digest-only and never auto-files. Filing is an explicit user choice via the FILE step; implementing is a separate run of the existing loop.

## Testing

- Each of the 10 query files runs read-only against the live index without error, returns sensible rows, and filters correctly under `SET VARIABLE` scoping.
- `bun run skill-lint` passes for both skills, and `references/discovery.md` validates at depth 1.
- `bun scripts/check-marketplace.ts` passes.

The end-to-end Discover run, dedup seeding, and FILE-step round-trip are runtime checks against live Things data, left to exercise on demand.
