### PR TITLE
stop: only block on check failures the session caused

### DIFF
--- a/.claude/hooks/stop/baseline.test.ts
+++ b/.claude/hooks/stop/baseline.test.ts
@@ -1,0 +1,457 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type BaselineVerifier,
+  type CheckResult,
+  createVerifier,
+  evaluateStop,
+  normalizeLine,
+  parsePrekOutput,
+  readState,
+  resolveHeadAt,
+  type StopState,
+  transcriptStartTime,
+  writeState,
+} from "./baseline";
+
+let tempDir: string;
+
+beforeAll(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "stop-baseline-test-"));
+});
+
+afterAll(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+const SAMPLE_OUTPUT = `Plugin tests.............................................................Passed
+Plugin validation....................................(no files to check)Skipped
+Settings validation......................................................Failed
+- hook id: settings-validate
+- exit code: 1
+
+  user/settings.json: /sandbox: must NOT have additional properties
+Marketplace completeness.................................................Failed
+- hook id: marketplace-check
+- exit code: 1
+
+  Plugins missing from marketplace.json:
+    bogus
+`;
+
+describe("normalizeLine", () => {
+  it("strips ANSI escapes and collapses whitespace", () => {
+    const esc = String.fromCharCode(27);
+    expect(normalizeLine(`  ${esc}[31mfail${esc}[0m   here `)).toBe("fail here");
+  });
+
+  it("masks durations", () => {
+    expect(normalizeLine("Ran 3 tests. [12.34ms]")).toBe("Ran 3 tests. [<duration>]");
+    expect(normalizeLine("timed out after 5 s")).toBe("timed out after <duration>");
+  });
+});
+
+describe("parsePrekOutput", () => {
+  it("parses statuses, hook ids, and bodies", () => {
+    const results = parsePrekOutput(SAMPLE_OUTPUT);
+    expect(results.map((r) => [r.name, r.status])).toEqual([
+      ["Plugin tests", "passed"],
+      ["Plugin validation", "skipped"],
+      ["Settings validation", "failed"],
+      ["Marketplace completeness", "failed"],
+    ]);
+
+    expect(results[2]).toMatchObject({
+      id: "settings-validate",
+      raw: "user/settings.json: /sandbox: must NOT have additional properties",
+      lines: ["user/settings.json: /sandbox: must NOT have additional properties"],
+    });
+
+    expect(results[3]).toMatchObject({
+      id: "marketplace-check",
+      lines: ["Plugins missing from marketplace.json:", "bogus"],
+    });
+  });
+
+  it("returns empty for unparseable output", () => {
+    expect(parsePrekOutput("error: something exploded")).toEqual([]);
+  });
+});
+
+function check(
+  name: string,
+  status: CheckResult["status"],
+  lines: string[] = [],
+  id = name,
+): CheckResult {
+  return { name, id, status, lines, raw: lines.join("\n") };
+}
+
+function verdictOf(failed: boolean): BaselineVerifier {
+  return async (checks) => new Map(checks.map((c) => [c.name, { failed, lines: c.lines }]));
+}
+
+const noVerdict: BaselineVerifier = async () => new Map();
+
+const mustNotVerify: BaselineVerifier = () => {
+  throw new Error("verify must not be called for already-baselined checks");
+};
+
+describe("evaluateStop", () => {
+  const failure = () => check("Settings validation", "failed", ["user/settings.json: bad"]);
+
+  it("notices a pre-existing failure once without blocking", async () => {
+    const state: StopState = { checks: {} };
+
+    const first = await evaluateStop(state, [failure()], verdictOf(true));
+    expect(first?.decision).toBeUndefined();
+    expect(first?.systemMessage).toContain("Pre-existing check failure");
+    expect(first?.systemMessage).toContain("Settings validation");
+
+    const second = await evaluateStop(state, [failure()], mustNotVerify);
+    expect(second).toBeNull();
+  });
+
+  it("blocks a failure that passes at the baseline", async () => {
+    const state: StopState = { checks: {} };
+    const output = await evaluateStop(state, [failure()], verdictOf(false));
+    expect(output?.decision).toBe("block");
+    expect(output?.reason).toContain("user/settings.json: bad");
+  });
+
+  it("blocks when the baseline cannot be verified", async () => {
+    const state: StopState = { checks: {} };
+    const output = await evaluateStop(state, [failure()], noVerdict);
+    expect(output?.decision).toBe("block");
+  });
+
+  it("blocks a pre-existing failure that the session fixed and re-broke", async () => {
+    const state: StopState = { checks: {} };
+
+    const noticed = await evaluateStop(state, [failure()], verdictOf(true));
+    expect(noticed?.systemMessage).toBeDefined();
+
+    const fixed = await evaluateStop(
+      state,
+      [check("Settings validation", "passed")],
+      mustNotVerify,
+    );
+    expect(fixed).toBeNull();
+    expect(state.checks["Settings validation"]?.failed).toBe(false);
+
+    const rebroken = await evaluateStop(state, [failure()], mustNotVerify);
+    expect(rebroken?.decision).toBe("block");
+  });
+
+  it("blocks a silent failure when the baseline failure had output", async () => {
+    const state: StopState = { checks: {} };
+    await evaluateStop(state, [failure()], verdictOf(true));
+
+    const silent = check("Settings validation", "failed", []);
+    const output = await evaluateStop(state, [silent], mustNotVerify);
+    expect(output?.decision).toBe("block");
+  });
+
+  it("treats a silent failure as pre-existing when the baseline was also silent", async () => {
+    const state: StopState = { checks: {} };
+    const silent = check("Settings validation", "failed", []);
+    const output = await evaluateStop(state, [silent], verdictOf(true));
+    expect(output?.decision).toBeUndefined();
+    expect(output?.systemMessage).toContain("Pre-existing");
+  });
+
+  it("blocks when a pre-existing failure grows new output lines", async () => {
+    const state: StopState = { checks: {} };
+    await evaluateStop(state, [failure()], verdictOf(true));
+
+    const grown = check("Settings validation", "failed", [
+      "user/settings.json: bad",
+      ".claude/settings.json: also bad",
+    ]);
+    const output = await evaluateStop(state, [grown], mustNotVerify);
+    expect(output?.decision).toBe("block");
+  });
+
+  it("blocks on the new failure while noting the pre-existing one", async () => {
+    const state: StopState = { checks: {} };
+    await evaluateStop(state, [failure()], verdictOf(true));
+
+    const fresh = check("Hook tests", "failed", ["(fail) stop hook > blocks"], "hook-test");
+    const output = await evaluateStop(state, [failure(), fresh], verdictOf(false));
+    expect(output?.decision).toBe("block");
+    expect(output?.reason).toContain("Hook tests (hook-test)");
+    expect(output?.reason).toContain("(fail) stop hook > blocks");
+    expect(output?.reason).toContain("Pre-existing failures");
+    expect(output?.reason).toContain("Settings validation");
+  });
+
+  it("returns null when everything passes", async () => {
+    const state: StopState = { checks: {} };
+    const output = await evaluateStop(
+      state,
+      [check("Settings validation", "passed")],
+      mustNotVerify,
+    );
+    expect(output).toBeNull();
+  });
+});
+
+describe("state persistence", () => {
+  it("round-trips state and tolerates a corrupt file", async () => {
+    const path = join(tempDir, "state.json");
+    const state: StopState = {
+      checks: { "Settings validation": { failed: true, lines: ["x"] } },
+    };
+    await writeState(path, state);
+    expect(await readState(path)).toEqual(state);
+
+    await Bun.write(path, "not json");
+    expect(await readState(path)).toEqual({ checks: {} });
+
+    expect(await readState(join(tempDir, "missing.json"))).toEqual({ checks: {} });
+  });
+});
+
+describe("transcriptStartTime", () => {
+  it("returns the first timestamped entry", async () => {
+    const path = join(tempDir, "transcript.jsonl");
+    const lines = [
+      JSON.stringify({ type: "mode", mode: "normal" }),
+      JSON.stringify({ type: "user", timestamp: "2026-07-01T10:00:00.000Z" }),
+      JSON.stringify({ type: "assistant", timestamp: "2026-07-01T10:05:00.000Z" }),
+    ];
+    await Bun.write(path, lines.join("\n"));
+    expect(await transcriptStartTime(path)).toEqual(new Date("2026-07-01T10:00:00.000Z"));
+  });
+
+  it("returns null for a missing transcript", async () => {
+    expect(await transcriptStartTime(join(tempDir, "nope.jsonl"))).toBeNull();
+  });
+});
+
+async function git(cwd: string, args: string[], date?: string): Promise<string> {
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_DATE: date ?? "2026-01-01T00:00:00Z",
+    GIT_COMMITTER_DATE: date ?? "2026-01-01T00:00:00Z",
+    GIT_AUTHOR_NAME: "test",
+    GIT_AUTHOR_EMAIL: "test@example.com",
+    GIT_COMMITTER_NAME: "test",
+    GIT_COMMITTER_EMAIL: "test@example.com",
+  };
+  const proc = Bun.spawn(["git", ...args], { cwd, env, stdout: "pipe", stderr: "pipe" });
+  const [stdout, code] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+  if (code !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} exited ${code}: ${await new Response(proc.stderr).text()}`,
+    );
+  }
+  return stdout.trim();
+}
+
+async function createRepo(): Promise<{ repo: string; first: string; second: string }> {
+  const repo = await mkdtemp(join(tempDir, "repo-"));
+  await git(repo, ["init", "-q"]);
+  await Bun.write(join(repo, "a.txt"), "baseline\n");
+  await git(repo, ["add", "a.txt"], "2026-01-01T00:00:00Z");
+  await git(repo, ["commit", "-q", "-m", "first"], "2026-01-01T00:00:00Z");
+  const first = await git(repo, ["rev-parse", "HEAD"]);
+
+  await Bun.write(join(repo, "b.txt"), "added later\n");
+  await git(repo, ["add", "b.txt"], "2026-01-03T00:00:00Z");
+  await git(repo, ["commit", "-q", "-m", "second"], "2026-01-03T00:00:00Z");
+  const second = await git(repo, ["rev-parse", "HEAD"]);
+
+  return { repo, first, second };
+}
+
+describe("resolveHeadAt", () => {
+  it("resolves the commit HEAD pointed at when the session started", async () => {
+    const { repo, first, second } = await createRepo();
+    expect(await resolveHeadAt(repo, new Date("2026-01-02T00:00:00Z"))).toBe(first);
+    expect(await resolveHeadAt(repo, new Date("2026-01-04T00:00:00Z"))).toBe(second);
+  });
+
+  it("dates a checkout of an old commit by when HEAD moved there", async () => {
+    const { repo, first, second } = await createRepo();
+    await git(repo, ["checkout", "-q", first], "2026-01-05T00:00:00Z");
+
+    expect(await resolveHeadAt(repo, new Date("2026-01-04T00:00:00Z"))).toBe(second);
+    expect(await resolveHeadAt(repo, new Date("2026-01-06T00:00:00Z"))).toBe(first);
+  });
+
+  it("returns null when the session predates the reflog", async () => {
+    const { repo } = await createRepo();
+    expect(await resolveHeadAt(repo, new Date("2020-01-01T00:00:00Z"))).toBeNull();
+  });
+
+  it("returns null outside a git repository", async () => {
+    const dir = await mkdtemp(join(tempDir, "not-a-repo-"));
+    expect(await resolveHeadAt(dir, new Date())).toBeNull();
+  });
+});
+
+describe("createVerifier", () => {
+  it("runs checks in a worktree at the session baseline and cleans up", async () => {
+    const { repo, second } = await createRepo();
+
+    const transcript = join(tempDir, "verifier-transcript.jsonl");
+    await Bun.write(
+      transcript,
+      JSON.stringify({ type: "user", timestamp: "2026-01-02T00:00:00Z" }),
+    );
+
+    let seen: { worktree: string; ids: string[]; files: string[]; hadLater: boolean } | undefined;
+    const verify = createVerifier({
+      cwd: repo,
+      transcriptPath: transcript,
+      files: ["a.txt", "b.txt"],
+      runChecks: async (worktree, ids, files) => {
+        seen = {
+          worktree,
+          ids,
+          files,
+          hadLater: await Bun.file(join(worktree, "b.txt")).exists(),
+        };
+        return [
+          "Settings validation......................................................Failed",
+          "- hook id: settings-validate",
+          "- exit code: 1",
+          "",
+          "  user/settings.json: bad",
+          "",
+        ].join("\n");
+      },
+    });
+
+    const verdicts = await verify([
+      check("Settings validation", "failed", [], "settings-validate"),
+    ]);
+
+    expect(seen).toBeDefined();
+    expect(seen?.ids).toEqual(["settings-validate"]);
+    expect(seen?.files).toEqual(["a.txt"]);
+    expect(seen?.hadLater).toBe(false);
+    expect(verdicts.get("Settings validation")).toEqual({
+      failed: true,
+      lines: ["user/settings.json: bad"],
+    });
+
+    expect(seen ? await Bun.file(join(seen.worktree, "a.txt")).exists() : true).toBe(false);
+    expect(await resolveHeadAt(repo, new Date("2026-01-04T00:00:00Z"))).toBe(second);
+  });
+
+  it("rewrites the worktree path to the session cwd in check output", async () => {
+    const { repo } = await createRepo();
+    const transcript = join(tempDir, "mask-transcript.jsonl");
+    await Bun.write(
+      transcript,
+      JSON.stringify({ type: "user", timestamp: "2026-01-02T00:00:00Z" }),
+    );
+
+    const verify = createVerifier({
+      cwd: repo,
+      transcriptPath: transcript,
+      files: ["a.txt"],
+      runChecks: async (worktree) =>
+        [
+          "Settings validation......................................................Failed",
+          "- hook id: settings-validate",
+          `  ${join(worktree, "a.txt")}: bad`,
+        ].join("\n"),
+    });
+
+    const verdicts = await verify([
+      check("Settings validation", "failed", [], "settings-validate"),
+    ]);
+    expect(verdicts.get("Settings validation")?.lines).toEqual([`${join(repo, "a.txt")}: bad`]);
+  });
+
+  it("skips checks without a parsed hook id", async () => {
+    const { repo } = await createRepo();
+    const transcript = join(tempDir, "no-id-transcript.jsonl");
+    await Bun.write(
+      transcript,
+      JSON.stringify({ type: "user", timestamp: "2026-01-02T00:00:00Z" }),
+    );
+
+    const verify = createVerifier({
+      cwd: repo,
+      transcriptPath: transcript,
+      files: ["a.txt"],
+      runChecks: async () => {
+        throw new Error("must not run checks without hook ids");
+      },
+    });
+
+    const anonymous: CheckResult = {
+      name: "Settings validation",
+      status: "failed",
+      lines: [],
+      raw: "",
+    };
+    expect((await verify([anonymous])).size).toBe(0);
+  });
+
+  it("removes worktrees leaked by an earlier verification", async () => {
+    const { repo } = await createRepo();
+    const stale = join(repo, "tmp", "stop-baseline-stale");
+    await git(repo, ["worktree", "add", "--detach", stale]);
+    expect(await Bun.file(join(stale, "a.txt")).exists()).toBe(true);
+
+    const transcript = join(tempDir, "stale-transcript.jsonl");
+    await Bun.write(
+      transcript,
+      JSON.stringify({ type: "user", timestamp: "2026-01-02T00:00:00Z" }),
+    );
+
+    const verify = createVerifier({
+      cwd: repo,
+      transcriptPath: transcript,
+      files: ["a.txt"],
+      runChecks: async () => "",
+    });
+    await verify([check("Settings validation", "failed", [], "settings-validate")]);
+
+    expect(await Bun.file(join(stale, "a.txt")).exists()).toBe(false);
+  });
+
+  it("returns no verdicts when the transcript has no timestamp", async () => {
+    const { repo } = await createRepo();
+    const transcript = join(tempDir, "empty-transcript.jsonl");
+    await Bun.write(transcript, JSON.stringify({ type: "mode" }));
+
+    const verify = createVerifier({
+      cwd: repo,
+      transcriptPath: transcript,
+      files: ["a.txt"],
+      runChecks: async () => {
+        throw new Error("must not run checks without a baseline");
+      },
+    });
+
+    expect((await verify([check("Settings validation", "failed")])).size).toBe(0);
+  });
+
+  it("returns no verdicts when no session file exists at the baseline", async () => {
+    const { repo } = await createRepo();
+    const transcript = join(tempDir, "new-files-transcript.jsonl");
+    await Bun.write(
+      transcript,
+      JSON.stringify({ type: "user", timestamp: "2026-01-02T00:00:00Z" }),
+    );
+
+    const verify = createVerifier({
+      cwd: repo,
+      transcriptPath: transcript,
+      files: ["b.txt"],
+      runChecks: async () => {
+        throw new Error("must not run checks on files missing from the baseline");
+      },
+    });
+
+    expect((await verify([check("Settings validation", "failed")])).size).toBe(0);
+  });
+});

--- a/.claude/hooks/stop/baseline.ts
+++ b/.claude/hooks/stop/baseline.ts
@@ -1,0 +1,355 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+
+const execFileAsync = promisify(execFile);
+const VERIFY_TIMEOUT = 60_000;
+
+const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+const SECTION_HEADER = /^(.+?)\.{3,}(?:\(.+?\))?(Passed|Failed|Skipped)$/;
+const HOOK_ID = /^- hook id: (.+)$/;
+const SECTION_META = /^- (?:exit code|duration): /;
+
+export interface CheckResult {
+  name: string;
+  id?: string;
+  status: "passed" | "failed" | "skipped";
+  /** Normalized output lines, used for baseline comparison. */
+  lines: string[];
+  /** Raw section body, used for display. */
+  raw: string;
+}
+
+export interface BaselineEntry {
+  /** Whether the check failed on the session's baseline commit. */
+  failed: boolean;
+  /** Normalized failure lines observed at the baseline. */
+  lines: string[];
+  /** Whether the pre-existing failure has already been surfaced to the user. */
+  notified?: boolean;
+}
+
+export interface StopState {
+  checks: Record<string, BaselineEntry>;
+}
+
+export type BaselineVerdict = Pick<BaselineEntry, "failed" | "lines">;
+
+export type BaselineVerifier = (checks: CheckResult[]) => Promise<Map<string, BaselineVerdict>>;
+
+export function normalizeLine(line: string): string {
+  return line
+    .replace(ANSI, "")
+    .replace(/\b\d+(?:\.\d+)?\s*m?s\b/g, "<duration>")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function parsePrekOutput(output: string): CheckResult[] {
+  const results: CheckResult[] = [];
+  let body: string[] = [];
+
+  for (const rawLine of output.split("\n")) {
+    const line = rawLine.replace(ANSI, "").replace(/\r$/, "");
+    const header = line.match(SECTION_HEADER);
+    if (header?.[1] !== undefined && header[2] !== undefined) {
+      results.push({
+        name: header[1].trim(),
+        status: header[2].toLowerCase() as CheckResult["status"],
+        lines: [],
+        raw: "",
+      });
+      body = [];
+      continue;
+    }
+    const current = results.at(-1);
+    if (!current) continue;
+
+    const id = line.match(HOOK_ID)?.[1];
+    if (id !== undefined) {
+      current.id = id.trim();
+      continue;
+    }
+    if (SECTION_META.test(line)) continue;
+    body.push(line);
+    current.raw = body.join("\n").trim();
+    current.lines = body.map(normalizeLine).filter((normalized) => normalized !== "");
+  }
+
+  return results;
+}
+
+function label(check: CheckResult): string {
+  return check.id ? `${check.name} (${check.id})` : check.name;
+}
+
+/**
+ * Applies one prek run to the session baseline and decides the hook outcome.
+ * Mutates `state`; the caller persists it.
+ *
+ * - A check passing tombstones its baseline entry: once the session has seen
+ *   it pass, any later failure is the session's to fix.
+ * - A failing check without a baseline entry is verified against the
+ *   session's baseline commit via `verify`. No verdict means "could not
+ *   verify", which is treated as a new failure (the status quo: block).
+ * - A failure is pre-existing only if the check failed at the baseline and
+ *   every normalized output line was already present there.
+ */
+export async function evaluateStop(
+  state: StopState,
+  results: CheckResult[],
+  verify: BaselineVerifier,
+): Promise<SyncHookJSONOutput | null> {
+  for (const result of results) {
+    const entry = state.checks[result.name];
+    if (result.status === "passed" && entry?.failed) {
+      entry.failed = false;
+      entry.lines = [];
+    }
+  }
+
+  const failed = results.filter((result) => result.status === "failed");
+  if (failed.length === 0) return null;
+
+  const unverified = failed.filter((result) => !(result.name in state.checks));
+  if (unverified.length > 0) {
+    const verdicts = await verify(unverified);
+    for (const result of unverified) {
+      const verdict = verdicts.get(result.name);
+      state.checks[result.name] = {
+        failed: verdict?.failed ?? false,
+        lines: verdict?.lines ?? [],
+      };
+    }
+  }
+
+  const preexisting: CheckResult[] = [];
+  const fresh: CheckResult[] = [];
+  for (const result of failed) {
+    const entry = state.checks[result.name];
+    // A silent failure (no output lines) matches only a silent baseline
+    // failure; [].every() alone would cover it vacuously.
+    const covered =
+      entry?.failed &&
+      (result.lines.length > 0
+        ? result.lines.every((line) => entry.lines.includes(line))
+        : entry.lines.length === 0);
+    (covered ? preexisting : fresh).push(result);
+  }
+
+  const markNotified = (result: CheckResult) => {
+    const entry = state.checks[result.name];
+    if (entry) entry.notified = true;
+  };
+
+  if (fresh.length > 0) {
+    for (const result of preexisting) {
+      markNotified(result);
+    }
+    const sections = fresh
+      .map((result) =>
+        result.raw ? `${label(result)}:\n${result.raw}` : `${label(result)} failed`,
+      )
+      .join("\n\n");
+    const note =
+      preexisting.length > 0
+        ? `\n\nPre-existing failures, not caused by this session (not blocking): ${preexisting.map(label).join(", ")}`
+        : "";
+    return {
+      decision: "block",
+      reason: `Check failures:\n\n${sections}${note}`,
+    };
+  }
+
+  const unnotified = preexisting.filter((result) => !state.checks[result.name]?.notified);
+  for (const result of unnotified) {
+    markNotified(result);
+  }
+  if (unnotified.length === 0) return null;
+
+  return {
+    systemMessage: `Pre-existing check failure${unnotified.length > 1 ? "s" : ""}, not caused by this session (not blocking): ${unnotified.map(label).join(", ")}`,
+  };
+}
+
+/**
+ * State is scoped to the session AND the working directory: a session
+ * re-rooted into a different worktree must not carry baselines recorded
+ * against another checkout.
+ */
+export function stateFilePath(sessionId: string, cwd: string): string {
+  const safe = sessionId.replace(/[^A-Za-z0-9-]/g, "-");
+  const dir = createHash("sha256").update(cwd).digest("hex").slice(0, 12);
+  return join(tmpdir(), `claude-stop-baseline-${safe}-${dir}.json`);
+}
+
+export async function readState(path: string): Promise<StopState> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) return { checks: {} };
+  try {
+    const parsed = (await file.json()) as StopState;
+    if (parsed && typeof parsed.checks === "object" && parsed.checks !== null) {
+      return parsed;
+    }
+  } catch {}
+  return { checks: {} };
+}
+
+export async function writeState(path: string, state: StopState): Promise<void> {
+  await Bun.write(path, JSON.stringify(state));
+}
+
+export async function transcriptStartTime(transcriptPath: string): Promise<Date | null> {
+  const file = Bun.file(transcriptPath);
+  if (!(await file.exists())) return null;
+
+  for (const line of (await file.text()).split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line) as { timestamp?: string };
+      if (entry.timestamp) {
+        const parsed = new Date(entry.timestamp);
+        if (!Number.isNaN(parsed.getTime())) return parsed;
+      }
+    } catch {}
+  }
+  return null;
+}
+
+const REFLOG_ENTRY = /^([0-9a-f]+) HEAD@\{(\d+)\}$/;
+
+/**
+ * Resolves what HEAD pointed at when the session started, via the HEAD
+ * reflog. %gd with --date=unix carries the time the ref moved; commit
+ * timestamps (%ct) would misdate checkouts of older commits.
+ */
+export async function resolveHeadAt(cwd: string, startedAt: Date): Promise<string | null> {
+  const cutoff = Math.floor(startedAt.getTime() / 1000);
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["log", "-g", "--date=unix", "--format=%H %gd", "HEAD"],
+      { cwd },
+    );
+    for (const line of stdout.split("\n")) {
+      const entry = line.trim().match(REFLOG_ENTRY);
+      if (entry?.[1] !== undefined && Number(entry[2]) <= cutoff) return entry[1];
+    }
+  } catch {}
+  return null;
+}
+
+async function runChecksInWorktree(
+  worktree: string,
+  ids: string[],
+  files: string[],
+): Promise<string> {
+  try {
+    await execFileAsync("bun", ["install", "--frozen-lockfile", "--cwd", worktree], {
+      timeout: VERIFY_TIMEOUT,
+    });
+  } catch {}
+
+  try {
+    const { stdout, stderr } = await execFileAsync("prek", ["run", ...ids, "--files", ...files], {
+      cwd: worktree,
+      timeout: VERIFY_TIMEOUT,
+    });
+    return stdout + stderr;
+  } catch (error) {
+    const execError = error as { stdout?: string; stderr?: string };
+    return (execError.stdout ?? "") + (execError.stderr ?? "");
+  }
+}
+
+export interface VerifierOptions {
+  cwd: string;
+  transcriptPath: string;
+  /** Session-edited files, relative to cwd (the same list passed to prek). */
+  files: string[];
+  runChecks?: typeof runChecksInWorktree;
+}
+
+const WORKTREE_PREFIX = "stop-baseline-";
+
+/** Removes worktrees leaked by a prior verification the platform killed mid-run. */
+async function removeStaleWorktrees(cwd: string): Promise<void> {
+  let names: string[];
+  try {
+    names = readdirSync(join(cwd, "tmp"));
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    if (!name.startsWith(WORKTREE_PREFIX)) continue;
+    await execFileAsync("git", ["worktree", "remove", "--force", join(cwd, "tmp", name)], {
+      cwd,
+    }).catch(() => {});
+  }
+}
+
+/**
+ * Verifies failing checks against the session's baseline: checks out the
+ * commit HEAD pointed at when the session started into a disposable worktree
+ * under tmp/ and re-runs just those checks there, scoped to the session files
+ * that exist at the baseline. Any failure to verify yields no verdict, which
+ * `evaluateStop` treats as a new failure. Checks without a parsed hook id are
+ * never verified: prek selects hooks by id, and passing a display name would
+ * error the whole run.
+ */
+export function createVerifier(options: VerifierOptions): BaselineVerifier {
+  const { cwd, transcriptPath, files, runChecks = runChecksInWorktree } = options;
+
+  return async (checks) => {
+    const verdicts = new Map<string, BaselineVerdict>();
+
+    const identified = checks.filter(
+      (check): check is CheckResult & { id: string } => check.id !== undefined,
+    );
+    if (identified.length === 0) return verdicts;
+
+    const startedAt = await transcriptStartTime(transcriptPath);
+    if (!startedAt) return verdicts;
+    const ref = await resolveHeadAt(cwd, startedAt);
+    if (!ref) return verdicts;
+
+    await removeStaleWorktrees(cwd);
+    const worktree = join(cwd, "tmp", `${WORKTREE_PREFIX}${process.pid}-${Date.now()}`);
+    try {
+      await execFileAsync("git", ["worktree", "add", "--detach", worktree, ref], { cwd });
+    } catch {
+      return verdicts;
+    }
+
+    try {
+      const present: string[] = [];
+      for (const file of files) {
+        if (await Bun.file(join(worktree, file)).exists()) present.push(file);
+      }
+      if (present.length === 0) return verdicts;
+
+      const ids = identified.map((check) => check.id);
+      // Baseline checks run under the worktree path; rewrite it to the
+      // session cwd so path-bearing output lines compare equal.
+      const output = (await runChecks(worktree, ids, present)).replaceAll(worktree, cwd);
+      for (const result of parsePrekOutput(output)) {
+        const match = identified.find(
+          (check) => check.id === result.id || check.name === result.name,
+        );
+        if (!match) continue;
+        verdicts.set(match.name, { failed: result.status === "failed", lines: result.lines });
+      }
+    } catch {
+    } finally {
+      await execFileAsync("git", ["worktree", "remove", "--force", worktree], { cwd }).catch(
+        () => {},
+      );
+    }
+
+    return verdicts;
+  };
+}

--- a/.claude/hooks/stop/index.test.ts
+++ b/.claude/hooks/stop/index.test.ts
@@ -3,7 +3,8 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { StopHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { parseTranscript, processStop, scopePaths } from ".";
+import { type PrekOutcome, parseTranscript, processStop, scopePaths } from ".";
+import type { BaselineVerifier } from "./baseline";
 
 let tempDir: string;
 
@@ -154,6 +155,97 @@ describe("processStop", () => {
     };
 
     expect(await processStop(input)).toBeNull();
+  });
+
+  it("tracks a pre-existing failure across the session: notice, prune on fix, block on re-break", async () => {
+    const filePath = join(tempDir, "flow", "edited.ts");
+    await Bun.write(filePath, "export {}");
+
+    const transcriptPath = join(tempDir, "transcript-flow.jsonl");
+    await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Edit" }]));
+
+    const input: StopHookInput = {
+      hook_event_name: "Stop",
+      session_id: "flow-test",
+      transcript_path: transcriptPath,
+      cwd: join(tempDir, "flow"),
+      stop_hook_active: false,
+      permission_mode: "default",
+    };
+
+    const failedOutput = [
+      "Settings validation......................................................Failed",
+      "- hook id: settings-validate",
+      "- exit code: 1",
+      "",
+      "  user/settings.json: /sandbox: must NOT have additional properties",
+      "",
+    ].join("\n");
+    const passedOutput =
+      "Settings validation......................................................Passed\n";
+
+    const statePath = join(tempDir, "flow-state.json");
+    const failsAtBaseline: BaselineVerifier = async (checks) =>
+      new Map(checks.map((c) => [c.name, { failed: true, lines: c.lines }]));
+    const mustNotVerify: BaselineVerifier = () => {
+      throw new Error("verify must not be called");
+    };
+    const run = (outcome: PrekOutcome) => async () => outcome;
+    const failing = run({ ok: false, output: failedOutput });
+    const passing = run({ ok: true, output: passedOutput });
+
+    const noticed = await processStop(input, {
+      runPrek: failing,
+      verify: failsAtBaseline,
+      statePath,
+    });
+    expect(noticed?.decision).toBeUndefined();
+    expect(noticed?.systemMessage).toContain("Pre-existing check failure");
+
+    const repeat = await processStop(input, {
+      runPrek: failing,
+      verify: mustNotVerify,
+      statePath,
+    });
+    expect(repeat).toBeNull();
+
+    const fixed = await processStop(input, {
+      runPrek: passing,
+      verify: mustNotVerify,
+      statePath,
+    });
+    expect(fixed).toBeNull();
+
+    const rebroken = await processStop(input, {
+      runPrek: failing,
+      verify: mustNotVerify,
+      statePath,
+    });
+    expect(rebroken?.decision).toBe("block");
+    expect(rebroken?.reason).toContain("must NOT have additional properties");
+  });
+
+  it("blocks with raw output when prek fails without parseable check sections", async () => {
+    const filePath = join(tempDir, "raw", "edited.ts");
+    await Bun.write(filePath, "export {}");
+
+    const transcriptPath = join(tempDir, "transcript-raw.jsonl");
+    await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Edit" }]));
+
+    const input: StopHookInput = {
+      hook_event_name: "Stop",
+      session_id: "raw-test",
+      transcript_path: transcriptPath,
+      cwd: join(tempDir, "raw"),
+      stop_hook_active: false,
+      permission_mode: "default",
+    };
+
+    const output = await processStop(input, {
+      runPrek: async () => ({ ok: false, output: "error: config is broken" }),
+    });
+    expect(output?.decision).toBe("block");
+    expect(output?.reason).toContain("error: config is broken");
   });
 
   it("returns null when every collected file is out-of-tree", async () => {

--- a/.claude/hooks/stop/index.ts
+++ b/.claude/hooks/stop/index.ts
@@ -5,6 +5,15 @@ import { isAbsolute, relative, sep } from "node:path";
 import { promisify } from "node:util";
 import type { StopHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import {
+  type BaselineVerifier,
+  createVerifier,
+  evaluateStop,
+  parsePrekOutput,
+  readState,
+  stateFilePath,
+  writeState,
+} from "./baseline";
 
 const execFileAsync = promisify(execFile);
 const PREK_TIMEOUT = 120_000;
@@ -73,7 +82,45 @@ export function scopePaths(files: string[], cwd: string): string[] {
   return scoped;
 }
 
-export async function processStop(input: StopHookInput): Promise<SyncHookJSONOutput | null> {
+export interface PrekOutcome {
+  ok: boolean;
+  output: string;
+  errorKind?: "enoent" | "timeout";
+}
+
+async function runPrek(cwd: string, files: string[]): Promise<PrekOutcome> {
+  try {
+    await execFileAsync("bun", ["install", "--cwd", cwd]);
+    const { stdout, stderr } = await execFileAsync("prek", ["run", "--files", ...files], {
+      cwd,
+      timeout: PREK_TIMEOUT,
+    });
+    return { ok: true, output: stdout + stderr };
+  } catch (error) {
+    const execError = error as {
+      code?: string;
+      killed?: boolean;
+      stdout?: string;
+      stderr?: string;
+    };
+    const output = ((execError.stdout || "") + (execError.stderr || "")).trim();
+
+    if (execError.code === "ENOENT") return { ok: false, output, errorKind: "enoent" };
+    if (execError.killed) return { ok: false, output, errorKind: "timeout" };
+    return { ok: false, output: output || (error as Error).message };
+  }
+}
+
+export interface StopDeps {
+  runPrek?: typeof runPrek;
+  verify?: BaselineVerifier;
+  statePath?: string;
+}
+
+export async function processStop(
+  input: StopHookInput,
+  deps: StopDeps = {},
+): Promise<SyncHookJSONOutput | null> {
   if (input.stop_hook_active) {
     return null;
   }
@@ -92,36 +139,40 @@ export async function processStop(input: StopHookInput): Promise<SyncHookJSONOut
     return null;
   }
 
-  try {
-    await execFileAsync("bun", ["install", "--cwd", input.cwd]);
-    await execFileAsync("prek", ["run", "--files", ...relativePaths], {
-      cwd: input.cwd,
-      timeout: PREK_TIMEOUT,
-    });
-    return null;
-  } catch (error) {
-    const execError = error as {
-      code?: string;
-      killed?: boolean;
-      stdout?: string;
-      stderr?: string;
-    };
-    const output = ((execError.stdout || "") + (execError.stderr || "")).trim();
+  const outcome = await (deps.runPrek ?? runPrek)(input.cwd, relativePaths);
 
-    let context: string;
-    if (execError.code === "ENOENT") {
-      context = "prek is not installed or not in PATH";
-    } else if (execError.killed) {
-      context = `Checks timed out after ${PREK_TIMEOUT / 1000}s. Partial output:\n\n${output}`;
-    } else {
-      context = `Check failures:\n\n${output || (error as Error).message}`;
-    }
-
+  if (outcome.errorKind === "enoent") {
+    return { decision: "block", reason: "prek is not installed or not in PATH" };
+  }
+  if (outcome.errorKind === "timeout") {
     return {
       decision: "block",
-      reason: context,
+      reason: `Checks timed out after ${PREK_TIMEOUT / 1000}s. Partial output:\n\n${outcome.output}`,
     };
   }
+
+  const results = parsePrekOutput(outcome.output);
+  if (!outcome.ok && !results.some((result) => result.status === "failed")) {
+    return { decision: "block", reason: `Check failures:\n\n${outcome.output}` };
+  }
+
+  const statePath = deps.statePath ?? stateFilePath(input.session_id, input.cwd);
+  const state = await readState(statePath);
+  const before = JSON.stringify(state);
+  const verify =
+    deps.verify ??
+    createVerifier({
+      cwd: input.cwd,
+      transcriptPath: input.transcript_path,
+      files: relativePaths,
+    });
+
+  const output = await evaluateStop(state, results, verify);
+  if (JSON.stringify(state) !== before) {
+    // A failed state write must not discard the decision.
+    await writeState(statePath, state).catch(() => {});
+  }
+  return output;
 }
 
 async function main(): Promise<void> {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -79,7 +79,8 @@
           },
           {
             "type": "command",
-            "command": "PREK_HOME=\"$CLAUDE_PROJECT_DIR/.prek\" bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop\""
+            "command": "PREK_HOME=\"$CLAUDE_PROJECT_DIR/.prek\" bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop\"",
+            "timeout": 300
           }
         ]
       }


### PR DESCRIPTION
The Stop gate blocks on any prek failure, including repo-wide failures the session did not cause. When `settings-validate` broke against a live upstream schema change, every session that touched a settings file got halted, repeatedly, for days (#860/#869 fixed that instance; a second case hit on 06-24 with `/teammateMode`). This PR classifies each failing check against the session's baseline and stops punishing sessions for failures that predate them.

## Design

#### Baseline Capture

Lazy, per check, at the first Stop where that check fails. There is no SessionStart hook and no always-on cost: the pass path adds only a state-file read and a parse of prek's output. When a failing check has no baseline entry yet, the hook resolves the commit HEAD pointed at when the session started, checks it out into a disposable worktree under `tmp/`, re-runs just the failing checks there (scoped to the session files that exist at that commit), and records the verdict.

#### Failure Signature

Check id plus normalized output lines. Normalization strips ANSI, masks durations, and collapses whitespace. A failure is pre-existing only if the check failed at the baseline and every current output line already appeared there, so a pre-existing failure that grows a new error line still blocks. A failure with no output lines matches only a baseline failure that was also silent, since `[].every()` would otherwise cover it vacuously. The verifier rewrites the worktree path to the session cwd before parsing so path-bearing output compares equal.

#### Staleness

Two mechanisms keep a mid-session capture from whitelisting session breakage. The baseline is keyed to git state: HEAD-at-session-start comes from the HEAD reflog (`--date=unix` entry times, which date checkouts by when the ref moved) compared against the transcript's first timestamp, so session commits made before the first Stop are excluded from the baseline checkout. And a check that passes on a later Stop is tombstoned: the session has seen it green, so re-breaking it blocks.

#### Failure Posture

Every verification error (no reflog entry before session start, missing transcript timestamp, worktree add failure, unparseable output, a check without a parsed hook id) yields no verdict, which classifies the failure as new and blocks. The status quo is the fallback in all uncertain paths. Pre-existing failures surface once per session as a non-blocking `systemMessage` and are silent after that.

#### Known Limits

Pre-session uncommitted changes are absent from the baseline checkout, so failures living only in them block as before. Duration masking can equate two failures that differ only in a timing value. A session that fixes and re-breaks a check within one turn produces the same signature as the baseline and passes; the required fixed-then-rebroken case across Stops blocks via the tombstone.

## Review

Ran the code-review skill at medium effort. Fixed from its findings: reflog `%ct` misdating checkouts of old commits (now `%gd --date=unix`), the vacuous empty-output subset, id-less checks poisoning the `prek run` selector, worktree path leakage breaking line comparison, stale worktrees leaked by a killed hook (swept on the next verification), state carried across a session re-rooted into another worktree (state file now keyed by session id and cwd), and an unguarded state write that could throw away a block decision. Added an explicit 300s timeout to the Stop hook entry since the failure path now includes a worktree checkout and the platform default is 60s. Accepted without change: the unconditional `bun install` on the pass path (pre-existing behavior) and blocking when reflog resolution fails for resumed sessions in fresh worktrees (conservative direction).

## Evidence

Local host only. Between 2026-06-18 and 06-24, `settings-validate` failed repo-wide (`user/settings.json: /sandbox: must NOT have additional properties`, schema lagging a live upstream key) and blocked Stop 9-11 times across 4-6 sessions over 6 days. One session was blocked 5 times in 26 minutes. Every other check in those runs passed or skipped, and no block in the window was retried away to success within 300s, so each block was a hard halt on a failure the session could not have caused.

## Testing

Added tests covering the required scenarios at the `evaluateStop` layer and end-to-end through `processStop` with injected prek/verifier/state deps: pre-existing failure notices once without blocking and stays silent after, new failure blocks, pre-existing then fixed then re-broken blocks, mixed new plus pre-existing blocks on the new check while noting the other. Verifier tests run against real scratch git repos: worktree created at the resolved baseline ref, session-created files filtered out, path rewriting, id-less skip, leaked-worktree sweep, and cleanup. Reflog resolution has a regression test for the checkout-of-old-commit case. Also exercised the real hook against this worktree: a passing run stays silent and a fabricated new failure blocks with verification running in a real baseline worktree, leaving no leftover worktrees.

Discovery: 83ab08f815d3

https://claude.ai/code/session_01LmBorNSEbodhWp4ndghgjy
