### PR TITLE
docs: sandboxed writes cover /tmp and the repo

### DIFF
--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -30,6 +30,7 @@ Every customization costs tokens on every session. Before adding one, define how
 - Always use the `pull-request:create` skill to create pull requests. If the skill is unavailable, create the PR with an empty body.
 - When executing build commands, output to `/dev/null` to avoid creating binaries.
 - Store temporary files in `tmp/` directory.
+- The sandbox can write `/tmp`, `$TMPDIR`, and the repo. Never disable the sandbox for file writes; only bypass after a sandboxed run of that command actually failed.
 - Use `pbcopy` and `pbpaste` for clipboard interaction.
 
 ### Bash `!` Escaping Bug


### PR DESCRIPTION
Clarifies that the sandbox can write to `/tmp`, `$TMPDIR`, and the repo—all paths that don't require `dangerouslyDisableSandbox`.

In the 4 days after the trustd TLS fix (#903), 194 sandbox bypasses across 12 local sessions were dominated by `mkdir`, `echo`, and `cat` into `/tmp` and repo `tmp/`, all sandbox-writable paths. Only 3.3% of bypasses in the two-week window followed an actual sandboxed failure. With `autoAllowBashIfSandboxed` enabled, each unnecessary bypass converts an auto-allowed command into a permission prompt.

Discovery: 65ff6deaff20
