### PR TITLE
review: auto-detect current branch's PR/MR in follow-up

### DIFF
--- a/plugins/review/skills/follow-up/SKILL.md
+++ b/plugins/review/skills/follow-up/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Follow up on a PR/MR you reviewed: assess whether the author's fixes actually grasped each
   concern, find silently resolved or mechanically-fixed threads, and get a graded re-review call.
   Use after leaving review feedback to see if the author acted on it.
-argument-hint: <pr-url>
+argument-hint: "[pr-url]"
 allowed-tools:
   - Bash(gh:*)
   - Bash(glab:*)
@@ -16,6 +16,10 @@ allowed-tools:
 
 Follow up on my review of: $ARGUMENTS
 
+`$ARGUMENTS` is optional. When it carries a PR/MR URL or identifier, follow up on that. When it's
+empty, resolve the target from the current branch's open PR/MR before anything else (see [Resolve
+Target](#resolve-target)). Only ask me to paste a URL when that resolution genuinely fails.
+
 You are the reviewer. The question is not "did the author reply?" but "did the fix actually grasp
 each concern, or just go through the motions?" Status is a signal. The code is the verdict.
 
@@ -23,6 +27,42 @@ All diff and file reading happens in Explore sub-agents. Your main session holds
 verdicts they return, never raw diffs. This keeps my development context free.
 
 ## Workflow
+
+### Resolve Target
+
+Settle on a PR/MR URL before any other step. Everything downstream (platform detection, sync, fetch)
+keys off that URL.
+
+- If `$ARGUMENTS` carries a PR/MR URL or identifier, use it. This is the prior behavior, unchanged.
+- If `$ARGUMENTS` is empty, resolve the current branch's open PR/MR:
+  - Pick the platform from the remote: `git remote get-url origin`. A host containing `github.com`
+    means GitHub; any other host is the GitLab instance the remote points at (`glab` reads the
+    instance from the same remote, so no extra configuration is needed).
+  - GitHub: `gh pr view --json url,state --jq '.url'`. With no positional argument, `gh pr view`
+    resolves the PR for the current branch.
+  - GitLab: `glab mr view --output json | jq -r '.web_url'`. With no argument it resolves the MR for
+    the current branch.
+
+Feed the resolved URL into [Detect Platform](#detect-platform) and the rest of the workflow
+unchanged.
+
+#### When Resolution Fails
+
+Don't silently bail. Ask me for a URL only after auto-detection genuinely comes up empty, and report
+what you tried first: the branch name (`git branch --show-current`) and the `origin` remote you
+resolved the platform from. The edge cases below shape that fallback.
+
+When the branch has no open PR/MR, `gh pr view` or `glab mr view` find nothing. Report the branch and
+remote, then ask for a URL.
+
+On a detached HEAD, `git symbolic-ref --quiet HEAD` fails, so there's no branch to resolve from. Skip
+detection and ask for a URL.
+
+With multiple remotes, resolve from `origin`. If that's not the right remote, I can pass a URL.
+
+A closed or merged target still resolves: `gh pr view --json state` (or the MR equivalent) may return
+a PR/MR whose `state` is not open. Surface the `state` so I can confirm it's the one I meant before
+you proceed.
 
 ### Detect Platform
 

--- a/plugins/review/skills/follow-up/SKILL.md
+++ b/plugins/review/skills/follow-up/SKILL.md
@@ -30,39 +30,24 @@ verdicts they return, never raw diffs. This keeps my development context free.
 
 ### Resolve Target
 
-Settle on a PR/MR URL before any other step. Everything downstream (platform detection, sync, fetch)
-keys off that URL.
+Settle on a PR/MR URL before any other step; everything downstream keys off it.
 
-- If `$ARGUMENTS` carries a PR/MR URL or identifier, use it. This is the prior behavior, unchanged.
-- If `$ARGUMENTS` is empty, resolve the current branch's open PR/MR:
-  - Pick the platform from the remote: `git remote get-url origin`. A host containing `github.com`
-    means GitHub; any other host is the GitLab instance the remote points at (`glab` reads the
-    instance from the same remote, so no extra configuration is needed).
-  - GitHub: `gh pr view --json url,state --jq '.url'`. With no positional argument, `gh pr view`
-    resolves the PR for the current branch.
-  - GitLab: `glab mr view --output json | jq -r '.web_url'`. With no argument it resolves the MR for
-    the current branch.
+If `$ARGUMENTS` carries a URL or identifier, use it. If it's empty, detect the current branch's open
+PR/MR. Pick the platform from `git remote get-url origin` (host contains `github.com` => GitHub,
+else the GitLab instance that remote points at), then:
 
-Feed the resolved URL into [Detect Platform](#detect-platform) and the rest of the workflow
-unchanged.
+- GitHub: `gh pr view --json url,state --jq '.url'`
+- GitLab: `glab mr view --output json | jq -r '.web_url'`
 
-#### When Resolution Fails
+Both resolve the current branch with no positional argument. Feed the URL into [Detect
+Platform](#detect-platform) unchanged.
 
-Don't silently bail. Ask me for a URL only after auto-detection genuinely comes up empty, and report
-what you tried first: the branch name (`git branch --show-current`) and the `origin` remote you
-resolved the platform from. The edge cases below shape that fallback.
+Ask me for a URL only after detection genuinely comes up empty, and report what you tried: the branch
+(`git branch --show-current`) and the `origin` you resolved from. Edge cases:
 
-When the branch has no open PR/MR, `gh pr view` or `glab mr view` find nothing. Report the branch and
-remote, then ask for a URL.
-
-On a detached HEAD, `git symbolic-ref --quiet HEAD` fails, so there's no branch to resolve from. Skip
-detection and ask for a URL.
-
-With multiple remotes, resolve from `origin`. If that's not the right remote, I can pass a URL.
-
-A closed or merged target still resolves: `gh pr view --json state` (or the MR equivalent) may return
-a PR/MR whose `state` is not open. Surface the `state` so I can confirm it's the one I meant before
-you proceed.
+- Detached HEAD (no branch) => skip detection, ask.
+- Multiple remotes => use `origin`; I can pass a URL if that's wrong.
+- Closed or merged => still resolves; surface the `state` so I can confirm before proceeding.
 
 ### Detect Platform
 


### PR DESCRIPTION
Makes the `$ARGUMENTS` URL optional in `review:follow-up`. When invoked with no URL, the skill resolves the current branch's open PR/MR instead of asking me to paste one.

A new Resolve Target step runs first in the workflow. It picks the platform from `git remote get-url origin`, then resolves the branch's target: `gh pr view --json url,state --jq '.url'` on GitHub, `glab mr view --output json | jq -r '.web_url'` on GitLab. The resolved URL feeds the existing Detect Platform and downstream steps unchanged.

The point is to stop silently bailing to a "paste a URL" prompt. The skill only asks when detection genuinely fails (no open PR/MR for the branch), and reports the branch and remote it tried first. Edge cases are stated: detached HEAD skips detection, multiple remotes resolve from `origin`, and a closed or merged target still resolves but surfaces its `state` so I can confirm.

These idioms mirror the no-arg resolution already in `github:actions-monitor` and `gitlab:ci-monitor`.

Original Task: [Upgrade review:follow-up skill to auto-detect current branch's PR/MR](https://things.bendrucker.me/show?id=4swsqHQeqk7kKDvCcSUFcN)
