### PR TITLE
skills: agent-ideas DMI flip + catalog description trims

### DIFF
--- a/.claude/skills/agent-ideas/SKILL.md
+++ b/.claude/skills/agent-ideas/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: agent-ideas
 description: Harvest agent-tooling ideas from prominent developers.
+disable-model-invocation: true
 allowed-tools:
   - Bash(bun ${CLAUDE_SKILL_DIR}/scripts/fetch.ts:*)
   - Read

--- a/plugins/claude-code/skills/hook/SKILL.md
+++ b/plugins/claude-code/skills/hook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-code:hook
-description: Use this skill when you need to configure, create, or troubleshoot Claude Code hooks. This includes setting up PreToolUse hooks, PostToolUse hooks, UserPromptSubmit hooks, debugging hook failures, or any automation within Claude Code. Examples include "I want to run tests before every file edit", "My hook isn't firing", "1 out of 2 hooks ran", or "How do I create a hook that formats JSON output with jq?"
+description: Configure, create, or troubleshoot Claude Code hooks (PreToolUse, PostToolUse, UserPromptSubmit), debug hook failures, or set up any automation within Claude Code. Examples include "I want to run tests before every file edit", "My hook isn't firing", "1 out of 2 hooks ran", or "How do I create a hook that formats JSON output with jq?"
 allowed-tools:
   - Read
   - Write

--- a/plugins/pull-request/skills/babysit/SKILL.md
+++ b/plugins/pull-request/skills/babysit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pull-request:babysit
 description: |
-  Monitor a PR's CI, fix trivial failures (lint, types, formatting), and self-cancel when green. Use after pushing when you want hands-off CI monitoring with automatic fixes. With --merge, drive the PR all the way to merged (handling merge-train/queue kickouts, rebase issues, and re-runs); with --reviews, hand off to AI-review triage after the first green.
+  Monitor a PR's CI, fix trivial failures (lint, types, formatting), and self-cancel when green. Use after pushing for hands-off CI monitoring. With --merge, drive the PR to merged (handling merge-train/queue kickouts, rebase issues, and re-runs); with --reviews, hand off to AI-review triage after the first green.
 argument-hint: "[--merge] [--reviews]"
 allowed-tools:
   - Monitor

--- a/plugins/pull-request/skills/follow-up/SKILL.md
+++ b/plugins/pull-request/skills/follow-up/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: pull-request:follow-up
 description: >
-  Follow up on review feedback you received on a PR/MR: check resolution state, find silent
-  resolves, draft replies. With --auto, autonomously triage AI-reviewer (bot) threads and loop
-  until the reviewer is satisfied. Use when checking what review comments need responses,
-  investigating how threads were resolved, drafting replies, or clearing a bot review hands-off.
+  Follow up on review feedback you received on a PR/MR: check what review comments need
+  responses, investigate how threads were resolved (including silent resolves), and draft
+  replies. With --auto, autonomously triage AI-reviewer (bot) threads and loop until the
+  reviewer is satisfied, clearing a bot review hands-off.
 argument-hint: "[pr-url] [--auto]"
 allowed-tools:
   - Bash(git:*)


### PR DESCRIPTION
Adds `disable-model-invocation: true` to `agent-ideas` and compresses the three longest auto-invocable skill descriptions. The skill catalog is re-injected into every subagent context, so DMI flips and description trims pay off on every spawn.

## Changes

- `agent-ideas`: it's a deliberate weekly slash workflow (3 slash invocations, 0 model-auto ever), so the description was pure recurring catalog cost. DMI removes it from the catalog entirely.
- `claude-code:hook` (407 → 336 chars): dropped the "Use this skill when you need to" preamble and the repeated "hooks" in the event-type list.
- `pull-request:babysit` (356 → 314): "with automatic fixes" restated the first sentence, and "all the way to" padded "drive the PR to merged".
- `pull-request:follow-up` (365 → 317): the trailing "Use when..." sentence restated the opening list ("draft replies" appeared twice), so I merged the two into one list.

This is compression, not rewriting: every activation trigger and example phrase from the originals survives.

## Testing

- `bun run skill-lint` passes on all four skills (it also caught a YAML break from an `Examples:` colon in a plain scalar, fixed by keeping the original "Examples include" phrasing).
- Scripted check that each trimmed description still contains the original trigger phrases verbatim (case-insensitive): no misses.

Original Task: [[discovery] agent-ideas DMI](https://things.bendrucker.me/show?id=HVgskYMeddsiFE1YTqpNmA)
Original Task: [[discovery] description trims](https://things.bendrucker.me/show?id=4H8HoLXZEQtTFJHYuAPrWK)
