### PR TITLE
afk: add skill to keep working while away

### DIFF
--- a/user/skills/afk/SKILL.md
+++ b/user/skills/afk/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: afk
+description: >
+  Signal that you are stepping away so the agent keeps working without
+  stalling on prompts. Drives the current task to completion, batches
+  reversible decisions behind safe defaults, raises only irreversible
+  ones via push, and defers bandwidth- or power-heavy work when tethered,
+  on battery, or lid-closed. Use via /afk or /afk <duration>.
+argument-hint: "[duration]"
+disable-model-invocation: true
+---
+
+# AFK
+
+Ben is stepping away. Keep the current task moving without him at the keyboard. Assume he cannot answer in real time, never idle on a prompt for a reversible decision, and avoid bandwidth- or power-heavy work when the machine is constrained.
+
+Duration argument: `$0` (e.g. `30m`, `2h`, `overnight`). It is a pacing and expected-return hint, not a hard timer. With no duration, run open-ended until the task is done or fully blocked.
+
+## Read state at invocation
+
+Ben is still present right now. Surface read-only state and let the model interpret the raw output. Interpretation and the sandbox caveat live in [references/resources.md](references/resources.md).
+
+- Local time: !`date "+%A %H:%M"`
+- Power source: !`pmset -g ps`
+- Lid / clamshell: !`ioreg -r -k AppleClamshellState`
+- Network addresses (tether): !`ifconfig | grep "inet "`
+
+Classify from the output above:
+
+- `AC Power` is plugged in, `Battery Power` is on battery. No `InternalBattery` line means a desktop (treat as AC, no battery constraint).
+- A node block with `"AppleClamshellState" = Yes` means the lid is closed. `= No` means open. Empty output means no lid (desktop). Treat empty as open.
+- An `inet` address in `172.20.10.0/28` (starts `172.20.10.`) means an iPhone Personal Hotspot, USB or Wi-Fi. Any other address means no tether detected. SSID is redacted in current macOS, so this subnet is the available hotspot signal.
+
+## Handshake while present
+
+Use this moment before Ben leaves. Keep it to a few lines, then proceed.
+
+1. One line of detected state: power, lid, tether, and expected return if a duration was given.
+2. State the contract being entered: finish the current task, batch reversible decisions behind logged defaults, defer bandwidth- and power-heavy steps under the detected constraints.
+3. Remind him to switch to a permissive mode (`shift+tab` to `acceptEdits`, or `auto`) so edits and commands do not stall while he is away. This skill cannot detect or set permission mode.
+4. Remind him that blocking questions reach his phone only if Remote Control is connected and push is enabled in `/config`.
+5. If the in-flight task already has a genuinely ambiguous priority or a visible irreversible fork, ask it **now** with `AskUserQuestion` while he can answer cheaply. Otherwise proceed without ceremony.
+
+## AFK contract
+
+Once he is away, follow this until the task completes or the session is fully blocked.
+
+### Keep moving
+
+Never idle waiting on a prompt for a reversible decision. Choose the sensible default, record it in the log, and continue.
+
+### Decision triage
+
+- Reversible / safe / expected: act, log the assumption.
+- Irreversible or outward-facing (rename a public API, push to a default branch, publish, send a message, delete something not created this session): never auto-do. `PushNotification` then `AskUserQuestion`. If unrelated work remains, continue it while waiting. If nothing else remains, stop.
+- Whole task blocked on his input: batch the open questions, send one `PushNotification`, then `AskUserQuestion`.
+
+### Resource gating (defer and note)
+
+Under battery, tether, or closed lid, skip installs, large pulls, large downloads, and heavy builds. Log each skipped step with its reason. Edits, tests, git, reviews, and reads proceed normally. The gating table is in [references/resources.md](references/resources.md).
+
+Re-read state live at the gate. Ben typically closes the lid, unplugs, and switches to a hotspot **after** typing `/afk`, as he walks away, so the invocation snapshot reflects the desk rather than the constraints that matter once he is gone. Before any gated action re-run `pmset -g ps`, `ioreg -r -k AppleClamshellState`, and `ifconfig | grep "inet "` and gate on the fresh result. These are infrequent actions and the commands are sandbox-safe, so the re-check is cheap.
+
+### Honor existing safety rules
+
+The base instruction against hard-to-reverse, outward-facing actions without authorization still holds and is reinforced here. AFK lowers the bar for reversible decisions only, never for irreversible ones.
+
+### Running log
+
+Keep a scratchpad at `tmp/afk-<HHMM>.md` (use the invocation time). Record completed steps, assumptions and defaults taken, deferred (gated) steps with reasons, and queued questions. This makes the return brief instant.
+
+### Pacing with duration
+
+If the task needs an external wait (CI, a deploy), use `ScheduleWakeup` to resume near the wait's end instead of idling. Aim to have a clean summary ready by the stated return. With no duration, run open-ended until done or blocked.
+
+## Return / wrap-up
+
+There is no signal for when Ben returns. Deliver the summary when work completes or blocks, and again on his next message. Send a final `PushNotification` (`done` or `blocked on N decisions`) so it reaches his phone if Remote Control is connected. Then present the scratchpad as a short brief: what shipped, what was assumed, what was deferred and why, and any queued questions.

--- a/user/skills/afk/references/resources.md
+++ b/user/skills/afk/references/resources.md
@@ -1,0 +1,56 @@
+# Resource detection
+
+The four detection commands run cleanly inside Claude Code's command sandbox. Read their raw output and classify as below.
+
+## Power
+
+```
+pmset -g ps
+```
+
+Output names the active source. `Now drawing from 'AC Power'` is plugged in. `Now drawing from 'Battery Power'` is on battery, and the battery line shows a percentage.
+
+A desktop has no battery. `pmset -g batt` prints no `InternalBattery` line on a desktop. Treat a desktop as always AC, with no battery constraint.
+
+## Lid / clamshell
+
+```
+ioreg -r -k AppleClamshellState
+```
+
+A node block containing `"AppleClamshellState" = Yes` means the lid is closed (clamshell mode, usually driving an external display). `= No` means open. Empty output means the machine has no lid (desktop) or the key is absent. Treat empty as open.
+
+## Tether
+
+```
+ifconfig | grep "inet "
+```
+
+An iPhone Personal Hotspot hands out addresses in the `172.20.10.0/28` subnet with gateway `172.20.10.1`, the same for USB and Wi-Fi. An `inet` line starting `172.20.10.` is therefore a reliable hotspot signal that covers both. The netmask reads `0xfffffff0` (/28). Ignore `utun`/`100.x` addresses (Tailscale) and loopback `127.0.0.1`.
+
+Limits, stated honestly:
+
+- SSID is redacted in current macOS and is not retrievable from the shell, so a non-iPhone hotspot or a captive metered Wi-Fi cannot be identified by name. The `172.20.10.0/28` check is specific to iPhone Personal Hotspot.
+- The OS metered / Low Data Mode / "expensive" flag is not shell-readable.
+
+When the subnet is ambiguous or unknown, prefer the conservative reading and gate bandwidth-heavy work.
+
+## Sandbox caveat
+
+`pmset`, `ioreg`, and `ifconfig` work in-sandbox and return through the normal Bash tool without a bypass prompt. `ifconfig` reads interface state directly, so it stays inside the sandbox.
+
+Do **not** use `route -n get default`, `scutil --dns` / `scutil -r`, `ipconfig getifaddr`, or `netstat -rn` for interface, gateway, or reachability detection. They go through configd or raw sockets, which the command sandbox blocks. Grep `ifconfig` for the address instead.
+
+## Gating table
+
+Under any active constraint, defer the listed action classes and log each skipped step with its reason. Everything not listed proceeds normally.
+
+| Action class | Battery | Tether | Closed lid |
+| --- | --- | --- | --- |
+| Package install (`npm install`, `bun install`, `brew install`, etc.) | defer | defer | defer |
+| Large `git pull` / fetch / clone | proceed | defer | defer |
+| Large download (assets, models, datasets) | defer | defer | defer |
+| Heavy build (full compile, Docker build, image bake) | defer | proceed | defer |
+| Edits, tests, lint, git commit, reviews, file reads | proceed | proceed | proceed |
+
+Closed lid is the strictest gate: a lidded laptop is often thermally constrained and on a metered link, so defer both bandwidth- and power-heavy work. Battery gates power-heavy and bandwidth-heavy work but not ordinary fetches. Tether gates bandwidth-heavy work but not local compute.


### PR DESCRIPTION
Adds a user-level `/afk` skill that signals you are stepping away so the agent drives the current in-flight task to completion instead of stalling on prompts. It batches reversible decisions behind logged defaults, raises only irreversible or outward-facing ones via `PushNotification` + `AskUserQuestion`, and defers bandwidth- or power-heavy work (installs, large pulls, heavy builds) when the machine is on battery, tethered, or running lid-closed.

The design works around three researched constraints: a running session cannot detect whether it is being viewed through Remote Control, a skill cannot read or change permission mode, and macOS state is only partly shell-readable. So the handshake runs while you are still at the keyboard. It reminds you to switch to a permissive mode and that blocking questions reach your phone only when Remote Control is connected, since the skill can neither set the mode nor guarantee the push.

Two decisions came out of testing the detection commands on real laptop hardware over SSH:

- **Tether detection keys on the iPhone hotspot subnet.** An earlier `iPhone USB` port check only caught a wired tether. The hotspot hands out `172.20.10.0/28` addresses for both USB and Wi-Fi, so `ifconfig | grep "inet "` matching `172.20.10.` covers the Wi-Fi hotspot case that the port check missed entirely. SSID is redacted in current macOS, so this subnet is the available signal.
- **The resource gate re-reads state live before each deferred action.** The lid usually closes and power unplugs *after* `/afk` is typed, as you walk away, so the invocation snapshot reflects the desk rather than the constraints that matter once you are gone. The gated actions are infrequent and the commands are sandbox-safe, so re-checking at the gate is cheap and accurate.

All four detection shapes are verified on hardware: `AC`/`Battery` power, `InternalBattery` present on a laptop, `AppleClamshellState` `= Yes`/`= No`, and the `172.20.10.x` hotspot address. The commands also return inside Claude Code's command sandbox without a bypass prompt. The reference documents the sandbox-blocked alternatives to avoid (`route`, `scutil`, `ipconfig getifaddr`, `netstat -rn`), which go through configd or raw sockets.

The skill mirrors the `job` skill: `disable-model-invocation: true` for zero recurring catalog cost, inline bang-execution for read-only state, and a `references/resources.md` for detail. It conforms to `skill-lint` (frontmatter, description length, reference resolution, bang-execution syntax).
