### PR TITLE
sandbox: allow Apple Events, drop JXA sandbox escape

### DIFF
--- a/packages/validate/validate.ts
+++ b/packages/validate/validate.ts
@@ -54,6 +54,7 @@ export async function loadSchema(schemaPath: string): Promise<Record<string, unk
     schema = await Bun.file(schemaPath).json();
   }
   patchHookSchema(schema);
+  patchSandboxSchema(schema);
   return schema;
 }
 
@@ -71,6 +72,18 @@ function patchHookSchema(schema: Record<string, unknown>): void {
       };
     }
   }
+}
+
+function patchSandboxSchema(schema: Record<string, unknown>): void {
+  const props = schema.properties as Record<string, Record<string, unknown>> | undefined;
+  const sandbox = props?.sandbox;
+  const sandboxProps = sandbox?.properties as Record<string, unknown> | undefined;
+  if (!sandboxProps) return;
+
+  sandboxProps.allowAppleEvents = {
+    type: "boolean",
+    description: "Allow sandboxed commands to send macOS Apple Events (osascript, open)",
+  };
 }
 
 export async function validateFile(

--- a/plugins/mac/hooks/sandbox.integration.ts
+++ b/plugins/mac/hooks/sandbox.integration.ts
@@ -54,8 +54,8 @@ describe("hasBypassMarker", () => {
     expect(await hasBypassMarker(gitlabWatchScript)).toBe(true);
   });
 
-  test("mac jxa.ts carries the marker", async () => {
-    expect(await hasBypassMarker(jxaScript)).toBe(true);
+  test("mac jxa.ts no longer carries the marker (Apple Events handled by sandbox.allowAppleEvents)", async () => {
+    expect(await hasBypassMarker(jxaScript)).toBe(false);
   });
 });
 
@@ -107,12 +107,8 @@ describe("processInput", () => {
     expect(result).not.toBeNull();
   });
 
-  test("disables sandbox for mac jxa.ts", async () => {
+  test("does not disable sandbox for mac jxa.ts (relies on sandbox.allowAppleEvents)", async () => {
     const result = await processInput(makeInput(`bun ${jxaScript} Finder 'app.name()'`), "darwin");
-    expect(result).not.toBeNull();
-    expect(result?.hookSpecificOutput).toMatchObject({
-      hookEventName: "PreToolUse",
-      updatedInput: { dangerouslyDisableSandbox: true },
-    });
+    expect(result).toBeNull();
   });
 });

--- a/plugins/mac/scripts/jxa.ts
+++ b/plugins/mac/scripts/jxa.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env bun
-// claude:dangerouslyDisableSandbox: osascript hands off to LaunchServices/Apple Events, which the command sandbox blocks
 
 import * as acorn from "acorn";
 

--- a/user/settings.json
+++ b/user/settings.json
@@ -336,6 +336,7 @@
   "sandbox": {
     "enabled": true,
     "autoAllowBashIfSandboxed": true,
+    "allowAppleEvents": true,
     "network": {
       "allowLocalBinding": true,
       "allowUnixSockets": [


### PR DESCRIPTION
Enables `sandbox.allowAppleEvents` so JXA and `osascript` Apple Events IPC work under the sandbox. The `mac` plugin previously fully disabled the sandbox for the JXA runner via a `claude:dangerouslyDisableSandbox` marker, which gave that path full egress. With `allowAppleEvents` on, the JXA path stays under sandbox egress control and only gains Apple Events.

Verified the setting against the official docs: it must live in user settings (project settings are ignored for this key) and defaults to `false`. Enabling it is global, so any sandboxed command can send Apple Events or launch apps unsandboxed without a prompt. For the JXA path specifically this is a net tightening over the old full-disable behavior.

The Things URL scripts (`inbox.ts`, `url.ts`, `reorder.ts`) keep their markers. They hand off to Launch Services via `open` with different error codes (`-10810`) and are out of scope here.

The mac plugin's sandbox-hook tests cover the marker handling and the JXA app-scope validation. The live sandbox behavior is not exercised here because the active session reads the installed `~/.claude/settings.json`, not this branch's copy.

Original Task: [sandbox.allowAppleEvents](https://things.bendrucker.me/show?id=L2W8Ld8Ef8BXsGMJg2qexG)
