### PR TITLE
plan: read session id from hook stdin

### DIFF
--- a/plugins/plan/README.md
+++ b/plugins/plan/README.md
@@ -5,7 +5,6 @@ Planning mode guidelines and context injection for Claude Code.
 ## Contents
 
 - **Hook**: Automatically injects planning guidelines when entering plan mode (via Shift+Tab or EnterPlanMode tool)
-- **Skill**: `plan:guidelines` - Detailed planning best practices for when explicit guidance is needed
 
 ## How It Works
 

--- a/plugins/plan/scripts/context.sh
+++ b/plugins/plan/scripts/context.sh
@@ -1,14 +1,26 @@
 #!/bin/bash
-if [ -z "${CLAUDE_SESSION_ID:-}" ]; then
+input=$(cat)
+
+mode=$(printf '%s' "$input" | jq -r '.permission_mode // empty')
+if [ "$mode" != "plan" ]; then
   exit 0
 fi
 
-dir="/tmp/claude/${CLAUDE_SESSION_ID}"
-mkdir -p "$dir"
-marker="$dir/plan-injected"
+session_id=$(printf '%s' "$input" | jq -r '.session_id // empty')
+marker_root="${CLAUDE_PLAN_MARKER_ROOT:-/tmp/claude}"
 
-mode=$(jq -r '.permission_mode // empty')
-if [ "$mode" = "plan" ] && [ ! -f "$marker" ]; then
-  cat "$(dirname "$0")/../references/guidelines.md"
+marker=""
+if [ -n "$session_id" ]; then
+  dir="$marker_root/$session_id"
+  mkdir -p "$dir"
+  marker="$dir/plan-injected"
+  if [ -f "$marker" ]; then
+    exit 0
+  fi
+fi
+
+cat "$(dirname "$0")/../references/guidelines.md"
+
+if [ -n "$marker" ]; then
   touch "$marker"
 fi

--- a/plugins/plan/scripts/context.test.ts
+++ b/plugins/plan/scripts/context.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const scriptPath = join(import.meta.dirname, "context.sh");
+
+async function run(input: unknown, markerRoot: string) {
+  const proc = Bun.spawn(["bash", scriptPath], {
+    stdin: Buffer.from(JSON.stringify(input)),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, CLAUDE_PLAN_MARKER_ROOT: markerRoot },
+  });
+  const stdout = await new Response(proc.stdout).text();
+  await proc.exited;
+  return stdout;
+}
+
+describe("plan context hook", () => {
+  let markerRoot: string;
+
+  beforeEach(() => {
+    markerRoot = mkdtempSync(join(tmpdir(), "plan-context-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(markerRoot, { recursive: true, force: true });
+  });
+
+  test("injects guidelines on first plan-mode prompt", async () => {
+    const stdout = await run({ permission_mode: "plan", session_id: "t1" }, markerRoot);
+    expect(stdout).toContain("plan");
+  });
+
+  test("stays silent on non-plan mode", async () => {
+    const stdout = await run({ permission_mode: "default", session_id: "t1" }, markerRoot);
+    expect(stdout).toBe("");
+  });
+
+  test("stays silent on repeat plan-mode prompt in the same session", async () => {
+    await run({ permission_mode: "plan", session_id: "t1" }, markerRoot);
+    const stdout = await run({ permission_mode: "plan", session_id: "t1" }, markerRoot);
+    expect(stdout).toBe("");
+  });
+
+  test("re-injects for a different session id", async () => {
+    await run({ permission_mode: "plan", session_id: "t1" }, markerRoot);
+    const stdout = await run({ permission_mode: "plan", session_id: "t2" }, markerRoot);
+    expect(stdout.length).toBeGreaterThan(0);
+  });
+
+  test("injects without deduping when session_id is missing", async () => {
+    const first = await run({ permission_mode: "plan" }, markerRoot);
+    const second = await run({ permission_mode: "plan" }, markerRoot);
+    expect(first.length).toBeGreaterThan(0);
+    expect(second.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Fixes the plan plugin's `UserPromptSubmit` hook, which has never fired: 0 injections across 164 plan-mode sessions since 2026-06-01, on both machines.

`context.sh` guarded on `$CLAUDE_SESSION_ID`, but hooks don't receive that as an environment variable. The guard exited the script before the mode check ever ran, every time, confirmed by repro: setting the env var by hand makes the script print the guidelines, unsetting it reproduces the silent exit.

The session id is available in the hook's stdin JSON as `session_id`, the same payload that already supplies `permission_mode`. The fix reads stdin once, pulls both fields via `jq`, and uses `session_id` for the once-per-session marker path. When `session_id` is absent, injection still fires; only the marker dedupe is skipped, since the marker is an optimization and injection is the feature.

The marker root is now overridable via `CLAUDE_PLAN_MARKER_ROOT` (default `/tmp/claude`), which the new test uses to isolate each run.

While in the file, dropped a README line pointing at a `plan:guidelines` skill that doesn't exist in this checkout.

## Testing

Added `plugins/plan/scripts/context.test.ts`, spawning the script as a subprocess with piped stdin, covering: plan mode injects and marks, non-plan mode stays silent, a repeat prompt in the same session stays silent, a different session re-injects, and a missing `session_id` injects on every call. Also verified end-to-end by piping plan-mode, default-mode, and repeat plan-mode JSON directly into the script.

Discovery: fe89d3a5d8d3
