### PR TITLE
user: add modernize skill

### DIFF
--- a/user/skills/modernize/SKILL.md
+++ b/user/skills/modernize/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: modernize
+disable-model-invocation: true
+description: Survey a project for ways to adopt newer language and major-dependency features that did not exist when the code was written, replacing boilerplate with modern idioms. Use when the user wants to modernize a codebase, adopt new language features, retire dependencies the stdlib now subsumes, or catch a project up to current framework APIs.
+---
+
+# Modernize
+
+Find where a project still does things the old way because newer features did not exist when it was written, and propose semantics-preserving swaps. The deliverable is a **ranked survey of candidates** the user picks from. Applying is a separate phase, run only on the candidates they choose.
+
+Language-agnostic by design. Detect the stack, never assume it.
+
+## Modernization axes
+
+Two axes, plus a third that is easy to miss:
+
+- **Language features.** Syntax and stdlib additions that replace boilerplate: pattern matching, comprehensions, `async`/`await` over callbacks, records and dataclasses, native nullability, structured concurrency.
+- **Major dependencies.** Framework and major-library APIs that supersede older usage, such as a new router, data-fetching primitive, or config format. Frameworks and load-bearing libraries only, not every transitive dependency.
+- **Stdlib subsumption.** A third-party dependency the language or runtime has since absorbed, like native `fetch`, `structuredClone`, `Array.prototype.flat`, or `std::format`. Retiring a now-redundant dependency is the highest-leverage move, because it deletes code and a dependency at once.
+
+## Three disciplines
+
+These separate modernization from churn. Hold them throughout.
+
+1. **Semantics-preserving.** A modernization changes *how* the code is written, never *what it does*. Behavior, public API, and error modes stay identical. A swap that would change behavior is a feature change, and belongs in the report only as a flagged note.
+
+2. **Earn its keep.** Newer is not a reason. Every candidate must buy something concrete: less boilerplate, stronger types or safety, a dropped dependency, real performance, or genuine clarity. Pure novelty is rejected. Churn has a cost (review burden, blame noise, risk) and the benefit must clear it.
+
+3. **Respect the floor.** A project has a *minimum supported version*: the oldest runtime or language version it promises to run on (an app's deploy target, a library's declared `engines`, edition, or `*_requires`). A feature newer than the floor cannot be adopted for free. Adopting it silently raises the floor and breaks consumers. Those candidates are **flagged bumps**, reported separately with the version they require, never applied as part of adopt-now. See [references/survey.md](references/survey.md).
+
+## Process
+
+### 1. Detect stack and floor
+
+Identify every language, its targeted or minimum version, and the major dependencies with their versions. Read manifests, not vibes. The cross-ecosystem cheat-sheet is in [references/detect.md](references/detect.md). Record, per language and major dependency, the floor and the current version installed or resolvable. The gap between them is the modernization budget.
+
+### 2. Research the gap
+
+Do not trust memory for "added in version X." Web-research the changelogs and release notes between the floor and current, for the language and each major dependency, and ground every claim in a dated source. Prefer official codemods and migration guides where they exist. Method and sourcing rules in [references/research.md](references/research.md).
+
+### 3. Survey the code
+
+Scan for the old patterns the researched features replace. Fan out with `Agent`/`Explore` for breadth on a large codebase. Each candidate maps a concrete code location to a specific feature, with a before and after. Apply the three disciplines as a filter before a candidate makes the list.
+
+### 4. Present the survey
+
+Group candidates by axis, rank within each group by leverage, and mark each as adopt-now or a flagged bump with a recommendation strength. Format and template in [references/survey.md](references/survey.md). Then ask which to apply. **Do not edit code in this phase.**
+
+### 5. Apply (follow-up)
+
+Only the picked candidates. Prefer official codemods over hand-edits. Work in small batches, run the project's own build, test, and lint after each, and commit per coherent batch. Verification and batching rules in [references/apply.md](references/apply.md).
+
+## Gotchas
+
+- **A short survey is a success.** A modern, well-kept project yields few candidates. Report that honestly. Padding the survey with lateral restyling violates earn-its-keep and trains the user to distrust it.
+- **Detect the real runtime before assuming a language floor.** A Bun or Deno project has no `engines.node`. Bun implements `node:fs`, `child_process`, and friends, so swapping them for `Bun.file`/`Bun.$` is lateral churn rather than a version-gap fix. See [references/detect.md](references/detect.md).
+- **Read the floor from the manifest range.** A lockfile often resolves a dependency far above the declared minimum. A feature the resolved version supports but the floor does not is a flagged bump, because adopting it raises the floor.
+- **No declared floor still has a budget.** A `private` app targeting `esnext` with no `engines` has its local toolchain as the floor. The work is idiom adoption (the code predates features its own target already allows), and raising the floor costs nothing because there are no consumers.
+- **Deprecation is a benefit. Availability alone is not.** If the old API is not deprecated and the swap buys nothing concrete, leave it. An API on a deprecation clock is worth migrating. A merely newer spelling of a working API is not.
+
+## Arguments
+
+`$ARGUMENTS` is an optional scope or focus hint: a path to confine the survey (`src/api`), a language to target in a polyglot repo (`typescript`), or a dependency to center on (`react`). With no argument, survey the whole project.

--- a/user/skills/modernize/references/apply.md
+++ b/user/skills/modernize/references/apply.md
@@ -1,0 +1,33 @@
+# Applying the chosen candidates
+
+Runs only on the candidates the user picked, and only on adopt-now candidates unless the user accepted a flagged bump. The discipline here is that the safety net (tests, build, lint) is what lets a semantics-preserving claim be trusted.
+
+## Verification commands
+
+Before changing anything, find how the project checks itself, and confirm it passes *now* so you have a clean baseline. Look in the manifest scripts, `Makefile`/`Justfile`/`Taskfile`, and CI config for the real commands: the build or compile command, the test command, and the lint, format, or typecheck command.
+
+Run them once up front. If the baseline is already red, stop and tell the user. You cannot attribute a later failure to your change against a broken baseline.
+
+If the project has thin or no tests, say so and narrow to changes that are mechanically obvious or codemod-driven. Without a safety net, the only safe modernizations are the ones whose correctness is visible in the diff.
+
+## Codemods first
+
+If research found an official codemod or migration tool for a candidate, run it rather than editing by hand. Codemods preserve semantics by construction, cover every site uniformly, and produce a reviewable diff. Run it, then read the diff critically. Codemods can miss edge cases or reformat more than intended.
+
+## Batching
+
+Work in small, coherent batches, one feature swap or one codemod at a time, not all picks at once. After each batch:
+
+1. Run the build, then the tests, then lint or typecheck.
+2. If anything that was green goes red, the swap was not semantics-preserving. Revert the batch and either downgrade it to a flagged note or report why it failed. Do not paper over a real behavior change.
+3. If green, commit the batch with a message naming the feature adopted (e.g. `Adopt native fetch, drop node-fetch`). One coherent batch per commit keeps blame legible.
+
+Do not bundle unrelated modernizations into one commit. Each should be revertable on its own.
+
+## Flagged bumps
+
+If the user accepted a bump, treat the version raise as its own first step. Update the manifest floor (`engines`, edition, dependency range, target framework), then adopt the feature, then verify. Call out in the summary that the project's minimum supported version changed. That is a support-policy decision with downstream effect, not just a code change.
+
+## Summary
+
+After applying, report per candidate whether it was applied, reverted, or skipped, with the commit and the verification result. For anything reverted, say why. For any bump applied, restate the new floor.

--- a/user/skills/modernize/references/detect.md
+++ b/user/skills/modernize/references/detect.md
@@ -1,0 +1,58 @@
+# Detecting the stack, the floor, and the gap
+
+For each language and each major dependency you need three numbers.
+
+- **Floor.** The oldest version the project promises to support. For an application this is its deploy or runtime target. For a library it is the declared minimum (`engines`, edition, `*_requires`, target framework).
+- **Current.** The latest stable version installed or trivially resolvable.
+- **Gap.** Everything between floor and current. This is the only range worth researching. Features below the floor are already adoptable, so the only question is whether the project uses them.
+
+When floor and current match, there is still a budget. The project may target a modern version yet predate features in it, written in an older style out of habit.
+
+## Floor sources
+
+Read the manifest. Do not infer the floor from the syntax in the code. That tells you the past, not the promise.
+
+| Ecosystem | Floor lives in | Current / installed |
+| :-- | :-- | :-- |
+| Node / JS | `package.json` `engines.node`; `.nvmrc`; CI matrix | `node --version`, `package.json` deps |
+| Bun | `package.json` `engines.bun`; CI; presence of `bun.lock`, `@types/bun` | `bun --version` |
+| Deno | `deno.json` imports/`compilerOptions`; CI | `deno --version` |
+| TypeScript | `tsconfig.json` `compilerOptions.target` / `lib` | `tsc --version` |
+| Python | `pyproject.toml` `requires-python`; `setup.cfg`/`setup.py` `python_requires`; `.python-version`; classifiers | `python --version`, lockfile |
+| Go | `go.mod` `go` directive | `go version` |
+| Rust | `Cargo.toml` `rust-version` (MSRV) and `edition` | `rustc --version` |
+| Java | `pom.xml` `maven.compiler.release`; Gradle `sourceCompatibility`/`toolchain` | `java -version` |
+| Kotlin | Gradle `jvmTarget`, `languageVersion` | compiler plugin version |
+| C# / .NET | `<TargetFramework>` / `<LangVersion>` in `.csproj` | `dotnet --version` |
+| Ruby | `.ruby-version`; gemspec `required_ruby_version`; `Gemfile` `ruby` | `ruby --version` |
+| PHP | `composer.json` `require.php` | `php --version` |
+| Swift | `Package.swift` `swift-tools-version`, platform mins | `swift --version` |
+| C / C++ | build flags `-std=`, CMake `CXX_STANDARD` | compiler version |
+
+## Tested floor
+
+The build manifest can lie. The CI matrix is the floor the project actually tests against, and the one consumers feel. If `engines.node` says `>=16` but CI runs only 20 and 22, the tested floor is 20, while a published library still promises 16. For libraries, trust the declared minimum and flag untested-but-promised versions as a risk. For apps, trust CI and the deploy target.
+
+## Runtime detection
+
+A `package.json` does not mean Node. A project may run on Bun or Deno, which set their own feature floors and ship their own stdlib. Check for `bun.lock`, `@types/bun`, `"types": ["bun"]`, or a `deno.json` before running `node --version` or reasoning about Node-version features. Two consequences follow.
+
+The language floor is the runtime's floor, not Node's. A Bun project's adoptable features track Bun, not whatever version a `.nvmrc` happens to name.
+
+These runtimes implement the `node:` builtins (`node:fs`, `child_process`, streams). Code using them is not stale. Replacing it with a runtime-native form like `Bun.file` or `Bun.$` is a lateral rewrite that must clear earn-its-keep on its own, not a version-gap modernization.
+
+## No declared floor
+
+A `private` application with no `engines` and a target or edition set to the newest version has its local toolchain as the floor. There is no support promise to break.
+
+Every language feature up to the target is adopt-now, never a bump. The budget is pure idiom adoption: the code may be written in an older style than its own target permits, out of habit or age. If a worthwhile feature needs a newer toolchain than the target, raising the target is cheap, unlike a published library where the floor is a contract.
+
+## Major dependencies
+
+The dependency axis is reserved for frameworks and load-bearing libraries, the ones whose APIs shape the code. Find them in the same manifests (usually `dependencies`, not `devDependencies`). Ignore transitive and incidental dependencies. A test: would adopting the new API touch many files and change how a core concern is expressed? If yes, it is major.
+
+For each major dependency, record its floor (the manifest range, e.g. `^4.0`) and the current stable release. Research the gap the same way as the language gap.
+
+## Polyglot repos
+
+Detect per language and keep the axes separate. A focus argument (`$ARGUMENTS`) may name one language or directory. Honor it and skip the rest. With no argument, survey each language but rank candidates globally so the report leads with the highest-leverage work regardless of language.

--- a/user/skills/modernize/references/research.md
+++ b/user/skills/modernize/references/research.md
@@ -1,0 +1,35 @@
+# Researching what's new in the gap
+
+The risk here is confident wrongness. "Added in 3.10" from memory, off by a version, and the candidate is invalid or breaks the floor. Ground every "new in version X" claim in a dated, official source before it earns a place in the survey.
+
+## Research targets
+
+For the language and each major dependency, read the changelog across the gap, floor to current. Look for two things.
+
+- **Additions.** Features that did not exist at the floor and now do. These are adoption candidates.
+- **Deprecations and replacements.** Old APIs the project may use that are now discouraged, and what replaced them. These are often the highest-value candidates, because the old path is on a clock.
+
+## Sourcing rules
+
+- Prefer the official changelog, release notes, or "what's new" page over blog posts and forum answers. Note the version each feature landed in.
+- A feature is adopt-now only if it landed at or below the floor. If it landed above, it is a flagged bump. Record the exact minimum version it needs.
+- For each candidate feature, capture one source URL and the introducing version. The survey cites them so the user can verify without re-researching.
+- When availability is version-sensitive and you cannot find a dated source, leave the feature out. Omission beats a wrong floor claim.
+
+## Codemods and migration guides
+
+Many ecosystems ship tools that perform a modernization mechanically and preserve semantics. Finding one turns a risky hand-edit into a reviewable, repeatable command. Look for these during research and note them on the relevant candidates.
+
+- JS/TS: framework codemod CLIs (React, Next, Vue), `eslint --fix` with modern rule sets, `ts-migrate`.
+- Python: `pyupgrade`, `ruff` autofixes, library-provided `2to3`-style tools.
+- Go: `gofmt -r` rewrite rules, `go fix`, vendored API migration tools.
+- Rust: `cargo fix --edition`, `cargo clippy --fix`.
+- Java/Kotlin: OpenRewrite recipes, IDE migration inspections.
+
+A migration guide from the dependency's maintainers is the authoritative map for the dependency axis. Read it before proposing framework-API candidates. It lists the exact old-to-new mappings and the version each requires.
+
+## Stdlib subsumption
+
+Check whether any major dependency has been absorbed into the language or runtime within the gap. The changelog phrasing is usually "now built in," or a new stdlib module matching a popular package's job. The candidate is to remove the dependency and replace it with the native equivalent. Flag it as high leverage and confirm the native version's floor.
+
+The canonical example is Go's `golang.org/x/exp/slices` and `golang.org/x/exp/maps`, promoted to the stdlib `slices` and `maps` packages in Go 1.21. A project on Go 1.21+ that still imports the `x/exp` versions can drop the dependency and switch the import path, often with no other change. Equivalents recur everywhere: a left-pad helper replaced by a string method, a UUID package replaced by a stdlib generator, a fetch polyfill replaced by the native global. The shape is always the same. Less code, one fewer dependency.

--- a/user/skills/modernize/references/survey.md
+++ b/user/skills/modernize/references/survey.md
@@ -1,0 +1,50 @@
+# Building the survey
+
+The survey is the skill's main deliverable. It is a ranked catalog of semantics-preserving swaps, clear enough that the user can pick from it without re-reading the code.
+
+## Filtering
+
+A candidate enters the survey only if it passes all three disciplines.
+
+- **Semantics-preserving.** Behavior, public API, and error modes are identical after the swap. If you are unsure, it does not enter as adopt-now. It can appear as a flagged note.
+- **Earns its keep.** Name the concrete benefit. If the only benefit is "newer," drop it.
+- **Floor-respecting.** The feature landed at or below the floor. If it landed above, it is a flagged bump, not a rejection.
+
+Reject silently, without listing, anything that is pure restyling with no benefit or that no part of the code exhibits. The survey's value is its signal-to-noise ratio.
+
+## Adopt-now versus flagged bump
+
+Every candidate is one or the other.
+
+- **Adopt-now.** The feature is available at the floor. Safe to apply without changing what the project supports.
+- **Flagged bump.** The feature is worth having but requires raising the floor, through a newer language version or a major-dependency upgrade. Report it with the exact version it needs and what raising the floor costs: dropped consumers, a CI matrix change, upgrade work. Never apply a bump as part of adopt-now. The user decides bumps deliberately.
+
+Keep these visually distinct so the user never confuses a free swap with a support-policy decision.
+
+## Recommendation strength
+
+Tag each candidate.
+
+- **Strong.** Clear benefit, mechanical and low-risk, often with a codemod, exhibited widely.
+- **Worth exploring.** Real benefit, but some judgment or scope to it.
+- **Speculative.** Plausible, but the benefit or safety is uncertain.
+
+## Report format
+
+Present in-conversation, grouped by axis (language features, major dependencies, stdlib subsumption), ranked by leverage within each group. Offer to also write the report to `tmp/modernize-<timestamp>.md`. Each candidate is a compact card.
+
+```
+### <short title>            [Strong] · [adopt-now | bump → needs vX.Y]
+Feature: <language/dependency feature>, since <version> (<source URL>)
+Files: <paths / count of sites>
+Benefit: <less boilerplate | dropped dep D | stronger types | perf | clarity>
+Codemod: <command, if one exists> | none
+Before:
+    <minimal old snippet>
+After:
+    <minimal new snippet>
+```
+
+Lead with a one-line stack summary (languages, floors, gaps researched) so the user sees the budget the survey came from. End with a **Top pick**, the one candidate you would apply first, and why.
+
+Then ask which candidates to apply (numbers, ranges, or `all`). Do not edit code in this phase. When the user picks, proceed to [apply.md](apply.md).


### PR DESCRIPTION
Adds a `modernize` user skill that surveys a project for chances to adopt newer language and major-dependency features that did not exist when the code was written, replacing boilerplate with current idioms. It is language-agnostic and survey-then-pick: it detects the stack, presents a ranked catalog of candidates, and stops. Applying is a separate verified phase run only on the candidates you choose.

## Design

The skill works across three axes: language features, major-dependency APIs, and stdlib subsumption (a dependency the runtime has since absorbed, like native `fetch` or Go's `slices`). The last is the biggest win because it deletes code and a dependency at once.

I built it around three disciplines so it proposes adoption rather than churn:

- **Semantics-preserving.** A modernization changes how code is written, never what it does. A swap that changes behavior is a feature change, not a candidate.
- **Earn its keep.** Newer is not a reason. Each candidate must buy less boilerplate, stronger types, a dropped dependency, performance, or clarity.
- **Respect the floor.** Each language has a minimum supported version. A feature newer than the floor is a flagged bump (reported with the version it needs), never a free adoption. This is the central distinction between what to apply now and what to surface for a deliberate decision.

Claims about "new in version X" are grounded in researched changelogs rather than memory, since being off by a version invalidates a candidate or silently raises the floor.

## Structure

A lean hub plus four references loaded on demand: `detect.md` (stack and floor detection across ecosystems), `research.md` (changelog research and codemod discovery), `survey.md` (filtering and report format), and `apply.md` (the verified apply phase).

## Dogfooding

I ran the detection and survey steps on this repo and reasoned through `tflint` as a second case. Two findings shaped the skill:

- This repo runs on Bun with no `engines` and `target: esnext`, which has no support floor in the usual sense. That surfaced a `## Gotchas` section: detect the real runtime before assuming a Node floor, and recognize that swapping Bun-supported `node:` APIs for `Bun.file`/`Bun.$` is lateral churn, not modernization. The honest survey here is one candidate (`import.meta.dirname` over a hand-rolled `__dirname`), which is the expected result for a well-kept repo.
- `tflint` validated the dependency and floor axes: the `golang.org/x/exp/slices` to stdlib `slices` migration is the textbook subsumption win, and bumping `go.mod` is a flagged bump because the plugin SDK floor is a contract.

## Testing

`bun run skill-lint user/skills/modernize` passes with no errors or warnings. The skill ships no code, so there are no unit tests.
