### PR TITLE
pull-request: stop referencing the unseen plan in PR bodies

### DIFF
--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -41,7 +41,7 @@ allowed-tools:
 
 The body conveys what the diff cannot: why this change, what you decided along the way, and how you know it works. The reviewer reads the diff for what changed, so don't restate it. Spend the body on intent and the decisions a reviewer can't reconstruct from the code.
 
-Mine the conversation that produced this change. The substance lives there: decisions and the alternatives you rejected, deviations from the issue or plan, theories you tried and overturned, what you observed testing locally, limitations you ruled out, naming or scope you settled by hand. Put it in the body, where the reviewer will read it. Keep it out of code comments.
+Mine the conversation that produced this change. The substance lives there: decisions and the alternatives you rejected, the scope you added or dropped, theories you tried and overturned, what you observed testing locally, limitations you ruled out, naming or scope you settled by hand. Put it in the body as a self-contained decision, not as a delta against a plan the reviewer never saw. Keep it out of code comments.
 
 - Open with what changed (a bare verb: "Adds", "Fixes", "Removes") when the change is self-evident, or with the problem when the change needs justifying. Don't restate the title.
 - Length tracks substance, not diff size. A subtle one-line fix may need paragraphs. A large mechanical change may need two sentences.
@@ -59,7 +59,7 @@ When a PR template is provided in context above, follow its structure instead of
 - Leave checklists (checkbox items) untouched for the user to complete manually
 - Remove HTML comments (`<!-- ... -->`) that serve as placeholder instructions
 - Map skill-generated content into corresponding template sections:
-  - Description/summary sections: the opening plus the conversation substance (decisions, deviations, what you observed testing)
+  - Description/summary sections: the opening plus the conversation substance (decisions, scope added or dropped, what you observed testing)
   - Changes/what sections: follow the `## Changes` guidance in `sections.md`
   - Testing/verification sections: follow the `## Testing` guidance in `sections.md`
   - Issue/references sections: the motivating issue ref and `## References` content

--- a/plugins/pull-request/skills/create/evals/evals.json
+++ b/plugins/pull-request/skills/create/evals/evals.json
@@ -17,10 +17,11 @@
     {
       "id": 2,
       "prompt": "Create a PR for this skill change. We deviated from the plan: an extra allowed-tools entry was added beyond what the plan listed, and you renamed the two modes mid-session at my request.",
-      "expected_output": "A body that surfaces the scope deviation and the user-driven rename as the decisions they were, organized by concept.",
+      "expected_output": "A body that surfaces the added scope and the user-driven rename as the self-contained decisions they were, organized by concept, without framing them as a delta against a plan the reader can't see.",
       "files": [],
       "expectations": [
-        "The body states the deviation from the plan (the extra scope added) rather than smoothing it over",
+        "The body states the added scope (the extra allowed-tools entry) as a decision with its reason, rather than smoothing it over",
+        "It does not reference 'the plan', 'as planned', or any unseen spec or conversation; the scope change reads as a self-contained decision",
         "It does not make a false claim that contradicts the diff (e.g. naming the wrong set of additions)",
         "The user-driven naming decision is surfaced as a decision, not presented as obvious",
         "Changes are organized by concept, never as **path**: description bullets"

--- a/plugins/pull-request/skills/create/sections.md
+++ b/plugins/pull-request/skills/create/sections.md
@@ -4,6 +4,8 @@ What goes in the body, and what to leave out. The create and update skills both 
 
 The body conveys what the diff cannot. The reviewer reads the code for what changed. Use the body for why it changed, the decisions you made, and how you know it works. If a sentence only restates what the diff shows, cut it.
 
+Write the body to stand on its own. The reviewer has the diff and the linked issue and nothing else — not your plan, not the issue you were handed, not the session that produced the change. Every reference must point to something they can open: a linked issue, a PR, a permalink. A phrase like "the plan", "as originally planned", or "the issue specified" points at an artifact they can't see, so it lands as a dead end. State the decision itself instead of the gap between it and an instruction only you saw.
+
 Write in active voice and first person for your own calls. "I chose X over Y because…", "I traced this to…". Don't write passively ("X was added", "the bug was caused by…"). Keep the prose plain. Technical terms are fine. Marketing and model flourishes (`source of truth`, `fail loudly`, `escape hatch`, `cleanly`, `wires up`) are not. Load the `writing` skill for the full set of tropes.
 
 ## Shape
@@ -33,7 +35,7 @@ A heading has slipped into a sentence when it carries a comma, a trailing period
 The most valuable content is the substance that lived in the session but never reached the code. Review the conversation that produced the change and surface what applies. This belongs in the PR body, not in code comments where Claude tends to leak it.
 
 - Decisions and the alternatives you rejected. Name what you chose against and why you didn't take it.
-- Deviations from the issue or plan. Where the implementation departed from what was specified, and the scope you added or dropped (an extra `allowed-tools` entry, files touched beyond the plan, a feature cut).
+- Scope you added or dropped, and decisions that took a different path than the obvious or specified one (an extra `allowed-tools` entry, a feature cut, files touched beyond the core change). Surface the substance — but state it as a self-contained decision, what you did and why, never as a delta against a plan or instruction the reader never saw. Write "I added a `Bash(git push:*)` entry because the workflow pushes the branch," not "I added an entry beyond what the plan listed." The reason makes it land; the comparison to an unseen plan does not.
 - Overturned theories. A root cause you diagnosed then disproved, an approach you built then abandoned. The diff shows the destination. The reviewer benefits from the wrong turn you already ruled out.
 - What you observed testing locally. The actual result, surprise, or failure mode, not just "verified". Benchmark or cost numbers. What you couldn't test and the concrete reason ("brew install failed locally", not "needs a real machine").
 - Limitations you ruled out. A workaround you considered and rejected as too fragile, a feature deferred as structural. This explains non-changes a reviewer might otherwise question.
@@ -46,7 +48,7 @@ Not every PR has all of these. Include only what a reviewer would act on. True b
 
 - Visual or GUI work: screenshots or a recording of the result. Rejected layouts. Bugs only live rendering surfaced.
 - Backend or API work: an example request and response. The mechanism proof for a fix (what breaks without it). Performance numbers.
-- Config, tooling, or prose: scope deviations, what you deliberately did not build, and the evidence that grounds the design.
+- Config, tooling, or prose: the scope you added or dropped, what you deliberately did not build, and the evidence that grounds the design.
 
 ## Ground Claims in Evidence
 
@@ -76,3 +78,4 @@ Related links, issues, or reviews that aren't the motivating issue. Use `Closes 
 - Test counts, "all tests pass", coverage inventories.
 - Count-padding ("six detectors, three and three"). The number is rarely the point.
 - The consequence chain (`, so the…`) used as a filler connective, and the antithesis (`not just X but Y`, `X instead of Y`) used as framing. Both read as tics when habitual.
+- Indirect references to an artifact the reader can't open: "deviations from the plan", "as originally planned", "the plan assumed", "per the plan", "the issue specified", a `## Deviations From the Plan` heading. The deviation's substance is worth keeping; framing it as a gap against an unseen plan, issue, or conversation is the tell. Restate it as a decision that stands on its own.


### PR DESCRIPTION
PR bodies kept describing changes as deviations from "the plan" — an indirect reference to an artifact the reader cannot open. It reads as an AI writing tell and as poor communication: the reviewer has the diff and the linked issue, never the plan or the session that produced the change.

The pattern traces to a single seed in the skill. `SKILL.md` and `sections.md` both told the body to mine "deviations from the issue or plan," which invites framing a change as a delta against the plan rather than as a decision on its own terms. Recent bodies show the result directly — a `## Deviations From the Plan` heading and "the plan assumed" (#879), "per the plan" (#855), "the plan asked" (#662), "I dropped the dead detection from the original plan" (#657).

The deviation's substance — the scope added or dropped, the decision taken — is worth keeping. Only the framing against an unseen plan is the problem, so the fix reframes rather than removes: state the substance as a self-contained decision with its reason.

## Changes

- `sections.md`: add a self-containment principle to the opening (every reference must point to something the reader can open); rewrite the deviation bullet to demand a decision-with-reason instead of a delta against a plan; add a `Slop to Cut` entry naming the giveaway phrasings (`per the plan`, `as originally planned`, the `## Deviations From the Plan` heading).
- `SKILL.md`: drop the "deviations from the issue or plan" trigger phrase from the mine-the-conversation guidance and the template-mapping gloss.
- `evals.json`: case 2 rewarded "states the deviation from the plan." Flipped it to require a self-contained decision and to penalize referencing the plan, so the eval enforces the new behavior instead of the old.

`sections.md` is shared by both `pull-request:create` and `pull-request:update`, so the change covers both skills.

## Testing

`bun run skill-lint plugins/pull-request/skills/create` passes with no errors or warnings; `jq empty` confirms the eval JSON is valid. The skill ships no runtime code, so there are no unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sFX61Ej317EssacXbqZek

---
_Generated by [Claude Code](https://claude.ai/code/session_014sFX61Ej317EssacXbqZek)_