### PR TITLE
pull-request: stop backticking auto-linked refs

### DIFF
--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -17,6 +17,9 @@ const TEST_COUNT_PATTERN =
 // over-structured. Reimplemented locally to avoid a cross-plugin import.
 const SMALL_BODY_WORD_LIMIT = 150;
 
+const AUTOLINK_REASON =
+  "Commit SHAs and issue/MR refs (`#123`, `!45`) auto-link on GitHub/GitLab. Backticks render them as code and suppress the link. Write them bare.";
+
 const CHANGES_HEADING_PATTERN = /^##\s+Changes\b/m;
 const TESTING_HEADING_PATTERN = /^##\s+Testing\b/m;
 
@@ -55,6 +58,50 @@ export function hasFileTourBullets(body: string): boolean {
   return false;
 }
 
+// Backticked hex run that could be a commit SHA. Only a filter: the git object
+// database settles whether a candidate is a real commit.
+const BACKTICKED_HEX_PATTERN = /`([0-9a-f]{7,40})`/g;
+
+// Backticked issue/MR reference: `#123`, `!45`, or `owner/repo#12`. Digits-only
+// after the sigil rules out CSS ids (`#main`) and code annotations. `@mentions`
+// are deliberately excluded because they have legitimate uses in code and prose.
+const BACKTICKED_REF_PATTERN = /`(?:[\w.-]+\/[\w.-]+)?[#!]\d+`/;
+
+export function extractBacktickedHexCandidates(body: string): string[] {
+  return Array.from(body.matchAll(BACKTICKED_HEX_PATTERN), (match) => match[1]).filter(
+    (token): token is string => token !== undefined,
+  );
+}
+
+export function hasBacktickedRef(body: string): boolean {
+  return BACKTICKED_REF_PATTERN.test(body);
+}
+
+export function gitCommitVerifier(cwd: string): (sha: string) => Promise<boolean> {
+  return async (sha) => {
+    try {
+      const proc = Bun.spawn(["git", "rev-parse", "--verify", "--quiet", `${sha}^{commit}`], {
+        cwd,
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      return (await proc.exited) === 0;
+    } catch {
+      return false;
+    }
+  };
+}
+
+export async function findBacktickedCommits(
+  candidates: string[],
+  verify: (sha: string) => Promise<boolean>,
+): Promise<string[]> {
+  const results = await Promise.all(
+    candidates.map(async (candidate) => ((await verify(candidate)) ? candidate : null)),
+  );
+  return results.filter((sha): sha is string => sha !== null);
+}
+
 export function extractBodyFilePath(command: string): string | null {
   const match = command.match(/--body-file[=\s]([^\s]+)/);
   return match?.[1] ?? null;
@@ -73,18 +120,21 @@ function warn(reasons: string[]): SyncHookJSONOutput {
   };
 }
 
-export function validateBody(body: string): SyncHookJSONOutput | null {
-  if (TEST_COUNT_PATTERN.test(body)) {
-    return {
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        permissionDecision: "deny",
-        permissionDecisionReason:
-          "Testing section should not mention test counts. Describe what is covered instead.",
-      },
-    };
+function denyForTestCount(body: string): SyncHookJSONOutput | null {
+  if (!TEST_COUNT_PATTERN.test(body)) {
+    return null;
   }
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason:
+        "Testing section should not mention test counts. Describe what is covered instead.",
+    },
+  };
+}
 
+function structuralReasons(body: string): string[] {
   const reasons: string[] = [];
   if (hasReflexiveScaffold(body)) {
     reasons.push(
@@ -96,11 +146,20 @@ export function validateBody(body: string): SyncHookJSONOutput | null {
       "Bullets shaped like `- **path/to/file**: ...` narrate a file tour. Describe the conceptual change instead of walking the diff file by file.",
     );
   }
-  if (reasons.length > 0) {
-    return warn(reasons);
+  if (hasBacktickedRef(body)) {
+    reasons.push(AUTOLINK_REASON);
+  }
+  return reasons;
+}
+
+export function validateBody(body: string): SyncHookJSONOutput | null {
+  const deny = denyForTestCount(body);
+  if (deny) {
+    return deny;
   }
 
-  return null;
+  const reasons = structuralReasons(body);
+  return reasons.length > 0 ? warn(reasons) : null;
 }
 
 export async function processInput(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
@@ -120,5 +179,20 @@ export async function processInput(input: PreToolUseHookInput): Promise<SyncHook
   }
 
   const body = await file.text();
-  return validateBody(body);
+
+  const deny = denyForTestCount(body);
+  if (deny) {
+    return deny;
+  }
+
+  const reasons = structuralReasons(body);
+
+  const cwd = input.cwd ?? process.cwd();
+  const candidates = extractBacktickedHexCandidates(body);
+  const commits = await findBacktickedCommits(candidates, gitCommitVerifier(cwd));
+  if (commits.length > 0 && !reasons.includes(AUTOLINK_REASON)) {
+    reasons.push(AUTOLINK_REASON);
+  }
+
+  return reasons.length > 0 ? warn(reasons) : null;
 }

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import {
+  extractBacktickedHexCandidates,
   extractBodyFilePath,
+  findBacktickedCommits,
+  hasBacktickedRef,
   hasFileTourBullets,
   hasReflexiveScaffold,
   processInput,
@@ -180,6 +184,70 @@ describe("hasFileTourBullets", () => {
   });
 });
 
+describe("extractBacktickedHexCandidates", () => {
+  it("pulls a backticked short SHA", () => {
+    expect(extractBacktickedHexCandidates("a `2554da15` b")).toEqual(["2554da15"]);
+  });
+
+  it("returns a backticked 40-char SHA", () => {
+    const sha = "2554da150000000000000000000000000000abcd";
+    expect(extractBacktickedHexCandidates(`Builds on \`${sha}\`.`)).toEqual([sha]);
+  });
+
+  it("ignores a bare (unbackticked) hex run", () => {
+    expect(extractBacktickedHexCandidates("commit 2554da15 landed")).toEqual([]);
+  });
+
+  it("ignores a backticked non-hex identifier", () => {
+    expect(extractBacktickedHexCandidates("calls `getUser` then")).toEqual([]);
+  });
+
+  it("ignores a backticked file path", () => {
+    expect(extractBacktickedHexCandidates("see `src/cache.ts`")).toEqual([]);
+  });
+});
+
+describe("findBacktickedCommits", () => {
+  const known = new Set(["2554da15", "dc8acf12"]);
+  const fakeVerifier = (sha: string) => Promise.resolve(known.has(sha));
+
+  it("returns candidates the verifier confirms", async () => {
+    const candidates = extractBacktickedHexCandidates("Builds on `2554da15`.");
+    expect(await findBacktickedCommits(candidates, fakeVerifier)).toEqual(["2554da15"]);
+  });
+
+  it("drops a hex candidate the verifier rejects", async () => {
+    const candidates = extractBacktickedHexCandidates("random `deadbeef` hash");
+    expect(await findBacktickedCommits(candidates, fakeVerifier)).toEqual([]);
+  });
+});
+
+describe("hasBacktickedRef", () => {
+  it("flags a backticked issue/PR ref", () => {
+    expect(hasBacktickedRef("Closes `#123`")).toBe(true);
+  });
+
+  it("flags a backticked GitLab MR ref", () => {
+    expect(hasBacktickedRef("See `!45`")).toBe(true);
+  });
+
+  it("flags a backticked cross-repo ref", () => {
+    expect(hasBacktickedRef("Relates to `owner/repo#12`")).toBe(true);
+  });
+
+  it("does not flag a bare ref", () => {
+    expect(hasBacktickedRef("Closes #123")).toBe(false);
+  });
+
+  it("does not flag a backticked mention", () => {
+    expect(hasBacktickedRef("thanks `@user`")).toBe(false);
+  });
+
+  it("does not flag a backticked CSS id", () => {
+    expect(hasBacktickedRef("the `#main` selector")).toBe(false);
+  });
+});
+
 describe("processInput", () => {
   let tempDir: string;
 
@@ -191,10 +259,16 @@ describe("processInput", () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  function createInput(command: string): PreToolUseHookInput {
+  const repoRoot = path.join(import.meta.dir, "..", "..", "..");
+  const headSha = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8" })
+    .stdout.trim()
+    .slice(0, 12);
+
+  function createInput(command: string, cwd?: string): PreToolUseHookInput {
     return {
       tool_name: "Bash",
       tool_input: { command },
+      ...(cwd ? { cwd } : {}),
     } as PreToolUseHookInput;
   }
 
@@ -228,6 +302,34 @@ describe("processInput", () => {
     await Bun.write(bodyFile, "## Test plan\nAdded 5 tests");
     const result = await processInput(createInput(`gh pr create --body-file ${bodyFile}`));
     expect(result).not.toBeNull();
+    expect(getPermissionDecision(result)).toBe("deny");
+  });
+
+  it("warns on a backticked real commit SHA", async () => {
+    const bodyFile = path.join(tempDir, "body.md");
+    await Bun.write(bodyFile, `Builds on \`${headSha}\`.`);
+    const result = await processInput(
+      createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
+    );
+    expect(getPermissionDecision(result)).toBeUndefined();
+    expect(getAdditionalContext(result)).toContain("auto-link");
+  });
+
+  it("does not warn on a bare commit SHA", async () => {
+    const bodyFile = path.join(tempDir, "body.md");
+    await Bun.write(bodyFile, `Builds on ${headSha}.`);
+    const result = await processInput(
+      createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("lets a test-count deny precede a backticked SHA warning", async () => {
+    const bodyFile = path.join(tempDir, "body.md");
+    await Bun.write(bodyFile, `Builds on \`${headSha}\`.\n\nAdded 5 tests`);
+    const result = await processInput(
+      createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
+    );
     expect(getPermissionDecision(result)).toBe("deny");
   });
 });

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -47,7 +47,7 @@ Mine the conversation that produced this change. The substance lives there: deci
 - Length tracks substance, not diff size. A subtle one-line fix may need paragraphs. A large mechanical change may need two sentences.
 - Default to prose. Use `##` sections only when the body is long enough to need them. Small PRs are a tight paragraph with no headers.
 - Reference the motivating issue at the end of the opening (`Closes #N`, `Fixes #N`, or `#N` if not closing). Related-for-context issues go in a `## References` section, never bare at the bottom.
-- Wrap code identifiers in backticks: function names, class names, file paths, endpoints, status codes.
+- Wrap code identifiers in backticks: function names, class names, file paths, endpoints, status codes. Do not backtick anything the platform auto-links: commit SHAs and issue/MR references (`#N`, `!N`, `owner/repo#N`). Backticks render them as code and kill the link. Write them bare.
 
 See [`sections.md`](sections.md) for the substance catalog (what to surface, by change type), optional-section guidance, how to ground claims in evidence, and the slop patterns to cut. Load the `writing` skill for the full set of tropes to avoid.
 

--- a/plugins/pull-request/skills/create/sections.md
+++ b/plugins/pull-request/skills/create/sections.md
@@ -54,6 +54,8 @@ Not every PR has all of these. Include only what a reviewer would act on. True b
 
 Prefer showing to asserting. Link a permalink to the exact lines instead of paraphrasing code. Blockquote the doc or spec you reason from. Paste the real error, stack trace, or test output in a fence rather than describing it. "Reverting the fix makes `TestX` fail with `exit 2`" beats "added a test for the fix".
 
+Leave commit SHAs and issue/MR references bare. GitHub and GitLab auto-link a bare SHA and a bare `#N` / `!N` / `owner/repo#N`. Backticks render them as code and suppress the link, so write them unbacktick'd.
+
 ## Optional Sections
 
 Use these only when the body is long enough to earn them. A small PR stays a paragraph.


### PR DESCRIPTION
The `pull-request:create` skill kept wrapping commit SHAs in backticks in PR bodies. GitHub and GitLab auto-link a bare SHA and a bare issue/MR reference, but a backticked token renders as inline code and suppresses the link, so the reference becomes a dead string a reviewer can't click. I was undoing this by hand on every PR.

The root cause was the create skill's backtick rule ("wrap code identifiers in backticks") with no exception for tokens the platform auto-links, so the model over-applied it to SHAs. The fix has two layers: state the exception in the skill prose so the model stops, and add a detector to the PR-body validation hook so it gets caught when the model does it anyway.

## Detector

Commit SHAs and forge references have different determinism properties, so the hook checks them two ways.

A hex-shape regex can't tell a SHA from any other backticked hex token, nor a made-up SHA from a real one. So the regex is only a filter and truth comes from the git object database. `findBacktickedCommits` takes an injected verifier; the default shells out to `git rev-parse --verify --quiet <sha>^{commit}` per candidate. The `^{commit}` peel matches only commit objects, so a blob or tree sharing a prefix won't trip it. A backticked `getUser`, a hex color, or a random config hash all fail `rev-parse` and never warn.

Issue/MR refs live in the forge, so git can't verify them, and verifying via `gh`/`glab` would mean a network call inside a hook. They're structurally unambiguous, so a tight regex is enough: a backticked `#N` / `!N`, optionally `owner/repo`-prefixed, digits-only after the sigil to rule out CSS ids like `#main`. I excluded `@mentions` on purpose. `@name` has legitimate uses in code annotations and prose, so flagging a backticked one would false-positive.

The check warns, never denies, matching the existing structural-slop patterns. The test-count deny still returns early and takes precedence. I added the same guidance to `sections.md` so the `update` skill inherits it too.

## Testing

The `findBacktickedCommits` tests inject a fake verifier (a `Set` of known SHAs), so they cover the git gate without touching a real repo. The `processInput` cases run the real verifier against the repo's own HEAD: a backticked HEAD SHA emits the auto-link warning as `additionalContext`, the same SHA left bare emits nothing, and a body with both a backticked SHA and a test count still hits the deny path. This PR body is itself a dogfood: it discusses `#N`/`!N` and a `getUser` token without tripping the detector.
