### PR TITLE
writing,claude-code: argument hints and flag wiring

### DIFF
--- a/plugins/claude-code/skills/agent-team/SKILL.md
+++ b/plugins/claude-code/skills/agent-team/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: claude-code:agent-team
 description: Orchestrating Claude Code agent teams. Use when creating teams, spawning teammates, assigning tasks, configuring teammate modes, or setting up team quality gate hooks.
+argument-hint: "[--plan-approval] [--delegate] [--shutdown]"
 allowed-tools:
   - Read
   - Write
@@ -12,6 +13,14 @@ allowed-tools:
 ---
 
 # Agent Teams
+
+## Arguments
+
+These select a team mode up front instead of toggling it interactively (see [Team Lifecycle](#team-lifecycle)):
+
+- `--delegate`: start the lead in delegate mode, coordination-only with no direct implementation. Default: the lead can implement.
+- `--plan-approval`: require teammates to plan before implementing, read-only until the lead approves. Default: off.
+- `--shutdown`: shut the current team down, teammates first and then the team, then stop. Default: create or operate a team.
 
 ## Team Lifecycle
 

--- a/plugins/claude-code/skills/session/SKILL.md
+++ b/plugins/claude-code/skills/session/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: claude-code:session
 description: Query Claude Code session history via a DuckDB index over `~/.claude/projects/`. Use when asked about Claude Code activity ("how many tokens today?", "what did I work on this week?") or instead of reading, grepping, or jq-ing session transcripts. Not for codebase search, git log queries, or arbitrary databases.
+argument-hint: "[--refresh] [--host label] [--since date]"
 allowed-tools:
   - Bash
   - Read
@@ -11,6 +12,14 @@ allowed-tools:
 Search and analyze Claude Code conversation history via a DuckDB index over JSONL session files.
 
 **Current Session ID**: `${CLAUDE_SESSION_ID}`
+
+## Arguments
+
+Map any arguments to the mechanisms below:
+
+- `--refresh`: force a full rescan via `refresh.ts --refresh` before querying. Default: incremental refresh keyed on file mtime.
+- `--host <label>`: scope queries to one imported machine through the `host` param. Default: span every host, including `local`. See [Cross-Machine History](#cross-machine-history).
+- `--since <date>`: pass as the `after_date` param to scope queries from that date forward. Default: the full index.
 
 ## Database
 

--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: claude-code:skill
 description: Creating and optimizing Claude Code Skills including activation patterns, content structure, and development workflows. Use when creating new skills, converting memory files to skills, debugging skill activation, or understanding skill architecture and best practices.
+argument-hint: "[--validate] [--structure]"
 allowed-tools:
   - Read
   - Write
@@ -24,6 +25,15 @@ hooks:
 # Claude Code Skills Development
 
 Reference for developing effective skills. The context window is a public good - only include information Claude doesn't already possess.
+
+## Arguments
+
+Run a check against a skill path in `$ARGUMENTS`, defaulting to the skill you just edited:
+
+- `--validate`: run `skill-lint` (`bun run skill-lint <path>`) for frontmatter, naming, and reference-depth validation.
+- `--structure`: run the directory-structure check (`${CLAUDE_SKILL_DIR}/scripts/check-structure.ts`) for the SKILL.md, `scripts/`, `references/`, `assets/` layout.
+
+With neither flag, use the skill as an authoring reference. See [Validation](#validation).
 
 ## Core Principles
 

--- a/plugins/writing/skills/analyze/SKILL.md
+++ b/plugins/writing/skills/analyze/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   session history and surfacing candidate phrases. Use when refreshing trope
   detection, reviewing wordlist health, or mining sessions for new AI-writing
   patterns to add or stale rules to remove.
+argument-hint: "[--since date] [--model glob] [--judge]"
 disable-model-invocation: true
 allowed-tools:
   - Bash
@@ -15,6 +16,14 @@ allowed-tools:
 # Writing Analyze
 
 Mine the session DuckDB index for assistant writing patterns, compare against the user's voice, and propose a diff to `plugins/writing/wordlists/*.txt`.
+
+## Arguments
+
+Forward these from `$ARGUMENTS` to `analyze.ts` (see [Run](#run)):
+
+- `--since <date>`: restrict the corpus to sessions on or after the date. Default: the full index.
+- `--model <glob>`: restrict to matching model IDs (e.g. `*opus*`). Default: all models.
+- `--judge`: add the LLM-judge pass over the deliverable corpus. See [Meaning-Layer Judge](#meaning-layer-judge). Default: off.
 
 ## Prerequisites
 

--- a/plugins/writing/skills/review/SKILL.md
+++ b/plugins/writing/skills/review/SKILL.md
@@ -2,6 +2,7 @@
 name: writing:review
 description: |
   Review a document through specialized lenses using parallel agents. Use when reviewing documentation, blog posts, READMEs, proposals, or any prose for quality issues across content, style, and embedded artifacts.
+argument-hint: "<doc-path> [--lens content|style|artifacts]"
 context: fork
 agent: general-purpose
 allowed-tools:
@@ -20,11 +21,15 @@ Review a document through parallel agents, each covering a different lens.
 
 $ARGUMENTS
 
-If no document path provided, ask the user. Optionally accept target audience and focus areas.
+The first positional is the document path. If none is provided, ask the user. Optionally accept target audience and focus areas.
+
+- `--lens content|style|artifacts`: run only the named lenses. Comma-separate to select more than one (`--lens content,style`). Default: all applicable lenses per [Dispatch Agents](#dispatch-agents).
 
 ## Dispatch Agents
 
 Read the document. Always spawn `writing:content` and `writing:style`. Spawn `writing:artifacts` only if the document contains URLs, markdown links, Mermaid code blocks, or markdown tables.
+
+When `--lens` is set, restrict the dispatch to the named lenses. `artifacts` still spawns only when the document actually contains links, diagrams, or tables, so a `--lens artifacts` run on a document with none spawns nothing.
 
 Spawn all applicable agents in parallel. Each receives the document content, audience, and focus areas.
 


### PR DESCRIPTION
Adds argument hints across the `writing` and `claude-code` skills.

- `writing:review`: `<doc-path> [--lens content|style|artifacts]` runs a subset of the three parallel review agents instead of all three, wired into the dispatch logic.
- `writing:analyze`: surfaces `[--since date] [--model glob] [--judge]`, which forward to `analyze.ts`.
- `claude-code:session`: `[--refresh] [--host label] [--since date]`, each mapped to an existing query mechanism.
- `claude-code:skill`: `[--validate] [--structure]` to run skill-lint or the structure check on a path.
- `claude-code:agent-team`: `[--plan-approval] [--delegate] [--shutdown]`, selecting a team mode up front.

Stacked on #843.
