### PR TITLE
things,linear,tmux: verb-routed argument hints

### DIFF
--- a/plugins/linear/skills/linear/SKILL.md
+++ b/plugins/linear/skills/linear/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: linear
 description: Interacting with Linear issues, projects, and teams. Use when creating issues, updating issues, querying issues, managing projects, working on tasks, discussing backlogs, or any interaction with Linear.
+argument-hint: "[create | update | list | view | comment] [issue ...]"
 allowed-tools:
   - mcp__linear
   - mcp__claude_ai_Linear
@@ -11,6 +12,18 @@ allowed-tools:
 # Linear
 
 Tools and workflows for managing issues, projects, and teams in Linear.
+
+## Arguments
+
+`$0` (optional verb) routes to an operation; pass the rest (issue id, title, filters) as its params. With no verb, infer the operation from the request.
+
+- `create`: create an issue. See [Creating vs Updating](#creating-vs-updating) and [Issue Status](#issue-status).
+- `update`: update an issue by id. See [Creating vs Updating](#creating-vs-updating).
+- `list`: query issues. See [Querying Issues](#querying-issues).
+- `view`: fetch a single issue; include its `url` for anything you may reference.
+- `comment`: comment on an issue, using full URLs per [Issue References](#issue-references).
+
+Pick MCP tools or the `linear api` CLI per [Tool Selection](#tool-selection).
 
 ## Tool Selection
 

--- a/plugins/things/skills/inbox/SKILL.md
+++ b/plugins/things/skills/inbox/SKILL.md
@@ -1,12 +1,17 @@
 ---
 name: things:inbox
 description: Quick captures to the Things 3 inbox. Not for reads (things:jxa), scheduled tasks, updates, or projects (things:url).
+argument-hint: "<text>"
 allowed-tools: ["Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts:*)"]
 ---
 
 # Things Inbox
 
 Add todos to the Things 3 inbox.
+
+## Arguments
+
+`$ARGUMENTS` is the capture text, passed as `title`. Multiple lines become multiple todos via `titles`. See [Add a Todo](#add-a-todo).
 
 ## Add a Todo
 

--- a/plugins/things/skills/url/SKILL.md
+++ b/plugins/things/skills/url/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: things:url
 description: Create, update, and manage Things 3 tasks and projects. Not for reads — use things:jxa to query data. For simple inbox captures, use things:inbox.
+argument-hint: "<add | update | show | search | json> [key=value ...]"
 allowed-tools:
   - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts:*)"
   - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/reorder.ts:*)"
@@ -11,6 +12,10 @@ allowed-tools:
 # Things URL Scheme
 
 Write operations for Things 3 via the `things:///` URL scheme.
+
+## Arguments
+
+`$0` is the command (`add`, `add-project`, `update`, `update-project`, `show`, `search`, `json`); the rest are its `key=value` params. Pass both straight to `url.ts` (see [Commands](#commands) and [Quick Start](#quick-start)). A command is required; with none, infer the operation from the request.
 
 ## Quick Start
 

--- a/plugins/tmux/skills/tmux/SKILL.md
+++ b/plugins/tmux/skills/tmux/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: tmux
 description: Tmux session, window, and pane management. Use when capturing output, sending keys, opening processes in panes, or checking notifications.
+argument-hint: "[capture | send | split | notify | list] [target ...]"
 allowed-tools:
   - "Bash(bash ${CLAUDE_SKILL_DIR}/scripts/pane.sh:*)"
   - "Bash(bash ${CLAUDE_SKILL_DIR}/scripts/window.sh:*)"
@@ -20,6 +21,16 @@ hooks:
 ---
 
 # tmux
+
+## Arguments
+
+`$0` (optional verb) routes to a section; pass the target pane, window, or session as the rest. With no verb, infer the operation from the request.
+
+- `capture`: print pane content. See [Capturing Pane Content](#capturing-pane-content).
+- `send`: send keys to a running pane. See [Starting Claude Sessions](#starting-claude-sessions).
+- `split`: open a pane. See [Opening Panes](#opening-panes).
+- `notify`: check which windows need attention (`bell`/`activity`). See [Session](#session).
+- `list`: inventory panes, windows, and sessions. See [Drilling Into Other Targets](#drilling-into-other-targets).
 
 ## Pane
 


### PR DESCRIPTION
Gives the command-oriented skills verb-routed hints that map to their existing patterns.

- `things:url`: `<add | update | show | search | json> [key=value ...]`, documenting the command positional already passed to `url.ts`.
- `things:inbox`: `<text>` capture positional.
- `linear:linear`: `[create | update | list | view | comment] [issue ...]`, routing each verb to the matching MCP-tool pattern.
- `tmux:tmux`: `[capture | send | split | notify | list] [target ...]`, routing each verb to the matching section.

The Linear and tmux verb routers are additive: the base reference content is untouched, the `## Arguments` section just adds a directable entry point.

Stacked on #843.
