### PR TITLE
writing: add voice-delta baseline comparison

### DIFF
--- a/plugins/writing/skills/analyze/SKILL.md
+++ b/plugins/writing/skills/analyze/SKILL.md
@@ -62,6 +62,7 @@ Run with `--help` for all flags. `--data-dir` overrides where the voice baseline
 ## Output
 
 - Summary stats (corpus sizes, voice-baseline size, rule count, model breakdown)
+- Voice delta (per-feature corpus rates beside the local baseline rates, each labeled **skill-prescribed**, **skill-encouraged**, or **ungoverned** so drift points at the right fix: tune the skill or build a detector; aggregate trends only, never per-document flags)
 - Proposed removals, each tagged **dead** (model produced it fewer than `--min-count` times on the surface where the hook fires it) or **not distinctive** (baseline uses it at least as often as the model)
 - Proposed additions (high-lift n-grams not already covered), each with its voice-baseline rate and a spot-checkable quote
 - Rule health table (every entry with type, audit surface, and `keep` / `remove (reason)`), plus deliverable quotes for the deliverable-surface tells

--- a/plugins/writing/skills/analyze/scripts/analyze.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.ts
@@ -22,6 +22,7 @@ import { type CandidatePhrase, type ReportInput, renderReport } from "./report";
 import { buildRuleHealth, type FtsAuditRow } from "./rule-health";
 import { auditStructuralPatterns } from "./structural";
 import { type TagSignatureRow, tagSequence } from "./tag-ngram";
+import { computeCorpusRates } from "./voice-delta";
 import { loadProfile, phraseProfileStat } from "./voice-profile";
 import type { WordlistEntry } from "./wordlists";
 import { loadWordlists } from "./wordlists";
@@ -354,6 +355,8 @@ export async function runAnalysis(db: Database, config: AnalysisConfig): Promise
       surface === "deliverable" ? findQuote(entry.phrase, deliverableRows) : null,
   });
 
+  const voiceDeltaRates = computeCorpusRates(deliverableRows.map((r) => r.text));
+
   return {
     generatedAt: config.generatedAt,
     since: config.since,
@@ -368,6 +371,7 @@ export async function runAnalysis(db: Database, config: AnalysisConfig): Promise
     deliverableTotalChars: totalChars(deliverableRows),
     userTotalChars: totalChars(userRows),
     voiceProfile,
+    voiceDeltaRates,
     ruleHealth,
     structuralAudit,
     structuralSignatures,

--- a/plugins/writing/skills/analyze/scripts/report.test.ts
+++ b/plugins/writing/skills/analyze/scripts/report.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type { CorrectionRow, CorrectiveRow, ModelSummaryRow } from "./dump";
 import { type CandidatePhrase, renderReport } from "./report";
+import type { FeatureRate } from "./voice-delta";
+import type { VoiceProfile } from "./voice-profile";
 import type { WordlistEntry } from "./wordlists";
 
 const baseInput = {
@@ -196,5 +198,100 @@ describe("renderReport", () => {
     expect(removalIdx).toBeGreaterThan(summaryIdx);
     expect(additionIdx).toBeGreaterThan(removalIdx);
     expect(healthIdx).toBeGreaterThan(additionIdx);
+  });
+});
+
+// Invented fixture profile. Rates are made-up numbers, never real baseline
+// content, which stays in the local data dir.
+const fixtureProfile: VoiceProfile = {
+  documentCount: 5,
+  totalTokens: 1200,
+  ngrams: {},
+  stemmedNgrams: {},
+  totalStemmedTokens: 1100,
+  generatedAt: "2026-01-01",
+  sources: ["github"],
+  voiceDelta: {
+    rates: { first_person_rate: 9.5, template_presence: 0.1 },
+    documentCount: 5,
+    computedAt: "2026-01-01",
+  },
+};
+
+function rateEntry(featureId: string, rate: number): [string, FeatureRate] {
+  return [featureId, { featureId, rate, documentCount: 4 }];
+}
+
+describe("renderReport voice delta", () => {
+  test("renders rates-only table with a hint when no baseline is loaded", () => {
+    const output = renderReport({
+      ...baseInput,
+      voiceDeltaRates: new Map([rateEntry("first_person_rate", 3.2)]),
+    });
+    expect(output).toContain("No voice-delta baseline loaded");
+    expect(output).toContain("| feature | provenance | corpus rate |");
+    expect(output).toContain("| First-person voice (I/we per 1k) | skill-encouraged | 3.20 |");
+  });
+
+  test("treats a profile without voiceDelta stats as no baseline", () => {
+    const { voiceDelta: _omitted, ...legacyProfile } = fixtureProfile;
+    const output = renderReport({
+      ...baseInput,
+      voiceProfile: legacyProfile,
+    });
+    expect(output).toContain("No voice-delta baseline loaded");
+  });
+
+  test("renders corpus rate, baseline rate, and delta per feature", () => {
+    const output = renderReport({
+      ...baseInput,
+      voiceProfile: fixtureProfile,
+      voiceDeltaRates: new Map([rateEntry("first_person_rate", 3.2)]),
+    });
+    expect(output).toContain("Baseline: 5 documents (computed 2026-01-01)");
+    expect(output).toContain("| feature | provenance | corpus rate | baseline rate | delta |");
+    expect(output).toContain(
+      "| First-person voice (I/we per 1k) | skill-encouraged | 3.20 | 9.50 | -6.30 |",
+    );
+  });
+
+  test("formats fraction features as percentages with pp deltas", () => {
+    const output = renderReport({
+      ...baseInput,
+      voiceProfile: fixtureProfile,
+      voiceDeltaRates: new Map([rateEntry("template_presence", 0.6)]),
+    });
+    expect(output).toContain(
+      "| Template presence (## Changes + ## Testing) | skill-prescribed | 60% | 10% | +50.0pp |",
+    );
+  });
+
+  test("marks features missing from the baseline stats", () => {
+    const output = renderReport({
+      ...baseInput,
+      voiceProfile: fixtureProfile,
+      voiceDeltaRates: new Map([rateEntry("url_rate", 2.5)]),
+    });
+    expect(output).toContain(
+      "| URL cross-references (per 1k words) | ungoverned | 2.50 | (no baseline stat) | - |",
+    );
+  });
+
+  test("labels every feature row with its provenance", () => {
+    const output = renderReport({
+      ...baseInput,
+      voiceProfile: fixtureProfile,
+    });
+    const section = output.slice(
+      output.indexOf("## Voice Delta"),
+      output.indexOf("## Proposed Wordlist Removals"),
+    );
+    const rows = section
+      .split("\n")
+      .filter((l) => l.startsWith("| ") && !l.includes("--- ") && !l.startsWith("| feature"));
+    expect(rows.length).toBe(14);
+    for (const row of rows) {
+      expect(row).toMatch(/\| (skill-prescribed|skill-encouraged|ungoverned) \|/);
+    }
   });
 });

--- a/plugins/writing/skills/analyze/scripts/report.test.ts
+++ b/plugins/writing/skills/analyze/scripts/report.test.ts
@@ -17,6 +17,7 @@ const baseInput = {
   deliverableTotalChars: 0,
   userTotalChars: 0,
   voiceProfile: null,
+  voiceDeltaRates: new Map(),
   ruleHealth: [],
   structuralAudit: [],
   structuralSignatures: [],
@@ -30,6 +31,7 @@ describe("renderReport", () => {
     const output = renderReport(baseInput);
     expect(output).toContain("# Writing trope analysis");
     expect(output).toContain("## Summary");
+    expect(output).toContain("## Voice Delta");
     expect(output).toContain("## Proposed Wordlist Removals");
     expect(output).toContain("## Proposed Wordlist Additions");
     expect(output).toContain("## Current Rule Health");

--- a/plugins/writing/skills/analyze/scripts/report.ts
+++ b/plugins/writing/skills/analyze/scripts/report.ts
@@ -4,6 +4,7 @@ import type { QuoteContext } from "./quote-context";
 import type { CurrentRuleHealth, RemoveReason } from "./rule-health";
 import type { StructuralAuditRow } from "./structural";
 import type { TagSignatureRow } from "./tag-ngram";
+import { type FeatureRate, VOICE_DELTA_FEATURES } from "./voice-delta";
 import type { VoiceProfile } from "./voice-profile";
 
 export interface ReportInput {
@@ -20,6 +21,9 @@ export interface ReportInput {
   deliverableTotalChars: number;
   userTotalChars: number;
   voiceProfile: VoiceProfile | null;
+  // Per-feature mean rates across the deliverable corpus for the analysis
+  // window. Compared against voiceProfile.voiceDelta baseline rates.
+  voiceDeltaRates: Map<string, FeatureRate>;
   ruleHealth: CurrentRuleHealth[];
   structuralAudit: StructuralAuditRow[];
   structuralSignatures: TagSignatureRow[];
@@ -39,6 +43,7 @@ export function renderReport(input: ReportInput): string {
   const sections = [
     renderHeader(input),
     renderSummary(input),
+    renderVoiceDelta(input),
     renderProposedRemovals(input),
     renderProposedAdditions(input),
     renderRuleHealthTable(input),
@@ -93,6 +98,57 @@ function renderSummary(input: ReportInput): string {
       );
     }
   }
+  return lines.join("\n");
+}
+
+function renderVoiceDelta(input: ReportInput): string {
+  const baseline = input.voiceProfile?.voiceDelta ?? null;
+  const hasBaseline = baseline !== null;
+
+  const lines = [
+    "## Voice Delta",
+    "",
+    hasBaseline
+      ? `Baseline: ${fmtNum(baseline.documentCount)} documents (computed ${baseline.computedAt}). Each rate is the mean across the deliverable corpus in this window vs the pre-AI baseline. Provenance labels: **skill-prescribed** = tune the skill if the aggregate drifts; **skill-encouraged** = under-application of the skill; **ungoverned** = genuine voice signal.`
+      : "No voice-delta baseline loaded. Run `ingest-voice.ts` then `voice-profile.ts` to build a baseline. Rates shown are corpus means only.",
+    "",
+  ];
+
+  if (hasBaseline) {
+    lines.push("| feature | provenance | corpus rate | baseline rate | delta |");
+    lines.push("| --- | --- | --- | --- | --- |");
+  } else {
+    lines.push("| feature | provenance | corpus rate |");
+    lines.push("| --- | --- | --- |");
+  }
+
+  for (const feature of VOICE_DELTA_FEATURES) {
+    const corpusEntry = input.voiceDeltaRates.get(feature.id);
+    const corpusRate = corpusEntry?.rate ?? 0;
+    const fmt = feature.format ?? ((r: number) => r.toFixed(2));
+    const corpusStr = fmt(corpusRate);
+
+    if (hasBaseline) {
+      const baselineRate = baseline.rates[feature.id];
+      if (baselineRate === undefined) {
+        lines.push(
+          `| ${feature.label} | ${feature.provenance} | ${corpusStr} | (no baseline stat) | - |`,
+        );
+      } else {
+        const baselineStr = fmt(baselineRate);
+        const delta = corpusRate - baselineRate;
+        const deltaStr = feature.isFraction
+          ? `${delta >= 0 ? "+" : ""}${(delta * 100).toFixed(1)}pp`
+          : `${delta >= 0 ? "+" : ""}${delta.toFixed(2)}`;
+        lines.push(
+          `| ${feature.label} | ${feature.provenance} | ${corpusStr} | ${baselineStr} | ${deltaStr} |`,
+        );
+      }
+    } else {
+      lines.push(`| ${feature.label} | ${feature.provenance} | ${corpusStr} |`);
+    }
+  }
+
   return lines.join("\n");
 }
 

--- a/plugins/writing/skills/analyze/scripts/voice-delta.test.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-delta.test.ts
@@ -143,6 +143,14 @@ describe("template_presence", () => {
   test("returns 0 when a section is missing", () => {
     expect(compute("## Changes\n\nStuff only.")).toBe(0);
   });
+
+  test("requires a word boundary after the section name", () => {
+    expect(compute("## Changeset\n\nStuff.\n\n## Testing\n\nMore.")).toBe(0);
+  });
+
+  test("ignores headings inside fenced code blocks", () => {
+    expect(compute("Prose.\n\n```md\n## Changes\n## Testing\n```")).toBe(0);
+  });
 });
 
 describe("unique_heading_variety", () => {
@@ -159,12 +167,28 @@ describe("heading_rate", () => {
     expect(compute("## Anything\n\nbody")).toBe(1);
     expect(compute("Plain prose with no headings.")).toBe(0);
   });
+
+  test("does not count shell comments in fenced code as headings", () => {
+    expect(compute("Run the script.\n\n```sh\n# this is a comment\nrun.sh\n```")).toBe(0);
+  });
 });
 
 describe("action_verb_opener_rate", () => {
+  const compute = feature("action_verb_opener_rate").compute;
+
   test("returns the fraction of lines opening with a present-tense verb", () => {
     const text = "Adds the cache layer.\nThe loader was slow.\nRemoves the old path.\n";
-    expect(feature("action_verb_opener_rate").compute(text)).toBeCloseTo(2 / 3, 5);
+    expect(compute(text)).toBeCloseTo(2 / 3, 5);
+  });
+
+  test("counts bullet lines, where the pattern stacks", () => {
+    const text = "- Adds the cache layer\n- Removes the old path\n";
+    expect(compute(text)).toBe(1);
+  });
+
+  test("excludes fenced code lines from the denominator", () => {
+    const text = "Adds the cache layer.\n\n```\nx = 1\ny = 2\nz = 3\n```\n";
+    expect(compute(text)).toBe(1);
   });
 });
 

--- a/plugins/writing/skills/analyze/scripts/voice-delta.test.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-delta.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, test } from "bun:test";
+import {
+  checkRegister,
+  computeCorpusRates,
+  sentenceSplit,
+  VOICE_DELTA_FEATURES,
+  type VoiceDeltaFeature,
+} from "./voice-delta";
+
+// All rates in this file are computed from invented fixture text. No baseline
+// corpus content or baseline-derived numbers appear here.
+
+function feature(id: string): VoiceDeltaFeature {
+  const found = VOICE_DELTA_FEATURES.find((f) => f.id === id);
+  if (!found) throw new Error(`missing feature: ${id}`);
+  return found;
+}
+
+describe("VOICE_DELTA_FEATURES", () => {
+  test("every feature has a unique id, a provenance label, and a source", () => {
+    const ids = VOICE_DELTA_FEATURES.map((f) => f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const f of VOICE_DELTA_FEATURES) {
+      expect(["skill-prescribed", "skill-encouraged", "ungoverned"]).toContain(f.provenance);
+      expect(f.source.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("provenance labels match the #789 spec table", () => {
+    const byProvenance = (p: string) =>
+      VOICE_DELTA_FEATURES.filter((f) => f.provenance === p)
+        .map((f) => f.id)
+        .sort();
+    expect(byProvenance("skill-encouraged")).toEqual([
+      "body_length",
+      "causal_language_rate",
+      "first_person_rate",
+    ]);
+    expect(byProvenance("skill-prescribed")).toEqual([
+      "action_verb_opener_rate",
+      "backtick_density",
+      "heading_rate",
+      "template_presence",
+      "unique_heading_variety",
+    ]);
+    expect(byProvenance("ungoverned")).toEqual([
+      "backtick_manifest_bullet_rate",
+      "consequence_chain_rate",
+      "median_sentence_length",
+      "p90_sentence_length",
+      "question_mark_rate",
+      "url_rate",
+    ]);
+  });
+
+  test("sources never embed baseline-vs-AI rate comparisons", () => {
+    // Baseline rates live only in the local profile. Skill-text sources may
+    // carry forward-looking thresholds but never measured baseline numbers.
+    for (const f of VOICE_DELTA_FEATURES) {
+      expect(f.source).not.toMatch(/\bvs\.?\b/i);
+    }
+  });
+});
+
+describe("first_person_rate", () => {
+  const compute = feature("first_person_rate").compute;
+
+  test("counts I, we, and sentence-initial We per 1k words", () => {
+    // 12 words, 3 first-person hits (I, We, we).
+    const text = "I tried the cache. We saw it fail. Then we shipped it.";
+    expect(compute(text)).toBeCloseTo((3 / 12) * 1000, 5);
+  });
+
+  test("ignores lowercase i and code spans", () => {
+    expect(compute("The loop uses i as `we` counters here.")).toBe(0);
+  });
+});
+
+describe("causal_language_rate", () => {
+  const compute = feature("causal_language_rate").compute;
+
+  test("counts since and because case-insensitively", () => {
+    // 14 words, 2 causal hits.
+    const text = "It failed because the lock timed out. Since retries masked it, I removed them.";
+    expect(compute(text)).toBeCloseTo((2 / 14) * 1000, 5);
+  });
+});
+
+describe("body_length", () => {
+  const compute = feature("body_length").compute;
+
+  test("counts words excluding code blocks", () => {
+    expect(compute("Four words of prose. ```\nconst ignored = true;\n```")).toBe(4);
+  });
+});
+
+describe("url_rate", () => {
+  const compute = feature("url_rate").compute;
+
+  test("counts URLs per 1k words", () => {
+    // Stripped text: "See URL for context on the fix." = 7 words, 1 URL.
+    const text = "See https://example.com/thread for context on the fix.";
+    expect(compute(text)).toBeCloseTo((1 / 7) * 1000, 5);
+  });
+
+  test("returns 0 with no URLs", () => {
+    expect(compute("No links here at all.")).toBe(0);
+  });
+});
+
+describe("sentence length features", () => {
+  const text = "One two three. One two three four five. One two three four five six seven.";
+
+  test("median over sentence word counts", () => {
+    expect(feature("median_sentence_length").compute(text)).toBe(5);
+  });
+
+  test("p90 over sentence word counts", () => {
+    expect(feature("p90_sentence_length").compute(text)).toBe(7);
+  });
+
+  test("both return 0 for empty input", () => {
+    expect(feature("median_sentence_length").compute("")).toBe(0);
+    expect(feature("p90_sentence_length").compute("")).toBe(0);
+  });
+});
+
+describe("question_mark_rate", () => {
+  test("counts question marks per 1k words", () => {
+    // 5 words, 1 question mark.
+    const rate = feature("question_mark_rate").compute("Does this hold? It does.");
+    expect(rate).toBeCloseTo((1 / 5) * 1000, 5);
+  });
+});
+
+describe("template_presence", () => {
+  const compute = feature("template_presence").compute;
+
+  test("returns 1 when both template sections are present", () => {
+    expect(compute("## Changes\n\nStuff.\n\n## Testing\n\nMore.")).toBe(1);
+  });
+
+  test("returns 0 when a section is missing", () => {
+    expect(compute("## Changes\n\nStuff only.")).toBe(0);
+  });
+});
+
+describe("unique_heading_variety", () => {
+  test("counts unique heading texts case-insensitively", () => {
+    const text = "# Title\n\n## Changes\n\n## changes\n\n## Testing\n\nbody";
+    expect(feature("unique_heading_variety").compute(text)).toBe(3);
+  });
+});
+
+describe("heading_rate", () => {
+  const compute = feature("heading_rate").compute;
+
+  test("returns 1 with any heading and 0 without", () => {
+    expect(compute("## Anything\n\nbody")).toBe(1);
+    expect(compute("Plain prose with no headings.")).toBe(0);
+  });
+});
+
+describe("action_verb_opener_rate", () => {
+  test("returns the fraction of lines opening with a present-tense verb", () => {
+    const text = "Adds the cache layer.\nThe loader was slow.\nRemoves the old path.\n";
+    expect(feature("action_verb_opener_rate").compute(text)).toBeCloseTo(2 / 3, 5);
+  });
+});
+
+describe("backtick_density", () => {
+  test("counts backticks per 1k prose words", () => {
+    // Inline code is stripped from the word count: 4 words, 4 backticks.
+    const text = "The `cache` and `loader` need work.";
+    expect(feature("backtick_density").compute(text)).toBeCloseTo((4 / 4) * 1000, 5);
+  });
+});
+
+describe("backtick_manifest_bullet_rate", () => {
+  test("returns the fraction of bullets in the backtick-colon form", () => {
+    const text = "- `foo.ts`: does things\n- a plain bullet\n";
+    expect(feature("backtick_manifest_bullet_rate").compute(text)).toBeCloseTo(0.5, 5);
+  });
+
+  test("returns 0 with no bullets", () => {
+    expect(feature("backtick_manifest_bullet_rate").compute("No bullets here.")).toBe(0);
+  });
+});
+
+describe("consequence_chain_rate", () => {
+  const compute = feature("consequence_chain_rate").compute;
+
+  test("counts comma-so-determiner chains per 1k words", () => {
+    // 9 words, 1 chain.
+    const text = "The cache was stale, so the loader refetched it.";
+    expect(compute(text)).toBeCloseTo((1 / 9) * 1000, 5);
+  });
+
+  test("ignores 'so' without a following determiner", () => {
+    expect(compute("It ran slowly, so slowly we noticed.")).toBe(0);
+  });
+});
+
+describe("sentenceSplit", () => {
+  test("splits on terminal punctuation and drops empties", () => {
+    expect(sentenceSplit("One. Two! Three? ")).toEqual(["One", "Two", "Three"]);
+  });
+});
+
+describe("checkRegister", () => {
+  test("rejects empty input", () => {
+    const result = checkRegister("");
+    expect(result.inRegister).toBe(false);
+    expect(result.reason).toContain("empty");
+  });
+
+  test("rejects too-short input", () => {
+    const result = checkRegister("One sentence only.");
+    expect(result.inRegister).toBe(false);
+    expect(result.reason).toContain("too short");
+  });
+
+  test("rejects markdown-dominated input", () => {
+    const result = checkRegister("#### a. #### b. #### c. ####################");
+    expect(result.inRegister).toBe(false);
+    expect(result.reason).toContain("markdown fraction");
+  });
+
+  test("accepts PR-body-shaped prose", () => {
+    const text =
+      "This fixes the loader race. I noticed it while testing retries. The fix holds the lock across the read.";
+    expect(checkRegister(text)).toEqual({ inRegister: true, reason: null });
+  });
+});
+
+describe("computeCorpusRates", () => {
+  test("averages per-document rates and records the document count", () => {
+    const docs = [
+      "I fixed the bug today and verified it.", // 8 words, 1 first-person hit
+      "The patch landed without any further changes there.", // 8 words, 0 hits
+    ];
+    const rates = computeCorpusRates(docs);
+    const firstPerson = rates.get("first_person_rate");
+    expect(firstPerson?.documentCount).toBe(2);
+    expect(firstPerson?.rate).toBeCloseTo((1 / 8) * 1000 * 0.5, 5);
+  });
+
+  test("returns zero rates for an empty corpus", () => {
+    const rates = computeCorpusRates([]);
+    for (const f of VOICE_DELTA_FEATURES) {
+      expect(rates.get(f.id)?.rate).toBe(0);
+      expect(rates.get(f.id)?.documentCount).toBe(0);
+    }
+  });
+});

--- a/plugins/writing/skills/analyze/scripts/voice-delta.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-delta.ts
@@ -53,6 +53,15 @@ function nonEmptyLines(text: string): string[] {
   return text.split("\n").filter((l) => l.trim().length > 0);
 }
 
+// Remove fenced code blocks while preserving line structure. Line- and
+// heading-based features use this so a `# comment` inside a shell snippet does
+// not register as a markdown heading and code lines do not inflate line
+// denominators. stripCode flattens whitespace, which would destroy line-based
+// rates.
+function stripFencedBlocks(text: string): string {
+  return text.replace(/```[\s\S]*?```/g, "");
+}
+
 // Strip fenced and inline code blocks before rate counting.
 function stripCode(text: string): string {
   return text
@@ -191,8 +200,9 @@ export const VOICE_DELTA_FEATURES: VoiceDeltaFeature[] = [
       'SKILL.md Body: "Use `##` sections for larger changes". Aggregate template rate is an analyze trend only',
     // Returns 1 if both template sections are present, 0 otherwise.
     compute: (text) => {
-      const hasChanges = /^##\s+(Changes|What Changed)/im.test(text);
-      const hasTesting = /^##\s+Testing/im.test(text);
+      const prose = stripFencedBlocks(text);
+      const hasChanges = /^##\s+(Changes|What Changed)\b/im.test(prose);
+      const hasTesting = /^##\s+Testing\b/im.test(prose);
       return hasChanges && hasTesting ? 1 : 0;
     },
     isFraction: true,
@@ -206,7 +216,7 @@ export const VOICE_DELTA_FEATURES: VoiceDeltaFeature[] = [
       "sections.md fixes the section vocabulary (Issue/Changes/Testing/References). Aggregate uniformity metric only, never per-document",
     // Returns the count of unique heading texts (lowercased) in this document.
     compute: (text) => {
-      const headings = [...text.matchAll(/^#{1,6}\s+(.+)$/gm)].map((m) =>
+      const headings = [...stripFencedBlocks(text).matchAll(/^#{1,6}\s+(.+)$/gm)].map((m) =>
         (m[1] ?? "").toLowerCase().trim(),
       );
       return new Set(headings).size;
@@ -219,7 +229,7 @@ export const VOICE_DELTA_FEATURES: VoiceDeltaFeature[] = [
     provenance: "skill-prescribed",
     source: 'Same "larger changes" clause as template presence. Report as a trend',
     // Returns 1 if the document contains any markdown heading, 0 otherwise.
-    compute: (text) => (/^#{1,6}\s+/m.test(text) ? 1 : 0),
+    compute: (text) => (/^#{1,6}\s+/m.test(stripFencedBlocks(text)) ? 1 : 0),
     isFraction: true,
     format: (rate) => `${(rate * 100).toFixed(0)}%`,
   },
@@ -230,11 +240,12 @@ export const VOICE_DELTA_FEATURES: VoiceDeltaFeature[] = [
     source:
       'SKILL.md Voice: "Open with a bare present-tense verb". Skill prescribes only the opening summary line; stacking across lines is the drift signal',
     compute: (text) => {
-      const lines = nonEmptyLines(text);
+      const lines = nonEmptyLines(stripFencedBlocks(text));
       if (lines.length === 0) return 0;
-      // Match lines opening with a common present-tense verb (capitalized).
+      // Match lines (including bullets, where the pattern stacks) opening with
+      // a common present-tense verb (capitalized).
       const verbOpener =
-        /^\s*(?:Add|Remove|Extract|Fix|Update|Refactor|Move|Rename|Delete|Enable|Disable|Replace|Expose|Allow|Prevent|Extend|Create|Set|Run|Use|Make|Build|Change|Skip|Drop|Emit|Load|Save|Return|Push|Pull|Pass|Wrap|Bump|Pin|Guard|Gate|Handle|Limit|Filter|Sort|Map|Merge|Split|Read|Write|Mark|Track|Log|Check|Test|Wire|Inject|Import|Export|Bind|Align|Trim|Convert|Compute|Parse|Validate|Normalize)[a-z]*(?:\s|$)/;
+        /^\s*(?:[-*]\s+)?(?:Add|Remove|Extract|Fix|Update|Refactor|Move|Rename|Delete|Enable|Disable|Replace|Expose|Allow|Prevent|Extend|Create|Set|Run|Use|Make|Build|Change|Skip|Drop|Emit|Load|Save|Return|Push|Pull|Pass|Wrap|Bump|Pin|Guard|Gate|Handle|Limit|Filter|Sort|Map|Merge|Split|Read|Write|Mark|Track|Log|Check|Test|Wire|Inject|Import|Export|Bind|Align|Trim|Convert|Compute|Parse|Validate|Normalize)[a-z]*(?:\s|$)/;
       const openers = lines.filter((l) => verbOpener.test(l)).length;
       return openers / lines.length;
     },
@@ -260,9 +271,10 @@ export const VOICE_DELTA_FEATURES: VoiceDeltaFeature[] = [
     source:
       'sections.md bans the bold form ("Never structure bullets as **path**: description"). The backtick variant evades the letter of the rule',
     compute: (text) => {
-      const bullets = bulletLines(text);
+      const prose = stripFencedBlocks(text);
+      const bullets = bulletLines(prose);
       if (bullets.length === 0) return 0;
-      return countBacktickManifestBullets(text) / bullets.length;
+      return countBacktickManifestBullets(prose) / bullets.length;
     },
     isFraction: true,
     format: (rate) => `${(rate * 100).toFixed(1)}%`,

--- a/plugins/writing/skills/analyze/scripts/voice-delta.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-delta.ts
@@ -1,0 +1,373 @@
+// Voice-delta rate features: structural and lexical rates computed from a
+// document or corpus that are compared against the pre-AI voice baseline.
+//
+// Each feature carries a provenance label sourced from the coordinator spec
+// (issue #789). The label governs how drift is read:
+//
+//   skill-prescribed  — the skill mandates the pattern. Aggregate drift means
+//                       tune the skill, not build a detector.
+//   skill-encouraged  — the skill asks for the feature. A deficit is
+//                       under-application of the skill.
+//   ungoverned        — no skill governs it. Genuine voice signal; detector
+//                       territory.
+//
+// Resolution principle: skill-prescribed features are NEVER reported as
+// per-document flags. They are rates-only in every surface. Only ungoverned
+// features may produce per-document flags.
+
+export type Provenance = "skill-prescribed" | "skill-encouraged" | "ungoverned";
+
+export interface VoiceDeltaFeature {
+  id: string;
+  label: string;
+  provenance: Provenance;
+  // Human-readable description of the provenance source. Matches the spec table.
+  source: string;
+  // Compute the feature rate from raw text. Rates are per-1000 words unless
+  // isFraction is true. Returns 0 when no content is present.
+  compute: (text: string) => number;
+  // Format a rate value for display. Most features show 2 decimal places.
+  format?: (rate: number) => string;
+  // When true, the rate is a fraction (0–1) rather than per-1000 words.
+  isFraction?: boolean;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+// Count raw words (whitespace-separated tokens, strip punctuation).
+function wordCount(text: string): number {
+  return (text.match(/\b[a-zA-Z'-]+\b/g) ?? []).length;
+}
+
+// Count sentences. Split on sentence-ending punctuation followed by whitespace
+// or end of string; treat each non-empty segment as a sentence.
+export function sentenceSplit(text: string): string[] {
+  return text
+    .split(/[.!?]+(?:\s+|$)/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+// Count non-empty lines.
+function nonEmptyLines(text: string): string[] {
+  return text.split("\n").filter((l) => l.trim().length > 0);
+}
+
+// Strip fenced and inline code blocks before rate counting.
+function stripCode(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]+`/g, " ")
+    .replace(/https?:\/\/\S+/g, " URL ");
+}
+
+// Count total words in stripped text. Avoids counting code tokens.
+function strippedWordCount(text: string): number {
+  return wordCount(stripCode(text));
+}
+
+// Count backtick characters in the original text (raw inline code fences).
+function countBackticks(text: string): number {
+  // Remove fenced blocks first to avoid double-counting their delimiters.
+  const nofence = text.replace(/```[\s\S]*?```/g, "");
+  return (nofence.match(/`/g) ?? []).length;
+}
+
+// Collect bullet lines: lines starting with `- ` or `* ` (possibly indented).
+function bulletLines(text: string): string[] {
+  return nonEmptyLines(text).filter((l) => /^\s*[-*]\s/.test(l));
+}
+
+// Count backtick-manifest bullets: `- \`identifier\`: description` pattern.
+function countBacktickManifestBullets(text: string): number {
+  return bulletLines(text).filter((l) => /^\s*[-*]\s+`[^`]+`\s*:/.test(l)).length;
+}
+
+// ─── Feature definitions ──────────────────────────────────────────────────────
+
+function per1k(count: number, words: number): number {
+  if (words === 0) return 0;
+  return (count / words) * 1000;
+}
+
+export const VOICE_DELTA_FEATURES: VoiceDeltaFeature[] = [
+  {
+    id: "first_person_rate",
+    label: "First-person voice (I/we per 1k)",
+    provenance: "skill-encouraged",
+    source:
+      'SKILL.md Body: "use \'I\' so it\'s clear you made the call". sections.md Issue: "Describe the root cause as the author"',
+    compute: (text) => {
+      const stripped = stripCode(text);
+      const words = strippedWordCount(stripped);
+      // "I" must stay uppercase (lowercase "i" is usually a loop variable),
+      // while "we" appears sentence-initial as "We".
+      const matches = stripped.match(/\b(?:I|[Ww]e)\b/g) ?? [];
+      return per1k(matches.length, words);
+    },
+  },
+  {
+    id: "causal_language_rate",
+    label: "Causal language (since/because per 1k)",
+    provenance: "skill-encouraged",
+    source:
+      'SKILL.md Voice: "State the mechanism first, then the motivation" and "Hedge and name rejected alternatives honestly"',
+    compute: (text) => {
+      const stripped = stripCode(text);
+      const words = strippedWordCount(stripped);
+      const matches = stripped.match(/\b(since|because)\b/gi) ?? [];
+      return per1k(matches.length, words);
+    },
+  },
+  {
+    id: "body_length",
+    label: "Body length (words)",
+    provenance: "skill-encouraged",
+    source:
+      'SKILL.md Voice: "Length tracks substance. A one-line change gets a one-line body. Don\'t pad"',
+    compute: (text) => strippedWordCount(text),
+    format: (rate) => rate.toFixed(0),
+  },
+  {
+    id: "url_rate",
+    label: "URL cross-references (per 1k words)",
+    provenance: "ungoverned",
+    source: "References section exists but no rate guidance",
+    compute: (text) => {
+      const words = strippedWordCount(text);
+      const urls = (text.match(/https?:\/\/\S+/g) ?? []).length;
+      return per1k(urls, words);
+    },
+  },
+  {
+    id: "median_sentence_length",
+    label: "Sentence length median (words)",
+    provenance: "ungoverned",
+    source: "no skill text",
+    compute: (text) => {
+      const stripped = stripCode(text);
+      const sentences = sentenceSplit(stripped);
+      if (sentences.length === 0) return 0;
+      const lengths = sentences.map((s) => wordCount(s)).sort((a, b) => a - b);
+      const mid = Math.floor(lengths.length / 2);
+      return lengths.length % 2 === 0
+        ? ((lengths[mid - 1] ?? 0) + (lengths[mid] ?? 0)) / 2
+        : (lengths[mid] ?? 0);
+    },
+    format: (rate) => rate.toFixed(1),
+  },
+  {
+    id: "p90_sentence_length",
+    label: "Sentence length p90 (words)",
+    provenance: "ungoverned",
+    source: "no skill text",
+    compute: (text) => {
+      const stripped = stripCode(text);
+      const sentences = sentenceSplit(stripped);
+      if (sentences.length === 0) return 0;
+      const lengths = sentences.map((s) => wordCount(s)).sort((a, b) => a - b);
+      const idx = Math.floor(lengths.length * 0.9);
+      return lengths[Math.min(idx, lengths.length - 1)] ?? 0;
+    },
+    format: (rate) => rate.toFixed(1),
+  },
+  {
+    id: "question_mark_rate",
+    label: "Question marks (per 1k words)",
+    provenance: "ungoverned",
+    source: "no skill text",
+    compute: (text) => {
+      const stripped = stripCode(text);
+      const words = strippedWordCount(stripped);
+      const qmarks = (stripped.match(/\?/g) ?? []).length;
+      return per1k(qmarks, words);
+    },
+  },
+  {
+    id: "template_presence",
+    label: "Template presence (## Changes + ## Testing)",
+    provenance: "skill-prescribed",
+    source:
+      'SKILL.md Body: "Use `##` sections for larger changes". Aggregate template rate is an analyze trend only',
+    // Returns 1 if both template sections are present, 0 otherwise.
+    compute: (text) => {
+      const hasChanges = /^##\s+(Changes|What Changed)/im.test(text);
+      const hasTesting = /^##\s+Testing/im.test(text);
+      return hasChanges && hasTesting ? 1 : 0;
+    },
+    isFraction: true,
+    format: (rate) => `${(rate * 100).toFixed(0)}%`,
+  },
+  {
+    id: "unique_heading_variety",
+    label: "Unique heading texts (count)",
+    provenance: "skill-prescribed",
+    source:
+      "sections.md fixes the section vocabulary (Issue/Changes/Testing/References). Aggregate uniformity metric only, never per-document",
+    // Returns the count of unique heading texts (lowercased) in this document.
+    compute: (text) => {
+      const headings = [...text.matchAll(/^#{1,6}\s+(.+)$/gm)].map((m) =>
+        (m[1] ?? "").toLowerCase().trim(),
+      );
+      return new Set(headings).size;
+    },
+    format: (rate) => rate.toFixed(0),
+  },
+  {
+    id: "heading_rate",
+    label: "Has any heading (fraction of documents)",
+    provenance: "skill-prescribed",
+    source: 'Same "larger changes" clause as template presence. Report as a trend',
+    // Returns 1 if the document contains any markdown heading, 0 otherwise.
+    compute: (text) => (/^#{1,6}\s+/m.test(text) ? 1 : 0),
+    isFraction: true,
+    format: (rate) => `${(rate * 100).toFixed(0)}%`,
+  },
+  {
+    id: "action_verb_opener_rate",
+    label: "Action-verb opener lines (fraction of lines)",
+    provenance: "skill-prescribed",
+    source:
+      'SKILL.md Voice: "Open with a bare present-tense verb". Skill prescribes only the opening summary line; stacking across lines is the drift signal',
+    compute: (text) => {
+      const lines = nonEmptyLines(text);
+      if (lines.length === 0) return 0;
+      // Match lines opening with a common present-tense verb (capitalized).
+      const verbOpener =
+        /^\s*(?:Add|Remove|Extract|Fix|Update|Refactor|Move|Rename|Delete|Enable|Disable|Replace|Expose|Allow|Prevent|Extend|Create|Set|Run|Use|Make|Build|Change|Skip|Drop|Emit|Load|Save|Return|Push|Pull|Pass|Wrap|Bump|Pin|Guard|Gate|Handle|Limit|Filter|Sort|Map|Merge|Split|Read|Write|Mark|Track|Log|Check|Test|Wire|Inject|Import|Export|Bind|Align|Trim|Convert|Compute|Parse|Validate|Normalize)[a-z]*(?:\s|$)/;
+      const openers = lines.filter((l) => verbOpener.test(l)).length;
+      return openers / lines.length;
+    },
+    isFraction: true,
+    format: (rate) => `${(rate * 100).toFixed(1)}%`,
+  },
+  {
+    id: "backtick_density",
+    label: "Backtick density (per 1k words)",
+    provenance: "skill-prescribed",
+    source:
+      'SKILL.md Body: "Wrap all code identifiers with backticks". Density beyond ~60/1k is over-application',
+    compute: (text) => {
+      const words = strippedWordCount(text);
+      const ticks = countBackticks(text);
+      return per1k(ticks, words);
+    },
+  },
+  {
+    id: "backtick_manifest_bullet_rate",
+    label: "Backtick-manifest bullets (fraction of bullets)",
+    provenance: "ungoverned",
+    source:
+      'sections.md bans the bold form ("Never structure bullets as **path**: description"). The backtick variant evades the letter of the rule',
+    compute: (text) => {
+      const bullets = bulletLines(text);
+      if (bullets.length === 0) return 0;
+      return countBacktickManifestBullets(text) / bullets.length;
+    },
+    isFraction: true,
+    format: (rate) => `${(rate * 100).toFixed(1)}%`,
+  },
+  {
+    id: "consequence_chain_rate",
+    label: "Consequence chains (, so <det>) per 1k words",
+    provenance: "ungoverned",
+    source: "no skill text. #788 detector",
+    compute: (text) => {
+      const stripped = stripCode(text);
+      const words = strippedWordCount(stripped);
+      // Pattern: ", so" followed by a determiner.
+      const matches =
+        stripped.match(/,\s+so\s+(?:the|a|an|this|that|these|those|its|their|our)\b/gi) ?? [];
+      return per1k(matches.length, words);
+    },
+  },
+];
+
+// ─── Register check ───────────────────────────────────────────────────────────
+
+// Minimum sentences to attempt baseline comparison. Too-short inputs produce
+// meaningless rate stats.
+const MIN_SENTENCES = 3;
+// Maximum markdown character fraction for the document to be prose-like.
+// Beyond this threshold the input is likely a code file, not a prose deliverable.
+const MAX_MARKDOWN_FRACTION = 0.7;
+
+export interface RegisterCheck {
+  inRegister: boolean;
+  reason: string | null;
+}
+
+// Returns whether the document is in-register (looks like a PR-body-shaped
+// prose deliverable) and therefore safe to compare against the PR baseline.
+export function checkRegister(text: string): RegisterCheck {
+  const total = text.length;
+  if (total === 0) return { inRegister: false, reason: "empty document" };
+
+  const sentences = sentenceSplit(stripCode(text));
+  if (sentences.length < MIN_SENTENCES) {
+    return {
+      inRegister: false,
+      reason: `too short (${sentences.length} sentence(s); need ${MIN_SENTENCES}+)`,
+    };
+  }
+
+  const mdChars = (text.match(/[#*_`[\]]/g) ?? []).length;
+  const mdFraction = mdChars / total;
+  if (mdFraction > MAX_MARKDOWN_FRACTION) {
+    return {
+      inRegister: false,
+      reason: `high markdown fraction (${(mdFraction * 100).toFixed(0)}%; threshold ${(MAX_MARKDOWN_FRACTION * 100).toFixed(0)}%)`,
+    };
+  }
+
+  return { inRegister: true, reason: null };
+}
+
+// ─── Corpus aggregation ───────────────────────────────────────────────────────
+
+export interface FeatureRate {
+  featureId: string;
+  rate: number;
+  documentCount: number;
+}
+
+// Compute per-feature mean rates across a corpus of document texts.
+// The register check applies to single-document scoring only. Corpus
+// aggregation runs over all documents regardless of individual length.
+export function computeCorpusRates(texts: string[]): Map<string, FeatureRate> {
+  const sums = new Map<string, number>();
+  const counts = new Map<string, number>();
+
+  for (const text of texts) {
+    for (const feature of VOICE_DELTA_FEATURES) {
+      const rate = feature.compute(text);
+      sums.set(feature.id, (sums.get(feature.id) ?? 0) + rate);
+      counts.set(feature.id, (counts.get(feature.id) ?? 0) + 1);
+    }
+  }
+
+  const result = new Map<string, FeatureRate>();
+  for (const feature of VOICE_DELTA_FEATURES) {
+    const total = sums.get(feature.id) ?? 0;
+    const n = counts.get(feature.id) ?? 0;
+    result.set(feature.id, {
+      featureId: feature.id,
+      rate: n > 0 ? total / n : 0,
+      documentCount: n,
+    });
+  }
+  return result;
+}
+
+// ─── Baseline stats from profile ─────────────────────────────────────────────
+
+// The additional aggregate stats that voice-profile.ts stores for voice-delta
+// comparison. Computed during profile build from the baseline corpus.
+// When a loaded profile predates this extension (voiceDelta missing), each
+// feature degrades to a "no baseline" display.
+export interface VoiceDeltaBaseline {
+  // Feature id -> mean rate across the baseline corpus.
+  rates: Record<string, number>;
+  documentCount: number;
+  computedAt: string;
+}

--- a/plugins/writing/skills/analyze/scripts/voice-profile.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-profile.ts
@@ -5,6 +5,7 @@ import { corpusPath, profilePath, resolveDataDir, voiceBaselineDir } from "./dat
 import { stemPhrase, stemTokens } from "./deliverable-audit";
 import { cleanText, splitSentences, tokenizeSentence } from "./ngram";
 import { parseCorpus, type VoiceDocument } from "./voice-corpus";
+import { computeCorpusRates, type VoiceDeltaBaseline } from "./voice-delta";
 
 // Word n-gram sizes the profile records. Unigrams cover single-word tells
 // (e.g. "cleanly"); bigrams and trigrams cover phrase tells (e.g. "source of
@@ -28,7 +29,13 @@ export interface VoiceProfile {
   totalStemmedTokens: number;
   generatedAt: string;
   sources: string[];
+  // Voice-delta aggregate stats from the baseline corpus. Optional: profiles
+  // built before this field was added will not have it. Callers should treat
+  // its absence as "no baseline for voice-delta features".
+  voiceDelta?: VoiceDeltaBaseline;
 }
+
+export type { VoiceDeltaBaseline };
 
 export function buildProfile(docs: VoiceDocument[], generatedAt: string): VoiceProfile {
   const ngrams = new Map<number, Map<string, number>>(PROFILE_SIZES.map((n) => [n, new Map()]));
@@ -52,6 +59,13 @@ export function buildProfile(docs: VoiceDocument[], generatedAt: string): VoiceP
     addNgramCounts(stemmedNgrams, stemmed);
   }
 
+  const corpusRates = computeCorpusRates(docs.map((d) => d.body));
+  const voiceDelta: VoiceDeltaBaseline = {
+    rates: Object.fromEntries([...corpusRates.entries()].map(([id, fr]) => [id, fr.rate])),
+    documentCount: docs.length,
+    computedAt: generatedAt,
+  };
+
   return {
     documentCount: docs.length,
     totalTokens,
@@ -60,6 +74,7 @@ export function buildProfile(docs: VoiceDocument[], generatedAt: string): VoiceP
     totalStemmedTokens,
     generatedAt,
     sources: Array.from(sources).sort(),
+    voiceDelta,
   };
 }
 

--- a/plugins/writing/skills/score/SKILL.md
+++ b/plugins/writing/skills/score/SKILL.md
@@ -42,6 +42,10 @@ A table per group with category, hits, and density, sorted by density. The `--js
 
 For non-prose source files, single-line comments (`//`, `#`) are extracted and scored as a separate `comments` group, so prose-only patterns apply to them without an AST. This is on by default for source files and off for prose files (`.md` and friends, whose fenced code blocks are already stripped). Force it with `--comments` or suppress it with `--no-comments`.
 
+## Voice Delta
+
+`--voice-delta` appends a table of voice rate features (first-person rate, sentence length, backtick density, and friends) beside the rates from the local voice baseline (`--data-dir` overrides the location). Each feature carries a provenance label: **skill-prescribed** drift means tune the skill, **skill-encouraged** deficits mean the skill is under-applied, and **ungoverned** features are genuine voice signal. A register check skips the baseline comparison for inputs too short or too markdown-heavy to compare against the PR-body baseline. The table is informational and never gates.
+
 ## Custom Vocabulary
 
 `--wordlist <path>` compiles an extra stemmed vocabulary file (one term per line, `#` comments allowed) and scores it as a `custom vocabulary` category in every group. Use it to measure context-specific terms a general wordlist would not flag.

--- a/plugins/writing/skills/score/scripts/score.test.ts
+++ b/plugins/writing/skills/score/scripts/score.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import { compileStemmedWordlist } from "../../../detection/wordlists";
-import { buildReport, extractComments, renderTable, scoreComments, scoreText } from "./score";
+import type { VoiceProfile } from "../../analyze/scripts/voice-profile";
+import {
+  buildReport,
+  extractComments,
+  renderTable,
+  renderVoiceDeltaTable,
+  scoreComments,
+  scoreText,
+} from "./score";
 
 function category(report: ReturnType<typeof buildReport>, group: string, name: string) {
   return report.groups.find((g) => g.group === group)?.categories.find((c) => c.category === name);
@@ -94,5 +102,55 @@ describe("renderTable", () => {
   it("reports no patterns for clean prose", () => {
     const report = buildReport("The function reads input.", "doc.md", { comments: false });
     expect(renderTable(report)).toContain("No patterns detected.");
+  });
+});
+
+// Invented fixture profile for voice-delta rendering. Rates are made-up
+// numbers; real baseline stats stay in the local data dir.
+const fixtureProfile: VoiceProfile = {
+  documentCount: 5,
+  totalTokens: 1200,
+  ngrams: {},
+  stemmedNgrams: {},
+  totalStemmedTokens: 1100,
+  generatedAt: "2026-01-01",
+  sources: ["github"],
+  voiceDelta: {
+    rates: { first_person_rate: 9.5 },
+    documentCount: 5,
+    computedAt: "2026-01-01",
+  },
+};
+
+const inRegisterText =
+  "This fixes the loader race. I noticed it while testing retries. The fix holds the lock across the read.";
+
+describe("renderVoiceDeltaTable", () => {
+  it("shows rate, baseline, and delta columns for in-register text", () => {
+    const out = renderVoiceDeltaTable(inRegisterText, fixtureProfile);
+    expect(out).toContain("Voice Delta Features");
+    expect(out).toContain("Baseline");
+    expect(out).toContain("Delta");
+    expect(out).toContain("skill-encouraged");
+    expect(out).toContain("9.50");
+  });
+
+  it("skips the baseline comparison for out-of-register input", () => {
+    const out = renderVoiceDeltaTable("Too short.", fixtureProfile);
+    expect(out).toContain("Register check: skipping baseline comparison");
+    expect(out).toContain("too short");
+    expect(out).not.toContain("Baseline");
+  });
+
+  it("reports a missing baseline and still renders rates", () => {
+    const out = renderVoiceDeltaTable(inRegisterText, null);
+    expect(out).toContain("No baseline loaded");
+    expect(out).toContain("Rate");
+    expect(out).not.toContain("Baseline");
+  });
+
+  it("marks features absent from the baseline stats", () => {
+    const out = renderVoiceDeltaTable(inRegisterText, fixtureProfile);
+    expect(out).toContain("(no stat)");
   });
 });

--- a/plugins/writing/skills/score/scripts/score.ts
+++ b/plugins/writing/skills/score/scripts/score.ts
@@ -6,6 +6,9 @@ import { scanAll } from "../../../detection/scan";
 import { stripCode } from "../../../detection/tropes";
 import { compileStemmedWordlist, countWords } from "../../../detection/wordlists";
 import { readInput } from "../../../scripts/io";
+import { profilePath, resolveDataDir } from "../../analyze/scripts/data-dir";
+import { checkRegister, VOICE_DELTA_FEATURES } from "../../analyze/scripts/voice-delta";
+import { loadProfile, type VoiceProfile } from "../../analyze/scripts/voice-profile";
 
 export type CategoryScore = { category: string; hits: number; density: number };
 
@@ -150,6 +153,56 @@ async function loadCustomMatch(
   return compileStemmedWordlist(content);
 }
 
+// Render voice-delta features for a single document. Accepts the loaded profile
+// (null when not available). Skips baseline comparison when the input is
+// out-of-register (too short or non-prose markdown fraction).
+export function renderVoiceDeltaTable(text: string, profile: VoiceProfile | null): string {
+  const register = checkRegister(text);
+  const baseline = profile?.voiceDelta ?? null;
+
+  const lines: string[] = ["Voice Delta Features"];
+
+  if (!register.inRegister) {
+    lines.push(`Register check: skipping baseline comparison (${register.reason}).`);
+    lines.push("");
+  } else if (baseline === null) {
+    lines.push("No baseline loaded. Run ingest-voice.ts then voice-profile.ts to build one.");
+    lines.push("");
+  }
+
+  const hasBaseline = baseline !== null && register.inRegister;
+
+  const headers = hasBaseline
+    ? ["Feature", "Provenance", "Rate", "Baseline", "Delta"]
+    : ["Feature", "Provenance", "Rate"];
+
+  const rows: string[][] = [];
+  for (const feature of VOICE_DELTA_FEATURES) {
+    const rate = feature.compute(text);
+    const fmt = feature.format ?? ((r: number) => r.toFixed(2));
+    const rateStr = fmt(rate);
+
+    if (hasBaseline) {
+      const baselineRate = baseline.rates[feature.id];
+      if (baselineRate === undefined) {
+        rows.push([feature.label, feature.provenance, rateStr, "(no stat)", "-"]);
+      } else {
+        const baselineStr = fmt(baselineRate);
+        const delta = rate - baselineRate;
+        const deltaStr = feature.isFraction
+          ? `${delta >= 0 ? "+" : ""}${(delta * 100).toFixed(1)}pp`
+          : `${delta >= 0 ? "+" : ""}${delta.toFixed(2)}`;
+        rows.push([feature.label, feature.provenance, rateStr, baselineStr, deltaStr]);
+      }
+    } else {
+      rows.push([feature.label, feature.provenance, rateStr]);
+    }
+  }
+
+  lines.push(table([headers, ...rows]).trimEnd());
+  return lines.join("\n");
+}
+
 async function main(): Promise<void> {
   const argv = cli({
     name: "score",
@@ -178,6 +231,17 @@ async function main(): Promise<void> {
         type: String,
         description: "Score an extra stemmed vocabulary file as a 'custom vocabulary' category",
       },
+      voiceDelta: {
+        type: Boolean,
+        description:
+          "Report voice-delta rate features alongside the baseline from the local voice profile. Skips baseline comparison when the input is out-of-register.",
+        default: false,
+      },
+      dataDir: {
+        type: String,
+        description:
+          "Local data dir for the voice baseline (default: CLAUDE_PLUGIN_DATA or ~/.claude/plugins/data/writing-bendrucker). Only used with --voice-delta.",
+      },
     },
   });
 
@@ -194,6 +258,13 @@ async function main(): Promise<void> {
   } else {
     console.log(renderTable(report));
   }
+
+  if (argv.flags.voiceDelta) {
+    const dataDir = resolveDataDir(argv.flags.dataDir);
+    const profileData = await loadProfile(profilePath(dataDir));
+    console.log(`\n${renderVoiceDeltaTable(text, profileData)}`);
+  }
+
   process.exit(0);
 }
 


### PR DESCRIPTION
Adds a voice-delta surface to `writing:analyze` and `writing:score` that reports rate features beside their rates in the local pre-AI voice baseline. Each feature carries a provenance label (`skill-prescribed`, `skill-encouraged`, `ungoverned`) with its skill-text source recorded, so a drift reading points at the right fix: edit the `pull-request:create` skill, or build a detector. Closes #789.

## Changes

- `voice-delta.ts` defines 14 rate features (first-person voice, causal language, body length, URLs, sentence length median/p90, question marks, template presence, heading variety, heading rate, action-verb openers, backtick density, manifest bullets, consequence chains) with provenance labels assigned per the coordinator spec
- The analyze report gains a Voice Delta section comparing per-feature corpus means against the baseline, with deltas. Skill-prescribed features report only as aggregate trends; voice delta produces no per-document flags anywhere
- `voice-profile.ts` stores per-feature baseline mean rates in the profile (`voiceDelta`). Profiles built before this field degrade to a rates-only display
- `score.ts` gains `--voice-delta`, with a register check (sentence count, markdown fraction) that skips the baseline comparison for inputs too short or too markdown-heavy to compare against the PR-body baseline
- Structural features strip fenced code blocks before matching, so a `# comment` in a shell snippet does not register as a heading and code lines stay out of line denominators

I left the stylometric scorer (function words, char 4-grams, POS bigrams) out per the spec's budget clause; it stays a follow-up. Baseline rates live only in the local `profile.json`. The committed code carries feature definitions and provenance labels; all test fixtures are invented.

## Testing

`voice-delta.test.ts` covers each feature computation, the provenance assignments against the spec table, the register check, and corpus aggregation. Report and score tests render with invented fixture profiles, including the legacy-profile and missing-stat paths. I also ran `score.ts --voice-delta` end-to-end against a temp fixture profile to check the baseline, no-baseline, and out-of-register outputs.

## References

- Stacked on #793's branch (`writing-analyze-corrections`); also picks up a biome formatting fix that branch needed
- #788 covers the per-document detectors for the skill-prescribed drift signals
