### PR TITLE
session: detect configured hooks that never fire

### DIFF
--- a/plugins/claude-code/skills/session/SKILL.md
+++ b/plugins/claude-code/skills/session/SKILL.md
@@ -100,6 +100,7 @@ Every query also takes an optional `host` param. Omit it to span every machine (
 - `skill-auto-vs-explicit`: per skill, model-auto (empty args) vs explicit/slash invocations, the core `disable-model-invocation` lever. Params: `min_calls` (default 1), `after_date`, `before_date`, `project`, `host`.
 - `sandbox-bypass-effective-command`: top `dangerouslyDisableSandbox` commands normalized to their real verb after stripping a leading `cd <path>` wrapper (`excludedCommands` candidates). Params: `min_count` (default 5), `after_date`, `before_date`, `project`, `host`.
 - `plans`: sessions that used plan mode (ExitPlanMode), with per-session plan count, redirect/approved breakdown, and a `replan_tier` label (`single` / `replan` / `off-rails` for plan_count >= 3). Sorted by plan_count descending. Params: `min_plans` (default 1), `after_date`, `before_date`, `project`, `host`.
+- `hook-config-vs-observed`: hooks CONFIGURED on disk (plugin `hooks.json`, `~/.claude/settings.json`, `.claude/settings.json`) left-joined against DISTINCT hooks OBSERVED in `hook_events`, surfacing `observed_fires = 0` rows: hooks that never left a trace, the blind spot every other hook query misses because a silently-succeeding hook produces no event at all. Params: `after_date`, `before_date`, `project`, `host` (scopes the observed side only), `hook` (glob on configured command), `hook_config_glob` (override the plugin-cache glob).
 
 ### Markdown and YAML on Disk
 

--- a/plugins/claude-code/skills/session/references/discovery.md
+++ b/plugins/claude-code/skills/session/references/discovery.md
@@ -19,6 +19,7 @@ Each dimension maps to the named queries that answer it (Tier-1 listed in `SKILL
 |-----------|---------------|-----------------|
 | Hook latency | `hook-origin-split` | `hooks` |
 | Hook blocks | `hook-block-then-retry-success` | `hook-blocks`, `hooks` |
+| Hook coverage | `hook-config-vs-observed` | `hooks` |
 | Permissions and sandbox | `sandbox-bypass-effective-command`, `already-allowed-still-prompting`, `sandbox-path-deny-recurrence` | `permissions`, `sandbox` |
 | Context tax | `catalog-reinjection-thrash-sessions` | `activity`, `hooks` (additionalContext) |
 | Tokens | `repeat-read-waste`, `top-sessions-by-output` | `stats`, `model-summary`, `skill-activity` |

--- a/plugins/claude-code/skills/session/resources/queries/hook-config-vs-observed.sql
+++ b/plugins/claude-code/skills/session/resources/queries/hook-config-vs-observed.sql
@@ -1,0 +1,133 @@
+-- Hooks that are CONFIGURED on disk but never OBSERVED firing in the session index.
+-- hooks.sql / hook-blocks.sql / stop-hook-noop-detector.sql all start from hook_events,
+-- which only gets a row when a hook produces stdout, a decision, or a non-zero exit. A
+-- hook that silently exits 0 on every invocation (an env-var guard gone stale, a broken
+-- path) leaves NO row at all, so those queries are blind to it: they mine what fired,
+-- never what should have fired. This query starts from disk config instead.
+--
+-- Configured side, read from local disk (not the index):
+--   1. Plugin hooks.json under the plugin cache. Content is duplicated across
+--      version-hash directories for the same plugin (same duplication frontmatter.sql
+--      documents for SKILL.md); pinned to one hash per plugin via QUALIFY row_number(),
+--      picking arbitrarily since the copies are byte-identical for the installed
+--      version.
+--   2. ~/.claude/settings.json (this machine's user-level hook config).
+--   3. .claude/settings.json relative to the invoking cwd (project-level hook config).
+-- Both settings paths are fixed, not globbed: point duckdb's cwd at the project you want
+-- scoped before running this query. Like plan-sections.sql and frontmatter.sql, a
+-- missing file at a fixed path errors rather than returning zero rows (a DuckDB
+-- read_json_objects limitation, not something this query works around); override
+-- hook_config_glob for the plugin-cache source if needed.
+--
+-- Matching a configured command to hook_events.command is heuristic: both sides may or
+-- may not have ${CLAUDE_PLUGIN_ROOT}/$CLAUDE_PROJECT_DIR expanded, and observed strings
+-- can carry a wrapping interpreter (`bun "..."`) or trailing args. match_key resolves,
+-- in order: the basename of the last path segment ending in a known script extension
+-- (sandbox.ts, context.sh, ...), else the last slash-delimited path segment when the
+-- command's final token is a bare path (`bun ~/.claude/hooks/worktree`), else the
+-- trimmed command text verbatim (inline one-liners like `make test-unit`). False-match
+-- risk: two different plugins' scripts sharing a basename collapse into one row.
+-- False-negative risk: a configured command with no extension, no bare trailing path,
+-- and a verbatim mismatch against its observed form (e.g. an alias or wrapper) reports
+-- as unobserved when it actually ran.
+--
+-- A 0 in observed_fires is a lead, not proof of breakage: a conditional injector that
+-- legitimately produces no output on most events looks identical here to a hook that
+-- never runs at all. Read the script before treating a 0 as a bug.
+--
+-- Params: after_date, before_date, project, host (scopes the OBSERVED side only; the
+-- configured side always reflects this machine's current disk state, so pass
+-- host='local' when grounding a finding rather than trusting another host's fire count),
+-- hook (GLOB on configured command), hook_config_glob (override the plugin-cache glob).
+WITH raw_configs AS (
+  SELECT
+    'plugin:' || regexp_extract(filename, 'cache/([^/]+)/([^/]+)/([^/]+)/hooks/hooks\.json$', 1)
+      || '/' || regexp_extract(filename, 'cache/([^/]+)/([^/]+)/([^/]+)/hooks/hooks\.json$', 2) AS source,
+    regexp_extract(filename, 'cache/([^/]+)/([^/]+)/([^/]+)/hooks/hooks\.json$', 3) AS hash,
+    json AS data
+  FROM read_json_objects(
+    COALESCE(TRY_CAST(getvariable('hook_config_glob') AS VARCHAR), '~/.claude/plugins/cache/*/*/*/hooks/hooks.json'),
+    filename := true
+  )
+  QUALIFY row_number() OVER (PARTITION BY source ORDER BY hash) = 1
+
+  UNION ALL
+
+  SELECT 'user:settings.json' AS source, NULL AS hash, json AS data
+  FROM read_json_objects('~/.claude/settings.json', filename := true)
+
+  UNION ALL
+
+  SELECT 'project:.claude/settings.json' AS source, NULL AS hash, json AS data
+  FROM read_json_objects('.claude/settings.json', filename := true)
+),
+events AS (
+  SELECT source, data, unnest(json_keys(data, '$.hooks')) AS event
+  FROM raw_configs
+),
+groups AS (
+  SELECT source, event, unnest(json_extract(data, '$.hooks.' || event)::JSON[]) AS grp
+  FROM events
+),
+configured AS (
+  SELECT DISTINCT
+    source,
+    event,
+    json_extract_string(entry, '$.command') AS command
+  FROM groups, unnest(json_extract(grp, '$.hooks')::JSON[]) AS t(entry)
+  WHERE json_extract_string(entry, '$.type') = 'command'
+),
+keyed_configured AS (
+  SELECT
+    source,
+    event,
+    command,
+    COALESCE(
+      NULLIF(regexp_extract(command, '([A-Za-z0-9_.-]+\.(?:sh|ts|js|mjs|cjs|py|rb))', 1), ''),
+      NULLIF(reverse(regexp_extract(reverse(rtrim(trim(command), chr(34) || chr(39))), '^([^/[:space:]]+)/', 1)), ''),
+      trim(command)
+    ) AS match_key
+  FROM configured
+  WHERE getvariable('hook') IS NULL OR command GLOB getvariable('hook')::VARCHAR
+),
+ev AS (
+  SELECT he.host, he.hook_event, COALESCE(he.command, he.hook_name) AS command, he.timestamp
+  FROM hook_events he
+  JOIN sessions s USING (host, session_id)
+  WHERE date_filter(s.start_time, getvariable('after_date'), getvariable('before_date'))
+    AND project_filter(s.project_path, getvariable('project'))
+    AND host_filter(s.host, getvariable('host'))
+),
+keyed_observed AS (
+  SELECT
+    hook_event,
+    COALESCE(
+      NULLIF(regexp_extract(command, '([A-Za-z0-9_.-]+\.(?:sh|ts|js|mjs|cjs|py|rb))', 1), ''),
+      NULLIF(reverse(regexp_extract(reverse(rtrim(trim(command), chr(34) || chr(39))), '^([^/[:space:]]+)/', 1)), ''),
+      trim(command)
+    ) AS match_key,
+    timestamp
+  FROM ev
+),
+observed_agg AS (
+  SELECT
+    hook_event,
+    match_key,
+    COUNT(*) AS observed_fires,
+    MIN(timestamp) AS first_observed,
+    MAX(timestamp) AS last_observed
+  FROM keyed_observed
+  GROUP BY hook_event, match_key
+)
+SELECT
+  kc.source AS config_source,
+  kc.event,
+  kc.command,
+  COALESCE(oa.observed_fires, 0) AS observed_fires,
+  oa.first_observed,
+  oa.last_observed
+FROM keyed_configured kc
+LEFT JOIN observed_agg oa
+  ON oa.hook_event = kc.event
+ AND oa.match_key = kc.match_key
+ORDER BY observed_fires ASC, kc.source, kc.event;


### PR DESCRIPTION
The plan plugin's UserPromptSubmit hook (`context.sh`) exited 0 silently on every prompt for weeks. Nothing caught it, because `hooks.sql`, `hook-blocks.sql`, and `stop-hook-noop-detector.sql` all start from `hook_events`, which only gets a row when a hook produces stdout, a decision, or a non-zero exit. A hook that says nothing leaves no row to find. Those queries mine what fired, never what should have fired.

Adds `hook-config-vs-observed.sql`, a named query in the `claude-code:session` skill. It reads CONFIGURED hooks straight from disk (plugin `hooks.json` under the plugin cache, `~/.claude/settings.json`, `.claude/settings.json`) and left-joins them against DISTINCT hooks OBSERVED in `hook_events`, surfacing rows with `observed_fires = 0`.

Matching a configured command string to an observed one is heuristic: both sides may or may not have `${CLAUDE_PLUGIN_ROOT}`/`$CLAUDE_PROJECT_DIR` expanded, and observed commands can carry a wrapping interpreter or trailing args. The query keys on, in order, the basename of a script-extension path segment, then the last slash-delimited segment when the command's final token is a bare path, then the trimmed command text verbatim. This is a real limitation documented in the query header: two plugins' scripts sharing a basename collapse into one row, and a configured command with none of those three shapes (an aliased or wrapped invocation) reports as unobserved when it actually ran. A 0 flags a candidate for manual review, since a conditional injector that legitimately stays quiet on most events looks identical to a dead one.

Plugin `hooks.json` is duplicated across cache version-hash directories per plugin (same duplication `frontmatter.sql` already documents for `SKILL.md`). The query pins one hash per plugin with `QUALIFY row_number()`, picking arbitrarily since the copies are byte-identical for the installed version.

## Testing

Ran the query read-only against the live index at `/tmp/claude-501/claude-session/session.duckdb` (never touched refresh/import). With `host = 'local'`:

```
config_source            event              command                                        observed_fires
plugin:bendrucker/plan   UserPromptSubmit   "${CLAUDE_PLUGIN_ROOT}/scripts/context.sh"                  0
plugin:bendrucker/mac    PreToolUse         bun "${CLAUDE_PLUGIN_ROOT}/hooks/sandbox.ts"              1403
plugin:bendrucker/writing PreToolUse        bun "${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts"           710
```

`context.sh` surfaces with 0 fires as expected. `sandbox.ts` and `check-tropes.ts`, both high-traffic hooks, surface as observed. Spanning all hosts (no `host` filter) shows `context.sh` at 1 fire, from a `work`-host row that is a sandbox `ENOENT` spawn failure. That row is why the query header recommends `host = 'local'` when grounding a finding rather than trusting another host's count.

Also confirmed the `hook` glob param and the no-params default both null-guard correctly, and that `bun run skill-lint "plugins/claude-code/skills/session"` still passes.

An in-flight PR (#932) touches `resources/views.sql`, `stop-hook-noop-detector.sql`, `plans.sql`, and `scripts/db.test.ts`, so this change stays additive: one new query file plus one line each in `SKILL.md` and `references/discovery.md`. For the same reason this PR skips an automated test: the harness's query tests live in `db.test.ts`, one of #932's files, so coverage here is the manual validation above.

Discovery: 49bbbf629d00
