### PR TITLE
user: add moshi-hook agent hooks

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -77,6 +77,16 @@
             "timeout": 86400
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "async": false,
+            "command": "'/opt/homebrew/bin/moshi-hook' claude-hook",
+            "timeout": 300,
+            "type": "command"
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -88,6 +98,26 @@
             "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "'/opt/homebrew/bin/moshi-hook' claude-hook",
+            "type": "command"
+          }
+        ],
+        "matcher": "AskUserQuestion"
+      },
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "'/opt/homebrew/bin/moshi-hook' claude-hook",
+            "type": "command"
+          }
+        ],
+        "matcher": "ExitPlanMode"
       }
     ],
     "PreCompact": [
@@ -148,6 +178,15 @@
             "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "'/opt/homebrew/bin/moshi-hook' claude-hook",
+            "type": "command"
+          }
+        ]
       }
     ],
     "Stop": [
@@ -156,6 +195,15 @@
           {
             "type": "command",
             "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "'/opt/homebrew/bin/moshi-hook' claude-hook",
+            "type": "command"
           }
         ]
       }
@@ -186,6 +234,15 @@
           {
             "type": "command",
             "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "'/opt/homebrew/bin/moshi-hook' claude-hook",
+            "type": "command"
           }
         ]
       }


### PR DESCRIPTION
Adds the hook entries that `moshi-hook install` writes for Claude Code to `user/settings.json`: `SessionStart`, `UserPromptSubmit`, `Stop`, `PermissionRequest` (blocking, 300s timeout), and `PostToolUse` matchers for `AskUserQuestion` and `ExitPlanMode`.

`moshi-hook install` had replaced the `~/.claude/settings.json` symlink with a forked copy of this file (same thing the vibe-island installer did). I restored the symlink and ported the entries here so the repo stays the managed source and `moshi-hook status` reports the hooks as current instead of rewriting the file.

The entries match `moshi-hook install` output byte-for-byte, including the quoted `/opt/homebrew/bin/moshi-hook` path, so the installer's drift check passes.

## Testing

- Sorted-JSON diff against the file `moshi-hook install` wrote shows no difference beyond pre-existing repo additions
