### PR TITLE
things: add --notes-contains filter to query-logbook.js

### DIFF
--- a/plugins/things/scripts/jxa/query-logbook.js
+++ b/plugins/things/scripts/jxa/query-logbook.js
@@ -3,9 +3,15 @@
 function run(argv) {
   var startIso = argv[0];
   var endIso = argv[1];
+  var notesContains = null;
+  if (argv[2] === "--notes-contains") {
+    notesContains = argv[3];
+  }
 
-  if (!startIso || !endIso) {
-    return JSON.stringify({ error: "Usage: query-logbook.js <start-iso> <end-iso>" });
+  if (!startIso || !endIso || (argv.length > 2 && !notesContains)) {
+    return JSON.stringify({
+      error: "Usage: query-logbook.js <start-iso> <end-iso> [--notes-contains <substring>]",
+    });
   }
 
   var startDate = new Date(startIso);
@@ -21,14 +27,19 @@ function run(argv) {
     if (!p.completionDate) continue;
     if (p.completionDate > endDate) continue;
     if (p.completionDate < startDate) break;
+    if (notesContains !== null && (p.notes || "").indexOf(notesContains) === -1) continue;
     var project = todo.project();
-    items.push({
+    var item = {
       id: p.id,
       name: p.name,
       completionDate: p.completionDate.toISOString(),
       status: p.status,
       project: project ? project.name() : null,
-    });
+    };
+    if (notesContains !== null) {
+      item.notes = p.notes || "";
+    }
+    items.push(item);
   }
 
   return JSON.stringify({ count: items.length, items: items });

--- a/plugins/things/skills/jxa/SKILL.md
+++ b/plugins/things/skills/jxa/SKILL.md
@@ -38,7 +38,7 @@ echo '<json>' | bun ${CLAUDE_PLUGIN_ROOT}/scripts/format-output.ts [--json] [--c
 |--------|-------|-------------|
 | `find-todos.js` | `<tag\|project> <name> [--logbook]` | Find todos by tag (across Inbox/Today/Anytime/Upcoming/Someday) or project |
 | `query-list.js` | `<list-id>` | Query todos from any built-in list |
-| `query-logbook.js` | `<start-iso> <end-iso>` | Query logbook with early termination. Full scans of 10k+ items are slow. |
+| `query-logbook.js` | `<start-iso> <end-iso> [--notes-contains <substring>]` | Query logbook with early termination. Full scans of 10k+ items are slow. `--notes-contains` filters by notes substring and includes `notes` in output (e.g. to find `Discovery:` markers). |
 | `query-metadata.js` | `<projects\|areas\|tags>` | List projects, areas, or tags (tags omit todoCount for performance) |
 | `export-markdown.js` | `[list-id]` | Export a list to markdown checklist |
 


### PR DESCRIPTION
The improve-claude-code dedup step needs completed logbook todos whose notes carry `Discovery: <fingerprint>` markers. Neither existing script can find them: `query-logbook.js` omits notes, and `find-todos.js --logbook` searches by tag, but the annotate phase strips the `claude-code` tag when a todo ships. Today's live run had to hand-write a throwaway JXA script to fetch notes by id.

Adds a `--notes-contains <substring>` flag to `query-logbook.js`. Notes come free with the existing `properties()` batch read, so the filter adds no Apple Events calls and keeps the early termination by completion date. The `notes` field is included in output only when filtering, so the default query stays light for 10k+-item logbooks. A filter beats an opt-in notes dump for both tokens and output size. Any third argument other than a complete `--notes-contains <substring>` pair returns the usage error.

Tested live against Things 3: the logbook since 2026-05-15 filtered on `Discovery:` returns exactly the 19 todos today's run found by hand. The unfiltered query output is unchanged.

Discovery: 4c95b44e9a5a
