### PR TITLE
pull-request: route babysit merge-wait through the CI watcher

### DIFF
--- a/plugins/github/skills/actions-monitor/SKILL.md
+++ b/plugins/github/skills/actions-monitor/SKILL.md
@@ -68,9 +68,10 @@ The script emits one JSON object per line on stdout:
 - `{"type":"api-error","consecutive":N}`
 - `{"type":"rate-limited","retry_after":"..."}`
 - `{"type":"pr-closed"}` (PR mode only)
+- `{"type":"merged"}` (PR mode only)
 - `{"type":"max-time-reached","minutes":60}`
 
-`conflicts`, `mergeable-unknown`, and `pr-closed` fire only in PR mode; run-id and branch mode never emit them. The script exits on `status:success`, `pr-closed`, and `max-time-reached`. In run-id mode it also exits on `status:failing`, since a specific run reaches a terminal conclusion and there is no "next run" to wait for. In PR and branch mode, `failing` is not terminal (the user may push a fix or start another run).
+`conflicts`, `mergeable-unknown`, `pr-closed`, and `merged` fire only in PR mode; run-id and branch mode never emit them. `merged` and `pr-closed` are distinct terminal events: `merged` means the PR landed, `pr-closed` means it closed without merging. The script exits on `status:success`, `pr-closed`, `merged`, and `max-time-reached`. In run-id mode it also exits on `status:failing`, since a specific run reaches a terminal conclusion and there is no "next run" to wait for. In PR and branch mode, `failing` is not terminal (the user may push a fix or start another run).
 
 #### React to status:failing
 
@@ -93,7 +94,8 @@ Use the agent's JSON response to report failures to the user. The agent persists
 - `queued-timeout`: surface to the user that a run has been queued past the threshold.
 - `api-error`: surface repeated CLI failures so the user can intervene.
 - `rate-limited`: back off or stop; retry once the window passes.
-- `pr-closed` (PR mode): the PR was merged, closed, or the branch was deleted. The script exits on its own.
+- `merged` (PR mode): the PR landed. The script exits on its own.
+- `pr-closed` (PR mode): the PR closed without merging, or the branch was deleted. The script exits on its own.
 - `max-time-reached`: the wall-clock cap fired. The script exits on its own.
 
 #### Initial-green case
@@ -102,7 +104,7 @@ No separate path. If the target is already green at startup, the script emits a 
 
 #### Stopping
 
-The monitor exits naturally on `status:success`, `pr-closed` (PR mode), `status:failing` (run-id mode only), or `max-time-reached`. To stop early, call `TaskStop` on the monitor task.
+The monitor exits naturally on `status:success`, `merged` or `pr-closed` (PR mode), `status:failing` (run-id mode only), or `max-time-reached`. To stop early, call `TaskStop` on the monitor task.
 
 ## References
 

--- a/plugins/github/skills/actions-monitor/scripts/watch.test.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.test.ts
@@ -399,43 +399,58 @@ describe("resolveMergeable", () => {
   });
 });
 
-describe("pr-closed", () => {
-  it("emits pr-closed for MERGED state", () => {
+describe("merged", () => {
+  it("emits merged (not pr-closed) for MERGED state", () => {
     const { events } = advance([{ probe: baseProbe({ prState: "MERGED" }) }]);
-    expect(events.find((e) => e.type === "pr-closed")).toBeDefined();
+    expect(events.find((e) => e.type === "merged")).toBeDefined();
+    expect(events.find((e) => e.type === "pr-closed")).toBeUndefined();
   });
 
-  it("emits pr-closed for CLOSED state", () => {
-    const { events } = advance([{ probe: baseProbe({ prState: "CLOSED" }) }]);
-    expect(events.find((e) => e.type === "pr-closed")).toBeDefined();
-  });
-
-  it("emits status:success before pr-closed when merged with success checks and lastState not success", () => {
+  it("emits status:success before merged when merged with success checks and lastState not success", () => {
     const { events } = advance([
       { probe: baseProbe({ prState: "MERGED", state: "success", sha: "s1" }) },
+    ]);
+    const statusIdx = events.findIndex((e) => e.type === "status");
+    const mergedIdx = events.findIndex((e) => e.type === "merged");
+    expect(statusIdx).toBeGreaterThanOrEqual(0);
+    expect(events[statusIdx]).toMatchObject({ type: "status", state: "success", sha: "s1" });
+    expect(mergedIdx).toBeGreaterThan(statusIdx);
+  });
+
+  it("emits only merged when merged with success checks and lastState already success", () => {
+    const initial: WatcherState = { ...initialState(), lastState: "success", lastSha: "s1" };
+    const { events } = advance(
+      [{ probe: baseProbe({ prState: "MERGED", state: "success", sha: "s1" }) }],
+      { initial },
+    );
+    expect(events).toEqual([{ type: "merged" }]);
+  });
+
+  it("emits only merged when merged with failing checks (no false success)", () => {
+    const { events } = advance([
+      { probe: baseProbe({ prState: "MERGED", state: "failing", sha: "s1" }) },
+    ]);
+    expect(events.find((e) => e.type === "status")).toBeUndefined();
+    expect(events.find((e) => e.type === "merged")).toBeDefined();
+  });
+});
+
+describe("pr-closed", () => {
+  it("emits pr-closed (not merged) for CLOSED state", () => {
+    const { events } = advance([{ probe: baseProbe({ prState: "CLOSED" }) }]);
+    expect(events.find((e) => e.type === "pr-closed")).toBeDefined();
+    expect(events.find((e) => e.type === "merged")).toBeUndefined();
+  });
+
+  it("emits status:success before pr-closed when closed with success checks and lastState not success", () => {
+    const { events } = advance([
+      { probe: baseProbe({ prState: "CLOSED", state: "success", sha: "s1" }) },
     ]);
     const statusIdx = events.findIndex((e) => e.type === "status");
     const closedIdx = events.findIndex((e) => e.type === "pr-closed");
     expect(statusIdx).toBeGreaterThanOrEqual(0);
     expect(events[statusIdx]).toMatchObject({ type: "status", state: "success", sha: "s1" });
     expect(closedIdx).toBeGreaterThan(statusIdx);
-  });
-
-  it("emits only pr-closed when merged with success checks and lastState already success", () => {
-    const initial: WatcherState = { ...initialState(), lastState: "success", lastSha: "s1" };
-    const { events } = advance(
-      [{ probe: baseProbe({ prState: "MERGED", state: "success", sha: "s1" }) }],
-      { initial },
-    );
-    expect(events).toEqual([{ type: "pr-closed" }]);
-  });
-
-  it("emits only pr-closed when merged with failing checks (no false success)", () => {
-    const { events } = advance([
-      { probe: baseProbe({ prState: "MERGED", state: "failing", sha: "s1" }) },
-    ]);
-    expect(events.find((e) => e.type === "status")).toBeUndefined();
-    expect(events.find((e) => e.type === "pr-closed")).toBeDefined();
   });
 });
 

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -45,6 +45,7 @@ export type Event =
   | { type: "api-error"; consecutive: number }
   | { type: "rate-limited"; retry_after: string }
   | { type: "pr-closed" }
+  | { type: "merged" }
   | { type: "max-time-reached"; minutes: number };
 
 // A conflict is definite when either signal says so; mergeability is
@@ -106,7 +107,7 @@ export function deriveEvents(
       });
       next = { ...next, lastSha: probe.sha, lastState: "success" };
     }
-    events.push({ type: "pr-closed" });
+    events.push(probe.prState === "MERGED" ? { type: "merged" } : { type: "pr-closed" });
     return { events, state: next };
   }
 
@@ -689,6 +690,7 @@ async function run(options: RunOptions): Promise<void> {
       const terminal = outcome.events.find(
         (e) =>
           e.type === "pr-closed" ||
+          e.type === "merged" ||
           (e.type === "status" && e.state === "success") ||
           (options.mode === "run-id" && e.type === "status" && e.state === "failing"),
       );

--- a/plugins/gitlab/skills/ci-monitor/SKILL.md
+++ b/plugins/gitlab/skills/ci-monitor/SKILL.md
@@ -54,10 +54,11 @@ Each line is one of:
 - `{"type":"queued-timeout","minutes":N}`: pipeline has been queued longer than the threshold.
 - `{"type":"api-error","consecutive":N}`: consecutive `glab` failures crossed the threshold.
 - `{"type":"rate-limited","retry_after":"..."}`: emitted only when `glab` surfaces structured rate-limit data.
-- `{"type":"pr-closed"}`: MR was merged, closed, or the source branch was deleted. MR mode only. The script exits after emitting.
+- `{"type":"pr-closed"}`: MR closed without merging, or the source branch was deleted. MR mode only. The script exits after emitting.
+- `{"type":"merged"}`: MR merged. MR mode only. The script exits after emitting.
 - `{"type":"max-time-reached","minutes":60}`: wall-clock cap hit. The script exits after emitting.
 
-In branch and pipeline-id modes, `conflicts`, `mergeable-unknown`, and `pr-closed` are never emitted (there is no MR metadata to derive them from).
+In branch and pipeline-id modes, `conflicts`, `mergeable-unknown`, `pr-closed`, and `merged` are never emitted (there is no MR metadata to derive them from). `merged` and `pr-closed` are distinct terminal events: `merged` means the MR landed, `pr-closed` means it closed without merging.
 
 The script exits on `status: success` in every mode. In pipeline-id mode it also exits on `status: failing` (the pipeline is terminal).
 
@@ -81,11 +82,11 @@ On `mergeable-unknown`, report the SHA; the caller decides whether to run an aut
 
 On `queued-timeout`, `api-error`, or `rate-limited`, surface the event once and keep the monitor running. Consecutive rate-limit or api-error events indicate the monitor should be stopped manually.
 
-On `pr-closed` or `max-time-reached`, the monitor has already exited. Report and finish.
+On `merged`, `pr-closed`, or `max-time-reached`, the monitor has already exited. Report and finish.
 
 #### Stopping
 
-The monitor exits on its own for `status: success`, `pr-closed`, and `max-time-reached`. In pipeline-id mode it also exits on `status: failing`. To stop earlier (for example after surfacing a failure summary to the user), call `TaskStop` on the monitor task.
+The monitor exits on its own for `status: success`, `merged`, `pr-closed`, and `max-time-reached`. In pipeline-id mode it also exits on `status: failing`. To stop earlier (for example after surfacing a failure summary to the user), call `TaskStop` on the monitor task.
 
 ## Reference
 

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
@@ -382,12 +382,12 @@ describe("deriveEvents", () => {
     expect(next.events).toContainEqual({ type: "mergeable-unknown", sha: "sha2" });
   });
 
-  it("emits pr-closed when the MR is closed", () => {
+  it("emits pr-closed (not merged) when the MR is closed", () => {
     const { events } = deriveEvents(makeProbe({ mrState: "closed" }), initialState(), 0, 15);
     expect(events).toEqual([{ type: "pr-closed" }]);
   });
 
-  it("emits pr-closed when the MR is merged (lastState already success)", () => {
+  it("emits merged (not pr-closed) when the MR is merged (lastState already success)", () => {
     const initial = { ...initialState(), lastState: "success" as const, lastSha: "sha1" };
     const { events } = deriveEvents(
       makeProbe({ mrState: "merged", state: "success" }),
@@ -395,10 +395,10 @@ describe("deriveEvents", () => {
       0,
       15,
     );
-    expect(events).toEqual([{ type: "pr-closed" }]);
+    expect(events).toEqual([{ type: "merged" }]);
   });
 
-  it("emits status:success before pr-closed when merged and lastState not success", () => {
+  it("emits status:success before merged when merged and lastState not success", () => {
     const { events } = deriveEvents(
       makeProbe({ mrState: "merged", state: "success", sha: "sha1", runId: "100" }),
       initialState(),
@@ -406,7 +406,7 @@ describe("deriveEvents", () => {
       15,
     );
     const statusIdx = events.findIndex((e) => e.type === "status");
-    const closedIdx = events.findIndex((e) => e.type === "pr-closed");
+    const mergedIdx = events.findIndex((e) => e.type === "merged");
     expect(statusIdx).toBeGreaterThanOrEqual(0);
     expect(events[statusIdx]).toEqual({
       type: "status",
@@ -414,10 +414,10 @@ describe("deriveEvents", () => {
       sha: "sha1",
       run_id: "100",
     });
-    expect(closedIdx).toBeGreaterThan(statusIdx);
+    expect(mergedIdx).toBeGreaterThan(statusIdx);
   });
 
-  it("emits only pr-closed when merged with failing checks (no false success)", () => {
+  it("emits only merged when merged with failing checks (no false success)", () => {
     const { events } = deriveEvents(
       makeProbe({ mrState: "merged", state: "failing" }),
       initialState(),
@@ -425,7 +425,7 @@ describe("deriveEvents", () => {
       15,
     );
     expect(events.find((e) => e.type === "status")).toBeUndefined();
-    expect(events.find((e) => e.type === "pr-closed")).toBeDefined();
+    expect(events.find((e) => e.type === "merged")).toBeDefined();
   });
 });
 

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
@@ -37,6 +37,7 @@ export type Event =
   | { type: "api-error"; consecutive: number }
   | { type: "rate-limited"; retry_after: string }
   | { type: "pr-closed" }
+  | { type: "merged" }
   | { type: "max-time-reached"; minutes: number };
 
 // `has_conflicts` is GitLab's authoritative conflict flag; `detailed_merge_status`
@@ -109,7 +110,7 @@ export function deriveEvents(
       });
       next = { ...next, lastSha: probe.sha, lastState: "success" };
     }
-    events.push({ type: "pr-closed" });
+    events.push(probe.mrState === "merged" ? { type: "merged" } : { type: "pr-closed" });
     return { events, state: next };
   }
 
@@ -610,6 +611,7 @@ function isTerminal(events: Event[], mode: RunTarget["mode"]): boolean {
   return events.some(
     (e) =>
       e.type === "pr-closed" ||
+      e.type === "merged" ||
       (e.type === "status" && e.state === "success") ||
       (mode === "pipeline-id" && e.type === "status" && e.state === "failing"),
   );

--- a/plugins/pull-request/skills/babysit/SKILL.md
+++ b/plugins/pull-request/skills/babysit/SKILL.md
@@ -39,7 +39,7 @@ Parse `$ARGUMENTS` for two optional flags, both off by default so plain babysit 
 
 ## Bounds
 
-One babysit invocation owns at most one watcher generation. The watcher enforces the wall clock (`--max-minutes`, default 60), poll interval, and dedup, so pass `--max-minutes` through when the user supplies one. After `max-time-reached` the watcher has exited: report and stop, never re-arm a fresh watcher. If babysit runs under `/loop`, the loop owns repetition, not babysit.
+Every wait babysit performs runs through a watcher, including the post-submit merge wait ([Merge Mode](#merge-mode)); babysit has no poll loop of its own. The watcher enforces the wall clock (`--max-minutes`, default 60), poll interval, and dedup, so pass `--max-minutes` through when the user supplies one. After a watcher emits `max-time-reached` it has exited: report and stop, never re-arm a fresh watcher. If babysit runs under `/loop`, the loop owns repetition, not babysit.
 
 ## Event Handlers
 
@@ -112,7 +112,11 @@ Report `retry_after` and wait. The watcher resumes polling once the window elaps
 
 #### pr-closed
 
-Report and stop. The watcher has already exited.
+The PR closed without merging, or its source branch no longer exists. Report and stop. The watcher has already exited.
+
+#### merged
+
+The PR landed. In [Merge Mode](#merge-mode) this is the success terminal: report the merge and the work done since the start SHA, then stop. The watcher has already exited.
 
 #### max-time-reached
 
@@ -138,7 +142,15 @@ Submit by the most automated path the repo allows (merge queue/train, else auto-
 - **GitHub**: `gh pr merge <pr-url> --auto --squash` enables auto-merge or queues the PR. If `--auto` is rejected, merge directly: `gh pr merge <pr-url> --squash`. Prefer squash → merge → rebase per `gh repo view --json squashMergeAllowed,mergeCommitAllowed,rebaseMergeAllowed`.
 - **GitLab**: delegate to the `gitlab:merge-request` skill.
 
-Then poll until it merges or is kicked out. This is babysit's only self-driven loop, so poll no faster than 60s and honor the 60-minute wall clock. On a kickout, diagnose and re-submit: a rebase/merge conflict routes through the [conflicts](#conflicts) handler, a CI failure through [status: failing](#status-failing) (each produces a new SHA). Stop on: merged (success); 3 submit attempts (re-submits included, an oscillation guard); the 60-minute wall clock; an unrecoverable block (missing human approval, non-trivial CI failure, non-lockfile conflict, permissions); or PR closed.
+Then watch the merge through the monitor rather than polling by hand: invoke the provider's monitor skill again on the PR and react to its events. The watcher enforces the interval and the wall clock, so this phase stays bounded like the CI wait (see [Bounds](#bounds)) and babysit owns no loop here. React to:
+
+- `merged`: the PR landed. Report success and `TaskStop`.
+- `conflicts`: route through the [conflicts](#conflicts) handler, then re-submit. Counts as a submit attempt.
+- `status: failing`: route through the [status: failing](#status-failing) handler; the pushed fix produces a new SHA, then re-submit. Counts as a submit attempt.
+- `pr-closed`: the PR closed without merging. Report and `TaskStop`.
+- `max-time-reached`: report and `TaskStop`; do not re-arm.
+
+Stop re-submitting after 3 attempts (re-submits included, an oscillation guard) or an unrecoverable block (missing human approval, non-trivial CI failure, non-lockfile conflict, permissions).
 
 ## Gotchas
 


### PR DESCRIPTION
Routes babysit's post-submit merge wait through the CI watcher rather than a hand-rolled poll loop.

The watchers (`github:actions-monitor`, `gitlab:ci-monitor`) already probe merge state on every poll, but folded a merged PR into the `pr-closed` event, so a consumer couldn't tell a landed PR from one closed without merging. This adds a distinct `merged` terminal event and splits the two.

Babysit's merge mode uses it: after submitting the merge, it re-invokes the monitor and reacts to `merged`/`conflicts`/`status: failing`/`pr-closed` events. That removes babysit's only self-driven loop, so every wait it does is now bounded by the watcher's wall clock and poll interval in code rather than by prose. Stacked on #736, which trimmed the prose bounds that stood in for the missing programmatic ones.

## Changes

- Both watchers emit `{"type":"merged"}` for a merged PR/MR; `pr-closed` now means closed without merging. Terminal-exit detection and the monitor skills' event docs updated to match.
- `pull-request:babysit` merge mode reacts to watcher events instead of polling; its `## Bounds` now reflects that babysit owns no loop.

## Testing

The watcher unit tests in both plugins now cover the split: a merged PR/MR emits `merged` and not `pr-closed`, a closed one emits `pr-closed` and not `merged`, and the trailing `status: success` still precedes each terminal event when checks were green but unreported.
