### PR TITLE
docs: correct disable-model-invocation description

### DIFF
--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -62,7 +62,7 @@ hooks:                                    # Optional: skill-scoped hooks
 - `context`: Set to `fork` to run in isolated subagent context
 - `agent`: Agent type when `context: fork` (`Explore`, `Plan`, `general-purpose`, or custom)
 - `user-invocable`: Hide from slash menu when `false` (default: `true`)
-- `disable-model-invocation`: Block programmatic invocation via Skill tool
+- `disable-model-invocation`: Block model (Skill-tool) invocation and drop the skill's name and description from the always-on catalog (zero recurring context cost); still slash-invocable. Opposite of `user-invocable: false`, which hides the slash menu but keeps the description loaded for the model.
 - `hooks`: Skill-scoped hooks (`PreToolUse`, `PostToolUse`, `Stop`)
 
 **Naming**: Plugin skills use `plugin-name:skill-name` with a colon namespace (e.g., `gitlab:ci`, `things:inbox`). The part after the colon should not repeat the plugin name. For standalone skills, use gerund form (verb + -ing): `processing-pdfs`, `analyzing-data`. Avoid vague names like `helper`, `utils`.

--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -46,7 +46,7 @@
     "disable-model-invocation": {
       "type": "boolean",
       "default": false,
-      "description": "Block programmatic invocation via the Skill tool. Does not affect slash menu or auto-discovery."
+      "description": "Block model (Skill tool) invocation and drop the skill's name and description from the always-on catalog, so it costs no recurring context. The skill still appears in the slash menu and loads its body when invoked with /name."
     }
   },
   "required": ["name", "description"],


### PR DESCRIPTION
The repo documented `disable-model-invocation` as only blocking programmatic Skill-tool invocation, with a clause stating it does not affect auto-discovery. That clause is wrong. Per the official docs, the flag also removes a skill's name and description from the always-on context, which is the real lever for cutting recurring skill-catalog token cost.

Corrects the schema property description and the authoring skill bullet, and contrasts the flag with `user-invocable: false`, which only hides the slash menu and keeps the description loaded for the model.

A discovery run surfaced this contradiction against a project memory note that claimed the flag costs zero recurring tokens. The memory note was right and the repo docs were wrong.

Original Task: [Verify whether disable-model-invocation actually shrinks the always-on skill catalog](https://things.bendrucker.me/show?id=KoKdtEdZwZrGE2hUZR6XC1)

Discovery: e1d99c87f832
