### PR TITLE
writing: detector-layer model and per-surface promotion bars

### DIFF
--- a/plugins/writing/skills/analyze/references/linguistics.md
+++ b/plugins/writing/skills/analyze/references/linguistics.md
@@ -1,8 +1,35 @@
 # Linguistic Tooling
 
-Evaluation record for replacing hand-rolled heading and trope detectors with part-of-speech-tagger-backed rules (issue #745). This file holds the tagger comparison, the promotion criteria for swapping a tagger-backed classifier into the hook, and the earn/retire rules for each dependency.
+The framework for deciding whether a linguistic detector is worth shipping, and the record of applying it to headings (issues #745, #769). It defines four detector layers, the surface-specific bars a detector must clear, and the earn/retire rules for each dependency. The heading classifier comparison is the first detector run through it.
 
 All numbers are aggregates over private session corpora. Example headings in this file are invented, never quoted from sessions.
+
+## Detector Layers
+
+Writing checks sort by the signal they need, and that sorting drives the architecture more than "tagger vs heuristic" does. Each candidate belongs to one layer, and the layer decides the right tool before any code is written:
+
+- **Lexical** (`delve`, `boasts`, "it's worth noting"): a wordlist is optimal. Linguistics adds nothing. The eval is corpus frequency and lift, which the analyze skill already measures.
+- **Morphosyntactic** (sentence-shaped headings, passive `COPULA PARTICIPLE`, "not X but Y", correlatives): patterns over part-of-speech sequences that do not reduce to a word list and break as brittle regexes. This is the only layer the tagger stack is the right tool for.
+- **Discourse / cross-sentence** (negation flip "It isn't X. It is Y.", escalating triads, question-then-answer cadence): structure above the sentence. Part-of-speech tagging alone does not reach it.
+- **Semantic / pragmatic** (reads like marketing, hedging density): no grammar captures it. LLM-judge territory.
+
+The failure mode to avoid is making the tagger the hammer for all four. Before a trope is built as a grammar rule it gets a wordlist-vs-regex-vs-grammar-vs-judge comparison; the migration candidates in the Trope Pattern Inventory each earn the grammar layer or stay where they are. A cheap LLM-judge run is the upper reference: if a judge ties the tagger stack on a trope at acceptable latency, that trope does not belong in the grammar layer.
+
+## Two Surfaces, Two Promotion Bars
+
+The same grammar engine serves two surfaces with opposite tolerances, so promotion is two bars, not one. The eval scores every candidate against both and reports which surface, if any, it clears.
+
+The hook is a PreToolUse nudge on every edit. A false positive is a cheap, ignorable nudge, but frequent ones train the user to dismiss the hook, so it is precision-critical and recall-tolerant. A candidate replaces a hook detector only when, on a labeled session sample with an interval tight enough to act on:
+
+- precision ≥ baseline precision
+- recall strictly greater than baseline recall
+- zero regressions on the committed seed (`linguistics/heading.test.ts`)
+
+The analyze and review skills are batch and human-in-the-loop. A reviewer triages flags, so precision can be far lower in exchange for recall. A classifier too noisy for the hook can be valuable here. The bar is recall above baseline at a precision a reviewer tolerates, with the false-positive rate reported rather than gated.
+
+The near-term win is shipping the grammar layer into analyze/review at the recall-leaning bar while the hook stays on the tuned heuristic. That needs no promotion-grade interval. The hook swap waits for a labeled pass with enough power.
+
+Interval width, not point estimates, decides hook promotion. Twenty-four positive flags in a random subset put roughly ±20pp on every metric, which promotes nothing. A power calculation sizes the labeling work to the interval the decision needs (rough target: 3-5x the current positive count). The labeling protocol concentrates new labels where they move the decision (baseline-candidate disagreements and the leader's flags) while keeping a uniform-random anchor for an honest precision estimate.
 
 ## Modules
 
@@ -119,28 +146,33 @@ Vary the document type (design doc, postmortem, evaluation, rollout plan, capaci
 bun skills/analyze/scripts/headings-eval.ts --docs tmp/synthetic-corpus --out tmp/synthetic
 ```
 
-## Promotion Criterion
+## Heading Verdict
 
-A tagger-backed classifier replaces `classifyHeadingBaseline` in the hook only when, on the labeled session sample:
+Applying the two bars to the heading classifiers:
 
-- precision ≥ baseline precision
-- recall strictly greater than baseline recall
-- zero regressions on the committed seed (`linguistics/heading.test.ts`)
+- No candidate clears the hook bar. `hybrid:natural` leads on point estimates (precision at or above baseline, roughly double the recall), but the intervals overlap heavily at 24 random-subset flags, so this is direction, not a verdict. The hook keeps `classifyHeadingBaseline`.
+- The grammar layer clears the analyze/review bar: `hybrid:natural`'s recall gain is worth its precision cost where a reviewer triages. This is the near-term ship.
+- `natural` stays a devDependency while the hook question is open. The next step is a labeled pass sized by the power calculation, concentrated on `natural`'s flags, before any hook swap.
 
-The hybrid family leads as #744 predicted, keeping the heuristic's structure and replacing only the word sets, but with `natural` doing the tagging rather than the expected `compromise` (see Labeled Sample Results). Until a candidate clears the bar with a tight enough interval, the hook keeps the heuristic and the linguistics layer surfaces through the analyze and review skills.
+The hybrid family leads as #744 predicted, keeping the heuristic's structure and replacing only the word sets, but with `natural` doing the tagging rather than the expected `compromise` (see Labeled Sample Results).
 
 ## Trope Pattern Inventory
 
-Where each existing detector class lands:
+Where each existing detector lands in the layer model, and what moving it would take:
 
-- Lexical wordlists (`wordlists/*.txt`): stay as word lists. They are cheap, the analyze skill audits their health each run, and tagger machinery adds nothing to an exact vocabulary match.
-- Structural regexes in `detection/tropes.ts`: migration candidates, one follow-up issue each, gated by the same corpus-eval discipline as headings:
+- **Lexical** (`wordlists/*.txt`): stay as word lists. Cheap, the analyze skill audits their health each run, and tagger machinery adds nothing to an exact vocabulary match.
+- **Morphosyntactic** (structural regexes in `detection/tropes.ts`): migration candidates, one follow-up issue each, each gated by a wordlist-vs-regex-vs-grammar-vs-judge comparison and the two-surface bars before it is built:
   - passive voice (`COPULA PARTICIPLE` tag sequence vs. the current participle regex)
   - "not X but Y" parallelism (tag-sequence shape vs. literal `not ... but` matching)
-  - cross-sentence negation ("It isn't X. It is Y.")
   - test-result reporting (function-based test, currently uncountable by the structural audit)
+- **Discourse** (cross-sentence negation, escalating triads): structure above the sentence, which part-of-speech tagging alone does not reach. Held until the layer has tooling.
+- **Semantic** (marketing tone, hedging density): LLM-judge territory, not grammar.
+
+Per-trope migrations hold until the two-surface bars and the power calculation exist, or each repeats the underpowered-eval mistake. In the meantime the `tropes.ts` regexes ship as hook nudges and stay as-is.
 
 ## Dependencies
+
+The tagger fork is now two-way. `wink-pos-tagger` is retired (dominated by `natural`), leaving `compromise` (primary, runtime) and `natural` (devDependency, promotion candidate). The framework resolves the rest: promote `natural` if a powered labeling pass clears it at the hook bar, otherwise collapse to `compromise` only. The analyze/review ship does not force this choice, since the grammar layer surfaces there regardless of which tagger backs it.
 
 | package | role | earns its place by | retired when |
 |---|---|---|---|

--- a/plugins/writing/skills/analyze/references/linguistics.md
+++ b/plugins/writing/skills/analyze/references/linguistics.md
@@ -1,64 +1,57 @@
 # Linguistic Tooling
 
-The framework for deciding whether a linguistic detector is worth shipping, and the record of applying it to headings (issues #745, #769). It defines four detector layers, the surface-specific bars a detector must clear, and the earn/retire rules for each dependency. The heading classifier comparison is the first detector run through it.
+Record of evaluating part-of-speech-tagger-backed detectors for the writing hook and skills, and the rules for shipping one. The heading classifier is the first detector evaluated here.
 
-All numbers are aggregates over private session corpora. Example headings in this file are invented, never quoted from sessions.
+Numbers are aggregates over private session corpora. Example headings are invented, never quoted from sessions.
 
 ## Detector Layers
 
-Writing checks sort by the signal they need, and that sorting drives the architecture more than "tagger vs heuristic" does. Each candidate belongs to one layer, and the layer decides the right tool before any code is written:
+A writing check belongs to one of four layers, and the layer decides the right tool before any code is written:
 
-- **Lexical** (`delve`, `boasts`, "it's worth noting"): a wordlist is optimal. Linguistics adds nothing. The eval is corpus frequency and lift, which the analyze skill already measures.
-- **Morphosyntactic** (sentence-shaped headings, passive `COPULA PARTICIPLE`, "not X but Y", correlatives): patterns over part-of-speech sequences that do not reduce to a word list and break as brittle regexes. This is the only layer the tagger stack is the right tool for.
-- **Discourse / cross-sentence** (negation flip "It isn't X. It is Y.", escalating triads, question-then-answer cadence): structure above the sentence. Part-of-speech tagging alone does not reach it.
-- **Semantic / pragmatic** (reads like marketing, hedging density): no grammar captures it. LLM-judge territory.
+- **Vocabulary** (`delve`, `boasts`, "it's worth noting"): a wordlist. Linguistics adds nothing here. The analyze skill already measures word frequency and lift.
+- **Grammar** (sentence-shaped headings, passive voice, "not X but Y"): patterns over part-of-speech sequences that a wordlist cannot express and a plain regex gets wrong. This is the only layer a tagger helps with.
+- **Cross-sentence** (negation flips, escalating triads): structure spanning sentences, which a tagger alone cannot see.
+- **Meaning** (marketing tone, hedging density): no grammar captures it. This needs an LLM judge.
 
-The failure mode to avoid is making the tagger the hammer for all four. Before a trope is built as a grammar rule it gets a wordlist-vs-regex-vs-grammar-vs-judge comparison; the migration candidates in the Trope Pattern Inventory each earn the grammar layer or stay where they are. A cheap LLM-judge run is the upper reference: if a judge ties the tagger stack on a trope at acceptable latency, that trope does not belong in the grammar layer.
+Before building a grammar rule, check whether a wordlist, a regex, or an LLM judge does the job as well. The tagger is not the default.
 
-## Two Surfaces, Two Promotion Bars
+## Promotion Bars
 
-The same grammar engine serves two surfaces with opposite tolerances, so promotion is two bars, not one. The eval scores every candidate against both and reports which surface, if any, it clears.
+The same engine feeds two surfaces with opposite tolerances, so a detector clears one bar or two:
 
-The hook is a PreToolUse nudge on every edit. A false positive is a cheap, ignorable nudge, but frequent ones train the user to dismiss the hook, so it is precision-critical and recall-tolerant. A candidate replaces a hook detector only when, on a labeled session sample with an interval tight enough to act on:
+- **The hook** nudges on every edit. Frequent false positives train the user to ignore it, so it is precision-critical. A detector replaces a hook check only when, on a labeled sample with a tight enough interval, it shows precision at least as high as the current check, higher recall, and no regressions on the committed seed (`linguistics/heading.test.ts`).
+- **The analyze and review skills** run in batches a person reviews. A reviewer triages flags, so recall matters more than precision. A detector too noisy for the hook can still ship here; track its false-positive rate rather than gating on it.
 
-- precision ≥ baseline precision
-- recall strictly greater than baseline recall
-- zero regressions on the committed seed (`linguistics/heading.test.ts`)
-
-The analyze and review skills are batch and human-in-the-loop. A reviewer triages flags, so precision can be far lower in exchange for recall. A classifier too noisy for the hook can be valuable here. The bar is recall above baseline at a precision a reviewer tolerates, with the false-positive rate reported rather than gated.
-
-The near-term win is shipping the grammar layer into analyze/review at the recall-leaning bar while the hook stays on the tuned heuristic. That needs no promotion-grade interval. The hook swap waits for a labeled pass with enough power.
-
-Interval width, not point estimates, decides hook promotion. Twenty-four positive flags in a random subset put roughly ±20pp on every metric, which promotes nothing. A power calculation sizes the labeling work to the interval the decision needs (rough target: 3-5x the current positive count). The labeling protocol concentrates new labels where they move the decision (baseline-candidate disagreements and the leader's flags) while keeping a uniform-random anchor for an honest precision estimate.
+Hook promotion turns on interval width. A sample with few positives carries intervals too wide to act on. Size the labeling pass with the power calculation, concentrate new labels on disagreements and the leading candidate's flags, and keep a uniform-random slice for an honest precision estimate.
 
 ## Modules
 
 `plugins/writing/linguistics/` is importable by both `hooks/` and `skills/analyze/scripts/`:
 
-- `tags.ts`, `preprocess.ts`, `grammar.ts`, `heading.ts`: pure, no tagger imports, safe for hooks. `heading.ts` exports `classifyHeadingBaseline`, the extracted heading heuristic the hook runs today.
-- `tagger.ts` plus `compromise.ts` and `natural.ts`: adapters mapping each tagger into one coarse tag space (`CoarseTag`), so grammar rules are tagger-neutral and the eval isolates tagging quality.
+- `tags.ts`, `preprocess.ts`, `grammar.ts`, `heading.ts`: pure, no tagger imports, safe for hooks. `heading.ts` exports `classifyHeadingBaseline`, the heuristic the hook runs today.
+- `tagger.ts`, `compromise.ts`, `natural.ts`: adapters mapping each tagger to one coarse tag set, so grammar rules stay tagger-neutral.
 - `classifiers.ts`: eval-only. It imports the tagger adapters, including `natural`, a devDependency the plugin cache omits.
 
-Hooks must never import tagger adapters. Distributed plugins run from the plugin cache where `bun` auto-install skips devDependencies, so a hook importing one works locally and breaks for every marketplace install.
+Hooks must never import a tagger adapter. The plugin cache skips devDependencies, so a hook that imports one works locally and breaks for every install.
 
-## Tagger Failure Modes on Headings
+## Tagger Failures
 
-PR #744 established why naive tagging fails on terse, title-cased headings:
+Naive tagging fails on terse, title-cased headings two ways:
 
-- Title Case biases taggers toward proper nouns: in "Latency Is the Main Bottleneck" (invented), `Is` reads as part of a proper-noun span and the copula disappears.
-- Lowercasing the heading first swings the bias the other way: single-word headings like "Changes" read as verbs, producing a ~45% flag rate where the tuned heuristic flags ~4%.
+- Title case biases taggers toward proper nouns. In "Latency Is the Main Bottleneck", `Is` reads as part of a name and the verb disappears.
+- Lowercasing first swings the bias the other way. "Changes" reads as a verb, flagging about 45% of headings where the tuned heuristic flags about 4%.
 
-The adapters defeat the copula half of this with a closed-class surface check: the eight finite copula forms (`is am are was were 's 're 'm`) are recognized lexically regardless of tagger output. That is grammar, not vocabulary, so it does not drift with model habits. The verb-bias half is handled positionally in `grammar.ts`: a finite verb counts as clause evidence only with a preceding subject candidate, never as the entire heading, and attributive participles ("a leaked key") are skipped.
+The adapters handle the first by recognizing the eight finite forms of "be" (`is am are was were 's 're 'm`) directly, regardless of tagger output. The second is positional: a verb counts as clause evidence only with a subject in front of it, never as the whole heading, and modifier participles ("a leaked key") are skipped.
 
-## Heading Classifier Comparison
+## Classifier Comparison
 
-Three candidates, each instantiated per tagger:
+Three candidates, each run on each tagger:
 
-- `finite-verb`: flag only on a finite verb with a preceding subject. Misses imperatives by design.
-- `np-test`: flag when the heading fails a noun-phrase parse and shows verb evidence. The most aggressive.
-- `hybrid`: the baseline's structural rules (colon clause, relative clause, imperative shape) with tagger judgment replacing the hand-maintained linking-verb and imperative-opener word sets.
+- `finite-verb`: flag a verb with a subject in front. Misses imperatives by design.
+- `np-test`: flag when the heading fails a noun-phrase parse and shows a verb. The most aggressive.
+- `hybrid`: the heuristic's structural rules with tagger judgment replacing its hand-maintained word sets.
 
-Flag rates on the session heading corpus (2,858 unique headings, 2025-12-08 to 2026-06-06):
+Flag rates on the session corpus (2,858 unique headings):
 
 | classifier | flags | flag rate | baseline agreement |
 |---|---|---|---|
@@ -66,18 +59,15 @@ Flag rates on the session heading corpus (2,858 unique headings, 2025-12-08 to 2
 | finite-verb:compromise | 418 | 14.6% | 86.6% |
 | np-test:compromise | 946 | 33.1% | 71.1% |
 | hybrid:compromise | 532 | 18.6% | 84.6% |
-| finite-verb:wink | 357 | 12.5% | 88.8% |
-| np-test:wink | 723 | 25.3% | 78.7% |
-| hybrid:wink | 413 | 14.5% | 88.8% |
 | finite-verb:natural | 252 | 8.8% | 91.8% |
 | np-test:natural | 688 | 24.1% | 79.7% |
 | hybrid:natural | 324 | 11.3% | 91.4% |
 
-Flag rate alone does not decide anything: the baseline's 5.3% includes documented misses, and a candidate flagging more could be finding real clauses or hallucinating them. The labeled sample settles which.
+A higher flag rate is neither good nor bad on its own: the candidate could be catching real clauses or inventing them. The labeled sample settles it.
 
-## Labeled Sample Results
+## Labeled Results
 
-A 499-row labeled sample (200 disagreement-biased rows plus a 299-row uniform random subset), labeled by grammatical form. Label distribution: 367 noun-phrase, 66 imperative, 29 fragment, 23 clause, 15 interrogative. Precision/recall on the random subset (the unbiased view), where `clause` and `imperative` count as should-flag:
+A 499-row sample (200 disagreement-biased rows, 299 uniform-random), labeled by grammatical form (367 noun-phrase, 66 imperative, 29 fragment, 23 clause, 15 interrogative). Precision and recall on the random subset, counting `clause` and `imperative` as should-flag:
 
 | classifier | precision | 95% CI | recall |
 |---|---|---|---|
@@ -85,35 +75,20 @@ A 499-row labeled sample (200 disagreement-biased rows plus a 299-row uniform ra
 | finite-verb:compromise | 41.4% | 25.5..59.3 | 25.0% |
 | np-test:compromise | 41.0% | 30.8..52.1 | 66.7% |
 | hybrid:compromise | 57.1% | 42.2..70.9 | 50.0% |
-| finite-verb:wink | 62.5% | 38.6..81.5 | 20.8% |
-| np-test:wink | 40.7% | 28.7..54.0 | 45.8% |
-| hybrid:wink | 73.9% | 53.5..87.5 | 35.4% |
 | finite-verb:natural | 70.6% | 46.9..86.7 | 25.0% |
 | np-test:natural | 45.2% | 33.4..57.5 | 58.3% |
 | hybrid:natural | 79.2% | 59.5..90.8 | 39.6% |
 
-What the numbers say:
+- The baseline is precise but misses four of five real sentence headings, mostly imperatives outside its opener word set.
+- `hybrid:natural` is the only candidate that beats the baseline on both, with precision at or above it and roughly double the recall. The intervals overlap heavily (24 flags), so this points a direction without settling it.
+- `hybrid:compromise` loses on precision: compromise reads terse title-case tokens as verbs more readily than natural, producing more false positives. The more conservative tagger wins.
+- The `np-test` family buys recall (58-71%) at a precision too low to use (40-45%).
 
-- The baseline is precision-tuned and recall-starved: it misses four of five true sentence headings, mostly imperatives (the dominant positive class at 66 of 104 labeled positives) that fall outside its nine-opener word set.
-- `hybrid:natural` is the only candidate meeting the promotion bar on point estimates: precision at or above baseline with roughly double the recall. The intervals overlap heavily (24 flags in the random subset), so this is direction, not a verdict.
-- The expected winner per #744, `hybrid:compromise`, loses on precision: compromise's eagerness to read terse Title Case tokens as verbs produces more false positives than the conservative Brill tagger in `natural`. Tagger conservatism beats tagger richness for this job.
-- The `np-test` family buys its recall (58–71%) with unacceptable precision (40–45%).
-
-No promotion happens on these numbers. The next step is a larger labeled pass concentrated on the leader's flags, plus dependency weight as a promotion factor: a hook tagger ships to every plugin install, and `natural` is a far heavier package than `compromise`.
-
-## Synthetic Corpus Results
-
-Ten generated documents (design docs, a postmortem, an evaluation, rollout/capacity/testing plans) yielded 114 unique headings containing zero true sentence headings: untreated model output did not produce the trope at this sample size, so the synthetic corpus measures false positives, not recall. The baseline flagged nothing. Candidates produced 1–15 false positives each, all on conventional heading shapes, and because the corpus is egress-clean the failures can be quoted:
-
-- Numbered section headings ("3.1 Unit Tests", "8. API Contract"): a plural head noun reads as a finite verb with the section number as its subject.
-- Trailing participle labels ("Lessons Learned"): the participle fails the noun-phrase parse.
-- Colon-prefixed noun phrases ("Testing Strategy: Payments Reconciliation Service").
-
-These shapes are tuning targets for the candidates (bare section-number enumerators, heading-final plural-noun verbs) and committable as regression fixtures.
+Nothing is promoted on these numbers. A larger labeled pass on the leader's flags comes next, weighed against package size: a hook tagger ships to every install, and `natural` is far heavier than `compromise`.
 
 ## Eval Harness
 
-`skills/analyze/scripts/headings-eval.ts` extracts headings from the deliverable-prose corpus exactly as the hook does (text children only, all-inline-code skipped), dedupes them, and runs every classifier:
+`skills/analyze/scripts/headings-eval.ts` extracts headings the same way the hook does, dedupes them, and runs every classifier:
 
 ```bash
 bun skills/analyze/scripts/headings-eval.ts --session-db "$DB_PATH"
@@ -121,13 +96,11 @@ bun skills/analyze/scripts/headings-eval.ts --session-db "$DB_PATH" --sample 300
 bun skills/analyze/scripts/headings-eval.ts --session-db "$DB_PATH" --labels tmp/heading-labels.tsv
 ```
 
-`--sample` writes `tmp/heading-labels.tsv` containing all baseline-vs-candidate disagreements (capped, biased toward informative cases) plus a uniform random sample (unbiased precision/recall). `--labels` scores both subsets separately with Wilson 95% intervals. Labels: `noun-phrase`, `clause`, `imperative`, `interrogative`, `fragment`; `clause` and `imperative` should flag.
-
-Corpus artifacts stay in `tmp/` and never leave the machine: the session corpus spans hosts marked `block_egress`.
+`--sample` writes a labeling file: all baseline-candidate disagreements (capped) plus a uniform-random sample. `--labels` scores both subsets with Wilson 95% intervals. Labels are `noun-phrase`, `clause`, `imperative`, `interrogative`, and `fragment`; `clause` and `imperative` should flag. Corpus artifacts stay in `tmp/` and never leave the machine.
 
 ## Synthetic Corpus
 
-The session corpus measures precision on the real heading distribution, but it is private and cannot be quoted or committed. A synthetic corpus complements it:
+The session corpus is private and cannot be committed, so it measures precision but cannot serve as a regression gate. Generate a corpus that is safe to commit (model output, never from a session):
 
 ```bash
 claude -p --no-session-persistence --setting-sources project \
@@ -135,49 +108,46 @@ claude -p --no-session-persistence --setting-sources project \
   > tmp/synthetic-corpus/<slug>.md
 ```
 
-- `--no-session-persistence` keeps the run out of the session index, so generation does not pollute the corpora the analyze skill mines.
-- `--setting-sources project` from a scratch directory drops the user-level writing instructions, so the output is the model's untreated style, the thing the detectors target.
-- The output is egress-clean: generated for this purpose, safe to quote in PRs and commit as fixtures.
-- Regenerating per model release turns the corpus into a drift tracker. Vocabulary tells change between models, but the structural detectors should hold across regenerations, and a regression shows up as a recall drop.
+- `--no-session-persistence` keeps generation out of the session index.
+- `--setting-sources project` from a scratch directory drops the user's writing instructions, so the output is the model's untreated style.
+- Regenerating per model release makes it a drift tracker: vocabulary changes between models, but the grammar detectors should hold, and a regression shows up as a recall drop.
 
-Vary the document type (design doc, postmortem, evaluation, rollout plan, capacity plan) so heading styles vary. Evaluate with `--docs`:
+Vary the document type (design doc, postmortem, rollout plan) so heading styles vary, then evaluate with `--docs`:
 
 ```bash
 bun skills/analyze/scripts/headings-eval.ts --docs tmp/synthetic-corpus --out tmp/synthetic
 ```
 
-## Heading Verdict
+Ten generated documents produced 114 headings, none of them real sentence headings, so the synthetic corpus measures false positives. With no real positives in the sample, it says nothing about recall. The baseline flagged none. Candidates produced 1-15 each, all on conventional shapes that are now committed regression fixtures:
 
-Applying the two bars to the heading classifiers:
+- Numbered headings ("3.1 Unit Tests"): a plural head noun reads as a verb with the number as its subject.
+- Trailing participles ("Lessons Learned"): the participle fails the noun-phrase parse.
+- Colon-prefixed noun phrases ("Testing Strategy: Payments Reconciliation Service").
 
-- No candidate clears the hook bar. `hybrid:natural` leads on point estimates (precision at or above baseline, roughly double the recall), but the intervals overlap heavily at 24 random-subset flags, so this is direction, not a verdict. The hook keeps `classifyHeadingBaseline`.
-- The grammar layer clears the analyze/review bar: `hybrid:natural`'s recall gain is worth its precision cost where a reviewer triages. This is the near-term ship.
-- `natural` stays a devDependency while the hook question is open. The next step is a labeled pass sized by the power calculation, concentrated on `natural`'s flags, before any hook swap.
+## Verdict
 
-The hybrid family leads as #744 predicted, keeping the heuristic's structure and replacing only the word sets, but with `natural` doing the tagging rather than the expected `compromise` (see Labeled Sample Results).
+- No candidate clears the hook bar. `hybrid:natural` leads, but the intervals are too wide to act on, so the hook keeps `classifyHeadingBaseline`.
+- The grammar layer clears the analyze and review bar, where the recall gain is worth the precision cost. That is where it ships now.
+- `natural` stays a devDependency until a larger labeled pass settles whether it earns a place in the hook.
 
-## Trope Pattern Inventory
+## Trope Inventory
 
-Where each existing detector lands in the layer model, and what moving it would take:
+Where each existing detector sits, and what moving it would take:
 
-- **Lexical** (`wordlists/*.txt`): stay as word lists. Cheap, the analyze skill audits their health each run, and tagger machinery adds nothing to an exact vocabulary match.
-- **Morphosyntactic** (structural regexes in `detection/tropes.ts`): migration candidates, one follow-up issue each, each gated by a wordlist-vs-regex-vs-grammar-vs-judge comparison and the two-surface bars before it is built:
-  - passive voice (`COPULA PARTICIPLE` tag sequence vs. the current participle regex)
-  - "not X but Y" parallelism (tag-sequence shape vs. literal `not ... but` matching)
-  - test-result reporting (function-based test, currently uncountable by the structural audit)
-- **Discourse** (cross-sentence negation, escalating triads): structure above the sentence, which part-of-speech tagging alone does not reach. Held until the layer has tooling.
-- **Semantic** (marketing tone, hedging density): LLM-judge territory, not grammar.
+- **Vocabulary** (`wordlists/*.txt`): stay as wordlists. The analyze skill audits them each run.
+- **Grammar** (regexes in `detection/tropes.ts`): candidates for a tagger rule, each only after the layer check confirms a tagger beats a regex. Passive voice, "not X but Y", and test-result reporting are the current candidates.
+- **Cross-sentence** (negation flips): no tooling yet.
+- **Meaning** (marketing tone, hedging): LLM-judge territory.
 
-Per-trope migrations hold until the two-surface bars and the power calculation exist, or each repeats the underpowered-eval mistake. In the meantime the `tropes.ts` regexes ship as hook nudges and stay as-is.
+Until the bars and the power calculation are in place, the `tropes.ts` regexes stay as they are and ship as hook nudges.
 
 ## Dependencies
 
-The tagger fork is now two-way. `wink-pos-tagger` is retired (dominated by `natural`), leaving `compromise` (primary, runtime) and `natural` (devDependency, promotion candidate). The framework resolves the rest: promote `natural` if a powered labeling pass clears it at the hook bar, otherwise collapse to `compromise` only. The analyze/review ship does not force this choice, since the grammar layer surfaces there regardless of which tagger backs it.
+`compromise` is the runtime tagger. `natural` is a devDependency under evaluation as a hook tagger. An earlier comparator, `wink-pos-tagger`, was dropped after `natural` beat it on precision and recall. The open choice is to promote `natural` if a powered labeling pass clears it at the hook bar, or drop it for `compromise` alone; either way the analyze and review surfaces work unchanged.
 
 | package | role | earns its place by | retired when |
 |---|---|---|---|
-| `compromise` | primary tagger | powering the heading eval and the part-of-speech-sequence structural signatures in analyze | structural signatures stop producing actionable rules and no classifier is promoted |
-| `wink-pos-tagger` | eval comparator | the tagger comparison above | removed after the comparison was recorded (numbers above); it was dominated by `natural` on both precision and recall |
-| `natural` | promotion candidate (devDependency) | `hybrid:natural` leads the labeled eval | removed if a larger labeled pass rejects it or promotion lands on another tagger |
+| `compromise` | runtime tagger | powering the heading eval and the part-of-speech structural signatures in analyze | structural signatures stop producing rules and no classifier is promoted |
+| `natural` | hook tagger candidate (devDependency) | leading the labeled eval | a larger labeled pass rejects it, or promotion lands elsewhere |
 
-`compromise` lives in `dependencies`: the analyze scripts import it at runtime, and distributed plugins run from the plugin cache where `bun` auto-install skips devDependencies. `natural` stays a devDependency (zero session and distribution cost) while the promotion question is open.
+`compromise` lives in `dependencies` because the analyze scripts import it at runtime and the plugin cache skips devDependencies. `natural` stays a devDependency while its promotion is open.


### PR DESCRIPTION
Rewrites `linguistics.md` as a standalone record: the four detector layers, which one a tagger actually helps with, and the two bars a detector clears before it ships.

## Changes

- Adds the four-layer model (vocabulary, grammar, cross-sentence, meaning) and states that a tagger only helps the grammar layer.
- Replaces the single hook-only promotion criterion with two bars: the precision-critical hook and the recall-leaning analyze and review surface.
- Records the heading verdict against those bars: no candidate clears the hook bar, the grammar layer ships to analyze/review, `natural` stays a devDependency.
- Drops the retired `wink` tagger from the comparison tables and dependency list, and merges the two duplicate synthetic-corpus sections.
- Removes issue and PR references so the doc stands on its own, and cuts the prose to the essentials (184 to 153 lines).

No code or behavior changes.

Part of #769.
