### PR TITLE
settings: drop playground from enabledPlugins

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -282,7 +282,6 @@
     "ast-grep@ast-grep-marketplace": true,
     "worktrunk@worktrunk": true,
     "plan@bendrucker": true,
-    "playground@claude-plugins-official": true,
     "linear-cli@linear-cli": true,
     "tmux@bendrucker": true,
     "bun@bendrucker": true,


### PR DESCRIPTION
Removes `playground@claude-plugins-official` from `enabledPlugins` in `user/settings.json`.

Grounded analysis over 68 days of session history across both the `local` and `work` hosts found zero skill invocations of `playground` on either host. It is the one clean prune candidate among the enabled plugins. The other idle plugins are out of scope: `gitlab`, `linear`, and `issue` are work-critical, and the rest already cost zero catalog tokens because they are passive hooks or carry `disable-model-invocation`.

Scope is deliberately narrow. This drops only `playground`. Whole-plugin pruning is otherwise marginal because the always-on catalog token mass lives in global personal skills, not the `enabledPlugins` array. The plugin still exists in `plugins/` and `.claude-plugin/marketplace.json`, so it remains installable. It is just no longer enabled by default.

`user/settings.json` conventions are documented in [`.claude/rules/settings.md`](.claude/rules/settings.md).

Original Task: [[discovery] Trim always-on catalog size (prune enabledPlugins)](https://things.bendrucker.me/show?id=EiBrqfsSUYCn4QAVxVUdtL)
