### PR TITLE
writing: power calc and labeling protocol for detector eval

### DIFF
--- a/plugins/writing/linguistics/power.test.ts
+++ b/plugins/writing/linguistics/power.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import { powerFromCurrentSample, requiredPositiveCount } from "./power";
+
+describe("requiredPositiveCount", () => {
+  it("solves z*sqrt(p(1-p)/n) <= delta/2 for n at the worst-case precision", () => {
+    // p=0.5, delta=10pp -> budget 0.05, n = ceil(1.96^2 * 0.25 / 0.05^2)
+    const { marginBudget, precision, requiredPositives } = requiredPositiveCount({
+      targetLiftPP: 10,
+    });
+    expect(marginBudget).toBeCloseTo(0.05, 10);
+    expect(precision).toBe(0.5);
+    expect(requiredPositives).toBe(Math.ceil((1.96 ** 2 * 0.25) / 0.05 ** 2));
+    expect(requiredPositives).toBe(385);
+  });
+
+  it("needs fewer positives for a wider target lift", () => {
+    const tight = requiredPositiveCount({ targetLiftPP: 5 });
+    const loose = requiredPositiveCount({ targetLiftPP: 20 });
+    expect(loose.requiredPositives).toBeLessThan(tight.requiredPositives);
+  });
+
+  it("needs fewer positives away from the worst-case precision", () => {
+    const worst = requiredPositiveCount({ targetLiftPP: 10, precision: 0.5 });
+    const skewed = requiredPositiveCount({ targetLiftPP: 10, precision: 0.9 });
+    // p(1-p) is maximal at 0.5, so a high-precision operating point is cheaper.
+    expect(skewed.requiredPositives).toBeLessThan(worst.requiredPositives);
+  });
+
+  it("respects a custom confidence z", () => {
+    const wide = requiredPositiveCount({ targetLiftPP: 10, z: 2.576 });
+    const narrow = requiredPositiveCount({ targetLiftPP: 10, z: 1.96 });
+    expect(wide.requiredPositives).toBeGreaterThan(narrow.requiredPositives);
+  });
+
+  it("rejects out-of-range inputs", () => {
+    expect(() => requiredPositiveCount({ targetLiftPP: 10, precision: -0.1 })).toThrow("precision");
+    expect(() => requiredPositiveCount({ targetLiftPP: 0 })).toThrow("targetLiftPP");
+  });
+});
+
+describe("powerFromCurrentSample", () => {
+  it("derives the flag rate from the current sample and reports the multiple", () => {
+    const result = powerFromCurrentSample({ positives: 24, total: 499 }, 10);
+    expect(result.flagRate).toBeCloseTo(24 / 499, 10);
+    expect(result.requiredPositives).toBe(385);
+    expect(result.positiveMultiple).toBeCloseTo(385 / 24, 10);
+    expect(result.additionalPositives).toBe(385 - 24);
+    // Uniform-random rows to yield the positives at the current flag rate.
+    expect(result.requiredSamples).toBe(Math.ceil(385 / (24 / 499)));
+  });
+
+  it("reaches the issue's 3-5x positive expectation at a lift near the current width", () => {
+    // The current ~24-positive interval is ±~19pp; a ~20pp detectable target
+    // lands in the issue's rough 3-5x range.
+    const result = powerFromCurrentSample({ positives: 24, total: 499 }, 20);
+    expect(result.positiveMultiple).toBeGreaterThanOrEqual(3);
+    expect(result.positiveMultiple).toBeLessThanOrEqual(5);
+  });
+
+  it("reports zero additional positives when the current sample already suffices", () => {
+    const result = powerFromCurrentSample({ positives: 400, total: 800 }, 10);
+    expect(result.additionalPositives).toBe(0);
+  });
+
+  it("rejects an empty current sample", () => {
+    expect(() => powerFromCurrentSample({ positives: 0, total: 0 }, 10)).toThrow("positive");
+  });
+});

--- a/plugins/writing/linguistics/power.ts
+++ b/plugins/writing/linguistics/power.ts
@@ -1,0 +1,116 @@
+/**
+ * Sample-size math for the detector eval (issue #769). The eval promotes a
+ * classifier only when its measured precision is distinguishable from the
+ * baseline's, and that precision is measured over the classifier's positive
+ * (flagged) labels: `wilson(tp, tp + fp)`. The heading pilot had ~24 positive
+ * flags in the random subset, giving a ±~19pp interval, too wide to separate
+ * candidates. These helpers compute how many positive labels tighten that
+ * interval to a target lift, and how large a uniform-random labeling pass must
+ * be to yield them at a given flag rate.
+ *
+ * The interval is the normal approximation to the Wilson interval used in
+ * `headings-eval.ts`: at precision p over n positives the 95% half-width is
+ * z * sqrt(p(1-p)/n). Two classifiers a target lift `delta` apart are
+ * distinguishable when their intervals stop overlapping, i.e. each half-width
+ * is at most delta/2. The required positive count follows by solving for n.
+ */
+
+/** z for a two-sided 95% interval, matching `wilson()` in the harness. */
+const Z_95 = 1.96;
+
+/** p(1-p) is maximal at 0.5; the worst-case (widest) interval per n. */
+const WORST_CASE_PRECISION = 0.5;
+
+export interface PowerInputs {
+  /** Target detectable lift in percentage points (e.g. 10 for 10pp). */
+  targetLiftPP: number;
+  /**
+   * Precision the interval is sized at. The interval is widest at 0.5, so the
+   * default is the conservative worst case. Pass a measured precision to size
+   * for a specific operating point.
+   */
+  precision?: number;
+  /** Confidence z-score; defaults to the harness's 95% value. */
+  z?: number;
+}
+
+export interface PowerResult {
+  /** Half-width budget per interval: delta/2 as a proportion. */
+  marginBudget: number;
+  /** Precision the sizing assumed. */
+  precision: number;
+  /**
+   * Positive (flagged) labels needed for the precision interval to fit the
+   * budget. This is the denominator of `wilson(tp, tp + fp)`.
+   */
+  requiredPositives: number;
+}
+
+/**
+ * Required positive-label count to detect `targetLiftPP` at the given
+ * confidence. Solves z*sqrt(p(1-p)/n) <= (delta/2) for n, where p is the
+ * precision (default worst case 0.5) and delta the lift as a proportion.
+ */
+export function requiredPositiveCount(inputs: PowerInputs): PowerResult {
+  const { targetLiftPP } = inputs;
+  const precision = inputs.precision ?? WORST_CASE_PRECISION;
+  const z = inputs.z ?? Z_95;
+  if (precision < 0 || precision > 1) {
+    throw new Error(`precision must be in [0, 1], got ${precision}`);
+  }
+  if (targetLiftPP <= 0 || targetLiftPP > 100) {
+    throw new Error(`targetLiftPP must be in (0, 100], got ${targetLiftPP}`);
+  }
+
+  const marginBudget = targetLiftPP / 100 / 2;
+  const variance = precision * (1 - precision);
+  const requiredPositives = Math.ceil((z ** 2 * variance) / marginBudget ** 2);
+
+  return { marginBudget, precision, requiredPositives };
+}
+
+export interface CurrentSample {
+  /** Positive (flagged) labels in the current sample. */
+  positives: number;
+  /** Total labeled rows in the current sample. */
+  total: number;
+}
+
+export interface PowerComparison extends PowerResult {
+  /** Flag rate of the current sample (positives / total). */
+  flagRate: number;
+  /**
+   * Uniform-random labels needed to yield `requiredPositives` at the current
+   * flag rate. Active labeling on disagreements raises the realized rate, so
+   * this is an upper bound on the labeling work.
+   */
+  requiredSamples: number;
+  /** How many more positive labels are needed beyond the current sample. */
+  additionalPositives: number;
+  /** Required positives as a multiple of the current positive count. */
+  positiveMultiple: number;
+}
+
+/**
+ * Size the labeling work against a current sample. The flag rate is taken from
+ * the current sample, so `requiredSamples` answers "how large a uniform-random
+ * pass yields enough positives to detect `targetLiftPP`?" Pass a measured
+ * `precision` to size at a specific operating point instead of the worst case.
+ */
+export function powerFromCurrentSample(
+  current: CurrentSample,
+  targetLiftPP: number,
+  options: { precision?: number; z?: number } = {},
+): PowerComparison {
+  if (current.total <= 0) throw new Error("current sample total must be positive");
+  if (current.positives <= 0) throw new Error("current sample must have at least one positive");
+  const result = requiredPositiveCount({ targetLiftPP, ...options });
+  const flagRate = current.positives / current.total;
+  return {
+    ...result,
+    flagRate,
+    requiredSamples: Math.ceil(result.requiredPositives / flagRate),
+    additionalPositives: Math.max(0, result.requiredPositives - current.positives),
+    positiveMultiple: result.requiredPositives / current.positives,
+  };
+}

--- a/plugins/writing/skills/analyze/references/methodology.md
+++ b/plugins/writing/skills/analyze/references/methodology.md
@@ -162,6 +162,26 @@ ORDER BY h.session_id, h.timestamp
 
 Sample sessions first, then rows within them. Without the session pool step, high-volume sessions dominate the sample and quieter sessions go unexamined.
 
+## Detector Labeling Protocol
+
+`headings-eval.ts` measures a candidate classifier's precision over its positive (flagged) labels with a Wilson interval. The interval width is governed by the positive count, not the corpus size, so an underpowered sample cannot separate two candidates. The heading pilot had ~24 positives in the random subset and a ±~19pp interval, too wide to promote any tagger. The protocol below sizes the labeling work once and is reusable per trope.
+
+#### Size the labels with the power calc
+
+`power.ts` solves the normal-approximation half-width `z * sqrt(p(1-p)/n)` for `n` at a target detectable lift. `--power <targetLiftPP>` prints the positive labels needed to detect that lift at 95%, the uniform-random rows that yield them at the current flag rate, and the multiple over the current sample. Worst-case precision (0.5) is the default; pass a measured precision to size at an operating point. The interval is widest at 0.5, so the default is conservative. A target lift near the current interval width lands around 3-5x the current positives; a tighter target costs more (10pp detectable at 0.5 needs ~385 positives).
+
+#### Concentrate labels where they move the decision
+
+Spend new labels on the candidates' disagreements with the baseline and on the leader classifier's flags. These are the items that change a promotion verdict. `--sample` writes a labeling file biased toward disagreements (capped by `--disagreement-cap`) plus a uniform-random remainder.
+
+#### Keep a uniform-random anchor
+
+Active labeling on disagreements inflates the apparent flag rate, so it cannot estimate precision honestly. The random subset (`source = random`, drawn from headings excluded from the disagreement set) gives the unbiased precision. Score it separately: `--labels` reports both the full labeled set and the random-only subset. Size the power calc against the random subset's positives, not the full labeled count.
+
+#### Freeze a test set separate from the dev set
+
+Tuning a classifier and measuring it on the same labels inflates the result. Hold out a frozen test set for the promotion estimate and tune thresholds on a separate dev set. The freeze is what makes a promotion number trustworthy across re-tuning.
+
 ## Tuning
 
 Raise `--min-lift` (default 5.0) if the candidate list is too noisy. Lower it if too quiet. Raise `--min-count` (default 5) to be stricter about what counts as a live rule (more removals tagged dead); lower it to keep rarer rules. N-grams larger than 4 tokens are not currently considered.

--- a/plugins/writing/skills/analyze/scripts/headings-eval.test.ts
+++ b/plugins/writing/skills/analyze/scripts/headings-eval.test.ts
@@ -4,7 +4,9 @@ import {
   dedupeHeadings,
   evaluateClassifiers,
   extractHeadings,
+  formatPowerReport,
   parseLabelsFile,
+  sampleForLabeling,
   scoreAgainstLabels,
   wilson,
 } from "./headings-eval";
@@ -115,6 +117,57 @@ describe("parseLabelsFile", () => {
 
   it("rejects unknown labels", () => {
     expect(() => parseLabelsFile("Heading\tbogus\trandom\n")).toThrow("Unknown label");
+  });
+});
+
+describe("sampleForLabeling", () => {
+  const headings = Array.from({ length: 10 }, (_, i) => ({
+    heading: `H${i}`,
+    occurrences: 1,
+    sessions: 1,
+  }));
+  const disagreements = ["H0", "H1", "H2", "H3"];
+
+  it("caps disagreements and keeps them out of the random pool", () => {
+    // The reproducibility leak (#769): uncapped disagreements polluting the
+    // unbiased random subset. The cap bounds the disagreement rows, and the
+    // random pool excludes every capped disagreement so the unbiased subset
+    // stays unbiased.
+    const sample = sampleForLabeling(headings, disagreements, 5, 2);
+    const byHeading = new Map(sample.map((row) => [row.heading, row.source]));
+
+    const disagreementRows = sample.filter((row) => row.source === "disagreement");
+    expect(disagreementRows.map((row) => row.heading).sort()).toEqual(["H0", "H1"]);
+
+    const randomRows = sample.filter((row) => row.source === "random");
+    for (const row of randomRows) {
+      expect(["H0", "H1"]).not.toContain(row.heading);
+    }
+    // A capped-out disagreement may still appear, but only as a random draw.
+    for (const capped of ["H2", "H3"]) {
+      if (byHeading.has(capped)) expect(byHeading.get(capped)).toBe("random");
+    }
+  });
+
+  it("never draws the same heading as both disagreement and random", () => {
+    const sample = sampleForLabeling(headings, disagreements, 10, 4);
+    const headingsSeen = sample.map((row) => row.heading);
+    expect(new Set(headingsSeen).size).toBe(headingsSeen.length);
+  });
+});
+
+describe("formatPowerReport", () => {
+  it("reports the positives needed to detect a target lift", () => {
+    const report = formatPowerReport(
+      { positives: 24, total: 499, label: "labeled random subset" },
+      20,
+    );
+    expect(report).toContain("20pp detectable lift");
+    expect(report).toContain("labeled random subset");
+    expect(report).toContain("positive labels");
+    // 20pp at worst-case 0.5 needs 97 positives, ~4x the current 24.
+    expect(report).toContain("97");
+    expect(report).toContain("4.0x");
   });
 });
 

--- a/plugins/writing/skills/analyze/scripts/headings-eval.ts
+++ b/plugins/writing/skills/analyze/scripts/headings-eval.ts
@@ -25,6 +25,7 @@ import { table } from "table";
 import { visit } from "unist-util-visit";
 import { CLASSIFIERS } from "../../../linguistics/classifiers";
 import type { HeadingClassifier, HeadingKind } from "../../../linguistics/heading";
+import { powerFromCurrentSample } from "../../../linguistics/power";
 import { openSessionDb } from "./db";
 import type { DeliverableRow } from "./dump";
 
@@ -230,7 +231,7 @@ export function parseLabelsFile(content: string): LabeledHeading[] {
   return labeled;
 }
 
-function sampleForLabeling(
+export function sampleForLabeling(
   headings: HeadingRecord[],
   disagreements: string[],
   sampleSize: number,
@@ -255,6 +256,39 @@ function sampleForLabeling(
 
 function percent(value: number): string {
   return `${(value * 100).toFixed(1)}%`;
+}
+
+/**
+ * Render the labeling-power report for a target detectable lift. The current
+ * sample sizes the flag rate and positive count: with hand labels, positives
+ * are the random subset's true positives; without, the leader classifier's
+ * flag count over the corpus. The table reports the positives needed to detect
+ * the lift, how that compares to the current count, and the uniform-random
+ * pass that would yield them.
+ */
+export function formatPowerReport(
+  current: { positives: number; total: number; label: string },
+  targetLiftPP: number,
+): string {
+  const power = powerFromCurrentSample(current, targetLiftPP);
+  return [
+    `Power, ${targetLiftPP}pp detectable lift at 95% (sized on ${current.label}):`,
+    table([
+      ["metric", "current", "required", "multiple"],
+      [
+        "positive labels",
+        String(current.positives),
+        String(power.requiredPositives),
+        `${power.positiveMultiple.toFixed(1)}x`,
+      ],
+      [
+        "uniform-random rows",
+        String(current.total),
+        String(power.requiredSamples),
+        `${(power.requiredSamples / current.total).toFixed(1)}x`,
+      ],
+    ]),
+  ].join("\n");
 }
 
 async function corpusFromDocs(dir: string): Promise<Array<{ session_id: string; text: string }>> {
@@ -323,6 +357,11 @@ async function main(): Promise<void> {
       labels: {
         type: String,
         description: "Labeled TSV (heading<TAB>label<TAB>source) to score against",
+      },
+      power: {
+        type: Number,
+        description:
+          "Target detectable lift in pp; print the labeled positives needed to act on it",
       },
       out: {
         type: String,
@@ -404,8 +443,9 @@ async function main(): Promise<void> {
     );
   }
 
+  let labeled: LabeledHeading[] | undefined;
   if (argv.flags.labels) {
-    const labeled = parseLabelsFile(await Bun.file(argv.flags.labels).text());
+    labeled = parseLabelsFile(await Bun.file(argv.flags.labels).text());
     const randomOnly = labeled.filter((row) => row.source === "random");
     console.log(`Labeled: ${labeled.length} rows (${randomOnly.length} random)`);
     for (const [title, subset] of [
@@ -431,6 +471,31 @@ async function main(): Promise<void> {
       );
     }
   }
+
+  if (argv.flags.power !== undefined) {
+    const current = currentSampleForPower(headings.length, evaluation, labeled);
+    console.log(formatPowerReport(current, argv.flags.power));
+  }
+}
+
+/**
+ * The current sample the power calc sizes against. Hand labels give the
+ * honest positive count (the random subset's true positives over the random
+ * total). Without labels, fall back to the leader classifier's flag count over
+ * the corpus, the upper-bound positive count active labeling would target.
+ */
+function currentSampleForPower(
+  corpusSize: number,
+  evaluation: Evaluation,
+  labeled: LabeledHeading[] | undefined,
+): { positives: number; total: number; label: string } {
+  if (labeled) {
+    const randomOnly = labeled.filter((row) => row.source === "random");
+    const positives = randomOnly.filter((row) => SHOULD_FLAG.has(row.label)).length;
+    return { positives, total: randomOnly.length, label: "labeled random subset" };
+  }
+  const leader = evaluation.stats.reduce((best, row) => (row.flags > best.flags ? row : best));
+  return { positives: leader.flags, total: corpusSize, label: `${leader.name} flags` };
 }
 
 function daysAgo(days: number): string {


### PR DESCRIPTION
Sizes the detector eval's labeling work from the precision-interval math instead of guessing. A candidate classifier's precision is measured over its positive (flagged) labels, so the Wilson interval width is governed by the positive count, not the corpus size. The heading pilot had ~24 positives in the random subset and a ±~19pp interval, too wide to promote any tagger. #769

## Changes

- `power.ts`: `requiredPositiveCount` solves the normal-approximation half-width `z * sqrt(p(1-p)/n)` for `n` at a target detectable lift, defaulting to the worst-case precision (0.5). `powerFromCurrentSample` sizes that against an existing sample and reports the multiple and the uniform-random rows needed at the current flag rate. Pure functions with a deterministic unit test.
- `headings-eval.ts`: `--power <targetLiftPP>` prints the positives needed to act on the lift, the uniform-random rows that yield them, and the multiple over the current sample. It sizes on the labeled random subset's true positives when `--labels` is present, else the leader classifier's flag count. `sampleForLabeling` is now exported so the reproducibility check can test it.
- `methodology.md`: the reusable per-trope labeling protocol. Size with the power calc, concentrate new labels on baseline disagreements and the leader's flags, keep a uniform-random anchor for an honest precision estimate, and freeze a test set separate from the dev set used for tuning.

## Findings

For the heading case (24 positives, 499 rows), the helper produces 97 required positives at a 20pp detectable lift (4.0x the current 24), and ~385 at 10pp (16x). The issue's rough 3-5x guess corresponds to a target lift near the current interval width (~20pp); a tighter target costs more. The helper produces the actual number rather than a hardcoded estimate.

I verified the `sampleForLabeling` leak the issue cites (uncapped disagreements polluting the unbiased random subset) is already fixed: the code caps disagreements via `disagreementCap` and excludes every capped disagreement from the random pool. Added focused tests confirming both properties rather than re-fixing.

## Testing

`power.test.ts` covers the half-width math (worst-case and skewed precision, custom confidence, wider-lift monotonicity, input validation) and the current-sample comparison (the multiple, additional positives, the empty-sample guard). `headings-eval.test.ts` adds coverage for `formatPowerReport`, the disagreement cap, and the random-pool exclusion that keeps the unbiased subset unbiased. I also ran `--power` end-to-end against a synthetic docs corpus to confirm the flag and table wire up.

## References

- Stacks alongside #782 (the detector-layer framework doc for `linguistics.md`).
- #769
