### PR TITLE
testing: add technique-selection conventions and fast-check

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -18,6 +18,30 @@ After making changes to plugin scripts, run them directly to verify they work en
 - **No `.js` imports in TypeScript**: Import from `./module` not `./module.js`. The bundler/runtime handles resolution.
 - **Prefer skills over agents**: Skills are invocable via the Skill tool. Agents require the Task tool. If something should be directly invocable, make it a skill.
 
+## Technique Selection
+
+Pick the test shape from the code under test. API patterns for each technique live in [`plugins/bun/skills/bun/references/testing.md`](../../plugins/bun/skills/bun/references/testing.md).
+
+#### Repeated Blocks → `test.each`
+
+When two or more `test()` blocks differ only in data, collapse them into one `test.each` with a typed table (tuple or object rows). Name each row through the title template (`$name` for object rows, `%s`/`%d` for tuples) so a failure identifies the row without counting.
+
+#### Formatted Output → Inline Snapshots
+
+Assert formatted or structured output with `toMatchInlineSnapshot()` by default. Use a file snapshot (`toMatchSnapshot()`) only when the output exceeds roughly 20 lines or is shared across tests. Never assert structured output field-by-field: one snapshot replaces a run of `expect(x.field).toBe(...)` lines and shows the whole shape in the diff. A live exemplar: `plugins/comments/apply/report.test.ts`.
+
+#### Statable Invariants → Properties
+
+For pure logic with a statable invariant, write one `fast-check` property plus a small example table for documentation. Invariant shapes to look for: roundtrip (`decode(encode(x))` equals `x`), idempotence (`f(f(x))` equals `f(x)`), permutation invariance, partition (parts recombine to the whole), and agreement with a simpler oracle. Put `expect` calls inside `fc.property`. Constrain the arbitrary (or use `fc.pre`) instead of generating values and filtering them.
+
+#### Fake Domain Instances → Arbitraries and Builders
+
+When tests need filler instances of a domain type, define a typed `fc.record` arbitrary next to the tests. Reuse it in properties, and in example tests via seeded `fc.sample` with per-case fields overridden by spread. When only one or two of many fields matter, a plain `make<Type>(overrides)` builder in the test file is fine. No faker-style dependencies: types are erased at runtime, and realistic-looking values add flake, not signal.
+
+#### Refactor Bar
+
+Test refactors must not change behavior: same assertions, net LOC down, and `bun test <dir>` green before and after.
+
 ## CI Structure
 
 Tests run per-plugin in the CI matrix for:

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -20,23 +20,74 @@ After making changes to plugin scripts, run them directly to verify they work en
 
 ## Technique Selection
 
-Pick the test shape from the code under test. API patterns for each technique live in [`plugins/bun/skills/bun/references/testing.md`](../../plugins/bun/skills/bun/references/testing.md).
+Pick the test shape from the code under test.
 
 #### Repeated Blocks → `test.each`
 
-When two or more `test()` blocks differ only in data, collapse them into one `test.each` with a typed table (tuple or object rows). Name each row through the title template (`$name` for object rows, `%s`/`%d` for tuples) so a failure identifies the row without counting.
+Two or more `test()` blocks differing only in data collapse into one `test.each` with a typed table. Name each row through the title template so a failure identifies the row without counting.
+
+```ts
+// Tuple rows: positional args, %s/%d/%p placeholders in the title
+test.each<[string, number]>([
+  ["", 0],
+  ["a", 1],
+])("length of %p is %d", (input, expected) => {
+  expect(input.length).toBe(expected);
+});
+
+// Object rows: named fields, $field placeholders in the title
+test.each<{ name: string; input: string; expected: number }>([
+  { name: "empty string", input: "", expected: 0 },
+  { name: "single char", input: "a", expected: 1 },
+])("$name", ({ input, expected }) => {
+  expect(input.length).toBe(expected);
+});
+```
+
+`describe.each` parametrizes an entire suite the same way.
 
 #### Formatted Output → Inline Snapshots
 
-Assert formatted or structured output with `toMatchInlineSnapshot()` by default. Use a file snapshot (`toMatchSnapshot()`) only when the output exceeds roughly 20 lines or is shared across tests. Never assert structured output field-by-field: one snapshot replaces a run of `expect(x.field).toBe(...)` lines and shows the whole shape in the diff. A live exemplar: `plugins/comments/apply/report.test.ts`.
+Assert formatted or structured output with `toMatchInlineSnapshot()` by default. Call it with no argument and the first run writes the received value into the test file. When output changes intentionally, rerun with `bun test <file> --update-snapshots` and review what it wrote. Never assert structured output field-by-field: one snapshot replaces a run of `expect(x.field).toBe(...)` lines and shows the whole shape in the diff. A live exemplar: `plugins/comments/apply/report.test.ts`.
+
+Use a file snapshot (`toMatchSnapshot()`, written to `__snapshots__/*.snap`) only when the output exceeds roughly 20 lines or is shared across tests.
 
 #### Statable Invariants → Properties
 
-For pure logic with a statable invariant, write one `fast-check` property plus a small example table for documentation. Invariant shapes to look for: roundtrip (`decode(encode(x))` equals `x`), idempotence (`f(f(x))` equals `f(x)`), permutation invariance, partition (parts recombine to the whole), and agreement with a simpler oracle. Put `expect` calls inside `fc.property`. Constrain the arbitrary (or use `fc.pre`) instead of generating values and filtering them.
+For pure logic with a statable invariant, write one `fast-check` property plus a small example table for documentation. Invariant shapes to look for: roundtrip (`decode(encode(x))` equals `x`), idempotence (`f(f(x))` equals `f(x)`), permutation invariance, partition (parts recombine to the whole), and agreement with a simpler oracle.
+
+`fast-check` runs under `bun test` with no adapter. On failure it shrinks to a minimal counterexample and prints a seed. Replay with `fc.assert(prop, { seed: <printed seed> })`.
+
+```ts
+import fc from "fast-check";
+
+test("encode/decode roundtrip", () => {
+  fc.assert(
+    fc.property(fc.array(fc.integer()), (values) => {
+      expect(decode(encode(values))).toEqual(values);
+    }),
+  );
+});
+```
+
+Put `expect` calls inside the property. Any throw fails the run. Constrain the arbitrary (`fc.integer({ min: 1 })`, `fc.string({ minLength: 1 })`) or use `fc.pre(condition)` instead of generating values and filtering them.
 
 #### Fake Domain Instances → Arbitraries and Builders
 
-When tests need filler instances of a domain type, define a typed `fc.record` arbitrary next to the tests. Reuse it in properties, and in example tests via seeded `fc.sample` with per-case fields overridden by spread. When only one or two of many fields matter, a plain `make<Type>(overrides)` builder in the test file is fine. No faker-style dependencies: types are erased at runtime, and realistic-looking values add flake, not signal.
+Tests that need filler instances of a domain type get a typed `fc.record` arbitrary defined next to them. Reuse it in properties, and in example tests via seeded `fc.sample` with per-case fields overridden by spread.
+
+```ts
+const finding = fc.record<Finding>({
+  path: fc.string({ minLength: 1 }),
+  line: fc.integer({ min: 1 }),
+  severity: fc.constantFrom("low", "high"),
+});
+
+const [base] = fc.sample(finding, { seed: 1, numRuns: 1 });
+const item = { ...base, path: "src/a.ts" };
+```
+
+When only one or two of many fields matter, a plain `make<Type>(overrides)` builder in the test file is fine. No faker-style dependencies: types are erased at runtime, and realistic-looking values add flake, not signal.
 
 #### Refactor Bar
 

--- a/.claude/workflows/test-upgrade.ts
+++ b/.claude/workflows/test-upgrade.ts
@@ -1,69 +1,34 @@
 export const meta = {
   name: "test-upgrade",
-  description: "Fan out per-plugin test refactors (tables, snapshots, properties) into one PR per unit",
-  whenToUse: "After the testing technique-selection rule is on main, to upgrade existing test suites unit by unit",
+  description: "Fan out per-unit test refactors (tables, snapshots, properties) into one PR per unit",
+  whenToUse:
+    "To apply the testing rule's technique-selection guide across existing suites, one test-upgrade-<unit> PR per unit. args: {units?: string[], targets?: {[unit]: string}}",
   phases: [
-    { title: "Ground", detail: "load the rule and reference text once" },
+    { title: "Ground", detail: "load the technique-selection rule text once" },
+    { title: "Discover", detail: "enumerate units that have test files" },
     { title: "Audit", detail: "read each unit's tests against the rule, emit a worklist" },
     { title: "Apply", detail: "refactor in isolated worktrees; mechanical work on sonnet" },
     { title: "Verify", detail: "test, review the diff, branch, push, open the PR" },
   ],
 };
 
-const REPO = "/Users/ben/src/bendrucker/claude";
-
-const ALL_UNITS = [
-  {
-    name: "writing",
-    paths: ["plugins/writing"],
-    targets:
-      "hooks/numbering.test.ts (language-by-pattern matrix as one table), detection/tropes.test.ts (tables), voice-delta.test.ts and ngram.test.ts (inline snapshots), linguistics/preprocess.ts (idempotence property)",
+const UNITS_SCHEMA = {
+  type: "object",
+  required: ["units"],
+  properties: {
+    units: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["name", "paths"],
+        properties: {
+          name: { type: "string" },
+          paths: { type: "array", items: { type: "string" } },
+        },
+      },
+    },
   },
-  {
-    name: "type-ignore",
-    paths: ["plugins/type-ignore"],
-    targets: "hooks/detect.test.ts (~30 near-identical blocks as a language-by-token table)",
-  },
-  {
-    name: "gitlab",
-    paths: ["plugins/gitlab"],
-    targets:
-      "watch.test.ts (tables for parseProject, normalizePipelineStatus, parseMrUrl), fetch.test.ts (inline snapshots), merge-request/scripts/diff.ts (hunk membership property)",
-  },
-  {
-    name: "github",
-    paths: ["plugins/github"],
-    targets: "watch.test.ts (deriveChecksState table), fetch.test.ts (inline snapshots)",
-  },
-  {
-    name: "tmux",
-    paths: ["plugins/tmux"],
-    targets: "hooks/target.test.ts (tables), injectTarget to hasExistingTarget roundtrip property",
-  },
-  {
-    name: "comments",
-    paths: ["plugins/comments"],
-    targets:
-      "detection/rank.ts properties (permutation invariance, idempotence, no drops or dupes), apply/edits.ts properties (order independence, unedited-region preservation)",
-  },
-  {
-    name: "claude-code",
-    paths: ["plugins/claude-code", "packages/skill-lint"],
-    targets:
-      "session/scripts/db.test.ts (field-by-field expects to inline snapshots), skill-lint rules as a table",
-  },
-  {
-    name: "pull-request",
-    paths: ["plugins/pull-request"],
-    targets: "scripts/validate.test.ts (formatted messages to inline snapshots)",
-  },
-  {
-    name: "scripts",
-    paths: ["scripts"],
-    targets:
-      "scripts/coverage/lcov.ts properties: formatRanges roundtrip and order independence, merge commutativity, covered/uncovered partition",
-  },
-];
+};
 
 const AUDIT_SCHEMA = {
   type: "object",
@@ -114,26 +79,43 @@ const VERIFY_SCHEMA = {
 phase("Ground");
 const ground = await agent(
   [
-    `Return, verbatim and clearly delimited, the contents of two files in ${REPO}:`,
-    "1. The '## Technique Selection' section of .claude/rules/testing.md",
-    "2. All of plugins/bun/skills/bun/references/testing.md",
+    "Return, verbatim, the '## Technique Selection' section of .claude/rules/testing.md in the current repo.",
     "No commentary.",
   ].join("\n"),
   { label: "ground:rule-text", phase: "Ground", effort: "low" },
 );
 
-const units = Array.isArray(args?.units)
-  ? ALL_UNITS.filter((u) => args.units.includes(u.name))
-  : ALL_UNITS;
+phase("Discover");
+const discovered = await agent(
+  [
+    "Enumerate the test units of the current repo. A unit is a directory that owns *.test.ts files and maps to one CI job:",
+    "- each plugins/<name> directory containing test files (name = plugin dir name)",
+    "- each packages/<name> directory containing test files",
+    "- root-level directories with test files (scripts/, hooks/, .claude/), named after the directory",
+    "Paths are repo-relative. Do not modify anything.",
+  ].join("\n"),
+  { label: "discover:units", phase: "Discover", effort: "low", schema: UNITS_SCHEMA },
+);
+
+const units = discovered.units.filter(
+  (u) => !Array.isArray(args?.units) || args.units.includes(u.name),
+);
+const hints = args?.targets ?? {};
+log(`${units.length} units to audit`);
+
+function testCommand(unit) {
+  return `bun test ${unit.paths.map((p) => `./${p}`).join(" ")}`;
+}
 
 function auditPrompt(unit) {
+  const hint = hints[unit.name];
   return [
-    `Audit the tests under ${unit.paths.map((p) => `${REPO}/${p}`).join(" and ")} against the repo's testing technique-selection rule.`,
+    `Audit the tests under ${unit.paths.join(" and ")} against the repo's testing technique-selection rule.`,
     "",
-    "Rule and API reference:",
+    "Rule text:",
     ground,
     "",
-    `Known candidates from an earlier survey (verify each, extend or drop as the code warrants): ${unit.targets}`,
+    hint ? `Known candidates from an earlier survey (verify each, extend or drop as the code warrants): ${hint}` : "",
     "",
     "Read every *.test.ts file in the unit. Emit a worklist item per opportunity:",
     "- technique 'table': two or more test() blocks differing only in data",
@@ -153,14 +135,14 @@ function mechanicalPrompt(unit, items) {
     "",
     "Apply ONLY the table and snapshot refactors below. Do not add property tests. Do not commit.",
     "",
-    "Rule and API reference:",
+    "Rule text:",
     ground,
     "",
     `Worklist for ${unit.name}:`,
     JSON.stringify(items, null, 2),
     "",
     "Hard constraints: no behavior change (the same things are asserted before and after), net test LOC down,",
-    `and \`bun test ${unit.paths.map((p) => (p.startsWith(".") ? `./${p}` : p)).join(" ")}\` green when you finish.`,
+    `and \`${testCommand(unit)}\` green when you finish.`,
     "Use `bun test <file> --update-snapshots` to fill inline snapshots, then review what it wrote.",
     "If a refactor would change what is asserted, leave that site alone and record it as an escalation.",
     "Return the absolute path of your worktree (pwd) as 'worktree'.",
@@ -176,7 +158,7 @@ function propertyPrompt(unit, items, workspace) {
     "",
     "Add the property tests and arbitraries below. Do not commit.",
     "",
-    "Rule and API reference:",
+    "Rule text:",
     ground,
     "",
     `Worklist for ${unit.name}:`,
@@ -185,7 +167,7 @@ function propertyPrompt(unit, items, workspace) {
     "For each property: one fc.assert(fc.property(...)) with expect inside, plus a small example table if none exists.",
     "Constrain arbitraries (or fc.pre) rather than filtering. Define typed fc.record arbitraries next to the tests.",
     "Seed-check every property: temporarily mutate the target function, confirm the property fails and shrinks, then revert the mutation.",
-    `Finish with \`bun test ${unit.paths.map((p) => (p.startsWith(".") ? `./${p}` : p)).join(" ")}\` green.`,
+    `Finish with \`${testCommand(unit)}\` green.`,
     "If an invariant does not actually hold, do not weaken it to pass: record an escalation instead.",
     "Return the absolute path of your worktree (pwd) as 'worktree'.",
   ].join("\n");
@@ -195,7 +177,7 @@ function verifyPrompt(unit, audit, workspace, escalations) {
   return [
     `cd ${workspace}. This worktree holds uncommitted test refactors for ${unit.name}.`,
     "",
-    `1. Run \`AGENT=1 bun test ${unit.paths.map((p) => (p.startsWith(".") ? `./${p}` : p)).join(" ")}\` and require it green.`,
+    `1. Run \`AGENT=1 ${testCommand(unit)}\` and require it green.`,
     "2. Review `git diff` in full: refactored sites must assert the same things as before, and pure refactors must reduce LOC.",
     "   Property tests may add lines. Recompute the unit's test LOC (wc -l over *.test.ts) as testLocAfter.",
     `   Test LOC before the refactor was ${audit.testLoc}.`,

--- a/.claude/workflows/test-upgrade.ts
+++ b/.claude/workflows/test-upgrade.ts
@@ -1,0 +1,271 @@
+export const meta = {
+  name: "test-upgrade",
+  description: "Fan out per-plugin test refactors (tables, snapshots, properties) into one PR per unit",
+  whenToUse: "After the testing technique-selection rule is on main, to upgrade existing test suites unit by unit",
+  phases: [
+    { title: "Ground", detail: "load the rule and reference text once" },
+    { title: "Audit", detail: "read each unit's tests against the rule, emit a worklist" },
+    { title: "Apply", detail: "refactor in isolated worktrees; mechanical work on sonnet" },
+    { title: "Verify", detail: "test, review the diff, branch, push, open the PR" },
+  ],
+};
+
+const REPO = "/Users/ben/src/bendrucker/claude";
+
+const ALL_UNITS = [
+  {
+    name: "writing",
+    paths: ["plugins/writing"],
+    targets:
+      "hooks/numbering.test.ts (language-by-pattern matrix as one table), detection/tropes.test.ts (tables), voice-delta.test.ts and ngram.test.ts (inline snapshots), linguistics/preprocess.ts (idempotence property)",
+  },
+  {
+    name: "type-ignore",
+    paths: ["plugins/type-ignore"],
+    targets: "hooks/detect.test.ts (~30 near-identical blocks as a language-by-token table)",
+  },
+  {
+    name: "gitlab",
+    paths: ["plugins/gitlab"],
+    targets:
+      "watch.test.ts (tables for parseProject, normalizePipelineStatus, parseMrUrl), fetch.test.ts (inline snapshots), merge-request/scripts/diff.ts (hunk membership property)",
+  },
+  {
+    name: "github",
+    paths: ["plugins/github"],
+    targets: "watch.test.ts (deriveChecksState table), fetch.test.ts (inline snapshots)",
+  },
+  {
+    name: "tmux",
+    paths: ["plugins/tmux"],
+    targets: "hooks/target.test.ts (tables), injectTarget to hasExistingTarget roundtrip property",
+  },
+  {
+    name: "comments",
+    paths: ["plugins/comments"],
+    targets:
+      "detection/rank.ts properties (permutation invariance, idempotence, no drops or dupes), apply/edits.ts properties (order independence, unedited-region preservation)",
+  },
+  {
+    name: "claude-code",
+    paths: ["plugins/claude-code", "packages/skill-lint"],
+    targets:
+      "session/scripts/db.test.ts (field-by-field expects to inline snapshots), skill-lint rules as a table",
+  },
+  {
+    name: "pull-request",
+    paths: ["plugins/pull-request"],
+    targets: "scripts/validate.test.ts (formatted messages to inline snapshots)",
+  },
+  {
+    name: "scripts",
+    paths: ["scripts"],
+    targets:
+      "scripts/coverage/lcov.ts properties: formatRanges roundtrip and order independence, merge commutativity, covered/uncovered partition",
+  },
+];
+
+const AUDIT_SCHEMA = {
+  type: "object",
+  required: ["skip", "items", "testLoc"],
+  properties: {
+    skip: { type: "boolean" },
+    reason: { type: "string" },
+    testLoc: { type: "integer" },
+    items: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["file", "technique", "sites"],
+        properties: {
+          file: { type: "string" },
+          technique: {
+            enum: ["table", "inline-snapshot", "file-snapshot", "property", "arbitrary"],
+          },
+          sites: { type: "string" },
+          invariant: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+const APPLY_SCHEMA = {
+  type: "object",
+  required: ["worktree", "summary", "escalations"],
+  properties: {
+    worktree: { type: "string" },
+    summary: { type: "string" },
+    escalations: { type: "array", items: { type: "string" } },
+  },
+};
+
+const VERIFY_SCHEMA = {
+  type: "object",
+  required: ["status", "notes"],
+  properties: {
+    status: { enum: ["pr", "skipped", "escalated"] },
+    pr: { type: "string" },
+    notes: { type: "string" },
+    testLocAfter: { type: "integer" },
+  },
+};
+
+phase("Ground");
+const ground = await agent(
+  [
+    `Return, verbatim and clearly delimited, the contents of two files in ${REPO}:`,
+    "1. The '## Technique Selection' section of .claude/rules/testing.md",
+    "2. All of plugins/bun/skills/bun/references/testing.md",
+    "No commentary.",
+  ].join("\n"),
+  { label: "ground:rule-text", phase: "Ground", effort: "low" },
+);
+
+const units = Array.isArray(args?.units)
+  ? ALL_UNITS.filter((u) => args.units.includes(u.name))
+  : ALL_UNITS;
+
+function auditPrompt(unit) {
+  return [
+    `Audit the tests under ${unit.paths.map((p) => `${REPO}/${p}`).join(" and ")} against the repo's testing technique-selection rule.`,
+    "",
+    "Rule and API reference:",
+    ground,
+    "",
+    `Known candidates from an earlier survey (verify each, extend or drop as the code warrants): ${unit.targets}`,
+    "",
+    "Read every *.test.ts file in the unit. Emit a worklist item per opportunity:",
+    "- technique 'table': two or more test() blocks differing only in data",
+    "- technique 'inline-snapshot': field-by-field assertions on one structured value, or formatted output asserted piecemeal",
+    "- technique 'file-snapshot': only when output exceeds roughly 20 lines or is shared across tests",
+    "- technique 'property': a pure function in the unit with a statable invariant; name the invariant in the 'invariant' field",
+    "- technique 'arbitrary': tests hand-building filler instances of a domain type that a typed fc.record arbitrary or make<Type>(overrides) builder should produce",
+    "In 'sites', identify the test names or line ranges involved.",
+    "Set testLoc to the total line count of the unit's *.test.ts files (wc -l).",
+    "If nothing meets the bar, return skip=true with a reason. Do not modify any files.",
+  ].join("\n");
+}
+
+function mechanicalPrompt(unit, items) {
+  return [
+    "You are in an isolated git worktree of this repo. Run `bun install` first (workspace deps are not installed).",
+    "",
+    "Apply ONLY the table and snapshot refactors below. Do not add property tests. Do not commit.",
+    "",
+    "Rule and API reference:",
+    ground,
+    "",
+    `Worklist for ${unit.name}:`,
+    JSON.stringify(items, null, 2),
+    "",
+    "Hard constraints: no behavior change (the same things are asserted before and after), net test LOC down,",
+    `and \`bun test ${unit.paths.map((p) => (p.startsWith(".") ? `./${p}` : p)).join(" ")}\` green when you finish.`,
+    "Use `bun test <file> --update-snapshots` to fill inline snapshots, then review what it wrote.",
+    "If a refactor would change what is asserted, leave that site alone and record it as an escalation.",
+    "Return the absolute path of your worktree (pwd) as 'worktree'.",
+  ].join("\n");
+}
+
+function propertyPrompt(unit, items, workspace) {
+  return [
+    workspace
+      ? `Work in the existing worktree at ${workspace} (it already contains table/snapshot refactors). cd there first.`
+      : "You are in an isolated git worktree of this repo.",
+    "Run `bun install` in the worktree if node_modules is missing.",
+    "",
+    "Add the property tests and arbitraries below. Do not commit.",
+    "",
+    "Rule and API reference:",
+    ground,
+    "",
+    `Worklist for ${unit.name}:`,
+    JSON.stringify(items, null, 2),
+    "",
+    "For each property: one fc.assert(fc.property(...)) with expect inside, plus a small example table if none exists.",
+    "Constrain arbitraries (or fc.pre) rather than filtering. Define typed fc.record arbitraries next to the tests.",
+    "Seed-check every property: temporarily mutate the target function, confirm the property fails and shrinks, then revert the mutation.",
+    `Finish with \`bun test ${unit.paths.map((p) => (p.startsWith(".") ? `./${p}` : p)).join(" ")}\` green.`,
+    "If an invariant does not actually hold, do not weaken it to pass: record an escalation instead.",
+    "Return the absolute path of your worktree (pwd) as 'worktree'.",
+  ].join("\n");
+}
+
+function verifyPrompt(unit, audit, workspace, escalations) {
+  return [
+    `cd ${workspace}. This worktree holds uncommitted test refactors for ${unit.name}.`,
+    "",
+    `1. Run \`AGENT=1 bun test ${unit.paths.map((p) => (p.startsWith(".") ? `./${p}` : p)).join(" ")}\` and require it green.`,
+    "2. Review `git diff` in full: refactored sites must assert the same things as before, and pure refactors must reduce LOC.",
+    "   Property tests may add lines. Recompute the unit's test LOC (wc -l over *.test.ts) as testLocAfter.",
+    `   Test LOC before the refactor was ${audit.testLoc}.`,
+    `3. Outstanding escalations from the apply stage: ${escalations.length ? escalations.join("; ") : "none"}.`,
+    "   If any escalation or diff concern makes the change unsafe to ship as-is, return status 'escalated' with notes and stop before pushing.",
+    `4. Otherwise: \`git checkout -b test-upgrade-${unit.name}\`, commit everything with subject \`test(${unit.name}): apply testing conventions\`,`,
+    "   push with -u, and open a PR by following plugins/pull-request/skills/create/SKILL.md (read it from the worktree).",
+    `   The PR body must state test LOC before (${audit.testLoc}) and after, what was tabled/snapshotted, and each property's invariant.`,
+    "5. Return status 'pr' with the PR URL, or 'skipped'/'escalated' with notes. Never guess on a judgment call: escalate it.",
+  ].join("\n");
+}
+
+phase("Audit");
+const results = await pipeline(
+  units,
+  (unit) => agent(auditPrompt(unit), { label: `audit:${unit.name}`, phase: "Audit", schema: AUDIT_SCHEMA }),
+  async (audit, unit) => {
+    if (!audit || audit.skip || audit.items.length === 0) return { audit, workspace: null };
+    const mechanical = audit.items.filter((i) => i.technique !== "property" && i.technique !== "arbitrary");
+    const properties = audit.items.filter((i) => i.technique === "property" || i.technique === "arbitrary");
+    let workspace = null;
+    const escalations = [];
+    if (mechanical.length) {
+      const applied = await agent(mechanicalPrompt(unit, mechanical), {
+        label: `apply:${unit.name}:mechanical`,
+        phase: "Apply",
+        model: "sonnet",
+        isolation: "worktree",
+        schema: APPLY_SCHEMA,
+      });
+      if (applied) {
+        workspace = applied.worktree;
+        escalations.push(...applied.escalations);
+      }
+    }
+    if (properties.length) {
+      const applied = await agent(propertyPrompt(unit, properties, workspace), {
+        label: `apply:${unit.name}:properties`,
+        phase: "Apply",
+        ...(workspace ? {} : { isolation: "worktree" }),
+        schema: APPLY_SCHEMA,
+      });
+      if (applied) {
+        workspace = workspace ?? applied.worktree;
+        escalations.push(...applied.escalations);
+      }
+    }
+    return { audit, workspace, escalations };
+  },
+  async (state, unit) => {
+    if (!state || !state.workspace) {
+      const reason = state?.audit?.reason ?? "audit or apply produced nothing";
+      log(`${unit.name}: skipped (${reason})`);
+      return { unit: unit.name, status: "skipped", notes: reason };
+    }
+    const verdict = await agent(verifyPrompt(unit, state.audit, state.workspace, state.escalations ?? []), {
+      label: `verify:${unit.name}`,
+      phase: "Verify",
+      effort: "low",
+      schema: VERIFY_SCHEMA,
+    });
+    if (!verdict) return { unit: unit.name, status: "escalated", notes: "verify agent died" };
+    log(`${unit.name}: ${verdict.status}${verdict.pr ? ` ${verdict.pr}` : ""}`);
+    return { unit: unit.name, ...verdict, testLocBefore: state.audit.testLoc };
+  },
+);
+
+const done = results.filter(Boolean);
+return {
+  prs: done.filter((r) => r.status === "pr"),
+  skipped: done.filter((r) => r.status === "skipped"),
+  escalations: done.filter((r) => r.status === "escalated"),
+};

--- a/biome.json
+++ b/biome.json
@@ -49,7 +49,7 @@
     }
   },
   "files": {
-    "includes": ["**/*.ts", "**/*.js", "**/*.json"],
+    "includes": ["**/*.ts", "**/*.js", "**/*.json", "!.claude/workflows/**"],
     "ignoreUnknown": true
   },
   "overrides": [

--- a/biome.json
+++ b/biome.json
@@ -49,7 +49,7 @@
     }
   },
   "files": {
-    "includes": ["**/*.ts", "**/*.js", "**/*.json", "!.claude/workflows/**"],
+    "includes": ["**/*.ts", "**/*.js", "**/*.json", "!.claude/workflows"],
     "ignoreUnknown": true
   },
   "overrides": [

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "@types/bun": "^1.3.12",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
+        "fast-check": "^4.8.0",
         "gray-matter": "^4.0.3",
       },
     },
@@ -906,6 +907,8 @@
 
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
+    "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
@@ -1267,6 +1270,8 @@
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
 
     "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/bun": "^1.3.12",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
+    "fast-check": "^4.8.0",
     "gray-matter": "^4.0.3"
   },
   "dependencies": {

--- a/plugins/bun/skills/bun/references/testing.md
+++ b/plugins/bun/skills/bun/references/testing.md
@@ -102,18 +102,85 @@ fn.mockImplementation((a, b) => a * b);
 fn.mockReturnValue(42);
 ```
 
-## Snapshot Testing
+## Parametrized Tests
 
-Compare output to saved snapshots:
+`test.each` runs one test per table row. Type the table explicitly so row mistakes fail at compile time:
 
 ```ts
-expect(value).toMatchSnapshot();
+// Tuple rows: positional args, %s/%d/%p placeholders in the title
+test.each<[string, number]>([
+  ["", 0],
+  ["a", 1],
+])("length of %p is %d", (input, expected) => {
+  expect(input.length).toBe(expected);
+});
+
+// Object rows: named fields, $field placeholders in the title
+test.each<{ name: string; input: string; expected: number }>([
+  { name: "empty string", input: "", expected: 0 },
+  { name: "single char", input: "a", expected: 1 },
+])("$name", ({ input, expected }) => {
+  expect(input.length).toBe(expected);
+});
 ```
 
-Update snapshots with `--update-snapshots`:
+`describe.each` parametrizes an entire suite the same way.
+
+## Snapshot Testing
+
+Prefer inline snapshots. Call the matcher with no argument and bun writes the received value into the test file on the first run:
+
+```ts
+expect(render(items)).toMatchInlineSnapshot();
+
+// after the first run, the file contains:
+expect(render(items)).toMatchInlineSnapshot(`
+"src/a.ts
+  :4  trim  restate-the-what  high"
+`);
+```
+
+File snapshots (`toMatchSnapshot()`) write to `__snapshots__/*.snap` next to the test file. Use them only when the output is too large to inline (roughly 20+ lines) or shared across tests.
+
+When output changes intentionally, rerun with `--update-snapshots` to rewrite both kinds:
 
 ```bash
-bun test --update-snapshots
+bun test path/to/file.test.ts --update-snapshots
+```
+
+## Property-Based Testing
+
+[fast-check](https://fast-check.dev) works under `bun test` with no adapter. Wrap a property in `fc.assert`. On failure it shrinks to a minimal counterexample and prints the seed that reproduces it:
+
+```ts
+import fc from "fast-check";
+import { expect, test } from "bun:test";
+
+test("encode/decode roundtrip", () => {
+  fc.assert(
+    fc.property(fc.array(fc.integer()), (values) => {
+      expect(decode(encode(values))).toEqual(values);
+    }),
+  );
+});
+```
+
+- Put `expect` calls inside the property. Any throw fails the run.
+- Constrain generation with arbitrary options (`fc.integer({ min: 1 })`, `fc.string({ minLength: 1 })`) or `fc.pre(condition)` rather than generating and filtering.
+- Replay a reported failure with `fc.assert(prop, { seed: <printed seed> })`.
+
+Define typed arbitraries for domain types next to the tests and reuse them:
+
+```ts
+const finding = fc.record<Finding>({
+  path: fc.string({ minLength: 1 }),
+  line: fc.integer({ min: 1 }),
+  severity: fc.constantFrom("low", "high"),
+});
+
+// Seeded sample when an example test needs a filler instance
+const [base] = fc.sample(finding, { seed: 1, numRuns: 1 });
+const item = { ...base, path: "src/a.ts" };
 ```
 
 ## Key Flags

--- a/plugins/bun/skills/bun/references/testing.md
+++ b/plugins/bun/skills/bun/references/testing.md
@@ -102,85 +102,18 @@ fn.mockImplementation((a, b) => a * b);
 fn.mockReturnValue(42);
 ```
 
-## Parametrized Tests
-
-`test.each` runs one test per table row. Type the table explicitly so row mistakes fail at compile time:
-
-```ts
-// Tuple rows: positional args, %s/%d/%p placeholders in the title
-test.each<[string, number]>([
-  ["", 0],
-  ["a", 1],
-])("length of %p is %d", (input, expected) => {
-  expect(input.length).toBe(expected);
-});
-
-// Object rows: named fields, $field placeholders in the title
-test.each<{ name: string; input: string; expected: number }>([
-  { name: "empty string", input: "", expected: 0 },
-  { name: "single char", input: "a", expected: 1 },
-])("$name", ({ input, expected }) => {
-  expect(input.length).toBe(expected);
-});
-```
-
-`describe.each` parametrizes an entire suite the same way.
-
 ## Snapshot Testing
 
-Prefer inline snapshots. Call the matcher with no argument and bun writes the received value into the test file on the first run:
+Compare output to saved snapshots:
 
 ```ts
-expect(render(items)).toMatchInlineSnapshot();
-
-// after the first run, the file contains:
-expect(render(items)).toMatchInlineSnapshot(`
-"src/a.ts
-  :4  trim  restate-the-what  high"
-`);
+expect(value).toMatchSnapshot();
 ```
 
-File snapshots (`toMatchSnapshot()`) write to `__snapshots__/*.snap` next to the test file. Use them only when the output is too large to inline (roughly 20+ lines) or shared across tests.
-
-When output changes intentionally, rerun with `--update-snapshots` to rewrite both kinds:
+Update snapshots with `--update-snapshots`:
 
 ```bash
-bun test path/to/file.test.ts --update-snapshots
-```
-
-## Property-Based Testing
-
-[fast-check](https://fast-check.dev) works under `bun test` with no adapter. Wrap a property in `fc.assert`. On failure it shrinks to a minimal counterexample and prints the seed that reproduces it:
-
-```ts
-import fc from "fast-check";
-import { expect, test } from "bun:test";
-
-test("encode/decode roundtrip", () => {
-  fc.assert(
-    fc.property(fc.array(fc.integer()), (values) => {
-      expect(decode(encode(values))).toEqual(values);
-    }),
-  );
-});
-```
-
-- Put `expect` calls inside the property. Any throw fails the run.
-- Constrain generation with arbitrary options (`fc.integer({ min: 1 })`, `fc.string({ minLength: 1 })`) or `fc.pre(condition)` rather than generating and filtering.
-- Replay a reported failure with `fc.assert(prop, { seed: <printed seed> })`.
-
-Define typed arbitraries for domain types next to the tests and reuse them:
-
-```ts
-const finding = fc.record<Finding>({
-  path: fc.string({ minLength: 1 }),
-  line: fc.integer({ min: 1 }),
-  severity: fc.constantFrom("low", "high"),
-});
-
-// Seeded sample when an example test needs a filler instance
-const [base] = fc.sample(finding, { seed: 1, numRuns: 1 });
-const item = { ...base, path: "src/a.ts" };
+bun test --update-snapshots
 ```
 
 ## Key Flags

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "skipLibCheck": true
   },
   "include": ["./**/*.ts", ".claude/**/*.ts"],
-  "exclude": ["**/fixtures/**"]
+  "exclude": ["**/fixtures/**", ".claude/workflows/**"]
 }


### PR DESCRIPTION
Adds a technique-selection guide to the testing rule so test-writing sessions (including cheaper fan-out agents) default to typed `test.each` tables, inline snapshots, and fast-check properties instead of repeated `test()` blocks and field-by-field assertions.

The survey behind this: most of the suite repeats near-identical test blocks, `toMatchInlineSnapshot` appears in exactly one file, and property-based testing is absent. `fast-check` runs under `bun test` with no adapter. Every pattern the rule documents was exercised in a scratch test in this branch's worktree (typed tuple and object tables, first-run inline snapshot fill, `expect` inside `fc.property`, a typed `fc.record` arbitrary, seeded `fc.sample` with spread overrides) and deleted before commit.

Decisions along the way: the guide lives entirely in the rule, code patterns included, rather than split between the rule and the bun skill's reference. The rule auto-injects on test files, which is exactly when the patterns are needed, while skill references only surface if the skill is activated. The bun plugin is untouched. No faker-style dependency, since types are erased at runtime and realistic-looking values add flake rather than signal. File snapshots remain for output past roughly 20 lines or shared across tests.

This is the conventions half of the effort. The fan-out that applies these techniques to the existing suite ships here as a saved workflow (`.claude/workflows/test-upgrade.ts`) but runs only after this merges, landing one `test-upgrade-<unit>` PR per unit. The workflow discovers units (plugins, packages, root script dirs with tests) at runtime and takes `args.units` to filter and `args.targets` for per-unit audit hints. Each unit is audited against the rule, mechanical table and snapshot refactors run on sonnet in isolated worktrees, property additions run at the session model, and a verify stage (tests green, behavior-neutral diff, net LOC accounting) gates each PR. Workflow scripts use harness globals and a top-level return, so `.claude/workflows/` is excluded from `tsc` and biome.

Per the curation policy: this text earns its cost if future test-writing sessions produce table, snapshot, and property tests unprompted. That signal surfaces in PR review. Revisit if new tests still arrive as repeated blocks.
