### PR TITLE
writing: collapse tag-ngram pass-through wrappers

### DIFF
--- a/plugins/writing/skills/analyze/scripts/analyze.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.ts
@@ -20,7 +20,7 @@ import { computeLift, excludePhrases, processCorpus, processRows } from "./ngram
 import { findQuote } from "./quote-context";
 import { buildRuleHealth, type CandidatePhrase, type FtsAuditRow, renderReport } from "./report";
 import { auditStructuralPatterns } from "./structural";
-import { processTagCorpus, processTagRows, type TagSignatureRow } from "./tag-ngram";
+import { type TagSignatureRow, tagSequence } from "./tag-ngram";
 import { loadProfile, phraseProfileStat } from "./voice-profile";
 import type { WordlistEntry } from "./wordlists";
 import { loadWordlists } from "./wordlists";
@@ -247,8 +247,13 @@ async function main(): Promise<void> {
     const deliverableAudit = auditDeliverableCorpus(wordlistEntries, deliverableRows);
 
     console.error("Computing structural signatures (part-of-speech tag sequences)");
-    const tagAssistant = processTagRows(deliverableRows);
-    const tagUser = processTagCorpus(userText);
+    const tagSizes = [3, 4, 5];
+    const tagExamples = new Map<string, string>();
+    const tagAssistant = processRows(deliverableRows, tagSizes, {
+      tokenize: (s) => tagSequence(s),
+      examples: tagExamples,
+    });
+    const tagUser = processCorpus(userText, tagSizes, (s) => tagSequence(s));
     // Tag sequences draw from an alphabet of ~17 tags, so they are far
     // denser than word n-grams; the floors are higher to compensate.
     const tagLifts = computeLift({
@@ -263,7 +268,7 @@ async function main(): Promise<void> {
       .map((r) => ({
         ...r,
         sessions: tagAssistant.sessionSpread.get(r.phrase) ?? 0,
-        example: tagAssistant.examples.get(r.phrase) ?? null,
+        example: tagExamples.get(r.phrase) ?? null,
       }));
 
     console.error("Fetching correction candidates");

--- a/plugins/writing/skills/analyze/scripts/tag-ngram.test.ts
+++ b/plugins/writing/skills/analyze/scripts/tag-ngram.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { processTagRows, tagSequence } from "./tag-ngram";
+import { processRows } from "./ngram";
+import { tagSequence } from "./tag-ngram";
 
 // Invented sentences exercising the structural shapes the signature
 // miner exists to catch: passive voice, participial openers, "not X
@@ -30,32 +31,34 @@ describe("tagSequence", () => {
   });
 });
 
-describe("processTagRows", () => {
+describe("tag sequences through processRows", () => {
   const passive = "The flag was removed after the rollout";
   const rows = [
     { session_id: "a", text: `${passive}. The flag was removed by the cleanup job.` },
     { session_id: "b", text: "The cache was invalidated by a background sweep." },
     { session_id: "c" },
   ];
+  const tokenize = (sentence: string) => tagSequence(sentence);
 
   it("counts tag trigrams across rows", () => {
-    const { stats } = processTagRows(rows, [3]);
+    const { stats } = processRows(rows, [3], { tokenize });
     const counts = stats.ngrams.get(3);
     expect(counts?.get("NOUN COPULA PARTICIPLE")).toBe(3);
   });
 
   it("tracks session spread per sequence", () => {
-    const { sessionSpread } = processTagRows(rows, [3]);
+    const { sessionSpread } = processRows(rows, [3], { tokenize });
     expect(sessionSpread.get("NOUN COPULA PARTICIPLE")).toBe(2);
   });
 
   it("keeps the shortest example sentence per sequence", () => {
-    const { examples } = processTagRows(rows, [3]);
+    const examples = new Map<string, string>();
+    processRows(rows, [3], { tokenize, examples });
     expect(examples.get("NOUN COPULA PARTICIPLE")).toBe(passive);
   });
 
   it("skips rows without text", () => {
-    const { stats } = processTagRows([{ session_id: "c" }], [3]);
+    const { stats } = processRows([{ session_id: "c" }], [3], { tokenize });
     expect(stats.tokens).toBe(0);
   });
 });

--- a/plugins/writing/skills/analyze/scripts/tag-ngram.ts
+++ b/plugins/writing/skills/analyze/scripts/tag-ngram.ts
@@ -10,14 +10,7 @@
  */
 import { compromiseTagger } from "../../../linguistics/compromise";
 import type { Tagger } from "../../../linguistics/tagger";
-import { type CorpusStats, type LiftRow, processCorpus, processRows } from "./ngram";
-
-export interface TagProcessedRows {
-  stats: CorpusStats;
-  sessionSpread: Map<string, number>;
-  /** Shortest corpus sentence seen for each tag sequence. */
-  examples: Map<string, string>;
-}
+import type { LiftRow } from "./ngram";
 
 export interface TagSignatureRow extends LiftRow {
   example: string | null;
@@ -35,30 +28,4 @@ export function tagSequence(sentence: string, tagger: Tagger = compromiseTagger)
     .flatMap((tagged) => tagged.tokens)
     .filter((token) => token.tag !== "PUNCT" && token.tag !== "X")
     .map((token) => token.tag);
-}
-
-/** Tag-sequence corpus stats plus session spread and shortest examples. */
-export function processTagRows(
-  rows: Array<{ session_id: string; text?: string }>,
-  sizes: number[] = [3, 4, 5],
-  tagger: Tagger = compromiseTagger,
-): TagProcessedRows {
-  const examples = new Map<string, string>();
-  const { stats, sessionSpread } = processRows(rows, sizes, {
-    tokenize: (sentence) => tagSequence(sentence, tagger),
-    examples,
-  });
-  return { stats, sessionSpread, examples };
-}
-
-/**
- * Tag-sequence corpus stats only, for the baseline corpus where session
- * spread and examples are not needed (mirrors `processCorpus` for words).
- */
-export function processTagCorpus(
-  text: string,
-  sizes: number[] = [3, 4, 5],
-  tagger: Tagger = compromiseTagger,
-): CorpusStats {
-  return processCorpus(text, sizes, (sentence) => tagSequence(sentence, tagger));
 }


### PR DESCRIPTION
Deletes the `processTagRows` and `processTagCorpus` wrappers in `tag-ngram.ts`. They forwarded to `ngram`'s `processRows`/`processCorpus` with `{tokenize: tagSequence}` and re-wrapped the result, but `ngram` already exposes the tokenizer seam. `analyze.ts` now calls `processRows`/`processCorpus` directly with `(s) => tagSequence(s)`, threading the `examples` map through the options the same way the wrapper did. Closes #776.

## Changes

- Keeps `tagSequence` and `TagSignatureRow` (used by `analyze.ts` and `report.ts`) in `tag-ngram.ts`. Drops `TagProcessedRows`, which only described the now-deleted wrapper return shape.
- `analyze.ts` supplies the default n-gram sizes `[3, 4, 5]` at the call site and owns the `examples` map directly.
- Updates `tag-ngram.test.ts` to exercise the tag tokenizer through `processRows`.

## Testing

The analyze script suite covers tag trigram counts, session spread, the shortest-example map, and rows without text, now through `processRows` with the tag tokenizer. `tsc --noEmit` passes. Behavior and output are unchanged.
