### PR TITLE
ci: drop libvips-dev, rely on sharp's prebuilt binary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,9 +203,6 @@ jobs:
           plugin="plugins/${{ matrix.plugin.name }}"
           deps=$(find "$plugin" -name package.json -not -path '*/node_modules/*' -not -path '*/.bun-cache/*' \
             -print0 | xargs -0 jq -r '[.dependencies // {}, .devDependencies // {}] | map(keys) | flatten[]' 2>/dev/null | sort -u)
-          if echo "$deps" | grep -q '^sharp$'; then
-            sudo apt-get update && sudo apt-get install -y libvips-dev
-          fi
           if echo "$deps" | grep -q '^playwright$'; then
             bun "$plugin/node_modules/.bin/playwright" install chromium --with-deps
           fi


### PR DESCRIPTION
Removes the `libvips-dev` apt install from the plugin matrix's `Install system dependencies` step. `sharp` no longer needs it.

`sharp` 0.34.5 ships prebuilt binaries through `optionalDependencies`: `@img/sharp-linux-x64` for the native binding and a bundled `@img/sharp-libvips-linux-x64` that includes SVG loading. On `ubuntu-latest` (linux x64 glibc) `sharp` resolves to those and uses no system libvips. The apt install was a defensive add during the npm-to-bun migration (#307), worded as "Add libvips-dev for plugins using sharp on Linux," not a response to an observed prebuilt failure.

Only `plugins/ui-design` pulls `sharp`, and it feeds SVG into `sharp()` in `render.ts`. SVG input is the one case that might have justified system libvips, so I verified it against the prebuilt path. Locally there is no system libvips (`brew list vips` finds nothing), yet `render.test.ts` passes using the prebuilt darwin binary, the same prebuilt model Linux uses. The CI run on this branch is the Linux confirmation.

The payoff is the matrix critical path. `ui-design` was the slowest plugin job, and its `Install system dependencies` step spent ~26s unpacking and configuring the `libvips-dev` dependency tree (~281MB across docs and `-dev` headers for the whole image stack). That dpkg time is gone.

This follows #881, which cached the Playwright browser download on the same step and left the libvips dpkg as the remaining floor.
