### PR TITLE
claude-code:skill: add argument-hint house style

### DIFF
--- a/plugins/claude-code/skills/agent-team/SKILL.md
+++ b/plugins/claude-code/skills/agent-team/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: claude-code:agent-team
 description: Orchestrating Claude Code agent teams. Use when creating teams, spawning teammates, assigning tasks, configuring teammate modes, or setting up team quality gate hooks.
+argument-hint: "[--plan-approval] [--delegate] [--shutdown]"
 allowed-tools:
   - Read
   - Write
@@ -12,6 +13,14 @@ allowed-tools:
 ---
 
 # Agent Teams
+
+## Arguments
+
+These select a team mode up front instead of toggling it interactively (see [Team Lifecycle](#team-lifecycle)):
+
+- `--delegate`: start the lead in delegate mode, coordination-only with no direct implementation. Default: the lead can implement.
+- `--plan-approval`: require teammates to plan before implementing, read-only until the lead approves. Default: off.
+- `--shutdown`: shut the current team down, teammates first and then the team, then stop. Default: create or operate a team.
 
 ## Team Lifecycle
 

--- a/plugins/claude-code/skills/session/SKILL.md
+++ b/plugins/claude-code/skills/session/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: claude-code:session
 description: Query Claude Code session history via a DuckDB index over `~/.claude/projects/`. Use when asked about Claude Code activity ("how many tokens today?", "what did I work on this week?") or instead of reading, grepping, or jq-ing session transcripts. Not for codebase search, git log queries, or arbitrary databases.
+argument-hint: "[--refresh] [--host label] [--since date]"
 allowed-tools:
   - Bash
   - Read
@@ -11,6 +12,14 @@ allowed-tools:
 Search and analyze Claude Code conversation history via a DuckDB index over JSONL session files.
 
 **Current Session ID**: `${CLAUDE_SESSION_ID}`
+
+## Arguments
+
+Map any arguments to the mechanisms below:
+
+- `--refresh`: force a full rescan via `refresh.ts --refresh` before querying. Default: incremental refresh keyed on file mtime.
+- `--host <label>`: scope queries to one imported machine through the `host` param. Default: span every host, including `local`. See [Cross-Machine History](#cross-machine-history).
+- `--since <date>`: pass as the `after_date` param to scope queries from that date forward. Default: the full index.
 
 ## Database
 

--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: claude-code:skill
 description: Creating and optimizing Claude Code Skills including activation patterns, content structure, and development workflows. Use when creating new skills, converting memory files to skills, debugging skill activation, or understanding skill architecture and best practices.
+argument-hint: "[--validate] [--structure]"
 allowed-tools:
   - Read
   - Write
@@ -24,6 +25,15 @@ hooks:
 # Claude Code Skills Development
 
 Reference for developing effective skills. The context window is a public good - only include information Claude doesn't already possess.
+
+## Arguments
+
+Run a check against a skill path in `$ARGUMENTS`, defaulting to the skill you just edited:
+
+- `--validate`: run `skill-lint` (`bun run skill-lint <path>`) for frontmatter, naming, and reference-depth validation.
+- `--structure`: run the directory-structure check (`${CLAUDE_SKILL_DIR}/scripts/check-structure.ts`) for the SKILL.md, `scripts/`, `references/`, `assets/` layout.
+
+With neither flag, use the skill as an authoring reference. See [Validation](#validation).
 
 ## Core Principles
 

--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -37,6 +37,7 @@ Reference for developing effective skills. The context window is a public good -
 ---
 name: plugin-name:skill-name
 description: Third-person capability description with trigger terms
+argument-hint: "[--flag] [<positional>]"  # Optional: arguments shown in slash menu
 allowed-tools: [Read, Grep, Glob]         # Optional: tool restrictions
 model: claude-sonnet-4-20250514           # Optional: override model
 context: fork                             # Optional: run in isolated subagent
@@ -57,6 +58,7 @@ hooks:                                    # Optional: skill-scoped hooks
 - `description`: Third-person, includes trigger terms and use cases (max 1024 chars).
 
 **Optional Fields**:
+- `argument-hint`: Arguments the skill accepts, shown in the slash menu after the skill name. See [Argument Hints](#argument-hints).
 - `allowed-tools`: Tools Claude can use without permission when skill is active
 - `model`: Override the conversation's model
 - `context`: Set to `fork` to run in isolated subagent context
@@ -119,6 +121,22 @@ Skill-scoped hooks activate only when the skill is invoked and last for the sess
 | `${CLAUDE_SKILL_DIR}` | Absolute path to the skill's directory. Substituted in skill content: the body, `!` injection commands, and `allowed-tools`. |
 
 These substitutions apply to skill content, not the frontmatter `hooks:` block. The hooks engine expands only `${CLAUDE_PROJECT_DIR}`, `${CLAUDE_PLUGIN_ROOT}`, and `${CLAUDE_PLUGIN_DATA}` ([hooks reference](https://code.claude.com/docs/en/hooks)); `${CLAUDE_SKILL_DIR}` there resolves to an empty string. In a hook command, reference a bundled script by plugin root instead: `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/scripts/check.ts`.
+
+### Argument Hints
+
+`argument-hint` declares the arguments a skill accepts. It renders in the slash menu after the skill name and reminds the user which flags exist. Give every directable skill a hint, even when it usually runs with none. A skill that branches internally ("if the user wants X") should expose that branch as a flag.
+
+#### Notation
+
+- Required tokens use angle brackets, optional tokens use square brackets: `<doc-path> [--draft]`.
+- Mutually-exclusive alternatives are pipe-separated with surrounding spaces: `[staged | <range> | HEAD]`.
+- Boolean flags are `[--flag]`. Value flags are `[--flag value]`. Enumerated values pipe-join without inner spaces: `[--role author|reviewer]`.
+- Order tokens as required positionals, then optional positionals, then flags.
+- Keep the hint compact and push parsing heuristics into the body. The hint reminds the user which flags exist; the body documents them.
+
+#### Parsing
+
+A skill that declares an `argument-hint` must parse `$ARGUMENTS` (or `$0`/`$1` for positionals) and act on what it finds. Add an `## Arguments` section to the body mapping each token to its behavior and stating the default when the token is absent. Every flag needs a stated default so the no-argument invocation stays well-defined.
 
 ### Dynamic Context Injection
 

--- a/plugins/git/skills/conflicts/SKILL.md
+++ b/plugins/git/skills/conflicts/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: git:conflicts
 description: Resolving git merge conflicts during rebase, merge, or cherry-pick. Use when conflicts arise. Can also drive the operation to completion and push when asked (e.g. "fix conflicts and push").
+argument-hint: "[--push]"
 allowed-tools:
   - Read
   - Edit
@@ -65,7 +66,7 @@ For each conflicted file:
 
 ## Committing and Pushing
 
-This step runs only when you are asked to take the operation to completion (e.g. the user ran `/git:conflicts push` or said "fix conflicts and push"). On auto-activation, or when asked only to resolve, stop after `git add` and do not commit, continue, or push.
+This step runs only when you are asked to take the operation to completion: the `--push` argument (its alias `push`), or a request like "fix conflicts and push". By default, on auto-activation or when asked only to resolve, stop after `git add` and do not commit, continue, or push.
 
 When driving to completion:
 

--- a/plugins/github/skills/actions-monitor/SKILL.md
+++ b/plugins/github/skills/actions-monitor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: github:actions-monitor
 description: Monitor GitHub Actions runs and extract failure diagnostics. Use when watching PR CI, branch builds, or specific workflow runs.
-argument-hint: "[pr-url | branch | run-id]"
+argument-hint: "[pr-url | branch | run-id] [--max-minutes N] [--interval S]"
 allowed-tools:
   - Monitor
   - TaskStop

--- a/plugins/gitlab/skills/ci-monitor/SKILL.md
+++ b/plugins/gitlab/skills/ci-monitor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gitlab:ci-monitor
 description: Investigate GitLab CI pipeline failures and extract diagnostics. Use when watching MR CI, branch builds, or specific pipelines.
-argument-hint: "[mr-url | branch | pipeline-id]"
+argument-hint: "[mr-url | branch | pipeline-id] [--max-minutes N] [--project group/project]"
 allowed-tools:
   - Monitor
   - TaskStop

--- a/plugins/gitlab/skills/merge-request/SKILL.md
+++ b/plugins/gitlab/skills/merge-request/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: gitlab:merge-request
 description: Working with GitLab merge requests via glab. Use when creating, updating, reviewing, or merging MRs.
+argument-hint: "[create | merge | review | discussions | block] [--draft] [--auto] [--role author|reviewer]"
 allowed-tools:
   - Bash(bun ${CLAUDE_SKILL_DIR}/scripts/*:*)
   - Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/merge.ts:*)
@@ -10,6 +11,18 @@ allowed-tools:
 # Merge Requests
 
 Working with GitLab merge requests via `glab mr`.
+
+## Arguments
+
+`$0` (optional verb) routes to a section below. With no verb, infer the operation from the request.
+
+- `create`: open an MR. See [Patterns](#patterns). `--draft` opens it as a draft (`glab mr create --draft`).
+- `merge`: merge the MR. See [Merging](#merging). `--auto` enables auto-merge (`merge.ts --auto-merge`).
+- `review`: review MRs. See [Reviews](#reviews). `--role reviewer` (default) fetches MRs awaiting your review; `--role author` triages threads on MRs you authored.
+- `discussions`: work MR discussion threads. See [Discussions](#discussions).
+- `block`: block an MR until another merges. See [Blocking](#blocking).
+
+Flag defaults: `--draft` off, `--auto` off, `--role reviewer`.
 
 ## Key Commands
 

--- a/plugins/issue/skills/refine/SKILL.md
+++ b/plugins/issue/skills/refine/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: issue:refine
 description: Refining issues with technical context and structured details. Use when expanding a brief bug, feature, or refactor description into a detailed issue suitable for developers and AI agents.
+argument-hint: "[--type bug|feature|refactor] [--compact]"
 ---
 
 # Issue Refinement
 
 Expand brief issue descriptions into structured issues for developers and AI agents.
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+
+- `--type bug|feature|refactor`: skip type identification and read that guide directly. Default: infer the type from the description per [Issue Types](#issue-types).
+- `--compact`: force the tight output, a sentence or two that names the problem and points at the code, with no Summary/Context frame. Default: size the output to the issue per [Section Selection](#section-selection).
 
 ## Issue Types
 
@@ -17,9 +25,9 @@ Expand brief issue descriptions into structured issues for developers and AI age
 
 ## Workflow
 
-1. Identify type and read the corresponding guide
+1. Identify type and read the corresponding guide. When `--type` is set, use it and skip identification.
 2. Gather context from code and related issues
-3. Draft refinement following the type-specific structure
+3. Draft refinement following the type-specific structure. Under `--compact`, produce the tight output described in [Section Selection](#section-selection).
 4. Output for user approval before updating the issue
 
 ## Output Structure
@@ -49,6 +57,8 @@ Links to related issues, prior attempts, upstream work.
 Every section must tell the reader something they couldn't have guessed. Cut sections whose content is tautological ("tests must pass"), template residue ("no behavior change"), or obvious given the issue's size.
 
 For a substantial issue, Summary plus one type section plus Context is the floor. Grow only when content demands. A trivial issue needs none of that frame: a sentence or two that names the problem and points at the code is enough.
+
+`--compact` forces that trivial output regardless of size: name the problem, point at the code, drop the Summary/Context frame.
 
 ## Style
 

--- a/plugins/linear/skills/linear/SKILL.md
+++ b/plugins/linear/skills/linear/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: linear
 description: Interacting with Linear issues, projects, and teams. Use when creating issues, updating issues, querying issues, managing projects, working on tasks, discussing backlogs, or any interaction with Linear.
+argument-hint: "[create | update | list | view | comment] [issue ...]"
 allowed-tools:
   - mcp__linear
   - mcp__claude_ai_Linear
@@ -11,6 +12,18 @@ allowed-tools:
 # Linear
 
 Tools and workflows for managing issues, projects, and teams in Linear.
+
+## Arguments
+
+`$0` (optional verb) routes to an operation; pass the rest (issue id, title, filters) as its params. With no verb, infer the operation from the request.
+
+- `create`: create an issue. See [Creating vs Updating](#creating-vs-updating) and [Issue Status](#issue-status).
+- `update`: update an issue by id. See [Creating vs Updating](#creating-vs-updating).
+- `list`: query issues. See [Querying Issues](#querying-issues).
+- `view`: fetch a single issue; include its `url` for anything you may reference.
+- `comment`: comment on an issue, using full URLs per [Issue References](#issue-references).
+
+Pick MCP tools or the `linear api` CLI per [Tool Selection](#tool-selection).
 
 ## Tool Selection
 

--- a/plugins/personal-review/skills/review/SKILL.md
+++ b/plugins/personal-review/skills/review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: personal-review:review
 description: Interactive daily review workflow across Calendar, Things, GitHub, and Linear. Use when the user asks for a daily review, morning review, evening review, or weekly review.
+argument-hint: "[morning | evening | weekly]"
 disable-model-invocation: true
 ---
 
@@ -15,7 +16,7 @@ Multi-phase workflow with checkpoints. Each phase ends with a summary before pro
 | Morning | Full scan + prep | Full processing | Full triage | Full triage | Full review | Full triage |
 | Evening | Tomorrow preview | Quick triage | Mark read, defer | Defer reviews | Skip | Skip |
 
-Ask which variant if not specified.
+`$0` selects the variant: `morning`, `evening`, or `weekly` (a fuller pass over the same phases). Ask which variant when none is given.
 
 ## Phase: Calendar
 

--- a/plugins/pull-request/skills/babysit/SKILL.md
+++ b/plugins/pull-request/skills/babysit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pull-request:babysit
 description: Monitor a PR's CI, fix trivial failures, and self-cancel when green; --merge drives to merged, --reviews hands off to AI-review triage.
-argument-hint: "[--merge] [--reviews]"
+argument-hint: "[pr-url] [--merge] [--reviews]"
 allowed-tools:
   - Monitor
   - TaskStop
@@ -33,8 +33,9 @@ Inspect the remote URL. For a `github.com` remote, invoke the `github:actions-mo
 
 Babysit consumes that event stream and reacts with the handlers below. The watcher handles polling, deduping by `(sha, state)`, rate limits, timeouts, and session-scoped lifecycle. Babysit handles fixes, pushes, and reporting. Remember the start SHA above so the success handler can summarize work done in the session.
 
-Parse `$ARGUMENTS` for two optional flags, both off by default so plain babysit stays CI-only:
+Parse `$ARGUMENTS` for an optional PR positional and two optional flags, both flags off by default so plain babysit stays CI-only:
 
+- `$0` (pr-url): the PR to babysit, given as a URL or number. Pass it through to `follow-up` and the merge commands below. Default: resolve the PR from the branch in Context.
 - `--reviews`: after the first green, triage AI-reviewer threads. See [Reviews Hand-off](#reviews-hand-off).
 - `--merge`: don't stop at green; drive the PR to merged. See [Merge Mode](#merge-mode).
 

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -4,6 +4,7 @@ description: |
   Create a pull request, merge request, or change request with proper formatting and content guidelines.
   Invoke when the user wants to create, open, or submit a PR, MR, or CR—including after committing changes.
 
+argument-hint: "[--draft] [--auto] [--dry-run]"
 allowed-tools:
   - mcp__github
   - "Bash(git add:*)"
@@ -98,6 +99,14 @@ This runs after you create the PR/MR, so it never delays creation. Resolve names
 - **GitHub**: `gh pr edit --add-reviewer <user>` (resolve emails to logins with `mcp__github` if needed)
 - **GitLab**: load `gitlab:merge-request` for username resolution, then `glab mr update --reviewer <user>`
 
+## Arguments
+
+Parse `$ARGUMENTS` for these flags. With none, create a normal PR/MR that is ready for review and does not auto-merge.
+
+- `--draft`: open the PR/MR as a draft. Default: ready for review.
+- `--auto`: after creating, enable auto-merge so it merges once checks pass and required approvals land. Default: off.
+- `--dry-run` (alias `--body-only`): produce the body without creating anything. See [Dry Run](#dry-run). Default: off.
+
 ## Dry Run
 
 If the arguments include `--dry-run` (alias `--body-only`), produce the body without creating anything. Determine the title and body from the context above as usual, write the body to `tmp/pr-body-<branch>.md`, then print the title and body to the user and stop. Do not stage, commit, push, or run `gh pr create` / `glab mr create`. Use this to preview or evaluate the body in isolation.
@@ -110,11 +119,14 @@ If `--dry-run` (or `--body-only`) is set, follow the Dry Run section instead of 
 1. Stage changes if not already staged: `git add .`
 1. Commit if there are no commits yet on the branch. Follow the same format for the commit message as for the pull request title (conventional or subject-oriented based on repo standard): `git commit -m "..."`
 1. Push the branch to remote: `git push -u origin HEAD`
-1. Create the PR/MR:
+1. Create the PR/MR. Append `--draft` to the create command when `--draft` is set:
    - Write the body to a temp file first (e.g., `tmp/pr-body-<branch>.md`)
    - Include the branch name in the filename to avoid conflicts with concurrent agents
    - **GitHub**: `gh pr create --title "..." --body-file tmp/pr-body-<branch>.md`
    - **GitLab**: `glab mr create --title "..." --description "$(cat tmp/pr-body-<branch>.md)"`
+1. Enable auto-merge when `--auto` is set, after the PR/MR exists:
+   - **GitHub**: `gh pr merge --auto` (add `--squash` or `--rebase` to match the repo's merge method when known)
+   - **GitLab**: load `gitlab:merge-request` and run its `merge.ts --auto-merge`, which handles merge trains and falls back to `glab mr merge` as needed
 1. Suggest reviewers on corporate repos (see [Reviewers](#reviewers)). Skip this step for OSS. The PR/MR already exists, so reviewer ranking runs after creation and adds no latency to it.
 
 ## GitLab Notes

--- a/plugins/pull-request/skills/follow-up/SKILL.md
+++ b/plugins/pull-request/skills/follow-up/SKILL.md
@@ -5,7 +5,7 @@ description: >
   responses, investigate how threads were resolved (including silent resolves), and draft
   replies. With --auto, autonomously triage AI-reviewer (bot) threads and loop until the
   reviewer is satisfied, clearing a bot review hands-off.
-argument-hint: "[pr-url] [--auto]"
+argument-hint: "[pr-url] [--auto] [--include-human-nits]"
 allowed-tools:
   - Bash(git:*)
   - Bash(gh:*)

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -4,6 +4,7 @@ description: |
   Update a pull request or merge request body to reflect the current state of changes.
   Use when a PR/MR has evolved through additional commits and the body needs to reflect what will be merged.
 
+argument-hint: "[pr-url | mr-url]"
 allowed-tools:
   - mcp__github
   - "Bash(git remote get-url:*)"
@@ -15,6 +16,10 @@ allowed-tools:
 # Update Pull Request
 
 The PR body documents what will happen when merged, not the journey. Don't echo review feedback. Only mention changes if the ultimate result is user-facing.
+
+## Arguments
+
+`$0` (optional): the PR/MR to update, given as a URL, number, or branch name. The Workflow passes it to `gh pr view`/`glab mr view`. Default: with no argument, the tools resolve the PR/MR from the current branch.
 
 ## Context
 

--- a/plugins/things/skills/inbox/SKILL.md
+++ b/plugins/things/skills/inbox/SKILL.md
@@ -1,12 +1,17 @@
 ---
 name: things:inbox
 description: Quick captures to the Things 3 inbox. Not for reads (things:jxa), scheduled tasks, updates, or projects (things:url).
+argument-hint: "<text>"
 allowed-tools: ["Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts:*)"]
 ---
 
 # Things Inbox
 
 Add todos to the Things 3 inbox.
+
+## Arguments
+
+`$ARGUMENTS` is the capture text, passed as `title`. Multiple lines become multiple todos via `titles`. See [Add a Todo](#add-a-todo).
 
 ## Add a Todo
 

--- a/plugins/things/skills/url/SKILL.md
+++ b/plugins/things/skills/url/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: things:url
 description: Create, update, and manage Things 3 tasks and projects. Not for reads — use things:jxa to query data. For simple inbox captures, use things:inbox.
+argument-hint: "<add | update | show | search | json> [key=value ...]"
 allowed-tools:
   - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts:*)"
   - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/reorder.ts:*)"
@@ -11,6 +12,10 @@ allowed-tools:
 # Things URL Scheme
 
 Write operations for Things 3 via the `things:///` URL scheme.
+
+## Arguments
+
+`$0` is the command (`add`, `add-project`, `update`, `update-project`, `show`, `search`, `json`); the rest are its `key=value` params. Pass both straight to `url.ts` (see [Commands](#commands) and [Quick Start](#quick-start)). A command is required; with none, infer the operation from the request.
 
 ## Quick Start
 

--- a/plugins/tmux/skills/tmux/SKILL.md
+++ b/plugins/tmux/skills/tmux/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: tmux
 description: Tmux session, window, and pane management. Use when capturing output, sending keys, opening processes in panes, or checking notifications.
+argument-hint: "[capture | send | split | notify | list] [target ...]"
 allowed-tools:
   - "Bash(bash ${CLAUDE_SKILL_DIR}/scripts/pane.sh:*)"
   - "Bash(bash ${CLAUDE_SKILL_DIR}/scripts/window.sh:*)"
@@ -20,6 +21,16 @@ hooks:
 ---
 
 # tmux
+
+## Arguments
+
+`$0` (optional verb) routes to a section; pass the target pane, window, or session as the rest. With no verb, infer the operation from the request.
+
+- `capture`: print pane content. See [Capturing Pane Content](#capturing-pane-content).
+- `send`: send keys to a running pane. See [Starting Claude Sessions](#starting-claude-sessions).
+- `split`: open a pane. See [Opening Panes](#opening-panes).
+- `notify`: check which windows need attention (`bell`/`activity`). See [Session](#session).
+- `list`: inventory panes, windows, and sessions. See [Drilling Into Other Targets](#drilling-into-other-targets).
 
 ## Pane
 

--- a/plugins/writing/skills/analyze/SKILL.md
+++ b/plugins/writing/skills/analyze/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   session history and surfacing candidate phrases. Use when refreshing trope
   detection, reviewing wordlist health, or mining sessions for new AI-writing
   patterns to add or stale rules to remove.
+argument-hint: "[--since date] [--model glob] [--judge]"
 disable-model-invocation: true
 allowed-tools:
   - Bash
@@ -15,6 +16,14 @@ allowed-tools:
 # Writing Analyze
 
 Mine the session DuckDB index for assistant writing patterns, compare against the user's voice, and propose a diff to `plugins/writing/wordlists/*.txt`.
+
+## Arguments
+
+Forward these from `$ARGUMENTS` to `analyze.ts` (see [Run](#run)):
+
+- `--since <date>`: restrict the corpus to sessions on or after the date. Default: the full index.
+- `--model <glob>`: restrict to matching model IDs (e.g. `*opus*`). Default: all models.
+- `--judge`: add the LLM-judge pass over the deliverable corpus. See [Meaning-Layer Judge](#meaning-layer-judge). Default: off.
 
 ## Prerequisites
 

--- a/plugins/writing/skills/review/SKILL.md
+++ b/plugins/writing/skills/review/SKILL.md
@@ -2,6 +2,7 @@
 name: writing:review
 description: |
   Review a document through specialized lenses using parallel agents. Use when reviewing documentation, blog posts, READMEs, proposals, or any prose for quality issues across content, style, and embedded artifacts.
+argument-hint: "<doc-path> [--lens content|style|artifacts]"
 context: fork
 agent: general-purpose
 allowed-tools:
@@ -20,11 +21,15 @@ Review a document through parallel agents, each covering a different lens.
 
 $ARGUMENTS
 
-If no document path provided, ask the user. Optionally accept target audience and focus areas.
+The first positional is the document path. If none is provided, ask the user. Optionally accept target audience and focus areas.
+
+- `--lens content|style|artifacts`: run only the named lenses. Comma-separate to select more than one (`--lens content,style`). Default: all applicable lenses per [Dispatch Agents](#dispatch-agents).
 
 ## Dispatch Agents
 
 Read the document. Always spawn `writing:content` and `writing:style`. Spawn `writing:artifacts` only if the document contains URLs, markdown links, Mermaid code blocks, or markdown tables.
+
+When `--lens` is set, restrict the dispatch to the named lenses. `artifacts` still spawns only when the document actually contains links, diagrams, or tables, so a `--lens artifacts` run on a document with none spawns nothing.
 
 Spawn all applicable agents in parallel. Each receives the document content, audience, and focus areas.
 


### PR DESCRIPTION
Most directable skills in this marketplace take no arguments, so following a frequent path means spelling it out in prose every time. This stack gives every directable skill an `argument-hint` and wires the flags into real behavior, so a known path can be invoked compactly and the hint reminds the user which flags exist.

This foundation PR codifies the `argument-hint` house style once, in the `claude-code:skill` authoring guide that `.claude/rules/plugins.md` points at:

- Notation: `<required>` vs `[optional]`, pipe-separated alternatives (`[staged | <range> | HEAD]`), boolean and value flags, inner-space-free enums (`[--role author|reviewer]`).
- Ordering: required positionals, then optional positionals, then flags.
- The body `## Arguments` contract: parse `$ARGUMENTS` (or `$0`/`$1`), and state a default for every flag so the no-argument invocation stays well-defined.

Six group PRs branch off this one and apply the convention across the skills.
