### PR TITLE
settings: add fallbackModel, retention, and autoMode rules

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -1,6 +1,20 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "theme": "auto",
+  "fallbackModel": ["sonnet"],
+  "cleanupPeriodDays": 90,
+  "autoMode": {
+    "hard_deny": [
+      "$defaults",
+      "Never git push to the default branch (main or master).",
+      "Never force-push to a shared branch or any branch you do not own; only your own stacked-PR branches may be force-pushed."
+    ],
+    "soft_deny": [
+      "$defaults",
+      "Pause before destructive filesystem operations such as rm -rf or overwriting existing files outside tmp/ and .worktrees/.",
+      "Do not create a pull request or merge request on a third-party repository (one I do not own or maintain) unless I explicitly asked for one; offer it for confirmation first."
+    ]
+  },
   "attribution": {
     "commit": "",
     "pr": ""


### PR DESCRIPTION
Configures three settings surfaced while auditing the docs for options I had never set.

`fallbackModel` is Sonnet, so an overloaded primary degrades transparently instead of stalling.

`cleanupPeriodDays` moves from the 30-day default to 90. I measured `~/.claude/projects/` first: ~607 MB across 2000 session files, growing ~18 MB/day, and the 30-day default was already pruning the corpus daily. 90 days keeps a full quarter of history for the DuckDB session-mining tooling while bounding disk at ~1.6 GB. 365 was too loose (~6 GB), 30 too short to mine.

`autoMode` augments the built-in classifier defaults (each array keeps `"$defaults"`) by encoding rules I already treat as inviolable, so auto mode cannot trip them:

- `hard_deny`: pushing to the default branch, and unsafe force-pushes to shared or unowned branches
- `soft_deny`: destructive filesystem operations outside `tmp/` and `.worktrees/`, and pull request creation on third-party repos unless I explicitly asked

I deferred any `allow` rules rather than grant them speculatively. They can go in the first time a repeated approval becomes a real annoyance.

Deliberately skipped from the same audit: remote control at startup (I curate that per session to avoid mobile clutter), `autoUpdatesChannel` (I update via Homebrew), `effortLevel`, `claudeMdExcludes`, and `disableBundledSkills` (several are in use).

## References

`fileSuggestion` is tracked separately in #876.
