### PR TITLE
pr-comments: no human-voiced replies to bot reviewers

### DIFF
--- a/plugins/github/skills/pr-comments/SKILL.md
+++ b/plugins/github/skills/pr-comments/SKILL.md
@@ -77,3 +77,11 @@ bun ${CLAUDE_PLUGIN_ROOT}/scripts/review-threads.ts resolve <thread-id>
 ```
 
 Pass the reply text with `--body`, `--bodyFile <path>`, or stdin. Don't resolve without a reply: a silent resolve hides why the thread closed.
+
+#### Bot Reviewer Threads
+
+A bot reviewer is any account the `--bots` filter catches: accounts the API types as `Bot` (Copilot, CodeRabbit, Greptile) plus logins in `$CLAUDE_PLUGIN_DATA/reviewers.txt`. Use that filter to detect them rather than hardcoding logins.
+
+Do not write human-voiced replies to these threads. No thanks, no "addressed in the latest revision", no conversation with the bot. Push the fix and resolve the thread, or just resolve it.
+
+If a reply is genuinely needed, state the resolution as a terse note for a human reader ("Guarded with a null check"), not a message to the bot.

--- a/plugins/pull-request/skills/follow-up/replies.md
+++ b/plugins/pull-request/skills/follow-up/replies.md
@@ -22,7 +22,7 @@ Short review comments get short replies. Detailed technical feedback gets a prop
 
 ## Replying to AI Reviewers
 
-When `--auto` replies to a bot thread, write the reply as a note for any reader, not a message to the bot:
+When replying to a bot thread (auto or gated), write the reply as a note for any reader, not a message to the bot:
 
 - **Don't name or address the reviewer.** No "@coderabbitai", no "thanks", no "good bot". The one place a bot is named is the `@<bot>` re-trigger, a top-level comment, not a thread reply.
 - **State the resolution, not the dialogue.** "Guarded with a null check" or "Intentional: this path only runs after validation" reads correctly whether a human or a bot raised it.


### PR DESCRIPTION
Claude posted pleasantry replies ("Thanks for the review, addressed in the latest revision") to Copilot review threads. A human does not thank or converse with a review bot, so this makes the account read as a bot.

The rule against this already existed, but only under `pull-request:follow-up --auto`. The interactive "address the Copilot reviews" path uses `github:pr-comments` directly and never saw it. This adds the rule at the reply action point, keyed off the existing `--bots` detection, and de-gates the `follow-up` copy from `--auto`-only to all reply paths.

Original Task: [Stop Claude writing human-voiced replies to bot PR reviews](https://things.bendrucker.me/show?id=T8DSrfWjHg37BZNWBwhKFL)
