### PR TITLE
issue(refine): emit a tool-agnostic frontmatter artifact

### DIFF
--- a/evals/issue-refine/.gitignore
+++ b/evals/issue-refine/.gitignore
@@ -1,0 +1,7 @@
+# Local-only: real issue content (internal work) and reviewer feedback.
+raw/
+data/
+feedback/
+
+# A/B run snapshots and outputs (transient)
+ab/

--- a/evals/issue-refine/README.md
+++ b/evals/issue-refine/README.md
@@ -1,0 +1,103 @@
+# issue:refine rubric
+
+A local harness for evaluating the `issue:refine` skill against real usage and
+A/B testing changes to it. The aim is a rubric: a concrete list of what makes a
+refined issue good or bad, derived from labeling real outputs, then used to
+score the skill before and after edits.
+
+The issue content here is internal work, so `raw/`, `data/`, and `feedback/`
+stay local (see `.gitignore`). Only the harness code is tracked.
+
+## Workflow
+
+### 1. Build the dataset
+
+Three exports in `raw/` come from the Claude Code session index (the
+`claude-code:session` skill), pulled from every session that invoked
+`issue:refine`:
+
+- `save_issues.json`: every `Linear.save_issue` call (the refined bodies)
+- `briefs.json`: the `issue:refine` skill args (the original brief, i.e. the input)
+- `types.json`: which guide (`bug` / `feature` / `refactor`) the skill read per session
+
+`build-dataset.ts` pairs each session's brief with its richest refined body,
+drops near-duplicate issues, and selects a type- and size-balanced sample:
+
+```bash
+bun evals/issue-refine/scripts/build-dataset.ts        # writes data/samples.json
+bun evals/issue-refine/scripts/build-dataset.ts --limit 24
+```
+
+To refresh `raw/` from the live session history, see the query in
+[`scripts/build-dataset.ts`](scripts/build-dataset.ts) header and re-run the
+`duckdb` exports against the session index.
+
+### 2. Label
+
+```bash
+bun evals/issue-refine/label/server.ts                 # http://localhost:4317
+```
+
+Open the URL and review each sample. Per issue you can:
+
+- Select any span in the rendered issue to attach an inline comment with a
+  severity (critical / minor / praise). Highlights persist across reloads.
+- Set a verdict (good / ok / bad), toggle quality tags, and write freeform notes.
+
+Everything autosaves to `feedback/<sample-id>.json`. The original brief (the
+skill's input) sits in a collapsible block above each issue for context.
+
+### 3. Derive the rubric
+
+Once a batch is labeled, the inline comments and tags become the rubric: the
+recurring critical spans and tags are the failure modes the skill should stop
+producing, the praise spans are what to preserve. This feeds concrete edits to
+`plugins/issue/skills/refine/`.
+
+### 4. A/B test a skill change
+
+The skill only refines text, so an A/B run takes a synthetic brief, runs it
+through two skill versions, and compares the refined outputs against the rubric.
+"Before" is the committed skill (`git show HEAD:...`), "after" is the working
+tree, snapshotted into `ab/before/` and `ab/after/`.
+
+Briefs live in `briefs/` as JSON (`brief` plus a synthetic `context`). Each one
+is deliberately seeded with the tropes the rubric targets, so a version that
+fixed them scores lower.
+
+Each version writes a refined artifact: YAML frontmatter (title, type, and any
+labels, priority, relations) followed by the body. The scorer reads the title
+and type from the frontmatter and runs its findings over the body.
+
+The run is driven from the session by spawning one agent per (brief, version):
+`ab-prompt.ts` packages a skill version and a brief into a self-contained agent
+prompt, the agent writes its refined artifact to `ab/out/<brief>.<version>.md`,
+and then:
+
+```bash
+bun evals/issue-refine/scripts/score.ts --input ab/out/<brief>.after.md   # one output
+bun evals/issue-refine/scripts/ab-report.ts                               # before vs after, all briefs
+```
+
+`ab-report.ts` is the mechanical score (rubric-as-code in `score.ts`). For the
+judgment-call findings, `judge.ts` blinds the outputs (random slot order, mapping
+withheld), prints a judge prompt, and a judge agent scores each against the
+rubric. Unblind the verdict:
+
+```bash
+bun evals/issue-refine/scripts/judge.ts                                   # writes blinded copies + prompt
+# (a judge agent writes ab/verdict.json)
+bun evals/issue-refine/scripts/judge.ts --unblind ab/verdict.json         # de-blinded result
+```
+
+## Layout
+
+- `scripts/build-dataset.ts`: assembles `data/samples.json` from `raw/`
+- `label/server.ts`, `label/index.html`: the review UI (inline span comments, verdict, tags, notes)
+- `scripts/frontmatter.ts`: parses an artifact into `{ title, type, body, data }`
+- `scripts/score.ts`: the rubric-as-code; scores one refined artifact
+- `scripts/ab-prompt.ts`: packages a skill version + brief into an agent prompt
+- `scripts/ab-report.ts`: scores before vs after across briefs
+- `scripts/judge.ts`: blinds outputs, prints a judge prompt, unblinds the verdict
+- `briefs/`: synthetic A/B scenarios (tracked)
+- `data/`, `feedback/`, `ab/`: generated or local-only (gitignored)

--- a/evals/issue-refine/RUBRIC.md
+++ b/evals/issue-refine/RUBRIC.md
@@ -1,0 +1,107 @@
+# Rubric
+
+What separates a good refined issue from a bad one, derived from labeling a batch
+of real `issue:refine` outputs. Each item names the rule, the evidence behind it,
+and the skill text that produces the violation. This drives both the skill edits
+and the A/B scorer.
+
+The cases that scored "good" with no marks share a shape: name the problem,
+point at the code, stop. The marked cases were longer and more structured, and
+that extra length and structure is what the reviewer cut.
+
+## Findings
+
+### 1. Title-Case Noun-Phrase Section Headings
+
+No sentence headings, no marketing phrasing, no "X, not Y" antithesis. Title-case
+every section heading. This covers the `##`/`###` headings; the issue title
+follows sentence case instead (finding 6).
+
+- Evidence: sample-01 flagged `Workspace, not cache` and `Pin, don't invalidate`
+  (both the antithesis trope and sentence case), sample-04 flagged
+  `Fix, preferred: Glue layer, no producer or data change`.
+- Skill location: nothing in `SKILL.md` or the guides constrains heading form.
+  The guide section names are already noun phrases, but free-form subsections
+  drift into sentences and slogans.
+- Note: this is the same rule already enforced for PR headings.
+
+### 2. Native Links for Issue and PR References
+
+Use the tracker's embedded link syntax so references expand into issue chips.
+A bare `ENG-1970`, `MR !578`, or `#123` is noise: a reader cannot resolve it.
+A related issue belongs in the tracker's native relations, so the refined issue
+never carries a standalone "Related Issues" section. Mention another issue in
+prose only when it adds what the relation can't.
+
+- Evidence: sample-01 flagged `ENG-1970, MR !578` inline and the whole
+  `Related Issues` URL dump as critical.
+- Skill location: `SKILL.md` Output Structure no longer lists a Related Issues
+  subsection, and the Context note plus the Style rule route related issues to
+  native relations and govern link syntax for the prose mentions that remain.
+
+### 3. No Volatile Line Numbers
+
+Bare line ranges (`file.py:26-56`, `#L26-L56`) go stale as the file changes and
+rarely help. Cite the symbol or function name, or quote the relevant code inline.
+Use a SHA-pinned permalink only when a stable anchor is genuinely needed.
+
+- Evidence: sample-02 flagged a `file:26-56` citation as unproductive.
+- Skill location: `SKILL.md` Style currently instructs the opposite:
+  "Use permalinks for GitHub ... and file paths elsewhere (`path/to/file:10-20`)".
+  This rule reverses that default.
+
+### 4. Plain Words Over Jargon and Marketing
+
+Plain words over jargon and promotional language. Flagged terms: `spike` (as a
+verb), `seam`, `disposition`, `reality`.
+
+- Evidence: sample-01 (`Spike`, `seam`), sample-02 (`reality`, `disposition`).
+- Skill location: `SKILL.md` Style says "State facts, not hedging" but does not
+  load the writing tropes or name jargon. The writing scan already catches some
+  of these.
+
+### 5. Structure Sized to the Problem
+
+The longer, more sectioned issues drew "too-long" consistently. State the goal
+and the acceptance criteria. Drop thin option menus that list approaches without
+evaluating them.
+
+- Evidence: sample-03 and sample-04 tagged `too-long`; sample-08 flagged an
+  `Approach options` list as "vague options not described well ... just state the
+  goal and acceptance criteria".
+- Skill location: `feature.md` (`#### Approach`, `#### Open Questions`) and
+  `refactor.md` (`Approach`) invite option enumeration. Section Selection in
+  `SKILL.md` already warns against filler sections but not against weak options.
+
+### 6. Sentence-Case, Concise Titles
+
+The issue title is sentence case: only the first word and proper nouns
+capitalize. Section headings stay title case (finding 1), so the two look
+different on purpose. Keep the title to one line, no wordy parentheticals.
+
+- Evidence: sample-02 and sample-11 tagged `bad-title`; sample-02's title carried
+  a long parenthetical. The sentence-case rule comes from reviewing the first
+  generated label batch, where every title came back in title case
+  ("404 Page Missing Top Nav Bar" should read "404 page missing top nav bar").
+- Skill location: `SKILL.md` Output Structure puts the title in the artifact's
+  `title` frontmatter field and requires sentence case there, distinct from the
+  title-case body headings. The scorer reads the title from that field.
+
+### 7. Possible Missing Spike Type
+
+A spike (timeboxed investigation, output is a recommendation not a shipped change)
+was typed as a bug and read wrong.
+
+- Evidence: sample-01 tagged `wrong-type`, note "should be labeled Spike".
+- Skill location: `SKILL.md` Issue Types lists only bug / feature / refactor.
+- Confidence: one data point. Confirm before acting.
+
+## How this scores an A/B run
+
+The scorer parses the artifact's frontmatter first and reads the title and type
+from it, then runs findings 1-5 over the body alone, so relation links in the
+frontmatter never register as bare references. Findings 1, 2, 3, and 6 are
+mechanical and check by pattern. Findings 4 and 5 are partly mechanical (word
+list) and partly judgment. The A/B harness runs a synthetic brief through both
+skill versions, counts violations per finding, and adds an LLM judge for the
+judgment calls.

--- a/evals/issue-refine/briefs/bug-partial-success.json
+++ b/evals/issue-refine/briefs/bug-partial-success.json
@@ -1,0 +1,16 @@
+{
+  "id": "bug-partial-success",
+  "type": "bug",
+  "brief": "The nightly data export reports success even when some object retrievals time out. Related to TEAM-412 (the retry work) and TEAM-388 (the timeout config). The wrong status comes from the summary builder and the orchestrator's retrieve loop. We need the overall status to reflect partial failures so downstream jobs don't consume an incomplete snapshot.",
+  "context": {
+    "files": [
+      "core/src/export/ExportSummary.java (builds the summary; the overallSuccess flag is set around lines 140-145 without checking per-object retrieve status)",
+      "core/src/export/ExportProcessorOrchestrator.java (the retrieve loop, lines 200-230, swallows per-object timeouts)",
+      "core/src/export/SalesforceRetrieveService.java (lines 250-272, where the timeout is caught and logged but not propagated)"
+    ],
+    "related_issues": [
+      "TEAM-412 — Add retry with backoff to object retrieval — https://tracker.example.com/issue/TEAM-412",
+      "TEAM-388 — Make per-object timeout configurable — https://tracker.example.com/issue/TEAM-388"
+    ]
+  }
+}

--- a/evals/issue-refine/briefs/label/bug-404-nav.json
+++ b/evals/issue-refine/briefs/label/bug-404-nav.json
@@ -1,0 +1,11 @@
+{
+  "id": "L-bug-404nav",
+  "type": "bug",
+  "size": "trivial",
+  "project": "synthetic",
+  "brief": "The 404 page is missing the top nav bar. Every other page has it. The error template doesn't extend the base layout.",
+  "context": {
+    "files": ["templates/404.html", "templates/base.html (defines the nav header block)"],
+    "related_issues": []
+  }
+}

--- a/evals/issue-refine/briefs/label/bug-webhook-duplicates.json
+++ b/evals/issue-refine/briefs/label/bug-webhook-duplicates.json
@@ -1,0 +1,17 @@
+{
+  "id": "L-bug-webhook",
+  "type": "bug",
+  "size": "full",
+  "project": "synthetic",
+  "brief": "Webhook deliveries are firing twice for some events. Customers integrating with us see duplicate order.created and order.updated events and are double-processing them. The retry path runs even after a delivery already returned 200.",
+  "context": {
+    "files": [
+      "webhooks/dispatcher.py (deliver_event sends the POST and records the result)",
+      "webhooks/retry_queue.py (RetryWorker re-enqueues deliveries it considers failed)",
+      "webhooks/models.py (DeliveryAttempt stores status_code and a delivered_at timestamp)"
+    ],
+    "related_issues": [
+      "TEAM-204: Add idempotency keys to outbound webhook payloads (open, in backlog)"
+    ]
+  }
+}

--- a/evals/issue-refine/briefs/label/bug-worker-memory-leak.json
+++ b/evals/issue-refine/briefs/label/bug-worker-memory-leak.json
@@ -1,0 +1,15 @@
+{
+  "id": "L-bug-leak",
+  "type": "bug",
+  "size": "full",
+  "project": "synthetic",
+  "brief": "The background job processor leaks memory under sustained load. Heap climbs steadily and the worker gets OOM-killed after roughly six hours. Restarting clears it. We suspect something is holding references to completed jobs so they never get collected.",
+  "context": {
+    "files": [
+      "jobs/worker.py (JobWorker.run pulls jobs off the queue in a loop)",
+      "jobs/registry.py (JobRegistry tracks in-flight jobs in a dict keyed by job id)",
+      "jobs/metrics.py (MetricsCollector appends a record per completed job)"
+    ],
+    "related_issues": []
+  }
+}

--- a/evals/issue-refine/briefs/label/feature-csv-export.json
+++ b/evals/issue-refine/briefs/label/feature-csv-export.json
@@ -1,0 +1,14 @@
+{
+  "id": "L-feat-csv",
+  "type": "feature",
+  "size": "full",
+  "project": "synthetic",
+  "brief": "Add a CSV export to the reports page. People want to pull the table they're currently looking at into a spreadsheet. It should respect the filters and sort they already applied, so the export matches what is on screen.",
+  "context": {
+    "files": [
+      "reports/views.py (ReportTableView renders the filtered, sorted rows)",
+      "reports/serializers.py (RowSerializer shapes each row for the table)"
+    ],
+    "related_issues": []
+  }
+}

--- a/evals/issue-refine/briefs/label/feature-pin-conversations.json
+++ b/evals/issue-refine/briefs/label/feature-pin-conversations.json
@@ -1,0 +1,16 @@
+{
+  "id": "L-feat-pin",
+  "type": "feature",
+  "size": "full",
+  "project": "synthetic",
+  "brief": "Let users pin conversations to the top of the sidebar so the ones they care about stay reachable. Pinned items should stay pinned across sessions and sort above the normal recency-ordered list.",
+  "context": {
+    "files": [
+      "sidebar/list.tsx (ConversationList renders items in recency order)",
+      "sidebar/store.ts (conversationStore holds the ordered list and persists it)"
+    ],
+    "related_issues": [
+      "TEAM-330: Rework sidebar ordering to a single sort comparator (in progress)"
+    ]
+  }
+}

--- a/evals/issue-refine/briefs/label/refactor-double-session-read.json
+++ b/evals/issue-refine/briefs/label/refactor-double-session-read.json
@@ -1,0 +1,13 @@
+{
+  "id": "L-refactor-session",
+  "type": "refactor",
+  "size": "compact",
+  "project": "synthetic",
+  "brief": "The auth middleware reads the session store twice on every request: once to validate the token and once to load the user record. Collapse it to a single read and pass the result through. No behavior change.",
+  "context": {
+    "files": [
+      "auth/middleware.py (AuthMiddleware.__call__ calls validate_token then load_user, each hitting the session store)"
+    ],
+    "related_issues": []
+  }
+}

--- a/evals/issue-refine/briefs/label/spike-thumbnail-offload.json
+++ b/evals/issue-refine/briefs/label/spike-thumbnail-offload.json
@@ -1,0 +1,14 @@
+{
+  "id": "L-spike-thumbnails",
+  "type": "spike",
+  "size": "full",
+  "project": "synthetic",
+  "brief": "Uploads feel slow and a chunk of the latency is thumbnail generation happening inline in the request. Figure out whether we can move thumbnailing off the request path (a queue, a background worker, something else) and what that would cost us in complexity and in time-to-first-thumbnail. Come back with a recommendation before we commit to building anything.",
+  "context": {
+    "files": [
+      "uploads/handler.py (UploadHandler.process generates thumbnails inline before returning)",
+      "media/thumbnails.py (generate_thumbnail does the resize work, ~300-800ms per image)"
+    ],
+    "related_issues": ["TEAM-512: Job queue infrastructure for async media work (open, scoping)"]
+  }
+}

--- a/evals/issue-refine/briefs/spike-workspace.json
+++ b/evals/issue-refine/briefs/spike-workspace.json
@@ -1,0 +1,14 @@
+{
+  "id": "spike-workspace",
+  "type": null,
+  "brief": "We need to decide whether per-chat database state should be file-backed in object storage or kept in-memory per request. Timebox about a week. The output is a recommendation backed by benchmark numbers on a real environment, plus a follow-up implementation issue if we go ahead. This is an investigation, not a committed build.",
+  "context": {
+    "files": [
+      "agent/db/connection.py (today opens a fresh in-memory database per request in connect_loaded)",
+      "agent/db/workspace.py (does not exist yet; would hold the file-backed workspace)"
+    ],
+    "related_issues": [
+      "TEAM-970 — Per-request connection lifecycle hooks — https://tracker.example.com/issue/TEAM-970"
+    ]
+  }
+}

--- a/evals/issue-refine/label/index.html
+++ b/evals/issue-refine/label/index.html
@@ -1,0 +1,380 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>issue:refine review</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
+    <style>
+      :root {
+        --bg: #0f1115;
+        --panel: #171a21;
+        --panel2: #1f242d;
+        --border: #2a313c;
+        --text: #d8dee9;
+        --muted: #8a94a6;
+        --accent: #6aa6ff;
+        --critical: #ff5d5d;
+        --minor: #ffb454;
+        --praise: #4ec88a;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+        display: grid;
+        grid-template-columns: 290px 1fr;
+        height: 100vh;
+      }
+      a { color: var(--accent); }
+      /* Sidebar */
+      #sidebar { background: var(--panel); border-right: 1px solid var(--border); overflow-y: auto; }
+      #progress { padding: 12px 14px; border-bottom: 1px solid var(--border); font-size: 13px; color: var(--muted); position: sticky; top: 0; background: var(--panel); }
+      #progress b { color: var(--text); }
+      .navitem { padding: 10px 14px; border-bottom: 1px solid var(--border); cursor: pointer; }
+      .navitem:hover { background: var(--panel2); }
+      .navitem.active { background: var(--panel2); border-left: 3px solid var(--accent); padding-left: 11px; }
+      .navitem .row1 { display: flex; gap: 6px; align-items: center; font-size: 12px; color: var(--muted); }
+      .navitem .title { color: var(--text); font-size: 13px; margin-top: 3px; }
+      .badge { font-size: 10px; text-transform: uppercase; letter-spacing: .04em; padding: 1px 6px; border-radius: 999px; background: var(--panel2); border: 1px solid var(--border); color: var(--muted); }
+      .badge.bug { color: #ff9b9b; }
+      .badge.feature { color: #8fd6ff; }
+      .badge.refactor { color: #c2a6ff; }
+      .badge.spike { color: #ffd479; }
+      .verdict-dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; margin-left: auto; background: #3a414c; }
+      .verdict-dot.good { background: var(--praise); }
+      .verdict-dot.ok { background: var(--minor); }
+      .verdict-dot.bad { background: var(--critical); }
+      .navitem .anncount { font-size: 11px; color: var(--muted); }
+      /* Main */
+      #main { overflow-y: auto; padding: 22px 30px 120px; }
+      .hd { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+      .hd h1 { font-size: 19px; margin: 0; flex: 1 1 100%; }
+      .meta { color: var(--muted); font-size: 12px; }
+      details.brief { margin: 16px 0; background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 10px 14px; }
+      details.brief summary { cursor: pointer; color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .05em; }
+      details.brief pre { white-space: pre-wrap; font: 12.5px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; color: #b9c2d0; margin: 10px 0 0; }
+      .section-label { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); margin: 22px 0 8px; }
+      #doc { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 6px 22px; }
+      #doc h1, #doc h2 { font-size: 17px; border-bottom: 1px solid var(--border); padding-bottom: 5px; }
+      #doc h3 { font-size: 14px; color: #c7d0dd; }
+      #doc code { background: #11151b; padding: 1px 5px; border-radius: 4px; font-size: 12.5px; }
+      #doc pre { background: #11151b; padding: 12px; border-radius: 6px; overflow-x: auto; }
+      #doc pre code { background: none; padding: 0; }
+      #doc table { border-collapse: collapse; }
+      #doc th, #doc td { border: 1px solid var(--border); padding: 5px 9px; }
+      #doc a { word-break: break-all; }
+      ::highlight(critical) { background: rgba(255,93,93,.30); text-decoration: underline wavy var(--critical); }
+      ::highlight(minor) { background: rgba(255,180,84,.26); text-decoration: underline wavy var(--minor); }
+      ::highlight(praise) { background: rgba(78,200,138,.24); }
+      /* Selection popover */
+      #pop { position: absolute; z-index: 50; display: none; background: var(--panel2); border: 1px solid var(--border); border-radius: 8px; padding: 8px; box-shadow: 0 8px 24px rgba(0,0,0,.5); width: 280px; }
+      #pop textarea { width: 100%; height: 54px; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 6px; padding: 6px; font: inherit; resize: vertical; }
+      #pop .quote { font-size: 11px; color: var(--muted); margin-bottom: 6px; max-height: 40px; overflow: hidden; font-style: italic; }
+      .sevrow { display: flex; gap: 6px; margin: 6px 0; }
+      .sevbtn { flex: 1; cursor: pointer; border: 1px solid var(--border); background: var(--bg); color: var(--text); border-radius: 6px; padding: 4px; font-size: 12px; }
+      .sevbtn[data-sev="critical"].on { background: var(--critical); color: #1a0000; border-color: var(--critical); }
+      .sevbtn[data-sev="minor"].on { background: var(--minor); color: #241500; border-color: var(--minor); }
+      .sevbtn[data-sev="praise"].on { background: var(--praise); color: #00200f; border-color: var(--praise); }
+      #pop .actions { display: flex; gap: 6px; justify-content: flex-end; margin-top: 6px; }
+      button.btn { cursor: pointer; border: 1px solid var(--border); background: var(--panel); color: var(--text); border-radius: 6px; padding: 5px 12px; font-size: 12px; }
+      button.btn.primary { background: var(--accent); color: #06121f; border-color: var(--accent); }
+      /* Right rail (verdict/tags/notes/annotations) */
+      .rail { margin-top: 26px; display: grid; grid-template-columns: 1fr 1fr; gap: 22px; }
+      .card { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 14px; }
+      .card h3 { margin: 0 0 10px; font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); }
+      .verdicts { display: flex; gap: 8px; }
+      .verdicts button { flex: 1; }
+      .verdicts button.on[data-v="good"] { background: var(--praise); color: #00200f; border-color: var(--praise); }
+      .verdicts button.on[data-v="ok"] { background: var(--minor); color: #241500; border-color: var(--minor); }
+      .verdicts button.on[data-v="bad"] { background: var(--critical); color: #1a0000; border-color: var(--critical); }
+      .tags { display: flex; flex-wrap: wrap; gap: 6px; }
+      .tag { cursor: pointer; border: 1px solid var(--border); border-radius: 999px; padding: 3px 10px; font-size: 12px; color: var(--muted); user-select: none; }
+      .tag.on { background: var(--accent); color: #06121f; border-color: var(--accent); }
+      #notes { width: 100%; min-height: 90px; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 6px; padding: 8px; font: inherit; resize: vertical; }
+      .annlist { grid-column: 1 / -1; }
+      .ann { border-left: 3px solid var(--border); padding: 6px 10px; margin-bottom: 8px; background: var(--bg); border-radius: 0 6px 6px 0; }
+      .ann.critical { border-color: var(--critical); }
+      .ann.minor { border-color: var(--minor); }
+      .ann.praise { border-color: var(--praise); }
+      .ann .q { font-style: italic; color: var(--muted); font-size: 12px; }
+      .ann .c { margin-top: 3px; }
+      .ann .del { float: right; cursor: pointer; color: var(--muted); }
+      .saved { font-size: 11px; color: var(--praise); }
+      .topbar { display: flex; gap: 10px; align-items: center; margin-bottom: 4px; }
+      .topbar .spacer { flex: 1; }
+    </style>
+  </head>
+  <body>
+    <div id="sidebar">
+      <div id="progress"></div>
+      <div id="nav"></div>
+    </div>
+    <div id="main"></div>
+    <div id="pop">
+      <div class="quote" id="popQuote"></div>
+      <div class="sevrow">
+        <button class="sevbtn on" data-sev="critical">critical</button>
+        <button class="sevbtn" data-sev="minor">minor</button>
+        <button class="sevbtn" data-sev="praise">praise</button>
+      </div>
+      <textarea id="popText" placeholder="What's wrong with this span? (optional)"></textarea>
+      <div class="actions">
+        <button class="btn" id="popCancel">cancel</button>
+        <button class="btn primary" id="popSave">comment</button>
+      </div>
+    </div>
+
+    <script>
+      const TAGS = [
+        "too-long", "filler", "vague", "wrong-type", "missing-context",
+        "bad-title", "over-structured", "inaccurate", "hallucinated", "good",
+      ];
+      let samples = [];
+      let feedback = {}; // id -> {verdict, tags[], notes, annotations[]}
+      let current = null;
+      let pending = null; // pending new annotation {field, start, end, quote}
+      let pendingSev = "critical";
+
+      const $ = (s, r = document) => r.querySelector(s);
+      const el = (t, props = {}, kids = []) => {
+        const n = Object.assign(document.createElement(t), props);
+        for (const k of [].concat(kids)) n.append(k);
+        return n;
+      };
+
+      async function boot() {
+        samples = await (await fetch("/api/samples")).json();
+        feedback = await (await fetch("/api/feedback")).json();
+        for (const s of samples) feedback[s.id] ??= { verdict: null, tags: [], notes: "", annotations: [] };
+        renderNav();
+        select(samples[0].id);
+        wirePopover();
+      }
+
+      function fb(id) { return feedback[id]; }
+
+      function renderNav() {
+        const done = samples.filter((s) => {
+          const f = fb(s.id);
+          return f.verdict || f.annotations.length || f.notes.trim() || f.tags.length;
+        }).length;
+        $("#progress").innerHTML = `<b>${done}</b> / ${samples.length} reviewed &nbsp;·&nbsp; <a href="#" id="exportLink">export</a>`;
+        $("#exportLink").onclick = (e) => { e.preventDefault(); exportAll(); };
+        const nav = $("#nav");
+        nav.innerHTML = "";
+        for (const s of samples) {
+          const f = fb(s.id);
+          const item = el("div", { className: "navitem" + (s.id === current ? " active" : "") });
+          item.onclick = () => select(s.id);
+          const dot = el("span", { className: "verdict-dot " + (f.verdict || "") });
+          item.append(
+            el("div", { className: "row1" }, [
+              el("span", { className: "badge " + s.type, textContent: s.type }),
+              el("span", { textContent: s.id }),
+              dot,
+            ]),
+            el("div", { className: "title", textContent: s.title }),
+            el("div", { className: "anncount", textContent: `${f.annotations.length} inline · ${f.tags.length} tags` }),
+          );
+          nav.append(item);
+        }
+      }
+
+      function select(id) {
+        current = id;
+        renderNav();
+        renderMain();
+      }
+
+      function renderMain() {
+        const s = samples.find((x) => x.id === current);
+        const f = fb(current);
+        const main = $("#main");
+        main.innerHTML = "";
+
+        const topbar = el("div", { className: "topbar" }, [
+          el("span", { className: "badge " + s.type, textContent: s.type }),
+          el("span", { className: "meta", textContent: `${s.project} · ${s.size} · ${s.refined.length} chars` }),
+          el("span", { className: "spacer" }),
+          el("span", { className: "saved", id: "savedFlag" }),
+        ]);
+        main.append(topbar, el("div", { className: "hd" }, [el("h1", { textContent: s.title })]));
+
+        const brief = el("details", { className: "brief" });
+        brief.append(el("summary", { textContent: "Original brief (skill input)" }), el("pre", { textContent: s.brief }));
+        main.append(brief);
+
+        main.append(el("div", { className: "section-label", textContent: "Refined issue (select any span to comment)" }));
+        const doc = el("div", { id: "doc" });
+        doc.innerHTML = marked.parse(s.refined);
+        doc.dataset.field = "refined";
+        main.append(doc);
+
+        renderRail(main, s, f);
+        requestAnimationFrame(() => applyHighlights());
+      }
+
+      function renderRail(main, s, f) {
+        const rail = el("div", { className: "rail" });
+
+        const vCard = el("div", { className: "card" });
+        vCard.append(el("h3", { textContent: "Verdict" }));
+        const vrow = el("div", { className: "verdicts" });
+        for (const v of ["good", "ok", "bad"]) {
+          const b = el("button", { className: "btn" + (f.verdict === v ? " on" : ""), textContent: v });
+          b.dataset.v = v;
+          b.onclick = () => { f.verdict = f.verdict === v ? null : v; save(); renderMain(); renderNav(); };
+          vrow.append(b);
+        }
+        vCard.append(vrow);
+
+        const tCard = el("div", { className: "card" });
+        tCard.append(el("h3", { textContent: "Tags" }));
+        const tags = el("div", { className: "tags" });
+        for (const t of TAGS) {
+          const on = f.tags.includes(t);
+          const chip = el("span", { className: "tag" + (on ? " on" : ""), textContent: t });
+          chip.onclick = () => {
+            f.tags = on ? f.tags.filter((x) => x !== t) : [...f.tags, t];
+            save(); renderMain(); renderNav();
+          };
+          tags.append(chip);
+        }
+        tCard.append(tags);
+
+        const nCard = el("div", { className: "card", style: "grid-column: 1 / -1" });
+        nCard.append(el("h3", { textContent: "Notes" }));
+        const ta = el("textarea", { id: "notes", value: f.notes, placeholder: "Freeform: what's good, what's bad, what the skill should have done differently." });
+        ta.oninput = () => { f.notes = ta.value; save(); };
+        nCard.append(ta);
+
+        const aCard = el("div", { className: "card annlist" });
+        aCard.append(el("h3", { textContent: `Inline comments (${f.annotations.length})` }));
+        if (!f.annotations.length) aCard.append(el("div", { className: "meta", textContent: "Select text in the issue above to add one." }));
+        f.annotations.forEach((a, i) => {
+          const row = el("div", { className: "ann " + a.severity });
+          const del = el("span", { className: "del", textContent: "✕" });
+          del.onclick = () => { f.annotations.splice(i, 1); save(); renderMain(); renderNav(); };
+          row.append(del, el("div", { className: "q", textContent: `“${a.quote}”` }));
+          if (a.comment) row.append(el("div", { className: "c", textContent: a.comment }));
+          aCard.append(row);
+        });
+
+        rail.append(vCard, tCard, nCard, aCard);
+        main.append(rail);
+      }
+
+      // ---- inline annotation engine (stable char offsets into rendered text) ----
+      function textNodes(container) {
+        const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+        const nodes = [];
+        let pos = 0, n;
+        while ((n = walker.nextNode())) {
+          nodes.push({ node: n, start: pos, len: n.nodeValue.length });
+          pos += n.nodeValue.length;
+        }
+        return nodes;
+      }
+      function globalOffset(nodes, node, offset) {
+        const e = nodes.find((x) => x.node === node);
+        return e ? e.start + offset : null;
+      }
+      function rangeFor(container, start, end) {
+        const nodes = textNodes(container);
+        const find = (off) => {
+          for (const e of nodes) if (off >= e.start && off <= e.start + e.len) return { node: e.node, offset: off - e.start };
+          return null;
+        };
+        const a = find(start), b = find(end);
+        if (!a || !b) return null;
+        const r = document.createRange();
+        r.setStart(a.node, a.offset);
+        r.setEnd(b.node, b.offset);
+        return r;
+      }
+      function applyHighlights() {
+        if (!window.Highlight || !CSS.highlights) return;
+        CSS.highlights.clear();
+        const doc = $("#doc");
+        if (!doc) return;
+        const buckets = { critical: [], minor: [], praise: [] };
+        for (const a of fb(current).annotations) {
+          const r = rangeFor(doc, a.start, a.end);
+          if (r) buckets[a.severity]?.push(r);
+        }
+        for (const sev of Object.keys(buckets)) {
+          if (buckets[sev].length) CSS.highlights.set(sev, new Highlight(...buckets[sev]));
+        }
+      }
+
+      function wirePopover() {
+        const pop = $("#pop");
+        document.addEventListener("mouseup", (ev) => {
+          if (pop.contains(ev.target)) return;
+          const sel = window.getSelection();
+          if (!sel.rangeCount || sel.isCollapsed) return;
+          const doc = $("#doc");
+          const r = sel.getRangeAt(0);
+          if (!doc || !doc.contains(r.commonAncestorContainer)) { pop.style.display = "none"; return; }
+          const nodes = textNodes(doc);
+          const start = globalOffset(nodes, r.startContainer, r.startOffset);
+          const end = globalOffset(nodes, r.endContainer, r.endOffset);
+          if (start == null || end == null || end <= start) return;
+          pending = { field: "refined", start, end, quote: sel.toString().trim() };
+          pendingSev = "critical";
+          $("#popQuote").textContent = `“${pending.quote.slice(0, 140)}”`;
+          $("#popText").value = "";
+          setSev("critical");
+          const rect = r.getBoundingClientRect();
+          pop.style.display = "block";
+          pop.style.top = window.scrollY + rect.bottom + 8 + "px";
+          pop.style.left = Math.min(window.scrollX + rect.left, window.innerWidth - 300) + "px";
+          $("#popText").focus();
+        });
+        $$(".sevbtn").forEach((b) => (b.onclick = () => setSev(b.dataset.sev)));
+        $("#popCancel").onclick = () => { pop.style.display = "none"; window.getSelection().removeAllRanges(); };
+        $("#popSave").onclick = commitPending;
+        $("#popText").addEventListener("keydown", (e) => { if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) commitPending(); });
+      }
+      function setSev(s) { pendingSev = s; $$(".sevbtn").forEach((b) => b.classList.toggle("on", b.dataset.sev === s)); }
+      function commitPending() {
+        if (!pending) return;
+        fb(current).annotations.push({ ...pending, severity: pendingSev, comment: $("#popText").value.trim() });
+        fb(current).annotations.sort((a, b) => a.start - b.start);
+        pending = null;
+        $("#pop").style.display = "none";
+        window.getSelection().removeAllRanges();
+        save(); renderMain(); renderNav();
+      }
+      const $$ = (s, r = document) => [...r.querySelectorAll(s)];
+
+      let saveTimer = null;
+      function save() {
+        const id = current;
+        const flag = $("#savedFlag");
+        if (flag) flag.textContent = "saving…";
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(async () => {
+          await fetch("/api/feedback", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ id, feedback: fb(id) }),
+          });
+          const f2 = $("#savedFlag");
+          if (f2) { f2.textContent = "saved ✓"; setTimeout(() => { if ($("#savedFlag") === f2) f2.textContent = ""; }, 1200); }
+        }, 350);
+      }
+
+      function exportAll() {
+        const blob = new Blob([JSON.stringify(feedback, null, 2)], { type: "application/json" });
+        const a = el("a", { href: URL.createObjectURL(blob), download: "issue-refine-feedback.json" });
+        a.click();
+      }
+
+      boot();
+    </script>
+  </body>
+</html>

--- a/evals/issue-refine/label/server.ts
+++ b/evals/issue-refine/label/server.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env bun
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { cli } from "cleye";
+
+// Local labeling server. Serves the review UI, hands the browser the curated
+// samples, and persists reviewer feedback to feedback/<id>.json so a later
+// analysis pass can read it back off disk.
+
+const argv = cli({
+  name: "label-server",
+  flags: {
+    port: { type: Number, default: 4317, description: "Port to listen on" },
+    data: {
+      type: String,
+      default: `${import.meta.dir}/../data/samples.json`,
+      description: "Curated samples to review",
+    },
+    feedback: {
+      type: String,
+      default: `${import.meta.dir}/../feedback`,
+      description: "Directory for saved feedback",
+    },
+  },
+});
+
+const html = join(import.meta.dir, "index.html");
+
+async function readAllFeedback(): Promise<Record<string, unknown>> {
+  const out: Record<string, unknown> = {};
+  let names: string[] = [];
+  try {
+    names = await readdir(argv.flags.feedback);
+  } catch {
+    return out;
+  }
+  for (const n of names) {
+    if (!n.endsWith(".json")) continue;
+    try {
+      out[n.replace(/\.json$/, "")] = await Bun.file(join(argv.flags.feedback, n)).json();
+    } catch {}
+  }
+  return out;
+}
+
+const server = Bun.serve({
+  port: argv.flags.port,
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/" || url.pathname === "/index.html") {
+      return new Response(Bun.file(html), {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
+
+    if (url.pathname === "/api/samples") {
+      return new Response(Bun.file(argv.flags.data), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (url.pathname === "/api/feedback" && req.method === "GET") {
+      return Response.json(await readAllFeedback());
+    }
+
+    if (url.pathname === "/api/feedback" && req.method === "POST") {
+      const body = (await req.json()) as { id?: string; feedback?: unknown };
+      if (!body.id || !/^[\w-]+$/.test(body.id)) return new Response("bad id", { status: 400 });
+      const path = join(argv.flags.feedback, `${body.id}.json`);
+      await Bun.write(path, JSON.stringify(body.feedback, null, 2));
+      return Response.json({ ok: true });
+    }
+
+    return new Response("not found", { status: 404 });
+  },
+});
+
+console.log(`Labeling UI: http://localhost:${server.port}`);
+console.log(`Samples:     ${argv.flags.data}`);
+console.log(`Feedback:    ${argv.flags.feedback}/`);

--- a/evals/issue-refine/scripts/ab-prompt.ts
+++ b/evals/issue-refine/scripts/ab-prompt.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env bun
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { cli } from "cleye";
+
+// Assembles the agent prompt for one A/B cell: a skill version (a directory of
+// SKILL.md + guide files) run against one synthetic brief. The agent identifies
+// the type itself and emits only the finished issue, so a version that lacks a
+// guide (e.g. before spike.md existed) simply cannot pick that type.
+
+const argv = cli({
+  name: "ab-prompt",
+  flags: {
+    version: { type: String, description: "Directory of skill files (SKILL.md + guides)" },
+    brief: { type: String, description: "Path to a brief JSON file" },
+  },
+});
+
+if (!argv.flags.version || !argv.flags.brief) {
+  console.error("usage: ab-prompt --version <dir> --brief <file.json>");
+  process.exit(1);
+}
+
+const brief = await Bun.file(argv.flags.brief).json();
+const files = (await readdir(argv.flags.version)).filter((f) => f.endsWith(".md")).sort();
+
+const skillBlocks: string[] = [];
+for (const f of files) {
+  const body = await Bun.file(join(argv.flags.version, f)).text();
+  skillBlocks.push(`================ ${f} ================\n${body.trim()}`);
+}
+
+const ctx = brief.context ?? {};
+const files_ctx = (ctx.files ?? []).map((x: string) => `- ${x}`).join("\n");
+const issues_ctx = (ctx.related_issues ?? []).map((x: string) => `- ${x}`).join("\n");
+
+const prompt = `You are the issue:refine skill. Refine the brief below into a structured issue by following the skill instructions verbatim.
+
+Rules for this run:
+- Use ONLY the brief and synthetic context below. Do not call tools or gather external context. Treat the listed files and related issues as what you found when investigating.
+- Identify the issue type yourself from the skill's Issue Types, then follow the matching guide.
+- The tracker is a Linear-style tracker: a reference written as a markdown link expands into an inline chip. Relation links under \`relations:\` are those links.
+- Output ONLY the finished issue as a Markdown artifact: YAML frontmatter between \`---\` fences (\`title\`, \`type\`, and any of \`labels\`, \`priority\`, \`relations\` you can fill), then the body below the closing \`---\`. The body opens with the summary prose directly. Do not put a \`# H1\` heading in the body. No preamble, no "for approval" question, no commentary.
+
+${skillBlocks.join("\n\n")}
+
+================ BRIEF ================
+${brief.brief}
+
+================ SYNTHETIC CONTEXT ================
+Files:
+${files_ctx || "(none)"}
+
+Related issues:
+${issues_ctx || "(none)"}
+`;
+
+console.log(prompt);

--- a/evals/issue-refine/scripts/ab-report.ts
+++ b/evals/issue-refine/scripts/ab-report.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env bun
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { cli } from "cleye";
+
+// Scores the before/after refined issues produced by an A/B run and prints the
+// per-brief delta. Expects ab/out/<brief>.<before|after>.md to exist. The
+// mechanical score is the rubric-as-code; the judgment findings are left to a
+// separate LLM judge.
+
+const argv = cli({
+  name: "ab-report",
+  flags: {
+    out: {
+      type: String,
+      default: `${import.meta.dir}/../ab/out`,
+      description: "Directory of <brief>.<version>.md outputs",
+    },
+    score: {
+      type: String,
+      default: `${import.meta.dir}/score.ts`,
+      description: "Path to score.ts",
+    },
+  },
+});
+
+async function score(file: string): Promise<{ score: number; byFinding: Record<number, number> }> {
+  const proc = Bun.spawn(["bun", argv.flags.score, "--input", file, "--json"], { stdout: "pipe" });
+  const out = await new Response(proc.stdout).text();
+  await proc.exited;
+  return JSON.parse(out);
+}
+
+const files = await readdir(argv.flags.out);
+const briefs = [
+  ...new Set(
+    files.filter((f) => f.endsWith(".md")).map((f) => f.replace(/\.(before|after)\.md$/, "")),
+  ),
+].sort();
+
+const FINDING_NAME: Record<number, string> = {
+  1: "headings",
+  2: "issue/PR refs",
+  3: "line numbers",
+  4: "jargon",
+  5: "structure",
+  6: "title",
+};
+
+let totalBefore = 0;
+let totalAfter = 0;
+for (const brief of briefs) {
+  const beforeFile = join(argv.flags.out, `${brief}.before.md`);
+  const afterFile = join(argv.flags.out, `${brief}.after.md`);
+  if (!(await Bun.file(beforeFile).exists()) || !(await Bun.file(afterFile).exists())) {
+    console.log(`${brief}: missing before/after output, skipping`);
+    continue;
+  }
+  const b = await score(beforeFile);
+  const a = await score(afterFile);
+  totalBefore += b.score;
+  totalAfter += a.score;
+  const delta = a.score - b.score;
+  const arrow = delta < 0 ? "improved" : delta > 0 ? "regressed" : "unchanged";
+  console.log(`\n${brief}`);
+  console.log(
+    `  score   before ${b.score}  ->  after ${a.score}   (${delta >= 0 ? "+" : ""}${delta}, ${arrow})`,
+  );
+  const findings = [...new Set([...Object.keys(b.byFinding), ...Object.keys(a.byFinding)])]
+    .map(Number)
+    .sort();
+  for (const f of findings) {
+    const bn = b.byFinding[f] ?? 0;
+    const an = a.byFinding[f] ?? 0;
+    if (bn === an) continue;
+    console.log(`    finding ${f} (${FINDING_NAME[f]}): ${bn} -> ${an}`);
+  }
+}
+
+console.log(`\n${"=".repeat(40)}`);
+console.log(`total mechanical score: before ${totalBefore}  ->  after ${totalAfter}`);
+console.log("(lower is better; this is the rubric-as-code, not the LLM judge)");

--- a/evals/issue-refine/scripts/build-dataset.ts
+++ b/evals/issue-refine/scripts/build-dataset.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env bun
+import { cli } from "cleye";
+
+// Builds a curated, type-balanced sample of real issue:refine runs from
+// session history. Inputs are the three JSON exports in raw/ (see README).
+// Each sample pairs the original brief (the skill's args) with the richest
+// refined issue body that was saved to Linear in the same session.
+
+const argv = cli({
+  name: "build-dataset",
+  flags: {
+    rawDir: {
+      type: String,
+      default: `${import.meta.dir}/../raw`,
+      description: "Directory holding save_issues.json, briefs.json, types.json",
+    },
+    out: {
+      type: String,
+      default: `${import.meta.dir}/../data/samples.json`,
+      description: "Output path for the curated dataset",
+    },
+    limit: { type: Number, default: 18, description: "Max samples to keep" },
+  },
+});
+
+type SaveIssue = {
+  session_id: string;
+  project_path: string;
+  title: string | null;
+  issue_id: string | null;
+  description: string;
+};
+type Brief = { session_id: string; project_path: string; brief: string };
+type TypeRow = { session_id: string; type: string };
+
+const saves: SaveIssue[] = await Bun.file(`${argv.flags.rawDir}/save_issues.json`).json();
+const briefs: Brief[] = await Bun.file(`${argv.flags.rawDir}/briefs.json`).json();
+const types: TypeRow[] = await Bun.file(`${argv.flags.rawDir}/types.json`).json();
+
+const typeBySession = new Map(types.map((t) => [t.session_id, t.type]));
+
+// Richest brief per session (longest args wins; that is the fullest input).
+const briefBySession = new Map<string, Brief>();
+for (const b of briefs) {
+  const cur = briefBySession.get(b.session_id);
+  if (!cur || (b.brief?.length ?? 0) > (cur.brief?.length ?? 0))
+    briefBySession.set(b.session_id, b);
+}
+
+// Richest refined body per session (longest description is the fullest draft).
+const refinedBySession = new Map<string, SaveIssue>();
+for (const s of saves) {
+  const cur = refinedBySession.get(s.session_id);
+  if (!cur || s.description.length > cur.description.length) refinedBySession.set(s.session_id, s);
+}
+
+// A save_issue update carries no title; recover it from any titled save in the session.
+const titleBySession = new Map<string, string>();
+for (const s of saves)
+  if (s.title && !titleBySession.has(s.session_id)) titleBySession.set(s.session_id, s.title);
+
+const project = (p: string) =>
+  p
+    .replace(/^.*\/src\//, "")
+    .replace(/\/\.worktrees\/.*$/, "")
+    .split(".")[0] ?? "";
+
+type Sample = {
+  id: string;
+  session_id: string;
+  project: string;
+  type: string;
+  size: "compact" | "full";
+  brief: string;
+  title: string;
+  refined: string;
+};
+
+const candidates: Sample[] = [];
+for (const [session_id, refined] of refinedBySession) {
+  const brief = briefBySession.get(session_id);
+  if (!brief) continue;
+  const title = refined.title ?? titleBySession.get(session_id) ?? "(untitled)";
+  candidates.push({
+    id: "",
+    session_id,
+    project: project(refined.project_path),
+    type: typeBySession.get(session_id) ?? "unknown",
+    size: refined.description.length < 1200 ? "compact" : "full",
+    brief: brief.brief,
+    title,
+    refined: refined.description,
+  });
+}
+
+// Drop near-duplicates (same normalized title).
+const norm = (t: string) =>
+  t
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+const seen = new Set<string>();
+const unique = candidates.filter((c) => {
+  const k = norm(c.title);
+  if (seen.has(k)) return false;
+  seen.add(k);
+  return true;
+});
+
+// Type-balanced round-robin selection, preferring fuller bodies within each type.
+const buckets = new Map<string, Sample[]>();
+for (const c of unique) {
+  const arr = buckets.get(c.type) ?? [];
+  arr.push(c);
+  buckets.set(c.type, arr);
+}
+// Interleave longest and shortest within each type so the sample spans both
+// the full Summary/Context bodies and the compact one-liners the skill emits.
+for (const [t, arr] of buckets) {
+  arr.sort((a, b) => b.refined.length - a.refined.length);
+  const woven: Sample[] = [];
+  let lo = 0;
+  let hi = arr.length - 1;
+  while (lo <= hi) {
+    const first = arr[lo++];
+    if (first) woven.push(first);
+    if (lo <= hi) {
+      const last = arr[hi--];
+      if (last) woven.push(last);
+    }
+  }
+  buckets.set(t, woven);
+}
+
+const order = ["bug", "feature", "refactor", "unknown"];
+const selected: Sample[] = [];
+let added = true;
+while (added && selected.length < argv.flags.limit) {
+  added = false;
+  for (const t of order) {
+    const arr = buckets.get(t);
+    const next = arr?.shift();
+    if (next && selected.length < argv.flags.limit) {
+      selected.push(next);
+      added = true;
+    }
+  }
+}
+
+selected.forEach((s, i) => {
+  s.id = `sample-${String(i + 1).padStart(2, "0")}`;
+});
+
+await Bun.write(argv.flags.out, JSON.stringify(selected, null, 2));
+
+function tally(key: (s: Sample) => string): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const s of selected) counts[key(s)] = (counts[key(s)] ?? 0) + 1;
+  return counts;
+}
+
+console.log(`Wrote ${selected.length} samples to ${argv.flags.out}`);
+console.log(
+  "By type:",
+  tally((s) => s.type),
+);
+console.log(
+  "By size:",
+  tally((s) => s.size),
+);

--- a/evals/issue-refine/scripts/build-labelset.ts
+++ b/evals/issue-refine/scripts/build-labelset.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env bun
+import { readdir } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { cli } from "cleye";
+import { parseIssue } from "./frontmatter";
+
+// Assembles a labeling dataset from generated issues. Pairs each brief in
+// briefs/label/ with the refined artifact an agent wrote to data/label-out/<id>.md,
+// reads the title from its frontmatter, and writes a samples.json the label
+// server can serve with --data. The briefs are synthetic, so unlike the
+// real-usage dataset this set is reproducible and safe to track.
+
+const argv = cli({
+  name: "build-labelset",
+  flags: {
+    briefs: {
+      type: String,
+      default: `${import.meta.dir}/../briefs/label`,
+      description: "Directory of brief JSON files",
+    },
+    out: {
+      type: String,
+      default: `${import.meta.dir}/../data/label-out`,
+      description: "Directory of generated <id>.md issues",
+    },
+    output: {
+      type: String,
+      default: `${import.meta.dir}/../data/label-set.json`,
+      description: "Samples file to write",
+    },
+  },
+});
+
+const files = (await readdir(argv.flags.briefs)).filter((f) => f.endsWith(".json")).sort();
+const samples: unknown[] = [];
+const missing: string[] = [];
+
+for (const f of files) {
+  const brief = await Bun.file(join(argv.flags.briefs, f)).json();
+  const id = brief.id ?? basename(f, ".json");
+  const outPath = join(argv.flags.out, `${id}.md`);
+  const file = Bun.file(outPath);
+  if (!(await file.exists())) {
+    missing.push(id);
+    continue;
+  }
+  const { title, type, body } = parseIssue(await file.text());
+  samples.push({
+    id,
+    type: brief.type || type || "unknown",
+    size: brief.size ?? "full",
+    project: brief.project ?? "synthetic",
+    brief: brief.brief,
+    title,
+    refined: body,
+  });
+}
+
+await Bun.write(argv.flags.output, JSON.stringify(samples, null, 2));
+console.log(`wrote ${samples.length} samples to ${argv.flags.output}`);
+if (missing.length) console.log(`missing output for: ${missing.join(", ")}`);

--- a/evals/issue-refine/scripts/frontmatter.ts
+++ b/evals/issue-refine/scripts/frontmatter.ts
@@ -1,0 +1,20 @@
+import matter from "gray-matter";
+
+// Parses a refined issue artifact (YAML frontmatter + body). The title and type
+// are frontmatter fields, so callers read them here rather than off a leading
+// H1. When frontmatter is absent, the whole input is the body and the metadata
+// fields come back empty.
+
+export interface ParsedIssue {
+  title: string;
+  type: string;
+  body: string;
+  data: Record<string, unknown>;
+}
+
+export function parseIssue(raw: string): ParsedIssue {
+  const { data, content } = matter(raw);
+  const title = typeof data.title === "string" ? data.title.trim() : "";
+  const type = typeof data.type === "string" ? data.type.trim() : "";
+  return { title, type, body: content.trim(), data };
+}

--- a/evals/issue-refine/scripts/judge.ts
+++ b/evals/issue-refine/scripts/judge.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+import { mkdir, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { cli } from "cleye";
+
+// Prepares a blinded LLM-judge run over an A/B output set. For each brief it
+// assigns before/after to slots "1" and "2" in random order, copies the outputs
+// under neutral names, records the mapping, and prints a judge prompt. A judge
+// agent then scores each slot against the rubric without knowing which is the
+// edited skill. Unblind with --unblind once the verdict is written.
+
+const argv = cli({
+  name: "judge",
+  flags: {
+    out: {
+      type: String,
+      default: `${import.meta.dir}/../ab/out`,
+      description: "Directory of <brief>.<version>.md outputs",
+    },
+    judgeDir: {
+      type: String,
+      default: `${import.meta.dir}/../ab/judge`,
+      description: "Working directory for blinded copies and mapping",
+    },
+    rubric: {
+      type: String,
+      default: `${import.meta.dir}/../RUBRIC.md`,
+      description: "Rubric to judge against",
+    },
+    unblind: {
+      type: String,
+      description: "Path to the judge's verdict JSON; prints the de-blinded result and exits",
+    },
+  },
+});
+
+const mappingPath = join(argv.flags.judgeDir, "mapping.json");
+
+if (argv.flags.unblind) {
+  const mapping = await Bun.file(mappingPath).json();
+  const verdict = await Bun.file(argv.flags.unblind).json();
+  for (const v of verdict.verdicts ?? verdict) {
+    const map = mapping[v.brief];
+    const better = v.better === "1" || v.better === 1 ? map["1"] : map["2"];
+    const s1 = `${map["1"]}=${v.scores?.["1"] ?? v.scores?.[1] ?? "?"}`;
+    const s2 = `${map["2"]}=${v.scores?.["2"] ?? v.scores?.[2] ?? "?"}`;
+    console.log(`\n${v.brief}: judge prefers ${better.toUpperCase()}  (${s1}, ${s2})`);
+    if (v.reason) console.log(`  ${v.reason}`);
+  }
+  process.exit(0);
+}
+
+await mkdir(argv.flags.judgeDir, { recursive: true });
+const files = await readdir(argv.flags.out);
+const briefs = [
+  ...new Set(
+    files.filter((f) => f.endsWith(".md")).map((f) => f.replace(/\.(before|after)\.md$/, "")),
+  ),
+].sort();
+
+const mapping: Record<string, Record<string, string>> = {};
+const blocks: string[] = [];
+for (const brief of briefs) {
+  const flip = Math.random() < 0.5;
+  const slot1 = flip ? "after" : "before";
+  const slot2 = flip ? "before" : "after";
+  mapping[brief] = { "1": slot1, "2": slot2 };
+  const v1 = await Bun.file(join(argv.flags.out, `${brief}.${slot1}.md`)).text();
+  const v2 = await Bun.file(join(argv.flags.out, `${brief}.${slot2}.md`)).text();
+  await Bun.write(join(argv.flags.judgeDir, `${brief}.1.md`), v1);
+  await Bun.write(join(argv.flags.judgeDir, `${brief}.2.md`), v2);
+  blocks.push(
+    `#### Brief: ${brief}\n\n--- Version 1 ---\n${v1.trim()}\n\n--- Version 2 ---\n${v2.trim()}`,
+  );
+}
+await Bun.write(mappingPath, JSON.stringify(mapping, null, 2));
+
+const rubric = await Bun.file(argv.flags.rubric).text();
+const prompt = `You are judging refined issues against a rubric. For each brief you get two refined issues, Version 1 and Version 2, produced from the same input. Each is a Markdown artifact: YAML frontmatter (title, type, and optional labels, priority, relations) between \`---\` fences, then the body. Score each on how well it follows the rubric, then say which is better. Judge only on the rubric. Do not assume either version is newer or preferred.
+
+================ RUBRIC ================
+${rubric.trim()}
+
+================ OUTPUTS TO JUDGE ================
+${blocks.join("\n\n")}
+
+================ YOUR TASK ================
+Return ONLY a JSON object, no prose around it:
+{
+  "verdicts": [
+    { "brief": "<brief id>", "scores": { "1": <0-10>, "2": <0-10> }, "better": "1" | "2", "reason": "<one or two sentences citing rubric findings by number>" }
+  ]
+}
+A higher score is better (10 = follows the rubric fully). Cite finding numbers (1-7) in each reason.`;
+
+console.log(prompt);

--- a/evals/issue-refine/scripts/score.ts
+++ b/evals/issue-refine/scripts/score.ts
@@ -1,0 +1,289 @@
+#!/usr/bin/env bun
+import { cli } from "cleye";
+import { parseIssue } from "./frontmatter";
+
+// Mechanical scorer for the issue:refine rubric (see ../RUBRIC.md). Reads a
+// refined issue artifact (YAML frontmatter + body) and reports rubric
+// violations. Title and type come from the frontmatter; findings 1-5 scan the
+// body only, so the frontmatter's relation URLs never trip the bare-reference
+// or file:line checks. The judgment-call findings (jargon-in-context,
+// over-structuring) are scored loosely here and left to the LLM judge in the
+// A/B harness.
+
+const argv = cli({
+  name: "score",
+  flags: {
+    input: {
+      type: String,
+      description: "Path to a refined issue markdown file. Omit to read stdin.",
+    },
+    title: { type: String, description: "Override the title (default: frontmatter title)" },
+    json: { type: Boolean, default: false, description: "Emit JSON instead of a human report" },
+  },
+});
+
+const SEVERITY_WEIGHT = { critical: 3, minor: 1 } as const;
+type Severity = keyof typeof SEVERITY_WEIGHT;
+
+type Violation = {
+  finding: number;
+  severity: Severity;
+  line: number;
+  excerpt: string;
+  message: string;
+};
+
+// Tunable word lists. These came out of the labeling and are meant to grow.
+const JARGON = [
+  "seam",
+  "disposition",
+  "leverage",
+  "robust",
+  "seamless",
+  "utilize",
+  "facilitate",
+  "holistic",
+  "synergy",
+  "paradigm",
+];
+const MARKETING = [
+  "blazing",
+  "powerful",
+  "cutting-edge",
+  "world-class",
+  "effortless",
+  "delightful",
+  "robustly",
+  "reality",
+];
+const SMALL_WORDS = new Set([
+  "a",
+  "an",
+  "the",
+  "and",
+  "but",
+  "or",
+  "nor",
+  "for",
+  "of",
+  "in",
+  "on",
+  "to",
+  "with",
+  "vs",
+  "via",
+  "per",
+  "at",
+  "by",
+  "as",
+  "from",
+  "into",
+  "over",
+  "under",
+]);
+
+const raw = argv.flags.input
+  ? await Bun.file(argv.flags.input).text()
+  : await Bun.readableStreamToText(Bun.stdin.stream());
+const { title: fmTitle, type, body } = parseIssue(raw);
+const title = argv.flags.title ?? fmTitle;
+
+// The frontmatter title has no line in the body; point title findings at the
+// top of the file.
+const TITLE_LINE = 1;
+
+const lines = body.split("\n");
+const headings = lines
+  .map((l, i) => ({ line: i + 1, m: l.match(/^(#{1,6})\s+(.*\S)\s*$/) }))
+  .filter((h): h is { line: number; m: RegExpMatchArray } => h.m != null)
+  .map((h) => ({ line: h.line, level: (h.m[1] ?? "").length, text: h.m[2] ?? "" }));
+
+const violations: Violation[] = [];
+const add = (finding: number, severity: Severity, line: number, excerpt: string, message: string) =>
+  violations.push({ finding, severity, line, excerpt, message });
+
+// Finding 1: title-case noun-phrase headings. A body H1 is a defect on its own:
+// the title lives in the frontmatter, so the body should never open one.
+const stripCode = (s: string) => s.replace(/`[^`]*`/g, "").replace(/\[[^\]]*\]\([^)]*\)/g, "$&");
+for (const h of headings) {
+  if (h.level === 1) {
+    add(
+      1,
+      "critical",
+      h.line,
+      h.text,
+      "Body has an H1 heading. The title belongs in the frontmatter.",
+    );
+    continue;
+  }
+  const bare = h.text.replace(/^\d+[.)]\s*/, "");
+  if (/,\s*(not|never|n't)\b/i.test(bare) || /\bn't\b/.test(bare)) {
+    add(
+      1,
+      "critical",
+      h.line,
+      h.text,
+      'Heading uses "X, not Y" antithesis. Make it a plain noun phrase.',
+    );
+    continue;
+  }
+  if (/[.?!]$/.test(bare))
+    add(1, "minor", h.line, h.text, "Heading reads as a sentence. Use a noun phrase.");
+  const words = stripCode(bare).split(/\s+/).filter(Boolean);
+  const major = words.filter(
+    (w) => /[a-z]/i.test(w) && !w.includes("`") && !/^[A-Z0-9_]+$/.test(w),
+  );
+  const lowerMajor = major
+    .filter((w, i) => !SMALL_WORDS.has(w.toLowerCase()) || i === 0)
+    .filter((w) => /^[a-z]/.test(w));
+  if (lowerMajor.length)
+    add(
+      1,
+      "minor",
+      h.line,
+      h.text,
+      `Not title case (lowercase: ${lowerMajor.slice(0, 3).join(", ")}).`,
+    );
+}
+
+// Finding 2: native links for issue/PR references; no bare numbers or raw URLs.
+const linkTargets = new Set([...body.matchAll(/\]\(([^)]+)\)/g)].map((m) => m[1]));
+lines.forEach((l, i) => {
+  const noLinks = l.replace(/\[[^\]]*\]\([^)]*\)/g, "").replace(/`[^`]*`/g, "");
+  for (const m of noLinks.matchAll(/\b[A-Z]{2,}-\d+\b/g))
+    add(2, "critical", i + 1, m[0], "Bare tracker reference. Use a link that expands inline.");
+  for (const m of noLinks.matchAll(/(?:^|\s)(#\d+|MR\s*!\d+|!\d+)\b/g))
+    add(
+      2,
+      "critical",
+      i + 1,
+      m[1] ?? m[0],
+      "Bare issue/PR number. Use a link that expands inline.",
+    );
+  for (const m of noLinks.matchAll(/https?:\/\/\S+/g)) {
+    if (!linkTargets.has(m[0]))
+      add(2, "minor", i + 1, m[0], "Raw URL pasted as text. Use a titled link or native relation.");
+  }
+});
+const relatedHeading = headings.find((h) => /related issues/i.test(h.text));
+if (relatedHeading)
+  add(
+    2,
+    "minor",
+    relatedHeading.line,
+    relatedHeading.text,
+    "Standalone Related Issues section. Prefer the tracker's native relations.",
+  );
+
+// Finding 3: no volatile line-number citations.
+lines.forEach((l, i) => {
+  for (const m of l.matchAll(/#L\d+(?:-L?\d+)?/g))
+    add(
+      3,
+      "critical",
+      i + 1,
+      m[0],
+      "Volatile line anchor. Cite the symbol and quote the lines inline.",
+    );
+  for (const m of l.matchAll(/\b[\w./-]+\.\w+:\d+(?:-\d+)?\b/g))
+    add(
+      3,
+      "critical",
+      i + 1,
+      m[0],
+      "Volatile file:line citation. Cite the symbol and quote the lines inline.",
+    );
+});
+
+// Finding 4: jargon and marketing words.
+lines.forEach((l, i) => {
+  const lower = l.toLowerCase();
+  for (const w of [...JARGON, ...MARKETING]) {
+    const re = new RegExp(`\\b${w}\\b`, "i");
+    if (re.test(lower))
+      add(4, "minor", i + 1, w, `Jargon/marketing word "${w}". Use a plainer word.`);
+  }
+});
+
+// Finding 5: over-structuring (heading density, thin option menus, filler heads).
+const bodyWords = body.split(/\s+/).filter(Boolean).length;
+const subHeadings = headings.filter((h) => h.level > 1).length;
+const headingBudget = Math.max(4, Math.floor(bodyWords / 150));
+if (subHeadings > headingBudget)
+  add(
+    5,
+    "minor",
+    1,
+    `${subHeadings} headings / ${bodyWords} words`,
+    `Over-structured: ${subHeadings} headings for ${bodyWords} words.`,
+  );
+const optionHeading = headings.find((h) => /\boption/i.test(h.text));
+if (optionHeading)
+  add(
+    5,
+    "minor",
+    optionHeading.line,
+    optionHeading.text,
+    "Option menu. Prefer the chosen approach or goal + acceptance criteria.",
+  );
+const summaryHeading = headings.find((h) => h.level === 2 && /^summary$/i.test(h.text));
+if (summaryHeading)
+  add(
+    5,
+    "minor",
+    summaryHeading.line,
+    summaryHeading.text,
+    "Summary heading is filler. The body opens with the summary prose directly.",
+  );
+
+// Finding 6: concise, sentence-case title from the frontmatter.
+if (title) {
+  if (title.length > 80)
+    add(6, "minor", TITLE_LINE, title, `Title is ${title.length} chars. Keep it short.`);
+  if (/\(.*\)/.test(title))
+    add(6, "minor", TITLE_LINE, title, "Title carries a parenthetical. Trim it.");
+  // Sentence case: only the first word and proper nouns capitalize. Skip the
+  // first word, pure acronyms/numbers (CSV, 200), and small words. Title case
+  // capitalizes every remaining content word, so flag only when two or more are
+  // capitalized and none stays lowercase; a proper noun or two leaves lowercase
+  // content words behind and reads as a sentence.
+  const titleContent = stripCode(title)
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(1)
+    .filter((w) => /[a-z]/.test(w) && !/^\d/.test(w))
+    .filter((w) => !SMALL_WORDS.has(w.toLowerCase()));
+  const capitalized = titleContent.filter((w) => /^[A-Z]/.test(w));
+  const lowercaseContent = titleContent.filter((w) => /^[a-z]/.test(w));
+  if (capitalized.length >= 2 && lowercaseContent.length === 0)
+    add(
+      6,
+      "minor",
+      TITLE_LINE,
+      title,
+      `Title looks title-cased (${capitalized.slice(0, 3).join(", ")}). Use sentence case.`,
+    );
+}
+
+const score = violations.reduce((s, v) => s + SEVERITY_WEIGHT[v.severity], 0);
+const byFinding = violations.reduce<Record<number, number>>((m, v) => {
+  m[v.finding] = (m[v.finding] ?? 0) + 1;
+  return m;
+}, {});
+
+if (argv.flags.json) {
+  console.log(JSON.stringify({ title, type, score, byFinding, violations }, null, 2));
+} else {
+  console.log(`Title: ${title || "(none)"}`);
+  console.log(`Type:  ${type || "(none)"}`);
+  console.log(`Score: ${score} (lower is better) · ${violations.length} violations\n`);
+  for (const v of violations.sort(
+    (a, b) => SEVERITY_WEIGHT[b.severity] - SEVERITY_WEIGHT[a.severity] || a.finding - b.finding,
+  )) {
+    console.log(
+      `  [${v.severity}] finding ${v.finding} · L${v.line} · "${v.excerpt.slice(0, 60)}"`,
+    );
+    console.log(`      ${v.message}`);
+  }
+  if (!violations.length) console.log("  clean");
+}

--- a/plugins/issue/skills/refine/SKILL.md
+++ b/plugins/issue/skills/refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: issue:refine
 description: Refining issues with technical context and structured details. Use when expanding a brief bug, feature, or refactor description into a detailed issue suitable for developers and AI agents.
-argument-hint: "[--type bug|feature|refactor] [--compact]"
+argument-hint: "[--type bug|feature|refactor|spike] [--compact]"
 ---
 
 # Issue Refinement
@@ -12,8 +12,8 @@ Expand brief issue descriptions into structured issues for developers and AI age
 
 Parse `$ARGUMENTS`:
 
-- `--type bug|feature|refactor`: skip type identification and read that guide directly. Default: infer the type from the description per [Issue Types](#issue-types).
-- `--compact`: force the tight output, a sentence or two that names the problem and points at the code, with no Summary/Context frame. Default: size the output to the issue per [Section Selection](#section-selection).
+- `--type bug|feature|refactor|spike`: skip type identification and read that guide directly. Default: infer the type from the description per [Issue Types](#issue-types).
+- `--compact`: force the tight body, a sentence or two that names the problem and points at the code, with no `## Context` frame. Frontmatter is always emitted. Default: size the body to the issue per [Section Selection](#section-selection).
 
 ## Issue Types
 
@@ -22,22 +22,37 @@ Parse `$ARGUMENTS`:
 | Bug | Something is broken | `bug.md` |
 | Feature | New capability | `feature.md` |
 | Refactor | Internal improvement, no behavior change | `refactor.md` |
+| Spike | Timeboxed investigation; output is a recommendation, not a shipped change | `spike.md` |
 
 ## Workflow
 
 1. Identify type and read the corresponding guide. When `--type` is set, use it and skip identification.
 2. Gather context from code and related issues
 3. Draft refinement following the type-specific structure. Under `--compact`, produce the tight output described in [Section Selection](#section-selection).
-4. Output for user approval before updating the issue
+4. Write `tmp/issue-<slug>.md`, output it for approval, then hand the file to the platform skill.
 
 ## Output Structure
 
-Lead with what's wrong or what's needed. For a substantial issue, open with Summary and close with Context, drawing middle sections from the type guide's menu. Include only those that earn their place. A trivial issue can be a tight paragraph or a single sentence. Don't wrap it in a Summary and Context skeleton it doesn't need.
+Refine writes the issue to `tmp/issue-<slug>.md`: YAML frontmatter for the
+metadata a tracker stores as fields, then the body below the closing `---`. The
+body leads with the summary prose directly, under no heading.
 
 ```markdown
-## Summary
+---
+title: fix connection pool exhaustion under load   # sentence case, one line
+type: bug                                           # bug | feature | refactor | spike
+labels: [performance, database]                     # optional; neutral tags
+priority: high                                      # optional; urgent | high | medium | low
+relations:                                          # optional; tracker links per relation
+  blocks: []
+  blocked-by: []
+  related:
+    - https://linear.app/acme/issue/ENG-1970
+  duplicate-of: []
+---
 
-One to two sentences.
+The nightly export marks its run successful even when per-object retrievals
+time out, so downstream jobs read a partial snapshot as if it were complete.
 
 [Type-specific sections from guide (select, don't fill)]
 
@@ -46,28 +61,45 @@ One to two sentences.
 ### Related Code
 
 Files that need changes or inform the work.
-
-### Related Issues
-
-Links to related issues, prior attempts, upstream work.
 ```
+
+Populate only the keys you can infer: `title`, `type`, `labels`, `priority`,
+`relations`. Omit any optional key you can't fill, and drop empty relation
+lists. The platform skill fills routing and workspace fields (team, assignee,
+state, estimate) at save time.
+
+Write the `title` in sentence case: capitalize the first word and proper nouns,
+and leave the rest lowercase. This sets it apart from the title-case body
+headings. Keep it to one line with no long parentheticals.
+
+A related issue you found belongs under `relations` as a tracker link, kept out
+of the body. Mention another issue in the body only when it tells the reader
+something the relation can't: what a prior attempt tried, why upstream work
+matters. Never append a standalone Related Issues section. It just restates
+links the relation already expresses.
 
 ## Section Selection
 
 Every section must tell the reader something they couldn't have guessed. Cut sections whose content is tautological ("tests must pass"), template residue ("no behavior change"), or obvious given the issue's size.
 
-For a substantial issue, Summary plus one type section plus Context is the floor. Grow only when content demands. A trivial issue needs none of that frame: a sentence or two that names the problem and points at the code is enough.
+For a substantial issue, the opening summary plus one type section plus `## Context` is the floor. Grow only when content demands. A trivial issue needs none of that frame: a sentence or two that names the problem and points at the code is enough.
 
-`--compact` forces that trivial output regardless of size: name the problem, point at the code, drop the Summary/Context frame.
+`--compact` forces that trivial body regardless of size: name the problem, point at the code, drop the `## Context` frame. Frontmatter is still emitted.
 
 ## Style
 
-State facts, not hedging. Name the function, file, or behavior rather than describing it vaguely. Every sentence should add information. A section present only to match the template is filler, so earn each heading.
+State facts and drop the hedging. Name the function, file, or behavior rather than describing it vaguely. Every sentence should add information. A section present only to match the template is filler, so earn each heading.
 
-Link to code. Use permalinks for GitHub (`https://github.com/{owner}/{repo}/blob/{sha}/path#L10-L20`) and file paths elsewhere (`path/to/file:10-20`).
+Section headings are title-case noun phrases. Keep them free of sentences, slogans, and "X, not Y" antithesis. Write "Connection Lifecycle" rather than "Pin, don't invalidate".
+
+Plain words over jargon and marketing. Drop terms like "spike" (as a verb), "seam", "disposition", "reality". Say what the thing does.
+
+Reference code by symbol. Name the function or type and quote the few relevant lines inline. Skip bare line ranges (`file.py:26-56`, `#L26-L56`): they go stale as the file changes. Use a SHA-pinned permalink only when a stable anchor is genuinely needed.
+
+Reference issues and PRs as tracker links that expand inline, never as bare numbers (`ENG-1970`, `!578`, `#123`) a reader can't resolve. The platform skill owns the link syntax.
 
 Don't use spaced em dashes. Split into two sentences without a semicolon or unspaced substitute.
 
 ## Issue Trackers
 
-Fetch the issue, output the refinement for approval, and update the tracker only after approval. Defer tracker-save mechanics to the platform skill. For Linear, use `linear:linear`.
+Fetch the issue, write `tmp/issue-<slug>.md`, and output it for approval. After approval, hand the file to the platform skill, which maps the frontmatter to tracker fields and saves the body from the file. Defer all save mechanics to that skill. For Linear, use `linear:linear`.

--- a/plugins/issue/skills/refine/feature.md
+++ b/plugins/issue/skills/refine/feature.md
@@ -20,7 +20,7 @@ Include subsections selectively.
 
 #### Approach
 
-High-level implementation. Reference existing patterns. Skip for trivially-designed features.
+High-level implementation. Reference existing patterns. Skip for trivially-designed features. Don't enumerate thin, unevaluated options. State the chosen approach, or the goal plus acceptance criteria, and leave option-weighing to a real decision.
 
 #### Changes
 

--- a/plugins/issue/skills/refine/refactor.md
+++ b/plugins/issue/skills/refine/refactor.md
@@ -12,7 +12,7 @@ What changes, what doesn't. State behavior changes explicitly (usually none).
 
 ### Approach
 
-Strategy (incremental vs. big bang), key transformations, risks. Skip for single-file or atomic refactors; include when strategy, migration, or rollback matters.
+Strategy (incremental vs. big bang), key transformations, risks. Skip for single-file or atomic refactors; include when strategy, migration, or rollback matters. Don't enumerate thin, unevaluated options. State the chosen strategy, or the goal plus acceptance criteria.
 
 ### Validation
 

--- a/plugins/issue/skills/refine/spike.md
+++ b/plugins/issue/skills/refine/spike.md
@@ -1,0 +1,32 @@
+# Spike
+
+A spike is a timeboxed investigation. The deliverable is a recommendation backed by findings. Any code written along the way is throwaway. Refine it so the reader knows the question, the budget, and what a good answer looks like.
+
+## Sections (menu: include only those that earn their place)
+
+### Question
+
+The decision the spike resolves. State it as a question with a clear yes/no or which-option answer.
+
+### Background
+
+Why the question is open now and what's blocked on it. Skip when the title and question convey it.
+
+### Approach
+
+Where to look and how to reach a defensible answer: the environment, the measurements, the throwaway prototype. Skip when the question implies the method.
+
+### Deliverable
+
+What the spike produces: a recommendation, the data behind it, a follow-up issue. Name the artifact, not "we'll know more".
+
+### Timebox
+
+The budget and the exit condition. Skip when there's a team default.
+
+## Key Questions
+
+- What decision does this unblock?
+- What evidence would settle it?
+- What's the budget, and what happens when it's spent?
+- Is the output a recommendation, a prototype, or a number?


### PR DESCRIPTION
Refine now treats the issue title as metadata rather than body content. It writes `tmp/issue-<slug>.md`: YAML frontmatter (`title`, `type`, and optional `labels`, `priority`, `relations`) followed by a body that opens with the summary prose. The old output started at `## Summary` with the title left implicit, which forced the eval harness to invent a `# Title` H1 convention that then fought the writing hook's title-case rule on every generated issue.

The artifact is tool-agnostic, which is the point. A thin per-tracker adapter reads the fields with `yq`/`jq` and passes the body by file (`--description-file` / `--body-file`), so the same file maps to Linear, GitHub, or Things without refine knowing anything about any tracker. Because the body lives in a file, it never round-trips through model context at save time.

Refine populates only the keys it can infer. Routing and workspace fields (team, assignee, state, estimate) are deferred to the adapter, which knows the target tool and can validate against it. The `relations` block is open, so a future neutral key is additive. The `## Summary` heading is gone: it labeled the opening sentence with what a reader already infers.

## Eval Harness

The `evals/issue-refine` rubric harness parses the artifact instead of splitting a leading H1. A shared `parseIssue` helper (on `gray-matter`) returns `{ title, type, body, data }` and degrades to `{ title: "", body: raw }` when frontmatter is absent. The scorer reads title and type from the frontmatter and runs findings 1-5 over the body alone. That also fixes a latent false positive: relation URLs in the frontmatter would otherwise have tripped the bare-reference and `file:line` scans. It now flags a body `# H1` as critical and a leading `## Summary` as filler.

This is the first of a stacked pair. The follow-up adds the Linear reference adapter that consumes the artifact.

## Testing

Exercised the scorer against a clean artifact and one seeded with a title-case title, a body H1, a leading `## Summary`, and a `file.py:26-56` citation, confirming each maps to its finding and that a relation URL in the frontmatter stays out of the bare-reference and `file:line` scans. Checked that `parseIssue` recovers the fields from a sample artifact and falls back to a body-only result when frontmatter is absent, and that `build-labelset.ts` reads titles from the frontmatter of the existing outputs. Ran `biome` over the scripts and `skill-lint` over the refine skill.
