### PR TITLE
writing: add per-token scoring command (writing:score)

### DIFF
--- a/plugins/writing/README.md
+++ b/plugins/writing/README.md
@@ -5,7 +5,7 @@ Writing style enforcement and slop detection for prose output (PR descriptions, 
 ## Contents
 
 - **Hooks**: Numbered heading detection, heading style enforcement, AI writing trope detection (em dashes, vocabulary, copula avoidance, promotional language, parallelism, connector density)
-- **Skills**: `writing` system reminder for prose writing guidelines, `writing:analyze` session-history-based trope ruleset curation, `writing:rewrite` user-invoked text rewriter, `writing:scan` user-invoked auditor for tropes in existing files, `writing:review` multi-agent document review
+- **Skills**: `writing` system reminder for prose writing guidelines, `writing:analyze` session-history-based trope ruleset curation, `writing:rewrite` user-invoked text rewriter, `writing:scan` user-invoked auditor for tropes in existing files, `writing:score` user-invoked per-1000-word trope density scorer, `writing:review` multi-agent document review
 - **Agents**: `content`, `style`, `artifacts` (conditional review lenses)
 
 ## Wordlists

--- a/plugins/writing/detection/wordlists.ts
+++ b/plugins/writing/detection/wordlists.ts
@@ -13,6 +13,12 @@ export type PlainWordlistOptions = {
 const COMMENT_OR_BLANK = /^\s*(?:#|$)/;
 const WORD_TOKEN = /[a-zA-Z]+/g;
 
+// Count word tokens the same way the wordlist matchers tokenize, so a per-token
+// density measured against this count lines up with what the matchers see.
+export function countWords(text: string): number {
+  return text.match(WORD_TOKEN)?.length ?? 0;
+}
+
 function parseLines(content: string): string[] {
   const lines: string[] = [];
   for (const raw of content.split(/\r?\n/)) {

--- a/plugins/writing/skills/score/SKILL.md
+++ b/plugins/writing/skills/score/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: writing:score
+description: >-
+  Score a single input for AI writing patterns on a per-1000-word basis. Use to
+  measure trope density across vocabulary, marketing verbs, and structural
+  patterns, compare two drafts, or score code comments separately, without
+  rewriting. Reports hit counts and density per category, never gates.
+argument-hint: <file-path-or-text>
+user-invocable: true
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Score
+
+Measure AI writing patterns in one input and report density per category. This quantifies trope load so you can compare drafts or track a file over time. To list every match with positions, use `writing:scan`. To rewrite an input, use `writing:rewrite`.
+
+## Input
+
+`$ARGUMENTS` is a single input: a file path, inline text, or stdin.
+
+```bash
+bun ${CLAUDE_SKILL_DIR}/scripts/score.ts path/to/file.md
+bun ${CLAUDE_SKILL_DIR}/scripts/score.ts "inline text to score"
+cat draft.md | bun ${CLAUDE_SKILL_DIR}/scripts/score.ts
+```
+
+Run with `--help` for all flags.
+
+## Scoring
+
+The word count is word tokens (`/[a-zA-Z]+/`) over the text with code stripped, matching how the detection wordlists tokenize. Density is `hits / (wordCount / 1000)`, so it reads as hits per 1000 words. The raw word count prints in each group header so you can judge whether the sample is large enough to trust.
+
+Hits are threshold-crossing counts from the shared detection engine (`detection/scan.ts`), the same categories the `tropes` hook and `writing:scan` use. A weighted group (marketing verbs, soft phrasing) counts as one hit when it crosses its threshold.
+
+## Output
+
+A table per group with category, hits, and density, sorted by density. The `--json` flag emits the structured report for diffing two runs. The command is informational: every run returns a success status, so it never gates anything.
+
+## Comments
+
+For non-prose source files, single-line comments (`//`, `#`) are extracted and scored as a separate `comments` group, so prose-only patterns apply to them without an AST. This is on by default for source files and off for prose files (`.md` and friends, whose fenced code blocks are already stripped). Force it with `--comments` or suppress it with `--no-comments`.
+
+## Custom Vocabulary
+
+`--wordlist <path>` compiles an extra stemmed vocabulary file (one term per line, `#` comments allowed) and scores it as a `custom vocabulary` category in every group. Use it to measure context-specific terms a general wordlist would not flag.

--- a/plugins/writing/skills/score/scripts/score.test.ts
+++ b/plugins/writing/skills/score/scripts/score.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "bun:test";
+import { compileStemmedWordlist } from "../../../detection/wordlists";
+import { buildReport, extractComments, renderTable, scoreComments, scoreText } from "./score";
+
+function category(report: ReturnType<typeof buildReport>, group: string, name: string) {
+  return report.groups.find((g) => g.group === group)?.categories.find((c) => c.category === name);
+}
+
+describe("scoreText", () => {
+  it("counts word tokens over stripped code", () => {
+    const text = "The function reads input. `ignored code here`";
+    const score = scoreText(text, undefined);
+    expect(score.wordCount).toBe(4);
+  });
+
+  it("reports density as hits per 1000 words", () => {
+    // One em dash in a 1000-word body lands at density 1.0.
+    const filler = `${"word ".repeat(998)}a — b`;
+    const score = scoreText(filler, "doc.md");
+    expect(score.wordCount).toBe(1000);
+    const emDash = score.categories.find((c) => c.category === "spaced em dash");
+    expect(emDash?.hits).toBe(1);
+    expect(emDash?.density).toBeCloseTo(1.0, 5);
+  });
+
+  it("returns no categories for clean prose", () => {
+    const score = scoreText("The function reads input and writes output.", undefined);
+    expect(score.categories).toHaveLength(0);
+  });
+
+  it("scores a custom vocabulary pass when given a matcher", () => {
+    const match = compileStemmedWordlist("widget\n");
+    const score = scoreText("The widget powers the widgets.", undefined, match);
+    const custom = score.categories.find((c) => c.category === "custom vocabulary");
+    expect(custom?.hits).toBe(2);
+  });
+});
+
+describe("extractComments", () => {
+  it("pulls single-line // and # comments and drops the markers", () => {
+    const src = ["const x = 1; // leverage the cache", "# delve into config", "code()"].join("\n");
+    const comments = extractComments(src);
+    expect(comments).toContain("leverage the cache");
+    expect(comments).toContain("delve into config");
+    expect(comments).not.toContain("code()");
+  });
+});
+
+describe("scoreComments", () => {
+  it("scores extracted comments as a separate prose group", () => {
+    const src = "function f() {\n  // We reach for the helper here.\n  return 1;\n}\n";
+    const group = scoreComments(src);
+    expect(group?.group).toBe("comments");
+    const reaching = group?.categories.find((c) => c.category === "reaching for");
+    expect(reaching?.hits).toBe(1);
+  });
+
+  it("returns undefined when there are no comments", () => {
+    expect(scoreComments("const x = 1;\nconst y = 2;\n")).toBeUndefined();
+  });
+});
+
+describe("buildReport", () => {
+  it("emits only the prose group when comments are off", () => {
+    const report = buildReport("// leverage this", "src.ts", { comments: false });
+    expect(report.groups.map((g) => g.group)).toEqual(["prose"]);
+  });
+
+  it("adds a comments group when comments are on", () => {
+    const src = "function f() {\n  // We delve into the leverage here today.\n}\n";
+    const report = buildReport(src, "src.ts", { comments: true });
+    expect(report.groups.map((g) => g.group)).toContain("comments");
+    expect(category(report, "comments", "AI vocabulary")?.hits).toBeGreaterThan(0);
+  });
+
+  it("applies the custom matcher to every group", () => {
+    const match = compileStemmedWordlist("widget\n");
+    const src = "const w = 1; // a widget comment\nwidget();\n";
+    const report = buildReport(src, "src.ts", { comments: true, customMatch: match });
+    expect(category(report, "prose", "custom vocabulary")?.hits).toBe(2);
+    expect(category(report, "comments", "custom vocabulary")?.hits).toBe(1);
+  });
+});
+
+describe("renderTable", () => {
+  it("renders a header with word count and a category row", () => {
+    const report = buildReport("a — b", "doc.md", { comments: false });
+    const out = renderTable(report);
+    expect(out).toContain("prose (2 words)");
+    expect(out).toContain("spaced em dash");
+    expect(out).toContain("Density /1k");
+  });
+
+  it("reports no patterns for clean prose", () => {
+    const report = buildReport("The function reads input.", "doc.md", { comments: false });
+    expect(renderTable(report)).toContain("No patterns detected.");
+  });
+});

--- a/plugins/writing/skills/score/scripts/score.ts
+++ b/plugins/writing/skills/score/scripts/score.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env bun
+import { cli } from "cleye";
+import { table } from "table";
+import { isProseFile } from "../../../detection/paths";
+import { scanAll } from "../../../detection/scan";
+import { stripCode } from "../../../detection/tropes";
+import { compileStemmedWordlist, countWords } from "../../../detection/wordlists";
+
+export type CategoryScore = { category: string; hits: number; density: number };
+
+export type GroupScore = {
+  group: string;
+  wordCount: number;
+  categories: CategoryScore[];
+};
+
+export type ScoreReport = {
+  filePath: string | undefined;
+  groups: GroupScore[];
+};
+
+type ReportOptions = {
+  comments: boolean;
+  customMatch?: (text: string) => { count: number };
+};
+
+const CUSTOM_VOCABULARY = "custom vocabulary";
+
+function density(hits: number, wordCount: number): number {
+  if (wordCount === 0) return 0;
+  return hits / (wordCount / 1000);
+}
+
+function categoryScores(
+  text: string,
+  filePath: string | undefined,
+  wordCount: number,
+): CategoryScore[] {
+  const counts = new Map<string, number>();
+  for (const result of scanAll(text, filePath)) {
+    counts.set(result.category, (counts.get(result.category) ?? 0) + 1);
+  }
+  return [...counts.entries()].map(([category, hits]) => ({
+    category,
+    hits,
+    density: density(hits, wordCount),
+  }));
+}
+
+function customVocabularyScore(
+  text: string,
+  match: (text: string) => { count: number },
+  wordCount: number,
+): CategoryScore {
+  const hits = match(stripCode(text)).count;
+  return { category: CUSTOM_VOCABULARY, hits, density: density(hits, wordCount) };
+}
+
+const SINGLE_LINE_COMMENT = /(?:^|\s)(?:\/\/|#)[^\n]*/g;
+
+// Pull single-line comments (`//`, `#`) out of source so they score as prose.
+// No AST: this catches the common case and treats every comment line as prose
+// regardless of language, which is the point of scoring comments separately.
+export function extractComments(text: string): string {
+  const lines: string[] = [];
+  for (const match of text.matchAll(SINGLE_LINE_COMMENT)) {
+    lines.push(match[0].replace(/^\s*(?:\/\/|#)\s?/, ""));
+  }
+  return lines.join("\n");
+}
+
+export function scoreText(
+  text: string,
+  filePath: string | undefined,
+  customMatch?: (text: string) => { count: number },
+): GroupScore {
+  const wordCount = countWords(stripCode(text));
+  const categories = categoryScores(text, filePath, wordCount);
+  if (customMatch) {
+    categories.push(customVocabularyScore(text, customMatch, wordCount));
+  }
+  return { group: "prose", wordCount, categories };
+}
+
+export function scoreComments(
+  text: string,
+  customMatch?: (text: string) => { count: number },
+): GroupScore | undefined {
+  const comments = extractComments(text);
+  if (comments.trim().length === 0) return undefined;
+  // Score comments as prose so prose-only patterns apply to them.
+  return { ...scoreText(comments, undefined, customMatch), group: "comments" };
+}
+
+export async function readInput(
+  arg: string | undefined,
+): Promise<{ text: string; filePath?: string }> {
+  if (arg && (await Bun.file(arg).exists())) {
+    return { text: await Bun.file(arg).text(), filePath: arg };
+  }
+  if (arg) {
+    return { text: arg };
+  }
+  return { text: await new Response(Bun.stdin.stream()).text() };
+}
+
+// Whether to extract and score code comments as a separate group. Prose files
+// (including `.md`, whose fenced code blocks stripCode already removes) are
+// scored whole; non-prose source files get their comments pulled out. Explicit
+// flags win: --no-comments forces off, --comments forces on.
+function shouldScoreComments(
+  filePath: string | undefined,
+  on: boolean | undefined,
+  off: boolean,
+): boolean {
+  if (off) return false;
+  if (on) return true;
+  if (filePath === undefined) return false;
+  return !isProseFile(filePath);
+}
+
+export function buildReport(
+  text: string,
+  filePath: string | undefined,
+  options: ReportOptions,
+): ScoreReport {
+  const groups: GroupScore[] = [scoreText(text, filePath, options.customMatch)];
+  if (options.comments) {
+    const comments = scoreComments(text, options.customMatch);
+    if (comments) groups.push(comments);
+  }
+  return { filePath, groups };
+}
+
+function formatDensity(value: number): string {
+  return value.toFixed(1);
+}
+
+export function renderTable(report: ScoreReport): string {
+  const sections: string[] = [];
+  for (const group of report.groups) {
+    const header = `${group.group} (${group.wordCount} words)`;
+    const rows = group.categories
+      .slice()
+      .sort((a, b) => b.density - a.density || a.category.localeCompare(b.category))
+      .map((c) => [c.category, String(c.hits), formatDensity(c.density)]);
+    if (rows.length === 0) {
+      sections.push(`${header}\nNo patterns detected.`);
+      continue;
+    }
+    sections.push(`${header}\n${table([["Category", "Hits", "Density /1k"], ...rows])}`.trimEnd());
+  }
+  return sections.join("\n\n");
+}
+
+async function loadCustomMatch(
+  path: string | undefined,
+): Promise<((text: string) => { count: number }) | undefined> {
+  if (!path) return undefined;
+  const content = await Bun.file(path).text();
+  return compileStemmedWordlist(content);
+}
+
+async function main(): Promise<void> {
+  const argv = cli({
+    name: "score",
+    parameters: ["[input]"],
+    help: {
+      description:
+        "Score a single input (file path, inline text, or stdin) for AI writing patterns on a per-1000-word basis. Reports hit counts and density per category. Informational: always exits 0.",
+    },
+    flags: {
+      json: {
+        type: Boolean,
+        description: "Emit the report as JSON for comparing two runs",
+        default: false,
+      },
+      comments: {
+        type: Boolean,
+        description:
+          "Force comment extraction on (defaults on for non-prose source files, off for prose)",
+      },
+      noComments: {
+        type: Boolean,
+        description: "Force comment extraction off",
+        default: false,
+      },
+      wordlist: {
+        type: String,
+        description: "Score an extra stemmed vocabulary file as a 'custom vocabulary' category",
+      },
+    },
+  });
+
+  const { text, filePath } = await readInput(argv._.input);
+  const customMatch = await loadCustomMatch(argv.flags.wordlist);
+  const options: ReportOptions = {
+    comments: shouldScoreComments(filePath, argv.flags.comments, argv.flags.noComments),
+  };
+  if (customMatch) options.customMatch = customMatch;
+  const report = buildReport(text, filePath, options);
+
+  if (argv.flags.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(renderTable(report));
+  }
+  process.exit(0);
+}
+
+if (import.meta.main) {
+  await main();
+}


### PR DESCRIPTION
Adds a `writing:score` skill that scores a single input (file path, inline text, or stdin) for AI writing patterns on a per-1000-word basis. It reuses the existing `scanAll` detection engine, normalizes hit counts by a `stripCode` word-token count, and prints a category/hits/density table, with `--json` for diffing two runs. The command is informational and always exits 0.

Closes #652.

## Changes

- `plugins/writing/skills/score/scripts/score.ts`: the CLI. Density per category is `hits / (wordCount / 1000)`. Each group header reports the raw word count so the caller can judge sample size.
- `plugins/writing/detection/wordlists.ts`: adds `countWords`, which wraps the private `WORD_TOKEN` regex so the per-token denominator stays single-sourced with the matchers' tokenization instead of duplicating the regex in the skill.
- `plugins/writing/skills/score/SKILL.md` and `README.md`: skill docs and the plugin index entry.

#### Comments

For non-prose source files, single-line comments (`//`, `#`) are extracted (no AST) and scored as a separate `comments` group so prose-only patterns apply to them. `--comments` forces it on, `--no-comments` forces it off.

#### Custom vocabulary

`--wordlist <path>` compiles an extra stemmed vocabulary via the existing `compileStemmedWordlist` helper and scores it as a `custom vocabulary` category in every group.

## Open-question decisions

The standby plan left three open questions. My calls:

1. **Hit counts, not raw weighted-stem totals.** Density uses threshold-crossing counts from `scanAll`, so a weighted group (marketing verbs, soft phrasing) contributes one hit when it crosses its threshold. This keeps `score` consistent with `scan` and the `tropes` hook, which all count the same way. Reporting raw stem weights would have meant a parallel scoring path for two categories only.
2. **Comments default off for prose, on for source.** `.md` and other prose files are scored whole (their fenced code is already stripped by `stripCode`), so there is nothing to extract separately. Non-prose source files default the comment group on. Both are overridable.
3. **Exit 0 always, confirmed.** `score` is a measurement tool, not a gate.

## Testing

- `score.test.ts` covers word counting over stripped code, density math, the custom-vocabulary pass, comment extraction, the comments group, and table rendering.
- Ran the script end-to-end against inline text, files, stdin, `--json`, `--wordlist`, and the comment flags.

## References

- #652
