### PR TITLE
plugins: document plugin:plugin entry-skill convention

### DIFF
--- a/.claude/rules/plugins.md
+++ b/.claude/rules/plugins.md
@@ -20,6 +20,8 @@ The plugin name forms a namespace for its contents (e.g., `gitlab:ci-monitor`). 
 
 Anti-stuttering applies to the part after the colon: `gitlab:gitlab-ci` is wrong, `gitlab:ci` is right. Run `bun run skill-lint` to catch namespace mismatches and stuttering.
 
+A plugin's primary skill MAY share the plugin name (`plugin:plugin`, e.g. `writing:writing`, `tmux:tmux`, `git:git`). This is the intentional entry-skill pattern: the namespace's default skill, named to leave room for siblings (`writing:analyze`, `writing:review`). The platform registers and accepts both the qualified and unqualified forms. The stutter to avoid is the redundant-suffix form (`plugin:plugin-foo`, e.g. `writing:writing-analyze`), which `skill-lint` flags. Exact `plugin:plugin` is permitted by design.
+
 ## MCP Tool Naming
 
 MCP tools appear with three naming patterns depending on how the server is connected:

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/rules/namespace.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/rules/namespace.ts
@@ -77,6 +77,9 @@ export const namespaceStutter: Rule = {
     }
 
     const suffix = name.slice(colonIndex + 1);
+    // Exact `plugin:plugin` (suffix === plugin) is the intentional entry-skill
+    // convention and is permitted. Only the redundant-suffix form
+    // (`plugin:plugin-foo`) stutters, so the check requires a trailing hyphen.
     if (suffix.startsWith(`${plugin}-`)) {
       return {
         rule: "namespace-stutter",

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
@@ -264,6 +264,19 @@ describe("namespace rules", () => {
       expect(result.passed).toBe(true);
     });
 
+    it("permits the entry-skill convention (plugin:plugin)", () => {
+      const content = parseSkill("---\nname: writing:writing\n---\n");
+      const result = single(namespaceStutter.check(content, pluginPath("writing")));
+      expect(result.passed).toBe(true);
+    });
+
+    it("warns on redundant-suffix stutter (plugin:plugin-foo)", () => {
+      const content = parseSkill("---\nname: writing:writing-analyze\n---\n");
+      const result = single(namespaceStutter.check(content, pluginPath("writing")));
+      expect(result.passed).toBe(false);
+      expect(result.severity).toBe("warn");
+    });
+
     it("passes when no prefix", () => {
       const content = parseSkill("---\nname: actions\n---\n");
       const result = single(namespaceStutter.check(content, pluginPath("github")));


### PR DESCRIPTION
Documents the `plugin:plugin` skill-naming convention and locks `skill-lint` to it. Closes #649.

The telemetry that prompted #649 (`writing` and `writing:writing` both appearing) reflects an intentional pattern, not a bug. A skill named after its plugin is the namespace's default entry skill, and the platform registers and accepts both the qualified and unqualified forms. No rename was needed.

## Changes

- `.claude/rules/plugins.md`: notes that a plugin's primary skill may share the plugin name (`writing:writing`, `tmux:tmux`, `git:git`), that this is the entry-skill pattern, and that the stutter to avoid is the redundant-suffix form (`plugin:plugin-foo`).
- `namespace.ts`: comments why the `namespace-stutter` rule permits exact `plugin:plugin`. The check already required a trailing hyphen (`${plugin}-`), so exact matches passed; the comment makes that intent explicit.
- `rules.test.ts`: adds tests asserting both directions. `writing:writing` passes, `writing:writing-analyze` warns.

## Testing

The new unit tests cover both directions of the convention: exact `plugin:plugin` is permitted, and the redundant-suffix form warns. Running `bun run skill-lint` on the `writing` and `tmux` skills confirms the real entry skills stay clean.
