### PR TITLE
fix(deps): use git-refs datasource for digest-pinned marketplaces

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -22,7 +22,9 @@
         '"repo":\\s*"(?<depName>[^"]+/[^"]+)"[^}]*"ref":\\s*"(?<currentDigest>[0-9a-f]{40})"',
       ],
       currentValueTemplate: "main",
-      datasourceTemplate: "github-digest",
+      packageNameTemplate: "https://github.com/{{{depName}}}",
+      datasourceTemplate: "git-refs",
+      versioningTemplate: "git",
     },
   ],
   packageRules: [


### PR DESCRIPTION
PR #905 switched the digest manager from `git-refs` to the `github-digest` datasource, which broke digest lookup for `anthropics/claude-plugins-official`. Renovate warned it could not determine the new digest.

`github-digest` resolves a branch by paging GitHub's GraphQL `refs` connection, but that query has a hard 300-branch cap and no `orderBy`. GitHub returns branches alphabetically, so pagination stops at 300. `anthropics/claude-plugins-official` has 431 branches with `main` at alphabetical position 324, so `getDigest("main")` never saw `main` and returned `null`. The other digest-pinned marketplace, `astral-sh/claude-code-plugins`, has only 10 branches and resolved fine. That asymmetry is the tell: the failure is branch-count dependent, not config-wide. The cap is not configurable, so `github-digest` fundamentally cannot track a branch that sorts past the first 300 in a large repo.

This returns the digest manager to `git-refs`, which uses `git ls-remote` and returns all refs with no cap. The original `git-refs` config failed only because its `packageName` was the bare `owner/repo`; `git-refs` requires a fully qualified URL. A `packageNameTemplate` now builds the URL from `depName` while keeping `depName` bare for readable branch and dashboard names.

## Verification

- `renovate-config-validator` passes.
- `git ls-remote https://github.com/anthropics/claude-plugins-official main` resolves `refs/heads/main` to `3dc50d51…`, which is what `git-refs`'s `getDigest` matches.

Both digest-pinned marketplaces will get a one-time digest-bump PR on the next run. Expected.
