### PR TITLE
settings: cut dataviz/claude-in-chrome catalog cost

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "theme": "auto",
+  "skillOverrides": {
+    "claude-in-chrome": "off",
+    "dataviz": "user-invocable-only"
+  },
   "fallbackModel": ["sonnet"],
   "cleanupPeriodDays": 90,
   "autoMode": {


### PR DESCRIPTION
Sets `skillOverrides` in `user/settings.json`: `dataviz` to `user-invocable-only`, `claude-in-chrome` to `off`.

## Evidence

Local session history over the last 2 weeks showed 0 invocations for both skills. `dataviz` carries a 1,156-character description that rode along on roughly 812 catalog injections in that window at ~16.8KB each, all with no corresponding use. `claude-in-chrome` had the same zero-use pattern.

`user-invocable-only` keeps `dataviz` reachable via the `/dataviz` slash command while dropping it from the model-visible catalog. `off` removes `claude-in-chrome` everywhere; the `/chrome` command and `--chrome` flag remain the on-demand path per the [skill visibility docs](https://code.claude.com/docs/en/skills#override-skill-visibility-from-settings).

## Verification

`bun packages/validate/settings.ts` covers `skillOverrides` against the schema, and `bun run schemas check` covers the overlay against live upstream. The upstream SchemaStore schema already defines `skillOverrides` with the four documented states, so the overlay in `schemas/overlays/settings.patch.json` is unchanged.

Verified live with `./dev.sh -p "..." --model haiku`, asking the model to list every available skill: `dataviz` and `claude-in-chrome` are both absent from the model-visible list.

The docs don't say whether `skillOverrides: off` also stops the Chrome MCP server's tools from loading. In this session, they did: with the override applied, the model reported no `mcp__claude-in-chrome__*` tools available.

Discovery: 4daa3fb821ff
