### PR TITLE
coverage: measure test coverage and surface uncovered lines

### DIFF
--- a/.claude/hooks/coverage/index.test.ts
+++ b/.claude/hooks/coverage/index.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { computeHint, formatHint, isStale, processPostToolUse } from "./index";
+
+const repoRoot = join(import.meta.dirname, "..", "..", "..");
+const workDir = join(repoRoot, "tmp", "cov-hook-test");
+const sourceFile = join(workDir, "sample.ts");
+const lcovPath = join(workDir, "lcov.info");
+
+function lcovFor(uncovered: number[]): string {
+  const rel = relative(repoRoot, sourceFile);
+  const da = [1, 2, 3, 4].map((n) => `DA:${n},${uncovered.includes(n) ? 0 : 1}`).join("\n");
+  return `TN:\nSF:${rel}\nFNF:1\nFNH:1\n${da}\nend_of_record\n`;
+}
+
+beforeEach(async () => {
+  mkdirSync(workDir, { recursive: true });
+  await Bun.write(sourceFile, "export const a = 1;\n");
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+describe("isStale", () => {
+  test.each([
+    [2000, 1000, true],
+    [1000, 2000, false],
+    [1000, 1000, false],
+  ])("isStale(%i, %i) -> %p", (file, lcov, expected) => {
+    expect(isStale(file, lcov)).toBe(expected);
+  });
+});
+
+describe("computeHint", () => {
+  test("returns null when no coverage data exists", async () => {
+    expect(await computeHint(sourceFile, lcovPath)).toBeNull();
+  });
+
+  test("returns null when the file is fully covered", async () => {
+    await Bun.write(lcovPath, lcovFor([]));
+    expect(await computeHint(sourceFile, lcovPath)).toBeNull();
+  });
+
+  test("returns null when the file was never measured", async () => {
+    await Bun.write(lcovPath, "TN:\nSF:other/file.ts\nDA:1,0\nend_of_record\n");
+    expect(await computeHint(sourceFile, lcovPath)).toBeNull();
+  });
+
+  test("surfaces uncovered lines when coverage is current", async () => {
+    // lcov written after the source, so it is at least as new -> not stale.
+    await Bun.write(lcovPath, lcovFor([2, 3]));
+    const hint = await computeHint(sourceFile, lcovPath);
+    expect(hint?.uncovered).toEqual([2, 3]);
+    expect(hint?.stale).toBe(false);
+  });
+});
+
+describe("formatHint", () => {
+  test("lists lines and points to the coverage skill", () => {
+    const message = formatHint({ file: "a.ts", uncovered: [2, 3], stale: false });
+    expect(message).toContain("a.ts has uncovered lines: 2, 3");
+    expect(message).toContain("coverage` skill");
+    expect(message).not.toContain("predates");
+  });
+
+  test("includes a refresh hint when stale", () => {
+    const message = formatHint({ file: "a.ts", uncovered: [2], stale: true });
+    expect(message).toContain("predates your edit");
+  });
+});
+
+describe("processPostToolUse", () => {
+  test("ignores non-edit tools", async () => {
+    const result = await processPostToolUse({
+      hook_event_name: "PostToolUse",
+      tool_name: "Read",
+      tool_input: { file_path: sourceFile },
+    } as Parameters<typeof processPostToolUse>[0]);
+    expect(result).toBeNull();
+  });
+
+  test("ignores test files", async () => {
+    const result = await processPostToolUse({
+      hook_event_name: "PostToolUse",
+      tool_name: "Edit",
+      tool_input: { file_path: join(workDir, "sample.test.ts") },
+    } as Parameters<typeof processPostToolUse>[0]);
+    expect(result).toBeNull();
+  });
+});

--- a/.claude/hooks/coverage/index.ts
+++ b/.claude/hooks/coverage/index.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env bun
+
+import { join, relative } from "node:path";
+import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { parseLcov, uncoveredLines } from "../../../scripts/coverage/lcov";
+
+const repoRoot = join(import.meta.dirname, "..", "..", "..");
+
+function isSourceFile(file: string): boolean {
+  return file.endsWith(".ts") && !file.endsWith(".test.ts") && !file.endsWith(".integration.ts");
+}
+
+export interface CoverageHint {
+  /** Repo-relative path, matching the lcov `SF:` key. */
+  file: string;
+  uncovered: number[];
+  /** The file was edited after the coverage data was produced. */
+  stale: boolean;
+}
+
+export function isStale(fileMtimeMs: number, lcovMtimeMs: number): boolean {
+  return fileMtimeMs > lcovMtimeMs;
+}
+
+// Look up the edited file in the latest coverage report. Returns null (stay
+// silent) when there is no coverage data, the file was never measured, or it is
+// already fully covered.
+export async function computeHint(
+  filePath: string,
+  lcovPath = join(repoRoot, "coverage", "lcov.info"),
+): Promise<CoverageHint | null> {
+  const lcovFile = Bun.file(lcovPath);
+  const sourceFile = Bun.file(filePath);
+  if (!(await lcovFile.exists()) || !(await sourceFile.exists())) return null;
+
+  const rel = relative(repoRoot, filePath);
+  const report = parseLcov(await lcovFile.text());
+  const fc = report.find((r) => r.file === rel);
+  if (!fc) return null;
+
+  const uncovered = uncoveredLines(fc);
+  if (uncovered.length === 0) return null;
+
+  return { file: rel, uncovered, stale: isStale(sourceFile.lastModified, lcovFile.lastModified) };
+}
+
+export function formatHint(hint: CoverageHint): string {
+  const lines = hint.uncovered.join(", ");
+  const staleNote = hint.stale
+    ? "\n\nThis coverage data predates your edit. Re-run `bun scripts/coverage/index.ts " +
+      `${hint.file}\` to refresh it.`
+    : "";
+  return (
+    `${hint.file} has uncovered lines: ${lines}.\n\n` +
+    "Add tests targeting these lines, then re-run coverage to confirm. " +
+    "The `coverage` skill documents the loop." +
+    staleNote
+  );
+}
+
+export async function processPostToolUse(
+  input: PostToolUseHookInput,
+): Promise<SyncHookJSONOutput | null> {
+  if (input.tool_name !== "Edit" && input.tool_name !== "Write") return null;
+
+  const filePath = (input.tool_input as { file_path?: string }).file_path;
+  if (!filePath || !isSourceFile(filePath)) return null;
+
+  const hint = await computeHint(filePath);
+  if (!hint) return null;
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      additionalContext: formatHint(hint),
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  let input: PostToolUseHookInput;
+  try {
+    input = await readStdinJson<PostToolUseHookInput>();
+  } catch (error) {
+    console.error(
+      `[coverage] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  const output = await processPostToolUse(input);
+  if (output) {
+    writeStdoutJson(output);
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,6 +56,11 @@
             "type": "command",
             "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/biome\"",
             "if": "Edit(**/*.ts)|Edit(**/*.tsx)|Edit(**/*.js)|Edit(**/*.jsx)|Edit(**/*.json)|Edit(**/*.jsonc)|Write(**/*.ts)|Write(**/*.tsx)|Write(**/*.js)|Write(**/*.jsx)|Write(**/*.json)|Write(**/*.jsonc)"
+          },
+          {
+            "type": "command",
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/coverage\"",
+            "if": "Edit(**/*.ts)|Write(**/*.ts)"
           }
         ]
       }

--- a/.claude/skills/coverage/SKILL.md
+++ b/.claude/skills/coverage/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: coverage
+description: Measure Bun test coverage and close gaps on a specific file. Use when adding or editing tests, when asked about coverage, or when the PostToolUse coverage hook reports uncovered lines.
+allowed-tools:
+  - Read
+  - Edit
+  - Bash(bun *scripts/coverage*)
+  - Bash(bun test:*)
+---
+
+# Coverage
+
+Measure which lines of a source file your tests exercise, then close the gaps. The engine is Bun's built-in coverage (`bun test --coverage`); `scripts/coverage/` resolves the test scope, runs it, and reports the uncovered lines.
+
+## Loop
+
+Work one source file at a time:
+
+1. **Measure.** Run coverage scoped to the file:
+
+   ```bash
+   bun scripts/coverage/index.ts <file>
+   ```
+
+   It runs the tests in the file's scope (its plugin, package, `.claude`, or `user` root) and prints a table plus the exact uncovered line numbers.
+
+2. **Read.** Open the file at those line numbers. Each uncovered line is a branch, error path, or case no test reaches.
+
+3. **Add tests.** Write or extend tests that drive execution through those lines. Target the specific uncovered behavior each line represents.
+
+4. **Re-measure.** Run the same command. Confirm the uncovered list shrinks toward empty. Repeat until the lines you care about are covered.
+
+## Notes
+
+- Pass multiple files to measure them together; the command merges their scopes.
+- Each run rewrites `coverage/lcov.info`, which the PostToolUse hook reads to flag uncovered lines after later edits. If the hook reports stale data, just re-run the command.
+- Coverage is opt-in. Plain `bun test` does not measure it, so normal test runs stay fast.
+- Pursue meaningful coverage. A line that only runs in an environment the tests can't reproduce is a worse target than a real untested branch.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run tests
-        run: bun test ./.claude ./user
+        run: bun test ./.claude ./user scripts/
 
   validate:
     runs-on: ubuntu-latest
@@ -266,6 +266,26 @@ jobs:
 
       - name: Lint skills
         run: bun run skill-lint "user/skills/*"
+
+  coverage:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Measure coverage on changed files
+        run: |
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          bun scripts/coverage/index.ts --report github --changed --base "origin/${{ github.base_ref }}"
 
   context:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,11 @@
 node_modules/
 .DS_Store
 **/fixtures/
+
+# Generated coverage output (bun test --coverage)
+/coverage/
+# The coverage tooling lives in directories named `coverage`. Re-include them
+# against a global `coverage` ignore so the source stays tracked.
+!scripts/coverage/
+!.claude/hooks/coverage/
+!.claude/skills/coverage/

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "@bendrucker/claude",
       "dependencies": {
+        "cleye": "^2.2.1",
+        "table": "^6.9.0",
         "typescript": "^5.9.3",
         "url-pattern": "^1.0.3",
       },
@@ -658,7 +660,7 @@
 
     "claude-code": ["claude-code@workspace:plugins/claude-code"],
 
-    "cleye": ["cleye@1.3.4", "", { "dependencies": { "terminal-columns": "^1.4.1", "type-flag": "^3.0.0" } }, "sha512-Rd6M8ecBDtdYdPR22h6gG37lPqqJ3hSOaplaGwuGYey9xKmEElOvTgupqfyLSlISshroRpVhYjDtW3vwNUNBaQ=="],
+    "cleye": ["cleye@2.6.0", "", { "dependencies": { "terminal-columns": "^2.0.0", "type-flag": "^4.1.0" } }, "sha512-u0SQCsega/ox+2GSuUlG6wvA9c2FtH8sPmv9G9Q3JRTs7FK6+LtaziRAQgx7lrJ1J7bOd3palhwgZKMg8R6JbQ=="],
 
     "cli-color": ["cli-color@1.4.0", "", { "dependencies": { "ansi-regex": "^2.1.1", "d": "1", "es5-ext": "^0.10.46", "es6-iterator": "^2.0.3", "memoizee": "^0.4.14", "timers-ext": "^0.1.5" } }, "sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w=="],
 
@@ -1320,7 +1322,7 @@
 
     "table": ["table@6.9.0", "", { "dependencies": { "ajv": "^8.0.1", "lodash.truncate": "^4.4.2", "slice-ansi": "^4.0.0", "string-width": "^4.2.3", "strip-ansi": "^6.0.1" } }, "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A=="],
 
-    "terminal-columns": ["terminal-columns@1.4.1", "", {}, "sha512-IKVL/itiMy947XWVv4IHV7a0KQXvKjj4ptbi7Ew9MPMcOLzkiQeyx3Gyvh62hKrfJ0RZc4M1nbhzjNM39Kyujw=="],
+    "terminal-columns": ["terminal-columns@2.0.0", "", {}, "sha512-6IByuUjyNZJXUtwDNm+OIe62zgwwaRbH+WMNTcx05O2G5V9WhvluAAHJY8OvUdwmzMPpqAD/7EUpGdI6ae1aiQ=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
@@ -1354,7 +1356,7 @@
 
     "type-fest": ["type-fest@0.18.1", "", {}, "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="],
 
-    "type-flag": ["type-flag@3.0.0", "", {}, "sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA=="],
+    "type-flag": ["type-flag@4.3.0", "", {}, "sha512-XwZWK+SOWleva2EjynfJT6tXHUkS+/TZAIc5fTJXVMArNf/5jBEt7Y/yBtGcxLFThtQCQ9v6nxXon0QZ86ZJhA=="],
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
@@ -1422,9 +1424,13 @@
 
     "@anthropic-ai/claude-agent-sdk/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.93.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA=="],
 
-    "@bendrucker/claude-writing/cleye": ["cleye@2.6.0", "", { "dependencies": { "terminal-columns": "^2.0.0", "type-flag": "^4.1.0" } }, "sha512-u0SQCsega/ox+2GSuUlG6wvA9c2FtH8sPmv9G9Q3JRTs7FK6+LtaziRAQgx7lrJ1J7bOd3palhwgZKMg8R6JbQ=="],
+    "@bendrucker/claude-review/cleye": ["cleye@1.3.4", "", { "dependencies": { "terminal-columns": "^1.4.1", "type-flag": "^3.0.0" } }, "sha512-Rd6M8ecBDtdYdPR22h6gG37lPqqJ3hSOaplaGwuGYey9xKmEElOvTgupqfyLSlISshroRpVhYjDtW3vwNUNBaQ=="],
+
+    "@bendrucker/claude-tmux/cleye": ["cleye@1.3.4", "", { "dependencies": { "terminal-columns": "^1.4.1", "type-flag": "^3.0.0" } }, "sha512-Rd6M8ecBDtdYdPR22h6gG37lPqqJ3hSOaplaGwuGYey9xKmEElOvTgupqfyLSlISshroRpVhYjDtW3vwNUNBaQ=="],
 
     "@constellos/claude-code-kit/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "agent-ideas/cleye": ["cleye@1.3.4", "", { "dependencies": { "terminal-columns": "^1.4.1", "type-flag": "^3.0.0" } }, "sha512-Rd6M8ecBDtdYdPR22h6gG37lPqqJ3hSOaplaGwuGYey9xKmEElOvTgupqfyLSlISshroRpVhYjDtW3vwNUNBaQ=="],
 
     "cli-color/ansi-regex": ["ansi-regex@2.1.1", "", {}, "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="],
 
@@ -1444,9 +1450,11 @@
 
     "execa/cross-spawn": ["cross-spawn@6.0.6", "", { "dependencies": { "nice-try": "^1.0.4", "path-key": "^2.0.1", "semver": "^5.5.0", "shebang-command": "^1.2.0", "which": "^1.2.9" } }, "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw=="],
 
-    "gitlab/cleye": ["cleye@2.6.0", "", { "dependencies": { "terminal-columns": "^2.0.0", "type-flag": "^4.1.0" } }, "sha512-u0SQCsega/ox+2GSuUlG6wvA9c2FtH8sPmv9G9Q3JRTs7FK6+LtaziRAQgx7lrJ1J7bOd3palhwgZKMg8R6JbQ=="],
+    "github/cleye": ["cleye@1.3.4", "", { "dependencies": { "terminal-columns": "^1.4.1", "type-flag": "^3.0.0" } }, "sha512-Rd6M8ecBDtdYdPR22h6gG37lPqqJ3hSOaplaGwuGYey9xKmEElOvTgupqfyLSlISshroRpVhYjDtW3vwNUNBaQ=="],
 
     "hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
+
+    "issue/cleye": ["cleye@1.3.4", "", { "dependencies": { "terminal-columns": "^1.4.1", "type-flag": "^3.0.0" } }, "sha512-Rd6M8ecBDtdYdPR22h6gG37lPqqJ3hSOaplaGwuGYey9xKmEElOvTgupqfyLSlISshroRpVhYjDtW3vwNUNBaQ=="],
 
     "jsdom/parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
 
@@ -1454,13 +1462,13 @@
 
     "json-schema-to-typescript/@types/node": ["@types/node@10.17.60", "", {}, "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="],
 
+    "mac/cleye": ["cleye@1.3.4", "", { "dependencies": { "terminal-columns": "^1.4.1", "type-flag": "^3.0.0" } }, "sha512-Rd6M8ecBDtdYdPR22h6gG37lPqqJ3hSOaplaGwuGYey9xKmEElOvTgupqfyLSlISshroRpVhYjDtW3vwNUNBaQ=="],
+
     "macos-version/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
     "memoizee/is-promise": ["is-promise@2.2.2", "", {}, "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="],
 
     "mermaid/uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
-
-    "mermaid-diagram/cleye": ["cleye@2.6.0", "", { "dependencies": { "terminal-columns": "^2.0.0", "type-flag": "^4.1.0" } }, "sha512-u0SQCsega/ox+2GSuUlG6wvA9c2FtH8sPmv9G9Q3JRTs7FK6+LtaziRAQgx7lrJ1J7bOd3palhwgZKMg8R6JbQ=="],
 
     "mongodb-connection-string-url/whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
@@ -1474,15 +1482,23 @@
 
     "redent/indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
-    "session/cleye": ["cleye@2.6.0", "", { "dependencies": { "terminal-columns": "^2.0.0", "type-flag": "^4.1.0" } }, "sha512-u0SQCsega/ox+2GSuUlG6wvA9c2FtH8sPmv9G9Q3JRTs7FK6+LtaziRAQgx7lrJ1J7bOd3palhwgZKMg8R6JbQ=="],
+    "things/cleye": ["cleye@1.3.4", "", { "dependencies": { "terminal-columns": "^1.4.1", "type-flag": "^3.0.0" } }, "sha512-Rd6M8ecBDtdYdPR22h6gG37lPqqJ3hSOaplaGwuGYey9xKmEElOvTgupqfyLSlISshroRpVhYjDtW3vwNUNBaQ=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
-    "ui-design/cleye": ["cleye@2.6.0", "", { "dependencies": { "terminal-columns": "^2.0.0", "type-flag": "^4.1.0" } }, "sha512-u0SQCsega/ox+2GSuUlG6wvA9c2FtH8sPmv9G9Q3JRTs7FK6+LtaziRAQgx7lrJ1J7bOd3palhwgZKMg8R6JbQ=="],
+    "vscode/cleye": ["cleye@1.3.4", "", { "dependencies": { "terminal-columns": "^1.4.1", "type-flag": "^3.0.0" } }, "sha512-Rd6M8ecBDtdYdPR22h6gG37lPqqJ3hSOaplaGwuGYey9xKmEElOvTgupqfyLSlISshroRpVhYjDtW3vwNUNBaQ=="],
 
-    "@bendrucker/claude-writing/cleye/terminal-columns": ["terminal-columns@2.0.0", "", {}, "sha512-6IByuUjyNZJXUtwDNm+OIe62zgwwaRbH+WMNTcx05O2G5V9WhvluAAHJY8OvUdwmzMPpqAD/7EUpGdI6ae1aiQ=="],
+    "@bendrucker/claude-review/cleye/terminal-columns": ["terminal-columns@1.4.1", "", {}, "sha512-IKVL/itiMy947XWVv4IHV7a0KQXvKjj4ptbi7Ew9MPMcOLzkiQeyx3Gyvh62hKrfJ0RZc4M1nbhzjNM39Kyujw=="],
 
-    "@bendrucker/claude-writing/cleye/type-flag": ["type-flag@4.3.0", "", {}, "sha512-XwZWK+SOWleva2EjynfJT6tXHUkS+/TZAIc5fTJXVMArNf/5jBEt7Y/yBtGcxLFThtQCQ9v6nxXon0QZ86ZJhA=="],
+    "@bendrucker/claude-review/cleye/type-flag": ["type-flag@3.0.0", "", {}, "sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA=="],
+
+    "@bendrucker/claude-tmux/cleye/terminal-columns": ["terminal-columns@1.4.1", "", {}, "sha512-IKVL/itiMy947XWVv4IHV7a0KQXvKjj4ptbi7Ew9MPMcOLzkiQeyx3Gyvh62hKrfJ0RZc4M1nbhzjNM39Kyujw=="],
+
+    "@bendrucker/claude-tmux/cleye/type-flag": ["type-flag@3.0.0", "", {}, "sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA=="],
+
+    "agent-ideas/cleye/terminal-columns": ["terminal-columns@1.4.1", "", {}, "sha512-IKVL/itiMy947XWVv4IHV7a0KQXvKjj4ptbi7Ew9MPMcOLzkiQeyx3Gyvh62hKrfJ0RZc4M1nbhzjNM39Kyujw=="],
+
+    "agent-ideas/cleye/type-flag": ["type-flag@3.0.0", "", {}, "sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA=="],
 
     "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
 
@@ -1498,15 +1514,19 @@
 
     "execa/cross-spawn/which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "which": "./bin/which" } }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
 
-    "gitlab/cleye/terminal-columns": ["terminal-columns@2.0.0", "", {}, "sha512-6IByuUjyNZJXUtwDNm+OIe62zgwwaRbH+WMNTcx05O2G5V9WhvluAAHJY8OvUdwmzMPpqAD/7EUpGdI6ae1aiQ=="],
+    "github/cleye/terminal-columns": ["terminal-columns@1.4.1", "", {}, "sha512-IKVL/itiMy947XWVv4IHV7a0KQXvKjj4ptbi7Ew9MPMcOLzkiQeyx3Gyvh62hKrfJ0RZc4M1nbhzjNM39Kyujw=="],
 
-    "gitlab/cleye/type-flag": ["type-flag@4.3.0", "", {}, "sha512-XwZWK+SOWleva2EjynfJT6tXHUkS+/TZAIc5fTJXVMArNf/5jBEt7Y/yBtGcxLFThtQCQ9v6nxXon0QZ86ZJhA=="],
+    "github/cleye/type-flag": ["type-flag@3.0.0", "", {}, "sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA=="],
+
+    "issue/cleye/terminal-columns": ["terminal-columns@1.4.1", "", {}, "sha512-IKVL/itiMy947XWVv4IHV7a0KQXvKjj4ptbi7Ew9MPMcOLzkiQeyx3Gyvh62hKrfJ0RZc4M1nbhzjNM39Kyujw=="],
+
+    "issue/cleye/type-flag": ["type-flag@3.0.0", "", {}, "sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA=="],
 
     "jsdom/parse5/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
-    "mermaid-diagram/cleye/terminal-columns": ["terminal-columns@2.0.0", "", {}, "sha512-6IByuUjyNZJXUtwDNm+OIe62zgwwaRbH+WMNTcx05O2G5V9WhvluAAHJY8OvUdwmzMPpqAD/7EUpGdI6ae1aiQ=="],
+    "mac/cleye/terminal-columns": ["terminal-columns@1.4.1", "", {}, "sha512-IKVL/itiMy947XWVv4IHV7a0KQXvKjj4ptbi7Ew9MPMcOLzkiQeyx3Gyvh62hKrfJ0RZc4M1nbhzjNM39Kyujw=="],
 
-    "mermaid-diagram/cleye/type-flag": ["type-flag@4.3.0", "", {}, "sha512-XwZWK+SOWleva2EjynfJT6tXHUkS+/TZAIc5fTJXVMArNf/5jBEt7Y/yBtGcxLFThtQCQ9v6nxXon0QZ86ZJhA=="],
+    "mac/cleye/type-flag": ["type-flag@3.0.0", "", {}, "sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA=="],
 
     "mongodb-connection-string-url/whatwg-url/tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 
@@ -1516,13 +1536,13 @@
 
     "read-pkg/normalize-package-data/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
-    "session/cleye/terminal-columns": ["terminal-columns@2.0.0", "", {}, "sha512-6IByuUjyNZJXUtwDNm+OIe62zgwwaRbH+WMNTcx05O2G5V9WhvluAAHJY8OvUdwmzMPpqAD/7EUpGdI6ae1aiQ=="],
+    "things/cleye/terminal-columns": ["terminal-columns@1.4.1", "", {}, "sha512-IKVL/itiMy947XWVv4IHV7a0KQXvKjj4ptbi7Ew9MPMcOLzkiQeyx3Gyvh62hKrfJ0RZc4M1nbhzjNM39Kyujw=="],
 
-    "session/cleye/type-flag": ["type-flag@4.3.0", "", {}, "sha512-XwZWK+SOWleva2EjynfJT6tXHUkS+/TZAIc5fTJXVMArNf/5jBEt7Y/yBtGcxLFThtQCQ9v6nxXon0QZ86ZJhA=="],
+    "things/cleye/type-flag": ["type-flag@3.0.0", "", {}, "sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA=="],
 
-    "ui-design/cleye/terminal-columns": ["terminal-columns@2.0.0", "", {}, "sha512-6IByuUjyNZJXUtwDNm+OIe62zgwwaRbH+WMNTcx05O2G5V9WhvluAAHJY8OvUdwmzMPpqAD/7EUpGdI6ae1aiQ=="],
+    "vscode/cleye/terminal-columns": ["terminal-columns@1.4.1", "", {}, "sha512-IKVL/itiMy947XWVv4IHV7a0KQXvKjj4ptbi7Ew9MPMcOLzkiQeyx3Gyvh62hKrfJ0RZc4M1nbhzjNM39Kyujw=="],
 
-    "ui-design/cleye/type-flag": ["type-flag@4.3.0", "", {}, "sha512-XwZWK+SOWleva2EjynfJT6tXHUkS+/TZAIc5fTJXVMArNf/5jBEt7Y/yBtGcxLFThtQCQ9v6nxXon0QZ86ZJhA=="],
+    "vscode/cleye/type-flag": ["type-flag@3.0.0", "", {}, "sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA=="],
 
     "execa/cross-spawn/shebang-command/shebang-regex": ["shebang-regex@1.0.0", "", {}, "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ=="],
   }

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,11 @@
+[test]
+# Coverage stays opt-in via the --coverage flag so plain `bun test` runs fast.
+# These only pin the shape of the report when coverage is requested.
+coverageReporter = ["text", "lcov"]
+coverageSkipTestFiles = true
+coveragePathIgnorePatterns = [
+  "**/*.test.ts",
+  "**/*.integration.ts",
+  "**/fixtures/**",
+  "**/node_modules/**",
+]

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "build": "tsc --noEmit",
     "check": "biome check",
+    "coverage": "bun scripts/coverage/index.ts",
     "format": "biome format --write",
     "format:check": "biome format",
     "lint": "biome lint",
@@ -51,6 +52,8 @@
     "gray-matter": "^4.0.3"
   },
   "dependencies": {
+    "cleye": "^2.2.1",
+    "table": "^6.9.0",
     "typescript": "^5.9.3",
     "url-pattern": "^1.0.3"
   },

--- a/scripts/coverage/index.ts
+++ b/scripts/coverage/index.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env bun
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { join, relative } from "node:path";
+import { cli } from "cleye";
+import { formatLcov } from "./lcov";
+import { githubReport, terminalReport } from "./report";
+import { repoRoot, runCoverage } from "./run";
+
+function git(args: string[]): string {
+  const result = spawnSync("git", args, { cwd: repoRoot, encoding: "utf8" });
+  return result.status === 0 ? result.stdout : "";
+}
+
+function isSourceFile(file: string): boolean {
+  return file.endsWith(".ts") && !file.endsWith(".test.ts") && !file.endsWith(".integration.ts");
+}
+
+// Repo-relative .ts source files that changed against the base ref.
+function changedFiles(base: string): string[] {
+  return git(["diff", "--name-only", `${base}...HEAD`])
+    .split("\n")
+    .map((f) => f.trim())
+    .filter((f) => f && isSourceFile(f));
+}
+
+// Map each changed file to the set of lines it added/modified, parsed from a
+// zero-context diff. lcov keys files by their repo-relative path, and so does
+// git diff, so the keys line up without rewriting.
+function changedLines(base: string): Map<string, Set<number>> {
+  const diff = git(["diff", "--unified=0", `${base}...HEAD`]);
+  const byFile = new Map<string, Set<number>>();
+  let current: Set<number> | null = null;
+
+  for (const line of diff.split("\n")) {
+    const fileMatch = line.match(/^\+\+\+ b\/(.+)$/);
+    if (fileMatch?.[1]) {
+      current = new Set();
+      byFile.set(fileMatch[1], current);
+      continue;
+    }
+    const hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
+    if (hunk?.[1] && current) {
+      const start = Number(hunk[1]);
+      const count = hunk[2] === undefined ? 1 : Number(hunk[2]);
+      for (let n = start; n < start + count; n++) current.add(n);
+    }
+  }
+  return byFile;
+}
+
+function persistLcov(reports: Parameters<typeof formatLcov>[0]): void {
+  const dir = join(repoRoot, "coverage");
+  mkdirSync(dir, { recursive: true });
+  Bun.write(join(dir, "lcov.info"), formatLcov(reports));
+}
+
+const argv = cli({
+  name: "coverage",
+  parameters: ["[files...]"],
+  help: {
+    description: "Measure Bun test coverage and report uncovered lines.",
+  },
+  flags: {
+    report: {
+      type: String,
+      default: "terminal",
+      description: "Output format: terminal or github",
+    },
+    changed: {
+      type: Boolean,
+      description: "Restrict to files/lines changed against the base ref",
+    },
+    base: {
+      type: String,
+      default: "origin/main",
+      description: "Base ref for --changed comparison",
+    },
+  },
+});
+
+let files = argv._.files;
+if (files.length === 0 && argv.flags.changed) {
+  files = changedFiles(argv.flags.base);
+  if (files.length === 0) {
+    console.log("No changed source files to measure.");
+    process.exit(0);
+  }
+}
+
+const reports = await runCoverage(files);
+
+// Persist a merged report so the PostToolUse hook has fresh data to surface.
+persistLcov(reports);
+
+// When specific files were requested, focus the report on them.
+const targets = files.length
+  ? new Set(files.map((f) => relative(repoRoot, join(process.cwd(), f))))
+  : null;
+const scoped = targets ? reports.filter((fc) => targets.has(fc.file)) : reports;
+
+if (argv.flags.report === "github") {
+  const { summary, annotations } = githubReport(
+    scoped,
+    argv.flags.changed ? changedLines(argv.flags.base) : undefined,
+  );
+  for (const annotation of annotations) console.log(annotation);
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    await Bun.write(
+      summaryPath,
+      `${await Bun.file(summaryPath)
+        .text()
+        .catch(() => "")}${summary}\n`,
+    );
+  } else {
+    console.log(summary);
+  }
+} else {
+  console.log(terminalReport(scoped));
+}

--- a/scripts/coverage/index.ts
+++ b/scripts/coverage/index.ts
@@ -25,31 +25,6 @@ function changedFiles(base: string): string[] {
     .filter((f) => f && isSourceFile(f));
 }
 
-// Map each changed file to the set of lines it added/modified, parsed from a
-// zero-context diff. lcov keys files by their repo-relative path, and so does
-// git diff, so the keys line up without rewriting.
-function changedLines(base: string): Map<string, Set<number>> {
-  const diff = git(["diff", "--unified=0", `${base}...HEAD`]);
-  const byFile = new Map<string, Set<number>>();
-  let current: Set<number> | null = null;
-
-  for (const line of diff.split("\n")) {
-    const fileMatch = line.match(/^\+\+\+ b\/(.+)$/);
-    if (fileMatch?.[1]) {
-      current = new Set();
-      byFile.set(fileMatch[1], current);
-      continue;
-    }
-    const hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
-    if (hunk?.[1] && current) {
-      const start = Number(hunk[1]);
-      const count = hunk[2] === undefined ? 1 : Number(hunk[2]);
-      for (let n = start; n < start + count; n++) current.add(n);
-    }
-  }
-  return byFile;
-}
-
 function persistLcov(reports: Parameters<typeof formatLcov>[0]): void {
   const dir = join(repoRoot, "coverage");
   mkdirSync(dir, { recursive: true });
@@ -101,11 +76,7 @@ const targets = files.length
 const scoped = targets ? reports.filter((fc) => targets.has(fc.file)) : reports;
 
 if (argv.flags.report === "github") {
-  const { summary, annotations } = githubReport(
-    scoped,
-    argv.flags.changed ? changedLines(argv.flags.base) : undefined,
-  );
-  for (const annotation of annotations) console.log(annotation);
+  const summary = githubReport(scoped);
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (summaryPath) {
     await Bun.write(

--- a/scripts/coverage/lcov.test.ts
+++ b/scripts/coverage/lcov.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import {
+  coveredLines,
+  formatLcov,
+  formatRanges,
+  lineCoverage,
+  merge,
+  parseLcov,
+  uncoveredLines,
+} from "./lcov";
+
+function defined<T>(value: T | undefined): T {
+  if (value === undefined) throw new Error("expected a value");
+  return value;
+}
+
+const SINGLE = `TN:
+SF:src/a.ts
+FNF:2
+FNH:1
+DA:1,5
+DA:2,0
+DA:3,0
+DA:4,2
+LF:4
+LH:2
+end_of_record
+`;
+
+const MULTI = `${SINGLE}TN:
+SF:src/b.ts
+FNF:1
+FNH:1
+DA:10,1
+DA:11,1
+LF:2
+LH:2
+end_of_record
+`;
+
+describe("parseLcov", () => {
+  test("extracts file, line hits, and function totals", () => {
+    const a = defined(parseLcov(SINGLE)[0]);
+    expect(a.file).toBe("src/a.ts");
+    expect(a.functionsFound).toBe(2);
+    expect(a.functionsHit).toBe(1);
+    expect(a.lineHits.get(1)).toBe(5);
+    expect(a.lineHits.get(2)).toBe(0);
+  });
+
+  test("parses multiple records", () => {
+    const records = parseLcov(MULTI);
+    expect(records.map((r) => r.file)).toEqual(["src/a.ts", "src/b.ts"]);
+  });
+
+  test("ignores text outside records and blank lines", () => {
+    expect(parseLcov("\n\nnot a record\n")).toEqual([]);
+  });
+
+  test.each([
+    ["covered", coveredLines, [1, 4]],
+    ["uncovered", uncoveredLines, [2, 3]],
+  ])("%s returns sorted line numbers", (_label, fn, expected) => {
+    const a = defined(parseLcov(SINGLE)[0]);
+    expect(fn(a)).toEqual(expected);
+  });
+
+  test("lineCoverage computes percentage", () => {
+    const a = defined(parseLcov(SINGLE)[0]);
+    expect(lineCoverage(a)).toEqual({ total: 4, covered: 2, pct: 50 });
+  });
+});
+
+describe("merge", () => {
+  test("unions line hits across scopes so either-covered counts as covered", () => {
+    const scopeA = parseLcov(`TN:
+SF:src/a.ts
+DA:1,0
+DA:2,1
+end_of_record
+`);
+    const scopeB = parseLcov(`TN:
+SF:src/a.ts
+DA:1,3
+DA:2,0
+end_of_record
+`);
+    const merged = defined(merge(scopeA, scopeB)[0]);
+    expect(uncoveredLines(merged)).toEqual([]);
+    expect(coveredLines(merged)).toEqual([1, 2]);
+  });
+
+  test("keeps distinct files separate and takes max function totals", () => {
+    const merged = merge(
+      parseLcov(MULTI),
+      parseLcov(`TN:
+SF:src/a.ts
+FNF:2
+FNH:2
+DA:2,1
+DA:3,1
+end_of_record
+`),
+    );
+    expect(merged.map((r) => r.file).sort()).toEqual(["src/a.ts", "src/b.ts"]);
+    const a = defined(merged.find((r) => r.file === "src/a.ts"));
+    expect(a.functionsHit).toBe(2);
+    expect(uncoveredLines(a)).toEqual([]);
+  });
+});
+
+describe("formatLcov", () => {
+  test("round-trips through the parser", () => {
+    const records = parseLcov(MULTI);
+    expect(parseLcov(formatLcov(records))).toEqual(records);
+  });
+
+  test("emits empty string for no records", () => {
+    expect(formatLcov([])).toBe("");
+  });
+});
+
+describe("formatRanges", () => {
+  test.each([
+    [[], ""],
+    [[5], "5"],
+    [[1, 2, 3], "1-3"],
+    [[1, 2, 3, 5, 8, 9], "1-3, 5, 8-9"],
+    [[9, 1, 2], "1-2, 9"],
+  ])("%j -> %p", (input, expected) => {
+    expect(formatRanges(input)).toBe(expected);
+  });
+});

--- a/scripts/coverage/lcov.ts
+++ b/scripts/coverage/lcov.ts
@@ -1,0 +1,149 @@
+// Minimal lcov reader/writer. lcov is a line-based format:
+//   SF:<source file>
+//   FNF:<functions found>  FNH:<functions hit>
+//   DA:<line>,<execution count>
+//   end_of_record
+// Bun emits exactly this subset, so a small parser beats an npm dependency and
+// keeps the coverage tooling self-contained.
+
+export interface FileCoverage {
+  /** Source file path, as written in the `SF:` record. */
+  file: string;
+  /** Line number to execution count, from `DA:` records. */
+  lineHits: Map<number, number>;
+  functionsFound: number;
+  functionsHit: number;
+}
+
+export function coveredLines(fc: FileCoverage): number[] {
+  return [...fc.lineHits.entries()]
+    .filter(([, hits]) => hits > 0)
+    .map(([line]) => line)
+    .sort((a, b) => a - b);
+}
+
+export function uncoveredLines(fc: FileCoverage): number[] {
+  return [...fc.lineHits.entries()]
+    .filter(([, hits]) => hits === 0)
+    .map(([line]) => line)
+    .sort((a, b) => a - b);
+}
+
+export interface LineCoverage {
+  total: number;
+  covered: number;
+  /** Percentage of executable lines covered, 0-100. 100 when there are no lines. */
+  pct: number;
+}
+
+export function lineCoverage(fc: FileCoverage): LineCoverage {
+  const total = fc.lineHits.size;
+  const covered = coveredLines(fc).length;
+  const pct = total === 0 ? 100 : (covered / total) * 100;
+  return { total, covered, pct };
+}
+
+export function parseLcov(text: string): FileCoverage[] {
+  const records: FileCoverage[] = [];
+  let current: FileCoverage | null = null;
+
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+
+    if (line.startsWith("SF:")) {
+      current = {
+        file: line.slice(3),
+        lineHits: new Map(),
+        functionsFound: 0,
+        functionsHit: 0,
+      };
+      continue;
+    }
+    if (!current) continue;
+
+    if (line.startsWith("DA:")) {
+      const [lineNo, count] = line.slice(3).split(",");
+      const n = Number(lineNo);
+      const c = Number(count);
+      if (Number.isFinite(n) && Number.isFinite(c)) {
+        current.lineHits.set(n, c);
+      }
+    } else if (line.startsWith("FNF:")) {
+      current.functionsFound = Number(line.slice(4)) || 0;
+    } else if (line.startsWith("FNH:")) {
+      current.functionsHit = Number(line.slice(4)) || 0;
+    } else if (line === "end_of_record") {
+      records.push(current);
+      current = null;
+    }
+  }
+
+  if (current) records.push(current);
+  return records;
+}
+
+// The repo runs tests in separate scopes (per plugin, per package), so a source
+// file can appear in more than one report. Union the per-line counts: a line
+// covered in any scope counts as covered.
+export function merge(...reports: FileCoverage[][]): FileCoverage[] {
+  const byFile = new Map<string, FileCoverage>();
+
+  for (const report of reports) {
+    for (const fc of report) {
+      const existing = byFile.get(fc.file);
+      if (!existing) {
+        byFile.set(fc.file, {
+          file: fc.file,
+          lineHits: new Map(fc.lineHits),
+          functionsFound: fc.functionsFound,
+          functionsHit: fc.functionsHit,
+        });
+        continue;
+      }
+      for (const [line, hits] of fc.lineHits) {
+        existing.lineHits.set(line, (existing.lineHits.get(line) ?? 0) + hits);
+      }
+      existing.functionsFound = Math.max(existing.functionsFound, fc.functionsFound);
+      existing.functionsHit = Math.max(existing.functionsHit, fc.functionsHit);
+    }
+  }
+
+  return [...byFile.values()];
+}
+
+export function formatLcov(reports: FileCoverage[]): string {
+  const blocks: string[] = [];
+  for (const fc of reports) {
+    const lines = ["TN:", `SF:${fc.file}`, `FNF:${fc.functionsFound}`, `FNH:${fc.functionsHit}`];
+    for (const line of [...fc.lineHits.keys()].sort((a, b) => a - b)) {
+      lines.push(`DA:${line},${fc.lineHits.get(line)}`);
+    }
+    const covered = coveredLines(fc).length;
+    lines.push(`LF:${fc.lineHits.size}`, `LH:${covered}`, "end_of_record");
+    blocks.push(lines.join("\n"));
+  }
+  return blocks.length ? `${blocks.join("\n")}\n` : "";
+}
+
+// Collapse sorted line numbers into human-readable ranges: [1,2,3,5,8,9] -> "1-3, 5, 8-9".
+export function formatRanges(lines: number[]): string {
+  const [first, ...rest] = [...lines].sort((a, b) => a - b);
+  if (first === undefined) return "";
+
+  const ranges: string[] = [];
+  let start = first;
+  let prev = first;
+
+  for (const n of rest) {
+    if (n === prev + 1) {
+      prev = n;
+      continue;
+    }
+    ranges.push(start === prev ? `${start}` : `${start}-${prev}`);
+    start = n;
+    prev = n;
+  }
+  ranges.push(start === prev ? `${start}` : `${start}-${prev}`);
+  return ranges.join(", ");
+}

--- a/scripts/coverage/report.test.ts
+++ b/scripts/coverage/report.test.ts
@@ -35,30 +35,14 @@ describe("terminalReport", () => {
 });
 
 describe("githubReport", () => {
-  const reports = [fileCoverage("a.ts", { 1: 1, 2: 0, 3: 0 })];
-
   test("builds a markdown summary table", () => {
-    const { summary } = githubReport(reports);
+    const summary = githubReport([fileCoverage("a.ts", { 1: 1, 2: 0, 3: 0 })]);
     expect(summary).toContain("## Coverage");
     expect(summary).toContain("| `a.ts` |");
+    expect(summary).toContain("33.3%");
   });
 
-  test("annotates every uncovered line without a changed-lines filter", () => {
-    const { annotations } = githubReport(reports);
-    expect(annotations).toEqual([
-      "::warning file=a.ts,line=2::Line not covered by tests",
-      "::warning file=a.ts,line=3::Line not covered by tests",
-    ]);
-  });
-
-  test("restricts annotations to changed lines", () => {
-    const changed = new Map([["a.ts", new Set([3])]]);
-    const { annotations } = githubReport(reports, changed);
-    expect(annotations).toEqual(["::warning file=a.ts,line=3::Line not covered by tests"]);
-  });
-
-  test("emits no annotations when no changed lines are uncovered", () => {
-    const changed = new Map([["a.ts", new Set([1])]]);
-    expect(githubReport(reports, changed).annotations).toEqual([]);
+  test("reports no data for an empty set", () => {
+    expect(githubReport([])).toBe("## Coverage\n\nNo coverage data.");
   });
 });

--- a/scripts/coverage/report.test.ts
+++ b/scripts/coverage/report.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import type { FileCoverage } from "./lcov";
+import { githubReport, terminalReport } from "./report";
+
+function fileCoverage(file: string, hits: Record<number, number>): FileCoverage {
+  return {
+    file,
+    lineHits: new Map(Object.entries(hits).map(([line, count]) => [Number(line), count])),
+    functionsFound: 1,
+    functionsHit: 1,
+  };
+}
+
+describe("terminalReport", () => {
+  test("reports no data for an empty set", () => {
+    expect(terminalReport([])).toBe("No coverage data.");
+  });
+
+  test("lists files, percentages, and uncovered ranges", () => {
+    // Color codes wrap the percentage and detail file name, so assert on
+    // substrings that survive between the escapes.
+    const out = terminalReport([fileCoverage("a.ts", { 1: 1, 2: 0, 3: 0, 4: 1 })]);
+    expect(out).toContain("a.ts");
+    expect(out).toContain("50.0%");
+    expect(out).toContain("2-3");
+    expect(out).toContain("Uncovered lines:");
+    expect(out).toContain(": 2, 3");
+  });
+
+  test("omits the uncovered detail section when everything is covered", () => {
+    const out = terminalReport([fileCoverage("a.ts", { 1: 1, 2: 1 })]);
+    expect(out).toContain("100.0%");
+    expect(out).not.toContain("Uncovered lines:");
+  });
+});
+
+describe("githubReport", () => {
+  const reports = [fileCoverage("a.ts", { 1: 1, 2: 0, 3: 0 })];
+
+  test("builds a markdown summary table", () => {
+    const { summary } = githubReport(reports);
+    expect(summary).toContain("## Coverage");
+    expect(summary).toContain("| `a.ts` |");
+  });
+
+  test("annotates every uncovered line without a changed-lines filter", () => {
+    const { annotations } = githubReport(reports);
+    expect(annotations).toEqual([
+      "::warning file=a.ts,line=2::Line not covered by tests",
+      "::warning file=a.ts,line=3::Line not covered by tests",
+    ]);
+  });
+
+  test("restricts annotations to changed lines", () => {
+    const changed = new Map([["a.ts", new Set([3])]]);
+    const { annotations } = githubReport(reports, changed);
+    expect(annotations).toEqual(["::warning file=a.ts,line=3::Line not covered by tests"]);
+  });
+
+  test("emits no annotations when no changed lines are uncovered", () => {
+    const changed = new Map([["a.ts", new Set([1])]]);
+    expect(githubReport(reports, changed).annotations).toEqual([]);
+  });
+});

--- a/scripts/coverage/report.ts
+++ b/scripts/coverage/report.ts
@@ -1,0 +1,77 @@
+import { table } from "table";
+import { type FileCoverage, formatRanges, lineCoverage, uncoveredLines } from "./lcov";
+
+// ANSI colors 0-15 (remapped by the terminal theme). See .claude/rules/scripts.md.
+const RESET = "\x1b[0m";
+function color(code: number, text: string): string {
+  return `\x1b[${code}m${text}${RESET}`;
+}
+
+function pctColor(pct: number): (text: string) => string {
+  const code = pct >= 90 ? 32 : pct >= 70 ? 33 : 31; // green / yellow / red
+  return (text) => color(code, text);
+}
+
+function sortByCoverage(reports: FileCoverage[]): FileCoverage[] {
+  return [...reports].sort((a, b) => lineCoverage(a).pct - lineCoverage(b).pct);
+}
+
+export function terminalReport(reports: FileCoverage[]): string {
+  if (reports.length === 0) return "No coverage data.";
+
+  const sorted = sortByCoverage(reports);
+  const rows = sorted.map((fc) => {
+    const { pct } = lineCoverage(fc);
+    const paint = pctColor(pct);
+    return [fc.file, paint(`${pct.toFixed(1)}%`), formatRanges(uncoveredLines(fc)) || "—"];
+  });
+
+  const summary = table([["File", "% Lines", "Uncovered"], ...rows]);
+
+  const details: string[] = [];
+  for (const fc of sorted) {
+    const uncovered = uncoveredLines(fc);
+    if (uncovered.length === 0) continue;
+    details.push(`${color(31, fc.file)}: ${uncovered.join(", ")}`);
+  }
+
+  return details.length ? `${summary}\nUncovered lines:\n${details.join("\n")}` : summary.trimEnd();
+}
+
+function markdownTable(reports: FileCoverage[]): string {
+  const header = "| File | % Lines | Uncovered |\n| --- | --- | --- |";
+  const rows = sortByCoverage(reports).map((fc) => {
+    const { pct } = lineCoverage(fc);
+    return `| \`${fc.file}\` | ${pct.toFixed(1)}% | ${formatRanges(uncoveredLines(fc)) || "—"} |`;
+  });
+  return [header, ...rows].join("\n");
+}
+
+export interface GithubReport {
+  summary: string;
+  /** Workflow command annotations, one per uncovered changed line. */
+  annotations: string[];
+}
+
+// `changedLines` maps a repo-relative file to the set of lines added/changed in
+// the PR. Annotations are restricted to those lines so they land in the diff
+// view rather than spamming untouched code.
+export function githubReport(
+  reports: FileCoverage[],
+  changedLines?: Map<string, Set<number>>,
+): GithubReport {
+  const summary = reports.length
+    ? `## Coverage\n\n${markdownTable(reports)}`
+    : "## Coverage\n\nNo coverage data.";
+
+  const annotations: string[] = [];
+  for (const fc of reports) {
+    const changed = changedLines?.get(fc.file);
+    for (const line of uncoveredLines(fc)) {
+      if (changedLines && !changed?.has(line)) continue;
+      annotations.push(`::warning file=${fc.file},line=${line}::Line not covered by tests`);
+    }
+  }
+
+  return { summary, annotations };
+}

--- a/scripts/coverage/report.ts
+++ b/scripts/coverage/report.ts
@@ -47,31 +47,11 @@ function markdownTable(reports: FileCoverage[]): string {
   return [header, ...rows].join("\n");
 }
 
-export interface GithubReport {
-  summary: string;
-  /** Workflow command annotations, one per uncovered changed line. */
-  annotations: string[];
-}
-
-// `changedLines` maps a repo-relative file to the set of lines added/changed in
-// the PR. Annotations are restricted to those lines so they land in the diff
-// view rather than spamming untouched code.
-export function githubReport(
-  reports: FileCoverage[],
-  changedLines?: Map<string, Set<number>>,
-): GithubReport {
-  const summary = reports.length
+// Markdown summary for the GitHub Actions job summary. Reporting only: no
+// per-line annotations, which read as defect-grade warnings and hit GitHub's
+// ~10-per-level render cap. Per-line detail lives in the local hook and skill.
+export function githubReport(reports: FileCoverage[]): string {
+  return reports.length
     ? `## Coverage\n\n${markdownTable(reports)}`
     : "## Coverage\n\nNo coverage data.";
-
-  const annotations: string[] = [];
-  for (const fc of reports) {
-    const changed = changedLines?.get(fc.file);
-    for (const line of uncoveredLines(fc)) {
-      if (changedLines && !changed?.has(line)) continue;
-      annotations.push(`::warning file=${fc.file},line=${line}::Line not covered by tests`);
-    }
-  }
-
-  return { summary, annotations };
 }

--- a/scripts/coverage/run.test.ts
+++ b/scripts/coverage/run.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { repoRoot, resolveScope, resolveScopes } from "./run";
+
+describe("resolveScope", () => {
+  test.each([
+    ["plugins/writing/detection/scan.ts", "plugins/writing/"],
+    ["plugins/writing/skills/scan/scripts/scan.ts", "plugins/writing/"],
+    ["packages/validate/run.ts", "packages/validate/"],
+    [".claude/hooks/biome/index.ts", "./.claude"],
+    [".claude/skills/agent-ideas/sources.ts", "./.claude"],
+    ["user/rules/typescript.md", "./user"],
+  ])("%s -> %s", (file, expected) => {
+    expect(resolveScope(file)).toBe(expected);
+  });
+
+  test("accepts absolute paths", () => {
+    expect(resolveScope(join(repoRoot, "packages/validate/run.ts"))).toBe("packages/validate/");
+  });
+
+  test("falls back to the nearest ancestor dir containing tests", () => {
+    expect(resolveScope("scripts/coverage/run.ts")).toBe("./scripts/coverage");
+  });
+});
+
+describe("resolveScopes", () => {
+  test("dedupes scopes shared by multiple files", () => {
+    expect(resolveScopes(["packages/validate/run.ts", "packages/validate/validate.ts"])).toEqual([
+      "packages/validate/",
+    ]);
+  });
+});

--- a/scripts/coverage/run.ts
+++ b/scripts/coverage/run.ts
@@ -1,0 +1,83 @@
+import { spawn } from "node:child_process";
+import { mkdtempSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, relative } from "node:path";
+import { type FileCoverage, merge, parseLcov } from "./lcov";
+
+export const repoRoot = join(import.meta.dirname, "..", "..");
+
+// Normalize an input path to a repo-relative POSIX path so scope matching is
+// stable whether the caller passes an absolute or relative path.
+function toRepoRelative(file: string): string {
+  const abs = isAbsolute(file) ? file : join(process.cwd(), file);
+  return relative(repoRoot, abs);
+}
+
+function hasTests(dir: string): boolean {
+  try {
+    return readdirSync(dir).some((entry) => entry.endsWith(".test.ts"));
+  } catch {
+    return false;
+  }
+}
+
+// Walk up from a file toward the repo root, returning the nearest ancestor
+// directory that directly contains test files.
+function nearestTestDir(relFile: string): string {
+  let dir = dirname(relFile);
+  while (dir && dir !== "." && dir !== "..") {
+    if (hasTests(join(repoRoot, dir))) return `./${dir}`;
+    dir = dirname(dir);
+  }
+  return "./";
+}
+
+// Map a source file to the test scope that exercises it. Each plugin and package
+// is a self-contained scope; `.claude` and `user` are their own roots.
+export function resolveScope(file: string): string {
+  const rel = toRepoRelative(file);
+
+  const plugin = rel.match(/^(plugins\/[^/]+)\//);
+  if (plugin) return `${plugin[1]}/`;
+
+  const pkg = rel.match(/^(packages\/[^/]+)\//);
+  if (pkg) return `${pkg[1]}/`;
+
+  if (rel.startsWith(".claude/")) return "./.claude";
+  if (rel.startsWith("user/")) return "./user";
+
+  return nearestTestDir(rel);
+}
+
+export function resolveScopes(files: string[]): string[] {
+  return [...new Set(files.map(resolveScope))];
+}
+
+function runScope(scope: string): Promise<FileCoverage[]> {
+  const coverageDir = mkdtempSync(join(tmpdir(), "cov-"));
+  return new Promise((resolve) => {
+    const child = spawn("bun", ["test", "--coverage", `--coverage-dir=${coverageDir}`, scope], {
+      cwd: repoRoot,
+      stdio: "ignore",
+    });
+    child.on("close", async () => {
+      const lcov = Bun.file(join(coverageDir, "lcov.info"));
+      if (!(await lcov.exists())) {
+        resolve([]);
+        return;
+      }
+      resolve(parseLcov(await lcov.text()));
+    });
+    child.on("error", () => resolve([]));
+  });
+}
+
+// Run Bun coverage for every scope the target files belong to, then merge.
+// With no files, measure the default scope set (the repo's test roots).
+export async function runCoverage(files: string[]): Promise<FileCoverage[]> {
+  const scopes = files.length ? resolveScopes(files) : DEFAULT_SCOPES;
+  const reports = await Promise.all(scopes.map(runScope));
+  return merge(...reports);
+}
+
+export const DEFAULT_SCOPES = ["./.claude", "./user", "packages/"];


### PR DESCRIPTION
Adds repo-local test-coverage tooling built around Bun's `bun test --coverage`. The goal is actionable coverage: when a source file is edited and tested, the exact uncovered lines surface so the gap can be closed. There is no percentage gate, reporting only.

One internal module (`scripts/coverage/`) is reused three ways:

- **CLI / skill.** `bun scripts/coverage/index.ts <file>` resolves the file's test scope, runs coverage, and prints a table plus the uncovered line numbers. The `coverage` skill documents the measure → add tests → re-measure loop.
- **Passive hook.** A `PostToolUse` hook reads the last `coverage/lcov.info` after a `.ts` edit and surfaces that file's uncovered lines via `additionalContext`, flagging the data stale (by mtime) when the file is newer. It stays silent when there's no data or the file is fully covered, so it only hints. The skill is the deliberate path.
- **CI reporter.** A PR-only `coverage` job runs `--report github --changed`, scoping to the files the PR touched and writing a coverage table to the job summary.

## Decisions

- **Internal lcov parser** over an npm dependency. lcov is a trivial line-based format (`SF:`/`DA:`/`end_of_record`), so a ~40-line parser keeps the tooling self-contained. It also serializes the merged report back out, since the repo runs tests in separate scopes (per plugin, per package, `.claude`, `user`) and a file can appear in more than one.
- **Coverage stays opt-in.** `bunfig.toml` pins the lcov reporter and ignore patterns but does not set `coverage = true`, so plain `bun test` is unaffected and fast. Verified locally that a normal run writes no coverage output.
- **Job summary only.** No sticky PR comment and no per-line annotations. Mainstream coverage tools report patch coverage as a check or comment; per-line `::warning` annotations read as defect-grade, hit GitHub's ~10-per-level render cap, and would crowd out real lint/type warnings. The per-line actionability lives in the local hook and skill instead. The job also needs no `pull-requests: write` permission.
- The CLI persists a merged `coverage/lcov.info` on every run so the hook has fresh data to read. That closes the loop: a skill run leaves data the hook later surfaces.

## Ignore Rules

The tooling lives in directories literally named `coverage`. A bare `coverage` pattern (common in global gitignores) matches every such directory, including `scripts/coverage/`, `.claude/hooks/coverage/`, and `.claude/skills/coverage/`, which would silently untrack the source. The `.gitignore` anchors the generated output to `/coverage/` and re-includes the three source directories so the repo stays self-contained regardless of a contributor's global ignore.