### PR TITLE
docs: correct Bash bang-escape workaround guidance

### DIFF
--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -34,7 +34,7 @@ Every customization costs tokens on every session. Before adding one, define how
 
 ### Bash `!` Escaping Bug
 
-The Bash tool escapes `!` to `\!`, breaking `jq !=`, `awk !~`, and similar operators ([#2941](https://github.com/anthropics/claude-code/issues/2941), [#10335](https://github.com/anthropics/claude-code/issues/10335)). For `jq`, use `| not` instead of `!=`. For any script, pass it via heredoc to bypass inline escaping.
+The Bash tool escapes `!` to `\!` on every path, including single quotes and heredocs, breaking `jq !=`, `awk !~`, and similar operators ([#2941](https://github.com/anthropics/claude-code/issues/2941), [#10335](https://github.com/anthropics/claude-code/issues/10335)). For `jq`, use `| not` instead of `!=`. For anything else, author the content with the Write tool, then run it. No shell quoting or heredoc bypasses the escape.
 
 ## Git
 

--- a/user/rules/json.md
+++ b/user/rules/json.md
@@ -9,4 +9,4 @@ paths:
 - Use `jq` to parse JSON input. If you know the structure, use `jq` filters to extract specific fields. JSON is often token-heavy, so optimize for size.
   - Use `jq` filters like `keys`, `type`, and length to inspect JSON structures.
   - When fetching from the internet, output JSON to temporary files in `tmp/` directory to allow for inspection.
-- The Bash tool escapes `!` to `\!`, breaking jq `!=`. Use `| not` instead (e.g., `select(.x == null | not)`) or pass the filter via heredoc.
+- The Bash tool escapes `!` to `\!` on every path (heredocs included), breaking jq `!=`. Use `| not` instead (e.g., `select(.x == null | not)`). For a filter that needs a literal `!`, write it to a `.jq` file with the Write tool and run `jq -f`.


### PR DESCRIPTION
Corrects a false claim in two always-on config files. Both said a heredoc bypasses the Bash tool's `\!` escaping. It does not. The Bash tool injects a literal backslash before `\!` on every invocation path, so the only reliable way to feed a literal `\!` to a command is to author the content with the Write tool and run it.

## Evidence

Re-ran the probe matrix in this session and inspected raw bytes with `od -c`. Look for `\ \!` (escaped) vs bare `\!`.

| Path | Command | `od -c` result |
| --- | --- | --- |
| inline double-quoted | `echo "double\!"` | `d o u b l e \ \! \n` |
| inline single-quoted | `echo 'single\!'` | `s i n g l e \ \! \n` |
| `printf` | `printf '%s' "printf\!"` | `p r i n t f \ \!` |
| quoted heredoc | `cat <<'EOF' ... quoted-heredoc\!` | `... o c \ \! \n` |
| unquoted heredoc | `cat <<EOF ... unquoted-heredoc\!` | `... o c \ \! \n` |
| Write tool | file authored with Write | `w r i t e - t o o l \! \n` |

The single-quoted case is decisive. Bash never expands or escapes inside single quotes, so the backslash proves the tool injects it at the transport layer before bash parses. Every Bash path produces `\\!`. The Write-tool file is the only one with a clean `\!`.

## Upstream re-check

Both linked issues are closed with no fix, flag, or version landed:

- [#2941](https://github.com/anthropics/claude-code/issues/2941): closed as not planned.
- [#10335](https://github.com/anthropics/claude-code/issues/10335): closed as duplicate. It even suggests the heredoc workaround, which the matrix above disproves.

No `auto-escape` opt-out or version fix has shipped. The correction stands.

## Adjacent, out of scope

`user/CLAUDE.md` (~line 43) advises passing complex commit messages "through a heredoc." A commit message containing `\!` would be mangled the same way. The safe path is `git commit -F <write-authored-file>`. Flagging for awareness; not changed here.

`~/.claude/CLAUDE.md` is a symlink to `user/CLAUDE.md` (confirmed with `ls -la`), so no second edit is needed.

Original Task: [Reinvestigate Bash tool bang-escaping bug (no known workaround)](https://things.bendrucker.me/show?id=26GsFHn22JnEpRJXkT29Yr)
