### PR TITLE
refactor(skill-lint): remove pass-through library re-export

### DIFF
--- a/packages/skill-lint/index.ts
+++ b/packages/skill-lint/index.ts
@@ -1,8 +1,0 @@
-export {
-  lintSkill,
-  parseSkill,
-} from "../../plugins/claude-code/skills/skill/scripts/skill-lint/index";
-export type {
-  RuleResult,
-  SkillLintResult,
-} from "../../plugins/claude-code/skills/skill/scripts/skill-lint/types";

--- a/packages/skill-lint/package.json
+++ b/packages/skill-lint/package.json
@@ -5,9 +5,6 @@
   "bin": {
     "skill-lint": "./cli.ts"
   },
-  "exports": {
-    ".": "./index.ts"
-  },
   "scripts": {
     "test": "bun test"
   }


### PR DESCRIPTION
Removes `packages/skill-lint/index.ts`, a pass-through that only re-exported `lintSkill`/`parseSkill` and the `RuleResult`/`SkillLintResult` types from the plugin implementation under `plugins/claude-code/skills/skill/scripts/skill-lint/`. Also drops the `exports` entry in `packages/skill-lint/package.json` that pointed at it.

## Importers

I grepped the repo for consumers before removing anything (`from "skill-lint"`, `packages/skill-lint/index`, `require("skill-lint")`, the bare `skill-lint` dependency, and the `main`/`exports`/`bin` fields). Nothing imports the re-export:

- `packages/skill-lint/cli.ts` imports the plugin impl directly (`../../plugins/claude-code/skills/skill/scripts/skill-lint/index`), not the package's `index.ts`.
- The hook in `plugins/claude-code/skills/skill/scripts/check-lint.ts` imports its own sibling impl via a relative path (`./skill-lint`), also not the package.
- The root `package.json` `skill-lint` script and the package `bin` both run `cli.ts`.

The `index.ts` re-export had no library consumer, so it bought one layer of indirection without anything varying across it. Removing it leaves the plugin impl as the single source of truth and `cli.ts` as the package's public face.

## Testing

- `bun run skill-lint "plugins/claude-code/skills/*"` produces the same output.
- `bun test plugins/claude-code/skills/skill/`: 96 pass.
- `bun run build` (`tsc --noEmit`) clean.
- `bun.lock` unchanged (dropping `exports` does not alter the dependency graph).
