### PR TITLE
fix(claude-code:skill): make frontmatter lint hooks actually run

### DIFF
--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -14,11 +14,11 @@ hooks:
     - matcher: "Write|Edit"
       hooks:
         - type: command
-          command: "bun ${CLAUDE_SKILL_DIR}/scripts/check-namespace.ts"
+          command: "bun ${CLAUDE_PLUGIN_ROOT}/skills/skill/scripts/check-namespace.ts"
         - type: command
-          command: "bun ${CLAUDE_SKILL_DIR}/scripts/check-structure.ts"
+          command: "bun ${CLAUDE_PLUGIN_ROOT}/skills/skill/scripts/check-structure.ts"
         - type: command
-          command: "bun ${CLAUDE_SKILL_DIR}/scripts/check-lint.ts"
+          command: "bun ${CLAUDE_PLUGIN_ROOT}/skills/skill/scripts/check-lint.ts"
 ---
 
 # Claude Code Skills Development
@@ -116,7 +116,9 @@ Skill-scoped hooks activate only when the skill is invoked and last for the sess
 | `$ARGUMENTS`           | All arguments passed when invoking the skill. Appended automatically if absent.  |
 | `$ARGUMENTS[N]` / `$N` | Access a specific argument by 0-based index.                                     |
 | `${CLAUDE_SESSION_ID}` | Current session ID.                                                              |
-| `${CLAUDE_SKILL_DIR}` | Absolute path to the skill's directory. Works in hooks and allowed-tools, but NOT in `!` context. |
+| `${CLAUDE_SKILL_DIR}` | Absolute path to the skill's directory. Substituted in skill content: the body, `!` injection commands, and `allowed-tools`. |
+
+These substitutions apply to skill content, not the frontmatter `hooks:` block. The hooks engine expands only `${CLAUDE_PROJECT_DIR}`, `${CLAUDE_PLUGIN_ROOT}`, and `${CLAUDE_PLUGIN_DATA}` ([hooks reference](https://code.claude.com/docs/en/hooks)); `${CLAUDE_SKILL_DIR}` there resolves to an empty string. In a hook command, reference a bundled script by plugin root instead: `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/scripts/check.ts`.
 
 ### Dynamic Context Injection
 

--- a/plugins/claude-code/skills/skill/scripts/check-lint.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-lint.ts
@@ -50,7 +50,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const output = processPostToolUse(input);
+  const output = await processPostToolUse(input);
   if (output) {
     writeStdoutJson(output);
   }


### PR DESCRIPTION
Fixes the `claude-code:skill` frontmatter lint hooks, which have never run successfully. The three PostToolUse commands referenced `${CLAUDE_SKILL_DIR}`, which the hooks engine does not substitute (it expands only `${CLAUDE_PROJECT_DIR}`, `${CLAUDE_PLUGIN_ROOT}`, and `${CLAUDE_PLUGIN_DATA}`), so the paths collapsed to `/scripts/<name>` and every fire died with "Module not found".

## Changes

- Point all three hook commands at `${CLAUDE_PLUGIN_ROOT}/skills/skill/scripts/...`
- Add the missing `await` on `processPostToolUse(input)` in `check-lint.ts` `main()`. Without it the Promise is always truthy and `writeStdoutJson` serializes it to `{}` on every invocation, so fixing the path alone would replace the module error with junk hook output. Both fixes land together for that reason.
- Correct the string-substitution table in `SKILL.md`, which claimed `${CLAUDE_SKILL_DIR}` works in hooks.

Overlaps with #722, which fixes the same variable in this skill plus `tmux:tmux` and `ui-design:wireframe` and adds a CI check, but does not include the `check-lint.ts` `await` fix. The `SKILL.md` hunks here match #722 verbatim so the branches reconcile cleanly; merging #722 alone would ship the `{}` output bug.

## Testing

- Piped synthetic PostToolUse JSON through all three scripts (`check-namespace`, `check-structure`, `check-lint`): clean SKILL.md input produces no output, exit 0.
- `check-lint` against a deliberately invalid SKILL.md: emits the correct `additionalContext` hook JSON; the pre-fix version prints `{}` for the same input.
- Non-SKILL.md input stays silent (no-op path).
- `bun run skill-lint plugins/claude-code/skills/skill` passes; `bun test plugins/claude-code` passes (154 tests).

Original Task: [[discovery] skill-lint hooks never ran](https://things.bendrucker.me/show?id=DB2tfKc4SAUfo9XBKGiNPu)
