### PR TITLE
comments: audit results against this repo

### DIFF
--- a/.claude/skills/agent-ideas/sources.ts
+++ b/.claude/skills/agent-ideas/sources.ts
@@ -29,7 +29,6 @@ export interface Source {
 }
 
 export const sources: Source[] = [
-  // --- Seeds (confirmed this session) ---
   {
     name: "Simon Willison",
     feedUrl: "https://simonwillison.net/atom/everything/",
@@ -74,7 +73,6 @@ export const sources: Source[] = [
     xHandle: "dillon_mulroy",
   },
 
-  // --- Discovered: confirmed feed (citation-graph run) ---
   {
     name: "Armin Ronacher",
     feedUrl: "https://lucumr.pocoo.org/feed.atom",
@@ -82,10 +80,9 @@ export const sources: Source[] = [
     xHandle: "mitsuhiko",
   },
 
-  // --- Discovered: high/medium relevance, feeds resolved during the foundation pass ---
   {
-    // humanlayer.dev is a Next.js app with no discoverable RSS feed as of the
-    // foundation pass; handled via the browser fallback until a feed surfaces.
+    // humanlayer.dev is a Next.js app with no discoverable RSS feed; handled via
+    // the browser fallback until a feed surfaces.
     name: "Dex Horthy",
     feedUrl: null,
     sourceType: "x-only",

--- a/packages/marketplace/index.ts
+++ b/packages/marketplace/index.ts
@@ -50,7 +50,6 @@ export interface HookCommandContext {
   file: string;
   /** The raw matcher entry, for access to `.matcher`. */
   entry: MatcherEntry;
-  /** Individual command object. */
   command: HookCommand;
 }
 

--- a/plugins/comments/evals/oracle.ts
+++ b/plugins/comments/evals/oracle.ts
@@ -5,10 +5,9 @@ import { BATCH_SIZE, parseVerdict } from "../judge/judge";
 import { batchVerdictSchema, type Verdict } from "../judge/schema";
 
 /**
- * The calibration oracle: the Anthropic SDK judge that survives only under
- * `evals/`. The product path fans out Claude Code agents instead. This remains
- * the deterministic ground truth the fixture corpus is scored against. It renders
- * an indexed batch, scores it at temperature 0, and validates the response.
+ * The calibration oracle: the Anthropic SDK judge used only under `evals/`, the
+ * deterministic ground truth the fixture corpus is scored against. It renders an
+ * indexed batch, scores it at temperature 0, and validates the response.
  */
 
 export const JUDGE_MODEL = "claude-sonnet-4-6";

--- a/plugins/comments/judge/judge.ts
+++ b/plugins/comments/judge/judge.ts
@@ -9,12 +9,10 @@ import {
 } from "./schema";
 
 /**
- * Shared judge primitives: the versioned prompt and per-verdict validation. The
- * product path shards comments in `job.ts` for the agent fan-out to judge, and
- * `apply/join.ts` validates the verdicts that come back. The calibration oracle
- * under `evals/` scores a fixed corpus. The prompt is a committed, versioned
- * artifact, and every run records its sha256, so a prompt edit invalidates prior
- * numbers.
+ * Shared judge primitives: the versioned prompt and per-verdict validation, used
+ * by both the agent fan-out and the eval oracle. The prompt is a committed,
+ * versioned artifact, and every run records its sha256, so a prompt edit
+ * invalidates prior numbers.
  */
 
 export const PROMPT_PATH = join(import.meta.dirname, "prompt.md");
@@ -33,7 +31,7 @@ export async function loadPrompt(promptPath: string = PROMPT_PATH): Promise<Vers
   return { text, sha256: sha256(text) };
 }
 
-/** Comments judged per shard on the product path, and per batch in the oracle. */
+/** Comments per shard in production, and per batch in the oracle. */
 export const BATCH_SIZE = 20;
 
 /**

--- a/plugins/comments/skills/audit/scripts/audit.ts
+++ b/plugins/comments/skills/audit/scripts/audit.ts
@@ -198,7 +198,7 @@ async function readJsonFiles(dir: string, prefix: string): Promise<unknown[]> {
   );
 }
 
-/** The files a job judged, recovered from the shards rather than a separate manifest. */
+/** The files a job judged, recovered from the shards. */
 async function judgedPaths(jobDir: string): Promise<string[]> {
   const shards = (await readJsonFiles(jobDir, "shard-")) as JobShard[];
   const paths = new Set<string>();

--- a/plugins/github/scripts/fetch.ts
+++ b/plugins/github/scripts/fetch.ts
@@ -76,10 +76,8 @@ export function matchRoute(path: string): RouteMatch | null {
 }
 
 export function parseGitHubUrl(url: string): { type: string; suggestion: string } | null {
-  // Strip the GitHub prefix to simplify pattern matching
   const path = url.slice("https://github.com/".length);
 
-  // Try pattern with additional path segments
   const pathMatch = repoPathPattern.match(path);
   if (pathMatch) {
     const subpath = pathMatch._ || "";
@@ -105,7 +103,6 @@ export function parseGitHubUrl(url: string): { type: string; suggestion: string 
     return null;
   }
 
-  // Try base pattern (repo root without trailing slash)
   const baseMatch = repoBasePattern.match(path);
   if (baseMatch) {
     return {

--- a/plugins/gitlab/scripts/fetch.ts
+++ b/plugins/gitlab/scripts/fetch.ts
@@ -92,7 +92,6 @@ export function parseGitLabUrl(url: string): { type: string; suggestion: string 
 
   // No /-/ means this is a project root (possibly with nested groups)
   // Match: group/project or group/subgroup/project etc.
-  // Must have at least one slash and no special characters that indicate other pages
   const pathWithoutSlash = path.replace(/\/$/, "");
   if (pathWithoutSlash.includes("/") && !pathWithoutSlash.includes("?")) {
     return {

--- a/plugins/go/scripts/check.ts
+++ b/plugins/go/scripts/check.ts
@@ -15,18 +15,15 @@ export function isGeneratedFile(content: string): boolean {
   let foundCode = false;
 
   for (const line of lines) {
-    // Skip blank lines
     if (/^\s*$/.test(line)) {
       continue;
     }
 
-    // Check for code generated marker
     if (GENERATED_MARKER.test(line)) {
       foundMarker = true;
       continue;
     }
 
-    // Check if this is a comment line
     if (line.startsWith("//") || line.startsWith("/*")) {
       continue;
     }
@@ -42,7 +39,6 @@ export function isGeneratedFile(content: string): boolean {
 export async function processInput(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
   const { file_path: filePath } = input.tool_input as FileInput;
 
-  // Only check .go files
   if (!filePath || !filePath.endsWith(".go")) {
     return null;
   }

--- a/plugins/linear/hooks/save-issue.ts
+++ b/plugins/linear/hooks/save-issue.ts
@@ -80,7 +80,6 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
   // creating and state is absent. Never override an explicitly set state.
   const needsDefaultState = isCreate && !state;
 
-  // Nothing to fix and no state to inject: pass the call through untouched.
   if (!mutated && !needsDefaultState) {
     return null;
   }

--- a/plugins/pull-request/scripts/pr-template.ts
+++ b/plugins/pull-request/scripts/pr-template.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env bun
-// Detect and output PR/MR template content from the repository
-// Outputs: template content if found, nothing otherwise
 
 import { execSync } from "node:child_process";
 import { join } from "node:path";

--- a/plugins/things/src/example.ts
+++ b/plugins/things/src/example.ts
@@ -9,7 +9,6 @@ import type { Things3 } from "./Things3";
 const app = Application("Things3");
 const list = app.lists.byId("TMTodayListSource");
 
-// Convert to JavaScript array
 const todos = toArray<Things3.ToDo>(list.toDos());
 
 // Filter for non-repeating todos (creation date not at midnight)
@@ -19,10 +18,8 @@ const nonRepeating = todos.filter((t) => {
   return cd.getHours() !== 0 || cd.getMinutes() !== 0 || cd.getSeconds() !== 0;
 });
 
-// Filter for todos with notes
 const withNotes = nonRepeating.filter((t) => t.notes() && t.notes().length > 0);
 
-// Map to simple objects
 const result = withNotes.map((t) => ({
   id: t.id(),
   name: t.name(),

--- a/plugins/writing/detection/sentences.ts
+++ b/plugins/writing/detection/sentences.ts
@@ -16,11 +16,6 @@ export function splitSentences(text: string): string[] {
     .filter((s) => !HEADING.test(s));
 }
 
-/**
- * Split text into paragraphs (blank-line separated), then for each paragraph
- * return its constituent sentences via splitSentences. Empty paragraphs are
- * dropped.
- */
 export function splitParagraphs(text: string): string[][] {
   return text
     .split(/\n{2,}/)

--- a/plugins/writing/hooks/numbering.ts
+++ b/plugins/writing/hooks/numbering.ts
@@ -61,7 +61,6 @@ export function checkMarkdown(content: string): string | null {
 }
 
 export async function checkCode(content: string, ext: string): Promise<string | null> {
-  // Check if sg is available
   try {
     execSync("command -v sg", { stdio: ["pipe", "pipe", "pipe"] });
   } catch {

--- a/plugins/writing/linguistics/classifiers.ts
+++ b/plugins/writing/linguistics/classifiers.ts
@@ -53,8 +53,8 @@ function clauseVerdict(tokens: TaggedToken[], index: number): HeadingVerdict {
 }
 
 /**
- * The clean signal from #744: flag only when a finite verb follows a
- * subject candidate. Misses imperatives by design.
+ * Flag only when a finite verb follows a subject candidate. Misses
+ * imperatives by design.
  */
 export function finiteVerbClassifier(tagger: Tagger): HeadingClassifier {
   return {

--- a/plugins/writing/linguistics/grammar.ts
+++ b/plugins/writing/linguistics/grammar.ts
@@ -37,9 +37,8 @@ function isAttributive(tokens: TaggedToken[], index: number): boolean {
 }
 
 /**
- * The positional rule from issue #745: a finite verb is clause evidence
- * only when a subject candidate precedes it and the verb is not the
- * entire heading. Single-token inputs never flag.
+ * A finite verb is clause evidence only when a subject candidate precedes it
+ * and the verb is not the entire heading. Single-token inputs never flag.
  */
 export function finiteVerbWithSubject(tokens: TaggedToken[]): { index: number } | null {
   if (tokens.length <= 1) return null;

--- a/plugins/writing/linguistics/heading.ts
+++ b/plugins/writing/linguistics/heading.ts
@@ -66,8 +66,7 @@ export const INTERROGATIVE_OPENERS = new Set([
 const NOUN_PHRASE: HeadingVerdict = { kind: "noun-phrase", flagged: false, evidence: [] };
 
 /**
- * The tuned heuristic from PR #744, extracted from the headings hook.
- * Operates on the heading display text; behavior matches the original
+ * Tuned heuristic operating on the heading display text. Behavior matches
  * checkSentenceHeading exactly.
  */
 export function classifyHeadingBaseline(heading: string): HeadingVerdict {

--- a/plugins/writing/skills/analyze/scripts/analyze.test.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.test.ts
@@ -133,11 +133,9 @@ describe("runAnalysis", () => {
     expect(result.corrective.length).toBeGreaterThan(0);
     expect(result.corrective[0]?.matched_term.length).toBeGreaterThan(0);
 
-    // Rate trends are present with a non-negative document count.
     expect(typeof result.rateTrends).toBe("object");
     expect(result.rateTrends.documentCount).toBeGreaterThanOrEqual(0);
 
-    // The remaining sections are present and typed as arrays.
     expect(Array.isArray(result.candidatePhrases)).toBe(true);
     expect(Array.isArray(result.structuralSignatures)).toBe(true);
     expect(Array.isArray(result.structuralAudit)).toBe(true);

--- a/plugins/writing/skills/analyze/scripts/judge.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.ts
@@ -41,7 +41,6 @@ export interface JudgeCriterion {
   id: string;
   /** JSON key in the judge's structured output. */
   key: CriterionKey;
-  /** Every judge criterion sits in the meaning layer of the detector model. */
   layer: "meaning";
   /** The rubric question, summarized for reports. */
   question: string;
@@ -477,9 +476,8 @@ export const DEFAULT_JUDGE_LIMIT = 100;
 export const DEFAULT_MIN_WORDS = 30;
 
 /**
- * Batch detector for the analyze pipeline, following the structural.ts
- * template: rows in, typed findings out, wired in runAnalysis, rendered via
- * ReportInput. Prints the cost estimate before any API call.
+ * Batch detector for the analyze pipeline. Prints the cost estimate before
+ * any API call.
  */
 export function meaningDetector(options: MeaningDetectorOptions = {}): MeaningDetector {
   return async (rows: DeliverableRow[]) => {
@@ -509,9 +507,8 @@ export function meaningDetector(options: MeaningDetectorOptions = {}): MeaningDe
 }
 
 /**
- * Heading reference baseline for #769: the same judge pointed at headings,
- * "is this heading sentence-shaped?". Headings are batched per call; the
- * verdict is one boolean per heading, by index.
+ * Schema for the heading baseline: one boolean per heading, by index, marking
+ * whether the heading is sentence-shaped.
  */
 export function headingBatchSchema(): Record<string, unknown> {
   return {

--- a/plugins/writing/skills/analyze/scripts/rate-detectors.ts
+++ b/plugins/writing/skills/analyze/scripts/rate-detectors.ts
@@ -61,7 +61,6 @@ export interface DocumentRateRow {
 }
 
 export interface CorpusRateTrends {
-  /** Number of documents analyzed. */
   documentCount: number;
   /** Mean action-verb opener rate across documents (0–1). */
   meanActionVerbOpenerRate: number;

--- a/plugins/writing/skills/analyze/scripts/report.ts
+++ b/plugins/writing/skills/analyze/scripts/report.ts
@@ -37,7 +37,6 @@ export interface ReportInput {
   corrective: CorrectiveRow[];
 }
 
-// A candidate phrase plus its baseline rate and a spot-checkable quote.
 export interface CandidatePhrase extends LiftRow {
   baselineCount: number;
   baselinePerM: number;

--- a/plugins/writing/skills/analyze/scripts/structural.ts
+++ b/plugins/writing/skills/analyze/scripts/structural.ts
@@ -91,10 +91,8 @@ export function auditStructuralPatterns(
 //   3. Extend ReportInput with the findings type.
 //   4. Render findings in report.ts under the appropriate section.
 //
-// The meaning layer is the first expected user of this seam (#791). Grammar
 // and cross-sentence detectors may follow as they graduate from the hook.
 export interface DetectorModule<TFinding> {
   layer: DetectorLayer;
-  /** Run the detector over corpus rows and return per-row findings. */
   detect(rows: Array<{ session_id: string; text?: string }>): Promise<TFinding[]>;
 }

--- a/plugins/writing/skills/analyze/scripts/voice-delta.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-delta.ts
@@ -21,20 +21,16 @@ export interface VoiceDeltaFeature {
   id: string;
   label: string;
   provenance: Provenance;
-  // Human-readable description of the provenance source. Matches the spec table.
+  // Human-readable description of the provenance source.
   source: string;
   // Compute the feature rate from raw text. Rates are per-1000 words unless
   // isFraction is true. Returns 0 when no content is present.
   compute: (text: string) => number;
-  // Format a rate value for display. Most features show 2 decimal places.
   format?: (rate: number) => string;
   // When true, the rate is a fraction (0–1) rather than per-1000 words.
   isFraction?: boolean;
 }
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-// Count raw words (whitespace-separated tokens, strip punctuation).
 function wordCount(text: string): number {
   return (text.match(/\b[a-zA-Z'-]+\b/g) ?? []).length;
 }
@@ -48,7 +44,6 @@ export function sentenceSplit(text: string): string[] {
     .filter((s) => s.length > 0);
 }
 
-// Count non-empty lines.
 function nonEmptyLines(text: string): string[] {
   return text.split("\n").filter((l) => l.trim().length > 0);
 }
@@ -75,14 +70,12 @@ function strippedWordCount(text: string): number {
   return wordCount(stripCode(text));
 }
 
-// Count backtick characters in the original text (raw inline code fences).
 function countBackticks(text: string): number {
   // Remove fenced blocks first to avoid double-counting their delimiters.
   const nofence = text.replace(/```[\s\S]*?```/g, "");
   return (nofence.match(/`/g) ?? []).length;
 }
 
-// Collect bullet lines: lines starting with `- ` or `* ` (possibly indented).
 function bulletLines(text: string): string[] {
   return nonEmptyLines(text).filter((l) => /^\s*[-*]\s/.test(l));
 }
@@ -91,8 +84,6 @@ function bulletLines(text: string): string[] {
 function countBacktickManifestBullets(text: string): number {
   return bulletLines(text).filter((l) => /^\s*[-*]\s+`[^`]+`\s*:/.test(l)).length;
 }
-
-// ─── Feature definitions ──────────────────────────────────────────────────────
 
 function per1k(count: number, words: number): number {
   if (words === 0) return 0;
@@ -198,7 +189,6 @@ export const VOICE_DELTA_FEATURES: VoiceDeltaFeature[] = [
     provenance: "skill-prescribed",
     source:
       'SKILL.md Body: "Use `##` sections for larger changes". Aggregate template rate is an analyze trend only',
-    // Returns 1 if both template sections are present, 0 otherwise.
     compute: (text) => {
       const prose = stripFencedBlocks(text);
       const hasChanges = /^##\s+(Changes|What Changed)\b/im.test(prose);
@@ -214,7 +204,6 @@ export const VOICE_DELTA_FEATURES: VoiceDeltaFeature[] = [
     provenance: "skill-prescribed",
     source:
       "sections.md fixes the section vocabulary (Issue/Changes/Testing/References). Aggregate uniformity metric only, never per-document",
-    // Returns the count of unique heading texts (lowercased) in this document.
     compute: (text) => {
       const headings = [...stripFencedBlocks(text).matchAll(/^#{1,6}\s+(.+)$/gm)].map((m) =>
         (m[1] ?? "").toLowerCase().trim(),
@@ -228,7 +217,6 @@ export const VOICE_DELTA_FEATURES: VoiceDeltaFeature[] = [
     label: "Has any heading (fraction of documents)",
     provenance: "skill-prescribed",
     source: 'Same "larger changes" clause as template presence. Report as a trend',
-    // Returns 1 if the document contains any markdown heading, 0 otherwise.
     compute: (text) => (/^#{1,6}\s+/m.test(stripFencedBlocks(text)) ? 1 : 0),
     isFraction: true,
     format: (rate) => `${(rate * 100).toFixed(0)}%`,
@@ -295,8 +283,6 @@ export const VOICE_DELTA_FEATURES: VoiceDeltaFeature[] = [
   },
 ];
 
-// ─── Register check ───────────────────────────────────────────────────────────
-
 // Minimum sentences to attempt baseline comparison. Too-short inputs produce
 // meaningless rate stats.
 const MIN_SENTENCES = 3;
@@ -335,15 +321,12 @@ export function checkRegister(text: string): RegisterCheck {
   return { inRegister: true, reason: null };
 }
 
-// ─── Corpus aggregation ───────────────────────────────────────────────────────
-
 export interface FeatureRate {
   featureId: string;
   rate: number;
   documentCount: number;
 }
 
-// Compute per-feature mean rates across a corpus of document texts.
 // The register check applies to single-document scoring only. Corpus
 // aggregation runs over all documents regardless of individual length.
 export function computeCorpusRates(texts: string[]): Map<string, FeatureRate> {
@@ -370,8 +353,6 @@ export function computeCorpusRates(texts: string[]): Map<string, FeatureRate> {
   }
   return result;
 }
-
-// ─── Baseline stats from profile ─────────────────────────────────────────────
 
 // The additional aggregate stats that voice-profile.ts stores for voice-delta
 // comparison. Computed during profile build from the baseline corpus.

--- a/plugins/x-callback-url/scripts/build.sh
+++ b/plugins/x-callback-url/scripts/build.sh
@@ -52,8 +52,8 @@ build_bundle() {
   swiftc "$SOURCE" -o "$BINARY"
 
   # CFBundleTypeRole=Editor ensures macOS delivers GetURL Apple Events to this app.
-  # LSUIElement hides from Dock and Cmd-Tab without disabling URL scheme handling
-  # (which LSBackgroundOnly would do — kept that out deliberately).
+  # LSUIElement hides from Dock and Cmd-Tab without disabling URL scheme handling.
+  # LSBackgroundOnly would disable it.
   cat > "$CONTENTS_DIR/Info.plist" << 'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/plugins/x-callback-url/scripts/run.sh
+++ b/plugins/x-callback-url/scripts/run.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-# Build xcall.app if needed, then invoke it with the given arguments
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BINARY="$("$SCRIPT_DIR/build.sh")"
 exec "$BINARY" "$@"

--- a/scripts/check-mcp-matchers.ts
+++ b/scripts/check-mcp-matchers.ts
@@ -40,8 +40,6 @@ async function checkMatchers(): Promise<string[]> {
         const tool = match[2];
         if (!server || !tool) continue;
 
-        // Determine plugin name: use known mapping, or fall back to
-        // enabled plugin names that match the server name
         const pluginName = knownServers.get(server) ?? (enabledNames.has(server) ? server : null);
         if (!pluginName) continue;
 

--- a/scripts/coverage/run.ts
+++ b/scripts/coverage/run.ts
@@ -21,8 +21,6 @@ function hasTests(dir: string): boolean {
   }
 }
 
-// Walk up from a file toward the repo root, returning the nearest ancestor
-// directory that directly contains test files.
 function nearestTestDir(relFile: string): string {
   let dir = dirname(relFile);
   while (dir && dir !== "." && dir !== "..") {


### PR DESCRIPTION
Running record of the `comments` skill judged against this repository. Each commit is one targeted pass: a scope-limited preflight, the blinded agent fan-out, and the applied trims and de-voiced rewrites. The base is `comment-skill`, so this PR's diff is exactly what the skill changed and nothing else. It is a review surface for how the skill does in aggregate, not a branch meant to merge.

The judge runs in a fresh-context agent per shard, seeing only the comment, the surrounding code, and the rubric. It never sees this repo's development conversation, so its verdicts are not biased by the discussion that produced the comments.

## Coverage

Six committed passes cover every code-bearing plugin plus repo tooling (`.claude/`, `scripts/`, `packages/`). A seventh batch (`bun`, `tmux`, `plan`, and other small plugins) came back clean and added no commit. Findings clustered in restated docstrings, decorative section banners, roadmap and ticket breadcrumbs, and AI-voice phrasing that carries a real fact. The voice cases are rewritten in place rather than deleted, so the fact survives. Hand-curated areas, including the comments plugin's own code, came back nearly or entirely clean.

The branch is rebased as `comment-skill` moves. A verdict whose target comment the base has since rewritten or deleted drops out during the rebase, so the diff always shows the surviving fixes against the current base.

## Defects the Sweep Surfaced

Dogfooding found bugs in the skill itself, since fixed on `comment-skill`:

- Judge agents wrote verdict JSON with a Bash heredoc, so the `!`-escaping bug corrupted any rationale mentioning a negation and silently dropped whole shards.
- The collector judged vendored, Apache-licensed code (`skill-creator`). It now skips subtrees carrying their own `LICENSE`.
- Line-comment runs were extracted one comment per line, so multi-line prose was judged as fragments. Contiguous same-column runs now coalesce into one comment.
- Trimming a blank-flanked banner left a double blank line. The applier now collapses the gap.
- A file write failing mid-apply left a half-applied state. Apply now builds the commit with git plumbing and never touches the working tree.

## How to Read It

The commit log is the history. Each pass names its scope. The diff shows the surviving fixes.
