### PR TITLE
rules: trim plugins.md to cut repeated-injection cost

### DIFF
--- a/.claude/rules/plugins.md
+++ b/.claude/rules/plugins.md
@@ -5,26 +5,17 @@ paths:
 
 # Plugin Architecture
 
-Each plugin in `plugins/` contains:
-- `.claude-plugin/plugin.json`: Plugin metadata
-- `skills/`: Skill definitions with `SKILL.md` and reference files
-- `hooks/`: Optional hook definitions (`hooks.json`)
-- `commands/`: Optional slash commands
-- `agents/`: Optional agent definitions
+Each plugin has `.claude-plugin/plugin.json` plus optional `skills/`, `hooks/`, `commands/`, `agents/`.
 
-When creating or modifying skills, load the `claude-code:skill` skill for authoring best practices, structure conventions, and content features.
+When creating or modifying skills, load the `claude-code:skill` skill.
 
 ## Naming
 
-The plugin name forms a namespace for its contents (e.g., `gitlab:ci-monitor`). Commands and agents are auto-namespaced by the plugin system: the filename becomes the qualified name (e.g., `ci-monitor.md` in the `gitlab` plugin becomes `gitlab:ci-monitor`). Skills are auto-prefixed with `plugin-name:` when the frontmatter `name` doesn't already start with that prefix. Including the prefix explicitly is optional but harmless (avoids double-prefixing).
-
-Anti-stuttering applies to the part after the colon: `gitlab:gitlab-ci` is wrong, `gitlab:ci` is right. Run `bun run skill-lint` to catch namespace mismatches and stuttering.
-
-A plugin's primary skill MAY share the plugin name (`plugin:plugin`, e.g. `writing:writing`, `tmux:tmux`). This is the intentional entry-skill pattern: the namespace's default skill, named to leave room for siblings (`writing:analyze`, `writing:review`). The platform registers and accepts both the qualified and unqualified forms. The stutter to avoid is the redundant-suffix form (`plugin:plugin-foo`, e.g. `writing:writing-analyze`), which `skill-lint` flags. Exact `plugin:plugin` is permitted by design.
+Commands, agents, and skills auto-namespace with `plugin-name:` (e.g. `ci-monitor.md` in `gitlab` becomes `gitlab:ci-monitor`); an explicit prefix in frontmatter is optional. Anti-stuttering applies after the colon: `gitlab:gitlab-ci` is wrong, `gitlab:ci` is right. A plugin's primary skill may exactly match the plugin name as an intentional entry-skill pattern (`plugin:plugin`, e.g. `writing:writing`, `tmux:tmux`); the stutter to avoid is the redundant-suffix form (`plugin:plugin-foo`, e.g. `writing:writing-analyze`). Run `bun run skill-lint` to catch namespace mismatches and stuttering.
 
 ## MCP Tool Naming
 
-MCP tools appear with three naming patterns depending on how the server is connected:
+MCP tools use one of three naming patterns, depending on connection type:
 
 | Pattern | Format | Example |
 |---------|--------|---------|
@@ -32,24 +23,13 @@ MCP tools appear with three naming patterns depending on how the server is conne
 | Plugin | `mcp__plugin_<pluginName>_<server>__<tool>` | `mcp__plugin_linear_linear__create_issue` |
 | Claude AI | `mcp__claude_ai_<DisplayName>__<tool>` | `mcp__claude_ai_Linear__save_issue` |
 
-Claude AI display names differ from server names (e.g., `Linear` not `linear`) and cannot be derived programmatically. Tool names may also differ between variants: Linear uses `save_issue` instead of `create_issue`/`update_issue`. Known mappings:
-
-| Server | Display Name | Local Tool | Claude AI Tool |
-|--------|-------------|------------|----------------|
-| `linear` | `Linear` | `create_issue` | `save_issue` |
-| `linear` | `Linear` | `update_issue` | `save_issue` |
+Claude AI display names and tool names can differ from local ones and aren't derivable (e.g. `linear`'s Claude AI display name is `Linear`, and it uses `save_issue` where local uses `create_issue`/`update_issue`).
 
 Hook matchers must include all three patterns for matched tools. Skill `allowed-tools` needs the `mcp__claude_ai_<Name>` prefix. Run `bun scripts/check-mcp-matchers.ts` to validate hook matchers include all variants.
 
 ## Plugin READMEs
 
-Each plugin should have a `README.md` with consistent sections:
-
-- **Title**: `# Plugin Name` with a one-line description
-- **Contents**: List what the plugin provides (skills, hooks, agents, commands)
-- **Testing**: How to run tests (if the plugin has tests)
-
-Do not include installation instructions or skill activation details, the README is an index, not documentation.
+Each plugin's `README.md` needs a title with one-line description, a contents list (skills/hooks/agents/commands), and how to run tests if the plugin has them. The README is an index, not documentation.
 
 ## Plugin Metadata
 
@@ -57,12 +37,4 @@ Plugin `settings.json` only supports `agent` and `subagentStatusLine` keys. Don'
 
 ## Dependencies
 
-The root `package.json` contains shared tooling (typescript) and dependencies used across multiple plugins (e.g., `url-pattern`). Plugin-specific dependencies belong in their own `package.json`:
-
-- Create `plugins/<name>/package.json` for plugin-specific dependencies
-- Add the plugin to the root `workspaces` array
-- Run `bun install` to link the workspace
-
-Avoid collecting all dependencies in the root package.json. Each plugin should be self-contained where practical.
-
-Plugins must not import from outside their own directory. No cross-plugin imports, no reaching into `packages/` or root-level modules via relative paths. If two plugins need shared code, extract it to an npm workspace package and declare the dependency in each plugin's `package.json`. Run `bun scripts/check-plugin-imports.ts` to verify.
+Plugin-specific dependencies go in the plugin's own `plugins/<name>/package.json`, added to the root `workspaces` array. No cross-plugin imports, and no reaching into `packages/` via relative paths. If two plugins need shared code, extract it to an npm workspace package and declare the dependency in each plugin's `package.json`. Run `bun scripts/check-plugin-imports.ts` to verify.


### PR DESCRIPTION
Trims `.claude/rules/plugins.md` from 4315 to 2648 bytes (39% cut). This rule auto-injects on every session touching `plugins/**` (77 injections over the last two weeks per session history, 1.5x per session since rules re-inject after clear/compact), so every byte is paid repeatedly.

Each section was cut to keep only facts that aren't derivable from looking at a plugin directory and aren't enforced by a check script.

| Section | Cut | Why cuttable |
|---|---|---|
| Plugin Architecture | 5-bullet directory list, `hooks.json`/`SKILL.md` filenames | Derivable. Open the directory |
| Naming | "named to leave room for siblings" rationale, "platform registers both qualified/unqualified forms" | Redundant with `skill-lint`, which enforces the naming rules directly |
| MCP Tool Naming | "Known mappings" table (two rows both saying Linear's display name is `Linear` and it uses `save_issue`) | Restated as one line, no fact lost |
| Plugin READMEs | Bulleted section list, "no installation instructions" caveat | Compressed to two lines, same facts |
| Plugin Metadata | Nothing | Already tight, all facts non-derivable |
| Dependencies | Root `package.json` shared-tooling rationale, `bun install` step, "avoid collecting deps in root" guidance | Not linter-enforced but explanatory filler around the two rules that matter (own `package.json` + workspace, no cross-plugin imports); the `check-plugin-imports.ts` script is what actually enforces the import boundary |

Kept despite being tempting to cut: the three-pattern MCP table (local/plugin/claude-ai variants aren't derivable from anywhere but this doc) and the exact `plugin:plugin` entry-skill exception (the one naming rule `skill-lint` explicitly permits rather than flags).

Discovery: fde03a793073
