### PR TITLE
user: add job skill for daily work routines

### DIFF
--- a/user/skills/job/SKILL.md
+++ b/user/skills/job/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: job
+description: >
+  Daily routines for a corporate software engineering job. Start mode
+  triages the inbound review queue, your own open PRs, and the issue
+  tracker's plan for today. End mode clears the outbox, surfaces review
+  debt, sweeps worktrees for unpushed work, and tidies tracker state for
+  tomorrow. Use via /job, /job start, /job end, or /job setup.
+argument-hint: "[start | end | setup]"
+disable-model-invocation: true
+---
+
+# Job
+
+Run a daily work routine: gather state read-only, present one prioritized brief, then execute confirmed bulk actions through installed skills.
+
+## Config
+
+!`cat ~/.config/claude-job-skill/config.json 2>/dev/null || echo CONFIG_MISSING`
+
+If the output above is `CONFIG_MISSING` and the requested mode is not `setup`, run the interview in [references/setup.md](references/setup.md) first, then continue into the requested mode.
+
+## Mode
+
+Requested mode: `$0`. Local time: !`date "+%A %H:%M"`.
+
+- `start`: read [references/start.md](references/start.md)
+- `end`: read [references/end.md](references/end.md)
+- `setup`: read [references/setup.md](references/setup.md)
+
+With no argument, suggest a mode from the local time above: before about 13:00 suggests start, after suggests end. On a weekend, suggest nothing and ask. Confirm the suggestion with AskUserQuestion before proceeding.
+
+Arguments beyond the mode are a focus hint ($ARGUMENTS). Weight the brief toward what they name.
+
+## Delegation
+
+This skill never names platforms. The config declares which version-control platform, issue tracker, and worktree tool the user works with. For each task:
+
+1. Find the installed skill that covers the configured tool's task (the skill for the configured platform's merge requests, the skill for the configured tracker's issues) and load it for mechanics.
+2. If no installed skill matches, use the configured CLI directly. Stay read-only until the user confirms actions.
+
+Platforms, hostnames, and usernames come only from the config or the user, never from this skill.
+
+## Brief, then act
+
+Both modes follow this contract.
+
+### Gather
+
+Read-only first. When sources are independent (review queue, own PRs, tracker), dispatch parallel read-only sub-agents and merge their results.
+
+### Brief
+
+One prioritized brief, sections in the mode's phase order. Within each section, order items blocking others first, then oldest. Each item gets an identifier with a link, a one-line state, and a recommended action.
+
+Omit sections with nothing in them and never pad. An empty queue is a two-line brief.
+
+### Act
+
+Split recommended actions into two groups:
+
+- Safe: reversible or expected. Assign a reviewer, retry CI, post a reply the user has seen drafted, update tracker status.
+- Ask-first: approve, close, merge, anything hard to walk back. Each needs its own confirmation.
+
+Present safe actions via AskUserQuestion (execute all, pick a subset, or none). Execute through the delegated skills, then give a short summary of what changed.

--- a/user/skills/job/references/end.md
+++ b/user/skills/job/references/end.md
@@ -16,8 +16,9 @@ Dispatch parallel read-only sub-agents:
 Everything pushed today should leave tonight with:
 
 - A reviewer assigned. Assigning one is safe; respect any reviewer conventions in the config notes.
-- A self-review pass before anything new goes out for review. Delegate to an installed code-review skill.
 - A body that matches the current diff. When commits have outrun the description, delegate to an installed PR-update skill.
+
+A PR/MR sitting without a reviewer is usually deliberate: doubt about the approach, a blocker, a dependency. Surface it with the likely reason and ask for the next step rather than defaulting to another review pass. Offer a self-review via an installed code-review skill only when the user wants one before sending.
 
 Flag items that need collaboration lead time (a reviewer in another timezone, a long CI run) so they go out tonight rather than tomorrow morning.
 
@@ -31,6 +32,8 @@ Review debt is inbound requests you did not reach today plus unanswered threads 
 Never silently drop an item.
 
 ## Unpushed Work Sweep
+
+The configured roots may span many repositories, so keep this phase cheap: one sub-agent, local git commands only, no platform API calls. This is the lowest-priority phase. Skip it when the focus hint points elsewhere or the rest of the brief already needs the time.
 
 Enumerate worktrees via the configured worktree tool. Fall back to `git worktree list` run across the configured roots. For each worktree, report:
 

--- a/user/skills/job/references/end.md
+++ b/user/skills/job/references/end.md
@@ -1,0 +1,49 @@
+# End
+
+The day ends with decisions. Nothing leaves it unsent, unanswered, or unpushed without one.
+
+## Gather
+
+Dispatch parallel read-only sub-agents:
+
+- Outbox: your own PRs/MRs created or pushed today, with reviewer assignment, CI state, draft state, and whether the body still matches the diff.
+- Inbound: review requests still open against you, and threads on others' PRs/MRs awaiting your reply.
+- Worktrees: every worktree's uncommitted and unpushed state (details under the sweep below).
+- Tracker: your in-flight issues and their current states.
+
+## Outbox Clearing
+
+Everything pushed today should leave tonight with:
+
+- A reviewer assigned. Assigning one is safe; respect any reviewer conventions in the config notes.
+- A self-review pass before anything new goes out for review. Delegate to an installed code-review skill.
+- A body that matches the current diff. When commits have outrun the description, delegate to an installed PR-update skill.
+
+Flag items that need collaboration lead time (a reviewer in another timezone, a long CI run) so they go out tonight rather than tomorrow morning.
+
+## Review Debt
+
+Review debt is inbound requests you did not reach today plus unanswered threads on others' PRs/MRs. Choose one path per item:
+
+- Reply now: draft the reply and include it in the brief. Posting a draft the user approved is safe.
+- Carry to tomorrow: record it explicitly so it appears in tomorrow's start brief.
+
+Never silently drop an item.
+
+## Unpushed Work Sweep
+
+Enumerate worktrees via the configured worktree tool. Fall back to `git worktree list` run across the configured roots. For each worktree, report:
+
+- Uncommitted changes (`git status --porcelain`)
+- Unpushed commits (`git log @{u}..HEAD --oneline`, or all local commits when no upstream exists)
+
+Offer per worktree: commit and push as WIP (safe on your own branch), or record it as deliberately local in the completion summary.
+
+## Tracker Hygiene and Tomorrow
+
+- Make states match reality: merged work marked done, in-progress only for what is actually in progress. Corrections are safe actions.
+- Capture next steps as issue comments or new issues, including monitor and follow-up intents like "when X merges, rebase Y", so tomorrow's start run has a starting point instead of a memory.
+
+## Brief and Act
+
+Assemble the brief in the phase order above and execute per the shared contract in `SKILL.md`.

--- a/user/skills/job/references/setup.md
+++ b/user/skills/job/references/setup.md
@@ -1,0 +1,46 @@
+# Setup
+
+First-run interview. Produces `~/.config/claude-job-skill/config.json`. The skill is open source, so everything employer-specific lives only in this file.
+
+## Detect Before Asking
+
+Build candidate answers from the environment rather than a hardcoded tool list:
+
+- Scan the installed-skills list already in context for version-control, issue-tracker, code-review, and worktree coverage.
+- Probe for CLIs read-only: `command -v`, then the CLI's authenticated-user query (its `whoami` or `me` equivalent) to learn the username, which doubles as verification for the interview's version-control answer.
+- Check `git config --get remote.origin.url` in likely repos for a host hint.
+
+Offer only what is present.
+
+## Interview
+
+Ask via AskUserQuestion with detected candidates as options, relying on the built-in Other choice to cover anything detection missed.
+
+- Version control: platform, host, work username (verify against the CLI's authenticated-user query), preferred CLI.
+- Issue tracker: platform, username and team, and how "current cycle" is expressed there, whether that is a cycle, sprint, iteration, or milestone, recording the exact term and how to query it.
+- Worktrees: the tool used, if any, plus every root directory the end-of-day sweep should walk when it checks for uncommitted changes and unpushed commits.
+- Working hours: optional, default 09:00 to 17:00, used only to suggest a mode when `/job` runs with no argument.
+- Notes: optional free-form text for reviewer conventions and team norms, the field where employer specifics belong rather than anywhere in the skill.
+
+## Persist
+
+Run `mkdir -p ~/.config/claude-job-skill`, then write `config.json`:
+
+```json
+{
+  "version": 1,
+  "vcs": { "platform": "...", "host": "...", "username": "...", "cli": "..." },
+  "tracker": { "platform": "...", "username": "...", "team": "..." },
+  "worktrees": { "tool": "...", "roots": ["~/src/..."] },
+  "hours": { "start": "09:00", "end": "17:00" },
+  "notes": "free-form conventions"
+}
+```
+
+Only `vcs` and `tracker` are required. Persist stable identities alone, since volatile state like open PRs, review queues, and CI results is discovered fresh on every run.
+
+Echo the written config back for confirmation, then continue into the originally requested mode if there was one.
+
+## Re-Run
+
+`/job setup` re-runs the interview. The current config is already injected at the top of `SKILL.md`, so offer each current value as the default answer.

--- a/user/skills/job/references/start.md
+++ b/user/skills/job/references/start.md
@@ -1,0 +1,46 @@
+# Start
+
+Start-of-work triage: what needs review, what is stuck in your outbox, and what today is for.
+
+## Gather
+
+Dispatch parallel read-only sub-agents:
+
+- Inbound: PRs/MRs where the configured username is a requested reviewer or approver, with age, author, and whether you reviewed before.
+- Outbox: your own open PRs/MRs, with CI status, unresolved threads, reviewer assignment, and draft state.
+- Tracker: issues assigned to the configured user, plus the current cycle as the config expresses it.
+
+Each sub-agent uses the delegated skill or CLI for its source and returns structured state: identifiers, links, and statuses the brief can consume directly.
+
+## Inbound Review Queue
+
+Order items blocking others first, then oldest.
+
+Separate fresh requests from re-reviews where the author responded to your earlier feedback. For re-reviews, delegate the addressed-or-not analysis to an installed review-follow-up skill if one exists. Otherwise compare the threads against your prior comments yourself.
+
+Recommended actions per item:
+
+- Review now: start immediately after the brief, via the installed review skill for the configured platform.
+- Queue for a time today: record it in the today plan with the chosen slot.
+- Decline or reassign: ask-first, since it hands work back.
+
+## Outbox
+
+For each of your open PRs/MRs, flag:
+
+- Failing or stuck CI. Retrying a flaky job is safe. A real failure becomes a candidate focus item.
+- Reviewer threads awaiting your reply. Draft replies and include them in the brief.
+- Ready for review but no reviewer assigned. Assigning per the config notes is safe.
+- Stale drafts. Recommend one of: finish today (focus item), send as-is (safe), or close (ask-first).
+
+## Today Plan
+
+From assignments and the current cycle, propose one to three focus items for the day, folding in anything the earlier phases produced (a real CI failure, a draft to finish). Confirm the list with the user.
+
+Queue tracker corrections as safe actions: stale statuses, items marked in-progress that are not, done work not closed.
+
+End with a one-line stated goal for the day.
+
+## Brief and Act
+
+Assemble the brief in the phase order above and execute per the shared contract in `SKILL.md`.


### PR DESCRIPTION
Adds a user-level `/job` skill encoding day-job routines: `/job start` triages the inbound review queue, your own open PRs, and the tracker's plan for today. `/job end` clears the outbox, surfaces review debt, sweeps worktrees for unpushed work, and tidies tracker state for tomorrow. Both modes gather read-only through parallel sub-agents, present one prioritized brief, then execute confirmed safe actions. Approve, close, and merge stay ask-first.

The skill is publishable: it names no platforms, hosts, or usernames. A first-run `/job setup` interview detects installed skills and CLIs, asks which tools apply, and persists the answers to `~/.config/claude-job-skill/config.json`. Each run bang-injects that config and delegates platform mechanics to whatever installed skill matches the configured tool, falling back to the configured CLI. I put the config under `~/.config` rather than `~/.claude` because `user/` symlinks into this public repo.

`disable-model-invocation: true` keeps recurring context cost at zero. The curation signal is `/job` usage in session history. Removal is deleting the directory.

## Testing

Verified with strict `skill-lint` (frontmatter, references, bang syntax) and a `writing:scan` pass over the prose, plus a grep of all four files for platform names, hostnames, and usernames to confirm nothing employer-specific leaked in.

Not exercised end-to-end. This was written on my home machine, so the live `/job setup` and mode runs happen on the work machine after merge, with revisions to follow.
