### PR TITLE
fix(deps): resolve Renovate lookupUpdates error for digest-pinned marketplaces

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -22,8 +22,7 @@
         '"repo":\\s*"(?<depName>[^"]+/[^"]+)"[^}]*"ref":\\s*"(?<currentDigest>[0-9a-f]{40})"',
       ],
       currentValueTemplate: "main",
-      datasourceTemplate: "git-refs",
-      versioningTemplate: "git",
+      datasourceTemplate: "github-digest",
     },
   ],
   packageRules: [

--- a/user/settings.json
+++ b/user/settings.json
@@ -314,7 +314,7 @@
     "ast-grep-marketplace": {
       "source": {
         "source": "github",
-        "repo": "ast-grep/claude-skill",
+        "repo": "ast-grep/agent-skill",
         "ref": "577f4d4507678f2c8cee150fae25e6ce309f70b1"
       }
     },


### PR DESCRIPTION
Fixes the `lookupUpdates error` reported on the Renovate [Dependency Dashboard](../issues/314) (#314). The digest custom manager routed SHA-pinned marketplaces through the `git-refs` datasource, which shells out to `git ls-remote <depName>`. `depName` was the bare `owner/repo` with no host, so git couldn't resolve it and every digest-pinned source errored. The tag-pinned manager was unaffected because `github-releases` resolves `owner/repo` through the GitHub API.

Switches the digest manager to the `github-digest` datasource instead of patching the URL. It fetches branches and commits over the GitHub API, accepts a bare `owner/repo`, and pins digests with exact versioning. That drops the `versioningTemplate: "git"` line and makes both managers symmetric: semver tags via `github-releases`, commit digests via `github-digest`, both API-based with no git CLI. The lower-risk alternative was keeping `git-refs` and adding `packageNameTemplate: "https://github.com/{{{depName}}}"`. I confirmed it resolves, but `github-digest` is simpler.

Also renames the `ast-grep-marketplace` source from `ast-grep/claude-skill` to `ast-grep/agent-skill`. The repo was renamed upstream. The pinned SHA `577f4d4` is already the current `main` head of the renamed repo, so the ref is unchanged.

Validated with `renovate-config-validator`.
