### PR TITLE
jxa: stop truncating merged output capture, add second retry

### DIFF
--- a/plugins/mac/scripts/jxa.test.ts
+++ b/plugins/mac/scripts/jxa.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
 import type { RunResult } from "./jxa";
 import { isRetriableAppleEventsError, runWithRetry, validateAppScope } from "./jxa";
 
@@ -115,12 +116,18 @@ describe("runWithRetry", () => {
     expect(calls).toHaveLength(2);
   });
 
-  it("retries once then surfaces the real error", async () => {
+  it("retries with backoff then surfaces the persistent error", async () => {
     const persistent: RunResult = { code: 1, stdout: "", stderr: "Connection Invalid" };
-    const { run, calls } = runner([persistent, { ...persistent }]);
-    const result = await runWithRetry(["-e", "x"], run, noSleep);
+    const { run, calls } = runner([persistent, { ...persistent }, { ...persistent }]);
+    const delays: number[] = [];
+    const sleep = (ms: number) => {
+      delays.push(ms);
+      return Promise.resolve();
+    };
+    const result = await runWithRetry(["-e", "x"], run, sleep);
     expect(result).toEqual(persistent);
-    expect(calls).toHaveLength(2);
+    expect(calls).toHaveLength(3);
+    expect(delays).toEqual([300, 900]);
   });
 
   it("does not retry a non-retriable failure", async () => {
@@ -135,5 +142,27 @@ describe("runWithRetry", () => {
     const result = await runWithRetry(["-e", "1 + 1"], run, noSleep);
     expect(result).toEqual({ code: 0, stdout: "2", stderr: "" });
     expect(calls).toHaveLength(1);
+  });
+});
+
+describe("emitResult", () => {
+  // Regression: stdout and stderr sharing one open file description (`2>&1`,
+  // how shell tools capture combined output). Bun.write(Bun.stderr, ...) used
+  // replace semantics on regular files, truncating the stdout content.
+  it("preserves stdout when stderr shares the capture file", async () => {
+    const dir = process.env.TMPDIR ?? "/tmp";
+    const capture = join(dir, `jxa-emit-${Date.now()}.txt`);
+    const fixture = join(dir, `jxa-emit-fixture-${Date.now()}.ts`);
+    const jxaPath = join(import.meta.dirname, "jxa.ts");
+    await Bun.write(
+      fixture,
+      `import { emitResult } from ${JSON.stringify(jxaPath)};\n` +
+        `emitResult({ code: 0, stdout: "OUT\\n", stderr: "ERR\\n" });\n`,
+    );
+
+    const proc = Bun.spawn(["sh", "-c", `bun '${fixture}' > '${capture}' 2>&1`]);
+    expect(await proc.exited).toBe(0);
+
+    expect(await Bun.file(capture).text()).toBe("OUT\nERR\n");
   });
 });

--- a/plugins/mac/scripts/jxa.ts
+++ b/plugins/mac/scripts/jxa.ts
@@ -86,8 +86,9 @@ export interface RunResult {
 
 // AppleEvents error codes that are safe to retry. They surface as transient XPC
 // dispatcher hiccups on the first event after a cold session: errAEPrivilegeError
-// (-10004) and errAEEventNotHandled / "application isn't running" (-600). A retry
-// clears them.
+// (-10004) and errAEEventNotHandled / "application isn't running" (-600). Retries
+// clear the transient case; a persistent failure (e.g. a sandbox deny) still
+// surfaces after the final attempt.
 const RETRIABLE_APPLE_EVENTS_CODES = [-10004, -600];
 
 export function isRetriableAppleEventsError(exitCode: number, stderr: string): boolean {
@@ -110,19 +111,33 @@ async function runOsascript(args: string[]): Promise<RunResult> {
   return { code, stdout, stderr };
 }
 
-const RETRY_DELAY_MS = 300;
+const RETRY_DELAYS_MS = [300, 900];
 
 export async function runWithRetry(
   args: string[],
   run: (args: string[]) => Promise<RunResult>,
   sleep: (ms: number) => Promise<void> = Bun.sleep,
 ): Promise<RunResult> {
-  const first = await run(args);
-  if (first.code === 0 || !isRetriableAppleEventsError(first.code, first.stderr)) {
-    return first;
+  let result = await run(args);
+  for (const delay of RETRY_DELAYS_MS) {
+    if (result.code === 0 || !isRetriableAppleEventsError(result.code, result.stderr)) {
+      return result;
+    }
+    await sleep(delay);
+    result = await run(args);
   }
-  await sleep(RETRY_DELAY_MS);
-  return run(args);
+  return result;
+}
+
+// Forward osascript's output on the process streams. Bun.write(Bun.stdout, ...)
+// is unsafe here: BunFile writes replace file contents, so when stdout and
+// stderr share one capture file (`2>&1`) the stderr write truncates everything
+// stdout just wrote. process.*.write appends at the fd offset, and setting
+// exitCode instead of calling process.exit lets pending pipe writes flush.
+export function emitResult({ code, stdout, stderr }: RunResult): void {
+  process.stdout.write(stdout);
+  process.stderr.write(stderr);
+  process.exitCode = code;
 }
 
 if (import.meta.main) {
@@ -168,8 +183,5 @@ if (import.meta.main) {
     process.exit(1);
   }
 
-  const { code, stdout, stderr } = await runWithRetry(osascriptArgs, runOsascript);
-  await Bun.write(Bun.stdout, stdout);
-  await Bun.write(Bun.stderr, stderr);
-  process.exit(code);
+  emitResult(await runWithRetry(osascriptArgs, runOsascript));
 }


### PR DESCRIPTION
Fixes JXA runs that exited 0 with no output at all, even though the same script through raw `osascript` printed a large JSON array.

The runner ended with `Bun.write(Bun.stdout, stdout); Bun.write(Bun.stderr, stderr)`. `Bun.write` to a `BunFile` has replace semantics on regular files. When stdout and stderr are merged into one capture file (`2>&1`, which is how Claude Code's Bash tool records command output), the final stderr write truncated the file to zero after the stdout content had landed. Minimal repro: `bun -e 'await Bun.write(Bun.stdout, "HELLO\n"); await Bun.write(Bun.stderr, "")' > f 2>&1` leaves `f` empty. With separate files or a pipe it works, which is why the bug only surfaced in captured sessions and never at an interactive terminal.

The fix forwards output with `process.stdout.write` / `process.stderr.write`, which append at the fd offset, and sets `process.exitCode` instead of calling `process.exit` so pending pipe writes flush on natural exit. Before/after on the same command with merged capture: 0 bytes, exit 0 vs 152 bytes, exit 0. Script-file mode (`find-todos.js tag ...`) verified at 5,772 bytes through a pipe, and error exits still propagate (`exit 1` with osascript's stderr intact).

The regression test spawns a fixture through `sh -c '... > file 2>&1'` rather than passing a shared fd, both because that is the exact failing shape and because the repo's biome config restricts `node:fs` imports.

Separately, one 300ms retry on transient Apple Events errors (#918) was observed insufficient: back-to-back sandboxed runs still failed with -10004. `runWithRetry` now makes up to three attempts with 300ms/900ms backoff. Testing here showed sandboxed denials can also be persistent, so the comment no longer claims a retry clears them; a hard sandbox deny still fails after the final attempt.

Discovery: 0f2d8a718f7d
