### PR TITLE
job: triage reviews with summary and effort before execution

### DIFF
--- a/user/skills/job/SKILL.md
+++ b/user/skills/job/SKILL.md
@@ -55,7 +55,7 @@ One prioritized brief, grouped by project. Resolve each item to its project thro
 
 Within a group, order blocking items first, then oldest. Each item gets an identifier with a link, a one-line state, and a recommended action. The mode's phases set what to surface and label each item's role within its project.
 
-Close with the mode's cross-project synthesis (the day's sequence, or the night's open decisions) and confirm it with the user. Omit empty groups and never pad. An empty queue is a two-line brief.
+Close with the mode's cross-project synthesis: the day's sequence, or the night's open decisions. This is the triage gate. The brief covers everything gathered, and nothing executes until the user approves the order. Omit empty groups and never pad. An empty queue is a two-line brief.
 
 ### Act
 
@@ -67,3 +67,5 @@ Split recommended actions into two groups:
 Drive inbound to zero. Every review request, message, notification, and email leaves the run with a terminal disposition: handled, deferred to a tracked task or issue, or archived. Nothing stays in an ambiguous unread state.
 
 Present safe actions via AskUserQuestion (execute all, pick a subset, or none). Execute through the delegated skills, then give a short summary of what changed.
+
+Run the quick safe actions and tracker corrections first. Session-length work like a review starts only at the end of the run, after the rest is cleared, and never before the approved order from triage.

--- a/user/skills/job/references/start.md
+++ b/user/skills/job/references/start.md
@@ -24,9 +24,10 @@ Before recommending an action, give each item a one-line summary of what it chan
 
 Recommended actions per item:
 
-- Review now: start immediately after the brief, via the installed review skill for the configured platform.
-- Queue for a time today: record it in the today plan with the chosen slot.
+- Review today: slot it into the day's order. The review runs through the installed review skill once triage is approved.
 - Decline or reassign: ask-first, since it hands work back.
+
+Triage covers the whole queue before any review begins. Reviews are session-length work, so they kick off at the end of the run, after the order is locked.
 
 ## Outbox
 

--- a/user/skills/job/references/start.md
+++ b/user/skills/job/references/start.md
@@ -20,6 +20,8 @@ Order items blocking others first, then oldest.
 
 Separate fresh requests from re-reviews where the author responded to your earlier feedback. For re-reviews, delegate the addressed-or-not analysis to an installed review-follow-up skill if one exists. Otherwise compare the threads against your prior comments.
 
+Before recommending an action, give each item a one-line summary of what it changes and an estimated review effort. Delegate both to the installed review skill's summary pass when it offers one, so the estimate uses the same effort scale the eventual review would, and the brief never starts the review itself. The estimate is what makes the queue schedulable: it shows the morning's total review load and lets a run of small reviews clear ahead of one deep one.
+
 Recommended actions per item:
 
 - Review now: start immediately after the brief, via the installed review skill for the configured platform.


### PR DESCRIPTION
Running `/job start` for real surfaced two gaps in the start brief.

First, the brief recommended reviews without saying how much each one would cost. With no effort estimate you cannot sequence the queue, so a quick approval and a deep read look the same in the plan. The inbound review queue now gives each item a one-line summary of what it changes and an estimated review effort. The effort scale and the diff reading stay in the review skill: the brief delegates to its summary pass rather than reimplementing either, so `job` stays platform-agnostic. A follow-up adds that summary mode to `review:peer`; until then the brief falls back to summarizing inline.

Second, the start mode's `Review now` disposition let a review begin "immediately after the brief," before the rest of the day was triaged. That inverts the skill's own brief-then-act contract. Triage now covers the whole queue and the user approves the order before anything executes. Reviews are session-length work, so they kick off at the end of the run after the quick safe actions and tracker corrections, never mid-brief. The approval is framed as an explicit triage gate in the shared contract so both modes inherit it.
