### PR TITLE
test: snapshot formatted output, use test.each

### DIFF
--- a/plugins/github/scripts/__snapshots__/pr-comments.test.ts.snap
+++ b/plugins/github/scripts/__snapshots__/pr-comments.test.ts.snap
@@ -1,0 +1,199 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`formatThreads empty result 1`] = `
+"# Add feature X
+
+0 unresolved of 10 total threads
+
+No unresolved threads found."
+`;
+
+exports[`formatThreads reviewer-opener header 1`] = `
+"# Add feature X
+
+0 unresolved of 10 total threads
+Showing threads started by @DouweM
+
+No unresolved threads found."
+`;
+
+exports[`formatThreads bot header 1`] = `
+"# Add feature X
+
+0 unresolved of 10 total threads
+Showing review-bot and opted-in reviewer threads
+
+No unresolved threads found."
+`;
+
+exports[`formatThreads grouped by file 1`] = `
+"# Add feature X
+
+3 unresolved of 10 total threads
+
+## src/a.ts
+
+### Line 10
+\`PRRT_test\`
+
+**@reviewer** (2025-01-15):
+> comment
+
+---
+
+### Line 30
+\`PRRT_test\`
+
+**@reviewer** (2025-01-15):
+> comment
+
+---
+
+## src/b.ts
+
+### Line 20
+\`PRRT_test\`
+
+**@reviewer** (2025-01-15):
+> comment
+
+---
+"
+`;
+
+exports[`formatThreads line range 1`] = `
+"# Add feature X
+
+1 unresolved of 1 total threads
+
+## src/index.ts
+
+### Lines 10–20
+\`PRRT_test\`
+
+**@reviewer** (2025-01-15):
+> comment
+
+---
+"
+`;
+
+exports[`formatThreads outdated thread 1`] = `
+"# Add feature X
+
+1 unresolved of 1 total threads
+
+## src/index.ts
+
+### Line 42 (outdated)
+\`PRRT_test\`
+
+**@reviewer** (2025-01-15):
+> comment
+
+---
+"
+`;
+
+exports[`formatThreads thread id 1`] = `
+"# Add feature X
+
+1 unresolved of 1 total threads
+
+## src/index.ts
+
+### Line 42
+\`PRRT_abc123\`
+
+**@reviewer** (2025-01-15):
+> comment
+
+---
+"
+`;
+
+exports[`formatThreads bot-opened thread 1`] = `
+"# Add feature X
+
+1 unresolved of 1 total threads
+
+## src/index.ts
+
+### Line 42 (bot)
+\`PRRT_test\`
+
+**@coderabbitai** (2025-01-15):
+> comment
+
+---
+"
+`;
+
+exports[`formatThreads multi-line blockquote body 1`] = `
+"# Add feature X
+
+1 unresolved of 1 total threads
+
+## src/index.ts
+
+### Line 42
+\`PRRT_test\`
+
+**@DouweM** (2025-01-15):
+> Fix this
+> and that
+
+---
+"
+`;
+
+exports[`formatThreads file-level thread 1`] = `
+"# Add feature X
+
+1 unresolved of 1 total threads
+
+## src/index.ts
+
+### File-level
+\`PRRT_test\`
+
+**@reviewer** (2025-01-15):
+> comment
+
+---
+"
+`;
+
+exports[`formatThreads ghost author 1`] = `
+"# Add feature X
+
+1 unresolved of 1 total threads
+
+## src/index.ts
+
+### Line 42
+\`PRRT_test\`
+
+**@ghost** (2025-01-15):
+> feedback
+
+---
+"
+`;
+
+exports[`formatThreads author and date 1`] = `
+"# Add feature X
+
+1 unresolved of 1 total threads
+
+## src/index.ts
+
+### Line 42
+\`PRRT_test\`
+
+**@DouweM** (2025-01-15):
+> looks good
+
+---
+"
+`;

--- a/plugins/github/scripts/pr-comments.test.ts
+++ b/plugins/github/scripts/pr-comments.test.ts
@@ -304,103 +304,117 @@ describe("formatThreads", () => {
     viewer: "bendrucker",
   };
 
-  it("formats empty result", () => {
-    const output = formatThreads([], 10, baseOptions);
-    expect(output).toContain("0 unresolved of 10 total threads");
-    expect(output).toContain("No unresolved threads found.");
+  const cases: Array<{
+    name: string;
+    threads: Thread[];
+    total: number;
+    options: Parameters<typeof formatThreads>[2];
+  }> = [
+    { name: "empty result", threads: [], total: 10, options: baseOptions },
+    {
+      name: "reviewer-opener header",
+      threads: [],
+      total: 10,
+      options: { ...baseOptions, role: "reviewer", viewer: "DouweM" },
+    },
+    {
+      name: "bot header",
+      threads: [],
+      total: 10,
+      options: { ...baseOptions, role: "reviewer", viewer: "DouweM", bots: true },
+    },
+    {
+      name: "grouped by file",
+      threads: [
+        makeThread({ path: "src/a.ts", line: 10 }),
+        makeThread({ path: "src/b.ts", line: 20 }),
+        makeThread({ path: "src/a.ts", line: 30 }),
+      ],
+      total: 10,
+      options: baseOptions,
+    },
+    {
+      name: "line range",
+      threads: [makeThread({ startLine: 10, line: 20 })],
+      total: 1,
+      options: baseOptions,
+    },
+    {
+      name: "outdated thread",
+      threads: [makeThread({ isOutdated: true })],
+      total: 1,
+      options: baseOptions,
+    },
+    {
+      name: "thread id",
+      threads: [makeThread({ id: "PRRT_abc123" })],
+      total: 1,
+      options: baseOptions,
+    },
+    {
+      name: "bot-opened thread",
+      threads: [
+        makeThread({ comments: [makeComment("coderabbitai", "2025-01-15", "comment", "Bot")] }),
+      ],
+      total: 1,
+      options: baseOptions,
+    },
+    {
+      name: "multi-line blockquote body",
+      threads: [
+        makeThread({ comments: [makeComment("DouweM", "2025-01-15", "Fix this\nand that")] }),
+      ],
+      total: 1,
+      options: baseOptions,
+    },
+    {
+      name: "file-level thread",
+      threads: [makeThread({ line: null, startLine: null })],
+      total: 1,
+      options: baseOptions,
+    },
+    {
+      name: "ghost author",
+      threads: [
+        makeThread({
+          comments: [{ author: null, body: "feedback", createdAt: "2025-01-15T00:00:00Z" }],
+        }),
+      ],
+      total: 1,
+      options: baseOptions,
+    },
+    {
+      name: "author and date",
+      threads: [makeThread({ comments: [makeComment("DouweM", "2025-01-15", "looks good")] })],
+      total: 1,
+      options: baseOptions,
+    },
+  ];
+
+  it.each(cases)("$name", ({ threads, total, options }) => {
+    expect(formatThreads(threads, total, options)).toMatchSnapshot();
   });
 
-  it("shows reviewer filter for reviewer role", () => {
-    const output = formatThreads([], 10, {
-      ...baseOptions,
-      role: "reviewer",
-      viewer: "DouweM",
-    });
-    expect(output).toContain("Showing threads started by @DouweM");
-  });
-
-  it("shows the bot header for bots, not the reviewer-opener header", () => {
+  it("suppresses the reviewer-opener header when showing bot threads", () => {
     const output = formatThreads([], 10, {
       ...baseOptions,
       role: "reviewer",
       viewer: "DouweM",
       bots: true,
     });
-    expect(output).toContain("Showing review-bot and opted-in reviewer threads");
     expect(output).not.toContain("Showing threads started by");
   });
 
-  it("groups threads by file", () => {
-    const threads = [
-      makeThread({ path: "src/a.ts", line: 10 }),
-      makeThread({ path: "src/b.ts", line: 20 }),
-      makeThread({ path: "src/a.ts", line: 30 }),
-    ];
-    const output = formatThreads(threads, 10, baseOptions);
-    const aMatches = output.match(/## src\/a\.ts/g);
-    expect(aMatches).toHaveLength(1);
-    expect(output).toContain("## src/b.ts");
-  });
-
-  it("formats line ranges", () => {
-    const threads = [makeThread({ startLine: 10, line: 20 })];
-    const output = formatThreads(threads, 1, baseOptions);
-    expect(output).toContain("Lines 10–20");
-  });
-
-  it("marks outdated threads", () => {
-    const threads = [makeThread({ isOutdated: true })];
-    const output = formatThreads(threads, 1, baseOptions);
-    expect(output).toContain("(outdated)");
-  });
-
-  it("includes the thread id", () => {
-    const threads = [makeThread({ id: "PRRT_abc123" })];
-    const output = formatThreads(threads, 1, baseOptions);
-    expect(output).toContain("`PRRT_abc123`");
-  });
-
-  it("marks bot-opened threads", () => {
-    const threads = [
-      makeThread({ comments: [makeComment("coderabbitai", "2025-01-15", "comment", "Bot")] }),
-    ];
-    const output = formatThreads(threads, 1, baseOptions);
-    expect(output).toContain("(bot)");
-  });
-
-  it("formats comment bodies as blockquotes", () => {
-    const threads = [
-      makeThread({
-        comments: [makeComment("DouweM", "2025-01-15", "Fix this\nand that")],
-      }),
-    ];
-    const output = formatThreads(threads, 1, baseOptions);
-    expect(output).toContain("> Fix this\n> and that");
-  });
-
-  it("renders file-level thread", () => {
-    const threads = [makeThread({ line: null, startLine: null })];
-    const output = formatThreads(threads, 1, baseOptions);
-    expect(output).toContain("### File-level");
-  });
-
-  it("renders null author as ghost", () => {
-    const threads = [
-      makeThread({
-        comments: [{ author: null, body: "feedback", createdAt: "2025-01-15T00:00:00Z" }],
-      }),
-    ];
-    const output = formatThreads(threads, 1, baseOptions);
-    expect(output).toContain("**@ghost**");
-  });
-
-  it("includes author and date on comments", () => {
-    const threads = [
-      makeThread({
-        comments: [makeComment("DouweM", "2025-01-15", "looks good")],
-      }),
-    ];
-    const output = formatThreads(threads, 1, baseOptions);
-    expect(output).toContain("**@DouweM** (2025-01-15):");
+  it("collapses repeated files under a single header", () => {
+    const output = formatThreads(
+      [
+        makeThread({ path: "src/a.ts", line: 10 }),
+        makeThread({ path: "src/b.ts", line: 20 }),
+        makeThread({ path: "src/a.ts", line: 30 }),
+      ],
+      10,
+      baseOptions,
+    );
+    expect(output.match(/## src\/a\.ts/g)).toHaveLength(1);
   });
 });

--- a/plugins/gitlab/skills/merge-request/scripts/__snapshots__/discussions.test.ts.snap
+++ b/plugins/gitlab/skills/merge-request/scripts/__snapshots__/discussions.test.ts.snap
@@ -1,0 +1,8 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`formatDigest emits one line per discussion with id, location, state, and body 1`] = `
+"111111111111  src/app.ts:42  [open]      Extract this
+222222222222  -              [resolved]  Nit: typo"
+`;
+
+exports[`formatDigest truncates bodies to the given width 1`] = `"abcdef012345  -  [open]  xxxxxxxxxxxxxxxxxxx…"`;

--- a/plugins/gitlab/skills/merge-request/scripts/discussions.test.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/discussions.test.ts
@@ -193,20 +193,12 @@ describe("formatDigest", () => {
       ],
       80,
     );
-    const lines = out.split("\n");
-    expect(lines).toHaveLength(2);
-    expect(lines[0]).toContain("111111111111");
-    expect(lines[0]).toContain("src/app.ts:42");
-    expect(lines[0]).toContain("[open]");
-    expect(lines[0]).toContain("Extract this");
-    expect(lines[1]).toContain("[resolved]");
-    expect(lines[1]).toContain("-");
+    expect(out.split("\n")).toHaveLength(2);
+    expect(out).toMatchSnapshot();
   });
 
   it("truncates bodies to the given width", () => {
-    const out = formatDigest([makeSummary({ body: "x".repeat(200) })], 20);
-    expect(out).toContain(`${"x".repeat(19)}…`);
-    expect(out).not.toContain("x".repeat(21));
+    expect(formatDigest([makeSummary({ body: "x".repeat(200) })], 20)).toMatchSnapshot();
   });
 
   it("returns an empty string with no discussions", () => {

--- a/plugins/writing/skills/analyze/scripts/__snapshots__/report.test.ts.snap
+++ b/plugins/writing/skills/analyze/scripts/__snapshots__/report.test.ts.snap
@@ -1,0 +1,1681 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`renderReport empty scaffold 1`] = `
+"# Writing trope analysis (2026-05-24)
+
+Window: 2026-04-24 to 2026-05-24
+Model filter: \`*opus*\`
+Project filter: (none)
+Min lift threshold (additions): 5.0x
+Min occurrences to count as alive: 5
+Top N candidates: 10
+
+## Summary
+
+- All assistant text: 0 chars
+- Deliverable prose (Write/Edit/Bash): 0 chars
+- User text (human only): 0 chars
+- Voice baseline: not loaded (run ingest-voice.ts + voice-profile.ts)
+- Current wordlist entries audited: 0
+- Rules kept (distinctive and alive): 0
+- Proposed removals: 0 (dead: 0, not distinctive: 0)
+- Proposed additions (new candidates above threshold): 0
+- Correction candidates surfaced: 0
+- Corrective-feedback moments surfaced: 0
+
+## Voice Delta
+
+No voice-delta baseline loaded. Run \`ingest-voice.ts\` then \`voice-profile.ts\` to build a baseline. Rates shown are corpus means only.
+
+| feature | provenance | corpus rate |
+| --- | --- | --- |
+| First-person voice (I/we per 1k) | skill-encouraged | 0.00 |
+| Causal language (since/because per 1k) | skill-encouraged | 0.00 |
+| Body length (words) | skill-encouraged | 0 |
+| URL cross-references (per 1k words) | ungoverned | 0.00 |
+| Sentence length median (words) | ungoverned | 0.0 |
+| Sentence length p90 (words) | ungoverned | 0.0 |
+| Question marks (per 1k words) | ungoverned | 0.00 |
+| Template presence (## Changes + ## Testing) | skill-prescribed | 0% |
+| Unique heading texts (count) | skill-prescribed | 0 |
+| Has any heading (fraction of documents) | skill-prescribed | 0% |
+| Action-verb opener lines (fraction of lines) | skill-prescribed | 0.0% |
+| Backtick density (per 1k words) | skill-prescribed | 0.00 |
+| Backtick-manifest bullets (fraction of bullets) | ungoverned | 0.0% |
+| Consequence chains (, so <det>) per 1k words | ungoverned | 0.00 |
+
+## Proposed Wordlist Removals
+
+Two reasons a rule earns removal:
+
+- **dead**: the model produced it fewer than 5 times in the window on the surface where the rule fires, so the rule rarely fires.
+- **not distinctive**: the comparison baseline uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.
+
+Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.
+
+_No removals proposed._
+
+## Proposed Wordlist Additions
+
+Phrases distinctive to the assistant (lift >= 5.0x) not yet in the wordlists. The baseline columns report the phrase's rate in the user's voice baseline; a count of 0 is the strongest "absent from my baseline" signal.
+
+_No additions proposed._
+
+## Current Rule Health
+
+Full audit of every wordlist entry on its firing surface. \`remove\` rules are either dead or not distinctive (see Proposed Removals). The surface column shows which corpora the model/baseline rates come from.
+
+_No wordlists found at \`plugins/writing/wordlists/\`._
+
+## Structural Pattern Audit
+
+Regex-based patterns from the writing hook, run against all model-generated text.
+Patterns are grouped by detector layer. Cross-sentence patterns shipping in the hook
+without a promotion record appear here as misplacement signals.
+
+_No structural patterns defined._
+
+## Structural Signatures
+
+Coarse part-of-speech tag sequences distinctive to the model's deliverable prose vs the user's voice. Word-independent: when vocabulary drifts between model releases, these shapes persist. Examples are verbatim corpus sentences. This report is local-only, so replace them with invented examples before quoting anywhere else.
+
+_No structural signatures above threshold._
+
+## Structural Trends
+
+Corpus-level rate metrics across deliverable documents. These are aggregate signals, not per-document flags.
+
+_No deliverable documents analyzed._
+
+## Meaning-Layer Audit (LLM Judge)
+
+Per-criterion flag rates from the batch LLM judge over the deliverable corpus, in rubric order (information-density leads; press-release-structure is deprioritized). The prompt is a versioned artifact: a different hash means these numbers are not comparable to prior runs. Sampled spans quote session text, so this section stays in the local report and is never committed.
+
+_Judge not run. Pass \`--judge\` (requires \`ANTHROPIC_API_KEY\`) to enable._
+
+## Corrective Feedback
+
+Short, human-authored user messages that name a writing problem (frustration lexicon match), paired with the preceding model output. These are labeled-slop moments: the user explicitly called out prose the model produced.
+
+_No corrective-feedback moments in window._
+
+## Correction Candidates
+
+Adjacent (long assistant, short user) pairs. Scan for prose corrections.
+
+_No correction candidates in window._
+"
+`;
+
+exports[`renderReport structural trends table 1`] = `
+"# Writing trope analysis (2026-05-24)
+
+Window: 2026-04-24 to 2026-05-24
+Model filter: \`*opus*\`
+Project filter: (none)
+Min lift threshold (additions): 5.0x
+Min occurrences to count as alive: 5
+Top N candidates: 10
+
+## Summary
+
+- All assistant text: 0 chars
+- Deliverable prose (Write/Edit/Bash): 0 chars
+- User text (human only): 0 chars
+- Voice baseline: not loaded (run ingest-voice.ts + voice-profile.ts)
+- Current wordlist entries audited: 0
+- Rules kept (distinctive and alive): 0
+- Proposed removals: 0 (dead: 0, not distinctive: 0)
+- Proposed additions (new candidates above threshold): 0
+- Correction candidates surfaced: 0
+- Corrective-feedback moments surfaced: 0
+
+## Voice Delta
+
+No voice-delta baseline loaded. Run \`ingest-voice.ts\` then \`voice-profile.ts\` to build a baseline. Rates shown are corpus means only.
+
+| feature | provenance | corpus rate |
+| --- | --- | --- |
+| First-person voice (I/we per 1k) | skill-encouraged | 0.00 |
+| Causal language (since/because per 1k) | skill-encouraged | 0.00 |
+| Body length (words) | skill-encouraged | 0 |
+| URL cross-references (per 1k words) | ungoverned | 0.00 |
+| Sentence length median (words) | ungoverned | 0.0 |
+| Sentence length p90 (words) | ungoverned | 0.0 |
+| Question marks (per 1k words) | ungoverned | 0.00 |
+| Template presence (## Changes + ## Testing) | skill-prescribed | 0% |
+| Unique heading texts (count) | skill-prescribed | 0 |
+| Has any heading (fraction of documents) | skill-prescribed | 0% |
+| Action-verb opener lines (fraction of lines) | skill-prescribed | 0.0% |
+| Backtick density (per 1k words) | skill-prescribed | 0.00 |
+| Backtick-manifest bullets (fraction of bullets) | ungoverned | 0.0% |
+| Consequence chains (, so <det>) per 1k words | ungoverned | 0.00 |
+
+## Proposed Wordlist Removals
+
+Two reasons a rule earns removal:
+
+- **dead**: the model produced it fewer than 5 times in the window on the surface where the rule fires, so the rule rarely fires.
+- **not distinctive**: the comparison baseline uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.
+
+Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.
+
+_No removals proposed._
+
+## Proposed Wordlist Additions
+
+Phrases distinctive to the assistant (lift >= 5.0x) not yet in the wordlists. The baseline columns report the phrase's rate in the user's voice baseline; a count of 0 is the strongest "absent from my baseline" signal.
+
+_No additions proposed._
+
+## Current Rule Health
+
+Full audit of every wordlist entry on its firing surface. \`remove\` rules are either dead or not distinctive (see Proposed Removals). The surface column shows which corpora the model/baseline rates come from.
+
+_No wordlists found at \`plugins/writing/wordlists/\`._
+
+## Structural Pattern Audit
+
+Regex-based patterns from the writing hook, run against all model-generated text.
+Patterns are grouped by detector layer. Cross-sentence patterns shipping in the hook
+without a promotion record appear here as misplacement signals.
+
+_No structural patterns defined._
+
+## Structural Signatures
+
+Coarse part-of-speech tag sequences distinctive to the model's deliverable prose vs the user's voice. Word-independent: when vocabulary drifts between model releases, these shapes persist. Examples are verbatim corpus sentences. This report is local-only, so replace them with invented examples before quoting anywhere else.
+
+_No structural signatures above threshold._
+
+## Structural Trends
+
+Corpus-level rate metrics across deliverable documents. These are aggregate signals, not per-document flags.
+
+Documents analyzed: 42
+
+| metric | value | note |
+| --- | --- | --- |
+| action-verb opener rate | 16.6% | mean fraction of non-first lines opening with a bare verb; 16.6% AI-era vs 2.4% baseline (2026-06) |
+| backtick ref density | 58.3/1k words | mean inline code spans per 1k words; ~60/1k marks over-reliance on identifiers as structure (2026-06) |
+| template document rate | 73.0% | fraction of documents with at least one ## section heading |
+| template on small document | 7 docs | full ## Changes + ## Testing on body under 150 words; pull-request:create scopes sections to larger changes |
+
+Section count distribution (## Changes / ## Testing / ## Issue / ## References):
+
+| sections present | documents |
+| --- | --- |
+| 0 | 11 |
+| 1 | 5 |
+| 2 | 26 |
+| 3 | 0 |
+| 4 | 0 |
+
+## Meaning-Layer Audit (LLM Judge)
+
+Per-criterion flag rates from the batch LLM judge over the deliverable corpus, in rubric order (information-density leads; press-release-structure is deprioritized). The prompt is a versioned artifact: a different hash means these numbers are not comparable to prior runs. Sampled spans quote session text, so this section stays in the local report and is never committed.
+
+_Judge not run. Pass \`--judge\` (requires \`ANTHROPIC_API_KEY\`) to enable._
+
+## Corrective Feedback
+
+Short, human-authored user messages that name a writing problem (frustration lexicon match), paired with the preceding model output. These are labeled-slop moments: the user explicitly called out prose the model produced.
+
+_No corrective-feedback moments in window._
+
+## Correction Candidates
+
+Adjacent (long assistant, short user) pairs. Scan for prose corrections.
+
+_No correction candidates in window._
+"
+`;
+
+exports[`renderReport structural signature rows 1`] = `
+"# Writing trope analysis (2026-05-24)
+
+Window: 2026-04-24 to 2026-05-24
+Model filter: \`*opus*\`
+Project filter: (none)
+Min lift threshold (additions): 5.0x
+Min occurrences to count as alive: 5
+Top N candidates: 10
+
+## Summary
+
+- All assistant text: 0 chars
+- Deliverable prose (Write/Edit/Bash): 0 chars
+- User text (human only): 0 chars
+- Voice baseline: not loaded (run ingest-voice.ts + voice-profile.ts)
+- Current wordlist entries audited: 0
+- Rules kept (distinctive and alive): 0
+- Proposed removals: 0 (dead: 0, not distinctive: 0)
+- Proposed additions (new candidates above threshold): 0
+- Correction candidates surfaced: 0
+- Corrective-feedback moments surfaced: 0
+
+## Voice Delta
+
+No voice-delta baseline loaded. Run \`ingest-voice.ts\` then \`voice-profile.ts\` to build a baseline. Rates shown are corpus means only.
+
+| feature | provenance | corpus rate |
+| --- | --- | --- |
+| First-person voice (I/we per 1k) | skill-encouraged | 0.00 |
+| Causal language (since/because per 1k) | skill-encouraged | 0.00 |
+| Body length (words) | skill-encouraged | 0 |
+| URL cross-references (per 1k words) | ungoverned | 0.00 |
+| Sentence length median (words) | ungoverned | 0.0 |
+| Sentence length p90 (words) | ungoverned | 0.0 |
+| Question marks (per 1k words) | ungoverned | 0.00 |
+| Template presence (## Changes + ## Testing) | skill-prescribed | 0% |
+| Unique heading texts (count) | skill-prescribed | 0 |
+| Has any heading (fraction of documents) | skill-prescribed | 0% |
+| Action-verb opener lines (fraction of lines) | skill-prescribed | 0.0% |
+| Backtick density (per 1k words) | skill-prescribed | 0.00 |
+| Backtick-manifest bullets (fraction of bullets) | ungoverned | 0.0% |
+| Consequence chains (, so <det>) per 1k words | ungoverned | 0.00 |
+
+## Proposed Wordlist Removals
+
+Two reasons a rule earns removal:
+
+- **dead**: the model produced it fewer than 5 times in the window on the surface where the rule fires, so the rule rarely fires.
+- **not distinctive**: the comparison baseline uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.
+
+Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.
+
+_No removals proposed._
+
+## Proposed Wordlist Additions
+
+Phrases distinctive to the assistant (lift >= 5.0x) not yet in the wordlists. The baseline columns report the phrase's rate in the user's voice baseline; a count of 0 is the strongest "absent from my baseline" signal.
+
+_No additions proposed._
+
+## Current Rule Health
+
+Full audit of every wordlist entry on its firing surface. \`remove\` rules are either dead or not distinctive (see Proposed Removals). The surface column shows which corpora the model/baseline rates come from.
+
+_No wordlists found at \`plugins/writing/wordlists/\`._
+
+## Structural Pattern Audit
+
+Regex-based patterns from the writing hook, run against all model-generated text.
+Patterns are grouped by detector layer. Cross-sentence patterns shipping in the hook
+without a promotion record appear here as misplacement signals.
+
+_No structural patterns defined._
+
+## Structural Signatures
+
+Coarse part-of-speech tag sequences distinctive to the model's deliverable prose vs the user's voice. Word-independent: when vocabulary drifts between model releases, these shapes persist. Examples are verbatim corpus sentences. This report is local-only, so replace them with invented examples before quoting anywhere else.
+
+| shape | n | assistant/M | user/M | sessions | lift | example |
+| --- | --- | --- | --- | --- | --- | --- |
+| \`COPULA PART DET NOUN\` | 4 | 120.0 | 10.0 | 6 | 8.4x | This is not a cache, it is a ledger |
+
+## Structural Trends
+
+Corpus-level rate metrics across deliverable documents. These are aggregate signals, not per-document flags.
+
+_No deliverable documents analyzed._
+
+## Meaning-Layer Audit (LLM Judge)
+
+Per-criterion flag rates from the batch LLM judge over the deliverable corpus, in rubric order (information-density leads; press-release-structure is deprioritized). The prompt is a versioned artifact: a different hash means these numbers are not comparable to prior runs. Sampled spans quote session text, so this section stays in the local report and is never committed.
+
+_Judge not run. Pass \`--judge\` (requires \`ANTHROPIC_API_KEY\`) to enable._
+
+## Corrective Feedback
+
+Short, human-authored user messages that name a writing problem (frustration lexicon match), paired with the preceding model output. These are labeled-slop moments: the user explicitly called out prose the model produced.
+
+_No corrective-feedback moments in window._
+
+## Correction Candidates
+
+Adjacent (long assistant, short user) pairs. Scan for prose corrections.
+
+_No correction candidates in window._
+"
+`;
+
+exports[`renderReport meaning audit 1`] = `
+"# Writing trope analysis (2026-05-24)
+
+Window: 2026-04-24 to 2026-05-24
+Model filter: \`*opus*\`
+Project filter: (none)
+Min lift threshold (additions): 5.0x
+Min occurrences to count as alive: 5
+Top N candidates: 10
+
+## Summary
+
+- All assistant text: 0 chars
+- Deliverable prose (Write/Edit/Bash): 0 chars
+- User text (human only): 0 chars
+- Voice baseline: not loaded (run ingest-voice.ts + voice-profile.ts)
+- Current wordlist entries audited: 0
+- Rules kept (distinctive and alive): 0
+- Proposed removals: 0 (dead: 0, not distinctive: 0)
+- Proposed additions (new candidates above threshold): 0
+- Correction candidates surfaced: 0
+- Corrective-feedback moments surfaced: 0
+
+## Voice Delta
+
+No voice-delta baseline loaded. Run \`ingest-voice.ts\` then \`voice-profile.ts\` to build a baseline. Rates shown are corpus means only.
+
+| feature | provenance | corpus rate |
+| --- | --- | --- |
+| First-person voice (I/we per 1k) | skill-encouraged | 0.00 |
+| Causal language (since/because per 1k) | skill-encouraged | 0.00 |
+| Body length (words) | skill-encouraged | 0 |
+| URL cross-references (per 1k words) | ungoverned | 0.00 |
+| Sentence length median (words) | ungoverned | 0.0 |
+| Sentence length p90 (words) | ungoverned | 0.0 |
+| Question marks (per 1k words) | ungoverned | 0.00 |
+| Template presence (## Changes + ## Testing) | skill-prescribed | 0% |
+| Unique heading texts (count) | skill-prescribed | 0 |
+| Has any heading (fraction of documents) | skill-prescribed | 0% |
+| Action-verb opener lines (fraction of lines) | skill-prescribed | 0.0% |
+| Backtick density (per 1k words) | skill-prescribed | 0.00 |
+| Backtick-manifest bullets (fraction of bullets) | ungoverned | 0.0% |
+| Consequence chains (, so <det>) per 1k words | ungoverned | 0.00 |
+
+## Proposed Wordlist Removals
+
+Two reasons a rule earns removal:
+
+- **dead**: the model produced it fewer than 5 times in the window on the surface where the rule fires, so the rule rarely fires.
+- **not distinctive**: the comparison baseline uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.
+
+Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.
+
+_No removals proposed._
+
+## Proposed Wordlist Additions
+
+Phrases distinctive to the assistant (lift >= 5.0x) not yet in the wordlists. The baseline columns report the phrase's rate in the user's voice baseline; a count of 0 is the strongest "absent from my baseline" signal.
+
+_No additions proposed._
+
+## Current Rule Health
+
+Full audit of every wordlist entry on its firing surface. \`remove\` rules are either dead or not distinctive (see Proposed Removals). The surface column shows which corpora the model/baseline rates come from.
+
+_No wordlists found at \`plugins/writing/wordlists/\`._
+
+## Structural Pattern Audit
+
+Regex-based patterns from the writing hook, run against all model-generated text.
+Patterns are grouped by detector layer. Cross-sentence patterns shipping in the hook
+without a promotion record appear here as misplacement signals.
+
+_No structural patterns defined._
+
+## Structural Signatures
+
+Coarse part-of-speech tag sequences distinctive to the model's deliverable prose vs the user's voice. Word-independent: when vocabulary drifts between model releases, these shapes persist. Examples are verbatim corpus sentences. This report is local-only, so replace them with invented examples before quoting anywhere else.
+
+_No structural signatures above threshold._
+
+## Structural Trends
+
+Corpus-level rate metrics across deliverable documents. These are aggregate signals, not per-document flags.
+
+_No deliverable documents analyzed._
+
+## Meaning-Layer Audit (LLM Judge)
+
+Per-criterion flag rates from the batch LLM judge over the deliverable corpus, in rubric order (information-density leads; press-release-structure is deprioritized). The prompt is a versioned artifact: a different hash means these numbers are not comparable to prior runs. Sampled spans quote session text, so this section stays in the local report and is never committed.
+
+Prompt: \`abc123def456\` | Model: \`claude-haiku-4-5\` | Documents: 40 | Est. cost: $0.1234
+
+| criterion | question | flagged | rate |
+| --- | --- | --- | --- |
+| information-density | Does this text tell the reviewer anything new? | 12/40 | 30% |
+| sycophancy | Does the text flatter the reader? | 0/40 | 0% |
+
+Sampled spans (local-only; spot-check before acting):
+
+- information-density: "These changes ensure correct behavior."
+
+## Corrective Feedback
+
+Short, human-authored user messages that name a writing problem (frustration lexicon match), paired with the preceding model output. These are labeled-slop moments: the user explicitly called out prose the model produced.
+
+_No corrective-feedback moments in window._
+
+## Correction Candidates
+
+Adjacent (long assistant, short user) pairs. Scan for prose corrections.
+
+_No correction candidates in window._
+"
+`;
+
+exports[`renderReport proposed removals diff block 1`] = `
+"# Writing trope analysis (2026-05-24)
+
+Window: 2026-04-24 to 2026-05-24
+Model filter: \`*opus*\`
+Project filter: (none)
+Min lift threshold (additions): 5.0x
+Min occurrences to count as alive: 5
+Top N candidates: 10
+
+## Summary
+
+- All assistant text: 0 chars
+- Deliverable prose (Write/Edit/Bash): 0 chars
+- User text (human only): 0 chars
+- Voice baseline: not loaded (run ingest-voice.ts + voice-profile.ts)
+- Current wordlist entries audited: 1
+- Rules kept (distinctive and alive): 0
+- Proposed removals: 1 (dead: 0, not distinctive: 1)
+- Proposed additions (new candidates above threshold): 0
+- Correction candidates surfaced: 0
+- Corrective-feedback moments surfaced: 0
+
+## Voice Delta
+
+No voice-delta baseline loaded. Run \`ingest-voice.ts\` then \`voice-profile.ts\` to build a baseline. Rates shown are corpus means only.
+
+| feature | provenance | corpus rate |
+| --- | --- | --- |
+| First-person voice (I/we per 1k) | skill-encouraged | 0.00 |
+| Causal language (since/because per 1k) | skill-encouraged | 0.00 |
+| Body length (words) | skill-encouraged | 0 |
+| URL cross-references (per 1k words) | ungoverned | 0.00 |
+| Sentence length median (words) | ungoverned | 0.0 |
+| Sentence length p90 (words) | ungoverned | 0.0 |
+| Question marks (per 1k words) | ungoverned | 0.00 |
+| Template presence (## Changes + ## Testing) | skill-prescribed | 0% |
+| Unique heading texts (count) | skill-prescribed | 0 |
+| Has any heading (fraction of documents) | skill-prescribed | 0% |
+| Action-verb opener lines (fraction of lines) | skill-prescribed | 0.0% |
+| Backtick density (per 1k words) | skill-prescribed | 0.00 |
+| Backtick-manifest bullets (fraction of bullets) | ungoverned | 0.0% |
+| Consequence chains (, so <det>) per 1k words | ungoverned | 0.00 |
+
+## Proposed Wordlist Removals
+
+Two reasons a rule earns removal:
+
+- **dead**: the model produced it fewer than 5 times in the window on the surface where the rule fires, so the rule rarely fires.
+- **not distinctive**: the comparison baseline uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.
+
+Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.
+
+| phrase | source | surface | reason | model/M | baseline/M | lift |
+| --- | --- | --- | --- | --- | --- | --- |
+| \`tapestry\` | vocabulary.txt | chat | not distinctive | 50.0 | 100.0 | 0.5x |
+
+\`\`\`diff
+- tapestry  # not distinctive, source=vocabulary.txt
+\`\`\`
+
+## Proposed Wordlist Additions
+
+Phrases distinctive to the assistant (lift >= 5.0x) not yet in the wordlists. The baseline columns report the phrase's rate in the user's voice baseline; a count of 0 is the strongest "absent from my baseline" signal.
+
+_No additions proposed._
+
+## Current Rule Health
+
+Full audit of every wordlist entry on its firing surface. \`remove\` rules are either dead or not distinctive (see Proposed Removals). The surface column shows which corpora the model/baseline rates come from.
+
+| phrase | source | type | surface | model/M | baseline/M | lift | status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| \`tapestry\` | vocabulary.txt | vocabulary | chat | 50.0 | 100.0 | 0.5x | remove (not distinctive) |
+
+## Structural Pattern Audit
+
+Regex-based patterns from the writing hook, run against all model-generated text.
+Patterns are grouped by detector layer. Cross-sentence patterns shipping in the hook
+without a promotion record appear here as misplacement signals.
+
+_No structural patterns defined._
+
+## Structural Signatures
+
+Coarse part-of-speech tag sequences distinctive to the model's deliverable prose vs the user's voice. Word-independent: when vocabulary drifts between model releases, these shapes persist. Examples are verbatim corpus sentences. This report is local-only, so replace them with invented examples before quoting anywhere else.
+
+_No structural signatures above threshold._
+
+## Structural Trends
+
+Corpus-level rate metrics across deliverable documents. These are aggregate signals, not per-document flags.
+
+_No deliverable documents analyzed._
+
+## Meaning-Layer Audit (LLM Judge)
+
+Per-criterion flag rates from the batch LLM judge over the deliverable corpus, in rubric order (information-density leads; press-release-structure is deprioritized). The prompt is a versioned artifact: a different hash means these numbers are not comparable to prior runs. Sampled spans quote session text, so this section stays in the local report and is never committed.
+
+_Judge not run. Pass \`--judge\` (requires \`ANTHROPIC_API_KEY\`) to enable._
+
+## Corrective Feedback
+
+Short, human-authored user messages that name a writing problem (frustration lexicon match), paired with the preceding model output. These are labeled-slop moments: the user explicitly called out prose the model produced.
+
+_No corrective-feedback moments in window._
+
+## Correction Candidates
+
+Adjacent (long assistant, short user) pairs. Scan for prose corrections.
+
+_No correction candidates in window._
+"
+`;
+
+exports[`renderReport proposed additions diff block 1`] = `
+"# Writing trope analysis (2026-05-24)
+
+Window: 2026-04-24 to 2026-05-24
+Model filter: \`*opus*\`
+Project filter: (none)
+Min lift threshold (additions): 5.0x
+Min occurrences to count as alive: 5
+Top N candidates: 10
+
+## Summary
+
+- All assistant text: 0 chars
+- Deliverable prose (Write/Edit/Bash): 0 chars
+- User text (human only): 0 chars
+- Voice baseline: not loaded (run ingest-voice.ts + voice-profile.ts)
+- Current wordlist entries audited: 0
+- Rules kept (distinctive and alive): 0
+- Proposed removals: 0 (dead: 0, not distinctive: 0)
+- Proposed additions (new candidates above threshold): 1
+- Correction candidates surfaced: 0
+- Corrective-feedback moments surfaced: 0
+
+## Voice Delta
+
+No voice-delta baseline loaded. Run \`ingest-voice.ts\` then \`voice-profile.ts\` to build a baseline. Rates shown are corpus means only.
+
+| feature | provenance | corpus rate |
+| --- | --- | --- |
+| First-person voice (I/we per 1k) | skill-encouraged | 0.00 |
+| Causal language (since/because per 1k) | skill-encouraged | 0.00 |
+| Body length (words) | skill-encouraged | 0 |
+| URL cross-references (per 1k words) | ungoverned | 0.00 |
+| Sentence length median (words) | ungoverned | 0.0 |
+| Sentence length p90 (words) | ungoverned | 0.0 |
+| Question marks (per 1k words) | ungoverned | 0.00 |
+| Template presence (## Changes + ## Testing) | skill-prescribed | 0% |
+| Unique heading texts (count) | skill-prescribed | 0 |
+| Has any heading (fraction of documents) | skill-prescribed | 0% |
+| Action-verb opener lines (fraction of lines) | skill-prescribed | 0.0% |
+| Backtick density (per 1k words) | skill-prescribed | 0.00 |
+| Backtick-manifest bullets (fraction of bullets) | ungoverned | 0.0% |
+| Consequence chains (, so <det>) per 1k words | ungoverned | 0.00 |
+
+## Proposed Wordlist Removals
+
+Two reasons a rule earns removal:
+
+- **dead**: the model produced it fewer than 5 times in the window on the surface where the rule fires, so the rule rarely fires.
+- **not distinctive**: the comparison baseline uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.
+
+Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.
+
+_No removals proposed._
+
+## Proposed Wordlist Additions
+
+Phrases distinctive to the assistant (lift >= 5.0x) not yet in the wordlists. The baseline columns report the phrase's rate in the user's voice baseline; a count of 0 is the strongest "absent from my baseline" signal.
+
+| phrase | n | assistant count | user count | sessions | baseline count | baseline/M | lift |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| \`reaching for\` | 2 | 20 | 1 | - | 0 | 0.0 | 16.0x |
+
+Context for each candidate (spot-check before adding):
+
+- \`reaching for\` (no deliverable occurrence found)
+
+\`\`\`diff
++ reaching for  # lift=16.0x, n=2, baseline=0
+\`\`\`
+
+## Current Rule Health
+
+Full audit of every wordlist entry on its firing surface. \`remove\` rules are either dead or not distinctive (see Proposed Removals). The surface column shows which corpora the model/baseline rates come from.
+
+_No wordlists found at \`plugins/writing/wordlists/\`._
+
+## Structural Pattern Audit
+
+Regex-based patterns from the writing hook, run against all model-generated text.
+Patterns are grouped by detector layer. Cross-sentence patterns shipping in the hook
+without a promotion record appear here as misplacement signals.
+
+_No structural patterns defined._
+
+## Structural Signatures
+
+Coarse part-of-speech tag sequences distinctive to the model's deliverable prose vs the user's voice. Word-independent: when vocabulary drifts between model releases, these shapes persist. Examples are verbatim corpus sentences. This report is local-only, so replace them with invented examples before quoting anywhere else.
+
+_No structural signatures above threshold._
+
+## Structural Trends
+
+Corpus-level rate metrics across deliverable documents. These are aggregate signals, not per-document flags.
+
+_No deliverable documents analyzed._
+
+## Meaning-Layer Audit (LLM Judge)
+
+Per-criterion flag rates from the batch LLM judge over the deliverable corpus, in rubric order (information-density leads; press-release-structure is deprioritized). The prompt is a versioned artifact: a different hash means these numbers are not comparable to prior runs. Sampled spans quote session text, so this section stays in the local report and is never committed.
+
+_Judge not run. Pass \`--judge\` (requires \`ANTHROPIC_API_KEY\`) to enable._
+
+## Corrective Feedback
+
+Short, human-authored user messages that name a writing problem (frustration lexicon match), paired with the preceding model output. These are labeled-slop moments: the user explicitly called out prose the model produced.
+
+_No corrective-feedback moments in window._
+
+## Correction Candidates
+
+Adjacent (long assistant, short user) pairs. Scan for prose corrections.
+
+_No correction candidates in window._
+"
+`;
+
+exports[`renderReport corrective feedback moments 1`] = `
+"# Writing trope analysis (2026-05-24)
+
+Window: 2026-04-24 to 2026-05-24
+Model filter: \`*opus*\`
+Project filter: (none)
+Min lift threshold (additions): 5.0x
+Min occurrences to count as alive: 5
+Top N candidates: 10
+
+## Summary
+
+- All assistant text: 0 chars
+- Deliverable prose (Write/Edit/Bash): 0 chars
+- User text (human only): 0 chars
+- Voice baseline: not loaded (run ingest-voice.ts + voice-profile.ts)
+- Current wordlist entries audited: 0
+- Rules kept (distinctive and alive): 0
+- Proposed removals: 0 (dead: 0, not distinctive: 0)
+- Proposed additions (new candidates above threshold): 0
+- Correction candidates surfaced: 0
+- Corrective-feedback moments surfaced: 1
+
+## Voice Delta
+
+No voice-delta baseline loaded. Run \`ingest-voice.ts\` then \`voice-profile.ts\` to build a baseline. Rates shown are corpus means only.
+
+| feature | provenance | corpus rate |
+| --- | --- | --- |
+| First-person voice (I/we per 1k) | skill-encouraged | 0.00 |
+| Causal language (since/because per 1k) | skill-encouraged | 0.00 |
+| Body length (words) | skill-encouraged | 0 |
+| URL cross-references (per 1k words) | ungoverned | 0.00 |
+| Sentence length median (words) | ungoverned | 0.0 |
+| Sentence length p90 (words) | ungoverned | 0.0 |
+| Question marks (per 1k words) | ungoverned | 0.00 |
+| Template presence (## Changes + ## Testing) | skill-prescribed | 0% |
+| Unique heading texts (count) | skill-prescribed | 0 |
+| Has any heading (fraction of documents) | skill-prescribed | 0% |
+| Action-verb opener lines (fraction of lines) | skill-prescribed | 0.0% |
+| Backtick density (per 1k words) | skill-prescribed | 0.00 |
+| Backtick-manifest bullets (fraction of bullets) | ungoverned | 0.0% |
+| Consequence chains (, so <det>) per 1k words | ungoverned | 0.00 |
+
+## Proposed Wordlist Removals
+
+Two reasons a rule earns removal:
+
+- **dead**: the model produced it fewer than 5 times in the window on the surface where the rule fires, so the rule rarely fires.
+- **not distinctive**: the comparison baseline uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.
+
+Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.
+
+_No removals proposed._
+
+## Proposed Wordlist Additions
+
+Phrases distinctive to the assistant (lift >= 5.0x) not yet in the wordlists. The baseline columns report the phrase's rate in the user's voice baseline; a count of 0 is the strongest "absent from my baseline" signal.
+
+_No additions proposed._
+
+## Current Rule Health
+
+Full audit of every wordlist entry on its firing surface. \`remove\` rules are either dead or not distinctive (see Proposed Removals). The surface column shows which corpora the model/baseline rates come from.
+
+_No wordlists found at \`plugins/writing/wordlists/\`._
+
+## Structural Pattern Audit
+
+Regex-based patterns from the writing hook, run against all model-generated text.
+Patterns are grouped by detector layer. Cross-sentence patterns shipping in the hook
+without a promotion record appear here as misplacement signals.
+
+_No structural patterns defined._
+
+## Structural Signatures
+
+Coarse part-of-speech tag sequences distinctive to the model's deliverable prose vs the user's voice. Word-independent: when vocabulary drifts between model releases, these shapes persist. Examples are verbatim corpus sentences. This report is local-only, so replace them with invented examples before quoting anywhere else.
+
+_No structural signatures above threshold._
+
+## Structural Trends
+
+Corpus-level rate metrics across deliverable documents. These are aggregate signals, not per-document flags.
+
+_No deliverable documents analyzed._
+
+## Meaning-Layer Audit (LLM Judge)
+
+Per-criterion flag rates from the batch LLM judge over the deliverable corpus, in rubric order (information-density leads; press-release-structure is deprioritized). The prompt is a versioned artifact: a different hash means these numbers are not comparable to prior runs. Sampled spans quote session text, so this section stays in the local report and is never committed.
+
+_Judge not run. Pass \`--judge\` (requires \`ANTHROPIC_API_KEY\`) to enable._
+
+## Corrective Feedback
+
+Short, human-authored user messages that name a writing problem (frustration lexicon match), paired with the preceding model output. These are labeled-slop moments: the user explicitly called out prose the model produced.
+
+### 2026-05-20T10:01:00Z (myproject): matched \`fluff\`
+
+Preceding model output (300 chars):
+
+\`\`\`
+the model wrote a flowery paragraph
+\`\`\`
+
+User feedback (40 chars):
+
+\`\`\`
+ugh this reads like marketing fluff
+\`\`\`
+
+## Correction Candidates
+
+Adjacent (long assistant, short user) pairs. Scan for prose corrections.
+
+_No correction candidates in window._
+"
+`;
+
+exports[`renderReport correction snippets 1`] = `
+"# Writing trope analysis (2026-05-24)
+
+Window: 2026-04-24 to 2026-05-24
+Model filter: \`*opus*\`
+Project filter: (none)
+Min lift threshold (additions): 5.0x
+Min occurrences to count as alive: 5
+Top N candidates: 10
+
+## Summary
+
+- All assistant text: 0 chars
+- Deliverable prose (Write/Edit/Bash): 0 chars
+- User text (human only): 0 chars
+- Voice baseline: not loaded (run ingest-voice.ts + voice-profile.ts)
+- Current wordlist entries audited: 0
+- Rules kept (distinctive and alive): 0
+- Proposed removals: 0 (dead: 0, not distinctive: 0)
+- Proposed additions (new candidates above threshold): 0
+- Correction candidates surfaced: 1
+- Corrective-feedback moments surfaced: 0
+
+## Voice Delta
+
+No voice-delta baseline loaded. Run \`ingest-voice.ts\` then \`voice-profile.ts\` to build a baseline. Rates shown are corpus means only.
+
+| feature | provenance | corpus rate |
+| --- | --- | --- |
+| First-person voice (I/we per 1k) | skill-encouraged | 0.00 |
+| Causal language (since/because per 1k) | skill-encouraged | 0.00 |
+| Body length (words) | skill-encouraged | 0 |
+| URL cross-references (per 1k words) | ungoverned | 0.00 |
+| Sentence length median (words) | ungoverned | 0.0 |
+| Sentence length p90 (words) | ungoverned | 0.0 |
+| Question marks (per 1k words) | ungoverned | 0.00 |
+| Template presence (## Changes + ## Testing) | skill-prescribed | 0% |
+| Unique heading texts (count) | skill-prescribed | 0 |
+| Has any heading (fraction of documents) | skill-prescribed | 0% |
+| Action-verb opener lines (fraction of lines) | skill-prescribed | 0.0% |
+| Backtick density (per 1k words) | skill-prescribed | 0.00 |
+| Backtick-manifest bullets (fraction of bullets) | ungoverned | 0.0% |
+| Consequence chains (, so <det>) per 1k words | ungoverned | 0.00 |
+
+## Proposed Wordlist Removals
+
+Two reasons a rule earns removal:
+
+- **dead**: the model produced it fewer than 5 times in the window on the surface where the rule fires, so the rule rarely fires.
+- **not distinctive**: the comparison baseline uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.
+
+Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.
+
+_No removals proposed._
+
+## Proposed Wordlist Additions
+
+Phrases distinctive to the assistant (lift >= 5.0x) not yet in the wordlists. The baseline columns report the phrase's rate in the user's voice baseline; a count of 0 is the strongest "absent from my baseline" signal.
+
+_No additions proposed._
+
+## Current Rule Health
+
+Full audit of every wordlist entry on its firing surface. \`remove\` rules are either dead or not distinctive (see Proposed Removals). The surface column shows which corpora the model/baseline rates come from.
+
+_No wordlists found at \`plugins/writing/wordlists/\`._
+
+## Structural Pattern Audit
+
+Regex-based patterns from the writing hook, run against all model-generated text.
+Patterns are grouped by detector layer. Cross-sentence patterns shipping in the hook
+without a promotion record appear here as misplacement signals.
+
+_No structural patterns defined._
+
+## Structural Signatures
+
+Coarse part-of-speech tag sequences distinctive to the model's deliverable prose vs the user's voice. Word-independent: when vocabulary drifts between model releases, these shapes persist. Examples are verbatim corpus sentences. This report is local-only, so replace them with invented examples before quoting anywhere else.
+
+_No structural signatures above threshold._
+
+## Structural Trends
+
+Corpus-level rate metrics across deliverable documents. These are aggregate signals, not per-document flags.
+
+_No deliverable documents analyzed._
+
+## Meaning-Layer Audit (LLM Judge)
+
+Per-criterion flag rates from the batch LLM judge over the deliverable corpus, in rubric order (information-density leads; press-release-structure is deprioritized). The prompt is a versioned artifact: a different hash means these numbers are not comparable to prior runs. Sampled spans quote session text, so this section stays in the local report and is never committed.
+
+_Judge not run. Pass \`--judge\` (requires \`ANTHROPIC_API_KEY\`) to enable._
+
+## Corrective Feedback
+
+Short, human-authored user messages that name a writing problem (frustration lexicon match), paired with the preceding model output. These are labeled-slop moments: the user explicitly called out prose the model produced.
+
+_No corrective-feedback moments in window._
+
+## Correction Candidates
+
+Adjacent (long assistant, short user) pairs. Scan for prose corrections.
+
+Signal-to-noise: 1/1 candidates carry a prose signal. If this ratio stays low across runs, the surface is mostly task pivots and should be retired.
+
+### 2026-05-20T10:00:00Z (myproject) [prose]
+
+Assistant (500 chars):
+
+\`\`\`
+long assistant response here
+\`\`\`
+
+User reply (50 chars):
+
+\`\`\`
+no, do it differently
+\`\`\`
+"
+`;
+
+exports[`renderReport rule health opener and vocabulary types 1`] = `
+"# Writing trope analysis (2026-05-24)
+
+Window: 2026-04-24 to 2026-05-24
+Model filter: \`*opus*\`
+Project filter: (none)
+Min lift threshold (additions): 5.0x
+Min occurrences to count as alive: 5
+Top N candidates: 10
+
+## Summary
+
+- All assistant text: 0 chars
+- Deliverable prose (Write/Edit/Bash): 0 chars
+- User text (human only): 0 chars
+- Voice baseline: not loaded (run ingest-voice.ts + voice-profile.ts)
+- Current wordlist entries audited: 2
+- Rules kept (distinctive and alive): 2
+- Proposed removals: 0 (dead: 0, not distinctive: 0)
+- Proposed additions (new candidates above threshold): 0
+- Correction candidates surfaced: 0
+- Corrective-feedback moments surfaced: 0
+
+## Voice Delta
+
+No voice-delta baseline loaded. Run \`ingest-voice.ts\` then \`voice-profile.ts\` to build a baseline. Rates shown are corpus means only.
+
+| feature | provenance | corpus rate |
+| --- | --- | --- |
+| First-person voice (I/we per 1k) | skill-encouraged | 0.00 |
+| Causal language (since/because per 1k) | skill-encouraged | 0.00 |
+| Body length (words) | skill-encouraged | 0 |
+| URL cross-references (per 1k words) | ungoverned | 0.00 |
+| Sentence length median (words) | ungoverned | 0.0 |
+| Sentence length p90 (words) | ungoverned | 0.0 |
+| Question marks (per 1k words) | ungoverned | 0.00 |
+| Template presence (## Changes + ## Testing) | skill-prescribed | 0% |
+| Unique heading texts (count) | skill-prescribed | 0 |
+| Has any heading (fraction of documents) | skill-prescribed | 0% |
+| Action-verb opener lines (fraction of lines) | skill-prescribed | 0.0% |
+| Backtick density (per 1k words) | skill-prescribed | 0.00 |
+| Backtick-manifest bullets (fraction of bullets) | ungoverned | 0.0% |
+| Consequence chains (, so <det>) per 1k words | ungoverned | 0.00 |
+
+## Proposed Wordlist Removals
+
+Two reasons a rule earns removal:
+
+- **dead**: the model produced it fewer than 5 times in the window on the surface where the rule fires, so the rule rarely fires.
+- **not distinctive**: the comparison baseline uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.
+
+Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.
+
+_No removals proposed._
+
+## Proposed Wordlist Additions
+
+Phrases distinctive to the assistant (lift >= 5.0x) not yet in the wordlists. The baseline columns report the phrase's rate in the user's voice baseline; a count of 0 is the strongest "absent from my baseline" signal.
+
+_No additions proposed._
+
+## Current Rule Health
+
+Full audit of every wordlist entry on its firing surface. \`remove\` rules are either dead or not distinctive (see Proposed Removals). The surface column shows which corpora the model/baseline rates come from.
+
+| phrase | source | type | surface | model/M | baseline/M | lift | status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| \`Perfect\` | openers.txt | opener | chat | 100.0 | 20.0 | 5.0x | keep |
+| \`tapestry\` | vocabulary.txt | vocabulary | chat | 50.0 | 10.0 | 5.0x | keep |
+
+## Structural Pattern Audit
+
+Regex-based patterns from the writing hook, run against all model-generated text.
+Patterns are grouped by detector layer. Cross-sentence patterns shipping in the hook
+without a promotion record appear here as misplacement signals.
+
+_No structural patterns defined._
+
+## Structural Signatures
+
+Coarse part-of-speech tag sequences distinctive to the model's deliverable prose vs the user's voice. Word-independent: when vocabulary drifts between model releases, these shapes persist. Examples are verbatim corpus sentences. This report is local-only, so replace them with invented examples before quoting anywhere else.
+
+_No structural signatures above threshold._
+
+## Structural Trends
+
+Corpus-level rate metrics across deliverable documents. These are aggregate signals, not per-document flags.
+
+_No deliverable documents analyzed._
+
+## Meaning-Layer Audit (LLM Judge)
+
+Per-criterion flag rates from the batch LLM judge over the deliverable corpus, in rubric order (information-density leads; press-release-structure is deprioritized). The prompt is a versioned artifact: a different hash means these numbers are not comparable to prior runs. Sampled spans quote session text, so this section stays in the local report and is never committed.
+
+_Judge not run. Pass \`--judge\` (requires \`ANTHROPIC_API_KEY\`) to enable._
+
+## Corrective Feedback
+
+Short, human-authored user messages that name a writing problem (frustration lexicon match), paired with the preceding model output. These are labeled-slop moments: the user explicitly called out prose the model produced.
+
+_No corrective-feedback moments in window._
+
+## Correction Candidates
+
+Adjacent (long assistant, short user) pairs. Scan for prose corrections.
+
+_No correction candidates in window._
+"
+`;
+
+exports[`renderReport voice delta rates only, no baseline 1`] = `
+"# Writing trope analysis (2026-05-24)
+
+Window: 2026-04-24 to 2026-05-24
+Model filter: \`*opus*\`
+Project filter: (none)
+Min lift threshold (additions): 5.0x
+Min occurrences to count as alive: 5
+Top N candidates: 10
+
+## Summary
+
+- All assistant text: 0 chars
+- Deliverable prose (Write/Edit/Bash): 0 chars
+- User text (human only): 0 chars
+- Voice baseline: not loaded (run ingest-voice.ts + voice-profile.ts)
+- Current wordlist entries audited: 0
+- Rules kept (distinctive and alive): 0
+- Proposed removals: 0 (dead: 0, not distinctive: 0)
+- Proposed additions (new candidates above threshold): 0
+- Correction candidates surfaced: 0
+- Corrective-feedback moments surfaced: 0
+
+## Voice Delta
+
+No voice-delta baseline loaded. Run \`ingest-voice.ts\` then \`voice-profile.ts\` to build a baseline. Rates shown are corpus means only.
+
+| feature | provenance | corpus rate |
+| --- | --- | --- |
+| First-person voice (I/we per 1k) | skill-encouraged | 3.20 |
+| Causal language (since/because per 1k) | skill-encouraged | 0.00 |
+| Body length (words) | skill-encouraged | 0 |
+| URL cross-references (per 1k words) | ungoverned | 0.00 |
+| Sentence length median (words) | ungoverned | 0.0 |
+| Sentence length p90 (words) | ungoverned | 0.0 |
+| Question marks (per 1k words) | ungoverned | 0.00 |
+| Template presence (## Changes + ## Testing) | skill-prescribed | 0% |
+| Unique heading texts (count) | skill-prescribed | 0 |
+| Has any heading (fraction of documents) | skill-prescribed | 0% |
+| Action-verb opener lines (fraction of lines) | skill-prescribed | 0.0% |
+| Backtick density (per 1k words) | skill-prescribed | 0.00 |
+| Backtick-manifest bullets (fraction of bullets) | ungoverned | 0.0% |
+| Consequence chains (, so <det>) per 1k words | ungoverned | 0.00 |
+
+## Proposed Wordlist Removals
+
+Two reasons a rule earns removal:
+
+- **dead**: the model produced it fewer than 5 times in the window on the surface where the rule fires, so the rule rarely fires.
+- **not distinctive**: the comparison baseline uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.
+
+Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.
+
+_No removals proposed._
+
+## Proposed Wordlist Additions
+
+Phrases distinctive to the assistant (lift >= 5.0x) not yet in the wordlists. The baseline columns report the phrase's rate in the user's voice baseline; a count of 0 is the strongest "absent from my baseline" signal.
+
+_No additions proposed._
+
+## Current Rule Health
+
+Full audit of every wordlist entry on its firing surface. \`remove\` rules are either dead or not distinctive (see Proposed Removals). The surface column shows which corpora the model/baseline rates come from.
+
+_No wordlists found at \`plugins/writing/wordlists/\`._
+
+## Structural Pattern Audit
+
+Regex-based patterns from the writing hook, run against all model-generated text.
+Patterns are grouped by detector layer. Cross-sentence patterns shipping in the hook
+without a promotion record appear here as misplacement signals.
+
+_No structural patterns defined._
+
+## Structural Signatures
+
+Coarse part-of-speech tag sequences distinctive to the model's deliverable prose vs the user's voice. Word-independent: when vocabulary drifts between model releases, these shapes persist. Examples are verbatim corpus sentences. This report is local-only, so replace them with invented examples before quoting anywhere else.
+
+_No structural signatures above threshold._
+
+## Structural Trends
+
+Corpus-level rate metrics across deliverable documents. These are aggregate signals, not per-document flags.
+
+_No deliverable documents analyzed._
+
+## Meaning-Layer Audit (LLM Judge)
+
+Per-criterion flag rates from the batch LLM judge over the deliverable corpus, in rubric order (information-density leads; press-release-structure is deprioritized). The prompt is a versioned artifact: a different hash means these numbers are not comparable to prior runs. Sampled spans quote session text, so this section stays in the local report and is never committed.
+
+_Judge not run. Pass \`--judge\` (requires \`ANTHROPIC_API_KEY\`) to enable._
+
+## Corrective Feedback
+
+Short, human-authored user messages that name a writing problem (frustration lexicon match), paired with the preceding model output. These are labeled-slop moments: the user explicitly called out prose the model produced.
+
+_No corrective-feedback moments in window._
+
+## Correction Candidates
+
+Adjacent (long assistant, short user) pairs. Scan for prose corrections.
+
+_No correction candidates in window._
+"
+`;
+
+exports[`renderReport voice delta corpus, baseline, and delta 1`] = `
+"# Writing trope analysis (2026-05-24)
+
+Window: 2026-04-24 to 2026-05-24
+Model filter: \`*opus*\`
+Project filter: (none)
+Min lift threshold (additions): 5.0x
+Min occurrences to count as alive: 5
+Top N candidates: 10
+
+## Summary
+
+- All assistant text: 0 chars
+- Deliverable prose (Write/Edit/Bash): 0 chars
+- User text (human only): 0 chars
+- Voice baseline: 5 documents, 1,200 tokens (sources: github)
+- Current wordlist entries audited: 0
+- Rules kept (distinctive and alive): 0
+- Proposed removals: 0 (dead: 0, not distinctive: 0)
+- Proposed additions (new candidates above threshold): 0
+- Correction candidates surfaced: 0
+- Corrective-feedback moments surfaced: 0
+
+## Voice Delta
+
+Baseline: 5 documents (computed 2026-01-01). Each rate is the mean across the deliverable corpus in this window vs the pre-AI baseline. Provenance labels: **skill-prescribed** = tune the skill if the aggregate drifts; **skill-encouraged** = under-application of the skill; **ungoverned** = genuine voice signal.
+
+| feature | provenance | corpus rate | baseline rate | delta |
+| --- | --- | --- | --- | --- |
+| First-person voice (I/we per 1k) | skill-encouraged | 3.20 | 9.50 | -6.30 |
+| Causal language (since/because per 1k) | skill-encouraged | 0.00 | (no baseline stat) | - |
+| Body length (words) | skill-encouraged | 0 | (no baseline stat) | - |
+| URL cross-references (per 1k words) | ungoverned | 0.00 | (no baseline stat) | - |
+| Sentence length median (words) | ungoverned | 0.0 | (no baseline stat) | - |
+| Sentence length p90 (words) | ungoverned | 0.0 | (no baseline stat) | - |
+| Question marks (per 1k words) | ungoverned | 0.00 | (no baseline stat) | - |
+| Template presence (## Changes + ## Testing) | skill-prescribed | 0% | 10% | -10.0pp |
+| Unique heading texts (count) | skill-prescribed | 0 | (no baseline stat) | - |
+| Has any heading (fraction of documents) | skill-prescribed | 0% | (no baseline stat) | - |
+| Action-verb opener lines (fraction of lines) | skill-prescribed | 0.0% | (no baseline stat) | - |
+| Backtick density (per 1k words) | skill-prescribed | 0.00 | (no baseline stat) | - |
+| Backtick-manifest bullets (fraction of bullets) | ungoverned | 0.0% | (no baseline stat) | - |
+| Consequence chains (, so <det>) per 1k words | ungoverned | 0.00 | (no baseline stat) | - |
+
+## Proposed Wordlist Removals
+
+Two reasons a rule earns removal:
+
+- **dead**: the model produced it fewer than 5 times in the window on the surface where the rule fires, so the rule rarely fires.
+- **not distinctive**: the comparison baseline uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.
+
+Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.
+
+_No removals proposed._
+
+## Proposed Wordlist Additions
+
+Phrases distinctive to the assistant (lift >= 5.0x) not yet in the wordlists. The baseline columns report the phrase's rate in the user's voice baseline; a count of 0 is the strongest "absent from my baseline" signal.
+
+_No additions proposed._
+
+## Current Rule Health
+
+Full audit of every wordlist entry on its firing surface. \`remove\` rules are either dead or not distinctive (see Proposed Removals). The surface column shows which corpora the model/baseline rates come from.
+
+_No wordlists found at \`plugins/writing/wordlists/\`._
+
+## Structural Pattern Audit
+
+Regex-based patterns from the writing hook, run against all model-generated text.
+Patterns are grouped by detector layer. Cross-sentence patterns shipping in the hook
+without a promotion record appear here as misplacement signals.
+
+_No structural patterns defined._
+
+## Structural Signatures
+
+Coarse part-of-speech tag sequences distinctive to the model's deliverable prose vs the user's voice. Word-independent: when vocabulary drifts between model releases, these shapes persist. Examples are verbatim corpus sentences. This report is local-only, so replace them with invented examples before quoting anywhere else.
+
+_No structural signatures above threshold._
+
+## Structural Trends
+
+Corpus-level rate metrics across deliverable documents. These are aggregate signals, not per-document flags.
+
+_No deliverable documents analyzed._
+
+## Meaning-Layer Audit (LLM Judge)
+
+Per-criterion flag rates from the batch LLM judge over the deliverable corpus, in rubric order (information-density leads; press-release-structure is deprioritized). The prompt is a versioned artifact: a different hash means these numbers are not comparable to prior runs. Sampled spans quote session text, so this section stays in the local report and is never committed.
+
+_Judge not run. Pass \`--judge\` (requires \`ANTHROPIC_API_KEY\`) to enable._
+
+## Corrective Feedback
+
+Short, human-authored user messages that name a writing problem (frustration lexicon match), paired with the preceding model output. These are labeled-slop moments: the user explicitly called out prose the model produced.
+
+_No corrective-feedback moments in window._
+
+## Correction Candidates
+
+Adjacent (long assistant, short user) pairs. Scan for prose corrections.
+
+_No correction candidates in window._
+"
+`;
+
+exports[`renderReport voice delta fraction features as percentages 1`] = `
+"# Writing trope analysis (2026-05-24)
+
+Window: 2026-04-24 to 2026-05-24
+Model filter: \`*opus*\`
+Project filter: (none)
+Min lift threshold (additions): 5.0x
+Min occurrences to count as alive: 5
+Top N candidates: 10
+
+## Summary
+
+- All assistant text: 0 chars
+- Deliverable prose (Write/Edit/Bash): 0 chars
+- User text (human only): 0 chars
+- Voice baseline: 5 documents, 1,200 tokens (sources: github)
+- Current wordlist entries audited: 0
+- Rules kept (distinctive and alive): 0
+- Proposed removals: 0 (dead: 0, not distinctive: 0)
+- Proposed additions (new candidates above threshold): 0
+- Correction candidates surfaced: 0
+- Corrective-feedback moments surfaced: 0
+
+## Voice Delta
+
+Baseline: 5 documents (computed 2026-01-01). Each rate is the mean across the deliverable corpus in this window vs the pre-AI baseline. Provenance labels: **skill-prescribed** = tune the skill if the aggregate drifts; **skill-encouraged** = under-application of the skill; **ungoverned** = genuine voice signal.
+
+| feature | provenance | corpus rate | baseline rate | delta |
+| --- | --- | --- | --- | --- |
+| First-person voice (I/we per 1k) | skill-encouraged | 0.00 | 9.50 | -9.50 |
+| Causal language (since/because per 1k) | skill-encouraged | 0.00 | (no baseline stat) | - |
+| Body length (words) | skill-encouraged | 0 | (no baseline stat) | - |
+| URL cross-references (per 1k words) | ungoverned | 0.00 | (no baseline stat) | - |
+| Sentence length median (words) | ungoverned | 0.0 | (no baseline stat) | - |
+| Sentence length p90 (words) | ungoverned | 0.0 | (no baseline stat) | - |
+| Question marks (per 1k words) | ungoverned | 0.00 | (no baseline stat) | - |
+| Template presence (## Changes + ## Testing) | skill-prescribed | 60% | 10% | +50.0pp |
+| Unique heading texts (count) | skill-prescribed | 0 | (no baseline stat) | - |
+| Has any heading (fraction of documents) | skill-prescribed | 0% | (no baseline stat) | - |
+| Action-verb opener lines (fraction of lines) | skill-prescribed | 0.0% | (no baseline stat) | - |
+| Backtick density (per 1k words) | skill-prescribed | 0.00 | (no baseline stat) | - |
+| Backtick-manifest bullets (fraction of bullets) | ungoverned | 0.0% | (no baseline stat) | - |
+| Consequence chains (, so <det>) per 1k words | ungoverned | 0.00 | (no baseline stat) | - |
+
+## Proposed Wordlist Removals
+
+Two reasons a rule earns removal:
+
+- **dead**: the model produced it fewer than 5 times in the window on the surface where the rule fires, so the rule rarely fires.
+- **not distinctive**: the comparison baseline uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.
+
+Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.
+
+_No removals proposed._
+
+## Proposed Wordlist Additions
+
+Phrases distinctive to the assistant (lift >= 5.0x) not yet in the wordlists. The baseline columns report the phrase's rate in the user's voice baseline; a count of 0 is the strongest "absent from my baseline" signal.
+
+_No additions proposed._
+
+## Current Rule Health
+
+Full audit of every wordlist entry on its firing surface. \`remove\` rules are either dead or not distinctive (see Proposed Removals). The surface column shows which corpora the model/baseline rates come from.
+
+_No wordlists found at \`plugins/writing/wordlists/\`._
+
+## Structural Pattern Audit
+
+Regex-based patterns from the writing hook, run against all model-generated text.
+Patterns are grouped by detector layer. Cross-sentence patterns shipping in the hook
+without a promotion record appear here as misplacement signals.
+
+_No structural patterns defined._
+
+## Structural Signatures
+
+Coarse part-of-speech tag sequences distinctive to the model's deliverable prose vs the user's voice. Word-independent: when vocabulary drifts between model releases, these shapes persist. Examples are verbatim corpus sentences. This report is local-only, so replace them with invented examples before quoting anywhere else.
+
+_No structural signatures above threshold._
+
+## Structural Trends
+
+Corpus-level rate metrics across deliverable documents. These are aggregate signals, not per-document flags.
+
+_No deliverable documents analyzed._
+
+## Meaning-Layer Audit (LLM Judge)
+
+Per-criterion flag rates from the batch LLM judge over the deliverable corpus, in rubric order (information-density leads; press-release-structure is deprioritized). The prompt is a versioned artifact: a different hash means these numbers are not comparable to prior runs. Sampled spans quote session text, so this section stays in the local report and is never committed.
+
+_Judge not run. Pass \`--judge\` (requires \`ANTHROPIC_API_KEY\`) to enable._
+
+## Corrective Feedback
+
+Short, human-authored user messages that name a writing problem (frustration lexicon match), paired with the preceding model output. These are labeled-slop moments: the user explicitly called out prose the model produced.
+
+_No corrective-feedback moments in window._
+
+## Correction Candidates
+
+Adjacent (long assistant, short user) pairs. Scan for prose corrections.
+
+_No correction candidates in window._
+"
+`;
+
+exports[`renderReport voice delta feature missing from baseline 1`] = `
+"# Writing trope analysis (2026-05-24)
+
+Window: 2026-04-24 to 2026-05-24
+Model filter: \`*opus*\`
+Project filter: (none)
+Min lift threshold (additions): 5.0x
+Min occurrences to count as alive: 5
+Top N candidates: 10
+
+## Summary
+
+- All assistant text: 0 chars
+- Deliverable prose (Write/Edit/Bash): 0 chars
+- User text (human only): 0 chars
+- Voice baseline: 5 documents, 1,200 tokens (sources: github)
+- Current wordlist entries audited: 0
+- Rules kept (distinctive and alive): 0
+- Proposed removals: 0 (dead: 0, not distinctive: 0)
+- Proposed additions (new candidates above threshold): 0
+- Correction candidates surfaced: 0
+- Corrective-feedback moments surfaced: 0
+
+## Voice Delta
+
+Baseline: 5 documents (computed 2026-01-01). Each rate is the mean across the deliverable corpus in this window vs the pre-AI baseline. Provenance labels: **skill-prescribed** = tune the skill if the aggregate drifts; **skill-encouraged** = under-application of the skill; **ungoverned** = genuine voice signal.
+
+| feature | provenance | corpus rate | baseline rate | delta |
+| --- | --- | --- | --- | --- |
+| First-person voice (I/we per 1k) | skill-encouraged | 0.00 | 9.50 | -9.50 |
+| Causal language (since/because per 1k) | skill-encouraged | 0.00 | (no baseline stat) | - |
+| Body length (words) | skill-encouraged | 0 | (no baseline stat) | - |
+| URL cross-references (per 1k words) | ungoverned | 2.50 | (no baseline stat) | - |
+| Sentence length median (words) | ungoverned | 0.0 | (no baseline stat) | - |
+| Sentence length p90 (words) | ungoverned | 0.0 | (no baseline stat) | - |
+| Question marks (per 1k words) | ungoverned | 0.00 | (no baseline stat) | - |
+| Template presence (## Changes + ## Testing) | skill-prescribed | 0% | 10% | -10.0pp |
+| Unique heading texts (count) | skill-prescribed | 0 | (no baseline stat) | - |
+| Has any heading (fraction of documents) | skill-prescribed | 0% | (no baseline stat) | - |
+| Action-verb opener lines (fraction of lines) | skill-prescribed | 0.0% | (no baseline stat) | - |
+| Backtick density (per 1k words) | skill-prescribed | 0.00 | (no baseline stat) | - |
+| Backtick-manifest bullets (fraction of bullets) | ungoverned | 0.0% | (no baseline stat) | - |
+| Consequence chains (, so <det>) per 1k words | ungoverned | 0.00 | (no baseline stat) | - |
+
+## Proposed Wordlist Removals
+
+Two reasons a rule earns removal:
+
+- **dead**: the model produced it fewer than 5 times in the window on the surface where the rule fires, so the rule rarely fires.
+- **not distinctive**: the comparison baseline uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.
+
+Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.
+
+_No removals proposed._
+
+## Proposed Wordlist Additions
+
+Phrases distinctive to the assistant (lift >= 5.0x) not yet in the wordlists. The baseline columns report the phrase's rate in the user's voice baseline; a count of 0 is the strongest "absent from my baseline" signal.
+
+_No additions proposed._
+
+## Current Rule Health
+
+Full audit of every wordlist entry on its firing surface. \`remove\` rules are either dead or not distinctive (see Proposed Removals). The surface column shows which corpora the model/baseline rates come from.
+
+_No wordlists found at \`plugins/writing/wordlists/\`._
+
+## Structural Pattern Audit
+
+Regex-based patterns from the writing hook, run against all model-generated text.
+Patterns are grouped by detector layer. Cross-sentence patterns shipping in the hook
+without a promotion record appear here as misplacement signals.
+
+_No structural patterns defined._
+
+## Structural Signatures
+
+Coarse part-of-speech tag sequences distinctive to the model's deliverable prose vs the user's voice. Word-independent: when vocabulary drifts between model releases, these shapes persist. Examples are verbatim corpus sentences. This report is local-only, so replace them with invented examples before quoting anywhere else.
+
+_No structural signatures above threshold._
+
+## Structural Trends
+
+Corpus-level rate metrics across deliverable documents. These are aggregate signals, not per-document flags.
+
+_No deliverable documents analyzed._
+
+## Meaning-Layer Audit (LLM Judge)
+
+Per-criterion flag rates from the batch LLM judge over the deliverable corpus, in rubric order (information-density leads; press-release-structure is deprioritized). The prompt is a versioned artifact: a different hash means these numbers are not comparable to prior runs. Sampled spans quote session text, so this section stays in the local report and is never committed.
+
+_Judge not run. Pass \`--judge\` (requires \`ANTHROPIC_API_KEY\`) to enable._
+
+## Corrective Feedback
+
+Short, human-authored user messages that name a writing problem (frustration lexicon match), paired with the preceding model output. These are labeled-slop moments: the user explicitly called out prose the model produced.
+
+_No corrective-feedback moments in window._
+
+## Correction Candidates
+
+Adjacent (long assistant, short user) pairs. Scan for prose corrections.
+
+_No correction candidates in window._
+"
+`;
+
+exports[`renderReport voice delta full feature table 1`] = `
+"# Writing trope analysis (2026-05-24)
+
+Window: 2026-04-24 to 2026-05-24
+Model filter: \`*opus*\`
+Project filter: (none)
+Min lift threshold (additions): 5.0x
+Min occurrences to count as alive: 5
+Top N candidates: 10
+
+## Summary
+
+- All assistant text: 0 chars
+- Deliverable prose (Write/Edit/Bash): 0 chars
+- User text (human only): 0 chars
+- Voice baseline: 5 documents, 1,200 tokens (sources: github)
+- Current wordlist entries audited: 0
+- Rules kept (distinctive and alive): 0
+- Proposed removals: 0 (dead: 0, not distinctive: 0)
+- Proposed additions (new candidates above threshold): 0
+- Correction candidates surfaced: 0
+- Corrective-feedback moments surfaced: 0
+
+## Voice Delta
+
+Baseline: 5 documents (computed 2026-01-01). Each rate is the mean across the deliverable corpus in this window vs the pre-AI baseline. Provenance labels: **skill-prescribed** = tune the skill if the aggregate drifts; **skill-encouraged** = under-application of the skill; **ungoverned** = genuine voice signal.
+
+| feature | provenance | corpus rate | baseline rate | delta |
+| --- | --- | --- | --- | --- |
+| First-person voice (I/we per 1k) | skill-encouraged | 0.00 | 9.50 | -9.50 |
+| Causal language (since/because per 1k) | skill-encouraged | 0.00 | (no baseline stat) | - |
+| Body length (words) | skill-encouraged | 0 | (no baseline stat) | - |
+| URL cross-references (per 1k words) | ungoverned | 0.00 | (no baseline stat) | - |
+| Sentence length median (words) | ungoverned | 0.0 | (no baseline stat) | - |
+| Sentence length p90 (words) | ungoverned | 0.0 | (no baseline stat) | - |
+| Question marks (per 1k words) | ungoverned | 0.00 | (no baseline stat) | - |
+| Template presence (## Changes + ## Testing) | skill-prescribed | 0% | 10% | -10.0pp |
+| Unique heading texts (count) | skill-prescribed | 0 | (no baseline stat) | - |
+| Has any heading (fraction of documents) | skill-prescribed | 0% | (no baseline stat) | - |
+| Action-verb opener lines (fraction of lines) | skill-prescribed | 0.0% | (no baseline stat) | - |
+| Backtick density (per 1k words) | skill-prescribed | 0.00 | (no baseline stat) | - |
+| Backtick-manifest bullets (fraction of bullets) | ungoverned | 0.0% | (no baseline stat) | - |
+| Consequence chains (, so <det>) per 1k words | ungoverned | 0.00 | (no baseline stat) | - |
+
+## Proposed Wordlist Removals
+
+Two reasons a rule earns removal:
+
+- **dead**: the model produced it fewer than 5 times in the window on the surface where the rule fires, so the rule rarely fires.
+- **not distinctive**: the comparison baseline uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.
+
+Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.
+
+_No removals proposed._
+
+## Proposed Wordlist Additions
+
+Phrases distinctive to the assistant (lift >= 5.0x) not yet in the wordlists. The baseline columns report the phrase's rate in the user's voice baseline; a count of 0 is the strongest "absent from my baseline" signal.
+
+_No additions proposed._
+
+## Current Rule Health
+
+Full audit of every wordlist entry on its firing surface. \`remove\` rules are either dead or not distinctive (see Proposed Removals). The surface column shows which corpora the model/baseline rates come from.
+
+_No wordlists found at \`plugins/writing/wordlists/\`._
+
+## Structural Pattern Audit
+
+Regex-based patterns from the writing hook, run against all model-generated text.
+Patterns are grouped by detector layer. Cross-sentence patterns shipping in the hook
+without a promotion record appear here as misplacement signals.
+
+_No structural patterns defined._
+
+## Structural Signatures
+
+Coarse part-of-speech tag sequences distinctive to the model's deliverable prose vs the user's voice. Word-independent: when vocabulary drifts between model releases, these shapes persist. Examples are verbatim corpus sentences. This report is local-only, so replace them with invented examples before quoting anywhere else.
+
+_No structural signatures above threshold._
+
+## Structural Trends
+
+Corpus-level rate metrics across deliverable documents. These are aggregate signals, not per-document flags.
+
+_No deliverable documents analyzed._
+
+## Meaning-Layer Audit (LLM Judge)
+
+Per-criterion flag rates from the batch LLM judge over the deliverable corpus, in rubric order (information-density leads; press-release-structure is deprioritized). The prompt is a versioned artifact: a different hash means these numbers are not comparable to prior runs. Sampled spans quote session text, so this section stays in the local report and is never committed.
+
+_Judge not run. Pass \`--judge\` (requires \`ANTHROPIC_API_KEY\`) to enable._
+
+## Corrective Feedback
+
+Short, human-authored user messages that name a writing problem (frustration lexicon match), paired with the preceding model output. These are labeled-slop moments: the user explicitly called out prose the model produced.
+
+_No corrective-feedback moments in window._
+
+## Correction Candidates
+
+Adjacent (long assistant, short user) pairs. Scan for prose corrections.
+
+_No correction candidates in window._
+"
+`;
+
+exports[`renderReport treats a profile without voiceDelta stats as no baseline 1`] = `
+"# Writing trope analysis (2026-05-24)
+
+Window: 2026-04-24 to 2026-05-24
+Model filter: \`*opus*\`
+Project filter: (none)
+Min lift threshold (additions): 5.0x
+Min occurrences to count as alive: 5
+Top N candidates: 10
+
+## Summary
+
+- All assistant text: 0 chars
+- Deliverable prose (Write/Edit/Bash): 0 chars
+- User text (human only): 0 chars
+- Voice baseline: 5 documents, 1,200 tokens (sources: github)
+- Current wordlist entries audited: 0
+- Rules kept (distinctive and alive): 0
+- Proposed removals: 0 (dead: 0, not distinctive: 0)
+- Proposed additions (new candidates above threshold): 0
+- Correction candidates surfaced: 0
+- Corrective-feedback moments surfaced: 0
+
+## Voice Delta
+
+No voice-delta baseline loaded. Run \`ingest-voice.ts\` then \`voice-profile.ts\` to build a baseline. Rates shown are corpus means only.
+
+| feature | provenance | corpus rate |
+| --- | --- | --- |
+| First-person voice (I/we per 1k) | skill-encouraged | 0.00 |
+| Causal language (since/because per 1k) | skill-encouraged | 0.00 |
+| Body length (words) | skill-encouraged | 0 |
+| URL cross-references (per 1k words) | ungoverned | 0.00 |
+| Sentence length median (words) | ungoverned | 0.0 |
+| Sentence length p90 (words) | ungoverned | 0.0 |
+| Question marks (per 1k words) | ungoverned | 0.00 |
+| Template presence (## Changes + ## Testing) | skill-prescribed | 0% |
+| Unique heading texts (count) | skill-prescribed | 0 |
+| Has any heading (fraction of documents) | skill-prescribed | 0% |
+| Action-verb opener lines (fraction of lines) | skill-prescribed | 0.0% |
+| Backtick density (per 1k words) | skill-prescribed | 0.00 |
+| Backtick-manifest bullets (fraction of bullets) | ungoverned | 0.0% |
+| Consequence chains (, so <det>) per 1k words | ungoverned | 0.00 |
+
+## Proposed Wordlist Removals
+
+Two reasons a rule earns removal:
+
+- **dead**: the model produced it fewer than 5 times in the window on the surface where the rule fires, so the rule rarely fires.
+- **not distinctive**: the comparison baseline uses it at least as often as the model (per token), so the rule would flag the user's own voice rather than slop.
+
+Each rule is judged on its firing surface. Chat-surface rules (openers, sycophantic patterns) compare the model's chat against the user's chat. Deliverable-surface rules (flowery phrases, soft phrasing) compare the model's deliverable prose against the user's voice baseline, so a tell frequent in PR bodies and absent from the baseline reads as keep, not dead.
+
+_No removals proposed._
+
+## Proposed Wordlist Additions
+
+Phrases distinctive to the assistant (lift >= 5.0x) not yet in the wordlists. The baseline columns report the phrase's rate in the user's voice baseline; a count of 0 is the strongest "absent from my baseline" signal.
+
+_No additions proposed._
+
+## Current Rule Health
+
+Full audit of every wordlist entry on its firing surface. \`remove\` rules are either dead or not distinctive (see Proposed Removals). The surface column shows which corpora the model/baseline rates come from.
+
+_No wordlists found at \`plugins/writing/wordlists/\`._
+
+## Structural Pattern Audit
+
+Regex-based patterns from the writing hook, run against all model-generated text.
+Patterns are grouped by detector layer. Cross-sentence patterns shipping in the hook
+without a promotion record appear here as misplacement signals.
+
+_No structural patterns defined._
+
+## Structural Signatures
+
+Coarse part-of-speech tag sequences distinctive to the model's deliverable prose vs the user's voice. Word-independent: when vocabulary drifts between model releases, these shapes persist. Examples are verbatim corpus sentences. This report is local-only, so replace them with invented examples before quoting anywhere else.
+
+_No structural signatures above threshold._
+
+## Structural Trends
+
+Corpus-level rate metrics across deliverable documents. These are aggregate signals, not per-document flags.
+
+_No deliverable documents analyzed._
+
+## Meaning-Layer Audit (LLM Judge)
+
+Per-criterion flag rates from the batch LLM judge over the deliverable corpus, in rubric order (information-density leads; press-release-structure is deprioritized). The prompt is a versioned artifact: a different hash means these numbers are not comparable to prior runs. Sampled spans quote session text, so this section stays in the local report and is never committed.
+
+_Judge not run. Pass \`--judge\` (requires \`ANTHROPIC_API_KEY\`) to enable._
+
+## Corrective Feedback
+
+Short, human-authored user messages that name a writing problem (frustration lexicon match), paired with the preceding model output. These are labeled-slop moments: the user explicitly called out prose the model produced.
+
+_No corrective-feedback moments in window._
+
+## Correction Candidates
+
+Adjacent (long assistant, short user) pairs. Scan for prose corrections.
+
+_No correction candidates in window._
+"
+`;

--- a/plugins/writing/skills/analyze/scripts/report.test.ts
+++ b/plugins/writing/skills/analyze/scripts/report.test.ts
@@ -5,6 +5,8 @@ import type { FeatureRate } from "./voice-delta";
 import type { VoiceProfile } from "./voice-profile";
 import type { WordlistEntry } from "./wordlists";
 
+type ReportInput = Parameters<typeof renderReport>[0];
+
 const baseInput = {
   generatedAt: "2026-05-24",
   since: "2026-04-24",
@@ -35,24 +37,62 @@ const baseInput = {
   candidatePhrases: [] as CandidatePhrase[],
   corrections: [] as CorrectionRow[],
   corrective: [] as CorrectiveRow[],
+} satisfies ReportInput;
+
+// Invented fixture profile. Rates are made-up numbers, never real baseline
+// content, which stays in the local data dir.
+const fixtureProfile: VoiceProfile = {
+  documentCount: 5,
+  totalTokens: 1200,
+  ngrams: {},
+  stemmedNgrams: {},
+  totalStemmedTokens: 1100,
+  generatedAt: "2026-01-01",
+  sources: ["github"],
+  voiceDelta: {
+    rates: { first_person_rate: 9.5, template_presence: 0.1 },
+    documentCount: 5,
+    computedAt: "2026-01-01",
+  },
 };
 
-describe("renderReport", () => {
-  test("includes header, summary, and section titles even when empty", () => {
-    const output = renderReport(baseInput);
-    expect(output).toContain("# Writing trope analysis");
-    expect(output).toContain("## Summary");
-    expect(output).toContain("## Voice Delta");
-    expect(output).toContain("## Proposed Wordlist Removals");
-    expect(output).toContain("## Proposed Wordlist Additions");
-    expect(output).toContain("## Current Rule Health");
-    expect(output).toContain("## Structural Signatures");
-    expect(output).toContain("## Structural Trends");
-    expect(output).toContain("## Correction Candidates");
-  });
+function rateEntry(featureId: string, rate: number): [string, FeatureRate] {
+  return [featureId, { featureId, rate, documentCount: 4 }];
+}
 
-  test("renders structural trends table when documents are present", () => {
-    const output = renderReport({
+const meaningAuditInput: ReportInput = {
+  ...baseInput,
+  meaningAudit: {
+    promptSha256: "abc123def456",
+    model: "claude-haiku-4-5",
+    documents: 40,
+    estimatedCostUsd: 0.1234,
+    criteria: [
+      {
+        id: "information-density",
+        question: "Does this text tell the reviewer anything new?",
+        flagged: 12,
+        total: 40,
+        spans: ["These changes ensure\ncorrect behavior."],
+      },
+      {
+        id: "sycophancy",
+        question: "Does the text flatter the reader?",
+        flagged: 0,
+        total: 40,
+        spans: [],
+      },
+    ],
+  },
+};
+
+const provenanceInput: ReportInput = { ...baseInput, voiceProfile: fixtureProfile };
+
+const cases: Array<{ name: string; input: ReportInput }> = [
+  { name: "empty scaffold", input: baseInput },
+  {
+    name: "structural trends table",
+    input: {
       ...baseInput,
       rateTrends: {
         documentCount: 42,
@@ -62,18 +102,11 @@ describe("renderReport", () => {
         sectionCountDistribution: { 0: 11, 1: 5, 2: 26 },
         templateOnSmallDocumentCount: 7,
       },
-    });
-    expect(output).toContain("## Structural Trends");
-    expect(output).toContain("42");
-    expect(output).toContain("action-verb opener rate");
-    expect(output).toContain("backtick ref density");
-    expect(output).toContain("template document rate");
-    expect(output).toContain("template on small document");
-    expect(output).toContain("7 docs");
-  });
-
-  test("renders structural signature rows with example sentences", () => {
-    const output = renderReport({
+    },
+  },
+  {
+    name: "structural signature rows",
+    input: {
       ...baseInput,
       structuralSignatures: [
         {
@@ -88,59 +121,16 @@ describe("renderReport", () => {
           example: "This is not a cache, it is a ledger",
         },
       ],
-    });
-    expect(output).toContain("`COPULA PART DET NOUN`");
-    expect(output).toContain("This is not a cache, it is a ledger");
-  });
-
-  test("explains how to enable the meaning audit when the judge did not run", () => {
-    const output = renderReport(baseInput);
-    expect(output).toContain("## Meaning-Layer Audit (LLM Judge)");
-    expect(output).toContain("Judge not run");
-  });
-
-  test("renders meaning-audit flag rates, prompt hash, and sampled spans", () => {
-    const output = renderReport({
-      ...baseInput,
-      meaningAudit: {
-        promptSha256: "abc123def456",
-        model: "claude-haiku-4-5",
-        documents: 40,
-        estimatedCostUsd: 0.1234,
-        criteria: [
-          {
-            id: "information-density",
-            question: "Does this text tell the reviewer anything new?",
-            flagged: 12,
-            total: 40,
-            spans: ["These changes ensure\ncorrect behavior."],
-          },
-          {
-            id: "sycophancy",
-            question: "Does the text flatter the reader?",
-            flagged: 0,
-            total: 40,
-            spans: [],
-          },
-        ],
-      },
-    });
-    expect(output).toContain("Prompt: `abc123def456`");
-    expect(output).toContain("| information-density |");
-    expect(output).toContain("| 12/40 | 30% |");
-    // Multi-line spans are flattened so they cannot break the list item.
-    expect(output).toContain('information-density: "These changes ensure correct behavior."');
-    expect(output).toContain("| sycophancy |");
-    expect(output).not.toContain('sycophancy: "');
-  });
-
-  test("renders proposed-removals diff block when entries collapse", () => {
-    const entry: WordlistEntry = { phrase: "tapestry", source: "vocabulary.txt" };
-    const output = renderReport({
+    },
+  },
+  { name: "meaning audit", input: meaningAuditInput },
+  {
+    name: "proposed removals diff block",
+    input: {
       ...baseInput,
       ruleHealth: [
         {
-          entry,
+          entry: { phrase: "tapestry", source: "vocabulary.txt" } satisfies WordlistEntry,
           surface: "chat",
           modelCount: 5,
           modelPerM: 50,
@@ -152,14 +142,11 @@ describe("renderReport", () => {
           quote: null,
         },
       ],
-    });
-    expect(output).toContain("- tapestry");
-    expect(output).toContain("vocabulary.txt");
-    expect(output).toContain("```diff");
-  });
-
-  test("renders proposed-additions diff block for high-lift phrases", () => {
-    const output = renderReport({
+    },
+  },
+  {
+    name: "proposed additions diff block",
+    input: {
       ...baseInput,
       candidatePhrases: [
         {
@@ -175,14 +162,11 @@ describe("renderReport", () => {
           quote: null,
         },
       ],
-    });
-    expect(output).toContain("+ reaching for");
-    expect(output).toContain("lift=16.0");
-    expect(output).toContain("baseline=0");
-  });
-
-  test("renders corrective-feedback moments with matched term", () => {
-    const output = renderReport({
+    },
+  },
+  {
+    name: "corrective feedback moments",
+    input: {
       ...baseInput,
       corrective: [
         {
@@ -198,14 +182,11 @@ describe("renderReport", () => {
           context_snippet: "the model wrote a flowery paragraph",
         },
       ],
-    });
-    expect(output).toContain("## Corrective Feedback");
-    expect(output).toContain("matched `fluff`");
-    expect(output).toContain("reads like marketing fluff");
-  });
-
-  test("renders correction snippets in their own subsections", () => {
-    const output = renderReport({
+    },
+  },
+  {
+    name: "correction snippets",
+    input: {
       ...baseInput,
       corrections: [
         {
@@ -220,13 +201,11 @@ describe("renderReport", () => {
           prose_signal: true,
         },
       ],
-    });
-    expect(output).toContain("### 2026-05-20T10:00:00Z (myproject)");
-    expect(output).toContain("no, do it differently");
-  });
-
-  test("labels openers and vocabulary rules with type column", () => {
-    const output = renderReport({
+    },
+  },
+  {
+    name: "rule health opener and vocabulary types",
+    input: {
       ...baseInput,
       ruleHealth: [
         {
@@ -254,10 +233,47 @@ describe("renderReport", () => {
           quote: null,
         },
       ],
-    });
-    expect(output).toContain("| type |");
-    expect(output).toMatch(/Perfect.*opener/);
-    expect(output).toMatch(/tapestry.*vocabulary/);
+    },
+  },
+  {
+    name: "voice delta rates only, no baseline",
+    input: { ...baseInput, voiceDeltaRates: new Map([rateEntry("first_person_rate", 3.2)]) },
+  },
+  {
+    name: "voice delta corpus, baseline, and delta",
+    input: {
+      ...baseInput,
+      voiceProfile: fixtureProfile,
+      voiceDeltaRates: new Map([rateEntry("first_person_rate", 3.2)]),
+    },
+  },
+  {
+    name: "voice delta fraction features as percentages",
+    input: {
+      ...baseInput,
+      voiceProfile: fixtureProfile,
+      voiceDeltaRates: new Map([rateEntry("template_presence", 0.6)]),
+    },
+  },
+  {
+    name: "voice delta feature missing from baseline",
+    input: {
+      ...baseInput,
+      voiceProfile: fixtureProfile,
+      voiceDeltaRates: new Map([rateEntry("url_rate", 2.5)]),
+    },
+  },
+  { name: "voice delta full feature table", input: provenanceInput },
+];
+
+describe("renderReport", () => {
+  test.each(cases)("$name", ({ input }) => {
+    expect(renderReport(input)).toMatchSnapshot();
+  });
+
+  test("treats a profile without voiceDelta stats as no baseline", () => {
+    const { voiceDelta: _omitted, ...legacyProfile } = fixtureProfile;
+    expect(renderReport({ ...baseInput, voiceProfile: legacyProfile })).toMatchSnapshot();
   });
 
   test("orders sections: summary, removals, additions, health", () => {
@@ -271,89 +287,17 @@ describe("renderReport", () => {
     expect(additionIdx).toBeGreaterThan(removalIdx);
     expect(healthIdx).toBeGreaterThan(additionIdx);
   });
-});
 
-// Invented fixture profile. Rates are made-up numbers, never real baseline
-// content, which stays in the local data dir.
-const fixtureProfile: VoiceProfile = {
-  documentCount: 5,
-  totalTokens: 1200,
-  ngrams: {},
-  stemmedNgrams: {},
-  totalStemmedTokens: 1100,
-  generatedAt: "2026-01-01",
-  sources: ["github"],
-  voiceDelta: {
-    rates: { first_person_rate: 9.5, template_presence: 0.1 },
-    documentCount: 5,
-    computedAt: "2026-01-01",
-  },
-};
-
-function rateEntry(featureId: string, rate: number): [string, FeatureRate] {
-  return [featureId, { featureId, rate, documentCount: 4 }];
-}
-
-describe("renderReport voice delta", () => {
-  test("renders rates-only table with a hint when no baseline is loaded", () => {
-    const output = renderReport({
-      ...baseInput,
-      voiceDeltaRates: new Map([rateEntry("first_person_rate", 3.2)]),
-    });
-    expect(output).toContain("No voice-delta baseline loaded");
-    expect(output).toContain("| feature | provenance | corpus rate |");
-    expect(output).toContain("| First-person voice (I/we per 1k) | skill-encouraged | 3.20 |");
+  test("flattens multi-line meaning-audit spans and omits unflagged criteria", () => {
+    const output = renderReport(meaningAuditInput);
+    // Multi-line spans are flattened so they cannot break the list item.
+    expect(output).toContain('information-density: "These changes ensure correct behavior."');
+    // Unflagged criteria contribute no sampled-span line.
+    expect(output).not.toContain('sycophancy: "');
   });
 
-  test("treats a profile without voiceDelta stats as no baseline", () => {
-    const { voiceDelta: _omitted, ...legacyProfile } = fixtureProfile;
-    const output = renderReport({
-      ...baseInput,
-      voiceProfile: legacyProfile,
-    });
-    expect(output).toContain("No voice-delta baseline loaded");
-  });
-
-  test("renders corpus rate, baseline rate, and delta per feature", () => {
-    const output = renderReport({
-      ...baseInput,
-      voiceProfile: fixtureProfile,
-      voiceDeltaRates: new Map([rateEntry("first_person_rate", 3.2)]),
-    });
-    expect(output).toContain("Baseline: 5 documents (computed 2026-01-01)");
-    expect(output).toContain("| feature | provenance | corpus rate | baseline rate | delta |");
-    expect(output).toContain(
-      "| First-person voice (I/we per 1k) | skill-encouraged | 3.20 | 9.50 | -6.30 |",
-    );
-  });
-
-  test("formats fraction features as percentages with pp deltas", () => {
-    const output = renderReport({
-      ...baseInput,
-      voiceProfile: fixtureProfile,
-      voiceDeltaRates: new Map([rateEntry("template_presence", 0.6)]),
-    });
-    expect(output).toContain(
-      "| Template presence (## Changes + ## Testing) | skill-prescribed | 60% | 10% | +50.0pp |",
-    );
-  });
-
-  test("marks features missing from the baseline stats", () => {
-    const output = renderReport({
-      ...baseInput,
-      voiceProfile: fixtureProfile,
-      voiceDeltaRates: new Map([rateEntry("url_rate", 2.5)]),
-    });
-    expect(output).toContain(
-      "| URL cross-references (per 1k words) | ungoverned | 2.50 | (no baseline stat) | - |",
-    );
-  });
-
-  test("labels every feature row with its provenance", () => {
-    const output = renderReport({
-      ...baseInput,
-      voiceProfile: fixtureProfile,
-    });
+  test("labels every voice-delta feature row with its provenance", () => {
+    const output = renderReport(provenanceInput);
     const section = output.slice(
       output.indexOf("## Voice Delta"),
       output.indexOf("## Proposed Wordlist Removals"),

--- a/plugins/writing/skills/score/scripts/__snapshots__/score.test.ts.snap
+++ b/plugins/writing/skills/score/scripts/__snapshots__/score.test.ts.snap
@@ -1,0 +1,124 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`renderTable header with word count and category rows 1`] = `
+"prose (2 words)
+╔════════════════╤══════╤═════════════╗
+║ Category       │ Hits │ Density /1k ║
+╟────────────────┼──────┼─────────────╢
+║ spaced em dash │ 1    │ 500.0       ║
+╚════════════════╧══════╧═════════════╝"
+`;
+
+exports[`renderTable no patterns for clean prose 1`] = `
+"prose (4 words)
+No patterns detected."
+`;
+
+exports[`renderVoiceDeltaTable rate, baseline, and delta columns for in-register text 1`] = `
+"Voice Delta Features
+╔═════════════════════════════════════════════════╤══════════════════╤═══════╤═══════════╤════════╗
+║ Feature                                         │ Provenance       │ Rate  │ Baseline  │ Delta  ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────┼───────────┼────────╢
+║ First-person voice (I/we per 1k)                │ skill-encouraged │ 52.63 │ 9.50      │ +43.13 ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────┼───────────┼────────╢
+║ Causal language (since/because per 1k)          │ skill-encouraged │ 0.00  │ (no stat) │ -      ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────┼───────────┼────────╢
+║ Body length (words)                             │ skill-encouraged │ 19    │ (no stat) │ -      ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────┼───────────┼────────╢
+║ URL cross-references (per 1k words)             │ ungoverned       │ 0.00  │ (no stat) │ -      ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────┼───────────┼────────╢
+║ Sentence length median (words)                  │ ungoverned       │ 6.0   │ (no stat) │ -      ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────┼───────────┼────────╢
+║ Sentence length p90 (words)                     │ ungoverned       │ 8.0   │ (no stat) │ -      ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────┼───────────┼────────╢
+║ Question marks (per 1k words)                   │ ungoverned       │ 0.00  │ (no stat) │ -      ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────┼───────────┼────────╢
+║ Template presence (## Changes + ## Testing)     │ skill-prescribed │ 0%    │ (no stat) │ -      ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────┼───────────┼────────╢
+║ Unique heading texts (count)                    │ skill-prescribed │ 0     │ (no stat) │ -      ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────┼───────────┼────────╢
+║ Has any heading (fraction of documents)         │ skill-prescribed │ 0%    │ (no stat) │ -      ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────┼───────────┼────────╢
+║ Action-verb opener lines (fraction of lines)    │ skill-prescribed │ 0.0%  │ (no stat) │ -      ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────┼───────────┼────────╢
+║ Backtick density (per 1k words)                 │ skill-prescribed │ 0.00  │ (no stat) │ -      ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────┼───────────┼────────╢
+║ Backtick-manifest bullets (fraction of bullets) │ ungoverned       │ 0.0%  │ (no stat) │ -      ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────┼───────────┼────────╢
+║ Consequence chains (, so <det>) per 1k words    │ ungoverned       │ 0.00  │ (no stat) │ -      ║
+╚═════════════════════════════════════════════════╧══════════════════╧═══════╧═══════════╧════════╝"
+`;
+
+exports[`renderVoiceDeltaTable skips the baseline comparison for out-of-register input 1`] = `
+"Voice Delta Features
+Register check: skipping baseline comparison (too short (1 sentence(s); need 3+)).
+
+╔═════════════════════════════════════════════════╤══════════════════╤══════╗
+║ Feature                                         │ Provenance       │ Rate ║
+╟─────────────────────────────────────────────────┼──────────────────┼──────╢
+║ First-person voice (I/we per 1k)                │ skill-encouraged │ 0.00 ║
+╟─────────────────────────────────────────────────┼──────────────────┼──────╢
+║ Causal language (since/because per 1k)          │ skill-encouraged │ 0.00 ║
+╟─────────────────────────────────────────────────┼──────────────────┼──────╢
+║ Body length (words)                             │ skill-encouraged │ 2    ║
+╟─────────────────────────────────────────────────┼──────────────────┼──────╢
+║ URL cross-references (per 1k words)             │ ungoverned       │ 0.00 ║
+╟─────────────────────────────────────────────────┼──────────────────┼──────╢
+║ Sentence length median (words)                  │ ungoverned       │ 2.0  ║
+╟─────────────────────────────────────────────────┼──────────────────┼──────╢
+║ Sentence length p90 (words)                     │ ungoverned       │ 2.0  ║
+╟─────────────────────────────────────────────────┼──────────────────┼──────╢
+║ Question marks (per 1k words)                   │ ungoverned       │ 0.00 ║
+╟─────────────────────────────────────────────────┼──────────────────┼──────╢
+║ Template presence (## Changes + ## Testing)     │ skill-prescribed │ 0%   ║
+╟─────────────────────────────────────────────────┼──────────────────┼──────╢
+║ Unique heading texts (count)                    │ skill-prescribed │ 0    ║
+╟─────────────────────────────────────────────────┼──────────────────┼──────╢
+║ Has any heading (fraction of documents)         │ skill-prescribed │ 0%   ║
+╟─────────────────────────────────────────────────┼──────────────────┼──────╢
+║ Action-verb opener lines (fraction of lines)    │ skill-prescribed │ 0.0% ║
+╟─────────────────────────────────────────────────┼──────────────────┼──────╢
+║ Backtick density (per 1k words)                 │ skill-prescribed │ 0.00 ║
+╟─────────────────────────────────────────────────┼──────────────────┼──────╢
+║ Backtick-manifest bullets (fraction of bullets) │ ungoverned       │ 0.0% ║
+╟─────────────────────────────────────────────────┼──────────────────┼──────╢
+║ Consequence chains (, so <det>) per 1k words    │ ungoverned       │ 0.00 ║
+╚═════════════════════════════════════════════════╧══════════════════╧══════╝"
+`;
+
+exports[`renderVoiceDeltaTable missing baseline still renders rates 1`] = `
+"Voice Delta Features
+No baseline loaded. Run ingest-voice.ts then voice-profile.ts to build one.
+
+╔═════════════════════════════════════════════════╤══════════════════╤═══════╗
+║ Feature                                         │ Provenance       │ Rate  ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────╢
+║ First-person voice (I/we per 1k)                │ skill-encouraged │ 52.63 ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────╢
+║ Causal language (since/because per 1k)          │ skill-encouraged │ 0.00  ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────╢
+║ Body length (words)                             │ skill-encouraged │ 19    ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────╢
+║ URL cross-references (per 1k words)             │ ungoverned       │ 0.00  ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────╢
+║ Sentence length median (words)                  │ ungoverned       │ 6.0   ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────╢
+║ Sentence length p90 (words)                     │ ungoverned       │ 8.0   ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────╢
+║ Question marks (per 1k words)                   │ ungoverned       │ 0.00  ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────╢
+║ Template presence (## Changes + ## Testing)     │ skill-prescribed │ 0%    ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────╢
+║ Unique heading texts (count)                    │ skill-prescribed │ 0     ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────╢
+║ Has any heading (fraction of documents)         │ skill-prescribed │ 0%    ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────╢
+║ Action-verb opener lines (fraction of lines)    │ skill-prescribed │ 0.0%  ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────╢
+║ Backtick density (per 1k words)                 │ skill-prescribed │ 0.00  ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────╢
+║ Backtick-manifest bullets (fraction of bullets) │ ungoverned       │ 0.0%  ║
+╟─────────────────────────────────────────────────┼──────────────────┼───────╢
+║ Consequence chains (, so <det>) per 1k words    │ ungoverned       │ 0.00  ║
+╚═════════════════════════════════════════════════╧══════════════════╧═══════╝"
+`;

--- a/plugins/writing/skills/score/scripts/score.test.ts
+++ b/plugins/writing/skills/score/scripts/score.test.ts
@@ -91,17 +91,13 @@ describe("buildReport", () => {
 });
 
 describe("renderTable", () => {
-  it("renders a header with word count and a category row", () => {
-    const report = buildReport("a — b", "doc.md", { comments: false });
-    const out = renderTable(report);
-    expect(out).toContain("prose (2 words)");
-    expect(out).toContain("spaced em dash");
-    expect(out).toContain("Density /1k");
-  });
+  const cases: Array<{ name: string; text: string }> = [
+    { name: "header with word count and category rows", text: "a — b" },
+    { name: "no patterns for clean prose", text: "The function reads input." },
+  ];
 
-  it("reports no patterns for clean prose", () => {
-    const report = buildReport("The function reads input.", "doc.md", { comments: false });
-    expect(renderTable(report)).toContain("No patterns detected.");
+  it.each(cases)("$name", ({ text }) => {
+    expect(renderTable(buildReport(text, "doc.md", { comments: false }))).toMatchSnapshot();
   });
 });
 
@@ -126,31 +122,26 @@ const inRegisterText =
   "This fixes the loader race. I noticed it while testing retries. The fix holds the lock across the read.";
 
 describe("renderVoiceDeltaTable", () => {
-  it("shows rate, baseline, and delta columns for in-register text", () => {
-    const out = renderVoiceDeltaTable(inRegisterText, fixtureProfile);
-    expect(out).toContain("Voice Delta Features");
-    expect(out).toContain("Baseline");
-    expect(out).toContain("Delta");
-    expect(out).toContain("skill-encouraged");
-    expect(out).toContain("9.50");
+  const cases: Array<{ name: string; text: string; profile: VoiceProfile | null }> = [
+    {
+      name: "rate, baseline, and delta columns for in-register text",
+      text: inRegisterText,
+      profile: fixtureProfile,
+    },
+    {
+      name: "skips the baseline comparison for out-of-register input",
+      text: "Too short.",
+      profile: fixtureProfile,
+    },
+    { name: "missing baseline still renders rates", text: inRegisterText, profile: null },
+  ];
+
+  it.each(cases)("$name", ({ text, profile }) => {
+    expect(renderVoiceDeltaTable(text, profile)).toMatchSnapshot();
   });
 
-  it("skips the baseline comparison for out-of-register input", () => {
-    const out = renderVoiceDeltaTable("Too short.", fixtureProfile);
-    expect(out).toContain("Register check: skipping baseline comparison");
-    expect(out).toContain("too short");
-    expect(out).not.toContain("Baseline");
-  });
-
-  it("reports a missing baseline and still renders rates", () => {
-    const out = renderVoiceDeltaTable(inRegisterText, null);
-    expect(out).toContain("No baseline loaded");
-    expect(out).toContain("Rate");
-    expect(out).not.toContain("Baseline");
-  });
-
-  it("marks features absent from the baseline stats", () => {
-    const out = renderVoiceDeltaTable(inRegisterText, fixtureProfile);
-    expect(out).toContain("(no stat)");
+  it("omits the baseline column when the comparison is skipped or unavailable", () => {
+    expect(renderVoiceDeltaTable("Too short.", fixtureProfile)).not.toContain("Baseline");
+    expect(renderVoiceDeltaTable(inRegisterText, null)).not.toContain("Baseline");
   });
 });

--- a/user/scripts/statusline.test.ts
+++ b/user/scripts/statusline.test.ts
@@ -122,11 +122,9 @@ const cases: RenderCase[] = [
 ];
 
 describe("rendered output", () => {
-  for (const c of cases) {
-    test(c.name, () => {
-      expect(buildStatusLine(c.stdin, c.columns, c.worktree)).toMatchSnapshot();
-    });
-  }
+  test.each(cases)("$name", (c) => {
+    expect(buildStatusLine(c.stdin, c.columns, c.worktree)).toMatchSnapshot();
+  });
 });
 
 describe("dialColor", () => {

--- a/user/scripts/subagent-statusline.test.ts
+++ b/user/scripts/subagent-statusline.test.ts
@@ -217,9 +217,7 @@ describe("rendered content", () => {
     },
   ];
 
-  for (const c of cases) {
-    test(c.name, () => {
-      expect(renderTask(c.task, c.columns, now, c.agentType).content).toMatchSnapshot();
-    });
-  }
+  test.each(cases)("$name", (c) => {
+    expect(renderTask(c.task, c.columns, now, c.agentType).content).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Several tests asserted against composed, formatted output (markdown reports, terminal tables, rendered PR-comment threads) with scattered `toContain`/`toMatch`/`indexOf` checks. Those assertions are both brittle and loose: any wording or layout change breaks them, yet they never pin the thing that actually matters about formatted output (table alignment, section ordering, whitespace, the full rendered shape). This swaps them for full-output snapshots, which catch the regressions the fragments missed while dropping the per-fragment boilerplate. Net is less test code and more coverage.

## Changes

Converted the formatted-output assertions to `toMatchSnapshot` for `renderReport` (writing analyze), `formatThreads` (github pr-comments), `renderTable` and `renderVoiceDeltaTable` (writing score), and `formatDigest` (gitlab merge-request). Genuine invariants that a snapshot doesn't make obvious stay as explicit assertions next to the snapshots: section ordering in the report, file-header dedup and the suppressed reviewer-opener header in pr-comments, the absent baseline column in score, and the one-line-per-discussion count in the digest.

The snapshot case tables now run through `test.each`/`it.each` with `$name` title interpolation instead of manual `for...of` loops, including the existing `statusline` and `subagent-statusline` tables. The interpolated names match the prior test names, so every existing snapshot key is unchanged.

Left alone: tests that already use `toEqual`/`toBe` on structured returns, and the hook/integration tests whose output wraps external tools (Biome, git), where a snapshot would churn on every upstream change.
