### PR TITLE
writing: add skillOnly detectors for figurative chat tropes

### DIFF
--- a/plugins/writing/detection/scan.test.ts
+++ b/plugins/writing/detection/scan.test.ts
@@ -111,6 +111,14 @@ describe("scanAll", () => {
     expect(categories).toContain("tricolon");
   });
 
+  it.each([
+    ["rides on", "The teardown rides on the normal end of a team."],
+    ["can bite", "A stale cache entry can bite at runtime."],
+    ["surface as verb", "The hook should surface the conflict to the user."],
+  ])("reports the skillOnly %s pattern", (category, text) => {
+    expect(scanAll(text, "doc.md").map((r) => r.category)).toContain(category);
+  });
+
   it("returns empty for clean prose", () => {
     expect(scanAll("The function reads input and writes output.")).toHaveLength(0);
   });

--- a/plugins/writing/detection/tropes.test.ts
+++ b/plugins/writing/detection/tropes.test.ts
@@ -812,6 +812,16 @@ describe("scan", () => {
       ).toBeUndefined();
     });
   });
+
+  describe("skillOnly patterns stay out of the hook", () => {
+    it.each([
+      ["rides on", "The teardown rides on the normal end of a team."],
+      ["can bite", "A stale cache entry can bite at runtime."],
+      ["surface as verb", "The hook should surface the conflict to the user."],
+    ])("scan() does not report %s", (category, text) => {
+      expect(scan(text, "doc.md", "file").find((m) => m.category === category)).toBeUndefined();
+    });
+  });
 });
 
 describe("firstByTier", () => {

--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -722,6 +722,61 @@ export const PATTERNS: PatternDef[] = [
   },
   {
     tier: "context",
+    layer: "vocabulary",
+    category: "rides on",
+    test: /\brid(?:e|es|ing)\s+(?:on|atop|alongside)\b/gi,
+    skillOnly: true,
+    message: (matched) =>
+      `"${matched}" is figurative dependency language. State the relationship plainly: "X depends on Y", "X reuses Y", or "X piggybacks on Y".`,
+    positives: [
+      "The teardown rides on the normal end of a team.",
+      "The new reader rides atop the existing httpfs layer.",
+      "The sync loop rides alongside the existing poll cycle.",
+    ],
+    negatives: ["The cyclists ride for charity.", "She takes the early train to work."],
+    evidence:
+      "User-flagged 2026-06 as a recurring figurative construction for dependency or coupling ('X rides on Y'). It appears mostly in conversational reasoning, which neither the hook nor the additions miner reads, so it ships skillOnly pending a chat-voice calibration decision.",
+    retire:
+      "Remove if a chat-voice corpus pass shows the construction is not distinctive versus the user baseline. Promote to hook (drop skillOnly) only after a deliverable-corpus pass clears it at the hook precision bar.",
+  },
+  {
+    tier: "context",
+    layer: "vocabulary",
+    category: "can bite",
+    test: /\b(?:can|could|will|may|might)\s+bite\b/gi,
+    skillOnly: true,
+    message: (matched) =>
+      `"${matched}" is figurative risk language for a latent bug. Name the failure: what breaks, and under what condition.`,
+    positives: [
+      "A stale cache entry can bite at runtime.",
+      "That assumption could bite once the schema changes.",
+    ],
+    negatives: ["The dog will bark at strangers.", "This could break under load."],
+    evidence:
+      "User-flagged 2026-06 as a recurring figurative construction for latent-bug risk ('this can bite later'). It lives almost entirely in conversational reasoning, so it ships skillOnly pending a chat-voice calibration decision.",
+    retire:
+      "Remove if a chat-voice corpus pass shows the construction is not distinctive versus the user baseline. Promote to hook only after a deliverable-corpus pass clears it at the hook precision bar.",
+  },
+  {
+    tier: "context",
+    layer: "vocabulary",
+    category: "surface as verb",
+    test: /\bsurfac(?:e|es|ed|ing)\s+(?:the|a|an|that|this|these|those|any|all|each|its|their|every)\b/gi,
+    skillOnly: true,
+    message: (matched) =>
+      `"${matched}" uses "surface" as a verb meaning reveal or report. Say "show", "report", or "expose".`,
+    positives: [
+      "The hook should surface the conflict to the user.",
+      "The report surfaces these gaps automatically.",
+    ],
+    negatives: ["The attack surface is large.", "Reduce the API surface area."],
+    evidence:
+      "User-flagged 2026-06 as the highest-frequency tell, but 'surface' is polysemous: it is a load-bearing domain noun in this plugin ('chat surface', 'deliverable surface') and a word the user writes legitimately ('surface area'). The determiner lookahead targets the verb-with-object sense and spares the noun sense. Ships skillOnly because the verb sense itself appears in the user's own writing, so distinctiveness is unverified.",
+    retire:
+      "Remove if a sense-aware corpus pass shows the verb usage is not distinctive versus the user baseline. Do not promote to hook or add 'surface' to vocabulary.txt: a stem match cannot separate the verb from the domain noun.",
+  },
+  {
+    tier: "context",
     layer: "grammar",
     category: "hedging observation",
     test: /\b(?:looks|appears|seems)\s+(?:like|to)\b/gi,


### PR DESCRIPTION
Adds three figurative constructions the detectors never covered, all flagged from recent sessions: `rides on/atop/alongside` (dependency framing), `can/could bite` (latent-bug risk), and `surface` used as a verb meaning reveal or report. They ship `skillOnly`, so they run on the batch surfaces (`writing:scan` and `writing:review`, and the lint step inside `writing:rewrite`) and never in the per-edit hook.

The patterns are the easy part. The harder question is *where* these tropes live, and the plugin's answer has firmed up since this branch opened. The open questions below track what is now built and what is still missing.

## Why these ship skillOnly

All three appear overwhelmingly in conversational reasoning. Committed prose almost never carries them. The hook is a `PreToolUse` handler on `Write`/`Edit`/`Bash`. It only ever sees file contents and command bodies. It cannot read the model's chat output, because that text is never a tool call. So a hook entry for these would catch only the rare deliverable leak and miss the channel where they actually occur.

`skillOnly` also matches the cost tradeoff. Steering chat voice hard is not free: it costs latency on every response, and reading past some jargon to get to an answer faster is often the right call. Batch surfaces are the opposite case. They run when you deliberately ask for a cleanup pass, where removing all of this is worth the time. This mirrors the existing `backtick path bullet` detector, which ships `skillOnly` for the same reason: real in deliverables, but held off the hook until a labeled sample justifies the per-response latency.

## The deliverable boundary now has a rewrite pass

When this branch opened, the durable fix was hypothetical: a rewrite step at the chat-to-deliverable boundary, where the model explains something to you and then rewrites part of it into a PR body or issue. That step now exists as [`writing:rewrite`](../../plugins/writing/skills/rewrite), which runs the same scan engine in single-input mode and clears every hard tell before returning. These three detectors feed directly into that lint, so the rewrite pass strips them from a deliverable draft even though the hook never sees them.

Two questions the rewrite skill does not yet answer:

- **Auto-triggering.** `writing:rewrite` is user-invoked. Nothing fires it automatically at the boundary (a `Write` to a `.md`, a `gh pr create --body`), so the leak still depends on you remembering to run the pass. Wiring it to the boundary without firing on every trivial edit is unsolved.
- **Discovery.** Per `methodology.md`, the additions miner only mines multi-word n-grams from deliverable prose and excludes conversational assistant text. `surface` is a single word it would never propose, and `rides on` / `can bite` live in chat, which it never reads. These three had to be added by hand. The `writing:rewrite` eval scaffold ([#996](https://github.com/bendrucker/claude/pull/996)) sizes the rewrite corpus but does not mine chat voice for new tropes, so the discovery gap is still open.

## Per-pattern confidence

Each new detector has a soft spot, spelled out in its `retire` note:

- `surface as verb`: the determiner lookahead spares the noun (`surface area`, `the firing surface`), but the verb sense appears in your own writing too, so distinctiveness is unverified. It also misses bare-object verb usage (`surfaces evictions`). Deliberately not added to `vocabulary.txt`: a stem match cannot separate the verb from the domain noun, and a blunt `surface` deny would light up this plugin's own docs.
- `rides on` and `can bite`: both will false-positive on literal usage (`ride for charity`, `the dog might bite`). Rare in this corpus, but real, and a reason to keep them off the hook.

None of the three has cleared a precision bar on a labeled sample, which is why all three ship `skillOnly` rather than promoted to the hook. The `retire` notes name the corpus condition each needs before promotion.

## Testing

`scan.test.ts` asserts `scanAll` reports all three on the batch surface. `tropes.test.ts` asserts the hook's `scan` skips them. `examples.test.ts` gates the embedded positives and negatives for each detector. The single-input scan that `writing:rewrite` calls surfaces all three, exercised against the batch path the rewrite pass depends on.
