### PR TITLE
plan: add an A/B harness for guidance candidates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 node_modules/
 .DS_Store
 **/fixtures/
+# The plan eval fixtures are authored input the harness reads by default, not
+# generated artifacts. Re-include them so the A/B works on a fresh clone.
+!plugins/plan/evals/fixtures/
 
 # Generated coverage output (bun test --coverage)
 /coverage/

--- a/bun.lock
+++ b/bun.lock
@@ -147,6 +147,14 @@
         "@constellos/claude-code-kit": "^0.4.0",
       },
     },
+    "plugins/plan": {
+      "name": "@bendrucker/claude-plan",
+      "dependencies": {
+        "cleye": "^2.2.1",
+        "gray-matter": "^4.0.3",
+        "table": "^6.9.0",
+      },
+    },
     "plugins/pull-request": {
       "name": "pull-request",
       "dependencies": {
@@ -283,6 +291,8 @@
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "@bendrucker/claude-marketplace": ["@bendrucker/claude-marketplace@workspace:packages/marketplace"],
+
+    "@bendrucker/claude-plan": ["@bendrucker/claude-plan@workspace:plugins/plan"],
 
     "@bendrucker/claude-review": ["@bendrucker/claude-review@workspace:plugins/review"],
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "plugins/linear",
     "plugins/mermaid/skills/diagram",
     "plugins/newline",
+    "plugins/plan",
     "plugins/pull-request",
     "plugins/shortcuts",
     "plugins/writing",

--- a/plugins/plan/README.md
+++ b/plugins/plan/README.md
@@ -6,7 +6,18 @@ Planning mode guidelines and context injection for Claude Code.
 
 - **Hook**: Automatically injects planning guidelines when entering plan mode (via Shift+Tab or EnterPlanMode tool)
 - **Skill**: `plan:guidelines` - Detailed planning best practices for when explicit guidance is needed
+- **Scanner**: `scripts/alternatives-scan.ts` - Baseline structural scan of a plan corpus measuring how often roads-not-taken leak inline instead of into a dedicated Alternatives section
+- **Eval**: `evals/` - Seeded A/B that measures whether a candidate guidance snippet changes how plans record declined alternatives
 
 ## How It Works
 
 The `UserPromptSubmit` hook checks `permission_mode` in the hook input. When the mode is `plan`, it injects the planning guidelines into the conversation context. A marker file prevents duplicate injection on subsequent prompts within the same session.
+
+## Testing
+
+`bun test plugins/plan` runs the scanner and eval helper unit tests over synthetic fixtures.
+
+The corpus scan and the A/B are local and manual. The corpus is local-only, and the A/B shells out to `claude -p`, so neither runs in CI:
+
+- `bun plugins/plan/scripts/alternatives-scan.ts --dir ~/.claude/plans` prints the inline-leak rate over the local corpus. Add `--ssh <host>` to scan a remote corpus read-only.
+- `bun plugins/plan/evals/ab.ts` runs the control-vs-treatment A/B. See [`evals/README.md`](evals/README.md).

--- a/plugins/plan/evals/README.md
+++ b/plugins/plan/evals/README.md
@@ -1,0 +1,59 @@
+# Plan Guidance A/B
+
+Measures whether a candidate guidance idea produces better implementation plans than the baseline plan guidelines alone. The harness compares the baseline against the baseline plus a candidate snippet, so an idea can be tested without editing [`../references/guidelines.md`](../references/guidelines.md).
+
+## How It Works
+
+[`ab.ts`](ab.ts) runs each fixture in [`fixtures/`](fixtures/) through `claude -p` under two conditions:
+
+- **control**: the baseline guidelines from [`../references/guidelines.md`](../references/guidelines.md).
+- **treatment**: the baseline with the candidate snippet (`--candidate`, default [`candidates/alternatives-section.md`](candidates/alternatives-section.md)) appended.
+
+Each fixture runs `--reps` times (default 5) so per-generation noise averages out. For each rep the harness generates a control plan and a treatment plan, then a judge pass ([`judge.md`](judge.md)) compares the two head-to-head and picks the better plan on four qualities, plus an overall verdict:
+
+- **right-sized detail**: confirms direction before committing to file lists, signatures, or test cases.
+- **outcome-focused**: states the goal and the verifiable end state it drives toward.
+- **scope discipline**: names what it is not doing and defers non-essential work.
+- **grounded**: refers to the actual code and constraints it was given, without inventing structure.
+
+Each quality is won by control, won by treatment, or tied. The overall verdict is the judge's holistic preference, not a tally. Which plan the judge sees first alternates by fixture and rep to counterbalance position bias, and the verdict is mapped back to control/treatment.
+
+## The Metric
+
+The headline is **treatment's win rate**: treatment wins as a share of decisive (non-tie) comparisons, reported per quality and overall with a Wilson 95% interval. Fifty percent means the candidate changed nothing. The verdict line reads `treatment wins` when the overall interval clears 50%, `control wins` when it falls below, and `no decision` when it spans 50%.
+
+## Candidates
+
+A candidate is a markdown snippet under [`candidates/`](candidates/) that the harness appends to the baseline to form the treatment. To test a new idea, write a snippet, run `ab.ts --candidate candidates/<name>.md`, and read the delta. The baseline guidelines stay untouched until an idea earns its place.
+
+[`candidates/alternatives-section.md`](candidates/alternatives-section.md) is the first idea tested. It adds an optional `## Alternatives` section for declined roads. It did not earn its place. An early run leaned positive (overall treatment near 62%, scope discipline pinned at treatment), but the lean tracked the candidate's extra section rather than better plans: once the judge was hardened to disregard length and section form, scope discipline collapsed toward 50% and the overall win rate landed around 54.8% [37.8–70.8], an interval spanning 50%. That run was also truncated by a spend limit (n=31), so the number is soft, but the de-confounded signal is null-to-marginal. The candidate did not ship. The harness stays, to test the next one.
+
+## Measurability
+
+The first cut of this harness produced a confounded result for reasons that had nothing to do with the candidate. Two fixture design choices address them:
+
+#### Isolation
+
+Generation runs in an empty temp directory with an explicit greenfield framing. The grounding rules in the guidelines tell the model to read the code before planning. Pointed at a real repo that lacks the fictional app a fixture describes, the model refuses the task instead of planning. The empty cwd and greenfield framing remove that basis for both conditions equally. Each fixture carries its own embedded codebase context (a file tree and a snippet or two) so the **grounded** quality has real structure to check against.
+
+#### Discrimination
+
+Each fixture embeds a genuine direction fork and an explicit scope boundary, so the qualities have something to separate the plans on. A fixture that pre-rejects an alternative in so many words, or that names no boundary, leaves both plans equivalent and the judge ties every comparison. The fork is implied by the situation, not handed over as finished prose.
+
+## Running
+
+```
+bun plugins/plan/evals/ab.ts
+```
+
+Cost is `fixtures x reps x 3` calls to `claude -p`, two plan generations and one judgment per rep (8 fixtures, 5 reps default = 120 calls). Flags: `--candidate` to test a different snippet, `--reps` to trade cost for tighter intervals, `--model` to pin the model, `--concurrency` for parallelism (default 4, kept low to avoid server-side rate limiting), `--fixtures`/`--guidelines` to point elsewhere, `--out` for the artifact directory. Generated plans and judge results land in `tmp/ab/`.
+
+A run that drops units (a generation or judgment that exhausts its retries) prints a prominent warning. Dropped units are not a random sample, so the win rate over the survivors can be biased. Re-run or raise `--reps` before trusting a verdict from a run that lost units.
+
+This is local and manual. The CI-safe coverage is the pure-helper unit tests ([`ab.test.ts`](ab.test.ts)) and the scanner tests under [`../scripts/`](../scripts/).
+
+## Reading the Result
+
+The **delta** between conditions is the signal. If treatment's interval contains 50%, the candidate changed nothing measurable. Treatment's interval clearing 50% is evidence the candidate earns its place in the guidelines.
+
+Absolute rates depend on the judge model and these synthetic fixtures, so treat them as relative. The reusable artifact is the harness: swap `--candidate` to see whether a new wording helps or hurts.

--- a/plugins/plan/evals/ab.test.ts
+++ b/plugins/plan/evals/ab.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "bun:test";
+import { composeTreatment, parseJudge, resolveComparison, resolveSide, summarize } from "./ab";
+
+const TIE_QUALITIES = {
+  right_sized_detail: "tie",
+  outcome_focused: "tie",
+  scope_discipline: "tie",
+  grounded: "tie",
+} as const;
+
+describe("composeTreatment", () => {
+  it("appends the candidate after the baseline", () => {
+    const baseline = "## Grounding\n\nRead before you propose.\n";
+    const candidate = "## Alternatives\n\nOptional and rare.\n";
+    const treatment = composeTreatment(baseline, candidate);
+    expect(treatment).toContain("## Grounding");
+    expect(treatment).toContain("Read before you propose.");
+    expect(treatment).toContain("## Alternatives");
+    expect(treatment).toContain("Optional and rare.");
+    expect(treatment.indexOf("## Grounding")).toBeLessThan(treatment.indexOf("## Alternatives"));
+  });
+
+  it("separates baseline and candidate with a blank line and ends with a newline", () => {
+    const treatment = composeTreatment("baseline text", "candidate text");
+    expect(treatment).toBe("baseline text\n\ncandidate text\n");
+  });
+
+  it("collapses surrounding whitespace so spacing is stable", () => {
+    const treatment = composeTreatment("baseline\n\n\n", "\n\ncandidate\n\n");
+    expect(treatment).toBe("baseline\n\ncandidate\n");
+  });
+});
+
+describe("parseJudge", () => {
+  it("parses a fenced JSON object", () => {
+    const output = [
+      "Here is the verdict:",
+      "```json",
+      '{ "overall": "B", "qualities": { "right_sized_detail": "A", "outcome_focused": "B", "scope_discipline": "tie", "grounded": "B" }, "rationale": "B scoped tighter." }',
+      "```",
+    ].join("\n");
+    expect(parseJudge(output)).toEqual({
+      overall: "B",
+      qualities: {
+        right_sized_detail: "A",
+        outcome_focused: "B",
+        scope_discipline: "tie",
+        grounded: "B",
+      },
+      rationale: "B scoped tighter.",
+    });
+  });
+
+  it("defaults missing qualities to tie", () => {
+    const output = '{ "overall": "A", "qualities": { "grounded": "A" } }';
+    expect(parseJudge(output)).toEqual({
+      overall: "A",
+      qualities: { ...TIE_QUALITIES, grounded: "A" },
+      rationale: "",
+    });
+  });
+
+  it("rejects an invalid overall verdict", () => {
+    const output = '{ "overall": "neither", "qualities": {} }';
+    expect(() => parseJudge(output)).toThrow(/invalid overall/);
+  });
+
+  it("throws when no JSON object is present", () => {
+    expect(() => parseJudge("the model refused")).toThrow(/no JSON object/);
+  });
+
+  it("ignores trailing prose that contains a stray brace", () => {
+    const output = '{ "overall": "A", "qualities": { "grounded": "A" } } Note: B uses }-syntax.';
+    expect(parseJudge(output)).toMatchObject({ overall: "A" });
+  });
+
+  it("keeps braces that appear inside string values", () => {
+    const output = '{ "overall": "B", "rationale": "A proposes a { } block." }';
+    expect(parseJudge(output)).toMatchObject({
+      overall: "B",
+      rationale: "A proposes a { } block.",
+    });
+  });
+});
+
+describe("resolveSide", () => {
+  it("maps A to control when control was shown first", () => {
+    expect(resolveSide("A", true)).toBe("control");
+    expect(resolveSide("B", true)).toBe("treatment");
+  });
+
+  it("maps A to treatment when treatment was shown first", () => {
+    expect(resolveSide("A", false)).toBe("treatment");
+    expect(resolveSide("B", false)).toBe("control");
+  });
+
+  it("keeps a tie a tie regardless of order", () => {
+    expect(resolveSide("tie", true)).toBe("tie");
+    expect(resolveSide("tie", false)).toBe("tie");
+  });
+});
+
+describe("resolveComparison", () => {
+  it("maps overall and every quality back to conditions", () => {
+    const judge = {
+      overall: "A" as const,
+      qualities: {
+        right_sized_detail: "A" as const,
+        outcome_focused: "B" as const,
+        scope_discipline: "tie" as const,
+        grounded: "A" as const,
+      },
+      rationale: "",
+    };
+    expect(resolveComparison(judge, false)).toEqual({
+      overall: "treatment",
+      qualities: {
+        right_sized_detail: "treatment",
+        outcome_focused: "control",
+        scope_discipline: "tie",
+        grounded: "treatment",
+      },
+    });
+  });
+});
+
+describe("summarize", () => {
+  it("tallies wins per dimension and rates treatment over decisive comparisons", () => {
+    const summary = summarize([
+      { overall: "treatment", qualities: TIE_QUALITIES },
+      { overall: "treatment", qualities: TIE_QUALITIES },
+      { overall: "control", qualities: TIE_QUALITIES },
+      { overall: "tie", qualities: TIE_QUALITIES },
+    ]);
+    expect(summary.n).toBe(4);
+    expect(summary.overall).toMatchObject({
+      control: 1,
+      treatment: 2,
+      tie: 1,
+      decisive: 3,
+    });
+    expect(summary.overall.treatmentWinRate).toBeCloseTo(2 / 3);
+  });
+
+  it("reports zero rates for an empty result set", () => {
+    const summary = summarize([]);
+    expect(summary.n).toBe(0);
+    expect(summary.overall).toMatchObject({ decisive: 0, treatmentWinRate: 0 });
+    expect(summary.qualities.grounded).toMatchObject({ decisive: 0, treatmentWinRate: 0 });
+  });
+});

--- a/plugins/plan/evals/ab.ts
+++ b/plugins/plan/evals/ab.ts
@@ -1,0 +1,462 @@
+#!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: shells out to `claude -p` to generate and judge plans
+/**
+ * Pairwise A/B harness for testing a candidate guidance idea against the
+ * baseline plan guidelines. For each fixture in fixtures/, it generates one
+ * plan under control (the baseline guidelines) and one under treatment (the
+ * baseline plus the candidate snippet from --candidate), then a judge pass
+ * compares the two head-to-head and picks the better plan on four qualities:
+ * right-sized detail, outcome focus, scope discipline, and grounding.
+ *
+ * The metric is treatment's win rate over control. Fifty percent means the
+ * candidate changed nothing. Each fixture runs `--reps` times to average out
+ * per-generation noise. Position bias is counterbalanced: which plan the
+ * judge sees first alternates by fixture and rep, then the verdict is mapped
+ * back to control/treatment.
+ *
+ * The candidate lives in its own file under candidates/ so the baseline
+ * guidelines stay unchanged while an idea is under test. Swap --candidate to
+ * measure a different wording; the win rate is the verdict.
+ *
+ * Generation runs in an empty temp directory with a greenfield framing, so
+ * the grounding rules ("read the code first") never trigger a refusal about
+ * the surrounding repo. Fixtures carry their own context for the plan to
+ * ground against.
+ *
+ * Local and manual. It runs `claude -p` fixtures x reps x 3 times (two
+ * generations and one judgment per rep), so it never runs in CI. Fixtures are
+ * authored and egress-clean, so generated plans are safe to inspect.
+ * Artifacts go to tmp/ab/.
+ */
+import { mkdirSync, mkdtempSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { cli } from "cleye";
+import matter from "gray-matter";
+import { table } from "table";
+import { BOLD, DIM, percent, RESET, wilson } from "../scripts/alternatives-scan";
+
+type Side = "A" | "B" | "tie";
+type Verdict = "control" | "treatment" | "tie";
+type Quality = "right_sized_detail" | "outcome_focused" | "scope_discipline" | "grounded";
+
+const QUALITIES: Quality[] = [
+  "right_sized_detail",
+  "outcome_focused",
+  "scope_discipline",
+  "grounded",
+];
+const QUALITY_LABELS: Record<Quality, string> = {
+  right_sized_detail: "right-sized detail",
+  outcome_focused: "outcome-focused",
+  scope_discipline: "scope discipline",
+  grounded: "grounded",
+};
+const SIDES: Side[] = ["A", "B", "tie"];
+
+interface Fixture {
+  name: string;
+  prompt: string;
+}
+
+export interface JudgeResult {
+  overall: Side;
+  qualities: Record<Quality, Side>;
+  rationale: string;
+}
+
+/** A judgment with sides mapped back to the conditions they stand for. */
+export interface Comparison {
+  overall: Verdict;
+  qualities: Record<Quality, Verdict>;
+}
+
+async function loadFixtures(dir: string): Promise<Fixture[]> {
+  const names = readdirSync(dir)
+    .filter((name) => name.endsWith(".md"))
+    .sort();
+  return Promise.all(
+    names.map(async (name) => {
+      const parsed = matter(await Bun.file(path.join(dir, name)).text());
+      const prompt = parsed.content.trim();
+      if (prompt.length === 0) {
+        throw new Error(`${name}: fixture has no request body`);
+      }
+      return { name, prompt };
+    }),
+  );
+}
+
+/**
+ * Compose the treatment guidelines by appending the candidate snippet to the
+ * baseline. Control is the baseline verbatim, so the candidate text is the
+ * only difference between conditions.
+ */
+export function composeTreatment(baseline: string, candidate: string): string {
+  return `${baseline.trimEnd()}\n\n${candidate.trim()}\n`;
+}
+
+/**
+ * The generator prompt. The greenfield framing is load-bearing: it removes
+ * the grounding rules' basis for refusing ("this repo has no such code"),
+ * which sank generations in the first cut. The fixture supplies whatever
+ * context the plan should ground against.
+ */
+function generatorPrompt(guidelines: string, fixturePrompt: string): string {
+  return [
+    "You are in planning mode. The following planning guidelines apply.",
+    "",
+    "<planning-guidelines>",
+    guidelines.trim(),
+    "</planning-guidelines>",
+    "",
+    "This is a greenfield design exercise. There is no repository on disk to",
+    "inspect beyond what the request itself provides. Plan from the request",
+    "and any context it gives. Produce an implementation plan as markdown for",
+    "the request below. Output only the plan, with no preamble.",
+    "",
+    fixturePrompt,
+  ].join("\n");
+}
+
+function judgePrompt(template: string, request: string, planA: string, planB: string): string {
+  return template
+    .replace("{{REQUEST}}", request)
+    .replace("{{PLAN_A}}", planA)
+    .replace("{{PLAN_B}}", planB);
+}
+
+/**
+ * Run `claude -p`, retrying on a non-zero exit. Transient CLI failures (rate
+ * limits, flaky API responses) are common across a long run. One bad call
+ * costs only a retry this way. Empty stderr is normal on these, so the error
+ * carries the head of stdout too for diagnosis.
+ */
+async function runClaude(
+  prompt: string,
+  model: string | undefined,
+  cwd: string,
+  attempts = 5,
+): Promise<string> {
+  const args = ["claude", "-p", "--no-session-persistence"];
+  if (model) args.push("--model", model);
+  let lastError = "";
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const proc = Bun.spawn(args, {
+      stdin: new Blob([prompt]),
+      stdout: "pipe",
+      stderr: "pipe",
+      cwd,
+    });
+    const [stdout, stderr, exit] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    if (exit === 0) return stdout.trim();
+    lastError = `exit ${exit}: ${(stderr.trim() || stdout.trim()).slice(0, 300)}`;
+    // Exponential backoff: server-side rate limiting ("temporarily limiting
+    // requests") clears on the order of seconds, so 2s, 4s, 8s, 16s.
+    if (attempt < attempts) await Bun.sleep(1000 * 2 ** attempt);
+  }
+  throw new Error(`claude -p failed after ${attempts} attempts (${lastError})`);
+}
+
+function asSide(value: unknown): Side | undefined {
+  return typeof value === "string" && SIDES.includes(value as Side) ? (value as Side) : undefined;
+}
+
+/**
+ * Slice the first complete JSON object out of the judge output. Scanning for
+ * the brace that balances the first `{` (skipping braces inside strings)
+ * tolerates prose on either side, where a stray `{` or `}` in a trailing
+ * sentence would otherwise corrupt a naive first-to-last-brace span.
+ */
+function extractJsonObject(output: string): string {
+  const start = output.indexOf("{");
+  if (start === -1) {
+    throw new Error(`judge returned no JSON object: ${output.slice(0, 200)}`);
+  }
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < output.length; i++) {
+    const char = output[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') inString = true;
+    else if (char === "{") depth++;
+    else if (char === "}" && --depth === 0) return output.slice(start, i + 1);
+  }
+  throw new Error(
+    `judge returned an unterminated JSON object: ${output.slice(start, start + 200)}`,
+  );
+}
+
+export function parseJudge(output: string): JudgeResult {
+  const parsed = JSON.parse(extractJsonObject(output)) as Record<string, unknown>;
+  const overall = asSide(parsed.overall);
+  if (overall === undefined) {
+    throw new Error(`judge returned an invalid overall verdict: ${String(parsed.overall)}`);
+  }
+  const rawQualities = (parsed.qualities ?? {}) as Record<string, unknown>;
+  const qualities = Object.fromEntries(
+    QUALITIES.map((key) => [key, asSide(rawQualities[key]) ?? "tie"]),
+  ) as Record<Quality, Side>;
+  return {
+    overall,
+    qualities,
+    rationale: typeof parsed.rationale === "string" ? parsed.rationale : "",
+  };
+}
+
+/**
+ * Map a judged side back to the condition it stood for. `controlFirst` records
+ * which condition was shown as plan A, so the verdict survives the position
+ * counterbalancing.
+ */
+export function resolveSide(side: Side, controlFirst: boolean): Verdict {
+  if (side === "tie") return "tie";
+  return (side === "A") === controlFirst ? "control" : "treatment";
+}
+
+export function resolveComparison(judge: JudgeResult, controlFirst: boolean): Comparison {
+  const qualities = Object.fromEntries(
+    QUALITIES.map((key) => [key, resolveSide(judge.qualities[key], controlFirst)]),
+  ) as Record<Quality, Verdict>;
+  return { overall: resolveSide(judge.overall, controlFirst), qualities };
+}
+
+export interface DimensionResult {
+  control: number;
+  treatment: number;
+  tie: number;
+  decisive: number;
+  /** Treatment wins as a share of decisive (non-tie) comparisons. */
+  treatmentWinRate: number;
+  ci: { lo: number; hi: number };
+}
+
+export interface Summary {
+  n: number;
+  overall: DimensionResult;
+  qualities: Record<Quality, DimensionResult>;
+}
+
+function tally(verdicts: Verdict[]): DimensionResult {
+  let control = 0;
+  let treatment = 0;
+  let tie = 0;
+  for (const verdict of verdicts) {
+    if (verdict === "control") control++;
+    else if (verdict === "treatment") treatment++;
+    else tie++;
+  }
+  const decisive = control + treatment;
+  return {
+    control,
+    treatment,
+    tie,
+    decisive,
+    treatmentWinRate: decisive > 0 ? treatment / decisive : 0,
+    ci: wilson(treatment, decisive),
+  };
+}
+
+export function summarize(comparisons: Comparison[]): Summary {
+  const qualities = Object.fromEntries(
+    QUALITIES.map((key) => [key, tally(comparisons.map((c) => c.qualities[key]))]),
+  ) as Record<Quality, DimensionResult>;
+  return {
+    n: comparisons.length,
+    overall: tally(comparisons.map((c) => c.overall)),
+    qualities,
+  };
+}
+
+async function mapPool<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    for (let i = next++; i < items.length; i = next++) {
+      const item = items[i];
+      if (item !== undefined) results[i] = await fn(item, i);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
+function dimensionRow(label: string, d: DimensionResult): string[] {
+  return [
+    label,
+    String(d.control),
+    String(d.treatment),
+    String(d.tie),
+    d.decisive > 0
+      ? `${percent(d.treatmentWinRate)} [${percent(d.ci.lo)}..${percent(d.ci.hi)}]`
+      : "—",
+  ];
+}
+
+interface Unit {
+  fixture: Fixture;
+  fixtureIndex: number;
+  rep: number;
+}
+
+async function main(): Promise<void> {
+  const argv = cli({
+    name: "ab",
+    flags: {
+      fixtures: {
+        type: String,
+        description: "Directory of fixture requests",
+        default: path.join(import.meta.dirname, "fixtures"),
+      },
+      guidelines: {
+        type: String,
+        description: "Baseline planning guidelines (the control condition)",
+        default: path.join(import.meta.dirname, "..", "references", "guidelines.md"),
+      },
+      candidate: {
+        type: String,
+        description: "Candidate snippet appended to the baseline to form the treatment",
+        default: path.join(import.meta.dirname, "candidates", "alternatives-section.md"),
+      },
+      reps: {
+        type: Number,
+        description: "Comparisons per fixture",
+        default: 5,
+      },
+      model: {
+        type: String,
+        description: "Model passed to claude -p (default: the CLI default)",
+      },
+      concurrency: {
+        type: Number,
+        description: "Concurrent comparison units",
+        default: 4,
+      },
+      out: {
+        type: String,
+        description: "Output directory for generated plans and judge results",
+        default: path.join("tmp", "ab"),
+      },
+    },
+  });
+
+  const control = await Bun.file(argv.flags.guidelines).text();
+  const candidate = await Bun.file(argv.flags.candidate).text();
+  if (candidate.trim().length === 0) {
+    console.error(`${argv.flags.candidate} is empty; nothing to A/B.`);
+    process.exit(1);
+  }
+  const treatment = composeTreatment(control, candidate);
+
+  const judgeTemplate = await Bun.file(path.join(import.meta.dirname, "judge.md")).text();
+  const fixtures = await loadFixtures(argv.flags.fixtures);
+  const units: Unit[] = fixtures.flatMap((fixture, fixtureIndex) =>
+    Array.from({ length: argv.flags.reps }, (_, rep) => ({ fixture, fixtureIndex, rep })),
+  );
+
+  mkdirSync(argv.flags.out, { recursive: true });
+  const genCwd = mkdtempSync(path.join(tmpdir(), "ab-gen-"));
+  console.error(`${DIM}Candidate: ${argv.flags.candidate}${RESET}`);
+  console.error(
+    `${DIM}Running ${units.length} comparison units ` +
+      `(${fixtures.length} fixtures x ${argv.flags.reps} reps, ${units.length * 3} claude calls), ` +
+      `concurrency ${argv.flags.concurrency}. Generation cwd: ${genCwd}.${RESET}`,
+  );
+
+  const judged = await mapPool(units, argv.flags.concurrency, async (unit) => {
+    const stem = `${unit.fixture.name.replace(/\.md$/, "")}.r${unit.rep}`;
+    const controlFirst = (unit.fixtureIndex + unit.rep) % 2 === 0;
+    try {
+      const controlPlan = await runClaude(
+        generatorPrompt(control, unit.fixture.prompt),
+        argv.flags.model,
+        genCwd,
+      );
+      const treatmentPlan = await runClaude(
+        generatorPrompt(treatment, unit.fixture.prompt),
+        argv.flags.model,
+        genCwd,
+      );
+      const planA = controlFirst ? controlPlan : treatmentPlan;
+      const planB = controlFirst ? treatmentPlan : controlPlan;
+      const judge = parseJudge(
+        await runClaude(
+          judgePrompt(judgeTemplate, unit.fixture.prompt, planA, planB),
+          argv.flags.model,
+          genCwd,
+        ),
+      );
+      const comparison = resolveComparison(judge, controlFirst);
+      await Bun.write(path.join(argv.flags.out, `${stem}.control.md`), controlPlan);
+      await Bun.write(path.join(argv.flags.out, `${stem}.treatment.md`), treatmentPlan);
+      await Bun.write(
+        path.join(argv.flags.out, `${stem}.judge.json`),
+        JSON.stringify({ controlFirst, judge, comparison }, null, 2),
+      );
+      console.error(`${DIM}  done: ${stem} (overall: ${comparison.overall})${RESET}`);
+      return comparison;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`  FAILED: ${stem}: ${message}`);
+      return null;
+    }
+  });
+
+  const ok = judged.filter((entry): entry is Comparison => Boolean(entry));
+  const failed = judged.length - ok.length;
+  if (failed > 0) {
+    // Dropped units are not a random sample: a condition that fails more often
+    // (e.g. the longer treatment prompt hitting a limit) skews the survivors,
+    // so the win rate below is computed over a biased subset. Flag it loudly.
+    console.error(
+      `${BOLD}Warning: ${failed} of ${judged.length} units failed and were dropped.${RESET} ` +
+        `Failures may correlate with condition, so the win rate is over a biased subset. ` +
+        `Re-run the failures or raise --reps before trusting a verdict.`,
+    );
+  }
+
+  const summary = summarize(ok);
+  console.log(
+    `${BOLD}Plan guidance A/B${RESET} ${DIM}(${fixtures.length} fixtures x ${argv.flags.reps} reps, n=${summary.n})${RESET}`,
+  );
+  console.log(
+    table([
+      ["dimension", "ctrl", "treat", "tie", "treat win [95% CI]"],
+      ...QUALITIES.map((key) => dimensionRow(QUALITY_LABELS[key], summary.qualities[key])),
+      dimensionRow("overall", summary.overall),
+    ]),
+  );
+  const headline = summary.overall;
+  const verdict =
+    headline.ci.lo > 0.5
+      ? "treatment wins"
+      : headline.ci.hi < 0.5
+        ? "control wins"
+        : "no decision (CI spans 50%)";
+  console.log(
+    `${DIM}Overall treatment win rate ${percent(headline.treatmentWinRate)} ` +
+      `[${percent(headline.ci.lo)}..${percent(headline.ci.hi)}] over ${headline.decisive} decisive ` +
+      `comparisons (${headline.tie} ties): ${verdict}. 50% means no effect.${RESET}`,
+  );
+  console.error(
+    `${DIM}Plans and judge results in ${argv.flags.out}/ (synthetic fixtures; safe to inspect).${RESET}`,
+  );
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/plugins/plan/evals/candidates/alternatives-section.md
+++ b/plugins/plan/evals/candidates/alternatives-section.md
@@ -1,0 +1,9 @@
+## Alternatives
+
+Optional, and rare. Most plans don't need it, and it is not a checklist item. `Direction Before Detail` handles the forward choice. This handles the backward record.
+
+Use it only for a non-obvious road not taken: an approach you genuinely weighed and rejected, or scope you decided against, where a reader would otherwise re-propose it. Skip anything self-evident.
+
+- One line each: name the alternative, state why you declined it. Don't relitigate.
+- Quarantine declined ideas under this heading. Keep them out of the plan body, where they otherwise scatter. Breaking that scatter is why this section exists.
+- A tracked follow-up (`#N`) is a forward pointer, not an alternative. It belongs in `Carryovers`, not here.

--- a/plugins/plan/evals/fixtures/cli-config.md
+++ b/plugins/plan/evals/fixtures/cli-config.md
@@ -1,0 +1,63 @@
+Our CLI takes a `--region` flag on almost every command. People are tired of typing it. I want a `config` subcommand so they can set a default once and have the other commands pick it up. Running `tool config set region us-west` should persist across runs, and after that `tool deploy` should behave as if `--region us-west` was passed.
+
+It is a Node + TypeScript CLI. Commands are defined with `cleye` for type-safe argv parsing. Here is the layout.
+
+```
+src/
+  cli.ts               # entrypoint, declares the command tree (below)
+  commands/
+    deploy.ts          # deploy command, reads --region (below)
+    status.ts          # status command, also reads --region
+  lib/
+    region.ts          # resolveRegion(flags) -> string, used by commands
+    paths.ts           # homeDir(), exposes the user's home directory
+```
+
+`src/cli.ts`:
+
+```ts
+import { cli, command } from "cleye";
+import { deploy } from "./commands/deploy";
+import { status } from "./commands/status";
+
+cli({
+  name: "tool",
+  commands: [deploy, status],
+});
+```
+
+`src/commands/deploy.ts`:
+
+```ts
+import { command } from "cleye";
+import { resolveRegion } from "../lib/region";
+
+export const deploy = command(
+  {
+    name: "deploy",
+    flags: {
+      region: { type: String, description: "Target region" },
+    },
+  },
+  (argv) => {
+    const region = resolveRegion(argv.flags);
+    // ... ships the build to `region`
+  },
+);
+```
+
+`src/lib/region.ts`:
+
+```ts
+export function resolveRegion(flags: { region?: string }): string {
+  const region = flags.region ?? process.env.TOOL_REGION;
+  if (!region) {
+    throw new Error("no region: pass --region or set TOOL_REGION");
+  }
+  return region;
+}
+```
+
+So today a command resolves its region from the explicit `--region` flag, then falls back to the `TOOL_REGION` environment variable. No stored config exists yet. Nothing reads or writes a file. I want `config get region` and `config set region <value>` to exist, and the stored value should slot in as a default that the existing commands honor. For now `region` is the only setting that matters. I would not be shocked if we add a couple more later.
+
+Keep it to the `config` command and making the stored value take effect. I do not want to redo how every command declares its flags, and I am not looking for anything pluggable. Plan the implementation.

--- a/plugins/plan/evals/fixtures/csv-export-streaming.md
+++ b/plugins/plan/evals/fixtures/csv-export-streaming.md
@@ -1,0 +1,48 @@
+Our CSV export endpoint falls over on large accounts. The handler loads every row for an account into memory, builds the whole CSV as one big string, and then sends it. On accounts with a lot of rows the process memory spikes and sometimes the whole thing crashes. I want the export to stream so memory stays roughly flat no matter how many rows an account has, while the client still gets a normal CSV download.
+
+Here is the relevant part of the service. It is a TypeScript HTTP API on Express with a Postgres database. The driver underneath is `pg`.
+
+```
+src/
+  server.ts            # express app, mounts routers
+  routes/
+    export.ts          # GET /accounts/:id/export.csv handler (below)
+    accounts.ts
+  lib/
+    db.ts              # pg Pool wrapper: db.query(sql, params), db.pool is the raw Pool
+    csv.ts             # toCsvRow(values: string[]) -> string, escapes + joins one row
+  middleware/
+    auth.ts            # sets req.accountId, checks the caller can read :id
+```
+
+`routes/export.ts`:
+
+```ts
+import { Router } from "express";
+import { db } from "../lib/db";
+import { toCsvRow } from "../lib/csv";
+
+export const exportRouter = Router();
+
+const COLUMNS = ["id", "created_at", "email", "plan", "status"];
+
+exportRouter.get("/accounts/:id/export.csv", async (req, res) => {
+  const { rows } = await db.query(
+    "SELECT id, created_at, email, plan, status FROM members WHERE account_id = $1 ORDER BY id",
+    [req.params.id],
+  );
+
+  const lines = [toCsvRow(COLUMNS)];
+  for (const row of rows) {
+    lines.push(toCsvRow([row.id, row.created_at, row.email, row.plan, row.status]));
+  }
+
+  res.setHeader("Content-Type", "text/csv");
+  res.setHeader("Content-Disposition", `attachment; filename="export-${req.params.id}.csv"`);
+  res.send(lines.join("\n"));
+});
+```
+
+`lib/db.ts` wraps a single `pg` `Pool`. `db.query` runs a one-shot query and buffers all rows, which is the part that hurts here. `db.pool` exposes the raw `Pool` if you need a dedicated client or anything lower level. `pg` supports server-side cursors and row-at-a-time streaming through `pg-query-stream`, which is not currently a dependency.
+
+The same columns should come out in the same order. This is just the one export endpoint. Plan the implementation.

--- a/plugins/plan/evals/fixtures/metrics-instrumentation.md
+++ b/plugins/plan/evals/fixtures/metrics-instrumentation.md
@@ -1,0 +1,55 @@
+Our checkout flow has no observability and we're flying blind. We can't tell how slow checkout is or how often it fails, and lately customers have reported slow or failed orders we can't reproduce. We already pay for a statsd-style metrics backend, so I want to instrument the checkout flow so latency and error rates show up there and we can build a dashboard off them.
+
+Here's the relevant code. It's a Node + TypeScript backend. The metrics client is already wired up and used elsewhere in the app.
+
+```
+src/
+  server.ts              # http server, mounts routes
+  routes/
+    checkout.ts          # POST /checkout calls services/checkout
+  services/
+    checkout.ts          # checkout() orchestration (below)
+    inventory.ts         # reserveInventory(items) -> Reservation
+    orders.ts            # createOrder(...) -> Order
+  lib/
+    payments.ts          # chargeCard(customerId, amountCents) -> Charge
+    metrics.ts           # metrics client (below)
+    logger.ts
+```
+
+`services/checkout.ts`:
+
+```ts
+import { reserveInventory } from "./inventory";
+import { createOrder } from "./orders";
+import { chargeCard } from "../lib/payments";
+
+export async function checkout(input: CheckoutInput): Promise<Order> {
+  const reservation = await reserveInventory(input.items);
+  const charge = await chargeCard(input.customerId, input.amountCents);
+  const order = await createOrder({
+    customerId: input.customerId,
+    items: input.items,
+    reservationId: reservation.id,
+    chargeId: charge.id,
+  });
+  return order;
+}
+```
+
+`lib/metrics.ts`:
+
+```ts
+export type Tags = Record<string, string>;
+
+export interface Metrics {
+  // increment a counter by 1
+  increment(name: string, tags?: Tags): void;
+  // record a duration in milliseconds
+  timing(name: string, ms: number, tags?: Tags): void;
+}
+
+export const metrics: Metrics = createStatsdClient(process.env.STATSD_URL);
+```
+
+Each of `reserveInventory`, `chargeCard`, and `createOrder` can throw on failure. Right now an error just propagates up out of `checkout()` and gets logged by the route handler. I want the checkout flow only. Plan the implementation.

--- a/plugins/plan/evals/fixtures/orders-filtering.md
+++ b/plugins/plan/evals/fixtures/orders-filtering.md
@@ -1,0 +1,37 @@
+Support staff need to track down specific orders, but the list endpoint only takes a customer ID today. They want to filter by order status, by a created-at date range, and by the customer's email address, and they often need several of those at once. Right now the handler dumps every order for a customer. Add filtering and search so support can narrow things down.
+
+Here is the relevant part of the service. It is a TypeScript HTTP API on Express, backed by Postgres. Orders and customers live in separate tables. The email lives on the customers table.
+
+```
+src/
+  server.ts            # express app, mounts routers
+  routes/
+    orders.ts          # GET /orders list handler (below)
+    fulfillment.ts
+  lib/
+    db.ts              # pg Pool wrapper: db.query(sql, params) -> { rows }
+  middleware/
+    auth.ts            # sets req.staffId for support staff requests
+```
+
+`routes/orders.ts`:
+
+```ts
+import { Router } from "express";
+import { db } from "../lib/db";
+
+export const orders = Router();
+
+orders.get("/orders", async (req, res) => {
+  const { customerId } = req.query;
+  const { rows } = await db.query(
+    "SELECT * FROM orders WHERE customer_id = $1",
+    [customerId],
+  );
+  res.json(rows);
+});
+```
+
+The `customers` table has `id`, `email`, and `name`. The `orders` table has `id`, `customer_id`, `status`, `created_at`, and `total_cents`. There's no index on `status` or `created_at` today.
+
+Status is one of `pending`, `shipped`, `delivered`, or `cancelled`. The date range and email filters are optional, and staff combine them freely (say, every `shipped` order for a given email in the last 30 days). Results should come back paginated so a wide search stays manageable. This is the read side of the orders list, nothing more. Plan the implementation.

--- a/plugins/plan/evals/fixtures/payments-idempotency.md
+++ b/plugins/plan/evals/fixtures/payments-idempotency.md
@@ -1,0 +1,50 @@
+Retried `POST /payments` requests can double-charge a customer when a client times out and resends. Add idempotency so a repeat of the same request returns the original response instead of charging again.
+
+Here is the relevant part of the service. It is a TypeScript HTTP API on Express with a Postgres database and a Redis instance already wired up.
+
+```
+src/
+  server.ts            # express app, mounts routers
+  routes/
+    payments.ts        # POST /payments handler (below)
+    refunds.ts
+  lib/
+    redis.ts           # shared redis client wrapper (below)
+    db.ts              # pg Pool wrapper: db.query(sql, params)
+    charge.ts          # charge(customerId, amountCents) -> { id, status }
+  middleware/
+    auth.ts            # sets req.customerId
+```
+
+`routes/payments.ts`:
+
+```ts
+import { Router } from "express";
+import { charge } from "../lib/charge";
+import { db } from "../lib/db";
+
+export const payments = Router();
+
+payments.post("/payments", async (req, res) => {
+  const { amountCents } = req.body;
+  const result = await charge(req.customerId, amountCents);
+  await db.query(
+    "INSERT INTO payments (id, customer_id, amount_cents, status) VALUES ($1, $2, $3, $4)",
+    [result.id, req.customerId, amountCents, result.status],
+  );
+  res.status(201).json(result);
+});
+```
+
+`lib/redis.ts`:
+
+```ts
+import { createClient } from "redis";
+
+export const redis = createClient({ url: process.env.REDIS_URL });
+await redis.connect();
+
+// get/set/del are the raw client methods. set takes options like { EX, NX }.
+```
+
+Clients send a `Idempotency-Key` header (a UUID they generate per logical request). Only `POST /payments` needs this for now. Plan the implementation.

--- a/plugins/plan/evals/fixtures/react-optimistic.md
+++ b/plugins/plan/evals/fixtures/react-optimistic.md
@@ -1,0 +1,65 @@
+Posting a comment feels sluggish right now. The new comment only appears after the server round trip finishes, so there's a visible delay between hitting submit and seeing the comment. Add optimistic updates so the comment shows up immediately and rolls back if the server rejects it.
+
+Here is the relevant part of the frontend. It is a React + TypeScript app using TanStack Query (react-query v5) for data fetching, with a shared `apiClient` for HTTP calls.
+
+```
+src/
+  api/
+    client.ts          # apiClient.get/post wrappers around fetch
+    comments.ts        # fetchComments(postId), createComment(postId, body)
+  hooks/
+    useComments.ts     # useQuery for the comments list
+    usePostComment.ts  # useMutation hook (below)
+  components/
+    CommentList.tsx     # renders comments + the composer (below)
+    CommentItem.tsx
+    Composer.tsx        # textarea + submit button, calls onSubmit(body)
+  types.ts             # Comment, NewComment
+```
+
+`hooks/usePostComment.ts`:
+
+```ts
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createComment } from "../api/comments";
+import type { Comment } from "../types";
+
+export function usePostComment(postId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: string): Promise<Comment> =>
+      createComment(postId, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["comments", postId] });
+    },
+  });
+}
+```
+
+`components/CommentList.tsx`:
+
+```tsx
+import { useComments } from "../hooks/useComments";
+import { usePostComment } from "../hooks/usePostComment";
+import { CommentItem } from "./CommentItem";
+import { Composer } from "./Composer";
+
+export function CommentList({ postId }: { postId: string }) {
+  const { data: comments = [], isLoading } = useComments(postId);
+  const { mutate, isPending } = usePostComment(postId);
+
+  if (isLoading) return <p>Loading comments…</p>;
+
+  return (
+    <section>
+      {comments.map((c) => (
+        <CommentItem key={c.id} comment={c} />
+      ))}
+      <Composer disabled={isPending} onSubmit={(body) => mutate(body)} />
+    </section>
+  );
+}
+```
+
+A `Comment` has `{ id: string; postId: string; body: string; author: string; createdAt: string }`. The server assigns `id`, `author`, and `createdAt`; the client only sends `body`. The comments query is keyed `["comments", postId]`. Only the comment posting flow needs this. Plan the implementation.

--- a/plugins/plan/evals/fixtures/session-expiry.md
+++ b/plugins/plan/evals/fixtures/session-expiry.md
@@ -1,0 +1,52 @@
+Sessions in our API never expire. We write them to Redis without a TTL on login, so a session id captured from a cookie stays valid forever. I want session expiration: an idle session should expire after a few minutes of inactivity, and every session should become invalid after an absolute cap of a few hours no matter how recently it was used.
+
+Here is the relevant part of the service. It is a TypeScript HTTP API on Express with a Redis instance already wired up. Auth is cookie-based: the browser sends a `sid` cookie, and the middleware loads the session from Redis.
+
+```
+src/
+  server.ts            # express app, mounts routers, cookie-parser
+  routes/
+    auth.ts            # POST /login, POST /logout (login below)
+    me.ts              # GET /me, reads req.session
+  lib/
+    redis.ts           # shared redis client: redis.get/set/del, set opts { EX, NX }
+    sessions.ts        # createSession(userId) -> sid
+  middleware/
+    auth.ts            # loads session from Redis, sets req.session (below)
+```
+
+`middleware/auth.ts`:
+
+```ts
+import type { Request, Response, NextFunction } from "express";
+import { redis } from "../lib/redis";
+
+export async function auth(req: Request, res: Response, next: NextFunction) {
+  const sid = req.cookies.sid;
+  if (!sid) return res.status(401).json({ error: "no session" });
+
+  const raw = await redis.get("session:" + sid);
+  if (!raw) return res.status(401).json({ error: "invalid session" });
+
+  req.session = JSON.parse(raw);
+  next();
+}
+```
+
+`lib/sessions.ts`:
+
+```ts
+import { randomUUID } from "crypto";
+import { redis } from "./redis";
+
+export async function createSession(userId: string): Promise<string> {
+  const sid = randomUUID();
+  const session = { userId, createdAt: Date.now() };
+  await redis.set("session:" + sid, JSON.stringify(session));
+  return sid;
+}
+```
+
+`createSession` is called from the `POST /login` handler in `routes/auth.ts` after the password check passes. The stored value is the JSON above. Right now nothing reads `createdAt`.
+
+This is about session lifetime only. Don't turn it into an auth rewrite, and I'm not looking for refresh tokens or OAuth here. Plan the implementation.

--- a/plugins/plan/evals/fixtures/webhook-retries.md
+++ b/plugins/plan/evals/fixtures/webhook-retries.md
@@ -1,0 +1,57 @@
+When a customer's webhook endpoint is down or times out, we lose the event. `deliver` does one `fetch` and just logs the failure, so the customer never finds out an order shipped or a payment cleared. Add retry with backoff and dead-letter a delivery after a few failed attempts instead of dropping it.
+
+Here is the relevant part of the service. It is a Node + TypeScript backend on Postgres. There is no message broker.
+
+```
+src/
+  index.ts             # service entrypoint, starts the HTTP server + workers
+  lib/
+    webhooks.ts        # outbound delivery (below)
+    db.ts              # pg Pool wrapper: db.query(sql, params)
+    events.ts          # records inbound events, enqueues outbound deliveries
+  workers/
+    jobs.ts            # claims rows from the `jobs` table and runs handlers
+  handlers/
+    inbound.ts         # receives webhooks FROM third parties (separate concern)
+```
+
+`lib/webhooks.ts`:
+
+```ts
+import { db } from "./db";
+
+export async function deliver(subscriptionId: string, payload: unknown) {
+  const sub = await db.query(
+    "SELECT url, secret FROM webhook_subscriptions WHERE id = $1",
+    [subscriptionId],
+  );
+  const { url, secret } = sub.rows[0];
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-signature": sign(payload, secret) },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) throw new Error(`status ${res.status}`);
+  } catch (err) {
+    console.error(`webhook ${subscriptionId} failed`, err);
+  }
+}
+```
+
+There is already a `jobs` table that the worker drains. It looks like this:
+
+```sql
+CREATE TABLE jobs (
+  id          BIGSERIAL PRIMARY KEY,
+  kind        TEXT NOT NULL,
+  args        JSONB NOT NULL,
+  run_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  attempts    INT NOT NULL DEFAULT 0,
+  status      TEXT NOT NULL DEFAULT 'pending'
+);
+```
+
+`workers/jobs.ts` polls for `status = 'pending' AND run_at <= now()`, runs the handler for the row's `kind`, and marks it `done`. Right now nothing registers a `kind` for webhook delivery. `deliver` is called directly from `events.ts`.
+
+We need failed deliveries to be retried on a backoff and dead-lettered after a cap (say a handful of attempts), so a flaky customer endpoint doesn't lose events. This is only about outbound delivery. Inbound webhook handling in `handlers/inbound.ts` is out of scope, and I don't want a broker or a rewrite of the job worker. Plan the implementation.

--- a/plugins/plan/evals/judge.md
+++ b/plugins/plan/evals/judge.md
@@ -1,0 +1,41 @@
+You are comparing two implementation plans written for the same request. Decide which plan is better, judged on the qualities below. The two plans are labeled A and B. You do not know which guidance produced either one. Judge only what is on the page.
+
+## Qualities
+
+- **Right-sized detail**: the plan confirms its direction before committing to file lists, line numbers, signatures, or test cases. It does not build elaborate detail around one unconfirmed approach. When more than one approach is viable, it surfaces the choice rather than presupposing one.
+- **Outcome-focused**: the plan states the goal and the end state it is driving toward, with outcomes a reader could verify. It reads as a path to a result. A flat checklist of tasks with no stated end state is weaker.
+- **Scope discipline**: the plan draws clear boundaries. It names what it is not doing and defers non-essential work instead of sprawling into everything adjacent.
+- **Grounded**: the plan refers to the actual code and constraints it was given. It does not invent files, symbols, or structure with no basis in the request. Where it needs something it was not given, it says so rather than assuming.
+
+## Request
+
+{{REQUEST}}
+
+## Plan A
+
+{{PLAN_A}}
+
+## Plan B
+
+{{PLAN_B}}
+
+## Output
+
+Compare the two plans on each quality, then overall. A plan can win a quality, lose it, or tie. The overall verdict is your holistic preference, not a tally of the per-quality calls. Use `tie` only when the two are genuinely close on that dimension.
+
+Judge the substance and disregard the form. Length is not quality: a longer plan, or one with more headings or extra labeled sections, is not better unless the added content makes one of the qualities above genuinely stronger. A section labeled "Alternatives" or "Out of scope" earns scope-discipline credit only when the boundary it draws is correct and not obvious. A section that restates the request, pads, or names a boundary no reader would have doubted is not a point in its favor. Reward a plan for drawing the right boundary, whether it does so in a dedicated section or in a sentence.
+
+Return only a JSON object, no prose, in this exact shape:
+
+```json
+{
+  "overall": "A|B|tie",
+  "qualities": {
+    "right_sized_detail": "A|B|tie",
+    "outcome_focused": "A|B|tie",
+    "scope_discipline": "A|B|tie",
+    "grounded": "A|B|tie"
+  },
+  "rationale": "<one or two sentences naming the deciding difference>"
+}
+```

--- a/plugins/plan/package.json
+++ b/plugins/plan/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@bendrucker/claude-plan",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "cleye": "^2.2.1",
+    "gray-matter": "^4.0.3",
+    "table": "^6.9.0"
+  }
+}

--- a/plugins/plan/scripts/alternatives-scan.test.ts
+++ b/plugins/plan/scripts/alternatives-scan.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "bun:test";
+import { aggregate, classifyPlan, wilson } from "./alternatives-scan";
+
+describe("classifyPlan", () => {
+  it("counts a rejection signal in the body as leaked", () => {
+    const plan = "# Plan\n\nWe will batch writes rather than flushing each row.\n";
+    expect(classifyPlan(plan)).toEqual({
+      hasAlternativesSection: false,
+      quarantined: 0,
+      leaked: 1,
+    });
+  });
+
+  it("counts a rejection signal under an Alternatives heading as quarantined", () => {
+    const plan = [
+      "# Plan",
+      "",
+      "Add a cache.",
+      "",
+      "## Alternatives",
+      "",
+      "- A Redis layer: rejected, the dataset fits in memory.",
+      "",
+    ].join("\n");
+    expect(classifyPlan(plan)).toEqual({
+      hasAlternativesSection: true,
+      quarantined: 1,
+      leaked: 0,
+    });
+  });
+
+  it("splits signal between the section and the leaking body", () => {
+    const plan = [
+      "# Plan",
+      "",
+      "We chose polling instead of a webhook for the first cut.",
+      "",
+      "## Alternatives",
+      "",
+      "- A queue: decided against it, no second consumer yet.",
+      "",
+    ].join("\n");
+    expect(classifyPlan(plan)).toEqual({
+      hasAlternativesSection: true,
+      quarantined: 1,
+      leaked: 1,
+    });
+  });
+
+  it("closes the section at a sibling or shallower heading", () => {
+    const plan = [
+      "## Alternatives",
+      "",
+      "- A daemon: rejected, too heavy.",
+      "",
+      "## Verification",
+      "",
+      "We ship the script rather than a service.",
+      "",
+    ].join("\n");
+    expect(classifyPlan(plan)).toEqual({
+      hasAlternativesSection: true,
+      quarantined: 1,
+      leaked: 1,
+    });
+  });
+
+  it("keeps a deeper heading inside the open section", () => {
+    const plan = [
+      "## Alternatives",
+      "",
+      "### Storage",
+      "",
+      "- Postgres: rejected, no relational need.",
+      "",
+    ].join("\n");
+    expect(classifyPlan(plan)).toMatchObject({ quarantined: 1, leaked: 0 });
+  });
+
+  it("recognizes an Alternatives Considered heading", () => {
+    const plan = "## Alternatives Considered\n\n- A plugin: rejected.\n";
+    expect(classifyPlan(plan)).toMatchObject({ hasAlternativesSection: true, quarantined: 1 });
+  });
+
+  it("recognizes a closed-ATX Alternatives heading", () => {
+    const plan = "## Alternatives ##\n\n- Redis: rejected.\n";
+    expect(classifyPlan(plan)).toMatchObject({ hasAlternativesSection: true, quarantined: 1 });
+  });
+
+  it("matches a rejection signal split across extra whitespace", () => {
+    expect(classifyPlan("We decided  against it.\n")).toMatchObject({ leaked: 1 });
+  });
+
+  it("ignores signal phrasing inside fenced code", () => {
+    const plan = ["# Plan", "", "```ts", "// rather than mutate, return a copy", "```", ""].join(
+      "\n",
+    );
+    expect(classifyPlan(plan)).toEqual({
+      hasAlternativesSection: false,
+      quarantined: 0,
+      leaked: 0,
+    });
+  });
+
+  it("counts a multi-signal line once", () => {
+    const plan = "We chose batching rather than flushing instead of streaming.\n";
+    expect(classifyPlan(plan)).toMatchObject({ leaked: 1 });
+  });
+});
+
+describe("aggregate", () => {
+  it("reports the leak rate over signal-carrying plans", () => {
+    const stats = aggregate([
+      { hasAlternativesSection: false, quarantined: 0, leaked: 2 },
+      { hasAlternativesSection: true, quarantined: 1, leaked: 0 },
+      { hasAlternativesSection: false, quarantined: 0, leaked: 0 },
+    ]);
+    expect(stats).toMatchObject({
+      plans: 3,
+      withSignal: 2,
+      withSection: 1,
+      leaking: 1,
+      quarantining: 1,
+      leakedLines: 2,
+      quarantinedLines: 1,
+    });
+    expect(stats.leakRate).toBeCloseTo(0.5);
+  });
+
+  it("reports a zero leak rate when no plan carries signal", () => {
+    expect(aggregate([{ hasAlternativesSection: false, quarantined: 0, leaked: 0 }])).toMatchObject(
+      {
+        withSignal: 0,
+        leakRate: 0,
+      },
+    );
+  });
+});
+
+describe("wilson", () => {
+  it("returns the full interval for an empty sample", () => {
+    expect(wilson(0, 0)).toEqual({ lo: 0, hi: 1 });
+  });
+
+  it("brackets the point estimate", () => {
+    const ci = wilson(47, 75);
+    expect(ci.lo).toBeLessThan(47 / 75);
+    expect(ci.hi).toBeGreaterThan(47 / 75);
+    expect(ci.lo).toBeGreaterThan(0);
+    expect(ci.hi).toBeLessThan(1);
+  });
+});

--- a/plugins/plan/scripts/alternatives-scan.ts
+++ b/plugins/plan/scripts/alternatives-scan.ts
@@ -1,0 +1,290 @@
+#!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: --ssh pulls a read-only remote plan corpus over ssh (Secretive agent needs the sandbox off)
+/**
+ * Baseline scanner for the "Alternatives" plan convention. Reads a
+ * directory of plan markdown and, per plan, classifies declined-alternative
+ * signal as quarantined (inside a dedicated `Alternatives` section) or
+ * leaked (anywhere else in the body). Prints an aggregate leak rate: the
+ * share of plans that carry roads-not-taken inline instead of under a
+ * named section.
+ *
+ * This is a coarse STRUCTURAL PROXY. It matches phrasing, never meaning. The
+ * rejection signals (`rejected`, `instead of`, ...) also fire on incidental
+ * contrastive phrasing ("instead of hardcoded SQL"), so the raw line counts
+ * overstate genuine alternatives. The value here is a re-runnable trend
+ * line over the real corpus, not an exact count. The seeded A/B in
+ * `../evals/` carries the real verdict on whether the guidance changes
+ * behavior.
+ *
+ * Local only. Plan content never leaves the machine: corpus artifacts go to
+ * tmp/ and only aggregate numbers are safe to share. `--ssh <host>` reads
+ * the work-machine corpus over ssh, read-only.
+ */
+import { mkdirSync, readdirSync } from "node:fs";
+import * as path from "node:path";
+import { cli } from "cleye";
+import { table } from "table";
+
+export interface PlanClassification {
+  /** A dedicated `Alternatives` (or `Alternatives Considered`) heading exists. */
+  hasAlternativesSection: boolean;
+  /** Rejection-signal lines inside the Alternatives section. */
+  quarantined: number;
+  /** Rejection-signal lines elsewhere in the body. */
+  leaked: number;
+}
+
+/**
+ * Phrases that mark a road not taken. Coarse by design: contrastive
+ * phrasing unrelated to a rejected alternative also matches.
+ */
+export const REJECTION_SIGNALS: RegExp[] = [
+  /\brejected\b/i,
+  /\bdecided\s+against\b/i,
+  /\bchose\s+not\b/i,
+  /\brather\s+than\b/i,
+  /\binstead\s+of\b/i,
+];
+
+const HEADING = /^(#{1,6})\s+(.+?)\s*#*\s*$/;
+const FENCE = /^\s*(```|~~~)/;
+const ALTERNATIVES_HEADING = /^alternatives(\s+considered)?$/i;
+
+/**
+ * Classify one plan. Walks lines tracking fenced-code state and the depth
+ * of an open Alternatives section. A heading at the section's depth or
+ * shallower closes it. Signal lines inside fenced code are ignored (they
+ * are example text, not plan prose).
+ */
+export function classifyPlan(markdown: string): PlanClassification {
+  let inFence = false;
+  let altDepth = 0;
+  let hasAlternativesSection = false;
+  let quarantined = 0;
+  let leaked = 0;
+
+  for (const line of markdown.split("\n")) {
+    if (FENCE.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    const heading = line.match(HEADING);
+    if (heading) {
+      const [, hashes, rawText] = heading;
+      if (hashes === undefined || rawText === undefined) continue;
+      const depth = hashes.length;
+      const text = rawText.trim();
+      if (altDepth > 0 && depth <= altDepth) altDepth = 0;
+      if (ALTERNATIVES_HEADING.test(text)) {
+        hasAlternativesSection = true;
+        altDepth = depth;
+      }
+      continue;
+    }
+
+    if (REJECTION_SIGNALS.some((signal) => signal.test(line))) {
+      if (altDepth > 0) quarantined++;
+      else leaked++;
+    }
+  }
+
+  return { hasAlternativesSection, quarantined, leaked };
+}
+
+export interface Aggregate {
+  plans: number;
+  withSignal: number;
+  withSection: number;
+  quarantining: number;
+  leaking: number;
+  leakedLines: number;
+  quarantinedLines: number;
+  /** Share of signal-carrying plans that leak roads-not-taken inline. */
+  leakRate: number;
+}
+
+export function aggregate(classifications: PlanClassification[]): Aggregate {
+  let withSignal = 0;
+  let withSection = 0;
+  let quarantining = 0;
+  let leaking = 0;
+  let leakedLines = 0;
+  let quarantinedLines = 0;
+
+  for (const c of classifications) {
+    if (c.hasAlternativesSection) withSection++;
+    if (c.quarantined > 0) quarantining++;
+    if (c.leaked > 0) leaking++;
+    if (c.quarantined + c.leaked > 0) withSignal++;
+    leakedLines += c.leaked;
+    quarantinedLines += c.quarantined;
+  }
+
+  return {
+    plans: classifications.length,
+    withSignal,
+    withSection,
+    quarantining,
+    leaking,
+    leakedLines,
+    quarantinedLines,
+    leakRate: withSignal > 0 ? leaking / withSignal : 0,
+  };
+}
+
+/** Wilson score interval for a binomial proportion (95%). */
+export function wilson(successes: number, n: number): { lo: number; hi: number } {
+  if (n === 0) return { lo: 0, hi: 1 };
+  const z = 1.96;
+  const p = successes / n;
+  const denom = 1 + z ** 2 / n;
+  const center = (p + z ** 2 / (2 * n)) / denom;
+  const margin = (z * Math.sqrt((p * (1 - p)) / n + z ** 2 / (4 * n ** 2))) / denom;
+  return { lo: Math.max(0, center - margin), hi: Math.min(1, center + margin) };
+}
+
+export interface PlanDoc {
+  name: string;
+  text: string;
+}
+
+async function corpusFromDir(dir: string): Promise<PlanDoc[]> {
+  const names = readdirSync(dir)
+    .filter((name) => name.endsWith(".md"))
+    .sort();
+  return Promise.all(
+    names.map(async (name) => ({
+      name,
+      text: await Bun.file(path.join(dir, name)).text(),
+    })),
+  );
+}
+
+const FILE_MARKER = "===ALT-SCAN-FILE===";
+
+/**
+ * Pull the remote plan corpus in a single ssh connection. Each file is
+ * framed by a marker line so one stream yields every plan. Read-only.
+ */
+async function corpusFromSsh(host: string, dir: string): Promise<PlanDoc[]> {
+  // `[ -e "$f" ] || continue` skips the literal pattern an empty dir leaves
+  // unexpanded, so a corpus with no .md files yields empty output and hits the
+  // clean empty-corpus guard instead of a confusing `cat: ...: No such file`.
+  const remote = `for f in ${dir}/*.md; do [ -e "$f" ] || continue; echo "${FILE_MARKER}$f"; cat "$f"; done`;
+  const proc = Bun.spawn(["ssh", host, remote], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exit] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exit !== 0) {
+    throw new Error(`ssh ${host} failed (exit ${exit}): ${stderr.trim()}`);
+  }
+
+  const docs: PlanDoc[] = [];
+  let current: PlanDoc | null = null;
+  for (const line of stdout.split("\n")) {
+    if (line.startsWith(FILE_MARKER)) {
+      if (current) docs.push(current);
+      current = { name: path.basename(line.slice(FILE_MARKER.length)), text: "" };
+      continue;
+    }
+    if (current) current.text += `${line}\n`;
+  }
+  if (current) docs.push(current);
+  return docs;
+}
+
+export function percent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+export const BOLD = "\x1b[1m";
+export const DIM = "\x1b[2m";
+export const RESET = "\x1b[0m";
+
+async function main(): Promise<void> {
+  const argv = cli({
+    name: "alternatives-scan",
+    flags: {
+      dir: {
+        type: String,
+        description:
+          "Directory of plan markdown (default: ~/.claude/plans, resolved on the target)",
+      },
+      ssh: {
+        type: String,
+        description: "Read the corpus from <host> over ssh (read-only) instead of --dir",
+      },
+      out: {
+        type: String,
+        description: "Output directory for the per-plan artifact",
+        default: "tmp",
+      },
+    },
+  });
+
+  // The local default bakes in this machine's HOME, which is wrong for a
+  // remote host. Over ssh, let the remote shell expand ~ against its own HOME.
+  const dir =
+    argv.flags.dir ??
+    (argv.flags.ssh ? "~/.claude/plans" : path.join(process.env.HOME ?? "", ".claude", "plans"));
+
+  const corpus = argv.flags.ssh
+    ? await corpusFromSsh(argv.flags.ssh, dir)
+    : await corpusFromDir(dir);
+
+  if (corpus.length === 0) {
+    console.error(`No .md plans found in ${argv.flags.ssh ? `${argv.flags.ssh}:${dir}` : dir}`);
+    process.exit(1);
+  }
+
+  const classified = corpus.map((doc) => ({ ...doc, ...classifyPlan(doc.text) }));
+  const stats = aggregate(classified);
+
+  mkdirSync(argv.flags.out, { recursive: true });
+  const artifact = path.join(argv.flags.out, "alternatives-scan.tsv");
+  await Bun.write(
+    artifact,
+    `# name\thasSection\tquarantined\tleaked\n${classified
+      .map((c) => `${c.name}\t${c.hasAlternativesSection}\t${c.quarantined}\t${c.leaked}`)
+      .join("\n")}\n`,
+  );
+
+  const source = argv.flags.ssh ? `${argv.flags.ssh}:${dir}` : dir;
+  const ci = wilson(stats.leaking, stats.withSignal);
+
+  // With no signal-carrying plans the leak/quarantine shares are undefined, so
+  // print a dash rather than a misleading 0.0% / 100.0% split over zero plans.
+  const leakShare = stats.withSignal > 0 ? percent(stats.leakRate) : "—";
+  const quarantineShare = stats.withSignal > 0 ? percent(1 - stats.leakRate) : "—";
+
+  console.log(`${BOLD}Alternatives scan${RESET} ${DIM}(${source}, ${stats.plans} plans)${RESET}`);
+  console.log(
+    table([
+      ["metric", "count", "share of signal-carrying"],
+      ["plans with declined-alternative signal", String(stats.withSignal), "—"],
+      ["leak it inline", String(stats.leaking), leakShare],
+      ["quarantine it in a section", String(stats.quarantining), quarantineShare],
+      ["have a dedicated Alternatives section", String(stats.withSection), "—"],
+    ]),
+  );
+  console.log(
+    `Inline leak rate: ${BOLD}${percent(stats.leakRate)}${RESET} ` +
+      `(95% CI ${percent(ci.lo)}..${percent(ci.hi)}); ` +
+      `${stats.leakedLines} leaked vs ${stats.quarantinedLines} quarantined signal lines.`,
+  );
+  console.log(
+    `${DIM}Coarse structural proxy: contrastive phrasing inflates the raw line counts. ` +
+      `The A/B in ../evals/ carries the real verdict.${RESET}`,
+  );
+  console.error(
+    `${DIM}Per-plan artifact: ${artifact} (local only; never commit or paste).${RESET}`,
+  );
+}
+
+if (import.meta.main) {
+  await main();
+}


### PR DESCRIPTION
Adds a local A/B harness and a corpus scanner to the `plan` plugin for testing whether a candidate guidance idea actually improves plan quality before it earns a place in `references/guidelines.md`. The shipped guidelines are unchanged. Adding guidance is cheap and accumulation is silent, so this is the measure-first instrument that curation discipline asks for.

The harness holds the baseline guidelines as the control and appends a candidate snippet (`evals/candidates/`) to form the treatment, so an idea can be tested without editing the guidelines. For each fixture it generates a plan under each condition, then a judge compares the two head-to-head on four qualities (right-sized detail, outcome focus, scope discipline, grounding) and overall. The metric is treatment's win rate over decisive comparisons with Wilson intervals. Position is counterbalanced and generation runs greenfield in an empty temp dir so the grounding rules never refuse the synthetic request. Fixtures carry their own embedded codebase context so the grounded quality has real structure to check.

## The First Candidate's Verdict

`evals/candidates/alternatives-section.md` adds an optional `## Alternatives` section for declined roads. It was the idea that motivated the harness, and the harness is why it is not in this PR. An early run leaned positive, but the lean tracked the candidate's extra section rather than better plans. Once the judge was hardened to disregard length and section form, scope discipline collapsed toward 50% and the overall win rate landed around 54.8% with an interval spanning 50%. That run was also truncated by a spend limit, so the number is soft, but the de-confounded signal is null-to-marginal. The candidate stays as a frozen record of what was tested. The harness stays to test the next idea.

## Scanner

`scripts/alternatives-scan.ts` is a coarse structural baseline over a real plan corpus, measuring how often declined-alternative phrasing leaks inline versus landing under a dedicated section. It is a phrasing proxy, not a meaning detector, and the A/B carries the real verdict. It reads a local directory by default and can pull a remote corpus read-only over `--ssh`.

## Testing

`bun test plugins/plan` covers the pure helpers in both files: treatment composition, judge-output parsing, side-to-condition mapping, win-rate summarization, and the scanner's plan classification and aggregation. The A/B shells out to `claude -p` and the corpus is local, so neither the A/B nor the corpus scan runs in CI. A `/code-review high` pass over this branch shaped the final form. It caught the eval fixtures being swept up by the root `**/fixtures/` ignore, where they would have crashed the harness on a fresh clone (now re-included), an eval README that documented an earlier metric the code no longer implements (rewritten to match), and scanner and judge-parsing edge cases (closed-ATX headings, an unquoted remote glob, a misleading full-quarantine share over zero signal, brittle brace-span JSON extraction). Each edge case has a regression test.
