### PR TITLE
improve-claude-code: build weekly Discover cadence

### DIFF
--- a/user/skills/improve-claude-code/SKILL.md
+++ b/user/skills/improve-claude-code/SKILL.md
@@ -81,7 +81,7 @@ Report how many todos landed. The existing triage, plan, implement, PR, CI, and 
 
 On-demand is primary: invoke this skill in Discover mode at your terminal and file keepers through the prompt. The weekly run is the [Non-Interactive Run](#non-interactive-run) above, and it must fire **locally**. The session DB and the `duckdb` CLI live on this Mac, so a cloud `/schedule` routine cannot reach them. Routines run in Anthropic's cloud from a fresh repo clone, with no local filesystem or CLI access. The `agent-ideas` headless-then-teleport bridge does not apply either (that works only because RSS is public).
 
-The trigger is a Claude Code Desktop scheduled task. It runs on this Mac with full filesystem and `duckdb` access and bills against the subscription, unlike headless `claude -p`, which now draws from a separate metered credit pool. It fires only while the Desktop app is open. A launchd-launched interactive session is the fallback. Either way the trigger lives in the dotfiles repo, configured there, not here.
+The trigger is a Claude Code Desktop scheduled task: on the Routines page, add a routine that runs `/improve-claude-code discover` weekly in Local mode. It runs on this Mac with full filesystem and `duckdb` access. It fires only while the Desktop app is open and the machine is awake. The routine is configured in the Desktop app, so nothing in this repo or dotfiles carries it. If you need the run to fire with the app closed, the fallback is a launchd job running `claude -p "/improve-claude-code discover"`, and that plist belongs in the dotfiles repo.
 
 #### Fingerprint
 

--- a/user/skills/improve-claude-code/SKILL.md
+++ b/user/skills/improve-claude-code/SKILL.md
@@ -62,7 +62,7 @@ One todo per candidate, not one blob. Filing lands findings in the same backlog 
 
 #### Non-Interactive Run
 
-A scheduled local run (`claude -p "/improve-claude-code discover"`) cannot stop for the [File the Keepers](#file-the-keepers) prompt, so it ends one step short of filing. Everything upstream runs unchanged: refresh the index, fan out the dimensions, and run the mandatory grounding pass. The verifier split stays exactly as it is on-demand. Skipping it would file week-stale findings against a config nobody re-checked.
+A scheduled local run (a Claude Code Desktop scheduled task firing `/improve-claude-code discover`) has nobody at the keyboard for the [File the Keepers](#file-the-keepers) prompt, so it ends one step short of filing. Everything upstream runs unchanged: refresh the index, fan out the dimensions, and run the mandatory grounding pass. The verifier split stays exactly as it is on-demand. Skipping it would file week-stale findings against a config nobody re-checked.
 
 Write the digest to `tmp/claude-discovery-digest-<YYYY-Www>.md` as always. Then, in place of the prompt, file exactly one Things doorway item that summarizes the run and hands triage back to you on demand. The run still never auto-files keepers. The doorway hands the filing choice back to you.
 
@@ -79,7 +79,9 @@ Report how many todos landed. The existing triage, plan, implement, PR, CI, and 
 
 #### Cadence
 
-On-demand is primary: invoke this skill in Discover mode at your terminal and file keepers through the prompt. The weekly run is the [Non-Interactive Run](#non-interactive-run) above, and it must fire **locally**. The session DB and the `duckdb` CLI live on this Mac, so a cloud `/schedule` routine cannot reach them and the `agent-ideas` headless-then-teleport bridge does not apply (that works only because RSS is public). The local trigger is a launchd job that lives in the dotfiles repo, paired with this skill and configured there, not here.
+On-demand is primary: invoke this skill in Discover mode at your terminal and file keepers through the prompt. The weekly run is the [Non-Interactive Run](#non-interactive-run) above, and it must fire **locally**. The session DB and the `duckdb` CLI live on this Mac, so a cloud `/schedule` routine cannot reach them. Routines run in Anthropic's cloud from a fresh repo clone, with no local filesystem or CLI access. The `agent-ideas` headless-then-teleport bridge does not apply either (that works only because RSS is public).
+
+The trigger is a Claude Code Desktop scheduled task. It runs on this Mac with full filesystem and `duckdb` access and bills against the subscription, unlike headless `claude -p`, which now draws from a separate metered credit pool. It fires only while the Desktop app is open. A launchd-launched interactive session is the fallback. Either way the trigger lives in the dotfiles repo, configured there, not here.
 
 #### Fingerprint
 

--- a/user/skills/improve-claude-code/SKILL.md
+++ b/user/skills/improve-claude-code/SKILL.md
@@ -60,13 +60,26 @@ Present the actionable (new, grounded) candidates and ask the user which to file
 
 One todo per candidate, not one blob. Filing lands findings in the same backlog the implement loop drains.
 
+#### Non-Interactive Run
+
+A scheduled local run (`claude -p "/improve-claude-code discover"`) cannot stop for the [File the Keepers](#file-the-keepers) prompt, so it ends one step short of filing. Everything upstream runs unchanged: refresh the index, fan out the dimensions, and run the mandatory grounding pass. The verifier split stays exactly as it is on-demand. Skipping it would file week-stale findings against a config nobody re-checked.
+
+Write the digest to `tmp/claude-discovery-digest-<YYYY-Www>.md` as always. Then, in place of the prompt, file exactly one Things doorway item that summarizes the run and hands triage back to you on demand. The run still never auto-files keepers. The doorway hands the filing choice back to you.
+
+Create the item via `things:url`, left untagged so the digest does not land in the `claude-code` backlog as one blob:
+
+- **Title**: `[discovery] Weekly digest: N candidates (YYYY-Www)`
+- **Notes**: the top-line summary (actionable count and the high-confidence standouts), then the digest path on its own line, then a one-line prompt to run `improve-claude-code` in Discover mode to file the keepers.
+
+When you pick the item up, re-run the skill interactively and flow through [File the Keepers](#file-the-keepers) against the same digest. The doorway item is the run's only signal. If creating it fails, say so loudly in the run output rather than ending silently.
+
 #### Hand Off
 
 Report how many todos landed. The existing triage, plan, implement, PR, CI, and annotate phases run on them later, unchanged. Filing is the default terminal action of Discover mode; implementing is a separate, explicit choice (run the loop below when ready).
 
 #### Cadence
 
-On-demand is primary: invoke this skill in Discover mode at your terminal. A weekly run is optional and must run **locally** (a `/loop` or `/schedule` trigger on this machine). The session DB and the `duckdb` CLI live here, so the `agent-ideas` headless-then-teleport bridge does not apply (that works only because RSS is public). A documented option, not built infrastructure.
+On-demand is primary: invoke this skill in Discover mode at your terminal and file keepers through the prompt. The weekly run is the [Non-Interactive Run](#non-interactive-run) above, and it must fire **locally**. The session DB and the `duckdb` CLI live on this Mac, so a cloud `/schedule` routine cannot reach them and the `agent-ideas` headless-then-teleport bridge does not apply (that works only because RSS is public). The local trigger is a launchd job that lives in the dotfiles repo, paired with this skill and configured there, not here.
 
 #### Fingerprint
 


### PR DESCRIPTION
Builds the weekly Discover cadence the skill already documented but never stood up. Adds a non-interactive run path so a scheduled local run produces the digest and one Things doorway item, instead of blocking on the interactive "which to file" prompt. Discover still never auto-files keepers. The doorway hands triage back to you on demand, and the mandatory grounding pass stays exactly as it is on-demand.

The trigger must be local. The session DB and `duckdb` live on this Mac, and cloud `/schedule` routines run from a fresh clone with no local access. The mechanism is a Claude Code Desktop scheduled task (Routines page, Local mode) running `/improve-claude-code discover` weekly. A launchd job invoking `claude -p` is the documented fallback for when the app is closed, and that plist is the paired dotfiles change.

An earlier draft justified the Desktop task with a billing claim: that headless `claude -p` draws from a separate metered credit pool. That is false, verified against the Claude Code cost and headless docs. Both bill against the same subscription. The claim is removed.

## Testing
- `bun run skill-lint "user/skills/improve-claude-code"`
- A paired dotfiles PR (the launchd fallback) is still needed and is not built here.
