### PR TITLE
writing: exempt plan-mode writes from style hooks

### DIFF
--- a/plugins/writing/hooks/check-tropes.test.ts
+++ b/plugins/writing/hooks/check-tropes.test.ts
@@ -94,6 +94,29 @@ describe("plan files", () => {
   });
 });
 
+describe("plan mode", () => {
+  it("skips Write in plan mode with spaced em dash", async () => {
+    const input: PreToolUseHookInput = {
+      ...mockWrite("This \u2014 is bad"),
+      permission_mode: "plan",
+    };
+    expect(await processInput(input)).toBeNull();
+  });
+
+  it("skips Edit in plan mode with trope", async () => {
+    const input: PreToolUseHookInput = {
+      ...mockEdit("This \u2014 is bad"),
+      permission_mode: "plan",
+    };
+    expect(await processInput(input)).toBeNull();
+  });
+
+  it("still flags trope in normal mode outside plan path", async () => {
+    const result = await processInput(mockWrite("This \u2014 is bad"));
+    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
+  });
+});
+
 describe("memory files", () => {
   const memoryPath = `${process.env.HOME}/.claude/projects/-Users-ben-test/memory/MEMORY.md`;
 

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -4,7 +4,7 @@ import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import { isMemoryPath, isPlanPath } from "../detection/paths";
 import { firstByTier, type PatternMatch, scan, scanIntroduced } from "../detection/tropes";
-import { formatContext, formatDecision, type SyncHookJSONOutput } from "./io";
+import { formatContext, formatDecision, isPlanMode, type SyncHookJSONOutput } from "./io";
 
 const FILE_OP_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
 
@@ -245,6 +245,7 @@ export async function processInput(input: PreToolUseHookInput): Promise<SyncHook
   if (isPlanFile(input)) return null;
   if (isMemoryFile(input)) return null;
   if (isWordlistFile(input)) return null;
+  if (isPlanMode(input)) return null;
 
   if (FILE_OP_TOOLS.has(input.tool_name)) return processFileOp(input);
   return processSideEffect(input);

--- a/plugins/writing/hooks/headings.test.ts
+++ b/plugins/writing/hooks/headings.test.ts
@@ -265,4 +265,30 @@ describe("processInput", () => {
     const memoryPath = `${process.env.HOME}/.claude/projects/-Users-ben-test/memory/MEMORY.md`;
     expect(getOutput(mockWriteInput(memoryPath, "# introduction"))).toBeNull();
   });
+
+  it("skips Write to plan path", () => {
+    const planPath = `${process.env.HOME}/.claude/plans/my-plan.md`;
+    expect(getOutput(mockWriteInput(planPath, "# introduction"))).toBeNull();
+  });
+
+  it("skips Write in plan mode", () => {
+    const input: PreToolUseHookInput = {
+      ...mockWriteInput("README.md", "# introduction"),
+      permission_mode: "plan",
+    };
+    expect(getOutput(input)).toBeNull();
+  });
+
+  it("skips Write with sentence heading in plan mode", () => {
+    const input: PreToolUseHookInput = {
+      ...mockWriteInput("README.md", "## Latency Is the Main Bottleneck"),
+      permission_mode: "plan",
+    };
+    expect(getOutput(input)).toBeNull();
+  });
+
+  it("still flags lowercase heading outside plan mode and plan path", () => {
+    const output = getOutput(mockWriteInput("README.md", "# introduction"));
+    expect(output?.additionalContext).toContain("AP-style title case");
+  });
 });

--- a/plugins/writing/hooks/headings.ts
+++ b/plugins/writing/hooks/headings.ts
@@ -6,9 +6,15 @@ import { apStyleTitleCase } from "ap-style-title-case";
 import type { Heading, Paragraph, Strong, Text } from "mdast";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { visit } from "unist-util-visit";
-import { getExtension, isMarkdownFile, isMemoryPath } from "../detection/paths";
+import { getExtension, isMarkdownFile, isMemoryPath, isPlanPath } from "../detection/paths";
 import { classifyHeadingBaseline } from "../linguistics/heading";
-import { type EditInput, formatContext, type SyncHookJSONOutput, type WriteInput } from "./io";
+import {
+  type EditInput,
+  formatContext,
+  isPlanMode,
+  type SyncHookJSONOutput,
+  type WriteInput,
+} from "./io";
 
 const PLACEHOLDER = "\0";
 
@@ -147,6 +153,8 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
   }
 
   if (isMemoryPath(filePath)) return null;
+  if (isPlanPath(filePath)) return null;
+  if (isPlanMode(input)) return null;
 
   const ext = getExtension(filePath);
   if (!isMarkdownFile(ext)) return null;

--- a/plugins/writing/hooks/io.ts
+++ b/plugins/writing/hooks/io.ts
@@ -1,9 +1,13 @@
-import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 
 export type { SyncHookJSONOutput };
 
 export type WriteInput = { file_path: string; content: string };
 export type EditInput = { file_path: string; new_string: string };
+
+export function isPlanMode(input: PreToolUseHookInput): boolean {
+  return input.permission_mode === "plan";
+}
 
 export function formatDecision(decision: "deny" | "ask", reason: string): SyncHookJSONOutput {
   return {

--- a/plugins/writing/hooks/numbering.ts
+++ b/plugins/writing/hooks/numbering.ts
@@ -12,7 +12,13 @@ import type { Heading, Text } from "mdast";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { visit } from "unist-util-visit";
 import { getExtension, isMarkdownFile, isMemoryPath, isPlanPath } from "../detection/paths";
-import { type EditInput, formatDecision, type SyncHookJSONOutput, type WriteInput } from "./io";
+import {
+  type EditInput,
+  formatDecision,
+  isPlanMode,
+  type SyncHookJSONOutput,
+  type WriteInput,
+} from "./io";
 
 type Mode = "write" | "edit";
 
@@ -27,10 +33,6 @@ type AstGrepMatch = {
 };
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-
-function isPlanMode(input: PreToolUseHookInput): boolean {
-  return input.permission_mode === "plan";
-}
 
 export function checkMarkdown(content: string): string | null {
   const ast = fromMarkdown(content);


### PR DESCRIPTION
Disables the three writing-plugin style hooks (`headings`, `numbering`, `check-tropes`) when `permission_mode === 'plan'` or the file is a plan path.

The style hooks exist for outbound, human-facing writing: PR bodies, issues, READMEs, Slack. They were also firing on Claude's writing to itself (plans, plan-mode notes), which is the friction this fixes. Plan mode is the reliable signal, so plans written anywhere (`tmp/`, a repo `plans/` dir) are covered, not just `~/.claude/plans/`.

## Changes

- Extracts a shared `isPlanMode` predicate into `hooks/io.ts` and de-dups the inline copy in `numbering.ts`.
- Adds `isPlanMode(input)` and `isPlanPath(filePath)` guards to each of the three hooks.

## Testing

Outbound writing stays fully enforced. New cases cover a normal-mode Write to `README.md` still getting the title-case nag and a normal-mode trope still flagging, alongside the plan-mode and plan-path exemptions.
