### PR TITLE
writing: add cross-sentence detector layer

### DIFF
--- a/plugins/writing/detection/examples.test.ts
+++ b/plugins/writing/detection/examples.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "bun:test";
+import { BATCH_PATTERNS } from "./scan";
 import { PATTERNS, type PatternDef } from "./tropes";
 
 // Regression gate for the examples embedded in every PatternDef. Each pattern
 // carries invented positives (must match) and negatives (must not match), so a
 // pattern edit that breaks its own examples fails here deterministically. This
 // generalizes the linguistics/fixtures.ts approach from headings to every rule.
+// Batch-only patterns (tagger-backed, never hook-loaded) face the same gate.
+
+const ALL_PATTERNS: PatternDef[] = [...PATTERNS, ...BATCH_PATTERNS];
 
 function hits(def: PatternDef, text: string): number {
   if (typeof def.test === "function") {
@@ -15,7 +19,7 @@ function hits(def: PatternDef, text: string): number {
 }
 
 describe("pattern examples", () => {
-  for (const def of PATTERNS) {
+  for (const def of ALL_PATTERNS) {
     describe(def.category, () => {
       it("has at least 2 positives and 2 negatives", () => {
         expect(def.positives.length).toBeGreaterThanOrEqual(2);
@@ -37,13 +41,13 @@ describe("pattern examples", () => {
   }
 
   it("labels every pattern with a layer", () => {
-    for (const def of PATTERNS) {
+    for (const def of ALL_PATTERNS) {
       expect(["vocabulary", "grammar", "cross-sentence", "meaning"]).toContain(def.layer);
     }
   });
 
   it("records evidence and a retirement condition for every pattern", () => {
-    for (const def of PATTERNS) {
+    for (const def of ALL_PATTERNS) {
       expect(def.evidence.length).toBeGreaterThan(0);
       expect(def.retire.length).toBeGreaterThan(0);
     }

--- a/plugins/writing/detection/scan.test.ts
+++ b/plugins/writing/detection/scan.test.ts
@@ -97,6 +97,24 @@ describe("scanAll", () => {
     expect(match?.col).toBe(1);
   });
 
+  it("locates a multi-sentence sample by its first segment", () => {
+    // Cross-sentence samples join sentence excerpts with " / ", which never
+    // appears verbatim in the source, so position falls back to segment one.
+    const text =
+      "Intro line.\nThe parser validates the incoming request payload quickly. The router dispatches the matching handler function cleanly. The logger records the final response status faithfully.";
+    const match = scanAll(text, "doc.md").find((r) => r.category === "tricolon");
+    expect(match).toBeDefined();
+    expect(match?.line).toBe(2);
+    expect(match?.col).toBe(1);
+  });
+
+  it("reports the batch-only tricolon pattern", () => {
+    const text =
+      "It reads the config file from disk at startup. It opens the network socket to the broker at boot. It starts the worker pool for the queue at launch.";
+    const categories = scanAll(text, "doc.md").map((r) => r.category);
+    expect(categories).toContain("tricolon");
+  });
+
   it("returns empty for clean prose", () => {
     expect(scanAll("The function reads input and writes output.")).toHaveLength(0);
   });

--- a/plugins/writing/detection/scan.ts
+++ b/plugins/writing/detection/scan.ts
@@ -1,3 +1,4 @@
+import { TRICOLON_PATTERN } from "../linguistics/tricolon";
 import { isProseFile } from "./paths";
 import {
   PATTERNS,
@@ -7,6 +8,11 @@ import {
   type WeightedPatternGroup,
 } from "./tropes";
 import { weightedStemHits } from "./wordlists";
+
+// Patterns that import tagger adapters and therefore run only on the batch
+// surfaces (scan, score). Hooks import detection/tropes directly and must
+// never import this module: that is the wall that keeps them deterministic.
+export const BATCH_PATTERNS: PatternDef[] = [TRICOLON_PATTERN];
 
 export type ScanResult = {
   line: number;
@@ -95,7 +101,7 @@ export function scanAll(text: string, filePath?: string): ScanResult[] {
   const prose = filePath === undefined || isProseFile(filePath);
   const results: ScanResult[] = [];
 
-  for (const def of PATTERNS) {
+  for (const def of [...PATTERNS, ...BATCH_PATTERNS]) {
     if (def.sideEffectOnly) continue;
     if (def.fileOnly && !prose) continue;
     results.push(...regexResults(stripped, def));

--- a/plugins/writing/detection/scan.ts
+++ b/plugins/writing/detection/scan.ts
@@ -36,10 +36,14 @@ function positionAt(text: string, index: number): Position {
   return { line, col: index - lastNewline };
 }
 
-// Best-effort position for a sample string the matcher reported without an index.
+// Best-effort position for a sample string the matcher reported without an
+// index. Cross-sentence detectors join sentence excerpts with " / ", so when
+// the joined sample is absent from the text, fall back to its first segment.
 function positionOfSample(text: string, sample: string): Position {
-  if (sample) {
-    const index = text.toLowerCase().indexOf(sample.toLowerCase());
+  const lower = text.toLowerCase();
+  for (const candidate of [sample, sample.split(" / ")[0] ?? ""]) {
+    if (candidate.length === 0) continue;
+    const index = lower.indexOf(candidate.toLowerCase());
     if (index >= 0) return positionAt(text, index);
   }
   return { line: 1, col: 1 };

--- a/plugins/writing/detection/sentences.ts
+++ b/plugins/writing/detection/sentences.ts
@@ -1,0 +1,29 @@
+const HEADING = /^#{1,6}\s/;
+const TABLE_ROW = /^\|/;
+
+/**
+ * Split text into sentences, filtering out headings and table rows.
+ * Splitting heuristic: period/exclamation/question followed by whitespace
+ * or end of string, or a bare newline. Returns trimmed, non-empty strings
+ * with at least one word token.
+ */
+export function splitSentences(text: string): string[] {
+  return text
+    .split(/(?<!\d)[.!?]+(?=\s|$)|\n+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .filter((s) => !TABLE_ROW.test(s))
+    .filter((s) => !HEADING.test(s));
+}
+
+/**
+ * Split text into paragraphs (blank-line separated), then for each paragraph
+ * return its constituent sentences via splitSentences. Empty paragraphs are
+ * dropped.
+ */
+export function splitParagraphs(text: string): string[][] {
+  return text
+    .split(/\n{2,}/)
+    .map((para) => splitSentences(para))
+    .filter((sentences) => sentences.length > 0);
+}

--- a/plugins/writing/detection/tropes.test.ts
+++ b/plugins/writing/detection/tropes.test.ts
@@ -420,20 +420,6 @@ describe("scan", () => {
     }
   });
 
-  describe("cross-sentence not-X", () => {
-    it("flags: It isn't X. It is Y.", () => {
-      expect(firstByTier(scan("It isn't broken. It is slow."), "context")?.category).toBe(
-        "cross-sentence not-X",
-      );
-    });
-
-    it("allows: single-sentence negation", () => {
-      expect(
-        scan("It isn't broken.").find((m) => m.category === "cross-sentence not-X"),
-      ).toBeUndefined();
-    });
-  });
-
   describe("contrast not", () => {
     const flag = [
       "This is a tool, not a framework.",

--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -716,7 +716,7 @@ export const PATTERNS: PatternDef[] = [
       "Go. The server starts up and begins processing the incoming queue of jobs that arrive throughout the day. Ok. The extremely long sentence that goes on and on with many clauses and sub-clauses describing the entire system architecture in exhaustive detail. Fine.",
     ],
     evidence:
-      "Literature heuristic. Session-corpus calibration pending. CV threshold 0.55 is a starting point derived from commercial detector documentation placing LLM output near CV 0.5 and human prose near CV 0.78. Gate: 8+ sentences. Batch-only; must not fire in the hook.",
+      "Literature heuristic. Session-corpus calibration pending. CV threshold 0.55 is a starting point derived from commercial detector documentation placing LLM output near CV 0.5 and human prose near CV 0.78. Gate: 8+ sentences. Batch-only. Must not fire in the hook.",
     retire:
       "Remove or recalibrate the threshold after session-corpus calibration. If the false-positive rate on technical prose is high, raise the threshold or narrow to prose-file context.",
   },
@@ -762,7 +762,7 @@ export const PATTERNS: PatternDef[] = [
       "However, the cache is cold. Nevertheless, the retry works.",
     ],
     evidence:
-      "Literature heuristic. Session-corpus calibration pending. PDTB-derived two-tier connective table. Tier 1 (unambiguous adversatives) counted anywhere; tier 2 (ambiguous) counted only at sentence start. 20% density threshold is a starting heuristic. Batch-only.",
+      "Literature heuristic. Session-corpus calibration pending. PDTB-derived two-tier connective table. Tier 1 (unambiguous adversatives) is counted anywhere. Tier 2 (ambiguous) is counted only at sentence start. 20% density threshold is a starting heuristic. Batch-only.",
     retire:
       "Remove or recalibrate after session-corpus calibration. If the false-positive rate on technical documentation is high, raise the threshold or restrict tier-2 markers.",
   },

--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -1,4 +1,5 @@
 import { isProseFile } from "./paths";
+import { splitParagraphs, splitSentences } from "./sentences";
 import {
   type Hits,
   type StemmedWeight,
@@ -86,11 +87,7 @@ function testResultHits(text: string): Hits {
   return { count: 0, sample: "" };
 }
 
-const CROSS_SENTENCE_NOT =
-  /\b(it|this|that|he|she|they|we|you)\s+(?:is|are|was|were)(?:n't|\s+not)\s+[^.!?]{1,80}[.!?]\s+\1\s+(?:is|are|was|were)\b/gi;
-
 const CLAUSE_CONNECTOR = /;|—|[A-Za-z] [-–] [A-Za-z]/;
-const HEADING = /^#{1,6}\s/;
 const LIST_ITEM = /^(?:[-*+]|\d+[.)])\s/;
 const MIN_SENTENCES = 5;
 const MIN_CONNECTOR_SENTENCES = 3;
@@ -104,12 +101,7 @@ function isConnectorSentence(sentence: string): boolean {
 }
 
 function connectorDensityHits(text: string): Hits {
-  const sentences = text
-    .split(/(?<!\d)[.!?]+(?=\s|$)|\n+/)
-    .map((s) => s.trim())
-    .filter((s) => !s.startsWith("|"))
-    .filter((s) => !HEADING.test(s))
-    .filter((s) => s.split(/\s+/).length >= 4);
+  const sentences = splitSentences(text).filter((s) => s.split(/\s+/).length >= 4);
   if (sentences.length < MIN_SENTENCES) return { count: 0, sample: "" };
   const connected = sentences.filter(isConnectorSentence);
   if (connected.length < MIN_CONNECTOR_SENTENCES) return { count: 0, sample: "" };
@@ -141,6 +133,134 @@ const openerPatterns: PatternDef[] = WORDLISTS.openers
       },
     ]
   : [];
+
+// Adversative negation-flip: sentence N contains a negation cue; sentence N+1
+// opens with an adversative conjunction. This signals the cross-sentence
+// contrast structure. Pure regex, two-sentence sliding window.
+const NEGATION_CUE = /\b(?:not|never|no\s)|n't\b/i;
+const ADVERSATIVE_OPENER = /^\s*(?:However|But|Yet|Nevertheless|Nonetheless|Still|That said),?\s/i;
+
+function adversativeNegationFlipHits(text: string): Hits {
+  const sentences = splitSentences(text);
+  for (let i = 0; i < sentences.length - 1; i++) {
+    const current = sentences[i] as string;
+    const next = sentences[i + 1] as string;
+    if (NEGATION_CUE.test(current) && ADVERSATIVE_OPENER.test(next)) {
+      return { count: 1, sample: `${current.slice(0, 60)} / ${next.slice(0, 40)}` };
+    }
+  }
+  return { count: 0, sample: "" };
+}
+
+// Burstiness: coefficient of variation (CV) of sentence word counts.
+// Literature: LLM output clusters near CV ~0.5; human prose near CV ~0.78.
+// Gate: 8+ sentences required; gated DEFAULT-OFF (batch-only, uncalibrated).
+const BURSTINESS_MIN_SENTENCES = 8;
+// CV threshold: flag when CV < 0.55 (suspiciously uniform).
+// Literature heuristic; session-corpus calibration pending.
+const BURSTINESS_CV_THRESHOLD = 0.55;
+
+function sentenceWordCount(sentence: string): number {
+  return sentence
+    .trim()
+    .split(/\s+/)
+    .filter((w) => w.length > 0).length;
+}
+
+function coefficientOfVariation(values: number[]): number {
+  if (values.length === 0) return 0;
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  if (mean === 0) return 0;
+  const variance = values.reduce((a, b) => a + (b - mean) ** 2, 0) / values.length;
+  return Math.sqrt(variance) / mean;
+}
+
+function burstinenssHits(text: string): Hits {
+  const sentences = splitSentences(text).filter((s) => s.split(/\s+/).length >= 2);
+  if (sentences.length < BURSTINESS_MIN_SENTENCES) return { count: 0, sample: "" };
+  const wordCounts = sentences.map(sentenceWordCount);
+  const cv = coefficientOfVariation(wordCounts);
+  if (cv >= BURSTINESS_CV_THRESHOLD) return { count: 0, sample: "" };
+  return {
+    count: 1,
+    sample: `CV=${cv.toFixed(2)} over ${sentences.length} sentences`,
+  };
+}
+
+// Question-then-answer cadence: 2 of 4+ paragraphs open with a question.
+// Pure regex; lower precision; near-zero cost.
+const MIN_PARAGRAPHS_FOR_QA = 4;
+const QA_QUESTION_THRESHOLD = 2;
+// Matches question-opening sentences after splitSentences strips the trailing '?'.
+const QUESTION_OPENER =
+  /^\s*(?:What|Why|How|When|Where|Who|Which|Is|Are|Does|Do|Can|Should|Could|Would|Will)\b/i;
+
+function questionAnswerCadenceHits(text: string): Hits {
+  const paragraphs = splitParagraphs(text);
+  if (paragraphs.length < MIN_PARAGRAPHS_FOR_QA) return { count: 0, sample: "" };
+  const questionOpeners: string[] = [];
+  for (const sentences of paragraphs) {
+    const first = sentences[0];
+    if (first && QUESTION_OPENER.test(first)) {
+      questionOpeners.push(first.slice(0, 60));
+    }
+  }
+  if (questionOpeners.length < QA_QUESTION_THRESHOLD) return { count: 0, sample: "" };
+  return { count: questionOpeners.length, sample: questionOpeners[0] as string };
+}
+
+// Discourse-marker density: two-tier PDTB-derived connective lookup.
+// Tier 1 (unambiguous adversatives): flat substring match, always count.
+// Tier 2 (ambiguous): only count when appearing at sentence start, where
+// they unambiguously signal a discourse move rather than a local modifier.
+//
+// Threshold: > 20% of sentences carry a tier-1 or tier-2 cue.
+// Literature heuristic; session-corpus calibration pending.
+const DISCOURSE_MIN_SENTENCES = 5;
+const DISCOURSE_DENSITY_THRESHOLD = 0.2;
+
+// Tier 1: unambiguously discourse-adversative / concessive when they appear
+// anywhere in a sentence.
+const DISCOURSE_TIER1 = [
+  /\bhowever\b/i,
+  /\bnevertheless\b/i,
+  /\bnonetheless\b/i,
+  /\bnotwithstanding\b/i,
+  /\bconversely\b/i,
+  /\bin contrast\b/i,
+  /\bon the other hand\b/i,
+  /\bthat said\b/i,
+  /\bby contrast\b/i,
+];
+
+// Tier 2: ambiguous connectives counted only at sentence start.
+const DISCOURSE_TIER2_START = [
+  /^(?:also|moreover|furthermore|in addition|additionally),?\s/i,
+  /^(?:therefore|thus|hence|consequently|as a result),?\s/i,
+  /^(?:similarly|likewise),?\s/i,
+  /^(?:specifically|for example|for instance|in particular),?\s/i,
+  /^(?:finally|first|second|third|lastly),?\s/i,
+];
+
+function hasDiscourseMarker(sentence: string): boolean {
+  for (const pattern of DISCOURSE_TIER1) {
+    if (pattern.test(sentence)) return true;
+  }
+  for (const pattern of DISCOURSE_TIER2_START) {
+    if (pattern.test(sentence)) return true;
+  }
+  return false;
+}
+
+function discourseMarkerDensityHits(text: string): Hits {
+  const sentences = splitSentences(text).filter((s) => s.split(/\s+/).length >= 3);
+  if (sentences.length < DISCOURSE_MIN_SENTENCES) return { count: 0, sample: "" };
+  const marked = sentences.filter(hasDiscourseMarker);
+  if (marked.length / sentences.length < DISCOURSE_DENSITY_THRESHOLD) {
+    return { count: 0, sample: "" };
+  }
+  return { count: marked.length, sample: (marked[0] as string).slice(0, 60) };
+}
 
 export const PATTERNS: PatternDef[] = [
   {
@@ -335,23 +455,6 @@ export const PATTERNS: PatternDef[] = [
       "Pre-dates the curation principle; no corpus evidence recorded. Retained because the parallelism structure is a consistent AI tell that a regex captures reliably.",
     retire:
       "Remove if corpus analysis shows the pattern fires at low lift or if a grammar-layer replacement (tagger rule) is promoted and has equal or higher precision.",
-  },
-  {
-    tier: "context",
-    layer: "cross-sentence",
-    category: "cross-sentence not-X",
-    test: CROSS_SENTENCE_NOT,
-    message: () =>
-      'Cross-sentence "It isn\'t X. It is Y." patterns are an AI tell. Combine into one sentence or drop the negation.',
-    positives: [
-      "It isn't broken. It is slow.",
-      "This isn't a regression. This is a design decision.",
-    ],
-    negatives: ["It isn't broken.", "The server is slow."],
-    evidence:
-      "Pre-dates the curation principle; no corpus evidence recorded. The cross-sentence structure is documented in linguistics.md (Trope Inventory) as a known AI tell with no tooling yet.",
-    retire:
-      "Remove if corpus analysis shows the pattern fires rarely or is not distinctive versus user text.",
   },
   {
     tier: "context",
@@ -555,6 +658,27 @@ export const PATTERNS: PatternDef[] = [
   {
     tier: "context",
     layer: "cross-sentence",
+    category: "adversative negation-flip",
+    fileOnly: true,
+    test: adversativeNegationFlipHits,
+    message: (matched) =>
+      `Cross-sentence negation-flip: "${matched}". Negating then immediately conceding with "However/But/Yet" is an AI prose pattern. Merge into a single sentence or drop the negation.`,
+    positives: [
+      "The cache does not warm instantly. However, the first request fills it.",
+      "This isn't a regression. But it does change observed behavior.",
+    ],
+    negatives: [
+      "The cache fills on first request. However, it can evict under pressure.",
+      "The server starts. The queue drains.",
+    ],
+    evidence:
+      "The CROSS_SENTENCE_NOT regex (8 hits in 2 sessions over 30 days) confirmed the contrast family fires rarely. This detector subsumes that narrow pronoun-repeat pattern and broadens coverage to any negation cue followed by an adversative opener. Session-corpus calibration pending before hook promotion.",
+    retire:
+      "Remove when corpus analysis shows the pattern fires at comparable rates on user text (not distinctive), or when session-corpus calibration shows precision below the hook bar.",
+  },
+  {
+    tier: "context",
+    layer: "cross-sentence",
     category: "consequence chain",
     test: /,\s*so\s+(?:the|it|they|this|that|a)\b/gi,
     fileOnly: true,
@@ -570,6 +694,76 @@ export const PATTERNS: PatternDef[] = [
       "2026-06 corpus comparison: consequence-chain rate ~3/1k words in AI-era deliverables. Per-document rate detector. Hook promotion requires cross-project validation.",
     retire:
       "Promote to hook after a cross-project labeling pass at the hook bar. Retire when the consequence-chain rate in deliverables falls below 1/1k words or matches the hand-written baseline.",
+  },
+  {
+    tier: "context",
+    layer: "cross-sentence",
+    category: "sentence burstiness",
+    fileOnly: true,
+    test: burstinenssHits,
+    message: (matched) =>
+      `Low sentence-length variation (${matched}). Uniform sentence length is an AI prose tell. Vary sentence rhythm.`,
+    positives: [
+      // 8 sentences, all near the same word count (~7-8 words each)
+      "The server starts up and runs tasks. The queue fills as jobs arrive. The workers drain the queue items. The logs show each completed entry. The metrics update with each pass. The cron job fires at midnight. The results post to the dashboard view. The cycle repeats the next morning.",
+      "A function receives the data input. It validates each field carefully. Then it calls the database layer. The result gets returned to caller. Errors propagate up the stack. The caller logs any failures found. The client retries failed requests now. The system recovers from each error.",
+    ],
+    negatives: [
+      // Fewer than 8 sentences
+      "The server starts. The queue fills. The workers drain it.",
+      // High CV (varied lengths)
+      "Go. The server starts up and begins processing the incoming queue of jobs that arrive throughout the day. Ok. The extremely long sentence that goes on and on with many clauses and sub-clauses describing the entire system architecture in exhaustive detail. Fine.",
+    ],
+    evidence:
+      "Literature heuristic; session-corpus calibration pending. CV threshold 0.55 is a starting point derived from commercial detector documentation placing LLM output near CV 0.5 and human prose near CV 0.78. Gate: 8+ sentences. Batch-only; must not fire in the hook.",
+    retire:
+      "Remove or recalibrate the threshold after session-corpus calibration. If the false-positive rate on technical prose is high, raise the threshold or narrow to prose-file context.",
+  },
+  {
+    tier: "context",
+    layer: "cross-sentence",
+    category: "question-answer cadence",
+    fileOnly: true,
+    test: questionAnswerCadenceHits,
+    message: (matched) =>
+      `Repeated question-opener paragraphs (e.g., "${matched}"). Using questions as section headers is an AI structuring pattern. State the point directly.`,
+    positives: [
+      "What does this do?\nIt processes jobs.\n\nWhy does it matter?\nPerformance improves.\n\nHow do you use it?\nCall the function.\n\nWhen should you avoid it?\nOn empty queues.",
+      "What changed?\nThe retry logic.\n\nWhy now?\nFlakiness spiked.\n\nHow was it tested?\nUnit tests added.\n\nWhat is next?\nMonitor the error rate.",
+    ],
+    negatives: [
+      // Fewer than 4 paragraphs
+      "What does this do?\nIt processes jobs.\n\nWhy does it matter?\nPerformance improves.",
+      // Only 1 question opener out of 4+ paragraphs
+      "What does this do?\nIt processes jobs.\n\nThe retry logic changed.\n\nUnit tests were added.\n\nThe error rate dropped.",
+    ],
+    evidence:
+      "Literature heuristic; session-corpus calibration pending. Question-opener cadence is a known AI structuring pattern in explanatory prose. Threshold: 2 of 4+ paragraphs. Batch-only.",
+    retire:
+      "Remove when session-corpus calibration shows the pattern does not distinguish assistant from user text, or when precision on a labeled sample is below the hook bar.",
+  },
+  {
+    tier: "context",
+    layer: "cross-sentence",
+    category: "discourse-marker density",
+    fileOnly: true,
+    test: discourseMarkerDensityHits,
+    message: (matched) =>
+      `High discourse-marker density (e.g., "${matched}"). Dense connective scaffolding is an AI prose pattern. Cut markers that do not carry meaning.`,
+    positives: [
+      "The cache warms on first access. However, under load it can evict entries. Nevertheless, the retry logic compensates. Furthermore, the metrics track hit rate. In addition, the dashboard surfaces evictions. Therefore, operators can tune the size.",
+      "First, the worker picks up the job. Then it validates the payload fields. Furthermore, it calls the downstream service. However, on failure it retries twice. Nevertheless, transient errors still surface. Consequently, the caller must handle them.",
+    ],
+    negatives: [
+      // Below the 20% threshold: only 1 of 6 sentences has a marker
+      "The server starts. The queue fills. The workers drain it. The logs update. The metrics post. However, errors propagate.",
+      // Fewer than 5 sentences
+      "However, the cache is cold. Nevertheless, the retry works.",
+    ],
+    evidence:
+      "Literature heuristic; session-corpus calibration pending. PDTB-derived two-tier connective table. Tier 1 (unambiguous adversatives) counted anywhere; tier 2 (ambiguous) counted only at sentence start. 20% density threshold is a starting heuristic. Batch-only.",
+    retire:
+      "Remove or recalibrate after session-corpus calibration. If the false-positive rate on technical documentation is high, raise the threshold or restrict tier-2 markers.",
   },
 ];
 

--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -134,7 +134,7 @@ const openerPatterns: PatternDef[] = WORDLISTS.openers
     ]
   : [];
 
-// Adversative negation-flip: sentence N contains a negation cue; sentence N+1
+// Adversative negation-flip: sentence N contains a negation cue and sentence N+1
 // opens with an adversative conjunction. This signals the cross-sentence
 // contrast structure. Pure regex, two-sentence sliding window.
 const NEGATION_CUE = /\b(?:not|never)\b|\bno\s|n't\b/i;
@@ -153,11 +153,11 @@ function adversativeNegationFlipHits(text: string): Hits {
 }
 
 // Burstiness: coefficient of variation (CV) of sentence word counts.
-// Literature: LLM output clusters near CV ~0.5; human prose near CV ~0.78.
-// Gate: 8+ sentences required; gated DEFAULT-OFF (batch-only, uncalibrated).
+// Literature: LLM output clusters near CV ~0.5, human prose near CV ~0.78.
+// Gate: 8+ sentences required. Gated DEFAULT-OFF (batch-only, uncalibrated).
 const BURSTINESS_MIN_SENTENCES = 8;
 // CV threshold: flag when CV < 0.55 (suspiciously uniform).
-// Literature heuristic; session-corpus calibration pending.
+// Literature heuristic. Session-corpus calibration pending.
 const BURSTINESS_CV_THRESHOLD = 0.55;
 
 function sentenceWordCount(sentence: string): number {
@@ -188,7 +188,7 @@ function burstinessHits(text: string): Hits {
 }
 
 // Question-then-answer cadence: 2 of 4+ paragraphs open with a question.
-// Pure regex; lower precision; near-zero cost.
+// Pure regex. Lower precision, near-zero cost.
 const MIN_PARAGRAPHS_FOR_QA = 4;
 const QA_QUESTION_THRESHOLD = 2;
 // Matches question-opening sentences after splitSentences strips the trailing '?'.
@@ -215,7 +215,7 @@ function questionAnswerCadenceHits(text: string): Hits {
 // they unambiguously signal a discourse move rather than a local modifier.
 //
 // Threshold: > 20% of sentences carry a tier-1 or tier-2 cue.
-// Literature heuristic; session-corpus calibration pending.
+// Literature heuristic. Session-corpus calibration pending.
 const DISCOURSE_MIN_SENTENCES = 5;
 const DISCOURSE_DENSITY_THRESHOLD = 0.2;
 
@@ -716,7 +716,7 @@ export const PATTERNS: PatternDef[] = [
       "Go. The server starts up and begins processing the incoming queue of jobs that arrive throughout the day. Ok. The extremely long sentence that goes on and on with many clauses and sub-clauses describing the entire system architecture in exhaustive detail. Fine.",
     ],
     evidence:
-      "Literature heuristic; session-corpus calibration pending. CV threshold 0.55 is a starting point derived from commercial detector documentation placing LLM output near CV 0.5 and human prose near CV 0.78. Gate: 8+ sentences. Batch-only; must not fire in the hook.",
+      "Literature heuristic. Session-corpus calibration pending. CV threshold 0.55 is a starting point derived from commercial detector documentation placing LLM output near CV 0.5 and human prose near CV 0.78. Gate: 8+ sentences. Batch-only; must not fire in the hook.",
     retire:
       "Remove or recalibrate the threshold after session-corpus calibration. If the false-positive rate on technical prose is high, raise the threshold or narrow to prose-file context.",
   },
@@ -739,7 +739,7 @@ export const PATTERNS: PatternDef[] = [
       "What does this do?\nIt processes jobs.\n\nThe retry logic changed.\n\nUnit tests were added.\n\nThe error rate dropped.",
     ],
     evidence:
-      "Literature heuristic; session-corpus calibration pending. Question-opener cadence is a known AI structuring pattern in explanatory prose. Threshold: 2 of 4+ paragraphs. Batch-only.",
+      "Literature heuristic. Session-corpus calibration pending. Question-opener cadence is a known AI structuring pattern in explanatory prose. Threshold: 2 of 4+ paragraphs. Batch-only.",
     retire:
       "Remove when session-corpus calibration shows the pattern does not distinguish assistant from user text, or when precision on a labeled sample is below the hook bar.",
   },
@@ -762,7 +762,7 @@ export const PATTERNS: PatternDef[] = [
       "However, the cache is cold. Nevertheless, the retry works.",
     ],
     evidence:
-      "Literature heuristic; session-corpus calibration pending. PDTB-derived two-tier connective table. Tier 1 (unambiguous adversatives) counted anywhere; tier 2 (ambiguous) counted only at sentence start. 20% density threshold is a starting heuristic. Batch-only.",
+      "Literature heuristic. Session-corpus calibration pending. PDTB-derived two-tier connective table. Tier 1 (unambiguous adversatives) counted anywhere; tier 2 (ambiguous) counted only at sentence start. 20% density threshold is a starting heuristic. Batch-only.",
     retire:
       "Remove or recalibrate after session-corpus calibration. If the false-positive rate on technical documentation is high, raise the threshold or restrict tier-2 markers.",
   },

--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -137,7 +137,7 @@ const openerPatterns: PatternDef[] = WORDLISTS.openers
 // Adversative negation-flip: sentence N contains a negation cue; sentence N+1
 // opens with an adversative conjunction. This signals the cross-sentence
 // contrast structure. Pure regex, two-sentence sliding window.
-const NEGATION_CUE = /\b(?:not|never|no\s)|n't\b/i;
+const NEGATION_CUE = /\b(?:not|never)\b|\bno\s|n't\b/i;
 const ADVERSATIVE_OPENER = /^\s*(?:However|But|Yet|Nevertheless|Nonetheless|Still|That said),?\s/i;
 
 function adversativeNegationFlipHits(text: string): Hits {
@@ -175,7 +175,7 @@ function coefficientOfVariation(values: number[]): number {
   return Math.sqrt(variance) / mean;
 }
 
-function burstinenssHits(text: string): Hits {
+function burstinessHits(text: string): Hits {
   const sentences = splitSentences(text).filter((s) => s.split(/\s+/).length >= 2);
   if (sentences.length < BURSTINESS_MIN_SENTENCES) return { count: 0, sample: "" };
   const wordCounts = sentences.map(sentenceWordCount);
@@ -670,9 +670,10 @@ export const PATTERNS: PatternDef[] = [
     negatives: [
       "The cache fills on first request. However, it can evict under pressure.",
       "The server starts. The queue drains.",
+      "The notable design held up under load. However, the rollout was slow.",
     ],
     evidence:
-      "The CROSS_SENTENCE_NOT regex (8 hits in 2 sessions over 30 days) confirmed the contrast family fires rarely. This detector subsumes that narrow pronoun-repeat pattern and broadens coverage to any negation cue followed by an adversative opener. Session-corpus calibration pending before hook promotion.",
+      "The CROSS_SENTENCE_NOT regex (8 hits in 2 sessions over 30 days) confirmed the contrast family fires rarely, so it was retired. This detector replaces it with a different shape: any negation cue followed by an adversative opener. Session-corpus calibration pending before hook promotion.",
     retire:
       "Remove when corpus analysis shows the pattern fires at comparable rates on user text (not distinctive), or when session-corpus calibration shows precision below the hook bar.",
   },
@@ -700,7 +701,7 @@ export const PATTERNS: PatternDef[] = [
     layer: "cross-sentence",
     category: "sentence burstiness",
     fileOnly: true,
-    test: burstinenssHits,
+    test: burstinessHits,
     message: (matched) =>
       `Low sentence-length variation (${matched}). Uniform sentence length is an AI prose tell. Vary sentence rhythm.`,
     positives: [

--- a/plugins/writing/hooks/check-tropes.test.ts
+++ b/plugins/writing/hooks/check-tropes.test.ts
@@ -3,10 +3,7 @@ import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type {
-  PreToolUseHookInput,
-  PreToolUseHookSpecificOutput,
-} from "@anthropic-ai/claude-agent-sdk";
+import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { collectText, processInput } from "./check-tropes";
 
 function mockWrite(content: string): PreToolUseHookInput {
@@ -74,14 +71,6 @@ function mockMcp(toolName: string, toolInput: Record<string, unknown>): PreToolU
     tool_input: toolInput,
     tool_use_id: "test",
   };
-}
-
-async function getDecision(
-  input: PreToolUseHookInput,
-): Promise<PreToolUseHookSpecificOutput | null> {
-  const result = await processInput(input);
-  if (!result) return null;
-  return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
 }
 
 describe("plan files", () => {

--- a/plugins/writing/linguistics/tricolon.test.ts
+++ b/plugins/writing/linguistics/tricolon.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import type { CoarseTag } from "./tags";
+import { normalizedDistance, tagShape, tricolonHits } from "./tricolon";
+
+const PARALLEL_TRIPLE =
+  "The parser validates the incoming request payload quickly. " +
+  "The router dispatches the matching handler function cleanly. " +
+  "The logger records the final response status faithfully.";
+
+describe("normalizedDistance", () => {
+  it("returns 0 for identical sequences", () => {
+    const shape: CoarseTag[] = ["NOUN", "VERB", "NOUN"];
+    expect(normalizedDistance(shape, shape)).toBe(0);
+  });
+
+  it("returns 1 for fully disjoint sequences", () => {
+    expect(normalizedDistance(["NOUN", "NOUN"], ["VERB", "ADJ"])).toBe(1);
+  });
+
+  it("returns 0 for two empty sequences", () => {
+    expect(normalizedDistance([], [])).toBe(0);
+  });
+
+  it("normalizes by the longer sequence", () => {
+    expect(normalizedDistance(["NOUN", "VERB"], ["NOUN", "VERB", "ADV", "ADV"])).toBe(0.5);
+  });
+});
+
+describe("tagShape", () => {
+  it("filters determiners, punctuation, and numbers", () => {
+    const shape = tagShape("The 3 parsers validate the payload.");
+    expect(shape).not.toContain("DET");
+    expect(shape).not.toContain("NUM");
+    expect(shape).not.toContain("PUNCT");
+    expect(shape).toContain("VERB");
+  });
+});
+
+describe("tricolonHits", () => {
+  it("flags three consecutive sentences with the same shape", () => {
+    const hits = tricolonHits(PARALLEL_TRIPLE);
+    expect(hits.count).toBe(1);
+    expect(hits.sample).toContain("The parser validates");
+  });
+
+  it("finds a triple in the middle of surrounding prose", () => {
+    const text = `The deployment finished without incident yesterday afternoon. ${PARALLEL_TRIPLE} Nothing else changed.`;
+    expect(tricolonHits(text).count).toBe(1);
+  });
+
+  it("ignores texts with fewer than three sentences", () => {
+    expect(
+      tricolonHits(
+        "The parser validates the incoming request payload quickly. The router dispatches the matching handler function cleanly.",
+      ).count,
+    ).toBe(0);
+  });
+
+  it("ignores parallel sentences below the token gate", () => {
+    expect(
+      tricolonHits("The cache starts cold. The queue fills fast. The worker drains it.").count,
+    ).toBe(0);
+  });
+
+  it("ignores structurally varied sentences of sufficient length", () => {
+    const text =
+      "The parser validates the incoming request payload quickly. " +
+      "The busy router near the gateway dispatches handlers cleanly under load. " +
+      "Because traffic spikes are unpredictable there, operators who watch the dashboards rarely intervene manually.";
+    expect(tricolonHits(text).count).toBe(0);
+  });
+
+  it("does not flag a drifting sequence whose outer sentences diverge", () => {
+    // Adjacent pairs sit under the threshold (0.25, 0.20) while the outer
+    // pair lands above it (0.40), so an adjacent-only comparison would flag
+    // this. The all-pairwise rule must not.
+    const text =
+      "The parser validates the incoming request payload quickly. " +
+      "The parser validates the incoming request payload quickly during startup. " +
+      "Early on, the parser validates the incoming request payload quickly during startup.";
+    expect(tricolonHits(text).count).toBe(0);
+  });
+});

--- a/plugins/writing/linguistics/tricolon.ts
+++ b/plugins/writing/linguistics/tricolon.ts
@@ -1,0 +1,109 @@
+/**
+ * Tricolon detector: three consecutive sentences whose coarse POS shapes
+ * are near-identical, the escalating-triad structure from linguistics.md.
+ *
+ * This module imports the compromise tagger adapter, so only batch tooling
+ * (scan, score, analyze) may import it, never hooks. Same wall as
+ * classifiers.ts: hooks stay deterministic with zero tagger imports.
+ */
+import { splitSentences } from "../detection/sentences";
+import type { PatternDef } from "../detection/tropes";
+import type { Hits } from "../detection/wordlists";
+import { compromiseTagger } from "./compromise";
+import type { CoarseTag } from "./tags";
+
+// Each sentence in a triple needs this many tokens after tag filtering;
+// shorter sentences converge on the same shapes by chance.
+const TRICOLON_MIN_TOKENS = 6;
+// Normalized edit distance at or below this counts as parallel.
+// Literature heuristic; session-corpus calibration pending per #769.
+const TRICOLON_DISTANCE_THRESHOLD = 0.35;
+
+// Determiners, punctuation, and numbers carry no parallelism signal:
+// "the parser" and "a router" share a shape regardless of the article.
+const SHAPE_NEUTRAL_TAGS: ReadonlySet<CoarseTag> = new Set(["DET", "PUNCT", "NUM"]);
+
+/** Coarse POS shape of a sentence with shape-neutral tags removed. */
+export function tagShape(sentence: string): CoarseTag[] {
+  return compromiseTagger
+    .tag(sentence)
+    .flatMap((tagged) => tagged.tokens)
+    .map((token) => token.tag)
+    .filter((tag) => !SHAPE_NEUTRAL_TAGS.has(tag));
+}
+
+function editDistance(a: CoarseTag[], b: CoarseTag[]): number {
+  let previous = Array.from({ length: b.length + 1 }, (_, j) => j);
+  for (let i = 1; i <= a.length; i++) {
+    const current: number[] = [i];
+    for (let j = 1; j <= b.length; j++) {
+      const substitution = (previous[j - 1] as number) + (a[i - 1] === b[j - 1] ? 0 : 1);
+      current[j] = Math.min(
+        (previous[j] as number) + 1,
+        (current[j - 1] as number) + 1,
+        substitution,
+      );
+    }
+    previous = current;
+  }
+  return previous[b.length] as number;
+}
+
+/** Edit distance between two tag sequences, normalized to [0, 1] by the longer length. */
+export function normalizedDistance(a: CoarseTag[], b: CoarseTag[]): number {
+  const longest = Math.max(a.length, b.length);
+  if (longest === 0) return 0;
+  return editDistance(a, b) / longest;
+}
+
+// A tricolon requires all three pairwise distances under the threshold,
+// not just adjacent pairs: adjacent-only would pass a drifting sequence
+// where the outer sentences share no structure.
+function isParallelTriple(a: CoarseTag[], b: CoarseTag[], c: CoarseTag[]): boolean {
+  return [normalizedDistance(a, b), normalizedDistance(b, c), normalizedDistance(a, c)].every(
+    (distance) => distance <= TRICOLON_DISTANCE_THRESHOLD,
+  );
+}
+
+export function tricolonHits(text: string): Hits {
+  const sentences = splitSentences(text);
+  if (sentences.length < 3) return { count: 0, sample: "" };
+  const shapes = sentences.map(tagShape);
+  for (let i = 0; i + 2 < sentences.length; i++) {
+    const a = shapes[i] as CoarseTag[];
+    const b = shapes[i + 1] as CoarseTag[];
+    const c = shapes[i + 2] as CoarseTag[];
+    if (Math.min(a.length, b.length, c.length) < TRICOLON_MIN_TOKENS) continue;
+    if (!isParallelTriple(a, b, c)) continue;
+    const sample = sentences
+      .slice(i, i + 3)
+      .map((sentence) => sentence.slice(0, 40))
+      .join(" / ");
+    return { count: 1, sample };
+  }
+  return { count: 0, sample: "" };
+}
+
+export const TRICOLON_PATTERN: PatternDef = {
+  tier: "context",
+  layer: "cross-sentence",
+  category: "tricolon",
+  fileOnly: true,
+  test: tricolonHits,
+  message: (matched) =>
+    `Tricolon: three consecutive sentences share the same grammatical shape ("${matched}"). Rhythmic triads are an AI prose pattern. Vary the structure or merge the sentences.`,
+  positives: [
+    "The parser validates the incoming request payload quickly. The router dispatches the matching handler function cleanly. The logger records the final response status faithfully.",
+    "It reads the config file from disk at startup. It opens the network socket to the broker at boot. It starts the worker pool for the queue at launch.",
+  ],
+  negatives: [
+    // Parallel shapes, but each sentence is under the 6-token gate.
+    "The cache starts cold. The queue fills fast. The worker drains it.",
+    // 6+ tokens each, but the shapes diverge.
+    "The cache begins cold on the first request of the day. Entries accumulate as traffic arrives, and reads accelerate once the working set stabilizes. Nobody should tune anything before measuring real production load.",
+  ],
+  evidence:
+    "Literature heuristic; session-corpus calibration pending per the #769 labeling protocol. Normalized edit distance over coarse POS shapes (DET/PUNCT/NUM filtered), threshold 0.35, 6+ tokens per sentence. Batch-only: this module imports the compromise tagger, so hooks never load it.",
+  retire:
+    "Remove if the labeled eval pass shows precision below the batch bar, or recalibrate the threshold if the session corpus places parallel triads elsewhere. Remove outright if assistant deliverables stop producing tricolons.",
+};

--- a/plugins/writing/linguistics/tricolon.ts
+++ b/plugins/writing/linguistics/tricolon.ts
@@ -16,7 +16,7 @@ import type { CoarseTag } from "./tags";
 // shorter sentences converge on the same shapes by chance.
 const TRICOLON_MIN_TOKENS = 6;
 // Normalized edit distance at or below this counts as parallel.
-// Literature heuristic; session-corpus calibration pending per #769.
+// Literature heuristic. Session-corpus calibration pending per #769.
 const TRICOLON_DISTANCE_THRESHOLD = 0.35;
 
 // Determiners, punctuation, and numbers carry no parallelism signal:
@@ -103,7 +103,7 @@ export const TRICOLON_PATTERN: PatternDef = {
     "The cache begins cold on the first request of the day. Entries accumulate as traffic arrives, and reads accelerate once the working set stabilizes. Nobody should tune anything before measuring real production load.",
   ],
   evidence:
-    "Literature heuristic; session-corpus calibration pending per the #769 labeling protocol. Normalized edit distance over coarse POS shapes (DET/PUNCT/NUM filtered), threshold 0.35, 6+ tokens per sentence. Batch-only: this module imports the compromise tagger, so hooks never load it.",
+    "Literature heuristic. Session-corpus calibration pending per the #769 labeling protocol. Normalized edit distance over coarse POS shapes (DET/PUNCT/NUM filtered), threshold 0.35, 6+ tokens per sentence. Batch-only: this module imports the compromise tagger, so hooks never load it.",
   retire:
     "Remove if the labeled eval pass shows precision below the batch bar, or recalibrate the threshold if the session corpus places parallel triads elsewhere. Remove outright if assistant deliverables stop producing tricolons.",
 };

--- a/plugins/writing/skills/analyze/references/linguistics.md
+++ b/plugins/writing/skills/analyze/references/linguistics.md
@@ -136,7 +136,7 @@ Where each existing detector sits, and what moving it would take:
 
 - **Vocabulary** (`wordlists/*.txt`): stay as wordlists. The analyze skill audits them each run.
 - **Grammar** (regexes in `detection/tropes.ts`): candidates for a tagger rule, each only after the layer check confirms a tagger beats a regex. Passive voice, "not X but Y", and test-result reporting are the current candidates.
-- **Cross-sentence** (negation flips): no tooling yet.
+- **Cross-sentence** (negation flips, burstiness, question cadence, discourse markers, tricolon): five batch-surface detectors in `detection/tropes.ts`, plus the tagger-backed tricolon in `linguistics/tricolon.ts` behind the hook wall. Thresholds are literature heuristics until the #769 labeling pass calibrates them.
 - **Meaning** (marketing tone, hedging): LLM-judge territory.
 
 Until the bars and the power calculation are in place, the `tropes.ts` regexes stay as they are and ship as hook nudges.


### PR DESCRIPTION
Adds the cross-sentence detector layer from the 2026-06-09 discourse-detection survey: five detectors, no new dependencies, all batch-surface. Closes #790.

Stacked on #792's base branch `writing-detector-lifecycle`: every detector carries `layer`, invented `positives`/`negatives` (enforced by the examples regression gate), and `evidence`/`retire` metadata.

## Changes

- Extracts `splitSentences`/`splitParagraphs` into `detection/sentences.ts`, shared by all cross-sentence detectors; `connectorDensityHits` now uses them.
- Retires `CROSS_SENTENCE_NOT` (8 hits in 2 sessions over 30 days, per its own retirement condition).
- Adds four deterministic detectors to `detection/tropes.ts`, all `fileOnly`: adversative negation-flip (negation cue then `However`/`But`/`Yet` opener), sentence burstiness (CV of word counts < 0.55, 8+ sentences), question-answer cadence (2 of 4+ paragraphs open with a question word), and discourse-marker density (two-tier PDTB connective table, 20% of sentences).
- Adds the tricolon detector in `linguistics/tricolon.ts`: normalized edit distance over coarse POS shapes (DET/PUNCT/NUM filtered) across consecutive sentence triples, threshold 0.35, 6+ tokens per sentence, all three pairwise distances required. It imports the compromise tagger, so it sits behind the same wall as `classifiers.ts`: `detection/scan.ts` exposes it as `BATCH_PATTERNS` for the scan/score surfaces, and hooks never import it.
- `positionOfSample` falls back to the first ` / ` segment so cross-sentence matches report real positions instead of `1:1`.

## Calibration

Every threshold is a literature heuristic. The tricolon detector in particular requires a labeled eval pass per the #769 protocol before its 0.35 threshold is trusted; that calibration against the session corpus is a pending user checkpoint, not part of this PR. Until then all five stay batch-only.

## Testing

The examples gate now covers batch patterns alongside hook patterns, so each detector's invented positives and negatives are committed regression fixtures. `tricolon.test.ts` pins the distance normalization, the token gate, and the all-pairwise rule (a drifting sequence whose adjacent pairs are similar but whose outer pair diverges must not flag). A hook-input run on a tricolon confirms the wall: the batch surfaces report it, the hook stays silent.

## References

- #769 (labeling protocol), #787 (lifecycle metadata)
