### PR TITLE
things: hide xcall->open fallback behind url dispatch

### DIFF
--- a/plugins/things/CLAUDE.md
+++ b/plugins/things/CLAUDE.md
@@ -25,9 +25,11 @@ JXA runs on JavaScriptCore (ES5). Scripts must:
 
 Biome linting is disabled for `scripts/jxa/` files via the root `biome.json` override.
 
-## Reorder Script
+## URL Dispatch
 
-`scripts/reorder.ts` is a bun TypeScript script that reuses `url.ts` exports (`getAuthToken`, `buildUrl`). It opens Things URLs via `open -g` to reorder items. Unlike the JXA scripts, it does not use `osascript`. Sandbox bypass comes from the `mac` plugin's marker hook, which detects the `claude:dangerouslyDisableSandbox` comment in the script head.
+`scripts/url.ts` owns the URL handoff. `dispatch(command, params)` builds the Things URL, runs it through the x-callback-url runner when available, and falls back to a Launch Services `open` on any xcall failure, returning the parsed todo id when xcall surfaces one. `inbox.ts`, `reorder.ts`, and `url.ts`'s own CLI call `dispatch` rather than re-implementing the runner-selection and fallback. `buildUrl`, `openUrl`, `xcall`, and `findXcallRunner` are internal to `url.ts`. Inject a `DispatchActions` to test runner selection and fallback without real Launch Services or keychain access, mirroring `plugins/gitlab/scripts/merge.ts`.
+
+`reorder.ts` and `inbox.ts` are bun TypeScript scripts (not `osascript`). Sandbox bypass comes from the `mac` plugin's marker hook, which detects the `claude:dangerouslyDisableSandbox` comment in the script head.
 
 ## What NOT to Do
 

--- a/plugins/things/scripts/inbox.ts
+++ b/plugins/things/scripts/inbox.ts
@@ -4,18 +4,13 @@
 import { cli } from "cleye";
 import { ensureThingsRunning } from "./ensure-running";
 import { mergeTags, parseTags } from "./tags";
-import { buildUrl, findXcallRunner, openUrl, xcall } from "./url";
+import { dispatch } from "./url";
 
 const INBOX_PARAMS = new Set(["title", "titles", "notes", "tags", "checklist-items"]);
 
 function buildAttribution(sessionId: string): string {
   const dir = process.cwd();
   return `---\n\n🤖 Created via Claude Code (Session: ${sessionId})\n\n\`\`\`sh\ncd ${dir} && claude --resume ${sessionId}\n\`\`\``;
-}
-
-function parseThingsId(xcallOutput: string): string | null {
-  const match = xcallOutput.match(/x-things-id=([^&\s]+)/);
-  return match?.[1] ?? null;
 }
 
 export function printCaptured(params: Map<string, string>): void {
@@ -33,16 +28,6 @@ export function printCaptured(params: Map<string, string>): void {
     return;
   }
   console.log("captured: (untitled)");
-}
-
-async function captureViaOpen(params: Map<string, string>): Promise<void> {
-  try {
-    await openUrl("add", params);
-    printCaptured(params);
-  } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exit(1);
-  }
 }
 
 if (import.meta.main) {
@@ -88,20 +73,15 @@ if (import.meta.main) {
 
   await ensureThingsRunning();
 
-  if (await findXcallRunner()) {
-    const url = await buildUrl("add", params);
-    try {
-      const result = await xcall(url);
-      const id = parseThingsId(result);
-      if (id) {
-        console.log(`https://things.bendrucker.me/show?id=${id}`);
-      } else {
-        printCaptured(params);
-      }
-    } catch {
-      await captureViaOpen(params);
+  try {
+    const result = await dispatch("add", params);
+    if (result.id) {
+      console.log(`https://things.bendrucker.me/show?id=${result.id}`);
+    } else {
+      printCaptured(params);
     }
-  } else {
-    await captureViaOpen(params);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
   }
 }

--- a/plugins/things/scripts/reorder.ts
+++ b/plugins/things/scripts/reorder.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env bun
 // claude:dangerouslyDisableSandbox: hands off to Launch Services (open) for Things URL schemes
 
-import { $ } from "bun";
+import { cli } from "cleye";
 import { ensureThingsRunning } from "./ensure-running";
-import { buildUrl } from "./url";
+import { dispatch } from "./url";
 
 const INTERMEDIATE_LIST: Record<string, string> = {
   today: "anytime",
@@ -11,11 +11,20 @@ const INTERMEDIATE_LIST: Record<string, string> = {
   someday: "anytime",
 };
 
-async function openJsonUrl(data: object[]): Promise<void> {
+async function updateWhen(ids: string[], when: string): Promise<void> {
   const params = new Map<string, string>();
-  params.set("data", JSON.stringify(data));
-  const url = await buildUrl("json", params);
-  await $`open -g ${url}`;
+  params.set(
+    "data",
+    JSON.stringify(
+      ids.map((id) => ({
+        type: "to-do",
+        operation: "update",
+        id,
+        attributes: { when },
+      })),
+    ),
+  );
+  await dispatch("json", params);
 }
 
 async function reorder(targetList: string, ids: string[]): Promise<void> {
@@ -30,30 +39,13 @@ async function reorder(targetList: string, ids: string[]): Promise<void> {
     process.exit(1);
   }
 
-  await openJsonUrl(
-    ids.map((id) => ({
-      type: "to-do",
-      operation: "update",
-      id,
-      attributes: { when: intermediate },
-    })),
-  );
-
-  await openJsonUrl(
-    ids.map((id) => ({
-      type: "to-do",
-      operation: "update",
-      id,
-      attributes: { when: targetList },
-    })),
-  );
+  await updateWhen(ids, intermediate);
+  await updateWhen(ids, targetList);
 
   console.log(JSON.stringify({ success: true, list: targetList, reordered: ids.length }));
 }
 
 if (import.meta.main) {
-  const { cli } = await import("cleye");
-
   const argv = cli({
     name: "reorder",
     parameters: ["[ids...]"],

--- a/plugins/things/scripts/url.test.ts
+++ b/plugins/things/scripts/url.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { buildJsonPayload, coerceAttributes, isSandboxBlockedHandoff } from "./url";
+import {
+  buildJsonPayload,
+  coerceAttributes,
+  type DispatchActions,
+  dispatch,
+  isSandboxBlockedHandoff,
+} from "./url";
 
 describe("buildJsonPayload", () => {
   test("single ID produces correct structure", () => {
@@ -150,5 +156,86 @@ describe("isSandboxBlockedHandoff", () => {
   test("does not match -10673 embedded in a larger number", () => {
     expect(isSandboxBlockedHandoff("some unrelated number 999-106730 here")).toBe(false);
     expect(isSandboxBlockedHandoff("error -106731 something else")).toBe(false);
+  });
+});
+
+describe("dispatch", () => {
+  function trackingActions(overrides: Partial<DispatchActions>): {
+    actions: DispatchActions;
+    calls: { xcall: string[]; open: string[] };
+  } {
+    const calls = { xcall: [] as string[], open: [] as string[] };
+    const actions: DispatchActions = {
+      findXcallRunner: async () => "/runner",
+      xcall: async (_runner, url) => {
+        calls.xcall.push(url);
+        return "";
+      },
+      openUrl: async (command) => {
+        calls.open.push(command);
+      },
+      ...overrides,
+    };
+    return { actions, calls };
+  }
+
+  test("runs via xcall and parses the returned id", async () => {
+    const { actions, calls } = trackingActions({
+      xcall: async (_runner, url) => {
+        calls.xcall.push(url);
+        return "things:///x-callback-url/add?x-things-id=ABC123&x-source=Things";
+      },
+    });
+
+    const result = await dispatch("add", new Map([["title", "Buy milk"]]), actions);
+
+    expect(result).toEqual({ id: "ABC123", output: expect.any(String), viaXcall: true });
+    expect(calls.open).toEqual([]);
+    expect(calls.xcall[0]).toContain("things:///add?");
+  });
+
+  test("returns a null id when xcall surfaces no id", async () => {
+    const { actions } = trackingActions({ xcall: async () => "" });
+
+    const result = await dispatch("add", new Map([["title", "Buy milk"]]), actions);
+
+    expect(result.id).toBeNull();
+    expect(result.viaXcall).toBe(true);
+  });
+
+  test("falls back to openUrl when no runner is available", async () => {
+    const { actions, calls } = trackingActions({ findXcallRunner: async () => null });
+
+    const result = await dispatch("add", new Map([["title", "Buy milk"]]), actions);
+
+    expect(result).toEqual({ id: null, output: null, viaXcall: false });
+    expect(calls.xcall).toEqual([]);
+    expect(calls.open).toEqual(["add"]);
+  });
+
+  test("falls back to openUrl when xcall throws", async () => {
+    const { actions, calls } = trackingActions({
+      xcall: async () => {
+        throw new Error("xcall failed (exit 1)");
+      },
+    });
+
+    const result = await dispatch("add", new Map([["title", "Buy milk"]]), actions);
+
+    expect(result.viaXcall).toBe(false);
+    expect(calls.open).toEqual(["add"]);
+  });
+
+  test("propagates openUrl errors", async () => {
+    const { actions } = trackingActions({
+      findXcallRunner: async () => null,
+      openUrl: async () => {
+        throw new Error("open blocked");
+      },
+    });
+
+    await expect(dispatch("add", new Map([["title", "Buy milk"]]), actions)).rejects.toThrow(
+      "open blocked",
+    );
   });
 });

--- a/plugins/things/scripts/url.ts
+++ b/plugins/things/scripts/url.ts
@@ -4,6 +4,7 @@
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { $ } from "bun";
+import { cli } from "cleye";
 import { ensureThingsRunning } from "./ensure-running";
 
 const AUTH_REQUIRED_COMMANDS = ["update", "update-project", "json"] as const;
@@ -29,7 +30,7 @@ function requiresAuth(command: string): boolean {
   return (AUTH_REQUIRED_COMMANDS as readonly string[]).includes(command);
 }
 
-export async function getAuthToken(): Promise<string> {
+async function getAuthToken(): Promise<string> {
   try {
     const result =
       await $`security find-generic-password -a "$USER" -s "things-auth-token" -w`.text();
@@ -41,11 +42,11 @@ export async function getAuthToken(): Promise<string> {
   }
 }
 
-export interface OpenUrlOptions {
+interface OpenUrlOptions {
   background?: boolean;
 }
 
-export async function buildUrl(command: string, params: Map<string, string>): Promise<string> {
+async function buildUrl(command: string, params: Map<string, string>): Promise<string> {
   if (!isValidCommand(command)) {
     throw new Error(`Invalid command: ${command}`);
   }
@@ -75,7 +76,7 @@ export function isSandboxBlockedHandoff(stderr: string): boolean {
   );
 }
 
-export async function openUrl(
+async function openUrl(
   command: string,
   params: Map<string, string>,
   options?: OpenUrlOptions,
@@ -102,7 +103,7 @@ export async function openUrl(
   }
 }
 
-export async function findXcallRunner(): Promise<string | null> {
+async function findXcallRunner(): Promise<string | null> {
   const pluginRoot = join(import.meta.dirname, "..");
 
   // Dev layout: sibling plugin directory
@@ -172,11 +173,7 @@ export function buildJsonPayload(ids: string[], attributes: Record<string, strin
   return JSON.stringify(data);
 }
 
-export async function xcall(url: string): Promise<string> {
-  const runner = await findXcallRunner();
-  if (!runner) {
-    throw new Error("xcall not found — x-callback-url plugin not installed");
-  }
+async function xcall(runner: string, url: string): Promise<string> {
   const proc = Bun.spawn([runner, url], { stdout: "pipe", timeout: 10_000 });
   const text = await new Response(proc.stdout).text();
   const code = await proc.exited;
@@ -184,10 +181,59 @@ export async function xcall(url: string): Promise<string> {
   return text.trim();
 }
 
+function parseThingsId(xcallOutput: string): string | null {
+  const match = xcallOutput.match(/x-things-id=([^&\s]+)/);
+  return match?.[1] ?? null;
+}
+
+export interface DispatchResult {
+  /** The created/updated todo id, when xcall returned one. */
+  id: string | null;
+  /** Raw xcall stdout, or null when the call fell back to Launch Services open. */
+  output: string | null;
+  /** Whether the call ran via xcall (true) or fell back to Launch Services open (false). */
+  viaXcall: boolean;
+}
+
+/**
+ * Runner and open hooks for {@link dispatch}, injectable for tests.
+ * Mirrors the MergeActions pattern in plugins/gitlab/scripts/merge.ts.
+ */
+export interface DispatchActions {
+  findXcallRunner(): Promise<string | null>;
+  xcall(runner: string, url: string): Promise<string>;
+  openUrl(command: string, params: Map<string, string>, options?: OpenUrlOptions): Promise<void>;
+}
+
+const defaultActions: DispatchActions = { findXcallRunner, xcall, openUrl };
+
+/**
+ * Builds the Things URL for an action, runs it through xcall when the
+ * x-callback-url runner is available, and falls back to a Launch Services open
+ * on any xcall failure. Returns the parsed todo id when xcall surfaced one.
+ */
+export async function dispatch(
+  command: string,
+  params: Map<string, string>,
+  actions: DispatchActions = defaultActions,
+): Promise<DispatchResult> {
+  const runner = await actions.findXcallRunner();
+  if (runner) {
+    const url = await buildUrl(command, params);
+    try {
+      const result = await actions.xcall(runner, url);
+      return { id: parseThingsId(result), output: result, viaXcall: true };
+    } catch {
+      // fall through to Launch Services
+    }
+  }
+
+  await actions.openUrl(command, params);
+  return { id: null, output: null, viaXcall: false };
+}
+
 if (import.meta.main) {
   await ensureThingsRunning();
-
-  const { cli } = await import("cleye");
 
   const argv = cli({
     name: "url",
@@ -218,6 +264,10 @@ if (import.meta.main) {
 
   const useBulkJson = command === "update" && ids.length > 1;
 
+  const callbackActions: DispatchActions = argv.flags.callback
+    ? defaultActions
+    : { ...defaultActions, findXcallRunner: async () => null };
+
   if (useBulkJson) {
     const attributes: Record<string, string> = {};
     for (const [key, value] of params) {
@@ -226,34 +276,18 @@ if (import.meta.main) {
     const payload = buildJsonPayload(ids, attributes);
     const jsonParams = new Map<string, string>();
     jsonParams.set("data", payload);
-    if (argv.flags.callback && (await findXcallRunner())) {
-      const url = await buildUrl("json", jsonParams);
-      try {
-        const result = await xcall(url);
-        console.log(result);
-      } catch (error) {
-        console.error("xcall failed, falling back to open", error);
-        await openUrl("json", jsonParams);
-      }
-    } else {
-      await openUrl("json", jsonParams);
+    const result = await dispatch("json", jsonParams, callbackActions);
+    if (result.output !== null) {
+      console.log(result.output);
     }
   } else {
     const singleId = ids[0];
     if (singleId) {
       params.set("id", singleId);
     }
-    if (argv.flags.callback && (await findXcallRunner())) {
-      const url = await buildUrl(command, params);
-      try {
-        const result = await xcall(url);
-        console.log(result);
-      } catch (error) {
-        console.error("xcall failed, falling back to open", error);
-        await openUrl(command, params);
-      }
-    } else {
-      await openUrl(command, params);
+    const result = await dispatch(command, params, callbackActions);
+    if (result.output !== null) {
+      console.log(result.output);
     }
   }
 }


### PR DESCRIPTION
Hides the Things URL handoff behind one deep entry point in `url.ts`. The real work was always a dispatch with a fallback: pick the xcall runner if available, run the x-callback-url call, and on failure fall back to `openUrl` (Launch Services). That fallback had leaked. `inbox.ts` re-implemented the `findXcallRunner` -> try `xcall` -> catch `openUrl` sequence, and `url.ts`'s own CLI did it twice.

## Changes

- Adds `dispatch(command, params)` to `url.ts`. It builds the URL, selects the runner, runs via `xcall`, and falls back to `openUrl` on any failure. It returns the parsed todo id when `xcall` surfaces one (`x-things-id`), plus the raw xcall output so the CLI can still print it.
- `inbox.ts` calls `dispatch` and keeps its existing output: the `https://things.bendrucker.me/show?id=...` URL when an id comes back, otherwise `captured: <title>`.
- `reorder.ts` and `url.ts`'s CLI call `dispatch` instead of opening URLs themselves.
- `buildUrl`, `openUrl`, `xcall`, `findXcallRunner`, and `getAuthToken` are now internal to `url.ts`. The tested helpers (`buildJsonPayload`, `coerceAttributes`, `isSandboxBlockedHandoff`) stay exported.
- Converts the dynamic `await import("cleye")` in `reorder.ts` and `url.ts` to static imports.

Caller CLI behavior is unchanged.

## Testing

`dispatch` takes an injectable `DispatchActions` (mirroring `MergeActions` in `plugins/gitlab/scripts/merge.ts`), so the runner-selection and fallback are covered without touching real Launch Services or the keychain: id parsing, the no-id case, falling back when no runner is found, falling back when `xcall` throws, and propagating `openUrl` errors. The existing URL-building and attribute-coercion tests are unchanged. `bun test plugins/things/` passes.
