### PR TITLE
validate: allowlist valid settings absent from schemastore

### DIFF
--- a/packages/validate/run.ts
+++ b/packages/validate/run.ts
@@ -12,6 +12,7 @@ export interface ValidationTarget {
   files: string[];
   schema: string;
   warnAdditional?: boolean;
+  allowAdditional?: string[];
   extraSchemas?: { schema: string; key: string }[];
   successMessage?: string;
 }
@@ -25,9 +26,10 @@ export async function runValidation(target: ValidationTarget): Promise<void> {
     }
   }
 
-  const options: { ajv?: Ajv; warnAdditional?: boolean } = {};
+  const options: { ajv?: Ajv; warnAdditional?: boolean; allowAdditional?: string[] } = {};
   if (ajv) options.ajv = ajv;
   if (target.warnAdditional) options.warnAdditional = true;
+  if (target.allowAdditional) options.allowAdditional = target.allowAdditional;
 
   const result: ValidationResult = { errors: [], warnings: [] };
   for (const file of target.files) {

--- a/packages/validate/settings.ts
+++ b/packages/validate/settings.ts
@@ -1,10 +1,24 @@
 import { runEntry, runValidation } from "./run";
 
+// Valid Claude Code settings that the schemastore schema does not yet list.
+// Without this allowlist, warnAdditional flags them as unknown properties.
+// Drop entries as schemastore adds them: https://github.com/SchemaStore/schemastore
+const knownUnlistedSettings = [
+  "theme",
+  "autoCompactEnabled",
+  "skipWorkflowUsageWarning",
+  "skipAutoPermissionPrompt",
+  "preferredNotifChannel",
+  "inputNeededNotifEnabled",
+  "agentPushNotifEnabled",
+];
+
 runEntry(() =>
   runValidation({
     files: [".claude/settings.json", "user/settings.json"],
     schema: "https://www.schemastore.org/claude-code-settings.json",
     warnAdditional: true,
+    allowAdditional: knownUnlistedSettings,
     successMessage: "All validations passed.",
   }),
 );

--- a/packages/validate/validate.test.ts
+++ b/packages/validate/validate.test.ts
@@ -32,6 +32,7 @@ describe("validateFile", () => {
     name: string;
     data: unknown;
     warnAdditional?: boolean;
+    allowAdditional?: string[];
     errors: string[];
     warnings: string[];
   }[] = [
@@ -80,6 +81,14 @@ describe("validateFile", () => {
       errors: ["must be string"],
       warnings: ['unknown property "extra"'],
     },
+    {
+      name: "allowAdditional suppresses listed properties",
+      data: { name: "test", allowed: true, unknown: "yes" },
+      warnAdditional: true,
+      allowAdditional: ["allowed"],
+      errors: [],
+      warnings: ['unknown property "unknown"'],
+    },
   ];
 
   for (const fixture of fixtures) {
@@ -90,7 +99,9 @@ describe("validateFile", () => {
       const result = await validateFile(
         file,
         schemaPath,
-        fixture.warnAdditional ? { warnAdditional: true } : undefined,
+        fixture.warnAdditional
+          ? { warnAdditional: true, allowAdditional: fixture.allowAdditional }
+          : undefined,
       );
 
       expect(result.errors).toHaveLength(fixture.errors.length);

--- a/packages/validate/validate.test.ts
+++ b/packages/validate/validate.test.ts
@@ -96,13 +96,13 @@ describe("validateFile", () => {
       const file = join(tempDir, `${fixture.name.replace(/\s+/g, "-")}.json`);
       await Bun.write(file, JSON.stringify(fixture.data));
 
-      const result = await validateFile(
-        file,
-        schemaPath,
-        fixture.warnAdditional
-          ? { warnAdditional: true, allowAdditional: fixture.allowAdditional }
-          : undefined,
-      );
+      const options = fixture.warnAdditional
+        ? {
+            warnAdditional: true,
+            ...(fixture.allowAdditional && { allowAdditional: fixture.allowAdditional }),
+          }
+        : undefined;
+      const result = await validateFile(file, schemaPath, options);
 
       expect(result.errors).toHaveLength(fixture.errors.length);
       for (const [i, pattern] of fixture.errors.entries()) {

--- a/packages/validate/validate.ts
+++ b/packages/validate/validate.ts
@@ -76,7 +76,7 @@ function patchHookSchema(schema: Record<string, unknown>): void {
 export async function validateFile(
   file: string,
   schemaPath: string,
-  options?: { ajv?: Ajv; warnAdditional?: boolean },
+  options?: { ajv?: Ajv; warnAdditional?: boolean; allowAdditional?: string[] },
 ): Promise<ValidationResult> {
   const instance = options?.ajv ?? createValidator();
 
@@ -98,8 +98,9 @@ export async function validateFile(
   const warnings: string[] = [];
   if (options?.warnAdditional && entry.schema.properties) {
     const known = new Set(Object.keys(entry.schema.properties as Record<string, unknown>));
+    const allowed = new Set(options.allowAdditional ?? []);
     for (const key of Object.keys(data as Record<string, unknown>)) {
-      if (key !== "$schema" && !known.has(key)) {
+      if (key !== "$schema" && !known.has(key) && !allowed.has(key)) {
         warnings.push(formatWarning(file, key));
       }
     }


### PR DESCRIPTION
The `validate` job emits a warning for every settings key the schemastore schema doesn't list. Seven valid Claude Code settings are not yet in that schema, so each run surfaces a spurious warning for `theme`, `autoCompactEnabled`, `skipWorkflowUsageWarning`, `skipAutoPermissionPrompt`, `preferredNotifChannel`, `inputNeededNotifEnabled`, and `agentPushNotifEnabled`.

Each is a legitimate setting, so silencing them at the schema level has to wait until [schemastore](https://github.com/SchemaStore/schemastore) adds them. `warnAdditional` still earns its keep for catching misspelled keys, so this keeps the check and adds an `allowAdditional` list threaded through `validateFile`. Listed keys are suppressed. Everything else still warns.

The allowlist lives in `settings.ts` with a note to drop entries as schemastore adds them. A `validateFile` test covers that listed keys stay quiet while unlisted ones still warn.
