### PR TITLE
writing: fix analyze pipeline correctness from 2026-06 audit

### DIFF
--- a/plugins/writing/detection/scan.test.ts
+++ b/plugins/writing/detection/scan.test.ts
@@ -101,8 +101,8 @@ describe("scanAll", () => {
     expect(scanAll("The function reads input and writes output.")).toHaveLength(0);
   });
 
-  it("reports a weighted group once with stacked samples listed", () => {
-    const text = "This release empowers users and streamlines deploys to delight teams.";
+  it("reports a weighted group once when threshold is cleared by repeated hits", () => {
+    const text = "One: empowers users. Two: empowers teams.";
     const marketing = scanAll(text).filter((r) => r.category === "marketing verbs");
     expect(marketing).toHaveLength(1);
     expect(marketing[0]?.message).toContain("empower");

--- a/plugins/writing/detection/tropes.test.ts
+++ b/plugins/writing/detection/tropes.test.ts
@@ -360,7 +360,9 @@ describe("scan", () => {
 
   describe("sycophantic opener", () => {
     it("does not fire when openers.txt is empty", () => {
-      expect(scan("Excellent. That works.").find((m) => m.category === "sycophantic opener")).toBeUndefined();
+      expect(
+        scan("Excellent. That works.").find((m) => m.category === "sycophantic opener"),
+      ).toBeUndefined();
     });
   });
 

--- a/plugins/writing/detection/tropes.test.ts
+++ b/plugins/writing/detection/tropes.test.ts
@@ -64,8 +64,6 @@ describe("scan", () => {
       "leverage",
       "leveraged",
       "robust",
-      "comprehensive",
-      "comprehensively",
       "nuance",
       "nuanced",
     ];
@@ -361,24 +359,9 @@ describe("scan", () => {
   });
 
   describe("sycophantic opener", () => {
-    const flag = ["Excellent. That works.", "Excellent! Moving on."];
-    const allow = [
-      "This was a perfect example of the issue.",
-      "An excellent question to consider.",
-      "It is great that the migration shipped.",
-    ];
-
-    for (const text of flag) {
-      it(`flags: "${text}"`, () => {
-        expect(firstByTier(scan(text), "deny")?.category).toBe("sycophantic opener");
-      });
-    }
-
-    for (const text of allow) {
-      it(`allows: "${text}"`, () => {
-        expect(scan(text).find((m) => m.category === "sycophantic opener")).toBeUndefined();
-      });
-    }
+    it("does not fire when openers.txt is empty", () => {
+      expect(scan("Excellent. That works.").find((m) => m.category === "sycophantic opener")).toBeUndefined();
+    });
   });
 
   describe("sycophantic acknowledgment", () => {
@@ -623,7 +606,6 @@ describe("scan", () => {
 
   describe("sideEffectOnly scoping", () => {
     const conversational = [
-      { text: "Excellent. That works.", category: "sycophantic opener" },
       { text: "You're right about that.", category: "sycophantic acknowledgment" },
       { text: "Want me to fix the bug?", category: "permission-seeking" },
       { text: "Would you like me to retry?", category: "hedging close" },
@@ -654,24 +636,11 @@ describe("scan", () => {
   });
 
   describe("marketing verbs (weighted)", () => {
-    it("does not flag a single low-weight hit", () => {
-      // enhance is 1.5, below the 3.0 threshold on its own.
-      expect(
-        scan("This change enhances the workflow.").find((m) => m.category === "marketing verbs"),
-      ).toBeUndefined();
-    });
-
-    it("does not flag a single mid-weight hit below threshold", () => {
+    it("does not flag a single hit below threshold", () => {
       // empower is 2.5, below the 3.0 threshold on its own.
       expect(
         scan("This release empowers users.").find((m) => m.category === "marketing verbs"),
       ).toBeUndefined();
-    });
-
-    it("flags when stacked verbs clear the threshold", () => {
-      // empower (2.5) + streamline (1.5) = 4.0, above 3.0.
-      const text = "This release empowers users and streamlines deploys.";
-      expect(firstByTier(scan(text), "context")?.category).toBe("marketing verbs");
     });
 
     it("flags repeated high-weight hits", () => {

--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -114,6 +114,29 @@ function connectorDensityHits(text: string): Hits {
   return { count: connected.length, sample: first.slice(Math.max(0, i - 20), i + 24).trim() };
 }
 
+const openerPatterns: PatternDef[] = WORDLISTS.openers
+  ? [
+      {
+        tier: "deny",
+        layer: "vocabulary",
+        category: "sycophantic opener",
+        test: WORDLISTS.openers,
+        sideEffectOnly: true,
+        message: (matched: string) =>
+          `"${matched.trim()}" reads as a sycophantic opener. Open with the substance.`,
+        positives: ["Excellent! Moving on.", "Excellent. That settles it."],
+        negatives: [
+          "An excellent question to consider.",
+          "It is great that the migration shipped.",
+        ],
+        evidence:
+          "Openers list curated from corpus. Entries are plain-word matches at line start, reviewed for false-positive rate against normal prose.",
+        retire:
+          "Remove individual openers when they no longer appear in assistant side-effect outputs or when corrective-feedback moments stop citing them.",
+      },
+    ]
+  : [];
+
 export const PATTERNS: PatternDef[] = [
   {
     tier: "deny",
@@ -160,21 +183,7 @@ export const PATTERNS: PatternDef[] = [
     retire:
       "Remove if corrective-feedback moments stop referencing copula avoidance or if the pattern begins flagging legitimate usage in corpus spot-checks.",
   },
-  {
-    tier: "deny",
-    layer: "vocabulary",
-    category: "sycophantic opener",
-    test: WORDLISTS.openers,
-    sideEffectOnly: true,
-    message: (matched) =>
-      `"${matched.trim()}" reads as a sycophantic opener. Open with the substance.`,
-    positives: ["Excellent! Moving on.", "Excellent. That settles it."],
-    negatives: ["An excellent question to consider.", "It is great that the migration shipped."],
-    evidence:
-      "Openers list curated from corpus. Entries are plain-word matches at line start, reviewed for false-positive rate against normal prose.",
-    retire:
-      "Remove individual openers when they no longer appear in assistant side-effect outputs or when corrective-feedback moments stop citing them.",
-  },
+  ...openerPatterns,
   {
     tier: "deny",
     layer: "vocabulary",

--- a/plugins/writing/detection/wordlists.test.ts
+++ b/plugins/writing/detection/wordlists.test.ts
@@ -175,10 +175,8 @@ describe("loaded WORDLISTS", () => {
     expect(WORDLISTS.vocabulary("a nuanced take").count).toBeGreaterThan(0);
   });
 
-  it("loads openers", () => {
-    expect("Excellent.".match(WORDLISTS.openers)).not.toBeNull();
-    expect("Excellent! Moving on.".match(WORDLISTS.openers)).not.toBeNull();
-    expect("an excellent example here".match(WORDLISTS.openers)).toBeNull();
+  it("loads openers (null when file is empty)", () => {
+    expect(WORDLISTS.openers).toBeNull();
   });
 
   it("loads marketing verbs as weighted stems", () => {

--- a/plugins/writing/detection/wordlists.ts
+++ b/plugins/writing/detection/wordlists.ts
@@ -163,7 +163,7 @@ async function readWordlist(name: string): Promise<string> {
 
 export type LoadedWordlists = {
   vocabulary: (text: string) => Hits;
-  openers: RegExp;
+  openers: RegExp | null;
   marketingVerbs: StemmedWeight[];
   softPhrasing: StemmedWeight[];
   floweryPhrases: StemmedPhrase[];
@@ -185,7 +185,6 @@ async function load(): Promise<LoadedWordlists> {
     suffix: "(?=[.!,])",
     flags: "gm",
   });
-  if (!openers) throw new Error("openers.txt produced no entries");
 
   const marketingVerbs = compileWeightedStems(marketingSrc);
   const softPhrasing = compileWeightedStems(softSrc);

--- a/plugins/writing/hooks/check-tropes.test.ts
+++ b/plugins/writing/hooks/check-tropes.test.ts
@@ -258,7 +258,7 @@ describe("diff-aware filtering", () => {
     expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
   });
 
-  it("skips sycophantic opener in file Edit (sideEffectOnly)", async () => {
+  it("skips text with no active tropes in file Edit", async () => {
     const input = mockEdit("Excellent. Let me proceed.\nNext line.", "Next line.");
     expect(await processInput(input)).toBeNull();
   });

--- a/plugins/writing/skills/analyze/SKILL.md
+++ b/plugins/writing/skills/analyze/SKILL.md
@@ -37,6 +37,8 @@ bun ${CLAUDE_SKILL_DIR}/scripts/ingest-voice.ts --source github --author <user> 
 bun ${CLAUDE_SKILL_DIR}/scripts/voice-profile.ts
 ```
 
+Both scripts write to the plugin data directory. That path is outside the default sandbox allowlist, so run them with `dangerouslyDisableSandbox: true` (or via a terminal outside Claude Code).
+
 If no profile exists, analyze still runs: deliverable-surface rules fall back to the chat audit and the report flags the baseline as not loaded.
 
 ## Run

--- a/plugins/writing/skills/analyze/resources/queries/correction-candidates.sql
+++ b/plugins/writing/skills/analyze/resources/queries/correction-candidates.sql
@@ -42,11 +42,19 @@ candidates AS (
     source_file      AS assistant_source_file,
     source_line      AS assistant_source_line,
     next_source_file AS user_source_file,
-    next_source_line AS user_source_line
+    next_source_line AS user_source_line,
+    -- Prose signal: true for written prose responses. Heuristic: at least two
+    -- sentence-ending marks and the text starts outside a code fence.
+    (
+      length(message_text) - length(replace(message_text, '.', ''))
+        + length(message_text) - length(replace(message_text, '!', ''))
+        + length(message_text) - length(replace(message_text, '?', ''))
+    ) >= 2
+    AND NOT starts_with(ltrim(message_text), '```') AS prose_signal
   FROM paired
   WHERE role = 'assistant'
     AND next_role = 'user'
-    AND chars >= COALESCE(getvariable('min_assistant_chars')::BIGINT, 300)
+    AND chars >= COALESCE(getvariable('min_assistant_chars')::BIGINT, 800)
     AND next_chars <= COALESCE(getvariable('max_user_chars')::BIGINT, 250)
 )
 SELECT * FROM candidates

--- a/plugins/writing/skills/analyze/resources/queries/deliverable-prose.sql
+++ b/plugins/writing/skills/analyze/resources/queries/deliverable-prose.sql
@@ -6,6 +6,18 @@ WITH hook_excluded AS (
   ]) AS pattern
 ),
 
+-- Sessions that contain at least one assistant message matching the model
+-- filter. Filters at session level because content_items (tool calls) carry
+-- no model column; a per-item filter would silently include tool calls from
+-- sidechain models (e.g. Haiku) in sessions that are primarily Opus.
+model_sessions AS (
+  SELECT DISTINCT tc.host, tc.session_id
+  FROM text_content tc
+  WHERE tc.role = 'assistant'
+    AND (getvariable('model') IS NULL OR (tc.model IS NOT NULL AND tc.model GLOB getvariable('model')::VARCHAR))
+    AND date_filter(tc.timestamp, getvariable('after_date'), getvariable('before_date'))
+),
+
 write_prose AS (
   SELECT
     ci.session_id,
@@ -15,6 +27,7 @@ write_prose AS (
     (ci.data->>'$.input.content') AS text
   FROM content_items ci
   JOIN sessions s USING (host, session_id)
+  JOIN model_sessions ms USING (host, session_id)
   WHERE ci.type = 'tool_use'
     AND ci.name = 'Write'
     AND regexp_matches((ci.data->>'$.input.file_path'), '\.(md|txt|rst|adoc)$')
@@ -35,6 +48,7 @@ edit_prose AS (
     (ci.data->>'$.input.new_string') AS text
   FROM content_items ci
   JOIN sessions s USING (host, session_id)
+  JOIN model_sessions ms USING (host, session_id)
   WHERE ci.type = 'tool_use'
     AND ci.name = 'Edit'
     AND regexp_matches((ci.data->>'$.input.file_path'), '\.(md|txt|rst|adoc)$')
@@ -59,6 +73,7 @@ bash_prose AS (
     ) AS text
   FROM content_items ci
   JOIN sessions s USING (host, session_id)
+  JOIN model_sessions ms USING (host, session_id)
   WHERE ci.type = 'tool_use'
     AND ci.name = 'Bash'
     AND regexp_matches(

--- a/plugins/writing/skills/analyze/scripts/analyze.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.ts
@@ -15,7 +15,7 @@ import {
   type TextRow,
   totalChars,
 } from "./dump";
-import { escapeRegex, frustrationRegex } from "./frustration";
+import { escapeRegex, frustrationRegex, gatedRegex } from "./frustration";
 import { computeLift, excludePhrases, processCorpus, processRows } from "./ngram";
 import { findQuote } from "./quote-context";
 import { type CandidatePhrase, type ReportInput, renderReport } from "./report";
@@ -236,7 +236,10 @@ export async function runAnalysis(db: Database, config: AnalysisConfig): Promise
   });
 
   console.error("Dumping deliverable-prose corpus (Write/Edit/Bash tool inputs)");
-  const deliverableRows = await db.runQuery<DeliverableRow>("deliverable-prose", baseParams);
+  const deliverableRows = await db.runQuery<DeliverableRow>("deliverable-prose", {
+    ...baseParams,
+    model: config.modelFilter,
+  });
 
   console.error("Dumping user corpus (human input only)");
   const userRows = await db.runQuery<TextRow>("text-export", {
@@ -325,12 +328,18 @@ export async function runAnalysis(db: Database, config: AnalysisConfig): Promise
   const corrections = await db.runQuery<CorrectionRow>("correction-candidates", baseParams);
 
   console.error("Fetching corrective feedback (frustration lexicon)");
-  const corrective = await db.runQuery<CorrectiveRow>("corrective-feedback", {
+  const primaryPattern = frustrationRegex();
+  const primaryRe = new RegExp(primaryPattern, "i");
+  const combinedLexicon = `(?:${primaryPattern})|(?:${gatedRegex()})`;
+  const rawCorrective = await db.runQuery<CorrectiveRow>("corrective-feedback", {
     ...baseParams,
-    lexicon: frustrationRegex(),
+    lexicon: combinedLexicon,
     max_user_chars: "400",
     limit: String(config.correctiveLimit),
   });
+  // Gated terms (e.g. "sounds like") only count when a primary frustration
+  // term also appears in the same message.
+  const corrective = rawCorrective.filter((row) => primaryRe.test(row.user_text));
 
   console.error("Auditing structural patterns against all model-generated text");
   const structuralAudit = auditStructuralPatterns(allModelText, userRows);

--- a/plugins/writing/skills/analyze/scripts/dump.ts
+++ b/plugins/writing/skills/analyze/scripts/dump.ts
@@ -33,6 +33,7 @@ export interface CorrectionRow {
   user_chars: number;
   assistant_snippet: string;
   user_snippet: string;
+  prose_signal: boolean;
 }
 
 export interface ModelSummaryRow {

--- a/plugins/writing/skills/analyze/scripts/frustration.test.ts
+++ b/plugins/writing/skills/analyze/scripts/frustration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { FRUSTRATION_TERMS, frustrationRegex } from "./frustration";
+import { FRUSTRATION_TERMS, frustrationRegex, GATED_TERMS, gatedRegex } from "./frustration";
 
 describe("frustrationRegex", () => {
   test("matches single-word and multi-word terms with boundaries", () => {
@@ -25,5 +25,25 @@ describe("frustrationRegex", () => {
     expect(FRUSTRATION_TERMS).toContain("flowery");
     expect(FRUSTRATION_TERMS).toContain("clanker");
     expect(FRUSTRATION_TERMS).toContain("reads like");
+    expect(FRUSTRATION_TERMS).toContain("jargon");
+    expect(FRUSTRATION_TERMS).toContain("marketing");
+  });
+
+  test("sounds like is not in the primary lexicon (gated)", () => {
+    expect(FRUSTRATION_TERMS).not.toContain("sounds like");
+    const re = new RegExp(frustrationRegex(), "i");
+    expect(re.test("sounds like a plan")).toBe(false);
+  });
+});
+
+describe("gatedRegex", () => {
+  test("sounds like is in the gated lexicon", () => {
+    expect(GATED_TERMS).toContain("sounds like");
+  });
+
+  test("matches sounds like with word boundaries", () => {
+    const re = new RegExp(gatedRegex(), "i");
+    expect(re.test("that sounds like marketing copy")).toBe(true);
+    expect(re.test("this is fine")).toBe(false);
   });
 });

--- a/plugins/writing/skills/analyze/scripts/frustration.ts
+++ b/plugins/writing/skills/analyze/scripts/frustration.ts
@@ -19,8 +19,12 @@ export const FRUSTRATION_TERMS = [
   "dramatic",
   "clanker",
   "reads like",
-  "sounds like",
 ];
+
+// Terms that only count when a writing-complaint word from FRUSTRATION_TERMS
+// also appears in the same message. "sounds like" is common in non-writing
+// contexts ("sounds like a plan"), so require co-occurrence to filter noise.
+export const GATED_TERMS = ["sounds like"];
 
 export function escapeRegex(literal: string): string {
   return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -31,6 +35,12 @@ export function escapeRegex(literal: string): string {
 // "stopped" is acceptable here (we want the standalone gripe), and "ugh" will
 // not fire on "tough".
 export function frustrationRegex(terms: string[] = FRUSTRATION_TERMS): string {
+  const fragments = terms.map(escapeRegex).join("|");
+  return `\\b(?:${fragments})\\b`;
+}
+
+// Regex matching gated terms that require co-occurrence with a primary term.
+export function gatedRegex(terms: string[] = GATED_TERMS): string {
   const fragments = terms.map(escapeRegex).join("|");
   return `\\b(?:${fragments})\\b`;
 }

--- a/plugins/writing/skills/analyze/scripts/report.test.ts
+++ b/plugins/writing/skills/analyze/scripts/report.test.ts
@@ -141,6 +141,7 @@ describe("renderReport", () => {
           user_chars: 50,
           assistant_snippet: "long assistant response here",
           user_snippet: "no, do it differently",
+          prose_signal: true,
         },
       ],
     });

--- a/plugins/writing/skills/analyze/scripts/report.ts
+++ b/plugins/writing/skills/analyze/scripts/report.ts
@@ -160,7 +160,9 @@ function renderProposedAdditions(input: ReportInput): string {
   }
   lines.push("", "```diff");
   for (const r of input.candidatePhrases) {
-    lines.push(`+ ${r.phrase}  # lift=${fmtLiftAgainstRate(r.lift, r.userPerM)}, n=${r.n}, baseline=${r.baselineCount}`);
+    lines.push(
+      `+ ${r.phrase}  # lift=${fmtLiftAgainstRate(r.lift, r.userPerM)}, n=${r.n}, baseline=${r.baselineCount}`,
+    );
   }
   lines.push("```");
   return lines.join("\n");

--- a/plugins/writing/skills/analyze/scripts/report.ts
+++ b/plugins/writing/skills/analyze/scripts/report.ts
@@ -123,7 +123,7 @@ function renderProposedRemovals(input: ReportInput): string {
   lines.push("| --- | --- | --- | --- | --- | --- | --- |");
   for (const r of removable) {
     lines.push(
-      `| \`${esc(r.entry.phrase)}\` | ${r.entry.source} | ${r.surface} | ${r.removeReason} | ${fmtPerM(r.modelPerM)} | ${fmtPerM(r.baselinePerM)} | ${fmtLift(r.lift)} |`,
+      `| \`${esc(r.entry.phrase)}\` | ${r.entry.source} | ${r.surface} | ${r.removeReason} | ${fmtPerM(r.modelPerM)} | ${fmtPerM(r.baselinePerM)} | ${fmtLiftAgainstRate(r.lift, r.baselinePerM)} |`,
     );
   }
   lines.push("", "```diff");
@@ -151,7 +151,7 @@ function renderProposedAdditions(input: ReportInput): string {
   lines.push("| --- | --- | --- | --- | --- | --- | --- | --- |");
   for (const r of input.candidatePhrases) {
     lines.push(
-      `| \`${esc(r.phrase)}\` | ${r.n} | ${r.assistantCount} | ${r.userCount} | ${r.sessions ?? "-"} | ${r.baselineCount} | ${fmtPerM(r.baselinePerM)} | ${r.lift.toFixed(1)} |`,
+      `| \`${esc(r.phrase)}\` | ${r.n} | ${r.assistantCount} | ${r.userCount} | ${r.sessions ?? "-"} | ${r.baselineCount} | ${fmtPerM(r.baselinePerM)} | ${fmtLiftAgainstRate(r.lift, r.userPerM)} |`,
     );
   }
   lines.push("", "Context for each candidate (spot-check before adding):", "");
@@ -160,7 +160,7 @@ function renderProposedAdditions(input: ReportInput): string {
   }
   lines.push("", "```diff");
   for (const r of input.candidatePhrases) {
-    lines.push(`+ ${r.phrase}  # lift=${r.lift.toFixed(1)}, n=${r.n}, baseline=${r.baselineCount}`);
+    lines.push(`+ ${r.phrase}  # lift=${fmtLiftAgainstRate(r.lift, r.userPerM)}, n=${r.n}, baseline=${r.baselineCount}`);
   }
   lines.push("```");
   return lines.join("\n");
@@ -194,7 +194,7 @@ function renderRuleHealthTable(input: ReportInput): string {
         : `remove (${r.removeReason})`;
     const ruleType = ruleTypeLabel(r.entry.source);
     lines.push(
-      `| \`${esc(r.entry.phrase)}\` | ${r.entry.source} | ${ruleType} | ${r.surface} | ${fmtPerM(r.modelPerM)} | ${fmtPerM(r.baselinePerM)} | ${fmtLift(r.lift)} | ${status} |`,
+      `| \`${esc(r.entry.phrase)}\` | ${r.entry.source} | ${ruleType} | ${r.surface} | ${fmtPerM(r.modelPerM)} | ${fmtPerM(r.baselinePerM)} | ${fmtLiftAgainstRate(r.lift, r.baselinePerM)} | ${status} |`,
     );
   }
   const withQuotes = input.ruleHealth.filter((r) => r.quote);
@@ -261,7 +261,7 @@ function renderStructuralSignatures(input: ReportInput): string {
   lines.push("| --- | --- | --- | --- | --- | --- | --- |");
   for (const r of input.structuralSignatures) {
     lines.push(
-      `| \`${r.phrase}\` | ${r.n} | ${fmtPerM(r.assistantPerM)} | ${fmtPerM(r.userPerM)} | ${r.sessions ?? "-"} | ${r.lift.toFixed(1)} | ${r.example ? esc(truncate(r.example, 100)) : "-"} |`,
+      `| \`${r.phrase}\` | ${r.n} | ${fmtPerM(r.assistantPerM)} | ${fmtPerM(r.userPerM)} | ${r.sessions ?? "-"} | ${fmtLiftAgainstRate(r.lift, r.userPerM)} | ${r.example ? esc(truncate(r.example, 100)) : "-"} |`,
     );
   }
   return lines.join("\n");
@@ -278,8 +278,14 @@ function renderCorrections(input: ReportInput): string {
     lines.push("_No correction candidates in window._");
     return lines.join("\n");
   }
+  const proseCount = input.corrections.filter((c) => c.prose_signal).length;
+  lines.push(
+    `Signal-to-noise: ${proseCount}/${input.corrections.length} candidates carry a prose signal. If this ratio stays low across runs, the surface is mostly task pivots and should be retired.`,
+    "",
+  );
   for (const c of input.corrections) {
-    lines.push(`### ${c.assistant_timestamp} (${c.project ?? "unknown"})`);
+    const signal = c.prose_signal ? "prose" : "non-prose";
+    lines.push(`### ${c.assistant_timestamp} (${c.project ?? "unknown"}) [${signal}]`);
     lines.push("");
     lines.push(`Assistant (${c.assistant_chars} chars):`);
     lines.push("", "```", c.assistant_snippet, "```", "");
@@ -332,6 +338,14 @@ function fmtPerM(value: number | null): string {
 function fmtLift(value: number | null): string {
   if (value === null) return "-";
   return `${value.toFixed(1)}x`;
+}
+
+// A lift computed against a zero user rate reflects the Laplace smoothing
+// floor: the phrase is absent from the comparison text. Label the absence
+// instead of printing a misleading multiplier.
+function fmtLiftAgainstRate(lift: number | null, userRate: number | null): string {
+  if (lift !== null && userRate === 0) return "absent from user text";
+  return fmtLift(lift);
 }
 
 function ruleTypeLabel(source: string): string {

--- a/plugins/writing/wordlists/marketing-verbs.txt
+++ b/plugins/writing/wordlists/marketing-verbs.txt
@@ -1,5 +1,3 @@
 # Marketing/promotional verbs, weighted by intensity. Format: <word> <weight>
 # Stemmed; fires when weighted hits reach the threshold in tropes.ts.
 empower 2.5
-enhance 1.5
-streamline 1.5

--- a/plugins/writing/wordlists/openers.txt
+++ b/plugins/writing/wordlists/openers.txt
@@ -5,4 +5,3 @@
 # Curated against session history by writing:analyze. Entries the user uses as
 # much as the model (Great, Absolutely, Perfect) or that the model has stopped
 # producing (Wonderful, Fantastic, Amazing, Awesome, Brilliant) were removed.
-Excellent

--- a/plugins/writing/wordlists/vocabulary.txt
+++ b/plugins/writing/wordlists/vocabulary.txt
@@ -5,5 +5,4 @@ tapestry
 meticulous
 leverage
 robust
-comprehensive
 nuance


### PR DESCRIPTION
Fixes six correctness problems in the `writing:analyze` pipeline surfaced by the 2026-06-09 audit run. Closes #786

## Changes

#### Wordlist Removals

Removes `streamline` and `enhance` from `marketing-verbs.txt`, `Excellent` from `openers.txt`, and `comprehensive` from `vocabulary.txt`. All four had user rates at or above the model rate in the audit window.

#### Frustration Lexicon

Moves `sounds like` to a new `GATED_TERMS` list that requires co-occurrence with a primary complaint term (e.g. `jargon`, `marketing`) to count. Without gating, "sounds like a plan" matched in non-writing contexts. Adds `jargon` and `marketing` as direct primary terms (the two most common complaint categories in the window).

#### Model Filter

The deliverable-prose query now filters at session level. The per-item filter was silently including Haiku sidechain tool calls in sessions that were otherwise filtered to `*opus*`. A new `model_sessions` CTE identifies qualifying sessions first, then the tool-call tables join to it.

#### Correction Candidates

Raises the `min_assistant_chars` default from 300 to 800 to cut task redirections. Adds a `prose_signal` column (heuristic: ≥2 sentence-ending marks, does not start in a code fence) and a signal-to-noise ratio in the report header so the surface can be tracked for retirement.

#### Lift Labels

Adds `fmtLiftAgainstRate` to `report.ts` and routes all lift cells through it. When the user rate is zero, Laplace smoothing dominates and the multiplier is meaningless. The cell now reads "absent from user text" rather than a numeric lift.

#### Voice Baseline Docs

Adds a note to `SKILL.md` that `ingest-voice.ts` and `voice-profile.ts` write to the plugin data directory, which is outside the default sandbox allowlist.

#### `openers.txt` Now Empty

`wordlists.ts` no longer throws when the compiled openers regex is null. `tropes.ts` uses a conditional spread so the pattern is simply absent from `PATTERNS` when the file is empty.
