### PR TITLE
pull-request: add outbox needs-action feed

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -182,6 +182,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
         "@constellos/claude-code-kit": "^0.4.0",
+        "cleye": "^2.2.1",
       },
     },
     "plugins/review": {

--- a/plugins/gitlab/skills/merge-request/SKILL.md
+++ b/plugins/gitlab/skills/merge-request/SKILL.md
@@ -112,6 +112,16 @@ See [review-state.md](review-state.md) for the underlying GraphQL query and filt
 
 To group all your review-requested MRs by next actor (not just the `UNREVIEWED` slice), see [Review Inbox (Next-Actor Triage)](review-state.md#review-inbox-next-actor-triage) in review-state.md.
 
+## Authored Queue
+
+Fetch your open authored MRs as a needs-action feed for `pull-request:outbox`. Emits `[{ url, platform, ci, review, isDraft, updatedAt }]` JSON, mapping each MR's head pipeline to `ci` and its reviewers to `review`:
+
+```bash
+bun ${CLAUDE_SKILL_DIR}/scripts/authored-queue.ts
+```
+
+This keeps the authored-MR query inside the gitlab plugin so outbox never reaches across the plugin boundary. The emitted shape is the contract outbox ranks.
+
 ## Re-request reviewers
 
 Re-trigger a review after a push reset approvals. The `mergeRequestReviewerRereview` mutation flips the target's `reviewState` back to `UNREVIEWED` and re-surfaces the MR. The reviewer must already be assigned. See [Re-Request Review](review-state.md#re-request-review) for the user-ID lookup and exact mutation.

--- a/plugins/gitlab/skills/merge-request/scripts/authored-queue.test.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/authored-queue.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { mapMr, mapPipeline, mapReviewers } from "./authored-queue";
+
+describe("mapPipeline", () => {
+  test.each([
+    ["SUCCESS", "green"],
+    ["FAILED", "red"],
+    ["CANCELED", "red"],
+    ["RUNNING", "pending"],
+    ["PENDING", "pending"],
+    ["SKIPPED", "none"],
+    ["MANUAL", "none"],
+    [null, "none"],
+  ] as const)("%s -> %s", (status, expected) => {
+    expect(mapPipeline(status)).toBe(expected);
+  });
+});
+
+describe("mapReviewers", () => {
+  test.each([
+    ["no reviewers", [], "none"],
+    ["requested changes outranks approval", ["REQUESTED_CHANGES", "APPROVED"], "changes_requested"],
+    ["an outstanding reviewer owes review", ["APPROVED", "UNREVIEWED"], "review_required"],
+    ["review started still owes review", ["REVIEW_STARTED"], "review_required"],
+    ["all approved", ["APPROVED", "APPROVED"], "approved"],
+  ] as const)("%s", (_label, states, expected) => {
+    const reviewers = states.map((reviewState) => ({ mergeRequestInteraction: { reviewState } }));
+    expect(mapReviewers(reviewers)).toBe(expected);
+  });
+});
+
+describe("mapMr", () => {
+  test("projects an authored MR node onto the ActionEntry contract", () => {
+    expect(
+      mapMr({
+        webUrl: "https://gitlab.com/o/r/-/merge_requests/3",
+        updatedAt: "2026-06-17T00:00:00Z",
+        draft: true,
+        headPipeline: { status: "FAILED" },
+        reviewers: { nodes: [{ mergeRequestInteraction: { reviewState: "UNREVIEWED" } }] },
+      }),
+    ).toEqual({
+      url: "https://gitlab.com/o/r/-/merge_requests/3",
+      platform: "gitlab",
+      ci: "red",
+      review: "review_required",
+      isDraft: true,
+      updatedAt: "2026-06-17T00:00:00Z",
+    });
+  });
+});

--- a/plugins/gitlab/skills/merge-request/scripts/authored-queue.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/authored-queue.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env bun
+
+import { $ } from "bun";
+import { cli } from "cleye";
+
+export type ReviewState = "UNREVIEWED" | "REVIEW_STARTED" | "REQUESTED_CHANGES" | "APPROVED";
+
+type Reviewer = {
+  mergeRequestInteraction: { reviewState: ReviewState | null } | null;
+};
+
+type MergeRequestNode = {
+  webUrl: string;
+  updatedAt: string;
+  draft: boolean;
+  headPipeline: { status: string | null } | null;
+  reviewers: { nodes: Reviewer[] } | null;
+};
+
+export type CurrentUser = {
+  authoredMergeRequests: { nodes: MergeRequestNode[] };
+};
+
+// The contract pull-request:outbox ranks. Defined here independently because
+// plugins must not import across the plugin boundary; the shape is the
+// documented agreement between gitlab and the outbox feed.
+export type CiState = "red" | "green" | "pending" | "none";
+export type ReviewVerdict = "changes_requested" | "approved" | "review_required" | "none";
+export type AuthoredEntry = {
+  url: string;
+  platform: "gitlab";
+  ci: CiState;
+  review: ReviewVerdict;
+  isDraft: boolean;
+  updatedAt: string;
+};
+
+export function mapPipeline(status: string | null | undefined): CiState {
+  switch ((status ?? "").toUpperCase()) {
+    case "SUCCESS":
+      return "green";
+    case "FAILED":
+    case "CANCELED":
+      return "red";
+    case "":
+    case "SKIPPED":
+    case "MANUAL":
+    case "SCHEDULED":
+      return "none";
+    default:
+      return "pending";
+  }
+}
+
+// Roll the reviewers' states into one verdict from the author's view: any
+// requested-changes outranks an approval, an outstanding reviewer means review
+// is still owed, and an MR with no reviewers needs none.
+export function mapReviewers(reviewers: Reviewer[]): ReviewVerdict {
+  const states = reviewers.map((reviewer) => reviewer.mergeRequestInteraction?.reviewState ?? null);
+  if (states.includes("REQUESTED_CHANGES")) return "changes_requested";
+  if (states.some((state) => state === "UNREVIEWED" || state === "REVIEW_STARTED")) {
+    return "review_required";
+  }
+  if (states.includes("APPROVED")) return "approved";
+  return "none";
+}
+
+export function mapMr(node: MergeRequestNode): AuthoredEntry {
+  return {
+    url: node.webUrl,
+    platform: "gitlab",
+    ci: mapPipeline(node.headPipeline?.status),
+    review: mapReviewers(node.reviewers?.nodes ?? []),
+    isDraft: Boolean(node.draft),
+    updatedAt: node.updatedAt,
+  };
+}
+
+const QUERY = `{
+  currentUser {
+    authoredMergeRequests(state: opened) {
+      nodes {
+        webUrl
+        updatedAt
+        draft
+        headPipeline {
+          status
+        }
+        reviewers {
+          nodes {
+            mergeRequestInteraction {
+              reviewState
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+if (import.meta.main) {
+  cli({ name: "authored-queue", flags: {} }, async () => {
+    const result = (await $`glab api graphql -f query=${QUERY}`.json()) as {
+      data?: { currentUser?: CurrentUser | null };
+      errors?: Array<{ message: string }>;
+    };
+    if (result.errors?.length) {
+      console.error(`GraphQL errors: ${result.errors.map((e) => e.message).join("; ")}`);
+      process.exit(1);
+    }
+    const currentUser = result.data?.currentUser;
+    if (!currentUser) {
+      console.error("No currentUser in GraphQL response (is glab authenticated?)");
+      process.exit(1);
+    }
+    console.log(JSON.stringify(currentUser.authoredMergeRequests.nodes.map(mapMr), null, 2));
+  });
+}

--- a/plugins/pull-request/README.md
+++ b/plugins/pull-request/README.md
@@ -8,6 +8,7 @@ Create and update pull requests (PRs), merge requests (MRs), and change requests
 - **Skill**: `pull-request:update` — Update a PR/MR body to reflect the current state of changes
 - **Skill**: `pull-request:follow-up` — Follow up on review feedback you received: check resolution state, find silent resolves, draft replies
 - **Skill**: `pull-request:babysit` — Monitor a PR's CI, fix trivial failures (lint, types, formatting), and self-cancel when green
+- **Skill**: `pull-request:outbox` — Ranked needs-action feed of your authored PRs/MRs across GitHub and GitLab, with per-item babysit dispatch
 - **Hook**: Validates PR body content before creation or edit
 
 ## Worktree Support

--- a/plugins/pull-request/package.json
+++ b/plugins/pull-request/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-    "@constellos/claude-code-kit": "^0.4.0"
+    "@constellos/claude-code-kit": "^0.4.0",
+    "cleye": "^2.2.1"
   }
 }

--- a/plugins/pull-request/skills/outbox/SKILL.md
+++ b/plugins/pull-request/skills/outbox/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: pull-request:outbox
+description: >
+  Ranked needs-action feed of your own open PRs and MRs across GitHub and GitLab, with per-item babysit dispatch.
+  Use to triage your authored work, find which PR needs you next, or batch-shepherd open PRs toward merge.
+disable-model-invocation: true
+allowed-tools:
+  - Monitor
+  - TaskStop
+  - Agent
+  - Skill(pull-request:babysit)
+  - Skill(gitlab:merge-request)
+  - Bash(gh:*)
+  - "Bash(bun ${CLAUDE_SKILL_DIR}/scripts/:*)"
+  - Bash(jq:*)
+---
+
+# Outbox
+
+The authored half of the inbox/outbox pair. Where `review:inbox` orchestrates the PRs waiting on *your review*, outbox ranks the PRs *you authored* by what needs you next and dispatches a `pull-request:babysit` watcher per item. babysit shepherds one PR; outbox is the fleet dispatcher above it.
+
+You are the orchestrator: fetch your open PRs/MRs, rank them, and hand the ones that need attention to babysit.
+
+## Queue Sources
+
+One command per platform, each emitting a JSON array of `ActionEntry`:
+
+```
+{ url, platform, ci, review, isDraft, updatedAt }
+```
+
+`ci` is `red | green | pending | none`; `review` is `changes_requested | approved | review_required | none`. Each source owns its own query and field mapping; the feed only ranks the union.
+
+#### GitHub
+
+```bash
+bun ${CLAUDE_SKILL_DIR}/scripts/github-queue.ts
+```
+
+Lists your open authored PRs (`gh search prs --author=@me --state=open`) and enriches each with `gh pr view --json statusCheckRollup,reviewDecision,isDraft,updatedAt`.
+
+#### GitLab
+
+Delegate to the gitlab plugin, which owns the authored-MR query. Pass `bun <ABS>`, where `<ABS>` is the absolute path that resolves for `gitlab/skills/merge-request/scripts/authored-queue.ts` (for example `/Users/you/.claude/plugins/cache/.../gitlab/skills/merge-request/scripts/authored-queue.ts`). Write the path out in full. `${CLAUDE_SKILL_DIR}` points at this outbox skill, so it resolves to the wrong directory for the gitlab source. Omit this source when you have no GitLab work.
+
+## Ranking
+
+Each entry falls into the single highest-priority bucket it qualifies for, ranked:
+
+`red CI` > `changes requested` > `stale-green` > `awaiting review` > `draft`
+
+A red CI outranks everything, so a draft or changes-requested PR with failing CI still leads. Stale-green is a PR whose CI is green but that has gone untouched past `--stale-days` (default 2): it is waiting to be merged or has been forgotten. Anything green, fresh, and unblocked falls into a no-action bucket, counted but kept out of the feed. Within a bucket, the oldest-updated item leads.
+
+`rank.ts` holds the classification and ordering. `red CI` first folds CI-failure triage into the feed: the top of the ranking is the PR whose build is broken.
+
+## Interactive Mode
+
+The default: fetch once, rank, present, ask. Run a single pass:
+
+```bash
+bun ${CLAUDE_SKILL_DIR}/scripts/poll.ts \
+  --data-dir ${CLAUDE_PLUGIN_DATA} \
+  --queue "bun ${CLAUDE_SKILL_DIR}/scripts/github-queue.ts" \
+  --queue "bun <ABS>"
+```
+
+`poll.ts` ranks the union, overwrites `needs-action.md` in `${CLAUDE_PLUGIN_DATA}/pull-request-outbox/` (top item first), and prints the actionable URLs not yet dispatched. Read `needs-action.md`, present it as a table, and ask which PRs to babysit. Then [dispatch a watcher](#dispatch-a-watcher) for each chosen item.
+
+A source that fails emits a `{"type":"source-error",...}` line to stderr and contributes zero entries, so one platform's outage never blanks the feed.
+
+## Dispatch a Watcher
+
+For each PR to shepherd, spawn a background `Agent` that invokes babysit, then record the dispatch so the feed stops surfacing it:
+
+1. Spawn an `Agent` whose prompt invokes `pull-request:babysit <url> --merge`. babysit is session-scoped and owns its own `Monitor` watcher, so running it inside a backgrounded Agent lets outbox keep ranking while the watch persists in the Agent.
+2. Record it:
+
+   ```bash
+   bun ${CLAUDE_SKILL_DIR}/scripts/dispatch.ts <url> --data-dir ${CLAUDE_PLUGIN_DATA}
+   ```
+
+`poll.ts` and the watch loop both filter dispatched URLs, so a PR already being shepherded never gets a second watcher. babysit keeps no shared run-state, so this dispatched set is how outbox dedupes. It persists in the data dir across sessions. Clear it at the start of a fresh hands-off session if you want every open PR reconsidered:
+
+```bash
+bun ${CLAUDE_SKILL_DIR}/scripts/dispatch.ts --reset --data-dir ${CLAUDE_PLUGIN_DATA}
+```
+
+## Hands-Off Mode (Monitor Loop)
+
+The opt-in unattended mode, fired from a morning routine. It polls your authored queues on an interval and dispatches babysit for each newly-actionable PR without prompting, so the feed drains itself while you work elsewhere.
+
+`watch.ts` owns the loop: each interval it ranks the queues, overwrites `needs-action.md`, and prints one URL per newly-actionable PR not already dispatched. Each printed URL is one event you react to by [dispatching a watcher](#dispatch-a-watcher).
+
+Pass this command to `Monitor` with `persistent: true` and a descriptive label. `${CLAUDE_SKILL_DIR}` is outbox's own directory; the GitLab `--queue` uses a full absolute path:
+
+```bash
+bun ${CLAUDE_SKILL_DIR}/scripts/watch.ts \
+  --data-dir ${CLAUDE_PLUGIN_DATA} \
+  --interval 300 \
+  --queue "bun ${CLAUDE_SKILL_DIR}/scripts/github-queue.ts" \
+  --queue "bun <ABS>"
+```
+
+#### Monitor Reliability
+
+Two rules for any command you hand `Monitor`:
+
+- Pass a **single long-lived process** that sleeps internally via `setTimeout`, not a shell `while/sleep` loop. This works around a macOS `Monitor` bug: the eval context strips `PATH` (so `sleep` and `date` are not found) and kills backgrounded children with `nice(5) failed: operation not permitted`. `watch.ts` already does this.
+- **Never suppress poll output** with `>/dev/null` or `|| true`. A silent poll is indistinguishable from "nothing new"; the sources emit a structured error line instead.
+
+#### Pacing and Stopping
+
+- A 300s interval is a reasonable floor. Authored PRs change over minutes-to-hours, and the queue sources hit rate-limited remote APIs. Shorten only when you expect a burst.
+- Call `TaskStop` on the `Monitor` task to stop early.
+- The loop runs until you stop it. Surface a summary when nothing is actionable across several consecutive intervals, but keep polling unless told otherwise (a fresh red CI can re-add a PR anytime).
+
+## Relationship to babysit
+
+outbox composes babysit; it does not reimplement it. Everything about a single PR's CI watch, trivial-fix loop, and merge drive lives in babysit. outbox decides *which* PRs to hand it and *in what order*. Keep `code-review` and `simplify` out of this path: self-review stays a deliberate pre-create gate, never an automatic step in the feed.

--- a/plugins/pull-request/skills/outbox/scripts/dispatch.ts
+++ b/plugins/pull-request/skills/outbox/scripts/dispatch.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env bun
+
+import { cli } from "cleye";
+import { markDispatched, resetDispatched } from "./store";
+
+// Record that a babysit watcher was dispatched for a PR/MR so the feed stops
+// re-emitting it, or reset the set at the start of a fresh hands-off session.
+cli(
+  {
+    name: "dispatch",
+    parameters: ["[url]"],
+    flags: {
+      dataDir: { type: String, description: "Data directory (defaults to CLAUDE_PLUGIN_DATA)" },
+      reset: { type: Boolean, description: "Clear all dispatched URLs and exit", default: false },
+    },
+  },
+  async (argv) => {
+    if (argv.flags.reset) {
+      await resetDispatched(argv.flags.dataDir);
+      return;
+    }
+    const url = argv._.url;
+    if (!url) throw new Error("a url is required (or pass --reset)");
+    await markDispatched(url, argv.flags.dataDir);
+  },
+);

--- a/plugins/pull-request/skills/outbox/scripts/github-queue.test.ts
+++ b/plugins/pull-request/skills/outbox/scripts/github-queue.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { mapPr, mapReview, rollupCi } from "./github-queue";
+
+describe("rollupCi", () => {
+  test.each([
+    ["no checks", [], "none"],
+    ["all success check runs", [{ status: "COMPLETED", conclusion: "SUCCESS" }], "green"],
+    [
+      "neutral and skipped count as green",
+      [
+        { status: "COMPLETED", conclusion: "NEUTRAL" },
+        { status: "COMPLETED", conclusion: "SKIPPED" },
+      ],
+      "green",
+    ],
+    [
+      "a failure makes it red",
+      [
+        { status: "COMPLETED", conclusion: "SUCCESS" },
+        { status: "COMPLETED", conclusion: "FAILURE" },
+      ],
+      "red",
+    ],
+    ["timed-out is red", [{ status: "COMPLETED", conclusion: "TIMED_OUT" }], "red"],
+    [
+      "in-progress with no failure is pending",
+      [
+        { status: "IN_PROGRESS", conclusion: null },
+        { status: "COMPLETED", conclusion: "SUCCESS" },
+      ],
+      "pending",
+    ],
+    [
+      "failure outranks pending",
+      [{ status: "IN_PROGRESS" }, { status: "COMPLETED", conclusion: "FAILURE" }],
+      "red",
+    ],
+    ["legacy status context success", [{ state: "SUCCESS" }], "green"],
+    ["legacy status context pending", [{ state: "PENDING" }], "pending"],
+    ["legacy status context error is red", [{ state: "ERROR" }], "red"],
+  ] as const)("%s", (_label, rollup, expected) => {
+    expect(rollupCi([...rollup])).toBe(expected);
+  });
+});
+
+describe("mapReview", () => {
+  test.each([
+    ["CHANGES_REQUESTED", "changes_requested"],
+    ["APPROVED", "approved"],
+    ["REVIEW_REQUIRED", "review_required"],
+    ["", "none"],
+    [null, "none"],
+  ] as const)("%s -> %s", (decision, expected) => {
+    expect(mapReview(decision)).toBe(expected);
+  });
+});
+
+describe("mapPr", () => {
+  test("projects a gh pr view payload onto the ActionEntry contract", () => {
+    expect(
+      mapPr({
+        url: "https://github.com/o/r/pull/7",
+        statusCheckRollup: [{ status: "COMPLETED", conclusion: "FAILURE" }],
+        reviewDecision: "REVIEW_REQUIRED",
+        isDraft: true,
+        updatedAt: "2026-06-18T00:00:00Z",
+      }),
+    ).toEqual({
+      url: "https://github.com/o/r/pull/7",
+      platform: "github",
+      ci: "red",
+      review: "review_required",
+      isDraft: true,
+      updatedAt: "2026-06-18T00:00:00Z",
+    });
+  });
+});

--- a/plugins/pull-request/skills/outbox/scripts/github-queue.ts
+++ b/plugins/pull-request/skills/outbox/scripts/github-queue.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: shells out to gh for TLS-bearing GitHub API calls
+
+import { $ } from "bun";
+import { cli } from "cleye";
+import type { ActionEntry, CiState, ReviewState } from "./rank";
+
+// One element of gh's statusCheckRollup: a CheckRun carries status/conclusion,
+// a legacy StatusContext carries state. We normalize both.
+type RollupItem = {
+  status?: string | null;
+  conclusion?: string | null;
+  state?: string | null;
+};
+
+type PrView = {
+  url: string;
+  statusCheckRollup?: RollupItem[] | null;
+  reviewDecision?: string | null;
+  isDraft?: boolean | null;
+  updatedAt: string;
+};
+
+function itemState(item: RollupItem): "red" | "green" | "pending" {
+  if (item.state) {
+    const state = item.state.toUpperCase();
+    if (state === "SUCCESS") return "green";
+    if (state === "PENDING" || state === "EXPECTED") return "pending";
+    return "red";
+  }
+  const status = (item.status ?? "").toUpperCase();
+  if (status !== "COMPLETED") return "pending";
+  const conclusion = (item.conclusion ?? "").toUpperCase();
+  if (conclusion === "SUCCESS" || conclusion === "NEUTRAL" || conclusion === "SKIPPED") {
+    return "green";
+  }
+  return "red";
+}
+
+// Roll the per-check states into one CI verdict: any failure is red, otherwise
+// any in-flight check is pending, otherwise green. No checks at all is "none".
+export function rollupCi(rollup: RollupItem[]): CiState {
+  if (!rollup.length) return "none";
+  const states = rollup.map(itemState);
+  if (states.includes("red")) return "red";
+  if (states.includes("pending")) return "pending";
+  return "green";
+}
+
+export function mapReview(decision: string | null | undefined): ReviewState {
+  switch ((decision ?? "").toUpperCase()) {
+    case "CHANGES_REQUESTED":
+      return "changes_requested";
+    case "APPROVED":
+      return "approved";
+    case "REVIEW_REQUIRED":
+      return "review_required";
+    default:
+      return "none";
+  }
+}
+
+export function mapPr(view: PrView): ActionEntry {
+  return {
+    url: view.url,
+    platform: "github",
+    ci: rollupCi(view.statusCheckRollup ?? []),
+    review: mapReview(view.reviewDecision),
+    isDraft: Boolean(view.isDraft),
+    updatedAt: view.updatedAt,
+  };
+}
+
+if (import.meta.main) {
+  cli({ name: "github-queue", flags: {} }, async () => {
+    const found = (await $`gh search prs --author=@me --state=open --json url`.json()) as {
+      url: string;
+    }[];
+    const entries = await Promise.all(
+      found.map(async ({ url }) => {
+        const view =
+          (await $`gh pr view ${url} --json url,statusCheckRollup,reviewDecision,isDraft,updatedAt`.json()) as PrView;
+        return mapPr(view);
+      }),
+    );
+    console.log(JSON.stringify(entries, null, 2));
+  });
+}

--- a/plugins/pull-request/skills/outbox/scripts/poll.test.ts
+++ b/plugins/pull-request/skills/outbox/scripts/poll.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { fetchEntries, renderNeedsAction } from "./poll";
+import { type ActionEntry, rankQueue } from "./rank";
+
+const NOW = new Date("2026-06-19T12:00:00Z");
+
+function ranked(entries: ActionEntry[]) {
+  return rankQueue(entries, NOW, 2);
+}
+
+describe("renderNeedsAction", () => {
+  test("renders the actionable slice as a ranked GFM table", () => {
+    const md = renderNeedsAction(
+      ranked([
+        {
+          url: "https://github.com/o/r/pull/2",
+          platform: "github",
+          ci: "green",
+          review: "approved",
+          isDraft: false,
+          updatedAt: NOW.toISOString(),
+        },
+        {
+          url: "https://github.com/o/r/pull/1",
+          platform: "github",
+          ci: "red",
+          review: "none",
+          isDraft: false,
+          updatedAt: "2026-06-18T09:00:00Z",
+        },
+      ]),
+    );
+    expect(md).toBe(
+      "# Needs action\n\n" +
+        "| Needs | CI | Review | Updated | PR |\n" +
+        "| --- | --- | --- | --- | --- |\n" +
+        "| CI failing | red | none | 2026-06-18 | https://github.com/o/r/pull/1 |\n",
+    );
+  });
+
+  test("reports the empty queue plainly", () => {
+    expect(renderNeedsAction([])).toContain("Nothing needs you");
+  });
+});
+
+describe("fetchEntries", () => {
+  test("parses a queue command's JSON array", async () => {
+    const result = await fetchEntries(
+      `echo '[{"url":"u","platform":"github","ci":"red","review":"none","isDraft":false,"updatedAt":"2026-06-19T00:00:00Z"}]'`,
+    );
+    expect(result).toEqual({
+      ok: true,
+      entries: [
+        {
+          url: "u",
+          platform: "github",
+          ci: "red",
+          review: "none",
+          isDraft: false,
+          updatedAt: "2026-06-19T00:00:00Z",
+        },
+      ],
+    });
+  });
+
+  test("reports a non-zero exit as a failed source", async () => {
+    const result = await fetchEntries("echo boom >&2; exit 3");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toContain("boom");
+  });
+});

--- a/plugins/pull-request/skills/outbox/scripts/poll.test.ts
+++ b/plugins/pull-request/skills/outbox/scripts/poll.test.ts
@@ -30,12 +30,14 @@ describe("renderNeedsAction", () => {
         },
       ]),
     );
-    expect(md).toBe(
-      "# Needs action\n\n" +
-        "| Needs | CI | Review | Updated | PR |\n" +
-        "| --- | --- | --- | --- | --- |\n" +
-        "| CI failing | red | none | 2026-06-18 | https://github.com/o/r/pull/1 |\n",
-    );
+    expect(md).toMatchInlineSnapshot(`
+      "# Needs action
+
+      | Needs | CI | Review | Updated | PR |
+      | --- | --- | --- | --- | --- |
+      | CI failing | red | none | 2026-06-18 | https://github.com/o/r/pull/1 |
+      "
+    `);
   });
 
   test("reports the empty queue plainly", () => {
@@ -48,19 +50,21 @@ describe("fetchEntries", () => {
     const result = await fetchEntries(
       `echo '[{"url":"u","platform":"github","ci":"red","review":"none","isDraft":false,"updatedAt":"2026-06-19T00:00:00Z"}]'`,
     );
-    expect(result).toEqual({
-      ok: true,
-      entries: [
-        {
-          url: "u",
-          platform: "github",
-          ci: "red",
-          review: "none",
-          isDraft: false,
-          updatedAt: "2026-06-19T00:00:00Z",
-        },
-      ],
-    });
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "entries": [
+          {
+            "ci": "red",
+            "isDraft": false,
+            "platform": "github",
+            "review": "none",
+            "updatedAt": "2026-06-19T00:00:00Z",
+            "url": "u",
+          },
+        ],
+        "ok": true,
+      }
+    `);
   });
 
   test("reports a non-zero exit as a failed source", async () => {

--- a/plugins/pull-request/skills/outbox/scripts/poll.ts
+++ b/plugins/pull-request/skills/outbox/scripts/poll.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: queue sources shell out to gh/glab for TLS-bearing API calls
+
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { cli } from "cleye";
+import { type ActionEntry, actionable, type RankBucket, type RankedEntry, rankQueue } from "./rank";
+import { readDispatched } from "./store";
+
+export type FetchResult = { ok: true; entries: ActionEntry[] } | { ok: false; reason: string };
+
+// Run a queue command that prints a JSON array of ActionEntry and return a
+// discriminated result. A failed command (network, auth, an unconfigured
+// source) reports ok:false so the caller can emit a visible error and treat the
+// source as contributing zero entries.
+export async function fetchEntries(command: string): Promise<FetchResult> {
+  const proc = Bun.spawn(["sh", "-c", command], { stdout: "pipe", stderr: "pipe" });
+  const [exit, stdoutText, stderrText] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  if (exit !== 0) {
+    return { ok: false, reason: stderrText.trim() || `exited with code ${exit}` };
+  }
+  try {
+    return { ok: true, entries: JSON.parse(stdoutText) as ActionEntry[] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, reason: `JSON parse failed: ${message}` };
+  }
+}
+
+const BUCKET_LABEL: Record<RankBucket, string> = {
+  "red-ci": "CI failing",
+  "changes-requested": "changes requested",
+  "stale-green": "stale (green)",
+  "waiting-on-review": "awaiting review",
+  draft: "draft",
+  none: "—",
+};
+
+// Render the actionable slice as a GFM table for needs-action.md, top item
+// first. The file is read back and presented to you, so it is markdown, not
+// terminal output.
+export function renderNeedsAction(ranked: RankedEntry[]): string {
+  const rows = actionable(ranked);
+  if (!rows.length) {
+    return "# Needs action\n\nNothing needs you. Every open PR/MR is green, fresh, and unblocked.\n";
+  }
+  const header = "| Needs | CI | Review | Updated | PR |\n| --- | --- | --- | --- | --- |";
+  const body = rows
+    .map(
+      (row) =>
+        `| ${BUCKET_LABEL[row.bucket]} | ${row.ci} | ${row.review} | ${row.updatedAt.slice(0, 10)} | ${row.url} |`,
+    )
+    .join("\n");
+  return `# Needs action\n\n${header}\n${body}\n`;
+}
+
+async function writeNeedsAction(ranked: RankedEntry[], dataDir: string): Promise<void> {
+  const dir = join(dataDir, "pull-request-outbox");
+  await mkdir(dir, { recursive: true });
+  await Bun.write(join(dir, "needs-action.md"), renderNeedsAction(ranked));
+}
+
+// Fetch every queue source, surface source failures, and return the ranked
+// union. Shared by poll (one-shot) and watch (loop).
+export async function collect(
+  queues: string[],
+  staleDays: number,
+  now: Date,
+): Promise<RankedEntry[]> {
+  const results = await Promise.all(queues.map(fetchEntries));
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result && !result.ok) {
+      console.error(
+        JSON.stringify({ type: "source-error", source: queues[i], detail: result.reason }),
+      );
+    }
+  }
+  const entries = results.flatMap((result) => (result?.ok ? result.entries : []));
+  return rankQueue(entries, now, staleDays);
+}
+
+// One full pass: rank the queues, overwrite needs-action.md, and return the
+// actionable URLs not already dispatched a babysit watcher this run.
+export async function pollOnce(
+  queues: string[],
+  dataDir: string,
+  staleDays: number,
+  now: Date,
+): Promise<string[]> {
+  const ranked = await collect(queues, staleDays, now);
+  await writeNeedsAction(ranked, dataDir);
+  const dispatched = await readDispatched(dataDir);
+  return actionable(ranked)
+    .map((entry) => entry.url)
+    .filter((url) => !dispatched.has(url));
+}
+
+if (import.meta.main) {
+  const argv = cli({
+    name: "poll",
+    flags: {
+      dataDir: { type: String, description: "Data directory (defaults to CLAUDE_PLUGIN_DATA)" },
+      queue: {
+        type: [String],
+        description: "Queue command emitting ActionEntry[] JSON; repeat once per platform source",
+      },
+      staleDays: {
+        type: Number,
+        description: "Days of inactivity before green counts as stale",
+        default: 2,
+      },
+    },
+  });
+
+  const dataDir = argv.flags.dataDir ?? process.env.CLAUDE_PLUGIN_DATA;
+  if (!dataDir) throw new Error("dataDir is required (or set CLAUDE_PLUGIN_DATA)");
+
+  for (const url of await pollOnce(argv.flags.queue, dataDir, argv.flags.staleDays, new Date())) {
+    console.log(url);
+  }
+}

--- a/plugins/pull-request/skills/outbox/scripts/rank.test.ts
+++ b/plugins/pull-request/skills/outbox/scripts/rank.test.ts
@@ -75,7 +75,14 @@ describe("rankQueue", () => {
       NOW,
       STALE_DAYS,
     );
-    expect(ranked.map((entry) => entry.url)).toEqual(["red-old", "red-new", "changes", "draft"]);
+    expect(ranked.map((entry) => entry.url)).toMatchInlineSnapshot(`
+      [
+        "red-old",
+        "red-new",
+        "changes",
+        "draft",
+      ]
+    `);
   });
 });
 

--- a/plugins/pull-request/skills/outbox/scripts/rank.test.ts
+++ b/plugins/pull-request/skills/outbox/scripts/rank.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { type ActionEntry, actionable, classify, rankQueue } from "./rank";
+
+const NOW = new Date("2026-06-19T12:00:00Z");
+const STALE_DAYS = 2;
+
+function entry(overrides: Partial<ActionEntry>): ActionEntry {
+  return {
+    url: "https://github.com/o/r/pull/1",
+    platform: "github",
+    ci: "green",
+    review: "none",
+    isDraft: false,
+    updatedAt: NOW.toISOString(),
+    ...overrides,
+  };
+}
+
+const fresh = NOW.toISOString();
+const stale = new Date("2026-06-15T12:00:00Z").toISOString();
+
+describe("classify", () => {
+  test.each([
+    [
+      "red CI beats every other signal",
+      { ci: "red", review: "changes_requested", isDraft: true },
+      "red-ci",
+    ],
+    [
+      "changes requested when CI not red",
+      { ci: "green", review: "changes_requested" },
+      "changes-requested",
+    ],
+    ["green but untouched past staleDays", { ci: "green", updatedAt: stale }, "stale-green"],
+    [
+      "fresh green awaiting review",
+      { ci: "green", review: "review_required", updatedAt: fresh },
+      "waiting-on-review",
+    ],
+    [
+      "pending CI awaiting review",
+      { ci: "pending", review: "review_required" },
+      "waiting-on-review",
+    ],
+    ["draft with nothing else pending", { isDraft: true, updatedAt: fresh }, "draft"],
+    [
+      "green, fresh, nothing pending",
+      { ci: "green", review: "approved", updatedAt: fresh },
+      "none",
+    ],
+    [
+      "changes-requested outranks staleness",
+      { ci: "green", review: "changes_requested", updatedAt: stale },
+      "changes-requested",
+    ],
+    [
+      "stale outranks awaiting-review",
+      { ci: "green", review: "review_required", updatedAt: stale },
+      "stale-green",
+    ],
+  ] as const)("%s", (_label, overrides, expected) => {
+    expect(classify(entry(overrides), NOW, STALE_DAYS)).toBe(expected);
+  });
+});
+
+describe("rankQueue", () => {
+  test("orders by bucket priority, then oldest-updated within a bucket", () => {
+    const ranked = rankQueue(
+      [
+        entry({ url: "draft", isDraft: true }),
+        entry({ url: "red-new", ci: "red", updatedAt: fresh }),
+        entry({ url: "red-old", ci: "red", updatedAt: stale }),
+        entry({ url: "changes", review: "changes_requested" }),
+      ],
+      NOW,
+      STALE_DAYS,
+    );
+    expect(ranked.map((entry) => entry.url)).toEqual(["red-old", "red-new", "changes", "draft"]);
+  });
+});
+
+describe("actionable", () => {
+  test("drops the no-action bucket and keeps everything else", () => {
+    const ranked = rankQueue(
+      [entry({ url: "act", ci: "red" }), entry({ url: "idle", ci: "green", review: "approved" })],
+      NOW,
+      STALE_DAYS,
+    );
+    expect(actionable(ranked).map((entry) => entry.url)).toEqual(["act"]);
+  });
+});

--- a/plugins/pull-request/skills/outbox/scripts/rank.ts
+++ b/plugins/pull-request/skills/outbox/scripts/rank.ts
@@ -1,0 +1,75 @@
+// The contract every queue source emits, one entry per authored PR/MR.
+// Platform queues (github-queue.ts here, gitlab's authored-queue.ts) produce
+// this shape independently as JSON, so the type is a documented contract, not a
+// cross-plugin import. `ci` and `review` use a "none" sentinel rather than null
+// so ranking never branches on absence.
+export type CiState = "red" | "green" | "pending" | "none";
+export type ReviewState = "changes_requested" | "approved" | "review_required" | "none";
+
+export interface ActionEntry {
+  url: string;
+  platform: "github" | "gitlab";
+  ci: CiState;
+  review: ReviewState;
+  isDraft: boolean;
+  updatedAt: string;
+}
+
+// Ranked highest-attention first. "none" is the no-action bucket: green, fresh,
+// and not waiting on anything you can act on.
+export type RankBucket =
+  | "red-ci"
+  | "changes-requested"
+  | "stale-green"
+  | "waiting-on-review"
+  | "draft"
+  | "none";
+
+export const BUCKET_ORDER: RankBucket[] = [
+  "red-ci",
+  "changes-requested",
+  "stale-green",
+  "waiting-on-review",
+  "draft",
+  "none",
+];
+
+export interface RankedEntry extends ActionEntry {
+  bucket: RankBucket;
+}
+
+function isStale(updatedAt: string, now: Date, staleDays: number): boolean {
+  const updated = new Date(updatedAt).getTime();
+  if (Number.isNaN(updated)) return false;
+  return now.getTime() - updated >= staleDays * 86_400_000;
+}
+
+// Assign the single highest-priority bucket an entry qualifies for. A red CI
+// outranks everything else, so a draft or changes-requested PR with failing CI
+// still sorts to the top.
+export function classify(entry: ActionEntry, now: Date, staleDays: number): RankBucket {
+  if (entry.ci === "red") return "red-ci";
+  if (entry.review === "changes_requested") return "changes-requested";
+  if (entry.ci === "green" && isStale(entry.updatedAt, now, staleDays)) return "stale-green";
+  if (entry.review === "review_required") return "waiting-on-review";
+  if (entry.isDraft) return "draft";
+  return "none";
+}
+
+// Rank the combined queue: by bucket priority, then oldest-updated first within
+// a bucket so the most-neglected item leads.
+export function rankQueue(entries: ActionEntry[], now: Date, staleDays: number): RankedEntry[] {
+  return entries
+    .map((entry) => ({ ...entry, bucket: classify(entry, now, staleDays) }))
+    .sort((a, b) => {
+      const order = BUCKET_ORDER.indexOf(a.bucket) - BUCKET_ORDER.indexOf(b.bucket);
+      if (order !== 0) return order;
+      return new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime();
+    });
+}
+
+// The feed surfaces only entries that need you. "none" is tracked for the
+// summary count but excluded from needs-action.md and from babysit dispatch.
+export function actionable(ranked: RankedEntry[]): RankedEntry[] {
+  return ranked.filter((entry) => entry.bucket !== "none");
+}

--- a/plugins/pull-request/skills/outbox/scripts/store.test.ts
+++ b/plugins/pull-request/skills/outbox/scripts/store.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { markDispatched, readDispatched, resetDispatched } from "./store";
+
+describe("dispatched store", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "outbox-store-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true });
+  });
+
+  test("returns an empty set before anything is dispatched", async () => {
+    expect(await readDispatched(tmpDir)).toEqual(new Set());
+  });
+
+  test("marks URLs and dedupes a repeat dispatch", async () => {
+    await markDispatched("a", tmpDir);
+    await markDispatched("b", tmpDir);
+    await markDispatched("a", tmpDir);
+    expect(await readDispatched(tmpDir)).toEqual(new Set(["a", "b"]));
+  });
+
+  test("reset clears the set", async () => {
+    await markDispatched("a", tmpDir);
+    await resetDispatched(tmpDir);
+    expect(await readDispatched(tmpDir)).toEqual(new Set());
+  });
+});

--- a/plugins/pull-request/skills/outbox/scripts/store.ts
+++ b/plugins/pull-request/skills/outbox/scripts/store.ts
@@ -1,0 +1,45 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+// Outbox dedup state: the URLs this session has already dispatched a babysit
+// watcher for. babysit is session-scoped and keeps no shared run-state, so the
+// feed tracks its own dispatches to avoid double-watching a PR it is already
+// shepherding. State persists in the data dir across sessions.
+export interface OutboxState {
+  dispatched: string[];
+}
+
+function resolveDataDir(dataDir?: string): string {
+  const base = dataDir ?? process.env.CLAUDE_PLUGIN_DATA;
+  if (!base) {
+    throw new Error("dataDir is required (or set CLAUDE_PLUGIN_DATA)");
+  }
+  return base;
+}
+
+function statePath(dataDir?: string): string {
+  return join(resolveDataDir(dataDir), "pull-request-outbox", "state.json");
+}
+
+export async function readDispatched(dataDir?: string): Promise<Set<string>> {
+  const file = Bun.file(statePath(dataDir));
+  if (!(await file.exists())) return new Set();
+  const data = (await file.json()) as Partial<OutboxState>;
+  return new Set(Array.isArray(data.dispatched) ? data.dispatched : []);
+}
+
+async function write(dispatched: Set<string>, dataDir?: string): Promise<void> {
+  const path = statePath(dataDir);
+  await mkdir(join(path, ".."), { recursive: true });
+  await Bun.write(path, JSON.stringify({ dispatched: [...dispatched] } satisfies OutboxState));
+}
+
+export async function markDispatched(url: string, dataDir?: string): Promise<void> {
+  const dispatched = await readDispatched(dataDir);
+  dispatched.add(url);
+  await write(dispatched, dataDir);
+}
+
+export async function resetDispatched(dataDir?: string): Promise<void> {
+  await write(new Set(), dataDir);
+}

--- a/plugins/pull-request/skills/outbox/scripts/watch.ts
+++ b/plugins/pull-request/skills/outbox/scripts/watch.ts
@@ -34,9 +34,18 @@ const { queue: queues, interval, staleDays } = argv.flags;
 // macOS due to PATH-stripped eval and nice(5) restrictions. Each printed URL is
 // one newly-actionable PR/MR not yet dispatched a babysit watcher; that is the
 // event the orchestrator reacts to.
+//
+// A transient I/O failure in a single pass (disk full, NFS hiccup, corrupt
+// state file) must not end the session-long watch. Report it to stderr and keep
+// looping so the next pass can recover.
 while (true) {
-  for (const url of await pollOnce(queues, dataDir, staleDays, new Date())) {
-    console.log(url);
+  try {
+    for (const url of await pollOnce(queues, dataDir, staleDays, new Date())) {
+      console.log(url);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(JSON.stringify({ type: "poll-error", detail: message }));
   }
   await sleep(interval * 1000);
 }

--- a/plugins/pull-request/skills/outbox/scripts/watch.ts
+++ b/plugins/pull-request/skills/outbox/scripts/watch.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: queue sources shell out to gh/glab for TLS-bearing API calls
+
+import { cli } from "cleye";
+import { pollOnce } from "./poll";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const argv = cli({
+  name: "watch",
+  flags: {
+    dataDir: { type: String, description: "Data directory (defaults to CLAUDE_PLUGIN_DATA)" },
+    queue: {
+      type: [String],
+      description: "Queue command emitting ActionEntry[] JSON; repeat once per platform source",
+    },
+    interval: { type: Number, description: "Poll interval in seconds", default: 300 },
+    staleDays: {
+      type: Number,
+      description: "Days of inactivity before green counts as stale",
+      default: 2,
+    },
+  },
+});
+
+const dataDir = argv.flags.dataDir ?? process.env.CLAUDE_PLUGIN_DATA;
+if (!dataDir) throw new Error("dataDir is required (or set CLAUDE_PLUGIN_DATA)");
+const { queue: queues, interval, staleDays } = argv.flags;
+
+// Run immediately on start, then loop with an internal setTimeout sleep so
+// Monitor sees a single long-lived process. A shell while/sleep loop breaks on
+// macOS due to PATH-stripped eval and nice(5) restrictions. Each printed URL is
+// one newly-actionable PR/MR not yet dispatched a babysit watcher; that is the
+// event the orchestrator reacts to.
+while (true) {
+  for (const url of await pollOnce(queues, dataDir, staleDays, new Date())) {
+    console.log(url);
+  }
+  await sleep(interval * 1000);
+}


### PR DESCRIPTION
Adds `pull-request:outbox`, the authored half of the inbox/outbox pair. Stacked on #854 (`review:inbox` rename). It ranks your open PRs and MRs across GitHub and GitLab by what needs you next and dispatches a `pull-request:babysit` watcher per item, replacing scattered per-repo `gh pr list` and `glab mr list` sweeps with one ranked feed.

Ranking runs `red CI > changes-requested > stale-green > awaiting-review > draft`, oldest-updated first within a bucket. A red CI is the top rank, so CI-failure triage folds into the same feed.

Decisions:
- A sibling orchestrator, not an extension of babysit. babysit shepherds one PR. outbox is the multi-PR dispatcher above it, symmetric to how `review:inbox` orchestrates review sessions.
- Mirrors inbox's platform-agnostic `--queue` design, with an interactive mode and a hands-off `Monitor` loop. `github-queue.ts` enriches authored PRs via `gh`. The gitlab plugin owns its authored-MR query (`authored-queue.ts`) so outbox never reaches across the plugin boundary. Both emit the same `ActionEntry` JSON contract that `rank.ts` ranks.
- babysit keeps no shared run-state, so outbox tracks its own dispatched set to avoid double-watching a PR it is already shepherding. `dispatch.ts --reset` clears it for a fresh hands-off session.
- Duplicated the small poll loop rather than extracting a workspace package, per the plan. A package is premature with two consumers. Revisit if a third appears.

`code-review` and `simplify` stay out of this path. Self-review remains a deliberate pre-create gate.

## Testing
- `bun run skill-lint "plugins/pull-request/skills/outbox"`, `bun test`, `bun scripts/check-plugin-imports.ts`, `bun scripts/check-marketplace.ts`.
- Ran `github-queue.ts` and `poll.ts` against my 20 real open PRs. Ranking puts red CI on top and orders oldest-first within buckets. Dispatching a PR marks it so a re-poll de-dups, and `--reset` brings it back.
