### PR TITLE
jxa: retry once on transient Apple Events error

### DIFF
--- a/plugins/mac/scripts/jxa.test.ts
+++ b/plugins/mac/scripts/jxa.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { isTransientAppleEventsError, runWithRetry, validateAppScope } from "./jxa";
 import type { RunResult } from "./jxa";
+import { isTransientAppleEventsError, runWithRetry, validateAppScope } from "./jxa";
 
 describe("validateAppScope", () => {
   it("allows Application matching the target app", () => {

--- a/plugins/mac/scripts/jxa.test.ts
+++ b/plugins/mac/scripts/jxa.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { validateAppScope } from "./jxa";
+import { isTransientAppleEventsError, runWithRetry, validateAppScope } from "./jxa";
+import type { RunResult } from "./jxa";
 
 describe("validateAppScope", () => {
   it("allows Application matching the target app", () => {
@@ -58,5 +59,81 @@ describe("validateAppScope", () => {
   it("allows scripts with no Application calls", () => {
     const result = validateAppScope("var x = 1 + 2;", "Things3");
     expect(result).toEqual({ valid: true, violations: [] });
+  });
+});
+
+describe("isTransientAppleEventsError", () => {
+  it("matches the -10004 privilege-violation code in stderr", () => {
+    expect(isTransientAppleEventsError(1, "execution error: not allowed (-10004)")).toBe(true);
+  });
+
+  it("matches the -600 code in stderr", () => {
+    expect(isTransientAppleEventsError(1, "execution error: isn't running (-600)")).toBe(true);
+  });
+
+  it("matches a Connection Invalid XPC hiccup", () => {
+    expect(
+      isTransientAppleEventsError(1, "Connection Invalid to com.apple.hiservices-xpcservice"),
+    ).toBe(true);
+  });
+
+  it("matches when the transient code surfaces as the exit code", () => {
+    expect(isTransientAppleEventsError(-10004, "")).toBe(true);
+    expect(isTransientAppleEventsError(-600, "")).toBe(true);
+  });
+
+  it("does not match an unrelated execution error", () => {
+    expect(isTransientAppleEventsError(1, "execution error: Can't get item 5 (-1728)")).toBe(false);
+  });
+
+  it("does not match success", () => {
+    expect(isTransientAppleEventsError(0, "")).toBe(false);
+  });
+});
+
+describe("runWithRetry", () => {
+  const noSleep = () => Promise.resolve();
+
+  function runner(results: RunResult[]) {
+    const calls: string[][] = [];
+    const run = (args: string[]) => {
+      calls.push(args);
+      const next = results.shift();
+      if (!next) throw new Error("runner called more times than expected");
+      return Promise.resolve(next);
+    };
+    return { run, calls };
+  }
+
+  it("retries once on a transient error then succeeds", async () => {
+    const { run, calls } = runner([
+      { code: 1, stdout: "", stderr: "execution error (-10004)" },
+      { code: 0, stdout: "ok", stderr: "" },
+    ]);
+    const result = await runWithRetry(["-e", "x"], run, noSleep);
+    expect(result).toEqual({ code: 0, stdout: "ok", stderr: "" });
+    expect(calls).toHaveLength(2);
+  });
+
+  it("retries once then surfaces the real error", async () => {
+    const persistent: RunResult = { code: 1, stdout: "", stderr: "Connection Invalid" };
+    const { run, calls } = runner([persistent, { ...persistent }]);
+    const result = await runWithRetry(["-e", "x"], run, noSleep);
+    expect(result).toEqual(persistent);
+    expect(calls).toHaveLength(2);
+  });
+
+  it("does not retry a non-transient failure", async () => {
+    const { run, calls } = runner([{ code: 1, stdout: "", stderr: "syntax error (-2740)" }]);
+    const result = await runWithRetry(["-e", "x"], run, noSleep);
+    expect(result).toEqual({ code: 1, stdout: "", stderr: "syntax error (-2740)" });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("does not retry on success", async () => {
+    const { run, calls } = runner([{ code: 0, stdout: "2", stderr: "" }]);
+    const result = await runWithRetry(["-e", "1 + 1"], run, noSleep);
+    expect(result).toEqual({ code: 0, stdout: "2", stderr: "" });
+    expect(calls).toHaveLength(1);
   });
 });

--- a/plugins/mac/scripts/jxa.test.ts
+++ b/plugins/mac/scripts/jxa.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { RunResult } from "./jxa";
-import { isTransientAppleEventsError, runWithRetry, validateAppScope } from "./jxa";
+import { isRetriableAppleEventsError, runWithRetry, validateAppScope } from "./jxa";
 
 describe("validateAppScope", () => {
   it("allows Application matching the target app", () => {
@@ -62,32 +62,32 @@ describe("validateAppScope", () => {
   });
 });
 
-describe("isTransientAppleEventsError", () => {
+describe("isRetriableAppleEventsError", () => {
   it("matches the -10004 privilege-violation code in stderr", () => {
-    expect(isTransientAppleEventsError(1, "execution error: not allowed (-10004)")).toBe(true);
+    expect(isRetriableAppleEventsError(1, "execution error: not allowed (-10004)")).toBe(true);
   });
 
   it("matches the -600 code in stderr", () => {
-    expect(isTransientAppleEventsError(1, "execution error: isn't running (-600)")).toBe(true);
+    expect(isRetriableAppleEventsError(1, "execution error: isn't running (-600)")).toBe(true);
   });
 
   it("matches a Connection Invalid XPC hiccup", () => {
     expect(
-      isTransientAppleEventsError(1, "Connection Invalid to com.apple.hiservices-xpcservice"),
+      isRetriableAppleEventsError(1, "Connection Invalid to com.apple.hiservices-xpcservice"),
     ).toBe(true);
   });
 
-  it("matches when the transient code surfaces as the exit code", () => {
-    expect(isTransientAppleEventsError(-10004, "")).toBe(true);
-    expect(isTransientAppleEventsError(-600, "")).toBe(true);
+  it("matches when the retriable code surfaces as the exit code", () => {
+    expect(isRetriableAppleEventsError(-10004, "")).toBe(true);
+    expect(isRetriableAppleEventsError(-600, "")).toBe(true);
   });
 
   it("does not match an unrelated execution error", () => {
-    expect(isTransientAppleEventsError(1, "execution error: Can't get item 5 (-1728)")).toBe(false);
+    expect(isRetriableAppleEventsError(1, "execution error: Can't get item 5 (-1728)")).toBe(false);
   });
 
   it("does not match success", () => {
-    expect(isTransientAppleEventsError(0, "")).toBe(false);
+    expect(isRetriableAppleEventsError(0, "")).toBe(false);
   });
 });
 
@@ -105,7 +105,7 @@ describe("runWithRetry", () => {
     return { run, calls };
   }
 
-  it("retries once on a transient error then succeeds", async () => {
+  it("retries once on a retriable error then succeeds", async () => {
     const { run, calls } = runner([
       { code: 1, stdout: "", stderr: "execution error (-10004)" },
       { code: 0, stdout: "ok", stderr: "" },
@@ -123,7 +123,7 @@ describe("runWithRetry", () => {
     expect(calls).toHaveLength(2);
   });
 
-  it("does not retry a non-transient failure", async () => {
+  it("does not retry a non-retriable failure", async () => {
     const { run, calls } = runner([{ code: 1, stdout: "", stderr: "syntax error (-2740)" }]);
     const result = await runWithRetry(["-e", "x"], run, noSleep);
     expect(result).toEqual({ code: 1, stdout: "", stderr: "syntax error (-2740)" });

--- a/plugins/mac/scripts/jxa.ts
+++ b/plugins/mac/scripts/jxa.ts
@@ -84,14 +84,15 @@ export interface RunResult {
   stderr: string;
 }
 
-// AppleEvents error codes for transient XPC dispatcher hiccups seen on the first
-// event after a cold session: errAEPrivilegeError (-10004) and errAEEventNotHandled
-// / "application isn't running" (-600). A retry clears them.
-const TRANSIENT_APPLE_EVENTS_CODES = [-10004, -600];
+// AppleEvents error codes that are safe to retry. They surface as transient XPC
+// dispatcher hiccups on the first event after a cold session: errAEPrivilegeError
+// (-10004) and errAEEventNotHandled / "application isn't running" (-600). A retry
+// clears them.
+const RETRIABLE_APPLE_EVENTS_CODES = [-10004, -600];
 
-export function isTransientAppleEventsError(exitCode: number, stderr: string): boolean {
+export function isRetriableAppleEventsError(exitCode: number, stderr: string): boolean {
   if (stderr.includes("Connection Invalid")) return true;
-  return TRANSIENT_APPLE_EVENTS_CODES.some(
+  return RETRIABLE_APPLE_EVENTS_CODES.some(
     (code) => exitCode === code || stderr.includes(`(${code})`),
   );
 }
@@ -109,7 +110,7 @@ async function runOsascript(args: string[]): Promise<RunResult> {
   return { code, stdout, stderr };
 }
 
-const TRANSIENT_RETRY_DELAY_MS = 300;
+const RETRY_DELAY_MS = 300;
 
 export async function runWithRetry(
   args: string[],
@@ -117,10 +118,10 @@ export async function runWithRetry(
   sleep: (ms: number) => Promise<void> = Bun.sleep,
 ): Promise<RunResult> {
   const first = await run(args);
-  if (first.code === 0 || !isTransientAppleEventsError(first.code, first.stderr)) {
+  if (first.code === 0 || !isRetriableAppleEventsError(first.code, first.stderr)) {
     return first;
   }
-  await sleep(TRANSIENT_RETRY_DELAY_MS);
+  await sleep(RETRY_DELAY_MS);
   return run(args);
 }
 

--- a/plugins/mac/scripts/jxa.ts
+++ b/plugins/mac/scripts/jxa.ts
@@ -78,6 +78,52 @@ export function validateAppScope(source: string, app: string): ValidationResult 
   return { valid: violations.length === 0, violations };
 }
 
+export interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+// AppleEvents error codes for transient XPC dispatcher hiccups seen on the first
+// event after a cold session: errAEPrivilegeError (-10004) and errAEEventNotHandled
+// / "application isn't running" (-600). A retry clears them.
+const TRANSIENT_APPLE_EVENTS_CODES = [-10004, -600];
+
+export function isTransientAppleEventsError(exitCode: number, stderr: string): boolean {
+  if (stderr.includes("Connection Invalid")) return true;
+  return TRANSIENT_APPLE_EVENTS_CODES.some(
+    (code) => exitCode === code || stderr.includes(`(${code})`),
+  );
+}
+
+async function runOsascript(args: string[]): Promise<RunResult> {
+  const proc = Bun.spawn(["osascript", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  return { code, stdout, stderr };
+}
+
+const TRANSIENT_RETRY_DELAY_MS = 300;
+
+export async function runWithRetry(
+  args: string[],
+  run: (args: string[]) => Promise<RunResult>,
+  sleep: (ms: number) => Promise<void> = Bun.sleep,
+): Promise<RunResult> {
+  const first = await run(args);
+  if (first.code === 0 || !isTransientAppleEventsError(first.code, first.stderr)) {
+    return first;
+  }
+  await sleep(TRANSIENT_RETRY_DELAY_MS);
+  return run(args);
+}
+
 if (import.meta.main) {
   const { cli } = await import("cleye");
 
@@ -121,10 +167,8 @@ if (import.meta.main) {
     process.exit(1);
   }
 
-  const proc = Bun.spawn(["osascript", ...osascriptArgs], {
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-  const code = await proc.exited;
+  const { code, stdout, stderr } = await runWithRetry(osascriptArgs, runOsascript);
+  await Bun.write(Bun.stdout, stdout);
+  await Bun.write(Bun.stderr, stderr);
   process.exit(code);
 }


### PR DESCRIPTION
The `mac` plugin's `jxa.ts` wrapper runs `osascript` sandboxed, and `sandbox.allowAppleEvents: true` reliably permits the Apple Event. The setting works. But the very first Apple Event after a cold session sometimes fails with a transient macOS XPC hiccup: an `errAEPrivilegeError` (`-10004`), a `-600`, or stderr carrying `Connection Invalid` from `com.apple.hiservices-xpcservice`. These are dispatcher-connection glitches, not real permission denials. A retry clears them.

Previously that transient surfaced as a hard error, which pushed callers to fall back to disabling the sandbox. Now the first call self-heals instead.

`osascript` output is captured (`pipe`) rather than inherited so the wrapper can inspect stderr, then forwarded to the caller unchanged with the real exit code. On a transient first failure the spawn waits a short backoff and retries exactly once. Any non-transient failure, or the result of the single retry, passes through untouched. The loop never runs more than once and never masks a genuine error.

The transient classification lives in an exported pure function, `isTransientAppleEventsError(exitCode, stderr)`. `runWithRetry` takes an injected runner and sleep, so the retry behavior is unit-tested without invoking real `osascript` or a running app: transient-then-success, transient-then-persistent-error, and no-retry-on-non-transient. `validateAppScope` and the cleye CLI are unchanged.
