### PR TITLE
ci: cache bun installs and overlap independent installs

### DIFF
--- a/.github/actions/bun-install/action.yml
+++ b/.github/actions/bun-install/action.yml
@@ -1,0 +1,19 @@
+name: Bun install
+description: Set up Bun, restore the dependency cache, and install with a frozen lockfile
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+        restore-keys: bun-${{ runner.os }}-
+
+    - name: Install dependencies
+      shell: bash
+      run: bun install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-install
 
       - name: Check
         run: bun run check
@@ -32,11 +28,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-install
 
       - name: TypeScript build
         run: bun run build
@@ -47,11 +39,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-install
 
       - name: Run tests
         run: bun test ./.claude ./user scripts/
@@ -64,11 +52,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-install
 
       - name: Test packages
         run: bun test packages/
@@ -161,11 +145,7 @@ jobs:
           echo "has_integration_tests=$(find "plugins/$plugin" -name '*.integration.ts' | grep -q . && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "has_swift=$(find "plugins/$plugin" -name '*.swift' | grep -q . && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-install
 
       - name: Install Claude Code CLI
         run: curl -fsSL https://claude.ai/install.sh | bash
@@ -257,11 +237,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-install
 
       - name: Lint skills
         run: bun run skill-lint "user/skills/*"
@@ -275,11 +251,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-install
 
       - name: Measure coverage on changed files
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,6 +144,7 @@ jobs:
           echo "has_tests=$(find "plugins/$plugin" -name '*.test.ts' | grep -q . && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "has_integration_tests=$(find "plugins/$plugin" -name '*.integration.ts' | grep -q . && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "has_swift=$(find "plugins/$plugin" -name '*.swift' | grep -q . && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "has_playwright=$(find "plugins/$plugin" -name package.json -not -path '*/node_modules/*' -print0 | xargs -0 grep -lF '"playwright"' 2>/dev/null | grep -q . && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: Install Claude Code CLI
         id: cli
@@ -181,6 +182,14 @@ jobs:
           if jq -e '.scripts.build' "plugins/${{ matrix.plugin.name }}/package.json" > /dev/null 2>&1; then
             bun run --cwd "plugins/${{ matrix.plugin.name }}" build
           fi
+
+      - name: Cache Playwright browsers
+        if: runner.os == 'Linux' && steps.inspect.outputs.has_playwright == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: playwright-${{ runner.os }}-
 
       - name: Install system dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,10 +145,15 @@ jobs:
           echo "has_integration_tests=$(find "plugins/$plugin" -name '*.integration.ts' | grep -q . && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "has_swift=$(find "plugins/$plugin" -name '*.swift' | grep -q . && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
+      - name: Install Claude Code CLI
+        id: cli
+        background: true
+        run: curl -fsSL https://claude.ai/install.sh | bash
+
       - uses: ./.github/actions/bun-install
 
-      - name: Install Claude Code CLI
-        run: curl -fsSL https://claude.ai/install.sh | bash
+      - name: Wait for CLI
+        wait: cli
 
       - name: Validate plugin
         run: claude plugin validate "plugins/${{ matrix.plugin.name }}"


### PR DESCRIPTION
Speeds up `test.yml` by overlapping the two independent installs in the plugin matrix and caching the slow downloads. Three commits, each independently revertible.

The plan started from per-step timing on runs `28147307809` and `28054269611`, which pointed at a 39s `bun install` as the bottleneck. Measuring against live runs reshaped that diagnosis: `bun install` is ~7s in steady state, cold or warm. The 39s was registry contention specific to that baseline run. The real long pole is the plugin matrix's `Install system dependencies` step.

## Caching Bun Installs

`setup-bun@v2` caches only the Bun binary, leaving dependencies uncached, so every job repeated `Setup Bun` + `Install dependencies`. Rather than edit caching into eight places, I extracted a `bun-install` composite action (`setup-bun` + `actions/cache` keyed on `bun.lock` + `bun install --frozen-lockfile`) and swapped it in across `lint`, `build`, `hooks`, `validate`, `skills`, `coverage`, and the `plugin` matrix.

This consolidates eight duplicated step pairs into one action, and the cache restores a single tarball from GitHub, which guards against the registry contention that produced the 39s baseline. In current conditions the steady-state install is already ~7s, so the cache itself shows no measurable win. The refactor and the contention insurance carry the commit. I cache `~/.bun/install/cache` only, not `node_modules`, to avoid the empty-integrity-hash breakage that `.claude/rules/lockfile.md` documents for platform-specific deps. `context` installs the Claude CLI but no bun deps, so it keeps a bare `Setup Bun`.

## Overlapping the Claude CLI Install

In the `plugin` matrix the CLI install is independent of `bun install` but ran after it. I backgrounded it with the new [`background:`/`wait:` step keywords](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/) so it installs concurrently, with a `wait: cli` barrier right before `Validate plugin`, the first step that needs `claude`. On `plugin (claude-code)` the 10s CLI install overlapped the 8s `bun install`, so `Wait for CLI` added only 2s. That is the ~7s overlap the plan predicted.

These keywords are days old, so they land as their own commit, revertible if a runner image lacks support. `actionlint` flags them as unknown keys for the same reason. Its schema predates the feature.

## Caching Playwright Browsers

The slowest job, `plugin (ui-design)`, spent ~38s in `Install system dependencies`: ~26s of `libvips-dev` dpkg unpack for sharp (download is only ~2s, the rest is unpack and configure, not cacheable) and ~7s of Playwright downloading chromium, ffmpeg, and the headless shell into `~/.cache/ms-playwright`. I cache that directory keyed on `bun.lock`, gated on a new `has_playwright` inspect output so only jobs that need it pay the lookup. Warm, the step drops to ~28s and the job from ~59s to ~49s. The libvips dpkg is the remaining floor for that job.

## Verified Results

Across cold and warm re-runs:

| | baseline (plan) | now (warm) |
|---|---|---|
| slowest plugin job | 64s (claude-code) | ~49s (ui-design) |
| its `bun install` | 39s | ~7s |
| `Install system deps` (ui-design) | n/a | 38s → 28s |
| CLI install on critical path | 7s serial | ~2-4s (overlapped) |

`actionlint` covers the workflow. Its only complaints are the `background`/`wait` keywords its schema predates, and the change adds no shellcheck findings beyond those already present.
