### PR TITLE
user: allow worktree hook teardown of throwaway worktrees

### DIFF
--- a/user/hooks/worktree/index.test.ts
+++ b/user/hooks/worktree/index.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { formatAskOutput, formatDenyOutput, isThrowawayAdd, processInput } from "./index";
+import {
+  formatAskOutput,
+  formatDenyOutput,
+  isThrowawayAdd,
+  isThrowawayRemove,
+  processInput,
+} from "./index";
 
 function bashInput(command: string): PreToolUseHookInput {
   return {
@@ -53,10 +59,19 @@ describe("processInput", () => {
     );
   });
 
-  it("denies git worktree remove under tmp/", () => {
-    expect(processInput(bashInput("git worktree remove tmp/verify"))).toEqual(
-      formatDenyOutput("remove"),
-    );
+  it("allows git worktree remove under tmp/", () => {
+    expect(processInput(bashInput("git worktree remove tmp/verify"))).toBeNull();
+  });
+
+  it("allows git worktree remove --force under tmp/", () => {
+    expect(processInput(bashInput("git worktree remove --force tmp/verify"))).toBeNull();
+  });
+
+  it("allows git worktree remove of agent worktrees", () => {
+    expect(processInput(bashInput("git worktree remove .claude/worktrees/agent-x"))).toBeNull();
+    expect(
+      processInput(bashInput("git worktree remove /Users/me/repo/.claude/worktrees/agent-x")),
+    ).toBeNull();
   });
 
   it("denies git worktree remove", () => {
@@ -65,9 +80,16 @@ describe("processInput", () => {
     );
   });
 
+  it("allows git worktree prune and unlock", () => {
+    expect(processInput(bashInput("git worktree prune"))).toBeNull();
+    expect(processInput(bashInput("git worktree prune --verbose"))).toBeNull();
+    expect(processInput(bashInput("git worktree unlock tmp/verify"))).toBeNull();
+    expect(processInput(bashInput("git worktree unlock ../path"))).toBeNull();
+  });
+
   it("asks for unknown git worktree subcommands", () => {
     expect(processInput(bashInput("git worktree lock ../path"))).toEqual(formatAskOutput());
-    expect(processInput(bashInput("git worktree prune"))).toEqual(formatAskOutput());
+    expect(processInput(bashInput("git worktree repair"))).toEqual(formatAskOutput());
   });
 
   it("ignores git worktree without a subcommand", () => {
@@ -104,5 +126,45 @@ describe("isThrowawayAdd", () => {
 
   it("does not match tmp/ nested below another directory", () => {
     expect(isThrowawayAdd("git worktree add a/tmp/x")).toBe(false);
+  });
+});
+
+describe("isThrowawayRemove", () => {
+  it("matches a tmp/ target", () => {
+    expect(isThrowawayRemove("git worktree remove tmp/x")).toBe(true);
+  });
+
+  it("matches a ./tmp/ target", () => {
+    expect(isThrowawayRemove("git worktree remove ./tmp/x")).toBe(true);
+  });
+
+  it("matches a relative .claude/worktrees/ target", () => {
+    expect(isThrowawayRemove("git worktree remove .claude/worktrees/agent-x")).toBe(true);
+  });
+
+  it("matches an absolute .claude/worktrees/ target", () => {
+    expect(isThrowawayRemove("git worktree remove /Users/me/repo/.claude/worktrees/agent-x")).toBe(
+      true,
+    );
+  });
+
+  it("skips flags and matches a later tmp/ target", () => {
+    expect(isThrowawayRemove("git worktree remove --force tmp/x")).toBe(true);
+  });
+
+  it("does not match a tmp-prefixed sibling directory", () => {
+    expect(isThrowawayRemove("git worktree remove tmpfoo/x")).toBe(false);
+  });
+
+  it("does not match tmp/ nested below another directory", () => {
+    expect(isThrowawayRemove("git worktree remove a/tmp/x")).toBe(false);
+  });
+
+  it("does not match a worktrees dir outside .claude/", () => {
+    expect(isThrowawayRemove("git worktree remove worktrees/x")).toBe(false);
+  });
+
+  it("does not match other subcommands", () => {
+    expect(isThrowawayRemove("git worktree add tmp/x")).toBe(false);
   });
 });

--- a/user/hooks/worktree/index.ts
+++ b/user/hooks/worktree/index.ts
@@ -7,9 +7,10 @@ export type BashInput = {
   command?: string;
 };
 
-const READ_ONLY_SUBCOMMANDS = new Set(["list"]);
+const ALLOWED_SUBCOMMANDS = new Set(["list", "prune", "unlock"]);
 const REPLACED_SUBCOMMANDS = new Set(["add", "remove"]);
 const TMP_TARGET = /^(\.\/)?tmp\//;
+const AGENT_WORKTREE_TARGET = /(^|\/)\.claude\/worktrees\//;
 
 export function isThrowawayAdd(command: string): boolean {
   const after = command.split(/\bgit\s+worktree\s+add\b/)[1];
@@ -17,12 +18,20 @@ export function isThrowawayAdd(command: string): boolean {
   return after.split(/\s+/).some((tok) => TMP_TARGET.test(tok));
 }
 
+export function isThrowawayRemove(command: string): boolean {
+  const after = command.split(/\bgit\s+worktree\s+remove\b/)[1];
+  if (after === undefined) return false;
+  return after.split(/\s+/).some((tok) => TMP_TARGET.test(tok) || AGENT_WORKTREE_TARGET.test(tok));
+}
+
 export function formatDenyOutput(subcommand: string): SyncHookJSONOutput {
   const base = `Use the worktrunk skill (/worktrunk) instead of \`git worktree ${subcommand}\`.`;
   const reason =
     subcommand === "add"
       ? `${base} For a throwaway verification checkout, add it under \`tmp/\`.`
-      : base;
+      : subcommand === "remove"
+        ? `${base} Throwaway worktrees under \`tmp/\` or \`.claude/worktrees/\` may be removed directly.`
+        : base;
   return {
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
@@ -54,10 +63,13 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
   if (!subcommand) {
     return null;
   }
-  if (READ_ONLY_SUBCOMMANDS.has(subcommand)) {
+  if (ALLOWED_SUBCOMMANDS.has(subcommand)) {
     return null;
   }
   if (subcommand === "add" && isThrowawayAdd(command)) {
+    return null;
+  }
+  if (subcommand === "remove" && isThrowawayRemove(command)) {
     return null;
   }
   if (REPLACED_SUBCOMMANDS.has(subcommand)) {


### PR DESCRIPTION
Allows the worktree hook to pass teardown of sanctioned disposable worktrees. The existing `isThrowawayAdd` exception only covered `git worktree add tmp/<name>`; removing the same worktree was denied, and `prune`/`unlock` fell through to ask. Every recent prompt from this hook fired on cleanup of disposables it had allowed creating.

## Changes

- Added `isThrowawayRemove`: `git worktree remove` of `tmp/` and `.claude/worktrees/` targets (relative or absolute) returns no decision, so the command proceeds
- Allowed `prune` and `unlock` outright alongside `list` (prune only deletes admin records for already-removed directories)
- Updated the `remove` deny message to point at the throwaway paths

## Testing

- Unit tests cover the new remove/prune/unlock paths plus `isThrowawayRemove` edge cases (flags, absolute paths, `tmpfoo/` and nested `a/tmp/` non-matches)
- Piped synthetic PreToolUse JSON: `git worktree remove tmp/x` and `git worktree prune` produce no output (allow); `git worktree remove ../other` still denies

Original Task: [[discovery] worktree hook teardown](https://things.bendrucker.me/show?id=5TZPvSVJmk43w9AuJsatSp)
