### PR TITLE
gitlab,github: command-oriented MR hint and monitor flags

### DIFF
--- a/plugins/github/skills/actions-monitor/SKILL.md
+++ b/plugins/github/skills/actions-monitor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: github:actions-monitor
 description: Monitor GitHub Actions runs and extract failure diagnostics. Use when watching PR CI, branch builds, or specific workflow runs.
-argument-hint: "[pr-url | branch | run-id]"
+argument-hint: "[pr-url | branch | run-id] [--max-minutes N] [--interval S]"
 allowed-tools:
   - Monitor
   - TaskStop

--- a/plugins/gitlab/skills/ci-monitor/SKILL.md
+++ b/plugins/gitlab/skills/ci-monitor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gitlab:ci-monitor
 description: Investigate GitLab CI pipeline failures and extract diagnostics. Use when watching MR CI, branch builds, or specific pipelines.
-argument-hint: "[mr-url | branch | pipeline-id]"
+argument-hint: "[mr-url | branch | pipeline-id] [--max-minutes N] [--project group/project]"
 allowed-tools:
   - Monitor
   - TaskStop

--- a/plugins/gitlab/skills/merge-request/SKILL.md
+++ b/plugins/gitlab/skills/merge-request/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: gitlab:merge-request
 description: Working with GitLab merge requests via glab. Use when creating, updating, reviewing, or merging MRs.
+argument-hint: "[create | merge | review | discussions | block] [--draft] [--auto] [--role author|reviewer]"
 allowed-tools:
   - Bash(bun ${CLAUDE_SKILL_DIR}/scripts/*:*)
   - Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/merge.ts:*)
@@ -10,6 +11,18 @@ allowed-tools:
 # Merge Requests
 
 Working with GitLab merge requests via `glab mr`.
+
+## Arguments
+
+`$0` (optional verb) routes to a section below. With no verb, infer the operation from the request.
+
+- `create`: open an MR. See [Patterns](#patterns). `--draft` opens it as a draft (`glab mr create --draft`).
+- `merge`: merge the MR. See [Merging](#merging). `--auto` enables auto-merge (`merge.ts --auto-merge`).
+- `review`: review MRs. See [Reviews](#reviews). `--role reviewer` (default) fetches MRs awaiting your review; `--role author` triages threads on MRs you authored.
+- `discussions`: work MR discussion threads. See [Discussions](#discussions).
+- `block`: block an MR until another merges. See [Blocking](#blocking).
+
+Flag defaults: `--draft` off, `--auto` off, `--role reviewer`.
 
 ## Key Commands
 


### PR DESCRIPTION
Makes the GitLab merge-request skill command-oriented and surfaces existing monitor flags in the CI hints.

- `gitlab:merge-request`: new verb router `[create | merge | review | discussions | block]` plus `[--draft] [--auto] [--role author|reviewer]`. An `## Arguments` section routes each verb to the section that already implements it; no behavior moved, the skill just gained a directable front door.
- `gitlab:ci-monitor`: hint now shows `[--max-minutes N] [--project group/project]`, both already documented in the body.
- `github:actions-monitor`: hint now shows `[--max-minutes N] [--interval S]`, both already documented in the body.

Stacked on #843.
