### PR TITLE
user: tmux sockets, drop dead worktrees entry and astral

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -263,7 +263,6 @@
     "pull-request@bendrucker": true,
     "interview@bendrucker": true,
     "github@claude-plugins-official": true,
-    "astral@astral-sh": true,
     "personal-review@bendrucker": true,
     "x-callback-url@bendrucker": true,
     "calendar@bendrucker": true,
@@ -341,14 +340,14 @@
       "allowLocalBinding": true,
       "allowUnixSockets": [
         "~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh",
-        "~/.tmux"
+        "~/.tmux",
+        "/tmp/claude"
       ]
     },
     "filesystem": {
       "allowWrite": [
         "/tmp",
         "~/.tmux",
-        ".claude/worktrees",
         "~/.terraform.d/plugin-cache",
         "~/.cache",
         "~/Library/Caches/go-build",


### PR DESCRIPTION
Makes three sandbox/plugin changes to `user/settings.json`, all from this week's discovery digest.

## Changes

- Adds `/tmp/claude` to `sandbox.network.allowUnixSockets`. Sandboxed-Bash `TMPDIR` is `/tmp/claude`, which is writable but not socket-allowed, so `tmux -S "$TMPDIR/x.sock"` isolated test servers fail even though the file write would succeed (9 denies plus 85 `SOCK=`-prefixed workarounds across 5 sessions).
- Removes the `.claude/worktrees` entry from `sandbox.filesystem.allowWrite` (added in #737). Per the sandboxing docs, a no-prefix sandbox path in user settings resolves relative to `~/.claude`, so the entry covered `~/.claude/.claude/worktrees` while agent worktrees actually live at `<project>/.claude/worktrees`. I removed it rather than fixing it because user settings have no syntax for project-relative paths; a repo that needs it can add the entry to its own `.claude/settings.json`, where no-prefix paths resolve against the project root.
- Removes `astral@astral-sh` from `enabledPlugins` so its skills stop riding in every session. The `astral-sh` marketplace stays in `extraKnownMarketplaces`, so the plugin remains available; re-enable it for a single repo with `claude plugin enable astral@astral-sh --scope project` (or `--scope local`), since scopes merge and project/local override user.

## Testing

- `jq empty user/settings.json`
- `bun packages/validate/settings.ts` (passes; the unknown-property warnings are pre-existing)
- `bun test packages/` and `bun scripts/check-marketplace.ts`

Original Task: [[discovery] tmux sockets](https://things.bendrucker.me/show?id=D1jTsBPk6DiJL5FcbuVuXX)
Original Task: [[discovery] inert worktrees entry](https://things.bendrucker.me/show?id=QALsUyZusQeyK4UnrZTAd1)
Original Task: [[discovery] astral plugin out of user config](https://things.bendrucker.me/show?id=K7ir7DExBpT2qqBidy6oib)
