### PR TITLE
sandbox: grant trustd mach lookup so Go CLIs verify TLS

### DIFF
--- a/schemas/overlays/settings.patch.json
+++ b/schemas/overlays/settings.patch.json
@@ -9,6 +9,15 @@
   },
   {
     "op": "add",
+    "path": "/properties/sandbox/properties/network/properties/allowMachLookup",
+    "value": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "macOS mach services the sandbox may look up (e.g. com.apple.trustd.agent for Go/Security.framework TLS)"
+    }
+  },
+  {
+    "op": "add",
     "path": "/properties/theme",
     "value": {
       "type": "string",

--- a/user/settings.json
+++ b/user/settings.json
@@ -346,6 +346,7 @@
     "allowAppleEvents": true,
     "network": {
       "allowLocalBinding": true,
+      "allowMachLookup": ["com.apple.trustd.agent"],
       "allowUnixSockets": [
         "~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh",
         "~/.tmux",


### PR DESCRIPTION
Go-based CLIs (`gh`, `glab`, `terraform`, `kubectl`, `go`) fail intermittently inside the macOS sandbox with `tls: failed to verify certificate: x509: OSStatus -26276`. On macOS, Go's `crypto/x509` does not verify certs in-process. It delegates to the system `trustd` daemon via a mach-service lookup (`com.apple.trustd.agent`). The Seatbelt sandbox denied that lookup, so Go could not get a trust verdict and surfaced valid certs as `OSStatus -26276`. `curl`/`git`/Node/Python verify in-process against a CA bundle, never call `trustd`, and so were unaffected. This regressed in Claude Code 2.1.172 via a Seatbelt profile change.

No env var fixes it: `SSL_CERT_FILE`, `SSL_CERT_DIR`, and `GODEBUG=x509usefallbackroots=1` all still fail under a live sandbox, because Go passes `RootCAs: nil` on darwin and goes straight to `trustd`.

This grants the one mach service Go needs, profile-wide, in `sandbox.network.allowMachLookup`. The fix is profile-level rather than command-parsed, so it covers every invocation shape. The current `mac` plugin hook statically parses commands for a Go binary at a segment head and misses the dominant cases: `for n in ...; do gh ...; done` never puts `gh` at a segment head, and wrapper scripts (`bun pr-comments.ts`, `make lint`) each need a hand-added bypass marker. Host isolation stays fully intact (non-allowlisted hosts a Go tool reaches are still blocked) and no new permission prompts appear. This is tighter than `sandbox.enableWeakerNetworkIsolation`, which loosens isolation broadly and is a validator-stripped no-op in some versions. It mirrors the precedent already in this repo, where Apple Events moved off the bypass marker onto `sandbox.allowAppleEvents`.

The matching RFC 6902 overlay entry keeps schema validation clean, since the key is underdocumented upstream (as `allowAppleEvents` was). `bun run schemas check` passes and does not flag the overlay as redundant.

## Verification

Sandbox config is read at session launch, so the fix cannot be exercised from the session that authored it. It will be confirmed after restart by running the reproduction that currently fails: `for i in 1; do gh api rate_limit --jq .rate.remaining; done`.

## Follow-up

Removing the now-obsolete workarounds (the Go-detection hook path, the TLS bypass markers, and the `gh:*` sandbox exclusion) is a separate change gated on that restart verification.

## References

anthropics/claude-code#26466
anthropics/claude-code#29533
anthropics/claude-code#23416
