### PR TITLE
scripts: extract shared check runner

### DIFF
--- a/scripts/check-enabled-plugins.ts
+++ b/scripts/check-enabled-plugins.ts
@@ -1,16 +1,15 @@
 #!/usr/bin/env bun
 
 import { loadPlugins } from "../packages/marketplace/index";
+import { runCheck } from "./check";
 
-const plugins = await loadPlugins();
-const missing = plugins.filter((p) => p.listing && !p.enabled).map((p) => p.name);
-
-if (missing.length > 0) {
-  console.log("Plugins in marketplace but not enabled in settings.json:");
-  for (const name of missing) {
-    console.log(`  ${name}`);
-  }
-  process.exit(1);
-}
-
-console.log("All marketplace plugins are enabled in settings.json");
+await runCheck(
+  async () => {
+    const plugins = await loadPlugins();
+    return {
+      header: "Plugins in marketplace but not enabled in settings.json:",
+      violations: plugins.filter((p) => p.listing && !p.enabled).map((p) => p.name),
+    };
+  },
+  { success: "All marketplace plugins are enabled in settings.json" },
+);

--- a/scripts/check-hook-quoting.ts
+++ b/scripts/check-hook-quoting.ts
@@ -1,31 +1,34 @@
 #!/usr/bin/env bun
 
 import { hookCommands, loadPlugins } from "../packages/marketplace/index";
+import { runCheck } from "./check";
 
 // Matches an unquoted ${CLAUDE_PLUGIN_ROOT}/... path segment in a command string.
 // The path is unquoted if it is NOT preceded by a double quote.
 const UNQUOTED_PATH = /(?<!")(\$\{CLAUDE_PLUGIN_ROOT\}\/\S+)/g;
 
-const plugins = await loadPlugins();
-const violations: string[] = [];
+async function checkQuoting(): Promise<string[]> {
+  const plugins = await loadPlugins();
+  const violations: string[] = [];
 
-for (const plugin of plugins) {
-  for (const { file, command: hook } of hookCommands(plugin)) {
-    if (!hook.command?.includes("${CLAUDE_PLUGIN_ROOT}")) continue;
+  for (const plugin of plugins) {
+    for (const { file, command: hook } of hookCommands(plugin)) {
+      if (!hook.command?.includes("${CLAUDE_PLUGIN_ROOT}")) continue;
 
-    for (const _match of hook.command.matchAll(UNQUOTED_PATH)) {
-      violations.push(`${file}: ${hook.command}`);
-      break;
+      for (const _match of hook.command.matchAll(UNQUOTED_PATH)) {
+        violations.push(`${file}: ${hook.command}`);
+        break;
+      }
     }
   }
+
+  return violations;
 }
 
-if (violations.length > 0) {
-  console.log("Hook commands with unquoted ${CLAUDE_PLUGIN_ROOT} paths:");
-  for (const v of violations) {
-    console.log(`  ${v}`);
-  }
-  process.exit(1);
-}
-
-console.log("All hook commands have properly quoted ${CLAUDE_PLUGIN_ROOT} paths");
+await runCheck(
+  async () => ({
+    header: "Hook commands with unquoted ${CLAUDE_PLUGIN_ROOT} paths:",
+    violations: await checkQuoting(),
+  }),
+  { success: "All hook commands have properly quoted ${CLAUDE_PLUGIN_ROOT} paths" },
+);

--- a/scripts/check-marketplace.ts
+++ b/scripts/check-marketplace.ts
@@ -1,16 +1,15 @@
 #!/usr/bin/env bun
 
 import { loadPlugins } from "../packages/marketplace/index";
+import { runCheck } from "./check";
 
-const plugins = await loadPlugins();
-const missing = plugins.filter((p) => p.dir && !p.listing?.local).map((p) => p.name);
-
-if (missing.length > 0) {
-  console.log("Plugins missing from marketplace.json:");
-  for (const name of missing) {
-    console.log(`  ${name}`);
-  }
-  process.exit(1);
-}
-
-console.log("All plugin directories are listed in marketplace.json");
+await runCheck(
+  async () => {
+    const plugins = await loadPlugins();
+    return {
+      header: "Plugins missing from marketplace.json:",
+      violations: plugins.filter((p) => p.dir && !p.listing?.local).map((p) => p.name),
+    };
+  },
+  { success: "All plugin directories are listed in marketplace.json" },
+);

--- a/scripts/check-mcp-matchers.ts
+++ b/scripts/check-mcp-matchers.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { enabledPluginNames, loadPlugins, matcherEntries } from "../packages/marketplace/index";
+import { runCheck } from "./check";
 
 const MCP_PATTERN = /^mcp__(?!plugin_)(?!claude_ai_)(\w+)__(.+)$/;
 
@@ -66,13 +67,10 @@ async function checkMatchers(): Promise<string[]> {
   return errors;
 }
 
-const errors = await checkMatchers();
-if (errors.length > 0) {
-  console.log("MCP hook matchers missing plugin variants:");
-  for (const err of errors) {
-    console.log(`  ${err}`);
-  }
-  process.exit(1);
-}
-
-console.log("All MCP hook matchers include plugin and Claude AI variants");
+await runCheck(
+  async () => ({
+    header: "MCP hook matchers missing plugin variants:",
+    violations: await checkMatchers(),
+  }),
+  { success: "All MCP hook matchers include plugin and Claude AI variants" },
+);

--- a/scripts/check-plugin-deps.ts
+++ b/scripts/check-plugin-deps.ts
@@ -3,6 +3,7 @@
 import { join } from "node:path";
 import { Glob } from "bun";
 import { loadPlugins } from "../packages/marketplace/index";
+import { runCheck } from "./check";
 
 async function getPluginDeps(pluginDir: string): Promise<Set<string>> {
   const deps = new Set<string>();
@@ -54,22 +55,23 @@ async function getImportedPackages(pluginDir: string): Promise<Set<string>> {
   return packages;
 }
 
-let failed = false;
+async function checkDeps(): Promise<string[]> {
+  const violations: string[] = [];
 
-for (const plugin of await loadPlugins()) {
-  if (!plugin.dir) continue;
+  for (const plugin of await loadPlugins()) {
+    if (!plugin.dir) continue;
 
-  const declared = await getPluginDeps(plugin.dir);
-  const imported = await getImportedPackages(plugin.dir);
+    const declared = await getPluginDeps(plugin.dir);
+    const imported = await getImportedPackages(plugin.dir);
 
-  for (const pkg of imported) {
-    if (!declared.has(pkg) && !declared.has(`@types/${pkg}`)) {
-      console.error(`${plugin.name}: missing dependency "${pkg}"`);
-      failed = true;
+    for (const pkg of imported) {
+      if (!declared.has(pkg) && !declared.has(`@types/${pkg}`)) {
+        violations.push(`${plugin.name}: missing dependency "${pkg}"`);
+      }
     }
   }
+
+  return violations;
 }
 
-if (failed) {
-  process.exit(1);
-}
+await runCheck(checkDeps, { stream: "stderr", indent: false });

--- a/scripts/check-plugin-imports.ts
+++ b/scripts/check-plugin-imports.ts
@@ -3,6 +3,7 @@
 import { dirname, join, relative, resolve } from "node:path";
 import { Glob } from "bun";
 import { loadPlugins } from "../packages/marketplace/index";
+import { runCheck } from "./check";
 
 // Exit codes: 0 clean, VIOLATION_EXIT when cross-plugin imports are found.
 // Anything else (bun exits 1 on uncaught errors) means the checker itself
@@ -57,20 +58,16 @@ async function checkPlugin(pluginDir: string): Promise<string[]> {
   return violations;
 }
 
-async function main(): Promise<void> {
+async function findViolations(): Promise<string[]> {
   const pluginDirs = await getPluginDirs();
   const results = await Promise.all(pluginDirs.map(checkPlugin));
-  const violations = results.flat();
-
-  for (const v of violations) {
-    console.error(v);
-  }
-
-  if (violations.length > 0) {
-    process.exit(VIOLATION_EXIT);
-  }
+  return results.flat();
 }
 
 if (import.meta.main) {
-  await main();
+  await runCheck(findViolations, {
+    stream: "stderr",
+    indent: false,
+    failureExit: VIOLATION_EXIT,
+  });
 }

--- a/scripts/check-skill-hook-vars.ts
+++ b/scripts/check-skill-hook-vars.ts
@@ -3,6 +3,7 @@
 import { globSync } from "node:fs";
 import { join } from "node:path";
 import matter from "gray-matter";
+import { runCheck } from "./check";
 
 // The hooks engine substitutes only ${CLAUDE_PROJECT_DIR}, ${CLAUDE_PLUGIN_ROOT},
 // and ${CLAUDE_PLUGIN_DATA} in hook command strings. ${CLAUDE_SKILL_DIR} is a
@@ -13,44 +14,46 @@ import matter from "gray-matter";
 const FORBIDDEN = /\$\{CLAUDE_SKILL_(?:DIR|ROOT)\}/;
 
 const root = join(import.meta.dirname, "..");
-const files = globSync("plugins/*/skills/*/SKILL.md", { cwd: root });
 
 interface MatcherEntry {
   hooks?: Array<{ command?: string; args?: string[] }>;
 }
 
-const violations: string[] = [];
+async function checkSkillHookVars(): Promise<string[]> {
+  const files = globSync("plugins/*/skills/*/SKILL.md", { cwd: root });
+  const violations: string[] = [];
 
-for (const file of files) {
-  if (file.includes("/test/")) continue;
+  for (const file of files) {
+    if (file.includes("/test/")) continue;
 
-  const raw = await Bun.file(join(root, file)).text();
-  const { data } = matter(raw);
-  const hooks = data.hooks as Record<string, MatcherEntry[]> | undefined;
-  if (!hooks) continue;
+    const raw = await Bun.file(join(root, file)).text();
+    const { data } = matter(raw);
+    const hooks = data.hooks as Record<string, MatcherEntry[]> | undefined;
+    if (!hooks) continue;
 
-  for (const entries of Object.values(hooks)) {
-    for (const entry of entries) {
-      for (const hook of entry.hooks ?? []) {
-        const command = hook.command ?? "";
-        const args = (hook.args ?? []).join(" ");
-        if (FORBIDDEN.test(command) || FORBIDDEN.test(args)) {
-          violations.push(`${file}: ${command || args}`);
+    for (const entries of Object.values(hooks)) {
+      for (const entry of entries) {
+        for (const hook of entry.hooks ?? []) {
+          const command = hook.command ?? "";
+          const args = (hook.args ?? []).join(" ");
+          if (FORBIDDEN.test(command) || FORBIDDEN.test(args)) {
+            violations.push(`${file}: ${command || args}`);
+          }
         }
       }
     }
   }
+
+  return violations;
 }
 
-if (violations.length > 0) {
-  console.log(
-    "Hook commands must not use CLAUDE_SKILL_DIR/CLAUDE_SKILL_ROOT (the hooks engine leaves them empty).",
-  );
-  console.log("Use CLAUDE_PLUGIN_ROOT/skills/<skill>/... instead:");
-  for (const v of violations) {
-    console.log(`  ${v}`);
-  }
-  process.exit(1);
-}
-
-console.log("All skill hook commands use supported path placeholders");
+await runCheck(
+  async () => ({
+    header: [
+      "Hook commands must not use CLAUDE_SKILL_DIR/CLAUDE_SKILL_ROOT (the hooks engine leaves them empty).",
+      "Use CLAUDE_PLUGIN_ROOT/skills/<skill>/... instead:",
+    ],
+    violations: await checkSkillHookVars(),
+  }),
+  { success: "All skill hook commands use supported path placeholders" },
+);

--- a/scripts/check.ts
+++ b/scripts/check.ts
@@ -1,0 +1,53 @@
+import { exit } from "node:process";
+
+export interface CheckResult {
+  /** Lines printed before the violation list when violations exist. */
+  header?: string | string[];
+  /** Violation messages, one per line. */
+  violations: string[];
+}
+
+export interface CheckOptions {
+  /** Line printed when the check finds no violations. Omit to print nothing. */
+  success?: string;
+  /** Stream for violation output. Defaults to stdout. */
+  stream?: "stdout" | "stderr";
+  /** Indent each violation by two spaces under the header. Defaults to true. */
+  indent?: boolean;
+  /** Exit code when violations exist. Defaults to 1. */
+  failureExit?: number;
+}
+
+type Check = () => CheckResult | Promise<CheckResult> | string[] | Promise<string[]>;
+
+function normalize(result: CheckResult | string[]): CheckResult {
+  return Array.isArray(result) ? { violations: result } : result;
+}
+
+/**
+ * Runs a check, reports its violations, and exits non-zero when any exist.
+ *
+ * The check returns either a bare list of violation messages or a
+ * {@link CheckResult} carrying a header to print above them. The runner owns
+ * the load/report/exit shell shared by every `check-*.ts` script: print the
+ * header and violations, exit on failure, and print the success line otherwise.
+ */
+export async function runCheck(check: Check, options: CheckOptions = {}): Promise<void> {
+  const { success, stream = "stdout", indent = true, failureExit = 1 } = options;
+  const { header, violations } = normalize(await check());
+  const write = stream === "stderr" ? console.error : console.log;
+
+  if (violations.length === 0) {
+    if (success !== undefined) write(success);
+    return;
+  }
+
+  for (const line of header === undefined ? [] : [header].flat()) {
+    write(line);
+  }
+  for (const violation of violations) {
+    write(indent ? `  ${violation}` : violation);
+  }
+
+  exit(failureExit);
+}


### PR DESCRIPTION
Adds `scripts/check.ts` exporting `runCheck` and routes all seven `scripts/check-*.ts` scripts through it. Each script previously repeated the same `load → compute violations → report → exit` shell, and their exit codes and message shapes drifted independently. Now each script computes its violations and hands them to the runner.

## Changes

`runCheck(check, options)` takes a function returning either a bare list of violation messages or a `{ header, violations }` result. The runner owns the shared tail: print the header and indented violation list, exit non-zero on failures, print the success line otherwise.

Options cover the variation across the seven scripts so all of them reduce to "compute violations, hand them to the runner":

- `success`: the line printed on a clean run (omitted for scripts that print nothing)
- `stream`: `stdout` or `stderr` (`check-plugin-deps` and `check-plugin-imports` write to `stderr`)
- `indent`: two-space indent under the header (off for the raw `stderr` checks)
- `failureExit`: exit code on failure (`check-plugin-imports` keeps its `VIOLATION_EXIT = 2`, which the plugin-imports Stop hook depends on)

`check-plugin-imports.ts` keeps its exported `VIOLATION_EXIT`, its `import.meta.main` guard, and its CLI-argument handling. No check's validation logic changed.

## Testing

- Ran all seven scripts on a clean tree and compared output and exit codes against the originals, including `check-enabled-plugins` and `check-hook-quoting` diffed against their `main` versions.
- Exercised the `check-plugin-imports` violation path with CLI args to confirm the runner preserves the contract the plugin-imports Stop hook relies on: exit 2, violation on `stderr`, nothing on `stdout`, no indent.
- Covered by the existing `bun test` suite, which includes the plugin-imports hook test that imports `VIOLATION_EXIT` from `check-plugin-imports`.
- `biome check` is clean. The three `${CLAUDE_PLUGIN_ROOT}` template-string warnings predate this PR.
