### PR TITLE
newline: isolate test fixtures and state per process

### DIFF
--- a/plugins/newline/scripts/newline.test.ts
+++ b/plugins/newline/scripts/newline.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -13,7 +13,11 @@ import { processInput as ensureInput, ensureTrailingNewline } from "./ensure";
 import { processInput as preserveInput, preserveNewlineState } from "./preserve";
 import { clearAllState, clearState, getState, setState } from "./state";
 
-const testDir = join(tmpdir(), "newline-test");
+// Isolate fixtures and state per test process so concurrent suites (prek runs many
+// at once) don't collide on shared /tmp paths.
+const testRoot = mkdtempSync(join(tmpdir(), "newline-test-"));
+const testDir = join(testRoot, "fixtures");
+process.env.CLAUDE_NEWLINE_STATE_FILE = join(testRoot, "state.json");
 
 function mockPreToolInput(filePath: string): PreToolUseHookInput {
   return {

--- a/plugins/newline/scripts/state.ts
+++ b/plugins/newline/scripts/state.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 type StateStore = Record<string, string>;
 
 function getStateFilePath(): string {
-  return join(tmpdir(), "claude-newline-state.json");
+  return process.env.CLAUDE_NEWLINE_STATE_FILE ?? join(tmpdir(), "claude-newline-state.json");
 }
 
 async function readStore(): Promise<StateStore> {


### PR DESCRIPTION
Isolates the `newline` plugin tests so they stop failing when prek runs plugin suites concurrently. Each test process now gets its own fixture directory and state file instead of the shared `/tmp/newline-test/` and `/tmp/claude-newline-state.json` paths, which collided when multiple suites ran at once.

Fixes #801.

## Changes

- `state.ts`: `getStateFilePath()` honors a `CLAUDE_NEWLINE_STATE_FILE` env override and otherwise keeps the fixed `/tmp/claude-newline-state.json` path, so production behavior (the check and preserve hooks share state across separate processes) is unchanged.
- `newline.test.ts`: allocates a per-process `mkdtemp` root for both the fixture dir and the state file, matching the pattern the `writing/analyze` tests already use.

## Testing

Six concurrent runs of the suite all pass where before they produced 1 to 7 failures per run. Single runs and `tsc --noEmit` stay green.
