### PR TITLE
review: read upstream issues for causal context in peer review

### DIFF
--- a/plugins/review/skills/peer/research.md
+++ b/plugins/review/skills/peer/research.md
@@ -3,6 +3,6 @@
 Gather context before reviewing:
 
 - [ ] Read the project's CLAUDE.md to understand conventions, coding standards, and project-specific guidelines
-- [ ] If issues are referenced in the body, fetch their content and comments from the platform API
+- [ ] Read any upstream issues linked in the PR body, including their comments, via the platform API. The issue is where the change originates, so it carries the causal context: the problem being solved, constraints discussed, and alternatives ruled out. Use that intent to judge whether the diff actually addresses the problem
 - [ ] If URLs are referenced, fetch with `WebFetch`
 - [ ] If insufficient context about motivation or implementation, ask me for additional information


### PR DESCRIPTION
Strengthens the peer-review research checklist to push the reviewer toward the upstream issue before reading the diff. The issue carries causal context the diff can't: the problem being solved, constraints discussed, and alternatives ruled out. The prior wording treated fetching linked issues as an optional lookup, so it left the reviewer judging the diff for internal correctness without knowing what it was meant to fix.
