### PR TITLE
review: add a curated-queue mode to the review inbox

### DIFF
--- a/plugins/review/skills/inbox/SKILL.md
+++ b/plugins/review/skills/inbox/SKILL.md
@@ -3,8 +3,8 @@ name: review:inbox
 description: >
   Live tmux inbox for reviewing inbound pull requests across GitHub and GitLab.
   Use when reviewing multiple PRs, checking the review queue, batch reviews, or managing your review inbox.
-  Pass --curated to spawn an already-ordered queue handed in by another skill, such as the job skill, instead of fetching one.
-argument-hint: "[--curated]"
+  Pass --queue to spawn an already-ordered queue.
+argument-hint: "[--queue]"
 allowed-tools:
   - Monitor
   - TaskStop
@@ -35,11 +35,11 @@ Orchestrate live PR/MR reviews in tmux. You are the sidebar orchestrator: fetch 
 
 ## Arguments
 
-- `--curated`: spawn an already-triaged, ordered queue handed in by a caller, rather than fetching your own. Default: off, the interactive flow that fetches and presents the queue below.
+- `--queue`: spawn an already-triaged, ordered queue handed in by a caller, rather than fetching your own. Default: off, the interactive flow that fetches and presents the queue below.
 
 ## Curated Queue
 
-When `--curated` is set, another skill has already gathered, triaged, and ordered the reviews. The `job` skill does this: its start brief sequences the queue and estimates each review's effort before any review begins, then hands the approved order here.
+When `--queue` is set, another skill has already gathered, triaged, and ordered the reviews.
 
 Skip [Fetch Pending Reviews](#fetch-pending-reviews) and [Present Results](#present-results). Take the queue from the invoking context as given: spawn each review in the order received, passing its triage summary as the `spawn.ts` `--context` so the session opens with the caller's framing. Everything from [Spawn Review Sessions](#spawn-review-sessions) onward, the sidebar resize, layout, monitoring, and worktree reclamation, is unchanged.
 

--- a/plugins/review/skills/inbox/SKILL.md
+++ b/plugins/review/skills/inbox/SKILL.md
@@ -3,7 +3,8 @@ name: review:inbox
 description: >
   Live tmux inbox for reviewing inbound pull requests across GitHub and GitLab.
   Use when reviewing multiple PRs, checking the review queue, batch reviews, or managing your review inbox.
-disable-model-invocation: true
+  Pass --curated to spawn an already-ordered queue handed in by another skill, such as the job skill, instead of fetching one.
+argument-hint: "[--curated]"
 allowed-tools:
   - Monitor
   - TaskStop
@@ -31,6 +32,16 @@ hooks:
 # Review Inbox
 
 Orchestrate live PR/MR reviews in tmux. You are the sidebar orchestrator: fetch pending reviews, spawn review sessions, and monitor their progress.
+
+## Arguments
+
+- `--curated`: spawn an already-triaged, ordered queue handed in by a caller, rather than fetching your own. Default: off, the interactive flow that fetches and presents the queue below.
+
+## Curated Queue
+
+When `--curated` is set, another skill has already gathered, triaged, and ordered the reviews. The `job` skill does this: its start brief sequences the queue and estimates each review's effort before any review begins, then hands the approved order here.
+
+Skip [Fetch Pending Reviews](#fetch-pending-reviews) and [Present Results](#present-results). Take the queue from the invoking context as given: spawn each review in the order received, passing its triage summary as the `spawn.ts` `--context` so the session opens with the caller's framing. Everything from [Spawn Review Sessions](#spawn-review-sessions) onward, the sidebar resize, layout, monitoring, and worktree reclamation, is unchanged.
 
 ## Fetch Pending Reviews
 


### PR DESCRIPTION
Adds a `--curated` mode to `review:inbox`. In it, another skill has already gathered, triaged, and ordered the reviews, so the inbox skips its own fetch and present steps and spawns the queue in the order handed to it, passing each item's triage summary as the `spawn.ts` `--context`. Everything downstream, the sidebar resize, layout, monitoring, and worktree reclamation, is unchanged.

This is the dispatch target for the `job` skill. Its start brief sequences the review queue and estimates each review's effort before any review begins (bendrucker/claude#865), then hands the approved order here at the end of the run. `spawn.ts` already takes a per-URL `--context`, so the curated path is a documented entry rather than a script change.

The PR also drops `disable-model-invocation` from the inbox. That flag blocked the Skill tool, so `job` could not delegate to the inbox at all. Removing it makes the handoff a clean `Skill(review:inbox)` delegation. The trade is the inbox's name and description rejoining the always-on catalog. I weighed that against a file-drop or a second slash step and chose the delegation; the recurring catalog cost is the price for the inbox owning the spawn end to end.

The `job` wiring that calls this lands as a follow-up.

#865
