### PR TITLE
review:peer: fix third-person author addressing

### DIFF
--- a/evals/review-voice/.gitignore
+++ b/evals/review-voice/.gitignore
@@ -1,0 +1,4 @@
+# Mined comment bodies and labels contain imported work-repo content that must
+# not leave this machine. Never commit them to this public marketplace repo.
+data/
+labels/

--- a/evals/review-voice/README.md
+++ b/evals/review-voice/README.md
@@ -1,0 +1,42 @@
+# review-voice
+
+Ad-hoc harness for grounding the `review:peer` addressing rules in real review
+comments. It mines comment bodies from the Claude Code session index, lets you
+label each one good or bad in a browser, and reports the bad phrasings so they
+can seed `tone.md` negative examples.
+
+The problem it targets: on the work machine `review:peer` writes comments that
+address the PR author by name in the third person, when the author should be
+addressed as "you" or impersonally.
+
+## Privacy
+
+The mined bodies include imported work-repo content. `data/` and `labels/` are
+gitignored and must never be committed to this public repo.
+
+## Workflow
+
+Build the session index first if it is stale (the session skill owns it):
+
+```bash
+bun plugins/claude-code/skills/session/scripts/refresh.ts
+```
+
+Then mine, label, and report:
+
+```bash
+bun evals/review-voice/scripts/mine.ts            # -> data/candidates.json
+bun evals/review-voice/label/server.ts            # browse http://localhost:4318
+bun evals/review-voice/scripts/report.ts          # summary + full text of bad cases
+```
+
+`mine.ts` reads Write tool calls that produced review payload files
+(`tmp/review*.json`, `tmp/replies/*.md`), since GitLab MR bodies never land inline
+in the `glab`/`draft-note` commands. It dedupes by body and drops fragments.
+Flags: `--host work`, `--min-chars`, `--db`, `--out`.
+
+In the labeler: `g` good, `b` bad, `s` skip, arrows to move, and a note field per
+case. Verdicts persist to `labels/<id>.json` as you go.
+
+`report.ts --show bad|good|skip|all` prints the full text of each labeled case
+with its note.

--- a/evals/review-voice/label/index.html
+++ b/evals/review-voice/label/index.html
@@ -1,0 +1,205 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Review Voice Labeler</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #1e1e2e;
+        --panel: #282a36;
+        --text: #cdd6f4;
+        --muted: #9399b2;
+        --good: #a6e3a1;
+        --bad: #f38ba8;
+        --skip: #f9e2af;
+        --accent: #89b4fa;
+        --border: #45475a;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font: 15px/1.55 -apple-system, system-ui, sans-serif;
+        background: var(--bg);
+        color: var(--text);
+      }
+      header {
+        position: sticky;
+        top: 0;
+        background: var(--bg);
+        border-bottom: 1px solid var(--border);
+        padding: 12px 20px;
+        display: flex;
+        gap: 16px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      header .counts { color: var(--muted); font-size: 13px; }
+      header .counts b { color: var(--text); }
+      main { max-width: 820px; margin: 0 auto; padding: 24px 20px 120px; }
+      .meta { color: var(--muted); font-size: 13px; margin-bottom: 10px; display: flex; gap: 12px; flex-wrap: wrap; }
+      .meta .tag { background: var(--panel); border: 1px solid var(--border); border-radius: 4px; padding: 1px 8px; }
+      .body {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 18px 20px;
+        white-space: pre-wrap;
+        word-break: break-word;
+        font-size: 15px;
+      }
+      .body code { background: #11111b; padding: 1px 5px; border-radius: 4px; font-size: 13px; }
+      textarea {
+        width: 100%;
+        margin-top: 14px;
+        background: var(--panel);
+        color: var(--text);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 10px 12px;
+        font: inherit;
+        resize: vertical;
+        min-height: 60px;
+      }
+      .actions { position: fixed; bottom: 0; left: 0; right: 0; background: var(--bg); border-top: 1px solid var(--border); padding: 14px 20px; display: flex; gap: 10px; justify-content: center; flex-wrap: wrap; }
+      button {
+        font: inherit;
+        font-weight: 600;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 9px 18px;
+        background: var(--panel);
+        color: var(--text);
+        cursor: pointer;
+      }
+      button.good { border-color: var(--good); color: var(--good); }
+      button.bad { border-color: var(--bad); color: var(--bad); }
+      button.skip { border-color: var(--skip); color: var(--skip); }
+      button.nav { color: var(--muted); }
+      button:hover { filter: brightness(1.25); }
+      .verdict { font-weight: 700; }
+      .verdict.good { color: var(--good); }
+      .verdict.bad { color: var(--bad); }
+      .verdict.skip { color: var(--skip); }
+      label.filter { color: var(--muted); font-size: 13px; margin-left: auto; display: flex; gap: 6px; align-items: center; }
+      kbd { background: #11111b; border: 1px solid var(--border); border-radius: 4px; padding: 0 5px; font-size: 11px; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <strong>Review Voice</strong>
+      <span class="counts" id="counts"></span>
+      <label class="filter"><input type="checkbox" id="unlabeledOnly" /> unlabeled only</label>
+    </header>
+    <main>
+      <div class="meta" id="meta"></div>
+      <div class="body" id="body">Loading…</div>
+      <textarea id="note" placeholder="Note (why is this good/bad?)"></textarea>
+    </main>
+    <div class="actions">
+      <button class="nav" id="prev">← Prev</button>
+      <button class="good" id="good">Good <kbd>g</kbd></button>
+      <button class="bad" id="bad">Bad <kbd>b</kbd></button>
+      <button class="skip" id="skip">Skip <kbd>s</kbd></button>
+      <button class="nav" id="next">Next →</button>
+    </div>
+
+    <script>
+      let candidates = [];
+      let labels = {};
+      let order = [];
+      let pos = 0;
+
+      const $ = (id) => document.getElementById(id);
+
+      function escapeHtml(s) {
+        return s.replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c]);
+      }
+      function renderBody(s) {
+        return escapeHtml(s).replace(/`([^`]+)`/g, "<code>$1</code>");
+      }
+
+      function rebuildOrder() {
+        const only = $("unlabeledOnly").checked;
+        order = candidates
+          .map((_, i) => i)
+          .filter((i) => !only || !labels[candidates[i].id]);
+        if (order.length === 0) order = candidates.map((_, i) => i);
+        if (pos >= order.length) pos = order.length - 1;
+        if (pos < 0) pos = 0;
+      }
+
+      function updateCounts() {
+        const vals = Object.values(labels);
+        const g = vals.filter((v) => v.label === "good").length;
+        const b = vals.filter((v) => v.label === "bad").length;
+        const s = vals.filter((v) => v.label === "skip").length;
+        $("counts").innerHTML =
+          `<b>${g + b + s}</b>/${candidates.length} labeled &middot; ` +
+          `<b>${g}</b> good &middot; <b>${b}</b> bad &middot; <b>${s}</b> skip`;
+      }
+
+      function render() {
+        rebuildOrder();
+        const c = candidates[order[pos]];
+        if (!c) return;
+        const existing = labels[c.id];
+        const verdict = existing
+          ? ` &middot; <span class="verdict ${existing.label}">${existing.label.toUpperCase()}</span>`
+          : "";
+        $("meta").innerHTML =
+          `<span class="tag">${pos + 1}/${order.length}</span>` +
+          `<span class="tag">${escapeHtml(c.host)}</span>` +
+          `<span class="tag">${escapeHtml(c.workdir)}</span>` +
+          `<span class="tag">${escapeHtml(c.source)}${c.line ? ":" + c.line : ""}</span>` +
+          verdict;
+        $("body").innerHTML = renderBody(c.body);
+        $("note").value = existing?.note ?? "";
+        updateCounts();
+      }
+
+      async function save(label) {
+        const c = candidates[order[pos]];
+        if (!c) return;
+        const note = $("note").value;
+        labels[c.id] = { id: c.id, label, note };
+        await fetch("/api/label", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ id: c.id, label, note }),
+        });
+        if (pos < order.length - 1) pos++;
+        render();
+      }
+
+      function move(delta) {
+        pos = Math.max(0, Math.min(order.length - 1, pos + delta));
+        render();
+      }
+
+      $("good").onclick = () => save("good");
+      $("bad").onclick = () => save("bad");
+      $("skip").onclick = () => save("skip");
+      $("prev").onclick = () => move(-1);
+      $("next").onclick = () => move(1);
+      $("unlabeledOnly").onchange = () => { pos = 0; render(); };
+
+      document.addEventListener("keydown", (e) => {
+        if (e.target.tagName === "TEXTAREA") return;
+        if (e.key === "g") save("good");
+        else if (e.key === "b") save("bad");
+        else if (e.key === "s") save("skip");
+        else if (e.key === "ArrowLeft") move(-1);
+        else if (e.key === "ArrowRight") move(1);
+      });
+
+      async function boot() {
+        candidates = await (await fetch("/api/candidates")).json();
+        labels = await (await fetch("/api/labels")).json();
+        render();
+      }
+      boot();
+    </script>
+  </body>
+</html>

--- a/evals/review-voice/label/server.ts
+++ b/evals/review-voice/label/server.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env bun
+import { mkdir, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { cli } from "cleye";
+
+// Local labeling server for review-voice candidates. Serves the UI, hands the
+// browser the mined candidates, and persists each verdict to labels/<id>.json so
+// report.ts can read them back off disk. Everything stays on this machine: the
+// mined bodies include imported work-repo content that must not leave it.
+
+const argv = cli({
+  name: "label-server",
+  flags: {
+    port: { type: Number, default: 4318, description: "Port to listen on" },
+    data: {
+      type: String,
+      default: join(import.meta.dirname, "..", "data", "candidates.json"),
+      description: "Mined candidates to label",
+    },
+    labels: {
+      type: String,
+      default: join(import.meta.dirname, "..", "labels"),
+      description: "Directory for saved labels",
+    },
+  },
+});
+
+const html = join(import.meta.dirname, "index.html");
+
+async function readAllLabels(): Promise<Record<string, unknown>> {
+  const out: Record<string, unknown> = {};
+  let names: string[] = [];
+  try {
+    names = await readdir(argv.flags.labels);
+  } catch {
+    return out;
+  }
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    try {
+      out[name.replace(/\.json$/, "")] = await Bun.file(join(argv.flags.labels, name)).json();
+    } catch {}
+  }
+  return out;
+}
+
+const server = Bun.serve({
+  port: argv.flags.port,
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/" || url.pathname === "/index.html") {
+      return new Response(Bun.file(html), {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
+
+    if (url.pathname === "/api/candidates") {
+      return new Response(Bun.file(argv.flags.data), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (url.pathname === "/api/labels" && req.method === "GET") {
+      return Response.json(await readAllLabels());
+    }
+
+    if (url.pathname === "/api/label" && req.method === "POST") {
+      const body = (await req.json()) as { id?: string; label?: string; note?: string };
+      if (!body.id || !/^[\w-]+$/.test(body.id)) return new Response("bad id", { status: 400 });
+      if (!body.label || !["good", "bad", "skip"].includes(body.label)) {
+        return new Response("bad label", { status: 400 });
+      }
+      await mkdir(argv.flags.labels, { recursive: true });
+      const record = { id: body.id, label: body.label, note: body.note ?? "" };
+      await Bun.write(join(argv.flags.labels, `${body.id}.json`), JSON.stringify(record, null, 2));
+      return Response.json({ ok: true });
+    }
+
+    return new Response("not found", { status: 404 });
+  },
+});
+
+console.log(`Labeling UI: http://localhost:${server.port}`);
+console.log(`Candidates:  ${argv.flags.data}`);
+console.log(`Labels:      ${argv.flags.labels}/`);

--- a/evals/review-voice/scripts/mine.ts
+++ b/evals/review-voice/scripts/mine.ts
@@ -1,0 +1,218 @@
+#!/usr/bin/env bun
+import { createHash } from "node:crypto";
+import { mkdir } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { cli } from "cleye";
+
+// Mine review-comment bodies out of the Claude Code session index. The bodies
+// posted on GitLab MRs never land inline in the `glab`/`draft-note` commands
+// (they arrive via `--input file.json` or `body=@file.md`), so the recoverable
+// text lives in the Write tool calls that produced those payload files.
+
+const argv = cli({
+  name: "mine",
+  flags: {
+    db: {
+      type: String,
+      description: "session.duckdb path (defaults to the session skill's data dir)",
+    },
+    out: {
+      type: String,
+      default: join(import.meta.dirname, "..", "data", "candidates.json"),
+      description: "Where to write the candidate set",
+    },
+    host: { type: String, description: "Limit to one host label (e.g. work, local)" },
+    minChars: { type: Number, default: 20, description: "Drop bodies shorter than this" },
+  },
+});
+
+function resolveDbPath(): string {
+  if (argv.flags.db) return argv.flags.db;
+  const dataDir =
+    process.env.CLAUDE_PLUGIN_DATA || join(process.env.TMPDIR || "/tmp", "claude-session");
+  return join(dataDir, "session.duckdb");
+}
+
+interface WriteRow {
+  host: string;
+  session_id: string;
+  timestamp: string;
+  file_path: string;
+  content: string;
+}
+
+interface Candidate {
+  id: string;
+  host: string;
+  session_id: string;
+  timestamp: string;
+  workdir: string;
+  source: string;
+  file: string | null;
+  line: number | null;
+  body: string;
+}
+
+const SQL = `
+SELECT host, session_id, timestamp,
+  (data->'$.input'->>'file_path') AS file_path,
+  (data->'$.input'->>'content')   AS content
+FROM content_items
+WHERE type = 'tool_use' AND name = 'Write'
+  AND (data->'$.input'->>'file_path') IS NOT NULL
+  AND (data->'$.input'->>'content')   IS NOT NULL
+  AND (data->'$.input'->>'file_path') ILIKE '%/tmp%'
+  AND (
+       (data->'$.input'->>'file_path') ILIKE '%review%'
+    OR (data->'$.input'->>'file_path') ILIKE '%/replies/%'
+    OR (data->'$.input'->>'file_path') ILIKE '%reply%'
+    OR (data->'$.input'->>'file_path') ILIKE '%discussion%'
+    OR (data->'$.input'->>'file_path') ILIKE '%/notes/%'
+  )
+ORDER BY timestamp
+`;
+
+async function queryRows(dbPath: string): Promise<WriteRow[]> {
+  const proc = Bun.spawn(["duckdb", "-readonly", "-json", dbPath], {
+    stdin: new TextEncoder().encode(SQL),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0) throw new Error(`duckdb failed (${code}): ${err.trim()}`);
+  const trimmed = out.trim();
+  if (!trimmed) return [];
+  return JSON.parse(trimmed) as WriteRow[];
+}
+
+function isText(fp: string): "json" | "md" | null {
+  const lower = fp.toLowerCase();
+  if (lower.endsWith(".json")) return "json";
+  if (lower.endsWith(".md")) return "md";
+  return null;
+}
+
+function workdirOf(fp: string): string {
+  const idx = fp.indexOf("/tmp");
+  const dir = idx > 0 ? fp.slice(0, idx) : dirname(fp);
+  return basename(dir) || dir;
+}
+
+// A review payload is either a bare array of comment objects or a wrapper with a
+// `comments`/`notes` array. Each element carries the comment body plus its diff
+// anchor. Anything else is treated as a single free-text body (a summary or reply).
+function bodiesFromJson(
+  content: string,
+): Array<{ body: string; file: string | null; line: number | null }> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return [];
+  }
+  const items = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray((parsed as Record<string, unknown>)?.comments)
+      ? ((parsed as Record<string, unknown>).comments as unknown[])
+      : Array.isArray((parsed as Record<string, unknown>)?.notes)
+        ? ((parsed as Record<string, unknown>).notes as unknown[])
+        : null;
+  if (!items) return [];
+  const out: Array<{ body: string; file: string | null; line: number | null }> = [];
+  for (const item of items) {
+    if (typeof item === "string") {
+      out.push({ body: item, file: null, line: null });
+      continue;
+    }
+    if (item && typeof item === "object") {
+      const rec = item as Record<string, unknown>;
+      const body = rec.body ?? rec.comment ?? rec.text;
+      if (typeof body !== "string") continue;
+      const file =
+        typeof rec.file === "string" ? rec.file : typeof rec.path === "string" ? rec.path : null;
+      const line = typeof rec.line === "number" ? rec.line : null;
+      out.push({ body, file, line });
+    }
+  }
+  return out;
+}
+
+function idFor(host: string, session: string, fp: string, index: number): string {
+  const hash = createHash("sha1")
+    .update(`${host}:${session}:${fp}:${index}`)
+    .digest("hex")
+    .slice(0, 10);
+  return `${host}-${hash}`;
+}
+
+function normalize(body: string): string {
+  return body.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+async function main() {
+  const dbPath = resolveDbPath();
+  if (!(await Bun.file(dbPath).exists())) {
+    console.error(`No session index at ${dbPath}.`);
+    console.error("Build it first: bun plugins/claude-code/skills/session/scripts/refresh.ts");
+    process.exit(1);
+  }
+
+  const rows = await queryRows(dbPath);
+  const hostFilter = argv.flags.host;
+
+  const candidates: Candidate[] = [];
+  const seen = new Set<string>();
+
+  for (const row of rows) {
+    if (hostFilter && row.host !== hostFilter) continue;
+    const kind = isText(row.file_path);
+    if (!kind) continue;
+
+    const extracted =
+      kind === "json"
+        ? bodiesFromJson(row.content)
+        : [{ body: row.content, file: null, line: null }];
+
+    extracted.forEach((entry, index) => {
+      const body = entry.body.trim();
+      if (body.length < argv.flags.minChars) return;
+      const key = normalize(body);
+      if (seen.has(key)) return;
+      seen.add(key);
+      candidates.push({
+        id: idFor(row.host, row.session_id, row.file_path, index),
+        host: row.host,
+        session_id: row.session_id,
+        timestamp: row.timestamp,
+        workdir: workdirOf(row.file_path),
+        source: basename(row.file_path),
+        file: entry.file,
+        line: entry.line,
+        body,
+      });
+    });
+  }
+
+  await mkdir(dirname(argv.flags.out), { recursive: true });
+  await Bun.write(argv.flags.out, `${JSON.stringify(candidates, null, 2)}\n`);
+
+  const byHost = candidates.reduce<Record<string, number>>((acc, c) => {
+    acc[c.host] = (acc[c.host] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  if (candidates.length === 0) {
+    console.log("No review-comment candidates found in the session index.");
+    console.log("Check that the source machine's history is imported (session skill hosts.ts).");
+    return;
+  }
+
+  console.log(`Wrote ${candidates.length} candidates to ${argv.flags.out}`);
+  for (const [host, n] of Object.entries(byHost)) console.log(`  ${host}: ${n}`);
+}
+
+main();

--- a/evals/review-voice/scripts/report.ts
+++ b/evals/review-voice/scripts/report.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env bun
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { cli } from "cleye";
+import { table } from "table";
+
+// Summarize labeled review-voice candidates: verdict counts and the full text of
+// every "bad" case with its note, so the failing phrasings can be lifted into
+// tone.md as negative examples.
+
+const argv = cli({
+  name: "report",
+  flags: {
+    data: {
+      type: String,
+      default: join(import.meta.dirname, "..", "data", "candidates.json"),
+      description: "Mined candidates",
+    },
+    labels: {
+      type: String,
+      default: join(import.meta.dirname, "..", "labels"),
+      description: "Directory of saved labels",
+    },
+    show: {
+      type: String,
+      default: "bad",
+      description: "Which verdict to print in full (bad, good, skip, all)",
+    },
+  },
+});
+
+const dim = (s: string) => `\x1b[90m${s}\x1b[0m`;
+const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+
+interface Candidate {
+  id: string;
+  host: string;
+  workdir: string;
+  source: string;
+  file: string | null;
+  line: number | null;
+  body: string;
+}
+interface Label {
+  id: string;
+  label: "good" | "bad" | "skip";
+  note: string;
+}
+
+async function readLabels(dir: string): Promise<Map<string, Label>> {
+  const map = new Map<string, Label>();
+  let names: string[] = [];
+  try {
+    names = await readdir(dir);
+  } catch {
+    return map;
+  }
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const rec = (await Bun.file(join(dir, name)).json()) as Label;
+    map.set(rec.id, rec);
+  }
+  return map;
+}
+
+async function main() {
+  const candidates = (await Bun.file(argv.flags.data).json()) as Candidate[];
+  const labels = await readLabels(argv.flags.labels);
+  const byId = new Map(candidates.map((c) => [c.id, c]));
+
+  const counts = { good: 0, bad: 0, skip: 0 };
+  for (const l of labels.values()) counts[l.label]++;
+  const unlabeled = candidates.length - labels.size;
+
+  console.log(
+    table([
+      ["verdict", "count"],
+      [green("good"), String(counts.good)],
+      [red("bad"), String(counts.bad)],
+      ["skip", String(counts.skip)],
+      [dim("unlabeled"), String(unlabeled)],
+      ["total", String(candidates.length)],
+    ]),
+  );
+
+  const wanted = argv.flags.show === "all" ? ["good", "bad", "skip"] : [argv.flags.show];
+
+  for (const [id, label] of labels) {
+    if (!wanted.includes(label.label)) continue;
+    const c = byId.get(id);
+    if (!c) continue;
+    const head = `${label.label.toUpperCase()} ${dim(`[${c.host}] ${c.source}${c.line ? ":" + c.line : ""}`)}`;
+    console.log(label.label === "bad" ? red(head) : green(head));
+    if (label.note) console.log(dim(`note: ${label.note}`));
+    console.log(c.body);
+    console.log(dim("─".repeat(72)));
+  }
+}
+
+main();

--- a/plugins/review/skills/peer/SKILL.md
+++ b/plugins/review/skills/peer/SKILL.md
@@ -27,6 +27,13 @@ allowed-tools:
 
 Assist me in reviewing this PR: $ARGUMENTS
 
+## Context
+
+Your own login as the reviewer. Everyone else in the diff and threads is either the author, addressed as "you", or a third party (see [tone.md](tone.md)). Whichever platform applies resolves. The other reads `unavailable`.
+
+- GitHub user: !`gh api graphql -f query='{viewer{login}}' --jq .data.viewer.login 2>/dev/null | grep . || echo "unavailable"`
+- GitLab user: !`glab api user 2>/dev/null | jq -r .username 2>/dev/null | grep . || echo "unavailable"`
+
 ## Arguments
 
 - `--triage`: assess the PR for sequencing instead of reviewing it. Produce a one-line summary of what it changes and an estimated review effort, then stop. Default: off, which runs the full review workflow below.
@@ -50,7 +57,7 @@ If not on the branch, first run `gh pr checkout` to switch.
 
 ## Workflow
 
-1. **Research** - Gather context (see [research.md](research.md))
+1. **Research** - Gather context and identify participants (see [research.md](research.md))
 2. **Context** - Determine review context using repository visibility. Private repositories use [corporate](references/corporate.md) defaults. Public repositories use [open-source](references/open-source.md) defaults. Check visibility via the platform API (`gh api repos/OWNER/REPO --jq .visibility` or `glab api projects/ENCODED_PATH | jq .visibility`). If ambiguous, ask me.
 3. **Review** - Examine changed files and existing comments
 4. **Delegate** - Run `/code-review` for code-quality analysis. Summarize the diff (rough line count, files touched, sensitive areas) and signals from the PR body, propose an effort level with one-line reasoning, and confirm via `AskUserQuestion` before invoking. Skip the call for trivial PRs (docs-only, dep bumps). Effort heuristics:

--- a/plugins/review/skills/peer/research.md
+++ b/plugins/review/skills/peer/research.md
@@ -2,6 +2,7 @@
 
 Gather context before reviewing:
 
+- [ ] Identify the participants. The reviewing user is in the skill's Context block. Fetch the author with `gh pr view <N> --json author --jq .author.login` (GitHub) or `glab mr view <N> --output json | jq -r .author.username` (GitLab). Record one line to work from, e.g. "Author: @alice, reviewing as @bob. Address the author as 'you' or impersonally, never in the third person or by name. Anyone else is a third party and may be named by handle." When the author is you (author matches the reviewing user), note that so comments still read naturally.
 - [ ] Read the project's CLAUDE.md to understand conventions, coding standards, and project-specific guidelines
 - [ ] Read any upstream issues linked in the PR body, including their comments, via the platform API. The issue is where the change originates, so it carries the causal context: the problem being solved, constraints discussed, and alternatives ruled out. Use that intent to judge whether the diff actually addresses the problem
 - [ ] If URLs are referenced, fetch with `WebFetch`

--- a/plugins/review/skills/peer/tone.md
+++ b/plugins/review/skills/peer/tone.md
@@ -4,7 +4,40 @@ Comments should be concise and instructive. Help the author understand why a sug
 
 Write in a natural, conversational tone. Avoid stiff or over-punctuated prose. Read the reviewer's comment history to match their voice.
 
-Don't address the author by name or with greetings ("Hey Alice,", "Hi @bob"). Comments are already targeted at the author, so open with the substance.
+Refer to code by symbol name. Line numbers drift as the change evolves and make the reader hunt for what you mean.
+
+## Who You're Addressing
+
+The Context block at the top of the skill records the reviewing user. The author is whoever opened the PR, identified in the Research step. Anyone else in the diff or the threads is a third party.
+
+### The Author
+
+Open with the substance. Never greet the author, name them, or write about them in the third person. Address them as "you", or write impersonally.
+
+Match the register to the length. A short, single-point note reads better impersonal. A longer comment that walks through a sequence of changes reads better in the second person.
+
+Good:
+- "This drops the status code, so callers can't separate a timeout from a missing record."
+- "You can fold the retry into the existing helper and call it from both branches, which keeps the backoff in one place."
+
+Bad:
+- "Hey Alice, this drops the status code." (greets and names the author)
+- "Alice should validate the input before the write." (third person about the author)
+
+### Yourself
+
+Use the first person for a judgment call. Drop the pronoun for a plain statement of fact.
+
+Good:
+- "I'd lean toward failing closed here."
+- "This runs on every request."
+
+### Third Parties
+
+Name someone only when they are not the author, such as a past contributor whose change is relevant. Use their handle.
+
+Good:
+- "This reverts the guard @carol added in #412, so the null case is unhandled again."
 
 ## Severity
 

--- a/plugins/review/skills/peer/tone.md
+++ b/plugins/review/skills/peer/tone.md
@@ -34,10 +34,7 @@ Good:
 
 ### Third Parties
 
-Name someone only when they are not the author, such as a past contributor whose change is relevant. Use their handle.
-
-Good:
-- "This reverts the guard @carol added in #412, so the null case is unhandled again."
+Only @-mention other users when a notification/mention is explicitly requested.
 
 ## Severity
 


### PR DESCRIPTION
Gives `review:peer` the author-versus-reviewer identity it needs to address the PR author correctly.

On corporate PRs the skill wrote comments that named the author and referred to them in the third person ("Alice should validate this"). The rule against that already lived in `tone.md`. What was missing is identity: the skill never established who the author was versus who was reviewing. With the diff, existing threads, and commit trailers full of real names, the model could not tell the addressee from a third party, so it named people.

Two changes close that gap:

- `SKILL.md` injects the reviewing user at load time for both GitHub and GitLab, with an `unavailable` fallback for the platform not in use. `research.md` then fetches the PR/MR author as the first research step and records an explicit "author is @x, reviewing as @y" fact before any comment is drafted.
- `tone.md` gains a "Who You're Addressing" section. The author is addressed as "you" or impersonally, matching register to length. The reviewer speaks in the first person for a judgment call and drops the pronoun for a plain fact. Only third parties are named.

The voice rules are grounded in real review comments rather than invented. `evals/review-voice/` mines comment bodies from the session index, serves them in a browser labeler, and reports the verdicts, so the rules track what actually reads wrong. The mined data stays on the machine (`data/` and `labels/` are gitignored) because it includes imported private-repo content, so the committed examples are synthetic.

Labeling also surfaced a recurring nit unrelated to naming: comments that cite line numbers instead of symbols. `tone.md` now asks for symbol names, since line numbers drift as the change evolves.
