### PR TITLE
review: dispatch reviews to a named tmux session

### DIFF
--- a/plugins/review/skills/inbox/SKILL.md
+++ b/plugins/review/skills/inbox/SKILL.md
@@ -79,7 +79,7 @@ bun ${CLAUDE_SKILL_DIR}/scripts/spawn.ts <pr-url> --repo-path <local-path> --dat
 
 `spawn.ts` handles `--worktree` for branch isolation, tmux layout computation, and state tracking. Pass `--context` with PR metadata (title, author, description summary) so the spawned review session has immediate context. Panes cycle in groups of 3: one horizontal split (new column at 70% width for the first, equal width after), then two vertical splits stacking in the column.
 
-Pass `--session <name>` to open reviews in a tmux session other than the one you orchestrate from. Without it, `spawn.ts` splits the orchestrator's own pane. That fits running the inbox as a sidebar inside the review session itself. With it, a remote orchestrator dispatches elsewhere: a `job` start run in your work session hands the queue here, and the reviews open in your dedicated review session. The first pane splits that session's active pane rather than carving a sidebar from the orchestrator.
+Pass `--session <name>` to open reviews in a tmux session other than the one you orchestrate from. Without it, `spawn.ts` splits the orchestrator's own pane.
 
 Resize the orchestrator to a sidebar before spawning the first pane, but only when the panes share your window. Skip the resize under `--session`, since the orchestrator does not share the panes' window.
 

--- a/plugins/review/skills/inbox/SKILL.md
+++ b/plugins/review/skills/inbox/SKILL.md
@@ -79,7 +79,9 @@ bun ${CLAUDE_SKILL_DIR}/scripts/spawn.ts <pr-url> --repo-path <local-path> --dat
 
 `spawn.ts` handles `--worktree` for branch isolation, tmux layout computation, and state tracking. Pass `--context` with PR metadata (title, author, description summary) so the spawned review session has immediate context. Panes cycle in groups of 3: one horizontal split (new column at 70% width for the first, equal width after), then two vertical splits stacking in the column.
 
-Before spawning the first pane, resize the orchestrator to a sidebar:
+Pass `--session <name>` to open reviews in a tmux session other than the one you orchestrate from. Without it, `spawn.ts` splits the orchestrator's own pane. That fits running the inbox as a sidebar inside the review session itself. With it, a remote orchestrator dispatches elsewhere: a `job` start run in your work session hands the queue here, and the reviews open in your dedicated review session. The first pane splits that session's active pane rather than carving a sidebar from the orchestrator.
+
+Resize the orchestrator to a sidebar before spawning the first pane, but only when the panes share your window. Skip the resize under `--session`, since the orchestrator does not share the panes' window.
 
 ```bash
 tmux resize-pane -t $TMUX_PANE -x 30%

--- a/plugins/review/skills/inbox/scripts/layout.test.ts
+++ b/plugins/review/skills/inbox/scripts/layout.test.ts
@@ -39,4 +39,17 @@ describe("layoutArgs", () => {
       "TMUX_PANE is not set (not running inside tmux)",
     );
   });
+
+  test("first pane with target session: split that session, no sidebar carve-out", () => {
+    expect(layoutArgs(0, undefined, "reviews")).toEqual(["-h", "-d", "-t", "reviews"]);
+  });
+
+  test("target session does not require TMUX_PANE for the first pane", () => {
+    delete process.env.TMUX_PANE;
+    expect(layoutArgs(0, undefined, "reviews")).toEqual(["-h", "-d", "-t", "reviews"]);
+  });
+
+  test("subsequent panes chain off the last pane even with a target session", () => {
+    expect(layoutArgs(1, "%1", "reviews")).toEqual(["-v", "-d", "-t", "%1"]);
+  });
 });

--- a/plugins/review/skills/inbox/scripts/layout.ts
+++ b/plugins/review/skills/inbox/scripts/layout.ts
@@ -1,17 +1,27 @@
-export function layoutArgs(existingPanes: number, lastPaneId: string | undefined): string[] {
+export function layoutArgs(
+  existingPanes: number,
+  lastPaneId: string | undefined,
+  targetSession?: string,
+): string[] {
+  if (existingPanes > 0 && lastPaneId) {
+    const positionInColumn = existingPanes % 3;
+    if (positionInColumn === 0) {
+      return ["-h", "-d", "-t", lastPaneId];
+    }
+    return ["-v", "-d", "-t", lastPaneId];
+  }
+
+  // First review pane. With a target session, split that session's active pane
+  // and leave it at the default size: the orchestrator lives elsewhere, so
+  // there is no local sidebar to carve out. Without one, the orchestrator
+  // shares this window, so claim 70% for the review and shrink it to a sidebar.
+  if (targetSession) {
+    return ["-h", "-d", "-t", targetSession];
+  }
+
   const orchestratorPane = process.env.TMUX_PANE;
   if (!orchestratorPane) {
     throw new Error("TMUX_PANE is not set (not running inside tmux)");
   }
-
-  if (existingPanes === 0 || !lastPaneId) {
-    return ["-h", "-d", "-l", "70%", "-t", orchestratorPane];
-  }
-
-  const positionInColumn = existingPanes % 3;
-  if (positionInColumn === 0) {
-    return ["-h", "-d", "-t", lastPaneId];
-  }
-
-  return ["-v", "-d", "-t", lastPaneId];
+  return ["-h", "-d", "-l", "70%", "-t", orchestratorPane];
 }

--- a/plugins/review/skills/inbox/scripts/spawn.ts
+++ b/plugins/review/skills/inbox/scripts/spawn.ts
@@ -22,6 +22,11 @@ const argv = cli({
       type: String,
       description: "Additional context to pass as the initial prompt to the spawned session",
     },
+    session: {
+      type: String,
+      description:
+        "Target tmux session for review panes (defaults to splitting the current pane as a sidebar)",
+    },
   },
 });
 
@@ -38,7 +43,11 @@ const sessionId = crypto.randomUUID();
 const paneName = derivePaneName(url);
 const state = await readState(dataDir);
 const activeReviews = state.reviews.filter((r) => r.status === "active");
-const splitArgs = layoutArgs(activeReviews.length, activeReviews.at(-1)?.paneId);
+const splitArgs = layoutArgs(
+  activeReviews.length,
+  activeReviews.at(-1)?.paneId,
+  argv.flags.session,
+);
 
 const prompt = argv.flags.context
   ? `${argv.flags.context}\n\n/review:peer ${url}`


### PR DESCRIPTION
Adds a `--session <name>` flag to `spawn.ts` so reviews can open in a tmux session other than the one running the inbox.

`spawn.ts` split `$TMUX_PANE`, so panes landed wherever the orchestrator ran. That is fine when you run the inbox as a sidebar inside your review session. It breaks once a remote orchestrator dispatches the queue: a `job` start run in your work session was splitting its own pane, so the review panes leaked into that session instead of your dedicated review session.

With `--session reviews`, `layout.ts` targets that session's active pane for the first review and skips the sidebar carve-out, since the orchestrator does not live there. Later panes still chain off the last review pane, which now sits in the target session, so the group-of-three column cycling is unchanged. Omit the flag and behavior is identical to before. The target path also drops the `TMUX_PANE` requirement, since a remote orchestrator need not be in tmux at all.

The layout tests gain cases for the target-session path: the first pane splits the named session, that path no longer needs `TMUX_PANE`, and later panes still chain off the last review pane.

For the actual `job → inbox` handoff to use this, the curated dispatch (#867, #868) has to pass `--session`, with the session name read from `job` config. That wiring is a follow-up on those branches.
