### PR TITLE
job: group brief by project, sweep inbox to zero

### DIFF
--- a/user/skills/job/SKILL.md
+++ b/user/skills/job/SKILL.md
@@ -34,10 +34,10 @@ Arguments beyond the mode are a focus hint ($ARGUMENTS). Weight the brief toward
 
 ## Delegation
 
-This skill never names platforms. The config declares which version-control platform, issue tracker, and worktree tool the user works with. For each task:
+This skill never names platforms. The config declares which version-control platform, issue tracker, worktree tool, messaging platform, and email account the user works with. For each task:
 
-1. Find the installed skill covering the configured tool's task (the skill for the configured platform's merge requests, the skill for the configured tracker's issues) and load it for mechanics.
-2. If no installed skill matches, use the configured CLI directly. Stay read-only until the user confirms actions.
+1. Find the installed skill covering the configured tool's task (the skill for the configured platform's merge requests, the skill for the configured tracker's issues, the skill or MCP for the configured messaging and email inboxes) and load it for mechanics.
+2. If no installed skill matches, use the configured CLI or MCP directly. Stay read-only until the user confirms actions.
 
 Platforms, hostnames, and usernames come only from the config or the user, never from this skill.
 
@@ -47,19 +47,23 @@ Both modes follow this contract.
 
 ### Gather
 
-Read-only first. When sources are independent (review queue, own PRs, tracker), dispatch parallel read-only sub-agents and merge their results.
+Read-only first. The sources are independent (review queue, own PRs, tracker, messaging inbox, email inbox), so dispatch parallel read-only sub-agents and merge their results.
 
 ### Brief
 
-One prioritized brief, sections in the mode's phase order. Within each section, order items blocking others first, then oldest. Each item gets an identifier with a link, a one-line state, and a recommended action.
+One prioritized brief, grouped by project. Resolve each item to its project through the tracker: an issue carries its project, and an MR or message inherits the project of the work it references. Collapse an MR, its issue, and any thread about the same work into one entry. Keep a `Misc` group for project-less items.
 
-Omit empty sections and never pad. An empty queue is a two-line brief.
+Within a group, order blocking items first, then oldest. Each item gets an identifier with a link, a one-line state, and a recommended action. The mode's phases set what to surface and label each item's role within its project.
+
+Close with the mode's cross-project synthesis (the day's sequence, or the night's open decisions) and confirm it with the user. Omit empty groups and never pad. An empty queue is a two-line brief.
 
 ### Act
 
 Split recommended actions into two groups:
 
-- Safe: reversible or expected. Assign a reviewer, retry CI, post a reply the user has seen drafted, update tracker status.
+- Safe: reversible or expected. Assign a reviewer, retry CI, post a reply the user has seen drafted, update tracker status, archive a handled notification or email.
 - Ask-first: approve, close, merge, anything hard to walk back. Each needs its own confirmation.
+
+Drive inbound to zero. Every review request, message, notification, and email leaves the run with a terminal disposition: handled, deferred to a tracked task or issue, or archived. Nothing stays in an ambiguous unread state.
 
 Present safe actions via AskUserQuestion (execute all, pick a subset, or none). Execute through the delegated skills, then give a short summary of what changed.

--- a/user/skills/job/references/end.md
+++ b/user/skills/job/references/end.md
@@ -1,6 +1,6 @@
 # End
 
-The day ends with decisions. Nothing leaves it unsent, unanswered, or unpushed without one.
+The day ends with decisions. Nothing leaves it unsent, unanswered, unfiled, or unpushed without one.
 
 ## Gather
 
@@ -8,8 +8,10 @@ Dispatch parallel read-only sub-agents:
 
 - Outbox: your own PRs/MRs created or pushed today, with reviewer assignment, CI state, draft state, and whether the body still matches the diff.
 - Inbound: review requests still open against you, and threads on others' PRs/MRs awaiting your reply.
+- Messaging (when configured): direct messages, mentions, and tracker notifications awaiting your reply, with sender and link.
+- Email (when configured): unhandled mail awaiting your reply or filing, with sender and link.
 - Worktrees: every worktree's uncommitted and unpushed state (details under the sweep below).
-- Tracker: your in-flight issues and their current states.
+- Tracker: your in-flight issues, their current states, and their projects.
 
 ## Outbox Clearing
 
@@ -24,7 +26,7 @@ Flag items that need collaboration lead time (a reviewer in another timezone, a 
 
 ## Review Debt
 
-Review debt is inbound requests you did not reach today plus unanswered threads on others' PRs/MRs. Choose one path per item:
+Review debt is inbound requests you did not reach today, unanswered threads on others' PRs/MRs, and any message, notification, or email still awaiting your reply or filing. Choose one path per item:
 
 - Reply now: draft the reply and include it in the brief. Posting a draft the user approved is safe.
 - Carry to tomorrow: record it explicitly so it appears in tomorrow's start brief.
@@ -49,4 +51,4 @@ Offer per worktree: commit and push as WIP (safe on your own branch), or record 
 
 ## Brief and Act
 
-Assemble the brief in the phase order above and execute per the shared contract in `SKILL.md`.
+Assemble the brief grouped by project per the contract in `SKILL.md` and execute per that shared contract.

--- a/user/skills/job/references/setup.md
+++ b/user/skills/job/references/setup.md
@@ -6,7 +6,7 @@ First-run interview. Produces `~/.config/claude-job-skill/config.json`. The skil
 
 Build candidate answers from the environment rather than a hardcoded tool list:
 
-- Scan the installed-skills list already in context for version-control, issue-tracker, code-review, and worktree coverage.
+- Scan the installed-skills list already in context for version-control, issue-tracker, code-review, worktree, messaging, and email coverage. Messaging and email often arrive as MCP servers rather than skills or CLIs, so check the connected MCP servers too.
 - Probe for CLIs read-only: `command -v`, then the CLI's authenticated-user query (its `whoami` or `me` equivalent) to learn the username, which doubles as verification for the interview's version-control answer.
 - Check `git config --get remote.origin.url` in likely repos for a host hint.
 
@@ -19,6 +19,8 @@ Ask via AskUserQuestion with detected candidates as options, relying on the buil
 - Version control: platform, host, work username (verify against the CLI's authenticated-user query), preferred CLI.
 - Issue tracker: platform, username and team, and how "current cycle" is expressed there, whether that is a cycle, sprint, iteration, or milestone, recording the exact term and how to query it.
 - Worktrees: the tool used, if any, plus every root directory the end-of-day sweep should walk when it checks for uncommitted changes and unpushed commits.
+- Messaging: the platform, how it is reached (an installed skill, an MCP server, or a CLI), and the work handle. Used to sweep inbound direct messages and mentions. Optional.
+- Email: the account, how it is reached (an installed skill, an MCP server, or a CLI), and the work address. Used to sweep unhandled mail. Optional.
 - Working hours: optional, default 09:00 to 17:00, used only to suggest a mode when `/job` runs with no argument.
 - Notes: optional free-form text for reviewer conventions and team norms, where employer specifics belong rather than anywhere in the skill.
 
@@ -31,6 +33,8 @@ Run `mkdir -p ~/.config/claude-job-skill`, then write `config.json`:
   "version": 1,
   "vcs": { "platform": "...", "host": "...", "username": "...", "cli": "..." },
   "tracker": { "platform": "...", "username": "...", "team": "..." },
+  "chat": { "platform": "...", "access": "...", "username": "..." },
+  "email": { "platform": "...", "access": "...", "address": "..." },
   "worktrees": { "tool": "...", "roots": ["~/src/..."] },
   "hours": { "start": "09:00", "end": "17:00" },
   "notes": "free-form conventions"

--- a/user/skills/job/references/start.md
+++ b/user/skills/job/references/start.md
@@ -1,6 +1,6 @@
 # Start
 
-Start-of-work triage: what needs review, what is stuck in your outbox, and what today is for.
+Start-of-work triage: what needs review, what is stuck in your outbox, what came in while you were away, and what today is for.
 
 ## Gather
 
@@ -8,9 +8,11 @@ Dispatch parallel read-only sub-agents:
 
 - Inbound: PRs/MRs where the configured username is a requested reviewer or approver, with age, author, and whether you reviewed before.
 - Outbox: your own open PRs/MRs, with CI status, unresolved threads, reviewer assignment, and draft state.
-- Tracker: issues assigned to the configured user, plus the current cycle as the config expresses it.
+- Tracker: issues assigned to the configured user, plus the current cycle as the config expresses it. Record each issue's project, since the brief groups by it. Include the tracker's notification inbox, which is separate from assigned issues.
+- Messaging (when configured): direct messages and mentions to the configured user since the last working day that imply an action, with sender, link, and the ask.
+- Email (when configured): unhandled mail that needs a reply, an action, or filing, with sender, subject, and link.
 
-Each sub-agent uses the delegated skill or CLI for its source and returns structured state: identifiers, links, and statuses the brief can consume directly.
+Each sub-agent uses the delegated skill, MCP, or CLI for its source and returns structured state: identifiers, links, and statuses the brief can consume directly.
 
 ## Inbound Review Queue
 
@@ -28,19 +30,27 @@ Recommended actions per item:
 
 For each of your open PRs/MRs, flag:
 
-- Failing or stuck CI. Retrying a flaky job is safe. A real failure becomes a candidate focus item.
+- Failing or stuck CI. Retrying a flaky job is safe. A real failure becomes a candidate focus item. Before planning around a red pipeline, confirm the failure is yours to fix. A shared build break or an upstream outage is not work, and the same job failing identically across several of your MRs is the tell.
 - Reviewer threads awaiting your reply. Draft replies and include them in the brief.
 - Ready for review but no reviewer assigned. Assigning per the config notes is safe.
 - Stale drafts. Recommend one of: finish today (focus item), send as-is (safe), or close (ask-first).
 
+## Inbox Triage
+
+Triage each inbound item, whether a message, a tracker notification, or an email, into an action: a review handoff, a decision you owe someone, a question to answer, or a new task. An item often carries the only signal for a focus item, so a thread that names an MR or issue belongs with that work in the brief, not stranded in a separate inbox list. Map every item to the project it concerns, or to `Misc`.
+
+Inbox zero is the target. Each item leaves the day in a terminal state: handled, deferred to a tracked task, or archived. Drafting a reply the user has read is safe, as is archiving something already handled. Sending a reply without review is ask-first.
+
 ## Today Plan
 
-From assignments and the current cycle, propose one to three focus items for the day, folding in anything the earlier phases produced (a real CI failure, a draft to finish). Confirm the list with the user.
+Group everything gathered by project, with a `Misc` group for project-less items. From assignments and the current cycle, propose one to three focus items for the day, folding in anything the earlier phases produced: a real CI failure, a draft to finish, a decision a message asked for.
 
-Queue tracker corrections as safe actions: stale statuses, items marked in-progress that are not, done work not closed.
+Confirm two things with the user. First, the focus items. Second, the sequence across projects, because working a project at a time and clearing every review first are both reasonable, and only the user knows which they want today.
+
+Queue tracker corrections as safe actions: stale statuses, items marked in-progress that are not, done work not closed, and issues with no project.
 
 End with a one-line stated goal for the day.
 
 ## Brief and Act
 
-Assemble the brief in the phase order above and execute per the shared contract in `SKILL.md`.
+Assemble the brief grouped by project per the contract in `SKILL.md`, drawing each item's role from the analysis above. Execute per that shared contract.


### PR DESCRIPTION
A real `/job start` run this morning exposed two gaps. The brief was organized by source (review queue, outbox, tracker), which buried the fact that the day's actual drivers arrived as Slack DMs the skill never read. It also interleaved unrelated projects into one undifferentiated pile.

This restructures the brief around projects and widens the inbound sweep.

## Inbound sources

The gather now sweeps the messaging inbox, the email inbox, and the tracker's notification inbox (separate from assigned issues), alongside the existing review queue, own PRs, and assigned issues. Messaging and email are config-driven like the existing platforms, so the skill still names no vendor. `setup` detects and interviews for both, and both are optional.

## Project-first brief, with inbox zero

The brief groups by project with a `Misc` bucket for project-less items, collapsing an MR, its issue, and any thread about the same work into one entry. The phases become each item's role inside its project rather than the top-level structure.

Grouping and execution order are deliberately separate axes. The plan still synthesizes a cross-project sequence (for example, clearing every review first) and confirms it with the user. I compared project-first against a phase-first variant on real data before settling here, since "triage by project" was the explicit ask.

Every inbound item now leaves a run with a terminal disposition: handled, deferred to a tracked task, or archived. That mirrors end mode's existing principle that nothing leaves unanswered, applied to inbound.

## CI-outage check

The outbox now says to confirm a red pipeline is yours to fix before planning around it. The same job failing identically across several of your MRs is the tell for a shared build break or upstream outage, which is not work. This came from mistaking a Chainguard outage for four broken MRs.

Verified with `skill-lint` (0 errors, 0 warnings). `SKILL.md` grows about 76 tokens.
