### PR TITLE
github,gitlab: surface conflicts the CI watchers miss

### DIFF
--- a/plugins/github/skills/actions-monitor/SKILL.md
+++ b/plugins/github/skills/actions-monitor/SKILL.md
@@ -63,13 +63,14 @@ The script emits one JSON object per line on stdout:
 
 - `{"type":"status","state":"running|failing|success","sha":"...","run_id":"..."}`
 - `{"type":"conflicts","sha":"..."}` (PR mode only)
+- `{"type":"mergeable-unknown","sha":"..."}` (PR mode only)
 - `{"type":"queued-timeout","minutes":N}`
 - `{"type":"api-error","consecutive":N}`
 - `{"type":"rate-limited","retry_after":"..."}`
 - `{"type":"pr-closed"}` (PR mode only)
 - `{"type":"max-time-reached","minutes":60}`
 
-`conflicts` and `pr-closed` fire only in PR mode; run-id and branch mode never emit them. The script exits on `status:success`, `pr-closed`, and `max-time-reached`. In run-id mode it also exits on `status:failing`, since a specific run reaches a terminal conclusion and there is no "next run" to wait for. In PR and branch mode, `failing` is not terminal (the user may push a fix or start another run).
+`conflicts`, `mergeable-unknown`, and `pr-closed` fire only in PR mode; run-id and branch mode never emit them. The script exits on `status:success`, `pr-closed`, and `max-time-reached`. In run-id mode it also exits on `status:failing`, since a specific run reaches a terminal conclusion and there is no "next run" to wait for. In PR and branch mode, `failing` is not terminal (the user may push a fix or start another run).
 
 #### React to status:failing
 
@@ -88,6 +89,7 @@ Use the agent's JSON response to report failures to the user. The agent persists
 #### React to other events
 
 - `conflicts` (PR mode): note the conflicting SHA; the caller (e.g. `pull-request:babysit`) decides whether to resolve.
+- `mergeable-unknown` (PR mode): GitHub could not settle mergeability after bounded re-polling. Note the SHA; the caller decides whether to run an authoritative local check.
 - `queued-timeout`: surface to the user that a run has been queued past the threshold.
 - `api-error`: surface repeated CLI failures so the user can intervene.
 - `rate-limited`: back off or stop; retry once the window passes.

--- a/plugins/github/skills/actions-monitor/scripts/watch.test.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.test.ts
@@ -16,8 +16,11 @@ import {
   probePr,
   probeRunId,
   registerApiError,
+  resolveMergeable,
   type WatcherState,
 } from "./watch";
+
+const noopSleep = (): Promise<void> => Promise.resolve();
 
 // Stub `exec` for probe* tests. Each entry maps a substring matcher (anything
 // the gh command line should contain) to a canned result. Tests assert that
@@ -58,6 +61,7 @@ function baseProbe(overrides: Partial<Probe> = {}): Probe {
     state: "running",
     runId: "run-1",
     mergeable: "MERGEABLE",
+    mergeStateStatus: "CLEAN",
     prState: "OPEN",
     ...overrides,
   };
@@ -317,6 +321,81 @@ describe("conflicts", () => {
     const { events } = advance(sequence);
     const conflicts = events.filter((e) => e.type === "conflicts");
     expect(conflicts).toHaveLength(2);
+  });
+
+  it("emits conflicts when mergeStateStatus is DIRTY even if mergeable lags UNKNOWN", () => {
+    const { events } = advance([
+      { probe: baseProbe({ sha: "s1", mergeable: "UNKNOWN", mergeStateStatus: "DIRTY" }) },
+    ]);
+    const conflicts = events.filter((e) => e.type === "conflicts");
+    expect(conflicts).toHaveLength(1);
+    expect(events.some((e) => e.type === "mergeable-unknown")).toBe(false);
+  });
+
+  it("emits both status:success and conflicts in one cycle on a green conflicting probe", () => {
+    const { events } = advance([
+      { probe: baseProbe({ sha: "s1", state: "success", mergeable: "CONFLICTING" }) },
+    ]);
+    expect(events.some((e) => e.type === "status" && e.state === "success")).toBe(true);
+    expect(events.some((e) => e.type === "conflicts" && e.sha === "s1")).toBe(true);
+  });
+});
+
+describe("mergeable-unknown", () => {
+  it("emits mergeable-unknown once per SHA when undetermined", () => {
+    const sequence = [
+      { probe: baseProbe({ sha: "s1", mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" }) },
+      { probe: baseProbe({ sha: "s1", mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" }) },
+    ];
+    const { events } = advance(sequence);
+    const unknowns = events.filter((e) => e.type === "mergeable-unknown");
+    expect(unknowns).toHaveLength(1);
+    expect(unknowns[0]).toMatchObject({ sha: "s1" });
+    expect(events.some((e) => e.type === "conflicts")).toBe(false);
+  });
+
+  it("re-emits mergeable-unknown when the SHA changes", () => {
+    const sequence = [
+      { probe: baseProbe({ sha: "s1", mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" }) },
+      { probe: baseProbe({ sha: "s2", mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" }) },
+    ];
+    const { events } = advance(sequence);
+    expect(events.filter((e) => e.type === "mergeable-unknown")).toHaveLength(2);
+  });
+
+  it("does not emit mergeable-unknown once mergeability resolves to a definite value", () => {
+    const sequence = [
+      { probe: baseProbe({ sha: "s1", mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" }) },
+      { probe: baseProbe({ sha: "s1", mergeable: "MERGEABLE", mergeStateStatus: "CLEAN" }) },
+    ];
+    const { events } = advance(sequence);
+    expect(events.filter((e) => e.type === "mergeable-unknown")).toHaveLength(1);
+  });
+});
+
+describe("resolveMergeable", () => {
+  const mergeJson = (mergeable: string, mergeStateStatus: string): string =>
+    JSON.stringify({ mergeable, mergeStateStatus });
+
+  it("resolves to CONFLICTING once a re-poll returns a definite value", async () => {
+    const { exec, remaining } = makeExec([
+      { match: "gh pr view 42", result: ok(mergeJson("UNKNOWN", "UNKNOWN")) },
+      { match: "gh pr view 42", result: ok(mergeJson("CONFLICTING", "DIRTY")) },
+    ]);
+    const resolved = await resolveMergeable(42, exec, noopSleep);
+    expect(resolved).toEqual({ mergeable: "CONFLICTING", mergeStateStatus: "DIRTY" });
+    expect(remaining()).toEqual([]);
+  });
+
+  it("returns undetermined after exhausting the retry budget", async () => {
+    const scripted = Array.from({ length: 4 }, () => ({
+      match: "gh pr view 42",
+      result: ok(mergeJson("UNKNOWN", "UNKNOWN")),
+    }));
+    const { exec, remaining } = makeExec(scripted);
+    const resolved = await resolveMergeable(42, exec, noopSleep);
+    expect(resolved).toEqual({ mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" });
+    expect(remaining()).toEqual([]);
   });
 });
 

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -8,25 +8,55 @@ import UrlPattern from "url-pattern";
 const DEFAULT_INTERVAL_SECONDS = 180;
 const NO_HISTORY_INTERVAL_SECONDS = 30;
 
+// GitHub computes mergeability asynchronously: right after the base branch
+// advances, `mergeable`/`mergeStateStatus` read UNKNOWN until a background job
+// settles. Re-querying drives that computation, so the watcher re-polls a
+// bounded number of times before deciding the platform is undecided.
+const MERGEABLE_UNKNOWN_RETRIES = 4;
+const MERGEABLE_RECHECK_SECONDS = 5;
+
 export type StatusState = "running" | "failing" | "success";
 export type InternalState = StatusState | "queued";
+
+export type MergeStateStatus =
+  | "BEHIND"
+  | "BLOCKED"
+  | "CLEAN"
+  | "DIRTY"
+  | "DRAFT"
+  | "HAS_HOOKS"
+  | "UNKNOWN"
+  | "UNSTABLE";
 
 export type Probe = {
   sha: string;
   state: InternalState;
   runId: string | null;
   mergeable: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
+  mergeStateStatus: MergeStateStatus;
   prState: "OPEN" | "CLOSED" | "MERGED";
 };
 
 export type Event =
   | { type: "status"; state: StatusState; sha: string; run_id: string | null }
   | { type: "conflicts"; sha: string }
+  | { type: "mergeable-unknown"; sha: string }
   | { type: "queued-timeout"; minutes: number }
   | { type: "api-error"; consecutive: number }
   | { type: "rate-limited"; retry_after: string }
   | { type: "pr-closed" }
   | { type: "max-time-reached"; minutes: number };
+
+// A conflict is definite when either signal says so; mergeability is
+// undetermined while either signal is UNKNOWN. The two probes are
+// belt-and-suspenders: `mergeable` and `mergeStateStatus` can lag each other.
+export function probeIsConflict(probe: Probe): boolean {
+  return probe.mergeable === "CONFLICTING" || probe.mergeStateStatus === "DIRTY";
+}
+
+export function probeIsUndetermined(probe: Probe): boolean {
+  return probe.mergeable === "UNKNOWN" || probe.mergeStateStatus === "UNKNOWN";
+}
 
 export type WatcherState = {
   lastSha: string | null;
@@ -36,6 +66,7 @@ export type WatcherState = {
   apiErrorCount: number;
   apiErrorEmittedAt: number | null;
   emittedConflictsForSha: string | null;
+  mergeableUnknownEmittedForSha: string | null;
 };
 
 export function initialState(): WatcherState {
@@ -47,6 +78,7 @@ export function initialState(): WatcherState {
     apiErrorCount: 0,
     apiErrorEmittedAt: null,
     emittedConflictsForSha: null,
+    mergeableUnknownEmittedForSha: null,
   };
 }
 
@@ -96,9 +128,14 @@ export function deriveEvents(
     };
   }
 
-  if (probe.mergeable === "CONFLICTING" && next.emittedConflictsForSha !== probe.sha) {
-    events.push({ type: "conflicts", sha: probe.sha });
-    next = { ...next, emittedConflictsForSha: probe.sha };
+  if (probeIsConflict(probe)) {
+    if (next.emittedConflictsForSha !== probe.sha) {
+      events.push({ type: "conflicts", sha: probe.sha });
+      next = { ...next, emittedConflictsForSha: probe.sha };
+    }
+  } else if (probeIsUndetermined(probe) && next.mergeableUnknownEmittedForSha !== probe.sha) {
+    events.push({ type: "mergeable-unknown", sha: probe.sha });
+    next = { ...next, mergeableUnknownEmittedForSha: probe.sha };
   }
 
   if (probe.state === "queued") {
@@ -237,6 +274,59 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+export type Mergeability = {
+  mergeable: Probe["mergeable"];
+  mergeStateStatus: MergeStateStatus;
+};
+
+function parseMergeability(stdout: string): Mergeability | null {
+  try {
+    const parsed = JSON.parse(stdout) as Record<string, unknown>;
+    const mergeable =
+      typeof parsed.mergeable === "string" && parsed.mergeable
+        ? (parsed.mergeable as Probe["mergeable"])
+        : "UNKNOWN";
+    const mergeStateStatus =
+      typeof parsed.mergeStateStatus === "string" && parsed.mergeStateStatus
+        ? (parsed.mergeStateStatus as MergeStateStatus)
+        : "UNKNOWN";
+    return { mergeable, mergeStateStatus };
+  } catch {
+    return null;
+  }
+}
+
+function mergeabilityUndetermined(m: Mergeability): boolean {
+  return m.mergeable === "UNKNOWN" || m.mergeStateStatus === "UNKNOWN";
+}
+
+// Re-poll mergeability until GitHub settles it or the retry budget runs out.
+// The act of querying `gh pr view --json mergeable,mergeStateStatus` nudges
+// GitHub's background computation, so repeated reads converge to a definite
+// value. Returns the last value seen; still-undetermined after the cap means
+// the caller should fall back to a local merge dry-run.
+export async function resolveMergeable(
+  prNumber: number,
+  run: ExecFn = exec,
+  sleepFn: (ms: number) => Promise<void> = sleep,
+): Promise<Mergeability> {
+  let current: Mergeability = { mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" };
+  for (let attempt = 0; attempt < MERGEABLE_UNKNOWN_RETRIES; attempt += 1) {
+    const result = run(`gh pr view ${prNumber} --json mergeable,mergeStateStatus`);
+    if (result.ok) {
+      const parsed = parseMergeability(result.stdout);
+      if (parsed) {
+        current = parsed;
+        if (!mergeabilityUndetermined(current)) return current;
+      }
+    }
+    if (attempt < MERGEABLE_UNKNOWN_RETRIES - 1) {
+      await sleepFn(MERGEABLE_RECHECK_SECONDS * 1000);
+    }
+  }
+  return current;
+}
+
 // `gh pr checks --json` exposes a unified `state` (status when in-flight,
 // conclusion when complete) and a normalized `bucket` ("pass" | "fail" |
 // "cancel" | "pending" | "skipping"). It does NOT expose `conclusion`. Use
@@ -288,7 +378,9 @@ export type Probed =
   | { kind: "not-found"; stderr: string };
 
 export function probePr(prNumber: number, run: ExecFn = exec): Probed {
-  const prResult = run(`gh pr view ${prNumber} --json headRefOid,headRefName,state,mergeable`);
+  const prResult = run(
+    `gh pr view ${prNumber} --json headRefOid,headRefName,state,mergeable,mergeStateStatus`,
+  );
   if (!prResult.ok) {
     return {
       kind: "error",
@@ -301,6 +393,7 @@ export function probePr(prNumber: number, run: ExecFn = exec): Probed {
   let branch = "";
   let prState: Probe["prState"] = "OPEN";
   let mergeable: Probe["mergeable"] = "UNKNOWN";
+  let mergeStateStatus: MergeStateStatus = "UNKNOWN";
   try {
     const parsed = JSON.parse(prResult.stdout) as Record<string, unknown>;
     if (typeof parsed.headRefOid === "string") sha = parsed.headRefOid;
@@ -308,6 +401,9 @@ export function probePr(prNumber: number, run: ExecFn = exec): Probed {
     if (typeof parsed.state === "string") prState = parsed.state as Probe["prState"];
     if (typeof parsed.mergeable === "string" && parsed.mergeable) {
       mergeable = parsed.mergeable as Probe["mergeable"];
+    }
+    if (typeof parsed.mergeStateStatus === "string" && parsed.mergeStateStatus) {
+      mergeStateStatus = parsed.mergeStateStatus as MergeStateStatus;
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -360,7 +456,7 @@ export function probePr(prNumber: number, run: ExecFn = exec): Probed {
   return {
     kind: "ok",
     branch,
-    probe: { sha, state, runId, mergeable, prState },
+    probe: { sha, state, runId, mergeable, mergeStateStatus, prState },
   };
 }
 
@@ -380,6 +476,7 @@ function buildRunProbe(run: Record<string, unknown>, fallbackRunId: string | nul
     state: deriveRunListState({ status, conclusion }),
     runId,
     mergeable: "MERGEABLE",
+    mergeStateStatus: "CLEAN",
     prState: "OPEN",
   };
 }
@@ -570,7 +667,18 @@ async function run(options: RunOptions): Promise<void> {
     } else {
       state = clearApiErrors(state);
       if (result.branch) branch = result.branch;
-      const outcome = deriveEvents(result.probe, state, now, options.queuedTimeoutMinutes);
+      // Settle mergeability before deriving events so `conflicts` lands in the
+      // same cycle as a stale `success`, ahead of the terminal return below.
+      let probe = result.probe;
+      if (options.mode === "pr" && prNumber !== null && probeIsUndetermined(probe)) {
+        const resolved = await resolveMergeable(prNumber, exec, sleep);
+        probe = {
+          ...probe,
+          mergeable: resolved.mergeable,
+          mergeStateStatus: resolved.mergeStateStatus,
+        };
+      }
+      const outcome = deriveEvents(probe, state, now, options.queuedTimeoutMinutes);
       state = outcome.state;
       for (const event of outcome.events) emit(event);
 

--- a/plugins/gitlab/skills/ci-monitor/SKILL.md
+++ b/plugins/gitlab/skills/ci-monitor/SKILL.md
@@ -50,13 +50,14 @@ Each line is one of:
 
 - `{"type":"status","state":"running|failing|success","sha":"...","run_id":"..."}`: `run_id` is the GitLab pipeline ID.
 - `{"type":"conflicts","sha":"..."}`: MR reports merge conflicts against the target branch. MR mode only.
+- `{"type":"mergeable-unknown","sha":"..."}`: GitLab could not settle merge status after bounded re-polling. MR mode only.
 - `{"type":"queued-timeout","minutes":N}`: pipeline has been queued longer than the threshold.
 - `{"type":"api-error","consecutive":N}`: consecutive `glab` failures crossed the threshold.
 - `{"type":"rate-limited","retry_after":"..."}`: emitted only when `glab` surfaces structured rate-limit data.
 - `{"type":"pr-closed"}`: MR was merged, closed, or the source branch was deleted. MR mode only. The script exits after emitting.
 - `{"type":"max-time-reached","minutes":60}`: wall-clock cap hit. The script exits after emitting.
 
-In branch and pipeline-id modes, `conflicts` and `pr-closed` are never emitted (there is no MR metadata to derive them from).
+In branch and pipeline-id modes, `conflicts`, `mergeable-unknown`, and `pr-closed` are never emitted (there is no MR metadata to derive them from).
 
 The script exits on `status: success` in every mode. In pipeline-id mode it also exits on `status: failing` (the pipeline is terminal).
 
@@ -75,6 +76,8 @@ Agent(
 Surface the summary to the parent conversation. Do not attempt fixes; `pull-request:babysit` owns that decision.
 
 On `conflicts`, report the SHA with conflicts and stop watching; conflict resolution belongs to the caller.
+
+On `mergeable-unknown`, report the SHA; the caller decides whether to run an authoritative local check.
 
 On `queued-timeout`, `api-error`, or `rate-limited`, surface the event once and keep the monitor running. Consecutive rate-limit or api-error events indicate the monitor should be stopped manually.
 

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
@@ -4,6 +4,8 @@ import {
   computeInterval,
   deriveEvents,
   type Event,
+  type ExecFn,
+  type ExecResult,
   initialState,
   isNotFoundError,
   normalizePipelineStatus,
@@ -11,6 +13,7 @@ import {
   parseMrUrl,
   parseProject,
   registerApiError,
+  resolveMergeStatus,
 } from "./watch";
 
 function makeProbe(overrides: Partial<Probe> = {}): Probe {
@@ -19,10 +22,39 @@ function makeProbe(overrides: Partial<Probe> = {}): Probe {
     state: "running",
     runId: "100",
     hasConflicts: false,
+    mergeStatus: "can_be_merged",
+    detailedMergeStatus: "mergeable",
     mrState: "opened",
     ...overrides,
   };
 }
+
+// Stub `exec` for resolveMergeStatus tests: each entry maps a substring matcher
+// against the glab command line to a canned result, exhausted in order.
+function makeExec(scripted: Array<{ match: string; result: ExecResult }>): {
+  exec: ExecFn;
+  remaining: () => Array<{ match: string; result: ExecResult }>;
+} {
+  const queue = [...scripted];
+  return {
+    exec: (command: string): ExecResult => {
+      const next = queue.shift();
+      if (!next) {
+        throw new Error(`unexpected exec call: ${command}`);
+      }
+      if (!command.includes(next.match)) {
+        throw new Error(
+          `exec call did not match expected substring "${next.match}". got: ${command}`,
+        );
+      }
+      return next.result;
+    },
+    remaining: () => queue,
+  };
+}
+
+const ok = (stdout: string): ExecResult => ({ ok: true, stdout });
+const noopSleep = (): Promise<void> => Promise.resolve();
 
 describe("parseMrUrl", () => {
   it("parses a standard group/project MR URL", () => {
@@ -280,6 +312,76 @@ describe("deriveEvents", () => {
     expect(next.events).toContainEqual({ type: "conflicts", sha: "sha2" });
   });
 
+  it("emits conflicts when detailed_merge_status is conflict even if has_conflicts lags false", () => {
+    const { events } = deriveEvents(
+      makeProbe({ sha: "sha1", hasConflicts: false, detailedMergeStatus: "conflict" }),
+      initialState(),
+      0,
+      15,
+    );
+    expect(events).toContainEqual({ type: "conflicts", sha: "sha1" });
+    expect(events.some((e) => e.type === "mergeable-unknown")).toBe(false);
+  });
+
+  it("emits both status:success and conflicts in one cycle when cannot_be_merged with conflicts", () => {
+    const { events } = deriveEvents(
+      makeProbe({
+        sha: "sha1",
+        state: "success",
+        hasConflicts: true,
+        mergeStatus: "cannot_be_merged",
+      }),
+      initialState(),
+      0,
+      15,
+    );
+    expect(events.some((e) => e.type === "status" && e.state === "success")).toBe(true);
+    expect(events.some((e) => e.type === "conflicts" && e.sha === "sha1")).toBe(true);
+  });
+
+  it("emits mergeable-unknown once per SHA while merge status is unchecked", () => {
+    let state = initialState();
+    const first = deriveEvents(
+      makeProbe({ sha: "sha1", mergeStatus: "unchecked", detailedMergeStatus: "checking" }),
+      state,
+      0,
+      15,
+    );
+    state = first.state;
+    expect(first.events).toContainEqual({ type: "mergeable-unknown", sha: "sha1" });
+    expect(first.events.some((e) => e.type === "conflicts")).toBe(false);
+
+    const second = deriveEvents(
+      makeProbe({ sha: "sha1", mergeStatus: "unchecked", detailedMergeStatus: "checking" }),
+      state,
+      1,
+      15,
+    );
+    expect(second.events.some((e) => e.type === "mergeable-unknown")).toBe(false);
+  });
+
+  it("re-emits mergeable-unknown when the SHA changes", () => {
+    let state = initialState();
+    state = deriveEvents(
+      makeProbe({ sha: "sha1", mergeStatus: "checking", detailedMergeStatus: "checking" }),
+      state,
+      0,
+      15,
+    ).state;
+    const next = deriveEvents(
+      makeProbe({
+        sha: "sha2",
+        mergeStatus: "checking",
+        detailedMergeStatus: "checking",
+        runId: "101",
+      }),
+      state,
+      1,
+      15,
+    );
+    expect(next.events).toContainEqual({ type: "mergeable-unknown", sha: "sha2" });
+  });
+
   it("emits pr-closed when the MR is closed", () => {
     const { events } = deriveEvents(makeProbe({ mrState: "closed" }), initialState(), 0, 15);
     expect(events).toEqual([{ type: "pr-closed" }]);
@@ -473,5 +575,47 @@ describe("deriveEvents in pipeline-id mode", () => {
       15,
     );
     expect(events).toEqual([{ type: "status", state: "failing", sha: "sha1", run_id: "9001" }]);
+  });
+});
+
+describe("resolveMergeStatus", () => {
+  const mrJson = (fields: Record<string, unknown>): string => JSON.stringify(fields);
+
+  it("resolves to a conflict once a re-poll settles merge status", async () => {
+    const { exec, remaining } = makeExec([
+      { match: "merge_requests/7", result: ok(mrJson({ merge_status: "checking" })) },
+      {
+        match: "merge_requests/7",
+        result: ok(
+          mrJson({
+            merge_status: "cannot_be_merged",
+            detailed_merge_status: "conflict",
+            has_conflicts: true,
+          }),
+        ),
+      },
+    ]);
+    const resolved = await resolveMergeStatus("group%2Fproject", 7, exec, noopSleep);
+    expect(resolved).toEqual({
+      hasConflicts: true,
+      mergeStatus: "cannot_be_merged",
+      detailedMergeStatus: "conflict",
+    });
+    expect(remaining()).toEqual([]);
+  });
+
+  it("returns undetermined after exhausting the retry budget", async () => {
+    const scripted = Array.from({ length: 4 }, () => ({
+      match: "merge_requests/7",
+      result: ok(mrJson({ merge_status: "unchecked", detailed_merge_status: "checking" })),
+    }));
+    const { exec, remaining } = makeExec(scripted);
+    const resolved = await resolveMergeStatus("group%2Fproject", 7, exec, noopSleep);
+    expect(resolved).toEqual({
+      hasConflicts: false,
+      mergeStatus: "unchecked",
+      detailedMergeStatus: "checking",
+    });
+    expect(remaining()).toEqual([]);
   });
 });

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
@@ -8,6 +8,13 @@ import UrlPattern from "url-pattern";
 const DEFAULT_INTERVAL_SECONDS = 180;
 const NO_HISTORY_INTERVAL_SECONDS = 30;
 
+// GitLab computes mergeability asynchronously: `has_conflicts` is only valid
+// once `merge_status` settles. While `unchecked`/`checking`, conflicts read as
+// false. Re-querying the MR drives that computation, so the watcher re-polls a
+// bounded number of times before deciding the platform is undecided.
+const MERGE_STATUS_UNKNOWN_RETRIES = 4;
+const MERGE_STATUS_RECHECK_SECONDS = 5;
+
 export type StatusState = "running" | "failing" | "success";
 export type InternalState = StatusState | "queued";
 export type MrState = "opened" | "closed" | "merged" | "locked";
@@ -17,17 +24,42 @@ export type Probe = {
   state: InternalState;
   runId: string | null;
   hasConflicts: boolean;
+  mergeStatus: string;
+  detailedMergeStatus: string;
   mrState: MrState;
 };
 
 export type Event =
   | { type: "status"; state: StatusState; sha: string; run_id: string | null }
   | { type: "conflicts"; sha: string }
+  | { type: "mergeable-unknown"; sha: string }
   | { type: "queued-timeout"; minutes: number }
   | { type: "api-error"; consecutive: number }
   | { type: "rate-limited"; retry_after: string }
   | { type: "pr-closed" }
   | { type: "max-time-reached"; minutes: number };
+
+// `has_conflicts` is GitLab's authoritative conflict flag; `detailed_merge_status`
+// reads "conflict" for the same condition and can lead the flag, so checking both
+// is belt-and-suspenders. Mergeability is undetermined while merge status is still
+// being computed (`unchecked`/`checking`/`preparing`).
+function isUndeterminedMergeStatus(mergeStatus: string, detailedMergeStatus: string): boolean {
+  return (
+    mergeStatus === "unchecked" ||
+    mergeStatus === "checking" ||
+    detailedMergeStatus === "checking" ||
+    detailedMergeStatus === "unchecked" ||
+    detailedMergeStatus === "preparing"
+  );
+}
+
+export function probeIsConflict(probe: Probe): boolean {
+  return probe.hasConflicts || probe.detailedMergeStatus === "conflict";
+}
+
+export function probeIsUndetermined(probe: Probe): boolean {
+  return isUndeterminedMergeStatus(probe.mergeStatus, probe.detailedMergeStatus);
+}
 
 export type WatcherState = {
   lastSha: string | null;
@@ -37,6 +69,7 @@ export type WatcherState = {
   apiErrorCount: number;
   apiErrorEmittedAt: number | null;
   emittedConflictsForSha: string | null;
+  mergeableUnknownEmittedForSha: string | null;
 };
 
 export function initialState(): WatcherState {
@@ -48,6 +81,7 @@ export function initialState(): WatcherState {
     apiErrorCount: 0,
     apiErrorEmittedAt: null,
     emittedConflictsForSha: null,
+    mergeableUnknownEmittedForSha: null,
   };
 }
 
@@ -97,9 +131,14 @@ export function deriveEvents(
     };
   }
 
-  if (probe.hasConflicts && next.emittedConflictsForSha !== probe.sha) {
-    events.push({ type: "conflicts", sha: probe.sha });
-    next = { ...next, emittedConflictsForSha: probe.sha };
+  if (probeIsConflict(probe)) {
+    if (next.emittedConflictsForSha !== probe.sha) {
+      events.push({ type: "conflicts", sha: probe.sha });
+      next = { ...next, emittedConflictsForSha: probe.sha };
+    }
+  } else if (probeIsUndetermined(probe) && next.mergeableUnknownEmittedForSha !== probe.sha) {
+    events.push({ type: "mergeable-unknown", sha: probe.sha });
+    next = { ...next, mergeableUnknownEmittedForSha: probe.sha };
   }
 
   if (probe.state === "queued") {
@@ -231,9 +270,11 @@ const execOptions: ExecSyncOptions = {
   stdio: ["pipe", "pipe", "pipe"],
 };
 
-type ExecResult =
+export type ExecResult =
   | { ok: true; stdout: string }
   | { ok: false; stderr: string; rateLimited: boolean; retryAfter: string };
+
+export type ExecFn = (command: string) => ExecResult;
 
 function exec(command: string): ExecResult {
   try {
@@ -267,6 +308,8 @@ type MrMetadata = {
   sha: string;
   sourceBranch: string;
   hasConflicts: boolean;
+  mergeStatus: string;
+  detailedMergeStatus: string;
   state: MrState;
 };
 
@@ -274,8 +317,12 @@ type MrMetadataResult =
   | { ok: true; metadata: MrMetadata }
   | { ok: false; rateLimited: boolean; retryAfter: string };
 
-function fetchMrMetadata(projectEncoded: string, iid: number): MrMetadataResult {
-  const result = exec(`glab api projects/${projectEncoded}/merge_requests/${iid}`);
+function fetchMrMetadata(
+  projectEncoded: string,
+  iid: number,
+  run: ExecFn = exec,
+): MrMetadataResult {
+  const result = run(`glab api projects/${projectEncoded}/merge_requests/${iid}`);
   if (!result.ok) {
     return { ok: false, rateLimited: result.rateLimited, retryAfter: result.retryAfter };
   }
@@ -284,10 +331,13 @@ function fetchMrMetadata(projectEncoded: string, iid: number): MrMetadataResult 
     const sha = typeof parsed.sha === "string" ? parsed.sha : "";
     const sourceBranch = typeof parsed.source_branch === "string" ? parsed.source_branch : "";
     const hasConflicts = parsed.has_conflicts === true;
+    const mergeStatus = typeof parsed.merge_status === "string" ? parsed.merge_status : "";
+    const detailedMergeStatus =
+      typeof parsed.detailed_merge_status === "string" ? parsed.detailed_merge_status : "";
     const state = (typeof parsed.state === "string" ? parsed.state : "opened") as MrState;
     return {
       ok: true,
-      metadata: { sha, sourceBranch, hasConflicts, state },
+      metadata: { sha, sourceBranch, hasConflicts, mergeStatus, detailedMergeStatus, state },
     };
   } catch (err) {
     console.error(
@@ -295,6 +345,47 @@ function fetchMrMetadata(projectEncoded: string, iid: number): MrMetadataResult 
     );
     return { ok: false, rateLimited: false, retryAfter: "" };
   }
+}
+
+export type MergeStatus = {
+  hasConflicts: boolean;
+  mergeStatus: string;
+  detailedMergeStatus: string;
+};
+
+// Re-poll the MR until GitLab settles its merge status or the retry budget runs
+// out. The act of querying nudges GitLab's background computation, so repeated
+// reads converge to a definite value. Returns the last value seen; still
+// undetermined after the cap means the caller should fall back to a local merge
+// dry-run.
+export async function resolveMergeStatus(
+  projectEncoded: string,
+  iid: number,
+  run: ExecFn = exec,
+  sleepFn: (ms: number) => Promise<void> = sleep,
+): Promise<MergeStatus> {
+  let current: MergeStatus = {
+    hasConflicts: false,
+    mergeStatus: "unchecked",
+    detailedMergeStatus: "",
+  };
+  for (let attempt = 0; attempt < MERGE_STATUS_UNKNOWN_RETRIES; attempt += 1) {
+    const result = fetchMrMetadata(projectEncoded, iid, run);
+    if (result.ok) {
+      current = {
+        hasConflicts: result.metadata.hasConflicts,
+        mergeStatus: result.metadata.mergeStatus,
+        detailedMergeStatus: result.metadata.detailedMergeStatus,
+      };
+      if (!isUndeterminedMergeStatus(current.mergeStatus, current.detailedMergeStatus)) {
+        return current;
+      }
+    }
+    if (attempt < MERGE_STATUS_UNKNOWN_RETRIES - 1) {
+      await sleepFn(MERGE_STATUS_RECHECK_SECONDS * 1000);
+    }
+  }
+  return current;
 }
 
 type PipelineSummary = { id: string; status: InternalState; sha: string } | null;
@@ -365,6 +456,8 @@ function probeMr(projectEncoded: string, iid: number, cachedBranch: string | nul
       state: pipelineState,
       runId,
       hasConflicts: mr.metadata.hasConflicts,
+      mergeStatus: mr.metadata.mergeStatus,
+      detailedMergeStatus: mr.metadata.detailedMergeStatus,
       mrState: mr.metadata.state,
     },
   };
@@ -429,6 +522,8 @@ function probePipelineId(projectEncoded: string, pipelineId: string): ProbedById
       state: pipeline.pipeline.status,
       runId: pipeline.pipeline.id,
       hasConflicts: false,
+      mergeStatus: "",
+      detailedMergeStatus: "",
       mrState: "opened",
     },
   };
@@ -448,6 +543,8 @@ function probeBranch(projectEncoded: string, branch: string): Probed {
       state: p?.status ?? "running",
       runId: p?.id ?? null,
       hasConflicts: false,
+      mergeStatus: "",
+      detailedMergeStatus: "",
       mrState: "opened",
     },
   };
@@ -587,7 +684,19 @@ async function run(options: RunOptions): Promise<void> {
     } else {
       state = clearApiErrors(state);
       if (result.sourceBranch) branch = result.sourceBranch;
-      const outcome = deriveEvents(result.probe, state, now, options.queuedTimeoutMinutes);
+      // Settle merge status before deriving events so `conflicts` lands in the
+      // same cycle as a stale `success`, ahead of the terminal return below.
+      let probe = result.probe;
+      if (target.mode === "mr" && iid !== null && probeIsUndetermined(probe)) {
+        const resolved = await resolveMergeStatus(projectEncoded, iid, exec, sleep);
+        probe = {
+          ...probe,
+          hasConflicts: resolved.hasConflicts,
+          mergeStatus: resolved.mergeStatus,
+          detailedMergeStatus: resolved.detailedMergeStatus,
+        };
+      }
+      const outcome = deriveEvents(probe, state, now, options.queuedTimeoutMinutes);
       state = outcome.state;
       for (const event of outcome.events) emit(event);
       if (isTerminal(outcome.events, target.mode)) return;

--- a/plugins/pull-request/skills/babysit/SKILL.md
+++ b/plugins/pull-request/skills/babysit/SKILL.md
@@ -58,6 +58,8 @@ For non-trivial failures (logic bugs, design issues, flaky tests, environment-de
 
 #### status: success
 
+Green on a conflicting PR is stale: if a `conflicts` or unresolved `mergeable-unknown` event arrived for the current SHA, address it (per [conflicts](#conflicts) or [mergeable-unknown](#mergeable-unknown)) before treating green as done.
+
 Summarize the session: run `git log ${start-sha}..HEAD --oneline` for the commits pushed while babysitting.
 
 Then branch on the flags parsed from `$ARGUMENTS`:
@@ -79,6 +81,19 @@ git merge --abort
 If the conflicting paths are only lockfiles (`bun.lock`, etc.) or generated files, regenerate per project convention (e.g. `rm bun.lock && bun install`), commit the result, and push. The watcher picks up the new SHA.
 
 Otherwise, report the conflicting file list and call `TaskStop`. Do not invoke `gh` or `glab` here; git alone is enough.
+
+#### mergeable-unknown
+
+The platform could not determine mergeability after its own bounded re-polling, so run the authoritative local check with the same dry-run as [conflicts](#conflicts):
+
+```
+git fetch origin <base>
+git merge origin/<base> --no-commit --no-ff
+git diff --name-only --diff-filter=U
+git merge --abort
+```
+
+If the dry-run surfaces conflicting paths, route them through the [conflicts](#conflicts) logic (lockfiles or generated files → regenerate, commit, push; source → report and `TaskStop`). If the merge is clean, report that the PR is mergeable and keep watching.
 
 #### queued-timeout
 


### PR DESCRIPTION
Settles PR mergeability to a definite value before deriving CI events, so a `conflicts` signal fires in the same poll cycle as a stale `success` instead of being delayed or dropped.

## Issue

The babysit watcher only emitted `conflicts` when `mergeable === "CONFLICTING"`. GitHub computes mergeability asynchronously: right after the base branch advances, `gh pr view --json mergeable` returns `"UNKNOWN"` until a background job settles. The watcher treated `UNKNOWN` as fine, slept a full poll interval, and often exited first on a stale `status: success`, so a PR that could not merge kept reporting green. GitLab had the same blind spot: `has_conflicts` is only valid once `merge_status` leaves `unchecked`/`checking`.

In the observed case (#735) the user had to tell babysit "it's got conflicts"; the watcher never surfaced it.

## Changes

- **GitHub watcher**: probes `mergeStateStatus` alongside `mergeable`. Conflict is `CONFLICTING || DIRTY`; undetermined is either field `UNKNOWN`. A new `resolveMergeable` helper re-polls up to 4 times (5s apart) before deriving events; querying GitHub itself drives the computation. A probe still undetermined after the cap emits a new `mergeable-unknown` event.
- **GitLab watcher**: mirrors the above with `merge_status`/`detailed_merge_status` and a `resolveMergeStatus` helper.
- **babysit**: adds a `mergeable-unknown` handler that runs a local `git merge --no-commit --no-ff` dry-run as the authoritative check, routing any conflicts into the existing handler. `status: success` now treats green on a conflicting SHA as stale.

## Testing

Unit tests cover undetermined probes emitting `mergeable-unknown` once per SHA, `DIRTY`/`cannot_be_merged` emitting `conflicts`, a probe that is both `success` and conflicting emitting both events in one cycle, and the resolve helpers converging or returning undetermined after the cap.

Live smoke test against #736 (`mergeable: CONFLICTING`) emitted `status:success` immediately followed by `conflicts` for the same SHA.
