### PR TITLE
writing: add meaning-layer batch LLM judge

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -222,6 +222,7 @@
       "name": "@bendrucker/claude-writing",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.25",
+        "@anthropic-ai/sdk": "^0.104.1",
         "@constellos/claude-code-kit": "^0.4.0",
         "@duckdb/node-api": "1.5.0-r.1",
         "ap-style-title-case": "^2.0.0",
@@ -271,7 +272,7 @@
 
     "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.141", "", { "os": "win32", "cpu": "x64" }, "sha512-IXuP29YJuWbR5Q6xOHrjFVGG54V2s1FC61UVNwEN5fpxL09MwPnbwtQL6fqgzt/U1MP7vWAwpXZriYAklkH/mg=="],
 
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.93.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.104.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-gGACa/+IaiXzRRmF96aOhamoBgapKRBiFWbmmTFP8aMkpaEcuStF+Q61bjo4vPxBM7gqWJNZqsngslRdnLHv0Q=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@4.1.2", "", { "dependencies": { "@csstools/css-calc": "^3.0.0", "@csstools/css-color-parser": "^4.0.1", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0", "lru-cache": "^11.2.5" } }, "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg=="],
 
@@ -486,6 +487,8 @@
     "@redis/time-series": ["@redis/time-series@5.12.1", "", { "peerDependencies": { "@redis/client": "^5.12.1" } }, "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ=="],
 
     "@rgrove/parse-xml": ["@rgrove/parse-xml@1.1.1", "", { "dependencies": { "babel-runtime": "^6.23.0" } }, "sha512-3wFRoPyAnb7w5oLdUuiXoMN5s19RZjTmdN7pz4G8XDVgjpXFCP6gUvb5k/GtzZwwFRNCYpBFxCEykcYdeWLiPQ=="],
+
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -850,6 +853,8 @@
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
     "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
 
@@ -1281,6 +1286,8 @@
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "stdin": ["stdin@0.0.1", "", {}, "sha512-2bacd1TXzqOEsqRa+eEWkRdOSznwptrs4gqFcpMq5tOtmJUGPZd10W5Lam6wQ4YQ/+qjQt4e9u35yXCF6mrlfQ=="],
@@ -1412,6 +1419,8 @@
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@anthropic-ai/claude-agent-sdk/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.93.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA=="],
 
     "@bendrucker/claude-writing/cleye": ["cleye@2.6.0", "", { "dependencies": { "terminal-columns": "^2.0.0", "type-flag": "^4.1.0" } }, "sha512-u0SQCsega/ox+2GSuUlG6wvA9c2FtH8sPmv9G9Q3JRTs7FK6+LtaziRAQgx7lrJ1J7bOd3palhwgZKMg8R6JbQ=="],
 

--- a/plugins/writing/package.json
+++ b/plugins/writing/package.json
@@ -4,9 +4,10 @@
   "type": "module",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.25",
+    "@anthropic-ai/sdk": "^0.104.1",
     "@constellos/claude-code-kit": "^0.4.0",
-    "ap-style-title-case": "^2.0.0",
     "@duckdb/node-api": "1.5.0-r.1",
+    "ap-style-title-case": "^2.0.0",
     "cleye": "^2.2.1",
     "compromise": "^14.15.1",
     "mdast-util-from-markdown": "^2.0.2",

--- a/plugins/writing/skills/analyze/SKILL.md
+++ b/plugins/writing/skills/analyze/SKILL.md
@@ -53,6 +53,24 @@ bun ${CLAUDE_SKILL_DIR}/scripts/analyze.ts --session-db "$DB_PATH" --project ben
 
 Run with `--help` for all flags. `--data-dir` overrides where the voice baseline is read from (default: `CLAUDE_PLUGIN_DATA` or `~/.claude/plugins/data/writing-bendrucker`). Writes a markdown report to `tmp/trope-analysis-<date>.md` (override with `--out`). The report may quote any host in the combined index, so keep it under `tmp/` and never paste host-specific content into committed work.
 
+## Meaning-Layer Judge
+
+`--judge` adds an LLM-judge pass over the deliverable corpus (six binary criteria, information-density first). It requires `ANTHROPIC_API_KEY`, prints a cost estimate before any call, and caps documents with `--judge-limit` (default 100, roughly cents per run on the default Haiku-class model):
+
+```bash
+bun ${CLAUDE_SKILL_DIR}/scripts/analyze.ts --session-db "$DB_PATH" --judge
+```
+
+The judge prompt is a versioned artifact (`resources/judge/prompt.md`). The report records its hash, and numbers from different hashes are not comparable. Judge flag rates are uncalibrated until the #791 labeling passes run (a user checkpoint). The standalone runner covers ad-hoc files, the reproducibility gate, and the #769 heading baseline:
+
+```bash
+bun ${CLAUDE_SKILL_DIR}/scripts/judge-run.ts files <paths...>
+bun ${CLAUDE_SKILL_DIR}/scripts/judge-run.ts gate
+bun ${CLAUDE_SKILL_DIR}/scripts/judge-run.ts headings tmp/heading-labels.tsv
+```
+
+See the "Meaning-Layer Judge" section of [references/methodology.md](references/methodology.md) for the rubric, prompt versioning, gate, and calibration protocol.
+
 ## Metrics
 
 **Lift**: how distinctive a phrase is to assistant output vs. user text. `lift = rate_assistant / rate_user_smoothed`, where rates are per-million-token frequencies. A lift of 10.0 means the assistant uses the phrase 10x more per token than the user. The `--min-lift` threshold (default 5.0) gates new candidate phrases only. Rule keep/remove uses a direct rate comparison plus `--min-count`, not lift (see methodology for why).
@@ -68,6 +86,7 @@ Run with `--help` for all flags. `--data-dir` overrides where the voice baseline
 - Rule health table (every entry with type, audit surface, and `keep` / `remove (reason)`), plus deliverable quotes for the deliverable-surface tells
 - Structural pattern audit (the hook's regex patterns, hit counts across sessions)
 - Structural signatures (part-of-speech tag sequences distinctive to the model's deliverable prose; word-independent, so they survive vocabulary drift between model releases)
+- Meaning-layer audit (per-criterion judge flag rates with sampled spans, only when `--judge` is passed)
 - Corrective feedback (short human messages naming a writing problem, with the preceding model output)
 - Correction candidates (long-assistant, short-user pairs suggesting prose pushback)
 

--- a/plugins/writing/skills/analyze/references/linguistics.md
+++ b/plugins/writing/skills/analyze/references/linguistics.md
@@ -11,7 +11,7 @@ A writing check belongs to one of four layers, and the layer decides the right t
 - **Vocabulary** (`delve`, `boasts`, "it's worth noting"): a wordlist. Linguistics adds nothing here. The analyze skill already measures word frequency and lift.
 - **Grammar** (sentence-shaped headings, passive voice, "not X but Y"): patterns over part-of-speech sequences that a wordlist cannot express and a plain regex gets wrong. This is the only layer a tagger helps with.
 - **Cross-sentence** (negation flips, escalating triads): structure spanning sentences, which a tagger alone cannot see.
-- **Meaning** (marketing tone, hedging density): no grammar captures it. This needs an LLM judge.
+- **Meaning** (vacuous specificity, motivation absence, marketing tone, hedging density): no grammar captures it. This is the LLM judge's layer (`skills/analyze/scripts/judge.ts`, batch-only). See the "Meaning-Layer Judge" section of `methodology.md`.
 
 Before building a grammar rule, check whether a wordlist, a regex, or an LLM judge does the job as well. The tagger is not the default.
 
@@ -124,6 +124,16 @@ Ten generated documents produced 114 headings, none of them real sentence headin
 - Trailing participles ("Lessons Learned"): the participle fails the noun-phrase parse.
 - Colon-prefixed noun phrases ("Testing Strategy: Payments Reconciliation Service").
 
+## Judge Reference Baseline
+
+The upper-reference run this eval calls for: the same LLM judge that scores the meaning layer, pointed at headings with one question ("is this heading sentence-shaped?", `resources/judge/headings-prompt.md`). If a cheap judge ties the tagger stack on a trope, that trope does not belong in the grammar layer.
+
+```bash
+bun skills/analyze/scripts/judge-run.ts headings tmp/heading-labels.tsv
+```
+
+The runner scores the judge against the existing labels with the same Wilson protocol and prints the full-set and random-subset aggregates. The comparison has not been run yet (it needs an API key and the labeled file, and sits behind the #791 calibration checkpoint). Record the resulting aggregate here, next to the classifier table, when it runs.
+
 ## Verdict
 
 - No candidate clears the hook bar. `hybrid:natural` leads, but the intervals are too wide to act on, so the hook keeps `classifyHeadingBaseline`.
@@ -137,7 +147,7 @@ Where each existing detector sits, and what moving it would take:
 - **Vocabulary** (`wordlists/*.txt`): stay as wordlists. The analyze skill audits them each run.
 - **Grammar** (regexes in `detection/tropes.ts`): candidates for a tagger rule, each only after the layer check confirms a tagger beats a regex. Passive voice, "not X but Y", and test-result reporting are the current candidates.
 - **Cross-sentence** (negation flips, burstiness, question cadence, discourse markers, tricolon): five batch-surface detectors in `detection/tropes.ts`, plus the tagger-backed tricolon in `linguistics/tricolon.ts` behind the hook wall. Thresholds are literature heuristics until the #769 labeling pass calibrates them.
-- **Meaning** (marketing tone, hedging): LLM-judge territory.
+- **Meaning** (vacuous specificity, motivation absence, marketing tone, hedging): the batch judge (`judge.ts`) covers this layer in analyze, pending calibration (#791). Hooks never run it.
 
 Until the bars and the power calculation are in place, the `tropes.ts` regexes stay as they are and ship as hook nudges.
 

--- a/plugins/writing/skills/analyze/references/methodology.md
+++ b/plugins/writing/skills/analyze/references/methodology.md
@@ -179,6 +179,36 @@ ORDER BY h.session_id, h.timestamp
 
 Sample sessions first, then rows within them. Without the session pool step, high-volume sessions dominate the sample and quieter sessions go unexamined.
 
+## Meaning-Layer Judge
+
+The meaning layer (vacuous specificity, motivation absence, marketing tone, hedging density, sycophancy, press-release structure) is judge territory per `linguistics.md`. No wordlist, regex, or tagger captures it. `judge.ts` implements the batch LLM judge from issue #791. It runs only in batch surfaces a person triages, behind the `BatchDetectors` seam in `runAnalysis` (the `structural.ts` template: rows in, typed findings out, rendered via `ReportInput`). The hook path never imports it. `judge.test.ts` asserts no module under `hooks/`, `detection/`, or `linguistics/` references the judge or the API client.
+
+#### Rubric
+
+Six binary criteria in ranked order: information-density first (per the #791 priority comment, vacuous specificity outranks marketing tone on the PR surface), then motivation-presence, marketing-phrasing, hedging-density, sycophancy, and press-release-structure last (structure is partly skill-governed). Each flag requires a verbatim quoted span. The deterministic layer keeps the cheap precursors (the test-result-reporting detector, the pull-request skill's section bans). The judge covers the unbounded remainder and does not duplicate the precursors as criteria checks in code.
+
+Each criterion in `JUDGE_CRITERIA` carries its layer label (`meaning`), the rubric question, and evidence/retire lifecycle metadata, mirroring the curation principle for wordlist entries.
+
+#### Prompt Versioning
+
+`resources/judge/prompt.md` is the rule, committed and hashed. Every audit records its sha256, and a report with a different hash is not comparable to prior numbers. `judge-fixtures.ts` pins the hash. Editing the prompt fails `judge-fixtures.test.ts` until the reproducibility tuples are re-validated and re-pinned. Bias instructions live in the prompt: do not reward length, quote the offending span, and state that the text is AI-written and the job is detecting AI-typical patterns (counters self-preference, since a Claude judge scores Claude output).
+
+#### Execution and Cost
+
+One call per document at temperature 0 with structured JSON output on a Haiku-class model, prompt sent as a cacheable system prefix. Documents over 1,500 words are chunked at paragraph boundaries and aggregated by per-criterion maxima. The runner prints an estimated cost before any call and accepts a document limit (default 100). A 200-document run of 1k-word bodies stays well under a dollar.
+
+#### Reproducibility Gate
+
+`judge-fixtures.ts` commits (prompt hash, input hash, expected flags) tuples over synthetic negatives and invented positives. The hash halves run in CI with no API key. The live half (`judge-run.ts gate`, or `judge.integration.ts` locally) replays the tuples against the real judge and fails on drift. The gate is deliberately not wired into default CI: CI has no API key, and the gate's job is drift detection at measurement time, not per-commit blocking.
+
+#### Calibration (Pending)
+
+Judge criteria are unstable until anchored against real examples, so calibration follows the labeling protocol below. Size dev and test splits with `linguistics/power.ts` first, run two criteria-refinement rounds on the dev split, then freeze the prompt and measure once on the held-out test split with the Wilson protocol. Promotion bar for analyze/review: precision at or above ~50% on the random subset with interval width at or under ±20pp, plus a human spot-check of flagged examples. The labeling passes are a user checkpoint and have not run. Until they do, treat judge flag rates as uncalibrated and the committed fixture expectations as design targets.
+
+#### Privacy
+
+The judged corpus is session text and never leaves the machine beyond the API call itself. Sampled spans appear only in the local report under `tmp/`. Committed content (prompt examples, fixtures) is invented, never quoted from sessions.
+
 ## Detector Labeling Protocol
 
 `headings-eval.ts` measures a candidate classifier's precision over its positive (flagged) labels with a Wilson interval. The interval width is governed by the positive count, not the corpus size, so an underpowered sample cannot separate two candidates. The heading pilot had ~24 positives in the random subset and a ±~19pp interval, too wide to promote any tagger. The protocol below sizes the labeling work once and is reusable per trope.

--- a/plugins/writing/skills/analyze/resources/judge/headings-prompt.md
+++ b/plugins/writing/skills/analyze/resources/judge/headings-prompt.md
@@ -1,0 +1,26 @@
+# Heading Shape Judge
+
+You are classifying markdown headings written by an AI assistant. For each heading, answer one question: is this heading sentence-shaped?
+
+A heading is sentence-shaped when it reads as a clause or a command rather than a label:
+
+- A clause: a subject followed by a finite verb ("Throughput Is the Limiting Factor", "The Queue Holds Every Pending Job").
+- An imperative: a command addressed to the reader ("Configure the Retry Budget Before Launch", "Validate the Payload Against the Schema").
+
+A heading is NOT sentence-shaped when it is a label:
+
+- A noun phrase ("Deployment Topology", "Testing Strategy: Payments Reconciliation Service").
+- A fragment or numbered section ("3.1 Unit Tests", "Lessons Learned").
+- A question is also not counted here ("Why Did the Cache Miss?").
+
+All examples above are invented.
+
+Input: one heading per line, each prefixed with its zero-based index and a tab.
+
+Output: respond with a single JSON object and nothing else, shaped as:
+
+```json
+{ "headings": [{ "index": 0, "sentence_shaped": false }] }
+```
+
+Include exactly one entry per input heading, using the given index.

--- a/plugins/writing/skills/analyze/resources/judge/prompt.md
+++ b/plugins/writing/skills/analyze/resources/judge/prompt.md
@@ -1,0 +1,115 @@
+# Meaning-Layer Judge
+
+You are auditing a document written by an AI assistant: a pull request body, issue comment, commit message, or documentation page produced as a work deliverable. The text IS AI-written. Your job is to detect AI-typical writing patterns in it, not to grade overall quality and not to defend the text.
+
+Judge the document against each criterion below and answer with the JSON object described at the end. Every example in this document is invented for illustration.
+
+Rules:
+
+- Do not reward length, thoroughness, or information density. A long detailed document and a three-line document are judged by the same criteria.
+- Judge only the listed criteria. Do not flag grammar, formatting, or factual claims.
+- When you flag a criterion, quote the single most representative offending span verbatim from the document (a phrase or sentence, not a paraphrase). Judge spans, not overall impressions.
+- A criterion is binary: flag it when the pattern is clearly present, leave it unflagged when absent or borderline.
+- The document may be a fragment of a larger document. Judge only what you see.
+
+## Criteria
+
+### `information_density`
+
+Given that the reviewer has the diff, does this text tell them anything they could not see for themselves? Flag sentences that restate the change in prose, enumerate what the reader can see (file lists, counts, statuses, "all tests pass"), or assert value without a mechanism ("this ensures correct behavior", "improving reliability").
+
+Flagged example:
+
+> Updated the parser to handle the new format and added three test cases. All 47 tests pass, ensuring correct behavior across every input.
+
+Neutral example:
+
+> The parser treated CRLF as two newlines, which double-counted blank lines on Windows checkouts. Normalizing before the split fixes the count without touching the tokenizer.
+
+### `motivation_presence`
+
+Does the document say why the change was needed, or only what changed? Flag when the body describes the change without any statement of the problem, constraint, or goal behind it. When you flag, quote the what-only summary sentence; if the document is purely descriptive with no single representative sentence, set the span to null.
+
+Flagged example:
+
+> Renamed `fetchAll` to `fetchPage` and added a `cursor` parameter. Updated all call sites and adjusted the tests.
+
+Neutral example:
+
+> `fetchAll` loaded the whole table into memory, which OOMed the worker on tenants with over a million rows. Paging bounds the working set, so the rename and `cursor` parameter follow from that.
+
+### `marketing_phrasing`
+
+Does the text sell the change instead of describing it? Flag promotional adjectives and verbs (powerful, seamless, blazing-fast, supercharge, streamline), benefit framing aimed at an imagined customer, or feature-announcement tone in what should be working prose.
+
+Flagged example:
+
+> This powerful new caching layer delivers blazing-fast lookups and a seamless developer experience across the entire platform.
+
+Neutral example:
+
+> Lookups now hit an in-process LRU before Redis. p99 latency dropped from 40ms to 6ms in the staging replay.
+
+### `hedging_density`
+
+Is the text padded with stacked qualifiers that avoid committing to a claim? Flag clusters of hedges (should probably, may potentially, in most cases, it's possible that, might not fully) that leave the reader unsure what the author actually asserts. A single honest caveat is not a flag; pervasive non-commitment is.
+
+Flagged example:
+
+> This should probably fix the issue in most cases, though there may be some edge cases where the new logic might not fully apply as expected.
+
+Neutral example:
+
+> This fixes the double-free; the repro from the bug report no longer crashes. Concurrent close during a pending read is untested and may still race.
+
+### `sycophancy`
+
+Does the text flatter the reader or perform agreement? Flag praise of the question or reviewer (great question, excellent point, you're absolutely right), enthusiasm theater, or validation-forward openers in what should be neutral working prose.
+
+Flagged example:
+
+> Great catch! You're absolutely right that the retry path was the issue, and your instinct to look there first was spot on.
+
+Neutral example:
+
+> Agreed, the retry path was the problem. Switched to the bounded backoff you suggested.
+
+### `press_release_structure`
+
+Is the document organized like a product announcement rather than working prose? Flag the overview/key-benefits/summary template: a scene-setting overview that repeats the title, sections present only to fill a template, or a closing paragraph that re-summarizes ("In summary, this change represents a significant step forward"). Ordinary headings over real content are not a flag.
+
+Flagged example:
+
+> ## Overview
+>
+> This PR introduces the new retry mechanism.
+>
+> ## Key Benefits
+>
+> - Improved reliability
+> - Better developer experience
+>
+> ## Summary
+>
+> In summary, this change represents a significant step toward a more resilient platform.
+
+Neutral example:
+
+> Retries now use bounded exponential backoff (base 50ms, cap 5s). The previous fixed 1s retry hammered the upstream during incidents; the incident review from the March outage asked for jitter.
+
+## Output
+
+Respond with a single JSON object and nothing else. One key per criterion, in this exact shape:
+
+```json
+{
+  "information_density": { "flagged": false, "span": null },
+  "motivation_presence": { "flagged": false, "span": null },
+  "marketing_phrasing": { "flagged": false, "span": null },
+  "hedging_density": { "flagged": false, "span": null },
+  "sycophancy": { "flagged": false, "span": null },
+  "press_release_structure": { "flagged": false, "span": null }
+}
+```
+
+`span` is a verbatim quote from the document when `flagged` is true (null only when no single span represents the flag, e.g. motivation absence), and null when `flagged` is false.

--- a/plugins/writing/skills/analyze/scripts/analyze.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.ts
@@ -16,6 +16,7 @@ import {
   totalChars,
 } from "./dump";
 import { escapeRegex, frustrationRegex, gatedRegex } from "./frustration";
+import { DEFAULT_JUDGE_LIMIT, JUDGE_MODEL, type MeaningDetector, meaningDetector } from "./judge";
 import { computeLift, excludePhrases, processCorpus, processRows } from "./ngram";
 import { findQuote } from "./quote-context";
 import { aggregateTrends, analyzeDocument } from "./rate-detectors";
@@ -47,6 +48,16 @@ export interface AnalysisConfig {
   pasteMaxChars: number;
   selfName: string;
   correctiveLimit: number;
+}
+
+/**
+ * Optional batch detector modules, following the structural.ts seam: rows in,
+ * typed findings out, wired here, rendered via ReportInput. LLM judges live
+ * behind this seam only; the hook path never sees them. `detect` is async
+ * because judge modules call the API.
+ */
+export interface BatchDetectors {
+  meaning?: MeaningDetector;
 }
 
 if (import.meta.main) {
@@ -135,6 +146,22 @@ function parseFlags() {
         description: "Max corrective-feedback moments to surface",
         default: 25,
       },
+      judge: {
+        type: Boolean,
+        description:
+          "Run the meaning-layer LLM judge over the deliverable corpus (requires ANTHROPIC_API_KEY; prints a cost estimate before calling)",
+        default: false,
+      },
+      judgeModel: {
+        type: String,
+        description: "Judge model (Haiku-class recommended)",
+        default: JUDGE_MODEL,
+      },
+      judgeLimit: {
+        type: Number,
+        description: "Max deliverable documents the judge scores per run (cost guardrail)",
+        default: DEFAULT_JUDGE_LIMIT,
+      },
     },
   });
 }
@@ -163,6 +190,18 @@ async function main(): Promise<void> {
   const dbPath = path.resolve(argv.flags.sessionDb ?? "");
   const outPath = argv.flags.out ?? path.join("tmp", `trope-analysis-${today}.md`);
 
+  const detectors: BatchDetectors = {};
+  if (argv.flags.judge) {
+    if (!process.env.ANTHROPIC_API_KEY) {
+      console.error("--judge requires ANTHROPIC_API_KEY. Run without --judge or set the key.");
+      process.exit(1);
+    }
+    detectors.meaning = meaningDetector({
+      model: argv.flags.judgeModel,
+      limit: argv.flags.judgeLimit,
+    });
+  }
+
   const sessionId = process.env.CLAUDE_SESSION_ID ?? "anonymous";
   const isolatedPath = path.join(
     process.env.TMPDIR || "/tmp",
@@ -173,7 +212,7 @@ async function main(): Promise<void> {
 
   const db = await openSessionDb(isolatedPath);
   try {
-    const report = renderReport(await runAnalysis(db, config));
+    const report = renderReport(await runAnalysis(db, config, detectors));
     mkdirSync(path.dirname(outPath), { recursive: true });
     await Bun.write(outPath, report);
     console.error(`Wrote report to ${outPath}`);
@@ -187,7 +226,11 @@ async function main(): Promise<void> {
 // Orchestrates the tested modules over an opened session DB into a ReportInput.
 // All inputs come from db + config; no flag parsing, clock reads, or report
 // rendering happen here, so a fixture DB can drive the whole composition.
-export async function runAnalysis(db: Database, config: AnalysisConfig): Promise<ReportInput> {
+export async function runAnalysis(
+  db: Database,
+  config: AnalysisConfig,
+  detectors: BatchDetectors = {},
+): Promise<ReportInput> {
   const baseParams: Record<string, string | null> = {
     after_date: config.since,
     before_date: config.until,
@@ -354,6 +397,12 @@ export async function runAnalysis(db: Database, config: AnalysisConfig): Promise
     .map((r) => analyzeDocument(r.session_id, r.text as string));
   const rateTrends = aggregateTrends(rateDocumentRows);
 
+  let meaningAudit: ReportInput["meaningAudit"] = null;
+  if (detectors.meaning) {
+    console.error("Running meaning-layer judge over the deliverable corpus");
+    meaningAudit = await detectors.meaning(deliverableRows);
+  }
+
   const ruleHealth = buildRuleHealth({
     entries: wordlistEntries,
     chatAudit: auditByTerm,
@@ -385,6 +434,7 @@ export async function runAnalysis(db: Database, config: AnalysisConfig): Promise
     structuralAudit,
     structuralSignatures,
     rateTrends,
+    meaningAudit,
     candidatePhrases,
     corrections,
     corrective,

--- a/plugins/writing/skills/analyze/scripts/analyze.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.ts
@@ -192,8 +192,10 @@ async function main(): Promise<void> {
 
   const detectors: BatchDetectors = {};
   if (argv.flags.judge) {
-    if (!process.env.ANTHROPIC_API_KEY) {
-      console.error("--judge requires ANTHROPIC_API_KEY. Run without --judge or set the key.");
+    if (!process.env.ANTHROPIC_API_KEY && !process.env.ANTHROPIC_AUTH_TOKEN) {
+      console.error(
+        "--judge requires API credentials (ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN). Run without --judge or set one.",
+      );
       process.exit(1);
     }
     detectors.meaning = meaningDetector({

--- a/plugins/writing/skills/analyze/scripts/judge-fixtures.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge-fixtures.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import {
-  HEADINGS_PROMPT_SHA256,
-  JUDGE_FIXTURES,
-  JUDGE_PROMPT_SHA256,
-} from "./judge-fixtures";
 import { HEADING_PROMPT_PATH, JUDGE_CRITERIA, loadPrompt, sha256 } from "./judge";
+import { HEADINGS_PROMPT_SHA256, JUDGE_FIXTURES, JUDGE_PROMPT_SHA256 } from "./judge-fixtures";
 
 // The reproducibility tuples are (prompt hash, input hash, expected flags).
 // This suite keeps the committed hashes in sync without an API key; the live

--- a/plugins/writing/skills/analyze/scripts/judge-fixtures.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge-fixtures.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import {
+  HEADINGS_PROMPT_SHA256,
+  JUDGE_FIXTURES,
+  JUDGE_PROMPT_SHA256,
+} from "./judge-fixtures";
+import { HEADING_PROMPT_PATH, JUDGE_CRITERIA, loadPrompt, sha256 } from "./judge";
+
+// The reproducibility tuples are (prompt hash, input hash, expected flags).
+// This suite keeps the committed hashes in sync without an API key; the live
+// half of the gate is `judge-run.ts --gate` (local-only by design).
+
+describe("prompt hash pins", () => {
+  test("JUDGE_PROMPT_SHA256 matches the committed prompt artifact", async () => {
+    const prompt = await loadPrompt();
+    expect(prompt.sha256).toBe(JUDGE_PROMPT_SHA256);
+  });
+
+  test("HEADINGS_PROMPT_SHA256 matches the committed headings prompt", async () => {
+    const prompt = await loadPrompt(HEADING_PROMPT_PATH);
+    expect(prompt.sha256).toBe(HEADINGS_PROMPT_SHA256);
+  });
+});
+
+describe("fixture tuples", () => {
+  test("input hashes match the fixture texts", () => {
+    for (const fixture of JUDGE_FIXTURES) {
+      expect(sha256(fixture.text)).toBe(fixture.inputSha256);
+    }
+  });
+
+  test("fixture ids are unique", () => {
+    const ids = JUDGE_FIXTURES.map((f) => f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("expectations only reference rubric criteria", () => {
+    const keys = new Set<string>(JUDGE_CRITERIA.map((c) => c.key));
+    for (const fixture of JUDGE_FIXTURES) {
+      for (const key of Object.keys(fixture.expect)) {
+        expect(keys.has(key)).toBe(true);
+      }
+    }
+  });
+
+  test("negatives pin every criterion false; positives pin their target true", () => {
+    for (const fixture of JUDGE_FIXTURES) {
+      const expectations = Object.entries(fixture.expect);
+      if (fixture.kind === "synthetic-negative") {
+        expect(expectations.length).toBe(JUDGE_CRITERIA.length);
+        expect(expectations.every(([, flagged]) => flagged === false)).toBe(true);
+      } else {
+        expect(expectations.some(([, flagged]) => flagged === true)).toBe(true);
+      }
+    }
+  });
+
+  test("every criterion has at least one invented positive", () => {
+    for (const criterion of JUDGE_CRITERIA) {
+      const covered = JUDGE_FIXTURES.some(
+        (f) => f.kind === "invented-positive" && f.expect[criterion.key] === true,
+      );
+      expect(covered).toBe(true);
+    }
+  });
+});

--- a/plugins/writing/skills/analyze/scripts/judge-fixtures.ts
+++ b/plugins/writing/skills/analyze/scripts/judge-fixtures.ts
@@ -1,0 +1,126 @@
+import type { CriterionKey } from "./judge";
+
+/**
+ * Reproducibility tuples for the meaning-layer judge (issue #791): committed
+ * (prompt hash, input hash, expected flags) over synthetic negatives and
+ * invented positives at temperature 0. Every text is invented; none is quoted
+ * from any session corpus, so the file is safe to commit.
+ *
+ * Two consumers:
+ *
+ * - `judge-fixtures.test.ts` (CI, no API key): asserts each `inputSha256`
+ *   matches its text and `JUDGE_PROMPT_SHA256` matches the committed
+ *   `resources/judge/prompt.md`, so a prompt or fixture edit cannot land
+ *   without re-pinning the tuples.
+ * - `judge-run.ts --gate` (local, API key required): replays each tuple
+ *   against the live judge and fails on any expectation mismatch. The gate is
+ *   drift detection at measurement time, not a per-commit block, so it is not
+ *   wired into default CI.
+ *
+ * GATE STATUS: the expectations below are design targets pending the first
+ * live gate run, which is part of the #791 calibration checkpoint (a user
+ * decision). Until that run, treat them as unvalidated.
+ */
+
+/** Pinned hash of resources/judge/prompt.md. A prompt edit must update this. */
+export const JUDGE_PROMPT_SHA256 =
+  "312c99b19d6a689deb762bea1a71c470a4362758dbda345c9471b918d479af52";
+
+/** Pinned hash of resources/judge/headings-prompt.md (#769 reference baseline). */
+export const HEADINGS_PROMPT_SHA256 =
+  "7f05ca8b8eecf96d574c487f7dda45f2800a1c757d50aed3091454a36e295c8c";
+
+export interface JudgeFixture {
+  id: string;
+  kind: "invented-positive" | "synthetic-negative";
+  text: string;
+  /** sha256 of `text`; the CI test recomputes and compares. */
+  inputSha256: string;
+  /**
+   * Committed expectations. Negatives pin all six criteria false; positives
+   * pin only their target criterion true, because a strongly slopful text may
+   * legitimately trip neighboring criteria and pinning those would make the
+   * gate brittle.
+   */
+  expect: Partial<Record<CriterionKey, boolean>>;
+}
+
+const ALL_CLEAN: Record<CriterionKey, boolean> = {
+  information_density: false,
+  motivation_presence: false,
+  marketing_phrasing: false,
+  hedging_density: false,
+  sycophancy: false,
+  press_release_structure: false,
+};
+
+export const JUDGE_FIXTURES: readonly JudgeFixture[] = [
+  {
+    id: "negative-mechanism-first",
+    kind: "synthetic-negative",
+    text: "The session index dropped rows when two hosts shared a session id, because the merge keyed on session_id alone. Keying on (host, session_id) preserves both copies. The cost is a wider primary key, which grows the index by about 4% on the current corpus.",
+    inputSha256: "c2a2ef0c20763862c84bc5402edda8f7bb5ee4a8cd4adbb101ee60001b8e8ae0",
+    expect: ALL_CLEAN,
+  },
+  {
+    id: "negative-tradeoff-stated",
+    kind: "synthetic-negative",
+    text: "Cap the retry queue at 1,000 entries. Unbounded growth during the May incident exhausted the broker's memory; dropping the oldest entry under pressure trades replay completeness for liveness.",
+    inputSha256: "a94d0a78422dbca1b09dab755e6da7ca898bcda840253bb9400f5d6ed5d509a7",
+    expect: ALL_CLEAN,
+  },
+  {
+    id: "positive-information-density",
+    kind: "invented-positive",
+    text: "This PR updates the validation logic in three files and adds two new test cases. All 12 tests pass. These changes ensure the validator behaves correctly for every supported input.",
+    inputSha256: "4e2c6c54b4128926707eb6d521d8e56081423248ac7c0b0dab8d54043d320ef1",
+    expect: { information_density: true },
+  },
+  {
+    id: "positive-motivation-presence",
+    kind: "invented-positive",
+    text: "Renamed the Config struct to Settings and moved it into its own module. Updated imports across the codebase and regenerated the mocks.",
+    inputSha256: "e824d5d4b5030d4d615a16cc8960c787c0e328609adeae7cb9299bc5072453c8",
+    expect: { motivation_presence: true },
+  },
+  {
+    id: "positive-marketing-phrasing",
+    kind: "invented-positive",
+    text: "Introducing a streamlined, lightning-fast export pipeline that supercharges report generation and delivers a truly seamless experience for downstream consumers.",
+    inputSha256: "c86fb5ab5094f376fa2223b453bc82e6d46fc396ba76c417608f18c83caa7bdc",
+    expect: { marketing_phrasing: true },
+  },
+  {
+    id: "positive-hedging-density",
+    kind: "invented-positive",
+    text: "This change should hopefully address the timeout in most situations. It may potentially also help with the memory issue, though it's possible that some workloads might still see occasional slowdowns in certain edge cases.",
+    inputSha256: "72efcd080ef5c6d879464b6814d893ff5b22c7ffd341a475c99f55babb9f42a0",
+    expect: { hedging_density: true },
+  },
+  {
+    id: "positive-sycophancy",
+    kind: "invented-positive",
+    text: "Excellent question! You're absolutely right to be concerned about the cache invalidation here, and honestly your intuition about the stale reads was spot on. Great catch!",
+    inputSha256: "f14a87361c2b2735f383c80f20cf46516fa7d9c999556e411294579ac1123f22",
+    expect: { sycophancy: true },
+  },
+  {
+    id: "positive-press-release-structure",
+    kind: "invented-positive",
+    text: `## Overview
+
+This PR introduces the new notification pipeline.
+
+## Key Benefits
+
+- Improved reliability
+- Better developer experience
+- Future-proof architecture
+
+## Summary
+
+In summary, this change represents a significant step toward a more scalable notification platform.`,
+    inputSha256: "4324d41e846309f51e054d23f97b3b94a39634bd8de247619c20a594ba24eb99",
+    expect: { press_release_structure: true },
+  },
+];

--- a/plugins/writing/skills/analyze/scripts/judge-run.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge-run.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { LabeledHeading } from "./headings-eval";
-import { JUDGE_CRITERIA, type CriterionKey, type JudgeVerdict } from "./judge";
+import { type CriterionKey, JUDGE_CRITERIA, type JudgeVerdict } from "./judge";
 import { JUDGE_PROMPT_SHA256 } from "./judge-fixtures";
 import { runGate, scoreHeadingBaseline } from "./judge-run";
 

--- a/plugins/writing/skills/analyze/scripts/judge-run.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge-run.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import type { LabeledHeading } from "./headings-eval";
+import { JUDGE_CRITERIA, type CriterionKey, type JudgeVerdict } from "./judge";
+import { JUDGE_PROMPT_SHA256 } from "./judge-fixtures";
+import { runGate, scoreHeadingBaseline } from "./judge-run";
+
+function verdictFor(flags: Partial<Record<CriterionKey, boolean>>): JudgeVerdict {
+  const v = {} as JudgeVerdict;
+  for (const c of JUDGE_CRITERIA) {
+    const flagged = flags[c.key] ?? false;
+    v[c.key] = { flagged, span: flagged ? `span for ${c.id}` : null };
+  }
+  return v;
+}
+
+describe("runGate", () => {
+  test("rejects a stale prompt hash before any judging", async () => {
+    const judge = async () => verdictFor({});
+    await expect(runGate(judge, "0".repeat(64))).rejects.toThrow("does not match the pinned");
+  });
+
+  test("passes when the judge matches every committed expectation", async () => {
+    // A mock judge that flags exactly the criterion each positive fixture
+    // targets and stays clean on negatives, keyed off the fixture text.
+    const judge = async (text: string) => {
+      const flags: Partial<Record<CriterionKey, boolean>> = {};
+      if (text.includes("All 12 tests pass")) flags.information_density = true;
+      if (text.includes("Renamed the Config struct")) flags.motivation_presence = true;
+      if (text.includes("lightning-fast")) flags.marketing_phrasing = true;
+      if (text.includes("should hopefully")) flags.hedging_density = true;
+      if (text.includes("Excellent question")) flags.sycophancy = true;
+      if (text.includes("## Key Benefits")) flags.press_release_structure = true;
+      return verdictFor(flags);
+    };
+    const results = await runGate(judge, JUDGE_PROMPT_SHA256);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((r) => r.pass)).toBe(true);
+  });
+
+  test("reports per-criterion mismatches when the judge drifts", async () => {
+    const judge = async () => verdictFor({ marketing_phrasing: true });
+    const results = await runGate(judge, JUDGE_PROMPT_SHA256);
+    const negative = results.find((r) => r.id === "negative-mechanism-first");
+    expect(negative?.pass).toBe(false);
+    expect(negative?.mismatches).toEqual([
+      {
+        criterion: "marketing-phrasing",
+        expected: false,
+        actual: true,
+        span: "span for marketing-phrasing",
+      },
+    ]);
+    const density = results.find((r) => r.id === "positive-information-density");
+    expect(density?.pass).toBe(false);
+    expect(density?.mismatches[0]?.criterion).toBe("information-density");
+  });
+});
+
+describe("scoreHeadingBaseline", () => {
+  const labeled: LabeledHeading[] = [
+    { heading: "Throughput Is the Limiting Factor", label: "clause", source: "random" },
+    { heading: "Deployment Topology", label: "noun-phrase", source: "random" },
+    { heading: "Add a Circuit Breaker to the Gateway", label: "imperative", source: "random" },
+    { heading: "Lessons Learned", label: "fragment", source: "disagreement" },
+  ];
+
+  test("computes precision and recall against should-flag labels", () => {
+    const score = scoreHeadingBaseline(labeled, [true, true, false, false]);
+    expect(score.tp).toBe(1);
+    expect(score.fp).toBe(1);
+    expect(score.fn).toBe(1);
+    expect(score.precision).toBe(0.5);
+    expect(score.recall).toBe(0.5);
+    expect(score.precisionLo).toBeGreaterThan(0);
+    expect(score.precisionHi).toBeLessThan(1);
+  });
+
+  test("rejects a verdict count mismatch", () => {
+    expect(() => scoreHeadingBaseline(labeled, [true])).toThrow("1 verdicts for 4");
+  });
+});

--- a/plugins/writing/skills/analyze/scripts/judge-run.ts
+++ b/plugins/writing/skills/analyze/scripts/judge-run.ts
@@ -1,0 +1,310 @@
+#!/usr/bin/env bun
+import { cli, command } from "cleye";
+import {
+  type LabeledHeading,
+  parseLabelsFile,
+  SHOULD_FLAG,
+  wilson,
+} from "./headings-eval";
+import {
+  anthropicChunkJudge,
+  anthropicHeadingJudge,
+  type ChunkJudge,
+  estimateCost,
+  HEADING_PROMPT_PATH,
+  type HeadingJudge,
+  JUDGE_CRITERIA,
+  JUDGE_MODEL,
+  judgeCorpus,
+  judgeDocument,
+  judgeHeadings,
+  loadPrompt,
+  type MeaningAudit,
+} from "./judge";
+import { JUDGE_FIXTURES, JUDGE_PROMPT_SHA256, type JudgeFixture } from "./judge-fixtures";
+
+/**
+ * Runner for the meaning-layer judge outside the analyze pipeline:
+ *
+ * - `files`: judge ad-hoc documents and print the per-criterion audit.
+ * - `gate`: replay the committed reproducibility tuples (judge-fixtures.ts)
+ *   against the live judge. Local-only by design: CI has no API key, and the
+ *   gate's job is drift detection at measurement time, not per-commit
+ *   blocking.
+ * - `headings`: the #769 reference baseline. Point the judge at a labeled
+ *   heading file and report precision/recall against the existing labels.
+ *
+ * Every mode requires ANTHROPIC_API_KEY and prints a cost estimate before
+ * making any call.
+ */
+
+export interface GateMismatch {
+  criterion: string;
+  expected: boolean;
+  actual: boolean;
+  span: string | null;
+}
+
+export interface GateResult {
+  id: string;
+  kind: JudgeFixture["kind"];
+  pass: boolean;
+  mismatches: GateMismatch[];
+}
+
+/**
+ * Replays each fixture tuple against `judge`. Throws when the committed
+ * prompt no longer matches the pinned hash: expectations from a different
+ * prompt version say nothing about this one.
+ */
+export async function runGate(judge: ChunkJudge, promptSha256: string): Promise<GateResult[]> {
+  if (promptSha256 !== JUDGE_PROMPT_SHA256) {
+    throw new Error(
+      `Prompt hash ${promptSha256.slice(0, 12)} does not match the pinned tuple hash ${JUDGE_PROMPT_SHA256.slice(0, 12)}. Re-validate the fixtures against the edited prompt and update JUDGE_PROMPT_SHA256.`,
+    );
+  }
+  const results: GateResult[] = [];
+  for (const fixture of JUDGE_FIXTURES) {
+    const verdict = await judgeDocument(judge, fixture.text);
+    const mismatches: GateMismatch[] = [];
+    for (const criterion of JUDGE_CRITERIA) {
+      const expected = fixture.expect[criterion.key];
+      if (expected === undefined) continue;
+      const actual = verdict[criterion.key];
+      if (actual.flagged !== expected) {
+        mismatches.push({
+          criterion: criterion.id,
+          expected,
+          actual: actual.flagged,
+          span: actual.span,
+        });
+      }
+    }
+    results.push({ id: fixture.id, kind: fixture.kind, pass: mismatches.length === 0, mismatches });
+  }
+  return results;
+}
+
+export interface HeadingBaselineScore {
+  total: number;
+  flagged: number;
+  tp: number;
+  fp: number;
+  fn: number;
+  precision: number;
+  precisionLo: number;
+  precisionHi: number;
+  recall: number;
+}
+
+/** Scores judge verdicts against the labeled headings (clause/imperative flag). */
+export function scoreHeadingBaseline(
+  labeled: LabeledHeading[],
+  verdicts: boolean[],
+): HeadingBaselineScore {
+  if (labeled.length !== verdicts.length) {
+    throw new Error(`Got ${verdicts.length} verdicts for ${labeled.length} labeled headings`);
+  }
+  let tp = 0;
+  let fp = 0;
+  let fn = 0;
+  labeled.forEach((row, i) => {
+    const flagged = verdicts[i] === true;
+    const want = SHOULD_FLAG.has(row.label);
+    if (flagged && want) tp++;
+    else if (flagged && !want) fp++;
+    else if (!flagged && want) fn++;
+  });
+  const ci = wilson(tp, tp + fp);
+  return {
+    total: labeled.length,
+    flagged: tp + fp,
+    tp,
+    fp,
+    fn,
+    precision: tp + fp > 0 ? tp / (tp + fp) : 1,
+    precisionLo: ci.lo,
+    precisionHi: ci.hi,
+    recall: tp + fn > 0 ? tp / (tp + fn) : 1,
+  };
+}
+
+function requireApiKey(): void {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error("ANTHROPIC_API_KEY is not set. The judge runs only with a live API key.");
+    process.exit(1);
+  }
+}
+
+function renderAudit(audit: MeaningAudit): string {
+  const lines = [
+    `prompt: ${audit.promptSha256}`,
+    `model: ${audit.model}`,
+    `documents: ${audit.documents}`,
+    `estimated cost: $${audit.estimatedCostUsd.toFixed(4)}`,
+    "",
+    "criterion                 flagged  rate",
+  ];
+  for (const stat of audit.criteria) {
+    const rate = stat.total > 0 ? `${((stat.flagged / stat.total) * 100).toFixed(0)}%` : "-";
+    lines.push(`${stat.id.padEnd(26)}${String(stat.flagged).padStart(7)}  ${rate}`);
+  }
+  for (const stat of audit.criteria) {
+    if (stat.spans.length === 0) continue;
+    lines.push("", `${stat.id} spans:`);
+    for (const span of stat.spans) lines.push(`  - "${span}"`);
+  }
+  return lines.join("\n");
+}
+
+async function filesMain(paths: string[], model: string, limit: number): Promise<void> {
+  requireApiKey();
+  const prompt = await loadPrompt();
+  const texts: string[] = [];
+  for (const p of paths.slice(0, limit)) {
+    texts.push(await Bun.file(p).text());
+  }
+  const cost = estimateCost(texts, { promptText: prompt.text, model });
+  console.error(
+    `Judging ${texts.length} documents: ${cost.calls} calls, est. $${cost.usd.toFixed(4)} on ${model}`,
+  );
+  const judge = anthropicChunkJudge({ prompt: prompt.text, model });
+  const audit = await judgeCorpus(judge, texts, {
+    promptSha256: prompt.sha256,
+    model,
+    estimatedCostUsd: cost.usd,
+  });
+  console.log(renderAudit(audit));
+}
+
+async function gateMain(model: string): Promise<void> {
+  requireApiKey();
+  const prompt = await loadPrompt();
+  const texts = JUDGE_FIXTURES.map((f) => f.text);
+  const cost = estimateCost(texts, { promptText: prompt.text, model });
+  console.error(
+    `Gating ${JUDGE_FIXTURES.length} fixtures: ${cost.calls} calls, est. $${cost.usd.toFixed(4)} on ${model}`,
+  );
+  const judge = anthropicChunkJudge({ prompt: prompt.text, model });
+  const results = await runGate(judge, prompt.sha256);
+  let failed = 0;
+  for (const result of results) {
+    if (result.pass) {
+      console.log(`PASS ${result.id}`);
+      continue;
+    }
+    failed++;
+    console.log(`FAIL ${result.id}`);
+    for (const mismatch of result.mismatches) {
+      console.log(
+        `  ${mismatch.criterion}: expected ${mismatch.expected}, got ${mismatch.actual}${mismatch.span ? ` (span: "${mismatch.span}")` : ""}`,
+      );
+    }
+  }
+  console.log(`\n${results.length - failed}/${results.length} tuples hold (prompt ${prompt.sha256.slice(0, 12)})`);
+  if (failed > 0) process.exit(1);
+}
+
+async function headingsMain(labelsPath: string, model: string, limit: number): Promise<void> {
+  requireApiKey();
+  const prompt = await loadPrompt(HEADING_PROMPT_PATH);
+  const labeled = parseLabelsFile(await Bun.file(labelsPath).text()).slice(0, limit);
+  if (labeled.length === 0) {
+    console.error(`No labeled headings found in ${labelsPath}`);
+    process.exit(1);
+  }
+  const cost = estimateCost(
+    labeled.map((l) => l.heading),
+    { promptText: prompt.text, model },
+  );
+  console.error(
+    `Judging ${labeled.length} headings (batched), est. $${cost.usd.toFixed(4)} on ${model}`,
+  );
+  const judge: HeadingJudge = anthropicHeadingJudge({ prompt: prompt.text, model });
+  const verdicts = await judgeHeadings(
+    judge,
+    labeled.map((l) => l.heading),
+  );
+  const all = scoreHeadingBaseline(labeled, verdicts);
+  const randomRows = labeled
+    .map((row, i) => ({ row, verdict: verdicts[i] === true }))
+    .filter((x) => x.row.source === "random");
+  const random = scoreHeadingBaseline(
+    randomRows.map((x) => x.row),
+    randomRows.map((x) => x.verdict),
+  );
+  console.log(`heading judge reference baseline (prompt ${prompt.sha256.slice(0, 12)}, ${model})`);
+  for (const [name, score] of [
+    ["all labeled", all],
+    ["random subset", random],
+  ] as const) {
+    console.log(
+      `${name.padEnd(15)} n=${score.total} flagged=${score.flagged} precision=${(score.precision * 100).toFixed(1)}% (${(score.precisionLo * 100).toFixed(1)}..${(score.precisionHi * 100).toFixed(1)}) recall=${(score.recall * 100).toFixed(1)}%`,
+    );
+  }
+  console.log(
+    "\nRecord this aggregate (not the headings) in skills/analyze/references/linguistics.md as the #769 upper-reference for the tagger promotion decision.",
+  );
+}
+
+if (import.meta.main) {
+  const filesCmd = command(
+    {
+      name: "files",
+      parameters: ["<paths...>"],
+      help: { description: "Judge documents from files and print the per-criterion audit" },
+      flags: {
+        model: { type: String, description: "Judge model", default: JUDGE_MODEL },
+        limit: { type: Number, description: "Max documents to judge", default: 100 },
+      },
+    },
+    async (parsed) => {
+      await filesMain(parsed._.paths, parsed.flags.model, parsed.flags.limit);
+    },
+  );
+
+  const gateCmd = command(
+    {
+      name: "gate",
+      help: {
+        description:
+          "Replay the committed reproducibility tuples against the live judge (local-only)",
+      },
+      flags: {
+        model: { type: String, description: "Judge model", default: JUDGE_MODEL },
+      },
+    },
+    async (parsed) => {
+      await gateMain(parsed.flags.model);
+    },
+  );
+
+  const headingsCmd = command(
+    {
+      name: "headings",
+      parameters: ["<labels>"],
+      help: {
+        description:
+          "Reference baseline for #769: judge labeled headings (TSV from headings-eval --sample) and score against the labels",
+      },
+      flags: {
+        model: { type: String, description: "Judge model", default: JUDGE_MODEL },
+        limit: { type: Number, description: "Max headings to judge", default: 500 },
+      },
+    },
+    async (parsed) => {
+      await headingsMain(parsed._.labels, parsed.flags.model, parsed.flags.limit);
+    },
+  );
+
+  cli(
+    {
+      name: "judge-run",
+      help: { description: "Run the meaning-layer LLM judge (batch-only, needs ANTHROPIC_API_KEY)" },
+      commands: [filesCmd, gateCmd, headingsCmd],
+    },
+    (parsed) => {
+      parsed.showHelp();
+    },
+  );
+}

--- a/plugins/writing/skills/analyze/scripts/judge-run.ts
+++ b/plugins/writing/skills/analyze/scripts/judge-run.ts
@@ -6,6 +6,7 @@ import {
   anthropicHeadingJudge,
   type ChunkJudge,
   estimateCost,
+  estimateHeadingCost,
   HEADING_PROMPT_PATH,
   type HeadingJudge,
   JUDGE_CRITERIA,
@@ -125,8 +126,10 @@ export function scoreHeadingBaseline(
 }
 
 function requireApiKey(): void {
-  if (!process.env.ANTHROPIC_API_KEY) {
-    console.error("ANTHROPIC_API_KEY is not set. The judge runs only with a live API key.");
+  if (!process.env.ANTHROPIC_API_KEY && !process.env.ANTHROPIC_AUTH_TOKEN) {
+    console.error(
+      "Neither ANTHROPIC_API_KEY nor ANTHROPIC_AUTH_TOKEN is set. The judge runs only with live API credentials.",
+    );
     process.exit(1);
   }
 }
@@ -210,12 +213,12 @@ async function headingsMain(labelsPath: string, model: string, limit: number): P
     console.error(`No labeled headings found in ${labelsPath}`);
     process.exit(1);
   }
-  const cost = estimateCost(
+  const cost = estimateHeadingCost(
     labeled.map((l) => l.heading),
     { promptText: prompt.text, model },
   );
   console.error(
-    `Judging ${labeled.length} headings (batched), est. $${cost.usd.toFixed(4)} on ${model}`,
+    `Judging ${labeled.length} headings in ${cost.calls} batched calls, est. $${cost.usd.toFixed(4)} on ${model}`,
   );
   const judge: HeadingJudge = anthropicHeadingJudge({ prompt: prompt.text, model });
   const verdicts = await judgeHeadings(

--- a/plugins/writing/skills/analyze/scripts/judge-run.ts
+++ b/plugins/writing/skills/analyze/scripts/judge-run.ts
@@ -4,6 +4,7 @@ import { type LabeledHeading, parseLabelsFile, SHOULD_FLAG, wilson } from "./hea
 import {
   anthropicChunkJudge,
   anthropicHeadingJudge,
+  anthropicTokenCounter,
   type ChunkJudge,
   estimateCost,
   estimateHeadingCost,
@@ -162,7 +163,11 @@ async function filesMain(paths: string[], model: string, limit: number): Promise
   for (const p of paths.slice(0, limit)) {
     texts.push(await Bun.file(p).text());
   }
-  const cost = estimateCost(texts, { promptText: prompt.text, model });
+  const cost = await estimateCost(texts, {
+    promptText: prompt.text,
+    model,
+    countTokens: anthropicTokenCounter({ prompt: prompt.text, model }),
+  });
   console.error(
     `Judging ${texts.length} documents: ${cost.calls} calls, est. $${cost.usd.toFixed(4)} on ${model}`,
   );
@@ -179,7 +184,11 @@ async function gateMain(model: string): Promise<void> {
   requireApiKey();
   const prompt = await loadPrompt();
   const texts = JUDGE_FIXTURES.map((f) => f.text);
-  const cost = estimateCost(texts, { promptText: prompt.text, model });
+  const cost = await estimateCost(texts, {
+    promptText: prompt.text,
+    model,
+    countTokens: anthropicTokenCounter({ prompt: prompt.text, model }),
+  });
   console.error(
     `Gating ${JUDGE_FIXTURES.length} fixtures: ${cost.calls} calls, est. $${cost.usd.toFixed(4)} on ${model}`,
   );
@@ -213,9 +222,13 @@ async function headingsMain(labelsPath: string, model: string, limit: number): P
     console.error(`No labeled headings found in ${labelsPath}`);
     process.exit(1);
   }
-  const cost = estimateHeadingCost(
+  const cost = await estimateHeadingCost(
     labeled.map((l) => l.heading),
-    { promptText: prompt.text, model },
+    {
+      promptText: prompt.text,
+      model,
+      countTokens: anthropicTokenCounter({ prompt: prompt.text, model }),
+    },
   );
   console.error(
     `Judging ${labeled.length} headings in ${cost.calls} batched calls, est. $${cost.usd.toFixed(4)} on ${model}`,

--- a/plugins/writing/skills/analyze/scripts/judge-run.ts
+++ b/plugins/writing/skills/analyze/scripts/judge-run.ts
@@ -1,11 +1,6 @@
 #!/usr/bin/env bun
 import { cli, command } from "cleye";
-import {
-  type LabeledHeading,
-  parseLabelsFile,
-  SHOULD_FLAG,
-  wilson,
-} from "./headings-eval";
+import { type LabeledHeading, parseLabelsFile, SHOULD_FLAG, wilson } from "./headings-eval";
 import {
   anthropicChunkJudge,
   anthropicHeadingJudge,
@@ -201,7 +196,9 @@ async function gateMain(model: string): Promise<void> {
       );
     }
   }
-  console.log(`\n${results.length - failed}/${results.length} tuples hold (prompt ${prompt.sha256.slice(0, 12)})`);
+  console.log(
+    `\n${results.length - failed}/${results.length} tuples hold (prompt ${prompt.sha256.slice(0, 12)})`,
+  );
   if (failed > 0) process.exit(1);
 }
 
@@ -300,7 +297,9 @@ if (import.meta.main) {
   cli(
     {
       name: "judge-run",
-      help: { description: "Run the meaning-layer LLM judge (batch-only, needs ANTHROPIC_API_KEY)" },
+      help: {
+        description: "Run the meaning-layer LLM judge (batch-only, needs ANTHROPIC_API_KEY)",
+      },
       commands: [filesCmd, gateCmd, headingsCmd],
     },
     (parsed) => {

--- a/plugins/writing/skills/analyze/scripts/judge.integration.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.integration.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { anthropicChunkJudge, loadPrompt } from "./judge";
+import { runGate } from "./judge-run";
+
+/**
+ * Live-API half of the reproducibility gate. Not auto-discovered by `bun test`
+ * (`*.integration.ts`), and every test self-skips without ANTHROPIC_API_KEY so
+ * CI stays green without a key. Run locally:
+ *
+ *   bun test plugins/writing/skills/analyze/scripts/judge.integration.ts
+ */
+const hasKey = Boolean(process.env.ANTHROPIC_API_KEY);
+
+describe("meaning judge (live API)", () => {
+  test.skipIf(!hasKey)(
+    "the committed reproducibility tuples hold at temperature 0",
+    async () => {
+      const prompt = await loadPrompt();
+      const judge = anthropicChunkJudge({ prompt: prompt.text });
+      const results = await runGate(judge, prompt.sha256);
+      const failures = results.filter((r) => !r.pass);
+      expect(failures).toEqual([]);
+    },
+    120_000,
+  );
+});

--- a/plugins/writing/skills/analyze/scripts/judge.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, test } from "bun:test";
+import {
+  aggregateVerdicts,
+  CHUNK_WORD_LIMIT,
+  chunkDocument,
+  countWords,
+  type CriterionKey,
+  estimateCost,
+  HEADING_BATCH_SIZE,
+  HEADING_PROMPT_PATH,
+  JUDGE_CRITERIA,
+  type JudgeVerdict,
+  judgeCorpus,
+  judgeDocument,
+  judgeHeadings,
+  loadPrompt,
+  parseHeadingVerdicts,
+  parseVerdict,
+  PROMPT_PATH,
+  sha256,
+  verdictSchema,
+} from "./judge";
+
+function verdict(overrides: Partial<Record<CriterionKey, boolean | string>> = {}): JudgeVerdict {
+  const v = {} as JudgeVerdict;
+  for (const c of JUDGE_CRITERIA) {
+    const override = overrides[c.key];
+    if (override === undefined) {
+      v[c.key] = { flagged: false, span: null };
+    } else if (typeof override === "boolean") {
+      v[c.key] = { flagged: override, span: null };
+    } else {
+      v[c.key] = { flagged: true, span: override };
+    }
+  }
+  return v;
+}
+
+describe("JUDGE_CRITERIA", () => {
+  test("rubric order leads with information-density and ends with press-release-structure", () => {
+    const ids = JUDGE_CRITERIA.map((c) => c.id);
+    expect(ids[0]).toBe("information-density");
+    expect(ids[1]).toBe("motivation-presence");
+    expect(ids[ids.length - 1]).toBe("press-release-structure");
+  });
+
+  test("every criterion carries layer, question, and lifecycle metadata", () => {
+    for (const c of JUDGE_CRITERIA) {
+      expect(c.layer).toBe("meaning");
+      expect(c.question.length).toBeGreaterThan(0);
+      expect(c.evidence.length).toBeGreaterThan(0);
+      expect(c.retire.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("keys are unique", () => {
+    const keys = JUDGE_CRITERIA.map((c) => c.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
+describe("prompt artifact", () => {
+  test("the committed prompt documents every criterion with both example blocks", async () => {
+    const prompt = await loadPrompt();
+    for (const c of JUDGE_CRITERIA) {
+      expect(prompt.text).toContain(`### \`${c.key}\``);
+    }
+    expect(prompt.text.match(/Flagged example:/g)?.length).toBe(JUDGE_CRITERIA.length);
+    expect(prompt.text.match(/Neutral example:/g)?.length).toBe(JUDGE_CRITERIA.length);
+  });
+
+  test("criteria appear in the prompt in rubric order", async () => {
+    const prompt = await loadPrompt();
+    const positions = JUDGE_CRITERIA.map((c) => prompt.text.indexOf(`### \`${c.key}\``));
+    expect([...positions].sort((a, b) => a - b)).toEqual(positions);
+  });
+
+  test("hash is the sha256 of the file contents", async () => {
+    const prompt = await loadPrompt(PROMPT_PATH);
+    const raw = await Bun.file(PROMPT_PATH).text();
+    expect(prompt.sha256).toBe(sha256(raw));
+    expect(prompt.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("heading prompt loads and hashes", async () => {
+    const prompt = await loadPrompt(HEADING_PROMPT_PATH);
+    expect(prompt.text).toContain("sentence-shaped");
+    expect(prompt.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("verdictSchema", () => {
+  test("requires every criterion and forbids extras", () => {
+    const schema = verdictSchema() as { required: string[]; additionalProperties: boolean };
+    expect(schema.required).toEqual(JUDGE_CRITERIA.map((c) => c.key));
+    expect(schema.additionalProperties).toBe(false);
+  });
+});
+
+describe("parseVerdict", () => {
+  test("parses a complete verdict", () => {
+    const json = JSON.stringify(verdict({ information_density: "All 12 tests pass." }));
+    const parsed = parseVerdict(json);
+    expect(parsed.information_density).toEqual({
+      flagged: true,
+      span: "All 12 tests pass.",
+    });
+    expect(parsed.sycophancy).toEqual({ flagged: false, span: null });
+  });
+
+  test("rejects invalid JSON", () => {
+    expect(() => parseVerdict("not json")).toThrow("invalid JSON");
+  });
+
+  test("rejects a missing criterion", () => {
+    const partial: Record<string, unknown> = JSON.parse(JSON.stringify(verdict()));
+    delete partial.hedging_density;
+    expect(() => parseVerdict(JSON.stringify(partial))).toThrow('missing criterion "hedging_density"');
+  });
+
+  test("rejects non-boolean flagged and non-string span", () => {
+    const bad = JSON.parse(JSON.stringify(verdict())) as Record<
+      string,
+      { flagged: unknown; span: unknown }
+    >;
+    bad.sycophancy.flagged = "yes";
+    expect(() => parseVerdict(JSON.stringify(bad))).toThrow("must be a boolean");
+    bad.sycophancy.flagged = true;
+    bad.sycophancy.span = 7;
+    expect(() => parseVerdict(JSON.stringify(bad))).toThrow("must be a string or null");
+  });
+});
+
+describe("chunkDocument", () => {
+  const paragraph = (words: number, word = "lorem") => Array(words).fill(word).join(" ");
+
+  test("returns short documents whole", () => {
+    const text = `${paragraph(10)}\n\n${paragraph(10)}`;
+    expect(chunkDocument(text)).toEqual([text]);
+  });
+
+  test("splits at paragraph boundaries above the word limit", () => {
+    const a = paragraph(600, "alpha");
+    const b = paragraph(600, "beta");
+    const c = paragraph(600, "gamma");
+    const chunks = chunkDocument([a, b, c].join("\n\n"));
+    expect(chunks).toEqual([`${a}\n\n${b}`, c]);
+    for (const chunk of chunks) {
+      expect(countWords(chunk)).toBeLessThanOrEqual(CHUNK_WORD_LIMIT);
+    }
+  });
+
+  test("keeps an oversized single paragraph whole", () => {
+    const huge = paragraph(CHUNK_WORD_LIMIT + 100);
+    expect(chunkDocument(`${paragraph(5)}\n\n${huge}`)).toEqual([paragraph(5), huge]);
+  });
+});
+
+describe("aggregateVerdicts", () => {
+  test("takes per-criterion maxima across chunks", () => {
+    const aggregated = aggregateVerdicts([
+      verdict({ marketing_phrasing: "blazing-fast" }),
+      verdict({ hedging_density: true }),
+      verdict(),
+    ]);
+    expect(aggregated.marketing_phrasing).toEqual({ flagged: true, span: "blazing-fast" });
+    expect(aggregated.hedging_density).toEqual({ flagged: true, span: null });
+    expect(aggregated.information_density.flagged).toBe(false);
+  });
+
+  test("keeps the first flagged span when a later chunk also flags", () => {
+    const aggregated = aggregateVerdicts([
+      verdict({ sycophancy: "Great question!" }),
+      verdict({ sycophancy: "Spot on!" }),
+    ]);
+    expect(aggregated.sycophancy.span).toBe("Great question!");
+  });
+
+  test("requires at least one verdict", () => {
+    expect(() => aggregateVerdicts([])).toThrow();
+  });
+});
+
+describe("judgeDocument", () => {
+  test("judges each chunk and aggregates", async () => {
+    const seen: string[] = [];
+    const judge = async (chunk: string) => {
+      seen.push(chunk);
+      return verdict({ information_density: seen.length === 2 });
+    };
+    const long = `${Array(1400).fill("alpha").join(" ")}\n\n${Array(1400).fill("beta").join(" ")}`;
+    const result = await judgeDocument(judge, long);
+    expect(seen.length).toBe(2);
+    expect(result.information_density.flagged).toBe(true);
+  });
+});
+
+describe("estimateCost", () => {
+  test("counts one call per chunk and prices by model", () => {
+    const longDoc = Array(3)
+      .fill(Array(1200).fill("word").join(" "))
+      .join("\n\n");
+    const docs = ["short doc one", longDoc];
+    const estimate = estimateCost(docs, { promptText: "prompt words here" });
+    expect(estimate.calls).toBe(4);
+    expect(estimate.usd).toBeGreaterThan(0);
+    expect(estimate.inputTokens).toBeGreaterThan(estimate.outputTokens);
+  });
+
+  test("a 200-document run of 1k-word PR bodies stays under a dollar on haiku", async () => {
+    const prompt = await loadPrompt();
+    const docs = Array(200).fill(Array(1000).fill("word").join(" "));
+    const estimate = estimateCost(docs, { promptText: prompt.text });
+    expect(estimate.usd).toBeLessThan(1);
+  });
+});
+
+describe("judgeCorpus", () => {
+  test("accumulates flag counts and sampled spans per criterion", async () => {
+    const verdicts = [
+      verdict({ information_density: "All tests pass." }),
+      verdict({ information_density: "Updated three files.", sycophancy: true }),
+      verdict(),
+    ];
+    let i = 0;
+    const judge = async () => verdicts[i++] as JudgeVerdict;
+    const audit = await judgeCorpus(judge, ["a", "b", "c"], {
+      promptSha256: "abc123",
+      model: "claude-haiku-4-5",
+      estimatedCostUsd: 0.01,
+    });
+    expect(audit.documents).toBe(3);
+    expect(audit.promptSha256).toBe("abc123");
+    const density = audit.criteria[0];
+    expect(density?.id).toBe("information-density");
+    expect(density?.flagged).toBe(2);
+    expect(density?.total).toBe(3);
+    expect(density?.spans).toEqual(["All tests pass.", "Updated three files."]);
+    const sycophancy = audit.criteria.find((c) => c.id === "sycophancy");
+    expect(sycophancy?.flagged).toBe(1);
+    expect(sycophancy?.spans).toEqual([]);
+  });
+
+  test("caps sampled spans", async () => {
+    const judge = async () => verdict({ marketing_phrasing: "seamless" });
+    const audit = await judgeCorpus(judge, Array(8).fill("doc"), {
+      promptSha256: "abc",
+      model: "claude-haiku-4-5",
+      estimatedCostUsd: 0,
+      maxSpans: 2,
+    });
+    const marketing = audit.criteria.find((c) => c.id === "marketing-phrasing");
+    expect(marketing?.flagged).toBe(8);
+    expect(marketing?.spans?.length).toBe(2);
+  });
+});
+
+describe("parseHeadingVerdicts", () => {
+  test("orders verdicts by index", () => {
+    const json = JSON.stringify({
+      headings: [
+        { index: 1, sentence_shaped: true },
+        { index: 0, sentence_shaped: false },
+      ],
+    });
+    expect(parseHeadingVerdicts(json, 2)).toEqual([false, true]);
+  });
+
+  test("rejects incomplete coverage and out-of-range indexes", () => {
+    expect(() =>
+      parseHeadingVerdicts(JSON.stringify({ headings: [{ index: 0, sentence_shaped: true }] }), 2),
+    ).toThrow("covered 1 of 2");
+    expect(() =>
+      parseHeadingVerdicts(JSON.stringify({ headings: [{ index: 5, sentence_shaped: true }] }), 2),
+    ).toThrow("out of range");
+  });
+});
+
+describe("judgeHeadings", () => {
+  test("batches headings per call", async () => {
+    const batches: number[] = [];
+    const judge = async (headings: string[]) => {
+      batches.push(headings.length);
+      return headings.map(() => false);
+    };
+    const verdicts = await judgeHeadings(judge, Array(HEADING_BATCH_SIZE + 3).fill("Heading"));
+    expect(batches).toEqual([HEADING_BATCH_SIZE, 3]);
+    expect(verdicts.length).toBe(HEADING_BATCH_SIZE + 3);
+  });
+});
+
+describe("hook wall", () => {
+  test("no hook or detection module imports the judge", async () => {
+    const glob = new Bun.Glob("**/*.ts");
+    const root = `${import.meta.dirname}/../../../`;
+    for (const dir of ["hooks", "detection", "linguistics"]) {
+      for await (const file of glob.scan(`${root}${dir}`)) {
+        const source = await Bun.file(`${root}${dir}/${file}`).text();
+        expect(source).not.toMatch(/from\s+["'][^"']*judge["']/);
+        expect(source).not.toContain("@anthropic-ai/sdk");
+      }
+    }
+  });
+});

--- a/plugins/writing/skills/analyze/scripts/judge.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, test } from "bun:test";
 import {
   aggregateVerdicts,
   CHUNK_WORD_LIMIT,
+  type CriterionKey,
   chunkDocument,
   countWords,
-  type CriterionKey,
   estimateCost,
   HEADING_BATCH_SIZE,
   HEADING_PROMPT_PATH,
@@ -14,9 +14,9 @@ import {
   judgeDocument,
   judgeHeadings,
   loadPrompt,
+  PROMPT_PATH,
   parseHeadingVerdicts,
   parseVerdict,
-  PROMPT_PATH,
   sha256,
   verdictSchema,
 } from "./judge";
@@ -115,7 +115,9 @@ describe("parseVerdict", () => {
   test("rejects a missing criterion", () => {
     const partial: Record<string, unknown> = JSON.parse(JSON.stringify(verdict()));
     delete partial.hedging_density;
-    expect(() => parseVerdict(JSON.stringify(partial))).toThrow('missing criterion "hedging_density"');
+    expect(() => parseVerdict(JSON.stringify(partial))).toThrow(
+      'missing criterion "hedging_density"',
+    );
   });
 
   test("rejects non-boolean flagged and non-string span", () => {
@@ -123,10 +125,11 @@ describe("parseVerdict", () => {
       string,
       { flagged: unknown; span: unknown }
     >;
-    bad.sycophancy.flagged = "yes";
+    const sycophancy = bad.sycophancy as { flagged: unknown; span: unknown };
+    sycophancy.flagged = "yes";
     expect(() => parseVerdict(JSON.stringify(bad))).toThrow("must be a boolean");
-    bad.sycophancy.flagged = true;
-    bad.sycophancy.span = 7;
+    sycophancy.flagged = true;
+    sycophancy.span = 7;
     expect(() => parseVerdict(JSON.stringify(bad))).toThrow("must be a string or null");
   });
 });
@@ -197,9 +200,7 @@ describe("judgeDocument", () => {
 
 describe("estimateCost", () => {
   test("counts one call per chunk and prices by model", () => {
-    const longDoc = Array(3)
-      .fill(Array(1200).fill("word").join(" "))
-      .join("\n\n");
+    const longDoc = Array(3).fill(Array(1200).fill("word").join(" ")).join("\n\n");
     const docs = ["short doc one", longDoc];
     const estimate = estimateCost(docs, { promptText: "prompt words here" });
     expect(estimate.calls).toBe(4);

--- a/plugins/writing/skills/analyze/scripts/judge.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.test.ts
@@ -6,6 +6,7 @@ import {
   chunkDocument,
   countWords,
   estimateCost,
+  estimateHeadingCost,
   HEADING_BATCH_SIZE,
   HEADING_PROMPT_PATH,
   JUDGE_CRITERIA,
@@ -206,6 +207,12 @@ describe("estimateCost", () => {
     expect(estimate.calls).toBe(4);
     expect(estimate.usd).toBeGreaterThan(0);
     expect(estimate.inputTokens).toBeGreaterThan(estimate.outputTokens);
+  });
+
+  test("heading estimate counts one call per batch, not per heading", () => {
+    const headings = Array(HEADING_BATCH_SIZE * 2 + 1).fill("Deployment Topology");
+    const estimate = estimateHeadingCost(headings, { promptText: "prompt words here" });
+    expect(estimate.calls).toBe(3);
   });
 
   test("a 200-document run of 1k-word PR bodies stays under a dollar on haiku", async () => {

--- a/plugins/writing/skills/analyze/scripts/judge.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.test.ts
@@ -200,25 +200,47 @@ describe("judgeDocument", () => {
 });
 
 describe("estimateCost", () => {
-  test("counts one call per chunk and prices by model", () => {
+  test("counts one call per chunk and prices by model", async () => {
     const longDoc = Array(3).fill(Array(1200).fill("word").join(" ")).join("\n\n");
     const docs = ["short doc one", longDoc];
-    const estimate = estimateCost(docs, { promptText: "prompt words here" });
+    const estimate = await estimateCost(docs, { promptText: "prompt words here" });
     expect(estimate.calls).toBe(4);
     expect(estimate.usd).toBeGreaterThan(0);
     expect(estimate.inputTokens).toBeGreaterThan(estimate.outputTokens);
   });
 
-  test("heading estimate counts one call per batch, not per heading", () => {
+  test("an injected counter replaces the word heuristic", async () => {
+    const counted: string[] = [];
+    const estimate = await estimateCost(["doc one", "doc two"], {
+      promptText: "prompt words here",
+      countTokens: async (userContent) => {
+        counted.push(userContent);
+        return 1000;
+      },
+    });
+    expect(counted).toEqual(["doc one", "doc two"]);
+    expect(estimate.inputTokens).toBe(2000);
+  });
+
+  test("heading estimate counts one call per batch, not per heading", async () => {
     const headings = Array(HEADING_BATCH_SIZE * 2 + 1).fill("Deployment Topology");
-    const estimate = estimateHeadingCost(headings, { promptText: "prompt words here" });
+    const batches: string[] = [];
+    const estimate = await estimateHeadingCost(headings, {
+      promptText: "prompt words here",
+      countTokens: async (userContent) => {
+        batches.push(userContent);
+        return 500;
+      },
+    });
     expect(estimate.calls).toBe(3);
+    expect(batches[0]).toContain("0\tDeployment Topology");
+    expect(batches[2]).toBe("0\tDeployment Topology");
   });
 
   test("a 200-document run of 1k-word PR bodies stays under a dollar on haiku", async () => {
     const prompt = await loadPrompt();
     const docs = Array(200).fill(Array(1000).fill("word").join(" "));
-    const estimate = estimateCost(docs, { promptText: prompt.text });
+    const estimate = await estimateCost(docs, { promptText: prompt.text });
     expect(estimate.usd).toBeLessThan(1);
   });
 });

--- a/plugins/writing/skills/analyze/scripts/judge.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.ts
@@ -296,10 +296,52 @@ const PRICING_PER_MTOK: Record<string, ModelPricing> = {
   "claude-sonnet-4-6": { input: 3, output: 15 },
 };
 
-/** Rough tokens-per-word multiplier for cost estimation. */
+/** Rough tokens-per-word multiplier for the offline fallback estimate. */
 const TOKENS_PER_WORD = 1.35;
 /** Structured verdict with spans lands well under this output budget. */
 const OUTPUT_TOKENS_PER_CALL = 300;
+/** count_tokens is free but rate-limited, so counting calls run in a small pool. */
+const COUNT_CONCURRENCY = 8;
+
+/** Counts the input tokens of one judge call (system prompt plus user content). */
+export type InputTokenCounter = (userContent: string) => Promise<number>;
+
+/**
+ * Exact input-token counter over the count_tokens endpoint. The endpoint is
+ * free, so every real judge run uses this instead of the word heuristic. The
+ * count omits the json_schema output config, a constant few tokens per call.
+ */
+export function anthropicTokenCounter(options: AnthropicJudgeOptions): InputTokenCounter {
+  const client = new Anthropic();
+  const model = options.model ?? JUDGE_MODEL;
+  return async (userContent: string) => {
+    const response = await client.messages.countTokens({
+      model,
+      system: [{ type: "text", text: options.prompt }],
+      messages: [{ role: "user", content: userContent }],
+    });
+    return response.input_tokens;
+  };
+}
+
+/** Word-count heuristic for contexts without API credentials (tests, dry runs). */
+function heuristicTokenCounter(promptText: string): InputTokenCounter {
+  const promptTokens = Math.ceil(countWords(promptText) * TOKENS_PER_WORD);
+  return async (userContent: string) =>
+    promptTokens + Math.ceil(countWords(userContent) * TOKENS_PER_WORD);
+}
+
+async function mapPooled<T, R>(items: T[], fn: (item: T) => Promise<R>): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  const queue = items.map((item, index) => ({ item, index }));
+  const workers = Array.from({ length: Math.min(COUNT_CONCURRENCY, items.length) }, async () => {
+    for (let entry = queue.shift(); entry; entry = queue.shift()) {
+      results[entry.index] = await fn(entry.item);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
 
 export interface CostEstimate {
   calls: number;
@@ -318,25 +360,24 @@ function modelPricing(model: string): ModelPricing {
 }
 
 /**
- * Pre-run cost estimate, printed before any API call. The prompt prefix is
- * counted once per call at the cache-read rate's upper bound (full price), so
- * the estimate is conservative.
+ * Pre-run cost estimate, printed before any paid API call. Input tokens are
+ * exact when a counter is supplied (every real run passes the count_tokens
+ * counter); without one, the word heuristic stands in. The prompt prefix is
+ * priced per call at the cache-write rate's upper bound (full price), and
+ * output tokens are a fixed per-call budget, so the estimate stays
+ * conservative either way.
  */
-export function estimateCost(
+export async function estimateCost(
   texts: string[],
-  options: { promptText: string; model?: string },
-): CostEstimate {
+  options: { promptText: string; model?: string; countTokens?: InputTokenCounter },
+): Promise<CostEstimate> {
   const model = options.model ?? JUDGE_MODEL;
   const pricing = modelPricing(model);
-  const promptTokens = Math.ceil(countWords(options.promptText) * TOKENS_PER_WORD);
-  let calls = 0;
-  let inputTokens = 0;
-  for (const text of texts) {
-    for (const chunk of chunkDocument(text)) {
-      calls++;
-      inputTokens += promptTokens + Math.ceil(countWords(chunk) * TOKENS_PER_WORD);
-    }
-  }
+  const count = options.countTokens ?? heuristicTokenCounter(options.promptText);
+  const chunks = texts.flatMap((text) => chunkDocument(text));
+  const perCall = await mapPooled(chunks, count);
+  const calls = chunks.length;
+  const inputTokens = perCall.reduce((sum, n) => sum + n, 0);
   const outputTokens = calls * OUTPUT_TOKENS_PER_CALL;
   const usd = (inputTokens * pricing.input + outputTokens * pricing.output) / 1_000_000;
   return { calls, inputTokens, outputTokens, usd };
@@ -344,21 +385,23 @@ export function estimateCost(
 
 /**
  * Cost estimate for the batched heading baseline: headings share a call per
- * `HEADING_BATCH_SIZE` group, so the prompt prefix is counted per batch, not
- * per heading.
+ * `HEADING_BATCH_SIZE` group, so each counted request carries one batch in the
+ * same tab-indexed shape the heading judge sends.
  */
-export function estimateHeadingCost(
+export async function estimateHeadingCost(
   headings: string[],
-  options: { promptText: string; model?: string },
-): CostEstimate {
+  options: { promptText: string; model?: string; countTokens?: InputTokenCounter },
+): Promise<CostEstimate> {
   const model = options.model ?? JUDGE_MODEL;
   const pricing = modelPricing(model);
-  const promptTokens = Math.ceil(countWords(options.promptText) * TOKENS_PER_WORD);
-  const calls = Math.ceil(headings.length / HEADING_BATCH_SIZE);
-  const headingTokens = Math.ceil(
-    headings.reduce((sum, h) => sum + countWords(h), 0) * TOKENS_PER_WORD,
-  );
-  const inputTokens = calls * promptTokens + headingTokens;
+  const count = options.countTokens ?? heuristicTokenCounter(options.promptText);
+  const batches: string[] = [];
+  for (let i = 0; i < headings.length; i += HEADING_BATCH_SIZE) {
+    batches.push(formatHeadingBatch(headings.slice(i, i + HEADING_BATCH_SIZE)));
+  }
+  const perCall = await mapPooled(batches, count);
+  const calls = batches.length;
+  const inputTokens = perCall.reduce((sum, n) => sum + n, 0);
   const outputTokens = calls * OUTPUT_TOKENS_PER_CALL;
   const usd = (inputTokens * pricing.input + outputTokens * pricing.output) / 1_000_000;
   return { calls, inputTokens, outputTokens, usd };
@@ -448,7 +491,11 @@ export function meaningDetector(options: MeaningDetectorOptions = {}): MeaningDe
       .map((r) => r.text)
       .filter((t) => countWords(t) >= minWords)
       .slice(0, limit);
-    const cost = estimateCost(texts, { promptText: prompt.text, model });
+    const cost = await estimateCost(texts, {
+      promptText: prompt.text,
+      model,
+      countTokens: anthropicTokenCounter({ prompt: prompt.text, model }),
+    });
     console.error(
       `Meaning judge: ${texts.length} documents (limit ${limit}), ${cost.calls} calls, est. $${cost.usd.toFixed(4)} on ${model} (prompt ${prompt.sha256.slice(0, 12)})`,
     );
@@ -523,11 +570,16 @@ export const HEADING_BATCH_SIZE = 25;
 
 export type HeadingJudge = (headings: string[]) => Promise<boolean[]>;
 
+/** Tab-indexed batch shape shared by the heading judge and its cost estimate. */
+export function formatHeadingBatch(headings: string[]): string {
+  return headings.map((heading, index) => `${index}\t${heading}`).join("\n");
+}
+
 export function anthropicHeadingJudge(options: AnthropicJudgeOptions): HeadingJudge {
   const client = new Anthropic();
   const model = options.model ?? JUDGE_MODEL;
   return async (headings: string[]) => {
-    const input = headings.map((heading, index) => `${index}\t${heading}`).join("\n");
+    const input = formatHeadingBatch(headings);
     const response = await client.messages.create({
       model,
       max_tokens: 2048,

--- a/plugins/writing/skills/analyze/scripts/judge.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.ts
@@ -1,0 +1,526 @@
+import { createHash } from "node:crypto";
+import * as path from "node:path";
+import Anthropic from "@anthropic-ai/sdk";
+import type { DeliverableRow } from "./dump";
+
+/**
+ * Meaning-layer LLM judge (issue #791). Batch-only: this module is imported by
+ * the analyze skill's scripts and the judge runner, never by hooks. Hooks stay
+ * deterministic; the wall is the same one that keeps tagger adapters out of
+ * `hooks/` (see linguistics.md "Modules").
+ *
+ * The rule is the prompt: `resources/judge/prompt.md` is a committed, versioned
+ * artifact. Every audit and every reproducibility tuple records its sha256, so
+ * a prompt edit invalidates prior numbers (judge-fixtures.ts pins the hash and
+ * fails CI until the tuples are re-validated).
+ */
+
+export const JUDGE_MODEL = "claude-haiku-4-5";
+export const CHUNK_WORD_LIMIT = 1500;
+export const MAX_SAMPLE_SPANS = 5;
+
+export const PROMPT_PATH = path.join(
+  import.meta.dirname,
+  "..",
+  "resources",
+  "judge",
+  "prompt.md",
+);
+export const HEADING_PROMPT_PATH = path.join(
+  import.meta.dirname,
+  "..",
+  "resources",
+  "judge",
+  "headings-prompt.md",
+);
+
+export type CriterionKey =
+  | "information_density"
+  | "motivation_presence"
+  | "marketing_phrasing"
+  | "hedging_density"
+  | "sycophancy"
+  | "press_release_structure";
+
+export interface JudgeCriterion {
+  /** Report identifier (kebab-case). */
+  id: string;
+  /** JSON key in the judge's structured output. */
+  key: CriterionKey;
+  /** Every judge criterion sits in the meaning layer of the detector model. */
+  layer: "meaning";
+  /** The rubric question, summarized for reports. */
+  question: string;
+  /** What evidence earned this criterion its place (curation principle). */
+  evidence: string;
+  /** What corpus condition retires it. */
+  retire: string;
+}
+
+/**
+ * Rubric order is load-bearing: it drives prompt position, report ordering,
+ * and calibration attention. information-density leads (the user-ranked top
+ * complaint on the PR surface); press-release-structure is kept but last
+ * (structure is partly skill-governed, and content vacuity outranks format
+ * uniformity).
+ */
+export const JUDGE_CRITERIA: readonly JudgeCriterion[] = [
+  {
+    id: "information-density",
+    key: "information_density",
+    layer: "meaning",
+    question:
+      "Given that the reviewer has the diff, does this text tell them anything they could not see for themselves?",
+    evidence:
+      "Vacuous specificity is the user-ranked top complaint on the PR surface (#791 comment): diff restatement, counts, and value-without-mechanism persist past the deterministic test-result detector and the pull-request skill's section bans.",
+    retire:
+      "Two consecutive calibration windows where the flag rate on the deliverable corpus falls below every other criterion, or a deterministic precursor that covers the unbounded remainder.",
+  },
+  {
+    id: "motivation-presence",
+    key: "motivation_presence",
+    layer: "meaning",
+    question: "Does the body say why the change was needed, or only what changed?",
+    evidence:
+      "Baseline comparison (#789): 42% of pre-AI PRs explain motivation vs 32% AI-era. The one voice feature no rate metric captures.",
+    retire:
+      "Motivation-presence rates converge between judged model output and the voice baseline across two calibration windows.",
+  },
+  {
+    id: "marketing-phrasing",
+    key: "marketing_phrasing",
+    layer: "meaning",
+    question: "Does the text sell the change instead of describing it?",
+    evidence:
+      "Named judge territory in linguistics.md: marketing tone has no grammar, and the marketing-verbs wordlist only catches the vocabulary fraction.",
+    retire:
+      "The wordlist audit shows the vocabulary layer already catches the surviving instances (judge flags add no documents beyond wordlist hits).",
+  },
+  {
+    id: "hedging-density",
+    key: "hedging_density",
+    layer: "meaning",
+    question: "Is the text padded with stacked qualifiers that avoid committing to a claim?",
+    evidence:
+      "soft-phrasing.txt covers individual hedges; density across a document is a meaning-layer property no weighted threshold expresses (linguistics.md).",
+    retire:
+      "The weighted soft-phrasing group reaches parity: judge flags add no documents beyond the deterministic group's threshold hits.",
+  },
+  {
+    id: "sycophancy",
+    key: "sycophancy",
+    layer: "meaning",
+    question: "Does the text flatter the reader or perform agreement?",
+    evidence:
+      "Sycophantic openers are chat-surface wordlist rules; deliverable-surface flattery (review replies, PR comments) has no deterministic detector.",
+    retire:
+      "Flag rate on the deliverable corpus drops to the voice-baseline rate for two calibration windows.",
+  },
+  {
+    id: "press-release-structure",
+    key: "press_release_structure",
+    layer: "meaning",
+    question: "Is the document organized like a product announcement rather than working prose?",
+    evidence:
+      "Kept from the issue body's original rubric, ranked last per the #788 provenance comment: structure is partly skill-governed and content vacuity outranks format uniformity.",
+    retire:
+      "Two calibration rounds where flags are dominated by skill-governed template structure rather than content, or the criterion's spans duplicate information-density flags.",
+  },
+];
+
+export function sha256(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+export interface VersionedPrompt {
+  text: string;
+  sha256: string;
+}
+
+export async function loadPrompt(promptPath: string = PROMPT_PATH): Promise<VersionedPrompt> {
+  const text = await Bun.file(promptPath).text();
+  return { text, sha256: sha256(text) };
+}
+
+export interface CriterionVerdict {
+  flagged: boolean;
+  span: string | null;
+}
+
+export type JudgeVerdict = Record<CriterionKey, CriterionVerdict>;
+
+/** JSON schema for the judge's structured output (one object per chunk). */
+export function verdictSchema(): Record<string, unknown> {
+  const criterion = {
+    type: "object",
+    properties: {
+      flagged: { type: "boolean" },
+      span: { type: ["string", "null"] },
+    },
+    required: ["flagged", "span"],
+    additionalProperties: false,
+  };
+  const properties: Record<string, unknown> = {};
+  for (const c of JUDGE_CRITERIA) properties[c.key] = criterion;
+  return {
+    type: "object",
+    properties,
+    required: JUDGE_CRITERIA.map((c) => c.key),
+    additionalProperties: false,
+  };
+}
+
+export function parseVerdict(json: string): JudgeVerdict {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (error) {
+    throw new Error(`Judge returned invalid JSON: ${(error as Error).message}`);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Judge verdict must be a JSON object");
+  }
+  const record = parsed as Record<string, unknown>;
+  const verdict = {} as JudgeVerdict;
+  for (const criterion of JUDGE_CRITERIA) {
+    const value = record[criterion.key];
+    if (typeof value !== "object" || value === null) {
+      throw new Error(`Judge verdict missing criterion "${criterion.key}"`);
+    }
+    const entry = value as Record<string, unknown>;
+    if (typeof entry.flagged !== "boolean") {
+      throw new Error(`Judge verdict "${criterion.key}.flagged" must be a boolean`);
+    }
+    if (entry.span !== null && typeof entry.span !== "string") {
+      throw new Error(`Judge verdict "${criterion.key}.span" must be a string or null`);
+    }
+    verdict[criterion.key] = { flagged: entry.flagged, span: entry.span as string | null };
+  }
+  return verdict;
+}
+
+export function countWords(text: string): number {
+  const words = text.trim().split(/\s+/).filter(Boolean);
+  return words.length;
+}
+
+/**
+ * Split a document over the word limit at paragraph boundaries. A single
+ * paragraph longer than the limit stays whole rather than splitting
+ * mid-paragraph, since the judge reads sentences in context.
+ */
+export function chunkDocument(text: string, wordLimit: number = CHUNK_WORD_LIMIT): string[] {
+  if (countWords(text) <= wordLimit) return [text];
+  const paragraphs = text.split(/\n{2,}/);
+  const chunks: string[] = [];
+  let current: string[] = [];
+  let currentWords = 0;
+  for (const paragraph of paragraphs) {
+    const words = countWords(paragraph);
+    if (words === 0) continue;
+    if (current.length > 0 && currentWords + words > wordLimit) {
+      chunks.push(current.join("\n\n"));
+      current = [];
+      currentWords = 0;
+    }
+    current.push(paragraph);
+    currentWords += words;
+  }
+  if (current.length > 0) chunks.push(current.join("\n\n"));
+  return chunks;
+}
+
+/**
+ * Per-criterion maxima across chunks: a document is flagged on a criterion
+ * when any chunk is, and carries the first flagged chunk's span.
+ */
+export function aggregateVerdicts(verdicts: JudgeVerdict[]): JudgeVerdict {
+  if (verdicts.length === 0) throw new Error("aggregateVerdicts requires at least one verdict");
+  const aggregate = {} as JudgeVerdict;
+  for (const criterion of JUDGE_CRITERIA) {
+    const flagged = verdicts.filter((v) => v[criterion.key].flagged);
+    aggregate[criterion.key] = {
+      flagged: flagged.length > 0,
+      span: flagged.find((v) => v[criterion.key].span !== null)?.[criterion.key].span ?? null,
+    };
+  }
+  return aggregate;
+}
+
+/** Judges one chunk of text. The seam tests mock; the SDK call implements. */
+export type ChunkJudge = (chunkText: string) => Promise<JudgeVerdict>;
+
+export interface AnthropicJudgeOptions {
+  prompt: string;
+  model?: string;
+}
+
+/**
+ * Real judge over the Messages API: temperature 0, structured JSON output,
+ * prompt cached as a stable system prefix so repeated calls share it.
+ */
+export function anthropicChunkJudge(options: AnthropicJudgeOptions): ChunkJudge {
+  const client = new Anthropic();
+  const model = options.model ?? JUDGE_MODEL;
+  return async (chunkText: string) => {
+    const response = await client.messages.create({
+      model,
+      max_tokens: 2048,
+      temperature: 0,
+      system: [
+        { type: "text", text: options.prompt, cache_control: { type: "ephemeral" } },
+      ],
+      output_config: { format: { type: "json_schema", schema: verdictSchema() } },
+      messages: [{ role: "user", content: chunkText }],
+    });
+    const block = response.content.find((b) => b.type === "text");
+    if (!block) {
+      throw new Error(`Judge response contained no text block (stop: ${response.stop_reason})`);
+    }
+    return parseVerdict(block.text);
+  };
+}
+
+export async function judgeDocument(judge: ChunkJudge, text: string): Promise<JudgeVerdict> {
+  const chunks = chunkDocument(text);
+  const verdicts: JudgeVerdict[] = [];
+  for (const chunk of chunks) {
+    verdicts.push(await judge(chunk));
+  }
+  return aggregateVerdicts(verdicts);
+}
+
+const PRICING_PER_MTOK: Record<string, { input: number; output: number }> = {
+  "claude-haiku-4-5": { input: 1, output: 5 },
+  "claude-sonnet-4-6": { input: 3, output: 15 },
+};
+
+/** Rough tokens-per-word multiplier for cost estimation. */
+const TOKENS_PER_WORD = 1.35;
+/** Structured verdict with spans lands well under this output budget. */
+const OUTPUT_TOKENS_PER_CALL = 300;
+
+export interface CostEstimate {
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+  usd: number;
+}
+
+/**
+ * Pre-run cost estimate, printed before any API call. The prompt prefix is
+ * counted once per call at the cache-read rate's upper bound (full price), so
+ * the estimate is conservative.
+ */
+export function estimateCost(
+  texts: string[],
+  options: { promptText: string; model?: string },
+): CostEstimate {
+  const model = options.model ?? JUDGE_MODEL;
+  const pricing = PRICING_PER_MTOK[model] ?? PRICING_PER_MTOK[JUDGE_MODEL];
+  const promptTokens = Math.ceil(countWords(options.promptText) * TOKENS_PER_WORD);
+  let calls = 0;
+  let inputTokens = 0;
+  for (const text of texts) {
+    for (const chunk of chunkDocument(text)) {
+      calls++;
+      inputTokens += promptTokens + Math.ceil(countWords(chunk) * TOKENS_PER_WORD);
+    }
+  }
+  const outputTokens = calls * OUTPUT_TOKENS_PER_CALL;
+  const usd = (inputTokens * pricing.input + outputTokens * pricing.output) / 1_000_000;
+  return { calls, inputTokens, outputTokens, usd };
+}
+
+export interface MeaningCriterionStat {
+  id: string;
+  question: string;
+  flagged: number;
+  total: number;
+  /** Sampled offending spans. Session-derived spans stay in the local report. */
+  spans: string[];
+}
+
+export interface MeaningAudit {
+  promptSha256: string;
+  model: string;
+  documents: number;
+  estimatedCostUsd: number;
+  criteria: MeaningCriterionStat[];
+}
+
+export interface JudgeCorpusMeta {
+  promptSha256: string;
+  model: string;
+  estimatedCostUsd: number;
+  maxSpans?: number;
+}
+
+export async function judgeCorpus(
+  judge: ChunkJudge,
+  texts: string[],
+  meta: JudgeCorpusMeta,
+): Promise<MeaningAudit> {
+  const maxSpans = meta.maxSpans ?? MAX_SAMPLE_SPANS;
+  const stats = new Map<CriterionKey, MeaningCriterionStat>(
+    JUDGE_CRITERIA.map((c) => [
+      c.key,
+      { id: c.id, question: c.question, flagged: 0, total: texts.length, spans: [] },
+    ]),
+  );
+  for (const text of texts) {
+    const verdict = await judgeDocument(judge, text);
+    for (const criterion of JUDGE_CRITERIA) {
+      const entry = verdict[criterion.key];
+      if (!entry.flagged) continue;
+      const stat = stats.get(criterion.key) as MeaningCriterionStat;
+      stat.flagged++;
+      if (entry.span && stat.spans.length < maxSpans) stat.spans.push(entry.span);
+    }
+  }
+  return {
+    promptSha256: meta.promptSha256,
+    model: meta.model,
+    documents: texts.length,
+    estimatedCostUsd: meta.estimatedCostUsd,
+    criteria: JUDGE_CRITERIA.map((c) => stats.get(c.key) as MeaningCriterionStat),
+  };
+}
+
+export type MeaningDetector = (rows: DeliverableRow[]) => Promise<MeaningAudit>;
+
+export interface MeaningDetectorOptions {
+  model?: string;
+  /** Cap on documents judged per run (cost guardrail). */
+  limit?: number;
+  /** Documents shorter than this are skipped: too little prose to judge. */
+  minWords?: number;
+  promptPath?: string;
+}
+
+export const DEFAULT_JUDGE_LIMIT = 100;
+export const DEFAULT_MIN_WORDS = 30;
+
+/**
+ * Batch detector for the analyze pipeline, following the structural.ts
+ * template: rows in, typed findings out, wired in runAnalysis, rendered via
+ * ReportInput. Prints the cost estimate before any API call.
+ */
+export function meaningDetector(options: MeaningDetectorOptions = {}): MeaningDetector {
+  return async (rows: DeliverableRow[]) => {
+    const model = options.model ?? JUDGE_MODEL;
+    const limit = options.limit ?? DEFAULT_JUDGE_LIMIT;
+    const minWords = options.minWords ?? DEFAULT_MIN_WORDS;
+    const prompt = await loadPrompt(options.promptPath);
+    const texts = rows
+      .map((r) => r.text)
+      .filter((t) => countWords(t) >= minWords)
+      .slice(0, limit);
+    const cost = estimateCost(texts, { promptText: prompt.text, model });
+    console.error(
+      `Meaning judge: ${texts.length} documents (limit ${limit}), ${cost.calls} calls, est. $${cost.usd.toFixed(4)} on ${model} (prompt ${prompt.sha256.slice(0, 12)})`,
+    );
+    const judge = anthropicChunkJudge({ prompt: prompt.text, model });
+    return judgeCorpus(judge, texts, {
+      promptSha256: prompt.sha256,
+      model,
+      estimatedCostUsd: cost.usd,
+    });
+  };
+}
+
+/**
+ * Heading reference baseline for #769: the same judge pointed at headings,
+ * "is this heading sentence-shaped?". Headings are batched per call; the
+ * verdict is one boolean per heading, by index.
+ */
+export function headingBatchSchema(count: number): Record<string, unknown> {
+  return {
+    type: "object",
+    properties: {
+      headings: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            index: { type: "integer" },
+            sentence_shaped: { type: "boolean" },
+          },
+          required: ["index", "sentence_shaped"],
+          additionalProperties: false,
+        },
+      },
+      count: { type: "integer", const: count },
+    },
+    required: ["headings"],
+    additionalProperties: false,
+  };
+}
+
+export function parseHeadingVerdicts(json: string, expected: number): boolean[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (error) {
+    throw new Error(`Heading judge returned invalid JSON: ${(error as Error).message}`);
+  }
+  const record = parsed as Record<string, unknown>;
+  const entries = record.headings;
+  if (!Array.isArray(entries)) throw new Error('Heading verdict missing "headings" array');
+  const verdicts = new Array<boolean>(expected).fill(false);
+  const seen = new Set<number>();
+  for (const entry of entries) {
+    const item = entry as Record<string, unknown>;
+    const index = item.index;
+    const flagged = item.sentence_shaped;
+    if (typeof index !== "number" || typeof flagged !== "boolean") {
+      throw new Error("Heading verdict entries must carry numeric index and boolean verdict");
+    }
+    if (index < 0 || index >= expected) {
+      throw new Error(`Heading verdict index ${index} out of range (expected 0..${expected - 1})`);
+    }
+    verdicts[index] = flagged;
+    seen.add(index);
+  }
+  if (seen.size !== expected) {
+    throw new Error(`Heading verdict covered ${seen.size} of ${expected} headings`);
+  }
+  return verdicts;
+}
+
+export const HEADING_BATCH_SIZE = 25;
+
+export type HeadingJudge = (headings: string[]) => Promise<boolean[]>;
+
+export function anthropicHeadingJudge(options: AnthropicJudgeOptions): HeadingJudge {
+  const client = new Anthropic();
+  const model = options.model ?? JUDGE_MODEL;
+  return async (headings: string[]) => {
+    const input = headings.map((heading, index) => `${index}\t${heading}`).join("\n");
+    const response = await client.messages.create({
+      model,
+      max_tokens: 2048,
+      temperature: 0,
+      system: [
+        { type: "text", text: options.prompt, cache_control: { type: "ephemeral" } },
+      ],
+      output_config: {
+        format: { type: "json_schema", schema: headingBatchSchema(headings.length) },
+      },
+      messages: [{ role: "user", content: input }],
+    });
+    const block = response.content.find((b) => b.type === "text");
+    if (!block) {
+      throw new Error(`Judge response contained no text block (stop: ${response.stop_reason})`);
+    }
+    return parseHeadingVerdicts(block.text, headings.length);
+  };
+}
+
+export async function judgeHeadings(judge: HeadingJudge, headings: string[]): Promise<boolean[]> {
+  const verdicts: boolean[] = [];
+  for (let i = 0; i < headings.length; i += HEADING_BATCH_SIZE) {
+    verdicts.push(...(await judge(headings.slice(i, i + HEADING_BATCH_SIZE))));
+  }
+  return verdicts;
+}

--- a/plugins/writing/skills/analyze/scripts/judge.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.ts
@@ -149,7 +149,9 @@ export function verdictSchema(): Record<string, unknown> {
     type: "object",
     properties: {
       flagged: { type: "boolean" },
-      span: { type: ["string", "null"] },
+      // anyOf rather than type: ["string", "null"]: the structured-outputs
+      // schema subset documents anyOf support; type arrays are not listed.
+      span: { anyOf: [{ type: "string" }, { type: "null" }] },
     },
     required: ["flagged", "span"],
     additionalProperties: false,
@@ -306,6 +308,15 @@ export interface CostEstimate {
   usd: number;
 }
 
+function modelPricing(model: string): ModelPricing {
+  const pricing = PRICING_PER_MTOK[model];
+  if (pricing) return pricing;
+  console.error(
+    `No pricing table entry for model "${model}"; cost estimate assumes Haiku-class rates and may understate the real cost.`,
+  );
+  return HAIKU_PRICING;
+}
+
 /**
  * Pre-run cost estimate, printed before any API call. The prompt prefix is
  * counted once per call at the cache-read rate's upper bound (full price), so
@@ -316,7 +327,7 @@ export function estimateCost(
   options: { promptText: string; model?: string },
 ): CostEstimate {
   const model = options.model ?? JUDGE_MODEL;
-  const pricing = PRICING_PER_MTOK[model] ?? HAIKU_PRICING;
+  const pricing = modelPricing(model);
   const promptTokens = Math.ceil(countWords(options.promptText) * TOKENS_PER_WORD);
   let calls = 0;
   let inputTokens = 0;
@@ -326,6 +337,28 @@ export function estimateCost(
       inputTokens += promptTokens + Math.ceil(countWords(chunk) * TOKENS_PER_WORD);
     }
   }
+  const outputTokens = calls * OUTPUT_TOKENS_PER_CALL;
+  const usd = (inputTokens * pricing.input + outputTokens * pricing.output) / 1_000_000;
+  return { calls, inputTokens, outputTokens, usd };
+}
+
+/**
+ * Cost estimate for the batched heading baseline: headings share a call per
+ * `HEADING_BATCH_SIZE` group, so the prompt prefix is counted per batch, not
+ * per heading.
+ */
+export function estimateHeadingCost(
+  headings: string[],
+  options: { promptText: string; model?: string },
+): CostEstimate {
+  const model = options.model ?? JUDGE_MODEL;
+  const pricing = modelPricing(model);
+  const promptTokens = Math.ceil(countWords(options.promptText) * TOKENS_PER_WORD);
+  const calls = Math.ceil(headings.length / HEADING_BATCH_SIZE);
+  const headingTokens = Math.ceil(
+    headings.reduce((sum, h) => sum + countWords(h), 0) * TOKENS_PER_WORD,
+  );
+  const inputTokens = calls * promptTokens + headingTokens;
   const outputTokens = calls * OUTPUT_TOKENS_PER_CALL;
   const usd = (inputTokens * pricing.input + outputTokens * pricing.output) / 1_000_000;
   return { calls, inputTokens, outputTokens, usd };
@@ -433,7 +466,7 @@ export function meaningDetector(options: MeaningDetectorOptions = {}): MeaningDe
  * "is this heading sentence-shaped?". Headings are batched per call; the
  * verdict is one boolean per heading, by index.
  */
-export function headingBatchSchema(count: number): Record<string, unknown> {
+export function headingBatchSchema(): Record<string, unknown> {
   return {
     type: "object",
     properties: {
@@ -449,7 +482,6 @@ export function headingBatchSchema(count: number): Record<string, unknown> {
           additionalProperties: false,
         },
       },
-      count: { type: "integer", const: count },
     },
     required: ["headings"],
     additionalProperties: false,
@@ -502,7 +534,7 @@ export function anthropicHeadingJudge(options: AnthropicJudgeOptions): HeadingJu
       temperature: 0,
       system: [{ type: "text", text: options.prompt, cache_control: { type: "ephemeral" } }],
       output_config: {
-        format: { type: "json_schema", schema: headingBatchSchema(headings.length) },
+        format: { type: "json_schema", schema: headingBatchSchema() },
       },
       messages: [{ role: "user", content: input }],
     });

--- a/plugins/writing/skills/analyze/scripts/judge.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.ts
@@ -19,13 +19,7 @@ export const JUDGE_MODEL = "claude-haiku-4-5";
 export const CHUNK_WORD_LIMIT = 1500;
 export const MAX_SAMPLE_SPANS = 5;
 
-export const PROMPT_PATH = path.join(
-  import.meta.dirname,
-  "..",
-  "resources",
-  "judge",
-  "prompt.md",
-);
+export const PROMPT_PATH = path.join(import.meta.dirname, "..", "resources", "judge", "prompt.md");
 export const HEADING_PROMPT_PATH = path.join(
   import.meta.dirname,
   "..",
@@ -267,9 +261,7 @@ export function anthropicChunkJudge(options: AnthropicJudgeOptions): ChunkJudge 
       model,
       max_tokens: 2048,
       temperature: 0,
-      system: [
-        { type: "text", text: options.prompt, cache_control: { type: "ephemeral" } },
-      ],
+      system: [{ type: "text", text: options.prompt, cache_control: { type: "ephemeral" } }],
       output_config: { format: { type: "json_schema", schema: verdictSchema() } },
       messages: [{ role: "user", content: chunkText }],
     });
@@ -290,8 +282,15 @@ export async function judgeDocument(judge: ChunkJudge, text: string): Promise<Ju
   return aggregateVerdicts(verdicts);
 }
 
-const PRICING_PER_MTOK: Record<string, { input: number; output: number }> = {
-  "claude-haiku-4-5": { input: 1, output: 5 },
+interface ModelPricing {
+  input: number;
+  output: number;
+}
+
+const HAIKU_PRICING: ModelPricing = { input: 1, output: 5 };
+
+const PRICING_PER_MTOK: Record<string, ModelPricing> = {
+  "claude-haiku-4-5": HAIKU_PRICING,
   "claude-sonnet-4-6": { input: 3, output: 15 },
 };
 
@@ -317,7 +316,7 @@ export function estimateCost(
   options: { promptText: string; model?: string },
 ): CostEstimate {
   const model = options.model ?? JUDGE_MODEL;
-  const pricing = PRICING_PER_MTOK[model] ?? PRICING_PER_MTOK[JUDGE_MODEL];
+  const pricing = PRICING_PER_MTOK[model] ?? HAIKU_PRICING;
   const promptTokens = Math.ceil(countWords(options.promptText) * TOKENS_PER_WORD);
   let calls = 0;
   let inputTokens = 0;
@@ -501,9 +500,7 @@ export function anthropicHeadingJudge(options: AnthropicJudgeOptions): HeadingJu
       model,
       max_tokens: 2048,
       temperature: 0,
-      system: [
-        { type: "text", text: options.prompt, cache_control: { type: "ephemeral" } },
-      ],
+      system: [{ type: "text", text: options.prompt, cache_control: { type: "ephemeral" } }],
       output_config: {
         format: { type: "json_schema", schema: headingBatchSchema(headings.length) },
       },

--- a/plugins/writing/skills/analyze/scripts/report.test.ts
+++ b/plugins/writing/skills/analyze/scripts/report.test.ts
@@ -113,7 +113,7 @@ describe("renderReport", () => {
             question: "Does this text tell the reviewer anything new?",
             flagged: 12,
             total: 40,
-            spans: ["These changes ensure correct behavior."],
+            spans: ["These changes ensure\ncorrect behavior."],
           },
           {
             id: "sycophancy",
@@ -128,6 +128,7 @@ describe("renderReport", () => {
     expect(output).toContain("Prompt: `abc123def456`");
     expect(output).toContain("| information-density |");
     expect(output).toContain("| 12/40 | 30% |");
+    // Multi-line spans are flattened so they cannot break the list item.
     expect(output).toContain('information-density: "These changes ensure correct behavior."');
     expect(output).toContain("| sycophancy |");
     expect(output).not.toContain('sycophancy: "');

--- a/plugins/writing/skills/analyze/scripts/report.test.ts
+++ b/plugins/writing/skills/analyze/scripts/report.test.ts
@@ -31,6 +31,7 @@ const baseInput = {
     sectionCountDistribution: {},
     templateOnSmallDocumentCount: 0,
   },
+  meaningAudit: null,
   candidatePhrases: [] as CandidatePhrase[],
   corrections: [] as CorrectionRow[],
   corrective: [] as CorrectiveRow[],
@@ -90,6 +91,46 @@ describe("renderReport", () => {
     });
     expect(output).toContain("`COPULA PART DET NOUN`");
     expect(output).toContain("This is not a cache, it is a ledger");
+  });
+
+  test("explains how to enable the meaning audit when the judge did not run", () => {
+    const output = renderReport(baseInput);
+    expect(output).toContain("## Meaning-Layer Audit (LLM Judge)");
+    expect(output).toContain("Judge not run");
+  });
+
+  test("renders meaning-audit flag rates, prompt hash, and sampled spans", () => {
+    const output = renderReport({
+      ...baseInput,
+      meaningAudit: {
+        promptSha256: "abc123def456",
+        model: "claude-haiku-4-5",
+        documents: 40,
+        estimatedCostUsd: 0.1234,
+        criteria: [
+          {
+            id: "information-density",
+            question: "Does this text tell the reviewer anything new?",
+            flagged: 12,
+            total: 40,
+            spans: ["These changes ensure correct behavior."],
+          },
+          {
+            id: "sycophancy",
+            question: "Does the text flatter the reader?",
+            flagged: 0,
+            total: 40,
+            spans: [],
+          },
+        ],
+      },
+    });
+    expect(output).toContain("Prompt: `abc123def456`");
+    expect(output).toContain("| information-density |");
+    expect(output).toContain("| 12/40 | 30% |");
+    expect(output).toContain('information-density: "These changes ensure correct behavior."');
+    expect(output).toContain("| sycophancy |");
+    expect(output).not.toContain('sycophancy: "');
   });
 
   test("renders proposed-removals diff block when entries collapse", () => {

--- a/plugins/writing/skills/analyze/scripts/report.ts
+++ b/plugins/writing/skills/analyze/scripts/report.ts
@@ -1,4 +1,5 @@
 import type { CorrectionRow, CorrectiveRow, ModelSummaryRow } from "./dump";
+import type { MeaningAudit } from "./judge";
 import type { LiftRow } from "./ngram";
 import type { QuoteContext } from "./quote-context";
 import type { CorpusRateTrends } from "./rate-detectors";
@@ -30,6 +31,7 @@ export interface ReportInput {
   structuralSignatures: TagSignatureRow[];
   /** Corpus-level rate trends (action-verb opener density, backtick ref density, template rates). */
   rateTrends: CorpusRateTrends;
+  meaningAudit: MeaningAudit | null;
   candidatePhrases: CandidatePhrase[];
   corrections: CorrectionRow[];
   corrective: CorrectiveRow[];
@@ -53,6 +55,7 @@ export function renderReport(input: ReportInput): string {
     renderStructuralAudit(input),
     renderStructuralSignatures(input),
     renderStructuralTrends(input),
+    renderMeaningAudit(input),
     renderCorrectiveFeedback(input),
     renderCorrections(input),
   ];
@@ -365,6 +368,40 @@ function renderStructuralTrends(input: ReportInput): string {
   for (let i = 0; i <= 4; i++) {
     const count = t.sectionCountDistribution[i] ?? 0;
     lines.push(`| ${i} | ${count} |`);
+  }
+  return lines.join("\n");
+}
+
+function renderMeaningAudit(input: ReportInput): string {
+  const lines = [
+    "## Meaning-Layer Audit (LLM Judge)",
+    "",
+    "Per-criterion flag rates from the batch LLM judge over the deliverable corpus, in rubric order (information-density leads; press-release-structure is deprioritized). The prompt is a versioned artifact: a different hash means these numbers are not comparable to prior runs. Sampled spans quote session text, so this section stays in the local report and is never committed.",
+    "",
+  ];
+  const audit = input.meaningAudit;
+  if (!audit) {
+    lines.push("_Judge not run. Pass `--judge` (requires `ANTHROPIC_API_KEY`) to enable._");
+    return lines.join("\n");
+  }
+  lines.push(
+    `Prompt: \`${audit.promptSha256}\` | Model: \`${audit.model}\` | Documents: ${fmtNum(audit.documents)} | Est. cost: $${audit.estimatedCostUsd.toFixed(4)}`,
+    "",
+    "| criterion | question | flagged | rate |",
+    "| --- | --- | --- | --- |",
+  );
+  for (const stat of audit.criteria) {
+    const rate = stat.total > 0 ? `${((stat.flagged / stat.total) * 100).toFixed(0)}%` : "-";
+    lines.push(`| ${stat.id} | ${esc(stat.question)} | ${stat.flagged}/${stat.total} | ${rate} |`);
+  }
+  const withSpans = audit.criteria.filter((c) => c.spans.length > 0);
+  if (withSpans.length > 0) {
+    lines.push("", "Sampled spans (local-only; spot-check before acting):", "");
+    for (const stat of withSpans) {
+      for (const span of stat.spans) {
+        lines.push(`- ${stat.id}: "${esc(truncate(span, 160))}"`);
+      }
+    }
   }
   return lines.join("\n");
 }

--- a/plugins/writing/skills/analyze/scripts/report.ts
+++ b/plugins/writing/skills/analyze/scripts/report.ts
@@ -399,7 +399,10 @@ function renderMeaningAudit(input: ReportInput): string {
     lines.push("", "Sampled spans (local-only; spot-check before acting):", "");
     for (const stat of withSpans) {
       for (const span of stat.spans) {
-        lines.push(`- ${stat.id}: "${esc(truncate(span, 160))}"`);
+        // Spans are verbatim quotes and may contain newlines, which would
+        // break the list item; collapse all whitespace runs to single spaces.
+        const flat = span.replace(/\s+/g, " ").trim();
+        lines.push(`- ${stat.id}: "${esc(truncate(flat, 160))}"`);
       }
     }
   }


### PR DESCRIPTION
Adds the meaning-layer batch LLM judge to `writing:analyze`: six binary criteria scored per deliverable document by a Haiku-class model at temperature 0, with structured JSON output and a verbatim span per flag. Closes #791.

## Changes

- `skills/analyze/resources/judge/prompt.md` is the rule: a committed, versioned artifact with one neutral and one flagged example per criterion (all invented) and the bias instructions from the issue (don't reward length, quote spans, state the text is AI-written). Every audit records its sha256; `judge-fixtures.ts` pins the hash, so editing the prompt fails CI until the tuples are re-validated.
- Rubric order follows the issue comment: `information-density` leads, then `motivation-presence`, `marketing-phrasing`, `hedging-density`, `sycophancy`, and `press-release-structure` last. Each criterion in `JUDGE_CRITERIA` carries `layer: "meaning"` plus evidence/retire metadata.
- The judge plugs into `runAnalysis` through a new `BatchDetectors` seam (the `structural.ts` shape: rows in, typed findings out, rendered via `ReportInput`). Hooks never see it: `judge.test.ts` asserts nothing under `hooks/`, `detection/`, or `linguistics/` imports the judge or `@anthropic-ai/sdk`.
- `analyze.ts --judge` adds the pass behind explicit opt-in, requires API credentials, prints a cost estimate before any call, and caps documents with `--judge-limit` (default 100). Documents over 1,500 words chunk at paragraph boundaries and aggregate per-criterion maxima. The report gains a meaning-layer section; sampled spans quote session text and stay in the local `tmp/` report.
- `judge-run.ts` covers ad-hoc files, the reproducibility gate (`gate` replays the committed (prompt hash, input hash, expected flags) tuples live), and the #769 reference baseline (`headings` points the judge at a labeled heading file and scores it with the Wilson protocol).

## Calibration Pending (User Checkpoint)

The labeling passes from the spec have not run. The two dev-split refinement rounds, the frozen test-split measurement, the first live gate run, and the #769 heading comparison all need an API key and your labels, batched with the #790 label session per the spec. Until then, judge flag rates are uncalibrated and the fixture expectations are design targets, marked as such in `judge-fixtures.ts` and `methodology.md`.

## Testing

Unit tests mock the chunk-judge seam, so nothing in `bun test` touches the API. The live half of the gate lives in `judge.integration.ts`, which CI runs but every test self-skips without `ANTHROPIC_API_KEY`.

## References

- #769 (heading eval reference baseline), #787 (detector seam), #789 (motivation-presence evidence)
