### PR TITLE
plan: gate ExitPlanMode re-presents with a PreToolUse hook

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -160,6 +160,13 @@
         "@constellos/claude-code-kit": "^0.4.0",
       },
     },
+    "plugins/plan": {
+      "name": "@bendrucker/claude-plan",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+        "@constellos/claude-code-kit": "^0.4.0",
+      },
+    },
     "plugins/pull-request": {
       "name": "pull-request",
       "dependencies": {
@@ -298,6 +305,8 @@
     "@bendrucker/claude-comments": ["@bendrucker/claude-comments@workspace:plugins/comments"],
 
     "@bendrucker/claude-marketplace": ["@bendrucker/claude-marketplace@workspace:packages/marketplace"],
+
+    "@bendrucker/claude-plan": ["@bendrucker/claude-plan@workspace:plugins/plan"],
 
     "@bendrucker/claude-review": ["@bendrucker/claude-review@workspace:plugins/review"],
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "plugins/gitlab",
     "packages/validate",
     "packages/marketplace",
+    "plugins/plan",
     "plugins/tmux",
     "plugins/mac",
     "plugins/x-callback-url",

--- a/plugins/plan/README.md
+++ b/plugins/plan/README.md
@@ -5,7 +5,16 @@ Planning mode guidelines and context injection for Claude Code.
 ## Contents
 
 - **Hook**: Automatically injects planning guidelines when entering plan mode (via Shift+Tab or EnterPlanMode tool)
+- **Hook**: Gates `ExitPlanMode`, denying byte-identical plan re-presents and asking once per session before presenting a plan over 12k characters
 
 ## How It Works
 
 The `UserPromptSubmit` hook checks `permission_mode` in the hook input. When the mode is `plan`, it injects the planning guidelines into the conversation context. A marker file prevents duplicate injection on subsequent prompts within the same session.
+
+The `PreToolUse` gate hook hashes each presented plan under `/tmp/claude/<session_id>/` and denies a resubmission whose text is unchanged since the last presentation, with instructions to revise instead of regrow. Plans over 12k characters trigger a one-time confirmation prompt. Infrastructure weirdness (missing session id, unreadable state) fails open.
+
+## Testing
+
+```sh
+bun test plugins/plan
+```

--- a/plugins/plan/hooks/gate.test.ts
+++ b/plugins/plan/hooks/gate.test.ts
@@ -97,7 +97,7 @@ describe("size advisory", () => {
     expect(await decision(bigPlan("a"))).toEqual({
       hookEventName: "PreToolUse",
       permissionDecision: "ask",
-      permissionDecisionReason: expect.stringContaining("over 12k characters"),
+      permissionDecisionReason: expect.stringContaining("exceeds 12k characters"),
     });
   });
 

--- a/plugins/plan/hooks/gate.test.ts
+++ b/plugins/plan/hooks/gate.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, readdirSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  PreToolUseHookInput,
+  PreToolUseHookSpecificOutput,
+} from "@anthropic-ai/claude-agent-sdk";
+import { processInput } from "./gate";
+
+let stateRoot: string;
+
+beforeEach(() => {
+  stateRoot = mkdtempSync(join(tmpdir(), "plan-gate-"));
+});
+
+afterEach(async () => {
+  await rm(stateRoot, { recursive: true, force: true });
+});
+
+function mockInput(plan: string, sessionId = "session-1"): PreToolUseHookInput {
+  return {
+    hook_event_name: "PreToolUse",
+    session_id: sessionId,
+    transcript_path: "/tmp/test",
+    cwd: "/tmp",
+    tool_name: "ExitPlanMode",
+    tool_input: { plan },
+    tool_use_id: "test",
+  };
+}
+
+async function decision(
+  plan: string,
+  sessionId = "session-1",
+): Promise<PreToolUseHookSpecificOutput | null> {
+  const result = await processInput(mockInput(plan, sessionId), stateRoot);
+  if (!result) return null;
+  return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
+}
+
+describe("first presentation", () => {
+  it("allows silently with no prior state", async () => {
+    expect(await decision("My plan")).toBeNull();
+  });
+
+  it("records the hash for the next call", async () => {
+    await decision("My plan");
+    expect(readdirSync(join(stateRoot, "session-1"))).toContain("exit-plan-hash");
+  });
+});
+
+describe("unchanged re-present", () => {
+  it("denies a byte-identical resubmission", async () => {
+    await decision("My plan");
+    expect(await decision("My plan")).toEqual({
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: expect.stringContaining("Plan text is unchanged"),
+    });
+  });
+
+  it("denies repeatedly until the text changes", async () => {
+    await decision("My plan");
+    expect((await decision("My plan"))?.permissionDecision).toBe("deny");
+    expect((await decision("My plan"))?.permissionDecision).toBe("deny");
+    expect(await decision("My plan, revised")).toBeNull();
+  });
+
+  it("allows a changed plan", async () => {
+    await decision("My plan");
+    expect(await decision("My revised plan")).toBeNull();
+  });
+
+  it("treats trailing-whitespace-only changes as changed", async () => {
+    await decision("My plan");
+    expect(await decision("My plan \n")).toBeNull();
+  });
+
+  it("updates the stored hash on allow, so re-presenting the new text denies", async () => {
+    await decision("Plan A");
+    await decision("Plan B");
+    expect((await decision("Plan B"))?.permissionDecision).toBe("deny");
+  });
+
+  it("keeps sessions independent", async () => {
+    await decision("My plan", "session-1");
+    expect(await decision("My plan", "session-2")).toBeNull();
+  });
+});
+
+describe("size advisory", () => {
+  const bigPlan = (seed: string) => seed + "x".repeat(12_001);
+
+  it("asks on a plan over 12k characters", async () => {
+    expect(await decision(bigPlan("a"))).toEqual({
+      hookEventName: "PreToolUse",
+      permissionDecision: "ask",
+      permissionDecisionReason: expect.stringContaining("over 12k characters"),
+    });
+  });
+
+  it("does not ask at exactly 12k characters", async () => {
+    expect(await decision("x".repeat(12_000))).toBeNull();
+  });
+
+  it("asks at most once per session", async () => {
+    expect((await decision(bigPlan("a")))?.permissionDecision).toBe("ask");
+    expect(await decision(bigPlan("b"))).toBeNull();
+  });
+
+  it("asks again in a different session", async () => {
+    await decision(bigPlan("a"), "session-1");
+    expect((await decision(bigPlan("a"), "session-2"))?.permissionDecision).toBe("ask");
+  });
+
+  it("prefers deny when the oversized plan is also unchanged", async () => {
+    expect((await decision(bigPlan("a")))?.permissionDecision).toBe("ask");
+    expect((await decision(bigPlan("a")))?.permissionDecision).toBe("deny");
+  });
+});
+
+describe("fail open", () => {
+  it("allows and skips state when session_id is missing", async () => {
+    const input = mockInput("My plan");
+    input.session_id = "";
+    expect(await processInput(input, stateRoot)).toBeNull();
+    expect(await processInput(input, stateRoot)).toBeNull();
+    expect(readdirSync(stateRoot)).toEqual([]);
+  });
+
+  it("allows when tool_input has no plan string", async () => {
+    const input = mockInput("unused");
+    input.tool_input = {};
+    expect(await processInput(input, stateRoot)).toBeNull();
+  });
+
+  it("allows when the stored hash is corrupt", async () => {
+    await decision("My plan");
+    await Bun.write(join(stateRoot, "session-1", "exit-plan-hash"), "not a real hash");
+    expect(await decision("My plan")).toBeNull();
+  });
+
+  it("allows when the state root is unusable", async () => {
+    await Bun.write(join(stateRoot, "blocked"), "");
+    const blocked = join(stateRoot, "blocked", "nested");
+    expect(await processInput(mockInput("My plan"), blocked)).toBeNull();
+    expect(await processInput(mockInput("My plan"), blocked)).toBeNull();
+  });
+});

--- a/plugins/plan/hooks/gate.ts
+++ b/plugins/plan/hooks/gate.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env bun
+
+import { createHash } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+
+const SIZE_THRESHOLD = 12_000;
+
+const DENY_REASON =
+  "Plan text is unchanged since the last presentation. Incorporate the redirect " +
+  "feedback with a targeted revision of the affected sections (do not regrow the " +
+  "document), lead with a short 'Changed since last plan' block, and re-present.";
+
+const ASK_REASON =
+  "This plan is over 12k characters; no plan over ~11.4k has been approved in two " +
+  "months. Consider consolidating superseded content into <plan>.decisions.md or " +
+  "splitting scope. Approve to present anyway.";
+
+function formatDecision(decision: "deny" | "ask", reason: string): SyncHookJSONOutput {
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: decision,
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
+async function readState(path: string): Promise<string | null> {
+  try {
+    return await Bun.file(path).text();
+  } catch {
+    return null;
+  }
+}
+
+async function writeState(path: string, content: string): Promise<void> {
+  try {
+    await Bun.write(path, content);
+  } catch {
+    // Fail open: losing state must never block the tool call.
+  }
+}
+
+export async function processInput(
+  input: PreToolUseHookInput,
+  stateRoot = process.env.CLAUDE_PLAN_MARKER_ROOT || "/tmp/claude",
+): Promise<SyncHookJSONOutput | null> {
+  const plan = (input.tool_input as { plan?: unknown }).plan;
+  if (typeof plan !== "string") return null;
+
+  const sessionId = input.session_id;
+  if (!sessionId) return null;
+
+  const dir = join(stateRoot, sessionId);
+  try {
+    mkdirSync(dir, { recursive: true });
+  } catch {
+    return null;
+  }
+
+  const hashPath = join(dir, "exit-plan-hash");
+  const askedPath = join(dir, "exit-plan-size-asked");
+
+  const hash = createHash("sha256").update(plan).digest("hex");
+  const previous = await readState(hashPath);
+  await writeState(hashPath, hash);
+
+  if (previous !== null && previous === hash) {
+    return formatDecision("deny", DENY_REASON);
+  }
+
+  if (plan.length > SIZE_THRESHOLD && (await readState(askedPath)) === null) {
+    await writeState(askedPath, "asked");
+    return formatDecision("ask", ASK_REASON);
+  }
+
+  return null;
+}
+
+async function main(): Promise<void> {
+  let input: PreToolUseHookInput;
+  try {
+    input = await readStdinJson<PreToolUseHookInput>();
+  } catch (error) {
+    console.error(
+      `[plan/gate] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  const output = await processInput(input);
+  if (output) {
+    writeStdoutJson(output);
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/plugins/plan/hooks/gate.ts
+++ b/plugins/plan/hooks/gate.ts
@@ -14,9 +14,9 @@ const DENY_REASON =
   "document), lead with a short 'Changed since last plan' block, and re-present.";
 
 const ASK_REASON =
-  "This plan is over 12k characters; no plan over ~11.4k has been approved in two " +
-  "months. Consider consolidating superseded content into <plan>.decisions.md or " +
-  "splitting scope. Approve to present anyway.";
+  "This plan exceeds 12k characters. Plans this large are rarely approved; " +
+  "consolidate superseded content into <plan>.decisions.md or split the scope. " +
+  "Approve to present anyway.";
 
 function formatDecision(decision: "deny" | "ask", reason: string): SyncHookJSONOutput {
   return {

--- a/plugins/plan/hooks/hooks.json
+++ b/plugins/plan/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Inject planning guidelines when entering plan mode",
+  "description": "Inject planning guidelines when entering plan mode and gate plan re-presents",
   "hooks": {
     "UserPromptSubmit": [
       {
@@ -7,6 +7,17 @@
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/context.sh\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/gate.ts\""
           }
         ]
       }

--- a/plugins/plan/package.json
+++ b/plugins/plan/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@bendrucker/claude-plan",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+    "@constellos/claude-code-kit": "^0.4.0"
+  }
+}


### PR DESCRIPTION
Adds a `PreToolUse` gate on `ExitPlanMode` to the `plan` plugin, implementing design item B from `tmp/claude-planning-redesign.md`. Two mechanical checks:

- **Deny unchanged re-presents.** The hook hashes each presented plan under `/tmp/claude/<session_id>/` and denies a resubmission whose text is byte-identical to the previous presentation. The deny reason carries the condensed iteration rules (targeted revision, "Changed since last plan" block), so the guidance re-injects at the exact moment it applies and survives compaction.
- **Ask once on oversized plans.** Plans over 12k characters get an `ask` decision once per session. No plan over ~11.4k characters was approved in two months of studied sessions, so the threshold is data-backed. When both conditions hit, the deny wins.

Evidence from the 8-session planning study: one session submitted a byte-identical 12k plan three consecutive times after two explicit user corrections, and byte-identical re-presents appeared in three of eight sessions. Both checks are things prompt-time guidance demonstrably failed to prevent.

Everything fails open: missing `session_id`, unwritable state dir, or corrupt hash files allow silently and skip state. Session id and plan text come from hook stdin JSON (there is no `CLAUDE_SESSION_ID` env var for hooks, per #938), and the state root honors the same `CLAUDE_PLAN_MARKER_ROOT` override `context.sh` uses, which the tests exploit with temp dirs. Hash comparison is on the raw plan string, so trailing-whitespace-only edits count as changed.

This required giving the plan plugin its own `package.json` (agent SDK types plus the stdin/stdout runners) and a root `workspaces` entry.

Removal signal: `hook_events` fire counts in the session index. Zero denies in a month means the guidelines internalized and the advisory can be dropped; high ask-approval friction means the threshold is wrong.

## Testing

Unit tests cover deny-on-identical, allow-on-changed (including whitespace-only edits), ask-once-per-session, deny-beats-ask, first presentation, cross-session isolation, and the fail-open paths (missing session id, corrupt hash, unusable state root). Also drove the hook end-to-end over stdin and observed all three outcomes plus silent exit 0 on garbage input.

Discovery: 598a58d91509

https://claude.ai/code/session_01LmBorNSEbodhWp4ndghgjy
