### PR TITLE
tmux: re-peg agent team shell-race hook to Agent spawn

### DIFF
--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -8,7 +8,7 @@ Tmux session, window, and pane awareness for Claude Code.
 - **Hook: context** — SessionStart hook that injects tmux env vars
 - **Hook: resume-command**, a SessionStart hook that records the session's resume command in a pane-scoped tmux option for plugins like [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) to use when resuming a pane
 - **Hook: notification** — Bell and status bar notifications for permission prompts
-- A PreToolUse hook on `TeamCreate` that fixes the [agent team pane startup race](https://github.com/anthropics/claude-code/issues/25315) for tmux-backed teammates
+- A PreToolUse hook on `Agent` that fixes the [agent team pane startup race](https://github.com/anthropics/claude-code/issues/25315) for tmux-backed teammates
 
 ## How It Works
 
@@ -22,9 +22,9 @@ The skill provides a PreToolUse hook that auto-allows safe tmux commands (read-o
 
 The tmux team backend spawns each teammate in a new pane and immediately sends the `claude` command with `send-keys`. A slow rc file breaks this. The keystrokes land before the login shell finishes sourcing it, get swallowed, and the teammate never starts.
 
-A PreToolUse hook on `TeamCreate` heads this off. It points tmux's `default-command` at [`shell-wrapper.sh`](hooks/shell-wrapper.sh) and pins `@claude_fast_shell` on the lead's window. New panes in that window exec a shell with rc loading skipped (`zsh --no-rcs`, `bash --norc`, `fish --no-config`), so the prompt is ready before `send-keys` fires. Every other window falls through to a normal login shell, so panes you open elsewhere behave as usual. One catch: a no-rc shell never rebuilds `PATH`, so the hook stashes the current value in the `CLAUDE_PATH` tmux environment variable and the wrapper restores it. Otherwise `claude` would not resolve.
+A PreToolUse hook on `Agent` heads this off. `Agent` is the tool that spawns teammates, and there is no longer a discrete team-creation event to hook: Claude Code removed the `TeamCreate` and `TeamDelete` tools in v2.1.178, and a team now forms implicitly on the first teammate spawn. The hook points tmux's `default-command` at [`shell-wrapper.sh`](hooks/shell-wrapper.sh) and pins `@claude_fast_shell` on the lead's window. New panes in that window exec a shell with rc loading skipped (`zsh --no-rcs`, `bash --norc`, `fish --no-config`), so the prompt is ready before `send-keys` fires. Every other window falls through to a normal login shell, so panes you open elsewhere behave as usual. The hook fires on every `Agent` call, including in-process subagents that never open a pane; the tmux options are idempotent, so the extra calls cost three `tmux set` invocations and nothing else. One catch: a no-rc shell never rebuilds `PATH`, so the hook stashes the current value in the `CLAUDE_PATH` tmux environment variable and the wrapper restores it. Otherwise `claude` would not resolve.
 
-A second hook on `TeamDelete` reverses all of this. It unsets `default-command`, clears the window's `@claude_fast_shell` pin, and removes `CLAUDE_PATH`. Teardown is optimistic. It rides on the normal end of a team and never touches the `Stop` path, where an earlier version burned a `bun` startup on every stop in every session. When a team is never deleted, its window keeps the no-rc shell until the tmux session ends. Kill the window to reset it sooner.
+A `SessionEnd` hook reverses all of this. It unsets `default-command`, clears the window's `@claude_fast_shell` pin, and removes `CLAUDE_PATH`. Teardown rides on the end of the lead session, not the per-turn `Stop` path, where an earlier version burned a `bun` startup on every stop in every session. If the session exits without firing the hook, its window keeps the no-rc shell until the tmux session ends. Kill the window to reset it sooner.
 
 ## Sandbox
 

--- a/plugins/tmux/hooks/hooks.json
+++ b/plugins/tmux/hooks/hooks.json
@@ -39,16 +39,17 @@
         ]
       },
       {
-        "matcher": "TeamCreate",
+        "matcher": "Agent",
         "hooks": [
           {
             "type": "command",
             "command": "[ -n \"$TMUX_PANE\" ] && tmux set-environment CLAUDE_PATH \"$PATH\" && tmux set-option default-command \"${CLAUDE_PLUGIN_ROOT}/hooks/shell-wrapper.sh\" && tmux set-option -w -t \"$TMUX_PANE\" @claude_fast_shell 1 || true"
           }
         ]
-      },
+      }
+    ],
+    "SessionEnd": [
       {
-        "matcher": "TeamDelete",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
The shell-race workaround from #825 stopped working. It hung its setup and teardown on `PreToolUse` matchers for `TeamCreate` and `TeamDelete`, but Claude Code removed both tools in v2.1.178. A team now forms implicitly when the first teammate is spawned through the `Agent` tool, with no discrete creation event to intercept. The matchers never match, none of the tmux options get set, and tmux-backed teammates spawn into a normal login shell and hit the original pane startup race again.

This re-pegs the hook to triggers that still exist:

- Setup moves to `PreToolUse` on `Agent`, the tool that spawns teammates. It fires in the lead's environment right before the backend opens the teammate pane, which is exactly when `default-command` and `@claude_fast_shell` need to be in place. It also fires for in-process subagents that never open a pane, but the tmux options are idempotent, so those calls cost three `tmux set` invocations and nothing else.
- Teardown moves to `SessionEnd`. There is no team-delete event anymore, and the lead session ending is the closest analog. It stays off the per-turn `Stop` path, which an earlier version used and which burned a `bun` startup on every stop in every session.

I confirmed the failure and the fix by hand. Spawning a teammate with the options unset reproduced the race: the pane's `claude` process died on startup and fell back to an idle shell. Setting the options the way the re-pegged hook does and spawning again brought the teammate up cleanly, same `tmux` backend both times.

Refs #825.
