### PR TITLE
writing: report all trope matches and flag "X, not Y" contrast

### DIFF
--- a/plugins/writing/hooks/tropes.test.ts
+++ b/plugins/writing/hooks/tropes.test.ts
@@ -330,9 +330,11 @@ describe("scan", () => {
     }
   });
 
-  it("returns at most one match per tier", () => {
+  it("returns all matches per tier", () => {
     const denyMatches = scan("This delve serves as a testament").filter((m) => m.tier === "deny");
-    expect(denyMatches).toHaveLength(1);
+    const categories = denyMatches.map((m) => m.category);
+    expect(categories).toContain("AI vocabulary");
+    expect(categories).toContain("copula avoidance");
   });
 
   it("returns empty for empty string", () => {
@@ -430,6 +432,38 @@ describe("scan", () => {
         scan("It isn't broken.").find((m) => m.category === "cross-sentence not-X"),
       ).toBeUndefined();
     });
+  });
+
+  describe("contrast not", () => {
+    const flag = [
+      "This is a tool, not a framework.",
+      "The goal is clarity, not perfection.",
+      "We want specificity, not abstraction.",
+      "It's a refactor, not a rewrite.",
+      "Focus on outcomes, not process.",
+      "Return an error, not an exception.",
+      "a command-line tool, not a library",
+    ];
+    const allow = [
+      "It is not the case that X.",
+      "not only X, but Y",
+      "a, not b",
+      "Not a framework, but a tool",
+      "Inline code: `foo, not bar`",
+      "```\nif err != nil, not ok\n```",
+    ];
+
+    for (const text of flag) {
+      it(`flags: "${text}"`, () => {
+        expect(firstByTier(scan(text), "context")?.category).toBe("contrast not");
+      });
+    }
+
+    for (const text of allow) {
+      it(`allows: ${JSON.stringify(text)}`, () => {
+        expect(scan(text).find((m) => m.category === "contrast not")).toBeUndefined();
+      });
+    }
   });
 
   describe("passive PR summary", () => {

--- a/plugins/writing/hooks/tropes.ts
+++ b/plugins/writing/hooks/tropes.ts
@@ -205,6 +205,13 @@ export const PATTERNS: PatternDef[] = [
   },
   {
     tier: "context",
+    category: "contrast not",
+    test: /\b\w[\w\s]{2,40},\s+not\s+\w[\w\s]{2,30}(?=[.!?,\n]|$)/gi,
+    message: (matched) =>
+      `"${matched}" is a rhetorical "X, not Y" contrast. State the positive directly.`,
+  },
+  {
+    tier: "context",
     category: "passive PR summary",
     test: /\b(?:is|was|are|were)\s+(?:added|updated|removed|refactored|introduced|created|deleted|modified|improved)\b/gi,
     fileOnly: true,
@@ -331,10 +338,8 @@ export function scanIntroduced(
   const newStripped = stripCode(newText);
   const oldStripped = stripCode(oldText);
   const matches: PatternMatch[] = [];
-  const seenTiers = new Set<PatternTier>();
 
   for (const def of PATTERNS) {
-    if (seenTiers.has(def.tier)) continue;
     if (def.fileOnly && filePath && !isProseFile(filePath)) continue;
     if (def.sideEffectOnly && context === "file") continue;
 
@@ -350,11 +355,9 @@ export function scanIntroduced(
       message: def.message(newHits.sample),
       structural: def.structural ?? false,
     });
-    seenTiers.add(def.tier);
   }
 
   for (const group of WEIGHTED_PATTERNS) {
-    if (seenTiers.has(group.tier)) continue;
     if (group.fileOnly && filePath && !isProseFile(filePath)) continue;
 
     const newWeighted = weightedStemHits(newStripped, group.entries);
@@ -369,7 +372,6 @@ export function scanIntroduced(
       message: group.message(newWeighted.samples, newWeighted.totalWeight),
       structural: false,
     });
-    seenTiers.add(group.tier);
   }
 
   return matches;


### PR DESCRIPTION
Two changes to `plugins/writing/hooks/tropes.ts` that share the file.

## Report all matches per tier

Removes the `seenTiers` guard from `scanIntroduced`, which skipped any pattern whose tier had already produced a match. With it gone, the returned `matches` array reflects every firing pattern. `check-tropes.ts` still calls `firstByTier` to surface one message per tier, so user-facing volume does not change. The accurate array makes it possible to tell whether a later same-tier pattern ever fires, which is the signal needed to prune dead patterns during curation.

The test that asserted at most one match per tier now asserts both expected categories appear.

Closes #650

## Flag "X, not Y" contrast

Adds a `context`-tier pattern for the single-sentence comma-before-"not" contrast ("This is a tool, not a framework"). The existing `cross-sentence not-X` pattern only catches the multi-sentence form. The comma is the primary false-positive guard: it separates the rhetorical contrast from ordinary negation like "it is not the case". Code is stripped before matching by the existing `stripCode` pass.

PR #744 added a contrastive-`not` check in `headings.ts` for headings only. This is the general-prose version and does not overlap.

Closes #653
