### PR TITLE
sandbox: allow npm cache writes to ~/.npm

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -354,6 +354,7 @@
         "~/src/go/pkg/mod",
         "~/src/go/pkg/sumdb",
         "~/.bun/install",
+        "~/.npm",
         "~/.local/share/uv",
         "~/.local/share/graphite"
       ]


### PR DESCRIPTION
npm cache writes were denied by the sandbox across several sessions. npm writes its cache under `~/.npm`, which the sandbox blocks. The registry hosts it reaches are already allowed.

npm stays sandboxed. It has no auth of its own and reaches the network, so per `.claude/rules/settings.md` it does not belong in `excludedCommands`. The fix is to allow its cache path. `npm config get cache` resolves to `~/.npm`, added next to the existing `~/.bun/install` entry.

Original Task: [Add ~/.npm to sandbox allowWrite (npm cache writes denied)](https://things.bendrucker.me/show?id=THcDqtf3aqSgphr4iDf4ou)

Discovery: 646faf2828ae
