### PR TITLE
skills: promote cleye skill as the fast path for CLI scripts

### DIFF
--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -15,7 +15,7 @@ Auto-install does not cover `workspace:*` specifiers. Scripts that import worksp
 
 When writing scripts (hooks, skill CLIs, etc.) that accept arguments:
 
-- **Argument parsing**: Use [cleye](https://github.com/privatenumber/cleye) for type-safe argument parsing with automatic `--help` generation
+- **Argument parsing**: Use [cleye](https://github.com/privatenumber/cleye) for type-safe argument parsing with automatic `--help` generation. Load the `cleye` skill for usage patterns (parameters, flags, subcommands) instead of reading existing scripts.
 - **Table output**: Use the `table` package for formatted terminal table output. Do not use `markdown-table` or similar GFM-oriented packages, script output is displayed in a terminal, not rendered as markdown.
 - **Ancestor paths**: Use `join(import.meta.dirname, "..")` to resolve parent directories. Avoid chaining `dirname()` calls; explicit `".."` is clearer.
 

--- a/.claude/skills/cleye/SKILL.md
+++ b/.claude/skills/cleye/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cleye
-description: Type-safe CLI argument parsing with cleye. Use when writing CLI scripts, adding flags or parameters to Bun scripts, or parsing command-line arguments.
+description: Type-safe CLI argument parsing with cleye, the standard parser for this repo's Bun scripts. Use when writing or editing any script that takes arguments (flags, positional parameters, subcommands, --help) instead of reading existing scripts for the pattern.
 ---
 
 # cleye
@@ -75,27 +75,50 @@ flags: {
 
 Kebab-case flags (`--dry-run`) become camelCase properties (`argv.flags.dryRun`).
 
+## Help Text
+
+Set `help.description` on `cli()` for a summary line above the generated usage block:
+
+```ts
+const argv = cli({
+  name: "scan",
+  parameters: ["<path>"],
+  help: {
+    description: "Scan repository prose for AI writing tropes.",
+  },
+  flags: { ... },
+});
+```
+
 ## Subcommands
 
-Pass to `cli()` via the `commands` array using the `command()` helper:
+Define each subcommand as a named `command()` const with its callback, pass them via the `commands` array, and give the root `cli()` a callback that shows help when no subcommand matches:
 
 ```ts
 import { cli, command } from "cleye";
 
-const argv = cli({
-  name: "tool",
-  commands: [
-    command({ name: "build", flags: { watch: Boolean } }, (argv) => {
-      console.log(argv.flags.watch);
-    }),
-  ],
-});
-```
+const replyCmd = command(
+  {
+    name: "reply",
+    parameters: ["<thread-id>"],
+    flags: {
+      body: { type: String, description: "Reply text" },
+    },
+  },
+  async (parsed) => {
+    console.log(parsed._.threadId, parsed.flags.body);
+  },
+);
 
-For manual dispatch (used in this codebase), pass `args` as the third argument:
-
-```ts
-const argv = cli({ name: "errors", flags: { ... } }, undefined, args);
+cli(
+  {
+    name: "review-threads",
+    commands: [replyCmd],
+  },
+  (parsed) => {
+    parsed.showHelp();
+  },
+);
 ```
 
 ## Conventions


### PR DESCRIPTION
Promotes the `cleye` project skill so it activates when writing CLI scripts, instead of the model rediscovering the patterns by reading existing scripts each time.

## Changes

- Tightened the skill description: triggers on any script that takes arguments and states it replaces reading existing scripts for the pattern
- Replaced the stale manual-dispatch example (`cli({...}, undefined, args)`, no longer present in the codebase) with the subcommand pattern the repo actually uses: named `command()` consts plus a root callback calling `parsed.showHelp()`
- Documented `help.description`, which 3 scripts use but the skill omitted
- Added a pointer to the skill in `.claude/rules/scripts.md`, which auto-injects on `**/*.ts` work

## Testing

- `bun run skill-lint ".claude/skills/cleye"` validates the frontmatter (name format, description length) and body size

Original Task: [[discovery] cleye (modified: keep + promote)](https://things.bendrucker.me/show?id=54pdmNdGWDANGvHkt2sobx)
