### PR TITLE
tmux: add inter-pane relay handoff protocol

### DIFF
--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -5,9 +5,11 @@ Tmux session, window, and pane awareness for Claude Code.
 ## Contents
 
 - **Skill: tmux** — Layout awareness, pane interaction, and notification monitoring
+- **Skill: relay** — A handoff protocol for passing messages between Claude sessions in different panes
 - **Hook: context** — SessionStart hook that injects tmux env vars
 - **Hook: resume-command**, a SessionStart hook that records the session's resume command in a pane-scoped tmux option for plugins like [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) to use when resuming a pane
 - **Hook: notification** — Bell and status bar notifications for permission prompts
+- **Hook: relay** — UserPromptSubmit hook that recognizes inbound relay messages and tells the receiving session how to reply
 
 ## How It Works
 
@@ -16,6 +18,14 @@ A SessionStart hook detects whether Claude is running inside tmux and writes ses
 Another SessionStart hook records the command that resumes the current session (`claude --resume <id>`) in the pane-scoped tmux option `@resume-command`, refreshed on every session start. Plugins like tmux-resurrect can read it back with `tmux show-options -p -t <pane> -qv @resume-command` to resume the session when restoring a pane. Outside tmux the hook is a no-op.
 
 The skill provides a PreToolUse hook that auto-allows safe tmux commands (read-only and within-window layout). The safe command list is maintained in [`safe-commands.json`](skills/tmux/resources/safe-commands.json). Window-switching verbs (`select-window`, `switch-client`, `next`/`previous`/`last-window`) are deliberately excluded, so they fall through to a permission prompt. This keeps cross-window navigation an explicit choice rather than a silent one during autonomous work.
+
+## Relay
+
+The [`relay` skill](skills/relay/SKILL.md) lets two Claude sessions on the same tmux server talk to each other. `relay.sh <pane> <kind> <message>` sends a message into another pane's prompt, prefixed with a `[[tmux-relay from=… reply-to=… kind=…]]` header stamped with the sender's pane id. Pane ids are server-global, so the channel spans windows and sessions, not just panes in one window.
+
+On the receiving side, a `UserPromptSubmit` hook ([`relay.ts`](hooks/relay.ts)) detects that header on an inbound prompt and injects the sender's pane, reply target, and message kind into the receiving session's context — so a session that has never loaded the skill still knows it received peer mail and how to reply. Ordinary prompts don't match the header, so the hook is a no-op on normal input.
+
+Sending is auto-allowed by the relay skill's PreToolUse hook (like the rest of the plugin's scripts), which makes a pane addressable by its peers without a permission prompt on every message. This is what lets a handoff proceed autonomously.
 
 ## Sandbox
 

--- a/plugins/tmux/hooks/hooks.json
+++ b/plugins/tmux/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Inject tmux context, persist the session's resume command for tmux-resurrect, and ring terminal bell for notifications",
+  "description": "Inject tmux context, persist the session's resume command for tmux-resurrect, ring terminal bell for notifications, and surface inter-pane relay messages",
   "hooks": {
     "SessionStart": [
       {
@@ -15,6 +15,16 @@
           {
             "type": "command",
             "command": "[ -n \"$TMUX_PANE\" ] && tmux set-option -p -t \"$TMUX_PANE\" @resume-command \"claude --resume $CLAUDE_CODE_SESSION_ID\" || true"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/relay.ts\""
           }
         ]
       }

--- a/plugins/tmux/hooks/relay.test.ts
+++ b/plugins/tmux/hooks/relay.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import { buildContext, parseEnvelope, processPrompt } from "./relay";
+
+const envelope = (attrs: string, body = "do the thing") => `[[tmux-relay ${attrs}]]\n${body}`;
+
+describe("parseEnvelope", () => {
+  it("parses a full envelope", () => {
+    expect(parseEnvelope(envelope("from=%3 reply-to=%3 kind=handoff window=feat/auth:2"))).toEqual({
+      from: "%3",
+      replyTo: "%3",
+      kind: "handoff",
+      window: "feat/auth:2",
+      body: "do the thing",
+    });
+  });
+
+  it("defaults reply-to to from and kind to message", () => {
+    const env = parseEnvelope(envelope("from=%5"));
+    expect(env?.replyTo).toBe("%5");
+    expect(env?.kind).toBe("message");
+    expect(env?.window).toBeNull();
+  });
+
+  it("keeps a multi-line body intact", () => {
+    expect(parseEnvelope(envelope("from=%1", "line one\nline two"))?.body).toBe(
+      "line one\nline two",
+    );
+  });
+
+  it("returns null for an ordinary prompt", () => {
+    expect(parseEnvelope("fix the failing test in foo.ts")).toBeNull();
+  });
+
+  it("returns null when the envelope is not at the start", () => {
+    expect(parseEnvelope("hey [[tmux-relay from=%3]]\nbody")).toBeNull();
+  });
+
+  it("returns null when from is missing", () => {
+    expect(parseEnvelope("[[tmux-relay kind=message]]\nbody")).toBeNull();
+  });
+});
+
+describe("buildContext", () => {
+  it("includes origin, reply target, and kind", () => {
+    const text = buildContext({
+      from: "%3",
+      replyTo: "%3",
+      kind: "handoff",
+      window: "feat/auth:2",
+      body: "x",
+    });
+    expect(text).toContain("%3 (window feat/auth:2)");
+    expect(text).toContain("Reply to pane: %3");
+    expect(text).toContain("Kind: handoff");
+    expect(text).toContain("tmux:relay");
+  });
+
+  it("omits the window clause when unknown", () => {
+    const text = buildContext({
+      from: "%3",
+      replyTo: "%3",
+      kind: "message",
+      window: null,
+      body: "x",
+    });
+    expect(text).toContain("From pane: %3\n");
+    expect(text).not.toContain("window");
+  });
+});
+
+describe("processPrompt", () => {
+  it("returns UserPromptSubmit context for a relay prompt", () => {
+    const result = processPrompt(envelope("from=%4 reply-to=%4 kind=message"));
+    const output = result?.hookSpecificOutput as Record<string, unknown>;
+    expect(output?.hookEventName).toBe("UserPromptSubmit");
+    expect(output?.additionalContext).toContain("Reply to pane: %4");
+  });
+
+  it("returns null for an ordinary prompt", () => {
+    expect(processPrompt("just a normal message")).toBeNull();
+  });
+
+  it("returns null for an undefined prompt", () => {
+    expect(processPrompt(undefined)).toBeNull();
+  });
+});

--- a/plugins/tmux/hooks/relay.ts
+++ b/plugins/tmux/hooks/relay.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env bun
+
+import type { SyncHookJSONOutput, UserPromptSubmitHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+
+export interface RelayEnvelope {
+  from: string;
+  replyTo: string;
+  kind: string;
+  window: string | null;
+  body: string;
+}
+
+const HEADER = /^\[\[tmux-relay\s+([^\]]*)\]\]\s*\n?([\s\S]*)$/;
+
+/**
+ * Parse a relay envelope from the first line of a submitted prompt. Returns
+ * null for ordinary prompts so the hook is a no-op on everything but peer mail.
+ */
+export function parseEnvelope(prompt: string): RelayEnvelope | null {
+  const match = prompt.match(HEADER);
+  if (!match) return null;
+
+  const attrs = new Map<string, string>();
+  for (const token of (match[1] ?? "").trim().split(/\s+/)) {
+    const eq = token.indexOf("=");
+    if (eq > 0) attrs.set(token.slice(0, eq), token.slice(eq + 1));
+  }
+
+  const from = attrs.get("from");
+  if (!from) return null;
+
+  return {
+    from,
+    replyTo: attrs.get("reply-to") ?? from,
+    kind: attrs.get("kind") ?? "message",
+    window: attrs.get("window") ?? null,
+    body: match[2] ?? "",
+  };
+}
+
+export function buildContext(env: RelayEnvelope): string {
+  const origin = env.window ? `${env.from} (window ${env.window})` : env.from;
+  return [
+    "This prompt is a tmux-relay message from another Claude Code session, not from the user.",
+    "",
+    `- From pane: ${origin}`,
+    `- Reply to pane: ${env.replyTo}`,
+    `- Kind: ${env.kind}`,
+    "",
+    "The text after the header line is the peer's message. Load the tmux:relay skill to",
+    `respond: send your reply to pane ${env.replyTo} so it routes back. Keep the exchange`,
+    "going until the request is resolved, and stamp every reply with your own pane.",
+  ].join("\n");
+}
+
+export function processPrompt(prompt: string | undefined): SyncHookJSONOutput | null {
+  if (!prompt) return null;
+  const env = parseEnvelope(prompt);
+  if (!env) return null;
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext: buildContext(env),
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  let input: UserPromptSubmitHookInput;
+  try {
+    input = await readStdinJson<UserPromptSubmitHookInput>();
+  } catch (error) {
+    console.error(
+      `[tmux/relay] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  const output = processPrompt(input.prompt);
+  if (output) writeStdoutJson(output);
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/plugins/tmux/skills/relay/SKILL.md
+++ b/plugins/tmux/skills/relay/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: relay
+description: Pass messages and hand off work between Claude Code sessions running in different tmux panes. Use when coordinating with, messaging, replying to, or handing context to a Claude in another pane or window.
+argument-hint: "[send | handoff | reply] <pane> <message>"
+allowed-tools:
+  - "Bash(bash ${CLAUDE_SKILL_DIR}/scripts/relay.sh:*)"
+  - "Bash(bash ${CLAUDE_SKILL_DIR}/../tmux/scripts/sessions.sh)"
+  - "Bash(bash ${CLAUDE_SKILL_DIR}/../tmux/scripts/session.sh:*)"
+hooks:
+  PreToolUse:
+    - matcher: "Bash(bash ${CLAUDE_SKILL_DIR}/scripts/:*)"
+      hooks:
+        - type: command
+          command: |
+            cat | jq '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"}}'
+---
+
+# relay
+
+A handoff protocol for Claude sessions sharing a tmux server. Each session lives
+in a pane; `relay.sh` carries a message into another pane's prompt, stamped with
+the sender's pane id so the peer knows who it's talking to and where to reply.
+Pane ids are server-global, so this works within a window and across windows and
+sessions.
+
+## Sending
+
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/relay.sh <target-pane> <kind> <message...>
+```
+
+- `target-pane` — the peer's pane id (e.g. `%3`).
+- `kind` — `hello`, `message`, `handoff`, or `ack` (see [Kinds](#kinds)).
+- `message` — the body; multiple args join with spaces.
+
+The peer receives a header line plus your body and submits it as its next
+prompt:
+
+```
+[[tmux-relay from=%4 reply-to=%4 kind=handoff window=main:1]]
+<your message>
+```
+
+## Finding a peer
+
+You need the target pane's id. Inventory the server with the sibling `tmux`
+skill's scripts:
+
+```bash
+bash ${CLAUDE_SKILL_DIR}/../tmux/scripts/sessions.sh        # all sessions
+bash ${CLAUDE_SKILL_DIR}/../tmux/scripts/session.sh <name>  # windows + pane ids
+```
+
+Match the user's reference ("the pane on the X branch", "the window running
+tests") to a pane id. Your own pane is `$TMUX_PANE` — never relay to yourself.
+
+## Receiving
+
+When a prompt arrives whose first line is `[[tmux-relay ...]]`, a
+`UserPromptSubmit` hook injects the sender's pane, reply target, and kind into
+your context. Treat the text after the header as the peer's message:
+
+1. Act on it (or answer it) as the situation warrants.
+2. Reply by relaying back to the `reply-to` pane, stamped with your own pane:
+   ```bash
+   bash ${CLAUDE_SKILL_DIR}/scripts/relay.sh <reply-to> message "<your reply>"
+   ```
+3. Continue until the request is resolved. Acknowledge completion with an `ack`
+   so the peer knows the link is idle.
+
+## Establishing a link
+
+Open with a `hello` so the peer learns your pane id without having to look it
+up; it replies with `ack`. After that, both sides hold each other's id and
+exchange `message`s freely.
+
+```bash
+# pane %4 -> pane %3
+bash ${CLAUDE_SKILL_DIR}/scripts/relay.sh %3 hello "Pairing on the auth refactor — ping me when the migration lands."
+```
+
+## Kinds
+
+| Kind | Use |
+|---|---|
+| `hello` | Open a link; announce your pane and intent. Expect an `ack`. |
+| `message` | Ongoing exchange once a link is open. |
+| `handoff` | Transfer a task. Include enough context to take over: branch/worktree, what's done, what's left, where to look. |
+| `ack` | Acknowledge receipt or completion; signals the link is idle. |
+
+## Handing off to a teammate
+
+A handoff is a `message` carrying everything the peer needs to continue without
+re-deriving state. Lead with the ask, then the context:
+
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/relay.sh %3 handoff "Take over the failing e2e suite on branch feat/checkout. \
+Root cause is the stubbed clock in tests/setup.ts; I've fixed unit tests, e2e still red. \
+Start at tests/e2e/checkout.spec.ts:42. Reply here when green."
+```
+
+## Notes
+
+- Relayed text submits as the peer's next prompt. If the peer is mid-turn the
+  keystrokes queue until its input is ready, so messages are never dropped but
+  may land after the current turn finishes.
+- Sending is auto-allowed (the skill's scripts run without a prompt) so an
+  autonomous session can drive an exchange. This is deliberate: it makes a
+  pane addressable by its peers. Don't relay to a pane the user hasn't asked
+  you to coordinate with.
+- Both panes must share one tmux server. The sandbox must allow the tmux socket
+  — see the plugin [README](../../README.md).

--- a/plugins/tmux/skills/relay/scripts/relay.integration.ts
+++ b/plugins/tmux/skills/relay/scripts/relay.integration.ts
@@ -1,0 +1,92 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Drives relay.sh through a real tmux server: it relays a message from one
+// pane to another and asserts the stamped envelope and body land in the target
+// pane. Gated on tmux being installed so it no-ops where tmux is absent.
+const hasTmux = Bun.which("tmux") !== null;
+const relayScript = join(import.meta.dir, "relay.sh");
+
+// Short socket dir — tmux's AF_UNIX path has a ~104-char limit, and the
+// scratchpad path is too long to nest a socket under.
+let socketDir: string;
+let env: Record<string, string>;
+
+function tmux(args: string[], extraEnv: Record<string, string> = {}): string {
+  const proc = Bun.spawnSync(["tmux", ...args], {
+    env: { ...env, ...extraEnv },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (proc.exitCode !== 0) {
+    throw new Error(`tmux ${args.join(" ")} failed: ${proc.stderr.toString().trim()}`);
+  }
+  return proc.stdout.toString().trim();
+}
+
+async function captureUntil(pane: string, needle: string, timeoutMs = 3000): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let content = "";
+  while (Date.now() < deadline) {
+    content = tmux(["capture-pane", "-t", pane, "-p"]);
+    if (content.includes(needle)) return content;
+    await Bun.sleep(50);
+  }
+  return content;
+}
+
+describe.skipIf(!hasTmux)("relay.sh end-to-end", () => {
+  beforeAll(() => {
+    socketDir = mkdtempSync(join(tmpdir(), "relay-it-"));
+    env = { ...process.env, TMUX_TMPDIR: socketDir } as Record<string, string>;
+  });
+
+  afterAll(() => {
+    try {
+      tmux(["kill-server"]);
+    } catch {
+      // server may already be gone
+    }
+    Bun.spawnSync(["rm", "-rf", socketDir]);
+  });
+
+  it("delivers a stamped multi-line envelope to the target pane", async () => {
+    const session = "relay-it";
+    tmux(["new-session", "-d", "-s", session, "-x", "200", "-y", "50"]);
+    const src = tmux(["display-message", "-t", session, "-p", "#{pane_id}"]);
+    tmux(["split-window", "-t", session, "-h", "-d"]);
+    const dst = tmux(["list-panes", "-t", session, "-F", "#{pane_id}"])
+      .split("\n")
+      .find((id) => id !== src);
+    if (!dst) throw new Error("split-window did not produce a second pane");
+
+    const body = "Take over branch feat/x\nStart at tests/e2e.spec.ts:42";
+    const proc = Bun.spawnSync(["bash", relayScript, dst, "handoff", body], {
+      env: { ...env, TMUX_PANE: src },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(proc.exitCode).toBe(0);
+
+    const content = await captureUntil(dst, "tmux-relay");
+    // Envelope stamps the sender pane, reply target, and kind.
+    expect(content).toContain(`from=${src}`);
+    expect(content).toContain(`reply-to=${src}`);
+    expect(content).toContain("kind=handoff");
+    // Both body lines crossed the pane boundary.
+    expect(content).toContain("Take over branch feat/x");
+    expect(content).toContain("tests/e2e.spec.ts:42");
+  });
+
+  it("refuses to relay without a target pane", () => {
+    const proc = Bun.spawnSync(["bash", relayScript], {
+      env: { ...env, TMUX_PANE: "%0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(proc.exitCode).not.toBe(0);
+    expect(proc.stderr.toString()).toContain("missing target pane");
+  });
+});

--- a/plugins/tmux/skills/relay/scripts/relay.sh
+++ b/plugins/tmux/skills/relay/scripts/relay.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Send an enveloped message to another Claude pane and submit it.
+#
+# Usage: relay.sh <target-pane> <kind> <body...>
+#   target-pane  tmux pane id of the peer (e.g. %3), in any window or session
+#   kind         hello | message | handoff | ack  (free-form; routes peer behavior)
+#   body         the message text; remaining args are joined with spaces
+#
+# The first line of what the peer receives is a machine-parseable envelope
+# stamped with this pane's id, so the peer knows who sent it and where to reply.
+
+source "$(dirname "${BASH_SOURCE[0]}")/../../tmux/scripts/lib.sh"
+
+self="${TMUX_PANE:-}"
+[ -z "$self" ] && { echo 'relay: not inside a tmux pane ($TMUX_PANE unset)' >&2; exit 1; }
+
+target="${1:-}"
+kind="${2:-message}"
+[ -z "$target" ] && { echo 'relay: missing target pane (usage: relay.sh <pane> <kind> <body...>)' >&2; exit 1; }
+shift 2 2>/dev/null || shift "$#"
+body="$*"
+[ -z "$body" ] && { echo 'relay: empty message body' >&2; exit 1; }
+
+# Verify the target pane exists before sending; lib.sh prints the sandbox hint.
+tmux display-message -t "$target" -p '' >/dev/null 2>&1 || lookup_failed pane
+
+# Label the sender by session:window so the peer has human context, not just an id.
+win="$(tmux display-message -t "$self" -p '#{session_name}:#{window_index}' 2>/dev/null || true)"
+
+header="[[tmux-relay from=${self} reply-to=${self} kind=${kind}${win:+ window=${win}}]]"
+
+# Deliver as a bracketed paste, then a separate Enter to submit. A raw
+# `send-keys -l` would turn each newline in the body into its own Enter,
+# fragmenting a multi-line handoff into several prompts; bracketed paste
+# (`paste-buffer -p`) keeps newlines soft so the whole message lands as one
+# prompt and the trailing Enter submits it.
+buf="tmux-relay-${self#%}-$$"
+printf '%s\n%s' "$header" "$body" | tmux load-buffer -b "$buf" -
+tmux paste-buffer -b "$buf" -t "$target" -p -d
+tmux send-keys -t "$target" Enter
+
+echo "relayed ${kind} -> ${target} (${#body} chars)"


### PR DESCRIPTION
Adds a relay protocol so Claude sessions in separate tmux panes can message each other and hand off context. Panes address each other by pane id, which is server-global, so a channel reaches any pane on the server across every window and session.

The protocol has two halves. `relay.sh` sends: it stamps the body with an envelope carrying the sender's pane id (`from`, `reply-to`, `kind`, and a human-readable `window` label), delivers it to the target pane, and submits. `relay.ts` is a `UserPromptSubmit` hook that recognizes an inbound envelope and injects routing context for the receiving session. The hook is what makes the receiver autonomous. A session that never loaded the skill still learns who messaged it and how to reply, so it can answer without any setup.

`kind` routes intent: `hello`/`ack` establish a link, `message` is ordinary mail, `handoff` passes work to a teammate.

## Delivery

Messages travel by bracketed paste (`load-buffer` + `paste-buffer -p`), not `send-keys -l`. A raw literal send turns every newline in a multi-line handoff into its own Enter, which splits one message into several prompts. Bracketed paste keeps the newlines soft so the whole envelope lands as a single prompt, and a trailing `Enter` submits it.

## Testing

- Unit tests cover envelope parsing, context building, and the hook's prompt handling (`relay.test.ts`).
- An integration test drives `relay.sh` through a real tmux server and asserts the stamped envelope and a multi-line body arrive in the target pane (`relay.integration.ts`). It is gated on tmux being present and runs in CI.
- Verified live against a real Claude TUI: a multi-line handoff renders as one collapsed paste block instead of fragmenting. This is the gap the integration test cannot reach, since a bare shell ignores bracketed paste while the TUI honors it.
