### PR TITLE
github: add sandbox bypass marker to gh-spawning scripts

### DIFF
--- a/plugins/github/scripts/pr-comments.ts
+++ b/plugins/github/scripts/pr-comments.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: shells out to gh (Go binary) for TLS-bearing API calls
 
 import { cli } from "cleye";
 import { type Author, isBot, isReviewTarget, loadExtraReviewers } from "./reviewers";

--- a/plugins/github/scripts/review-threads.ts
+++ b/plugins/github/scripts/review-threads.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: shells out to gh (Go binary) for TLS-bearing API calls
 
 import { cli, command } from "cleye";
 


### PR DESCRIPTION
Adds the `claude:dangerouslyDisableSandbox` marker comment after the shebang in `pr-comments.ts` and `review-threads.ts`. Both scripts spawn `gh` as a bun child process, so `excludedCommands` (which matches only the top-level command) never applies, and `gh` (a Go binary) fails TLS verification under the Seatbelt sandbox on every invocation.

The mac plugin's sandbox hook scans the head of invoked `bun`/`node` scripts for this marker and injects `dangerouslyDisableSandbox: true`. This is the same fix already applied to `github/skills/actions-monitor/scripts/watch.ts` and `gitlab/skills/ci-monitor/scripts/watch.ts`, with matching marker text.

## Testing

- Confirmed the marker string matches `SCRIPT_MARKER` in `plugins/mac/hooks/sandbox.ts` exactly.
- Ran the mac sandbox hook's existing test suite, which covers marker detection in script heads.
- Piped synthetic `PreToolUse` JSON for `bun plugins/github/scripts/<script>.ts` through the sandbox hook; both scripts now emit `updatedInput` with `dangerouslyDisableSandbox: true`.
- Ran the github plugin's test suite to confirm the scripts still parse and behave unchanged.

Original Task: [[discovery] github scripts sandbox](https://things.bendrucker.me/show?id=GB8FZHuvErBMW26vEuqPq4)
