### PR TITLE
tmux: simplify theme colors and dedup trunc helper

### DIFF
--- a/plugins/tmux/hooks/notification.ts
+++ b/plugins/tmux/hooks/notification.ts
@@ -68,15 +68,17 @@ function updateSummary(): void {
     text += ` (+${entries.length - 1})`;
   }
 
-  const color = "#d97757";
-  const crust = "#11111b";
-  const fg = "#cdd6f4";
-  const surface = "#313244";
+  // ANSI colours 0-15 are remapped by the terminal's Catppuccin theme, so the
+  // status segment adapts to light and dark mode (see scripts.md).
+  const accent = "colour3";
+  const crust = "colour0";
+  const fg = "colour7";
+  const surface = "colour8";
   const sep = "\uE0B6";
 
   const styled = [
-    `#[fg=${color}]${sep}`,
-    `#[fg=${crust},bg=${color}]󰂞 `,
+    `#[fg=${accent}]${sep}`,
+    `#[fg=${crust},bg=${accent}]󰂞 `,
     `#[fg=${fg},bg=${surface}] ${text}`,
     `#[fg=${surface}] `,
   ].join("");

--- a/plugins/tmux/skills/tmux/scripts/lib.sh
+++ b/plugins/tmux/skills/tmux/scripts/lib.sh
@@ -5,3 +5,13 @@ lookup_failed() {
   echo "$1 lookup failed: cannot reach tmux${TMUX:+ at ${TMUX%%,*}}. If Claude Code's Bash sandbox is enabled, allow the tmux socket's directory under sandbox.network.allowUnixSockets (see the tmux plugin README)." >&2
   exit 1
 }
+
+# Truncate $1 to at most $2 (default 48) characters, appending an ellipsis when cut.
+trunc() {
+  local str=$1 max=${2:-48}
+  if [ ${#str} -gt "$max" ]; then
+    printf '%s…' "${str:0:$((max-1))}"
+  else
+    printf '%s' "$str"
+  fi
+}

--- a/plugins/tmux/skills/tmux/scripts/session.sh
+++ b/plugins/tmux/skills/tmux/scripts/session.sh
@@ -3,17 +3,6 @@ set -euo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-MAX_TITLE=48
-
-trunc() {
-  local max=$1 str=$2
-  if [ ${#str} -gt "$max" ]; then
-    printf '%s…' "${str:0:$((max-1))}"
-  else
-    printf '%s' "$str"
-  fi
-}
-
 TAB=$'\t'
 
 target="${1:-}"
@@ -32,5 +21,5 @@ tmux list-windows -t "$target" -F "$fmt" 2>/dev/null | while IFS=$'\t' read -r i
   [ "$idx" = "$current_window" ] && flags="here"
   [ "$bell" = "1" ] && flags="${flags:+$flags, }bell"
   [ "$activity" = "1" ] && flags="${flags:+$flags, }activity"
-  printf '%-6s %-16s %-6s %-25s %s\n' "$idx" "$name" "$panes" "$flags" "$(trunc $MAX_TITLE "$title")"
+  printf '%-6s %-16s %-6s %-25s %s\n' "$idx" "$name" "$panes" "$flags" "$(trunc "$title")"
 done

--- a/plugins/tmux/skills/tmux/scripts/window.sh
+++ b/plugins/tmux/skills/tmux/scripts/window.sh
@@ -3,17 +3,6 @@ set -euo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
-MAX_TITLE=48
-
-trunc() {
-  local max=$1 str=$2
-  if [ ${#str} -gt "$max" ]; then
-    printf '%s…' "${str:0:$((max-1))}"
-  else
-    printf '%s' "$str"
-  fi
-}
-
 # Print "<branch> (worktree|main)" for a pane's path, or nothing outside a repo.
 git_segment() {
   local path=$1 branch gdir cdir kind
@@ -42,7 +31,7 @@ tmux list-panes -t "$target" -F "$fmt" 2>/dev/null | while IFS=$'\t' read -r id 
   line="${id}${tag} ${cmd}"
 
   if [ -n "$title" ]; then
-    line="${line} $(trunc $MAX_TITLE "$title")"
+    line="${line} $(trunc "$title")"
   fi
 
   if [ "$path" != "$PWD" ]; then


### PR DESCRIPTION
Two small simplifications to the tmux plugin's status styling and helpers.

The notification status segment hardcoded a Catppuccin Mocha palette as truecolor hex, so it only rendered correctly in dark mode and ignored the repo's `scripts.md` rule to use ANSI colors 0-15. Swapping the hex for `colourN` indices lets the terminal's Catppuccin theme remap them, so the segment adapts to light and dark. The powerline shape and icon are unchanged.

The `trunc()` helper and its `MAX_TITLE` constant were copy-pasted identically in `window.sh` and `session.sh`. Both already source `lib.sh`, so the helper moves there (defaulting the max to 48) and the callers simplify to `trunc "$title"`.

Verified `tsc --noEmit` and `biome check` clean, `bash -n` on all three scripts, and live `window.sh` / `session.sh` output.
