### PR TITLE
deps: auto-merge routine updates with a 7-day window

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,24 @@
+name: dependabot-automerge
+
+on:
+  pull_request: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,7 +1,8 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:recommended", "schedule:weekly", ":preserveSemverRanges"],
-  enabledManagers: ["custom.regex"],
+  minimumReleaseAge: "7 days",
+  internalChecksFilter: "strict",
   customManagers: [
     {
       customType: "regex",
@@ -27,11 +28,16 @@
   ],
   packageRules: [
     {
+      matchUpdateTypes: ["minor", "patch"],
+      automerge: true,
+    },
+    {
       matchManagers: ["custom.regex"],
       matchFileNames: ["user/settings.json"],
       commitMessagePrefix: "chore(plugins):",
       additionalBranchPrefix: "plugin-",
       semanticCommits: "disabled",
+      automerge: false,
     },
   ],
 }


### PR DESCRIPTION
Routine dependency PRs that pass CI should merge themselves, but only after a new release has been out long enough (7 days) to surface yanks or regressions. Today that batch-merge is a manual chore.

Two independent pieces, each owning a distinct PR stream.

## Renovate for Routine Version Updates

Renovate was already active but narrow: it only managed third-party marketplace plugin refs in `user/settings.json` via a `custom.regex` manager. This drops the `enabledManagers` restriction so all default managers run (npm, github-actions, and the rest), keeping the existing `custom.regex` manager alongside them.

Renovate has native Bun lockfile support, so it avoids the exact problem that retired Dependabot for npm in #361 (`package.json` bumped without the Bun lockfile, breaking `bun install --frozen-lockfile`). It manages both the root `bun.lock` workspace and `plugins/things/package-lock.json`, keeping each lockfile in sync.

A global `minimumReleaseAge: "7 days"` holds every PR until the release has aged. `internalChecksFilter: "strict"` (the modern default, set explicitly) means a PR is not even opened until the release clears the window. Minor and patch updates auto-merge on green via GitHub native auto-merge, which respects the required checks. Majors are excluded so they default to manual. This matches the history exactly: every major was rejected (jsdom 27→28, `@linear/sdk` 72→73, setup-swift 2→3, setup-go 5→6, cleye 1→2), every patch/minor was eventually merged.

Plugin-pin updates from the `custom.regex` manager stay manual. The broad auto-merge rule is listed first and the `custom.regex` rule sets `automerge: false` after it, so it wins for those deps.

## Dependabot Security Auto-Merge

A stability window applies only to scheduled version updates. Security updates intentionally bypass it (delaying a vuln fix is harmful). Dependabot security updates (repo-level `automated-security-fixes`, no config file) stay enabled and proven. They operate on `plugins/things`, the only directory with a `package-lock.json`.

The new `dependabot-automerge.yml` workflow follows GitHub's documented pattern: guard on the Dependabot actor, elevate the token to `contents: write` / `pull-requests: write`, read `update-type` via `dependabot/fetch-metadata@v2`, and enable squash auto-merge for patch/minor. `--squash` matches the squash-only ruleset.

Renovate and Dependabot can rarely both touch the same package in one window. Auto-merge resolves the first and the second closes as already-updated.

## Verification

Config validity is checked locally with `bunx --bun --package renovate renovate-config-validator renovate.json5`, since CI has no Renovate gate.

Post-merge behavior to watch on the Dependency Dashboard: that it proposes npm + github-actions updates without being confused by the dual lockfile in `plugins/things`, that it holds releases younger than 7 days, and that a patch/minor PR enables auto-merge while a major is left open.
