### PR TITLE
pull-request,git: fix bang-exec allowed-tools matching (#486)

### DIFF
--- a/plugins/claude-code/skills/skill/scripts/skill-lint/rules/bang-execution.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/rules/bang-execution.ts
@@ -1,0 +1,73 @@
+import type { Rule, RuleResult, SkillContent } from "../types";
+
+const BANG_COMMAND = /!`([^`]+)`/g;
+const BASH_ENTRY = /^Bash\((.+)\)$/;
+
+function bangCommands(body: string): string[] {
+  const commands: string[] = [];
+  for (const match of body.matchAll(BANG_COMMAND)) {
+    const command = match[1]?.trim();
+    if (command) commands.push(command);
+  }
+  return commands;
+}
+
+function bashMatchers(allowedTools: unknown): string[] {
+  if (!Array.isArray(allowedTools)) return [];
+  const matchers: string[] = [];
+  for (const tool of allowedTools) {
+    if (typeof tool !== "string") continue;
+    const match = tool.match(BASH_ENTRY);
+    if (match?.[1]) matchers.push(match[1]);
+  }
+  return matchers;
+}
+
+function matchesBang(matcherCommand: string, bangCommands: string[]): boolean {
+  const star = matcherCommand.indexOf("*");
+  if (star === -1) return false;
+  const prefix = matcherCommand.slice(0, star);
+  return bangCommands.some((command) => command.startsWith(prefix));
+}
+
+export const bangExecutionMatcher: Rule = {
+  name: "bang-execution-matcher",
+  severity: "warn",
+  check(content: SkillContent): RuleResult {
+    const commands = bangCommands(content.body);
+    if (commands.length === 0) {
+      return {
+        rule: "bang-execution-matcher",
+        severity: "warn",
+        passed: true,
+        message: "no bang execution in body",
+      };
+    }
+
+    const offenders = bashMatchers(content.frontmatter["allowed-tools"])
+      .filter((matcher) => matcher.endsWith(":*"))
+      .filter((matcher) => matchesBang(matcher.slice(0, -2), commands));
+
+    if (offenders.length > 0) {
+      return {
+        rule: "bang-execution-matcher",
+        severity: "warn",
+        passed: false,
+        message: `allowed-tools entries end in ":*" but match a bang-executed command: ${offenders
+          .map((matcher) => `Bash(${matcher})`)
+          .join(
+            ", ",
+          )}\n  Bang execution includes the !\`\` syntax markers in the checked pattern, so a ":*" argument matcher never matches. Drop the trailing ":*" to use an open glob, e.g. Bash(bun \${CLAUDE_PLUGIN_ROOT}/scripts/*).`,
+      };
+    }
+
+    return {
+      rule: "bang-execution-matcher",
+      severity: "warn",
+      passed: true,
+      message: "bang execution matchers use open globs",
+    };
+  },
+};
+
+export const bangExecutionRules: Rule[] = [bangExecutionMatcher];

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/rules/index.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/rules/index.ts
@@ -1,4 +1,5 @@
 import type { Rule } from "../types";
+import { bangExecutionRules } from "./bang-execution";
 import { bodyRules } from "./body";
 import { frontmatterRules } from "./frontmatter";
 import { namespaceRules } from "./namespace";
@@ -8,6 +9,7 @@ export const allRules: Rule[] = [
   ...frontmatterRules,
   ...namespaceRules,
   ...bodyRules,
+  ...bangExecutionRules,
   ...tokenRules,
 ];
 

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import { lintSkill } from "../index";
 import { parseSkill } from "../parse";
+import { bangExecutionMatcher } from "../rules/bang-execution";
 import {
   allowedToolsFormat,
   descriptionLength,
@@ -212,6 +213,53 @@ describe("frontmatter rules", () => {
       const result = single(allowedToolsFormat.check(content, ""));
       expect(result.passed).toBe(false);
     });
+  });
+});
+
+describe("bangExecutionMatcher", () => {
+  const root = ["$", "{CLAUDE_PLUGIN_ROOT}"].join("");
+  const skill = (allowedTools: string, body: string) =>
+    parseSkill(`---\nname: test\nallowed-tools:\n${allowedTools}\n---\n\n${body}\n`);
+
+  it("passes when the open-glob shape matches a bang command", () => {
+    const content = skill(
+      `  - "Bash(bun ${root}/scripts/*)"`,
+      `- Out: !\`bun ${root}/scripts/context.ts\``,
+    );
+    const result = single(bangExecutionMatcher.check(content, ""));
+    expect(result.passed).toBe(true);
+  });
+
+  it("warns when a :* glob matcher matches a bang command", () => {
+    const content = skill(
+      `  - "Bash(bun ${root}/scripts/*:*)"`,
+      `- Out: !\`bun ${root}/scripts/context.ts\``,
+    );
+    const result = single(bangExecutionMatcher.check(content, ""));
+    expect(result.passed).toBe(false);
+    expect(result.severity).toBe("warn");
+    expect(result.message).toContain(`Bash(bun ${root}/scripts/*:*)`);
+  });
+
+  it("passes when there is no bang execution", () => {
+    const content = skill(`  - "Bash(bun ${root}/scripts/*:*)"`, "Run the script when needed.");
+    const result = single(bangExecutionMatcher.check(content, ""));
+    expect(result.passed).toBe(true);
+  });
+
+  it("ignores a :* glob matcher that no bang command uses", () => {
+    const content = skill(
+      '  - "Bash(git show :*:*)"\n  - "Bash(jq:*)"',
+      "- List: !`hunk session list`",
+    );
+    const result = single(bangExecutionMatcher.check(content, ""));
+    expect(result.passed).toBe(true);
+  });
+
+  it("passes when a bang command is matched by a command-prefix matcher", () => {
+    const content = skill('  - "Bash(uname:*)"', "- OS: !`uname -s`");
+    const result = single(bangExecutionMatcher.check(content, ""));
+    expect(result.passed).toBe(true);
   });
 });
 

--- a/plugins/git/skills/conflicts/SKILL.md
+++ b/plugins/git/skills/conflicts/SKILL.md
@@ -19,7 +19,7 @@ allowed-tools:
   - Bash(git update-index:*)
   - Bash(git fetch:*)
   - Bash(git push:*)
-  - Bash(bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/*:*)
+  - Bash(bun ${CLAUDE_PLUGIN_ROOT}/skills/conflicts/scripts/*)
 hooks:
   PreToolUse:
     - matcher: "Bash(git commit:*)|Bash(git rebase --continue:*)|Bash(git merge --continue:*)|Bash(git cherry-pick --continue:*)"

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -12,11 +12,7 @@ allowed-tools:
   - "Bash(git remote get-url:*)"
   - "Bash(gh pr:*)"
   - "Bash(glab mr:*)"
-  - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/*:*)"
-  # workaround: inline skill execution includes syntax markers in the permission
-  # check pattern, breaking allowed-tools matching.
-  # https://github.com/bendrucker/claude/issues/486
-  - "Bash(!`bun ${CLAUDE_PLUGIN_ROOT}/scripts/*`:*)"
+  - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/*)"
 ---
 
 # Create Pull Request

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -9,11 +9,7 @@ allowed-tools:
   - "Bash(git remote get-url:*)"
   - "Bash(gh pr:*)"
   - "Bash(glab mr:*)"
-  - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/*:*)"
-  # workaround: inline skill execution includes syntax markers in the permission
-  # check pattern, breaking allowed-tools matching.
-  # https://github.com/bendrucker/claude/issues/486
-  - "Bash(!`bun ${CLAUDE_PLUGIN_ROOT}/scripts/*`:*)"
+  - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/*)"
 ---
 
 # Update Pull Request


### PR DESCRIPTION
Fixes skill `!`...`` inline execution failing its permission check in three skills, and adds a lint guard so it cannot regress. Closes #486.

## Issue

Skills inject context at load time with `!`-backtick inline execution, e.g. `- Remote URL: !`git remote get-url origin``. The command runs through the permission checker before it executes. The checked pattern still contains the bang and backtick syntax markers:

```
Shell command permission check failed for pattern "!`bun /abs/.../scripts/pr-template.ts`": This command requires approval
```

An `allowed-tools` entry of the form `Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/*:*)` cannot match that pattern. The trailing `:*` is an argument-boundary matcher, and the bang-wrapped command presents no `:`-delimited boundary (it ends in a backtick). An open `/*` glob with no `:*` does match, because the trailing `*` absorbs the closing backtick.

`pull-request:create` and `pull-request:update` carried a second `allowed-tools` entry `Bash(!`bun ${CLAUDE_PLUGIN_ROOT}/scripts/*`:*)` as a workaround for #486. I verified it does not match either, so it was dead. `git:conflicts` used the same `:*`-glob shape with no workaround and was silently blocked on every load.

The upstream bug (syntax markers leaking into the checked pattern) remains. Per maintainer direction I did not file it.

## Changes

Drops the trailing `:*` from the script matcher in all three skills so the open-glob form matches the bang commands:

- `pull-request:create`
- `pull-request:update`
- `git:conflicts`

Deletes the dead bang-wrapped workaround entry and its comment from the two `pull-request` skills.

Swept every `SKILL.md` for the antipattern (a bang-executed command whose matching `allowed-tools` entry ends in `:*`). These three were the only matches. Skills that bang-execute against a command-prefix matcher like `Bash(uname:*)` or an exact path are unaffected and were left alone.

Adds a `bang-execution-matcher` skill-lint rule. It warns when a skill bang-executes a command whose `allowed-tools` entry ends in `:*`, and steers toward the open-glob shape. The heuristic flags an entry only when its globbed command prefix actually prefixes a bang command in the body, so command-prefix matchers do not false-positive.

## Testing

- `bun test`: 1426 pass, including 5 new cases for the lint rule (open-glob passes, `:*`+bang warns, no-bang passes, unrelated `:*` glob ignored, command-prefix matcher passes).
- `bun run skill-lint` across all skills: clean, no new warnings.
- Headless repro against each fixed skill in a real repo: the Context bang lines load with no permission block. The same harness still shows the block before the fix.
- `bun run check`, `bun run build`, `bun scripts/check-marketplace.ts`: pass.
