### PR TITLE
review: pre-authorize peer review's git and jq

### DIFF
--- a/plugins/review/skills/peer/SKILL.md
+++ b/plugins/review/skills/peer/SKILL.md
@@ -6,6 +6,17 @@ argument-hint: <pr-url-or-number>
 allowed-tools:
   - Bash(gh:*)
   - Bash(glab:*)
+  - Bash(git log:*)
+  - Bash(git diff:*)
+  - Bash(git show:*)
+  - Bash(git branch:*)
+  - Bash(git fetch:*)
+  - Bash(git checkout:*)
+  - Bash(git remote:*)
+  - Bash(git rev-parse:*)
+  - Bash(git cat-file:*)
+  - Bash(git status:*)
+  - Bash(jq:*)
   - mcp__github
   - WebFetch
   - Skill(code-review)


### PR DESCRIPTION
Reviewing a PR runs on `git` and `jq`, but `review:peer` only pre-authorized `gh`, `glab`, `mcp__github`, and `WebFetch`. So every `git log`, `git diff`, `git fetch`, and `git checkout` prompted. The `glab … | jq` pipes prompted too, because a pipe's trailing command also has to be allowed. A dispatched review fired a permission prompt on nearly every step.

This adds the read-only `git` subcommands a review uses, plus `jq`. File reading stays on `Read`/`Grep`/`Glob` as the skill already directs, so `cat`, `grep`, and `find` are left out on purpose. There is no mutating `git` here (`push`, `commit`, `reset`), and submitting a review still routes through the existing "check with me before submitting" guardrail.

The diagnosis came from four live MR review sessions: `git` was the dominant prompt source, standalone `jq` second. The fix quiets interactive and dispatched reviews alike, short of auto-accept or bypass mode.
