### PR TITLE
settings: add StopFailure hook for vibe-island bridge

### DIFF
--- a/.claude/hooks/settings/index.test.ts
+++ b/.claude/hooks/settings/index.test.ts
@@ -38,6 +38,26 @@ describe("settings validation", () => {
     expect(errors.size).toBeGreaterThan(0);
   });
 
+  it("allows allowAppleEvents on sandbox even when the schema omits it", async () => {
+    const sandboxSchema = {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        sandbox: {
+          type: "object",
+          additionalProperties: false,
+          properties: { enabled: { type: "boolean" } },
+        },
+      },
+    };
+    await Bun.write(
+      join(tempDir, ".claude/settings.json"),
+      JSON.stringify({ sandbox: { enabled: true, allowAppleEvents: true } }),
+    );
+    const errors = await validate(tempDir, sandboxSchema);
+    expect(errors.size).toBe(0);
+  });
+
   it("skips missing files", async () => {
     await rm(join(tempDir, ".claude/settings.json"), { force: true });
     await rm(join(tempDir, "user/settings.json"), { force: true });

--- a/.claude/hooks/settings/index.ts
+++ b/.claude/hooks/settings/index.ts
@@ -36,6 +36,11 @@ interface SchemaObject {
 }
 
 function patchSchema(schema: SchemaObject): void {
+  patchHookIfField(schema);
+  patchSandboxAppleEvents(schema);
+}
+
+function patchHookIfField(schema: SchemaObject): void {
   const hookCommand = schema.$defs?.hookCommand;
   if (!hookCommand?.anyOf) return;
 
@@ -49,6 +54,16 @@ function patchSchema(schema: SchemaObject): void {
       variant.properties.if = ifProperty;
     }
   }
+}
+
+function patchSandboxAppleEvents(schema: SchemaObject): void {
+  const sandbox = schema.properties?.sandbox;
+  if (!sandbox?.properties) return;
+
+  sandbox.properties.allowAppleEvents = {
+    type: "boolean",
+    description: "Allow sandboxed processes to send Apple Events (macOS automation).",
+  };
 }
 
 export async function validate(

--- a/user/settings.json
+++ b/user/settings.json
@@ -160,6 +160,16 @@
         ]
       }
     ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+          }
+        ]
+      }
+    ],
     "SubagentStart": [
       {
         "hooks": [


### PR DESCRIPTION
Adds a `StopFailure` hook to `user/settings.json` that fires the vibe-island bridge, mirroring the existing `Stop` hook. This surfaces the stop-on-failure lifecycle event to vibe-island alongside the other hooks already wired to the bridge.

The change also patches the settings validator. Schemastore's `sandbox` schema sets `additionalProperties: false` and doesn't know `allowAppleEvents` (added in `c3e87b57`), so `settings-validate` rejected the live config the moment any commit touched `user/settings.json`. The validator already patches in the hook `if` field for the same schema-lag reason, so `allowAppleEvents` goes in the same way, with a test.
