### PR TITLE
newline: silence ensure hook on no-op and empty-file paths

### DIFF
--- a/plugins/newline/scripts/ensure.ts
+++ b/plugins/newline/scripts/ensure.ts
@@ -15,12 +15,12 @@ export async function ensureTrailingNewline(filePath: string): Promise<string | 
   }
 
   if (file.size === 0) {
-    return "File is empty, skipping";
+    return null;
   }
 
   const content = await file.text();
   if (content.endsWith("\n")) {
-    return "File already has trailing newline";
+    return null;
   }
 
   await Bun.write(filePath, `${content}\n`);

--- a/plugins/newline/scripts/newline.test.ts
+++ b/plugins/newline/scripts/newline.test.ts
@@ -133,19 +133,19 @@ describe("ensure.ts", () => {
       expect(await hasNewline(filePath)).toBe(true);
     });
 
-    it("preserves existing newline", async () => {
+    it("silently preserves existing newline", async () => {
       const filePath = join(testDir, "with_newline.txt");
       await Bun.write(filePath, "content\n");
       const message = await ensureTrailingNewline(filePath);
-      expect(message).toBe("File already has trailing newline");
+      expect(message).toBeNull();
       expect(await hasNewline(filePath)).toBe(true);
     });
 
-    it("skips empty files", async () => {
+    it("silently skips empty files", async () => {
       const filePath = join(testDir, "empty.txt");
       await Bun.write(filePath, "");
       const message = await ensureTrailingNewline(filePath);
-      expect(message).toBe("File is empty, skipping");
+      expect(message).toBeNull();
     });
 
     it("returns null for nonexistent file", async () => {
@@ -160,6 +160,20 @@ describe("ensure.ts", () => {
       const output = await ensureInput(mockPostToolInput(filePath));
       const hookOutput = output?.hookSpecificOutput as PostToolUseHookSpecificOutput | undefined;
       expect(hookOutput?.additionalContext).toContain("Added trailing newline");
+    });
+
+    it("returns null when file already has trailing newline", async () => {
+      const filePath = join(testDir, "with_newline.txt");
+      await Bun.write(filePath, "content\n");
+      const output = await ensureInput(mockPostToolInput(filePath));
+      expect(output).toBeNull();
+    });
+
+    it("returns null for empty file", async () => {
+      const filePath = join(testDir, "empty.txt");
+      await Bun.write(filePath, "");
+      const output = await ensureInput(mockPostToolInput(filePath));
+      expect(output).toBeNull();
     });
   });
 });


### PR DESCRIPTION
Silences the `newline/ensure` PostToolUse hook on the no-op and empty-file paths. The hook injected "File already has trailing newline" (~13 tokens of system-reminder) after 665 of 668 Writes since April; the message carries no information when nothing changed. `ensureTrailingNewline` now returns `null` for files that already end in a newline and for empty files, and only emits "Added trailing newline" when it actually rewrites the file.

## Testing

- Updated the unit tests to expect `null` on both silent paths and added `processInput` coverage confirming no hook output for already-newline and empty files; `bun test plugins/newline` passes (28 tests).
- Piped synthetic PostToolUse JSON through `ensure.ts` for three cases: a file ending in newline, an empty file, and a file missing the newline. Only the third produced output, and the script appended the newline to the file.

Original Task: [[discovery] newline narration](https://things.bendrucker.me/show?id=DZkg14PQR7sHBd3C34BF4C)
