### PR TITLE
settings: add footer link badges for standard IDs

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -5,6 +5,50 @@
     "commit": "",
     "pr": ""
   },
+  "footerLinksRegexes": [
+    {
+      "type": "regex",
+      "pattern": "\\b(?<repo>[A-Za-z0-9][\\w.-]*/[A-Za-z0-9][\\w.-]*)#(?<number>\\d+)\\b",
+      "url": "https://github.com/{repo}/issues/{number}",
+      "label": "{repo}#{number}"
+    },
+    {
+      "type": "regex",
+      "pattern": "\\bPEP[ -]?(?<number>\\d{3,4})\\b",
+      "url": "https://peps.python.org/pep-{number}/",
+      "label": "PEP {number}"
+    },
+    {
+      "type": "regex",
+      "pattern": "\\bRFC[ -]?(?<number>\\d{3,5})\\b",
+      "url": "https://datatracker.ietf.org/doc/html/rfc{number}",
+      "label": "RFC {number}"
+    },
+    {
+      "type": "regex",
+      "pattern": "\\b(?<id>CVE-\\d{4}-\\d{4,})\\b",
+      "url": "https://nvd.nist.gov/vuln/detail/{id}",
+      "label": "{id}"
+    },
+    {
+      "type": "regex",
+      "pattern": "\\bCWE-(?<number>\\d+)\\b",
+      "url": "https://cwe.mitre.org/data/definitions/{number}.html",
+      "label": "CWE-{number}"
+    },
+    {
+      "type": "regex",
+      "pattern": "\\b(?<id>GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4})\\b",
+      "url": "https://github.com/advisories/{id}",
+      "label": "{id}"
+    },
+    {
+      "type": "regex",
+      "pattern": "\\b(?<id>GO-\\d{4}-\\d+)\\b",
+      "url": "https://pkg.go.dev/vuln/{id}",
+      "label": "{id}"
+    }
+  ],
   "permissions": {
     "allow": [
       "Bash(mkdir:*)",


### PR DESCRIPTION
Adds `footerLinksRegexes` so standard identifiers in turn output render as clickable footer badges. Claude Code's built-in detection only resolves the current repo's `#123` PRs against the git remote. A regex has no git context, so these cover identifiers that carry their own globally-resolvable URL.

Each entry is a public SaaS with no org name in the URL, which keeps this config safe to publish:

- Cross-repo GitHub refs: `owner/repo#N` to `github.com/{repo}/issues/{number}` (GitHub redirects `/issues/N` to the PR when N is one).
- `PEP N`, `RFC N` to the canonical spec sites.
- The security family `CVE`, `CWE`, `GHSA`, and Go's `GO-YYYY-NNNN` vuln IDs to NVD, MITRE, GitHub advisories, and `pkg.go.dev/vuln`.

## Deliberate Exclusions

The dominant identifier in my history is a Linear team prefix (`ENG-NNNN`). It's proprietary, so it stays out until a settings-merge layer can hold work-only patterns. `prUrlTemplate` is out for the same reason. Its only real use is remapping PR links to an internal review tool, and it globally overrides the `github.com` default that public repos want. GitLab MRs can't work here at all: their URLs need a `group/project` that a regex has no way to recover.

## Verification

I mined assistant turn output across the session corpus to ground the patterns and check false positives. The matched tokens were real PEPs, RFCs, and cross-repo refs (one stray diff anchor, `file.md#21145`, the only false positive). I fetched a live URL for each template to confirm the slug format resolves: non-padded `pep-649`, `cwe.mitre.org/data/definitions/79.html`, and `pkg.go.dev/vuln/GO-2022-0969` all load.
