### PR TITLE
Add ask skill for converting prose to structured questions

### DIFF
--- a/user/skills/ask/SKILL.md
+++ b/user/skills/ask/SKILL.md
@@ -11,3 +11,5 @@ I just read a wall of text from you. Stop and turn it into structured questions 
 - Pull out each open decision from what you just wrote and make it its own question. Don't bury choices in a paragraph.
 - Prefer options that carry a `preview` (the code-example form). A preview lets me select a suggestion and attach my own notes on top of it, so I can accept your direction while adding commentary. Use it whenever an option has a concrete artifact to show: a snippet, a diff, a config block, sample output.
 - Only ask about decisions that are genuinely mine. Decide anything with an obvious default yourself and say so.
+- Every question should have a recommended option. If you can't recommend one, you don't understand the problem well enough to ask it. Don't ask a blind question and infer my intent from which option I pick. Ask more, smaller questions that let me clarify intent first.
+- Err toward asking more questions, not fewer. My invoking this command means I want to be asked.

--- a/user/skills/ask/SKILL.md
+++ b/user/skills/ask/SKILL.md
@@ -6,10 +6,8 @@ disable-model-invocation: true
 
 # Ask
 
-I just read a wall of text from you. Stop and turn it into structured questions with the `AskUserQuestion` tool instead of asking me in prose.
+I just read a wall of text from you. Stop and turn it into structured questions with the `AskUserQuestion` tool instead of asking me in prose. You know how the tool works. This is what I care about:
 
 - Pull out each open decision from what you just wrote and make it its own question. Don't bury choices in a paragraph.
-- Give every option a concrete `label` and a `description` of the trade-off. Lead with your recommended option and mark it `(Recommended)`.
 - Prefer options that carry a `preview` (the code-example form). A preview lets me select a suggestion and attach my own notes on top of it, so I can accept your direction while adding commentary. Use it whenever an option has a concrete artifact to show: a snippet, a diff, a config block, sample output.
-- Use `multiSelect: true` when the choices aren't mutually exclusive.
 - Only ask about decisions that are genuinely mine. Decide anything with an obvious default yourself and say so.

--- a/user/skills/ask/SKILL.md
+++ b/user/skills/ask/SKILL.md
@@ -6,11 +6,11 @@ disable-model-invocation: true
 
 # Ask
 
-I just read a wall of text from you. Stop and turn it into structured questions with the `AskUserQuestion` tool instead of asking me in prose. You know how the tool works. This is what I care about:
+Turn that wall of text into structured questions with the `AskUserQuestion` tool instead of prose. You know the tool. This is what I care about:
 
-- Pull out each open decision from what you just wrote and make it its own question. Don't bury choices in a paragraph.
-- Prefer options that carry a `preview` (the code-example form). A preview lets me select a suggestion and attach my own notes on top of it, so I can accept your direction while adding commentary. Use it whenever an option has a concrete artifact to show: a snippet, a diff, a config block, sample output.
-- Only ask about decisions that are genuinely mine. Decide anything with an obvious default yourself and say so.
-- Every question should have a recommended option. If you can't recommend one, you don't understand the problem well enough to ask it. Don't ask a blind question and infer my intent from which option I pick. Ask more, smaller questions that let me clarify intent first.
-- Err toward asking more questions, not fewer. My invoking this command means I want to be asked.
-- The questions in one batch are answered in parallel, so no answer can shape a later question in the same batch. When a follow-up depends on how I answered something, don't cram it into the same batch. Ask the first batch, read my answers, then call the tool again with the next batch informed by them.
+- Make each open decision its own question. Don't bury choices in a paragraph.
+- Prefer options with a `preview` (the code-example form). It lets me select a suggestion and add my own notes on top, accepting your direction while adding commentary. Use it whenever an option has a concrete artifact: a snippet, diff, config block, sample output.
+- Only ask decisions that are genuinely mine. Decide obvious defaults yourself and say so.
+- Every question needs a recommended option. If you can't recommend one, you don't understand the problem well enough to ask it. Don't ask blind and infer intent from my pick. Ask more, smaller questions instead.
+- Err toward more questions, not fewer. Invoking this command means I want to be asked.
+- A batch is answered in parallel, so no answer can shape a later question in the same batch. When a follow-up depends on an earlier answer, split it: ask, read my answers, then call the tool again informed by them.

--- a/user/skills/ask/SKILL.md
+++ b/user/skills/ask/SKILL.md
@@ -13,3 +13,4 @@ I just read a wall of text from you. Stop and turn it into structured questions 
 - Only ask about decisions that are genuinely mine. Decide anything with an obvious default yourself and say so.
 - Every question should have a recommended option. If you can't recommend one, you don't understand the problem well enough to ask it. Don't ask a blind question and infer my intent from which option I pick. Ask more, smaller questions that let me clarify intent first.
 - Err toward asking more questions, not fewer. My invoking this command means I want to be asked.
+- The questions in one batch are answered in parallel, so no answer can shape a later question in the same batch. When a follow-up depends on how I answered something, don't cram it into the same batch. Ask the first batch, read my answers, then call the tool again with the next batch informed by them.

--- a/user/skills/ask/SKILL.md
+++ b/user/skills/ask/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: ask
+description: Shorthand to make Claude convert a wall of prose into structured questions via the AskUserQuestion tool. Invoke with /ask.
+disable-model-invocation: true
+---
+
+# Ask
+
+I just read a wall of text from you. Stop and turn it into structured questions with the `AskUserQuestion` tool instead of asking me in prose.
+
+- Pull out each open decision from what you just wrote and make it its own question. Don't bury choices in a paragraph.
+- Give every option a concrete `label` and a `description` of the trade-off. Lead with your recommended option and mark it `(Recommended)`.
+- Prefer options that carry a `preview` (the code-example form). A preview lets me select a suggestion and attach my own notes on top of it, so I can accept your direction while adding commentary. Use it whenever an option has a concrete artifact to show: a snippet, a diff, a config block, sample output.
+- Use `multiSelect: true` when the choices aren't mutually exclusive.
+- Only ask about decisions that are genuinely mine. Decide anything with an obvious default yourself and say so.

--- a/user/skills/ask/SKILL.md
+++ b/user/skills/ask/SKILL.md
@@ -6,11 +6,11 @@ disable-model-invocation: true
 
 # Ask
 
-Turn that wall of text into structured questions with the `AskUserQuestion` tool instead of prose. You know the tool. This is what I care about:
+Turn the preceding prose into `AskUserQuestion` calls.
 
-- Make each open decision its own question. Don't bury choices in a paragraph.
-- Prefer options with a `preview` (the code-example form). It lets me select a suggestion and add my own notes on top, accepting your direction while adding commentary. Use it whenever an option has a concrete artifact: a snippet, diff, config block, sample output.
-- Only ask decisions that are genuinely mine. Decide obvious defaults yourself and say so.
-- Every question needs a recommended option. If you can't recommend one, you don't understand the problem well enough to ask it. Don't ask blind and infer intent from my pick. Ask more, smaller questions instead.
-- Err toward more questions, not fewer. Invoking this command means I want to be asked.
-- A batch is answered in parallel, so no answer can shape a later question in the same batch. When a follow-up depends on an earlier answer, split it: ask, read my answers, then call the tool again informed by them.
+- One question per open decision. Don't bury choices in a paragraph.
+- Prefer options with a `preview` (snippet, diff, config, sample output). It lets me accept a suggestion and add my own notes on top.
+- Only ask decisions that are mine. Decide obvious defaults yourself and say so.
+- Every question needs a recommended option. If you can't recommend one, you don't understand it well enough to ask. Ask more, smaller questions instead of inferring intent from one blind pick.
+- Err toward more questions. Invoking this means I want to be asked.
+- A batch is answered in parallel, so an answer can't shape a later question in the same batch. When a follow-up depends on an earlier answer, split the batches.


### PR DESCRIPTION
Adds a new user-level skill that provides a shorthand workflow for converting prose into structured `AskUserQuestion` calls.

## Summary

This skill (`/ask`) helps convert unstructured prose into well-formed decision questions by enforcing best practices for clarity, actionability, and user control. It's designed to be invoked explicitly when you want to be prompted for decisions rather than having the model make assumptions.

## Key Changes

- Added `user/skills/ask/SKILL.md` with skill definition and guidelines
- Skill enforces one question per decision with clear options
- Requires recommended options and preview snippets where possible
- Prevents the model from inferring intent; defers obvious defaults to the model itself
- Supports batching with awareness that follow-up questions depending on earlier answers should be split into separate batches

## Implementation Details

- Marked with `disable-model-invocation: true` to require explicit `/ask` invocation
- Provides clear heuristics for when to ask vs. decide (only ask user decisions, decide obvious defaults)
- Emphasizes quality over quantity while still encouraging comprehensive questioning

https://claude.ai/code/session_01GPA3gdmmtBWbDGLewjnT3i