### PR TITLE
pull-request: lead bodies with intent, add dry-run

### DIFF
--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -36,27 +36,17 @@ allowed-tools:
 
 ## Body
 
-- Start with 1-3 sentences summarizing the change (no preceding header). Stick to active voice. Don't use passive ("Retry logic was added"); rewrite so something is actually doing the verb
-  - Self-evident description of what the PR does: PR-as-subject is fine ("Adds retry logic to the HTTP client") or subject-elided in bullets ("Added retry logic")
-  - Design decisions and judgment calls: use "I" so it's clear you made the call ("I chose X over Y because…", "I kept the old endpoint to avoid a breaking change")
-- If the PR is directly motivated by an issue, reference it at the end of the opening summary (`Closes #N`, `Fixes #N`, or just `#N` if not closing). Related issues mentioned for context belong in a `## References` section. Never drop issue refs at the bottom of the body without a section
-- **Wrap all code identifiers with backticks**: function names, class names, file paths, endpoints, status codes, etc.
-- Use `##` sections for larger changes. See [`sections.md`](sections.md) for detailed guidance on:
-  - `## Issue` - Root cause analysis and issue linking
-  - `## Changes` - High-level description of changes
-  - `## Testing` - Test coverage insights
-  - `## References` - Related links and issues
+The body conveys what the diff cannot: why this change, what you decided along the way, and how you know it works. The reviewer reads the diff for what changed, so don't restate it. Spend the body on intent and the decisions a reviewer can't reconstruct from the code.
 
-#### Voice
+Mine the conversation that produced this change. The substance lives there: decisions and the alternatives you rejected, deviations from the issue or plan, theories you tried and overturned, what you observed testing locally, limitations you ruled out, naming or scope you settled by hand. Put it in the body, where the reviewer will read it. Keep it out of code comments.
 
-Write plainly. Technical precision is good, marketing is not. Match the author's own voice: a developer explaining the change to a reviewer, not selling it.
+- Open with what changed (a bare verb: "Adds", "Fixes", "Removes") when the change is self-evident, or with the problem when the change needs justifying. Don't restate the title.
+- Length tracks substance, not diff size. A subtle one-line fix may need paragraphs. A large mechanical change may need two sentences.
+- Default to prose. Use `##` sections only when the body is long enough to need them. Small PRs are a tight paragraph with no headers.
+- Reference the motivating issue at the end of the opening (`Closes #N`, `Fixes #N`, or `#N` if not closing). Related-for-context issues go in a `## References` section, never bare at the bottom.
+- Wrap code identifiers in backticks: function names, class names, file paths, endpoints, status codes.
 
-- Open with a bare present-tense verb: "Adds", "Fixes", "Changes", "Updates". State the mechanism first, then the motivation
-- Use a concrete noun where one exists. A metaphor is rarely shorter than the real name
-- Length tracks substance. A one-line change gets a one-line body. Don't pad
-- Hedge and name rejected alternatives honestly ("I doubt anyone has hit this", "I chose X over Y because…", "unrelated, required to run tests")
-- Avoid model flourishes: `source of truth`, `fail loudly`, `escape hatch`, `wires up`, `cleanly`. The antithesis construction (`X instead of Y`) is usually padding
-- Load the `writing` skill for the full set of tropes to avoid
+See [`sections.md`](sections.md) for the substance catalog (what to surface, by change type), optional-section guidance, how to ground claims in evidence, and the slop patterns to cut. Load the `writing` skill for the full set of tropes to avoid.
 
 ## Template
 
@@ -66,10 +56,10 @@ When a PR template is provided in context above, follow its structure instead of
 - Leave checklists (checkbox items) untouched for the user to complete manually
 - Remove HTML comments (`<!-- ... -->`) that serve as placeholder instructions
 - Map skill-generated content into corresponding template sections:
-  - Description/summary sections: use the opening summary sentences
-  - Changes/what sections: use `## Changes` content from `sections.md`
-  - Testing/verification sections: use `## Testing` content from `sections.md`
-  - Issue/references sections: use `## Issue` and `## References` content
+  - Description/summary sections: the opening plus the conversation substance (decisions, deviations, what you observed testing)
+  - Changes/what sections: follow the `## Changes` guidance in `sections.md`
+  - Testing/verification sections: follow the `## Testing` guidance in `sections.md`
+  - Issue/references sections: the motivating issue ref and `## References` content
 - For template sections with no skill equivalent (e.g., type-of-change dropdowns), fill them based on the diff context
 - Within each template section, follow the style rules from `sections.md`
 - If the template has a free-form description section, place the summary sentences there and add skill subsections within it as needed
@@ -101,7 +91,13 @@ Resolve names to platform usernames only after the user accepts, then pass them 
 - **GitHub**: `gh pr create --reviewer <user>` (resolve emails to logins with `mcp__github` if needed)
 - **GitLab**: load `gitlab:merge-request` for username resolution before `--reviewer`
 
+## Dry Run
+
+If the arguments include `--dry-run` (alias `--body-only`), produce the body without creating anything. Determine the title and body from the context above as usual, write the body to `tmp/pr-body-<branch>.md`, then print the title and body to the user and stop. Do not stage, commit, push, or run `gh pr create` / `glab mr create`. Use this to preview or evaluate the body in isolation.
+
 ## Workflow
+
+If `--dry-run` (or `--body-only`) is set, follow the Dry Run section instead of the steps below.
 
 1. **Branch validation**: If the context above shows you're on a default branch (main/master), stop and ask the user to switch to a feature branch first.
 1. Stage changes if not already staged: `git add .`

--- a/plugins/pull-request/skills/create/evals/evals.json
+++ b/plugins/pull-request/skills/create/evals/evals.json
@@ -1,0 +1,42 @@
+{
+  "skill_name": "pull-request:create",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Open a PR for this fix. The session above traced the bug to a wrong theory first (we thought the exit code was lost) before finding the real cause, and we dropped a unit test because the test runner couldn't make it fail.",
+      "expected_output": "A prose-led body that leads with the real cause, names the disproven theory, and notes the dropped test with its reason. No reflexive section scaffold on a small fix.",
+      "files": [],
+      "expectations": [
+        "The body leads with intent or the real root cause, not a file-by-file summary",
+        "It surfaces the overturned theory that was discussed in the session, not just the final fix",
+        "It notes the dropped test and the concrete reason it was dropped",
+        "A small fix is a tight paragraph with no reflexive ## Changes plus ## Testing scaffold",
+        "No test counts and no 'all tests pass' phrasing"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Create a PR for this skill change. We deviated from the plan: an extra allowed-tools entry was added beyond what the plan listed, and you renamed the two modes mid-session at my request.",
+      "expected_output": "A body that surfaces the scope deviation and the user-driven rename as the decisions they were, organized by concept.",
+      "files": [],
+      "expectations": [
+        "The body states the deviation from the plan (the extra scope added) rather than smoothing it over",
+        "It does not make a false claim that contradicts the diff (e.g. naming the wrong set of additions)",
+        "The user-driven naming decision is surfaced as a decision, not presented as obvious",
+        "Changes are organized by concept, never as **path**: description bullets"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Write the PR body. I verified this manually against the live tool since it couldn't be unit tested, and I benchmarked the slow path.",
+      "expected_output": "A body whose testing notes state what was observed and what could not be automated, with the concrete reason, not a coverage inventory.",
+      "files": [],
+      "expectations": [
+        "Testing notes state what manual verification showed or what breaks without the fix, not that tests exist",
+        "What could not be tested is named with a concrete reason",
+        "Benchmark or observed numbers from the session appear in the body",
+        "No test counts, no 'all tests pass', no listing of test file names without coverage detail"
+      ]
+    }
+  ]
+}

--- a/plugins/pull-request/skills/create/sections.md
+++ b/plugins/pull-request/skills/create/sections.md
@@ -1,60 +1,63 @@
-# Pull Request Sections
+# Pull Request Body
 
-Detailed guidance for optional PR body sections.
+What goes in the body, and what to leave out. The create and update skills both use this.
 
-Stick to active voice. Don't use passive ("X was added"). Rewrite so something is doing the verb.
+The body conveys what the diff cannot. The reviewer reads the code for what changed. Use the body for why it changed, the decisions you made, and how you know it works. If a sentence only restates what the diff shows, cut it.
 
-- Self-evident description of what the PR does: PR-as-subject is fine ("Adds retry logic") or subject-elided in bullets ("Added retry logic", "Extracted the helper")
-- Design decisions and judgment calls: use "I" so it's clear you made the call ("I chose X over Y because…")
+Write in active voice and first person for your own calls. "I chose X over Y because…", "I traced this to…". Don't write passively ("X was added", "the bug was caused by…"). Keep the prose plain. Technical terms are fine. Marketing and model flourishes (`source of truth`, `fail loudly`, `escape hatch`, `cleanly`, `wires up`) are not. Load the `writing` skill for the full set of tropes.
 
-Keep the prose plain. Technical terms are fine. Marketing phrasing and model flourishes (`source of truth`, `fail loudly`, `escape hatch`, `cleanly`) are not. Load the `writing` skill for the full set of tropes to avoid.
+## Shape
 
-## Issue
+Default to prose, not a scaffold.
 
-Use for bug fixes, which should include a related issue.
+- Open with what changed (a bare verb: "Adds", "Fixes", "Removes") when the change is self-evident, or with the problem when the change needs justifying. Don't restate the title. Don't open with "This PR introduces".
+- Length tracks substance, not diff size. A subtle one-line fix may need paragraphs of root-cause reasoning. A large mechanical change may need two sentences.
+- Use `##` sections only when the body is long enough to need them. A small PR is a tight paragraph with no headers.
 
-- Describe the root cause as the author ("I traced this to…", "I found that…"). Avoid passive writeups ("the bug was caused by…")
-- Link existing issues with `Closes #123` or `Fixes #456`
+## Mine the Conversation
 
-## Changes
+The most valuable content is the substance that lived in the session but never reached the code. Review the conversation that produced the change and surface what applies. This belongs in the PR body, not in code comments where Claude tends to leak it.
 
-Organize by concept, not by file. Each bullet should describe a single conceptual shift, even when it spans multiple files. The reviewer reads this to understand *what's different and why*, not to get a tour of modified files.
+- Decisions and the alternatives you rejected. Name what you chose against and why you didn't take it.
+- Deviations from the issue or plan. Where the implementation departed from what was specified, and the scope you added or dropped (an extra `allowed-tools` entry, files touched beyond the plan, a feature cut).
+- Overturned theories. A root cause you diagnosed then disproved, an approach you built then abandoned. The diff shows the destination. The reviewer benefits from the wrong turn you already ruled out.
+- What you observed testing locally. The actual result, surprise, or failure mode, not just "verified". Benchmark or cost numbers. What you couldn't test and the concrete reason ("brew install failed locally", not "needs a real machine").
+- Limitations you ruled out. A workaround you considered and rejected as too fragile, a feature deferred as structural. This explains non-changes a reviewer might otherwise question.
+- Naming or interface settled by hand. A name the user chose during the work, surfaced as the decision it was rather than presented as obvious.
+- Deferred follow-ups, named concretely ("follow-up in #N to…"), not a vague TODO.
 
-- Lead with the conceptual change, not the file location. Subject-elided phrasing works for plain description ("Extracted the helper", "Replaced X with Y"); use "I" when a bullet explains a judgment call. Don't use passive ("X was added")
-- Omit cleanup that follows naturally from the main change (e.g. removing dead imports). The diff shows this
-- Never structure bullets as `**path**: description`
-- Reference code identifiers only when they add information beyond what the diff shows. Use the shortest unambiguous name (module, filename, or component, not full paths)
-- When referring to a set of things changed, write naturally: enumerate short lists inline (e.g. "hook command variants (command, model, prompt)"), use "all" or "each" for large sets. Never pair a count with the enumeration ("all three X (a, b, c)"). Either enumerate or summarize, not both
+Not every PR has all of these. Include only what a reviewer would act on. True but inert detail is padding. Aim for the substance that changes how someone reviews or uses the change. When the work ran through sub-agents, the substance is in their returned summaries. Pull it forward before it gets smoothed away.
 
-## Testing
+### By Change Type
 
-Only include if tests were added/modified or manual testing was performed. Omit entirely if no testing discussion is relevant.
+- Visual or GUI work: screenshots or a recording of the result. Rejected layouts. Bugs only live rendering surfaced.
+- Backend or API work: an example request and response. The mechanism proof for a fix (what breaks without it). Performance numbers.
+- Config, tooling, or prose: scope deviations, what you deliberately did not build, and the evidence that grounds the design.
 
-**NEVER mention test counts** - phrases like "Added N tests" or "13 unit tests" provide no value. The number of tests doesn't indicate coverage quality, and readers can count tests themselves if they care.
+## Ground Claims in Evidence
 
-Focus on **what** is covered and **why** it matters:
+Prefer showing to asserting. Link a permalink to the exact lines instead of paraphrasing code. Blockquote the doc or spec you reason from. Paste the real error, stack trace, or test output in a fence rather than describing it. "Reverting the fix makes `TestX` fail with `exit 2`" beats "added a test for the fix".
 
-**Good examples:**
-- "Added tests covering error handling for malformed JSON responses"
-- "Added integration tests for the full request/response cycle"
-- "Extended the auth tests to cover the new OAuth flow"
-- "Verified edge cases: empty input, null values, and Unicode handling"
+## Optional Sections
 
-**Coverage gaps**: Note anything that merited testing but was difficult to automate:
-- "Left rate-limiting behavior for manual verification against the live API"
-- "Verified visual layout changes in the browser but didn't add snapshot coverage"
+Use these only when the body is long enough to earn them. A small PR stays a paragraph.
 
-**Manual verification**: Include any testing done outside of automated tests—running commands, checking output, verifying behavior in a browser or tool. This counts whether performed by the user or by Claude during the session.
+### Changes
 
-**Patterns to avoid:**
-- "Added N tests" or "N unit tests" (counts are noise)
-- "All tests passed" (CI shows this)
-- "Tests work correctly" (too vague)
-- Listing test file names without explaining coverage
+Organize by concept, not by file. Each bullet is one conceptual shift, even when it spans files. Never write `**path**: description`. Reference an identifier only when it adds something the diff doesn't. Don't pair a count with an enumeration ("all three X (a, b, c)"). Enumerate or summarize, not both. Omit cleanup that follows from the main change (dead imports). The diff shows it.
 
-## References
+### Testing
 
-Only include if there are relevant links or related issues.
+Only if you added tests or tested by hand. State what the test proves, not that it exists. The falsification ("reverting the fix makes `TestX` fail"), the edge cases covered, what you verified manually and what you couldn't. Never test counts ("added 5 tests"). They measure nothing. Never "all tests pass". CI shows that. Paste real output over claiming success.
 
-- Bulleted list of links, related issues, code reviews
-- Use `Closes #<issue>` if the change closes an issue
+### References
+
+Related links, issues, or reviews that aren't the motivating issue. Use `Closes #N` for what this resolves and `Relates to #N` for context, keeping the two distinct.
+
+## Slop to Cut
+
+- The reflexive `## Changes` plus `## Testing` scaffold on every PR. Small PRs don't need it.
+- Bullets that narrate which file changed. If a bullet only says what the diff shows, delete it.
+- Test counts, "all tests pass", coverage inventories.
+- Count-padding ("six detectors, three and three"). The number is rarely the point.
+- The consequence chain (`, so the…`) used as a filler connective, and the antithesis (`not just X but Y`, `X instead of Y`) used as framing. Both read as tics when habitual.

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -41,7 +41,7 @@ The PR body documents what will happen when merged, not the journey. Don't echo 
 
 ## Writing
 
-1. Rewrite the PR body following the same title and body rules as the create skill, including its plain-voice guidance. Load the `writing` skill for the full set of tropes to avoid. If a PR template is provided in context, preserve its structure. See [`sections.md`](../create/sections.md) for section guidance.
+1. Rewrite the PR body following the same rules as the create skill. Lead with intent and the decisions a reviewer can't read off the diff, default to prose, and add `##` sections only when length earns them. Load the `writing` skill for the full set of tropes to avoid. If a PR template is provided in context, preserve its structure. See [`sections.md`](../create/sections.md) for the body guidance.
 2. Write the updated body to a temp file (e.g., `tmp/pr-body-<branch>.md`) and apply:
    - **GitHub**: `gh pr edit --body-file tmp/pr-body-<branch>.md`
    - **GitLab**: `glab mr update --description "$(cat tmp/pr-body-<branch>.md)"`


### PR DESCRIPTION
Reworks the `pull-request` body guidance to lead with intent and mine the working conversation, instead of stamping a `## Changes` plus `## Testing` scaffold on every PR. Adds a `--dry-run` mode to the create skill that writes and prints the body without opening anything.

The old guidance produced formulaic bodies: a code summary, a file-by-file change tour, and a reflexive testing section. The substance a reviewer actually needs (the decisions made along the way, deviations from the issue, what local testing showed) was treated as optional garnish and often leaked into code comments. In sensitive open-source repos that reads as AI slop.

The redesign reframes the body's job as conveying what the diff cannot. `sections.md` becomes a substance catalog: decisions and rejected alternatives, deviations from the plan, overturned theories, what you observed testing locally, limitations you ruled out, naming settled by hand. Named sections are optional now, earned by length. The default is prose whose length tracks substance.

#### Decisions

I kept some structure rather than reverting to native behavior, which defaults to checklists and code summaries. The shape I chose is intent-first prose with optional sections, picked over a looser "keep the sections but demote them" variant and a "substance menu" variant. The target was my own pre-AI PR voice: prose-first, decision-focused, grounded in links and pasted output.

#### Validation

I grounded the rewrite in three research passes: a slop catalog of recent AI-era bodies, a voice study of my hand-written pre-AI PRs, and a substance catalog mined from session transcripts paired to their merged PRs. The finding that shaped the design: the slop is structural. It lives in the scaffold and the diff-restating bullets, which `writing:score` barely measures.

To check the result, I ran a before/after eval on five merged PRs, each paired with its originating session transcript. Two writer agents got identical inputs (the diff and the conversation) and differed only in old-versus-new guidance. A blind judge preferred the new guidance on all five, with equal or better coverage of the substance that lived in each conversation. Eval inputs hold private session data and stay local under `tmp/`. A reusable assertion set lands in `evals/`.

One caveat worth watching: the new bodies trend longer on substance-rich PRs. The guidance guards against padding, but over-surfacing is the failure mode to watch.
