### PR TITLE
ci: render context report as markdown, not a code block

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -293,6 +293,4 @@ jobs:
           mkdir -p tmp
           echo '## Claude Code Context Usage' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
           claude --print '/context' --output-format json --verbose | jq -r '.[-1].result' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
The `/context` report is already markdown (headers and tables), but the workflow wrapped it in a fenced code block before appending it to `$GITHUB_STEP_SUMMARY`. GitHub rendered the fences literally, so the summary showed raw `##` headers and pipe-delimited tables instead of a formatted report.

Removes the `echo '```'` lines so the markdown renders.
