### PR TITLE
pull-request: warn on structural body slop

### DIFF
--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -12,9 +12,65 @@ function hasBashCommand(input: unknown): input is { command: string } {
 const TEST_COUNT_PATTERN =
   /[Aa]dded [0-9]+ (unit |integration )?tests|[0-9]+ (unit |integration )?tests/;
 
+// Mirrors the writing plugin's "template on small document" detector: a full
+// `## Changes` + `## Testing` scaffold on a body under this many words is
+// over-structured. Reimplemented locally to avoid a cross-plugin import.
+const SMALL_BODY_WORD_LIMIT = 150;
+
+const CHANGES_HEADING_PATTERN = /^##\s+Changes\b/m;
+const TESTING_HEADING_PATTERN = /^##\s+Testing\b/m;
+
+// File-tour bullet: a `- **label:**` or `* **label:**` item whose bold label
+// names a file rather than a concept. Captures the label so the path heuristic
+// can inspect it.
+const BOLD_LABEL_BULLET_PATTERN = /^\s*[-*]\s+\*\*([^*]+?)\*\*:/gm;
+
+const FILE_EXTENSION_PATTERN =
+  /\.(ts|tsx|js|jsx|mjs|cjs|json|md|txt|py|rb|go|rs|java|c|h|cpp|sh|yml|yaml|toml|css|html|sql)$/i;
+
+function countWords(text: string): number {
+  return text.split(/\s+/).filter(Boolean).length;
+}
+
+function looksLikeFilePath(label: string): boolean {
+  const trimmed = label
+    .trim()
+    .replace(/^`+|`+$/g, "")
+    .trim();
+  if (trimmed.length === 0) return false;
+  if (trimmed.includes("/")) return true;
+  return FILE_EXTENSION_PATTERN.test(trimmed);
+}
+
+export function hasReflexiveScaffold(body: string): boolean {
+  if (countWords(body) >= SMALL_BODY_WORD_LIMIT) return false;
+  return CHANGES_HEADING_PATTERN.test(body) && TESTING_HEADING_PATTERN.test(body);
+}
+
+export function hasFileTourBullets(body: string): boolean {
+  for (const match of body.matchAll(BOLD_LABEL_BULLET_PATTERN)) {
+    const label = match[1];
+    if (label && looksLikeFilePath(label)) return true;
+  }
+  return false;
+}
+
 export function extractBodyFilePath(command: string): string | null {
   const match = command.match(/--body-file[=\s]([^\s]+)/);
   return match?.[1] ?? null;
+}
+
+function warn(reasons: string[]): SyncHookJSONOutput {
+  const intro =
+    reasons.length === 1
+      ? "PR body has a structural-slop pattern:"
+      : "PR body has structural-slop patterns:";
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      additionalContext: `${intro}\n${reasons.map((reason) => `- ${reason}`).join("\n")}`,
+    },
+  };
 }
 
 export function validateBody(body: string): SyncHookJSONOutput | null {
@@ -27,6 +83,21 @@ export function validateBody(body: string): SyncHookJSONOutput | null {
           "Testing section should not mention test counts. Describe what is covered instead.",
       },
     };
+  }
+
+  const reasons: string[] = [];
+  if (hasReflexiveScaffold(body)) {
+    reasons.push(
+      "Small PRs don't need a `## Changes` + `## Testing` scaffold. Length tracks substance. Use prose for a short change.",
+    );
+  }
+  if (hasFileTourBullets(body)) {
+    reasons.push(
+      "Bullets shaped like `- **path/to/file**: ...` narrate a file tour. Describe the conceptual change instead of walking the diff file by file.",
+    );
+  }
+  if (reasons.length > 0) {
+    return warn(reasons);
   }
 
   return null;

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -4,7 +4,13 @@ import { rm } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { extractBodyFilePath, processInput, validateBody } from "./validate-body";
+import {
+  extractBodyFilePath,
+  hasFileTourBullets,
+  hasReflexiveScaffold,
+  processInput,
+  validateBody,
+} from "./validate-body";
 
 function getPermissionDecision(result: Awaited<ReturnType<typeof validateBody>>) {
   const output = result?.hookSpecificOutput;
@@ -13,6 +19,20 @@ function getPermissionDecision(result: Awaited<ReturnType<typeof validateBody>>)
   }
   return undefined;
 }
+
+function getAdditionalContext(result: Awaited<ReturnType<typeof validateBody>>) {
+  const output = result?.hookSpecificOutput;
+  if (output && "additionalContext" in output) {
+    return output.additionalContext;
+  }
+  return undefined;
+}
+
+const LONG_PROSE = Array(40)
+  .fill(
+    "The cache reduces round-trips to the database by storing frequently accessed records in memory with a configurable TTL.",
+  )
+  .join(" ");
 
 describe("extractBodyFilePath", () => {
   it("returns null when command has no --body-file", () => {
@@ -73,6 +93,90 @@ describe("validateBody", () => {
     const result = validateBody("## Test plan\nadded 10 tests");
     expect(result).not.toBeNull();
     expect(getPermissionDecision(result)).toBe("deny");
+  });
+
+  it("warns (does not deny) on a reflexive scaffold in a small body", () => {
+    const result = validateBody(
+      "## Changes\n\n- Adds a flag\n\n## Testing\n\nRan the suite.\n\nFixes #1",
+    );
+    expect(result).not.toBeNull();
+    expect(getPermissionDecision(result)).toBeUndefined();
+    expect(getAdditionalContext(result)).toContain("scaffold");
+  });
+
+  it("warns on file-tour bullets", () => {
+    const result = validateBody(
+      "## Changes\n\n- **src/cache.ts**: adds an LRU cache\n- **src/index.ts**: wires it up",
+    );
+    expect(result).not.toBeNull();
+    expect(getPermissionDecision(result)).toBeUndefined();
+    expect(getAdditionalContext(result)).toContain("file tour");
+  });
+
+  it("combines both structural warnings into one message", () => {
+    const result = validateBody(
+      "## Changes\n\n- **src/cache.ts**: adds a cache\n\n## Testing\n\nManual.",
+    );
+    expect(getPermissionDecision(result)).toBeUndefined();
+    const context = getAdditionalContext(result);
+    expect(context).toContain("scaffold");
+    expect(context).toContain("file tour");
+  });
+
+  it("lets a test-count deny take precedence over structural warnings", () => {
+    const result = validateBody(
+      "## Changes\n\n- **src/cache.ts**: adds a cache\n\n## Testing\n\nAdded 5 tests",
+    );
+    expect(getPermissionDecision(result)).toBe("deny");
+  });
+
+  it("does not warn on a large PR with earned sections", () => {
+    const body = `${LONG_PROSE}\n\n## Changes\n\n- Adds the LRU cache\n\n## Testing\n\nManual exercise of expiry and eviction.`;
+    expect(validateBody(body)).toBeNull();
+  });
+
+  it("does not warn on concept-labeled bold bullets", () => {
+    const result = validateBody(
+      "## Changes\n\n- **Caching**: stores records in memory\n- **Eviction**: drops the oldest entry",
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("hasReflexiveScaffold", () => {
+  it("flags a small body with both Changes and Testing headings", () => {
+    expect(hasReflexiveScaffold("## Changes\n\n- x\n\n## Testing\n\ny")).toBe(true);
+  });
+
+  it("does not flag when only one heading is present", () => {
+    expect(hasReflexiveScaffold("## Changes\n\n- x")).toBe(false);
+  });
+
+  it("does not flag a body at or over the word limit", () => {
+    const body = `${LONG_PROSE}\n\n## Changes\n\n- x\n\n## Testing\n\ny`;
+    expect(hasReflexiveScaffold(body)).toBe(false);
+  });
+});
+
+describe("hasFileTourBullets", () => {
+  it("flags a bold label with a path separator", () => {
+    expect(hasFileTourBullets("- **src/cache.ts**: adds a cache")).toBe(true);
+  });
+
+  it("flags a bold label that ends in a file extension", () => {
+    expect(hasFileTourBullets("* **cache.ts**: adds a cache")).toBe(true);
+  });
+
+  it("flags a bold label wrapped in backticks denoting a path", () => {
+    expect(hasFileTourBullets("- **`lib/foo.ts`**: refactors it")).toBe(true);
+  });
+
+  it("does not flag a plain concept label", () => {
+    expect(hasFileTourBullets("- **Caching**: stores records in memory")).toBe(false);
+  });
+
+  it("does not flag a multi-word concept label", () => {
+    expect(hasFileTourBullets("- **Retry logic**: backs off exponentially")).toBe(false);
   });
 });
 


### PR DESCRIPTION
Adds two structural-slop checks to the `pull-request` PR-body validation hook. #818 reworked the body guidance to be intent-first and to warn against the two worst structural patterns in prose, but nothing enforced it. The existing hook only caught test-count mentions. This extends `validateBody` to also flag the reflexive `## Changes` + `## Testing` scaffold on small bodies and file-tour bullets shaped like `- **path/to/file**: ...`.

Both new checks warn, they don't block. I chose warn-not-block deliberately because the heuristics trade recall for precision and I'd rather surface advice than gate a `gh pr create` on a false positive. The test-count check stays a `deny`, and when a deny and a warning both fire the deny wins since it's more restrictive. The warning surfaces through the `PreToolUse` hook's non-blocking `additionalContext` field (the same mechanism the `writing` plugin's hooks use), not a `permissionDecision`. When only structural issues are found I emit one combined `additionalContext` message listing them and let the command run.

The detection is reimplemented locally rather than imported from `plugins/writing`. Plugins can't import across the plugin boundary, so I mirrored the writing plugin's "template on small document" threshold (~150 words) and wrote a self-contained path heuristic for the bullet check. The bullet check only fires when the bold label resembles a file: it contains a `/`, ends in a known extension, or is a backtick-wrapped path. A plain concept label like `**Caching**:` is left alone.

## Testing

Unit tests cover both checks at the pure-function and `validateBody` levels: the true positives, the deny-takes-precedence ordering, the combined-warning message, and the false negatives that matter (a long body with earned sections, and concept-labeled bold bullets).
