### PR TITLE
test: run swift plugins on macOS instead of setup-swift

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,10 +183,6 @@ jobs:
         if: steps.inspect.outputs.has_skills == 'true'
         run: bun run skill-lint "plugins/${{ matrix.plugin.name }}/skills/*"
 
-      - name: Setup Swift
-        if: steps.inspect.outputs.has_swift == 'true'
-        uses: swift-actions/setup-swift@v2
-
       - name: Validate Swift syntax
         if: steps.inspect.outputs.has_swift == 'true'
         run: find "plugins/${{ matrix.plugin.name }}" -name "*.swift" -exec swiftc -parse {} +

--- a/plugins/calendar/.ci.json
+++ b/plugins/calendar/.ci.json
@@ -1,0 +1,3 @@
+{
+  "runner": "macos-latest"
+}

--- a/plugins/shortcuts/.ci.json
+++ b/plugins/shortcuts/.ci.json
@@ -1,0 +1,3 @@
+{
+  "runner": "macos-latest"
+}

--- a/plugins/x-callback-url/.ci.json
+++ b/plugins/x-callback-url/.ci.json
@@ -1,0 +1,3 @@
+{
+  "runner": "macos-latest"
+}


### PR DESCRIPTION
The `plugin` jobs for `calendar`, `shortcuts`, and `x-callback-url` each ran `swift-actions/setup-swift@v2`, which GitHub flagged with the Node 20 deprecation warning. Every release of that action, `v3` included, still declares `using: node20`, so bumping the version doesn't help.

All three plugins target macOS, where `swiftc` ships with the preinstalled Xcode toolchain. Pinning them to `macos-latest` (via `.ci.json`, the same mechanism the `mac` plugin already uses) lets `swiftc -parse` run natively, so the Node-based setup action drops out entirely along with its warning.

`Validate Swift syntax` is the only step that needed Swift, and it stays. The `mac` plugin already exercises the full `plugin` job on a macOS runner, so the install and validate steps are known to work there.
