### PR TITLE
biome hook: stop blocking on files Biome ignores

### DIFF
--- a/.claude/hooks/biome/index.test.ts
+++ b/.claude/hooks/biome/index.test.ts
@@ -1,7 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { exec } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import type {
   PostToolUseHookInput,
   PreToolUseHookInput,
@@ -16,6 +18,8 @@ import {
   runBiomeCheck,
   runBiomeFix,
 } from ".";
+
+const execAsync = promisify(exec);
 
 const FIXTURES_DIR = join(import.meta.dirname, "fixtures");
 
@@ -86,6 +90,23 @@ async function copyFixture(name: string, destDir: string): Promise<string> {
   return dest;
 }
 
+// A git repo whose Biome config excludes ignored.ts. Checking that file makes
+// Biome report "no files were processed", which must not read as a lint
+// failure. The git init matters: runBiomeCheck resolves its cwd from the
+// file's git toplevel, which is where Biome discovers this config.
+async function createIgnoredFixture(baseDir: string): Promise<string> {
+  const repoDir = await mkdtemp(join(baseDir, "ignored-repo-"));
+  await execAsync("git init", { cwd: repoDir });
+  await Bun.write(
+    join(repoDir, "biome.json"),
+    JSON.stringify({ files: { includes: ["**", "!**/ignored.ts"] } }),
+  );
+  const filePath = join(repoDir, "ignored.ts");
+  const content = await Bun.file(join(FIXTURES_DIR, "unfixable.ts")).text();
+  await Bun.write(filePath, content);
+  return filePath;
+}
+
 describe("biome hook", () => {
   beforeAll(async () => {
     tempDir = await mkdtemp(join(tmpdir(), "biome-test-"));
@@ -113,6 +134,11 @@ describe("biome hook", () => {
       const result = await runBiomeCheck(filePath);
       expect(result).not.toBeNull();
       expect(result).toContain("noDuplicateObjectKeys");
+    });
+
+    it("returns null for files the Biome config ignores", async () => {
+      const filePath = await createIgnoredFixture(tempDir);
+      expect(await runBiomeCheck(filePath)).toBeNull();
     });
   });
 
@@ -297,6 +323,15 @@ describe("biome hook", () => {
       expect(result?.decision).toBe("block");
       expect(result?.reason).toContain("Biome check failed");
       expect(result?.reason).toContain("noDuplicateObjectKeys");
+    });
+
+    it("returns null when the only modified file is ignored by Biome config", async () => {
+      const filePath = await createIgnoredFixture(tempDir);
+      const transcriptPath = join(tempDir, `transcript-ignored-${Date.now()}.jsonl`);
+      await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Edit" }]));
+
+      const input = mockStopHookInput(transcriptPath);
+      expect(await processStop(input)).toBeNull();
     });
 
     it("processes multiple files in parallel", async () => {

--- a/.claude/hooks/biome/index.ts
+++ b/.claude/hooks/biome/index.ts
@@ -127,6 +127,9 @@ async function biomeWorkingTree(filePath: string): Promise<string | undefined> {
   }
 }
 
+// --no-errors-on-unmatched keeps Biome from exiting non-zero on files its
+// config ignores (gitignored paths, fixtures). Without it, edits to excluded
+// files read as lint failures and block Stop.
 export async function runBiomeCheck(filePath: string): Promise<string | null> {
   const command = await biomeCommand();
   if (!command) {
@@ -134,7 +137,10 @@ export async function runBiomeCheck(filePath: string): Promise<string | null> {
   }
   const cwd = await biomeWorkingTree(filePath);
   try {
-    await execAsync(`${command} check "${filePath}"`, cwd ? { cwd } : undefined);
+    await execAsync(
+      `${command} check --no-errors-on-unmatched "${filePath}"`,
+      cwd ? { cwd } : undefined,
+    );
     return null;
   } catch (error) {
     const execError = error as { stdout?: string; stderr?: string };
@@ -150,7 +156,10 @@ export async function runBiomeFix(filePath: string): Promise<void> {
   }
   const cwd = await biomeWorkingTree(filePath);
   try {
-    await execAsync(`${command} check --write "${filePath}"`, cwd ? { cwd } : undefined);
+    await execAsync(
+      `${command} check --write --no-errors-on-unmatched "${filePath}"`,
+      cwd ? { cwd } : undefined,
+    );
   } catch {
     // biome check --write exits non-zero if there are unfixable issues
   }


### PR DESCRIPTION
Biome exits non-zero when the path it's given matches no files, printing `Checked 0 files` and "No files were processed in the specified paths". This happens for files excluded by config or gitignore (Biome runs with `vcs.useIgnoreFile`). The hook treated any non-zero exit from `biome check` as a lint failure, so editing an excluded file blocked Stop with a bogus error.

The fix passes `--no-errors-on-unmatched` to both the check and the fix (`--write`) invocations. The flag is supported by the pinned Biome (2.4.16) and turns the unmatched case into exit 0, which the hook already treats as clean. Real lint failures still exit non-zero and block as before.

Verified by reproducing directly: `biome check packages/toolkit/fixtures/echo-hook.ts` (gitignored) exits 1 without the flag and 0 with it, and `runBiomeCheck` on such a path now returns null. New regression tests build a temp git repo whose `biome.json` excludes the file and cover `runBiomeCheck` and the Stop path passing it through; they reproduce the false block without the fix.

## Evidence

Session history on this host, 2026-06-18 through 2026-07-02: 3 of 7 Stop blocks from this hook were this false positive, on `plugins/comments/evals/fixtures/*.json`, `packages/toolkit/fixtures/echo-hook.ts`, and `workflow/judge.workflow.js`, all excluded by Biome config yet blocking Stop.

Discovery: d61180da3666
