### PR TITLE
writing: detect the "no X needed" marketing brag

### DIFF
--- a/plugins/writing/detection/tropes.test.ts
+++ b/plugins/writing/detection/tropes.test.ts
@@ -176,6 +176,38 @@ describe("scan", () => {
     }
   });
 
+  describe("no X needed brag", () => {
+    // The flag side is open-ended: these artifact nouns are not enumerated
+    // anywhere in the detector, proving it generalizes past a fixed list.
+    const flag = [
+      "Handlers are auto-discovered, no config needed.",
+      "It runs inline (no wrapper needed).",
+      "Spin it up with no docker needed.",
+      "Drop the file in place, no namespace required.",
+      "It reads the token directly, no auth needed.",
+    ];
+    const allow = [
+      "Reviewed the helper, no change needed.",
+      "No further action needed here.",
+      "Patch-ids matched, no rebase needed.",
+      "No adjustment needed, it scales on its own.",
+      "It is no longer needed.",
+      "There is no way the runtime needed that much memory.",
+    ];
+
+    for (const text of flag) {
+      it(`flags: "${text}"`, () => {
+        expect(firstByTier(scan(text), "context")?.category).toBe("no X needed brag");
+      });
+    }
+
+    for (const text of allow) {
+      it(`allows: ${JSON.stringify(text)}`, () => {
+        expect(scan(text).find((m) => m.category === "no X needed brag")).toBeUndefined();
+      });
+    }
+  });
+
   describe("parallelism", () => {
     const flag = [
       "It is not just fast, but also reliable",

--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -72,6 +72,93 @@ const RESULT_SENTENCES = [
   /^(?:\w+\s+){0,3}pass(?:es|ed|ing)?(?:\s|$)/im,
 ];
 
+// "no X needed" is a marketing brag when X is an artifact the design lacks
+// ("no config needed"), but a legitimate status report when X is an action that
+// was not required ("no change needed"). The artifact side is open-ended, so we
+// flag the construction and carve out the status side, whose vocabulary is
+// concentrated: function words, deverbal nouns (-tion/-sion/-ment), and dev
+// actions. A determiner in the gap marks a clause boundary ("no way the runtime
+// needed ..."), not an intervening adjective.
+const NO_X_CONSTRUCTION = /\bno\s+((?:\w+\s+){0,3}?)(\w+)\s+(?:needed|required|necessary)\b/gi;
+const NO_X_FUNCTION_WORDS = new Set([
+  "longer",
+  "more",
+  "further",
+  "additional",
+  "extra",
+  "fewer",
+  "less",
+  "other",
+]);
+const NO_X_ACTION_WORDS = new Set([
+  "change",
+  "changes",
+  "fix",
+  "fixes",
+  "edit",
+  "edits",
+  "work",
+  "move",
+  "moves",
+  "update",
+  "updates",
+  "override",
+  "overrides",
+  "touch",
+  "tweak",
+  "tweaks",
+  "patch",
+  "patches",
+  "bump",
+  "bumps",
+  "swap",
+  "swaps",
+  "merge",
+  "merges",
+  "sync",
+  "run",
+  "runs",
+  "check",
+  "checks",
+  "review",
+  "reviews",
+  "test",
+  "tests",
+  "cleanup",
+  "dedup",
+  "retry",
+  "retries",
+  "rebuild",
+  "rebase",
+  "restack",
+  "restart",
+  "reload",
+  "resize",
+  "reorder",
+  "recompile",
+  "redeploy",
+  "reinstall",
+  "rerun",
+  "refactor",
+]);
+const DEVERBAL_NOUN = /(?:tion|sion|ment)s?$/i;
+
+function isStatusHead(head: string): boolean {
+  const word = head.toLowerCase();
+  return NO_X_FUNCTION_WORDS.has(word) || NO_X_ACTION_WORDS.has(word) || DEVERBAL_NOUN.test(word);
+}
+
+function noXNeededHits(text: string): Hits {
+  for (const match of text.matchAll(NO_X_CONSTRUCTION)) {
+    const gap = match[1] ?? "";
+    const head = match[2] ?? "";
+    if (gap.split(/\s+/).some((token) => DETERMINERS.test(token))) continue;
+    if (isStatusHead(head)) continue;
+    return { count: 1, sample: match[0].trim() };
+  }
+  return { count: 0, sample: "" };
+}
+
 function testResultHits(text: string): Hits {
   for (const sentence of text.split(/[.!?\n]+/)) {
     const s = sentence.trim();
@@ -423,6 +510,28 @@ export const PATTERNS: PatternDef[] = [
       "Pre-dates the curation principle; no corpus evidence recorded. Each word in this list was identified as promotional AI vocabulary, but none has a per-entry corpus audit. Candidates for migration to vocabulary.txt once audited.",
     retire:
       "Migrate each entry to vocabulary.txt after a corpus audit confirms lift. Remove entries that fail the audit (not distinctive or dead).",
+  },
+  {
+    tier: "context",
+    layer: "vocabulary",
+    category: "no X needed brag",
+    test: noXNeededHits,
+    message: (matched) =>
+      `"${matched}" advertises what the design avoids. Describe what it does instead.`,
+    positives: [
+      "Handlers are auto-discovered, no config needed.",
+      "It runs inline (no wrapper needed).",
+      "Spin it up with no docker needed.",
+    ],
+    negatives: [
+      "Reviewed the helper, no change needed.",
+      "No further action needed here.",
+      "There is no way the runtime needed that much memory.",
+    ],
+    evidence:
+      'User flagged this trope directly; the working branch was named for it. The brag advertises an absent artifact ("no config/wrapper/docker needed") and its noun space is open-ended, so the detector flags the construction and carves out legitimate status reports instead. The assistant corpus shows why: status reports concentrate in a small set (change, action, fix, deverbal -tion/-sion/-ment nouns, re- dev verbs) while brags scatter across an unbounded artifact vocabulary. An allowlist of brag nouns goes stale; a status carve-out fails toward a visible, prunable over-nudge. A clean distinctiveness audit against the hand-written PR baseline is outstanding: user-role session text is contaminated because it contains pasted assistant output.',
+    retire:
+      "Add a word to the status carve-out (NO_X_ACTION_WORDS) when writing:scan shows it producing a false-positive nudge. Remove the pattern when the construction stops appearing in assistant deliverables or in corrective-feedback moments.",
   },
   {
     tier: "context",


### PR DESCRIPTION
Adds a `writing` detector for the "no X needed" refactor brag, where Claude markets a change by advertising an absent artifact: "no config needed", "no wrapper needed", "(no boilerplate required)". It fires as a `context` nudge in the edit hook and the batch scan/score surfaces.

## Denylist Over Allowlist

The first cut enumerated brag nouns (`config|setup|wrapper|...`). That's the wrong shape. The construction is dual-use: "no X needed" is a brag when X is an artifact the design lacks, but a legitimate status report when X is an action that wasn't required ("no change needed", "no rebuild needed").

Grounding the split in the session corpus settled the direction. Status reports dominate and concentrate in a small, stable vocabulary (`change`, `action`, `fix`, deverbal `-tion/-sion/-ment` nouns, `re-` dev verbs). The brags scatter across an open-ended artifact vocabulary (`worktree`, `namespace`, `docker`, `vault`, `cron`...) that can't be enumerated and won't hold over time.

So the detector inverts: it flags the construction and carves out the status side. The failure mode flips the right way. A missing brag noun in an allowlist is a silent permanent miss; a missing status word in the carve-out is one visible, prunable over-nudge. The carve-out leans on morphology (the `-tion/-sion/-ment` suffix) so the action-noun tail is covered by rule rather than by list, keeping the enumerated set small. A determiner in the gap is treated as a clause boundary, so "no way the runtime needed that much memory" is left alone.

One deliberate tradeoff: `-ing` is excluded from the morphology. It's ambiguous, and including it would suppress infra brags like "no caching needed" or "no polling needed" at the cost of occasionally nudging on `-ing` status words like "no reordering needed". Those are prunable via the action-word set if they prove noisy.

## Implementation

`noXNeededHits` is a function detector in `detection/tropes.ts`, alongside `testResultHits` and `connectorDensityHits`. Function detectors sit outside `regexCatalog()`, so the carve-out lists are plain inline consts and the analyze rule-health harness needs no changes. The new category flows through `scan()` (hook), `scanAll()` (skills), and the `examples.test.ts` per-pattern gate automatically.

A methodology caveat is recorded in the pattern's `evidence`: user-role session text is a contaminated baseline for distinctiveness because it contains pasted-back assistant output, so the clean audit against the hand-written PR corpus is still outstanding.

## Testing

The new `tropes.test.ts` block covers the inversion: brags across several artifact nouns that appear nowhere in the detector, plus the carve-outs (status reports, the `no longer` idiom, the clause-boundary sentence). The `examples.test.ts` gate covers the pattern's own declared positives and negatives. Hook spot-checks exercise unseen nouns ("no daemon required", "no sidecar needed", "no cron needed") against silent status reports.
