### PR TITLE
type-ignore: read session id from hook stdin

### DIFF
--- a/plugins/type-ignore/hooks/detect.ts
+++ b/plugins/type-ignore/hooks/detect.ts
@@ -70,16 +70,12 @@ export function findLineNumber(content: string, pattern: string): number {
   return 1;
 }
 
-function getSessionId(): string {
-  return process.env.CLAUDE_SESSION_ID || "unknown";
+function getMarkerPath(sessionId: string): string {
+  return path.join(MARKER_DIR, sessionId || "unknown");
 }
 
-function getMarkerPath(): string {
-  return path.join(MARKER_DIR, getSessionId());
-}
-
-export async function isCleanupAgentActive(): Promise<boolean> {
-  const markerPath = getMarkerPath();
+export async function isCleanupAgentActive(sessionId: string): Promise<boolean> {
+  const markerPath = getMarkerPath(sessionId);
   const file = Bun.file(markerPath);
   if (!(await file.exists())) return false;
   const age = Date.now() - file.lastModified;
@@ -90,9 +86,9 @@ export async function isCleanupAgentActive(): Promise<boolean> {
   return true;
 }
 
-async function setMarker(): Promise<void> {
+async function setMarker(sessionId: string): Promise<void> {
   mkdirSync(MARKER_DIR, { recursive: true });
-  await Bun.write(getMarkerPath(), String(Date.now()));
+  await Bun.write(getMarkerPath(sessionId), String(Date.now()));
 }
 
 export function formatOutput(
@@ -139,7 +135,7 @@ export async function processInput(
     return null;
   }
 
-  if (await isCleanupAgentActive()) {
+  if (await isCleanupAgentActive(input.session_id)) {
     return null;
   }
 
@@ -150,7 +146,7 @@ export async function processInput(
 
   const lineNumber = findLineNumber(newContent, pattern.match);
 
-  await setMarker();
+  await setMarker(input.session_id);
 
   return formatOutput(filePath, lineNumber, pattern.label);
 }

--- a/plugins/type-ignore/tests/detect.integration.ts
+++ b/plugins/type-ignore/tests/detect.integration.ts
@@ -34,17 +34,27 @@ describe("type-ignore detection hook", () => {
 
   describe("isCleanupAgentActive", () => {
     it("returns false when no marker exists", async () => {
-      expect(await isCleanupAgentActive()).toBe(false);
+      expect(await isCleanupAgentActive("test-session")).toBe(false);
     });
 
     it("returns true when recent marker exists", async () => {
-      const sessionId = process.env.CLAUDE_SESSION_ID || "unknown";
+      const sessionId = "test-session";
       const markerPath = path.join(MARKER_DIR, sessionId);
 
       mkdirSync(MARKER_DIR, { recursive: true });
       await Bun.write(markerPath, String(Date.now()));
 
-      expect(await isCleanupAgentActive()).toBe(true);
+      expect(await isCleanupAgentActive(sessionId)).toBe(true);
+    });
+
+    it("keeps markers independent across session ids", async () => {
+      const markerPath = path.join(MARKER_DIR, "session-a");
+
+      mkdirSync(MARKER_DIR, { recursive: true });
+      await Bun.write(markerPath, String(Date.now()));
+
+      expect(await isCleanupAgentActive("session-a")).toBe(true);
+      expect(await isCleanupAgentActive("session-b")).toBe(false);
     });
   });
 
@@ -102,9 +112,8 @@ describe("type-ignore detection hook", () => {
       expect(result).toBeNull();
     });
 
-    it("suppresses when cleanup agent is active", async () => {
-      const sessionId = process.env.CLAUDE_SESSION_ID || "unknown";
-      const markerPath = path.join(MARKER_DIR, sessionId);
+    it("suppresses when cleanup agent is active for the same session", async () => {
+      const markerPath = path.join(MARKER_DIR, "test-session");
 
       mkdirSync(MARKER_DIR, { recursive: true });
       await Bun.write(markerPath, String(Date.now()));
@@ -117,6 +126,22 @@ describe("type-ignore detection hook", () => {
 
       const result = await processInput(input);
       expect(result).toBeNull();
+    });
+
+    it("does not suppress when cleanup agent is active for a different session", async () => {
+      const markerPath = path.join(MARKER_DIR, "other-session");
+
+      mkdirSync(MARKER_DIR, { recursive: true });
+      await Bun.write(markerPath, String(Date.now()));
+
+      const input = mockPostToolUseInput("Edit", {
+        file_path: "/path/to/file.ts",
+        old_string: "const x = bad();",
+        new_string: "// @ts-ignore\nconst x = bad();",
+      });
+
+      const result = await processInput(input);
+      expect(result).not.toBeNull();
     });
 
     it("returns null when no new ignore added", async () => {


### PR DESCRIPTION
Hooks never receive a `CLAUDE_SESSION_ID` env var, so `getSessionId()` always fell back to `"unknown"` (confirmed while fixing the identical bug in the plan plugin, #938). The session id namespaces the cleanup-agent marker file (`getMarkerPath` → `isCleanupAgentActive`), so every concurrent session shared one marker: while one session's cleanup agent was active (within `MARKER_TTL_MS`), every other session's type-ignore detection was silently suppressed.

`detect.ts` already parses the `PostToolUse` stdin payload in `main()`, which includes `session_id` as a common hook field. `getMarkerPath`, `isCleanupAgentActive`, and `setMarker` now take `sessionId` as a parameter instead of reading the env var, and `processInput` threads `input.session_id` through. The `"unknown"` fallback stays for an empty/missing id.

## Testing

Added cases to `detect.integration.ts` cover two different session ids getting independent markers, both directly (`isCleanupAgentActive`) and through `processInput` (an active marker for one session no longer suppresses detection for another).

Discovery: b8d3ff6dc47d
