### PR TITLE
discovery: ground disable-model-invocation against Skill() consumers

### DIFF
--- a/plugins/claude-code/skills/session/references/discovery.md
+++ b/plugins/claude-code/skills/session/references/discovery.md
@@ -39,6 +39,7 @@ Re-check every candidate against the live files under `/Users/ben/src/bendrucker
 
 - Hooks run in parallel. Never sum hook durations as wall-clock; the cost the user waits on is the single slowest hook plus a fixed per-process overhead, not the sum across matching hooks. `hook-origin-split`'s `total_s` is aggregate process work, not latency.
 - Split friction into the part a setting can change and the part it cannot. `ExitPlanMode` and `AskUserQuestion` rejections are not allowlistable; the named `permissions` and `errors` queries already exclude them, so only custom SQL over `permission_requests`/`tool_errors` needs that filter. Compound commands defeat `excludedCommands` prefix matching. Counting raw rejections without that split inflates the actionable set.
+- A `disable-model-invocation: true` proposal is breaking if any other skill invokes the target via the `Skill` tool. The current binary blocks `Skill()` on a disabled skill even when the caller grants `Skill(<name>)` in its `allowed-tools`. Before grounding such a finding, grep `plugins` and `user` for `Skill(<name>)` and for the skill's name in other skills' bodies; a single cross-skill consumer fails it. Confirming only that the frontmatter key is absent is not enough.
 
 Verify any claim about harness behavior against the primary Claude Code docs, not a paraphrase, before grounding a finding on it.
 


### PR DESCRIPTION
A history-discovery run proposed setting `disable-model-invocation: true` on `mac:jxa-run` and passed grounding as high-confidence. The grounding only confirmed the frontmatter key was absent. It never checked who invokes the skill. `things:jxa`, `things:triage`, and `improve-claude-code` all invoke `mac:jxa-run` via `Skill(mac:jxa-run)` granted in their `allowed-tools`, so the change would have broken those workflows.

A throwaway-plugin test settled the behavior. The current binary blocks `Skill()` on a `disable-model-invocation` skill even when the caller grants `Skill(<name>)` in its `allowed-tools` (`cannot be used with Skill tool due to disable-model-invocation`). Any cross-skill consumer therefore makes the change breaking, and confirming the key's absence is not enough.

The new grounding bullet directs the check: grep `plugins` and `user` for `Skill(<name>)` and for the skill's name in other skill bodies before grounding a `disable-model-invocation` finding. A single cross-skill consumer fails it.

## References

Related: #840 corrected the `disable-model-invocation` description in the schema.
