### PR TITLE
gitlab: match group/project token service accounts in bot filter

### DIFF
--- a/plugins/gitlab/skills/merge-request/scripts/discussions.test.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/discussions.test.ts
@@ -66,7 +66,9 @@ describe("filterDiscussions", () => {
 
   it("keeps structural bots and listed reviewers with bots", () => {
     const discussions = [
-      makeDiscussion("1", { author: { username: "group_123_bot" } }),
+      makeDiscussion("1", {
+        author: { username: "group_108656794_bot_52b7e4c7a732080fa3b51efe36863e09" },
+      }),
       makeDiscussion("2", { author: { username: "coderabbitai" } }),
       makeDiscussion("3", { author: { username: "alice" } }),
     ];

--- a/plugins/gitlab/skills/merge-request/scripts/reviewers.test.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/reviewers.test.ts
@@ -4,6 +4,8 @@ import { isBotUsername, isReviewTarget, parseReviewers } from "./reviewers";
 describe("isBotUsername", () => {
   test.each([
     "group_1234_bot",
+    "group_108656794_bot_52b7e4c7a732080fa3b51efe36863e09",
+    "project_42_bot_abc123def456",
     "my-reviewer-bot",
     "greptile_bot",
     "Project-Bot",
@@ -16,6 +18,8 @@ describe("isBotUsername", () => {
     "jacob",
     "coderabbitai",
     "robotnik",
+    "group_bot_user",
+    "my_bot_friend",
   ])("rejects %s (no bot suffix)", (username) => {
     expect(isBotUsername(username)).toBe(false);
   });

--- a/plugins/gitlab/skills/merge-request/scripts/reviewers.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/reviewers.ts
@@ -1,12 +1,17 @@
 import { join } from "node:path";
 
 // GitLab has no `__typename` to distinguish bots from users. Service accounts
-// follow a `*-bot` / `*_bot` convention (CodeRabbit posts under `group_<id>_bot`),
-// which is the structural signal. Named bots that break the convention, and any
-// humans you want the autonomous loop to act on, are listed additively; see
-// loadExtraReviewers.
+// follow a `*-bot` / `*_bot` convention, and token service accounts use
+// `group_<id>_bot_<hash>` / `project_<id>_bot_<hash>` (CodeRabbit posts under
+// a group token account). These are the structural signals. Named bots that
+// break the conventions, and any humans you want the autonomous loop to act
+// on, are listed additively; see loadExtraReviewers.
+
+const SERVICE_ACCOUNT = /^(?:group|project)_\d+_bot_[0-9a-f]+$/;
+
 export function isBotUsername(username: string): boolean {
-  return /[_-]bot$/.test(username.toLowerCase());
+  const name = username.toLowerCase();
+  return /[_-]bot$/.test(name) || SERVICE_ACCOUNT.test(name);
 }
 
 // One username per line in `$CLAUDE_PLUGIN_DATA/reviewers.txt`; blank lines and

--- a/plugins/pull-request/skills/follow-up/reviewers.md
+++ b/plugins/pull-request/skills/follow-up/reviewers.md
@@ -11,7 +11,7 @@ Third-party reviewers converge on one shape: each leaves a single summary commen
 
 A reviewer is done when its latest summary on the current HEAD reports nothing actionable and no unresolved bot threads remain. A stale signal from an earlier SHA does not count. Each vendor phrases "none left" differently; use the string as a fast path, fall back to the thread count:
 
-- **CodeRabbit** (GitHub `coderabbitai`, GitLab `group_<id>_bot`): `Actionable comments posted: 0`. Nitpick and LGTM notes are noise unless obviously correct.
+- **CodeRabbit** (GitHub `coderabbitai`, GitLab `group_<id>_bot_<hash>`): `Actionable comments posted: 0`. Nitpick and LGTM notes are noise unless obviously correct.
 - **Greptile** (GitHub `greptile-apps[bot]` / `greptileai`): top confidence score (e.g. `5/5`); actionable items live in its "fix all with AI" section.
 
 > Verify these strings against recent PR history when a reviewer's wording drifts. The reliable cross-cutting signal is **zero new actionable bot threads on the current HEAD after a re-review**.
@@ -32,7 +32,7 @@ This @-mention is the only place a bot is named. Thread replies never name or th
 
 ## Adding a Reviewer
 
-Common reviewers need no maintenance: GitHub reports `__typename: "Bot"` for App and bot accounts, and GitLab service accounts follow the `*-bot` / `*_bot` convention (`group_<id>_bot` for CodeRabbit). Whatever those signals catch is handled automatically.
+Common reviewers need no maintenance: GitHub reports `__typename: "Bot"` for App and bot accounts, and GitLab service accounts follow the `*-bot` / `*_bot` convention or the token service-account form `group_<id>_bot_<hash>` / `project_<id>_bot_<hash>` (CodeRabbit posts under a group token account). Whatever those signals catch is handled automatically.
 
 For an account they miss (a GitLab bot with an off-convention username) or a human reviewer you want the loop to triage, add one username per line to `reviewers.txt` in that plugin's data directory (`$CLAUDE_PLUGIN_DATA`, e.g. `~/.claude/plugins/data/github-bendrucker/reviewers.txt`). Blank lines and `#` comments are ignored, and the list only ever adds to the structural detection.
 


### PR DESCRIPTION
Fixes the gitlab plugin's bot filter so `discussions.ts list --bots` catches CodeRabbit reviews posted via a GitLab group access token. GitLab generates token service-account usernames as `group_<id>_bot_<hash>` / `project_<id>_bot_<hash>`, so the existing `/[_-]bot$/` suffix rule never matched and the filter returned zero results.

`isBotUsername` keeps the suffix rule and adds an anchored `SERVICE_ACCOUNT` pattern for the hashed token form. The numeric id requirement guards against overmatching names like `group_bot_user`. Also corrects the stale `group_<id>_bot` references in `pull-request/skills/follow-up/reviewers.md`.

## Testing

Added positive cases for hashed group/project accounts, plus negatives for `group_bot_user` and `my_bot_friend`. The `filterDiscussions` bots test now uses a full hashed username to exercise the `--bots` path end to end.

Original Task: [Fix gitlab discussions.ts --bots filter: misses CodeRabbit group-bot identity](https://things.bendrucker.me/show?id=6oU44NYwR7ttcSmXTVVfEq)
