### PR TITLE
Strip filler from skills to reclaim instruction tokens

### DIFF
--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -6,9 +6,9 @@ paths:
 
 # Hooks
 
-See the `claude-code:hook` skill for hook documentation. Plugin hooks are defined in `hooks/hooks.json`. This repository includes a Biome PostToolUse hook (`.claude/hooks/biome/`) that runs after file edits to check for lint errors.
+See the `claude-code:hook` skill for hook documentation. Plugin hooks are defined in `hooks/hooks.json`. A Biome PostToolUse hook (`.claude/hooks/biome/`) runs after file edits to check lint errors.
 
-Raw `git worktree add` is denied in favor of the `worktrunk` skill, except when the target is under `tmp/`, which is allowed for disposable scripted verification checkouts.
+Raw `git worktree add` is denied in favor of the `worktrunk` skill, except under `tmp/`, allowed for disposable scripted verification checkouts.
 
 Wrap `${CLAUDE_PLUGIN_ROOT}` in double quotes in shell-form hook commands: `bun "${CLAUDE_PLUGIN_ROOT}/scripts/foo.ts"`. Matcher fields are not shell commands and should not be quoted. Run `bun scripts/check-hook-quoting.ts` to validate.
 

--- a/.claude/rules/lockfile.md
+++ b/.claude/rules/lockfile.md
@@ -6,6 +6,6 @@ paths:
 
 # Lockfile Conflicts
 
-Resolve `bun.lock` conflicts by deleting the lockfile and running `bun install` to regenerate from scratch. Do not merge lockfile contents or use `git checkout origin/main -- bun.lock && bun install`, which produces empty integrity hashes for platform-specific packages and breaks CI on other platforms.
+Resolve `bun.lock` conflicts by deleting the lockfile and running `bun install` to regenerate. Do not merge lockfile contents or use `git checkout origin/main -- bun.lock && bun install`, which produces empty integrity hashes for platform-specific packages and breaks CI on other platforms.
 
 See [`plugins/bun/skills/bun/references/lockfile.md`](../../plugins/bun/skills/bun/references/lockfile.md) for the full explanation.

--- a/.claude/rules/plugins.md
+++ b/.claude/rules/plugins.md
@@ -49,7 +49,7 @@ Each plugin should have a `README.md` with consistent sections:
 - **Contents**: List what the plugin provides (skills, hooks, agents, commands)
 - **Testing**: How to run tests (if the plugin has tests)
 
-Do not include installation instructions or skill activation details, the README is an index, not documentation. Users can read the skill files directly for activation patterns.
+Do not include installation instructions or skill activation details, the README is an index, not documentation.
 
 ## Plugin Metadata
 

--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -18,7 +18,7 @@ Repo-internal tooling (`scripts/`, `.claude/hooks/`) must import `packages/` cod
 When writing scripts (hooks, skill CLIs, etc.) that accept arguments:
 
 - **Argument parsing**: Use [cleye](https://github.com/privatenumber/cleye) for type-safe argument parsing with automatic `--help` generation. Load the `cleye` skill for usage patterns (parameters, flags, subcommands) instead of reading existing scripts.
-- **Table output**: Use the `table` package for formatted terminal table output. Do not use `markdown-table` or similar GFM-oriented packages, script output is displayed in a terminal, not rendered as markdown.
+- **Table output**: Use the `table` package for terminal table output. Do not use `markdown-table` or similar GFM-oriented packages, script output is displayed in a terminal, not rendered as markdown.
 - **Ancestor paths**: Use `join(import.meta.dirname, "..")` to resolve parent directories. Avoid chaining `dirname()` calls; explicit `".."` is clearer.
 
 # Terminal Colors

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -22,6 +22,6 @@ After making changes to plugin scripts, run them directly to verify they work en
 
 Tests run per-plugin in the CI matrix for:
 - **Parallelization**: Integration tests can take seconds; running in parallel across plugins is faster
-- **Clear feedback**: Failed tests clearly indicate which plugin has the issue
+- **Clear feedback**: Failed tests indicate which plugin has the issue
 
 Root-level tests (e.g., `hooks/`) run in a dedicated job since they're not part of any plugin.

--- a/plugins/bun/skills/bun/SKILL.md
+++ b/plugins/bun/skills/bun/SKILL.md
@@ -7,13 +7,13 @@ description: Bun runtime patterns. Use when running bun commands, working with p
 
 ## bunx
 
-Use `--bun` before the executable name to force the Bun runtime over Node shebangs. Use `-p`/`--package` when the binary name differs from the package name (e.g., `bunx -p @angular/cli ng`).
+Put `--bun` before the executable name to force the Bun runtime over Node shebangs. Use `-p`/`--package` when the binary name differs from the package name (e.g., `bunx -p @angular/cli ng`).
 
 See [references/bunx.md](references/bunx.md)
 
 ## Lockfile
 
-`bun.lock` is a text-based lockfile. Resolve merge conflicts by deleting it and running `bun install` to regenerate from scratch — never attempt to merge lockfile contents.
+`bun.lock` is a text-based lockfile. Resolve merge conflicts by deleting it and running `bun install` to regenerate — never merge it.
 
 See [references/lockfile.md](references/lockfile.md)
 
@@ -25,13 +25,13 @@ See [references/resolution.md](references/resolution.md)
 
 ## Shell
 
-`Bun.$` is a tagged template for shell execution. Use response methods (`.text()`, `.json()`, `.lines()`) to extract output, `.nothrow()` to handle failures without exceptions, and pipe/redirect syntax for composing commands.
+`Bun.$` is a tagged template for shell execution. Use response methods (`.text()`, `.json()`, `.lines()`) to extract output, `.nothrow()` to handle failures without exceptions, and pipe/redirect syntax to compose commands.
 
 See [references/shell.md](references/shell.md)
 
 ## Subprocess
 
-`Bun.spawn` spawns subprocesses with streaming I/O. Use `Bun.spawnSync` for synchronous execution. Configure stdin/stdout/stderr, environment variables, and working directory. Check `exitCode` for error handling.
+`Bun.spawn` spawns subprocesses with streaming I/O; `Bun.spawnSync` runs synchronously. Configure stdin/stdout/stderr, environment variables, and working directory. Check `exitCode` for errors.
 
 See [references/spawn.md](references/spawn.md)
 

--- a/plugins/bun/skills/bun/references/file-io.md
+++ b/plugins/bun/skills/bun/references/file-io.md
@@ -41,7 +41,7 @@ console.log(file.type); // "image/png"
 
 ## Bun.write()
 
-`Bun.write()` writes content to a file, creating it if it doesn't exist:
+`Bun.write()` writes content to a file, creating it if absent:
 
 ```ts
 await Bun.write("output.txt", "content");

--- a/plugins/bun/skills/bun/references/lockfile.md
+++ b/plugins/bun/skills/bun/references/lockfile.md
@@ -4,10 +4,10 @@
 
 ## Conflict Resolution
 
-Regenerate from scratch:
+Regenerate:
 
 ```bash
 rm bun.lock && bun install
 ```
 
-Do **not** use `git checkout origin/main -- bun.lock && bun install`. This produces empty integrity hashes for platform-specific packages (e.g., `@img/sharp-libvips-linux-x64`), breaking CI on other platforms.
+Do **not** use `git checkout origin/main -- bun.lock && bun install` — it produces empty integrity hashes for platform-specific packages (e.g., `@img/sharp-libvips-linux-x64`), breaking CI on other platforms.

--- a/plugins/bun/skills/bun/references/shell.md
+++ b/plugins/bun/skills/bun/references/shell.md
@@ -44,7 +44,7 @@ const { exitCode, stdout } = await $`cmd`.nothrow().quiet();
 
 ## Piping
 
-Pipe output between commands:
+Pipe between commands:
 
 ```ts
 const text = await $`echo hello | tr a-z A-Z`.text();

--- a/plugins/bun/skills/bun/references/spawn.md
+++ b/plugins/bun/skills/bun/references/spawn.md
@@ -44,7 +44,7 @@ console.log(proc.exitCode); // 1
 
 ## Bun.spawnSync
 
-For synchronous execution, use `Bun.spawnSync`:
+For synchronous execution:
 
 ```ts
 const result = Bun.spawnSync(["echo", "hello"]);

--- a/plugins/bun/skills/bun/references/testing.md
+++ b/plugins/bun/skills/bun/references/testing.md
@@ -80,7 +80,7 @@ afterAll(() => {
 
 ## Mocking
 
-Use `mock()` to create function mocks:
+Create function mocks with `mock()`:
 
 ```ts
 import { mock } from "bun:test";

--- a/plugins/calendar/skills/calendar/SKILL.md
+++ b/plugins/calendar/skills/calendar/SKILL.md
@@ -23,13 +23,13 @@ hooks:
 
 Interact with Calendar.app using a Swift CLI that wraps EventKit.
 
-The CLI lives at `@skills/calendar/scripts/cal.swift` and is invoked via `swift <path> <command> [options]`. It uses EventKit's native date range predicates for efficient queries and returns JSON.
+The CLI lives at `@skills/calendar/scripts/cal.swift`, invoked via `swift <path> <command> [options]`. It uses EventKit's native date range predicates for efficient queries and returns JSON.
 
 ## Setup
 
 Calendar access must be granted to the terminal app (Ghostty, Terminal.app, etc.) in **System Settings → Privacy & Security → Calendars**.
 
-EventKit requires TCC permissions tied to an app bundle. Over SSH, in tmux, or in any context where the responsible process has no app bundle, EventKit access is unavailable. Use a local terminal session launched directly from an app (not through a multiplexer).
+EventKit requires TCC permissions tied to an app bundle. Over SSH, in tmux, or any context where the responsible process has no app bundle, EventKit access is unavailable. Use a local terminal session launched directly from an app, not through a multiplexer.
 
 ## Read Operations
 
@@ -38,7 +38,7 @@ EventKit requires TCC permissions tied to an app bundle. Over SSH, in tmux, or i
 timeout 5 swift @scripts/cal.swift calendars
 ```
 
-Returns `id`, `name`, `writable`, and `source` (Google, iCloud, etc.) for each calendar. Use `id` or `name` to filter in other commands.
+Returns `id`, `name`, `writable`, and `source` (Google, iCloud, etc.) per calendar. Use `id` or `name` to filter in other commands.
 
 **List events in a date range:**
 ```bash
@@ -118,13 +118,13 @@ When creating events with `--calendar`, the CLI tries:
 1. Exact calendar ID match
 2. Calendar name match (first writable match if duplicates exist)
 
-For calendars with duplicate names (e.g., "Personal" on both Google and iCloud), use the calendar ID from the `calendars` command.
+For duplicate names (e.g., "Personal" on both Google and iCloud), use the calendar ID from the `calendars` command.
 
 ## Troubleshooting
 
 **"Calendar access denied"**: Grant access in System Settings → Privacy & Security → Calendars for your terminal app.
 
-**"Calendar access denied" with `"reason": "no-app-bundle"`**: The responsible process has no app bundle context. This occurs in tmux, SSH, or similar environments where macOS cannot identify a bundled app to associate TCC permissions with. Switch to a direct terminal session (e.g., Ghostty or Terminal.app, not inside tmux).
+**"Calendar access denied" with `"reason": "no-app-bundle"`**: The responsible process has no app bundle context. Occurs in tmux, SSH, or similar environments where macOS cannot identify a bundled app to associate TCC permissions with. Switch to a direct terminal session (e.g., Ghostty or Terminal.app, not tmux).
 
 **"Event not found"**: Event IDs are EventKit identifiers returned by `list` and `create`. IDs from other tools (icalBuddy, JXA) are incompatible.
 

--- a/plugins/claude-code/skills/agent-team/SKILL.md
+++ b/plugins/claude-code/skills/agent-team/SKILL.md
@@ -45,7 +45,7 @@ Teams are stored locally:
 
 The config contains a `members` array with each teammate's name, agent ID, and type. Teammates read this file to discover each other.
 
-Teammates inherit the lead's permission settings at spawn. Each teammate loads project context (CLAUDE.md, MCP servers, skills) plus the spawn prompt — the lead's conversation history does not carry over.
+Teammates inherit the lead's permission settings at spawn. Each loads project context (CLAUDE.md, MCP servers, skills) plus the spawn prompt — the lead's conversation history does not carry over.
 
 ## Limitations
 

--- a/plugins/claude-code/skills/agent-team/references/practices.md
+++ b/plugins/claude-code/skills/agent-team/references/practices.md
@@ -12,7 +12,7 @@ Teammates don't inherit the lead's conversation history. Include task-specific d
 |---|---|
 | Too small | Coordination overhead exceeds the benefit |
 | Too large | Teammates work too long without check-ins, risking wasted effort |
-| Right | Self-contained units producing a clear deliverable (a function, test file, or review) |
+| Right | Self-contained units producing a clear deliverable (function, test file, or review) |
 
 Aim for 5-6 tasks per teammate.
 

--- a/plugins/claude-code/skills/changelog/SKILL.md
+++ b/plugins/claude-code/skills/changelog/SKILL.md
@@ -67,7 +67,7 @@ What the feature does and a concrete explanation of why this user should care.
 * **things:** Store tag mappings in the plugin data directory so they persist across plugin updates, eliminating the need to re-configure after each update.
 ```
 
-**Bug Fixes, Performance, Quality of Life**: Summarize each category in 2-3 sentences highlighting the most impactful changes. Don't list every entry. The goal is to extract what's useful, not mirror the changelog. If the user asks about a specific area, then go deeper on that area.
+**Bug Fixes, Performance, Quality of Life**: Summarize each category in 2-3 sentences highlighting the most impactful changes. Don't list every entry. Extract what's useful, not mirror the changelog. If the user asks about a specific area, go deeper there.
 
 ## Gotchas
 

--- a/plugins/claude-code/skills/hook/SKILL.md
+++ b/plugins/claude-code/skills/hook/SKILL.md
@@ -13,7 +13,7 @@ allowed-tools:
 
 # Claude Code Hooks
 
-Reference for creating and configuring Claude Code hooks. When uncertain about syntax or features, use the Task tool with `subagent_type='claude-code-guide'` to consult official documentation.
+Reference for creating and configuring Claude Code hooks. When uncertain about syntax or features, use the Task tool with `subagent_type='claude-code-guide'` to consult official docs.
 
 ## Hook Types
 

--- a/plugins/claude-code/skills/skill-creator/SKILL.md
+++ b/plugins/claude-code/skills/skill-creator/SKILL.md
@@ -6,40 +6,28 @@ disable-model-invocation: true
 
 # Skill Creator
 
-A skill for creating new skills and iteratively improving them.
+Create new skills and iteratively improve them. The process:
 
-At a high level, the process of creating a skill goes like this:
-
-- Decide what you want the skill to do and roughly how it should do it
-- Write a draft of the skill
+- Decide what the skill should do and roughly how
+- Write a draft
 - Create a few test prompts and run claude-with-access-to-the-skill on them
-- Help the user evaluate the results both qualitatively and quantitatively
-  - While the runs happen in the background, draft some quantitative evals if there aren't any (if there are some, you can either use as is or modify if you feel something needs to change about them). Then explain them to the user (or if they already existed, explain the ones that already exist)
-  - Use the `scripts/generate_review.py` script to show the user the results for them to look at, and also let them look at the quantitative metrics
-- Rewrite the skill based on feedback from the user's evaluation of the results (and also if there are any glaring flaws that become apparent from the quantitative benchmarks)
-- Repeat until you're satisfied
+- Help the user evaluate the results qualitatively and quantitatively
+  - While the runs happen in the background, draft quantitative evals if there aren't any (use or modify existing ones). Then explain them to the user
+  - Use `scripts/generate_review.py` to show the user the results and the quantitative metrics
+- Rewrite the skill based on the user's evaluation (and any glaring flaws the benchmarks reveal)
+- Repeat until satisfied
 - Expand the test set and try again at larger scale
 
-Your job when using this skill is to figure out where the user is in this process and then jump in and help them progress through these stages. So for instance, maybe they're like "I want to make a skill for X". You can help narrow down what they mean, write a draft, write the test cases, figure out how they want to evaluate, run all the prompts, and repeat.
-
-On the other hand, maybe they already have a draft of the skill. In this case you can go straight to the eval/iterate part of the loop.
-
-Of course, you should always be flexible and if the user is like "I don't need to run a bunch of evaluations, just vibe with me", you can do that instead.
-
-Then after the skill is done (but again, the order is flexible), you can also run the skill description improver, which we have a whole separate script for, to optimize the triggering of the skill.
-
-Cool? Cool.
+Figure out where the user is in this process and help them progress. If they say "I want to make a skill for X", help narrow down what they mean, write a draft, write test cases, evaluate, run the prompts, and repeat. If they already have a draft, go straight to the eval/iterate loop. Stay flexible: if they say "I don't need evaluations, just vibe with me", do that. After the skill is done (order is flexible), run the skill description improver (separate script) to optimize triggering.
 
 ## Communicating with the user
 
-The skill creator is liable to be used by people across a wide range of familiarity with coding jargon. If you haven't heard (and how could you, it's only very recently that it started), there's a trend now where the power of Claude is inspiring plumbers to open up their terminals, parents and grandparents to google "how to install npm". On the other hand, the bulk of users are probably fairly computer-literate.
-
-So please pay attention to context cues to understand how to phrase your communication! In the default case, just to give you some idea:
+Users range widely in familiarity with coding jargon — from plumbers and grandparents newly opening a terminal to fully computer-literate developers. Read context cues to phrase your communication. As a guide:
 
 - "evaluation" and "benchmark" are borderline, but OK
-- for "JSON" and "assertion" you want to see serious cues from the user that they know what those things are before using them without explaining them
+- for "JSON" and "assertion", wait for serious cues that the user knows the terms before using them unexplained
 
-It's OK to briefly explain terms if you're in doubt, and feel free to clarify terms with a short definition if you're unsure if the user will get it.
+Briefly explain or define terms when in doubt.
 
 ---
 
@@ -47,7 +35,7 @@ It's OK to briefly explain terms if you're in doubt, and feel free to clarify te
 
 ### Capture Intent
 
-Start by understanding the user's intent. The current conversation might already contain a workflow the user wants to capture (e.g., they say "turn this into a skill"). If so, extract answers from the conversation history first — the tools used, the sequence of steps, corrections the user made, input/output formats observed. The user may need to fill the gaps, and should confirm before proceeding to the next step.
+Start by understanding the user's intent. The current conversation might already contain a workflow the user wants to capture (e.g., they say "turn this into a skill"). If so, extract answers from the conversation history first — the tools used, the sequence of steps, corrections the user made, input/output formats observed. The user may need to fill the gaps, and should confirm before proceeding.
 
 1. What should this skill enable Claude to do?
 2. When should this skill trigger? (what user phrases/contexts)
@@ -56,18 +44,18 @@ Start by understanding the user's intent. The current conversation might already
 
 ### Interview and Research
 
-Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Wait to write test prompts until you've got this part ironed out.
+Proactively ask about edge cases, input/output formats, example files, success criteria, and dependencies. Wait to write test prompts until this is ironed out.
 
-Check available MCPs - if useful for research (searching docs, finding similar skills, looking up best practices), research in parallel via subagents if available, otherwise inline. Come prepared with context to reduce burden on the user.
+Check available MCPs — if useful for research (searching docs, finding similar skills, looking up best practices), research in parallel via subagents if available, otherwise inline. Come prepared with context to reduce burden on the user.
 
 ### Write the SKILL.md
 
-Based on the user interview, fill in these components:
+Based on the interview, fill in these components:
 
 - **name**: Skill identifier
-- **description**: When to trigger, what it does. This is the primary triggering mechanism - include both what the skill does AND specific contexts for when to use it. All "when to use" info goes here, not in the body. Note: currently Claude has a tendency to "undertrigger" skills -- to not use them when they'd be useful. To combat this, please make the skill descriptions a little bit "pushy". So for instance, instead of "How to build a simple fast dashboard to display internal Anthropic data.", you might write "How to build a simple fast dashboard to display internal Anthropic data. Make sure to use this skill whenever the user mentions dashboards, data visualization, internal metrics, or wants to display any kind of company data, even if they don't explicitly ask for a 'dashboard.'"
+- **description**: When to trigger, what it does. This is the primary triggering mechanism — include both what the skill does AND specific contexts for when to use it. All "when to use" info goes here, not in the body. Claude tends to "undertrigger" skills — to not use them when they'd be useful. To combat this, make descriptions a little "pushy". Instead of "How to build a simple fast dashboard to display internal Anthropic data.", write "How to build a simple fast dashboard to display internal Anthropic data. Make sure to use this skill whenever the user mentions dashboards, data visualization, internal metrics, or wants to display any kind of company data, even if they don't explicitly ask for a 'dashboard.'"
 - **compatibility**: Required tools, dependencies (optional, rarely needed)
-- **the rest of the skill :)**
+- the rest of the skill
 
 ### Skill Writing Guide
 
@@ -91,10 +79,10 @@ Skills use a three-level loading system:
 2. **SKILL.md body** - In context whenever skill triggers (<500 lines ideal)
 3. **Bundled resources** - As needed (unlimited, scripts can execute without loading)
 
-These word counts are approximate and you can feel free to go longer if needed.
+These word counts are approximate; go longer if needed.
 
 **Key patterns:**
-- Keep SKILL.md under 500 lines; if you're approaching this limit, add an additional layer of hierarchy along with clear pointers about where the model using the skill should go next to follow up.
+- Keep SKILL.md under 500 lines; if approaching this limit, add another layer of hierarchy with clear pointers to where the model should go next.
 - Reference files clearly from SKILL.md with guidance on when to read them
 - For large reference files (>300 lines), include a table of contents
 
@@ -111,13 +99,13 @@ Claude reads only the relevant reference file.
 
 #### Principle of Lack of Surprise
 
-This goes without saying, but skills must not contain malware, exploit code, or any content that could compromise system security. A skill's contents should not surprise the user in their intent if described. Don't go along with requests to create misleading skills or skills designed to facilitate unauthorized access, data exfiltration, or other malicious activities. Things like a "roleplay as an XYZ" are OK though.
+Skills must not contain malware, exploit code, or content that could compromise system security. A skill's contents should not surprise the user given its description. Don't create misleading skills or skills designed to facilitate unauthorized access, data exfiltration, or other malicious activities. Things like "roleplay as an XYZ" are OK.
 
 #### Writing Patterns
 
-Prefer using the imperative form in instructions.
+Prefer imperative form in instructions.
 
-**Defining output formats** - You can do it like this:
+**Defining output formats** — like this:
 ```markdown
 ## Report structure
 ALWAYS use this exact template:
@@ -127,7 +115,7 @@ ALWAYS use this exact template:
 ## Recommendations
 ```
 
-**Examples pattern** - It's useful to include examples. You can format them like this (but if "Input" and "Output" are in the examples you might want to deviate a little):
+**Examples pattern** — include examples, formatted like this (deviate a little if "Input" and "Output" appear in the examples themselves):
 ```markdown
 ## Commit message format
 **Example 1:**
@@ -137,11 +125,11 @@ Output: feat(auth): implement JWT-based authentication
 
 ### Writing Style
 
-Try to explain to the model why things are important in lieu of heavy-handed musty MUSTs. Use theory of mind and try to make the skill general and not super-narrow to specific examples. Start by writing a draft and then look at it with fresh eyes and improve it.
+Explain to the model why things matter rather than relying on heavy-handed MUSTs. Use theory of mind; keep the skill general, not narrow to specific examples. Write a draft, then review it with fresh eyes and improve it.
 
 ### Test Cases
 
-After writing the skill draft, come up with 2-3 realistic test prompts — the kind of thing a real user would actually say. Share them with the user: [you don't have to use this exact language] "Here are a few test cases I'd like to try. Do these look right, or do you want to add more?" Then run them.
+After drafting, come up with 2-3 realistic test prompts — the kind of thing a real user would say. Share them with the user (you don't have to use this exact language): "Here are a few test cases I'd like to try. Do these look right, or do you want to add more?" Then run them.
 
 Save test cases to `evals/evals.json`. Don't write assertions yet — just the prompts. You'll draft assertions in the next step while the runs are in progress.
 
@@ -165,11 +153,11 @@ See `references/schemas.md` for the full schema (including the `assertions` fiel
 
 This section is one continuous sequence — don't stop partway through. Do NOT use `/skill-test` or any other testing skill.
 
-Put results in `<skill-name>-workspace/` as a sibling to the skill directory. Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
+Put results in `<skill-name>-workspace/` as a sibling to the skill directory. Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — create directories as you go.
 
 ### Step 1: Spawn all runs (with-skill AND baseline) in the same turn
 
-For each test case, spawn two subagents in the same turn — one with the skill, one without. This is important: don't spawn the with-skill runs first and then come back for baselines later. Launch everything at once so it all finishes around the same time.
+For each test case, spawn two subagents in the same turn — one with the skill, one without. Don't spawn the with-skill runs first and come back for baselines later. Launch everything at once so it finishes around the same time.
 
 **With-skill run:**
 
@@ -199,11 +187,11 @@ Write an `eval_metadata.json` for each test case (assertions can be empty for no
 
 ### Step 2: While runs are in progress, draft assertions
 
-Don't just wait for the runs to finish — you can use this time productively. Draft quantitative assertions for each test case and explain them to the user. If assertions already exist in `evals/evals.json`, review them and explain what they check.
+Use this time productively. Draft quantitative assertions for each test case and explain them to the user. If assertions already exist in `evals/evals.json`, review them and explain what they check.
 
 Good assertions are objectively verifiable and have descriptive names — they should read clearly in the benchmark viewer so someone glancing at the results immediately understands what each one checks. Subjective skills (writing style, design quality) are better evaluated qualitatively — don't force assertions onto things that need human judgment.
 
-Update the `eval_metadata.json` files and `evals/evals.json` with the assertions once drafted. Also explain to the user what they'll see in the viewer — both the qualitative outputs and the quantitative benchmark.
+Update the `eval_metadata.json` files and `evals/evals.json` with the assertions once drafted. Also explain to the user what they'll see in the viewer — the qualitative outputs and the quantitative benchmark.
 
 ### Step 3: As runs complete, capture timing data
 
@@ -217,13 +205,13 @@ When each subagent task completes, you receive a notification containing `total_
 }
 ```
 
-This is the only opportunity to capture this data — it comes through the task notification and isn't persisted elsewhere. Process each notification as it arrives rather than trying to batch them.
+This is the only opportunity to capture this data — it comes through the task notification and isn't persisted elsewhere. Process each notification as it arrives rather than batching them.
 
 ### Step 4: Grade, aggregate, and launch the viewer
 
 Once all runs are done:
 
-1. **Grade each run** — spawn a grader subagent (or grade inline) that reads `agents/grader.md` and evaluates each assertion against the outputs. Save results to `grading.json` in each run directory. The grading.json expectations array must use the fields `text`, `passed`, and `evidence` (not `name`/`met`/`details` or other variants) — the viewer depends on these exact field names. For assertions that can be checked programmatically, write and run a script rather than eyeballing it — scripts are faster, more reliable, and can be reused across iterations.
+1. **Grade each run** — spawn a grader subagent (or grade inline) that reads `agents/grader.md` and evaluates each assertion against the outputs. Save results to `grading.json` in each run directory. The grading.json expectations array must use the fields `text`, `passed`, and `evidence` (not `name`/`met`/`details` or other variants) — the viewer depends on these exact field names. For assertions checkable programmatically, write and run a script rather than eyeballing it — scripts are faster, more reliable, and reusable across iterations.
 
 2. **Aggregate into benchmark** — run the aggregation script from the skill-creator directory:
    ```bash
@@ -232,7 +220,7 @@ Once all runs are done:
    This produces `benchmark.json` and `benchmark.md` with pass_rate, time, and tokens for each configuration, with mean ± stddev and the delta. If generating benchmark.json manually, see `references/schemas.md` for the exact schema the viewer expects.
 Put each with_skill version before its baseline counterpart.
 
-3. **Do an analyst pass** — read the benchmark data and surface patterns the aggregate stats might hide. See `agents/analyzer.md` (the "Analyzing Benchmark Results" section) for what to look for — things like assertions that always pass regardless of skill (non-discriminating), high-variance evals (possibly flaky), and time/token tradeoffs.
+3. **Do an analyst pass** — read the benchmark data and surface patterns the aggregate stats hide. See `agents/analyzer.md` ("Analyzing Benchmark Results" section) for what to look for: assertions that always pass regardless of skill (non-discriminating), high-variance evals (possibly flaky), and time/token tradeoffs.
 
 4. **Launch the viewer** with both qualitative outputs and quantitative data:
    ```bash
@@ -245,9 +233,9 @@ Put each with_skill version before its baseline counterpart.
    ```
    For iteration 2+, also pass `--previous-workspace <workspace>/iteration-<N-1>`.
 
-   **Cowork / headless environments:** If `webbrowser.open()` is not available or the environment has no display, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Feedback will be downloaded as a `feedback.json` file when the user clicks "Submit All Reviews". After download, copy `feedback.json` into the workspace directory for the next iteration to pick up.
+   **Cowork / headless environments:** If `webbrowser.open()` is unavailable or the environment has no display, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Feedback downloads as a `feedback.json` file when the user clicks "Submit All Reviews". After download, copy `feedback.json` into the workspace directory for the next iteration to pick up.
 
-Note: please use generate_review.py to create the viewer; there's no need to write custom HTML.
+Use generate_review.py to create the viewer; don't write custom HTML.
 
 5. **Tell the user** something like: "I've opened the results in your browser. There are two tabs — 'Outputs' lets you click through each test case and leave feedback, 'Benchmark' shows the quantitative comparison. When you're done, come back here and let me know."
 
@@ -280,9 +268,9 @@ When the user tells you they're done, read `feedback.json`:
 }
 ```
 
-Empty feedback means the user thought it was fine. Focus your improvements on the test cases where the user had specific complaints.
+Empty feedback means the user thought it was fine. Focus improvements on test cases where the user had specific complaints.
 
-Kill the viewer server when you're done with it:
+Kill the viewer server when done:
 
 ```bash
 kill $VIEWER_PID 2>/dev/null
@@ -292,26 +280,26 @@ kill $VIEWER_PID 2>/dev/null
 
 ## Improving the skill
 
-This is the heart of the loop. You've run the test cases, the user has reviewed the results, and now you need to make the skill better based on their feedback.
+The heart of the loop: you've run the test cases, the user reviewed the results, now make the skill better based on their feedback.
 
 ### How to think about improvements
 
-1. **Generalize from the feedback.** The big picture thing that's happening here is that we're trying to create skills that can be used a million times (maybe literally, maybe even more who knows) across many different prompts. Here you and the user are iterating on only a few examples over and over again because it helps move faster. The user knows these examples in and out and it's quick for them to assess new outputs. But if the skill you and the user are codeveloping works only for those examples, it's useless. Rather than put in fiddly overfitty changes, or oppressively constrictive MUSTs, if there's some stubborn issue, you might try branching out and using different metaphors, or recommending different patterns of working. It's relatively cheap to try and maybe you'll land on something great.
+1. **Generalize from the feedback.** Skills are meant to be used across many different prompts. You and the user iterate on only a few examples because it moves faster — the user knows them well and can assess new outputs quickly. But a skill that works only for those examples is useless. Rather than fiddly overfit changes or constrictive MUSTs, when an issue is stubborn try different metaphors or recommend different working patterns. It's cheap to try and may land on something great.
 
-2. **Keep the prompt lean.** Remove things that aren't pulling their weight. Make sure to read the transcripts, not just the final outputs — if it looks like the skill is making the model waste a bunch of time doing things that are unproductive, you can try getting rid of the parts of the skill that are making it do that and seeing what happens.
+2. **Keep the prompt lean.** Remove things that aren't pulling their weight. Read the transcripts, not just the final outputs — if the skill is making the model waste time, try removing the parts causing that and see what happens.
 
-3. **Explain the why.** Try hard to explain the **why** behind everything you're asking the model to do. Today's LLMs are *smart*. They have good theory of mind and when given a good harness can go beyond rote instructions and really make things happen. Even if the feedback from the user is terse or frustrated, try to actually understand the task and why the user is writing what they wrote, and what they actually wrote, and then transmit this understanding into the instructions. If you find yourself writing ALWAYS or NEVER in all caps, or using super rigid structures, that's a yellow flag — if possible, reframe and explain the reasoning so that the model understands why the thing you're asking for is important. That's a more humane, powerful, and effective approach.
+3. **Explain the why.** Explain the **why** behind everything you ask the model to do. Today's LLMs are smart; with a good harness they go beyond rote instructions. Even when feedback is terse or frustrated, understand the task and why the user wrote what they wrote, then transmit that understanding into the instructions. Writing ALWAYS or NEVER in all caps, or rigid structures, is a yellow flag — reframe and explain the reasoning so the model understands why it matters.
 
-4. **Look for repeated work across test cases.** Read the transcripts from the test runs and notice if the subagents all independently wrote similar helper scripts or took the same multi-step approach to something. If all 3 test cases resulted in the subagent writing a `create_docx.py` or a `build_chart.py`, that's a strong signal the skill should bundle that script. Write it once, put it in `scripts/`, and tell the skill to use it. This saves every future invocation from reinventing the wheel.
+4. **Look for repeated work across test cases.** Read the transcripts and notice if subagents all independently wrote similar helper scripts or took the same multi-step approach. If all 3 test cases produced a `create_docx.py` or `build_chart.py`, that's a strong signal to bundle that script: write it once, put it in `scripts/`, and tell the skill to use it. Saves every future invocation from reinventing the wheel.
 
-This task is pretty important (we are trying to create billions a year in economic value here!) and your thinking time is not the blocker; take your time and really mull things over. I'd suggest writing a draft revision and then looking at it anew and making improvements. Really do your best to get into the head of the user and understand what they want and need.
+Take your time; thinking time isn't the blocker. Write a draft revision, then review it anew and improve. Get into the user's head to understand what they want and need.
 
 ### The iteration loop
 
 After improving the skill:
 
 1. Apply your improvements to the skill
-2. Rerun all test cases into a new `iteration-<N+1>/` directory, including baseline runs. If you're creating a new skill, the baseline is always `without_skill` (no skill) — that stays the same across iterations. If you're improving an existing skill, use your judgment on what makes sense as the baseline: the original version the user came in with, or the previous iteration.
+2. Rerun all test cases into a new `iteration-<N+1>/` directory, including baseline runs. If creating a new skill, the baseline is always `without_skill` (no skill) — that stays the same across iterations. If improving an existing skill, use your judgment on the baseline: the original version the user came in with, or the previous iteration.
 3. Launch the reviewer with `--previous-workspace` pointing at the previous iteration
 4. Wait for the user to review and tell you they're done
 5. Read the new feedback, improve again, repeat
@@ -325,15 +313,15 @@ Keep going until:
 
 ## Advanced: Blind comparison
 
-For situations where you want a more rigorous comparison between two versions of a skill (e.g., the user asks "is the new version actually better?"), there's a blind comparison system. Read `agents/comparator.md` and `agents/analyzer.md` for the details. The basic idea is: give two outputs to an independent agent without telling it which is which, and let it judge quality. Then analyze why the winner won.
+For a more rigorous comparison between two versions of a skill (e.g., "is the new version actually better?"), there's a blind comparison system. Read `agents/comparator.md` and `agents/analyzer.md` for details. The idea: give two outputs to an independent agent without telling it which is which, let it judge quality, then analyze why the winner won.
 
-This is optional, requires subagents, and most users won't need it. The human review loop is usually sufficient.
+Optional, requires subagents, and most users won't need it. The human review loop is usually sufficient.
 
 ---
 
 ## Description Optimization
 
-The description field in SKILL.md frontmatter is the primary mechanism that determines whether Claude invokes a skill. After creating or improving a skill, offer to optimize the description for better triggering accuracy.
+The description field in SKILL.md frontmatter is the primary mechanism determining whether Claude invokes a skill. After creating or improving a skill, offer to optimize the description for better triggering accuracy.
 
 ### Step 1: Generate trigger eval queries
 
@@ -346,17 +334,17 @@ Create 20 eval queries — a mix of should-trigger and should-not-trigger. Save 
 ]
 ```
 
-The queries must be realistic and something a Claude Code or Claude.ai user would actually type. Not abstract requests, but requests that are concrete and specific and have a good amount of detail. For instance, file paths, personal context about the user's job or situation, column names and values, company names, URLs. A little bit of backstory. Some might be in lowercase or contain abbreviations or typos or casual speech. Use a mix of different lengths, and focus on edge cases rather than making them clear-cut (the user will get a chance to sign off on them).
+The queries must be realistic — something a Claude Code or Claude.ai user would actually type. Concrete and specific with detail: file paths, personal context about the user's job or situation, column names and values, company names, URLs, a little backstory. Some in lowercase or with abbreviations, typos, or casual speech. Mix lengths, and focus on edge cases rather than clear-cut ones (the user signs off on them).
 
 Bad: `"Format this data"`, `"Extract text from PDF"`, `"Create a chart"`
 
 Good: `"ok so my boss just sent me this xlsx file (its in my downloads, called something like 'Q4 sales final FINAL v2.xlsx') and she wants me to add a column that shows the profit margin as a percentage. The revenue is in column C and costs are in column D i think"`
 
-For the **should-trigger** queries (8-10), think about coverage. You want different phrasings of the same intent — some formal, some casual. Include cases where the user doesn't explicitly name the skill or file type but clearly needs it. Throw in some uncommon use cases and cases where this skill competes with another but should win.
+For the **should-trigger** queries (8-10), think about coverage: different phrasings of the same intent, some formal, some casual. Include cases where the user doesn't explicitly name the skill or file type but clearly needs it. Add uncommon use cases and cases where this skill competes with another but should win.
 
-For the **should-not-trigger** queries (8-10), the most valuable ones are the near-misses — queries that share keywords or concepts with the skill but actually need something different. Think adjacent domains, ambiguous phrasing where a naive keyword match would trigger but shouldn't, and cases where the query touches on something the skill does but in a context where another tool is more appropriate.
+For the **should-not-trigger** queries (8-10), the most valuable are near-misses — queries that share keywords or concepts but need something different. Adjacent domains, ambiguous phrasing where a naive keyword match would trigger but shouldn't, and cases where the query touches what the skill does but in a context where another tool fits better.
 
-The key thing to avoid: don't make should-not-trigger queries obviously irrelevant. "Write a fibonacci function" as a negative test for a PDF skill is too easy — it doesn't test anything. The negative cases should be genuinely tricky.
+Don't make should-not-trigger queries obviously irrelevant. "Write a fibonacci function" as a negative test for a PDF skill tests nothing. Negatives should be genuinely tricky.
 
 ### Step 2: Review with user
 
@@ -369,9 +357,9 @@ Present the eval set to the user for review using the HTML template:
    - `__SKILL_DESCRIPTION_PLACEHOLDER__` → the skill's current description
 3. Write to a temp file (e.g., `/tmp/eval_review_<skill-name>.html`) and open it: `open /tmp/eval_review_<skill-name>.html`
 4. The user can edit queries, toggle should-trigger, add/remove entries, then click "Export Eval Set"
-5. The file downloads to `~/Downloads/eval_set.json` — check the Downloads folder for the most recent version in case there are multiple (e.g., `eval_set (1).json`)
+5. The file downloads to `~/Downloads/eval_set.json` — check Downloads for the most recent version if there are multiple (e.g., `eval_set (1).json`)
 
-This step matters — bad eval queries lead to bad descriptions.
+Bad eval queries lead to bad descriptions.
 
 ### Step 3: Run the optimization loop
 
@@ -392,13 +380,13 @@ Use the model ID from your system prompt (the one powering the current session) 
 
 While it runs, periodically tail the output to give the user updates on which iteration it's on and what the scores look like.
 
-This handles the full optimization loop automatically. It splits the eval set into 60% train and 40% held-out test, evaluates the current description (running each query 3 times to get a reliable trigger rate), then calls Claude with extended thinking to propose improvements based on what failed. It re-evaluates each new description on both train and test, iterating up to 5 times. When it's done, it opens an HTML report in the browser showing the results per iteration and returns JSON with `best_description` — selected by test score rather than train score to avoid overfitting.
+This handles the full optimization loop automatically: splits the eval set into 60% train and 40% held-out test, evaluates the current description (each query 3 times for a reliable trigger rate), then calls Claude with extended thinking to propose improvements based on what failed. It re-evaluates each new description on train and test, iterating up to 5 times. When done, it opens an HTML report showing per-iteration results and returns JSON with `best_description` — selected by test score rather than train score to avoid overfitting.
 
 ### How skill triggering works
 
-Understanding the triggering mechanism helps design better eval queries. Skills appear in Claude's `available_skills` list with their name + description, and Claude decides whether to consult a skill based on that description. The important thing to know is that Claude only consults skills for tasks it can't easily handle on its own — simple, one-step queries like "read this PDF" may not trigger a skill even if the description matches perfectly, because Claude can handle them directly with basic tools. Complex, multi-step, or specialized queries reliably trigger skills when the description matches.
+Understanding the triggering mechanism helps design better eval queries. Skills appear in Claude's `available_skills` list with their name + description, and Claude decides whether to consult a skill based on that description. Claude only consults skills for tasks it can't easily handle on its own — simple one-step queries like "read this PDF" may not trigger a skill even with a perfectly matching description, because Claude handles them directly with basic tools. Complex, multi-step, or specialized queries reliably trigger skills when the description matches.
 
-This means your eval queries should be substantive enough that Claude would actually benefit from consulting a skill. Simple queries like "read file X" are poor test cases — they won't trigger skills regardless of description quality.
+So eval queries should be substantive enough that Claude would benefit from consulting a skill. Simple queries like "read file X" are poor test cases — they won't trigger skills regardless of description quality.
 
 ### Step 4: Apply the result
 
@@ -408,7 +396,7 @@ Take `best_description` from the JSON output and update the skill's SKILL.md fro
 
 ### Package and Present (only if `present_files` tool is available)
 
-Check whether you have access to the `present_files` tool. If you don't, skip this step. If you do, package the skill and present the .skill file to the user:
+If you don't have the `present_files` tool, skip this step. If you do, package the skill and present the .skill file to the user:
 
 ```bash
 python -m scripts.package_skill <path/to/skill-folder>
@@ -420,34 +408,34 @@ After packaging, direct the user to the resulting `.skill` file path so they can
 
 ## Claude.ai-specific instructions
 
-In Claude.ai, the core workflow is the same (draft → test → review → improve → repeat), but because Claude.ai doesn't have subagents, some mechanics change. Here's what to adapt:
+In Claude.ai, the core workflow is the same (draft → test → review → improve → repeat), but Claude.ai has no subagents, so some mechanics change:
 
-**Running test cases**: No subagents means no parallel execution. For each test case, read the skill's SKILL.md, then follow its instructions to accomplish the test prompt yourself. Do them one at a time. This is less rigorous than independent subagents (you wrote the skill and you're also running it, so you have full context), but it's a useful sanity check — and the human review step compensates. Skip the baseline runs — just use the skill to complete the task as requested.
+**Running test cases**: No subagents means no parallel execution. For each test case, read the skill's SKILL.md, then follow its instructions to accomplish the test prompt yourself, one at a time. Less rigorous than independent subagents (you wrote the skill and you're running it, so you have full context), but a useful sanity check — the human review step compensates. Skip baseline runs; just use the skill to complete the task.
 
-**Reviewing results**: If you can't open a browser (e.g., Claude.ai's VM has no display, or you're on a remote server), skip the browser reviewer entirely. Instead, present results directly in the conversation. For each test case, show the prompt and the output. If the output is a file the user needs to see (like a .docx or .xlsx), save it to the filesystem and tell them where it is so they can download and inspect it. Ask for feedback inline: "How does this look? Anything you'd change?"
+**Reviewing results**: If you can't open a browser (Claude.ai's VM has no display, or you're on a remote server), skip the browser reviewer. Present results in the conversation: for each test case, show the prompt and output. If the output is a file the user needs to see (.docx, .xlsx), save it to the filesystem and tell them where, so they can download and inspect it. Ask for feedback inline: "How does this look? Anything you'd change?"
 
-**Benchmarking**: Skip the quantitative benchmarking — it relies on baseline comparisons which aren't meaningful without subagents. Focus on qualitative feedback from the user.
+**Benchmarking**: Skip quantitative benchmarking — it relies on baseline comparisons that aren't meaningful without subagents. Focus on qualitative feedback.
 
-**The iteration loop**: Same as before — improve the skill, rerun the test cases, ask for feedback — just without the browser reviewer in the middle. You can still organize results into iteration directories on the filesystem if you have one.
+**The iteration loop**: Same as before — improve, rerun, ask for feedback — without the browser reviewer in the middle. You can still organize results into iteration directories on the filesystem.
 
-**Description optimization**: This section requires the `claude` CLI tool (specifically `claude -p`) which is only available in Claude Code. Skip it if you're on Claude.ai.
+**Description optimization**: Requires the `claude` CLI (`claude -p`), only available in Claude Code. Skip on Claude.ai.
 
 **Blind comparison**: Requires subagents. Skip it.
 
-**Packaging**: The `package_skill.py` script works anywhere with Python and a filesystem. On Claude.ai, you can run it and the user can download the resulting `.skill` file.
+**Packaging**: `package_skill.py` works anywhere with Python and a filesystem. On Claude.ai, run it and the user can download the resulting `.skill` file.
 
 ---
 
 ## Cowork-Specific Instructions
 
-If you're in Cowork, the main things to know are:
+In Cowork:
 
-- You have subagents, so the main workflow (spawn test cases in parallel, run baselines, grade, etc.) all works. (However, if you run into severe problems with timeouts, it's OK to run the test prompts in series rather than parallel.)
-- You don't have a browser or display, so when generating the eval viewer, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Then proffer a link that the user can click to open the HTML in their browser.
-- For whatever reason, the Cowork setup seems to disincline Claude from generating the eval viewer after running the tests, so just to reiterate: whether you're in Cowork or in Claude Code, after running tests, you should always generate the eval viewer for the human to look at examples before revising the skill yourself and trying to make corrections, using `generate_review.py` (not writing your own boutique html code). Sorry in advance but I'm gonna go all caps here: GENERATE THE EVAL VIEWER *BEFORE* evaluating inputs yourself. You want to get them in front of the human ASAP!
-- Feedback works differently: since there's no running server, the viewer's "Submit All Reviews" button will download `feedback.json` as a file. You can then read it from there (you may have to request access first).
-- Packaging works — `package_skill.py` just needs Python and a filesystem.
-- Description optimization (`run_loop.py` / `run_eval.py`) should work in Cowork just fine since it uses `claude -p` via subprocess, not a browser, but please save it until you've fully finished making the skill and the user agrees it's in good shape.
+- You have subagents, so the main workflow (spawn test cases in parallel, run baselines, grade) works. If you hit severe timeout problems, run test prompts in series rather than parallel.
+- No browser or display, so generate the eval viewer with `--static <output_path>` to write a standalone HTML file instead of starting a server. Then offer a link the user can click to open it.
+- Cowork seems to disincline Claude from generating the eval viewer after running tests, so to reiterate: in Cowork or Claude Code, after running tests, always generate the eval viewer with `generate_review.py` (not your own HTML) so the human can review examples before you revise the skill. GENERATE THE EVAL VIEWER *BEFORE* evaluating inputs yourself — get them in front of the human ASAP.
+- Feedback works differently: with no running server, the viewer's "Submit All Reviews" button downloads `feedback.json` as a file. Read it from there (you may have to request access first).
+- Packaging works — `package_skill.py` needs only Python and a filesystem.
+- Description optimization (`run_loop.py` / `run_eval.py`) works in Cowork since it uses `claude -p` via subprocess, not a browser, but save it until the skill is finished and the user agrees it's in good shape.
 
 ---
 
@@ -464,7 +452,7 @@ The references/ directory has additional documentation:
 
 ---
 
-Repeating one more time the core loop here for emphasis:
+The core loop, restated:
 
 - Figure out what the skill is about
 - Draft or edit the skill
@@ -473,8 +461,6 @@ Repeating one more time the core loop here for emphasis:
   - Create benchmark.json and run `scripts/generate_review.py` to help the user review them
   - Run quantitative evals
 - Repeat until you and the user are satisfied
-- Package the final skill and return it to the user.
+- Package the final skill and return it to the user
 
-Please add steps to your TodoList, if you have such a thing, to make sure you don't forget. If you're in Cowork, please specifically put "Create evals JSON and run `scripts/generate_review.py` so human can review test cases" in your TodoList to make sure it happens.
-
-Good luck!
+Add steps to your TodoList so you don't forget. In Cowork, add "Create evals JSON and run `scripts/generate_review.py` so human can review test cases" to make sure it happens.

--- a/plugins/claude-code/skills/skill-creator/agents/analyzer.md
+++ b/plugins/claude-code/skills/skill-creator/agents/analyzer.md
@@ -4,7 +4,7 @@ Analyze blind comparison results to understand WHY the winner won and generate i
 
 ## Role
 
-After the blind comparator determines a winner, the Post-hoc Analyzer "unblids" the results by examining the skills and transcripts. The goal is to extract actionable insights: what made the winner better, and how can the loser be improved?
+After the blind comparator determines a winner, the Post-hoc Analyzer unblinds the results by examining the skills and transcripts. Extract actionable insights: what made the winner better, and how can the loser be improved?
 
 ## Inputs
 
@@ -190,7 +190,7 @@ When analyzing benchmark results, the analyzer's purpose is to **surface pattern
 
 ## Role
 
-Review all benchmark run results and generate freeform notes that help the user understand skill performance. Focus on patterns that wouldn't be visible from aggregate metrics alone.
+Review all benchmark run results and generate freeform notes that help the user understand skill performance. Focus on patterns not visible from aggregate metrics alone.
 
 ## Inputs
 

--- a/plugins/claude-code/skills/skill-creator/agents/comparator.md
+++ b/plugins/claude-code/skills/skill-creator/agents/comparator.md
@@ -4,9 +4,7 @@ Compare two outputs WITHOUT knowing which skill produced them.
 
 ## Role
 
-The Blind Comparator judges which output better accomplishes the eval task. You receive two outputs labeled A and B, but you do NOT know which skill produced which. This prevents bias toward a particular skill or approach.
-
-Your judgment is based purely on output quality and task completion.
+The Blind Comparator judges which output better accomplishes the eval task. You receive two outputs labeled A and B, but you do NOT know which skill produced which. This prevents bias toward a particular skill or approach. Judge purely on output quality and task completion.
 
 ## Inputs
 

--- a/plugins/claude-code/skills/skill-creator/agents/grader.md
+++ b/plugins/claude-code/skills/skill-creator/agents/grader.md
@@ -4,9 +4,9 @@ Evaluate expectations against an execution transcript and outputs.
 
 ## Role
 
-The Grader reviews a transcript and output files, then determines whether each expectation passes or fails. Provide clear evidence for each judgment.
+The Grader reviews a transcript and output files, then determines whether each expectation passes or fails, with clear evidence for each judgment.
 
-You have two jobs: grade the outputs, and critique the evals themselves. A passing grade on a weak assertion is worse than useless — it creates false confidence. When you notice an assertion that's trivially satisfied, or an important outcome that no assertion checks, say so.
+You have two jobs: grade the outputs, and critique the evals themselves. A passing grade on a weak assertion is worse than useless — it creates false confidence. When you notice a trivially-satisfied assertion, or an important outcome no assertion checks, say so.
 
 ## Inputs
 

--- a/plugins/claude-code/skills/skill-creator/references/schemas.md
+++ b/plugins/claude-code/skills/skill-creator/references/schemas.md
@@ -1,6 +1,6 @@
 # JSON Schemas
 
-This document defines the JSON schemas used by skill-creator.
+JSON schemas used by skill-creator.
 
 ---
 

--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -73,7 +73,7 @@ hooks:                                    # Optional: skill-scoped hooks
 
 #### Description Is a Trigger
 
-The description field is not a summary. It's what Claude scans to decide whether to activate the skill. Write it for the model: include trigger terms, use cases, and "Use when..." phrasing. Make it slightly pushy to combat under-triggering.
+The description field is not a summary. It's what Claude scans to decide whether to activate the skill. Write it for the model: trigger terms, use cases, and "Use when..." phrasing. Make it slightly pushy to combat under-triggering.
 
 #### Skip the Obvious
 
@@ -85,7 +85,7 @@ The highest-signal content in any skill is a `## Gotchas` section documenting fa
 
 #### Progressive Disclosure
 
-A skill is a folder, not just a markdown file. Keep `SKILL.md` concise (~30 lines for the hub) and push details into `references/`, `scripts/`, and `assets/`. Tell Claude what files exist and when to read them. It will load them at appropriate times.
+A skill is a folder, not just a markdown file. Keep `SKILL.md` concise (~30 lines for the hub) and push details into `references/`, `scripts/`, and `assets/`. Tell Claude what files exist and when to read them; it loads them at the right times.
 
 #### Don't Railroad Claude
 
@@ -122,7 +122,7 @@ These substitutions apply to skill content, not the frontmatter `hooks:` block. 
 
 ### Dynamic Context Injection
 
-The bang-backtick syntax runs shell commands **before** the skill content is sent to Claude. The command output replaces the placeholder — Claude only sees the final result, not the command. This is preprocessing, not something Claude executes. Use this to inject live data (git state, CLI output, file contents) so the application harness extracts and runs the commands without waiting on the model.
+The bang-backtick syntax runs shell commands **before** the skill content is sent to Claude. The output replaces the placeholder — Claude sees only the result, not the command. This is preprocessing, not something Claude executes. Use it to inject live data (git state, CLI output, file contents) so the harness extracts and runs the commands without waiting on the model.
 
 See [references/patterns.md](references/patterns.md) for syntax, examples, and gotchas.
 

--- a/plugins/claude-code/skills/skill/references/patterns.md
+++ b/plugins/claude-code/skills/skill/references/patterns.md
@@ -28,7 +28,7 @@ bigquery-skill/
     └── product.md (API usage)
 ```
 
-When user asks about sales, Claude only reads `sales.md`.
+When the user asks about sales, Claude reads only `sales.md`.
 
 ### Pattern 3: Conditional details
 
@@ -52,7 +52,7 @@ The bang-backtick syntax runs shell commands as preprocessing before Claude sees
 - Recent commits: !`git log --oneline -5`
 ```
 
-When the skill runs, each bang-backtick expression executes immediately and its stdout replaces the placeholder. Claude never sees the command — only the output.
+Each bang-backtick expression executes immediately and its stdout replaces the placeholder. Claude never sees the command — only the output.
 
 ### When to Use
 
@@ -261,11 +261,11 @@ agent: Explore
 ---
 ```
 
-The sub-agent starts with a **clean context** — it does not inherit the parent conversation. It only sees the skill content (with `!`shell`` injections expanded) and `CLAUDE.md`. Results are summarized and returned to the main conversation.
+The sub-agent starts with a **clean context** — it does not inherit the parent conversation. It sees only the skill content (with `!`shell`` injections expanded) and `CLAUDE.md`. Results are summarized and returned to the main conversation.
 
 ### When Not to Fork
 
-`context: fork` loses all conversation history. If the skill needs awareness of what the user has been working on, run it inline instead and use Task agents to offload verbose work. The inline skill retains full context while keeping the heavy lifting out of the main conversation.
+`context: fork` loses all conversation history. If the skill needs awareness of what the user has been working on, run it inline and use Task agents to offload verbose work. The inline skill retains full context while keeping the heavy lifting out of the main conversation.
 
 ## Skill-Scoped Hooks
 
@@ -336,7 +336,7 @@ hooks:
 
 ### Tool Overlap Confuses the Model
 
-Exposing several near-duplicate tools makes Claude pick the wrong one. Three "fetch" variants or two "search" tools force a choice the model often gets wrong. Consolidate overlapping capabilities into a single parameterized tool, where an argument selects behavior.
+Exposing several near-duplicate tools makes Claude pick the wrong one. Three "fetch" variants or two "search" tools force a choice the model often gets wrong. Consolidate overlapping capabilities into a single parameterized tool where an argument selects behavior.
 
 ```yaml
 # Avoid: near-duplicate tools competing for the same job
@@ -352,7 +352,7 @@ The same overlap appears at the skill level. Two near-duplicate skills whose `de
 
 ### Over-Prescription Lowers Quality
 
-Prompts that micromanage the exact sequence of tool calls degrade output and become brittle. Spelling out every call ties the skill to one path, so any change upstream breaks it. Prefer high-level guidance that states the goal and the constraints, then trust the model to sequence the work.
+Prompts that micromanage the exact sequence of tool calls degrade output and become brittle. Spelling out every call ties the skill to one path, so any upstream change breaks it. Prefer high-level guidance that states the goal and constraints, then trust the model to sequence the work.
 
 This is the operational elaboration of [Don't Railroad Claude](../SKILL.md) and the appropriate-freedom principle: give Claude the outcome and let it choose the steps. When a skill keeps accreting prescriptive steps to patch failures, the fix is usually a clearer goal or a helper script, not more steps.
 

--- a/plugins/git/commands/fix-conflicts.md
+++ b/plugins/git/commands/fix-conflicts.md
@@ -17,17 +17,17 @@ Fix all merge conflicts in the working tree, then commit and push the result.
 
 ## Workflow
 
-1. **Load the conflicts skill** via the Skill tool (`git:conflicts`) to get conflict status, context, and resolution tooling.
+1. **Load the conflicts skill** via the Skill tool (`git:conflicts`) for conflict status, context, and resolution tooling.
 
 2. **Initiate merge if needed.** If the skill reports no in-progress conflict operation but upstream divergence exists:
    - Run `git merge origin/<default-branch>` to surface conflicts.
    - If the merge completes cleanly, push and finish.
-   - If the merge produces conflicts, proceed to resolution below.
+   - If it produces conflicts, proceed to resolution below.
    - Skip this step if a rebase, merge, or cherry-pick is already in progress.
 
-3. **Assess complexity.** After the skill loads, count the conflicted files and conflict markers:
-   - **Simple** (all conflicts are in generated files like lockfiles, or fewer than 3 conflicts across 1-2 files with obvious resolutions): proceed without confirmation.
-   - **Complex** (3+ files, non-trivial code conflicts, or ambiguous intent): summarize the conflicts and ask the user for confirmation before resolving.
+3. **Assess complexity.** Count the conflicted files and conflict markers:
+   - **Simple** (all conflicts in generated files like lockfiles, or fewer than 3 conflicts across 1-2 files with obvious resolutions): proceed without confirmation.
+   - **Complex** (3+ files, non-trivial code conflicts, or ambiguous intent): summarize the conflicts and ask the user to confirm before resolving.
 
 4. **Resolve conflicts.** For each conflicted file:
    - Use three-way access (`:1:`, `:2:`, `:3:` slots via `git show`) to understand base, ours, and theirs.
@@ -35,16 +35,16 @@ Fix all merge conflicts in the working tree, then commit and push the result.
    - `git add` the resolved file.
    - For generated files (lockfiles, build artifacts), prefer deleting and regenerating over manual merge.
 
-5. **Stash unrelated dirty files.** Before continuing, check for unstaged changes unrelated to the conflicts via `git status --porcelain`.
+5. **Stash unrelated dirty files.** Check for unstaged changes unrelated to the conflicts via `git status --porcelain`.
    - If dirty files exist beyond the resolved conflicts, try `git stash push -m "fix-conflicts: temp" -- <file1> <file2>` with all unrelated dirty files.
-   - If stash fails (the sandbox may block unlinking protected files like `.mcp.json`), stash files individually and skip failures. For files that cannot be stashed, hide them temporarily with `git update-index --assume-unchanged <file>`.
+   - If stash fails (the sandbox may block unlinking protected files like `.mcp.json`), stash files individually and skip failures. For files that cannot be stashed, hide them with `git update-index --assume-unchanged <file>`.
 
 6. **Continue the operation.** Run the appropriate continuation command (`git rebase --continue`, `git merge --continue`, or `git cherry-pick --continue`).
 
-7. **Push and restore.** Run `git push` to update the remote branch. Then restore any hidden files with `git update-index --no-assume-unchanged <file>` and run `git stash pop` if anything was stashed.
+7. **Push and restore.** Run `git push`. Then restore any hidden files with `git update-index --no-assume-unchanged <file>` and `git stash pop` if anything was stashed.
 
 ## Notes
 
-- Follow the project's `CLAUDE.md` for any lockfile-specific guidance (e.g., regenerating `bun.lock` from scratch).
-- If a conflict is in a file you don't understand, ask the user rather than guessing.
+- Follow the project's `CLAUDE.md` for lockfile-specific guidance (e.g., regenerating `bun.lock` from scratch).
+- If a conflict is in a file you don't understand, ask rather than guess.
 - Never silently drop changes from either side — when in doubt, keep both and ask.

--- a/plugins/git/skills/conflicts/SKILL.md
+++ b/plugins/git/skills/conflicts/SKILL.md
@@ -44,7 +44,7 @@ hooks:
 
 ## Three-Way Access
 
-Git stores three versions in staging slots during conflicts:
+Git stores three versions in staging slots during a conflict:
 
 | Slot | Version | Command |
 |------|---------|---------|

--- a/plugins/git/skills/conflicts/references/rerere.md
+++ b/plugins/git/skills/conflicts/references/rerere.md
@@ -12,7 +12,7 @@ git config --global rerere.enabled true
 
 1. Resolve a conflict manually
 2. Git records the resolution
-3. Same conflict later: git auto-applies the recorded resolution
+3. Same conflict later: git auto-applies it
 4. Verify with `git diff` before committing
 
 ## Commands

--- a/plugins/git/skills/git/SKILL.md
+++ b/plugins/git/skills/git/SKILL.md
@@ -7,14 +7,14 @@ description: >-
 
 # Git
 
-* **Never** `git push` to the default branch (usually `main` or `master`) unless I explicitly instruct you to do so.
-* **Always** use a topic branch with a few brief word hyphenated name
+* **Never** `git push` to the default branch (usually `main` or `master`) unless I explicitly instruct you.
+* **Always** use a topic branch with a few-word hyphenated name
 
 ## Commit Messages
 
 For multi-line commit messages:
 
-- **Simple (subject + body):** Use multiple `-m` flags. Each `-m` creates a separate paragraph:
+- **Simple (subject + body):** Use multiple `-m` flags; each creates a separate paragraph:
   ```bash
   git commit -m "Subject line" -m "Body paragraph here."
   ```

--- a/plugins/github/agents/logs.md
+++ b/plugins/github/agents/logs.md
@@ -6,7 +6,7 @@ tools: Bash(gh run view:*), Bash(gh run list:*), Bash(jq:*), Bash(mkdir:*), Writ
 model: haiku
 ---
 
-You extract failing-job diagnostics from a GitHub Actions run. You are invoked with a run ID and a PR URL. Return a structured JSON summary and persist the raw logs to a known path for the caller to re-read if needed.
+You extract failing-job diagnostics from a GitHub Actions run. You are invoked with a run ID and a PR URL. Return a structured JSON summary and persist the raw logs to a known path for the caller to re-read.
 
 ## Inputs
 
@@ -17,8 +17,6 @@ You extract failing-job diagnostics from a GitHub Actions run. You are invoked w
 
 ### Enumerate failing jobs
 
-Fetch the list of failing jobs:
-
 ```bash
 gh run view <run-id> --json jobs --jq '[.jobs[] | select(.conclusion == "failure") | {name, databaseId}]'
 ```
@@ -27,16 +25,16 @@ gh run view <run-id> --json jobs --jq '[.jobs[] | select(.conclusion == "failure
 
 Run `gh run view <run-id> --log-failed` once to capture every failing step across the run.
 
-Write the raw output to `$TMPDIR/$CLAUDE_SESSION_ID/github/<run-id>.log`. Create parent directories with `mkdir -p` before writing.
+Write the raw output to `$TMPDIR/$CLAUDE_SESSION_ID/github/<run-id>.log`. Create parent directories with `mkdir -p` first.
 
 ### Identify relevant lines
 
 Use the strategy in `plugins/github/skills/actions-monitor/references/log-parsing.md`:
 
 - GitHub Actions prefixes every log line with the step name. Filter to the failing step's lines to discard noise.
-- If a job is still very large, take the last 100 to 200 lines. Most tools print a summary at the end.
+- If a job is still large, take the last 100 to 200 lines. Most tools print a summary at the end.
 
-Use the `Grep` tool on the temp file to locate matches, and `Read` with offset/limit to read specific ranges.
+Use `Grep` on the temp file to locate matches, and `Read` with offset/limit for specific ranges.
 
 ### Return JSON
 
@@ -52,10 +50,10 @@ Respond with a single JSON object on stdout:
 }
 ```
 
-Keep `lines` short (10 to 50 lines per job). The caller can read `log_file` if more context is needed.
+Keep `lines` short (10 to 50 lines per job). The caller can read `log_file` for more context.
 
 ## Notes
 
 - Log-parsing strategy lives in `plugins/github/skills/actions-monitor/references/log-parsing.md`. Keep this agent and that reference in sync.
-- Do not analyze root causes or suggest fixes. Just extract and summarize.
-- If no jobs are failing, return `failing_jobs: []` and a summary noting the run is not in a failed state.
+- Do not analyze root causes or suggest fixes. Extract and summarize.
+- If no jobs are failing, return `failing_jobs: []` and a summary noting the run is not failed.

--- a/plugins/github/agents/rulesets-manager.md
+++ b/plugins/github/agents/rulesets-manager.md
@@ -7,24 +7,24 @@ model: sonnet
 color: green
 ---
 
-You are a GitHub Rulesets Management Expert specializing in configuring and maintaining GitHub repository rulesets. Your expertise covers creating, modifying, and optimizing rulesets to enforce repository policies and branch protection rules.
+You configure and maintain GitHub repository rulesets: creating, modifying, and optimizing them to enforce repository policies and branch protection rules.
 
 You have access to:
 - `Bash(gh:*)` for GitHub CLI operations
 - `mcp__github` for GitHub API interactions
 - `gh api` for advanced ruleset modifications
 
-Your core responsibilities:
+Core responsibilities:
 
-1. **Ruleset Discovery**: Always start by listing existing rulesets to understand the current configuration. Use `gh api repos/{owner}/{repo}/rulesets` to retrieve all rulesets.
+1. **Ruleset Discovery**: List existing rulesets with `gh api repos/{owner}/{repo}/rulesets`.
 
-2. **Smart Ruleset Selection**: When multiple rulesets exist, identify the most appropriate one based on:
+2. **Ruleset Selection**: When multiple rulesets exist, pick the most appropriate based on:
    - Target branches (prioritize default branch rulesets)
    - Existing rules and scope
-   - Ask for user confirmation when ambiguous
+   - Ask the user to confirm when ambiguous
 
 3. **Status Check Integration**: When adding required status checks:
-   - Query recent check runs using `gh api repos/{owner}/{repo}/commits/{sha}/check-runs` or similar endpoints
+   - Query recent check runs via `gh api repos/{owner}/{repo}/commits/{sha}/check-runs` or similar endpoints
    - Extract exact job names from GitHub Actions workflows
    - Ensure status check names match exactly what appears in check runs
 
@@ -38,18 +38,18 @@ Your core responsibilities:
    - Default to "active" enforcement unless specified otherwise
    - Include bypass permissions for repository administrators when appropriate
    - Validate that required status checks correspond to actual workflow jobs
-   - Provide clear summaries of changes made
+   - Summarize changes made
 
 6. **Error Handling**:
    - If a ruleset modification fails, check permissions and repository settings
    - Verify that status check names exist in recent workflow runs
    - Provide actionable error messages and suggest alternatives
 
-When responding to requests:
-- Always confirm the repository context before making changes
+When responding:
+- Confirm the repository context before making changes
 - Explain what ruleset will be modified or created
 - Show the specific changes being made
-- Verify successful application of changes
-- Provide a clear summary of the final configuration
+- Verify successful application
+- Summarize the final configuration
 
-You should proactively gather information about existing workflows and check runs to ensure accurate status check configuration. Always prioritize repository security while maintaining developer workflow efficiency.
+Proactively gather existing workflows and check runs for accurate status check configuration. Prioritize repository security while maintaining developer workflow efficiency.

--- a/plugins/github/skills/actions-monitor/SKILL.md
+++ b/plugins/github/skills/actions-monitor/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools:
 
 # Actions Monitor
 
-Watch a PR, a branch, or a specific run's GitHub Actions progress and react to failures by pulling logs through the `github:logs` agent. The monitor handles state tracking, deduplication, and the initial-green fast path; this skill is the thin coordinator that starts it, reacts to events, and stops it.
+Watch a PR, branch, or specific run's GitHub Actions progress and react to failures by pulling logs through the `github:logs` agent. The monitor handles state tracking, deduplication, and the initial-green fast path; this skill coordinates: it starts the monitor, reacts to events, and stops it.
 
 ## Target
 
@@ -26,8 +26,8 @@ Accepted forms:
 
 - A GitHub PR URL (e.g. `https://github.com/owner/repo/pull/42`) runs in **PR mode**.
 - A branch name (e.g. `main`) runs in **branch mode**. The script infers the repo from `git remote get-url origin` in the current directory; pass `--repo <owner/repo>` to override.
-- A run ID (e.g. `12345678`) runs in **run-id mode**, watching a specific workflow run directly. Covers `workflow_dispatch`, manually-triggered, and re-run cases where the exact run ID is known. The script infers the repo from the git remote; pass `--repo <owner/repo>` to override.
-- No argument: derive the current PR from the current branch with `gh pr view --json url --jq '.url'`. If the current branch has no PR, fall back to branch mode with the current branch name.
+- A run ID (e.g. `12345678`) runs in **run-id mode**, watching a specific workflow run directly. Covers `workflow_dispatch`, manually-triggered, and re-run cases where the run ID is known. The repo is inferred from the git remote; pass `--repo <owner/repo>` to override.
+- No argument: derive the current PR from the current branch with `gh pr view --json url --jq '.url'`. If the branch has no PR, fall back to branch mode with the current branch name.
 
 ## Workflow
 
@@ -71,7 +71,7 @@ The script emits one JSON object per line on stdout:
 - `{"type":"merged"}` (PR mode only)
 - `{"type":"max-time-reached","minutes":60}`
 
-`conflicts`, `mergeable-unknown`, `pr-closed`, and `merged` fire only in PR mode; run-id and branch mode never emit them. `merged` and `pr-closed` are distinct terminal events: `merged` means the PR landed, `pr-closed` means it closed without merging. The script exits on `status:success`, `pr-closed`, `merged`, and `max-time-reached`. In run-id mode it also exits on `status:failing`, since a specific run reaches a terminal conclusion and there is no "next run" to wait for. In PR and branch mode, `failing` is not terminal (the user may push a fix or start another run).
+`conflicts`, `mergeable-unknown`, `pr-closed`, and `merged` fire only in PR mode; run-id and branch mode never emit them. `merged` and `pr-closed` are distinct terminal events: `merged` means the PR landed, `pr-closed` means it closed without merging. The script exits on `status:success`, `pr-closed`, `merged`, and `max-time-reached`. In run-id mode it also exits on `status:failing`, since a specific run reaches a terminal conclusion with no "next run" to wait for. In PR and branch mode, `failing` is not terminal (the user may push a fix or start another run).
 
 #### React to status:failing
 
@@ -85,13 +85,13 @@ Agent({
 })
 ```
 
-Use the agent's JSON response to report failures to the user. The agent persists the raw logs to a known temp path; read that file if you need more context.
+Use the agent's JSON response to report failures to the user. The agent persists the raw logs to a known temp path; read that file for more context.
 
 #### React to other events
 
 - `conflicts` (PR mode): note the conflicting SHA; the caller (e.g. `pull-request:babysit`) decides whether to resolve.
 - `mergeable-unknown` (PR mode): GitHub could not settle mergeability after bounded re-polling. Note the SHA; the caller decides whether to run an authoritative local check.
-- `queued-timeout`: surface to the user that a run has been queued past the threshold.
+- `queued-timeout`: surface that a run has been queued past the threshold.
 - `api-error`: surface repeated CLI failures so the user can intervene.
 - `rate-limited`: back off or stop; retry once the window passes.
 - `merged` (PR mode): the PR landed. The script exits on its own.
@@ -100,7 +100,7 @@ Use the agent's JSON response to report failures to the user. The agent persists
 
 #### Initial-green case
 
-No separate path. If the target is already green at startup, the script emits a single `status:success` event and exits. Report that the target is green and stop.
+No separate path. If the target is already green at startup, the script emits a single `status:success` event and exits. Report green and stop.
 
 #### Stopping
 

--- a/plugins/github/skills/pr-comments/SKILL.md
+++ b/plugins/github/skills/pr-comments/SKILL.md
@@ -32,7 +32,7 @@ hooks:
 
 # PR Review Comments
 
-Fetch unresolved review threads from a GitHub pull request, filtered for context efficiency. Avoids flooding the context with resolved threads. Outdated threads are included but marked.
+Fetch unresolved review threads from a GitHub pull request, filtered for context efficiency: resolved threads are excluded, outdated threads included but marked.
 
 ## Usage
 
@@ -49,13 +49,13 @@ bun ${CLAUDE_PLUGIN_ROOT}/scripts/pr-comments.ts <pr-url> [--role author|reviewe
 
 ## Role
 
-- **author** (default when authenticated user is the PR author): shows all unresolved threads, the feedback that needs addressing.
-- **reviewer** (default when authenticated user is not the PR author): shows only unresolved threads started by the authenticated user, to check whether comments have been resolved.
+- **author** (default when authenticated user is the PR author): all unresolved threads, the feedback that needs addressing.
+- **reviewer** (default when authenticated user is not the PR author): only unresolved threads started by the authenticated user, to check whether comments have been resolved.
 
 ## Since
 
-- `last-review`: Scopes to threads with activity since the last relevant review.
-  - As author: since the most recent review by a human other than you (bot reviews are excluded)
+- `last-review`: threads with activity since the last relevant review.
+  - As author: since the most recent review by a human other than you (bot reviews excluded)
   - As reviewer: since your most recent submitted review
 - ISO date: explicit cutoff (e.g., `2025-01-15`)
 
@@ -65,7 +65,7 @@ Compact markdown grouped by file with line numbers and full comment bodies, enou
 
 ## Replying and Resolving
 
-Reply to and resolve threads through the `addPullRequestReviewThreadReply` and `resolveReviewThread` mutations, addressing a thread by the `id` from the fetch output.
+Reply to and resolve threads via the `addPullRequestReviewThreadReply` and `resolveReviewThread` mutations, addressing a thread by the `id` from the fetch output.
 
 ```bash
 # Reply, or reply and resolve in one call

--- a/plugins/gitlab/agents/logs.md
+++ b/plugins/gitlab/agents/logs.md
@@ -9,8 +9,6 @@ You are the `gitlab:logs` agent. Given a GitLab pipeline ID and MR URL, fetch fa
 
 ## Inputs
 
-The caller provides:
-
 - `pipeline_id`: the GitLab pipeline ID from a `status: failing` event
 - `mr_url`: the merge request URL (used to derive the project path)
 
@@ -40,7 +38,7 @@ Create the target directory and write the combined raw logs:
 mkdir -p "$TMPDIR/$CLAUDE_SESSION_ID/gitlab"
 ```
 
-For each failing job, fetch the trace with `glab ci trace <job-id>` (or `glab api "projects/<encoded>/jobs/<job-id>/trace"` as fallback). Concatenate all failing-job traces into `$TMPDIR/$CLAUDE_SESSION_ID/gitlab/<pipeline-id>.log`. Include a job header line before each trace so the file is self-describing (e.g., `===== job: <name> (<id>) =====`).
+For each failing job, fetch the trace with `glab ci trace <job-id>` (or `glab api "projects/<encoded>/jobs/<job-id>/trace"` as fallback). Concatenate all failing-job traces into `$TMPDIR/$CLAUDE_SESSION_ID/gitlab/<pipeline-id>.log`. Prefix each trace with a job header so the file is self-describing (e.g., `===== job: <name> (<id>) =====`).
 
 ## Identify the failing section
 

--- a/plugins/gitlab/skills/ci-monitor/SKILL.md
+++ b/plugins/gitlab/skills/ci-monitor/SKILL.md
@@ -27,7 +27,7 @@ Accepts an MR URL, a branch name, a pipeline ID, or derives one from the current
 - MR mode: pass a URL like `https://gitlab.com/group/project/-/merge_requests/123`.
 - Branch mode: pass a branch name (e.g. `main`, a release branch). Project path `group/project` is inferred from `git remote get-url origin` in the current directory; pass `--project <group/project>` to override.
 - Pipeline-id mode: pass a pipeline ID (e.g. from a manually-triggered pipeline or a re-run). Project is inferred from the git remote; override with `--project <group/project>`.
-- If no argument is given, derive an MR URL from the current branch: `glab mr view --output json | jq -r '.web_url'`.
+- No argument: derive an MR URL from the current branch: `glab mr view --output json | jq -r '.web_url'`.
 
 ## Workflow
 
@@ -42,7 +42,7 @@ Launch the watch script via the `Monitor` tool with `persistent: true`:
 
 Exactly one of `--mr`, `--branch`, or `--pipeline-id` is required. In branch and pipeline-id modes, `--project` is inferred from the current git remote when omitted. Pipeline-id mode queries `glab api projects/:id/pipelines/:pid` directly; if the pipeline does not exist the watcher exits non-zero on the first call.
 
-The script emits one JSON object per line on stdout. When the first probe is already green, it emits a single `status: success` event and exits, so there is no separate initial-green path to handle. In pipeline-id mode the script also exits after emitting `status: failing`, because a specific pipeline has a finite lifetime and will not restart on its own.
+The script emits one JSON object per line on stdout. When the first probe is already green, it emits a single `status: success` event and exits, so there is no separate initial-green path. In pipeline-id mode it also exits after emitting `status: failing`, because a specific pipeline has a finite lifetime and will not restart on its own.
 
 #### Event schema
 
@@ -64,7 +64,7 @@ The script exits on `status: success` in every mode. In pipeline-id mode it also
 
 #### React to events
 
-On `status: failing`, invoke the `gitlab:logs` agent via the `Agent` tool with the pipeline ID from `run_id`. This applies to all three modes; the logs agent accepts a pipeline ID, so pipeline-id mode fits naturally:
+On `status: failing`, invoke the `gitlab:logs` agent via the `Agent` tool with the pipeline ID from `run_id`. This applies to all three modes; the logs agent accepts a pipeline ID, so pipeline-id mode fits:
 
 ```
 Agent(
@@ -80,13 +80,13 @@ On `conflicts`, report the SHA with conflicts and stop watching; conflict resolu
 
 On `mergeable-unknown`, report the SHA; the caller decides whether to run an authoritative local check.
 
-On `queued-timeout`, `api-error`, or `rate-limited`, surface the event once and keep the monitor running. Consecutive rate-limit or api-error events indicate the monitor should be stopped manually.
+On `queued-timeout`, `api-error`, or `rate-limited`, surface the event once and keep the monitor running. Consecutive rate-limit or api-error events mean the monitor should be stopped manually.
 
 On `merged`, `pr-closed`, or `max-time-reached`, the monitor has already exited. Report and finish.
 
 #### Stopping
 
-The monitor exits on its own for `status: success`, `merged`, `pr-closed`, and `max-time-reached`. In pipeline-id mode it also exits on `status: failing`. To stop earlier (for example after surfacing a failure summary to the user), call `TaskStop` on the monitor task.
+The monitor exits on its own for `status: success`, `merged`, `pr-closed`, and `max-time-reached`. In pipeline-id mode it also exits on `status: failing`. To stop earlier (e.g. after surfacing a failure summary to the user), call `TaskStop` on the monitor task.
 
 ## Reference
 

--- a/plugins/gitlab/skills/ci/SKILL.md
+++ b/plugins/gitlab/skills/ci/SKILL.md
@@ -21,7 +21,7 @@ Use `glab ci --help` and `glab ci <command> --help` for full options.
 
 ## Debugging Failures
 
-- `glab ci view` - Interactive view of pipeline jobs (can also trace/retry from here)
+- `glab ci view` - Interactive view of pipeline jobs (trace/retry from here too)
 - `glab ci trace <job-id>` - Stream job logs in real-time
 - `glab ci retry <job-id>` - Retry a failed job
 

--- a/plugins/gitlab/skills/merge-request/SKILL.md
+++ b/plugins/gitlab/skills/merge-request/SKILL.md
@@ -24,7 +24,7 @@ Use `glab mr --help` and `glab mr <command> --help` for full options.
 
 ## Merging
 
-Always use `merge.ts` to merge. It handles merge trains, auto-merge, and squash automatically, falling back to `glab mr merge` internally when appropriate.
+Always use `merge.ts` to merge. It handles merge trains, auto-merge, and squash, falling back to `glab mr merge` internally when appropriate.
 
 ```bash
 bun ${CLAUDE_PLUGIN_ROOT}/scripts/merge.ts
@@ -45,7 +45,7 @@ git push -u origin feature-branch && glab mr create --fill
 
 **Body from file:** No `--body-file` flag; use `--description "$(cat file.md)"`.
 
-**Username resolution:** Flags like `--reviewer` and `--assignee` require exact usernames. Invalid names are silently ignored. Look up users first:
+**Username resolution:** Flags like `--reviewer` and `--assignee` require exact usernames; invalid names are silently ignored. Look up users first:
 
 ```bash
 glab api projects/:id/members/all --paginate | jq '.[] | select(.name | test("<name>"; "i")) | {name, username}'
@@ -53,7 +53,7 @@ glab api projects/:id/members/all --paginate | jq '.[] | select(.name | test("<n
 
 ## Blocking
 
-Prevent an MR from merging until another MR merges first. Uses the REST API directly since `glab mr` has no blocking subcommand.
+Prevent an MR from merging until another MR merges first. Uses the REST API since `glab mr` has no blocking subcommand.
 
 ```bash
 # Block MR !10 until MR !5 merges
@@ -70,7 +70,7 @@ glab api projects/:id/merge_requests/10/blocks/<block-id> -X DELETE
 
 Submit review feedback as draft notes that accumulate before publishing. See [review.md](review.md) for the draft notes workflow, code suggestions, and approvals.
 
-Fetch the MRs awaiting your first review across all projects (the `UNREVIEWED` bucket; REST's `scope=reviews_for_me` cannot filter by review state). Emits `[{ url, reference, title }]` as JSON:
+Fetch MRs awaiting your first review across all projects (the `UNREVIEWED` bucket; REST's `scope=reviews_for_me` cannot filter by review state). Emits `[{ url, reference, title }]` as JSON:
 
 ```bash
 bun ${CLAUDE_SKILL_DIR}/scripts/review-queue.ts
@@ -82,7 +82,7 @@ To group all your review-requested MRs by next actor (not just the `UNREVIEWED` 
 
 ## Re-request reviewers
 
-Re-trigger a review after a push reset approvals. The `mergeRequestReviewerRereview` mutation flips the target's `reviewState` back to `UNREVIEWED` and re-surfaces the MR. The reviewer must already be assigned. See [Re-Request Review](review-state.md#re-request-review) for the user-ID lookup and the exact mutation.
+Re-trigger a review after a push reset approvals. The `mergeRequestReviewerRereview` mutation flips the target's `reviewState` back to `UNREVIEWED` and re-surfaces the MR. The reviewer must already be assigned. See [Re-Request Review](review-state.md#re-request-review) for the user-ID lookup and exact mutation.
 
 ## Discussions
 
@@ -90,7 +90,7 @@ Fetch, filter, resolve, and summarize MR discussion threads. See [discussions.md
 
 ## Stacking
 
-`glab stack` manages stacked diffs—small changes that build on each other. See [stack.md](stack.md).
+`glab stack` manages stacked diffs — small changes that build on each other. See [stack.md](stack.md).
 
 ## Reference Files
 

--- a/plugins/gitlab/skills/merge-request/discussions.md
+++ b/plugins/gitlab/skills/merge-request/discussions.md
@@ -26,7 +26,7 @@ bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts list <iid> --format digest
 bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts list <iid> --format table
 ```
 
-Three output formats are supported: `json` (default), `digest`, and `table`.
+Three output formats: `json` (default), `digest`, and `table`.
 
 To filter `--author` to yourself, resolve your username with `glab api user 2>/dev/null | jq -r .username`. The `glab api user --jq .username` form returns empty on glab 1.102.0.
 
@@ -34,7 +34,7 @@ The script resolves the project from the current directory's git remote. Run it 
 
 #### JSON output schema
 
-The default (`--format json`) is a flat array of summary objects, one per discussion (the first note of each thread). It is not the raw GitLab `{ notes: [...] }` shape, so query the top-level fields directly.
+The default (`--format json`) is a flat array of summary objects, one per discussion (the first note of each thread). Not the raw GitLab `{ notes: [...] }` shape, so query the top-level fields directly.
 
 | Field | Type | Notes |
 | --- | --- | --- |
@@ -47,7 +47,7 @@ The default (`--format json`) is a flat array of summary objects, one per discus
 | `line` | number (optional) | Present only for positioned (inline) comments |
 | `lineRange` | `{ start, end }` or `null` | `null` for single-line and non-positioned comments |
 
-`file` and `line` are omitted entirely for general (non-inline) discussions, so handle them as optional. `lineRange` is always present but is `null` unless the comment spans multiple lines.
+`file` and `line` are omitted entirely for general (non-inline) discussions, so handle them as optional. `lineRange` is always present but `null` unless the comment spans multiple lines.
 
 The summary flattens each thread to its **first note only**. To see the author's replies or the full thread, fetch the raw payload, which keeps every note:
 
@@ -59,7 +59,7 @@ A GitLab "reply" that is a `changed line in version N` system note (`notes[].sys
 
 #### Compact triage
 
-For triage, prefer a compact format over the full JSON. Both truncate each body to `--truncate` characters (default 80); raise it when bodies are clipped too aggressively.
+For triage, prefer a compact format over the full JSON. Both truncate each body to `--truncate` characters (default 80); raise it when bodies are clipped too much.
 
 `--format digest` prints one line per discussion: id, location (`file:line`, `file:start-end` for ranges, or `-` when not positioned), resolution state, and a truncated body.
 
@@ -117,7 +117,7 @@ bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts create <iid> --file src/app.ts --
 bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts create <iid> --file src/app.ts --old-line 10 --body-file tmp/note.md
 ```
 
-Diff refs are fetched automatically. Positioned comments are validated against diff hunks before posting. If a line is not in the diff, the command exits with valid line ranges.
+Diff refs are fetched automatically. Positioned comments are validated against diff hunks before posting. If a line is not in the diff, the command exits with the valid line ranges.
 
 ### Suggestions
 
@@ -147,7 +147,7 @@ bun ${CLAUDE_SKILL_DIR}/scripts/discussions.ts create <iid> --file src/app.ts --
 
 ## Pitfalls
 
-**Pagination concatenation**: `glab api --paginate` concatenates JSON arrays as `][` across pages, producing invalid JSON. The script handles this automatically with `parseGlabPaginated`, which replaces `][` with `,`.
+**Pagination concatenation**: `glab api --paginate` concatenates JSON arrays as `][` across pages, producing invalid JSON. The script handles this with `parseGlabPaginated`, which replaces `][` with `,`.
 
 **Resolution status location**: Check `notes[0].resolved`, not the top-level discussion `resolved` field. The top-level field may not reflect the current state accurately.
 

--- a/plugins/gitlab/skills/merge-request/review-state.md
+++ b/plugins/gitlab/skills/merge-request/review-state.md
@@ -123,7 +123,7 @@ The REST queue (`scope=reviews_for_me`) reports every reviewer as `active`, so i
 }
 ```
 
-Keep nodes where the reviewer whose `username` equals `currentUser.username` has `reviewState === "UNREVIEWED"`. That is the canonical "awaiting my first review" bucket, the analog of GitHub's `gh search prs --review-requested=@me`. [`scripts/review-queue.ts`](scripts/review-queue.ts) runs the query and applies the filter, emitting `[{ url, reference, title }]` as JSON:
+Keep nodes where the reviewer whose `username` equals `currentUser.username` has `reviewState === "UNREVIEWED"`. That is the canonical "awaiting my first review" bucket, the analog of GitHub's `gh search prs --review-requested=@me`. [`scripts/review-queue.ts`](scripts/review-queue.ts) runs the query and filter, emitting `[{ url, reference, title }]` as JSON:
 
 ```bash
 bun ${CLAUDE_SKILL_DIR}/scripts/review-queue.ts
@@ -142,4 +142,4 @@ The cross-project queue above filters to `UNREVIEWED`. To triage everything you 
 
 The API never returns `REVIEWED`; the web UI's "Reviewed" label maps to `REVIEW_STARTED` or `REQUESTED_CHANGES`.
 
-A re-request ([`mergeRequestReviewerRereview`](#re-request-review)) resets your entry to `UNREVIEWED` and re-surfaces the MR. Triage off `reviewState` rather than the GitLab todos inbox: a dismissed todo does not mean the review is handled, and re-requests do not reliably regenerate one.
+A re-request ([`mergeRequestReviewerRereview`](#re-request-review)) resets your entry to `UNREVIEWED` and re-surfaces the MR. Triage off `reviewState`, not the GitLab todos inbox: a dismissed todo does not mean the review is handled, and re-requests do not reliably regenerate one.

--- a/plugins/gitlab/skills/merge-request/review.md
+++ b/plugins/gitlab/skills/merge-request/review.md
@@ -27,7 +27,7 @@ bun ${CLAUDE_SKILL_DIR}/scripts/draft-note.ts create <iid> --reply-to <discussio
 bun ${CLAUDE_SKILL_DIR}/scripts/draft-note.ts create <iid> --reply-to <discussion-id> --resolve --body-file tmp/note.md
 ```
 
-Positioned comments are validated against the MR diff before posting. If a line is not within a diff hunk, the command exits with an error showing valid line ranges.
+Positioned comments are validated against the MR diff before posting. If a line is not within a diff hunk, the command exits with an error showing the valid line ranges.
 
 ### Batch Review
 
@@ -60,7 +60,7 @@ bun ${CLAUDE_SKILL_DIR}/scripts/draft-note.ts list <iid>
 
 ### Submit Review
 
-Publish all draft notes and optionally set a review decision. GitLab's REST API has no atomic "submit review" endpoint, so this runs up to three sequential calls: bulk publish, summary comment, and decision.
+Publish all draft notes and optionally set a review decision. GitLab's REST API has no atomic "submit review" endpoint, so this runs up to three sequential calls: bulk publish, summary comment, decision.
 
 ```bash
 # Publish only (equivalent to "Comment" in web UI)
@@ -108,12 +108,12 @@ third line
 ## API Pitfalls
 
 - **Content-Type required**: `glab api --input <file>` requires `-H "Content-Type: application/json"`. Without it, GitLab returns HTTP 415.
-- **No nested `-f` fields**: `glab api -f "position[base_sha]=..."` silently fails. Nested objects must be sent as JSON via `--input`.
+- **No nested `-f` fields**: `glab api -f "position[base_sha]=..."` silently fails. Send nested objects as JSON via `--input`.
 - **Reply field**: Use `in_reply_to_discussion_id`, not `discussion_id`.
 - **Don't update positioned notes**: PUT to update a draft note strips the position. Delete and recreate instead.
 - **No atomic review submit**: The REST API's `bulk_publish` only publishes drafts (no summary comment or review decision). The web UI uses an internal controller that combines all three, but it's session-authenticated only. The `submit` command above sequences the calls separately.
 - **Review state is GraphQL-only**: See [review-state.md](review-state.md) for mutations (`mergeRequestRequestChanges`, `mergeRequestDestroyRequestedChanges`) and querying review state. Key: `projectPath` is `ID!` not `String!`, caller must be assigned as reviewer, requires Premium/Ultimate.
-- **Range comments need `new_line`**: `line_range` alone is rejected ("position is incomplete"). Always set `new_line` to the range end line. The comment anchors at this line in the UI.
+- **Range comments need `new_line`**: `line_range` alone is rejected ("position is incomplete"). Set `new_line` to the range end line; the comment anchors there in the UI.
 
 ## Discussions
 

--- a/plugins/gitlab/skills/merge-request/stack.md
+++ b/plugins/gitlab/skills/merge-request/stack.md
@@ -1,6 +1,6 @@
 # Stacked Diffs
 
-`glab stack` manages stacked diffs—small changes that build on each other while earlier ones are under review.
+`glab stack` manages stacked diffs — small changes that build on each other while earlier ones are under review.
 
 ## Workflow
 
@@ -37,7 +37,7 @@ glab stack amend           # Modify existing stack commits
 bun plugins/gitlab/scripts/stack-merge.ts
 ```
 
-The script reads stack refs from `.git/stacked/<title>/*.json`, checks project approval settings, and merges each entry. It automatically detects merge trains and uses the correct API.
+The script reads stack refs from `.git/stacked/<title>/*.json`, checks project approval settings, and merges each entry. It detects merge trains and uses the correct API.
 
 ### How the cascade works
 
@@ -49,6 +49,6 @@ The script reads stack refs from `.git/stacked/<title>/*.json`, checks project a
 ### Requirements
 
 - **GitLab 16.7+** for smart `git patch-id` approval reset. When `reset_approvals_on_push` is enabled (the default), GitLab compares patch-ids before and after a rebase. If the logical diff is unchanged, approvals are preserved. The script checks this setting via `glab api projects/:id/approvals`.
-- **Don't squash** individual stack MRs. Squash replaces the original commits with a single commit, changing the patch-id when the next MR is retargeted. This resets approvals and breaks the cascade.
+- **Don't squash** individual stack MRs. Squash replaces the original commits with a single commit, changing the patch-id when the next MR is retargeted, which resets approvals and breaks the cascade.
 
 Use `glab stack --help` for full options. This feature is experimental.

--- a/plugins/interview/skills/plan/SKILL.md
+++ b/plugins/interview/skills/plan/SKILL.md
@@ -24,7 +24,7 @@ When you have a recommendation, put it first and append "(Recommended)". For vis
 
 ## Topics
 
-Adapt to context. Skip questions with obvious answers. Challenge implicit decisions.
+Adapt to context. Skip obvious answers. Challenge implicit decisions.
 
 - Requirements: what it should and shouldn't do
 - Technical implementation: architecture, data flow, dependencies

--- a/plugins/linear/skills/linear/SKILL.md
+++ b/plugins/linear/skills/linear/SKILL.md
@@ -14,10 +14,8 @@ Tools and workflows for managing issues, projects, and teams in Linear.
 
 ## Tool Selection
 
-Choose the right tool for the task:
-
-1. **MCP tools** - Use for simple operations (create/update/query single issues, basic filters)
-2. **`linear api` CLI** - Use for complex queries, bulk operations, or anything not supported by MCP tools
+1. **MCP tools** - simple operations (create/update/query single issues, basic filters)
+2. **`linear api` CLI** - complex queries, bulk operations, or anything not supported by MCP tools
 
 ## Conventions
 
@@ -28,20 +26,20 @@ The Claude.ai Linear connector exposes a single tool, `save_issue`, for both cre
 - **Create**: omit the issue id. `title` is **required** (omitting it produces "title is required when creating an issue").
 - **Update**: supply the issue id. `title` is optional.
 
-The local and plugin variants use separate tools (`create_issue` and `update_issue`). The examples below use those names. When connected via the Claude.ai connector, substitute `save_issue` and apply the preconditions above.
+The local and plugin variants use separate tools (`create_issue` and `update_issue`), used in the examples below. When connected via the Claude.ai connector, substitute `save_issue` and apply the preconditions above.
 
 ### Issue References
 
-When writing text that references other issues (descriptions, comments, updates), never use bare identifiers like `ENG-123`. Linear auto-renders issue URLs as inline preview components, so use the full URL:
+When writing text that references other issues (descriptions, comments, updates), never use bare identifiers like `ENG-123`. Linear auto-renders issue URLs as inline previews, so use the full URL:
 
 - **Bare URL**: `https://linear.app/workspace/issue/ENG-123` (renders as an inline preview)
 - **Hyperlinked text**: `[the auth bug](https://linear.app/workspace/issue/ENG-123)` (when linking specific words is more natural)
 
-Both MCP tools and GraphQL queries return a `url` field on issues. Always include `url` when querying issues you may reference in written content.
+Both MCP tools and GraphQL queries return a `url` field on issues. Always include `url` when querying issues you may reference in writing.
 
 ### Issue Status
 
-When creating issues, set the appropriate status based on assignment:
+When creating issues, set status based on assignment:
 
 - **Assigned to me** (`assignee: "me"`): Set `state: "Todo"`
 - **Unassigned**: Set `state: "Backlog"`
@@ -78,7 +76,7 @@ await linear.list_issues({ team: "ENG", state: "Backlog" })
 
 ### Labels
 
-You can use label names directly in `create_issue` and `update_issue` - no need to look up IDs:
+Use label names directly in `create_issue` and `update_issue` — no need to look up IDs:
 
 ```typescript
 await linear.create_issue({
@@ -88,7 +86,7 @@ await linear.create_issue({
 })
 ```
 
-**Label Lookup**: Labels can exist at the workspace level or team level. When searching for labels, check both:
+**Label Lookup**: Labels can exist at the workspace or team level. Check both:
 
 1. Workspace labels: `list_issue_labels()` (no team filter)
 2. Team labels: `list_issue_labels({ team: "TEAM" })`
@@ -97,7 +95,7 @@ If a label isn't found at the workspace level, check the team before concluding 
 
 ## GraphQL API
 
-Use `linear api` for queries and mutations not supported by MCP tools. See `api.md` for full documentation.
+Use `linear api` for queries and mutations not supported by MCP tools. See `api.md`.
 
 ```bash
 linear api 'query { viewer { id name } }'
@@ -124,7 +122,7 @@ Use the `linear://` URL scheme to open issues in the native Mac app instead of t
 open "linear://team-slug/issue/ENG-123"
 ```
 
-The desktop app must be installed. When given an issue identifier (e.g., `ENG-123`), construct the URL using the team's workspace slug and issue identifier.
+The desktop app must be installed. Construct the URL from the team's workspace slug and issue identifier.
 
 ## Reference
 

--- a/plugins/linear/skills/linear/api.md
+++ b/plugins/linear/skills/linear/api.md
@@ -1,6 +1,6 @@
 # Linear GraphQL API via CLI
 
-Run GraphQL queries and mutations against Linear using the `linear api` CLI subcommand.
+Run GraphQL queries and mutations against Linear with the `linear api` CLI subcommand.
 
 ## Authentication
 
@@ -24,7 +24,7 @@ Or pipe from stdin:
 echo '{ viewer { id } }' | linear api
 ```
 
-Output is JSON on stdout. Pipe through `jq` for formatting or field extraction:
+Output is JSON on stdout. Pipe through `jq` for formatting or field extraction.
 
 ```bash
 linear api 'query { viewer { id name email } }' | jq '.data.viewer'
@@ -47,7 +47,7 @@ linear api 'mutation($input: IssueCreateInput!) { issueCreate(input: $input) { s
 
 ## Pagination
 
-Use `--paginate` to automatically fetch all pages:
+Use `--paginate` to fetch all pages:
 
 ```bash
 linear api 'query { issues(first: 50) { nodes { id title } pageInfo { hasNextPage endCursor } } }' --paginate
@@ -110,8 +110,8 @@ linear api 'mutation($id: String!, $input: IssueUpdateInput!) {
 - **Team IDs**: Required for most operations involving issues and projects
 - **State IDs**: Issues default to the team's first Backlog state unless specified
 - **Archived Resources**: Hidden by default; use `includeArchived: true` to retrieve
-- **Error Handling**: Always check the `errors` array in responses before assuming success
-- **Rate Limiting**: Monitor HTTP status codes and handle rate limits appropriately
+- **Error Handling**: Check the `errors` array in responses before assuming success
+- **Rate Limiting**: Monitor HTTP status codes and handle limits
 
 ## Schema Introspection
 

--- a/plugins/linear/skills/notifications/SKILL.md
+++ b/plugins/linear/skills/notifications/SKILL.md
@@ -53,7 +53,7 @@ linear api 'mutation { notificationMarkAllAsRead(input: {}) { success } }'
 
 ## Filtering
 
-Add filters to the query:
+Add filters to the query.
 
 ```graphql
 notifications(first: 50, filter: { type: { eq: "IssueAssignedToYou" } })

--- a/plugins/mac/skills/jxa-run/SKILL.md
+++ b/plugins/mac/skills/jxa-run/SKILL.md
@@ -15,7 +15,7 @@ hooks:
 
 # Run JXA
 
-Run the JXA expression or script file provided in the arguments. `$0` is the app name, remaining arguments are passed to the runner.
+Run the JXA expression or script file from the arguments. `$0` is the app name; remaining arguments pass to the runner.
 
 ```bash
 bun ${CLAUDE_PLUGIN_ROOT}/scripts/jxa.ts $ARGUMENTS

--- a/plugins/mac/skills/jxa/SKILL.md
+++ b/plugins/mac/skills/jxa/SKILL.md
@@ -27,7 +27,7 @@ for (var i = 0; i < windows.length; i++) {
 
 ## Script Files
 
-Script files define a `function run(argv)` entry point. `osascript` calls it automatically and prints the return value. The function must be named `run`, not `_run`.
+Script files define a `function run(argv)` entry point. `osascript` calls it and prints the return value. The function must be named `run`, not `_run`.
 
 ```javascript
 #!/usr/bin/env osascript -l JavaScript

--- a/plugins/mail/skills/mail/archiving.md
+++ b/plugins/mail/skills/mail/archiving.md
@@ -46,7 +46,7 @@ if (archiveBox) {
 
 ## Batch Archiving
 
-Process in reverse index order to avoid index shifting:
+Process in reverse index order to avoid index shifting.
 
 ```javascript
 for (var i = toArchive.length - 1; i >= 0; i--) {
@@ -56,5 +56,5 @@ for (var i = toArchive.length - 1; i >= 0; i--) {
 
 ## Gmail Notes
 
-- "All Mail" may appear as `[Gmail]/All Mail` or just `All Mail` depending on IMAP config
-- Test with a single message first before batch operations
+- "All Mail" may appear as `[Gmail]/All Mail` or `All Mail` depending on IMAP config
+- Test with a single message before batch operations

--- a/plugins/mermaid/skills/diagram/references/flowchart.md
+++ b/plugins/mermaid/skills/diagram/references/flowchart.md
@@ -115,4 +115,4 @@ flowchart LR
 - Minimize edge crossings by ordering nodes logically
 - Use subgraphs to reduce visual complexity
 - Keep labels short—expand in surrounding text
-- For wide diagrams, consider `TB` instead of `LR`
+- For wide diagrams, prefer `TB` over `LR`

--- a/plugins/opentelemetry/skills/opentelemetry/SKILL.md
+++ b/plugins/opentelemetry/skills/opentelemetry/SKILL.md
@@ -30,7 +30,7 @@ Import from the versioned semconv package (e.g., `go.opentelemetry.io/otel/semco
 
 ## Status
 
-Only set status on errors: `span.SetStatus(codes.Error, err.Error())`. Never set `Ok` — unset is the success state. Call `RecordError` alongside `SetStatus` (it only adds a span event, doesn't change status).
+Only set status on errors: `span.SetStatus(codes.Error, err.Error())`. Never set `Ok` — unset is the success state. Call `RecordError` alongside `SetStatus`; it only adds a span event, doesn't change status.
 
 For HTTP: 4xx is `Error` on client spans, `Unset` on server spans. 5xx is always `Error`.
 

--- a/plugins/personal-review/skills/review/SKILL.md
+++ b/plugins/personal-review/skills/review/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Daily Review
 
-Multi-phase workflow with checkpoints between phases. Each phase ends with a summary before proceeding.
+Multi-phase workflow with checkpoints. Each phase ends with a summary before proceeding.
 
 ## Variants
 
@@ -21,9 +21,9 @@ Ask which variant if not specified.
 
 Dispatch a read-only sub-agent (Task tool) to scan today's events. See [calendar.md](calendar.md).
 
-If the sub-agent reports calendar access denied (the `"reason": "no-app-bundle"` error), skip silently. Do not prompt to fix permissions. Note "Calendar: skipped (access denied)" and proceed to the next phase.
+If the sub-agent reports calendar access denied (`"reason": "no-app-bundle"`), skip silently. Do not prompt to fix permissions. Note "Calendar: skipped (access denied)" and proceed to the next phase.
 
-Otherwise, present time budget (available hours, focus windows, meetings needing prep). Ask user to proceed.
+Otherwise, present time budget (available hours, focus windows, meetings needing prep). Ask the user to proceed.
 
 ## Phase: Things Inbox
 
@@ -37,11 +37,11 @@ Batch items by pattern, ask user for each batch:
 
 Goal: inbox count = 0.
 
-After inbox processing, re-query calendar (see Re-Check in [calendar.md](calendar.md)). If calendar was skipped due to access denied in the initial phase, skip the re-check too. Otherwise, present any new events and updated time budget. Ask user to proceed.
+After inbox processing, re-query calendar (see Re-Check in [calendar.md](calendar.md)). If calendar was skipped due to access denied in the initial phase, skip the re-check too. Otherwise, present new events and updated time budget. Ask the user to proceed.
 
 ## Phase: Notifications
 
-Dispatch read-only sub-agents in parallel (Task tool) for GitHub, GitLab, and Linear. Then triage each interactively.
+Dispatch read-only sub-agents in parallel (Task tool) for GitHub, GitLab, and Linear, then triage each interactively.
 
 ### GitHub Notifications
 
@@ -78,7 +78,7 @@ Review unread notifications:
 - **Mentions** — read, respond, archive
 - **Status changes** — acknowledge, archive
 
-After all notification inboxes are processed, ask user to proceed.
+After all notification inboxes are processed, ask the user to proceed.
 
 ## Phase: Today Triage
 

--- a/plugins/personal-review/skills/review/automation.md
+++ b/plugins/personal-review/skills/review/automation.md
@@ -4,7 +4,7 @@ Future automation for common patterns.
 
 ## Auto-Handle Candidates
 
-Patterns that could be handled without user input:
+Patterns handleable without user input:
 
 ### GitHub
 
@@ -43,8 +43,8 @@ To enable automation, log decisions:
 }
 ```
 
-Pattern detection from logged decisions enables smart defaults.
+Pattern detection from logged decisions enables defaults.
 
 ## Not Yet Implemented
 
-This file documents extension points. No automation is active yet. All items require user decision.
+No automation is active yet. All items require user decision.

--- a/plugins/personal-review/skills/review/calendar.md
+++ b/plugins/personal-review/skills/review/calendar.md
@@ -12,7 +12,7 @@ Calculate from a standard workday (9am-6pm, 9 hours):
 
 ## Query
 
-Load the `calendar:calendar` skill. Query today's events using the date range for today only.
+Load the `calendar:calendar` skill. Query today's events using the date range for today.
 
 ## Analysis
 
@@ -40,18 +40,18 @@ After Things inbox processing, re-query today's events:
 
 - Use the same query as the initial scan
 - Compare with the initial results
-- Note any new events (e.g., work calendar additions during personal triage)
+- Note new events (e.g., work calendar additions during personal triage)
 - Update the time budget if new meetings were added
 
 ## Access Denied
 
-When the calendar sub-agent reports `"reason": "no-app-bundle"`, EventKit cannot obtain TCC permissions. This happens in tmux, SSH, or any context where the responsible process lacks an app bundle. The review workflow skips calendar silently:
+When the calendar sub-agent reports `"reason": "no-app-bundle"`, EventKit cannot obtain TCC permissions. This happens in tmux, SSH, or any context where the responsible process lacks an app bundle. Skip calendar silently:
 
 - Initial scan: note "Calendar: skipped (access denied)" and proceed
 - Post-inbox re-check: skip entirely
 - Summary: report calendar as skipped
 
-Do not prompt the user to fix permissions — the environment does not support EventKit.
+Do not prompt the user to fix permissions; the environment does not support EventKit.
 
 ## Evening Variant
 

--- a/plugins/personal-review/skills/review/github.md
+++ b/plugins/personal-review/skills/review/github.md
@@ -10,7 +10,7 @@ Load the `github:notifications` skill. Query active notifications (not done).
 
 Before presenting notifications for triage, auto-handle these patterns and report counts.
 
-**Read mentions:** Filter notifications where `reason == "MENTION"` and `isUnread == false`. Bulk mark done:
+**Read mentions:** Filter where `reason == "MENTION"` and `isUnread == false`. Bulk mark done:
 
 ```bash
 ... --jq '[... | select(.reason == "MENTION" and .isUnread == false)] | .[].summaryId' | \
@@ -29,7 +29,7 @@ If count > 0, auto-mark the notification done. Report: "Auto-marked N already-re
 
 ## Group by Reason
 
-Present groups in priority order — action needed first, then engagement, then informational.
+Present in priority order — action needed first, then engagement, then informational.
 
 | Priority | Reason | Typical Actions |
 |----------|--------|-----------------|

--- a/plugins/personal-review/skills/review/gitlab.md
+++ b/plugins/personal-review/skills/review/gitlab.md
@@ -60,7 +60,7 @@ glab api groups/<group>/merge_requests --paginate -f state=opened -f author_id=<
 
 ### Triage
 
-For each MR, use `AskUserQuestion` to determine next steps (e.g., follow up on review, rebase, close).
+For each MR, use `AskUserQuestion` for next steps (e.g., follow up on review, rebase, close).
 
 ## Evening Variant
 

--- a/plugins/personal-review/skills/review/things.md
+++ b/plugins/personal-review/skills/review/things.md
@@ -29,7 +29,7 @@ For each batch, use `AskUserQuestion`:
 Load the `things:url` skill for mutations:
 - Use `update` to set `when`, `list-id`, or `tags`
 - Use `add` to create follow-ups if breaking down tasks
-- For quick-do items, mark complete or just tell user to do it now
+- For quick-do items, mark complete or tell user to do it now
 
 ## Goal
 

--- a/plugins/personal-review/skills/review/triage.md
+++ b/plugins/personal-review/skills/review/triage.md
@@ -10,7 +10,7 @@ Load the `things:jxa` skill. Query all Today items as JSON from `TMTodayListSour
 
 Apply the midnight heuristic: a task is a repeating instance if `creationDate` ends with `T00:00:00` (midnight local time in ISO). Manually created tasks have non-zero hours/minutes/seconds.
 
-Overdue repeating tasks (where `dueDate` or `activationDate` is before today) should be batched for a single "Defer all overdue repeating tasks to tomorrow?" prompt. Load the `things:url` skill for batch defer.
+Batch overdue repeating tasks (where `dueDate` or `activationDate` is before today) into a single "Defer all overdue repeating tasks to tomorrow?" prompt. Load the `things:url` skill for batch defer.
 
 ## Grouping
 

--- a/plugins/plan/references/guidelines.md
+++ b/plugins/plan/references/guidelines.md
@@ -1,7 +1,5 @@
 # Planning Guidelines
 
-When creating implementation plans, follow these principles:
-
 ## Structure
 
 - Reference specific files and line numbers from the existing codebase
@@ -27,10 +25,8 @@ Before presenting a plan, verify:
 
 ## Skills
 
-Plans should mention which skills to activate at appropriate points in the execution lifecycle. Rather than a dedicated "Skills" section, reference skills inline where they're needed:
+Mention which skills to activate at appropriate points in the execution lifecycle. Rather than a dedicated "Skills" section, reference skills inline where they're needed:
 
 - "Use `pull-request:create` after committing changes"
 - "Activate `typescript:typescript` for type-aware refactoring"
 - "Load `git:git` before branch operations"
-
-This helps ensure consistent skill activation during implementation.

--- a/plugins/plan/skills/guidelines/SKILL.md
+++ b/plugins/plan/skills/guidelines/SKILL.md
@@ -13,18 +13,18 @@ disable-model-invocation: true
 
 ### Reading Before Planning
 
-Before proposing any changes:
+Before proposing changes:
 
 1. Read the files you intend to modify
-2. Understand the existing patterns and conventions
+2. Understand existing patterns and conventions
 3. Identify related code that might be affected
-4. Check for existing tests that cover the area
+4. Check for existing tests covering the area
 
 ### Plan Structure
 
 A good plan includes:
 
-- **Context**: What problem are we solving? What's the current state?
+- **Context**: What problem are we solving? Current state?
 - **Changes**: Specific files and modifications, with line references
 - **Dependencies**: What must happen in order? What can be parallelized?
 - **Verification**: How do we confirm success? What tests to run?
@@ -34,14 +34,14 @@ A good plan includes:
 
 Plans should match the request exactly:
 
-- If asked to fix a bug, don't refactor surrounding code
-- If asked to add a feature, don't add "nice to have" extras
-- If asked to refactor, don't fix unrelated issues you notice
+- Asked to fix a bug: don't refactor surrounding code
+- Asked to add a feature: don't add "nice to have" extras
+- Asked to refactor: don't fix unrelated issues you notice
 - Document out-of-scope observations separately if important
 
 ### When Plans Get Rejected
 
-Common reasons for plan rejection:
+Common reasons:
 
 - Too vague (no specific file/line references)
 - Too broad (scope creep beyond the request)

--- a/plugins/pull-request/skills/babysit/SKILL.md
+++ b/plugins/pull-request/skills/babysit/SKILL.md
@@ -31,7 +31,7 @@ Delegate CI monitoring to a provider-specific watcher and react to its events wi
 
 Inspect the remote URL. For a `github.com` remote, invoke the `github:actions-monitor` skill. For a `gitlab.com` remote, invoke the `gitlab:ci-monitor` skill. Each provider skill owns the watcher process (via the `Monitor` tool) and emits a structured JSON event stream describing CI state changes.
 
-Babysit consumes that event stream and reacts with the handlers below. The watcher handles polling, deduping by `(sha, state)`, rate limits, timeouts, and session-scoped lifecycle. Babysit handles fixes, pushes, and reporting. Remember the start SHA captured above so the success handler can summarize work done during the session.
+Babysit consumes that event stream and reacts with the handlers below. The watcher handles polling, deduping by `(sha, state)`, rate limits, timeouts, and session-scoped lifecycle. Babysit handles fixes, pushes, and reporting. Remember the start SHA above so the success handler can summarize work done in the session.
 
 Parse `$ARGUMENTS` for two optional flags, both off by default so plain babysit stays CI-only:
 
@@ -54,7 +54,7 @@ Compare `git rev-parse HEAD` against the event's `sha`. If HEAD is newer, a fix 
 
 The monitor skill's flow has already invoked the provider's logs agent (`github:logs` or `gitlab:logs`) and produced a summary plus a log-file path. Read the summary to decide triviality.
 
-Check whether the start SHA's CI run had the same failure. If so, the failure is pre-existing, not a regression from this branch. Report it and call `TaskStop`.
+Check whether the start SHA's CI run had the same failure. If so, it's pre-existing, not a regression from this branch. Report it and call `TaskStop`.
 
 For trivial failures (lint, type, format, lockfile), attempt a fix. Reproduce the CI step locally to verify (skip reproduction for lockfile-only changes). Commit, push. The watcher picks up the new SHA on its next poll.
 
@@ -66,7 +66,7 @@ Green on a conflicting PR is stale: if a `conflicts` or unresolved `mergeable-un
 
 Summarize the session: run `git log ${start-sha}..HEAD --oneline` for the commits pushed while babysitting.
 
-Then branch on the flags parsed from `$ARGUMENTS`:
+Then branch on the `$ARGUMENTS` flags:
 
 - **`--reviews`**: hand off to AI-review triage before finishing. See [Reviews Hand-off](#reviews-hand-off).
 - **`--merge`**: don't stop here. Drive the PR to merged. See [Merge Mode](#merge-mode).
@@ -74,7 +74,7 @@ Then branch on the flags parsed from `$ARGUMENTS`:
 
 #### conflicts
 
-Reproduce the conflict locally to identify which files conflict:
+Reproduce the conflict locally to identify the conflicting files:
 
 ```
 git merge origin/<base> --no-commit --no-ff
@@ -84,7 +84,7 @@ git merge --abort
 
 Lockfiles or generated files (`bun.lock`, etc.): regenerate per project convention (e.g. `rm bun.lock && bun install`), commit, push.
 
-Real source conflicts: rebase on `origin/<base>` and delegate to the `git:conflicts` skill. Resolve, commit, and push where mechanically clear. Where ambiguous or semantic, report the conflicting hunks and call `TaskStop` (this runs unattended, so never guess an ambiguous merge).
+Real source conflicts: rebase on `origin/<base>` and delegate to the `git:conflicts` skill. Resolve, commit, and push where mechanically clear. Where ambiguous or semantic, report the conflicting hunks and call `TaskStop` (this runs unattended, so never guess a merge).
 
 In Merge Mode, after any push here, [re-arm](#re-arm) and count it as a submit attempt.
 
@@ -127,7 +127,7 @@ Report the event (include `minutes`) and the work done since the start SHA, then
 
 ## Reviews Hand-off
 
-With `--reviews`, after the first green invoke `pull-request:follow-up --auto <pr-url>` to triage AI-reviewer threads (fix, reply, resolve, looping until the reviewer is satisfied). follow-up calls back into babysit for each post-push CI wait, so let it own the review loop.
+With `--reviews`, after the first green invoke `pull-request:follow-up --auto <pr-url>` to triage AI-reviewer threads (fix, reply, resolve, loop until the reviewer is satisfied). follow-up calls back into babysit for each post-push CI wait, so let it own the review loop.
 
 When it returns satisfied, re-request the **human** reviewers whose approval a push (follow-up's fixes or babysit's own) invalidated. Don't re-request bots; follow-up owns the `@bot` re-trigger.
 
@@ -143,9 +143,9 @@ This human re-request happens only in the `--reviews` flow. Review *threads* sta
 
 ## Merge Mode
 
-With `--merge`, don't stop at green; drive the PR to **merged**. CI green is the entry condition; from here, submit to the repo's merge mechanism and recover from kickouts until it lands. GitHub merges run through `gh` directly; delegate all GitLab merge behavior (trains, endpoint, squash) to the `gitlab:merge-request` skill.
+With `--merge`, don't stop at green; drive the PR to **merged**. CI green is the entry condition; from here, submit to the repo's merge mechanism and recover from kickouts until it lands. GitHub merges run through `gh` directly; delegate all GitLab merge behavior (trains, endpoint, squash) to `gitlab:merge-request`.
 
-First confirm the PR can merge on its own. Don't bypass blocks you can't resolve: missing **human** approval (you can't self-approve; if a bot was the blocker and `--reviews` ran, it's already handled), branch protection, draft state, or requested changes. Report and `TaskStop`. Read state via `gh pr view --json mergeable,mergeStateStatus,reviewDecision,state` (GitLab: `gitlab:merge-request`).
+First confirm the PR can merge on its own. Don't bypass blocks you can't resolve: missing **human** approval (you can't self-approve; if a bot was the blocker and `--reviews` ran, it's already handled), branch protection, draft state, or requested changes; report and `TaskStop`. Read state via `gh pr view --json mergeable,mergeStateStatus,reviewDecision,state` (GitLab: `gitlab:merge-request`).
 
 Submit by the most automated path the repo allows (merge queue/train, else auto-merge, else direct, valid since CI is green):
 
@@ -170,10 +170,10 @@ Stop re-submitting after 3 attempts (re-submits included, an oscillation guard) 
 
 The monitor script delivers structured JSON events. Do not pipe CLI output to `python3 -c`, `bun -e`, `node -e`, or any inline interpreter for parsing.
 
-CI may run on synthetic merge commits whose SHA never matches the branch tip. The watcher already reports the source branch SHA in each event; compare against `git rev-parse HEAD`.
+CI may run on synthetic merge commits whose SHA never matches the branch tip. The watcher reports the source branch SHA in each event; compare against `git rev-parse HEAD`.
 
 The Bash tool escapes `!` to `\!`. Use `| not` in jq filters (e.g. `select(.x == null | not)`), or pass filters via heredoc.
 
 The watcher dedupes by `(sha, state)`. A `failing` event for a SHA older than `git rev-parse HEAD` means a fix was already pushed; ignore it.
 
-Babysit is session-scoped. If the session ends, the watcher process ends with it. Re-invoke this skill from a new session to resume monitoring.
+Babysit is session-scoped. If the session ends, the watcher process ends with it. Re-invoke this skill from a new session to resume.

--- a/plugins/pull-request/skills/follow-up/SKILL.md
+++ b/plugins/pull-request/skills/follow-up/SKILL.md
@@ -19,27 +19,27 @@ allowed-tools:
 
 Follow up on review feedback for: $ARGUMENTS
 
-Parse the URL and flags from `$ARGUMENTS`. GitHub URLs contain `github.com`; GitLab URLs contain the instance hostname. GitHub is primary: work through `gh`, `mcp__github`, and `github:*` skills directly. Delegate all GitLab behavior to `gitlab:merge-request` (no `glab` calls here).
+Parse the URL and flags from `$ARGUMENTS`. GitHub URLs contain `github.com`; GitLab URLs contain the instance hostname. GitHub is primary: work through `gh`, `mcp__github`, and `github:*` skills directly. Delegate all GitLab behavior to `gitlab:merge-request` (no `glab` calls).
 
 - `--auto`: autonomously triage **bot** threads, looping until the reviewer is satisfied (see [The Autonomous Loop](#the-autonomous-loop)).
 - `--include-human-nits`: under `--auto`, also act on **human** threads, but only trivial high-confidence changes (typos, renames, one-liners). Off by default.
 
 ## Default Workflow (Gated)
 
-Without `--auto`, stay read-only: fetch, classify, draft, and **check with me before posting or resolving**.
+Without `--auto`, stay read-only: fetch, classify, draft, **check with me before posting or resolving**.
 
-Fetch all resolvable threads (resolved and unresolved) via `github:pr-comments` (`--role author`) or `gitlab:merge-request`, then classify each:
+Fetch all resolvable threads (resolved and unresolved) via `github:pr-comments` (`--role author`) or `gitlab:merge-request`, then classify:
 
 - **Unresolved / no reply**
 - **Unresolved / replied**
 - **Resolved / with reply**
 - **Resolved / silent**: resolved with no author reply; flag these, they hide context
 
-For unresolved threads, diff the comment's creation date against HEAD to see whether later commits already addressed the feedback. Draft replies per [replies.md](replies.md).
+For unresolved threads, diff the comment's creation date against HEAD to see whether later commits addressed the feedback. Draft replies per [replies.md](replies.md).
 
 ## The Autonomous Loop
 
-With `--auto`, drive bot threads to closure without asking. Partition threads with each provider's `--bots` filter (`github:pr-comments`, `gitlab:merge-request`): fetch once filtered for the bot set, once unfiltered to see the human threads you're leaving alone. Add new reviewers per [reviewers.md](reviewers.md).
+With `--auto`, drive bot threads to closure without asking. Partition threads with each provider's `--bots` filter (`github:pr-comments`, `gitlab:merge-request`): fetch once filtered for the bot set, once unfiltered to see the human threads you're leaving alone. Add reviewers per [reviewers.md](reviewers.md).
 
 Triage each bot thread:
 
@@ -52,7 +52,7 @@ Then run each round:
 1. Apply batched fixes, commit, push **once** (one new SHA to re-review).
 2. Reply-and-resolve the noise threads (`github:pr-comments` or `gitlab:merge-request` do both in one call).
 3. Escalate the unsure threads and pause **that subset only**; actionable pushes proceed.
-4. Hand CI back to `pull-request:babysit` (it owns CI, stops at green). babysit's Monitor watcher re-invokes you on CI events, so don't wrap that wait in `ScheduleWakeup`. The harness already wakes you.
+4. Hand CI back to `pull-request:babysit` (it owns CI, stops at green). babysit's Monitor watcher re-invokes you on CI events, so don't wrap that wait in `ScheduleWakeup`; the harness wakes you.
 5. Wait for the bot to re-review the green SHA. No Monitor watcher tracks this, so self-pace with `ScheduleWakeup`: arm a tick (`prompt` set to this same `/pull-request:follow-up` invocation so the wake re-enters the loop) at ~270s for an idle wait before re-triggering, or 180-240s when a fast re-review is expected. Never 300s (the cache-expiry boundary). On wake, re-fetch bot threads and evaluate the loop-exit conditions below: if the reviewer is satisfied or another exit fires, stop; otherwise, if no re-review landed, post one top-level `@<bot>` re-trigger, then re-arm the next tick.
 
 Loop until: the reviewer's satisfaction signal hits on HEAD ([reviewers.md](reviewers.md)); no new bot threads for two rounds after a green push; max 4 rounds (oscillation guard); the idle timeout outlasts the re-trigger; or the PR closes/merges.

--- a/plugins/pull-request/skills/follow-up/replies.md
+++ b/plugins/pull-request/skills/follow-up/replies.md
@@ -6,7 +6,7 @@ Start with what changed, not "thanks for the feedback." If the reviewer caught a
 
 ## Explain What Changed
 
-Reference the specific fix: a function name, a line, a commit. Avoid vague "I updated the code" replies. The reviewer should be able to verify without re-reading the whole diff.
+Reference the specific fix: a function name, a line, a commit. Avoid vague "I updated the code" replies. The reviewer should be able to verify without re-reading the diff.
 
 ## Disagree With Reasoning
 
@@ -14,16 +14,16 @@ When pushing back, provide code context or a concrete reason. "I kept this becau
 
 ## Keep It Concise
 
-One to three sentences is typical. Don't pad replies with filler or restate the reviewer's comment back to them. If the fix is self-evident from the diff, "Fixed" or "Done" is acceptable.
+One to three sentences. Don't pad replies with filler or restate the reviewer's comment. If the fix is self-evident from the diff, "Fixed" or "Done" is acceptable.
 
 ## Match the Reviewer's Detail Level
 
-Short review comments get short replies. Detailed technical feedback deserves a proportional response explaining your reasoning. Don't write a paragraph in response to a one-liner.
+Short review comments get short replies. Detailed technical feedback gets a proportional response explaining your reasoning. Don't write a paragraph in response to a one-liner.
 
 ## Replying to AI Reviewers
 
-When `--auto` replies to a bot thread, write the reply as a note for any future reader, not a message to the bot:
+When `--auto` replies to a bot thread, write the reply as a note for any reader, not a message to the bot:
 
-- **Don't name or address the reviewer.** No "@coderabbitai", no "thanks", no "good bot". The one place a bot is named is the `@<bot>` re-trigger, which is a top-level comment, not a thread reply.
+- **Don't name or address the reviewer.** No "@coderabbitai", no "thanks", no "good bot". The one place a bot is named is the `@<bot>` re-trigger, a top-level comment, not a thread reply.
 - **State the resolution, not the dialogue.** "Guarded with a null check" or "Intentional: this path only runs after validation" reads correctly whether a human or a bot raised it.
 - **For a false positive, give the one-line reason** before resolving, so the resolve isn't silent: "Not reachable here, the caller already validates `id`."

--- a/plugins/pull-request/skills/follow-up/reviewers.md
+++ b/plugins/pull-request/skills/follow-up/reviewers.md
@@ -4,7 +4,7 @@ Per-reviewer "satisfied" signals for the `--auto` loop, plus how to add a review
 
 ## Satisfaction Signals
 
-Third-party reviewers converge on one shape: each leaves a single summary comment, edited in place across review cycles, holding both the satisfaction signal and sometimes actionable items that never become inline threads. Read the summary, not just the thread list:
+Third-party reviewers converge on one shape: each leaves a single summary comment, edited in place across review cycles, holding the satisfaction signal and sometimes actionable items that never become inline threads. Read the summary, not just the thread list:
 
 - Select the summary comment by `updated_at`, not `created_at`. The current signal is an edit to a comment created rounds ago, so newest-created points at the wrong one.
 - Treat the summary body as a thread source. A thread-count check alone reads an unfinished review, with actionable items parked in the summary, as satisfied.
@@ -18,11 +18,11 @@ A reviewer is done when its latest summary on the current HEAD reports nothing a
 
 #### Copilot
 
-GitHub Copilot (`copilot-pull-request-reviewer` / `github-copilot[bot]`) diverges: it posts a fresh native GitHub review each cycle instead of editing one comment in place, so take its latest review by submission, not by `updated_at`. Satisfied when that review on the current HEAD adds no actionable threads ("reviewed N files and found no issues" / "no further comments").
+GitHub Copilot (`copilot-pull-request-reviewer` / `github-copilot[bot]`) diverges: it posts a fresh native GitHub review each cycle instead of editing one comment in place, so take its latest review by submission, not `updated_at`. Satisfied when that review on the current HEAD adds no actionable threads ("reviewed N files and found no issues" / "no further comments").
 
 ## Re-triggering an Idle Reviewer
 
-If a reviewer does not re-review within ~5 minutes of a green push, post **one** top-level comment mentioning it to re-trigger, then reset the idle timer:
+If a reviewer doesn't re-review within ~5 minutes of a green push, post **one** top-level comment mentioning it to re-trigger, then reset the idle timer:
 
 - CodeRabbit: `@coderabbitai review`
 - Greptile: `@greptileai review` (or the bot's documented trigger phrase)
@@ -34,6 +34,6 @@ This @-mention is the only place a bot is named. Thread replies never name or th
 
 Common reviewers need no maintenance: GitHub reports `__typename: "Bot"` for App and bot accounts, and GitLab service accounts follow the `*-bot` / `*_bot` convention or the token service-account form `group_<id>_bot_<hash>` / `project_<id>_bot_<hash>` (CodeRabbit posts under a group token account). Whatever those signals catch is handled automatically.
 
-For an account they miss (a GitLab bot with an off-convention username) or a human reviewer you want the loop to triage, add one username per line to `reviewers.txt` in that plugin's data directory (`$CLAUDE_PLUGIN_DATA`, e.g. `~/.claude/plugins/data/github-bendrucker/reviewers.txt`). Blank lines and `#` comments are ignored, and the list only ever adds to the structural detection.
+For an account they miss (a GitLab bot with an off-convention username) or a human reviewer you want the loop to triage, add one username per line to `reviewers.txt` in that plugin's data directory (`$CLAUDE_PLUGIN_DATA`, e.g. `~/.claude/plugins/data/github-bendrucker/reviewers.txt`). Blank lines and `#` comments are ignored; the list only adds to the structural detection.
 
 Then add a satisfaction signal and re-trigger phrase for the new reviewer here.

--- a/plugins/raycast/skills/raycast/SKILL.md
+++ b/plugins/raycast/skills/raycast/SKILL.md
@@ -33,7 +33,7 @@ See [references/hooks.md](references/hooks.md)
 
 ## AI Tools
 
-Tools export a default async function with a typed `Input` parameter. JSDoc comments on the `Input` type teach the AI how to use the tool. Export a `confirmation` function for destructive operations. Configure `ai.instructions` in `package.json` for extension-level guidance.
+Tools export a default async function with a typed `Input` parameter. JSDoc comments on the `Input` type teach the AI to use the tool. Export a `confirmation` function for destructive operations. Configure `ai.instructions` in `package.json` for extension-level guidance.
 
 See [references/ai-tools.md](references/ai-tools.md)
 

--- a/plugins/raycast/skills/raycast/references/ai-tools.md
+++ b/plugins/raycast/skills/raycast/references/ai-tools.md
@@ -25,7 +25,7 @@ The default export receives a typed `Input` object and returns a value. JSDoc co
 
 ## Confirmation
 
-Export a `confirmation` function for operations with side effects:
+Export a `confirmation` function for operations with side effects.
 
 ```ts
 // src/tools/delete-todo.ts

--- a/plugins/raycast/skills/raycast/references/components.md
+++ b/plugins/raycast/skills/raycast/references/components.md
@@ -1,6 +1,6 @@
 # Components
 
-All UI is built with React components from `@raycast/api`.
+UI is built with React components from `@raycast/api`.
 
 ## List
 
@@ -155,7 +155,7 @@ Form items: `TextField`, `TextArea`, `PasswordField`, `Checkbox`, `DatePicker`, 
 
 ## ActionPanel
 
-Actions are grouped in `ActionPanel`, optionally split into sections:
+Actions are grouped in `ActionPanel`, optionally split into sections.
 
 ```tsx
 <ActionPanel>
@@ -176,7 +176,7 @@ Custom actions accept `title`, `icon`, `shortcut`, and `onAction`.
 
 ## Toasts
 
-Show feedback with `showToast`:
+Show feedback with `showToast`.
 
 ```tsx
 import { showToast, Toast } from "@raycast/api";

--- a/plugins/raycast/skills/raycast/references/hooks.md
+++ b/plugins/raycast/skills/raycast/references/hooks.md
@@ -4,7 +4,7 @@ All hooks from `@raycast/utils`. Install with `npm install @raycast/utils`.
 
 ## useFetch
 
-Fetch data from a URL with automatic JSON parsing:
+Fetch data from a URL with automatic JSON parsing.
 
 ```tsx
 import { List } from "@raycast/api";
@@ -54,7 +54,7 @@ Key options: `keepPreviousData`, `initialData`, `execute`, `mapResult`, `parseRe
 
 ## usePromise
 
-Wrap any async function:
+Wrap any async function.
 
 ```tsx
 import { usePromise } from "@raycast/utils";
@@ -91,7 +91,7 @@ Cached data must be JSON-serializable. Returns cached data immediately, then rev
 
 ## useForm
 
-Form state management with validation:
+Form state management with validation.
 
 ```tsx
 import { useForm, FormValidation } from "@raycast/utils";
@@ -112,7 +112,7 @@ Spread `itemProps.<field>` onto form items. `handleSubmit` only fires `onSubmit`
 
 ## useLocalStorage
 
-Persistent key-value storage:
+Persistent key-value storage.
 
 ```tsx
 import { useLocalStorage } from "@raycast/utils";
@@ -134,7 +134,7 @@ Returns `value`, `setValue`, `removeValue`, and `isLoading`.
 
 ## useExec
 
-Execute shell commands with stale-while-revalidate caching:
+Execute shell commands with stale-while-revalidate caching.
 
 ```tsx
 import { useExec } from "@raycast/utils";

--- a/plugins/raycast/skills/raycast/references/manifest.md
+++ b/plugins/raycast/skills/raycast/references/manifest.md
@@ -85,7 +85,7 @@ Each tool maps to `src/tools/<name>.ts`.
 }
 ```
 
-Move lengthy AI config to a separate `ai.yaml` or `ai.json5` file alongside `package.json`.
+Move lengthy AI config to a separate `ai.yaml` or `ai.json5` alongside `package.json`.
 
 ## Complete Example
 

--- a/plugins/raycast/skills/raycast/references/store.md
+++ b/plugins/raycast/skills/raycast/references/store.md
@@ -34,7 +34,7 @@ Extension titles should be nouns ("Emoji Search" not "Search Emoji"). Command ti
 - Fixed pagination for large result sets
 ```
 
-Use `{PR_MERGE_DATE}` instead of a hardcoded date — the Raycast Store replaces it with the actual merge date when the PR lands. This avoids stale dates when review takes longer than expected. Title must be in square brackets, separated from the date by ` - `.
+Use `{PR_MERGE_DATE}` instead of a hardcoded date — the Raycast Store replaces it with the actual merge date when the PR lands, avoiding stale dates when review takes longer than expected. Title must be in square brackets, separated from the date by ` - `.
 
 **README.md** (required if setup is needed):
 - Place at extension root

--- a/plugins/research/skills/prior-art/SKILL.md
+++ b/plugins/research/skills/prior-art/SKILL.md
@@ -25,10 +25,10 @@ Run searches in parallel. Infer the ecosystem from:
 
 Start with 2-3 most promising projects:
 1. Read README and high-level docs to assess relevance
-2. Only examine code when relevance is confirmed AND implementation details matter
-3. Dispatch parallel Task agents for each project, with explicit focus areas
+2. Examine code only when relevance is confirmed AND implementation details matter
+3. Dispatch parallel Task agents per project, with explicit focus areas
 
-If initial results don't satisfy the query, expand to additional projects.
+If results don't satisfy the query, expand to more projects.
 
 **Agent dispatch example:**
 ```
@@ -43,13 +43,13 @@ Investigate [project] for prior art on [topic]:
 Gather findings and produce a recommendation:
 - Identify common patterns across solutions
 - Note meaningful variations in approach
-- Infer user intent:
+- Infer intent:
   - "build X" → learn patterns, inform implementation
   - "library for X" → find dependencies to use directly
 
 ## Output Format
 
-Respond in the conversation with structured markdown (not files):
+Respond in the conversation with structured markdown, not files:
 
 ```markdown
 ## Prior Art: [Topic]
@@ -78,4 +78,4 @@ Respond in the conversation with structured markdown (not files):
 - **Honest reporting**: Acknowledge when prior art is sparse—don't force results
 - **Research only**: Don't offer to integrate dependencies or modify the project
 - **Ecosystem inference**: Derive from context, don't require explicit specification
-- **Adaptive depth**: Investigate more projects if initial batch is insufficient
+- **Adaptive depth**: Investigate more projects if the initial batch is insufficient

--- a/plugins/review/skills/dashboard/SKILL.md
+++ b/plugins/review/skills/dashboard/SKILL.md
@@ -50,7 +50,7 @@ Load `gitlab:merge-request` and run its `review-queue` command for the UNREVIEWE
 
 ### Present Results
 
-Combine results from both platforms into a summary table. Ask the user which reviews to start.
+Combine results from both platforms into a summary table. Ask which reviews to start.
 
 ## Spawn Review Sessions
 
@@ -66,7 +66,7 @@ Ask the user where the repo is cloned locally. If it's not cloned, clone it firs
 bun ${CLAUDE_SKILL_DIR}/scripts/spawn.ts <pr-url> --repo-path <local-path> --data-dir ${CLAUDE_PLUGIN_DATA} --context "<PR metadata: title, author, description summary>"
 ```
 
-`spawn.ts` handles `--worktree` for branch isolation, tmux layout computation, and state tracking. Pass `--context` with PR metadata (title, author, description summary) so the spawned review session has immediate context. Panes cycle in groups of 3: one horizontal split (new column at 70% width for the first, equal width after), then two vertical splits stacking within the column.
+`spawn.ts` handles `--worktree` for branch isolation, tmux layout computation, and state tracking. Pass `--context` with PR metadata (title, author, description summary) so the spawned review session has immediate context. Panes cycle in groups of 3: one horizontal split (new column at 70% width for the first, equal width after), then two vertical splits stacking in the column.
 
 Before spawning the first pane, resize the orchestrator to a sidebar:
 
@@ -90,7 +90,7 @@ Detect exited panes, mark them completed, and prune their worktrees:
 bun ${CLAUDE_SKILL_DIR}/scripts/state.ts sync --data-dir ${CLAUDE_PLUGIN_DATA}
 ```
 
-When a review transitions `active → completed`, `sync` reclaims its worktree through Worktrunk: `spawn.ts` created the worktree as `wt switch --create <paneName>`, so `sync` removes it by that same stored branch (`wt remove <paneName> --force`) with no lookup. `wt remove` deletes the worktree (including untracked files), fires your `pre-remove` hooks, and drops the branch when it has no unmerged commits. `sync` prints `N completed, M worktrees removed` and surfaces any removal failures on stderr. A `pre-remove` hook that needs approval fails the removal (it surfaces in the failure list) rather than removing unattended; pre-approve with `wt config approvals add` if you want the dashboard to reclaim those worktrees on its own.
+When a review transitions `active → completed`, `sync` reclaims its worktree through Worktrunk: `spawn.ts` created the worktree as `wt switch --create <paneName>`, so `sync` removes it by that same stored branch (`wt remove <paneName> --force`) with no lookup. `wt remove` deletes the worktree (including untracked files), fires your `pre-remove` hooks, and drops the branch when it has no unmerged commits. `sync` prints `N completed, M worktrees removed` and surfaces any removal failures on stderr. A `pre-remove` hook that needs approval fails the removal (it surfaces in the failure list) rather than removing unattended; pre-approve with `wt config approvals add` to let the dashboard reclaim those worktrees on its own.
 
 #### Quick Glance
 
@@ -100,7 +100,7 @@ tmux capture-pane -t <pane_id> -p -S -50
 
 #### Deep Inspection via JSONL
 
-Each session's logs are at `~/.claude/projects/<encoded-path>/<session-id>.jsonl`. The encoded path replaces non-alphanumeric characters with `-` and prefixes with `-`. Since review sessions run in a Worktrunk worktree, the CWD is the worktree path (not the repo root). Discover the JSONL path by globbing:
+Each session's logs are at `~/.claude/projects/<encoded-path>/<session-id>.jsonl`. The encoded path replaces non-alphanumeric characters with `-` and prefixes with `-`. Since review sessions run in a Worktrunk worktree, the CWD is the worktree path, not the repo root. Discover the JSONL path by globbing:
 
 ```bash
 ls ~/.claude/projects/*/<session-id>.jsonl
@@ -116,20 +116,20 @@ Periodically run `state.ts sync` to detect completed reviews. When all reviews a
 
 The interactive flow above is the default: fetch once, present, ask, spawn. The loop is the opt-in hands-off mode. It polls the UNREVIEWED queues on an interval and spawns a session for each newly-arrived review without prompting, so the queue drains itself while you work elsewhere.
 
-The `Monitor` command does the polling itself and emits one line per newly-arrived review; you react to each event by spawning. `watch.ts` owns the loop: each interval it syncs completed reviews, then runs the fetch-and-diff (read tracked URLs from state, run each `--queue` source command, print the URLs not already tracked). `Monitor` is not a bare metronome.
+The `Monitor` command does the polling and emits one line per newly-arrived review; you react to each event by spawning. `watch.ts` owns the loop: each interval it syncs completed reviews, then runs the fetch-and-diff (read tracked URLs from state, run each `--queue` source command, print the URLs not already tracked). `Monitor` is not a bare metronome.
 
 #### Wire the Review-Queue Sources
 
 `poll.ts` knows no platforms. Each `--queue` is a command that emits an UNREVIEWED queue as `[{ url }]` JSON. Pass one per platform you want polled, and omit the rest:
 
 - GitHub: `gh search prs --review-requested=@me --state=open --json url`.
-- GitLab: load `gitlab:merge-request` and pass `bun <ABS>`, where `<ABS>` is the absolute path the gitlab docs resolve to for `scripts/review-queue.ts` (for example `/Users/you/.claude/plugins/cache/.../gitlab/skills/merge-request/scripts/review-queue.ts`). Write the resolved path out in full. Do not reuse `${CLAUDE_SKILL_DIR}` from the examples below: it points at this dashboard skill, not gitlab, so it would resolve to the wrong directory.
+- GitLab: load `gitlab:merge-request` and pass `bun <ABS>`, where `<ABS>` is the absolute path the gitlab docs resolve to for `scripts/review-queue.ts` (for example `/Users/you/.claude/plugins/cache/.../gitlab/skills/merge-request/scripts/review-queue.ts`). Write the resolved path out in full. Do not reuse `${CLAUDE_SKILL_DIR}` from the examples below: it points at this dashboard skill, not gitlab, so it resolves to the wrong directory.
 
 A platform plugin that owns its queue keeps the query; the dashboard only runs the command it hands back.
 
 #### Arm the Monitor
 
-Pass this command to `Monitor` with `persistent: true` and a descriptive label. `watch.ts` runs a single long-lived bun process: each iteration syncs completed reviews, fetches all `--queue` sources, and prints one URL per line for every newly-arrived review. Each printed URL is one event.
+Pass this command to `Monitor` with `persistent: true` and a descriptive label. `watch.ts` runs a single long-lived bun process: each iteration syncs completed reviews, fetches all `--queue` sources, and prints one URL per line per newly-arrived review. Each printed URL is one event.
 
 `${CLAUDE_SKILL_DIR}` below is the dashboard's own directory (where `watch.ts` lives). The GitLab `--queue` uses a full absolute path instead, since it points into a different skill:
 
@@ -147,15 +147,15 @@ A failed source emits a `{"type":"source-error",...}` line to stderr and contrib
 
 Two rules for any command you hand `Monitor`:
 
-- Pass a **single long-lived process** that sleeps internally via `setTimeout`, not a shell `while/sleep` loop. This is a temporary workaround for a macOS `Monitor` bug: the eval context strips `PATH` (so `sleep` and `date` are not found) and kills backgrounded children with `nice(5) failed: operation not permitted`. When that harness bug is fixed, shell loops should work again.
+- Pass a **single long-lived process** that sleeps internally via `setTimeout`, not a shell `while/sleep` loop. This is a temporary workaround for a macOS `Monitor` bug: the eval context strips `PATH` (so `sleep` and `date` are not found) and kills backgrounded children with `nice(5) failed: operation not permitted`. When that harness bug is fixed, shell loops work again.
 - **Never suppress poll output** with `>/dev/null` or `|| true`. A silent poll is indistinguishable from "nothing new"; emit a structured line on error so failures are visible.
 
 #### React to Each Event
 
-For each emitted URL, spawn a session without prompting, reusing [Resolve the Local Repo Path](#resolve-the-local-repo-path). In unattended runs there is no one to answer the clone prompt, so skip any review whose repo is not cloned locally and report it rather than blocking the loop. `spawn.ts` refuses a URL already tracked, so a URL re-emitted before its `spawn.ts` lands is a harmless no-op.
+For each emitted URL, spawn a session without prompting, reusing [Resolve the Local Repo Path](#resolve-the-local-repo-path). In unattended runs there is no one to answer the clone prompt, so skip any review whose repo is not cloned locally and report it rather than blocking the loop. `spawn.ts` refuses a URL already tracked, so a URL re-emitted before its `spawn.ts` lands is a no-op.
 
 #### Pacing and Stopping
 
 - A 300s interval is a reasonable floor. Reviews arrive over minutes-to-hours, and the queue sources hit rate-limited remote APIs. Shorten only when you expect a burst.
 - Call `TaskStop` on the `Monitor` task to stop early.
-- The loop runs until you stop it. Surface a summary when the queue is empty across several consecutive intervals, but keep polling unless told otherwise (a re-request can re-add a review at any time).
+- The loop runs until you stop it. Surface a summary when the queue is empty across several consecutive intervals, but keep polling unless told otherwise (a re-request can re-add a review anytime).

--- a/plugins/review/skills/follow-up/SKILL.md
+++ b/plugins/review/skills/follow-up/SKILL.md
@@ -21,10 +21,10 @@ empty, resolve the target from the current branch's open PR/MR before anything e
 Target](#resolve-target)). Only ask me to paste a URL when that resolution genuinely fails.
 
 You are the reviewer. The question is not "did the author reply?" but "did the fix actually grasp
-each concern, or just go through the motions?" Status is a signal. The code is the verdict.
+each concern, or go through the motions?" Status is a signal. The code is the verdict.
 
 All diff and file reading happens in Explore sub-agents. Your main session holds only the structured
-verdicts they return, never raw diffs. This keeps my development context free.
+verdicts they return, never raw diffs, keeping my development context free.
 
 ## Workflow
 
@@ -59,14 +59,13 @@ Load the `gitlab:api` and `gitlab:merge-request` skills for API patterns and MR 
 
 ### Sync to the Latest Pushed State
 
-Before judging anything, make sure your assessment reflects what the author actually pushed, not a
-stale local checkout.
+Your assessment must reflect what the author actually pushed, not a stale local checkout.
 
 **The worktree-behind-origin trap**: judging a local worktree that is N commits behind origin makes
-clean fixes look unaddressed. This is a real near-miss. Never assess local state without syncing.
+clean fixes look unaddressed. Never assess local state without syncing.
 
 - Prefer the remote-of-record diff. `glab` and `gh` API diffs always reflect the server, so favor
-  them over reading the local worktree.
+  them over the local worktree.
 - If a sub-agent must read the local worktree, it has to `git fetch` first and compare against
   `origin/<branch>`, never the local checkout.
 
@@ -80,8 +79,8 @@ The fix assessment diffs that range, not the whole MR.
 ### Fetch Threads
 
 Gather all resolvable discussion threads that I started (both resolved and unresolved). Retain each
-thread's **original comment body and location**. The sub-agents need the concern's intent, not just
-its status.
+thread's **original comment body and location**. The sub-agents need the concern's intent, not its
+status.
 
 #### GitHub
 
@@ -96,7 +95,7 @@ summary. That skill covers the script, username lookup, and the raw-payload cave
 
 ### Classify Threads
 
-Sort each thread into one of four buckets, but treat the bucket as a **signal, not a verdict**:
+Sort each thread into one of four buckets, treating the bucket as a **signal, not a verdict**:
 
 - **Unresolved / no author reply**: Author hasn't responded
 - **Unresolved / author replied**: Author responded, evaluate the reply
@@ -108,14 +107,14 @@ Don't count it as the author engaging with the concern. The fetch step's skill c
 on each platform.
 
 The code-grounded verdict from the next step is the source of truth. A mismatch between status and
-code reality (resolved but not fixed, unresolved but fixed) is itself a finding.
+code reality (resolved but not fixed, unresolved but fixed) is a finding.
 
 ### Assess Fixes
 
-This is the core step. Dispatch read-only Explore sub-agents (Task tool) to read the post-review diff
+The core step. Dispatch read-only Explore sub-agents (Task tool) to read the post-review diff
 and judge each fix. **Group threads by the file they sit on and dispatch one Explore agent per file.**
-When a single file carries many threads, fall back to per-thread agents. Cap parallelism sensibly
-(roughly 6-8 concurrent).
+When a single file carries many threads, fall back to per-thread agents. Cap parallelism at roughly
+6-8 concurrent.
 
 Give each agent:
 
@@ -149,17 +148,17 @@ Spell out these assessment lenses in each agent's prompt:
 ### Quick Pass for New Issues
 
 Have the same per-file agents flag problems the fixes **introduced** that aren't tied to any thread.
-Real runs always end with this. Surface these separately from the thread verdicts.
+Surface these separately from the thread verdicts.
 
 ### Verify Author Claims
 
 If the author claims they tested, validated, or ran something, check for evidence: relevant commits,
-test changes, MR-body checkboxes that are actually checked. Flag unsubstantiated claims rather than
+test changes, MR-body checkboxes that are checked. Flag unsubstantiated claims rather than
 taking them at face value.
 
 ### Present: Attention-Ranked Report
 
-Lead with what needs my eyes. Do not emit a uniform full-detail row per thread.
+Lead with what needs my eyes. Don't emit a uniform full-detail row per thread.
 
 #### Needs your attention
 
@@ -175,10 +174,10 @@ Collapse solid fixes to a count plus one-liners. Don't expand them.
 A graded call:
 
 - **Approve**: everything addressed cleanly
-- **Approve with comments**: addressed, with minor nits you can fix in a follow-up or follow-up PR
+- **Approve with comments**: addressed, with minor nits you can fix in a follow-up PR
 - **Request changes**: partial, mechanical, or unaddressed concerns remain
 
-Name the minor-nit lane explicitly: approving while requesting trivial follow-ups is a real option,
+Name the minor-nit lane explicitly: approving while requesting trivial follow-ups is an option,
 not a forced choice between approve and block.
 
 ### Execute Actions
@@ -198,7 +197,7 @@ Approve, resolve or unresolve threads, and comment via the `gitlab:merge-request
 ## Guardrails
 
 - **Check with me** before submitting any review or comments.
-- **Don't approve automatically**: present the evidence and let me decide.
+- **Don't approve automatically**: present the evidence, let me decide.
 - **Flag silently resolved threads** so I can decide whether to reopen or accept.
 - **Distinguish code fixes from dismissals**: a resolved thread with matching code changes is different from one resolved with no changes.
 - **Sync before judging**: never assess stale local state. Fetch and diff against origin first.

--- a/plugins/review/skills/peer/SKILL.md
+++ b/plugins/review/skills/peer/SKILL.md
@@ -22,7 +22,7 @@ If not on the branch, first run `gh pr checkout` to switch.
 
 - **Must** check with me before submitting. Show file comments and review comment.
 - **Don't** insist on commenting on every PR. Propose approving with no comment if everything looks good.
-- **Don't** run Python, Ruby, or other interpreters for library introspection. Use Read to examine source files or WebFetch to read documentation instead.
+- **Don't** run Python, Ruby, or other interpreters for library introspection. Use Read for source files or WebFetch for documentation instead.
 - **Do** match my writing style. You're commenting as me, not a generic AI assistant.
 - **Do** present technical questions to me for ambiguous code. Don't proceed until you understand fully.
 
@@ -31,17 +31,17 @@ If not on the branch, first run `gh pr checkout` to switch.
 1. **Research** - Gather context (see [research.md](research.md))
 2. **Context** - Determine review context using repository visibility. Private repositories use [corporate](references/corporate.md) defaults. Public repositories use [open-source](references/open-source.md) defaults. Check visibility via the platform API (`gh api repos/OWNER/REPO --jq .visibility` or `glab api projects/ENCODED_PATH | jq .visibility`). If ambiguous, ask me.
 3. **Review** - Examine changed files and existing comments
-4. **Delegate** - Run `/code-review` for code-quality analysis. Summarize the diff (rough line count, files touched, sensitive areas) and signals from the PR body, propose an effort level with one-line reasoning, and confirm via `AskUserQuestion` before invoking. Skip the call entirely for trivial PRs (docs-only, dep bumps). Effort heuristics:
+4. **Delegate** - Run `/code-review` for code-quality analysis. Summarize the diff (rough line count, files touched, sensitive areas) and signals from the PR body, propose an effort level with one-line reasoning, and confirm via `AskUserQuestion` before invoking. Skip the call for trivial PRs (docs-only, dep bumps). Effort heuristics:
    - **low**: docs-only, dep bumps, config tweaks, trivial fixes (<50 lines)
    - **medium**: typical features or fixes, single module, ~50–500 lines
    - **high**: large refactors, multi-module, public API or schema changes, ~500–2000 lines
    - **xhigh**: security-sensitive (auth, payments, data access), breaking changes, migrations
    - **max**: rare — incident hotfix or change with extreme blast radius
 5. **Think** - Evaluate against priorities (see [priorities.md](priorities.md)), incorporating `/code-review` findings
-6. **Stage** - Open the PR diff in tuicr via `review:tuicr` (`tuicr pr <N>` for GitHub, `tuicr mr <N>` for GitLab) and seed proposed comments with `tuicr review add` (pass `--username` so they read as agent comments). Capture the PR head SHA (and base/start SHAs for GitLab, from the MR `diff_refs`) for mapping. Skip staging entirely when approving with no comments.
-7. **Revise** - I curate in the tuicr pane: delete comments I reject, reword, and add my own at any line. The surviving set is what gets posted.
-8. **Submit a GitHub PR yourself from the TUI** - For a GitHub PR you curated in the tuicr pane, the fastest path is tuicr's own `:submit` (Comment / Approve / Request changes / Draft), which posts a real PR review via `gh`. When that fits, skip the map-and-post steps below entirely. Claude maps and posts only for GitLab (tuicr cannot post to GitLab at all) or when the review runs headless with no TUI.
-9. **Map** - When Claude posts, read back the final set (`tuicr review comments --repo <repo> --session <slug>`) and map each comment to a platform position with `review:tuicr`'s mapping CLI (`mapping.ts map --platform <github|gitlab> --comments ... --diff ... --commit <sha>`). It runs the in-diff pre-check and returns `{ payloads, dropped }`. Off-diff anchors land in `dropped` (GitHub rejects them with `422 "Line could not be resolved"`), so surface those to me rather than silently losing them.
+6. **Stage** - Open the PR diff in tuicr via `review:tuicr` (`tuicr pr <N>` for GitHub, `tuicr mr <N>` for GitLab) and seed proposed comments with `tuicr review add` (pass `--username` so they read as agent comments). Capture the PR head SHA (and base/start SHAs for GitLab, from the MR `diff_refs`) for mapping. Skip staging when approving with no comments.
+7. **Revise** - I curate in the tuicr pane: delete comments I reject, reword, and add my own at any line. The surviving set gets posted.
+8. **Submit a GitHub PR yourself from the TUI** - For a GitHub PR you curated in the tuicr pane, the fastest path is tuicr's own `:submit` (Comment / Approve / Request changes / Draft), which posts a real PR review via `gh`. When that fits, skip the map-and-post steps below. Claude maps and posts only for GitLab (tuicr cannot post to GitLab at all) or when the review runs headless with no TUI.
+9. **Map** - When Claude posts, read back the final set (`tuicr review comments --repo <repo> --session <slug>`) and map each comment to a platform position with `review:tuicr`'s mapping CLI (`mapping.ts map --platform <github|gitlab> --comments ... --diff ... --commit <sha>`). It runs the in-diff pre-check and returns `{ payloads, dropped }`. Off-diff anchors land in `dropped` (GitHub rejects them with `422 "Line could not be resolved"`), so surface those to me rather than losing them.
 10. **Post** - Show me the mapped set, then on my go post as one batch and choose Approve / Comment / Request Changes based on severity. GitHub: a pending review submitted as a batch. GitLab: draft notes published together.
 
 See [tone.md](tone.md) for comment style guidelines.
@@ -50,4 +50,4 @@ See [tone.md](tone.md) for comment style guidelines.
 
 This skill assumes GitHub. For GitLab merge requests, load `gitlab:merge-request` for the submission workflow; use `draft-note.ts submit` to publish draft notes with an optional summary and review decision.
 
-tuicr's own `:submit` is interactive and GitHub-only. When I curate a GitHub PR live in the pane, I submit it there and Claude posts nothing. Claude's programmatic path (`mcp__github` / `gh` / `glab`) covers the two cases tuicr can't: a GitLab MR (tuicr never posts to GitLab) and a headless GitHub run with no TUI. When tuicr is not running or I prefer to skip it, stage nothing and post directly the same way. On follow-up, resolution is native: resolve addressed threads on the platform (`review-threads.ts` for GitHub, the resolve flow in `gitlab:merge-request` for GitLab), not in tuicr.
+tuicr's own `:submit` is interactive and GitHub-only. When I curate a GitHub PR live in the pane, I submit it there and Claude posts nothing. Claude's programmatic path (`mcp__github` / `gh` / `glab`) covers the two cases tuicr can't: a GitLab MR (tuicr never posts to GitLab) and a headless GitHub run with no TUI. When tuicr is not running or I prefer to skip it, stage nothing and post directly the same way. On follow-up, resolution is native: resolve addressed threads on the platform (`review-threads.ts` for GitHub, the resolve flow in `gitlab:merge-request` for GitLab), not tuicr.

--- a/plugins/review/skills/peer/magic-numbers.md
+++ b/plugins/review/skills/peer/magic-numbers.md
@@ -27,7 +27,7 @@ const maxRetries = 3;
 if (retries > maxRetries) { ... }
 ```
 
-For Go, suggest package-level constants. For Python, suggest module-level constants. Match the project's existing naming convention.
+For Go, suggest package-level constants. For Python, module-level constants. Match the project's existing naming convention.
 
 ## Severity
 

--- a/plugins/review/skills/peer/priorities.md
+++ b/plugins/review/skills/peer/priorities.md
@@ -8,6 +8,6 @@ Prioritize in order when making comments:
 4. **Anti-patterns** - Flag magic numbers (see [magic-numbers.md](magic-numbers.md)) and other code smells that hurt readability or maintainability.
 5. **Style** - Note deviations from project/language style, but limit these. Prefer automated linting. When you spot something automatable, file an issue in the project tracker to add the lint rule or CI check and link it in the review comment.
 
-Priority weighting shifts by context. See [corporate](references/corporate.md) and [open-source](references/open-source.md) references for how disposition and thresholds differ.
+Priority weighting shifts by context. See [corporate](references/corporate.md) and [open-source](references/open-source.md) for how disposition and thresholds differ.
 
 Think hard about the problem the PR solves and whether the approach is optimal.

--- a/plugins/review/skills/peer/references/corporate.md
+++ b/plugins/review/skills/peer/references/corporate.md
@@ -13,5 +13,5 @@
 
 ## How to Comment
 
-- Use code snippets when they communicate the idea more clearly than prose. The goal is actionable advice, not necessarily a complete fix.
+- Use code snippets when they communicate the idea more clearly than prose. The goal is actionable advice, not a complete fix.
 - See [tone.md](../tone.md) for general comment style. Corporate-specific additions: blocking comments should be matter-of-fact about the risk, non-blocking suggestions should be collaborative ("what about...", "have you considered...", "worth adding").

--- a/plugins/review/skills/peer/references/open-source.md
+++ b/plugins/review/skills/peer/references/open-source.md
@@ -8,11 +8,11 @@
 
 ## What to Review
 
-- Enforce minimal PR scope. Push back on unrelated changes (dependency bumps, formatting, contributor additions) that aren't part of the stated goal. Be persistent if unrelated changes reappear after feedback.
-- Focus on subjective qualities. When you spot something automatable (lint rule, CI check), file an issue to automate it and link it in the review comment rather than just requesting the manual fix.
+- Enforce minimal PR scope. Push back on unrelated changes (dependency bumps, formatting, contributor additions) that aren't part of the stated goal. Be persistent if they reappear after feedback.
+- Focus on subjective qualities. When you spot something automatable (lint rule, CI check), file an issue to automate it and link it in the review comment rather than requesting the manual fix.
 
 ## How to Comment
 
-- See [tone.md](../tone.md) for general comment style. Open-source additions: thank contributors for their work, then clearly explain what needs to change and why.
+- See [tone.md](../tone.md) for general comment style. Open-source additions: thank contributors for their work, then explain what needs to change and why.
 - Scale teaching depth with contributor experience. Newer contributors benefit from enumerated edge cases, alternative approaches, and links to relevant documentation. Experienced contributors get terser feedback.
 - Cite authoritative sources (official docs, upstream source code, specs) when requesting changes so contributors can verify the reasoning themselves.

--- a/plugins/review/skills/peer/tone.md
+++ b/plugins/review/skills/peer/tone.md
@@ -2,7 +2,7 @@
 
 Comments should be concise and instructive. Help the author understand why a suggestion was made. Provide inline links to relevant sources.
 
-Write in a natural, conversational tone. Avoid stiff or over-punctuated prose. Read the reviewer's actual comment history to match their voice.
+Write in a natural, conversational tone. Avoid stiff or over-punctuated prose. Read the reviewer's comment history to match their voice.
 
 Don't address the author by name or with greetings ("Hey Alice,", "Hi @bob"). Comments are already targeted at the author, so open with the substance.
 
@@ -26,10 +26,10 @@ The keyword conveys severity without drawing attention to itself.
 
 Blocking comments should be matter-of-fact about the risk. State the problem and its impact directly without hedging.
 
-Non-blocking suggestions should be collaborative. Use phrasing like "what about...", "have you considered...", or "worth adding" to invite discussion rather than direct.
+Non-blocking suggestions should be collaborative. Use phrasing like "what about...", "have you considered...", or "worth adding" to invite discussion.
 
 ## Nitpicks
 
-Prefix unimportant comments with `Nit:` to indicate a nitpick.
+Prefix unimportant comments with `Nit:`.
 
 Any review with only nitpick comments should be approved.

--- a/plugins/review/skills/self/SKILL.md
+++ b/plugins/review/skills/self/SKILL.md
@@ -18,8 +18,8 @@ allowed-tools:
 I review my own changes in tuicr; you read my comments back and apply them. The live session is
 the buffer: I annotate lines, you edit. Nothing lives in a hand-edited JSON file.
 
-Load `review:tuicr` for all session mechanics (discovery, launch, seeding, read-back, the
-ledger). This skill is the inbound loop on top of it.
+Load `review:tuicr` for session mechanics (discovery, launch, seeding, read-back, the ledger).
+This skill is the inbound loop on it.
 
 ## Target
 
@@ -35,16 +35,16 @@ Default to the working tree. Override with $ARGUMENTS (`staged`, `main..HEAD`, `
 3. **Hand off**: I add comments at lines (the `c` key) in the tuicr pane.
    - **Batch**: I tell you when I am done.
    - **Live**: if I ask to work as I go, arm monitor mode (`review:tuicr` Monitor section) and
-     act on each comment as it lands, holding the applied edits for my review.
+     act on each comment as it lands, holding the edits for my review.
 4. **Collect**: `tuicr review comments --repo <repo> --session <slug>`.
 5. **Apply**: for each comment, read the referenced file and lines, then make the edit. tuicr
    reloads the diff as you go.
 6. **Resolve, don't delete**: tuicr exposes `lifecycle_state` but has no CLI to resolve a
    comment, so mark each applied comment resolved with `review:tuicr`'s ledger CLI
    (`ledger.ts resolve <id> --action ...`), keyed by the tuicr comment `id`. The comment stays
-   visible and nothing is lost. The ledger is the source of truth for open vs resolved, since the
-   diff reload orphans rather than resolves. Sync the current comments with `ledger.ts upsert`
-   first, and use `ledger.ts list --open` to report what remains.
+   visible. The ledger is the source of truth for open vs resolved, since the diff reload orphans
+   rather than resolves. Sync the current comments with `ledger.ts upsert` first, and use
+   `ledger.ts list --open` to report what remains.
 7. **Repeat** until I say done, then summarize what changed and what is still open (from the
    ledger).
 
@@ -52,6 +52,5 @@ Default to the working tree. Override with $ARGUMENTS (`staged`, `main..HEAD`, `
 
 - Apply comments in file order, but ask before any change that is ambiguous or that you would
   push back on.
-- A comment you disagree with stays open: leave it and tell me why rather than silently resolving
-  it.
-- When done, offer next steps (commit, peer review, PR) without taking them unprompted.
+- A comment you disagree with stays open: leave it and tell me why rather than resolving it.
+- When done, offer next steps (commit, peer review, PR) without taking them.

--- a/plugins/review/skills/tuicr/SKILL.md
+++ b/plugins/review/skills/tuicr/SKILL.md
@@ -25,7 +25,7 @@ You launch and drive it in a sibling pane; the TUI is the user's. `review:self` 
 ## Session Discovery
 
 tuicr persists each review as a session with a `slug`. The CLI is the agent's interface; the TUI
-is the user's. List sessions and pick the active one by `slug`:
+is the user's. List sessions and pick the active one by `slug`.
 
 ```bash
 tuicr review list --repo <repo>   # checkout path or owner/repo: local + PR sessions
@@ -48,7 +48,7 @@ tmux split-window -h -d -c "<repo>" "cd '<repo>' && tuicr -w"
 - Swap the inner command for other targets: `tuicr -r main..HEAD` (commit range),
   `tuicr pr <N>` (GitHub PR), `tuicr mr <N>` (GitLab MR). On a direct `/review:tuicr` invocation the
   target comes from `$ARGUMENTS` (default `-w`); `review:self` and `review:peer` pass their own.
-- tuicr reloads the diff as the working tree changes, which drives the inbound loop.
+- tuicr reloads the diff as the working tree changes, driving the inbound loop.
 
 After ~3s, `tuicr review list --repo <repo>` confirms the session `slug`, and
 `git rev-parse HEAD` captures the head SHA for outbound mapping. A single active session
@@ -66,9 +66,9 @@ tuicr review add --repo <repo> --session <slug> --input - < "$TMPDIR/comments.js
 ```
 
 `--input` also accepts literal JSON or `@file.json`. Pass `--username` (e.g. the agent's name)
-so seeded comments are visually distinct from the user's. The flag form
+so seeded comments are distinct from the user's. The flag form
 (`--target-file --line --end-line --side --type --username`) adds a single comment; `--input`
-batches structured JSON. Supported target types are `review`, `file`, `line`, and `line_range`;
+batches structured JSON. Target types are `review`, `file`, `line`, and `line_range`;
 `--type` is `issue`, `suggestion`, `note`, or `praise`.
 
 #### Reading Back

--- a/plugins/shortcuts/skills/cli/SKILL.md
+++ b/plugins/shortcuts/skills/cli/SKILL.md
@@ -41,7 +41,7 @@ Shortcuts with GUI actions (alerts, menus, input prompts) fail with "Running was
 
 ### Permissions
 
-First-time actions (notifications, location, contacts, etc.) trigger a macOS permission dialog. The shortcut pauses until the user approves. Inform the user when running a shortcut that may trigger permission prompts.
+First-time actions (notifications, location, contacts, etc.) trigger a macOS permission dialog. The shortcut pauses until the user approves. Inform the user when running a shortcut that may trigger prompts.
 
 ## List
 
@@ -54,7 +54,7 @@ shortcuts list --folders
 
 ## View
 
-Opens a shortcut in the Shortcuts app editor:
+Opens a shortcut in the Shortcuts app editor.
 
 ```bash
 shortcuts view "My Shortcut"
@@ -69,11 +69,11 @@ mkdir -p out
 shortcuts sign -i "My Shortcut.shortcut" -o "out/My Shortcut.shortcut"
 ```
 
-Sign into an output directory to preserve the unsigned binary. The filename (minus `.shortcut`) becomes the shortcut name on import — do not add suffixes.
+Sign into an output directory to preserve the unsigned binary. The filename (minus `.shortcut`) becomes the shortcut name on import — don't add suffixes.
 
 ## Import
 
-There is no `shortcuts import` command. Open the signed file to trigger import:
+There is no `shortcuts import` command. Open the signed file to trigger import.
 
 ```bash
 open "out/My Shortcut.shortcut"

--- a/plugins/shortcuts/skills/shortcut/SKILL.md
+++ b/plugins/shortcuts/skills/shortcut/SKILL.md
@@ -33,7 +33,7 @@ Generate Apple Shortcuts as XML property list files.
 - **OS**: !`uname -s`
 - **shortcuts CLI**: !`which shortcuts 2>/dev/null && echo "available" || echo "not available"`
 
-If the OS is **Darwin** (macOS), use the discovery CLI and the full deployment pipeline (convert, sign, import, run). If **Linux**, generate XML only — signing and import are unavailable. Inform the user.
+If the OS is **Darwin** (macOS), use the discovery CLI and the full deployment pipeline (convert, sign, import, run). If **Linux**, generate XML only — signing and import are unavailable; inform the user.
 
 ## Discovery
 
@@ -43,7 +43,7 @@ If the OS is **Darwin** (macOS), use the discovery CLI and the full deployment p
 
 ## Generation
 
-Write the shortcut as an XML plist. Load references as needed:
+Write the shortcut as an XML plist. Load references as needed.
 
 - **Starting a shortcut?** See [references/plist-structure.md](references/plist-structure.md) for top-level keys, icon, types
 - **Writing control flow?** See [references/control-flow.md](references/control-flow.md) for if/else, repeat, menu XML

--- a/plugins/shortcuts/skills/shortcut/references/actions.md
+++ b/plugins/shortcuts/skills/shortcut/references/actions.md
@@ -1,6 +1,6 @@
 # Shortcut Actions Reference
 
-This file covers programming constructs and a selection of commonly-used built-in actions. It is not exhaustive — built-in actions change with each OS release and there are hundreds of them.
+Programming constructs and a selection of common built-in actions. Not exhaustive — built-in actions change with each OS release and there are hundreds of them.
 
 **On macOS**, use `discover.swift` to read `WFActions.plist` for the full, current list. See [discovery.md](discovery.md).
 
@@ -25,7 +25,7 @@ Built-in actions use the `is.workflow.actions.*` prefix. Third-party apps use th
 
 ## Control Flow
 
-These are the core programming constructs. All use `GroupingIdentifier` (a UUID shared across the start/middle/end actions) and `WFControlFlowMode` (0 = start, 1 = middle, 2 = end).
+Core programming constructs. All use `GroupingIdentifier` (a UUID shared across the start/middle/end actions) and `WFControlFlowMode` (0 = start, 1 = middle, 2 = end).
 
 | Action | Identifier | Key Parameters |
 |--------|-----------|----------------|
@@ -92,7 +92,7 @@ To capture action output, add `UUID` and `CustomOutputName` to the source action
 
 ## Default App Example: Calendar
 
-These actions interact with the built-in Calendar app. Included as an example of how default app actions are structured — other default apps (Reminders, Contacts, Maps, Music, etc.) follow similar patterns.
+These actions interact with the built-in Calendar app — an example of how default app actions are structured. Other default apps (Reminders, Contacts, Maps, Music, etc.) follow similar patterns.
 
 | Action | Identifier | Key Parameters |
 |--------|-----------|----------------|
@@ -103,7 +103,7 @@ These actions interact with the built-in Calendar app. Included as an example of
 
 ## Discovering More Actions
 
-This reference cannot be exhaustive. To find actions not listed here:
+To find actions not listed here:
 
 1. **macOS discovery**: Use `discover.swift` to parse `WFActions.plist` (see [discovery.md](discovery.md))
 2. **Export and inspect**: Create a shortcut in the GUI, export with `shortcuts export`, convert with `plutil -convert xml1`

--- a/plugins/shortcuts/skills/shortcut/references/control-flow.md
+++ b/plugins/shortcuts/skills/shortcut/references/control-flow.md
@@ -9,7 +9,7 @@ Generate a fresh UUID for each control flow block.
 
 ## If / Otherwise / End If
 
-Three actions sharing a `GroupingIdentifier`:
+Three actions sharing a `GroupingIdentifier`.
 
 ```xml
 <!-- If -->

--- a/plugins/shortcuts/skills/shortcut/references/deployment.md
+++ b/plugins/shortcuts/skills/shortcut/references/deployment.md
@@ -16,7 +16,7 @@ Sign into an `out/` directory to preserve the unsigned binary for re-signing aft
 
 ## Convert XML to Binary
 
-The Shortcuts app expects binary plist. Validate and convert:
+The Shortcuts app expects binary plist. Validate and convert.
 
 ```bash
 plutil -lint "My Shortcut.plist"
@@ -27,7 +27,7 @@ plutil -convert binary1 -o "My Shortcut.shortcut" "My Shortcut.plist"
 
 Shortcuts must be signed before import. Signing contacts Apple's validation service (requires network).
 
-Sign into an output directory so the unsigned binary is preserved for iteration:
+Sign into an output directory to preserve the unsigned binary for iteration:
 
 ```bash
 mkdir -p out
@@ -45,7 +45,7 @@ shortcuts sign --mode people-who-know-me -i "My Shortcut.shortcut" -o "out/My Sh
 
 ## Import
 
-Open the signed file to trigger the Shortcuts app import flow:
+Open the signed file to trigger the Shortcuts app import flow.
 
 ```bash
 open "out/My Shortcut.shortcut"
@@ -55,7 +55,7 @@ The user confirms the import in the Shortcuts app GUI.
 
 ## Iterate
 
-To update an imported shortcut, delete it in the Shortcuts app, rebuild and reimport:
+To update an imported shortcut, delete it in the Shortcuts app, then rebuild and reimport:
 
 ```bash
 plutil -convert binary1 -o "My Shortcut.shortcut" "My Shortcut.plist"

--- a/plugins/shortcuts/skills/shortcut/references/discovery.md
+++ b/plugins/shortcuts/skills/shortcut/references/discovery.md
@@ -18,7 +18,7 @@ Outputs a JSON array of all built-in Shortcuts actions with identifier, name, de
 swift @scripts/discover.swift actions
 ```
 
-**Cache on first use.** The output is stable within a session. Write it to a temp file and query from there:
+**Cache on first use.** The output is stable within a session. Write it to a temp file and query from there.
 
 ```bash
 swift @scripts/discover.swift actions > /tmp/shortcut-actions.json
@@ -57,7 +57,7 @@ swift @scripts/discover.swift apps | jq '.[] | select(.name | test("Things"; "i"
 
 ## Third-Party App Actions
 
-The `apps` command finds which apps have Shortcuts support but cannot enumerate their individual actions. To discover a third-party app's actions, create a shortcut using that app in the GUI, then inspect it:
+The `apps` command finds which apps have Shortcuts support but cannot enumerate their individual actions. To discover a third-party app's actions, create a shortcut using that app in the GUI, then inspect it.
 
 ```bash
 # Open a shortcut in the editor to examine its structure
@@ -66,4 +66,4 @@ shortcuts view "My Shortcut"
 
 ## Data Source
 
-The CLI uses the WorkflowKit framework's runtime API (`WFActionRegistry`) to enumerate actions. This reflects the current system's available actions regardless of macOS version.
+The CLI uses the WorkflowKit framework's runtime API (`WFActionRegistry`) to enumerate actions, reflecting the current system's available actions regardless of macOS version.

--- a/plugins/shortcuts/skills/shortcut/references/parameters.md
+++ b/plugins/shortcuts/skills/shortcut/references/parameters.md
@@ -76,4 +76,4 @@ The `WFSerializationType` key signals that a value uses a structured encoding:
 
 ## Variable-Containing Parameters
 
-When a parameter that normally takes a literal value needs to reference a variable instead, wrap it in the appropriate serialization type. See [variables.md](variables.md) for `WFTextTokenAttachment` and `WFTextTokenString` details.
+When a parameter that normally takes a literal value needs to reference a variable, wrap it in the appropriate serialization type. See [variables.md](variables.md) for `WFTextTokenAttachment` and `WFTextTokenString` details.

--- a/plugins/shortcuts/skills/shortcut/references/plist-structure.md
+++ b/plugins/shortcuts/skills/shortcut/references/plist-structure.md
@@ -56,7 +56,7 @@ Controls where the shortcut appears:
 
 ## WFWorkflowInputContentItemClasses
 
-Accepted input types when the shortcut receives input from the share sheet or another shortcut:
+Input types accepted when the shortcut receives input from the share sheet or another shortcut:
 
 - `WFAppStoreAppContentItem`
 - `WFArticleContentItem`

--- a/plugins/shortcuts/skills/shortcut/references/variables.md
+++ b/plugins/shortcuts/skills/shortcut/references/variables.md
@@ -46,7 +46,7 @@ Retrieves a named variable:
 
 ## Action Output UUIDs
 
-Any action can capture its output for later use. Add `UUID` and `CustomOutputName` to the action's parameters:
+Any action can capture its output for later use. Add `UUID` and `CustomOutputName` to the action's parameters.
 
 ```xml
 <dict>
@@ -66,7 +66,7 @@ Any action can capture its output for later use. Add `UUID` and `CustomOutputNam
 
 ## Referencing Action Output
 
-To use a captured output in a later action's parameters, use `WFTextTokenAttachment`:
+To use a captured output in a later action's parameters, use `WFTextTokenAttachment`.
 
 ```xml
 <dict>
@@ -118,4 +118,4 @@ For strings that contain inline variable references, use `WFTextTokenString`. Th
 - `{6, 1}` is `{offset, length}` — the character position of the replacement character
 - Each embedded variable needs its own entry in `attachmentsByRange`
 
-**Recommendation**: For simplicity, prefer `Set Variable` / `Get Variable` actions over inline token strings. Use `WFTextTokenString` only when you need variables embedded mid-string.
+**Recommendation**: Prefer `Set Variable` / `Get Variable` actions over inline token strings. Use `WFTextTokenString` only when you need variables embedded mid-string.

--- a/plugins/tech-spec/skills/create/SKILL.md
+++ b/plugins/tech-spec/skills/create/SKILL.md
@@ -46,11 +46,9 @@ Invoke `interview:plan` to clarify requirements. Guide the interview toward:
 
 ### Write Initial Draft
 
-Write incrementally to the output file. Use the template structure from [references/template.md](references/template.md).
+Write incrementally to the output file, section by section. Use the template structure from [references/template.md](references/template.md).
 
-For architecture diagrams, always use `mermaid:diagram` to ensure proper syntax and rendering.
-
-Write sections incrementally.
+For architecture diagrams, always use `mermaid:diagram` for correct syntax and rendering.
 
 ### Expert Review
 
@@ -58,7 +56,7 @@ Invoke `tech-spec:review` on the draft spec.
 
 ### Iterate
 
-Continue refining until the user is satisfied. Long sessions with incremental changes create drift—validate consistency before concluding:
+Refine until the user is satisfied. Long sessions with incremental changes create drift—validate consistency before concluding:
 
 - **Stale references**: Scope changes in one section may leave dangling references elsewhere
 - **Contradictions**: Later decisions may conflict with earlier sections
@@ -78,7 +76,7 @@ Captures architecture trade-offs:
 |----------|--------|--------------|-----------|-------|
 | Brief description | What we chose | What we didn't | Why this choice | Caveats, follow-ups |
 
-Populate this table throughout the process as decisions emerge. Focus on:
+Populate as decisions emerge. Focus on:
 - Choices that required deliberation
 - Trade-offs between valid alternatives
 - Decisions that future readers would question

--- a/plugins/tech-spec/skills/create/references/template.md
+++ b/plugins/tech-spec/skills/create/references/template.md
@@ -20,7 +20,7 @@ High-level system design:
 
 ### Implementation
 
-Scaffolding for the technical work. Subsections vary by project. Common categories:
+Scaffolding for the technical work. Subsections vary by project. Common:
 
 | Section | When to Include |
 |---------|-----------------|
@@ -31,7 +31,7 @@ Scaffolding for the technical work. Subsections vary by project. Common categori
 | Services | Background jobs, integrations, external APIs |
 | Security | Auth, permissions, data protection |
 
-Adapt based on what's relevant. Add sections as needed during exploration.
+Adapt to what's relevant. Add sections as needed during exploration.
 
 For each subsection:
 - Code snippets only when they clarify the change

--- a/plugins/tech-spec/skills/review/SKILL.md
+++ b/plugins/tech-spec/skills/review/SKILL.md
@@ -22,7 +22,7 @@ When repositories are provided, consult code to verify:
 - Referenced files and structures exist
 - Implementation assumptions are accurate
 
-Explore on demand during review rather than upfront.
+Explore on demand during review, not upfront.
 
 ## Review Process
 
@@ -35,7 +35,7 @@ Select relevant personas from [references/experts.md](references/experts.md):
 
 ### Conduct Review
 
-For each relevant persona:
+For each persona:
 
 1. Scan the spec for areas within their expertise
 2. Identify findings: gaps, risks, unclear decisions, missing considerations
@@ -58,7 +58,7 @@ For findings with meaningful trade-offs:
 
 ### Update Spec
 
-Apply agreed changes directly to the spec file:
+Apply agreed changes to the spec file:
 - Add missing sections or considerations
 - Expand the Design Decisions table
 - Clarify ambiguous areas

--- a/plugins/tech-spec/skills/review/references/experts.md
+++ b/plugins/tech-spec/skills/review/references/experts.md
@@ -2,7 +2,7 @@
 
 ## Standard Personas
 
-Always consider these perspectives:
+Always consider these:
 
 | Persona | Focus Areas |
 |---------|-------------|
@@ -15,7 +15,7 @@ Always consider these perspectives:
 
 ## Dynamic Personas
 
-Generate additional personas based on spec content:
+Generate additional personas from spec content:
 
 | Persona | When to Include |
 |---------|-----------------|

--- a/plugins/terraform/skills/terraform/SKILL.md
+++ b/plugins/terraform/skills/terraform/SKILL.md
@@ -26,11 +26,11 @@ Use MCP tools to find and inspect runs:
 2. `list_runs` with the workspace ID to see recent runs
 3. `get_run_details` with the run ID for status, relationships, and timestamps
 
-The run details include `relationships.plan.data.id` and `relationships.apply.data.id` — use these to fetch logs.
+Run details include `relationships.plan.data.id` and `relationships.apply.data.id` — use these to fetch logs.
 
 ## Fetching Plan/Apply Logs
 
-The MCP server does not expose log retrieval. Use the TFC API directly:
+The MCP server does not expose log retrieval; use the TFC API directly.
 
 ```bash
 # Get the apply details (includes log-read-url)
@@ -48,7 +48,7 @@ curl -s "$(archivist_url)"
 
 The same pattern works for plans via `/api/v2/plans/{plan-id}`.
 
-See [references/api.md](references/api.md) for full API details.
+See [references/api.md](references/api.md).
 
 ## Authentication
 
@@ -60,4 +60,4 @@ The MCP server reads `TFE_TOKEN` from the environment. For curl calls, use it as
 
 ## Registry
 
-Provider and module searches are available via MCP tools (`search_providers`, `search_modules`, `provider_details`, `module_details`). No curl needed for registry operations.
+Provider and module searches use MCP tools (`search_providers`, `search_modules`, `provider_details`, `module_details`). No curl needed.

--- a/plugins/things/skills/inbox/SKILL.md
+++ b/plugins/things/skills/inbox/SKILL.md
@@ -14,7 +14,7 @@ Add todos to the Things 3 inbox.
 bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts --session-id ${CLAUDE_SESSION_ID} title="Buy milk"
 ```
 
-The script handles URL encoding, session attribution, and the `Claude` tag automatically. Extra tags can be added via the `--tag` flag (repeatable). For example, `--tag claude-code` adds the `claude-code` tag to all captured todos. Multiple tags: `--tag foo --tag bar`.
+The script handles URL encoding, session attribution, and the `Claude` tag. Add extra tags via the `--tag` flag (repeatable): `--tag claude-code` adds the `claude-code` tag to all captured todos. Multiple tags: `--tag foo --tag bar`.
 
 The script always prints a confirmation to stdout on success. When the `x-callback-url` plugin is installed, xcall returns the todo ID and the script outputs `https://things.bendrucker.me/show?id=...`. Present this URL to the user so they can click to open the todo. Without xcall (or when xcall succeeds but returns no ID), the script prints `captured: <title>`. No stdout output means the call failed; read stderr and surface the cause to the user rather than retrying.
 
@@ -60,8 +60,8 @@ Things supports [Markdown in notes](https://culturedcode.com/things/support/arti
 
 #### Never retry on silent output
 
-The script always prints to stdout on success. If you see no output, the call failed. Read stderr, surface the cause to the user, and only retry once the root cause is understood. Silent retries have historically created duplicate todos.
+The script always prints to stdout on success. If you see no output, the call failed. Read stderr, surface the cause to the user, and only retry once the root cause is understood. Silent retries have created duplicate todos.
 
 #### Sandbox-blocked URL handoff
 
-If stderr mentions `procNotFound`, `-10810`, or `LSOpenURLsWithRole`, the macOS sandbox blocked the URL handoff to Things. The plugin's PreToolUse hook should disable the sandbox for `bun ${CLAUDE_PLUGIN_ROOT}/scripts/...` invocations. If this still happens, the hook is not firing for the invocation form being used. Investigate the invocation rather than disabling the sandbox manually.
+If stderr mentions `procNotFound`, `-10810`, or `LSOpenURLsWithRole`, the macOS sandbox blocked the URL handoff to Things. The plugin's PreToolUse hook should disable the sandbox for `bun ${CLAUDE_PLUGIN_ROOT}/scripts/...` invocations. If this still happens, the hook is not firing for the invocation form used. Investigate the invocation rather than disabling the sandbox manually.

--- a/plugins/things/skills/jxa/jxa.md
+++ b/plugins/things/skills/jxa/jxa.md
@@ -1,6 +1,6 @@
 # Things 3 AppleScript/JXA Reference
 
-Complete documentation for Things 3 automation via AppleScript and JavaScript for Automation (JXA).
+Things 3 automation via AppleScript and JavaScript for Automation (JXA).
 
 **Source**: Things3.sdef (AppleScript dictionary from Things.app)
 
@@ -26,7 +26,7 @@ sdef /Applications/Things3.app > Things3.sdef
 
 ## Overview
 
-Things 3 provides full AppleScript support. Use JXA (JavaScript for Automation) for JSON-friendly output.
+Things 3 provides full AppleScript support. Use JXA for JSON-friendly output.
 
 **Basic JXA Pattern:**
 ```bash
@@ -40,7 +40,7 @@ const app = Application("Things3");
 
 ## Application Object
 
-The top-level scripting object representing the Things application.
+The top-level scripting object.
 
 **Properties:**
 - `name` (text, read-only) - Application name
@@ -70,7 +70,7 @@ app.lists().length; // Number of lists
 
 ## List Object
 
-Represents a Things list (Inbox, Today, Anytime, etc.).
+A Things list (Inbox, Today, Anytime, etc.).
 
 **Properties:**
 - `id` (text, read-only) - Unique identifier
@@ -117,7 +117,7 @@ const today = app.lists.byId("TMTodayListSource");
 
 ## To Do Object
 
-Represents a Things to-do item.
+A Things to-do item.
 
 **Properties:**
 - `id` (text, read-only) - Unique identifier
@@ -300,7 +300,7 @@ if (home) {
 
 ## Tag Object
 
-Represents a Things tag.
+A Things tag.
 
 **Properties:**
 - `id` (text, read-only) - Unique identifier
@@ -372,7 +372,7 @@ JSON.stringify(contacts, null, 2);
 
 ## Status Enumeration
 
-Represents the status of a to-do or project.
+The status of a to-do or project.
 
 **Values:**
 - `open` - To-do is open/active
@@ -448,7 +448,7 @@ const workTodos = app.toDos.whose({tagNames: "Work"});
 
 ### Iterate with Map
 
-Map todos to JSON-friendly objects:
+Map todos to JSON-friendly objects.
 
 ```javascript
 const todos = app.lists.byId("TMTodayListSource")
@@ -465,7 +465,7 @@ JSON.stringify(todos, null, 2);
 
 ### Filter Arrays
 
-Use standard JavaScript array methods:
+Use standard JavaScript array methods.
 
 ```javascript
 const todos = today.toDos();
@@ -484,7 +484,7 @@ const overdue = todos.filter(todo => {
 
 ### Handle Dates
 
-Dates require conversion to/from JavaScript Date objects:
+Convert to/from JavaScript Date objects.
 
 ```javascript
 // Read date
@@ -504,7 +504,7 @@ todo.dueDate = null;
 
 ### Batch Operations
 
-Process multiple todos efficiently:
+Process multiple todos efficiently.
 
 ```javascript
 const app = Application("Things3");
@@ -524,7 +524,7 @@ inbox.toDos().forEach(todo => {
 
 ### Error Handling
 
-Wrap queries in try-catch for safety:
+Wrap queries in try-catch.
 
 ```javascript
 try {
@@ -579,13 +579,13 @@ JSON.stringify({
 
 ## Detecting Repeating Tasks
 
-Things does not expose repeating task configuration through JXA. However, repeating task instances can be reliably detected using a simple heuristic.
+Things does not expose repeating task configuration through JXA, but repeating instances can be detected with a heuristic.
 
 ### Detection Rule
 
 **A task is a repeating instance if `creationDate` is at midnight local time (00:00:00 in the local timezone).**
 
-When Things auto-generates a task from a repeating template, it sets the `creationDate` to midnight on the day the task is created. This is the reliable indicator that distinguishes repeating instances from manually created tasks, which have creation timestamps reflecting the actual time they were created.
+When Things auto-generates a task from a repeating template, it sets `creationDate` to midnight on the day created. This distinguishes repeating instances from manually created tasks, whose timestamps reflect the actual creation time.
 
 ### How Repeating Tasks Work
 

--- a/plugins/things/skills/jxa/setup.md
+++ b/plugins/things/skills/jxa/setup.md
@@ -56,4 +56,4 @@ The `src/` directory contains TypeScript type definitions for reference:
 - **`Things3.d.ts`**: Generated from Things.app AppleScript dictionary. Covers Application, List, ToDo, Project, Area, Tag, Contact.
 - **`jxa-globals.d.ts`**: Global JXA functions like `Application()`.
 
-These provide API documentation even when writing plain JXA.
+These document the API even when writing plain JXA.

--- a/plugins/things/skills/jxa/troubleshooting.md
+++ b/plugins/things/skills/jxa/troubleshooting.md
@@ -4,7 +4,7 @@ Common issues, solutions, and best practices for Things automation.
 
 ## Things App Not Running
 
-JXA commands require Things 3 to be running. If not running, you'll see errors like:
+JXA commands require Things 3 to be running. If not, you'll see errors like:
 
 ```
 Error: Application can't be found.
@@ -20,7 +20,7 @@ The `-g` flag opens in background without stealing focus.
 
 ### Sandbox Errors vs App Not Running
 
-**Important**: Sandbox permission errors can look similar to "app not running" errors. If you see errors about file access or permissions, the issue is likely sandbox restrictions, not Things being closed.
+Sandbox permission errors can look similar to "app not running" errors. If you see errors about file access or permissions, the issue is likely sandbox restrictions, not Things being closed.
 
 Sandbox errors typically mention:
 - `Operation not permitted`
@@ -87,7 +87,7 @@ open "things:///update?id=TODO_ID&auth-token=$auth_token&list-id=AREA_ID"
 
 ## Filtering Repeating Tasks
 
-Things doesn't expose repeating task configuration through JXA, but you can detect repeating instances using a reliable heuristic.
+Things doesn't expose repeating task configuration through JXA, but you can detect repeating instances with a heuristic.
 
 ### Detection Rule
 
@@ -115,7 +115,7 @@ isRepeating ? "Repeating instance" : "Manual task"
 
 ### Filter Out Repeating Tasks
 
-Exclude repeating instances from processing:
+Exclude repeating instances from processing.
 
 ```bash
 osascript -l JavaScript -e '
@@ -136,7 +136,7 @@ JSON.stringify(result, null, 2)
 
 ### Finding Repeating Templates
 
-Templates are todos with `activationDate: null`:
+Templates are todos with `activationDate: null`.
 
 ```bash
 osascript -l JavaScript -e '
@@ -155,7 +155,7 @@ JSON.stringify(templates, null, 2)
 
 ### Matching Instances to Templates
 
-Find the template for a specific instance:
+Find the template for a specific instance.
 
 ```bash
 osascript -l JavaScript -e '
@@ -198,7 +198,7 @@ osascript -l JavaScript -e 'var app = Application("Things3"); app.toDos.byId("AB
 
 ### Retrieve Auth Token Per Session
 
-Don't hardcode tokens; retrieve from keychain when needed:
+Don't hardcode tokens; retrieve from keychain when needed.
 
 ```bash
 # At start of automation session
@@ -211,7 +211,7 @@ open "things:///update?id=DEF-456&auth-token=$AUTH_TOKEN&..."
 
 ### URL Encode Properly
 
-Use `jq` for reliable URL encoding:
+Use `jq` for URL encoding.
 
 ```bash
 # Encode notes
@@ -224,7 +224,7 @@ open "things:///update?id=ABC-123&auth-token=$auth_token&append-notes=$encoded"
 
 ### Handle Missing Values
 
-Use optional chaining in JXA for properties that might be null:
+Use optional chaining in JXA for properties that might be null.
 
 ```javascript
 const todo = app.toDos.byId("ABC-123");
@@ -244,7 +244,7 @@ const todos = today.toDos().map(todo => ({
 
 ### Batch Operations Carefully
 
-Respect rate limits (250 operations per 10 seconds):
+Respect rate limits (250 operations per 10 seconds).
 
 ```bash
 # Add small delays between operations
@@ -256,7 +256,7 @@ done
 
 ## Reorder Script Issues
 
-The `scripts/reorder.ts` script requires running outside the sandbox to access the keychain for auth tokens. The `things:url` skill's inline hook automatically handles this.
+`scripts/reorder.ts` requires running outside the sandbox to access the keychain for auth tokens. The `things:url` skill's inline hook handles this.
 
 If reorder fails with permission errors:
 1. Verify the hook is active (check skill frontmatter)

--- a/plugins/things/skills/triage/SKILL.md
+++ b/plugins/things/skills/triage/SKILL.md
@@ -10,7 +10,7 @@ Group, prioritize, defer, and reorder the Things Today list.
 
 ## Query
 
-Load the `things:jxa` skill. Run the query to get all Today items as JSON:
+Load the `things:jxa` skill. Run the query to get all Today items as JSON.
 
 ```
 /mac:jxa-run Things3 ${CLAUDE_PLUGIN_ROOT}/scripts/jxa/query-list.js TMTodayListSource
@@ -24,11 +24,11 @@ Filter to open items.
 
 Apply the midnight heuristic: a task is a repeating instance if `creationDate` ends with `T00:00:00` (midnight local time in ISO). Manually created tasks have non-zero hours/minutes/seconds.
 
-Overdue repeating tasks (where `dueDate` or `activationDate` is before today) should be batched for a single "Defer all overdue repeating tasks to tomorrow?" prompt. Load the `things:url` skill for batch defer via URL scheme.
+Batch overdue repeating tasks (where `dueDate` or `activationDate` is before today) for a single "Defer all overdue repeating tasks to tomorrow?" prompt. Load the `things:url` skill for batch defer via URL scheme.
 
 ## Grouping
 
-Group remaining items by area (primary) and tag (secondary) for batch triage. This is a presentation strategy — read the JSON and form logical groups.
+Group remaining items by area (primary) and tag (secondary) for batch triage. Read the JSON and form logical groups.
 
 ## Triage Questions
 
@@ -50,7 +50,7 @@ Present proposed order for user confirmation.
 
 ## Reorder
 
-Load the `things:url` skill. Use the reorder script:
+Load the `things:url` skill. Use the reorder script.
 
 ```bash
 bun ${CLAUDE_PLUGIN_ROOT}/scripts/reorder.ts [--list today|anytime|someday] <id1> <id2> <id3> ...

--- a/plugins/things/skills/url/1password.md
+++ b/plugins/things/skills/url/1password.md
@@ -16,7 +16,7 @@ AUTH_TOKEN=$(security find-generic-password -a "$USER" -s "things-auth-token" -w
 
 - **No approval prompts**: Works unattended for background processes
 - **Secure**: Token stored in macOS Keychain, not filesystem
-- **1Password source of truth**: Manual updates sync from 1Password item `5iene5gxngiqrxknafb7gslm4q`
+- **1Password source of truth**: Updates sync from 1Password item `5iene5gxngiqrxknafb7gslm4q`
 
 ## Update Token
 

--- a/plugins/things/skills/url/SKILL.md
+++ b/plugins/things/skills/url/SKILL.md
@@ -14,7 +14,7 @@ Write operations for Things 3 via the `things:///` URL scheme.
 
 ## Quick Start
 
-Use `url.ts` for most operations — it handles auth tokens and URL encoding:
+Use `url.ts` for most operations — it handles auth tokens and URL encoding.
 
 ```bash
 bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts <command> [key=value ...]
@@ -51,7 +51,7 @@ Items appear at the top of the list in the order specified. Default list is `tod
 
 ## Callback
 
-When the `x-callback-url` plugin is installed, `url.ts` automatically uses xcall to get a response from Things on stdout. Present the result to the user as clickable `https://things.bendrucker.me/show?id=<id>` links:
+When the `x-callback-url` plugin is installed, `url.ts` uses xcall to get a response from Things on stdout. Present the result as clickable `https://things.bendrucker.me/show?id=<id>` links:
 
 - **Single todo** (`add`, `update`): returns `x-things-id=<id>` — present one link
 - **Batch** (`json`): returns `x-things-ids=["id1","id2"]` — present a bulleted list with each todo's title and link

--- a/plugins/things/skills/url/examples.md
+++ b/plugins/things/skills/url/examples.md
@@ -1,6 +1,6 @@
 # Things URL Scheme Examples
 
-Detailed usage examples for the `url.ts` wrapper and raw URL scheme commands.
+Usage examples for the `url.ts` wrapper and raw URL scheme commands.
 
 ## Creating Todos
 
@@ -104,7 +104,7 @@ Item 2"
 
 ## Bulk Updating Todos
 
-Pass multiple `id=` params to batch updates into a single JSON command:
+Pass multiple `id=` params to batch updates into a single JSON command.
 
 ```bash
 bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts update id=ABC-123 id=DEF-456 id=GHI-789 when=tomorrow

--- a/plugins/things/skills/url/url-scheme.md
+++ b/plugins/things/skills/url/url-scheme.md
@@ -1,6 +1,6 @@
 # Things 3 URL Scheme Reference
 
-Complete documentation for Things 3 automation via URL schemes.
+Things 3 automation via URL schemes.
 
 **Source**: [Things URL Scheme](https://culturedcode.com/things/support/articles/2803573/)
 
@@ -20,7 +20,7 @@ All commands follow the pattern: `things:///commandName?param1=value1&param2=val
 
 ### add - Create To-dos
 
-Creates new to-do items in Things.
+Creates new to-do items.
 
 **Parameters:**
 - `title` (string) - Todo title
@@ -48,7 +48,7 @@ open -g "things:///add?title=Buy%20milk&notes=Low%20fat&when=evening&tags=Errand
 
 ### add-project - Create Projects
 
-Creates new projects with optional to-dos and areas.
+Creates projects with optional to-dos and areas.
 
 **Parameters:**
 - `title` (string) - Project title
@@ -69,7 +69,7 @@ open -g "things:///add-project?title=Build%20treehouse&when=today&area=Home"
 
 ### update - Modify To-dos
 
-Updates existing to-do properties. **Requires `auth-token` and `id`.**
+Updates to-do properties. **Requires `auth-token` and `id`.**
 
 **Parameters:**
 - `id` (string, required) - Todo ID
@@ -103,14 +103,14 @@ open -g "things:///update?id=4BE64FEA-8FEF-4F4F-B8B2-4E74605D5FA5&auth-token=YOU
 
 ### update-project - Modify Projects
 
-Updates existing project properties. **Requires `auth-token` and `id`.**
+Updates project properties. **Requires `auth-token` and `id`.**
 
 Supports same parameters as `update` plus:
 - `area` or `area-id` - Move to different area
 
 ### show - Navigate & Display
 
-Navigates to specific items or built-in lists.
+Navigates to items or built-in lists.
 
 **Parameters:**
 - `id` (string) - Item ID or built-in list name
@@ -138,7 +138,7 @@ open -g "things:///show?query=Weekly%20Review&filter=Work,Planning"
 
 ### search - Open Search
 
-Invokes the search interface.
+Opens the search interface.
 
 **Parameters:**
 - `query` (string, optional) - Pre-filled search text
@@ -186,7 +186,7 @@ open -g "things:///version"
 
 ## JSON Command Format
 
-The `json` command enables creating complex structures with projects, to-dos, headings, and checklist items.
+The `json` command creates complex structures with projects, to-dos, headings, and checklist items.
 
 **Basic Usage:**
 ```bash
@@ -311,7 +311,7 @@ open -g "things:///json?data=$(echo "$data" | jq -sRr @uri)"
 
 ### URL Encoding
 
-All URL parameters must be properly encoded:
+All URL parameters must be encoded:
 - Space → `%20`
 - Newline → `%0a`
 - Comma → `%2C` (if not used as separator)
@@ -371,5 +371,5 @@ Controls when a to-do appears:
 - **Auth token required**: All `update`, `update-project` operations and `json` updates require auth token from Things > Settings > General
 
 ### Data Constraints
-- JSON payload size limited by URL length constraints
+- JSON payload size limited by URL length
 - Complex structures should use `json` command instead of individual `add` commands

--- a/plugins/tmux/hooks/prompt.md
+++ b/plugins/tmux/hooks/prompt.md
@@ -12,8 +12,7 @@ A hook tries to auto-inject `-t` with your pane ID on tmux commands
 that accept a target. If `-t` is already present, the command passes
 through unchanged. Injection is best-effort: it does NOT fire when the
 command's argument contains shell metacharacters (`$(...)`, `;`,
-`&&`, etc.), so pass `-t "$TMUX_PANE"` explicitly in those cases to
-stay anchored to your own pane.
+`&&`, etc.), so pass `-t "$TMUX_PANE"` explicitly in those cases.
 
 To target the user's currently active pane, resolve it first:
 

--- a/plugins/tmux/skills/tmux/SKILL.md
+++ b/plugins/tmux/skills/tmux/SKILL.md
@@ -35,13 +35,13 @@ Each pane line ends with its geometry as `@<left>,<top> <width>x<height>`, in ce
 
 ### Worktrees and Parallel Panes
 
-Panes in a git repo show their branch and whether the checkout is a linked `(worktree)` or the primary `(main)` one. When the user refers to work by branch or worktree ("the pane on the X branch", "the worktree for Y", "the other pane, which is ready"), match the reference to a pane's branch and dispatch to it with `send-keys` (or treat it as already running) rather than entering a worktree of your own. A pane already sitting in a worktree is set up for parallel work; hand off to it instead of duplicating the checkout.
+Panes in a git repo show their branch and whether the checkout is a linked `(worktree)` or the primary `(main)` one. When the user refers to work by branch or worktree ("the pane on the X branch", "the worktree for Y", "the other pane, which is ready"), match the reference to a pane's branch and dispatch to it with `send-keys` (or treat it as already running) rather than entering a worktree of your own. A pane already in a worktree is set up for parallel work; hand off to it instead of duplicating the checkout.
 
 ## Session
 
 !`bash ${CLAUDE_SKILL_DIR}/scripts/session.sh`
 
-The `TITLE` column shows the active pane's title in each window. Claude sessions advertise their current task there, which is usually enough to identify a window without capturing its content. Windows marked `here` are the current window; `bell` or `activity` flags mean the window needs attention (a process finished, errored, or produced output).
+The `TITLE` column shows the active pane's title in each window. Claude sessions advertise their current task there, usually enough to identify a window without capturing its content. Windows marked `here` are the current window; `bell` or `activity` flags mean the window needs attention (a process finished, errored, or produced output).
 
 ## Sessions
 
@@ -49,7 +49,7 @@ The `TITLE` column shows the active pane's title in each window. Claude sessions
 
 ### Drilling Into Other Targets
 
-Each script accepts an optional target argument so you can inspect any pane, window, or session — not just the current one:
+Each script accepts an optional target argument to inspect any pane, window, or session — not just the current one:
 
 ```bash
 bash ${CLAUDE_SKILL_DIR}/scripts/session.sh other-session
@@ -80,7 +80,7 @@ Use `split-window` with `-t $TMUX_PANE` so new panes open relative to Claude's p
 tmux split-window -h -d -t $TMUX_PANE 'tail -f logs/dev.log'
 ```
 
-The command string runs in the new pane's shell. When it exits, the pane closes. Use `$SHELL` or omit the command to open an interactive shell.
+The command runs in the new pane's shell. When it exits, the pane closes. Use `$SHELL` or omit the command to open an interactive shell.
 
 ### Starting Claude Sessions
 
@@ -94,7 +94,7 @@ Use `send-keys` only for follow-up messages to an already-running session.
 
 ## Collaborative File Viewing
 
-When collaborating on a file, open it in a sidebar pane so the user can see changes in real-time as you edit.
+When collaborating on a file, open it in a sidebar pane so the user sees changes in real-time as you edit.
 
 ```bash
 tmux split-window -h -d -l 40% -t $TMUX_PANE '<command> <file>'
@@ -127,11 +127,11 @@ Open with `$EDITOR` when set, otherwise fall back to read-only viewers:
 | bat | `bat --paging always file.ts` | Syntax-highlighted, read-only |
 | less | `less file.ts` | Plain text fallback |
 
-Use the first available option. If the pane exits immediately, the tool is missing, try the next.
+Use the first available option. If the pane exits immediately, the tool is missing; try the next.
 
 ## Capturing Pane Content
 
-Use `capture-pane -p` to print to stdout instead of a paste buffer:
+Use `capture-pane -p` to print to stdout instead of a paste buffer.
 
 ```bash
 tmux capture-pane -t $TARGET -p

--- a/plugins/type-ignore/skills/fix/SKILL.md
+++ b/plugins/type-ignore/skills/fix/SKILL.md
@@ -32,4 +32,4 @@ If no scope provided, scan the entire codebase.
 2. Run type checking to verify fixes
 3. Report summary: files fixed, ignores resolved, issues remaining
 
-Spawn agents in parallel using multiple Task tool calls in a single message.
+Spawn agents in parallel via multiple Task calls in a single message.

--- a/plugins/ui-design/skills/wireframe/SKILL.md
+++ b/plugins/ui-design/skills/wireframe/SKILL.md
@@ -25,7 +25,7 @@ hooks:
 
 Create wireframes for UI mockups with two approaches.
 
-Wireframes are skeletal, black-and-white representations of UI layout. They focus on structure, content priority, and function—not visual design. No colors, no styling, minimal fidelity.
+Wireframes are skeletal, black-and-white representations of UI layout, focused on structure, content priority, and function—not visual design. No colors, no styling, minimal fidelity.
 
 ## Choose Your Approach
 
@@ -34,7 +34,7 @@ Wireframes are skeletal, black-and-white representations of UI layout. They focu
 | **SVG** | Precise positioning, overlapping elements, custom shapes, artistic layouts | `render.ts` |
 | **HTML/Tailwind** | Standard UI patterns (forms, grids, navigation, modals), flexbox layouts | `render-html.ts` |
 
-**Before creating any wireframe**: Read the reference file for your chosen approach. The references contain required patterns, component examples, and the exact rendering workflow.
+**Before creating any wireframe**: Read the reference file for your chosen approach. The references contain required patterns, component examples, and the rendering workflow.
 
 ## References
 

--- a/plugins/ui-design/skills/wireframe/references/html.md
+++ b/plugins/ui-design/skills/wireframe/references/html.md
@@ -79,7 +79,7 @@ Wireframes use black borders on white background:
 
 ### Image Placeholder
 
-Use a bordered div with centered placeholder text (not X-pattern):
+Bordered div with centered placeholder text (not X-pattern):
 
 ```html
 <div class="border border-black h-48 flex items-center justify-center text-gray-400">

--- a/plugins/ui-design/skills/wireframe/references/svg.md
+++ b/plugins/ui-design/skills/wireframe/references/svg.md
@@ -11,7 +11,7 @@ Create SVG wireframes for UI mockups with layout validation and PNG rendering.
 
 ## Guidelines
 
-Wireframes use only black strokes on white background:
+Wireframes use only black strokes on a white background:
 
 - **Containers**: `<rect>` with black stroke, dashed for sections (`stroke-dasharray="4"`)
 - **Buttons/inputs**: `<rect>` with solid black stroke, no fill
@@ -36,10 +36,10 @@ Wireframes use only black strokes on white background:
 
 ## Layout Rules
 
-These rules are enforced by validation:
+Enforced by validation:
 
 1. **Child bounds**: Children must fit within parent containers
-2. **No overlap**: Sibling elements should not overlap
+2. **No overlap**: Sibling elements must not overlap
 3. **Text fit**: Text must fit within its container
 
 ## Coordinate System
@@ -116,7 +116,7 @@ Checks layout constraints and reports violations. Exit code 0 if valid.
 bun {SKILL_DIR}/scripts/render.ts [--scale N] <svg-file> [output.png]
 ```
 
-Renders SVG to PNG using sharp. Output path defaults to same name with `.png` extension.
+Renders SVG to PNG using sharp. Output path defaults to the same name with `.png` extension.
 
 **Scale options:**
 - `--scale 1` (default): 1x resolution for quick verification during iteration

--- a/plugins/writing/README.md
+++ b/plugins/writing/README.md
@@ -10,15 +10,15 @@ Writing style enforcement and slop detection for prose output (PR descriptions, 
 
 ## Wordlists
 
-Trope patterns that take the form of a list of words live as line-delimited files under [`wordlists/`](wordlists/).
+Word-list trope patterns live as line-delimited files under [`wordlists/`](wordlists/).
 
 #### Stemmed Wordlists
 
-One word per line. Matching uses a Porter stemmer (`stemmer` npm package), so inflected forms are caught automatically from base entries. `#` comments and blank lines are ignored. Multi-word and hyphenated phrases are not supported in stemmed wordlists (the stemmer tokenizes on word boundaries). Use inline regex patterns in `tropes.ts` for phrase matching.
+One word per line. Matching uses a Porter stemmer (`stemmer` npm package), so inflected forms are caught from base entries. `#` comments and blank lines are ignored. Multi-word and hyphenated phrases are not supported (the stemmer tokenizes on word boundaries). Use inline regex patterns in `tropes.ts` for phrase matching.
 
 #### Plain Wordlists (Regex)
 
-Used for openers and let-me-verbs where the match depends on position context (line start, "let me" prefix). One entry per line, compiled to a regex alternation with configurable prefix/suffix.
+Used for openers and let-me-verbs where the match depends on position (line start, "let me" prefix). One entry per line, compiled to a regex alternation with configurable prefix/suffix.
 
 #### Weighted Wordlists
 
@@ -28,9 +28,9 @@ The loader lives in [`detection/wordlists.ts`](detection/wordlists.ts). Compiled
 
 ## Hook Commands
 
-Each existing hook command runs `bun install --cwd ${CLAUDE_PLUGIN_ROOT}` before the hook script. Installed plugins have no `node_modules` — bun auto-installs dependencies from its global cache, but packages like `unist-util-visit-parents` use self-referencing subpath exports that fail without a local `node_modules`. Running `bun install` ensures Node.js-style resolution works. With everything already installed, `bun install` completes in ~50ms.
+Each hook command runs `bun install --cwd ${CLAUDE_PLUGIN_ROOT}` before the hook script. Installed plugins have no `node_modules`. Bun auto-installs dependencies from its global cache, but packages like `unist-util-visit-parents` use self-referencing subpath exports that fail without a local `node_modules`. `bun install` restores Node.js-style resolution and completes in ~50ms once installed.
 
-The `check-tropes.ts` hook does not need `bun install` since it has no dependencies requiring local resolution.
+The `check-tropes.ts` hook skips `bun install`: it has no dependencies requiring local resolution.
 
 ## Testing
 

--- a/plugins/writing/skills/analyze/SKILL.md
+++ b/plugins/writing/skills/analyze/SKILL.md
@@ -18,7 +18,7 @@ Mine the session DuckDB index for assistant writing patterns, compare against th
 
 ## Prerequisites
 
-Activate the `claude-code:session` skill first. Run its refresh script to ensure the index is current and capture the DB path:
+Activate the `claude-code:session` skill first. Run its refresh script to update the index and capture the DB path:
 
 ```bash
 DB_PATH=$(<session-skill-dir>/scripts/refresh.ts --refresh)
@@ -26,7 +26,7 @@ DB_PATH=$(<session-skill-dir>/scripts/refresh.ts --refresh)
 
 The refresh script prints the resolved DB path to stdout.
 
-Build the local voice baseline once (and refresh it as new writing accumulates). It is the comparison surface for deliverable-aware rule health. The baseline is local-only and never committed. It is stored in the plugin data directory (`CLAUDE_PLUGIN_DATA`, else `~/.claude/plugins/data/writing-bendrucker`).
+Build the local voice baseline once, and refresh it as new writing accumulates. It is the comparison surface for deliverable-aware rule health, local-only and never committed, stored in the plugin data directory (`CLAUDE_PLUGIN_DATA`, else `~/.claude/plugins/data/writing-bendrucker`).
 
 ```bash
 # Seed from the already-present delimited corpus (no re-fetch needed)
@@ -37,7 +37,7 @@ bun ${CLAUDE_SKILL_DIR}/scripts/ingest-voice.ts --source github --author <user> 
 bun ${CLAUDE_SKILL_DIR}/scripts/voice-profile.ts
 ```
 
-Both scripts write to the plugin data directory. That path is outside the default sandbox allowlist, so run them with `dangerouslyDisableSandbox: true` (or via a terminal outside Claude Code).
+Both scripts write to the plugin data directory, outside the default sandbox allowlist, so run them with `dangerouslyDisableSandbox: true` (or via a terminal outside Claude Code).
 
 If no profile exists, analyze still runs: deliverable-surface rules fall back to the chat audit and the report flags the baseline as not loaded.
 
@@ -55,7 +55,7 @@ Run with `--help` for all flags. `--data-dir` overrides where the voice baseline
 
 ## Meaning-Layer Judge
 
-`--judge` adds an LLM-judge pass over the deliverable corpus (six binary criteria, information-density first). It requires `ANTHROPIC_API_KEY`, prints a cost estimate before any call, and caps documents with `--judge-limit` (default 100, roughly cents per run on the default Haiku-class model):
+`--judge` adds an LLM-judge pass over the deliverable corpus (six binary criteria, information-density first). It requires `ANTHROPIC_API_KEY`, prints a cost estimate before any call, and caps documents with `--judge-limit` (default 100, cents per run on the default Haiku-class model):
 
 ```bash
 bun ${CLAUDE_SKILL_DIR}/scripts/analyze.ts --session-db "$DB_PATH" --judge
@@ -73,9 +73,9 @@ See the "Meaning-Layer Judge" section of [references/methodology.md](references/
 
 ## Metrics
 
-**Lift**: how distinctive a phrase is to assistant output vs. user text. `lift = rate_assistant / rate_user_smoothed`, where rates are per-million-token frequencies. A lift of 10.0 means the assistant uses the phrase 10x more per token than the user. The `--min-lift` threshold (default 5.0) gates new candidate phrases only. Rule keep/remove uses a direct rate comparison plus `--min-count`, not lift (see methodology for why).
+**Lift**: how distinctive a phrase is to assistant output vs. user text. `lift = rate_assistant / rate_user_smoothed`, where rates are per-million-token frequencies. A lift of 10.0 means the assistant uses the phrase 10x more per token than the user. The `--min-lift` threshold (default 5.0) gates new candidate phrases only. Rule keep/remove uses a direct rate comparison plus `--min-count`, not lift (see methodology).
 
-**Session count**: number of distinct sessions containing a phrase. Candidates require session count >= 3 to filter project-specific jargon that dominates a single session.
+**Session count**: distinct sessions containing a phrase. Candidates require session count >= 3 to filter project-specific jargon that dominates a single session.
 
 ## Output
 
@@ -90,13 +90,13 @@ See the "Meaning-Layer Judge" section of [references/methodology.md](references/
 - Corrective feedback (short human messages naming a writing problem, with the preceding model output)
 - Correction candidates (long-assistant, short-user pairs suggesting prose pushback)
 
-Each rule is judged on the surface where the hook fires it. Chat-surface rules (openers, sycophantic patterns, conversational vocabulary) compare the model's chat against the user's chat. Deliverable-surface rules (`flowery-phrases.txt`, `soft-phrasing.txt`) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as **keep**, not dead. A rule the model uses far more than the baseline is kept even when its lift reads low. Lift is not used for removal decisions because the smoothed user baseline (see methodology) compresses it for any word the user never types, which would flag the model's strongest tells (`delve`, `comprehensive`, `robust`) for removal.
+Each rule is judged on the surface where the hook fires it. Chat-surface rules (openers, sycophantic patterns, conversational vocabulary) compare the model's chat against the user's chat. Deliverable-surface rules (`flowery-phrases.txt`, `soft-phrasing.txt`) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as **keep**, not dead. A rule the model uses far more than the baseline is kept even when its lift reads low. Lift is not used for removal: the smoothed user baseline (see methodology) compresses it for any word the user never types, which would flag the model's strongest tells (`delve`, `comprehensive`, `robust`) for removal.
 
 ## Corpora
 
 Four corpora, each serving a different purpose:
 
-- **All model-generated text**: conversational assistant text (`text-export`, role=assistant) combined with deliverable prose (`deliverable-prose.sql`). The session DB's `text_content` view only captures conversational text blocks, not tool inputs (Write/Edit/Bash). The deliverable query fills this gap. The combined corpus is used for n-gram candidates.
+- **All model-generated text**: conversational assistant text (`text-export`, role=assistant) combined with deliverable prose (`deliverable-prose.sql`). The session DB's `text_content` view captures only conversational text blocks, not tool inputs (Write/Edit/Bash); the deliverable query fills this gap. Used for n-gram candidates.
 - **Deliverable prose** (`deliverable-prose.sql`): Write/Edit to prose files, Bash commands with `--body`/`--message`/`-m`. The candidate-mining corpus and the model side of the deliverable-aware rule audit.
 - **Human-only user text** (`text-export`, role=user, filtered): the baseline for lift calculation. Filters out system-injected content (skill injections, context compaction summaries, task notifications, system reminders) and pasted model output (see methodology) that arrives as user-role messages but is machine-generated.
 - **Voice baseline** (local-only, `voice-profile.ts`): the user's hand-written, pre-AI pull requests. The baseline side of the deliverable-aware rule audit and the "absent from my baseline" signal for additions.
@@ -105,7 +105,7 @@ The FTS rule health audit uses `text_content` (a view covering both roles) with 
 
 ## Workflow
 
-Review the report. Edit `plugins/writing/wordlists/*.txt` by hand, then re-run to confirm. The skill never edits wordlists itself.
+Review the report. Edit `plugins/writing/wordlists/*.txt` by hand, then re-run to confirm. The skill never edits wordlists.
 
 ## Methodology
 

--- a/plugins/writing/skills/analyze/references/linguistics.md
+++ b/plugins/writing/skills/analyze/references/linguistics.md
@@ -9,9 +9,9 @@ Numbers are aggregates over private session corpora. Example headings are invent
 A writing check belongs to one of four layers, and the layer decides the right tool before any code is written:
 
 - **Vocabulary** (`delve`, `boasts`, "it's worth noting"): a wordlist. Linguistics adds nothing here. The analyze skill already measures word frequency and lift.
-- **Grammar** (sentence-shaped headings, passive voice, "not X but Y"): patterns over part-of-speech sequences that a wordlist cannot express and a plain regex gets wrong. This is the only layer a tagger helps with.
+- **Grammar** (sentence-shaped headings, passive voice, "not X but Y"): patterns over part-of-speech sequences that a wordlist cannot express and a plain regex gets wrong. The only layer a tagger helps with.
 - **Cross-sentence** (negation flips, escalating triads): structure spanning sentences, which a tagger alone cannot see.
-- **Meaning** (vacuous specificity, motivation absence, marketing tone, hedging density): no grammar captures it. This is the LLM judge's layer (`skills/analyze/scripts/judge.ts`, batch-only). See the "Meaning-Layer Judge" section of `methodology.md`.
+- **Meaning** (vacuous specificity, motivation absence, marketing tone, hedging density): no grammar captures it. The LLM judge's layer (`skills/analyze/scripts/judge.ts`, batch-only). See the "Meaning-Layer Judge" section of `methodology.md`.
 
 Before building a grammar rule, check whether a wordlist, a regex, or an LLM judge does the job as well. The tagger is not the default.
 
@@ -32,7 +32,7 @@ Hook promotion turns on interval width. A sample with few positives carries inte
 - `tagger.ts`, `compromise.ts`, `natural.ts`: adapters mapping each tagger to one coarse tag set, so grammar rules stay tagger-neutral.
 - `classifiers.ts`: eval-only. It imports the tagger adapters, including `natural`, a devDependency the plugin cache omits.
 
-Hooks must never import a tagger adapter. The plugin cache skips devDependencies, so a hook that imports one works locally and breaks for every install.
+Hooks must never import a tagger adapter. The plugin cache skips devDependencies, so a hook importing one works locally and breaks for every install.
 
 ## Tagger Failures
 
@@ -100,7 +100,7 @@ bun skills/analyze/scripts/headings-eval.ts --session-db "$DB_PATH" --labels tmp
 
 ## Synthetic Corpus
 
-The session corpus is private and cannot be committed, so it measures precision but cannot serve as a regression gate. Generate a corpus that is safe to commit (model output, never from a session):
+The session corpus is private and cannot be committed, so it measures precision but cannot serve as a regression gate. Generate a corpus safe to commit (model output, never from a session):
 
 ```bash
 claude -p --no-session-persistence --setting-sources project \
@@ -118,7 +118,7 @@ Vary the document type (design doc, postmortem, rollout plan) so heading styles 
 bun skills/analyze/scripts/headings-eval.ts --docs tmp/synthetic-corpus --out tmp/synthetic
 ```
 
-Ten generated documents produced 114 headings, none of them real sentence headings, so the synthetic corpus measures false positives. With no real positives in the sample, it says nothing about recall. The baseline flagged none. Candidates produced 1-15 each, all on conventional shapes that are now committed regression fixtures:
+Ten generated documents produced 114 headings, none of them real sentence headings, so the synthetic corpus measures false positives. With no real positives in the sample, it says nothing about recall. The baseline flagged none. Candidates produced 1-15 each, all on conventional shapes now committed as regression fixtures:
 
 - Numbered headings ("3.1 Unit Tests"): a plural head noun reads as a verb with the number as its subject.
 - Trailing participles ("Lessons Learned"): the participle fails the noun-phrase parse.
@@ -132,7 +132,7 @@ The upper-reference run this eval calls for: the same LLM judge that scores the 
 bun skills/analyze/scripts/judge-run.ts headings tmp/heading-labels.tsv
 ```
 
-The runner scores the judge against the existing labels with the same Wilson protocol and prints the full-set and random-subset aggregates. The comparison has not been run yet (it needs an API key and the labeled file, and sits behind the #791 calibration checkpoint). Record the resulting aggregate here, next to the classifier table, when it runs.
+The runner scores the judge against the existing labels with the same Wilson protocol and prints the full-set and random-subset aggregates. The comparison has not run yet (it needs an API key and the labeled file, and sits behind the #791 calibration checkpoint). Record the resulting aggregate here, next to the classifier table, when it runs.
 
 ## Verdict
 

--- a/plugins/writing/skills/analyze/references/methodology.md
+++ b/plugins/writing/skills/analyze/references/methodology.md
@@ -14,7 +14,7 @@ Run the session skill's `refresh.ts --refresh` before analyze. It rescans `~/.cl
 
 #### Lift
 
-How distinctive a phrase is to assistant output versus the user's voice, borrowed from association rule mining:
+How distinctive a phrase is to assistant output versus the user's voice, from association rule mining:
 
 ```
 lift = rate_assistant / rate_user_smoothed
@@ -36,23 +36,23 @@ Installs DuckDB's FTS extension and materializes per-role corpus tables (`fts_as
 
 `fts-phrase-audit.sql` batch-audits wordlist entries: it Porter-stems each entry, looks up term frequencies in both FTS indexes, and returns per-term assistant/user counts, per-million rates, and lift.
 
-A rule is **kept** when the model uses it strictly more per token than the comparison baseline (`model_per_m > baseline_per_m`) and it appears at least `--min-count` times (default 5) on its firing surface. Otherwise the report proposes removal with one of two reasons:
+A rule is **kept** when the model uses it strictly more per token than the baseline (`model_per_m > baseline_per_m`) and it appears at least `--min-count` times (default 5) on its firing surface. Otherwise the report proposes removal with one of two reasons:
 
 - **dead**: fewer than `--min-count` model occurrences on the firing surface. The rule rarely fires regardless of distinctiveness.
 - **not distinctive**: the baseline uses it at least as often per token. The rule would flag the user's own voice.
 
-Removal does **not** use lift. The user baseline is small (often tens of thousands of tokens, even with cross-machine history merged in), so the Laplace smoothing floor (`1/user_total`) dominates: any word the user never types needs a high per-million rate in assistant text just to reach a lift of 5.0. That gate is nearly unreachable for single words, so a pure lift threshold would flag the model's strongest surviving tells (`delve`, `comprehensive`, `robust`) for removal. The direct rate comparison is smoothing-free and keeps them.
+Removal does **not** use lift. The user baseline is small (often tens of thousands of tokens, even with cross-machine history merged in), so the Laplace smoothing floor (`1/user_total`) dominates: any word the user never types needs a high per-million rate in assistant text to reach a lift of 5.0. That gate is nearly unreachable for single words, so a pure lift threshold would flag the model's strongest surviving tells (`delve`, `comprehensive`, `robust`) for removal. The direct rate comparison is smoothing-free and keeps them.
 
 #### Per-surface auditing
 
-Each rule is judged on the surface where the hook fires it, so the audit measures the rule against the corpus it actually polices.
+Each rule is judged on the surface where the hook fires it, so the audit measures it against the corpus it polices.
 
 - **Chat-surface rules** (`openers.txt`, the conversational vocabulary, the sycophantic patterns) compare the model's chat assistant text against the user's chat text in `text_content`, via the FTS pass. The model's chat usage of these terms tracks its overall habit. A consequence: a term both the model and the user say conversationally (`Perfect` as an acknowledgment) reads as not distinctive and is dropped even if it might still open a deliverable.
 - **Deliverable-surface rules** (`flowery-phrases.txt` and `soft-phrasing.txt`, both `fileOnly` in the hook) compare the model's deliverable-prose rate against the user's voice-baseline rate. Each entry is stem-matched against the deliverable corpus (the same Porter-stemmed subsequence scan the hook uses) and looked up in the voice profile (`voice-profile.ts`). A phrase frequent in the model's PR bodies and absent from the user's hand-written baseline reads as **keep**, which is the correct verdict: `source of truth`, `escape hatch`, `self-sufficient`, and `fail loudly` each occur dozens of times in deliverable prose and zero times across the 209 pre-AI baseline PRs.
 
 `marketing-verbs.txt` stays on the chat audit even though it reads as deliverable phrasing: its hook group is not `fileOnly`, so it fires on Bash side-effect inputs too, and auditing it against deliverables alone undercounts it (the few deliverable hits are often the user's own meta-discussion of the wordlist file). See `deliverable-audit.ts` for the surface assignment.
 
-When no voice profile is loaded, deliverable-surface rules are still measured on the deliverable corpus, not the chat audit. The chat audit cannot score them: it stems each entry and joins against single-word FTS tokens, so a multi-word phrase never matches and would read as a false `dead`. Without a baseline the distinctiveness check is skipped, so an alive rule is reported `keep (no baseline)` rather than proposed for removal. Build the baseline with `ingest-voice.ts` then `voice-profile.ts` (see "Voice baseline") for the full deliverable-aware verdicts.
+When no voice profile is loaded, deliverable-surface rules are still measured on the deliverable corpus, not the chat audit. The chat audit cannot score them: it stems each entry and joins against single-word FTS tokens, so a multi-word phrase never matches and reads as a false `dead`. Without a baseline the distinctiveness check is skipped, so an alive rule is reported `keep (no baseline)` rather than proposed for removal. Build the baseline with `ingest-voice.ts` then `voice-profile.ts` (see "Voice baseline") for the full deliverable-aware verdicts.
 
 Because removed single words are no longer in the wordlist, a later audit cannot resurface them (the additions pipeline only mines multi-word n-grams). If the model regresses to a removed word, add it back by hand.
 
@@ -98,7 +98,7 @@ Pulls two corpora:
 
 #### User text filtering
 
-User-role messages in Claude Code contain a mix of human input and machine-generated content. The `text_content` view classifies these with two boolean columns:
+User-role messages in Claude Code mix human input and machine-generated content. The `text_content` view classifies these with two boolean columns:
 
 - `is_subagent`: `source_file` contains `/subagents/` (subagent prompts, task dispatches)
 - `is_system`: prefix-based heuristics covering XML-tagged injections (`<task-notification>`, `<command-name>`, `<system-reminder>`), context compaction summaries (`This session is being continued from a previous conversation`), plan injections (`Implement the following plan:`), interruption markers (`[Request interrupted by user]`), ultraplan/ultrareview UI (`◇ `, `◆ `, `Ultraplan `), and goal injections (`Goal set:`)
@@ -111,13 +111,13 @@ Two cleaning pipelines serve different jobs. Use the right one for the right con
 
 `stripCode` (`detection/tropes.ts`) removes only fenced code blocks and inline code, replacing them with whitespace that preserves line and column offsets. Use it in any path where position accuracy matters: the hook, `scan.ts`, `structural.ts`. Never use it for corpus mining.
 
-`cleanText` (`skills/analyze/scripts/ngram.ts`) aggressively removes URLs, table lines, headers, file paths, CLI flags, function calls, snake_case, and CamelCase in addition to code blocks. Position accuracy is not preserved. Use it for n-gram mining and voice-profile building where noise suppression matters more than fidelity.
+`cleanText` (`skills/analyze/scripts/ngram.ts`) removes URLs, table lines, headers, file paths, CLI flags, function calls, snake_case, and CamelCase in addition to code blocks. Position accuracy is not preserved. Use it for n-gram mining and voice-profile building where noise suppression matters more than fidelity.
 
 These pipelines are intentionally different. Do not converge them.
 
 ## Structural pattern audit
 
-`structural.ts` consumes the detection engine's `regexCatalog()` (from `detection/tropes.ts`) rather than re-declaring patterns, so the audit cannot drift from what the hook enforces. The catalog keeps only the regex patterns whose source is not a wordlist (the FTS pass covers stemmed vocabulary, weighted verbs, and the compiled openers regex) and normalizes each to the global flag for counting. Function-based tests (e.g. test-result reporting) are excluded because a single regex match cannot count them.
+`structural.ts` consumes the detection engine's `regexCatalog()` (from `detection/tropes.ts`) rather than re-declaring patterns, so the audit cannot drift from what the hook enforces. The catalog keeps only regex patterns whose source is not a wordlist (the FTS pass covers stemmed vocabulary, weighted verbs, and the compiled openers regex) and normalizes each to the global flag for counting. Function-based tests (e.g. test-result reporting) are excluded because a single regex match cannot count them.
 
 The patterns run against all assistant text (not just deliverables). Each reports total hits, rows containing hits, and session spread, labeled by hook scope (all, file-only, side-effect-only) and detector layer. Patterns are grouped by layer in the report:
 
@@ -132,7 +132,7 @@ Cross-sentence patterns shipping in the hook without a promotion record appear a
 
 `tag-ngram.ts` is the word-independent analogue of the n-gram candidate miner. Each sentence in the deliverable corpus and the human user corpus is tagged with the `compromise` adapter from `plugins/writing/linguistics/`, mapped to coarse part-of-speech tags, and the tag sequences (3- to 5-grams like `COPULA PARTICIPLE ADP`) run through the same lift math as word n-grams. Punctuation is dropped, so these are part-of-speech sequences (word types only), not syntax.
 
-The motivation: vocabulary tells drift with model releases, so wordlists need constant re-curation. The structural shape of a habit (passive voice, "not X but Y" parallelism, negated appositives, participial openers) persists across that drift. A high-lift tag sequence is a candidate for a structural rule that no vocabulary change invalidates.
+Motivation: vocabulary tells drift with model releases, so wordlists need constant re-curation. The structural shape of a habit (passive voice, "not X but Y" parallelism, negated appositives, participial openers) persists across that drift. A high-lift tag sequence is a candidate for a structural rule that no vocabulary change invalidates.
 
 Tag sequences draw from an alphabet of ~17 tags, so they are far denser than word n-grams: the per-size count floors are higher (3-grams: 30, 4-grams: 15, 5-grams: 8), the lift threshold is lower (`--tag-min-lift`, default 2.0, vs 5.0 for words), and most grammar is shared between the corpora so lift hovers near 1.0 for ordinary shapes.
 
@@ -148,7 +148,7 @@ Each rule is labeled in the **type** column by how the hook enforces it:
 
 ## Surface corrections
 
-Runs `correction-candidates` with `min_assistant_chars=300`, `max_user_chars=250`, `limit=--corrections-limit`. It finds adjacent pairs where a long assistant message is followed by a short user reply, which often indicates a correction or pushback.
+Runs `correction-candidates` with `min_assistant_chars=300`, `max_user_chars=250`, `limit=--corrections-limit`. It finds adjacent pairs where a long assistant message is followed by a short user reply, often a correction or pushback.
 
 ## Spot-checking with DuckDB samples
 
@@ -195,7 +195,7 @@ Each criterion in `JUDGE_CRITERIA` carries its layer label (`meaning`), the rubr
 
 #### Execution and Cost
 
-One call per document at temperature 0 with structured JSON output on a Haiku-class model, prompt sent as a cacheable system prefix. Documents over 1,500 words are chunked at paragraph boundaries and aggregated by per-criterion maxima. The runner prints an estimated cost before any call and accepts a document limit (default 100). A 200-document run of 1k-word bodies stays well under a dollar.
+One call per document at temperature 0 with structured JSON output on a Haiku-class model, prompt sent as a cacheable system prefix. Documents over 1,500 words are chunked at paragraph boundaries and aggregated by per-criterion maxima. The runner prints an estimated cost before any call and accepts a document limit (default 100). A 200-document run of 1k-word bodies stays under a dollar.
 
 #### Reproducibility Gate
 
@@ -203,7 +203,7 @@ One call per document at temperature 0 with structured JSON output on a Haiku-cl
 
 #### Calibration (Pending)
 
-Judge criteria are unstable until anchored against real examples, so calibration follows the labeling protocol below. Size dev and test splits with `linguistics/power.ts` first, run two criteria-refinement rounds on the dev split, then freeze the prompt and measure once on the held-out test split with the Wilson protocol. Promotion bar for analyze/review: precision at or above ~50% on the random subset with interval width at or under ±20pp, plus a human spot-check of flagged examples. The labeling passes are a user checkpoint and have not run. Until they do, treat judge flag rates as uncalibrated and the committed fixture expectations as design targets.
+Judge criteria are unstable until anchored against real examples, so calibration follows the labeling protocol below. Size dev and test splits with `linguistics/power.ts` first, run two criteria-refinement rounds on the dev split, then freeze the prompt and measure once on the held-out test split with the Wilson protocol. Promotion bar for analyze/review: precision at or above ~50% on the random subset with interval width at or under ±20pp, plus a human spot-check of flagged examples. The labeling passes are a user checkpoint and have not run. Until then, treat judge flag rates as uncalibrated and the committed fixture expectations as design targets.
 
 #### Privacy
 
@@ -227,7 +227,7 @@ Active labeling on disagreements inflates the apparent flag rate, so it cannot e
 
 #### Freeze a test set separate from the dev set
 
-Tuning a classifier and measuring it on the same labels inflates the result. Hold out a frozen test set for the promotion estimate and tune thresholds on a separate dev set. The freeze is what makes a promotion number trustworthy across re-tuning.
+Tuning a classifier and measuring it on the same labels inflates the result. Hold out a frozen test set for the promotion estimate and tune thresholds on a separate dev set. The freeze makes a promotion number trustworthy across re-tuning.
 
 ## Tuning
 

--- a/plugins/writing/skills/review/SKILL.md
+++ b/plugins/writing/skills/review/SKILL.md
@@ -31,7 +31,7 @@ Spawn all applicable agents in parallel. Each receives the document content, aud
 For `writing:style`, also inject these writing preferences (sub-agents cannot see skills):
 
 - Avoid AI-typical vocabulary: `meticulous`/`meticulously`, `pivotal`, `testament`, `underscore` (figurative), `interplay`, `intricacies`, `bolstered`, `garner`/`garnered`, `foster`/`fostering`
-  - These words are **review-only**. They do not appear in the hook wordlists because none has a corpus audit behind it. The review skill runs in batch mode where a human triages flags (recall matters more than precision), matching the analyze-and-review bar from linguistics.md. Promoting any of them to the hook wordlists requires a corpus audit confirming lift and distinctiveness versus the user's voice baseline.
+  - These words are **review-only**. They do not appear in the hook wordlists because none has a corpus audit behind it. The review skill runs in batch mode where a human triages flags (recall matters more than precision), matching the analyze-and-review bar from linguistics.md. Promoting any to the hook wordlists requires a corpus audit confirming lift and distinctiveness versus the user's voice baseline.
 - Avoid promotional language: `boasts`, `vibrant`, `showcasing`, `nestled`, `groundbreaking`, `renowned`, `diverse array`
 - Avoid copula avoidance ("X is Y" not fancy alternatives)
 - Split connector-joined clauses (semicolons, dashes) into separate sentences

--- a/plugins/writing/skills/rewrite/SKILL.md
+++ b/plugins/writing/skills/rewrite/SKILL.md
@@ -61,7 +61,7 @@ Clear the lint findings as described above, then apply the structural rules from
 - Cutting sentences that restate previous ones
 - Removing filler phrases and hedging
 
-Do not add, remove, or restructure the content's meaning. The output should convey the same information in fewer, clearer words.
+Do not add, remove, or restructure the content's meaning. Convey the same information in fewer, clearer words.
 
 ## Output
 

--- a/plugins/writing/skills/scan/SKILL.md
+++ b/plugins/writing/skills/scan/SKILL.md
@@ -37,4 +37,4 @@ Pass `--no-summary` to suppress the table when piping the per-line output elsewh
 
 The scan is report-only. To fix a flagged file, open it and run `writing:rewrite` on the offending passages, or edit directly using the reported positions. Bulk auto-fixing is not part of this skill.
 
-The detection engine is shared with the `tropes` hook and the `writing:rewrite` skill, which runs this script in `--input` mode for a single file, inline text, or stdin (`detection/scan.ts` over `detection/tropes.ts`), so a clean scan matches what the hook would allow on new edits.
+The detection engine is shared with the `tropes` hook and the `writing:rewrite` skill, which runs this script in `--input` mode for a single file, inline text, or stdin (`detection/scan.ts` over `detection/tropes.ts`), so a clean scan matches what the hook allows on new edits.

--- a/plugins/writing/skills/score/SKILL.md
+++ b/plugins/writing/skills/score/SKILL.md
@@ -14,7 +14,7 @@ allowed-tools:
 
 # Score
 
-Measure AI writing patterns in one input and report density per category. This quantifies trope load so you can compare drafts or track a file over time. To list every match with positions, use `writing:scan`. To rewrite an input, use `writing:rewrite`.
+Measure AI writing patterns in one input and report density per category. Quantifies trope load so you can compare drafts or track a file over time. To list every match with positions, use `writing:scan`. To rewrite an input, use `writing:rewrite`.
 
 ## Input
 
@@ -36,11 +36,11 @@ Hits are threshold-crossing counts from the shared detection engine (`detection/
 
 ## Output
 
-A table per group with category, hits, and density, sorted by density. The `--json` flag emits the structured report for diffing two runs. The command is informational: every run returns a success status, so it never gates anything.
+A table per group with category, hits, and density, sorted by density. The `--json` flag emits the structured report for diffing two runs. The command is informational: every run returns success, so it never gates anything.
 
 ## Comments
 
-For non-prose source files, single-line comments (`//`, `#`) are extracted and scored as a separate `comments` group, so prose-only patterns apply to them without an AST. This is on by default for source files and off for prose files (`.md` and friends, whose fenced code blocks are already stripped). Force it with `--comments` or suppress it with `--no-comments`.
+For non-prose source files, single-line comments (`//`, `#`) are extracted and scored as a separate `comments` group, so prose-only patterns apply to them without an AST. On by default for source files, off for prose files (`.md` and friends, whose fenced code blocks are already stripped). Force it with `--comments` or suppress it with `--no-comments`.
 
 ## Voice Delta
 

--- a/plugins/x-callback-url/skills/xcall/SKILL.md
+++ b/plugins/x-callback-url/skills/xcall/SKILL.md
@@ -13,7 +13,7 @@ Send [x-callback-url](https://x-callback-url.com/) requests from the command lin
 
 ## How It Works
 
-`xcall` is a Swift CLI that builds into a macOS `.app` bundle. The `.app` is required because macOS only delivers URL scheme callbacks to registered applications. On first use, `run.sh` compiles the source into `${CLAUDE_PLUGIN_DATA}/xcall.app` and registers the callback scheme (`xcall-claude://`) with Launch Services. Installing into the plugin's data directory (instead of the plugin source/cache tree) keeps the registered path stable across plugin updates: the marketplace cache is content-addressed, so building xcall.app inside it would orphan the Launch Services registration on the next update.
+`xcall` is a Swift CLI that builds into a macOS `.app` bundle. The `.app` is required because macOS only delivers URL scheme callbacks to registered applications. On first use, `run.sh` compiles the source into `${CLAUDE_PLUGIN_DATA}/xcall.app` and registers the callback scheme (`xcall-claude://`) with Launch Services. Installing into the plugin's data directory (not the plugin source/cache tree) keeps the registered path stable across plugin updates: the marketplace cache is content-addressed, so building xcall.app inside it would orphan the Launch Services registration on the next update.
 
 ## Usage
 
@@ -53,13 +53,13 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/run.sh "bear://x-callback-url/create?title=Meeting
 
 ## x-callback-url Protocol
 
-The [x-callback-url](https://x-callback-url.com/specification/) protocol defines three callback parameters:
+The [x-callback-url](https://x-callback-url.com/specification/) protocol defines three callback parameters.
 
 - **x-success** — called on success, with app-specific result parameters
 - **x-error** — called on failure, with `errorCode` and `errorMessage`
 - **x-cancel** — called when the user cancels
 
-`xcall` appends these automatically using its registered `xcall-claude://` scheme.
+`xcall` appends these using its registered `xcall-claude://` scheme.
 
 ## Supported Apps
 
@@ -80,5 +80,5 @@ Apps with their own CLI (e.g., Shortcuts via `shortcuts run`) don't need xcall �
 - Callback scheme: `xcall-claude://`
 - `Info.plist`: `CFBundleTypeRole=Editor`, `LSUIElement=true`. `LSBackgroundOnly` is intentionally not set: combining it with `LSUIElement` causes macOS to refuse to route URL scheme callbacks to the app, surfacing as a "no application set" dialog.
 - After building, `build.sh` calls `lsregister -f` and verifies the scheme handler is the freshly built bundle. If verification fails it exits non-zero.
-- Build is cached — only recompiles if `main.swift` is newer than the binary
+- Build is cached — recompiles only if `main.swift` is newer than the binary
 - Timeout: 10 seconds

--- a/user/rules/json.md
+++ b/user/rules/json.md
@@ -6,7 +6,7 @@ paths:
 # JSON
 
 - ALWAYS use `jq` for producing JSON output to ensure validity.
-- Use `jq` to parse JSON input. If you know the structure, use `jq` filters to extract specific fields. JSON is often token-heavy, so optimizing for size is important.
+- Use `jq` to parse JSON input. If you know the structure, use `jq` filters to extract specific fields. JSON is often token-heavy, so optimize for size.
   - Use `jq` filters like `keys`, `type`, and length to inspect JSON structures.
   - When fetching from the internet, output JSON to temporary files in `tmp/` directory to allow for inspection.
 - The Bash tool escapes `!` to `\!`, breaking jq `!=`. Use `| not` instead (e.g., `select(.x == null | not)`) or pass the filter via heredoc.

--- a/user/rules/terraform.md
+++ b/user/rules/terraform.md
@@ -8,7 +8,7 @@ paths:
 
 ## Version-Specific Guidance
 
-**CRITICAL**: Before providing any language syntax or CLI advice, run `terraform version` to determine the project's Terraform version.
+**CRITICAL**: Before providing any language syntax or CLI advice, run `terraform version` to determine the project's version.
 
 ```bash
 terraform version

--- a/user/skills/doc-coauthoring/SKILL.md
+++ b/user/skills/doc-coauthoring/SKILL.md
@@ -6,23 +6,23 @@ description: Guide users through a structured workflow for co-authoring document
 
 # Doc Co-Authoring Workflow
 
-This skill provides a structured workflow for guiding users through collaborative document creation. Act as an active guide, walking users through three stages: Context Gathering, Refinement & Structure, and Reader Testing.
+Act as an active guide, walking users through three stages: Context Gathering, Refinement & Structure, and Reader Testing.
 
 ## When to Offer This Workflow
 
 **Trigger conditions:**
 - User mentions writing documentation: "write a doc", "draft a proposal", "create a spec", "write up"
 - User mentions specific doc types: "PRD", "design doc", "decision doc", "RFC"
-- User seems to be starting a substantial writing task
+- User is starting a substantial writing task
 
 **Initial offer:**
-Offer the user a structured workflow for co-authoring the document. Explain the three stages:
+Offer the structured workflow. Explain the three stages:
 
-1. **Context Gathering**: User provides all relevant context while Claude asks clarifying questions
+1. **Context Gathering**: User provides relevant context while Claude asks clarifying questions
 2. **Refinement & Structure**: Iteratively build each section through brainstorming and editing
 3. **Reader Testing**: Test the doc with a fresh Claude (no context) to catch blind spots before others read it
 
-Explain that this approach helps ensure the doc works well when others read it (including when they paste it into Claude). Ask if they want to try this workflow or prefer to work freeform.
+This helps the doc work when others read it (including when they paste it into Claude). Ask if they want this workflow or prefer freeform.
 
 If user declines, work freeform. If user accepts, proceed to Stage 1.
 
@@ -32,7 +32,7 @@ If user declines, work freeform. If user accepts, proceed to Stage 1.
 
 ### Initial Questions
 
-Start by asking the user for meta-context about the document:
+Ask the user for meta-context about the document:
 
 1. What type of document is this? (e.g., technical spec, decision doc, proposal)
 2. Who's the primary audience?
@@ -40,7 +40,7 @@ Start by asking the user for meta-context about the document:
 4. Is there a template or specific format to follow?
 5. Any other constraints or context to know?
 
-Inform them they can answer in shorthand or dump information however works best for them.
+They can answer in shorthand or dump information however works for them.
 
 **If user provides a template or mentions a doc type:**
 - Ask if they have a template document to share
@@ -50,11 +50,11 @@ Inform them they can answer in shorthand or dump information however works best 
 **If user mentions editing an existing shared document:**
 - Use the appropriate integration to read the current state
 - Check for images without alt-text
-- If images exist without alt-text, explain that when others use Claude to understand the doc, Claude won't be able to see them. Ask if they want alt-text generated. If so, request they paste each image into chat for descriptive alt-text generation.
+- If images exist without alt-text, explain that when others use Claude to understand the doc, Claude won't see them. Ask if they want alt-text generated. If so, request they paste each image into chat.
 
 ### Info Dumping
 
-Once initial questions are answered, encourage the user to dump all the context they have. Request information such as:
+Once initial questions are answered, encourage the user to dump all their context:
 - Background on the project/problem
 - Related team discussions or shared documents
 - Why alternative solutions aren't being used
@@ -63,24 +63,24 @@ Once initial questions are answered, encourage the user to dump all the context 
 - Technical architecture or dependencies
 - Stakeholder concerns
 
-Advise them not to worry about organizing it - just get it all out. Offer multiple ways to provide context:
+Tell them not to organize it - get it all out. Offer multiple ways to provide context:
 - Info dump stream-of-consciousness
 - Point to team channels or threads to read
 - Link to shared documents
 
-**If integrations are available** (e.g., Slack, Teams, Google Drive, SharePoint, or other MCP servers), mention that these can be used to pull in context directly.
+**If integrations are available** (e.g., Slack, Teams, Google Drive, SharePoint, or other MCP servers), mention these can pull in context directly.
 
-**If no integrations are detected and in Claude.ai or Claude app:** Suggest they can enable connectors in their Claude settings to allow pulling context from messaging apps and document storage directly.
+**If no integrations are detected and in Claude.ai or Claude app:** Suggest they enable connectors in Claude settings to pull context from messaging apps and document storage directly.
 
-Inform them clarifying questions will be asked once they've done their initial dump.
+Tell them clarifying questions come after their initial dump.
 
 **During context gathering:**
 
 - If user mentions team channels or shared documents:
-  - If integrations available: Inform them the content will be read now, then use the appropriate integration
-  - If integrations not available: Explain lack of access. Suggest they enable connectors in Claude settings, or paste the relevant content directly.
+  - If integrations available: Tell them the content will be read now, then use the appropriate integration
+  - If integrations not available: Explain lack of access. Suggest they enable connectors in Claude settings, or paste the content directly.
 
-- If user mentions entities/projects that are unknown:
+- If user mentions unknown entities/projects:
   - Ask if connected tools should be searched to learn more
   - Wait for user confirmation before searching
 
@@ -88,17 +88,17 @@ Inform them clarifying questions will be asked once they've done their initial d
 
 **Asking clarifying questions:**
 
-When user signals they've done their initial dump (or after substantial context provided), ask clarifying questions to ensure understanding:
+When user signals they've done their initial dump (or after substantial context), ask clarifying questions to confirm understanding:
 
 Generate 5-10 numbered questions based on gaps in the context.
 
-Inform them they can use shorthand to answer (e.g., "1: yes, 2: see #channel, 3: no because backwards compat"), link to more docs, point to channels to read, or just keep info-dumping. Whatever's most efficient for them.
+They can use shorthand to answer (e.g., "1: yes, 2: see #channel, 3: no because backwards compat"), link to more docs, point to channels to read, or keep info-dumping. Whatever's most efficient.
 
 **Exit condition:**
-Sufficient context has been gathered when questions show understanding - when edge cases and trade-offs can be asked about without needing basics explained.
+Sufficient context exists when questions show understanding - when edge cases and trade-offs can be asked about without needing basics explained.
 
 **Transition:**
-Ask if there's any more context they want to provide at this stage, or if it's time to move on to drafting the document.
+Ask if there's more context to provide, or if it's time to draft.
 
 If user wants to add more, let them. When ready, proceed to Stage 2.
 
@@ -107,24 +107,24 @@ If user wants to add more, let them. When ready, proceed to Stage 2.
 **Goal:** Build the document section by section through brainstorming, curation, and iterative refinement.
 
 **Instructions to user:**
-Explain that the document will be built section by section. For each section:
-1. Clarifying questions will be asked about what to include
-2. 5-20 options will be brainstormed
-3. User will indicate what to keep/remove/combine
-4. The section will be drafted
-5. It will be refined through surgical edits
+Explain the document is built section by section. For each section:
+1. Clarifying questions about what to include
+2. 5-20 options brainstormed
+3. User indicates what to keep/remove/combine
+4. The section is drafted
+5. Refined through surgical edits
 
 Start with whichever section has the most unknowns (usually the core decision/proposal), then work through the rest.
 
 **Section ordering:**
 
 If the document structure is clear:
-Ask which section they'd like to start with.
+Ask which section to start with.
 
-Suggest starting with whichever section has the most unknowns. For decision docs, that's usually the core proposal. For specs, it's typically the technical approach. Summary sections are best left for last.
+Suggest the section with the most unknowns. For decision docs, that's usually the core proposal. For specs, the technical approach. Leave summary sections for last.
 
 If user doesn't know what sections they need:
-Based on the type of document and template, suggest 3-5 sections appropriate for the doc type.
+Based on the doc type and template, suggest 3-5 sections.
 
 Ask if this structure works, or if they want to adjust it.
 
@@ -133,79 +133,65 @@ Ask if this structure works, or if they want to adjust it.
 Create the initial document structure with placeholder text for all sections.
 
 **If access to artifacts is available:**
-Use `create_file` to create an artifact. This gives both Claude and the user a scaffold to work from.
-
-Inform them that the initial structure with placeholders for all sections will be created.
-
-Create artifact with all section headers and brief placeholder text like "[To be written]" or "[Content here]".
+Use `create_file` to create an artifact, giving Claude and the user a scaffold to work from. Use all section headers and brief placeholder text like "[To be written]" or "[Content here]".
 
 Provide the scaffold link and indicate it's time to fill in each section.
 
 **If no access to artifacts:**
-Create a markdown file in the working directory. Name it appropriately (e.g., `decision-doc.md`, `technical-spec.md`).
+Create a markdown file in the working directory, named appropriately (e.g., `decision-doc.md`, `technical-spec.md`), with all section headers and placeholder text.
 
-Inform them that the initial structure with placeholders for all sections will be created.
-
-Create file with all section headers and placeholder text.
-
-Confirm the filename has been created and indicate it's time to fill in each section.
+Confirm the filename and indicate it's time to fill in each section.
 
 **For each section:**
 
 ### Clarifying Questions
 
-Announce work will begin on the [SECTION NAME] section. Ask 5-10 clarifying questions about what should be included.
+Announce work on the [SECTION NAME] section. Ask 5-10 clarifying questions about what to include.
 
 ### Brainstorming
 
-For the [SECTION NAME] section, brainstorm [5-20] things that might be included, depending on the section's complexity. Look for:
+For the [SECTION NAME] section, brainstorm 5-20 things that might be included, depending on complexity. Look for:
 - Context shared that might have been forgotten
 - Angles or considerations not yet mentioned
 
-Generate 5-20 numbered options based on section complexity. At the end, offer to brainstorm more if they want additional options.
+Generate 5-20 numbered options based on complexity. Offer to brainstorm more.
 
 ### Curation
 
-Ask which points should be kept, removed, or combined. Request brief justifications to help learn priorities for the next sections.
+Ask which points to keep, remove, or combine. Request brief justifications to learn priorities for the next sections.
 
-Provide examples:
+Examples:
 - "Keep 1,4,7,9"
 - "Remove 3 (duplicates 1)"
 - "Remove 6 (audience already knows this)"
 - "Combine 11 and 12"
 
-**If user gives freeform feedback** (e.g., "looks good" or "I like most of it but...") instead of numbered selections, extract their preferences and proceed. Parse what they want kept/removed/changed and apply it.
+**If user gives freeform feedback** (e.g., "looks good" or "I like most of it but...") instead of numbered selections, parse what they want kept/removed/changed and apply it.
 
 ### Gap Check
 
-Based on what they've selected, ask if there's anything important missing for the [SECTION NAME] section.
+Based on what they selected, ask if anything important is missing for the [SECTION NAME] section.
 
 ### Drafting
 
-Use `str_replace` to replace the placeholder text for this section with the actual drafted content.
-
-Announce the [SECTION NAME] section will be drafted now based on what they've selected.
+Use `str_replace` to replace this section's placeholder with the drafted content. Announce the [SECTION NAME] section is being drafted from their selections.
 
 **If using artifacts:**
-After drafting, provide a link to the artifact.
-
-Ask them to read through it and indicate what to change. Note that being specific helps learning for the next sections.
+After drafting, provide a link to the artifact. Ask them to read it and indicate what to change. Being specific helps learning for the next sections.
 
 **If using a file (no artifacts):**
-After drafting, confirm completion.
-
-Inform them the [SECTION NAME] section has been drafted in [filename]. Ask them to read through it and indicate what to change. Note that being specific helps learning for the next sections.
+After drafting, confirm the [SECTION NAME] section is drafted in [filename]. Ask them to read it and indicate what to change. Being specific helps learning for the next sections.
 
 **Key instruction for user (include when drafting the first section):**
-Provide a note: Instead of editing the doc directly, ask them to indicate what to change. This helps learning of their style for future sections. For example: "Remove the X bullet - already covered by Y" or "Make the third paragraph more concise".
+Instead of editing the doc directly, ask them to indicate what to change. This learns their style for future sections. For example: "Remove the X bullet - already covered by Y" or "Make the third paragraph shorter".
 
 ### Iterative Refinement
 
 As user provides feedback:
 - Use `str_replace` to make edits (never reprint the whole doc)
 - **If using artifacts:** Provide link to artifact after each edit
-- **If using files:** Just confirm edits are complete
-- If user edits doc directly and asks to read it: mentally note the changes they made and keep them in mind for future sections (this shows their preferences)
+- **If using files:** Confirm edits are complete
+- If user edits the doc directly and asks to read it: note their changes and keep them in mind for future sections (this shows their preferences)
 
 **Continue iterating** until user is satisfied with the section.
 
@@ -213,35 +199,33 @@ As user provides feedback:
 
 After 3 consecutive iterations with no substantial changes, ask if anything can be removed without losing important information.
 
-When section is done, confirm [SECTION NAME] is complete. Ask if ready to move to the next section.
+When the section is done, confirm [SECTION NAME] is complete. Ask if ready for the next section.
 
 **Repeat for all sections.**
 
 ### Near Completion
 
-As approaching completion (80%+ of sections done), announce intention to re-read the entire document and check for:
+At 80%+ of sections done, announce re-reading the entire document to check for:
 - Flow and consistency across sections
 - Redundancy or contradictions
 - Anything that feels like "slop" or generic filler
 - Whether every sentence carries weight
 
-Read entire document and provide feedback.
+Read the entire document and provide feedback.
 
 **When all sections are drafted and refined:**
-Announce all sections are drafted. Indicate intention to review the complete document one more time.
-
-Review for overall coherence, flow, completeness.
+Announce all sections are drafted and review the complete document once more for coherence, flow, completeness.
 
 Provide any final suggestions.
 
-Ask if ready to move to Reader Testing, or if they want to refine anything else.
+Ask if ready for Reader Testing, or if they want to refine anything else.
 
 ## Stage 3: Reader Testing
 
 **Goal:** Test the document with a fresh Claude (no context bleed) to verify it works for readers.
 
 **Instructions to user:**
-Explain that testing will now occur to see if the document actually works for readers. This catches blind spots - things that make sense to the authors but might confuse others.
+Explain that testing checks whether the document works for readers. This catches blind spots - things that make sense to the authors but might confuse others.
 
 ### Testing Approach
 
@@ -251,13 +235,13 @@ Perform the testing directly without user involvement.
 
 ### Predict Reader Questions
 
-Announce intention to predict what questions readers might ask when trying to discover this document.
+Announce predicting what questions readers might ask when discovering this document.
 
 Generate 5-10 questions that readers would realistically ask.
 
 ### Test with Sub-Agent
 
-Announce that these questions will be tested with a fresh Claude instance (no context from this conversation).
+Announce testing these questions with a fresh Claude instance (no context from this conversation).
 
 For each question, invoke a sub-agent with just the document content and the question.
 
@@ -265,20 +249,14 @@ Summarize what Reader Claude got right/wrong for each question.
 
 ### Run Additional Checks
 
-Announce additional checks will be performed.
-
-Invoke sub-agent to check for ambiguity, false assumptions, contradictions.
+Invoke a sub-agent to check for ambiguity, false assumptions, contradictions.
 
 Summarize any issues found.
 
 ### Report and Fix
 
 If issues found:
-Report that Reader Claude struggled with specific issues.
-
-List the specific issues.
-
-Indicate intention to fix these gaps.
+Report that Reader Claude struggled, list the specific issues, and announce fixing these gaps.
 
 Loop back to refinement for problematic sections.
 
@@ -286,11 +264,11 @@ Loop back to refinement for problematic sections.
 
 **If no access to sub-agents (e.g., claude.ai web interface):**
 
-The user will need to do the testing manually.
+The user does the testing manually.
 
 ### Predict Reader Questions
 
-Ask what questions people might ask when trying to discover this document. What would they type into Claude.ai?
+Ask what questions people might ask when discovering this document. What would they type into Claude.ai?
 
 Generate 5-10 questions that readers would realistically ask.
 
@@ -304,7 +282,7 @@ Provide testing instructions:
 For each question, instruct Reader Claude to provide:
 - The answer
 - Whether anything was ambiguous or unclear
-- What knowledge/context the doc assumes is already known
+- What knowledge/context the doc assumes is known
 
 Check if Reader Claude gives correct answers or misinterprets anything.
 
@@ -349,10 +327,10 @@ Announce document completion. Provide a few final tips:
 **Tone:**
 - Be direct and procedural
 - Explain rationale briefly when it affects user behavior
-- Don't try to "sell" the approach - just execute it
+- Don't try to "sell" the approach - execute it
 
 **Handling Deviations:**
-- If user wants to skip a stage: Ask if they want to skip this and write freeform
+- If user wants to skip a stage: Ask if they want to skip it and write freeform
 - If user seems frustrated: Acknowledge this is taking longer than expected. Suggest ways to move faster
 - Always give user agency to adjust the process
 
@@ -364,9 +342,9 @@ Announce document completion. Provide a few final tips:
 - Use `create_file` for drafting full sections
 - Use `str_replace` for all edits
 - Provide artifact link after every change
-- Never use artifacts for brainstorming lists - that's just conversation
+- Never use artifacts for brainstorming lists - that's conversation
 
 **Quality over Speed:**
 - Don't rush through stages
 - Each iteration should make meaningful improvements
-- The goal is a document that actually works for readers
+- The goal is a document that works for readers

--- a/user/skills/improve-claude-code/SKILL.md
+++ b/user/skills/improve-claude-code/SKILL.md
@@ -17,13 +17,13 @@ allowed-tools:
 
 Work through the `claude-code` Things backlog: fetch todos, triage with the user, then plan and implement each in parallel as separate PRs.
 
-The backlog has two sources. The user files todos tagged `claude-code` by hand (and `agent-ideas` files external-harvest ideas in the same shape). **Discover mode** adds a second source: it mines this machine's session history for config-change candidates, grounds them against the live config, and files the keepers as `claude-code` todos. Both sources feed the one implement loop below. Discover is upstream of triage, not a replacement for it.
+The backlog has two sources. The user files todos tagged `claude-code` by hand (and `agent-ideas` files external-harvest ideas in the same shape). **Discover mode** adds a second source: it mines this machine's session history for config-change candidates, grounds them against the live config, and files the keepers as `claude-code` todos. Both sources feed the one implement loop below. Discover is upstream of triage, not a replacement.
 
 All Things interaction goes through the `things:jxa` and `things:url` skills (never inline JXA). PRs go through `pull-request:create` (never `gh pr create`).
 
 ## Discover
 
-Mine session history for improvement candidates, ground them against the live config, write a digest, and file the keepers. Discover never auto-implements and never auto-files: filing is an explicit user choice, implementing is a separate run of the loop below. The engine is the `claude-code:session` skill's fan-out, whose `references/discovery.md` carries the full recipe (dimension cheat sheet, grounding mandate, host safety, Tier-2 catalog). Load that skill to read it.
+Mine session history for improvement candidates, ground them against the live config, write a digest, and file the keepers. Discover never auto-implements and never auto-files: filing is an explicit user choice, implementing is a separate run of the loop below. The engine is the `claude-code:session` skill's fan-out, whose `references/discovery.md` carries the recipe (dimension cheat sheet, grounding mandate, host safety, Tier-2 catalog). Load that skill to read it.
 
 #### Refresh
 
@@ -31,11 +31,11 @@ Run the session skill's `scripts/refresh.ts --refresh` once, alone (it takes an 
 
 #### Fan-Out
 
-Launch one `Task` agent per dimension (hook latency, hook blocks, permissions and sandbox, context tax, tokens, turns and compaction, skill economy), the same mining fan-out `agent-ideas` uses. Give each agent the `$DB` path and point it at `references/discovery.md`. Each agent runs its dimension's named queries (by name, read-only) plus any inline rollups, and returns structured candidate findings **plus the exact SQL it ran**. Read-only opens take no lock, so the agents never contend.
+Launch one `Task` agent per dimension (hook latency, hook blocks, permissions and sandbox, context tax, tokens, turns and compaction, skill economy), the same mining fan-out `agent-ideas` uses. Give each agent the `$DB` path and point it at `references/discovery.md`. Each agent runs its dimension's named queries (by name, read-only) plus any inline rollups, and returns structured candidate findings **plus the exact SQL it ran**. Read-only opens take no lock, so agents never contend.
 
 #### Grounding
 
-Mandatory. Launch one or more grounding agents that re-check every candidate against the live files under `/Users/ben/src/bendrucker/claude`. Drop anything the config already addresses. Downgrade anything thin or host-skewed. Carry `grounded` (boolean) and `confidence` (high/medium/low) per candidate. Raw query findings go stale within a week against a config that changes weekly: a prior run overturned four of its own headline findings here. See the grounding rules in `references/discovery.md` (hooks run in parallel, so never sum durations as wall-clock, and split friction into what a setting can fix and what it cannot).
+Mandatory. Launch one or more grounding agents that re-check every candidate against the live files under `/Users/ben/src/bendrucker/claude`. Drop anything the config already addresses. Downgrade anything thin or host-skewed. Carry `grounded` (boolean) and `confidence` (high/medium/low) per candidate. Raw query findings go stale within a week against a config that changes weekly: a prior run overturned four of its own headline findings. See the grounding rules in `references/discovery.md` (hooks run in parallel, so never sum durations as wall-clock, and split friction into what a setting can fix and what it cannot).
 
 #### Dedup
 
@@ -45,7 +45,7 @@ Fingerprint each candidate (see [Fingerprint](#fingerprint)). Then query Things 
 - `already-shipped`: fingerprint found in a completed todo (the annotate phase removes the `claude-code` tag on a shipped todo, so the marker persists in notes or the logbook).
 - `new`: fingerprint not found.
 
-Suppress `already-filed` and `already-shipped` from the actionable set; still count them in the digest tail. Things is the ledger: there is no separate dedup store.
+Suppress `already-filed` and `already-shipped` from the actionable set; still count them in the digest tail. Things is the ledger: no separate dedup store.
 
 #### Digest
 
@@ -58,7 +58,7 @@ Present the actionable (new, grounded) candidates and ask the user which to file
 - **Title**: `[discovery] <finding title>`
 - **Notes**: the pitch, then the SQL/evidence, then `Discovery: <fingerprint>` on its own line.
 
-One todo per candidate, not one blob. Filing lands findings in the same backlog the implement loop already drains.
+One todo per candidate, not one blob. Filing lands findings in the same backlog the implement loop drains.
 
 #### Hand Off
 
@@ -66,7 +66,7 @@ Report how many todos landed. The existing triage, plan, implement, PR, CI, and 
 
 #### Cadence
 
-On-demand is primary: invoke this skill in Discover mode at your terminal. A weekly run is optional and must run **locally** (a `/loop` or `/schedule` trigger on this machine). The session DB and the `duckdb` CLI live here, so the `agent-ideas` headless-then-teleport bridge does not apply (that works only because RSS is public). This is a documented option, not built infrastructure.
+On-demand is primary: invoke this skill in Discover mode at your terminal. A weekly run is optional and must run **locally** (a `/loop` or `/schedule` trigger on this machine). The session DB and the `duckdb` CLI live here, so the `agent-ideas` headless-then-teleport bridge does not apply (that works only because RSS is public). A documented option, not built infrastructure.
 
 #### Fingerprint
 
@@ -77,7 +77,7 @@ printf '%s' "hook-noop|team-workaround.ts" | shasum -a 256 | cut -c1-12
 ```
 
 - `finding_type` is a stable slug for the class of finding (`hook-noop`, `permission-allowlist-miss`, `repeat-read`, `sandbox-deny`).
-- `normalized_target` is the specific config object the finding is about (a hook script basename, a permission pattern, a skill name), **never** a count or a date, so re-runs of the same underlying finding collapse to one identity.
+- `normalized_target` is the config object the finding is about (a hook script basename, a permission pattern, a skill name), **never** a count or a date, so re-runs of the same underlying finding collapse to one identity.
 
 Filed todos carry `Discovery: <fingerprint>` in notes. The dedup step extracts those markers from Things and suppresses matches. Suppressing *dismissed* findings (surfaced but not filed) is deferred: dismissed findings reappear as `new` until filed.
 
@@ -94,7 +94,7 @@ Ask the user which items to work on (numbers, ranges like `1-3`, or `all`). Cap 
 
 Each todo's notes embed the originating session as `Session: <uuid>`. For every selected todo, parse that UUID and use the `claude-code:session` skill to pull the original context: what you were doing, the commands that ran, and the errors that prompted the todo. This is richer than the todo's prose summary and grounds each plan in the real failure.
 
-Refresh the index once (`refresh.ts --refresh`), then look up each todo's session over the shared file with `duckdb -readonly "$DB"` (see the session skill's "Parallel queries" section). Read-only opens take no lock, so a batch of lookups runs concurrently without contending; never re-refresh per todo. Query `messages` / `content_items` / `text_content` filtered by `WHERE session_id = '<uuid>'`. Do not filter by `host`: many todos come from the work machine, whose corpus is imported as a separate host, and omitting the filter spans every machine. Distill the result to a few lines per todo and pass it to the matching `Plan` agent alongside the title and notes.
+Refresh the index once (`refresh.ts --refresh`), then look up each todo's session over the shared file with `duckdb -readonly "$DB"` (see the session skill's "Parallel queries" section). Read-only opens take no lock, so a batch of lookups runs concurrently without contending; never re-refresh per todo. Query `messages` / `content_items` / `text_content` filtered by `WHERE session_id = '<uuid>'`. Do not filter by `host`: many todos come from the work machine, whose corpus is imported as a separate host, and omitting the filter spans every machine. Distill the result to a few lines per todo and pass it to the matching `Plan` agent with the title and notes.
 
 If the UUID is absent from the index (not yet imported, or the index needs a refresh), proceed with notes only and say so for that todo.
 
@@ -104,7 +104,7 @@ Session context informs local planning only. Imported hosts may be marked `block
 
 ## Plan
 
-Launch parallel `Plan` agents (one per todo). Give each the todo title, full notes, the session context from the previous step, and instruction to explore the repo and produce a concrete implementation plan.
+Launch parallel `Plan` agents (one per todo). Give each the todo title, full notes, the session context from the previous step, and instruction to explore the repo and produce an implementation plan.
 
 Point agents to relevant domain skills: `claude-code:skill` for skill changes, `claude-code:hook` for hooks, `bun:bun` for scripts.
 

--- a/user/skills/improve-codebase-architecture/DEEPENING.md
+++ b/user/skills/improve-codebase-architecture/DEEPENING.md
@@ -12,7 +12,7 @@ Pure computation, in-memory state, no I/O. Always deepenable — merge the modul
 
 ### 2. Local-substitutable
 
-Dependencies that have local test stand-ins (PGLite for Postgres, in-memory filesystem). Deepenable if the stand-in exists. The deepened module is tested with the stand-in running in the test suite. The seam is internal; no port at the module's external interface.
+Dependencies with local test stand-ins (PGLite for Postgres, in-memory filesystem). Deepenable if the stand-in exists. The deepened module is tested with the stand-in running in the test suite. The seam is internal; no port at the module's external interface.
 
 ### 3. Remote but owned (Ports & Adapters)
 

--- a/user/skills/improve-codebase-architecture/HTML-REPORT.md
+++ b/user/skills/improve-codebase-architecture/HTML-REPORT.md
@@ -1,6 +1,6 @@
 # HTML Report Format
 
-The architectural review is rendered as a single self-contained HTML file in the OS temp directory. Tailwind and Mermaid both come from CDNs. Mermaid handles graph-shaped diagrams reliably; hand-built divs and inline SVG handle the more editorial visuals (mass diagrams, cross-sections). Mix the two — don't lean on Mermaid for everything, it'll start to look generic.
+The architectural review is rendered as a single self-contained HTML file in the OS temp directory. Tailwind and Mermaid both come from CDNs. Mermaid handles graph-shaped diagrams reliably; hand-built divs and inline SVG handle the more editorial visuals (mass diagrams, cross-sections). Mix the two — don't lean on Mermaid for everything, it'll look generic.
 
 ## Scaffold
 
@@ -59,7 +59,7 @@ Pick the pattern that fits the candidate. Mix them. Don't make every diagram loo
 
 ### Mermaid graph (the workhorse for dependencies / call flow)
 
-Use a Mermaid `flowchart` or `graph` when the point is "X calls Y calls Z, and look at the mess." Wrap it in a Tailwind-styled card so it doesn't feel parachuted in. Style with classDef to colour leakage edges red and the deep module dark. Sequence diagrams work well for "before: 6 round-trips; after: 1."
+Use a Mermaid `flowchart` or `graph` when the point is "X calls Y calls Z, and look at the mess." Wrap it in a Tailwind-styled card so it doesn't feel parachuted in. Style with classDef to colour leakage edges red and the deep module dark. Sequence diagrams work for "before: 6 round-trips; after: 1."
 
 ```html
 <div class="rounded-lg border border-slate-200 bg-white p-4">
@@ -92,9 +92,9 @@ Before: a tree of function calls rendered as nested boxes. After: the same tree 
 
 ## Style guidance
 
-- Lean editorial, not corporate-dashboard. Generous whitespace. Serif optional for headings (`font-serif` works well with stone/slate).
+- Lean editorial, not corporate-dashboard. Generous whitespace. Serif optional for headings (`font-serif` works with stone/slate).
 - Colour sparingly: one accent (emerald or indigo) plus red for leakage and amber for warnings.
-- Keep diagrams ~320px tall so before/after sits comfortably side by side without scrolling.
+- Keep diagrams ~320px tall so before/after sits side by side without scrolling.
 - Use `text-xs uppercase tracking-wider` for module labels inside diagrams — they should read as schematic, not as UI.
 - The only scripts are the Tailwind CDN and the Mermaid ESM import. The report is otherwise static — no app code, no interactivity beyond Mermaid's own rendering.
 

--- a/user/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
+++ b/user/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
@@ -1,6 +1,6 @@
 # Interface Design
 
-When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" (Ousterhout) — your first idea is unlikely to be the best.
+When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" (Ousterhout) — your first idea is unlikely to be best.
 
 Uses the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**, **leverage**.
 

--- a/user/skills/improve-codebase-architecture/LANGUAGE.md
+++ b/user/skills/improve-codebase-architecture/LANGUAGE.md
@@ -1,11 +1,11 @@
 # Language
 
-Shared vocabulary for every suggestion this skill makes. Use these terms exactly — don't substitute "component," "service," "API," or "boundary." Consistent language is the whole point.
+Shared vocabulary for every suggestion this skill makes. Use these terms exactly — don't substitute "component," "service," "API," or "boundary." Consistent language is the point.
 
 ## Terms
 
 **Module**
-Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
+Anything with an interface and an implementation. Scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
 _Avoid_: unit, component, service.
 
 **Interface**

--- a/user/skills/improve-codebase-architecture/SKILL.md
+++ b/user/skills/improve-codebase-architecture/SKILL.md
@@ -6,11 +6,11 @@ description: Find deepening opportunities in a codebase. Use when the user wants
 
 # Improve Codebase Architecture
 
-Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim: testability and AI-navigability.
 
 ## Glossary
 
-Use these terms exactly in every suggestion. Consistent language is the point — don't drift into "component," "service," "API," or "boundary." Full definitions in [LANGUAGE.md](LANGUAGE.md).
+Use these terms exactly in every suggestion. Consistent language is the point — don't drift into "component," "service," "API," or "boundary." Definitions in [LANGUAGE.md](LANGUAGE.md).
 
 - **Module** — anything with an interface and an implementation (function, class, package, slice).
 - **Interface** — everything a caller must know to use the module: types, invariants, error modes, ordering, config. Not just the type signature.
@@ -49,7 +49,7 @@ Write a self-contained HTML file to the OS temp directory so nothing lands in th
 
 The report uses **Tailwind via CDN** for layout and styling, and **Mermaid via CDN** for diagrams where a graph/flow/sequence reliably communicates the structure. Mix Mermaid with hand-crafted CSS/SVG visuals — use Mermaid when relationships are graph-shaped (call graphs, dependencies, sequences), and hand-built divs/SVG when you want something more editorial (mass diagrams, cross-sections, collapse animations). Each candidate gets a **before/after visualisation**. Be visual.
 
-For each candidate, the same template as before, but rendered as a card:
+For each candidate, the same template, but rendered as a card:
 
 - **Files** — which files/modules are involved
 - **Problem** — why the current architecture is causing friction

--- a/user/skills/job/SKILL.md
+++ b/user/skills/job/SKILL.md
@@ -36,7 +36,7 @@ Arguments beyond the mode are a focus hint ($ARGUMENTS). Weight the brief toward
 
 This skill never names platforms. The config declares which version-control platform, issue tracker, and worktree tool the user works with. For each task:
 
-1. Find the installed skill that covers the configured tool's task (the skill for the configured platform's merge requests, the skill for the configured tracker's issues) and load it for mechanics.
+1. Find the installed skill covering the configured tool's task (the skill for the configured platform's merge requests, the skill for the configured tracker's issues) and load it for mechanics.
 2. If no installed skill matches, use the configured CLI directly. Stay read-only until the user confirms actions.
 
 Platforms, hostnames, and usernames come only from the config or the user, never from this skill.
@@ -53,7 +53,7 @@ Read-only first. When sources are independent (review queue, own PRs, tracker), 
 
 One prioritized brief, sections in the mode's phase order. Within each section, order items blocking others first, then oldest. Each item gets an identifier with a link, a one-line state, and a recommended action.
 
-Omit sections with nothing in them and never pad. An empty queue is a two-line brief.
+Omit empty sections and never pad. An empty queue is a two-line brief.
 
 ### Act
 

--- a/user/skills/job/references/end.md
+++ b/user/skills/job/references/end.md
@@ -33,7 +33,7 @@ Never silently drop an item.
 
 ## Unpushed Work Sweep
 
-The configured roots may span many repositories, so keep this phase cheap: one sub-agent, local git commands only, no platform API calls. This is the lowest-priority phase. Skip it when the focus hint points elsewhere or the rest of the brief already needs the time.
+The configured roots may span many repositories, so keep this phase cheap: one sub-agent, local git commands only, no platform API calls. This is the lowest-priority phase. Skip it when the focus hint points elsewhere or the rest of the brief needs the time.
 
 Enumerate worktrees via the configured worktree tool. Fall back to `git worktree list` run across the configured roots. For each worktree, report:
 

--- a/user/skills/job/references/setup.md
+++ b/user/skills/job/references/setup.md
@@ -20,7 +20,7 @@ Ask via AskUserQuestion with detected candidates as options, relying on the buil
 - Issue tracker: platform, username and team, and how "current cycle" is expressed there, whether that is a cycle, sprint, iteration, or milestone, recording the exact term and how to query it.
 - Worktrees: the tool used, if any, plus every root directory the end-of-day sweep should walk when it checks for uncommitted changes and unpushed commits.
 - Working hours: optional, default 09:00 to 17:00, used only to suggest a mode when `/job` runs with no argument.
-- Notes: optional free-form text for reviewer conventions and team norms, the field where employer specifics belong rather than anywhere in the skill.
+- Notes: optional free-form text for reviewer conventions and team norms, where employer specifics belong rather than anywhere in the skill.
 
 ## Persist
 

--- a/user/skills/job/references/start.md
+++ b/user/skills/job/references/start.md
@@ -16,7 +16,7 @@ Each sub-agent uses the delegated skill or CLI for its source and returns struct
 
 Order items blocking others first, then oldest.
 
-Separate fresh requests from re-reviews where the author responded to your earlier feedback. For re-reviews, delegate the addressed-or-not analysis to an installed review-follow-up skill if one exists. Otherwise compare the threads against your prior comments yourself.
+Separate fresh requests from re-reviews where the author responded to your earlier feedback. For re-reviews, delegate the addressed-or-not analysis to an installed review-follow-up skill if one exists. Otherwise compare the threads against your prior comments.
 
 Recommended actions per item:
 


### PR DESCRIPTION
Deep pass over every `SKILL.md`, reference, and rule file, treating them as natural-language programs rather than prose. Cuts motivational framing, throat-clearing, redundant restatement, empty intensifiers, and padding clauses while preserving all commands, examples, constraints, tables, and frontmatter trigger keywords.

129 files, ~1,760 words removed. The aggregate is modest because most files were already tight; the wins concentrated where filler lived:

- `skill-creator/SKILL.md`: 5014 → 4192 (−16%) — cut conversational asides ("Cool? Cool.", "Good luck!", the plumbers/grandparents aside, "billions a year in economic value") and pervasive throat-clearing
- `doc-coauthoring/SKILL.md`: 2414 → 2176
- Smaller intensifier/restatement/padding trims across the rest

## Scope

- Diff is 100% `.md`. No code touched.
- Frontmatter `name:` and `description:` fields unchanged — every "Use when…" trigger keyword preserved.

## Verification

- `bun scripts/check-marketplace.ts` passes
- `bun run skill-lint` — 0 errors / 0 warnings across all skills
- `bun test` — 3784 pass / 0 fail locally (the 13 failures seen in the web sandbox were environmental: missing `node_modules` plus git/`gh` state)

## Follow-up tasks

All completed locally (these were blocked in the web session):

- [x] **Tighten `.claude/rules/*.md`.** These six files were write-protected in the web environment. Done locally — trimmed `hooks`, `lockfile`, `plugins`, `scripts`, `testing`; left `settings.md` intact since its trust-model rationale is load-bearing.
- [x] **Sanity-read the `skill-creator/SKILL.md` diff.** Reviewed — all behavioral instructions, JSON field names, script names, and the "pushy description" example preserved; only conversational filler removed.
- [x] **Run the full `bun test` suite locally.** 3784 pass / 0 fail, confirming the web-sandbox failures were environmental.
