### PR TITLE
tmux: soft-block cross-window navigation verbs

### DIFF
--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -16,7 +16,7 @@ A SessionStart hook detects whether Claude is running inside tmux and writes ses
 
 Another SessionStart hook records the command that resumes the current session (`claude --resume <id>`) in the pane-scoped tmux option `@resume-command`, refreshed on every session start. Plugins like tmux-resurrect can read it back with `tmux show-options -p -t <pane> -qv @resume-command` to resume the session when restoring a pane. Outside tmux the hook is a no-op.
 
-The skill provides a PreToolUse hook that auto-allows safe tmux commands (read-only, navigation, layout). The safe command list is maintained in [`safe-commands.json`](skills/tmux/resources/safe-commands.json).
+The skill provides a PreToolUse hook that auto-allows safe tmux commands (read-only and within-window layout). The safe command list is maintained in [`safe-commands.json`](skills/tmux/resources/safe-commands.json). Window-switching verbs (`select-window`, `switch-client`, `next`/`previous`/`last-window`) are deliberately excluded, so they fall through to a permission prompt. This keeps cross-window navigation an explicit choice rather than a silent one during autonomous work.
 
 ## Agent Team Shell Race
 

--- a/plugins/tmux/hooks/prompt.md
+++ b/plugins/tmux/hooks/prompt.md
@@ -14,6 +14,9 @@ through unchanged. Injection is best-effort: it does NOT fire when the
 command's argument contains shell metacharacters (`$(...)`, `;`,
 `&&`, etc.), so pass `-t "$TMUX_PANE"` explicitly in those cases.
 
-To target the user's currently active pane, resolve it first:
+Default to your own pane and window. Reaching into another window is the
+exception: the window-switching verbs (`select-window`, `switch-client`,
+`next`/`previous`/`last-window`) prompt for permission, so cross-window work
+should follow an explicit request. When it does, resolve the target first:
 
     target=$(tmux display-message -p '#{pane_id}') && tmux send-keys -t "$target" ...

--- a/plugins/tmux/skills/tmux/resources/safe-commands.json
+++ b/plugins/tmux/skills/tmux/resources/safe-commands.json
@@ -15,14 +15,6 @@
   "has",
   "select-pane",
   "selectp",
-  "select-window",
-  "selectw",
-  "last-window",
-  "last",
-  "next-window",
-  "next",
-  "previous-window",
-  "prev",
   "swap-pane",
   "swapp",
   "swap-window",
@@ -38,7 +30,5 @@
   "rename-window",
   "renamew",
   "rename-session",
-  "rename",
-  "switch-client",
-  "switchc"
+  "rename"
 ]

--- a/plugins/tmux/skills/tmux/scripts/safe-command.test.ts
+++ b/plugins/tmux/skills/tmux/scripts/safe-command.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+
+const script = join(import.meta.dir, "safe-command.sh");
+
+async function run(command: string): Promise<string> {
+  const proc = Bun.spawn(["bash", script], {
+    stdin: new TextEncoder().encode(JSON.stringify({ tool_input: { command } })),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const output = await new Response(proc.stdout).text();
+  await proc.exited;
+  return output.trim();
+}
+
+function isAllow(output: string): boolean {
+  if (!output) return false;
+  const parsed = JSON.parse(output) as {
+    hookSpecificOutput?: { permissionDecision?: string };
+  };
+  return parsed.hookSpecificOutput?.permissionDecision === "allow";
+}
+
+describe("safe-command", () => {
+  it("auto-allows read-only commands", async () => {
+    expect(isAllow(await run("tmux capture-pane -p"))).toBe(true);
+    expect(isAllow(await run("tmux display-message -p '#{pane_id}'"))).toBe(true);
+    expect(isAllow(await run("tmux list-windows"))).toBe(true);
+  });
+
+  it("auto-allows within-window layout and pane commands", async () => {
+    expect(isAllow(await run("tmux select-pane -t %3"))).toBe(true);
+    expect(isAllow(await run("tmux resize-pane -D 5"))).toBe(true);
+  });
+
+  it("does not auto-allow window-navigation commands", async () => {
+    expect(await run("tmux select-window -t :2")).toBe("");
+    expect(await run("tmux switch-client -t other")).toBe("");
+    expect(await run("tmux next-window")).toBe("");
+    expect(await run("tmux previous-window")).toBe("");
+    expect(await run("tmux last-window")).toBe("");
+  });
+
+  it("does not auto-allow non-tmux commands", async () => {
+    expect(await run("ls -la")).toBe("");
+  });
+});


### PR DESCRIPTION
The tmux targeting hook felt "persistently defeated," but mining the session index (1,292 real `tmux` calls across 76 sessions) showed a different story. There is no accidental mis-targeting into the user's pane, and the targeting hook is a near-no-op rather than evaded: 207 of 225 targetable commands already carried an explicit `-t` Claude wrote itself. The only *silent* path into other windows during autonomous work is the auto-allowed window-navigation verbs, which change the attached user's view without prompting.

Removes the window-navigation verbs (`select-window`, `switch-client`, `next`/`previous`/`last-window`, and their aliases) from `safe-commands.json` so they fall through to a permission prompt. This makes cross-window navigation an explicit choice while leaving the dominant, legitimate idiom untouched: self-rooted orchestration (`split-window -t "$TMUX_PANE"` then `send-keys`) already prompts because those verbs were never auto-allowed.

This is a soft-block by classification, not a hard block. A hard block would break the intentional multi-Claude dispatch that is the actual dominant usage, to fix leakage the data shows does not happen. The lever is the permission list alone, identifiable from the subcommand, so there is no new always-on hook and no per-Bash runtime cost.

## Changes

- `safe-commands.json`: drop the five navigation verbs and their aliases. Read-only verbs and within-window layout/pane verbs (`select-pane`, `resize-pane`, `select-layout`, `swap-*`, `move-*`, `rename-*`) stay auto-allowed.
- Add `safe-command.test.ts` pinning the boundary: read-only and layout verbs allow, navigation verbs and non-tmux commands fall through.
- `README.md` and `prompt.md`: reword to match, and reframe cross-window targeting as an explicit opt-in rather than a routine move.

## Testing

`bun test plugins/tmux` passes (30 tests). The new test confirms `select-window`/`switch-client`/`next`/`previous`/`last-window` yield no auto-allow while `capture-pane`/`select-pane`/`resize-pane` still do.

The permission prompt is itself the feedback signal: frequent cross-window prompts for legitimate work mean the block is miscalibrated (whitelist the verb in that workflow or revert); rare prompts mean it is working at zero recurring cost.
