### PR TITLE
pull-request: suggest reviewers from blame and recent in-area PRs

### DIFF
--- a/plugins/pull-request/scripts/suggest-reviewers.test.ts
+++ b/plugins/pull-request/scripts/suggest-reviewers.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { execSync } from "node:child_process";
+import { mkdtempSync, realpathSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  areaRefs,
+  blameOwners,
+  changedFiles,
+  selfIdentities,
+  suggestReviewers,
+} from "./suggest-reviewers";
+
+const ME = { name: "Me Dev", email: "me@example.com" };
+const OTHER = { name: "Other Dev", email: "other@example.com" };
+
+describe("suggest-reviewers", () => {
+  let dir: string;
+
+  function git(args: string): string {
+    return execSync(`git ${args}`, { cwd: dir, encoding: "utf-8", stdio: "pipe" }).trim();
+  }
+
+  async function commit(
+    file: string,
+    content: string,
+    author: typeof ME,
+    subject: string,
+  ): Promise<void> {
+    await Bun.write(path.join(dir, file), content);
+    git(`add "${file}"`);
+    git(`commit --author="${author.name} <${author.email}>" -m "${subject}"`);
+  }
+
+  beforeEach(() => {
+    dir = realpathSync(mkdtempSync(path.join(os.tmpdir(), "suggest-reviewers-")));
+    git("init -q");
+    git("symbolic-ref HEAD refs/heads/main");
+    git(`config user.name "${ME.name}"`);
+    git(`config user.email "${ME.email}"`);
+    git("config commit.gpgsign false");
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("ranks blame owners and excludes you", async () => {
+    await commit("foo.txt", "a\nb\nc\nd\n", OTHER, "feat: add foo (#10)");
+    git("checkout -q -b feature");
+    await commit("foo.txt", "a\nb\nc\nd\ne\n", ME, "tweak foo");
+
+    const result = suggestReviewers(dir, "main");
+    expect(result.owners).toEqual([{ name: OTHER.name, email: OTHER.email, lines: 4 }]);
+    expect(result.soleAuthor).toBe(false);
+    expect(result.areaRefs).toEqual(["#10"]);
+  });
+
+  it("flags sole authorship when only you touched the area", async () => {
+    await commit("foo.txt", "a\nb\n", ME, "feat: add foo (#7)");
+    git("checkout -q -b feature");
+    await commit("foo.txt", "a\nb\nc\n", ME, "extend foo");
+
+    const result = suggestReviewers(dir, "main");
+    expect(result.owners).toHaveLength(0);
+    expect(result.soleAuthor).toBe(true);
+    expect(result.areaRefs).toEqual(["#7"]);
+  });
+
+  it("parses GitLab MR refs from in-area history", async () => {
+    await commit("foo.txt", "a\n", OTHER, "feat: add foo\n\nSee merge request grp/proj!45");
+    git("checkout -q -b feature");
+    await commit("foo.txt", "a\nb\n", ME, "extend foo");
+
+    expect(areaRefs(["foo.txt"], dir, "main")).toEqual(["!45"]);
+  });
+
+  it("excludes your name even when committed under a different email", async () => {
+    await commit("foo.txt", "a\nb\n", { name: ME.name, email: "alias@example.com" }, "feat: foo");
+    expect(blameOwners(["foo.txt"], selfIdentities(dir), dir)).toHaveLength(0);
+  });
+
+  it("ignores files deleted at HEAD", async () => {
+    await commit("gone.txt", "x\n", OTHER, "add gone");
+    git("checkout -q -b feature");
+    git("rm -q gone.txt");
+    git('commit -m "remove gone"');
+
+    expect(changedFiles(dir, "main")).toEqual([]);
+  });
+});

--- a/plugins/pull-request/scripts/suggest-reviewers.ts
+++ b/plugins/pull-request/scripts/suggest-reviewers.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env bun
+// Suggest PR/MR reviewers from the git history of the changed files, as JSON.
+// Provider-agnostic: emits git identities and recent in-area PR/MR refs.
+// Username resolution and actually requesting reviews stay in the skill.
+
+import { execSync } from "node:child_process";
+
+function git(args: string, cwd?: string): string {
+  try {
+    return execSync(`git ${args}`, {
+      encoding: "utf-8",
+      cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+export interface Owner {
+  name: string;
+  email: string;
+  /** Surviving blamed lines across the changed files. */
+  lines: number;
+}
+
+export interface Suggestion {
+  /** Blame owners of the changed files, ranked by lines owned, you excluded. */
+  owners: Owner[];
+  /** True when you're the only author of the area: fall back to areaRefs. */
+  soleAuthor: boolean;
+  /** Recent PR/MR refs (#123, !45) from commits touching these files. */
+  areaRefs: string[];
+}
+
+/** Your own git identities, lowercased, to exclude from suggestions. */
+export function selfIdentities(cwd?: string): Set<string> {
+  const ids = ["user.email", "user.name"].map((key) => git(`config ${key}`, cwd).toLowerCase());
+  return new Set(ids.filter(Boolean));
+}
+
+/** The base ref to diff against (the default branch). */
+function baseRef(cwd?: string, override?: string): string | null {
+  if (override) return override;
+  const head = git("symbolic-ref --quiet refs/remotes/origin/HEAD", cwd);
+  if (head) return head.replace(/^refs\/remotes\//, "");
+  return (
+    ["origin/main", "origin/master", "main", "master"].find((ref) =>
+      git(`rev-parse --verify --quiet ${ref}`, cwd),
+    ) ?? null
+  );
+}
+
+/** Files you changed on the branch plus working-tree edits, deletions dropped. */
+export function changedFiles(cwd?: string, base?: string): string[] {
+  const ref = baseRef(cwd, base);
+  const commands = [
+    ref && `diff --name-only --diff-filter=d ${ref}...HEAD`,
+    "diff --name-only --diff-filter=d HEAD",
+  ];
+  const files = commands.flatMap((c) => (c ? git(c, cwd).split("\n") : [])).filter(Boolean);
+  return [...new Set(files)];
+}
+
+/** Tally blame line ownership across the changed files, excluding your own identities. */
+export function blameOwners(files: string[], self: Set<string>, cwd?: string): Owner[] {
+  const byEmail = new Map<string, Owner>();
+  for (const file of files) {
+    let name = "";
+    for (const line of git(`blame --line-porcelain HEAD -- "${file}"`, cwd).split("\n")) {
+      if (line.startsWith("author ")) {
+        name = line.slice("author ".length).trim();
+      } else if (line.startsWith("author-mail ")) {
+        const email = line.slice("author-mail ".length).trim().replace(/^<|>$/g, "");
+        const key = email.toLowerCase();
+        if (self.has(key) || self.has(name.toLowerCase())) continue;
+        const owner = byEmail.get(key) ?? { name, email, lines: 0 };
+        owner.lines += 1;
+        byEmail.set(key, owner);
+      }
+    }
+  }
+  return [...byEmail.values()].sort((a, b) => b.lines - a.lines);
+}
+
+/** PR/MR refs parsed from recent commits touching the changed files on the base branch. */
+export function areaRefs(files: string[], cwd?: string, base?: string): string[] {
+  if (files.length === 0) return [];
+  const quoted = files.map((f) => `"${f}"`).join(" ");
+  const log = git(`log ${baseRef(cwd, base) ?? "HEAD"} -n 40 --format=%s%n%b -- ${quoted}`, cwd);
+  const refs = [...log.matchAll(/[#!]\d+/g)].map((m) => m[0]);
+  return [...new Set(refs)].slice(0, 5);
+}
+
+export function suggestReviewers(cwd?: string, base?: string): Suggestion {
+  const files = changedFiles(cwd, base);
+  const owners = blameOwners(files, selfIdentities(cwd), cwd);
+  return { owners, soleAuthor: owners.length === 0, areaRefs: areaRefs(files, cwd, base) };
+}
+
+if (import.meta.main) {
+  console.log(JSON.stringify(suggestReviewers(), null, 2));
+}

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -83,17 +83,36 @@ When an issue is referenced:
 - **ONLY reference the issue** in the PR body (e.g., `Closes #123`, `Fixes #456`)
 - **NEVER modify the issue directly** - no comments, labels, milestones, or assignees
 
+## Reviewers
+
+Suggest reviewers; never assign them. The user always chooses from the suggestions.
+
+Run the script to rank candidates from the git history of the changed files. It excludes you and needs no arguments:
+
+```bash
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/suggest-reviewers.ts
+```
+
+- **Blame owners**: people who wrote the lines you're changing. Suggest the top one or two.
+- **Sole-author fallback**: when the output reports you're the sole author of the area, use the recent in-area PR/MR refs it prints—look up who you requested review from on those and suggest the recurring names.
+
+Resolve names to platform usernames only after the user accepts, then pass them when creating the PR/MR:
+
+- **GitHub**: `gh pr create --reviewer <user>` (resolve emails to logins with `mcp__github` if needed)
+- **GitLab**: load `gitlab:merge-request` for username resolution before `--reviewer`
+
 ## Workflow
 
 1. **Branch validation**: If the context above shows you're on a default branch (main/master), stop and ask the user to switch to a feature branch first.
 1. Stage changes if not already staged: `git add .`
 1. Commit if there are no commits yet on the branch. Follow the same format for the commit message as for the pull request title (conventional or subject-oriented based on repo standard): `git commit -m "..."`
 1. Push the branch to remote: `git push -u origin HEAD`
+1. Suggest reviewers (see [Reviewers](#reviewers)). Present the candidates and include only the ones the user accepts via `--reviewer` below.
 1. Create the PR/MR:
    - Write the body to a temp file first (e.g., `tmp/pr-body-<branch>.md`)
    - Include the branch name in the filename to avoid conflicts with concurrent agents
-   - **GitHub**: `gh pr create --title "..." --body-file tmp/pr-body-<branch>.md`
-   - **GitLab**: `glab mr create --title "..." --description "$(cat tmp/pr-body-<branch>.md)"`
+   - **GitHub**: `gh pr create --title "..." --body-file tmp/pr-body-<branch>.md [--reviewer u1,u2]`
+   - **GitLab**: `glab mr create --title "..." --description "$(cat tmp/pr-body-<branch>.md)" [--reviewer u1,u2]`
 
 ## GitLab Notes
 


### PR DESCRIPTION
Adds reviewer suggestions to `pull-request:create`. A new `suggest-reviewers.ts` ranks candidates from `git blame` of the changed files, excluding you. When you're the sole author of the area, it surfaces recent in-area PR/MR refs so the skill can fall back to people you've requested review from there.

The script is provider-agnostic (pure git) and emits JSON. Username resolution and the actual `--reviewer` request stay in the skill, with GitLab's lookup delegated to `gitlab:merge-request`. Suggestions are never auto-assigned—the create workflow presents them and adds only what you accept.

## Changes

- `scripts/suggest-reviewers.ts` — emits `{ owners, soleAuthor, areaRefs }`: blame owners ranked by lines owned (you excluded by both email and name), a sole-author flag, and recent `#`/`!` refs parsed from commits touching the changed paths on the base branch.
- `skills/create/SKILL.md` — a `## Reviewers` section plus one workflow step that runs the script, presents candidates, and adds only accepted reviewers via `--reviewer`.

## Testing

`bun test plugins/pull-request` (29 pass), `tsc --noEmit`, and `biome check` all clean. Unit tests cover blame ranking, self-exclusion (including a differing-email alias matched by name), the sole-author fallback, GitLab `!`-ref parsing, and dropping files deleted at HEAD.

https://claude.ai/code/session_011bU8XvqWE3es6F4cY62TB6

---
_Generated by [Claude Code](https://claude.ai/code/session_011bU8XvqWE3es6F4cY62TB6)_