### PR TITLE
pull-request: argument hints and create-flag wiring

### DIFF
--- a/plugins/pull-request/skills/babysit/SKILL.md
+++ b/plugins/pull-request/skills/babysit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pull-request:babysit
 description: Monitor a PR's CI, fix trivial failures, and self-cancel when green; --merge drives to merged, --reviews hands off to AI-review triage.
-argument-hint: "[--merge] [--reviews]"
+argument-hint: "[pr-url] [--merge] [--reviews]"
 allowed-tools:
   - Monitor
   - TaskStop
@@ -33,8 +33,9 @@ Inspect the remote URL. For a `github.com` remote, invoke the `github:actions-mo
 
 Babysit consumes that event stream and reacts with the handlers below. The watcher handles polling, deduping by `(sha, state)`, rate limits, timeouts, and session-scoped lifecycle. Babysit handles fixes, pushes, and reporting. Remember the start SHA above so the success handler can summarize work done in the session.
 
-Parse `$ARGUMENTS` for two optional flags, both off by default so plain babysit stays CI-only:
+Parse `$ARGUMENTS` for an optional PR positional and two optional flags, both flags off by default so plain babysit stays CI-only:
 
+- `$0` (pr-url): the PR to babysit, given as a URL or number. Pass it through to `follow-up` and the merge commands below. Default: resolve the PR from the branch in Context.
 - `--reviews`: after the first green, triage AI-reviewer threads. See [Reviews Hand-off](#reviews-hand-off).
 - `--merge`: don't stop at green; drive the PR to merged. See [Merge Mode](#merge-mode).
 

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -4,6 +4,7 @@ description: |
   Create a pull request, merge request, or change request with proper formatting and content guidelines.
   Invoke when the user wants to create, open, or submit a PR, MR, or CR—including after committing changes.
 
+argument-hint: "[--draft] [--auto] [--dry-run]"
 allowed-tools:
   - mcp__github
   - "Bash(git add:*)"
@@ -98,6 +99,14 @@ This runs after you create the PR/MR, so it never delays creation. Resolve names
 - **GitHub**: `gh pr edit --add-reviewer <user>` (resolve emails to logins with `mcp__github` if needed)
 - **GitLab**: load `gitlab:merge-request` for username resolution, then `glab mr update --reviewer <user>`
 
+## Arguments
+
+Parse `$ARGUMENTS` for these flags. With none, create a normal PR/MR that is ready for review and does not auto-merge.
+
+- `--draft`: open the PR/MR as a draft. Default: ready for review.
+- `--auto`: after creating, enable auto-merge so it merges once checks pass and required approvals land. Default: off.
+- `--dry-run` (alias `--body-only`): produce the body without creating anything. See [Dry Run](#dry-run). Default: off.
+
 ## Dry Run
 
 If the arguments include `--dry-run` (alias `--body-only`), produce the body without creating anything. Determine the title and body from the context above as usual, write the body to `tmp/pr-body-<branch>.md`, then print the title and body to the user and stop. Do not stage, commit, push, or run `gh pr create` / `glab mr create`. Use this to preview or evaluate the body in isolation.
@@ -110,11 +119,14 @@ If `--dry-run` (or `--body-only`) is set, follow the Dry Run section instead of 
 1. Stage changes if not already staged: `git add .`
 1. Commit if there are no commits yet on the branch. Follow the same format for the commit message as for the pull request title (conventional or subject-oriented based on repo standard): `git commit -m "..."`
 1. Push the branch to remote: `git push -u origin HEAD`
-1. Create the PR/MR:
+1. Create the PR/MR. Append `--draft` to the create command when `--draft` is set:
    - Write the body to a temp file first (e.g., `tmp/pr-body-<branch>.md`)
    - Include the branch name in the filename to avoid conflicts with concurrent agents
    - **GitHub**: `gh pr create --title "..." --body-file tmp/pr-body-<branch>.md`
    - **GitLab**: `glab mr create --title "..." --description "$(cat tmp/pr-body-<branch>.md)"`
+1. Enable auto-merge when `--auto` is set, after the PR/MR exists:
+   - **GitHub**: `gh pr merge --auto` (add `--squash` or `--rebase` to match the repo's merge method when known)
+   - **GitLab**: load `gitlab:merge-request` and run its `merge.ts --auto-merge`, which handles merge trains and falls back to `glab mr merge` as needed
 1. Suggest reviewers on corporate repos (see [Reviewers](#reviewers)). Skip this step for OSS. The PR/MR already exists, so reviewer ranking runs after creation and adds no latency to it.
 
 ## GitLab Notes

--- a/plugins/pull-request/skills/follow-up/SKILL.md
+++ b/plugins/pull-request/skills/follow-up/SKILL.md
@@ -5,7 +5,7 @@ description: >
   responses, investigate how threads were resolved (including silent resolves), and draft
   replies. With --auto, autonomously triage AI-reviewer (bot) threads and loop until the
   reviewer is satisfied, clearing a bot review hands-off.
-argument-hint: "[pr-url] [--auto]"
+argument-hint: "[pr-url] [--auto] [--include-human-nits]"
 allowed-tools:
   - Bash(git:*)
   - Bash(gh:*)

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -4,6 +4,7 @@ description: |
   Update a pull request or merge request body to reflect the current state of changes.
   Use when a PR/MR has evolved through additional commits and the body needs to reflect what will be merged.
 
+argument-hint: "[pr-url | mr-url]"
 allowed-tools:
   - mcp__github
   - "Bash(git remote get-url:*)"
@@ -15,6 +16,10 @@ allowed-tools:
 # Update Pull Request
 
 The PR body documents what will happen when merged, not the journey. Don't echo review feedback. Only mention changes if the ultimate result is user-facing.
+
+## Arguments
+
+`$0` (optional): the PR/MR to update, given as a URL, number, or branch name. The Workflow passes it to `gh pr view`/`glab mr view`. Default: with no argument, the tools resolve the PR/MR from the current branch.
 
 ## Context
 


### PR DESCRIPTION
Adds argument hints to the four `pull-request` skills and wires the new `create` flags into real behavior.

- `create`: `[--draft] [--auto] [--dry-run]`. `--draft` appends `--draft` to `gh pr create` / `glab mr create`. `--auto` enables auto-merge after creation (`gh pr merge --auto`, or the `gitlab:merge-request` `merge.ts --auto-merge` path for GitLab). `--dry-run` already existed. Both new flags default off, and the Workflow steps are updated to apply them.
- `update`: documents the existing optional `[pr-url | mr-url]` target positional (`$0`).
- `babysit`: adds a `[pr-url]` positional ahead of the existing `[--merge] [--reviews]`.
- `follow-up`: surfaces the already-documented `--include-human-nits` in the hint.

Stacked on #843.
