### PR TITLE
writing: stop re-asking on edits to already-numbered files

### DIFF
--- a/plugins/writing/hooks/numbering.test.ts
+++ b/plugins/writing/hooks/numbering.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { execSync } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type {
   PreToolUseHookInput,
   PreToolUseHookSpecificOutput,
@@ -399,6 +403,71 @@ describe("plan mode", () => {
   it("still asks when permission_mode is not plan", async () => {
     const output = await getOutput(mockWriteInput("README.md", "# 1. Introduction"), "write");
     expect(output?.permissionDecision).toBe("ask");
+  });
+});
+
+describe("already-numbered files", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "numbering-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("allows Edit when the file already has numbered headings", async () => {
+    const filePath = join(dir, "review.md");
+    await Bun.write(filePath, "# Findings\n\n## 1. First issue\n\nDetails.\n");
+    const output = await getOutput(mockEditInput(filePath, "## 2. Second issue"), "edit");
+    expect(output).toBeNull();
+  });
+
+  it("asks when Edit introduces numbering into a clean file", async () => {
+    const filePath = join(dir, "clean.md");
+    await Bun.write(filePath, "# Findings\n\nDetails.\n");
+    const output = await getOutput(mockEditInput(filePath, "## 1. First issue"), "edit");
+    expect(output?.permissionDecision).toBe("ask");
+  });
+
+  it("allows non-numbered Edit to an already-numbered file", async () => {
+    const filePath = join(dir, "review.md");
+    await Bun.write(filePath, "# Findings\n\n## 1. First issue\n");
+    const output = await getOutput(mockEditInput(filePath, "More details."), "edit");
+    expect(output).toBeNull();
+  });
+
+  it("allows Write overwriting a file that already has numbered headings", async () => {
+    const filePath = join(dir, "review.md");
+    await Bun.write(filePath, "## 1. First issue\n");
+    const output = await getOutput(
+      mockWriteInput(filePath, "## 1. First issue\n\n## 2. Second issue\n"),
+      "write",
+    );
+    expect(output).toBeNull();
+  });
+
+  it("asks when Write creates a new numbered file", async () => {
+    const filePath = join(dir, "new.md");
+    const output = await getOutput(mockWriteInput(filePath, "# 1. Introduction"), "write");
+    expect(output?.permissionDecision).toBe("ask");
+  });
+
+  describe.skipIf(!hasSg())("code files (requires sg)", () => {
+    it("allows Edit when the file already has numbered identifiers", async () => {
+      const filePath = join(dir, "main.go");
+      await Bun.write(filePath, "package main\nfunc step1() {}\n");
+      const output = await getOutput(mockEditInput(filePath, "func step2() {}"), "edit");
+      expect(output).toBeNull();
+    });
+
+    it("asks when Edit introduces numbering into a clean code file", async () => {
+      const filePath = join(dir, "main.go");
+      await Bun.write(filePath, "package main\nfunc processItems() {}\n");
+      const output = await getOutput(mockEditInput(filePath, "func step1() {}"), "edit");
+      expect(output?.permissionDecision).toBe("ask");
+    });
   });
 });
 

--- a/plugins/writing/hooks/numbering.ts
+++ b/plugins/writing/hooks/numbering.ts
@@ -103,6 +103,20 @@ export async function checkCode(content: string, ext: string): Promise<string | 
   return null;
 }
 
+async function fileAlreadyNumbered(filePath: string, ext: string): Promise<boolean> {
+  let existing: string;
+  try {
+    const file = Bun.file(filePath);
+    if (!(await file.exists())) return false;
+    existing = await file.text();
+  } catch {
+    return false;
+  }
+
+  const match = isMarkdownFile(ext) ? checkMarkdown(existing) : await checkCode(existing, ext);
+  return match !== null;
+}
+
 export async function processInput(
   input: PreToolUseHookInput,
   mode: Mode,
@@ -138,6 +152,13 @@ export async function processInput(
   }
 
   if (!match) {
+    return null;
+  }
+
+  // Numbering already present in the target file was adjudicated when it was
+  // introduced (approved by the user or pre-existing). Only first
+  // introductions should prompt.
+  if (await fileAlreadyNumbered(filePath, ext)) {
     return null;
   }
 


### PR DESCRIPTION
In edit mode the numbering hook inspected only `new_string`, so a file that already contained numbered headings re-triggered the ask on every subsequent edit to it. The hook now reads the target file and allows silently when the existing content already matches its own pattern: that numbering was already adjudicated (approved by the user or pre-existing), so re-asking adds friction without information.

Introducing numbering into a clean file still asks, and missing files or read errors fall through to the old behavior. The same guard applies to Write overwrites of already-numbered files, chosen over an edit-only carve-out because one uniform rule ("already adjudicated for this file → allow") is easier to reason about than mode-specific exceptions.

## Evidence

Local session history (2026-06-30): one session writing a review-findings doc with intentional ordered headings got 12 asks, 7 within about 90 seconds, and the user approved every one. Across two weeks the hook logged 19 ask events with a 100% friction rate (every logged run was an ask).

## Testing

New tests cover the matrix: edit to an already-numbered file (allow), fresh numbering into a clean file (ask), non-numbered edit to a numbered file (allow), Write overwrite of a numbered file (allow), Write of a new numbered file (ask), plus the code-file equivalents under ast-grep.

Discovery: fe0631c07773
