### PR TITLE
settings: add plugin-deps Stop hook to catch undeclared deps locally

### DIFF
--- a/.claude/hooks/plugin-deps/index.test.ts
+++ b/.claude/hooks/plugin-deps/index.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { StopHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { VIOLATION_EXIT } from "../../../scripts/check-plugin-deps";
+import { processStop } from ".";
+
+let tempDir: string;
+
+beforeAll(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "plugin-deps-hook-"));
+});
+
+afterAll(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+function stopInput(overrides?: Partial<StopHookInput>): StopHookInput {
+  return {
+    hook_event_name: "Stop",
+    session_id: "test",
+    transcript_path: "/dev/null",
+    cwd: tempDir,
+    stop_hook_active: false,
+    permission_mode: "default",
+    ...overrides,
+  };
+}
+
+async function fakeChecker(name: string, source: string): Promise<string> {
+  const path = join(tempDir, name);
+  await Bun.write(path, source);
+  return path;
+}
+
+describe("processStop", () => {
+  it("returns null when the stop hook is already active", async () => {
+    expect(await processStop(stopInput({ stop_hook_active: true }))).toBeNull();
+  });
+
+  it("returns null when the checker passes", async () => {
+    const checker = await fakeChecker("clean.ts", "process.exit(0);");
+    expect(await processStop(stopInput(), checker)).toBeNull();
+  });
+
+  it("blocks with the checker's stderr on the violation exit code", async () => {
+    const checker = await fakeChecker(
+      "violation.ts",
+      `console.error('plugin-a: missing dependency "cleye"');
+process.exit(${VIOLATION_EXIT});`,
+    );
+
+    const output = await processStop(stopInput(), checker);
+    expect(output?.decision).toBe("block");
+    expect(output?.reason).toContain("Missing plugin dependencies detected");
+    expect(output?.reason).toContain('missing dependency "cleye"');
+  });
+
+  it("reports a non-blocking systemMessage when the checker crashes", async () => {
+    const checker = await fakeChecker(
+      "crash.ts",
+      `throw new Error("Cannot find module '@bendrucker/claude-marketplace'");`,
+    );
+
+    const output = await processStop(stopInput(), checker);
+    expect(output?.decision).toBeUndefined();
+    expect(output?.systemMessage).toContain("checker could not run");
+  });
+
+  it("does not block when the checker script is missing", async () => {
+    const output = await processStop(stopInput(), join(tempDir, "missing.ts"));
+    expect(output?.decision).toBeUndefined();
+    expect(output?.systemMessage).toContain("checker could not run");
+  });
+});

--- a/.claude/hooks/plugin-deps/index.ts
+++ b/.claude/hooks/plugin-deps/index.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env bun
+
+import { join } from "node:path";
+import type { StopHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+
+// Mirrors VIOLATION_EXIT in scripts/check-plugin-deps.ts. Deliberately a
+// literal rather than an import: importing the checker would pull its module
+// graph into the hook, so a checker that cannot load would crash the hook
+// instead of reaching the non-blocking "checker could not run" path below.
+// The hook's test imports both to keep the values in sync.
+const VIOLATION_EXIT = 2;
+
+const CHECKER_PATH = join(import.meta.dirname, "..", "..", "..", "scripts", "check-plugin-deps.ts");
+
+export async function processStop(
+  input: StopHookInput,
+  checkerPath = CHECKER_PATH,
+): Promise<SyncHookJSONOutput | null> {
+  if (input.stop_hook_active) return null;
+
+  const proc = Bun.spawn(["bun", checkerPath], {
+    cwd: input.cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const exitCode = await proc.exited;
+  if (exitCode === 0) return null;
+
+  const stderr = await new Response(proc.stderr).text();
+
+  if (exitCode === VIOLATION_EXIT) {
+    return {
+      decision: "block",
+      reason: `Missing plugin dependencies detected:\n\n${stderr}\n\nDeclare these in the plugin's package.json before stopping. Plugins must declare every npm package they import.`,
+    };
+  }
+
+  // Any other non-zero exit means the checker itself failed to run (e.g.
+  // module resolution failure). Surface it without blocking the stop.
+  return {
+    systemMessage: `plugin-deps: checker could not run (exit ${exitCode}); skipping plugin dependency check.\n\n${stderr.trim()}`,
+  };
+}
+
+async function main(): Promise<void> {
+  const input = await readStdinJson<StopHookInput>();
+  if (input.hook_event_name !== "Stop") return;
+
+  const output = await processStop(input);
+  if (output) writeStdoutJson(output);
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,6 +75,10 @@
           },
           {
             "type": "command",
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/plugin-deps\""
+          },
+          {
+            "type": "command",
             "command": "PREK_HOME=\"$CLAUDE_PROJECT_DIR/.prek\" bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop\""
           }
         ]

--- a/scripts/check-plugin-deps.ts
+++ b/scripts/check-plugin-deps.ts
@@ -5,6 +5,12 @@ import { Glob } from "bun";
 import { loadPlugins } from "../packages/marketplace/index";
 import { runCheck } from "./check";
 
+// Exit codes: 0 clean, VIOLATION_EXIT when undeclared dependencies are found.
+// Anything else (bun exits 1 on uncaught errors) means the checker itself
+// failed to run. The Stop hook in .claude/hooks/plugin-deps relies on this
+// distinction to avoid reporting a crash as a violation.
+export const VIOLATION_EXIT = 2;
+
 async function getPluginDeps(pluginDir: string): Promise<Set<string>> {
   const deps = new Set<string>();
   const glob = new Glob("**/package.json");
@@ -74,4 +80,10 @@ async function checkDeps(): Promise<string[]> {
   return violations;
 }
 
-await runCheck(checkDeps, { stream: "stderr", indent: false });
+if (import.meta.main) {
+  await runCheck(checkDeps, {
+    stream: "stderr",
+    indent: false,
+    failureExit: VIOLATION_EXIT,
+  });
+}


### PR DESCRIPTION
Plugins that ship TypeScript must declare every npm package they import in their own `package.json`. `scripts/check-plugin-deps.ts` enforces this, but only in CI. Its sibling, `scripts/check-plugin-imports.ts`, already had a local `Stop` hook (`.claude/hooks/plugin-imports`) that blocks a session from stopping on a violation. The deps checker had no such hook, so a missing declaration only surfaced in CI.

That gap cost a round-trip recently: the `pull-request:outbox` skill imported `cleye` without the `pull-request` plugin declaring it. Local checks stayed green and CI caught it. This hook closes the gap by running the same check at `Stop` time.

## Exit-code alignment

The hook needs to tell a real violation apart from the checker failing to load (Bun exits 1 on an uncaught error). The imports checker already solved this by exiting with a dedicated `VIOLATION_EXIT = 2`. The deps checker used the default `failureExit: 1`, which collides with Bun's crash code. It now exports `VIOLATION_EXIT = 2` and passes it as `failureExit`, mirroring the imports checker. On exit 2 the hook blocks with the missing dependencies; on any other non-zero exit it surfaces a non-blocking "checker could not run" message rather than reporting a crash as a violation.

The `runCheck` call is now guarded by `import.meta.main` so the hook's test can import `VIOLATION_EXIT` without triggering the check as an import side effect. Detection logic is unchanged.

## Removal trigger

If this hook never fires across several weeks of plugin work, the CI gate alone is sufficient and the local hook can be dropped. The signal surfaces at `Stop` time, so a recurring block is evidence it earns its cost.
