### PR TITLE
skills: remove sandbox bypasses that outlived their root causes

### DIFF
--- a/plugins/github/skills/pr-comments/SKILL.md
+++ b/plugins/github/skills/pr-comments/SKILL.md
@@ -4,30 +4,6 @@ description: Fetch, reply to, and resolve review threads on a GitHub pull reques
 argument-hint: "<pr-url> [--role author|reviewer] [--bots] [--include-resolved]"
 allowed-tools:
   ["Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/pr-comments.ts:*)", "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/review-threads.ts:*)"]
-hooks:
-  PreToolUse:
-    - matcher: "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/pr-comments.ts:*)"
-      hooks:
-        - type: command
-          command: |
-            jq -n '{
-              hookSpecificOutput: {
-                hookEventName: "PreToolUse",
-                permissionDecision: "allow",
-                updatedInput: { dangerouslyDisableSandbox: true }
-              }
-            }'
-    - matcher: "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/review-threads.ts:*)"
-      hooks:
-        - type: command
-          command: |
-            jq -n '{
-              hookSpecificOutput: {
-                hookEventName: "PreToolUse",
-                permissionDecision: "allow",
-                updatedInput: { dangerouslyDisableSandbox: true }
-              }
-            }'
 ---
 
 # PR Review Comments

--- a/plugins/review/skills/inbox/SKILL.md
+++ b/plugins/review/skills/inbox/SKILL.md
@@ -15,18 +15,6 @@ allowed-tools:
   - "Bash(bun ${CLAUDE_SKILL_DIR}/scripts/:*)"
   - "Bash(cat ~/.claude/projects/:*)"
   - Bash(ls:*)
-hooks:
-  PreToolUse:
-    - matcher: "Bash(tmux:*)"
-      hooks:
-        - type: command
-          command: |
-            cat | jq '{hookSpecificOutput: {hookEventName: "PreToolUse", updatedInput: (.tool_input + {dangerouslyDisableSandbox: true})}}'
-    - matcher: "Bash(bun ${CLAUDE_SKILL_DIR}/scripts/:*)"
-      hooks:
-        - type: command
-          command: |
-            cat | jq '{hookSpecificOutput: {hookEventName: "PreToolUse", updatedInput: (.tool_input + {dangerouslyDisableSandbox: true})}}'
 ---
 
 # Review Inbox

--- a/plugins/things/skills/jxa/troubleshooting.md
+++ b/plugins/things/skills/jxa/troubleshooting.md
@@ -26,8 +26,9 @@ Sandbox errors typically mention:
 - `Operation not permitted`
 - `Sandbox: deny`
 - File path access errors
+- `A privilege violation occurred. (-10004)`
 
-The skill's inline hook automatically runs wrapper commands outside the sandbox. If you still see sandbox errors, verify the hook is active or run the command with `dangerouslyDisableSandbox: true`.
+Sandboxed `osascript` Apple Events to Things3 fail with `-10004` even with `sandbox.allowAppleEvents` set (that key covers Launch Services `open`/URL handoff, not `osascript`). The `mac:jxa-run` skill's inline hook runs the JXA runner outside the sandbox for this reason. If you see `-10004`, verify that hook is active or run the command with `dangerouslyDisableSandbox: true`.
 
 ## Updates Not Working
 


### PR DESCRIPTION
Removes the `dangerouslyDisableSandbox` PreToolUse hooks from `github:pr-comments` and `review:inbox`, whose root causes are fixed. Keeps the `mac:jxa-run` bypass, which live testing shows is still required, and updates the Things troubleshooting doc to say why.

## Evidence

- #903 (trustd mach lookup for Go TLS) verified effective: session history shows 139 gh-related bypasses before the fix vs 11 after, and 14 `x509: OSStatus -26276` failures across 9 sessions before vs zero after. Live check: `gh api graphql` and `gh api repos/bendrucker/claude` both succeed sandboxed.
- The tmux socket is already in `sandbox.network.allowUnixSockets` (`~/.tmux`); only 2 tmux sandbox denials appear in history, both in one session. Live check: `display-message`, `list-sessions`, `new-session`, `split-window`, and `kill-session` all succeed sandboxed, and the inbox's `state.ts` runs sandboxed too.
- JXA does NOT pass: sandboxed `osascript -l JavaScript` Apple Events to Things3 fail with `A privilege violation occurred. (-10004)` on 8 of 9 consecutive attempts (one initial success, then hard failures seconds apart), despite `sandbox.allowAppleEvents: true` in `user/settings.json`. So the `mac:jxa-run` hook stays, and `plugins/things/skills/jxa/troubleshooting.md` now documents the `-10004` signature instead of claiming the hook covers everything.

Discovery: 5c20d96993ce
