### PR TITLE
pull-request: shape headings as noun-phrase summaries

### DIFF
--- a/plugins/pull-request/skills/create/evals/evals.json
+++ b/plugins/pull-request/skills/create/evals/evals.json
@@ -37,6 +37,18 @@
         "Benchmark or observed numbers from the session appear in the body",
         "No test counts, no 'all tests pass', no listing of test file names without coverage detail"
       ]
+    },
+    {
+      "id": 4,
+      "prompt": "Open a PR for this multi-part change. It refactors the auth callback handler, narrows the 401/403 error matching, and persists the DCR client ID. I deferred the token-refresh rework and left the existing retry behavior unchanged.",
+      "expected_output": "A sectioned body whose headings are Title-Cased noun phrases naming each topic, with deferred and unchanged work named as topics rather than as meta-headings.",
+      "files": [],
+      "expectations": [
+        "Section headings are Title-Cased noun phrases, not sentences, fragments, or questions",
+        "No heading carries a qualifying tail, a trailing clause, or a parenthetical that belongs in the body",
+        "Deferred and unchanged work is named by topic (e.g. Deferred Work, Unchanged Behavior), not as a What Changed or What I Didn't Do meta-heading",
+        "No Why/What/How question headings and no sentence-case headings"
+      ]
     }
   ]
 }

--- a/plugins/pull-request/skills/create/sections.md
+++ b/plugins/pull-request/skills/create/sections.md
@@ -14,6 +14,20 @@ Default to prose, not a scaffold.
 - Length tracks substance, not diff size. A subtle one-line fix may need paragraphs of root-cause reasoning. A large mechanical change may need two sentences.
 - Use `##` sections only when the body is long enough to need them. A small PR is a tight paragraph with no headers.
 
+## Headings
+
+A heading names the section's topic. It is not a sentence about the topic. Write a Title-Cased noun phrase, usually two or three words, and let the prose below carry the explanation.
+
+- Cut the qualifying tail: `Structural audit sourced from the hook` → `Structural Audit`. The clause explaining the head noun goes in the first sentence under it.
+- Drop parentheticals: `Context Tier (Soft Reminder Only)` → `Context Tier`. A parenthetical holding a clause or a file path is the body trying to live in the heading.
+- Let the parent frame the leaf: under `## Tiers`, `Deny Tier` → `Deny`; under `## Decisions`, `Why Not an N-Gram View in DuckDB` → `N-Gram View`. Nest so the child heading stays bare.
+- Keep the question out of the heading. The "why" is the prose, or the parent section (`## Decisions`, `## Alternatives`), not a `Why`/`What`/`How` heading.
+- Name the topic, not the meta-move: `What Changed` → `Changes`; `What I Didn't Do` → `Deferred Work`; `What I Didn't Change` → `Unchanged Behavior`.
+- Keep imperatives tight: `Hide the Inherited `--format` Flag` → `Hide Inherited `--format` Flag`. Drop the article, lose the trailing clause.
+- Use Title Case: `Two fixes found while testing the tmux calls` → `Two Fixes`.
+
+A heading has slipped into a sentence when it carries a comma, a trailing period or question mark, a linking verb (`is`, `are`, `exits`), a relative clause (`that`, `which`), or a subject pronoun (`this`, `it`).
+
 ## Mine the Conversation
 
 The most valuable content is the substance that lived in the session but never reached the code. Review the conversation that produced the change and surface what applies. This belongs in the PR body, not in code comments where Claude tends to leak it.
@@ -57,6 +71,7 @@ Related links, issues, or reviews that aren't the motivating issue. Use `Closes 
 ## Slop to Cut
 
 - The reflexive `## Changes` plus `## Testing` scaffold on every PR. Small PRs don't need it.
+- Sentence or fragment headings. A heading names the topic, it doesn't narrate it.
 - Bullets that narrate which file changed. If a bullet only says what the diff shows, delete it.
 - Test counts, "all tests pass", coverage inventories.
 - Count-padding ("six detectors, three and three"). The number is rarely the point.


### PR DESCRIPTION
Adds a `## Headings` section to the create skill's `sections.md`, steering section headings toward Title-Cased noun phrases instead of the sentences, fragments, and questions that crept back after #818 loosened the rigid template.

## Motivation

Once the template stopped prescribing `## Issue` / `## Changes` / `## Testing`, headings drifted into captions: `Callback handler scoped to GET /callback`, `Why dynamic registration matters here`, `What I didn't do`. A heading should name the section's topic. The narration belongs in the prose below it.

## Method

I pulled the headings from 981 of my merged public PRs and labeled the ambiguous ones (three or more words) good or bad, then wrote rewrites for the bad ones. The rewrites were consistent: cut the qualifying tail, drop parentheticals, let the parent section frame a bare leaf, name the topic rather than the meta-move. The guidance and its examples come from those pairs.

To grade the guidance I built two detectors calibrated against the labels: a lexical classifier (F1 0.92) for the structural tells, and an LLM judge for the semantic ones a regex can't see (a vague or meta topic that is still grammatically a noun phrase). The combined grader catches 96% of the headings I marked bad.

## Result

An A/B over 18 scenarios reconstructed from real PRs (same diff and context, body stripped) generated each body twice with Sonnet, differing only by this section:

- Bad-heading rate fell from 64.7% to 10.7%.
- Neither arm sectioned the 6 small PRs. The guidance fixes heading quality without provoking spurious sections.

`evals/evals.json` gains a case asserting noun-phrase headings so the regression stays caught.

The corpus, labeling UI, classifier, judge, and eval harness are local scratch (`tmp/`), so this PR is the guidance and the eval case alone.


## Scratch

<details>
<summary>Local harness (gitignored, <code>tmp/pr-headings/</code>) — corpus, labeling UI, detectors, eval</summary>

Not committed. Rebuild from here to iterate. The judge and generation steps need `ANTHROPIC_API_KEY`.

**Data**
- `fetch.ts` — pull merged public PR bodies via GraphQL → `bodies/` (981) + `manifest.json`
- `parse.ts`, `analyze.ts` — extract headings with `marked` → `headings.json`
- `make-label.ts` — emit the ambiguous-heading set (three or more words)

**Labeling**
- `build-label-html.ts` → `label.html` — self-contained labeling UI (verdict, notes, rewrite; localStorage autosave; import/export)
- `labels.json` — 102 labels, notes, and 22 rewrites (ground truth)

**Detectors**
- `classifier.ts` (`classifyPrHeading`) + `calibrate.ts` — lexical screen, F1 0.92
- `judge-prompt.md`, `judge.ts`, `judge-calibrate.ts` — LLM judge with section context; scores the combined grader

**Generation A/B**
- `scenarios/` (18) + `scenarios-selection.json` — real-PR scenarios
- `assemble-prompts.ts` — build baseline/treatment system prompts from the live skill + `treatment-headings.md`
- `run-eval.ts` — generate + grade both arms → `gen-outputs/`, `gen-graded.json`, `gen-eval-report.md`

</details>
