### PR TITLE
pr-comments: react with thumbs up instead of replying

### DIFF
--- a/plugins/github/scripts/review-threads.test.ts
+++ b/plugins/github/scripts/review-threads.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { REPLY_MUTATION, RESOLVE_MUTATION } from "./review-threads";
+import {
+  REACT_MUTATION,
+  REPLY_MUTATION,
+  RESOLVE_MUTATION,
+  THREAD_COMMENT_QUERY,
+} from "./review-threads";
 
 describe("mutations", () => {
   test("reply targets the review thread and posts a body", () => {
@@ -11,5 +16,16 @@ describe("mutations", () => {
   test("resolve targets the review thread", () => {
     expect(RESOLVE_MUTATION).toContain("resolveReviewThread");
     expect(RESOLVE_MUTATION).toContain("threadId: $threadId");
+  });
+
+  test("react adds a reaction to a subject", () => {
+    expect(REACT_MUTATION).toContain("addReaction");
+    expect(REACT_MUTATION).toContain("subjectId: $subjectId");
+    expect(REACT_MUTATION).toContain("content: $content");
+  });
+
+  test("thread comment query reads the first comment of a thread", () => {
+    expect(THREAD_COMMENT_QUERY).toContain("PullRequestReviewThread");
+    expect(THREAD_COMMENT_QUERY).toContain("comments(first: 1)");
   });
 });

--- a/plugins/github/scripts/review-threads.ts
+++ b/plugins/github/scripts/review-threads.ts
@@ -19,6 +19,24 @@ mutation($threadId: ID!) {
 }
 `;
 
+export const THREAD_COMMENT_QUERY = `
+query($threadId: ID!) {
+  node(id: $threadId) {
+    ... on PullRequestReviewThread {
+      comments(first: 1) { nodes { id } }
+    }
+  }
+}
+`;
+
+export const REACT_MUTATION = `
+mutation($subjectId: ID!, $content: ReactionContent!) {
+  addReaction(input: { subjectId: $subjectId, content: $content }) {
+    reaction { content }
+  }
+}
+`;
+
 async function ghGraphQL(query: string, variables: Record<string, string>): Promise<unknown> {
   const args = ["gh", "api", "graphql", "-f", `query=${query}`];
   for (const [key, value] of Object.entries(variables)) {
@@ -88,11 +106,56 @@ const resolveCmd = command(
   },
 );
 
+interface ThreadCommentResponse {
+  data: { node: { comments: { nodes: { id: string }[] } } | null };
+}
+
+async function firstCommentId(threadId: string): Promise<string> {
+  const result = (await ghGraphQL(THREAD_COMMENT_QUERY, { threadId })) as ThreadCommentResponse;
+  const id = result.data.node?.comments.nodes[0]?.id;
+  if (!id) {
+    throw new Error(`No comment found for thread ${threadId}`);
+  }
+  return id;
+}
+
+const reactCmd = command(
+  {
+    name: "react",
+    parameters: ["<thread-id>"],
+    flags: {
+      down: {
+        type: Boolean,
+        description: "React with thumbs down instead of thumbs up",
+        default: false,
+      },
+      resolve: {
+        type: Boolean,
+        description: "Resolve the thread after reacting",
+        default: false,
+      },
+    },
+  },
+  async (parsed) => {
+    const threadId = parsed._.threadId;
+    const content = parsed.flags.down ? "THUMBS_DOWN" : "THUMBS_UP";
+    const subjectId = await firstCommentId(threadId);
+
+    await ghGraphQL(REACT_MUTATION, { subjectId, content });
+    if (parsed.flags.resolve) {
+      await ghGraphQL(RESOLVE_MUTATION, { threadId });
+    }
+    console.error(
+      `Reacted ${parsed.flags.down ? "👎" : "👍"} to ${threadId}${parsed.flags.resolve ? " and resolved" : ""}`,
+    );
+  },
+);
+
 if (import.meta.main) {
   cli(
     {
       name: "review-threads",
-      commands: [replyCmd, resolveCmd],
+      commands: [replyCmd, resolveCmd, reactCmd],
     },
     (parsed) => {
       parsed.showHelp();

--- a/plugins/github/skills/pr-comments/SKILL.md
+++ b/plugins/github/skills/pr-comments/SKILL.md
@@ -78,10 +78,22 @@ bun ${CLAUDE_PLUGIN_ROOT}/scripts/review-threads.ts resolve <thread-id>
 
 Pass the reply text with `--body`, `--bodyFile <path>`, or stdin. Don't resolve without a reply: a silent resolve hides why the thread closed.
 
+## Reacting Instead of Replying
+
+A reply is not always warranted. When the fix is straightforward and a reply would only acknowledge it (test coverage, a rename, an obvious guard), react with a thumbs up instead of writing a reply. A fleshed-out reply with code references to a bot is mechanical noise. The goal is fewer comments, not a new acknowledgement on every thread, so prefer a reaction only where you would otherwise have written a low-value reply, and stay silent where you would have stayed silent.
+
+```bash
+# Thumbs up, optionally resolving in the same call
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/review-threads.ts react <thread-id> --resolve
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/review-threads.ts react <thread-id> --down --resolve
+```
+
+The reaction lands on the thread's first comment. Thumbs down (`--down`) is feedback to a bot reviewer whose comment was wrong or unhelpful. Never thumbs down a human, and never in an autonomous run.
+
 #### Bot Reviewer Threads
 
 A bot reviewer is any account the `--bots` filter catches: accounts the API types as `Bot` (Copilot, CodeRabbit, Greptile) plus logins in `$CLAUDE_PLUGIN_DATA/reviewers.txt`. Use that filter to detect them rather than hardcoding logins.
 
-Do not write human-voiced replies to these threads. No thanks, no "addressed in the latest revision", no conversation with the bot. Push the fix and resolve the thread, or just resolve it.
+Do not write human-voiced replies to these threads. No thanks, no "addressed in the latest revision", no conversation with the bot. Push the fix and resolve the thread, or just resolve it. For a straightforward change, a thumbs up reaction (see [Reacting Instead of Replying](#reacting-instead-of-replying)) acknowledges the bot without a reply.
 
 If a reply is genuinely needed, state the resolution as a terse note for a human reader ("Guarded with a null check"), not a message to the bot.

--- a/plugins/github/skills/pr-comments/SKILL.md
+++ b/plugins/github/skills/pr-comments/SKILL.md
@@ -78,7 +78,7 @@ bun ${CLAUDE_PLUGIN_ROOT}/scripts/review-threads.ts resolve <thread-id>
 
 Pass the reply text with `--body`, `--bodyFile <path>`, or stdin. Don't resolve without a reply: a silent resolve hides why the thread closed.
 
-## Reacting Instead of Replying
+## Reactions
 
 A reply is not always warranted. When the fix is straightforward and a reply would only acknowledge it (test coverage, a rename, an obvious guard), react with a thumbs up instead of writing a reply. A fleshed-out reply with code references to a bot is mechanical noise. The goal is fewer comments, not a new acknowledgement on every thread, so prefer a reaction only where you would otherwise have written a low-value reply, and stay silent where you would have stayed silent.
 
@@ -94,6 +94,6 @@ The reaction lands on the thread's first comment. Thumbs down (`--down`) is feed
 
 A bot reviewer is any account the `--bots` filter catches: accounts the API types as `Bot` (Copilot, CodeRabbit, Greptile) plus logins in `$CLAUDE_PLUGIN_DATA/reviewers.txt`. Use that filter to detect them rather than hardcoding logins.
 
-Do not write human-voiced replies to these threads. No thanks, no "addressed in the latest revision", no conversation with the bot. Push the fix and resolve the thread, or just resolve it. For a straightforward change, a thumbs up reaction (see [Reacting Instead of Replying](#reacting-instead-of-replying)) acknowledges the bot without a reply.
+Do not write human-voiced replies to these threads. No thanks, no "addressed in the latest revision", no conversation with the bot. Push the fix and resolve the thread, or just resolve it. For a straightforward change, a thumbs up reaction (see [Reactions](#reactions)) acknowledges the bot without a reply.
 
 If a reply is genuinely needed, state the resolution as a terse note for a human reader ("Guarded with a null check"), not a message to the bot.

--- a/plugins/pull-request/skills/follow-up/SKILL.md
+++ b/plugins/pull-request/skills/follow-up/SKILL.md
@@ -43,8 +43,8 @@ With `--auto`, drive bot threads to closure without asking. Partition threads wi
 
 Triage each bot thread:
 
-- **Actionable** → fix in the working tree, batching across threads
-- **Noise / false positive** → reply with a one-line reason and resolve
+- **Actionable** → fix in the working tree, batching across threads. For a straightforward fix (test coverage, a rename, an obvious guard), acknowledge with a thumbs up reaction rather than a fleshed-out reply (see `github:pr-comments`, Reacting Instead of Replying)
+- **Noise / false positive** → reply with a one-line reason and resolve, or thumbs down a clearly wrong bot comment
 - **Unsure** → collect to escalate; don't guess
 
 Then run each round:
@@ -65,6 +65,7 @@ On stop, report fixes, replies/resolves, and escalations. If the reviewer is sat
 
 The gated default requires checking before any post or resolve. `--auto` lifts this for **bot threads only**; human threads stay gated unless `--include-human-nits`. Always:
 
-- Resolve only after replying; silent resolves hide context.
-- Never name or thank the bot in a reply; write it as a note for any reader. The `@<bot>` re-trigger is the one exception.
+- Resolve only after replying or reacting; silent resolves hide context.
+- Never name or thank the bot in a reply; write it as a note for any reader. The `@<bot>` re-trigger is the one exception. A thumbs up is the lighter-weight acknowledgement, preferred over a reply for straightforward changes.
+- Thumbs down is bot-only feedback. Never thumbs down a human thread, autonomously or otherwise.
 - Match my writing style; you're replying as me.

--- a/plugins/pull-request/skills/follow-up/SKILL.md
+++ b/plugins/pull-request/skills/follow-up/SKILL.md
@@ -43,7 +43,7 @@ With `--auto`, drive bot threads to closure without asking. Partition threads wi
 
 Triage each bot thread:
 
-- **Actionable** → fix in the working tree, batching across threads. For a straightforward fix (test coverage, a rename, an obvious guard), acknowledge with a thumbs up reaction rather than a fleshed-out reply (see `github:pr-comments`, Reacting Instead of Replying)
+- **Actionable** → fix in the working tree, batching across threads. For a straightforward fix (test coverage, a rename, an obvious guard), acknowledge with a thumbs up reaction rather than a fleshed-out reply (see `github:pr-comments`, Reactions)
 - **Noise / false positive** → reply with a one-line reason and resolve, or thumbs down a clearly wrong bot comment
 - **Unsure** → collect to escalate; don't guess
 


### PR DESCRIPTION
Writing a fully fleshed-out reply with code references to a bot is mechanical behavior, especially for straightforward changes like adding test coverage. Adds a thumbs up reaction as a lighter-weight acknowledgement so those threads close without a reply.

`review-threads.ts` gains a `react` subcommand. It puts a thumbs up (or `--down` thumbs down) on the thread's first comment via the `addReaction` mutation, optionally resolving in the same call. The reaction subject is the bot's comment, looked up from the thread node id.

The `github:pr-comments` and `pull-request:follow-up` guidance now prefers a reaction over a reply for straightforward changes. The intent is fewer comments, not a new acknowledgement on every thread. React only where a low-value reply would otherwise have gone, and stay silent where you would have stayed silent. Thumbs down is reserved for bot threads whose comment was wrong, never a human thread, and never in an autonomous run.
