### PR TITLE
claude.md: add planning guidance on plan size and redirects

### DIFF
--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -38,8 +38,8 @@ The Bash tool escapes `!` to `\!` on every path, including single quotes and her
 
 ## Planning
 
-- Keep plans focused and under roughly 10k characters. Large plans get rejected: in my session history, no plan over 11k characters was ever approved.
-- When I redirect a plan, revise the sections my feedback touches. Do not regrow the whole plan, and never re-present a plan unchanged.
+- Keep plans focused and under roughly 10k characters.
+- When I redirect a plan, revise the sections my feedback covers. Do not exclusively grow the whole plan or log every decision and revision.
 
 ## Git
 

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -36,6 +36,11 @@ Every customization costs tokens on every session. Before adding one, define how
 
 The Bash tool escapes `!` to `\!` on every path, including single quotes and heredocs, breaking `jq !=`, `awk !~`, and similar operators ([#2941](https://github.com/anthropics/claude-code/issues/2941), [#10335](https://github.com/anthropics/claude-code/issues/10335)). For `jq`, use `| not` instead of `!=`. For anything else, author the content with the Write tool, then run it. No shell quoting or heredoc bypasses the escape.
 
+## Planning
+
+- Keep plans focused and under roughly 10k characters. Large plans get rejected: in my session history, no plan over 11k characters was ever approved.
+- When I redirect a plan, revise the sections my feedback touches. Do not regrow the whole plan, and never re-present a plan unchanged.
+
 ## Git
 
 - Never `git push` to the default branch (usually `main` or `master`) unless I explicitly instruct you.


### PR DESCRIPTION
Adds a `## Planning` section to `user/CLAUDE.md` with guidance on plan size and how to handle redirects.

Two weeks of plan-mode session history across two machines shows approved plans averaged 7.4k characters (max 11.4k), while redirected plans averaged 10.2k (max 55.5k). No plan over roughly 11.4k characters was ever approved. One session grew a plan from 9.8k to 55.5k characters across five consecutive redirects, and twice a byte-identical plan was re-presented after a redirect.

The new guidance asks Claude to keep plans under roughly 10k characters and, on redirect, to revise only the sections the feedback touches rather than regrowing or re-presenting the plan unchanged.

Discovery: 5000179db341
