### PR TITLE
biome: migrate config schema to 2.4.16

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
Updates the `biome.json` schema declaration from 2.3.12 to 2.4.16 via `biome migrate`, matching the version `bun.lock` resolves. CI lint started failing on every fresh PR run because the schema mismatch now surfaces as an error-level diagnostic, so `biome check` exits 1 with no actual lint findings. PRs #792 and #793 are blocked on this.
