### PR TITLE
writing: catch inflected 'dig into' exploration filler

### DIFF
--- a/plugins/writing/detection/tropes.test.ts
+++ b/plugins/writing/detection/tropes.test.ts
@@ -533,16 +533,19 @@ describe("scan", () => {
   });
 
   describe("dig into", () => {
-    it("flags: 'dig into the codebase'", () => {
-      expect(firstByTier(scan("Let's dig into the codebase."), "context")?.category).toBe(
-        "dig into",
-      );
+    it.each([
+      "Let's dig into the codebase.",
+      "We'll dive into the data later.",
+      "I dug into the parser internals.",
+      "She dove into the schema migration.",
+      "We're digging into the root cause.",
+      "The audit dives into each subsystem.",
+    ])("flags: %j", (text) => {
+      expect(firstByTier(scan(text), "context")?.category).toBe("dig into");
     });
 
-    it("flags: 'dive into the data'", () => {
-      expect(firstByTier(scan("We'll dive into the data later."), "context")?.category).toBe(
-        "dig into",
-      );
+    it.each(["She dug a trench.", "Water drains into the basin."])("allows: %j", (text) => {
+      expect(scan(text).find((m) => m.category === "dig into")).toBeUndefined();
     });
   });
 

--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -556,15 +556,20 @@ export const PATTERNS: PatternDef[] = [
     tier: "context",
     layer: "vocabulary",
     category: "dig into",
-    test: /\b(?:dig|dive|wade)\s+into\b/gi,
+    test: /\b(?:dig|digs|digging|dug|dive|dives|diving|dove|dived|wade|wades|wading|waded)\s+into\b/gi,
     message: (matched) =>
       `"${matched}" is exploration filler. Describe what you're actually looking at.`,
-    positives: ["Let's dig into the codebase.", "We'll dive into the data later."],
-    negatives: ["She dug a trench.", "The code dives into the network stack."],
+    positives: [
+      "Let's dig into the codebase.",
+      "I dug into the parser internals.",
+      "She dove into the schema migration.",
+      "We're digging into the root cause.",
+    ],
+    negatives: ["She dug a trench.", "Water drains into the basin."],
     evidence:
-      "Pre-dates the curation principle; no corpus evidence recorded. Retained as a vocabulary-level filler marker.",
+      "Corpus audit of assistant output found exploration-filler 'into' constructions in inflected forms the base-form regex missed, including the irregular past tenses 'dug into' and 'dove into'. Porter stemming cannot unify irregular verbs ('dug' stems to 'dug', not 'dig'), so each inflection is enumerated explicitly.",
     retire:
-      "Remove if corpus analysis shows the phrase is no longer distinctive, or migrate to vocabulary.txt after a per-entry audit.",
+      "Remove if corpus analysis shows the construction is no longer distinctive. Drop individual inflections that stop appearing in assistant output.",
   },
   {
     tier: "context",


### PR DESCRIPTION
The `dig into` exploration-filler detector matched only the base forms `dig`, `dive`, and `wade`, so every inflection slipped through. The irregular past tenses are the common offenders in practice: "I dug into the parser", "she dove into the schema". A spot check of assistant output confirmed `dug into` and `dove into` recurring, none of them flagged.

Stemming would not close this gap. Porter stems `dug` to `dug`, not `dig`, so an irregular past tense shares no stem with its base. The fix enumerates the inflections (`dig`/`digs`/`digging`/`dug`, `dive`/`dives`/`diving`/`dove`/`dived`, `wade`/`wades`/`wading`/`waded`) directly in the regex.

This also corrects a quietly wrong example: the old negative "The code dives into the network stack" passed only because `dive` did not match `dives`, so the rule looked covered while leaving the whole inflection set unguarded. The negatives now require either a missing object (`dug` with no `into`) or a non-trope verb (`drains into`).
