### PR TITLE
tmux: fix agent team pane startup race

### DIFF
--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -24,7 +24,7 @@ The tmux team backend spawns each teammate in a new pane and immediately sends t
 
 A PreToolUse hook on `TeamCreate` heads this off. It points tmux's `default-command` at [`shell-wrapper.sh`](hooks/shell-wrapper.sh) and pins `@claude_fast_shell` on the lead's window. New panes in that window exec a shell with rc loading skipped (`zsh --no-rcs`, `bash --norc`, `fish --no-config`), so the prompt is ready before `send-keys` fires. Every other window falls through to a normal login shell, so panes you open elsewhere behave as usual. One catch: a no-rc shell never rebuilds `PATH`, so the hook stashes the current value in the `CLAUDE_PATH` tmux environment variable and the wrapper restores it. Otherwise `claude` would not resolve.
 
-There is no teardown. The override lasts for the life of the tmux session and leaves the team window stuck with a no-rc shell. Kill the window to reset it. That tradeoff is deliberate. It keeps the hook off the `Stop` path, where an earlier teardown version burned a `bun` startup on every stop in every session for no benefit.
+A second hook on `TeamDelete` reverses all of this. It unsets `default-command`, clears the window's `@claude_fast_shell` pin, and removes `CLAUDE_PATH`. Teardown is optimistic. It rides on the normal end of a team and never touches the `Stop` path, where an earlier version burned a `bun` startup on every stop in every session. When a team is never deleted, its window keeps the no-rc shell until the tmux session ends. Kill the window to reset it sooner.
 
 ## Sandbox
 

--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -8,6 +8,7 @@ Tmux session, window, and pane awareness for Claude Code.
 - **Hook: context** — SessionStart hook that injects tmux env vars
 - **Hook: resume-command**, a SessionStart hook that records the session's resume command in a pane-scoped tmux option for plugins like [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) to use when resuming a pane
 - **Hook: notification** — Bell and status bar notifications for permission prompts
+- A PreToolUse hook on `TeamCreate` that fixes the [agent team pane startup race](https://github.com/anthropics/claude-code/issues/25315) for tmux-backed teammates
 
 ## How It Works
 
@@ -16,6 +17,14 @@ A SessionStart hook detects whether Claude is running inside tmux and writes ses
 Another SessionStart hook records the command that resumes the current session (`claude --resume <id>`) in the pane-scoped tmux option `@resume-command`, refreshed on every session start. Plugins like tmux-resurrect can read it back with `tmux show-options -p -t <pane> -qv @resume-command` to resume the session when restoring a pane. Outside tmux the hook is a no-op.
 
 The skill provides a PreToolUse hook that auto-allows safe tmux commands (read-only, navigation, layout). The safe command list is maintained in [`safe-commands.json`](skills/tmux/resources/safe-commands.json).
+
+## Agent Team Shell Race
+
+The tmux team backend spawns each teammate in a new pane and immediately sends the `claude` command with `send-keys`. A slow rc file breaks this. The keystrokes land before the login shell finishes sourcing it, get swallowed, and the teammate never starts.
+
+A PreToolUse hook on `TeamCreate` heads this off. It points tmux's `default-command` at [`shell-wrapper.sh`](hooks/shell-wrapper.sh) and pins `@claude_fast_shell` on the lead's window. New panes in that window exec a shell with rc loading skipped (`zsh --no-rcs`, `bash --norc`, `fish --no-config`), so the prompt is ready before `send-keys` fires. Every other window falls through to a normal login shell, so panes you open elsewhere behave as usual. One catch: a no-rc shell never rebuilds `PATH`, so the hook stashes the current value in the `CLAUDE_PATH` tmux environment variable and the wrapper restores it. Otherwise `claude` would not resolve.
+
+There is no teardown. The override lasts for the life of the tmux session and leaves the team window stuck with a no-rc shell. Kill the window to reset it. That tradeoff is deliberate. It keeps the hook off the `Stop` path, where an earlier teardown version burned a `bun` startup on every stop in every session for no benefit.
 
 ## Sandbox
 

--- a/plugins/tmux/hooks/hooks.json
+++ b/plugins/tmux/hooks/hooks.json
@@ -46,6 +46,15 @@
             "command": "[ -n \"$TMUX_PANE\" ] && tmux set-environment CLAUDE_PATH \"$PATH\" && tmux set-option default-command \"${CLAUDE_PLUGIN_ROOT}/hooks/shell-wrapper.sh\" && tmux set-option -w -t \"$TMUX_PANE\" @claude_fast_shell 1 || true"
           }
         ]
+      },
+      {
+        "matcher": "TeamDelete",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$TMUX_PANE\" ] && { tmux set-option -u default-command; tmux set-option -wu -t \"$TMUX_PANE\" @claude_fast_shell; tmux set-environment -u CLAUDE_PATH; } || true"
+          }
+        ]
       }
     ],
     "Notification": [

--- a/plugins/tmux/hooks/hooks.json
+++ b/plugins/tmux/hooks/hooks.json
@@ -37,6 +37,15 @@
             "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/target.ts\""
           }
         ]
+      },
+      {
+        "matcher": "TeamCreate",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$TMUX_PANE\" ] && tmux set-environment CLAUDE_PATH \"$PATH\" && tmux set-option default-command \"${CLAUDE_PLUGIN_ROOT}/hooks/shell-wrapper.sh\" && tmux set-option -w -t \"$TMUX_PANE\" @claude_fast_shell 1 || true"
+          }
+        ]
       }
     ],
     "Notification": [

--- a/plugins/tmux/hooks/shell-wrapper.sh
+++ b/plugins/tmux/hooks/shell-wrapper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Window-local fast shell for Claude agent team panes.
 # Falls through to normal login shell for all other windows.
-if [ "$(tmux show-option -wqv @claude_fast_shell)" = "1" ]; then
+if [ "$(tmux show-option -wqv -t "$TMUX_PANE" @claude_fast_shell)" = "1" ]; then
   claude_path="$(tmux show-environment CLAUDE_PATH 2>/dev/null)"
   if [ -n "$claude_path" ]; then
     export PATH="${claude_path#CLAUDE_PATH=}"

--- a/plugins/tmux/hooks/shell-wrapper.sh
+++ b/plugins/tmux/hooks/shell-wrapper.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Window-local fast shell for Claude agent team panes.
+# Falls through to normal login shell for all other windows.
+if [ "$(tmux show-option -wqv @claude_fast_shell)" = "1" ]; then
+  claude_path="$(tmux show-environment CLAUDE_PATH 2>/dev/null)"
+  if [ -n "$claude_path" ]; then
+    export PATH="${claude_path#CLAUDE_PATH=}"
+  fi
+
+  shell="${SHELL:-/bin/zsh}"
+  case "$(basename "$shell")" in
+    zsh)  exec "$shell" --no-rcs --no-globalrcs ;;
+    bash) exec "$shell" --norc --noprofile ;;
+    fish) exec "$shell" --no-config ;;
+    *)    exec "$shell" ;;
+  esac
+fi
+exec "${SHELL:-/bin/zsh}" -l


### PR DESCRIPTION
Recent Claude versions use `TeamCreate` often, and the tmux team backend's pane startup race ([anthropics/claude-code#25315](https://github.com/anthropics/claude-code/issues/25315)) is biting again. A teammate's `claude` command is sent with `send-keys` before its login shell finishes sourcing rc files, the keystrokes are swallowed, and the teammate never starts.

This restores the workaround removed in #750, minus the part that made it too expensive to keep.

## What's different from #750

That version paid for itself on the wrong axis. Its teardown ran on `Stop`, so it spent a `bun` cold-start on every stop in every session (1,089 fires across 166 sessions) to discover there was nothing to undo. Meanwhile the setup hook never even fired, because teams weren't in use then.

Teardown now rides on `TeamDelete` instead. A `PreToolUse: TeamCreate` hook points tmux's `default-command` at `shell-wrapper.sh` and pins `@claude_fast_shell` on the lead's window. Pinned windows exec a no-rc shell so the prompt is ready before `send-keys` fires. Every other window falls through to a normal login shell. A `PreToolUse: TeamDelete` hook reverses all of it: unsets `default-command`, clears the pin, removes `CLAUDE_PATH`.

Cleanup is optimistic by design. It rides the normal end of a team and stays off the `Stop` path entirely, so cost on non-team sessions is zero and both hooks are pure `tmux` calls with no `bun`. The accepted cost: a team that is never deleted leaves its window on a no-rc shell until the tmux session ends, recoverable by killing the window.

The wrapper stashes `PATH` into the `CLAUDE_PATH` tmux env var and restores it, since a no-rc shell won't rebuild it and `claude` has to resolve.

## Two fixes found while testing the tmux calls

Both existed latently in the #750 code:

- The wrapper read `@claude_fast_shell` with no `-t`, which resolves to the session's *active* window, not the spawning pane's window. A teammate pane created while another window is focused would miss the pin and get a slow login shell. Now targets `$TMUX_PANE`.
- Teardown used `set-environment -r CLAUDE_PATH`, which only marks the variable for removal from child environments rather than unsetting it. Switched to `-u`, confirmed it clears.

## Verification

Ran both one-liners against a live tmux session and confirmed setup sets all three options and teardown clears them with no residue. Repo checks pass (hook quoting, JSON, wrapper `bash -n`). One thing still needs a real team, since `TeamCreate`/`TeamDelete` can't be triggered from a hook test: that teammate panes land in the lead's window, which is what makes the window-scoped pin cover them.
