### PR TITLE
tmux: record session resume command in pane option

### DIFF
--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -6,11 +6,14 @@ Tmux session, window, and pane awareness for Claude Code.
 
 - **Skill: tmux** — Layout awareness, pane interaction, and notification monitoring
 - **Hook: context** — SessionStart hook that injects tmux env vars
+- **Hook: agent-resume-command**, a SessionStart hook that records the session's resume command in a pane-scoped tmux option for plugins like tmux-resurrect to use when resuming a pane
 - **Hook: notification** — Bell and status bar notifications for permission prompts
 
 ## How It Works
 
 A SessionStart hook detects whether Claude is running inside tmux and writes session/window/pane identifiers to `CLAUDE_ENV_FILE`. These env vars are available in all subsequent Bash calls.
+
+Another SessionStart hook records the command that resumes the current session (`claude --resume <id>`) in the pane-scoped tmux option `@agent_resume_command`, refreshed on both `startup` and `resume`. Plugins like tmux-resurrect can read it back with `tmux show-options -p -t <pane> -qv @agent_resume_command` to resume the session when restoring a pane. Outside tmux the hook is a no-op.
 
 The skill provides a PreToolUse hook that auto-allows safe tmux commands (read-only, navigation, layout). The safe command list is maintained in [`safe-commands.json`](skills/tmux/resources/safe-commands.json).
 

--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -6,7 +6,7 @@ Tmux session, window, and pane awareness for Claude Code.
 
 - **Skill: tmux** — Layout awareness, pane interaction, and notification monitoring
 - **Hook: context** — SessionStart hook that injects tmux env vars
-- **Hook: resume-command**, a SessionStart hook that records the session's resume command in a pane-scoped tmux option for plugins like tmux-resurrect to use when resuming a pane
+- **Hook: resume-command**, a SessionStart hook that records the session's resume command in a pane-scoped tmux option for plugins like [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) to use when resuming a pane
 - **Hook: notification** — Bell and status bar notifications for permission prompts
 
 ## How It Works

--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -6,14 +6,14 @@ Tmux session, window, and pane awareness for Claude Code.
 
 - **Skill: tmux** — Layout awareness, pane interaction, and notification monitoring
 - **Hook: context** — SessionStart hook that injects tmux env vars
-- **Hook: agent-resume-command**, a SessionStart hook that records the session's resume command in a pane-scoped tmux option for plugins like tmux-resurrect to use when resuming a pane
+- **Hook: resume-command**, a SessionStart hook that records the session's resume command in a pane-scoped tmux option for plugins like tmux-resurrect to use when resuming a pane
 - **Hook: notification** — Bell and status bar notifications for permission prompts
 
 ## How It Works
 
 A SessionStart hook detects whether Claude is running inside tmux and writes session/window/pane identifiers to `CLAUDE_ENV_FILE`. These env vars are available in all subsequent Bash calls.
 
-Another SessionStart hook records the command that resumes the current session (`claude --resume <id>`) in the pane-scoped tmux option `@agent_resume_command`, refreshed on every session start. Plugins like tmux-resurrect can read it back with `tmux show-options -p -t <pane> -qv @agent_resume_command` to resume the session when restoring a pane. Outside tmux the hook is a no-op.
+Another SessionStart hook records the command that resumes the current session (`claude --resume <id>`) in the pane-scoped tmux option `@resume-command`, refreshed on every session start. Plugins like tmux-resurrect can read it back with `tmux show-options -p -t <pane> -qv @resume-command` to resume the session when restoring a pane. Outside tmux the hook is a no-op.
 
 The skill provides a PreToolUse hook that auto-allows safe tmux commands (read-only, navigation, layout). The safe command list is maintained in [`safe-commands.json`](skills/tmux/resources/safe-commands.json).
 

--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -13,7 +13,7 @@ Tmux session, window, and pane awareness for Claude Code.
 
 A SessionStart hook detects whether Claude is running inside tmux and writes session/window/pane identifiers to `CLAUDE_ENV_FILE`. These env vars are available in all subsequent Bash calls.
 
-Another SessionStart hook records the command that resumes the current session (`claude --resume <id>`) in the pane-scoped tmux option `@agent_resume_command`, refreshed on both `startup` and `resume`. Plugins like tmux-resurrect can read it back with `tmux show-options -p -t <pane> -qv @agent_resume_command` to resume the session when restoring a pane. Outside tmux the hook is a no-op.
+Another SessionStart hook records the command that resumes the current session (`claude --resume <id>`) in the pane-scoped tmux option `@agent_resume_command`, refreshed on every session start. Plugins like tmux-resurrect can read it back with `tmux show-options -p -t <pane> -qv @agent_resume_command` to resume the session when restoring a pane. Outside tmux the hook is a no-op.
 
 The skill provides a PreToolUse hook that auto-allows safe tmux commands (read-only, navigation, layout). The safe command list is maintained in [`safe-commands.json`](skills/tmux/resources/safe-commands.json).
 

--- a/plugins/tmux/hooks/hooks.json
+++ b/plugins/tmux/hooks/hooks.json
@@ -11,16 +11,6 @@
         ]
       },
       {
-        "matcher": "startup",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "[ -n \"$TMUX_PANE\" ] && tmux set-option -p -t \"$TMUX_PANE\" @agent_resume_command \"claude --resume $CLAUDE_CODE_SESSION_ID\" || true"
-          }
-        ]
-      },
-      {
-        "matcher": "resume",
         "hooks": [
           {
             "type": "command",

--- a/plugins/tmux/hooks/hooks.json
+++ b/plugins/tmux/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Inject tmux context and ring terminal bell for notifications",
+  "description": "Inject tmux context, persist the agent resume command for tmux-resurrect, and ring terminal bell for notifications",
   "hooks": {
     "SessionStart": [
       {
@@ -7,6 +7,24 @@
           {
             "type": "command",
             "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/context.ts\""
+          }
+        ]
+      },
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$TMUX_PANE\" ] && tmux set-option -p -t \"$TMUX_PANE\" @agent_resume_command \"claude --resume $CLAUDE_CODE_SESSION_ID\" || true"
+          }
+        ]
+      },
+      {
+        "matcher": "resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$TMUX_PANE\" ] && tmux set-option -p -t \"$TMUX_PANE\" @agent_resume_command \"claude --resume $CLAUDE_CODE_SESSION_ID\" || true"
           }
         ]
       }

--- a/plugins/tmux/hooks/hooks.json
+++ b/plugins/tmux/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Inject tmux context, persist the agent resume command for tmux-resurrect, and ring terminal bell for notifications",
+  "description": "Inject tmux context, persist the session's resume command for tmux-resurrect, and ring terminal bell for notifications",
   "hooks": {
     "SessionStart": [
       {
@@ -14,7 +14,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -n \"$TMUX_PANE\" ] && tmux set-option -p -t \"$TMUX_PANE\" @agent_resume_command \"claude --resume $CLAUDE_CODE_SESSION_ID\" || true"
+            "command": "[ -n \"$TMUX_PANE\" ] && tmux set-option -p -t \"$TMUX_PANE\" @resume-command \"claude --resume $CLAUDE_CODE_SESSION_ID\" || true"
           }
         ]
       }


### PR DESCRIPTION
Adds a SessionStart hook to the `tmux` plugin that records the session's resume command (`claude --resume <id>`) in the pane-scoped tmux option `@resume-command`. A pane that was running Claude can then be resumed instead of relaunched fresh after a tmux restart.

The contract is one pane option. The consumer side lives in tmux-resurrect: at save time it reads `@resume-command` and swaps the value into the pane's saved restore command, so the resume syntax stays entirely on this side and tmux never needs to know it. The only coupling between the two repos is the option name.

## Changes

- A single matcher-less SessionStart hook, so it fires on every source. The command is idempotent (the value derives only from the stable session id and pane), so re-running it on `resume`, `clear`, or `compact` rewrites the same value and costs nothing.
- The command is a guarded one-liner: `[ -n "$TMUX_PANE" ] && tmux set-option -p -t "$TMUX_PANE" @resume-command "claude --resume $CLAUDE_CODE_SESSION_ID" || true`. The `$TMUX_PANE` guard makes it a clean no-op outside tmux, and the trailing `|| true` keeps it from ever blocking session start.
- I put this in the plugin rather than user-level config: it runs once per session (not per turn) and is a no-op when tmux isn't in play, so shipping it by default costs nothing.

## Testing

Ran the command verbatim in a tmux pane and read it back with the consumer's `tmux show-options -p -t <pane> -qv @resume-command`. It returned the exact `claude --resume <id>` value. `check-hook-quoting.ts` and `check-mcp-matchers.ts` both pass.

## References

- bendrucker/dotfiles#477 sets up the tmux-resurrect side that consumes the `@resume-command` pane option this PR writes.
