### PR TITLE
marketplace: add hook iterators for check scripts

### DIFF
--- a/packages/marketplace/index.ts
+++ b/packages/marketplace/index.ts
@@ -45,6 +45,36 @@ export interface Plugin {
   mcpServers: string[];
 }
 
+export interface HookCommandContext {
+  /** e.g. "plugins/linear/hooks/hooks.json" */
+  file: string;
+  /** The raw matcher entry, for access to `.matcher`. */
+  entry: MatcherEntry;
+  /** Individual command object. */
+  command: HookCommand;
+}
+
+export interface MatcherEntryContext {
+  file: string;
+  entry: MatcherEntry;
+}
+
+/** Yields every hook command across a plugin's hooks file, tagged with its source file. */
+export function* hookCommands(plugin: Plugin): Generator<HookCommandContext> {
+  if (!plugin.hooks) return;
+  const file = `plugins/${plugin.name}/hooks/hooks.json`;
+  for (const entries of Object.values(plugin.hooks.hooks))
+    for (const entry of entries) for (const command of entry.hooks) yield { file, entry, command };
+}
+
+/** Yields every matcher entry across a plugin's hooks file, tagged with its source file. */
+export function* matcherEntries(plugin: Plugin): Generator<MatcherEntryContext> {
+  if (!plugin.hooks) return;
+  const file = `plugins/${plugin.name}/hooks/hooks.json`;
+  for (const entries of Object.values(plugin.hooks.hooks))
+    for (const entry of entries) yield { file, entry };
+}
+
 export interface LoadOptions {
   /** Repository root. Defaults to the repo containing this package. */
   root?: string;

--- a/packages/marketplace/marketplace.test.ts
+++ b/packages/marketplace/marketplace.test.ts
@@ -2,7 +2,13 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { enabledPluginNames, loadPlugins, type Plugin } from "./index";
+import {
+  enabledPluginNames,
+  hookCommands,
+  loadPlugins,
+  matcherEntries,
+  type Plugin,
+} from "./index";
 
 let root: string;
 
@@ -116,6 +122,37 @@ describe("loadPlugins", () => {
   test("settingsPath override is honored", async () => {
     const plugins = await loadPlugins({ root, settingsPath: join(root, "user", "settings.json") });
     expect(plugins.find((p) => p.name === "alpha")?.enabled).toBe(true);
+  });
+});
+
+describe("hookCommands", () => {
+  test("yields one item for alpha plugin", async () => {
+    const alpha = (await catalog()).get("alpha")!;
+    const items = [...hookCommands(alpha)];
+    expect(items).toHaveLength(1);
+    expect(items[0]?.file).toBe("plugins/alpha/hooks/hooks.json");
+    expect(items[0]?.entry.matcher).toBe("Bash");
+    expect(items[0]?.command.command).toBe("bun x.ts");
+  });
+
+  test("yields nothing for plugin without hooks", async () => {
+    const beta = (await catalog()).get("beta")!;
+    expect([...hookCommands(beta)]).toHaveLength(0);
+  });
+});
+
+describe("matcherEntries", () => {
+  test("yields one entry for alpha plugin", async () => {
+    const alpha = (await catalog()).get("alpha")!;
+    const items = [...matcherEntries(alpha)];
+    expect(items).toHaveLength(1);
+    expect(items[0]?.file).toBe("plugins/alpha/hooks/hooks.json");
+    expect(items[0]?.entry.matcher).toBe("Bash");
+  });
+
+  test("yields nothing for plugin without hooks", async () => {
+    const beta = (await catalog()).get("beta")!;
+    expect([...matcherEntries(beta)]).toHaveLength(0);
   });
 });
 

--- a/scripts/check-hook-quoting.ts
+++ b/scripts/check-hook-quoting.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { loadPlugins } from "../packages/marketplace/index";
+import { hookCommands, loadPlugins } from "../packages/marketplace/index";
 
 // Matches an unquoted ${CLAUDE_PLUGIN_ROOT}/... path segment in a command string.
 // The path is unquoted if it is NOT preceded by a double quote.
@@ -10,19 +10,12 @@ const plugins = await loadPlugins();
 const violations: string[] = [];
 
 for (const plugin of plugins) {
-  if (!plugin.hooks) continue;
-  const file = `plugins/${plugin.name}/hooks/hooks.json`;
+  for (const { file, command: hook } of hookCommands(plugin)) {
+    if (!hook.command?.includes("${CLAUDE_PLUGIN_ROOT}")) continue;
 
-  for (const entries of Object.values(plugin.hooks.hooks)) {
-    for (const entry of entries) {
-      for (const hook of entry.hooks) {
-        if (!hook.command?.includes("${CLAUDE_PLUGIN_ROOT}")) continue;
-
-        for (const _match of hook.command.matchAll(UNQUOTED_PATH)) {
-          violations.push(`${file}: ${hook.command}`);
-          break;
-        }
-      }
+    for (const _match of hook.command.matchAll(UNQUOTED_PATH)) {
+      violations.push(`${file}: ${hook.command}`);
+      break;
     }
   }
 }

--- a/scripts/check-mcp-matchers.ts
+++ b/scripts/check-mcp-matchers.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { enabledPluginNames, loadPlugins } from "../packages/marketplace/index";
+import { enabledPluginNames, loadPlugins, matcherEntries } from "../packages/marketplace/index";
 
 const MCP_PATTERN = /^mcp__(?!plugin_)(?!claude_ai_)(\w+)__(.+)$/;
 
@@ -27,43 +27,36 @@ async function checkMatchers(): Promise<string[]> {
   const errors: string[] = [];
 
   for (const plugin of plugins) {
-    if (!plugin.hooks) continue;
-    const file = `plugins/${plugin.name}/hooks/hooks.json`;
+    for (const { file, entry } of matcherEntries(plugin)) {
+      if (typeof entry.matcher !== "string") continue;
+      const patterns = entry.matcher.split("|");
 
-    for (const entries of Object.values(plugin.hooks.hooks)) {
-      for (const entry of entries) {
-        if (typeof entry.matcher !== "string") continue;
-        const patterns = entry.matcher.split("|");
+      for (const pattern of patterns) {
+        const match = MCP_PATTERN.exec(pattern);
+        if (!match) continue;
 
-        for (const pattern of patterns) {
-          const match = MCP_PATTERN.exec(pattern);
-          if (!match) continue;
+        const server = match[1];
+        const tool = match[2];
+        if (!server || !tool) continue;
 
-          const server = match[1];
-          const tool = match[2];
-          if (!server || !tool) continue;
+        // Determine plugin name: use known mapping, or fall back to
+        // enabled plugin names that match the server name
+        const pluginName = knownServers.get(server) ?? (enabledNames.has(server) ? server : null);
+        if (!pluginName) continue;
 
-          // Determine plugin name: use known mapping, or fall back to
-          // enabled plugin names that match the server name
-          const pluginName = knownServers.get(server) ?? (enabledNames.has(server) ? server : null);
-          if (!pluginName) continue;
+        const pluginVariant = `mcp__plugin_${pluginName}_${server}__${tool}`;
+        if (!patterns.includes(pluginVariant)) {
+          errors.push(`${file}: matcher "${pattern}" is missing plugin variant "${pluginVariant}"`);
+        }
 
-          const pluginVariant = `mcp__plugin_${pluginName}_${server}__${tool}`;
-          if (!patterns.includes(pluginVariant)) {
+        const claudeAi = CLAUDE_AI_MAPPINGS[server];
+        if (claudeAi) {
+          const mappedTool = claudeAi.tools[tool] ?? tool;
+          const claudeAiVariant = `mcp__claude_ai_${claudeAi.displayName}__${mappedTool}`;
+          if (!patterns.includes(claudeAiVariant)) {
             errors.push(
-              `${file}: matcher "${pattern}" is missing plugin variant "${pluginVariant}"`,
+              `${file}: matcher "${pattern}" is missing Claude AI variant "${claudeAiVariant}"`,
             );
-          }
-
-          const claudeAi = CLAUDE_AI_MAPPINGS[server];
-          if (claudeAi) {
-            const mappedTool = claudeAi.tools[tool] ?? tool;
-            const claudeAiVariant = `mcp__claude_ai_${claudeAi.displayName}__${mappedTool}`;
-            if (!patterns.includes(claudeAiVariant)) {
-              errors.push(
-                `${file}: matcher "${pattern}" is missing Claude AI variant "${claudeAiVariant}"`,
-              );
-            }
           }
         }
       }


### PR DESCRIPTION
Adds `hookCommands(plugin)` and `matcherEntries(plugin)` generators to `packages/marketplace`, alongside the `HooksFile`, `MatcherEntry`, and `HookCommand` types it already owns. Each generator flattens the three-level hook nesting and tags every item with its source `hooks.json` path, so consumers stop re-deriving the shape.

Closes #702

## Changes

- `hookCommands` yields `{ file, entry, command }` per command. `HookCommandContext` carries `entry` so callers that need the raw `matcher` string avoid a second iterator.
- `matcherEntries` yields `{ file, entry }` per matcher entry. `check-mcp-matchers.ts` splits `entry.matcher` on `|` once per entry, so the entry-level surface matches its access pattern.
- Rewrote `check-hook-quoting.ts` and `check-mcp-matchers.ts` to consume the iterators. The inner pattern checks are untouched.

## Testing

Added unit tests covering both iterators against the existing `alpha` (hooks present) and `beta` (no hooks) fixtures. Both check scripts produce identical output to before.
