### PR TITLE
writing: extract runAnalysis from analyze CLI for testing

### DIFF
--- a/plugins/writing/skills/analyze/scripts/analyze.test.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.test.ts
@@ -1,0 +1,154 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { type AnalysisConfig, runAnalysis } from "./analyze";
+import { type Database, openSessionDb } from "./db";
+
+// The queries reference macros and tables supplied by the external session
+// index (built by the claude-code:session skill), not defined in this repo. The
+// fixture recreates the minimal seam each query touches: the date/project
+// filter macros and the sessions/text_content/content_items tables. The macros
+// cast their variable arguments because getvariable() yields untyped NULLs.
+async function seedSchema(db: Database): Promise<void> {
+  await db.run(`
+    CREATE MACRO date_filter(ts, after, before) AS (
+      (after IS NULL OR ts::DATE >= after::VARCHAR::DATE)
+      AND (before IS NULL OR ts::DATE <= before::VARCHAR::DATE)
+    );
+    CREATE MACRO project_filter(project_path, pattern) AS (
+      pattern IS NULL OR project_path GLOB pattern::VARCHAR
+    );
+  `);
+  await db.run(`
+    CREATE TABLE sessions (
+      host VARCHAR, session_id VARCHAR, project_path VARCHAR
+    );
+    CREATE TABLE text_content (
+      host VARCHAR, session_id VARCHAR, source_file VARCHAR, source_line BIGINT,
+      timestamp TIMESTAMP, role VARCHAR, model VARCHAR, text VARCHAR,
+      is_system BOOLEAN, is_subagent BOOLEAN
+    );
+    CREATE TABLE content_items (
+      host VARCHAR, session_id VARCHAR, source_file VARCHAR, source_line BIGINT,
+      timestamp TIMESTAMP, type VARCHAR, name VARCHAR, data JSON
+    );
+  `);
+}
+
+async function seedRows(db: Database, projectPath: string): Promise<void> {
+  await db.run(`
+    INSERT INTO sessions VALUES ('h1', 's1', '${projectPath}');
+    INSERT INTO text_content VALUES
+      ('h1','s1','f.jsonl',1,'2026-05-20T10:00:00Z','assistant','claude-opus-4',
+       'This is a delightful tapestry of ideas that we can weave together for you here today and beyond.',
+       false, false),
+      ('h1','s1','f.jsonl',2,'2026-05-20T10:01:00Z','user',NULL,
+       'no thats wrong fix the flowery writing please it reads like marketing fluff to me okay friend',
+       false, false);
+    INSERT INTO content_items VALUES
+      ('h1','s1','f.jsonl',3,'2026-05-20T10:02:00Z','tool_use','Write',
+       '{"input":{"file_path":"${projectPath}/README.md","content":"This document is a comprehensive source of truth that delves into the rich tapestry of our delightful project offering."}}');
+  `);
+}
+
+async function fixtureWordlists(): Promise<string> {
+  const dir = mkdtempSync(path.join(tmpdir(), "analyze-wordlists-"));
+  await Bun.write(path.join(dir, "vocabulary.txt"), "tapestry\ndelve\n");
+  await Bun.write(path.join(dir, "flowery-phrases.txt"), "source of truth\n");
+  return dir;
+}
+
+function baseConfig(wordlistsDir: string): AnalysisConfig {
+  return {
+    generatedAt: "2026-05-24",
+    since: "2026-05-01",
+    until: "2026-05-31",
+    modelFilter: "*opus*",
+    projectFilter: null,
+    minLift: 5,
+    minCount: 5,
+    topN: 10,
+    tagMinLift: 2,
+    tagTop: 10,
+    wordlistsDir,
+    // No profile on disk: loadProfile returns null and the deliverable-surface
+    // rule is kept pending a baseline rather than measured for distinctiveness.
+    dataDir: path.join(tmpdir(), "analyze-no-such-data-dir"),
+    pasteMaxChars: 2000,
+    selfName: "",
+    correctiveLimit: 25,
+  };
+}
+
+describe("runAnalysis", () => {
+  let db: Database;
+  let wordlistsDir: string;
+
+  beforeAll(async () => {
+    wordlistsDir = await fixtureWordlists();
+    db = await openSessionDb(":memory:");
+    await seedSchema(db);
+    await seedRows(db, "/home/u/proj");
+  });
+
+  afterAll(() => {
+    db.close();
+  });
+
+  test("assembles a well-formed ReportInput over the fixture DB", async () => {
+    const result = await runAnalysis(db, baseConfig(wordlistsDir));
+
+    // Config-derived fields pass through unchanged.
+    expect(result.generatedAt).toBe("2026-05-24");
+    expect(result.since).toBe("2026-05-01");
+    expect(result.until).toBe("2026-05-31");
+    expect(result.modelFilter).toBe("*opus*");
+    expect(result.projectFilter).toBeNull();
+    expect(result.minLift).toBe(5);
+    expect(result.minCount).toBe(5);
+    expect(result.topN).toBe(10);
+
+    // Corpus character totals come from the seeded rows, routed by role and
+    // deliverable extraction.
+    expect(result.assistantTotalChars).toBeGreaterThan(0);
+    expect(result.deliverableTotalChars).toBeGreaterThan(0);
+    expect(result.userTotalChars).toBeGreaterThan(0);
+
+    // One assistant model in window.
+    expect(result.modelSummary).toHaveLength(1);
+    expect(result.modelSummary[0]?.model).toBe("claude-opus-4");
+
+    // No profile on disk: voice baseline is absent.
+    expect(result.voiceProfile).toBeNull();
+
+    // Rule health covers every fixture wordlist entry (one per surface kind).
+    expect(result.ruleHealth).toHaveLength(3);
+    const surfaces = new Set(result.ruleHealth.map((r) => r.surface));
+    expect(surfaces.has("chat")).toBe(true);
+    expect(surfaces.has("deliverable")).toBe(true);
+
+    // The corrective-feedback query matched the frustration lexicon on the
+    // seeded user reply.
+    expect(result.corrective.length).toBeGreaterThan(0);
+    expect(result.corrective[0]?.matched_term.length).toBeGreaterThan(0);
+
+    // The remaining sections are present and typed as arrays.
+    expect(Array.isArray(result.candidatePhrases)).toBe(true);
+    expect(Array.isArray(result.structuralSignatures)).toBe(true);
+    expect(Array.isArray(result.structuralAudit)).toBe(true);
+    expect(Array.isArray(result.corrections)).toBe(true);
+  });
+
+  test("scopes the corpus to the date window", async () => {
+    const outOfWindow = baseConfig(wordlistsDir);
+    outOfWindow.since = "2026-01-01";
+    outOfWindow.until = "2026-01-31";
+    const result = await runAnalysis(db, outOfWindow);
+
+    expect(result.assistantTotalChars).toBe(0);
+    expect(result.deliverableTotalChars).toBe(0);
+    expect(result.modelSummary).toHaveLength(0);
+    expect(result.corrective).toHaveLength(0);
+  });
+});

--- a/plugins/writing/skills/analyze/scripts/analyze.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.ts
@@ -4,7 +4,7 @@ import { rm } from "node:fs/promises";
 import * as path from "node:path";
 import { cli } from "cleye";
 import { corpusPath, profilePath, resolveDataDir } from "./data-dir";
-import { openSessionDb } from "./db";
+import { type Database, openSessionDb } from "./db";
 import { auditDeliverableCorpus } from "./deliverable-audit";
 import {
   type CorrectionRow,
@@ -18,7 +18,7 @@ import {
 import { escapeRegex, frustrationRegex } from "./frustration";
 import { computeLift, excludePhrases, processCorpus, processRows } from "./ngram";
 import { findQuote } from "./quote-context";
-import { type CandidatePhrase, renderReport } from "./report";
+import { type CandidatePhrase, type ReportInput, renderReport } from "./report";
 import { buildRuleHealth, type FtsAuditRow } from "./rule-health";
 import { auditStructuralPatterns } from "./structural";
 import { type TagSignatureRow, tagSequence } from "./tag-ngram";
@@ -26,117 +26,141 @@ import { loadProfile, phraseProfileStat } from "./voice-profile";
 import type { WordlistEntry } from "./wordlists";
 import { loadWordlists } from "./wordlists";
 
-const argv = cli({
-  name: "analyze",
-  flags: {
-    since: {
-      type: String,
-      description: "Lower bound date YYYY-MM-DD (default: 30 days ago)",
-    },
-    until: {
-      type: String,
-      description: "Upper bound date YYYY-MM-DD (default: today)",
-    },
-    model: {
-      type: String,
-      description: "Model glob filter for assistant corpus",
-      default: "*opus*",
-    },
-    project: {
-      type: String,
-      description: "Project glob filter",
-    },
-    minLift: {
-      type: Number,
-      description: "Minimum lift threshold for surfacing new candidate phrases",
-      default: 5.0,
-    },
-    minCount: {
-      type: Number,
-      description:
-        "Minimum assistant occurrences for a rule to count as alive (below this is 'dead')",
-      default: 5,
-    },
-    top: {
-      type: Number,
-      description: "Top N candidate phrases to surface",
-      default: 30,
-    },
-    tagMinLift: {
-      type: Number,
-      description: "Minimum lift threshold for structural (part-of-speech tag sequence) signatures",
-      default: 2.0,
-    },
-    tagTop: {
-      type: Number,
-      description: "Top N structural signatures to surface",
-      default: 20,
-    },
-    out: {
-      type: String,
-      description: "Output report path (default: tmp/trope-analysis-<date>.md)",
-    },
-    sessionDb: {
-      type: String,
-      description: "Path to session DuckDB database file",
-      required: true as const,
-    },
-    wordlistsDir: {
-      type: String,
-      description: "Wordlists directory (defaults to plugins/writing/wordlists)",
-    },
-    dataDir: {
-      type: String,
-      description:
-        "Local data dir for the voice baseline (default: CLAUDE_PLUGIN_DATA or ~/.claude/plugins/data/writing-bendrucker)",
-    },
-    pasteMaxChars: {
-      type: Number,
-      description: "Length ceiling for human-authored user messages (paste filter)",
-      default: 2000,
-    },
-    selfName: {
-      type: String,
-      description:
-        "Your name, used to drop pasted prose that refers to you in the third person from the user baseline (case-insensitive; empty disables this signal)",
-      default: "",
-    },
-    correctiveLimit: {
-      type: Number,
-      description: "Max corrective-feedback moments to surface",
-      default: 25,
-    },
-  },
-});
+// Everything runAnalysis needs once flag parsing and date defaulting are done.
+// generatedAt is supplied by the caller so the orchestration stays pure (no
+// clock reads inside runAnalysis); the CLI passes today's date.
+export interface AnalysisConfig {
+  generatedAt: string;
+  since: string;
+  until: string;
+  modelFilter: string;
+  projectFilter: string | null;
+  minLift: number;
+  minCount: number;
+  topN: number;
+  tagMinLift: number;
+  tagTop: number;
+  wordlistsDir: string;
+  dataDir: string;
+  pasteMaxChars: number;
+  selfName: string;
+  correctiveLimit: number;
+}
 
-const today = new Date().toISOString().slice(0, 10);
-const since = argv.flags.since ?? daysAgo(30);
-const until = argv.flags.until ?? today;
-const modelFilter = argv.flags.model;
-const projectFilter = argv.flags.project ?? null;
-const minLift = argv.flags.minLift;
-const minCount = argv.flags.minCount;
-const topN = argv.flags.top;
-const dbPath = path.resolve(argv.flags.sessionDb ?? "");
-const wordlistsDir =
-  argv.flags.wordlistsDir ?? path.join(import.meta.dirname, "..", "..", "..", "wordlists");
-const outPath = argv.flags.out ?? path.join("tmp", `trope-analysis-${today}.md`);
-const dataDir = resolveDataDir(argv.flags.dataDir);
-const pasteMaxChars = String(argv.flags.pasteMaxChars);
-const correctiveLimit = String(argv.flags.correctiveLimit);
-const baseParams: Record<string, string | null> = {
-  after_date: since,
-  before_date: until,
-  project: projectFilter,
-  paste_max_chars: pasteMaxChars,
-  // Escape regex metacharacters: the paste filter interpolates this into an RE2
-  // pattern (\b...\b), so a literal name with metachars must match literally.
-  self_name: escapeRegex(argv.flags.selfName ?? ""),
-};
+if (import.meta.main) {
+  await main();
+}
 
-await main();
+function parseFlags() {
+  return cli({
+    name: "analyze",
+    flags: {
+      since: {
+        type: String,
+        description: "Lower bound date YYYY-MM-DD (default: 30 days ago)",
+      },
+      until: {
+        type: String,
+        description: "Upper bound date YYYY-MM-DD (default: today)",
+      },
+      model: {
+        type: String,
+        description: "Model glob filter for assistant corpus",
+        default: "*opus*",
+      },
+      project: {
+        type: String,
+        description: "Project glob filter",
+      },
+      minLift: {
+        type: Number,
+        description: "Minimum lift threshold for surfacing new candidate phrases",
+        default: 5.0,
+      },
+      minCount: {
+        type: Number,
+        description:
+          "Minimum assistant occurrences for a rule to count as alive (below this is 'dead')",
+        default: 5,
+      },
+      top: {
+        type: Number,
+        description: "Top N candidate phrases to surface",
+        default: 30,
+      },
+      tagMinLift: {
+        type: Number,
+        description:
+          "Minimum lift threshold for structural (part-of-speech tag sequence) signatures",
+        default: 2.0,
+      },
+      tagTop: {
+        type: Number,
+        description: "Top N structural signatures to surface",
+        default: 20,
+      },
+      out: {
+        type: String,
+        description: "Output report path (default: tmp/trope-analysis-<date>.md)",
+      },
+      sessionDb: {
+        type: String,
+        description: "Path to session DuckDB database file",
+        required: true as const,
+      },
+      wordlistsDir: {
+        type: String,
+        description: "Wordlists directory (defaults to plugins/writing/wordlists)",
+      },
+      dataDir: {
+        type: String,
+        description:
+          "Local data dir for the voice baseline (default: CLAUDE_PLUGIN_DATA or ~/.claude/plugins/data/writing-bendrucker)",
+      },
+      pasteMaxChars: {
+        type: Number,
+        description: "Length ceiling for human-authored user messages (paste filter)",
+        default: 2000,
+      },
+      selfName: {
+        type: String,
+        description:
+          "Your name, used to drop pasted prose that refers to you in the third person from the user baseline (case-insensitive; empty disables this signal)",
+        default: "",
+      },
+      correctiveLimit: {
+        type: Number,
+        description: "Max corrective-feedback moments to surface",
+        default: 25,
+      },
+    },
+  });
+}
 
 async function main(): Promise<void> {
+  const argv = parseFlags();
+  const today = new Date().toISOString().slice(0, 10);
+  const config: AnalysisConfig = {
+    generatedAt: today,
+    since: argv.flags.since ?? daysAgo(30),
+    until: argv.flags.until ?? today,
+    modelFilter: argv.flags.model,
+    projectFilter: argv.flags.project ?? null,
+    minLift: argv.flags.minLift,
+    minCount: argv.flags.minCount,
+    topN: argv.flags.top,
+    tagMinLift: argv.flags.tagMinLift,
+    tagTop: argv.flags.tagTop,
+    wordlistsDir:
+      argv.flags.wordlistsDir ?? path.join(import.meta.dirname, "..", "..", "..", "wordlists"),
+    dataDir: resolveDataDir(argv.flags.dataDir),
+    pasteMaxChars: argv.flags.pasteMaxChars,
+    selfName: argv.flags.selfName,
+    correctiveLimit: argv.flags.correctiveLimit,
+  };
+  const dbPath = path.resolve(argv.flags.sessionDb ?? "");
+  const outPath = argv.flags.out ?? path.join("tmp", `trope-analysis-${today}.md`);
+
   const sessionId = process.env.CLAUDE_SESSION_ID ?? "anonymous";
   const isolatedPath = path.join(
     process.env.TMPDIR || "/tmp",
@@ -146,178 +170,8 @@ async function main(): Promise<void> {
   await Bun.write(isolatedPath, Bun.file(dbPath));
 
   const db = await openSessionDb(isolatedPath);
-
-  console.error("Loading current wordlists");
-  const wordlistEntries = await loadWordlists(wordlistsDir);
-  console.error(`Loaded ${wordlistEntries.length} wordlist entries from ${wordlistsDir}`);
-
-  console.error(`Loading voice profile from ${profilePath(dataDir)}`);
-  const voiceProfile = await loadProfile(profilePath(dataDir));
-  if (voiceProfile) {
-    console.error(
-      `Voice baseline: ${voiceProfile.documentCount} documents, ${voiceProfile.totalTokens.toLocaleString()} tokens`,
-    );
-  } else {
-    console.error(
-      `No voice profile found. Run ingest-voice.ts (seed: ${corpusPath(dataDir)}) then voice-profile.ts. Deliverable-surface rules are kept pending a baseline (distinctiveness unverified) instead of falling back to the chat audit.`,
-    );
-  }
-
   try {
-    console.error("Creating paste filter for the user baseline");
-    await db.execQuery("paste-filter", baseParams);
-
-    console.error("Building FTS indexes");
-    await db.execQuery("fts-setup", { ...baseParams, model: modelFilter });
-
-    console.error("Auditing wordlists via FTS");
-    const auditTerms = wordlistEntries.map((e) => e.phrase.toLowerCase()).join(",");
-    const auditRows = await db.runQuery<FtsAuditRow>("fts-phrase-audit", { terms: auditTerms });
-    const auditByTerm = new Map(auditRows.map((r) => [r.term, r]));
-
-    console.error("Fetching model summary");
-    const modelSummary = await db.runQuery<ModelSummaryRow>("model-summary", baseParams);
-
-    console.error("Dumping all assistant text");
-    const assistantRows = await db.runQuery<TextRow>("text-export", {
-      ...baseParams,
-      role: "assistant",
-      model: modelFilter,
-      min_chars: "50",
-    });
-
-    console.error("Dumping deliverable-prose corpus (Write/Edit/Bash tool inputs)");
-    const deliverableRows = await db.runQuery<DeliverableRow>("deliverable-prose", baseParams);
-
-    console.error("Dumping user corpus (human input only)");
-    const userRows = await db.runQuery<TextRow>("text-export", {
-      ...baseParams,
-      role: "user",
-      model: null,
-      min_chars: "50",
-      human_only: "true",
-    });
-
-    console.error(
-      `All assistant: ${assistantRows.length} (${totalChars(assistantRows).toLocaleString()} chars), deliverable: ${deliverableRows.length} (${totalChars(deliverableRows).toLocaleString()} chars), user: ${userRows.length} (${totalChars(userRows).toLocaleString()} chars)`,
-    );
-
-    const allModelText = [...assistantRows, ...deliverableRows];
-    const ngramSizes = [3, 4];
-    // Mine candidates from deliverable prose only (file writes and Bash
-    // commit/PR/MR bodies), not conversational assistant text. The hook scans
-    // deliverables and side-effect inputs, never the model's chat, so chat
-    // narration ("now let me", "let me check") would otherwise dominate the
-    // candidate list with phrases the hook can never act on.
-    const { stats: assistantCorpus, sessionSpread: sessionCounts } = processRows(
-      deliverableRows,
-      ngramSizes,
-    );
-    const userText = serializeCorpus(userRows);
-    const userCorpus = processCorpus(userText, ngramSizes);
-    const candidateSessions = new Set(deliverableRows.map((r) => r.session_id)).size;
-    const minSessions = Math.max(3, Math.round(candidateSessions * 0.05));
-    console.error(
-      `Session threshold: ${minSessions} (${candidateSessions} deliverable sessions in window)`,
-    );
-
-    const allLifts = computeLift({
-      assistant: assistantCorpus,
-      user: userCorpus,
-      minAssistantCount: { 3: 5, 4: 3 },
-    });
-    const exclusionSet = new Set(wordlistEntries.map((e) => e.phrase));
-    const candidatePhrases: CandidatePhrase[] = excludePhrases(allLifts, exclusionSet)
-      .filter((r) => r.lift >= minLift)
-      .filter((r) => (sessionCounts.get(r.phrase) ?? 0) >= minSessions)
-      .slice(0, topN)
-      .map((r) => {
-        const baseline = voiceProfile
-          ? phraseProfileStat(voiceProfile, r.phrase)
-          : { count: 0, perMillion: 0 };
-        return {
-          ...r,
-          sessions: sessionCounts.get(r.phrase) ?? 0,
-          baselineCount: baseline.count,
-          baselinePerM: baseline.perMillion,
-          quote: findQuote(r.phrase, deliverableRows),
-        };
-      });
-
-    console.error("Auditing deliverable corpus for wordlist rules");
-    const deliverableAudit = auditDeliverableCorpus(wordlistEntries, deliverableRows);
-
-    console.error("Computing structural signatures (part-of-speech tag sequences)");
-    const tagSizes = [3, 4, 5];
-    const tagExamples = new Map<string, string>();
-    const tagAssistant = processRows(deliverableRows, tagSizes, {
-      tokenize: (s) => tagSequence(s),
-      examples: tagExamples,
-    });
-    const tagUser = processCorpus(userText, tagSizes, (s) => tagSequence(s));
-    // Tag sequences draw from an alphabet of ~17 tags, so they are far
-    // denser than word n-grams; the floors are higher to compensate.
-    const tagLifts = computeLift({
-      assistant: tagAssistant.stats,
-      user: tagUser,
-      minAssistantCount: { 3: 30, 4: 15, 5: 8 },
-    });
-    const structuralSignatures: TagSignatureRow[] = tagLifts
-      .filter((r) => r.lift >= argv.flags.tagMinLift)
-      .filter((r) => (tagAssistant.sessionSpread.get(r.phrase) ?? 0) >= minSessions)
-      .slice(0, argv.flags.tagTop)
-      .map((r) => ({
-        ...r,
-        sessions: tagAssistant.sessionSpread.get(r.phrase) ?? 0,
-        example: tagExamples.get(r.phrase) ?? null,
-      }));
-
-    console.error("Fetching correction candidates");
-    const corrections = await db.runQuery<CorrectionRow>("correction-candidates", baseParams);
-
-    console.error("Fetching corrective feedback (frustration lexicon)");
-    const corrective = await db.runQuery<CorrectiveRow>("corrective-feedback", {
-      ...baseParams,
-      lexicon: frustrationRegex(),
-      max_user_chars: "400",
-      limit: correctiveLimit,
-    });
-
-    console.error("Auditing structural patterns against all model-generated text");
-    const structuralAudit = auditStructuralPatterns(allModelText, userRows);
-
-    const ruleHealth = buildRuleHealth({
-      entries: wordlistEntries,
-      chatAudit: auditByTerm,
-      deliverableAudit,
-      voiceProfile,
-      minCount,
-      findQuote: (entry: WordlistEntry, surface) =>
-        surface === "deliverable" ? findQuote(entry.phrase, deliverableRows) : null,
-    });
-
-    const report = renderReport({
-      generatedAt: today,
-      since,
-      until,
-      modelFilter,
-      projectFilter,
-      minLift,
-      minCount,
-      topN,
-      modelSummary,
-      assistantTotalChars: totalChars(assistantRows),
-      deliverableTotalChars: totalChars(deliverableRows),
-      userTotalChars: totalChars(userRows),
-      voiceProfile,
-      ruleHealth,
-      structuralAudit,
-      structuralSignatures,
-      candidatePhrases,
-      corrections,
-      corrective,
-    });
-
+    const report = renderReport(await runAnalysis(db, config));
     mkdirSync(path.dirname(outPath), { recursive: true });
     await Bun.write(outPath, report);
     console.error(`Wrote report to ${outPath}`);
@@ -326,6 +180,192 @@ async function main(): Promise<void> {
     db.close();
     await rm(isolatedPath, { force: true });
   }
+}
+
+// Orchestrates the tested modules over an opened session DB into a ReportInput.
+// All inputs come from db + config; no flag parsing, clock reads, or report
+// rendering happen here, so a fixture DB can drive the whole composition.
+export async function runAnalysis(db: Database, config: AnalysisConfig): Promise<ReportInput> {
+  const baseParams: Record<string, string | null> = {
+    after_date: config.since,
+    before_date: config.until,
+    project: config.projectFilter,
+    paste_max_chars: String(config.pasteMaxChars),
+    // Escape regex metacharacters: the paste filter interpolates this into an
+    // RE2 pattern (\b...\b), so a literal name with metachars must match
+    // literally.
+    self_name: escapeRegex(config.selfName),
+  };
+
+  console.error("Loading current wordlists");
+  const wordlistEntries = await loadWordlists(config.wordlistsDir);
+  console.error(`Loaded ${wordlistEntries.length} wordlist entries from ${config.wordlistsDir}`);
+
+  console.error(`Loading voice profile from ${profilePath(config.dataDir)}`);
+  const voiceProfile = await loadProfile(profilePath(config.dataDir));
+  if (voiceProfile) {
+    console.error(
+      `Voice baseline: ${voiceProfile.documentCount} documents, ${voiceProfile.totalTokens.toLocaleString()} tokens`,
+    );
+  } else {
+    console.error(
+      `No voice profile found. Run ingest-voice.ts (seed: ${corpusPath(config.dataDir)}) then voice-profile.ts. Deliverable-surface rules are kept pending a baseline (distinctiveness unverified) instead of falling back to the chat audit.`,
+    );
+  }
+
+  console.error("Creating paste filter for the user baseline");
+  await db.execQuery("paste-filter", baseParams);
+
+  console.error("Building FTS indexes");
+  await db.execQuery("fts-setup", { ...baseParams, model: config.modelFilter });
+
+  console.error("Auditing wordlists via FTS");
+  const auditTerms = wordlistEntries.map((e) => e.phrase.toLowerCase()).join(",");
+  const auditRows = await db.runQuery<FtsAuditRow>("fts-phrase-audit", { terms: auditTerms });
+  const auditByTerm = new Map(auditRows.map((r) => [r.term, r]));
+
+  console.error("Fetching model summary");
+  const modelSummary = await db.runQuery<ModelSummaryRow>("model-summary", baseParams);
+
+  console.error("Dumping all assistant text");
+  const assistantRows = await db.runQuery<TextRow>("text-export", {
+    ...baseParams,
+    role: "assistant",
+    model: config.modelFilter,
+    min_chars: "50",
+  });
+
+  console.error("Dumping deliverable-prose corpus (Write/Edit/Bash tool inputs)");
+  const deliverableRows = await db.runQuery<DeliverableRow>("deliverable-prose", baseParams);
+
+  console.error("Dumping user corpus (human input only)");
+  const userRows = await db.runQuery<TextRow>("text-export", {
+    ...baseParams,
+    role: "user",
+    model: null,
+    min_chars: "50",
+    human_only: "true",
+  });
+
+  console.error(
+    `All assistant: ${assistantRows.length} (${totalChars(assistantRows).toLocaleString()} chars), deliverable: ${deliverableRows.length} (${totalChars(deliverableRows).toLocaleString()} chars), user: ${userRows.length} (${totalChars(userRows).toLocaleString()} chars)`,
+  );
+
+  const allModelText = [...assistantRows, ...deliverableRows];
+  const ngramSizes = [3, 4];
+  // Mine candidates from deliverable prose only (file writes and Bash
+  // commit/PR/MR bodies), not conversational assistant text. The hook scans
+  // deliverables and side-effect inputs, never the model's chat, so chat
+  // narration ("now let me", "let me check") would otherwise dominate the
+  // candidate list with phrases the hook can never act on.
+  const { stats: assistantCorpus, sessionSpread: sessionCounts } = processRows(
+    deliverableRows,
+    ngramSizes,
+  );
+  const userText = serializeCorpus(userRows);
+  const userCorpus = processCorpus(userText, ngramSizes);
+  const candidateSessions = new Set(deliverableRows.map((r) => r.session_id)).size;
+  const minSessions = Math.max(3, Math.round(candidateSessions * 0.05));
+  console.error(
+    `Session threshold: ${minSessions} (${candidateSessions} deliverable sessions in window)`,
+  );
+
+  const allLifts = computeLift({
+    assistant: assistantCorpus,
+    user: userCorpus,
+    minAssistantCount: { 3: 5, 4: 3 },
+  });
+  const exclusionSet = new Set(wordlistEntries.map((e) => e.phrase));
+  const candidatePhrases: CandidatePhrase[] = excludePhrases(allLifts, exclusionSet)
+    .filter((r) => r.lift >= config.minLift)
+    .filter((r) => (sessionCounts.get(r.phrase) ?? 0) >= minSessions)
+    .slice(0, config.topN)
+    .map((r) => {
+      const baseline = voiceProfile
+        ? phraseProfileStat(voiceProfile, r.phrase)
+        : { count: 0, perMillion: 0 };
+      return {
+        ...r,
+        sessions: sessionCounts.get(r.phrase) ?? 0,
+        baselineCount: baseline.count,
+        baselinePerM: baseline.perMillion,
+        quote: findQuote(r.phrase, deliverableRows),
+      };
+    });
+
+  console.error("Auditing deliverable corpus for wordlist rules");
+  const deliverableAudit = auditDeliverableCorpus(wordlistEntries, deliverableRows);
+
+  console.error("Computing structural signatures (part-of-speech tag sequences)");
+  const tagSizes = [3, 4, 5];
+  const tagExamples = new Map<string, string>();
+  const tagAssistant = processRows(deliverableRows, tagSizes, {
+    tokenize: (s) => tagSequence(s),
+    examples: tagExamples,
+  });
+  const tagUser = processCorpus(userText, tagSizes, (s) => tagSequence(s));
+  // Tag sequences draw from an alphabet of ~17 tags, so they are far
+  // denser than word n-grams; the floors are higher to compensate.
+  const tagLifts = computeLift({
+    assistant: tagAssistant.stats,
+    user: tagUser,
+    minAssistantCount: { 3: 30, 4: 15, 5: 8 },
+  });
+  const structuralSignatures: TagSignatureRow[] = tagLifts
+    .filter((r) => r.lift >= config.tagMinLift)
+    .filter((r) => (tagAssistant.sessionSpread.get(r.phrase) ?? 0) >= minSessions)
+    .slice(0, config.tagTop)
+    .map((r) => ({
+      ...r,
+      sessions: tagAssistant.sessionSpread.get(r.phrase) ?? 0,
+      example: tagExamples.get(r.phrase) ?? null,
+    }));
+
+  console.error("Fetching correction candidates");
+  const corrections = await db.runQuery<CorrectionRow>("correction-candidates", baseParams);
+
+  console.error("Fetching corrective feedback (frustration lexicon)");
+  const corrective = await db.runQuery<CorrectiveRow>("corrective-feedback", {
+    ...baseParams,
+    lexicon: frustrationRegex(),
+    max_user_chars: "400",
+    limit: String(config.correctiveLimit),
+  });
+
+  console.error("Auditing structural patterns against all model-generated text");
+  const structuralAudit = auditStructuralPatterns(allModelText, userRows);
+
+  const ruleHealth = buildRuleHealth({
+    entries: wordlistEntries,
+    chatAudit: auditByTerm,
+    deliverableAudit,
+    voiceProfile,
+    minCount: config.minCount,
+    findQuote: (entry: WordlistEntry, surface) =>
+      surface === "deliverable" ? findQuote(entry.phrase, deliverableRows) : null,
+  });
+
+  return {
+    generatedAt: config.generatedAt,
+    since: config.since,
+    until: config.until,
+    modelFilter: config.modelFilter,
+    projectFilter: config.projectFilter,
+    minLift: config.minLift,
+    minCount: config.minCount,
+    topN: config.topN,
+    modelSummary,
+    assistantTotalChars: totalChars(assistantRows),
+    deliverableTotalChars: totalChars(deliverableRows),
+    userTotalChars: totalChars(userRows),
+    voiceProfile,
+    ruleHealth,
+    structuralAudit,
+    structuralSignatures,
+    candidatePhrases,
+    corrections,
+    corrective,
+  };
 }
 
 function daysAgo(n: number): string {


### PR DESCRIPTION
Extracts `runAnalysis(db, config)` from `analyze.ts` so the report composition has a test surface. Every module the pipeline calls was already tested; their assembly into a `ReportInput` was not, because the only entry point was the CLI `main()`. #776

`runAnalysis` takes an opened `Database` and an `AnalysisConfig`, then orchestrates the wordlist load, FTS audit, n-gram mining, structural signatures, and rule health into the `ReportInput` that `renderReport` already consumes. `main()` keeps flag parsing, date defaulting, the temp-DB copy, and report writing; it calls `runAnalysis` for the middle. I moved `generatedAt` into the config so the orchestration reads no clock and a fixture can pin the date.

## Changes

- Added `AnalysisConfig` and the exported `runAnalysis` in `analyze.ts`; `main()` now parses flags, opens the isolated DB, calls `runAnalysis`, and renders + writes the report.
- Guarded `main()` behind `import.meta.main` and moved flag parsing into `parseFlags()` so importing the module for tests does not run the CLI.
- Added `analyze.test.ts`, which drives `runAnalysis` over an in-memory DuckDB. The fixture recreates the minimal seam the queries touch (the `date_filter`/`project_filter` macros and the `sessions`/`text_content`/`content_items` tables) and asserts a well-formed `ReportInput`: config pass-through, corpus totals, model summary, rule health across both audit surfaces, and a corrective-feedback match. A second case checks the date window scopes the corpus to empty.

The test asserts the composition, not the individual modules, which keep their own tests.

## Testing

`bun test plugins/writing/skills/analyze/scripts/` (101 pass). Typecheck (`bun run build`) and `biome check` are clean. I also ran the CLI against a real DuckDB file to confirm it still parses flags, writes the report, and prints the path.
