### PR TITLE
git:conflicts --push; personal-review variant hint

### DIFF
--- a/plugins/git/skills/conflicts/SKILL.md
+++ b/plugins/git/skills/conflicts/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: git:conflicts
 description: Resolving git merge conflicts during rebase, merge, or cherry-pick. Use when conflicts arise. Can also drive the operation to completion and push when asked (e.g. "fix conflicts and push").
+argument-hint: "[--push]"
 allowed-tools:
   - Read
   - Edit
@@ -65,7 +66,7 @@ For each conflicted file:
 
 ## Committing and Pushing
 
-This step runs only when you are asked to take the operation to completion (e.g. the user ran `/git:conflicts push` or said "fix conflicts and push"). On auto-activation, or when asked only to resolve, stop after `git add` and do not commit, continue, or push.
+This step runs only when you are asked to take the operation to completion: the `--push` argument (its alias `push`), or a request like "fix conflicts and push". By default, on auto-activation or when asked only to resolve, stop after `git add` and do not commit, continue, or push.
 
 When driving to completion:
 

--- a/plugins/personal-review/skills/review/SKILL.md
+++ b/plugins/personal-review/skills/review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: personal-review:review
 description: Interactive daily review workflow across Calendar, Things, GitHub, and Linear. Use when the user asks for a daily review, morning review, evening review, or weekly review.
+argument-hint: "[morning | evening | weekly]"
 disable-model-invocation: true
 ---
 
@@ -15,7 +16,7 @@ Multi-phase workflow with checkpoints. Each phase ends with a summary before pro
 | Morning | Full scan + prep | Full processing | Full triage | Full triage | Full review | Full triage |
 | Evening | Tomorrow preview | Quick triage | Mark read, defer | Defer reviews | Skip | Skip |
 
-Ask which variant if not specified.
+`$0` selects the variant: `morning`, `evening`, or `weekly` (a fuller pass over the same phases). Ask which variant when none is given.
 
 ## Phase: Calendar
 


### PR DESCRIPTION
Two remaining hints.

- `git:conflicts`: `[--push]` surfaces the drive-to-completion-and-push behavior the description already mentions. The trigger now recognizes `--push` (alias `push`) alongside the natural-language phrasing.
- `personal-review:review`: `[morning | evening | weekly]` selects the variant via `$0` instead of always asking.

Stacked on #843.
