### PR TITLE
review: grade fix quality in follow-up

### DIFF
--- a/plugins/gitlab/skills/merge-request/discussions.md
+++ b/plugins/gitlab/skills/merge-request/discussions.md
@@ -28,6 +28,10 @@ bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts list <iid> --format table
 
 Three output formats are supported: `json` (default), `digest`, and `table`.
 
+To filter `--author` to yourself, resolve your username with `glab api user 2>/dev/null | jq -r .username`. The `glab api user --jq .username` form returns empty on glab 1.102.0.
+
+The script resolves the project from the current directory's git remote. Run it from a checkout of the MR's repo; from an unrelated directory it returns `[]`.
+
 #### JSON output schema
 
 The default (`--format json`) is a flat array of summary objects, one per discussion (the first note of each thread). It is not the raw GitLab `{ notes: [...] }` shape, so query the top-level fields directly.
@@ -44,6 +48,14 @@ The default (`--format json`) is a flat array of summary objects, one per discus
 | `lineRange` | `{ start, end }` or `null` | `null` for single-line and non-positioned comments |
 
 `file` and `line` are omitted entirely for general (non-inline) discussions, so handle them as optional. `lineRange` is always present but is `null` unless the comment spans multiple lines.
+
+The summary flattens each thread to its **first note only**. To see the author's replies or the full thread, fetch the raw payload, which keeps every note:
+
+```bash
+glab api "projects/:id/merge_requests/<iid>/discussions?per_page=100" 2>/dev/null
+```
+
+A GitLab "reply" that is a `changed line in version N` system note (`notes[].system == true`) is not a substantive response. Filter those out before treating a thread as answered.
 
 #### Compact triage
 

--- a/plugins/review/skills/follow-up/SKILL.md
+++ b/plugins/review/skills/follow-up/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: review:follow-up
 description: >
-  Follow up on a PR/MR you reviewed: check whether your comments were addressed, find silently
-  resolved threads, and decide whether to re-review or approve.
+  Follow up on a PR/MR you reviewed: assess whether the author's fixes actually grasped each
+  concern, find silently resolved or mechanically-fixed threads, and get a graded re-review call.
   Use after leaving review feedback to see if the author acted on it.
 argument-hint: <pr-url>
 allowed-tools:
   - Bash(gh:*)
   - Bash(glab:*)
+  - Bash(git:*)
+  - Task
 ---
 
 # Review Follow-Up
 
 Follow up on my review of: $ARGUMENTS
+
+You are the reviewer. The question is not "did the author reply?" but "did the fix actually grasp
+each concern, or just go through the motions?" Status is a signal. The code is the verdict.
+
+All diff and file reading happens in Explore sub-agents. Your main session holds only the structured
+verdicts they return, never raw diffs. This keeps my development context free.
 
 ## Workflow
 
@@ -24,9 +32,31 @@ Parse the URL from `$ARGUMENTS` to determine the platform. GitHub URLs contain `
 
 Load the `gitlab:api` and `gitlab:merge-request` skills for API patterns and MR tooling.
 
+### Sync to the Latest Pushed State
+
+Before judging anything, make sure your assessment reflects what the author actually pushed, not a
+stale local checkout.
+
+**The worktree-behind-origin trap**: judging a local worktree that is N commits behind origin makes
+clean fixes look unaddressed. This is a real near-miss. Never assess local state without syncing.
+
+- Prefer the remote-of-record diff. `glab` and `gh` API diffs always reflect the server, so favor
+  them over reading the local worktree.
+- If a sub-agent must read the local worktree, it has to `git fetch` first and compare against
+  `origin/<branch>`, never the local checkout.
+
+Establish the **review baseline**: the commit/version at which you last reviewed, plus current head.
+The fix assessment diffs that range, not the whole MR.
+
+- GitLab: the `gitlab:merge-request` skill exposes MR versions and `diff_refs` to bound the range
+  from your last-reviewed version to head.
+- GitHub: use your review's commit SHA to head.
+
 ### Fetch Threads
 
-Gather all resolvable discussion threads that I started (both resolved and unresolved).
+Gather all resolvable discussion threads that I started (both resolved and unresolved). Retain each
+thread's **original comment body and location**. The sub-agents need the concern's intent, not just
+its status.
 
 #### GitHub
 
@@ -34,42 +64,97 @@ Use the `github:pr-comments` skill's script to fetch threads. Run with `--role r
 
 #### GitLab
 
-Get the authenticated username, then use the `gitlab:merge-request` skill's `discussions.ts` script to fetch threads:
-
-```bash
-glab api user --jq .username 2>/dev/null
-bun <gitlab:merge-request skill>/scripts/discussions.ts list <iid> --resolvable --author <username>
-```
-
-Include both resolved and unresolved threads (do not pass `--unresolved`) for classification.
-
-When making direct `glab api` calls, append `2>/dev/null` to prevent config warnings from polluting JSON output.
+Use the `gitlab:merge-request` skill's discussions tooling to fetch the resolvable threads you
+started, both resolved and unresolved. You need each thread's original body, its location, and any
+later notes (the author's replies), so pull the full discussion payload, not just the first-note
+summary. That skill covers the script, username lookup, and the raw-payload caveat.
 
 ### Classify Threads
 
-Sort each thread into one of four buckets:
+Sort each thread into one of four buckets, but treat the bucket as a **signal, not a verdict**:
 
-- **Unresolved / no author reply**: Author hasn't responded to my feedback
-- **Unresolved / author replied**: Author responded, I need to evaluate their reply
-- **Resolved / with reply**: Author replied and resolved (verify the reply is satisfactory)
-- **Resolved / silent**: Author resolved without replying (was my feedback addressed or dismissed?)
+- **Unresolved / no author reply**: Author hasn't responded
+- **Unresolved / author replied**: Author responded, evaluate the reply
+- **Resolved / with reply**: Author replied and resolved
+- **Resolved / silent**: Author resolved without replying
 
-### Present Summary
+A system-generated note (a version or diff note, not a human comment) is **not** a substantive reply.
+Don't count it as the author engaging with the concern. The fetch step's skill covers how these look
+on each platform.
 
-Show a table with counts per category. List each thread with the file, line, one-line summary of my original feedback, and whether the author replied.
+The code-grounded verdict from the next step is the source of truth. A mismatch between status and
+code reality (resolved but not fixed, unresolved but fixed) is itself a finding.
 
-### Check Commit Coverage
+### Assess Fixes
 
-For each thread, examine commits pushed after my review submission. Indicate which threads appear addressed by code changes vs. which have no corresponding changes.
+This is the core step. Dispatch read-only Explore sub-agents (Task tool) to read the post-review diff
+and judge each fix. **Group threads by the file they sit on and dispatch one Explore agent per file.**
+When a single file carries many threads, fall back to per-thread agents. Cap parallelism sensibly
+(roughly 6-8 concurrent).
 
-### Re-Review Decision
+Give each agent:
 
-Help decide next action based on thread states:
+- the file path
+- every thread on that file: original comment body, location, and the underlying intent
+- the review-baseline→head diff range from the sync step
 
-- All threads addressed with replies and code changes: suggest approving
-- Some threads have author replies but no code changes: present replies for evaluation
-- Silent resolves found: flag each so I can decide whether to accept or reopen
-- Unresolved threads with no reply: note these as still pending author action
+Each agent reads that file's post-review diff **once** and returns a compact structured verdict per
+thread. **No raw diffs come back**, only these fields:
+
+- `location`: `file:line` or thread id
+- `concern`: the original intent, one line
+- `change`: what the author actually did, code-grounded, one line (or "no change found")
+- `verdict`: `Addressed` | `Partial` | `Not addressed` | `Dismissed` | `Can't tell`
+- `quality`: `Solid` | `Mechanical` (satisfies the words, misses the intent) | `Went further` |
+  `Adopted verbatim` | `Workaround/band-aid` | `Introduced new issue` | `n/a` (use when nothing
+  changed; quality only applies to a fix that exists)
+- `status_mismatch`: e.g. "resolved but not actually fixed", "unresolved but fixed", or none
+- `confidence`: `high` | `med` | `low`
+- `focus`: boolean, does this warrant my eyes
+
+Spell out these assessment lenses in each agent's prompt:
+
+- Does the fix address the underlying concern, or only the literal surface words?
+- Is it partial, fixing one call site but not the others, or handling the happy path only?
+- Was it dismissed? If so, is the dismissal reasonable?
+- Did the author go further than asked, or adopt my wording verbatim (a sign they fed my comment
+  back into a model without engaging)?
+- Did the fix introduce a new issue near the change?
+
+### Quick Pass for New Issues
+
+Have the same per-file agents flag problems the fixes **introduced** that aren't tied to any thread.
+Real runs always end with this. Surface these separately from the thread verdicts.
+
+### Verify Author Claims
+
+If the author claims they tested, validated, or ran something, check for evidence: relevant commits,
+test changes, MR-body checkboxes that are actually checked. Flag unsubstantiated claims rather than
+taking them at face value.
+
+### Present: Attention-Ranked Report
+
+Lead with what needs my eyes. Do not emit a uniform full-detail row per thread.
+
+#### Needs your attention
+
+Flagged thread verdicts (`focus = true`), new issues, and unverified claims. Each one concise and
+code-grounded, with its confidence. Include any status-vs-reality mismatch.
+
+#### Cleanly addressed
+
+Collapse solid fixes to a count plus one-liners. Don't expand them.
+
+#### Recommendation
+
+A graded call:
+
+- **Approve**: everything addressed cleanly
+- **Approve with comments**: addressed, with minor nits you can fix in a follow-up or follow-up PR
+- **Request changes**: partial, mechanical, or unaddressed concerns remain
+
+Name the minor-nit lane explicitly: approving while requesting trivial follow-ups is a real option,
+not a forced choice between approve and block.
 
 ### Execute Actions
 
@@ -83,10 +168,7 @@ After I decide on next steps, use platform-appropriate commands:
 
 #### GitLab
 
-- Approve: `glab api projects/:id/merge_requests/<iid>/approve -X POST 2>/dev/null`
-- Resolve thread: `glab api projects/:id/merge_requests/<iid>/discussions/<id> -X PUT -f resolved=true 2>/dev/null`
-- Unresolve: same endpoint with `-f resolved=false`
-- Comment: use `gitlab:merge-request` skill's `discussions.ts create` command
+Approve, resolve or unresolve threads, and comment via the `gitlab:merge-request` skill.
 
 ## Guardrails
 
@@ -94,3 +176,6 @@ After I decide on next steps, use platform-appropriate commands:
 - **Don't approve automatically**: present the evidence and let me decide.
 - **Flag silently resolved threads** so I can decide whether to reopen or accept.
 - **Distinguish code fixes from dismissals**: a resolved thread with matching code changes is different from one resolved with no changes.
+- **Sync before judging**: never assess stale local state. Fetch and diff against origin first.
+- **Status is a signal, the code is the verdict**: a mismatch between the two is a finding, not noise.
+- **Intent over words**: distinguish a fix that meets the concern from one that mechanically satisfies its literal wording.

--- a/plugins/review/skills/follow-up/evals/evals.json
+++ b/plugins/review/skills/follow-up/evals/evals.json
@@ -4,39 +4,59 @@
     {
       "id": 1,
       "prompt": "Check if my review comments were addressed on https://github.com/acme/api-server/pull/247",
-      "expected_output": "Summary of the reviewer's threads with resolution state and whether the author replied or made code changes",
+      "expected_output": "An attention-ranked assessment of how well each fix grasped the concern, with a graded re-review recommendation",
       "files": [],
       "expectations": [
         "Uses --role reviewer to fetch only threads started by the authenticated user",
-        "Threads are classified into the four buckets from the reviewer's perspective",
-        "Silently resolved threads are flagged for attention",
-        "A re-review recommendation is presented based on thread states"
+        "Syncs to the latest pushed state before judging, preferring the gh API diff over a local checkout",
+        "Dispatches read-only Explore sub-agents (Task tool) to read the post-review diff and judge fix quality",
+        "Returns code-grounded per-thread verdicts (addressed / partial / not addressed / dismissed) rather than a uniform status table",
+        "Treats resolution status as a signal and flags status-vs-code mismatches as findings",
+        "Leads with what needs attention and collapses cleanly-addressed threads",
+        "Ends with a graded recommendation (approve / approve with comments / request changes) including a minor-nit lane"
       ]
     },
     {
       "id": 2,
       "prompt": "I reviewed https://gitlab.example.com/team/service/-/merge_requests/89 yesterday. Were my comments addressed?",
-      "expected_output": "Thread-by-thread status showing which reviewer comments have author replies, code fixes, or were silently resolved",
+      "expected_output": "An attention-ranked fix-quality assessment built from sub-agent verdicts, ending in a graded recommendation",
       "files": [],
       "expectations": [
         "Detects GitLab from URL and loads gitlab:api and gitlab:merge-request skills",
         "Uses discussions.ts list with --resolvable --author to fetch reviewer threads",
-        "Checks commits after the reviewer's last review for code changes addressing feedback",
-        "Distinguishes threads resolved with code fixes from those resolved without changes",
-        "Presents a re-review decision rather than draft replies",
+        "Establishes the review baseline from MR versions / diff_refs and diffs baseline-to-head, not the whole MR",
+        "Does not count a 'changed line in version N' system note as a substantive author reply",
+        "Dispatches Explore sub-agents that read the diff and return compact structured verdicts, never raw diffs to the main session",
+        "Flags new issues the fixes introduced and any unverified author claims separately from thread verdicts",
         "Does not load GitHub MCP tools for GitLab MRs"
       ]
     },
     {
       "id": 3,
       "prompt": "Follow up on my feedback for https://github.com/org/repo/pull/55 -- some threads were resolved but I didn't see replies",
-      "expected_output": "Identification of silently resolved threads with analysis of whether corresponding code changes exist",
+      "expected_output": "Identification of silently resolved threads with a code-grounded verdict on whether each was actually fixed",
       "files": [],
       "expectations": [
         "Fetches both resolved and unresolved threads started by the reviewer",
-        "Flags resolved threads that have no author reply",
-        "For silently resolved threads, checks if the diff shows changes addressing the feedback",
-        "Suggests reopening threads where feedback appears unaddressed"
+        "Flags resolved threads that have no substantive author reply",
+        "Has sub-agents read the post-review diff to judge whether each silently resolved thread was actually addressed",
+        "Reports a status mismatch when a thread is resolved but the code shows no real fix",
+        "Suggests reopening threads where the fix is missing or mechanical"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Round 3 of my review on https://gitlab.example.com/whirlai/api/-/merge_requests/548 -- 19 threads, check if they're actually fixed this time",
+      "expected_output": "A per-thread fix-quality verdict that catches threads marked resolved but only mechanically or partially fixed, ranked by attention",
+      "files": [],
+      "expectations": [
+        "Syncs and fetches before judging so it never assesses a worktree behind origin",
+        "Diffs from the last-reviewed MR version to head rather than re-reading the full multi-round diff",
+        "Batches the 19 threads by file into Explore sub-agents, falling back to per-thread when a file carries many",
+        "Catches a thread that is resolved but only partially or mechanically fixed and marks it focus=true",
+        "Distinguishes a fix that meets the underlying intent from one that mechanically satisfies the literal wording",
+        "Collapses the cleanly-addressed threads to a count and leads with the ones needing attention",
+        "Ends with a graded recommendation including the option to approve while requesting trivial follow-ups"
       ]
     }
   ]


### PR DESCRIPTION
Rewrites `review:follow-up` to judge whether each fix actually grasped the concern, not just whether the thread is resolved. The old skill reported status (resolved/unresolved, replied or not) and whether some code change existed after the review. It never assessed whether a fix met the intent or just went through the motions.

All diff reading moves into Explore sub-agents, so the main session holds only compact per-thread verdicts and never raw diffs. Keeping the heavy reading off the reviewer's session was the point.

## Changes

- Sub-agent fix assessment, batched by file. Each Explore agent reads the post-review diff once and returns a per-thread verdict (addressed / partial / not addressed / dismissed) plus a quality read (solid, mechanical, went further, band-aid, introduced new issue).
- Sync before judging. Establishes the review baseline (last-reviewed commit/version through head) and warns about the worktree-behind-origin trap that made a real run judge clean fixes as unaddressed.
- Status is a signal, the code is the verdict. A mismatch (resolved but not fixed, unresolved but fixed) is itself a finding.
- New-issues pass and author-claim verification. Flags problems a fix introduced and checks claimed testing against the diff.
- Attention-ranked report. Leads with what needs eyes, collapses clean fixes to a count, and ends with a graded approve / approve-with-comments / request-changes call.
- Adds `Task` and `Bash(git:*)` to `allowed-tools`. The gate is unchanged: no auto-approve, resolve, or comment.

GitLab mechanics stay in `gitlab:merge-request`. `review:follow-up` points to it instead of inlining `glab` plumbing, so the GitLab specifics don't accrete across reviewer skills.

## Testing

I exercised the workflow against a staged multi-round GitLab MR covering the cases the skill is meant to catch: a clean fix, a mechanical fix that satisfies the wording but misses the intent, a band-aid resolved-but-not-fixed thread carrying an unsubstantiated test claim, and an unaddressed thread. This covers the verdict spread, the status-vs-code mismatch, the new-issue pass, and the claim check feeding the graded recommendation.

Live testing surfaced GitLab gotchas now recorded in `discussions.md`: author replies need the raw discussions payload (the summary is first-note-only), system notes aren't substantive replies, the reliable username form (`glab api user --jq` returns empty on glab 1.102.0), and that the script resolves the repo from the current directory.

The `review:follow-up` evals assert the new behavior (sub-agent assessment, sync-before-judging, attention-ranked output, graded recommendation with a minor-nit lane, mismatch detection), with a round-3 multi-thread case where a thread is resolved but only mechanically fixed.
