### PR TITLE
github: add --include-resolved to pr-comments, fix follow-up fetch

### DIFF
--- a/plugins/github/scripts/pr-comments.test.ts
+++ b/plugins/github/scripts/pr-comments.test.ts
@@ -215,7 +215,9 @@ describe("filterThreads", () => {
   });
 
   it("drops resolved threads by default when the flag is unset", () => {
-    const threads = [makeThread({ isResolved: true, comments: [makeComment("DouweM", "2025-01-15")] })];
+    const threads = [
+      makeThread({ isResolved: true, comments: [makeComment("DouweM", "2025-01-15")] }),
+    ];
     const result = filterThreads(threads, {
       role: "reviewer",
       viewer: "DouweM",

--- a/plugins/github/scripts/pr-comments.test.ts
+++ b/plugins/github/scripts/pr-comments.test.ts
@@ -199,6 +199,30 @@ describe("filterThreads", () => {
     expect(result[0]!.comments.nodes[0]!.author?.login).toBe("jacob");
   });
 
+  it("keeps the viewer's resolved threads with includeResolved in reviewer role", () => {
+    const threads = [
+      makeThread({ isResolved: true, comments: [makeComment("DouweM", "2025-01-15")] }),
+      makeThread({ isResolved: true, comments: [makeComment("bendrucker", "2025-01-15")] }),
+    ];
+    const result = filterThreads(threads, {
+      role: "reviewer",
+      viewer: "DouweM",
+      includeResolved: true,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.comments.nodes[0]!.author?.login).toBe("DouweM");
+    expect(result[0]!.isResolved).toBe(true);
+  });
+
+  it("drops resolved threads by default when the flag is unset", () => {
+    const threads = [makeThread({ isResolved: true, comments: [makeComment("DouweM", "2025-01-15")] })];
+    const result = filterThreads(threads, {
+      role: "reviewer",
+      viewer: "DouweM",
+    });
+    expect(result).toHaveLength(0);
+  });
+
   it("keeps review-target threads in reviewer role (bots overrides opener filter)", () => {
     const threads = [
       makeThread({ comments: [makeComment("copilot", "2025-01-15", "comment", "Bot")] }),
@@ -403,6 +427,22 @@ describe("formatThreads", () => {
       bots: true,
     });
     expect(output).not.toContain("Showing threads started by");
+  });
+
+  it("tags resolved threads and counts them with includeResolved", () => {
+    const output = formatThreads(
+      [makeThread({ isResolved: true }), makeThread({ isResolved: false })],
+      2,
+      { ...baseOptions, includeResolved: true },
+    );
+    expect(output).toContain("(resolved)");
+    expect(output).toContain("2 of 2 total threads (1 resolved)");
+  });
+
+  it("omits the resolved tag and count without includeResolved", () => {
+    const output = formatThreads([makeThread({ isResolved: false })], 2, baseOptions);
+    expect(output).not.toContain("(resolved)");
+    expect(output).toContain("1 unresolved of 2 total threads");
   });
 
   it("collapses repeated files under a single header", () => {

--- a/plugins/github/scripts/pr-comments.ts
+++ b/plugins/github/scripts/pr-comments.ts
@@ -102,9 +102,10 @@ export function filterThreads(
     since?: Date | undefined;
     bots?: boolean | undefined;
     extra?: Set<string> | undefined;
+    includeResolved?: boolean | undefined;
   },
 ): Thread[] {
-  let filtered = threads.filter((t) => !t.isResolved);
+  let filtered = options.includeResolved ? [...threads] : threads.filter((t) => !t.isResolved);
 
   if (options.bots) {
     // Review targets (API bots plus opted-in reviewers) open their own threads,
@@ -140,12 +141,17 @@ export function findLastReviewDate(reviews: Review[], viewer: string, role: Role
 export function formatThreads(
   threads: Thread[],
   totalCount: number,
-  options: { title: string; role: Role; viewer: string; bots?: boolean },
+  options: { title: string; role: Role; viewer: string; bots?: boolean; includeResolved?: boolean },
 ): string {
   const lines: string[] = [];
   lines.push(`# ${options.title}`);
   lines.push("");
-  lines.push(`${threads.length} unresolved of ${totalCount} total threads`);
+  if (options.includeResolved) {
+    const resolvedCount = threads.filter((t) => t.isResolved).length;
+    lines.push(`${threads.length} of ${totalCount} total threads (${resolvedCount} resolved)`);
+  } else {
+    lines.push(`${threads.length} unresolved of ${totalCount} total threads`);
+  }
   if (options.bots) {
     lines.push("Showing review-bot and opted-in reviewer threads");
   } else if (options.role === "reviewer") {
@@ -154,7 +160,7 @@ export function formatThreads(
   lines.push("");
 
   if (threads.length === 0) {
-    lines.push("No unresolved threads found.");
+    lines.push(options.includeResolved ? "No threads found." : "No unresolved threads found.");
     return lines.join("\n");
   }
 
@@ -181,7 +187,8 @@ export function formatThreads(
 
       const outdated = thread.isOutdated ? " (outdated)" : "";
       const botTag = isBotThread(thread) ? " (bot)" : "";
-      lines.push(`### ${lineInfo}${outdated}${botTag}`);
+      const resolvedTag = options.includeResolved && thread.isResolved ? " (resolved)" : "";
+      lines.push(`### ${lineInfo}${outdated}${botTag}${resolvedTag}`);
       lines.push(`\`${thread.id}\``);
       lines.push("");
 
@@ -272,6 +279,11 @@ async function main(): Promise<void> {
         description: "Only review-bot threads (plus logins in $CLAUDE_PLUGIN_DATA/reviewers.txt)",
         default: false,
       },
+      includeResolved: {
+        type: Boolean,
+        description: "Include resolved threads (excluded by default)",
+        default: false,
+      },
     },
   });
 
@@ -337,12 +349,14 @@ async function main(): Promise<void> {
     since,
     bots: argv.flags.bots,
     extra: argv.flags.bots ? await loadExtraReviewers() : undefined,
+    includeResolved: argv.flags.includeResolved,
   });
   const output = formatThreads(filtered, totalCount, {
     title: prTitle,
     role,
     viewer,
     bots: argv.flags.bots,
+    includeResolved: argv.flags.includeResolved,
   });
 
   console.log(output);

--- a/plugins/github/skills/pr-comments/SKILL.md
+++ b/plugins/github/skills/pr-comments/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: github:pr-comments
 description: Fetch, reply to, and resolve review threads on a GitHub pull request. Use when checking what review feedback needs addressing, whether threads are resolved, replying to review comments, or clearing AI-reviewer threads after acting on them.
-argument-hint: "<pr-url> [--role author|reviewer] [--bots]"
+argument-hint: "<pr-url> [--role author|reviewer] [--bots] [--include-resolved]"
 allowed-tools:
   ["Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/pr-comments.ts:*)", "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/review-threads.ts:*)"]
 hooks:
@@ -37,7 +37,7 @@ Fetch unresolved review threads from a GitHub pull request, filtered for context
 ## Usage
 
 ```bash
-bun ${CLAUDE_PLUGIN_ROOT}/scripts/pr-comments.ts <pr-url> [--role author|reviewer] [--since last-review|<date>] [--bots]
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/pr-comments.ts <pr-url> [--role author|reviewer] [--since last-review|<date>] [--bots] [--include-resolved]
 ```
 
 ## Arguments
@@ -46,6 +46,7 @@ bun ${CLAUDE_PLUGIN_ROOT}/scripts/pr-comments.ts <pr-url> [--role author|reviewe
 - `--role`: `author` or `reviewer` (default: auto-detect based on authenticated user)
 - `--since`: filter to threads with activity since `last-review` or an ISO date
 - `--bots`: only review-bot threads (accounts the API types as `Bot`), plus any logins in `$CLAUDE_PLUGIN_DATA/reviewers.txt`
+- `--include-resolved`: resolved threads are excluded by default. This flag includes them for follow-up-style flows that must surface silently resolved threads. Resolved threads carry a `(resolved)` tag.
 
 ## Role
 

--- a/plugins/review/skills/follow-up/SKILL.md
+++ b/plugins/review/skills/follow-up/SKILL.md
@@ -90,7 +90,9 @@ status.
 
 #### GitHub
 
-Use the `github:pr-comments` skill's script to fetch threads. Run with `--role reviewer` to get threads started by the authenticated user. For resolved threads, use the GraphQL API via `gh api graphql` to query `pullRequest.reviewThreads`, filtering to threads where the first comment author matches the viewer.
+Use the `github:pr-comments` skill's script with `--role reviewer --include-resolved` to get every thread you started, resolved and unresolved, each with its full comment chain so silent resolves are visible. Do not pass `--since`. Follow-up needs the whole history.
+
+If a query ever needs hand-authoring, write it to a file with the Write tool and pass `gh api graphql -F query=@file`. Never use an inline shell heredoc. A `!` in a GraphQL type marker breaks under the Bash tool's escaping.
 
 #### GitLab
 


### PR DESCRIPTION
The `review:follow-up` skill exists to catch silently resolved review threads, but its GitHub "Fetch Threads" step could not actually fetch them. `pr-comments.ts` unconditionally dropped resolved threads, so the skill worked around it with a second, inline `gh api graphql` query against `pullRequest.reviewThreads`. That workaround is brittle and hits the Bash-tool `!`-escaping bug on GraphQL non-null markers (`ID!`, `String!`). The GitLab side of the same skill already delegates cleanly to a script that returns both resolved and unresolved threads, so this fixes the GitHub asymmetry.

Adds an opt-in `--include-resolved` boolean flag to `pr-comments.ts` (default off, so every existing caller is unchanged). When set, `filterThreads` keeps resolved threads. The reviewer-opener and `--since` filters still run after it, so `--role reviewer --include-resolved` yields exactly "all threads I started, resolved and unresolved." `formatThreads` tags each resolved thread `(resolved)` alongside the existing `(outdated)`/`(bot)` tags, reflects the resolved count in the header, and switches the empty state to a neutral "No threads found." The GraphQL query already selected `isResolved` and the full comment chain, so only the filter and formatter changed.

`review:follow-up`'s GitHub fetch now points at the script with `--role reviewer --include-resolved` and the inline-GraphQL instruction is gone. It deliberately omits `--since` because follow-up needs the full history. A guardrail line covers the rare hand-authored-query case: write the query to a file and pass `gh api graphql -F query=@file` rather than an inline heredoc, since `!` in a GraphQL type marker breaks under the Bash tool's escaping.

Two notes for the reviewer:

- The original task described the fetch script as `review-threads.ts`, but the actual thread-fetch script is `pr-comments.ts`. `review-threads.ts` only handles reply/resolve/react.
- The adjacent `resolveReviewThread` inline-GraphQL in follow-up's Execute Actions step is out of scope here and remains a future cleanup.

Added unit tests covering the reviewer-role `includeResolved` filter (keeps the viewer's resolved thread, still drops someone else's), the default-off regression, and the formatter's `(resolved)` tag and resolved count.

Original Task: [review:follow-up skill: thread fetch is brittle, fix it](https://things.bendrucker.me/show?id=GiEUeqPbhBVDcT8C3gS3NL)
