### PR TITLE
plugin-imports: fix workspace-package crash, harden hook

### DIFF
--- a/.claude/hooks/plugin-imports/index.test.ts
+++ b/.claude/hooks/plugin-imports/index.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { StopHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { VIOLATION_EXIT } from "../../../scripts/check-plugin-imports";
+import { processStop } from ".";
+
+let tempDir: string;
+
+beforeAll(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "plugin-imports-hook-"));
+});
+
+afterAll(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+function stopInput(overrides?: Partial<StopHookInput>): StopHookInput {
+  return {
+    hook_event_name: "Stop",
+    session_id: "test",
+    transcript_path: "/dev/null",
+    cwd: tempDir,
+    stop_hook_active: false,
+    permission_mode: "default",
+    ...overrides,
+  };
+}
+
+async function fakeChecker(name: string, source: string): Promise<string> {
+  const path = join(tempDir, name);
+  await Bun.write(path, source);
+  return path;
+}
+
+describe("processStop", () => {
+  it("returns null when the stop hook is already active", async () => {
+    expect(await processStop(stopInput({ stop_hook_active: true }))).toBeNull();
+  });
+
+  it("returns null when the checker passes", async () => {
+    const checker = await fakeChecker("clean.ts", "process.exit(0);");
+    expect(await processStop(stopInput(), checker)).toBeNull();
+  });
+
+  it("blocks with the checker's stderr on the violation exit code", async () => {
+    const checker = await fakeChecker(
+      "violation.ts",
+      `console.error("plugin-a: foo.ts imports outside plugin boundary");
+process.exit(${VIOLATION_EXIT});`,
+    );
+
+    const output = await processStop(stopInput(), checker);
+    expect(output?.decision).toBe("block");
+    expect(output?.reason).toContain("Cross-plugin imports detected");
+    expect(output?.reason).toContain("imports outside plugin boundary");
+  });
+
+  it("reports a non-blocking systemMessage when the checker crashes", async () => {
+    const checker = await fakeChecker(
+      "crash.ts",
+      `throw new Error("Cannot find module '@bendrucker/claude-marketplace'");`,
+    );
+
+    const output = await processStop(stopInput(), checker);
+    expect(output?.decision).toBeUndefined();
+    expect(output?.systemMessage).toContain("checker could not run");
+  });
+
+  it("does not block when the checker script is missing", async () => {
+    const output = await processStop(stopInput(), join(tempDir, "missing.ts"));
+    expect(output?.decision).toBeUndefined();
+    expect(output?.systemMessage).toContain("checker could not run");
+  });
+});

--- a/.claude/hooks/plugin-imports/index.ts
+++ b/.claude/hooks/plugin-imports/index.ts
@@ -1,13 +1,17 @@
 #!/usr/bin/env bun
 
 import { join } from "node:path";
-import type { StopHookInput } from "@anthropic-ai/claude-agent-sdk";
+import type { StopHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
-const input = await readStdinJson<StopHookInput>();
-if (input.hook_event_name !== "Stop" || input.stop_hook_active) process.exit(0);
+// Mirrors VIOLATION_EXIT in scripts/check-plugin-imports.ts. Deliberately a
+// literal rather than an import: importing the checker would pull its module
+// graph into the hook, so a checker that cannot load would crash the hook
+// instead of reaching the non-blocking "checker could not run" path below.
+// The hook's test imports both to keep the values in sync.
+const VIOLATION_EXIT = 2;
 
-const scriptPath = join(
+const CHECKER_PATH = join(
   import.meta.dirname,
   "..",
   "..",
@@ -15,17 +19,46 @@ const scriptPath = join(
   "scripts",
   "check-plugin-imports.ts",
 );
-const proc = Bun.spawn(["bun", scriptPath], {
-  cwd: input.cwd,
-  stdout: "pipe",
-  stderr: "pipe",
-});
 
-const exitCode = await proc.exited;
-if (exitCode === 0) process.exit(0);
+export async function processStop(
+  input: StopHookInput,
+  checkerPath = CHECKER_PATH,
+): Promise<SyncHookJSONOutput | null> {
+  if (input.stop_hook_active) return null;
 
-const stderr = await new Response(proc.stderr).text();
-writeStdoutJson({
-  decision: "block",
-  reason: `Cross-plugin imports detected:\n\n${stderr}\n\nFix these imports before stopping. Plugins must not import from outside their own directory.`,
-});
+  const proc = Bun.spawn(["bun", checkerPath], {
+    cwd: input.cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const exitCode = await proc.exited;
+  if (exitCode === 0) return null;
+
+  const stderr = await new Response(proc.stderr).text();
+
+  if (exitCode === VIOLATION_EXIT) {
+    return {
+      decision: "block",
+      reason: `Cross-plugin imports detected:\n\n${stderr}\n\nFix these imports before stopping. Plugins must not import from outside their own directory.`,
+    };
+  }
+
+  // Any other non-zero exit means the checker itself failed to run (e.g.
+  // module resolution failure). Surface it without blocking the stop.
+  return {
+    systemMessage: `plugin-imports: checker could not run (exit ${exitCode}); skipping cross-plugin import check.\n\n${stderr.trim()}`,
+  };
+}
+
+async function main(): Promise<void> {
+  const input = await readStdinJson<StopHookInput>();
+  if (input.hook_event_name !== "Stop") return;
+
+  const output = await processStop(input);
+  if (output) writeStdoutJson(output);
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -9,7 +9,9 @@ Hooks and scripts use [Bun](https://bun.sh) to run TypeScript. Bun auto-installs
 
 #### Workspace Dependencies
 
-Auto-install does not cover `workspace:*` specifiers. Scripts that import workspace packages (`@bendrucker/*`) need `bun install` first to create the `node_modules` symlinks; without it they fail with `Cannot find module`. The project Worktrunk `post-start` hook (`.config/wt.toml`) runs `bun install` for new worktrees so this resolves automatically.
+Auto-install does not cover `workspace:*` specifiers. Scripts that import workspace packages (`@bendrucker/*`) need `bun install` first to create the `node_modules` symlinks; without it they fail with `Cannot find module`. The project Worktrunk `post-start` hook (`.config/wt.toml`) runs `bun install` for new worktrees so this resolves automatically, but it does not cover `Agent(isolation='worktree')` worktrees, which skip wt hooks.
+
+Repo-internal tooling (`scripts/`, `.claude/hooks/`) must import `packages/` code via relative paths (e.g. `../packages/marketplace/index`) instead of the `@bendrucker/*` specifier, so it runs in fresh worktrees without install. Reserve workspace specifiers for distributed plugin code, which cannot use relative imports across the plugin boundary.
 
 # Script Conventions
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
     "": {
       "name": "@bendrucker/claude",
       "dependencies": {
-        "@bendrucker/claude-marketplace": "workspace:*",
         "typescript": "^5.9.3",
         "url-pattern": "^1.0.3",
       },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "gray-matter": "^4.0.3"
   },
   "dependencies": {
-    "@bendrucker/claude-marketplace": "workspace:*",
     "typescript": "^5.9.3",
     "url-pattern": "^1.0.3"
   },

--- a/scripts/check-enabled-plugins.ts
+++ b/scripts/check-enabled-plugins.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { loadPlugins } from "@bendrucker/claude-marketplace";
+import { loadPlugins } from "../packages/marketplace/index";
 
 const plugins = await loadPlugins();
 const missing = plugins.filter((p) => p.listing && !p.enabled).map((p) => p.name);

--- a/scripts/check-hook-quoting.ts
+++ b/scripts/check-hook-quoting.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { loadPlugins } from "@bendrucker/claude-marketplace";
+import { loadPlugins } from "../packages/marketplace/index";
 
 // Matches an unquoted ${CLAUDE_PLUGIN_ROOT}/... path segment in a command string.
 // The path is unquoted if it is NOT preceded by a double quote.

--- a/scripts/check-marketplace.ts
+++ b/scripts/check-marketplace.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { loadPlugins } from "@bendrucker/claude-marketplace";
+import { loadPlugins } from "../packages/marketplace/index";
 
 const plugins = await loadPlugins();
 const missing = plugins.filter((p) => p.dir && !p.listing?.local).map((p) => p.name);

--- a/scripts/check-mcp-matchers.ts
+++ b/scripts/check-mcp-matchers.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { enabledPluginNames, loadPlugins } from "@bendrucker/claude-marketplace";
+import { enabledPluginNames, loadPlugins } from "../packages/marketplace/index";
 
 const MCP_PATTERN = /^mcp__(?!plugin_)(?!claude_ai_)(\w+)__(.+)$/;
 

--- a/scripts/check-plugin-deps.ts
+++ b/scripts/check-plugin-deps.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env bun
 
 import { join } from "node:path";
-import { loadPlugins } from "@bendrucker/claude-marketplace";
 import { Glob } from "bun";
+import { loadPlugins } from "../packages/marketplace/index";
 
 async function getPluginDeps(pluginDir: string): Promise<Set<string>> {
   const deps = new Set<string>();

--- a/scripts/check-plugin-imports.ts
+++ b/scripts/check-plugin-imports.ts
@@ -1,8 +1,14 @@
 #!/usr/bin/env bun
 
 import { dirname, join, relative, resolve } from "node:path";
-import { loadPlugins } from "@bendrucker/claude-marketplace";
 import { Glob } from "bun";
+import { loadPlugins } from "../packages/marketplace/index";
+
+// Exit codes: 0 clean, VIOLATION_EXIT when cross-plugin imports are found.
+// Anything else (bun exits 1 on uncaught errors) means the checker itself
+// failed to run. The Stop hook in .claude/hooks/plugin-imports relies on this
+// distinction to avoid reporting a crash as a violation.
+export const VIOLATION_EXIT = 2;
 
 const rootDir = join(import.meta.dirname, "..");
 const pluginsDir = join(rootDir, "plugins");
@@ -51,14 +57,20 @@ async function checkPlugin(pluginDir: string): Promise<string[]> {
   return violations;
 }
 
-const pluginDirs = await getPluginDirs();
-const results = await Promise.all(pluginDirs.map(checkPlugin));
-const violations = results.flat();
+async function main(): Promise<void> {
+  const pluginDirs = await getPluginDirs();
+  const results = await Promise.all(pluginDirs.map(checkPlugin));
+  const violations = results.flat();
 
-for (const v of violations) {
-  console.error(v);
+  for (const v of violations) {
+    console.error(v);
+  }
+
+  if (violations.length > 0) {
+    process.exit(VIOLATION_EXIT);
+  }
 }
 
-if (violations.length > 0) {
-  process.exit(1);
+if (import.meta.main) {
+  await main();
 }

--- a/scripts/list-plugins.ts
+++ b/scripts/list-plugins.ts
@@ -1,5 +1,5 @@
 import { parseArgs } from "node:util";
-import { loadPlugins } from "@bendrucker/claude-marketplace";
+import { loadPlugins } from "../packages/marketplace/index";
 
 interface CiConfig {
   runner?: string;


### PR DESCRIPTION
Fixes the `plugin-imports` Stop hook's false blocks at the root. Every block the hook has produced was a checker crash, not a violation: `scripts/check-plugin-imports.ts` imports `@bendrucker/claude-marketplace`, a `workspace:*` package that bun auto-install skips, so any worktree without `node_modules` failed with `Cannot find module` and the hook reported it as "Cross-plugin imports detected".

## Changes

- Switches all repo-internal tooling under `scripts/` to relative imports of `packages/marketplace`, so it runs in fresh worktrees without `bun install`. Distributed plugin code is untouched; plugins still cannot use relative imports across the plugin boundary, and the rule in `.claude/rules/scripts.md` now spells out the split.
- Removes the now-unused `@bendrucker/claude-marketplace` dependency from the root `package.json`.
- The checker exits `VIOLATION_EXIT` (2) when it finds violations. Any other non-zero exit means the checker itself failed to run.
- The hook blocks only on the violation exit. Other failures produce a non-blocking `systemMessage` ("checker could not run") with the checker's stderr instead of a false block.
- I kept `VIOLATION_EXIT` as a literal in the hook rather than importing it from the checker: the import would pull the checker's module graph into the hook, so a checker that cannot load would crash the hook before reaching the non-blocking path. The hook test imports both to keep the values in sync.
- The `wt.toml` `post-start = "bun install"` stays; worktrees still want `node_modules` for tests, and `Agent(isolation='worktree')` worktrees skip wt hooks entirely, which is exactly the path this fix covers.

## Testing

- New hook tests cover the clean checker pass, blocking with the checker's stderr on the violation exit code, and the non-blocking `systemMessage` when the checker crashes or the script is missing.
- Verified from a disposable nested worktree without `node_modules`: the checker runs clean, and synthetic Stop JSON piped through the hook produces no output on the clean path, a `block` decision for a planted cross-plugin import, and a `systemMessage` with a sabotaged marketplace module.
- Type checking, lint, and the marketplace package's own tests cover the import rewrites across the converted scripts.

Original Task: [[discovery] plugin-imports root cause](https://things.bendrucker.me/show?id=QvCyuUrbadTd5htoDwSBDd)
