### PR TITLE
writing: detect full-sentence headings

### DIFF
--- a/plugins/writing/hooks/headings.test.ts
+++ b/plugins/writing/hooks/headings.test.ts
@@ -3,7 +3,7 @@ import type {
   PreToolUseHookInput,
   PreToolUseHookSpecificOutput,
 } from "@anthropic-ai/claude-agent-sdk";
-import { checkBoldAsHeading, checkTitleCase, processInput } from "./headings";
+import { checkBoldAsHeading, checkSentenceHeading, checkTitleCase, processInput } from "./headings";
 
 function mockWriteInput(filePath: string, content: string): PreToolUseHookInput {
   return {
@@ -90,6 +90,125 @@ describe("checkBoldAsHeading", () => {
   }
 });
 
+const sentenceHeadingCases: { description: string; content: string; match: boolean }[] = [
+  {
+    description: "topic colon with linking verb",
+    content: "## The Cache Layer: Redis Holds the Session State",
+    match: true,
+  },
+  {
+    description: "subject plus linking verb",
+    content: "## Latency Is the Main Bottleneck",
+    match: true,
+  },
+  {
+    description: "colon clause with not an",
+    content: "## Rollback: A Safety Net, Not an Undo Button",
+    match: true,
+  },
+  {
+    description: "colon clause with is the default",
+    content: "## Caching Strategy: Write-Through Is the Default",
+    match: true,
+  },
+  {
+    description: "relative clause with how/handle",
+    content: "## Prior Art: How Other Brokers Handle This",
+    match: true,
+  },
+  {
+    description: "imperative opener build",
+    content: "## Build Against the Documented Limits",
+    match: true,
+  },
+  {
+    description: "relative clause with that and keep",
+    content: "## Joints That Keep the Prototype From Becoming Debt",
+    match: true,
+  },
+  {
+    description: "imperative list document/stabilize/expose",
+    content: "## Document, Stabilize, and Expose the Internal Cache API",
+    match: true,
+  },
+  {
+    description: "parenthetical with trailing clause and linking verb",
+    content: "## Token Exchange (RFC 8693) So the Proxy Never Holds a User Token",
+    match: true,
+  },
+  { description: "short topic label", content: "## Cache Layer", match: false },
+  { description: "short topic label prior art", content: "## Prior Art", match: false },
+  { description: "short topic label blast radius", content: "## Blast Radius", match: false },
+  { description: "short topic label error taxonomy", content: "## Error Taxonomy", match: false },
+  {
+    description: "topic with parenthetical citation",
+    content: "## Token Exchange (RFC 8693)",
+    match: false,
+  },
+  { description: "single word size", content: "## Size", match: false },
+  { description: "single word proposal", content: "## Proposal", match: false },
+  { description: "imperative two words below threshold", content: "## Build Now", match: false },
+  { description: "enumerator stage", content: "## Stage 1: Context Gathering", match: false },
+  { description: "enumerator step", content: "## Step 1: Read the Transcript", match: false },
+  { description: "enumerator phase", content: "## Phase: Calendar", match: false },
+  { description: "enumerator example", content: "## Example: Blog Schema", match: false },
+  {
+    description: "enumerator pattern",
+    content: "## Pattern 2: Domain-specific organization",
+    match: false,
+  },
+  {
+    description: "documented miss: 5 words, of-phrase, no verb",
+    content: "## Blast Radius of a Leaked Key",
+    match: false,
+  },
+  {
+    description: "documented miss: verb-less, 4 words after stripping parenthetical",
+    content: "## Machine-Readable Internal Error Taxonomy (Client vs Server Cases)",
+    match: false,
+  },
+  {
+    description: "documented miss: colon clause whose verb is outside the linking set",
+    content: "## Refresh: Now Supported at the Edge, Unconfirmed for the Client",
+    match: false,
+  },
+  {
+    description: "documented miss: long verb-less noun phrase",
+    content: "## Programmatic, Conformant Schema Registration Guidance for Multi-Tenant Setups",
+    match: false,
+  },
+  {
+    description: "long noun-phrase title with no verb",
+    content: "## Architecture Review: CLI Command Package Layout",
+    match: false,
+  },
+  {
+    description: "ticket-prefixed task heading",
+    content: "## ABC-1234: Defer eager view binding in the loader",
+    match: false,
+  },
+  {
+    description: "interrogative rationale label with linking verb",
+    content: "## Why the Default Is Unsafe",
+    match: false,
+  },
+  { description: "interrogative section label", content: "## What was wrong", match: false },
+  { description: "inline-code-only heading", content: "## `context: fork`", match: false },
+];
+
+describe("checkSentenceHeading", () => {
+  for (const { description, content, match } of sentenceHeadingCases) {
+    it(description, () => {
+      const result = checkSentenceHeading(content);
+      if (match) {
+        expect(result).not.toBeNull();
+      } else {
+        expect(result).toBeNull();
+      }
+    });
+  }
+});
+
 describe("processInput", () => {
   it("returns title case guidance", () => {
     const output = getOutput(mockWriteInput("README.md", "# introduction"));
@@ -99,6 +218,15 @@ describe("processInput", () => {
   it("returns bold-as-heading guidance", () => {
     const output = getOutput(mockWriteInput("README.md", "**Configuration:**\nSome text"));
     expect(output?.additionalContext).toContain("markdown heading");
+  });
+
+  it("returns sentence-heading guidance", () => {
+    const output = getOutput(mockWriteInput("README.md", "## Latency Is the Main Bottleneck"));
+    expect(output?.additionalContext).toContain("first sentence");
+  });
+
+  it("returns null for a short noun-phrase heading", () => {
+    expect(getOutput(mockWriteInput("README.md", "# Cache Layer"))).toBeNull();
   });
 
   it("skips non-markdown files", () => {

--- a/plugins/writing/hooks/headings.ts
+++ b/plugins/writing/hooks/headings.ts
@@ -18,6 +18,46 @@ import {
 
 const PLACEHOLDER = "\0";
 
+const LINKING_VERBS = new Set([
+  "is",
+  "are",
+  "was",
+  "were",
+  "be",
+  "been",
+  "being",
+  "am",
+  "holds",
+  "hold",
+  "keeps",
+  "keep",
+  "makes",
+  "make",
+  "becomes",
+  "become",
+  "handles",
+  "handle",
+  "supports",
+  "support",
+]);
+
+const IMPERATIVE_OPENERS = new Set([
+  "build",
+  "document",
+  "stabilize",
+  "expose",
+  "add",
+  "remove",
+  "configure",
+  "implement",
+  "ensure",
+]);
+
+const ENUMERATOR_STOPLIST =
+  /^(step|stage|phase|pattern|example|part|section|option|level|tier|q)\b/i;
+
+const INTERROGATIVE_OPENERS = new Set(["what", "why", "how", "whether", "when", "where", "which"]);
+
 export function checkTitleCase(content: string): string | null {
   const ast = fromMarkdown(content);
   let result: string | null = null;
@@ -82,6 +122,82 @@ export function checkBoldAsHeading(content: string): string | null {
   return result;
 }
 
+export function checkSentenceHeading(content: string): string | null {
+  const ast = fromMarkdown(content);
+  let result: string | null = null;
+
+  visit(ast, "heading", (node: Heading) => {
+    if (result) return;
+
+    const allCode = node.children.every((child) => child.type === "inlineCode");
+    if (allCode) return;
+
+    const display = node.children
+      .filter((child): child is Text => child.type === "text")
+      .map((child) => child.value)
+      .join("")
+      .trim();
+
+    const analysis = display
+      .replace(/\s*\([^)]*\)\s*$/, "")
+      .replace(
+        /^(step|stage|phase|pattern|example|part|section|option|level|tier|q)\s*\d*\s*:?\s*/i,
+        "",
+      )
+      .trim();
+
+    const words = analysis.split(/\s+/).filter((word) => word.length > 0);
+    const lower = words.map((word) => word.toLowerCase().replace(/[^a-z']/g, ""));
+
+    // Interrogative-led headings ("Why X is Y", "What was wrong") are a
+    // conventional rationale-section label, not the sentence-heading trope.
+    if (lower[0] && INTERROGATIVE_OPENERS.has(lower[0])) return;
+
+    const message = `Heading "${display}" reads like a sentence. Cut it to the noun phrase that names the topic (a couple of words), and move the explanation into the first sentence of the section.`;
+
+    const colonIndex = analysis.indexOf(":");
+    if (colonIndex !== -1) {
+      const before = analysis
+        .slice(0, colonIndex)
+        .trim()
+        .split(/\s+/)
+        .filter((word) => word.length > 0);
+      const after = analysis
+        .slice(colonIndex + 1)
+        .trim()
+        .split(/\s+/)
+        .map((word) => word.toLowerCase().replace(/[^a-z']/g, ""))
+        .filter((word) => word.length > 0);
+      const afterPredicate = after.some((word) => LINKING_VERBS.has(word) || word === "not");
+      const preEnumerator = before[0] ? ENUMERATOR_STOPLIST.test(before[0]) : false;
+      if (before.length <= 4 && after.length >= 3 && afterPredicate && !preEnumerator) {
+        result = message;
+        return;
+      }
+    }
+
+    if (lower.some((word) => LINKING_VERBS.has(word))) {
+      result = message;
+      return;
+    }
+
+    if (
+      words.length >= 4 &&
+      lower.some((word) => word === "that" || word === "which" || word === "who")
+    ) {
+      result = message;
+      return;
+    }
+
+    if (words.length >= 3 && lower[0] && IMPERATIVE_OPENERS.has(lower[0])) {
+      result = message;
+      return;
+    }
+  });
+
+  return result;
+}
+
 export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {
   const toolName = input.tool_name;
 
@@ -117,6 +233,11 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
     return formatContext(
       `${boldHeading}. Replace the bold-colon pattern with a markdown heading (## ) at the appropriate level.`,
     );
+  }
+
+  const sentenceHeading = checkSentenceHeading(content);
+  if (sentenceHeading) {
+    return formatContext(sentenceHeading);
   }
 
   return null;

--- a/plugins/writing/skills/review/SKILL.md
+++ b/plugins/writing/skills/review/SKILL.md
@@ -35,6 +35,7 @@ For `writing:style`, also inject these writing preferences (sub-agents cannot se
 - Avoid copula avoidance ("X is Y" not fancy alternatives)
 - Prefer shorter sentences over semicolons
 - Direct, conversational tone
+- Headings are short noun-phrase topic labels, not sentences. Flag a heading that contains a finite verb, reads as a `Topic: explanatory clause`, or is otherwise a full clause. Cut to the noun phrase; push the explanation into the first sentence.
 
 ## Synthesize
 

--- a/plugins/writing/skills/writing/SKILL.md
+++ b/plugins/writing/skills/writing/SKILL.md
@@ -19,6 +19,7 @@ The hook enforces these automatically. Vocabulary and marketing-verb lists are i
 - Avoid semicolons. Prefer shorter sentences or commas.
 - Don't structure bullets as `- **path/to/file**: description`.
 - Use `####` headers instead of `**Label:**` for labeled subsections.
+- Headings name the topic in a couple of words. No verbs, no `Topic: clause`, no sentence-shaped headings. Move the explanation into the body.
 
 #### Word Choice
 


### PR DESCRIPTION
Adds `checkSentenceHeading` to the writing plugin's headings hook. It flags markdown headings that read like sentences and steers toward short noun-phrase topic labels, pushing the explanation into the body. Advisory only, never blocking, matching the existing title-case and bold-as-heading checks.

## Signals

The detector tokenizes the heading (stripping a trailing parenthetical and a leading enumerator like `Step 1:`) and fires on the first match:

- Gated colon: a `Topic: explanatory clause` shape where the pre-colon side is short, the post-colon side runs long and carries a predicate, and the topic is not an enumerator. Also accepts a contrastive `not` predicate (`Topic: X, Not Y`).
- Linking verb: any standalone closed-class verb (`is`, `holds`, `supports`, etc.).
- Relative clause: a standalone `that`/`which`/`who` in a heading of four or more words.
- Imperative opener: a leading command verb (`build`, `document`, `expose`, etc.) in a heading of three or more words.

Interrogative-led headings (`What`, `Why`, `How`, `Whether`, ...) are exempt. They are a conventional rationale-section label, not the trope.

## Tuning Against History

An earlier draft also flagged any heading of seven or more words. Validated against local session history, that length signal produced about 70% of the flags and was almost all false positives: long noun-phrase titles (`Architecture Review: CLI Command Package Layout`), ticket-prefixed task headings (`ABC-1234: ...`), and numbered plan sections. Word count is a poor proxy for "sentence," and it cannot separate a long title from a long clause without parts-of-speech analysis. Dropping it took the flag rate on real `.md` headings from about 20% to about 4%. The interrogative exemption removes the next cluster, rationale labels like `Why the Default Is Unsafe`.

## Documented Misses

Two noun-phrase shapes slip through and are asserted null as boundary cases:

- `Blast Radius of a Leaked Key` (five words, of-phrase, no verb).
- `Machine-Readable Internal Error Taxonomy (Client vs Server Cases)` (verb-less, four words after stripping the parenthetical).

Both are noun phrases with no finite verb. Catching them would need length or preposition heuristics that over-fire on legitimate topic labels.

## Follow-up

A real parts-of-speech tagger is not a drop-in win here. Off-the-shelf it mis-tags terse, title-cased headings in both directions. A ground-up redesign of the writing skill's detection around proper linguistic tooling is tracked in #745.

## Testing

Added a `checkSentenceHeading` case table covering each signal, the interrogative exemption, the two documented misses, an inline-code-only skip, and short noun-phrase labels that must stay quiet. The `processInput` cases cover the Write path emitting guidance and a short heading returning null. Verified the hook end-to-end by piping a mock `PreToolUse` payload into `headings.ts`.

Also updated the `writing` and `review` skills so the guidance reaches both the always-on hook and the parallel review agents.

Original Task: [Writing rule: steer away from full-sentence headings](https://things.bendrucker.me/show?id=NT7EeWYgLXGSRN5FmMixRN)
