### PR TITLE
skills: bang-inject review startup context, fix skill-dir gotcha

### DIFF
--- a/plugins/claude-code/skills/skill/references/patterns.md
+++ b/plugins/claude-code/skills/skill/references/patterns.md
@@ -138,7 +138,7 @@ Dynamic context works alongside other skill features:
 
 ### Gotchas
 
-- Commands run in the **project root**, not the skill directory. For plugin skills, use `${CLAUDE_PLUGIN_ROOT}/skills/<skill-name>` to reference skill-local scripts. `${CLAUDE_SKILL_DIR}` works in hooks and allowed-tools but NOT in `!` context.
+- Commands run in the **project root**, not the skill directory. For plugin skills, use `${CLAUDE_PLUGIN_ROOT}/skills/<skill-name>` to reference skill-local scripts. `${CLAUDE_SKILL_DIR}` also expands in `!` context, the body, and `allowed-tools`, but NOT in the frontmatter `hooks:` block (there it resolves to empty; reference bundled scripts by `${CLAUDE_PLUGIN_ROOT}/skills/<skill-name>` in hook commands).
 - **stderr is discarded** — only stdout replaces the placeholder.
 - Failed commands produce empty output. Handle this in the command itself with a fallback (e.g., `some-cmd 2>/dev/null || echo "unavailable"`).
 - Commands run **synchronously and sequentially**. Avoid slow commands that would delay skill loading.

--- a/plugins/review/skills/follow-up/SKILL.md
+++ b/plugins/review/skills/follow-up/SKILL.md
@@ -32,6 +32,11 @@ each concern, or go through the motions?" Status is a signal. The code is the ve
 All diff and file reading happens in Explore sub-agents. Your main session holds only the structured
 verdicts they return, never raw diffs, keeping my development context free.
 
+## Context
+
+- Remote URL: !`git remote get-url origin 2>/dev/null || echo "unavailable"`
+- Branch: !`git branch --show-current 2>/dev/null || echo "unavailable"`
+
 ## Workflow
 
 ### Resolve Target

--- a/plugins/review/skills/tuicr/SKILL.md
+++ b/plugins/review/skills/tuicr/SKILL.md
@@ -22,6 +22,11 @@ Core layer for reviewing changes through a live [tuicr](https://github.com/agavr
 You launch and drive it in a sibling pane; the TUI is the user's. `review:self` (inbound) and
 `review:peer` (outbound) build on this.
 
+## Context
+
+- Repo: !`git rev-parse --show-toplevel 2>/dev/null || echo "unavailable"`
+- Sessions: !`tuicr review list --repo . 2>/dev/null || echo "none"`
+
 ## Session Discovery
 
 tuicr persists each review as a session with a `slug`. The CLI is the agent's interface; the TUI


### PR DESCRIPTION
Adds `\!` startup injection to two review skills and corrects a `${CLAUDE_SKILL_DIR}` gotcha in the skill-authoring reference.

`review:follow-up` and `review:tuicr` both run the same read-only orientation on every invocation before any decision. Injecting it at load removes a tool round-trip and makes the startup deterministic. `review:follow-up` gets the remote URL and branch, which its Resolve Target step keys off. `review:tuicr` gets the repo root and `tuicr review list`, since Session Discovery is always its first step. Both commands are already covered by the skills' existing `allowed-tools` matchers (`Bash(git:*)`, `Bash(tuicr:*)`), so there are no new permissions and no prompt risk. `skill-lint` passes clean on both.

The `patterns.md` gotcha stated the rule backwards: it claimed `${CLAUDE_SKILL_DIR}` works in hooks but not `\!` context. The reverse is true. It expands in the body, `\!` injections, and `allowed-tools`, and resolves to empty only in the frontmatter `hooks:` block. `skill/SKILL.md` and the shipped `tmux:tmux` skill both confirm the corrected behavior.

These came out of a fan-out audit of all 54 skills for bang-injection opportunities. The broader result: the heavily-used skills that suit injection already have it (`pull-request:*`, `git:conflicts`, `tmux`), so this is a targeted diff rather than a sweep.
