### PR TITLE
fix(stop-hook): scope plugin-validate to in-tree files

### DIFF
--- a/.claude/hooks/stop/index.test.ts
+++ b/.claude/hooks/stop/index.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { StopHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { parseTranscript, processStop } from ".";
+import { parseTranscript, processStop, scopePaths } from ".";
 
 let tempDir: string;
 
@@ -96,6 +96,34 @@ describe("parseTranscript", () => {
   });
 });
 
+describe("scopePaths", () => {
+  it("returns a clean relative path for a file inside cwd", () => {
+    const cwd = join(tempDir, "repo");
+    const file = join(cwd, "plugins", "mac", "plugin.json");
+    expect(scopePaths([file], cwd)).toEqual([join("plugins", "mac", "plugin.json")]);
+  });
+
+  it("excludes an absolute path in a sibling worktree", () => {
+    const cwd = join(tempDir, "repo");
+    const sibling = join(tempDir, "other-worktree", "plugins", "mac", "plugin.json");
+    expect(scopePaths([sibling], cwd)).toEqual([]);
+  });
+
+  it("excludes a path whose relative form starts with ..", () => {
+    const cwd = join(tempDir, "a", "b", "c");
+    const outside = join(tempDir, "a", "elsewhere.ts");
+    const scoped = scopePaths([outside], cwd);
+    expect(scoped.every((p) => !p.startsWith(".."))).toBe(true);
+    expect(scoped).toEqual([]);
+  });
+
+  it("keeps a sibling file literally named ..foo.ts directly under cwd", () => {
+    const cwd = join(tempDir, "repo");
+    const file = join(cwd, "..foo.ts");
+    expect(scopePaths([file], cwd)).toEqual(["..foo.ts"]);
+  });
+});
+
 describe("processStop", () => {
   const originalRemoteEnv = process.env.CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE;
 
@@ -121,6 +149,29 @@ describe("processStop", () => {
       session_id: "test",
       transcript_path: transcriptPath,
       cwd: tempDir,
+      stop_hook_active: false,
+      permission_mode: "default",
+    };
+
+    expect(await processStop(input)).toBeNull();
+  });
+
+  it("returns null when every collected file is out-of-tree", async () => {
+    const sibling = join(tempDir, "sibling-worktree");
+    const filePath = join(sibling, "plugins", "mac", "plugin.json");
+    await Bun.write(filePath, "{}");
+
+    const cwd = join(tempDir, "main-worktree");
+    await Bun.write(join(cwd, ".keep"), "");
+
+    const transcriptPath = join(tempDir, "transcript-out-of-tree.jsonl");
+    await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Edit" }]));
+
+    const input: StopHookInput = {
+      hook_event_name: "Stop",
+      session_id: "test",
+      transcript_path: transcriptPath,
+      cwd,
       stop_hook_active: false,
       permission_mode: "default",
     };

--- a/.claude/hooks/stop/index.ts
+++ b/.claude/hooks/stop/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { execFile } from "node:child_process";
-import { relative } from "node:path";
+import { isAbsolute, relative, sep } from "node:path";
 import { promisify } from "node:util";
 import type { StopHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
@@ -62,6 +62,17 @@ export async function parseTranscript(transcriptPath: string): Promise<string[]>
   return [...files];
 }
 
+export function scopePaths(files: string[], cwd: string): string[] {
+  const scoped: string[] = [];
+  for (const file of files) {
+    const rel = relative(cwd, file);
+    if (rel !== "" && !isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${sep}`)) {
+      scoped.push(rel);
+    }
+  }
+  return scoped;
+}
+
 export async function processStop(input: StopHookInput): Promise<SyncHookJSONOutput | null> {
   if (input.stop_hook_active) {
     return null;
@@ -76,7 +87,10 @@ export async function processStop(input: StopHookInput): Promise<SyncHookJSONOut
     return null;
   }
 
-  const relativePaths = files.map((f) => relative(input.cwd, f));
+  const relativePaths = scopePaths(files, input.cwd);
+  if (relativePaths.length === 0) {
+    return null;
+  }
 
   try {
     await execFileAsync("bun", ["install", "--cwd", input.cwd]);

--- a/scripts/prek-check.sh
+++ b/scripts/prek-check.sh
@@ -4,7 +4,15 @@ set -euo pipefail
 extract_dirs() {
   local depth=$1
   shift
-  printf '%s\n' "$@" | cut -d/ -f1-"$depth" | sort -u
+  local path dir
+  for path in "$@"; do
+    case "$path" in
+      /* | ../* | */../*) continue ;;
+    esac
+    dir=$(printf '%s\n' "$path" | cut -d/ -f1-"$depth")
+    [ -d "$dir" ] || continue
+    printf '%s\n' "$dir"
+  done | sort -u
 }
 
 case "${1:-}" in

--- a/scripts/prek-check.test.ts
+++ b/scripts/prek-check.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+
+const script = join(import.meta.dir, "prek-check.sh");
+const repoRoot = join(import.meta.dir, "..");
+
+interface RunResult {
+  exitCode: number;
+  stderr: string;
+}
+
+async function run(...args: string[]): Promise<RunResult> {
+  const proc = Bun.spawn(["bash", script, ...args], {
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  return { exitCode, stderr };
+}
+
+describe("prek-check plugin-validate", () => {
+  it("skips a relative path pointing outside the tree without ENOENT", async () => {
+    const { exitCode, stderr } = await run(
+      "plugin-validate",
+      "../../other/plugins/foo/.claude-plugin/plugin.json",
+    );
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("ENOENT");
+  });
+
+  it("skips an absolute path", async () => {
+    const { exitCode, stderr } = await run(
+      "plugin-validate",
+      "/abs/plugins/foo/.claude-plugin/plugin.json",
+    );
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("ENOENT");
+  });
+
+  it("still validates a real in-tree plugin", async () => {
+    const { exitCode } = await run("plugin-validate", "plugins/mac/.claude-plugin/plugin.json");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
The Stop hook validates files that Claude edited during a session by feeding them to `prek`. A session that spans two worktrees collects Edit/Write paths into the sibling worktree, and `processStop` mapped each through `relative(cwd, f)`. That produced paths like `../../<other>/plugins/<name>/.claude-plugin/plugin.json`, which `prek` still matched against `plugin-validate`'s `files:` regex. `prek-check.sh` then truncated the traversal to a real directory (`../..`), so nothing rejected it, and `packages/validate/plugin.ts` read a nonexistent `plugin.json`, hit `ENOENT`, and blocked the stop with a confusing failure.

Two independent defects, both fixed here:

- The hook now scopes collected paths to files inside `cwd` via an exported `scopePaths()`. A path is kept only when its relative form is non-empty, not absolute, and does not start with a parent-traversal segment. The check is `rel !== ".."` plus a `..${sep}` prefix test rather than a blanket `..` startsWith, so a sibling file literally named `..foo.ts` is not wrongly dropped. When nothing remains in tree, the hook skips both `bun install` and `prek` entirely.
- `extract_dirs` in `prek-check.sh` rejects absolute and parent-traversal paths before truncating, so an out-of-tree path can never collapse into a valid-looking directory. The `plugin-validate` hook's `files:` regex stays intentionally unanchored, so this guards by traversal shape rather than requiring a `plugins/` prefix.

`scopePaths` is exported so the in-tree / sibling-worktree / `..`-prefix / `..foo.ts` cases are unit-testable without invoking `prek`. A new `scripts/prek-check.test.ts` spawns the script at the repo root to cover the regression directly: a relative out-of-tree path and an absolute path both exit clean with no `ENOENT`, while a real in-tree plugin still validates.

Symlinked worktree roots (realpath normalization) are a pre-existing concern and out of scope.

Original Task: [Fix Stop hook cross-worktree false positive in plugin-validate](https://things.bendrucker.me/show?id=Ld15w6hpwiZU6SurG8zaPc)
