### PR TITLE
job: hand the triaged review queue to a review skill

### DIFF
--- a/user/skills/job/SKILL.md
+++ b/user/skills/job/SKILL.md
@@ -36,7 +36,7 @@ Arguments beyond the mode are a focus hint ($ARGUMENTS). Weight the brief toward
 
 This skill never names platforms. The config declares which version-control platform, issue tracker, worktree tool, messaging platform, and email account the user works with. For each task:
 
-1. Find the installed skill covering the configured tool's task (the skill for the configured platform's merge requests, the skill for the configured tracker's issues, the skill or MCP for the configured messaging and email inboxes) and load it for mechanics.
+1. Find the installed skill covering the configured tool's task (the skill for the configured platform's merge requests, the skill for the configured tracker's issues, the skill or MCP for the configured messaging and email inboxes, the skill that runs a review queue) and load it for mechanics.
 2. If no installed skill matches, use the configured CLI or MCP directly. Stay read-only until the user confirms actions.
 
 Platforms, hostnames, and usernames come only from the config or the user, never from this skill.

--- a/user/skills/job/references/start.md
+++ b/user/skills/job/references/start.md
@@ -27,7 +27,7 @@ Recommended actions per item:
 - Review today: slot it into the day's order. The review runs through the installed review skill once triage is approved.
 - Decline or reassign: ask-first, since it hands work back.
 
-Triage covers the whole queue before any review begins. Reviews are session-length work, so they kick off at the end of the run, after the order is locked.
+Triage covers the whole queue before any review begins. Reviews are session-length work, so they kick off at the end of the run, after the order is locked. If a skill that runs a review queue is installed, hand it the locked queue so it opens each review in order, with the triage summary as context. Otherwise run the reviews inline through the review skill.
 
 ## Outbox
 


### PR DESCRIPTION
Builds on #865 and #867. The start brief already triages the review queue and locks an order before any review runs. This lets `job` hand that locked queue to a separate review skill at the end of a run, instead of reviewing each PR inline.

If a skill that runs a review queue is installed, `job` hands it the queue and each review opens in order with its triage summary as context. The review inbox (#867) is that skill. Without one installed, reviews run inline through the review skill, as before.

`job` finds that skill the same way it finds the merge-request, tracker, and messaging skills: by what it does, never by name. So it works with whatever review skill you have installed instead of a hardcoded one.

Stacked on #865. Depends on the queue handoff from #867.