### PR TITLE
skills: add argument-hint to skills that take user arguments

### DIFF
--- a/plugins/github/skills/actions-monitor/SKILL.md
+++ b/plugins/github/skills/actions-monitor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: github:actions-monitor
 description: Monitor GitHub Actions runs and extract failure diagnostics. Use when watching PR CI, branch builds, or specific workflow runs.
+argument-hint: "[pr-url | branch | run-id]"
 allowed-tools:
   - Monitor
   - TaskStop

--- a/plugins/github/skills/pr-comments/SKILL.md
+++ b/plugins/github/skills/pr-comments/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: github:pr-comments
 description: Fetch, reply to, and resolve review threads on a GitHub pull request. Use when checking what review feedback needs addressing, whether threads are resolved, replying to review comments, or clearing AI-reviewer threads after acting on them.
+argument-hint: "<pr-url> [--role author|reviewer] [--bots]"
 allowed-tools:
   ["Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/pr-comments.ts:*)", "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/review-threads.ts:*)"]
 hooks:

--- a/plugins/gitlab/skills/ci-monitor/SKILL.md
+++ b/plugins/gitlab/skills/ci-monitor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: gitlab:ci-monitor
 description: Investigate GitLab CI pipeline failures and extract diagnostics. Use when watching MR CI, branch builds, or specific pipelines.
+argument-hint: "[mr-url | branch | pipeline-id]"
 allowed-tools:
   - Monitor
   - TaskStop

--- a/plugins/issue/skills/issue/SKILL.md
+++ b/plugins/issue/skills/issue/SKILL.md
@@ -2,6 +2,7 @@
 name: issue
 description: |
   Implement a feature or fix based on an issue. Use when given an issue URL to work on, or when implementing changes described in a tracked issue. Supports GitHub, Linear, and GitLab.
+argument-hint: <issue-url>
 allowed-tools:
   - Bash(gh:*)
   - Bash(glab:*)

--- a/plugins/mac/skills/jxa-run/SKILL.md
+++ b/plugins/mac/skills/jxa-run/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mac:jxa-run
 description: Execute JXA scripts scoped to a macOS application. Use when running JXA expressions or script files against an app via osascript. Validates Application() scope via AST.
+argument-hint: <app> <expression-or-script-file>
 allowed-tools:
   - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/jxa.ts:*)"
 hooks:

--- a/plugins/pull-request/skills/babysit/SKILL.md
+++ b/plugins/pull-request/skills/babysit/SKILL.md
@@ -2,6 +2,7 @@
 name: pull-request:babysit
 description: |
   Monitor a PR's CI, fix trivial failures (lint, types, formatting), and self-cancel when green. Use after pushing when you want hands-off CI monitoring with automatic fixes. With --merge, drive the PR all the way to merged (handling merge-train/queue kickouts, rebase issues, and re-runs); with --reviews, hand off to AI-review triage after the first green.
+argument-hint: "[--merge] [--reviews]"
 allowed-tools:
   - Monitor
   - TaskStop

--- a/plugins/pull-request/skills/follow-up/SKILL.md
+++ b/plugins/pull-request/skills/follow-up/SKILL.md
@@ -5,6 +5,7 @@ description: >
   resolves, draft replies. With --auto, autonomously triage AI-reviewer (bot) threads and loop
   until the reviewer is satisfied. Use when checking what review comments need responses,
   investigating how threads were resolved, drafting replies, or clearing a bot review hands-off.
+argument-hint: "[pr-url] [--auto]"
 allowed-tools:
   - Bash(git:*)
   - Bash(gh:*)

--- a/plugins/research/skills/prior-art/SKILL.md
+++ b/plugins/research/skills/prior-art/SKILL.md
@@ -2,6 +2,7 @@
 name: research:prior-art
 description: |
   Research existing solutions when exploring a new problem space. Use when the user mentions "prior art", "existing solutions", "what libraries exist for", or wants to understand the landscape before building.
+argument-hint: <topic>
 ---
 
 Research prior art for: $ARGUMENTS

--- a/plugins/review/skills/follow-up/SKILL.md
+++ b/plugins/review/skills/follow-up/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Follow up on a PR/MR you reviewed: check whether your comments were addressed, find silently
   resolved threads, and decide whether to re-review or approve.
   Use after leaving review feedback to see if the author acted on it.
+argument-hint: <pr-url>
 allowed-tools:
   - Bash(gh:*)
   - Bash(glab:*)

--- a/plugins/review/skills/peer/SKILL.md
+++ b/plugins/review/skills/peer/SKILL.md
@@ -2,6 +2,7 @@
 name: review:peer
 description: |
   Review a pull request when requested by a peer. Use when reviewing PRs, providing code review feedback, or analyzing proposed changes. Supports GitHub and GitLab.
+argument-hint: <pr-url-or-number>
 allowed-tools:
   - Bash(gh:*)
   - Bash(glab:*)

--- a/plugins/type-ignore/skills/fix/SKILL.md
+++ b/plugins/type-ignore/skills/fix/SKILL.md
@@ -2,6 +2,7 @@
 name: type-ignore:fix
 disable-model-invocation: true
 description: Fix type errors instead of ignoring them. Use when cleaning up type ignores across files or batch-fixing type errors.
+argument-hint: <file-or-glob>
 context: fork
 agent: general-purpose
 allowed-tools:


### PR DESCRIPTION
Adds `argument-hint` frontmatter to the skills that genuinely take user input, so the slash-command menu shows what to type after the skill name. Previously only `writing:scan`, `writing:rewrite`, and `writing/commands/review.md` set it, even though several skills parse `$ARGUMENTS` for positional args and flags.

## Changes

Each edit adds exactly one frontmatter line, placed right after the `description` block. No body changes.

Flag-bearing skills:

| File | `argument-hint` |
|------|-----------------|
| `pull-request:babysit` | `[--merge] [--reviews]` |
| `pull-request:follow-up` | `[pr-url] [--auto]` |
| `github:actions-monitor` | `[pr-url \| branch \| run-id]` |
| `gitlab:ci-monitor` | `[mr-url \| branch \| pipeline-id]` |
| `github:pr-comments` | `<pr-url> [--role author\|reviewer] [--bots]` |

Positional-argument skills:

| File | `argument-hint` |
|------|-----------------|
| `review:peer` | `<pr-url-or-number>` |
| `review:follow-up` | `<pr-url>` |
| `issue:issue` | `<issue-url>` |
| `research:prior-art` | `<topic>` |
| `type-ignore:fix` | `<file-or-glob>` |
| `mac:jxa-run` | `<app> <expression-or-script-file>` |

Skills whose `--flags` only pass through to a wrapped CLI (`gh`, `glab`, `git`) are deliberately excluded, since those flags aren't skill arguments. Hints starting with `[` (or containing `|`) are quoted so YAML doesn't parse them as flow sequences.

## Testing

- `grep -rn "argument-hint" plugins/` confirms the new lines.
- `bun run skill-lint` passes with 0 errors / 0 warnings across the edited plugins.
