### PR TITLE
writing: structural detectors for manifests, conditionality, and consequence chains

### DIFF
--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -551,7 +551,7 @@ export const PATTERNS: PatternDef[] = [
     fileOnly: true,
     skillOnly: true,
     message: (matched) =>
-      `"${matched}" chains clauses with ", so". Split into two sentences; state the cause and effect separately.`,
+      `"${matched}" chains clauses with ", so". Split into two sentences. State the cause and effect separately.`,
     positives: [
       "The cache fills up, so the old entries get evicted.",
       "The worker finishes, so the queue clears.",

--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -30,6 +30,11 @@ export type PatternDef = {
   fileOnly?: boolean;
   sideEffectOnly?: boolean;
   structural?: boolean;
+  /**
+   * When true, this pattern ships in the batch analyze/review/score surfaces
+   * only. The hook never runs it. Hook promotion is an explicit user checkpoint.
+   */
+  skillOnly?: boolean;
   /** Invented examples that must match this pattern. Never quoted from sessions. */
   positives: string[];
   /** Invented examples that must not match this pattern. Never quoted from sessions. */
@@ -490,6 +495,73 @@ export const PATTERNS: PatternDef[] = [
     retire:
       "Remove when corrective-feedback moments stop citing sycophantic preambles, or if the pattern stops appearing in assistant side-effect outputs.",
   },
+  {
+    tier: "context",
+    layer: "grammar",
+    category: "backtick path bullet",
+    test: /^\s*-\s*`[^`\n]+`\s*:\s*/m,
+    fileOnly: true,
+    skillOnly: true,
+    message: () =>
+      "`` - `path`: description `` bullets read as file manifests. Describe the conceptual change in prose.",
+    positives: ["- `src/foo.ts`: refactors the helper", "- `index.ts`: adds the middleware"],
+    negatives: ["- Added retry logic to the HTTP client", "- **src/foo.ts**: refactors the helper"],
+    evidence:
+      "2026-06 corpus comparison: backtick path-bullet form appears in ~30% of AI-era bullets vs ~4% of the hand-written baseline. Hook promotion requires cross-project validation before shipping at hook frequency.",
+    retire:
+      "Promote to hook (remove skillOnly) after a cross-project labeling pass confirms precision at the hook bar. Retire when the pattern drops below baseline rate in the deliverable corpus.",
+  },
+  {
+    tier: "context",
+    layer: "cross-sentence",
+    category: "template on small document",
+    test: (text: string): Hits => {
+      const wordCount = text.split(/\s+/).filter(Boolean).length;
+      if (wordCount >= 150) return { count: 0, sample: "" };
+      const hasChanges = /^##\s+Changes\b/m.test(text);
+      const hasTesting = /^##\s+Testing\b/m.test(text);
+      if (hasChanges && hasTesting) {
+        return { count: 1, sample: "## Changes / ## Testing on small document" };
+      }
+      return { count: 0, sample: "" };
+    },
+    fileOnly: true,
+    skillOnly: true,
+    message: () =>
+      "pull-request:create scopes ## Changes and ## Testing sections to larger changes. Length tracks substance. A short body with the full section template is over-structured. Use prose instead.",
+    positives: [
+      "## Changes\n\n- Adds retry logic\n\n## Testing\n\nRan the suite.\n\nFixes #1",
+      "## Summary\n\nAdds a flag.\n\n## Changes\n\n- Adds `--verbose`\n\n## Testing\n\nManual.",
+    ],
+    negatives: [
+      `Adds a cache layer. ${Array(20).fill("The cache reduces round-trips to the database by storing frequently accessed records in memory with a configurable TTL.").join(" ")}\n\n## Changes\n\n- Adds the LRU cache\n\n## Testing\n\nAdded tests for cache expiry and eviction.`,
+      "## Changes\n\nAdds retry logic to the HTTP client.",
+      "Fixes the race condition in the cache layer by adding a mutex.",
+    ],
+    evidence:
+      "pull-request:create (SKILL.md) states: 'Use ## sections for larger changes. Length tracks substance.' A full section template on a body under ~150 words violates the skill's own rule. Threshold from corpus review of 209 hand-written PRs.",
+    retire:
+      "Remove or widen the word-count threshold if the corpus shows most short PRs include sections naturally, or if pull-request:create updates its conditionality guidance.",
+  },
+  {
+    tier: "context",
+    layer: "cross-sentence",
+    category: "consequence chain",
+    test: /,\s*so\s+(?:the|it|they|this|that|a)\b/gi,
+    fileOnly: true,
+    skillOnly: true,
+    message: (matched) =>
+      `"${matched}" chains clauses with ", so". Split into two sentences; state the cause and effect separately.`,
+    positives: [
+      "The cache fills up, so the old entries get evicted.",
+      "The worker finishes, so the queue clears.",
+    ],
+    negatives: ["So the next step is to fix the test.", "This happens because the cache is full."],
+    evidence:
+      "2026-06 corpus comparison: consequence-chain rate ~3/1k words in AI-era deliverables. Per-document rate detector. Hook promotion requires cross-project validation.",
+    retire:
+      "Promote to hook after a cross-project labeling pass at the hook bar. Retire when the consequence-chain rate in deliverables falls below 1/1k words or matches the hand-written baseline.",
+  },
 ];
 
 const MARKETING_VERB_THRESHOLD = 3.0;
@@ -539,6 +611,7 @@ export type RegexCatalogEntry = {
   pattern: RegExp;
   fileOnly?: boolean;
   sideEffectOnly?: boolean;
+  skillOnly?: boolean;
   retire: string;
 };
 
@@ -553,6 +626,10 @@ function globalize(pattern: RegExp): RegExp {
 // counting. Wordlist-backed patterns (stemmed vocabulary, weighted verbs, and
 // the compiled openers regex) and function-based tests are excluded: a single
 // regex match cannot count those, and the corpus FTS pass covers the wordlists.
+//
+// skillOnly patterns are included here so the batch analyze surface can audit
+// them. The hook never calls this catalog; it calls scan() directly, which
+// already skips skillOnly patterns.
 export function regexCatalog(): RegexCatalogEntry[] {
   return PATTERNS.filter(
     (def): def is PatternDef & { test: RegExp } =>
@@ -563,6 +640,7 @@ export function regexCatalog(): RegexCatalogEntry[] {
     pattern: globalize(def.test),
     fileOnly: def.fileOnly ?? false,
     sideEffectOnly: def.sideEffectOnly ?? false,
+    skillOnly: def.skillOnly ?? false,
     retire: def.retire,
   }));
 }
@@ -609,6 +687,7 @@ export function scanIntroduced(
   const matches: PatternMatch[] = [];
 
   for (const def of PATTERNS) {
+    if (def.skillOnly) continue;
     if (def.fileOnly && filePath && !isProseFile(filePath)) continue;
     if (def.sideEffectOnly && context === "file") continue;
 

--- a/plugins/writing/skills/analyze/scripts/analyze.test.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.test.ts
@@ -133,6 +133,10 @@ describe("runAnalysis", () => {
     expect(result.corrective.length).toBeGreaterThan(0);
     expect(result.corrective[0]?.matched_term.length).toBeGreaterThan(0);
 
+    // Rate trends are present with a non-negative document count.
+    expect(typeof result.rateTrends).toBe("object");
+    expect(result.rateTrends.documentCount).toBeGreaterThanOrEqual(0);
+
     // The remaining sections are present and typed as arrays.
     expect(Array.isArray(result.candidatePhrases)).toBe(true);
     expect(Array.isArray(result.structuralSignatures)).toBe(true);

--- a/plugins/writing/skills/analyze/scripts/analyze.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.ts
@@ -18,6 +18,7 @@ import {
 import { escapeRegex, frustrationRegex } from "./frustration";
 import { computeLift, excludePhrases, processCorpus, processRows } from "./ngram";
 import { findQuote } from "./quote-context";
+import { aggregateTrends, analyzeDocument } from "./rate-detectors";
 import { type CandidatePhrase, type ReportInput, renderReport } from "./report";
 import { buildRuleHealth, type FtsAuditRow } from "./rule-health";
 import { auditStructuralPatterns } from "./structural";
@@ -335,6 +336,14 @@ export async function runAnalysis(db: Database, config: AnalysisConfig): Promise
   console.error("Auditing structural patterns against all model-generated text");
   const structuralAudit = auditStructuralPatterns(allModelText, userRows);
 
+  console.error(
+    "Computing corpus-level rate trends (action-verb opener, backtick density, template rates)",
+  );
+  const rateDocumentRows = deliverableRows
+    .filter((r) => r.text)
+    .map((r) => analyzeDocument(r.session_id, r.text as string));
+  const rateTrends = aggregateTrends(rateDocumentRows);
+
   const ruleHealth = buildRuleHealth({
     entries: wordlistEntries,
     chatAudit: auditByTerm,
@@ -362,6 +371,7 @@ export async function runAnalysis(db: Database, config: AnalysisConfig): Promise
     ruleHealth,
     structuralAudit,
     structuralSignatures,
+    rateTrends,
     candidatePhrases,
     corrections,
     corrective,

--- a/plugins/writing/skills/analyze/scripts/rate-detectors.test.ts
+++ b/plugins/writing/skills/analyze/scripts/rate-detectors.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import { aggregateTrends, analyzeDocument } from "./rate-detectors";
+
+describe("analyzeDocument", () => {
+  test("counts words and backtick references", () => {
+    const text = "Adds `foo` to `bar`. Removes `baz` from the list.";
+    const row = analyzeDocument("s1", text);
+    expect(row.wordCount).toBeGreaterThan(0);
+    expect(row.backtickRefDensity).toBeGreaterThan(0);
+  });
+
+  test("computes action-verb opener rate, skipping first line", () => {
+    const text =
+      "Adds the cache layer.\nAdds retry logic.\nAdds timeout handling.\nThe server validates input.";
+    const row = analyzeDocument("s1", text);
+    // Lines 2-4: "Adds retry logic" and "Adds timeout handling" open with action verb; "The server..." does not.
+    expect(row.actionVerbOpenerRate).toBeCloseTo(2 / 3);
+  });
+
+  test("first line is never counted in action-verb opener rate", () => {
+    // Document with only one line: the first line is skipped, so rate is 0.
+    const row = analyzeDocument("s1", "Adds the cache layer.");
+    expect(row.actionVerbOpenerRate).toBe(0);
+  });
+
+  test("detects template sections", () => {
+    const text = "Adds retry logic.\n\n## Changes\n\n- Added retry\n\n## Testing\n\nManual.";
+    const row = analyzeDocument("s1", text);
+    expect(row.hasTemplateSections).toBe(true);
+    expect(row.templateSectionCount).toBe(2);
+  });
+
+  test("no template sections when absent", () => {
+    const row = analyzeDocument("s1", "Adds the cache layer. Fixes the race condition.");
+    expect(row.hasTemplateSections).toBe(false);
+    expect(row.templateSectionCount).toBe(0);
+    expect(row.templateOnSmallDocument).toBe(false);
+  });
+
+  test("flags templateOnSmallDocument for short body with both sections", () => {
+    const text = "Adds retry logic.\n\n## Changes\n\n- Added retry\n\n## Testing\n\nManual.";
+    const row = analyzeDocument("s1", text);
+    expect(row.templateOnSmallDocument).toBe(true);
+  });
+
+  test("does not flag templateOnSmallDocument when document is large", () => {
+    const large = Array(30)
+      .fill(
+        "The cache reduces round-trips to the database by storing frequently accessed records in memory.",
+      )
+      .join(" ");
+    const text = `${large}\n\n## Changes\n\n- Adds the LRU cache\n\n## Testing\n\nAdded integration tests.`;
+    const row = analyzeDocument("s1", text);
+    expect(row.templateOnSmallDocument).toBe(false);
+  });
+
+  test("does not flag templateOnSmallDocument with only one section", () => {
+    const text = "Adds retry logic.\n\n## Changes\n\n- Added retry.";
+    const row = analyzeDocument("s1", text);
+    expect(row.templateOnSmallDocument).toBe(false);
+  });
+
+  test("backtick ref density is per 1k words", () => {
+    // 100 words, 10 backtick refs -> 100/1k = 100.0
+    const words = Array(95).fill("word").join(" ");
+    const backticks = Array(10).fill("`ref`").join(" ");
+    const row = analyzeDocument("s1", `${words} ${backticks}`);
+    expect(row.backtickRefDensity).toBeCloseTo((10 / row.wordCount) * 1000, 0);
+  });
+
+  test("strips code blocks before counting words and verb openers", () => {
+    const text = "Adds the cache layer.\n```\nAdds fake code\n```\nUpdates the config.";
+    const row = analyzeDocument("s1", text);
+    // Only non-code lines: "Adds the cache layer." (first, skipped) and "Updates the config."
+    // "Updates" is an action verb opener. Rate should be 1/1 = 1.0 among non-first lines.
+    expect(row.actionVerbOpenerRate).toBe(1);
+  });
+});
+
+describe("aggregateTrends", () => {
+  test("returns zero-filled trends for empty input", () => {
+    const trends = aggregateTrends([]);
+    expect(trends.documentCount).toBe(0);
+    expect(trends.meanActionVerbOpenerRate).toBe(0);
+    expect(trends.meanBacktickRefDensity).toBe(0);
+    expect(trends.templateOnSmallDocumentCount).toBe(0);
+  });
+
+  test("averages rates across documents", () => {
+    const rows = [
+      analyzeDocument("s1", "Adds foo.\nAdds bar.\nUpdates baz."),
+      analyzeDocument("s2", "Fixes bug.\nThe server validates input."),
+    ];
+    const trends = aggregateTrends(rows);
+    expect(trends.documentCount).toBe(2);
+    expect(trends.meanActionVerbOpenerRate).toBeGreaterThanOrEqual(0);
+    expect(trends.meanActionVerbOpenerRate).toBeLessThanOrEqual(1);
+  });
+
+  test("computes template document rate", () => {
+    const rows = [
+      analyzeDocument("s1", "## Changes\n\n- foo\n\n## Testing\n\nbar"),
+      analyzeDocument("s2", "Plain prose without sections."),
+    ];
+    const trends = aggregateTrends(rows);
+    expect(trends.templateDocumentRate).toBeCloseTo(0.5);
+  });
+
+  test("builds section count distribution", () => {
+    const rows = [
+      analyzeDocument("s1", "## Changes\n\n- foo\n\n## Testing\n\nbar"),
+      analyzeDocument("s2", "Plain prose."),
+    ];
+    const trends = aggregateTrends(rows);
+    expect(trends.sectionCountDistribution[2]).toBe(1);
+    expect(trends.sectionCountDistribution[0]).toBe(1);
+  });
+});

--- a/plugins/writing/skills/analyze/scripts/rate-detectors.ts
+++ b/plugins/writing/skills/analyze/scripts/rate-detectors.ts
@@ -1,0 +1,150 @@
+import { stripCode } from "../../../detection/tropes";
+
+// Rate detectors measure per-document density rather than binary presence.
+// They are batch-only (analyze/review surfaces), never promoted to the hook
+// without an explicit cross-project validation pass.
+//
+// Evidence cites the 2026-06 corpus comparison aggregates from issue #788.
+// All thresholds were derived from a single-repo AI-era corpus.
+// Cross-project validation is required before hook promotion.
+
+// ACTION_VERB_OPENER matches lines that begin with a bare third-person present
+// verb, the pattern that fills AI-era bulleted change lists. The first line of
+// a document is always skipped because pull-request:create prescribes exactly
+// this opener form for the opening summary sentence; the detector targets rate
+// stacking across subsequent lines.
+//
+// Layer: grammar. Batch-only.
+// Evidence: 2026-06 corpus: 16.6% of AI-era lines vs 2.4% of hand-written baseline.
+const ACTION_VERB_OPENER =
+  /^(?:Adds|Removes|Extracts|Fixes|Updates|Changes|Refactors|Introduces|Replaces|Moves|Renames|Converts|Extends|Improves|Simplifies|Drops|Exposes|Wraps|Migrates|Handles|Enables|Disables|Cleans|Deletes|Creates|Generates|Validates|Returns|Allows|Prevents|Ensures|Sets|Gets|Reads|Writes)\b/;
+
+// BACKTICK_REF matches inline code spans. Density above ~60/1k words signals
+// over-reliance on technical identifiers as structural substitutes for prose.
+// Reported as a continuous metric, never a binary flag.
+//
+// Layer: cross-sentence. Batch-only.
+// Evidence: 2026-06 corpus: backtick reference density ~60/1k words threshold.
+const BACKTICK_REF = /`[^`\n]+`/g;
+
+// HEADING_RE matches markdown `##`-level section headings (PR body sections).
+const HEADING_RE = /^##\s+\S/m;
+
+// TEMPLATE_SECTIONS are the canonical section headings from pull-request:create.
+const TEMPLATE_SECTIONS = ["## Changes", "## Testing", "## Issue", "## References"];
+
+// TEMPLATE_ON_SMALL_DOC_THRESHOLD matches pull-request:create's own rule:
+// "Use ## sections for larger changes. Length tracks substance." A body under
+// ~150 words with both ## Changes and ## Testing present violates that rule.
+const TEMPLATE_ON_SMALL_DOC_THRESHOLD = 150;
+const HAS_CHANGES_RE = /^##\s+Changes\b/m;
+const HAS_TESTING_RE = /^##\s+Testing\b/m;
+
+export interface DocumentRateRow {
+  session_id: string;
+  /** Word count after stripping code blocks. */
+  wordCount: number;
+  /** Fraction of non-first lines that open with a bare action verb (0–1). */
+  actionVerbOpenerRate: number;
+  /** Inline backtick references per 1,000 words. */
+  backtickRefDensity: number;
+  /** Whether the document contains at least one ## section heading. */
+  hasTemplateSections: boolean;
+  /** Number of canonical template sections present (max 4). */
+  templateSectionCount: number;
+  /**
+   * True when both ## Changes and ## Testing are present on a document under
+   * the word-count threshold. pull-request:create scopes sections to larger
+   * changes; this flags over-structured short bodies.
+   */
+  templateOnSmallDocument: boolean;
+}
+
+export interface CorpusRateTrends {
+  /** Number of documents analyzed. */
+  documentCount: number;
+  /** Mean action-verb opener rate across documents (0–1). */
+  meanActionVerbOpenerRate: number;
+  /** Mean backtick reference density across documents (per 1k words). */
+  meanBacktickRefDensity: number;
+  /** Fraction of documents with at least one ## heading. */
+  templateDocumentRate: number;
+  /** Distribution of canonical section counts (0–4 keys). */
+  sectionCountDistribution: Record<number, number>;
+  /** Number of documents with full section template on a small body (<150 words). */
+  templateOnSmallDocumentCount: number;
+}
+
+function countWords(text: string): number {
+  return text.split(/\s+/).filter(Boolean).length;
+}
+
+function countBacktickRefs(text: string): number {
+  BACKTICK_REF.lastIndex = 0;
+  return text.match(BACKTICK_REF)?.length ?? 0;
+}
+
+function actionVerbOpenerRate(text: string): number {
+  // Skip blank lines (produced by stripCode fenced-block replacement and normal spacing).
+  const lines = text
+    .split("\n")
+    .slice(1)
+    .filter((line) => line.trimStart().length > 0);
+  if (lines.length === 0) return 0;
+  const openerLines = lines.filter((line) => ACTION_VERB_OPENER.test(line.trimStart()));
+  return openerLines.length / lines.length;
+}
+
+function templateSectionCount(text: string): number {
+  return TEMPLATE_SECTIONS.filter((s) => text.includes(s)).length;
+}
+
+export function analyzeDocument(session_id: string, rawText: string): DocumentRateRow {
+  const stripped = stripCode(rawText);
+  const wordCount = countWords(stripped);
+  const backtickCount = countBacktickRefs(rawText);
+  const sectionCount = templateSectionCount(rawText);
+  const isSmall = wordCount < TEMPLATE_ON_SMALL_DOC_THRESHOLD;
+  return {
+    session_id,
+    wordCount,
+    actionVerbOpenerRate: actionVerbOpenerRate(stripped),
+    backtickRefDensity: wordCount > 0 ? (backtickCount / wordCount) * 1000 : 0,
+    hasTemplateSections: HEADING_RE.test(rawText),
+    templateSectionCount: sectionCount,
+    templateOnSmallDocument:
+      isSmall && HAS_CHANGES_RE.test(rawText) && HAS_TESTING_RE.test(rawText),
+  };
+}
+
+export function aggregateTrends(rows: DocumentRateRow[]): CorpusRateTrends {
+  if (rows.length === 0) {
+    return {
+      documentCount: 0,
+      meanActionVerbOpenerRate: 0,
+      meanBacktickRefDensity: 0,
+      templateDocumentRate: 0,
+      sectionCountDistribution: {},
+      templateOnSmallDocumentCount: 0,
+    };
+  }
+
+  const totalActionVerb = rows.reduce((sum, r) => sum + r.actionVerbOpenerRate, 0);
+  const totalBacktick = rows.reduce((sum, r) => sum + r.backtickRefDensity, 0);
+  const templateDocs = rows.filter((r) => r.hasTemplateSections).length;
+  const templateOnSmall = rows.filter((r) => r.templateOnSmallDocument).length;
+
+  const dist: Record<number, number> = {};
+  for (const r of rows) {
+    dist[r.templateSectionCount] = (dist[r.templateSectionCount] ?? 0) + 1;
+  }
+
+  return {
+    documentCount: rows.length,
+    meanActionVerbOpenerRate: totalActionVerb / rows.length,
+    meanBacktickRefDensity: totalBacktick / rows.length,
+    templateDocumentRate: templateDocs / rows.length,
+    sectionCountDistribution: dist,
+    templateOnSmallDocumentCount: templateOnSmall,
+  };
+}

--- a/plugins/writing/skills/analyze/scripts/report.test.ts
+++ b/plugins/writing/skills/analyze/scripts/report.test.ts
@@ -20,6 +20,14 @@ const baseInput = {
   ruleHealth: [],
   structuralAudit: [],
   structuralSignatures: [],
+  rateTrends: {
+    documentCount: 0,
+    meanActionVerbOpenerRate: 0,
+    meanBacktickRefDensity: 0,
+    templateDocumentRate: 0,
+    sectionCountDistribution: {},
+    templateOnSmallDocumentCount: 0,
+  },
   candidatePhrases: [] as CandidatePhrase[],
   corrections: [] as CorrectionRow[],
   corrective: [] as CorrectiveRow[],
@@ -34,7 +42,29 @@ describe("renderReport", () => {
     expect(output).toContain("## Proposed Wordlist Additions");
     expect(output).toContain("## Current Rule Health");
     expect(output).toContain("## Structural Signatures");
+    expect(output).toContain("## Structural Trends");
     expect(output).toContain("## Correction Candidates");
+  });
+
+  test("renders structural trends table when documents are present", () => {
+    const output = renderReport({
+      ...baseInput,
+      rateTrends: {
+        documentCount: 42,
+        meanActionVerbOpenerRate: 0.166,
+        meanBacktickRefDensity: 58.3,
+        templateDocumentRate: 0.73,
+        sectionCountDistribution: { 0: 11, 1: 5, 2: 26 },
+        templateOnSmallDocumentCount: 7,
+      },
+    });
+    expect(output).toContain("## Structural Trends");
+    expect(output).toContain("42");
+    expect(output).toContain("action-verb opener rate");
+    expect(output).toContain("backtick ref density");
+    expect(output).toContain("template document rate");
+    expect(output).toContain("template on small document");
+    expect(output).toContain("7 docs");
   });
 
   test("renders structural signature rows with example sentences", () => {

--- a/plugins/writing/skills/analyze/scripts/report.ts
+++ b/plugins/writing/skills/analyze/scripts/report.ts
@@ -1,6 +1,7 @@
 import type { CorrectionRow, CorrectiveRow, ModelSummaryRow } from "./dump";
 import type { LiftRow } from "./ngram";
 import type { QuoteContext } from "./quote-context";
+import type { CorpusRateTrends } from "./rate-detectors";
 import type { CurrentRuleHealth, RemoveReason } from "./rule-health";
 import type { StructuralAuditRow } from "./structural";
 import type { TagSignatureRow } from "./tag-ngram";
@@ -23,6 +24,8 @@ export interface ReportInput {
   ruleHealth: CurrentRuleHealth[];
   structuralAudit: StructuralAuditRow[];
   structuralSignatures: TagSignatureRow[];
+  /** Corpus-level rate trends (action-verb opener density, backtick ref density, template rates). */
+  rateTrends: CorpusRateTrends;
   candidatePhrases: CandidatePhrase[];
   corrections: CorrectionRow[];
   corrective: CorrectiveRow[];
@@ -44,6 +47,7 @@ export function renderReport(input: ReportInput): string {
     renderRuleHealthTable(input),
     renderStructuralAudit(input),
     renderStructuralSignatures(input),
+    renderStructuralTrends(input),
     renderCorrectiveFeedback(input),
     renderCorrections(input),
   ];
@@ -267,6 +271,46 @@ function renderStructuralSignatures(input: ReportInput): string {
   return lines.join("\n");
 }
 
+function renderStructuralTrends(input: ReportInput): string {
+  const t = input.rateTrends;
+  const lines = [
+    "## Structural Trends",
+    "",
+    "Corpus-level rate metrics across deliverable documents. These are aggregate signals, not per-document flags.",
+    "",
+  ];
+  if (t.documentCount === 0) {
+    lines.push("_No deliverable documents analyzed._");
+    return lines.join("\n");
+  }
+  lines.push(`Documents analyzed: ${fmtNum(t.documentCount)}`);
+  lines.push("");
+  lines.push("| metric | value | note |");
+  lines.push("| --- | --- | --- |");
+  lines.push(
+    `| action-verb opener rate | ${fmtPct(t.meanActionVerbOpenerRate)} | mean fraction of non-first lines opening with a bare verb; 16.6% AI-era vs 2.4% baseline (2026-06) |`,
+  );
+  lines.push(
+    `| backtick ref density | ${t.meanBacktickRefDensity.toFixed(1)}/1k words | mean inline code spans per 1k words; ~60/1k marks over-reliance on identifiers as structure (2026-06) |`,
+  );
+  lines.push(
+    `| template document rate | ${fmtPct(t.templateDocumentRate)} | fraction of documents with at least one ## section heading |`,
+  );
+  lines.push(
+    `| template on small document | ${t.templateOnSmallDocumentCount} docs | full ## Changes + ## Testing on body under 150 words; pull-request:create scopes sections to larger changes |`,
+  );
+  lines.push("");
+  lines.push("Section count distribution (## Changes / ## Testing / ## Issue / ## References):");
+  lines.push("");
+  lines.push("| sections present | documents |");
+  lines.push("| --- | --- |");
+  for (let i = 0; i <= 4; i++) {
+    const count = t.sectionCountDistribution[i] ?? 0;
+    lines.push(`| ${i} | ${count} |`);
+  }
+  return lines.join("\n");
+}
+
 function renderCorrections(input: ReportInput): string {
   const lines = [
     "## Correction Candidates",
@@ -317,6 +361,10 @@ function reasonRank(reason: RemoveReason | null): number {
   if (reason === "dead") return 0;
   if (reason === "not distinctive") return 1;
   return 2;
+}
+
+function fmtPct(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
 }
 
 function fmtNum(value: number | null): string {


### PR DESCRIPTION
Adds six structural detectors for the writing plugin: three in `PATTERNS` (batch-only via `skillOnly`) and three as corpus-level rate metrics in a new `rate-detectors.ts` module. All are batch-surface only. Nothing new fires in the hook. Closes #788

## Changes

- Adds `skillOnly` flag to `PatternDef` and `RegexCatalogEntry`. `scan()`/`scanIntroduced()` skip patterns with this flag; `regexCatalog()` includes them so the analyze surface can audit them
- Adds `backtick path bullet` pattern (grammar, fileOnly): the `` - `path`: desc `` file-manifest form, 30% AI-era vs 4% baseline rate (2026-06)
- Adds `template on small document` pattern (cross-sentence, fileOnly): full `## Changes` + `## Testing` on a body under 150 words violates pull-request:create's own "length tracks substance" rule
- Adds `consequence chain` pattern (cross-sentence, fileOnly): `, so the/it/they/...` clause connector, ~3/1k words threshold
- Adds `rate-detectors.ts` with `analyzeDocument` and `aggregateTrends`: computes action-verb opener rate (16.6% AI-era vs 2.4% baseline), backtick ref density (~60/1k threshold), template section counts, and template-on-small-document count per document
- Extends `ReportInput` with `rateTrends: CorpusRateTrends` and adds a `## Structural Trends` section to the analyze report with aggregate metrics across deliverable documents
- Wires `rate-detectors` into `runAnalysis`

Every new `PATTERNS` entry carries `layer`, `positives`/`negatives` (wired into the existing `examples.test.ts` regression gate), and `evidence`/`retire` metadata noting the 2026-06 corpus numbers and that cross-project validation is required before hook promotion.

## References

- #787 (base branch: `writing-detector-lifecycle`)
