### PR TITLE
validate: skip missing files instead of ENOENT crash

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: plugin-validate
         name: Plugin validation
         language: system
-        files: \.claude-plugin/plugin\.json$
+        files: ^plugins/[^/]+/\.claude-plugin/plugin\.json$
         entry: scripts/prek-check.sh plugin-validate
 
       - id: hooks-validate

--- a/packages/validate/run.test.ts
+++ b/packages/validate/run.test.ts
@@ -67,6 +67,21 @@ describe("runValidation", () => {
     expect(lines.some((line) => typeof line === "string" && line.includes("extra"))).toBe(true);
   });
 
+  it("skips a missing file with a one-line report instead of throwing", async () => {
+    const present = await writeFixture("valid-present", { name: "ok" });
+    const missing = join(tempDir, "does-not-exist/.claude-plugin/plugin.json");
+
+    await runValidation({ files: [missing, present], schema: schemaPath });
+
+    const lines = logSpy.mock.calls.map((call) => call[0]);
+    expect(lines).toEqual([
+      `• ${missing} (not found, skipped)`,
+      `• ${present}`,
+      "",
+      "Validation passed.",
+    ]);
+  });
+
   it("exits non-zero on validation errors", async () => {
     const file = await writeFixture("invalid", { name: 123 });
     const exitSpy = spyOn(process, "exit").mockImplementation((() => {

--- a/packages/validate/run.ts
+++ b/packages/validate/run.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import type Ajv from "ajv";
 import {
   createValidator,
@@ -32,6 +32,10 @@ export async function runValidation(target: ValidationTarget): Promise<void> {
 
   const result: ValidationResult = { errors: [], warnings: [] };
   for (const file of target.files) {
+    if (!(await Bun.file(resolve(file)).exists())) {
+      console.log(`• ${file} (not found, skipped)`);
+      continue;
+    }
     console.log(`• ${file}`);
     const r = await validateFile(file, target.schema, options);
     result.errors.push(...r.errors);


### PR DESCRIPTION
Fixes a latent crash in the plugin-validate check that blocks Stop with a raw stack trace. Twice on 2026-06-28, from the `.worktrees/retire-sandbox-marker` worktree, prek handed `packages/validate/plugin.ts` a path escaping the worktree root (`../../.claude-plugin/plugin.json`), and `validateFile` threw an unhandled ENOENT instead of reporting a validation result.

The escaping path has two ingredients. A stale stop hook (worktrees branched before #908 still carry the pre-`scopePaths` code) relativizes cross-worktree Edit/Write paths into `../../...` form. prek 0.4.6 then forwards such a path verbatim to the hook entry whenever the file exists, because the `plugin-validate` `files` regex was unanchored and matched anywhere in the string. The old `extract_dirs` truncated it to `../..`, and the validator joined `../../.claude-plugin/plugin.json`, which does not exist in the main checkout.

Two layers change:

- `.pre-commit-config.yaml`: anchor the regex to `^plugins/[^/]+/\.claude-plugin/plugin\.json$`. Every `plugin.json` lives under `plugins/<name>/`, so escaping and absolute paths can never match, matching the anchoring the sibling hooks already use.
- `packages/validate/run.ts`: `runValidation` resolves each file against the invocation root and skips nonexistent ones with a one-line `(not found, skipped)` report instead of throwing. The unresolved path still flows to `validateFile` so CI `::error file=` annotations stay repo-relative.

Skipping (rather than failing) is deliberate: prek only forwards paths it can see, so a missing file at this layer is always a stale or escaping path, and failing Stop on it reintroduces the noise this fixes.

## Evidence

Local repro from a nested worktree (`git worktree add tmp/enoent-repro`):

- Before: `bun packages/validate/plugin.ts ../..` printed the ENOENT stack trace from `validate.ts:85` and exited 1.
- After: same invocation prints `• ../../.claude-plugin/plugin.json (not found, skipped)` and exits 0.
- prek probe confirmed 0.4.6 forwards an existing escaping path verbatim under the old regex and skips it (`no files to check`) under the anchored one, while in-tree paths still run.
- A new `run.test.ts` case covers the missing-path skip alongside the existing prek-check escaping-path tests.

Discovery: 9fa67b8e1c17
