### PR TITLE
linear: map a refined issue artifact to Linear

### DIFF
--- a/plugins/linear/skills/linear/SKILL.md
+++ b/plugins/linear/skills/linear/SKILL.md
@@ -13,6 +13,12 @@ allowed-tools:
 
 Tools and workflows for managing issues, projects, and teams in Linear.
 
+## Environment
+
+- **`linear` CLI**: !`command -v linear >/dev/null 2>&1 && linear --version 2>/dev/null || echo "not installed"`
+
+The connector and MCP paths need no CLI. The CLI-only operations (relations, bulk work) require `linear`; when it reads "not installed", stay on the connector. The version above tells you which CLI is installed. Confirm its exact subcommands and flags with `linear <cmd> --help` or the `linear-cli:linear-cli` skill rather than assuming them.
+
 ## Arguments
 
 `$0` (optional verb) routes to an operation; pass the rest (issue id, title, filters) as its params. With no verb, infer the operation from the request.
@@ -31,7 +37,9 @@ Three runtime paths reach Linear, in order of preference:
 
 1. **Claude.ai connector** (`mcp__claude_ai_Linear__save_issue`, `get_issue`) is the primary path. One tool, `save_issue`, handles both create and update. See [Creating vs Updating](#creating-vs-updating).
 2. **Local or plugin MCP** (`create_issue`, `update_issue`, `list_issues`) exposes separate tools for create and update. Use it for simple single-issue operations when the connector is unavailable.
-3. **`linear` CLI and raw GraphQL** is the fallback for what the connector and MCP tools do not cover (complex queries, bulk operations). Defer to the `linear-cli:linear-cli` skill for the CLI surface. See [GraphQL API](#graphql-api).
+3. **`linear` CLI and raw GraphQL** is the fallback for what the connector and MCP tools do not cover (complex queries, bulk operations, relations). Defer to the `linear-cli:linear-cli` skill for the CLI surface. See [GraphQL API](#graphql-api).
+
+Turning a structured issue file (from issue refinement, project planning, or any skill that emits one) into an issue follows this order. The connector handles a simple save. The CLI path is required only when the file declares relations, which the connector and MCP tools cannot set. See [Saving a Structured Issue File](#saving-a-structured-issue-file).
 
 ## Creating vs Updating
 
@@ -63,6 +71,42 @@ Update (`id` present, change only what you need):
 ```
 
 The local and plugin MCP variants split these into `create_issue` and `update_issue`, shown in the examples below. The create precondition (`title` required) applies to both paths.
+
+## Saving a Structured Issue File
+
+Several skills hand off a Markdown file with YAML frontmatter for issue metadata and a body below the closing `---`. Issue refinement emits one, project planning emits a similar file, and others will follow. This section maps that shape to a Linear issue. The schema varies by producer, so read the file's frontmatter to see which keys it actually carries, extract them with whatever fits that file, and write the body to its own file so it passes by path and stays out of context.
+
+Map the metadata keys these files tend to carry onto the `linear` CLI:
+
+| Frontmatter | Linear |
+|-------------|--------|
+| `title` | `--title` |
+| body (below the closing `---`) | `--description-file <path>` |
+| `labels` | one `--label` per entry |
+| `priority` (`urgent`, `high`, `medium`, `low`) | `--priority` `1`..`4` |
+| `relations` (`blocks`, `blocked-by`, `related`, `duplicate-of`) | `linear issue relation add <id> <type> <relatedId>` |
+
+A relation's `type` is the frontmatter key, except `duplicate-of` maps to `duplicate`. Its `relatedId` is the issue identifier in the relation's tracker URL. For keys the file omits, or ones this table does not name, map them when Linear has a matching field and ask when the mapping is unclear.
+
+Routing fields (team, assignee, state) are not in the file. Take them from the user at save time. Default the state from assignment as in [Issue Status](#issue-status). `getDefaultState` in `hooks/save-issue.ts` encodes that rule.
+
+### Simple Saves
+
+When the file declares no relations, the connector `save_issue` is enough: pass the title, the body as `description`, the labels, and the routing fields, per [Creating vs Updating](#creating-vs-updating). This is the default.
+
+### Relations
+
+The connector and MCP tools cannot set relations, so a file that declares any needs the `linear` CLI. When the Environment block shows it is not installed, save through the connector and report the relation targets you skipped so the user can add them by hand.
+
+With the CLI present, create the issue with the body by file, then add one relation per entry from the parsed frontmatter:
+
+```bash
+new_id=$(linear issue create --title "$title" --description-file "$body_file" \
+  --team "$team" --state "$state" | grep -oE '[A-Z][A-Z0-9]*-[0-9]+' | head -1)
+linear issue relation add "$new_id" blocked-by ENG-100
+```
+
+Add `--label`, `--assignee`, and `--priority` when the file carries them. The `linear-cli:linear-cli` skill documents the full CLI surface.
 
 ## Conventions
 


### PR DESCRIPTION
Adds the first per-tracker adapter for the artifact `issue:refine` now emits (#915). A "Saving a Refined Artifact" subsection in the `linear:linear` skill maps the file to Linear: read the frontmatter fields with `yq`, strip the body to a file, and create the issue with `--description-file` so the body is passed by path rather than re-sent as a tool argument.

What matters here is the generic mapping. The same shape (`yq` the fields, pass the body by file) maps to `gh issue create --body-file` or to Things, so this stays deliberately thin rather than growing into a Linear framework.

Relations are the one field the connector and MCP tools cannot set. Rather than the raw `issueRelationCreate` GraphQL mutation the plan sketched, the adapter uses the `linear` CLI's native `issue relation add <id> <type> <relatedId>` subcommand, which is simpler and covers all four relation types (`blocks`, `blocked-by`, `related`, `duplicate`). The frontmatter `duplicate-of` key maps to `duplicate`. When the `linear` binary is absent, the adapter falls back to the connector and reports the relation URLs it skipped rather than dropping them silently. The connector stays the default for interactive and simple saves.

Routing fields (team, assignee, state) come from the user at save time, since the adapter is where tracker-specific validation belongs. The state default reuses `getDefaultState` from `hooks/save-issue.ts` so that rule keeps a single tested home.

## Testing

Verified the entire command surface against the external `linear-cli:linear-cli` skill before committing: `issue create` accepts `--description-file`, `--priority` (1-4), repeatable `--label`, `--team`, `--state`, and `--assignee`, and `issue relation add` takes the four relation types as shown. Exercised the `yq` field reads and the `awk` body-strip against a sample artifact to confirm the body comes out without the frontmatter and that a hyphenated relations key resolves. Checked the skill with `skill-lint`, `check-plugin-imports`, and `check-hook-quoting`.

Stacked on #915.
