### PR TITLE
session: query plan structure and frontmatter from disk

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -25,7 +25,7 @@ The sandbox is egress control, not filesystem lockdown. Credentials stay outside
 
 ### Hosts (`WebFetch(domain:...)` Permissions)
 
-- Package registries: `registry.npmjs.org`, `www.npmjs.com`, `pypi.org`, `rubygems.org`, `proxy.golang.org`, `sum.golang.org`.
+- Package registries: `registry.npmjs.org`, `www.npmjs.com`, `pypi.org`, `rubygems.org`, `proxy.golang.org`, `sum.golang.org`, `community-extensions.duckdb.org` (DuckDB community extensions `markdown`/`yaml`, fetched on first `INSTALL ... FROM community`).
 - Docs and source: `docs.anthropic.com`, `code.claude.com`, `modelcontextprotocol.io`, `pkg.go.dev`, `bun.sh`, `bun.com`, `github.com`, `raw.githubusercontent.com`.
 - Credentialed APIs: `api.github.com`, `api.linear.app`, `api.anthropic.com`, `claude.ai`. Trusted only because each secret lives outside the sandbox.
 

--- a/plugins/claude-code/skills/session/README.md
+++ b/plugins/claude-code/skills/session/README.md
@@ -12,7 +12,14 @@ Search and analyze Claude Code conversation history using a DuckDB index over JS
 - `scripts/db.ts` - DuckDB index, schema, host enumeration, and query logic
 - `resources/schema/` - Table and view definitions (ordered, run on startup)
 - `resources/queries/` - Parameterized SQL for built-in queries
+- `resources/extensions.sql` - Community extension setup (`markdown`, `yaml`), pulled into a query process via `-init`
 - `resources/import.sql` - JSONL parsing and flattening
+
+## Community Extensions
+
+The `plan-sections` and `frontmatter` queries read markdown and YAML from disk through DuckDB's `markdown` and `yaml` community extensions. Run them with `duckdb -readonly -init resources/extensions.sql`, which loads both before the piped query. The index/refresh path needs no extensions.
+
+DuckDB fetches these from `community-extensions.duckdb.org` on first `INSTALL ... FROM community`, then caches them per host under `~/.duckdb/extensions/`. The sandbox blocks network by default, so that host is allowlisted in `user/settings.json` (`WebFetch(domain:community-extensions.duckdb.org)`). Without it, the first install fails with a download error until the extension is cached.
 
 ## Testing
 

--- a/plugins/claude-code/skills/session/SKILL.md
+++ b/plugins/claude-code/skills/session/SKILL.md
@@ -101,6 +101,32 @@ Every query also takes an optional `host` param. Omit it to span every machine (
 - `sandbox-bypass-effective-command`: top `dangerouslyDisableSandbox` commands normalized to their real verb after stripping a leading `cd <path>` wrapper (`excludedCommands` candidates). Params: `min_count` (default 5), `after_date`, `before_date`, `project`, `host`.
 - `plans`: sessions that used plan mode (ExitPlanMode), with per-session plan count, redirect/approved breakdown, and a `replan_tier` label (`single` / `replan` / `off-rails` for plan_count >= 3). Sorted by plan_count descending. Params: `min_plans` (default 1), `after_date`, `before_date`, `project`, `host`.
 
+### Markdown and YAML on Disk
+
+Two queries read files on disk through community extensions instead of the index. They need `markdown`/`yaml` loaded, so run them with `-init resources/extensions.sql`, which loads both in the same process before the piped query and runs under `-readonly`. The common-path queries above omit `-init` and pay nothing.
+
+```bash
+duckdb -readonly -init ${CLAUDE_SKILL_DIR}/resources/extensions.sql "$DB" \
+  < ${CLAUDE_SKILL_DIR}/resources/queries/plan-sections.sql
+```
+
+- `plan-sections`: one row per markdown section across plan files on disk, joined to the session that produced each plan (outcome, replan sequence). The glob self-defaults to `~/.claude/plans/*.md` and takes an optional `plans_glob` override. Reads plan structure rather than re-parsing headings by hand, e.g. "which plans have no Verification section":
+
+  ```sql
+  -- prepend SET VARIABLE plans_glob = '...'; to scope
+  WITH s AS (
+    SELECT file_path, bool_or(title = 'Verification') AS has_verification
+    FROM read_markdown_sections('~/.claude/plans/*.md', filename=true)
+    GROUP BY file_path
+  )
+  SELECT file_path FROM s WHERE NOT has_verification;
+  ```
+
+  Local-host caveat: plans are read from the local disk, so a `plan_calls.plan_file` from an imported host (or a deleted plan) has no file to read. The `LEFT JOIN` simply omits its sections, so session-side data is unaffected. Embedded `$.input.plan` (via `plan_calls.plan_chars` / `content_items`) stays the source for cross-host and point-in-time needs.
+- `frontmatter`: one row per markdown file with YAML frontmatter, returning typed `name`/`description` and `content_chars`. The glob self-defaults to the memory corpus (`~/.claude/projects/*/memory/*.md`), where the nested `metadata` frontmatter auto-expands into a typed struct. Override with `frontmatter_glob` for skills, which live under `~/.claude/plugins` (not `~/.claude/skills`) and are duplicated across cache version-hashes, so pin one copy: `plugins/*/skills/*/SKILL.md` for repo skills.
+
+The reusable pattern for markdown/YAML on disk: a self-defaulting glob (`~` expands to home, override via `SET VARIABLE`) feeding a table function over files (`read_markdown_sections` for body structure, `read_yaml_frontmatter` for frontmatter), never materializing file bodies into a column, with extension setup centralized in `resources/extensions.sql` and pulled in via `-init`. Follow it for new markdown-on-disk needs rather than reinventing regex parsing.
+
 ## Cross-Machine History
 
 Session history copied from another machine is queryable alongside this machine's. Each machine is a `host`: this one is always `local`, and every imported machine gets a label you choose. With nothing imported, the index behaves exactly as the single-machine case.

--- a/plugins/claude-code/skills/session/fixtures/plans/feature-plan.md
+++ b/plugins/claude-code/skills/session/fixtures/plans/feature-plan.md
@@ -1,0 +1,19 @@
+# Feature Plan
+
+## Context
+
+The widget pipeline drops events under load. This plan adds backpressure.
+
+## Plan
+
+- Add a bounded queue in front of the consumer.
+- Surface a depth metric.
+
+### Queue Sizing
+
+Default to 1024 entries, override via config.
+
+## Verification
+
+- `bun test` passes.
+- Load test shows no dropped events at 2x throughput.

--- a/plugins/claude-code/skills/session/fixtures/plans/quick-plan.md
+++ b/plugins/claude-code/skills/session/fixtures/plans/quick-plan.md
@@ -1,0 +1,9 @@
+# Quick Plan
+
+## Context
+
+A one-line config typo breaks startup. Fix the default value.
+
+## Plan
+
+- Correct the default in `config.ts`.

--- a/plugins/claude-code/skills/session/resources/extensions.sql
+++ b/plugins/claude-code/skills/session/resources/extensions.sql
@@ -1,0 +1,7 @@
+-- Community extensions shared by the queries that read markdown/YAML from disk.
+-- Pulled into a query process via `duckdb -readonly -init extensions.sql`, which
+-- runs this before stdin so the piped query sees the extensions. Query files stay
+-- pure SQL; never inline INSTALL/LOAD there. The schema/index path (refresh.ts,
+-- resources/schema/) is untouched and stays extension-free.
+INSTALL markdown FROM community; LOAD markdown;
+INSTALL yaml FROM community; LOAD yaml;

--- a/plugins/claude-code/skills/session/resources/queries/frontmatter.sql
+++ b/plugins/claude-code/skills/session/resources/queries/frontmatter.sql
@@ -1,0 +1,29 @@
+-- Frontmatter: one row per markdown file with YAML frontmatter, parsed with the
+-- `yaml` community extension (load it via `-init resources/extensions.sql`). Returns
+-- the typed `name`/`description` fields plus the body in one shot, replacing a
+-- regex `^---...---$` split. The glob self-defaults to the memory corpus (the clean,
+-- frontmatter-native set under ~/.claude) and accepts an optional `frontmatter_glob`
+-- override. On memory files the nested `metadata` frontmatter auto-expands into a
+-- typed struct; select `metadata` directly when querying that corpus.
+--
+-- Override the glob for skills, which live under ~/.claude/plugins (not the personal
+-- ~/.claude/skills dir) and are duplicated across cache version-hashes, so a path that
+-- pins one copy reads cleaner:
+--   SET VARIABLE frontmatter_glob = 'plugins/*/skills/*/SKILL.md';                  -- repo skills
+--   SET VARIABLE frontmatter_glob = '~/.claude/plugins/marketplaces/*/*/skills/*/SKILL.md';
+--
+-- Params: frontmatter_glob (override the default memory dir).
+SELECT
+  filename AS file_path,
+  name,
+  description,
+  length(content) AS content_chars
+FROM read_yaml_frontmatter(
+  COALESCE(
+    TRY_CAST(getvariable('frontmatter_glob') AS VARCHAR),
+    '~/.claude/projects/*/memory/*.md'
+  ),
+  content:=true,
+  filename:=true
+)
+ORDER BY file_path;

--- a/plugins/claude-code/skills/session/resources/queries/plan-sections.sql
+++ b/plugins/claude-code/skills/session/resources/queries/plan-sections.sql
@@ -1,0 +1,39 @@
+-- Plan structure: one row per markdown section across plan files on disk, joined to
+-- the session that produced each plan. Reads plans with the `markdown` community
+-- extension (load it via `-init resources/extensions.sql`). The glob self-defaults to
+-- the local plans dir and accepts an optional `plans_glob` override.
+--
+-- Disk plans are local-host current state: a `plan_calls.plan_file` from another
+-- machine (or a deleted plan) has no file on disk, so the LEFT JOIN leaves it out of
+-- the section rows without affecting session-side data. Use embedded `$.input.plan`
+-- (via plan_calls.plan_chars / content_items) for cross-host or point-in-time needs.
+--
+-- Params: plans_glob (override the default plans dir).
+-- Example: plans whose section titles never include "Verification".
+WITH sections AS (
+  SELECT
+    file_path,
+    level,
+    title,
+    md_to_text(content) AS content_text,
+    start_line,
+    end_line
+  FROM read_markdown_sections(
+    COALESCE(
+      TRY_CAST(getvariable('plans_glob') AS VARCHAR),
+      '~/.claude/plans/*.md'
+    ),
+    filename=true
+  )
+)
+SELECT
+  pc.session_id,
+  pc.outcome,
+  pc.plan_seq,
+  s.file_path,
+  s.level,
+  s.title,
+  s.end_line - s.start_line AS section_lines
+FROM sections s
+LEFT JOIN plan_calls pc ON pc.plan_file = s.file_path
+ORDER BY s.file_path, s.start_line;

--- a/plugins/claude-code/skills/session/resources/queries/plan-sections.sql
+++ b/plugins/claude-code/skills/session/resources/queries/plan-sections.sql
@@ -8,6 +8,13 @@
 -- the section rows without affecting session-side data. Use embedded `$.input.plan`
 -- (via plan_calls.plan_chars / content_items) for cross-host or point-in-time needs.
 --
+-- TODO(https://github.com/teaguesterling/duckdb_markdown/pull/20): we read sections
+-- from disk because `md_extract_sections` is binder-ambiguous on VARCHAR input, so the
+-- embedded `$.input.plan` text can't be sectioned in-memory. Once that fix is released,
+-- `md_extract_sections` over `plan_calls`' embedded plan supersedes the disk read: it
+-- works cross-host and point-in-time with no missing-file caveat. Revisit whether this
+-- on-disk query is still worth keeping at that point.
+--
 -- Params: plans_glob (override the default plans dir).
 -- Example: plans whose section titles never include "Verification".
 WITH sections AS (

--- a/plugins/claude-code/skills/session/scripts/db.test.ts
+++ b/plugins/claude-code/skills/session/scripts/db.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import * as path from "node:path";
@@ -24,6 +24,20 @@ function queryParams(overrides: Record<string, string | null> = {}) {
 let db: Database;
 let tmpDir: string;
 let importsDir: string;
+
+// The first `INSTALL ... FROM community` downloads the markdown/yaml extensions over
+// the network, which can exceed the default per-test timeout on a cold CI runner.
+// Warm the shared extension cache once so the per-test LOAD reads from disk.
+beforeAll(async () => {
+  const warmDir = mkdtempSync(path.join(process.env.TMPDIR || "/tmp", "session-warm-"));
+  const warm = await getDb(warmDir);
+  try {
+    await loadExtensions(warm);
+  } finally {
+    warm.close();
+    await rm(warmDir, { recursive: true, force: true });
+  }
+}, 120_000);
 
 async function importFixtureHost(label: string, opts: { source?: string } = {}) {
   const projects = path.join(importsDir, label, "projects");

--- a/plugins/claude-code/skills/session/scripts/db.test.ts
+++ b/plugins/claude-code/skills/session/scripts/db.test.ts
@@ -6,6 +6,12 @@ import { $ } from "bun";
 import { type Database, dirExists, ensureIndex, getDb, rebuildViews, runQuery } from "./db";
 
 const fixturesDir = path.join(import.meta.dirname, "..", "fixtures", "sessions");
+const resourcesDir = path.join(import.meta.dirname, "..", "resources");
+const plansFixtureDir = path.join(import.meta.dirname, "..", "fixtures", "plans");
+
+async function loadExtensions(database: Database) {
+  await database.run(await Bun.file(path.join(resourcesDir, "extensions.sql")).text());
+}
 
 function filterParams(overrides: Record<string, string | null> = {}) {
   return { after_date: null, before_date: null, project: null, host: null, ...overrides };
@@ -935,5 +941,138 @@ describe("plan_calls view and plans query", () => {
       min_plans: "3",
     });
     expect(rows.find((r) => r.session_id === "plan-session")).toBeUndefined();
+  });
+});
+
+describe("plan-sections query", () => {
+  const plansGlob = path.join(plansFixtureDir, "*.md");
+  const featurePlan = path.join(plansFixtureDir, "feature-plan.md");
+
+  type Section = {
+    session_id: string | null;
+    outcome: string | null;
+    title: string;
+    level: number;
+    file_path: string;
+  };
+
+  beforeEach(async () => {
+    await loadExtensions(db);
+  });
+
+  async function insertDiskPlan() {
+    // A plan_calls row whose planFilePath points at an on-disk fixture, so its
+    // sections join to session context. content_items rebuilds from raw on rebuildViews.
+    const assistant = JSON.stringify({
+      type: "assistant",
+      sessionId: "disk-plan-session",
+      cwd: "/Users/test/project",
+      timestamp: "2026-02-01T10:00:00.000Z",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "disk-plan-1",
+            name: "ExitPlanMode",
+            input: { plan: "# Feature Plan", planFilePath: featurePlan },
+          },
+        ],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+    });
+    const result = JSON.stringify({
+      type: "user",
+      sessionId: "disk-plan-session",
+      timestamp: "2026-02-01T10:01:00.000Z",
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "disk-plan-1",
+            content: "User has approved your plan. You can now start coding.",
+          },
+        ],
+      },
+    });
+    for (const [type, line, ts] of [
+      ["assistant", assistant, "2026-02-01T10:00:00"],
+      ["user", result, "2026-02-01T10:01:00"],
+    ] as const) {
+      await db.run(
+        `INSERT INTO raw (host, session_id, type, project_path, timestamp, data)
+         VALUES ('local', 'disk-plan-session', $type, '/Users/test/project',
+                 $ts::TIMESTAMP, $line::JSON)`,
+        { type, ts, line },
+      );
+    }
+    await rebuildViews(db);
+  }
+
+  it("parses one row per section with level and title", async () => {
+    const rows = await runQuery<Section>(db, "plan-sections", { plans_glob: plansGlob });
+    const feature = rows.filter((r) => r.file_path === featurePlan);
+    expect(feature.map((r) => r.title)).toEqual([
+      "Feature Plan",
+      "Context",
+      "Plan",
+      "Queue Sizing",
+      "Verification",
+    ]);
+    expect(feature.find((r) => r.title === "Queue Sizing")?.level).toBe(3);
+  });
+
+  it("finds plans whose sections lack a Verification heading", async () => {
+    const rows = await runQuery<Section>(db, "plan-sections", { plans_glob: plansGlob });
+    const byFile = new Map<string, Set<string>>();
+    for (const r of rows) {
+      if (!byFile.has(r.file_path)) byFile.set(r.file_path, new Set());
+      byFile.get(r.file_path)!.add(r.title);
+    }
+    const missing = [...byFile.entries()]
+      .filter(([, titles]) => !titles.has("Verification"))
+      .map(([file]) => file);
+    expect(missing).toContain(path.join(plansFixtureDir, "quick-plan.md"));
+    expect(missing).not.toContain(featurePlan);
+  });
+
+  it("joins sections to the session that produced the plan", async () => {
+    await insertDiskPlan();
+    const rows = await runQuery<Section>(db, "plan-sections", { plans_glob: plansGlob });
+
+    const feature = rows.filter((r) => r.file_path === featurePlan);
+    expect(feature.length).toBeGreaterThan(0);
+    for (const r of feature) {
+      expect(r.session_id).toBe("disk-plan-session");
+      expect(r.outcome).toBe("approved");
+    }
+
+    // quick-plan.md has no matching plan_calls row, so the LEFT JOIN leaves it null.
+    const quick = rows.filter((r) => r.file_path === path.join(plansFixtureDir, "quick-plan.md"));
+    expect(quick.length).toBeGreaterThan(0);
+    for (const r of quick) expect(r.session_id).toBeNull();
+  });
+
+  it("omits a plan whose planFilePath does not exist on disk (cross-host/deleted)", async () => {
+    // The plan-session fixture's planFilePath is /Users/test/.claude/plans/plan-session.md,
+    // outside the glob. The LEFT JOIN from sections means that plan yields no section rows.
+    const rows = await runQuery<Section>(db, "plan-sections", { plans_glob: plansGlob });
+    expect(rows.some((r) => r.session_id === "plan-session")).toBe(false);
+  });
+});
+
+describe("frontmatter query", () => {
+  it("parses name and description from a SKILL.md frontmatter", async () => {
+    await loadExtensions(db);
+    const skill = path.join(import.meta.dirname, "..", "SKILL.md");
+    const rows = await runQuery<{ file_path: string; name: string; description: string }>(
+      db,
+      "frontmatter",
+      { frontmatter_glob: skill },
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.name).toBe("claude-code:session");
+    expect(rows[0]?.description).toContain("DuckDB index");
   });
 });

--- a/user/settings.json
+++ b/user/settings.json
@@ -19,6 +19,7 @@
       "WebFetch(domain:www.npmjs.com)",
       "WebFetch(domain:pypi.org)",
       "WebFetch(domain:rubygems.org)",
+      "WebFetch(domain:community-extensions.duckdb.org)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)",
       "WebFetch(domain:api.github.com)",


### PR DESCRIPTION
Adds two queries to the session skill that read markdown and YAML from disk through DuckDB community extensions, so plan *structure* becomes queryable instead of regex-parsed. The plan view already exposed plan metadata (`plan_chars`, outcome) from the JSONL index, but answering "which of my plans actually have a Context and Verification section?" still meant reading each file and parsing headings by hand.

`plan-sections` reads plan files with the `markdown` extension and joins each section to the session that produced it via `plan_calls`, carrying outcome and replan sequence onto structural rows. `frontmatter` reads YAML frontmatter with the `yaml` extension.

## Decisions

Plans are read from **disk**, not from the embedded `$.input.plan` string in the JSONL. "Do my plans follow the guidance structure" is inherently a local, current-state question, and the disk path (`read_markdown_sections`) is the clean one. The embedded-string path is blocked anyway: `md_extract_sections(<column>)` can't resolve overloads because the `md` type implicitly casts to/from `VARCHAR`, so both candidates always match. Embedded `$.input.plan` stays the source for `plan_chars` and cross-host rows, so nothing regresses there. A `plan_file` from an imported host (or a deleted plan) simply has no file on disk; the `LEFT JOIN` omits its sections and leaves session-side data untouched.

Extension setup lives in one `resources/extensions.sql`, pulled into a query process via `duckdb -init` (it runs before stdin in the same process, so the piped query sees the extensions, and it works under `-readonly`). Query files stay pure SQL with no `INSTALL`/`LOAD`, and the common-path queries omit `-init` and pay nothing. The index/refresh path stays extension-free.

No view yet. This starts as named queries and promotes to a view only if a second caller appears.

## Deviations From the Plan

Two things the plan assumed didn't hold, and I corrected them while building:

- **`getenv` is CLI-only.** The plan used `getenv('HOME')` for the default glob. That function isn't registered in the `@duckdb/node-api` client the tests (and CI) run on, and it fails at *bind* time even inside an unused `COALESCE` branch, so the query wouldn't even parse in-process. Switched the defaults to a plain `~/...` literal, which DuckDB expands to the home dir and binds in every client.
- **The frontmatter skills default was wrong.** `~/.claude/skills/**/SKILL.md` matches zero files. Real skills are plugin skills under `~/.claude/plugins`, duplicated across cache version-hashes, which makes them a noisy default. Re-defaulted to the memory corpus (clean and frontmatter-native) and documented the skill globs as overrides.

## Testing

The tests in `db.test.ts` load the real `extensions.sql` in-process and cover section parsing, the join to `plan_calls`, and the graceful case where `planFilePath` points at a file absent from disk. I also exercised the `-init` invocation against the live index to check that sections join to their sessions and that the "plans missing a Verification section" query behaves.

The `markdown`/`yaml` extensions are fetched from `community-extensions.duckdb.org` on first `INSTALL ... FROM community` and cached per host after. That host is allowlisted in the sandbox so the first fetch can reach it.
