### PR TITLE
test(plugins/git): apply testing conventions

### DIFF
--- a/plugins/git/scripts/block-default-branch-commit.test.ts
+++ b/plugins/git/scripts/block-default-branch-commit.test.ts
@@ -71,13 +71,13 @@ describe("processInput", () => {
     expect(output).toBeNull();
   });
 
-  test.each<[string]>([['git commit -m "test"'], ['git commit -a -m "test"']])(
-    "blocks %p on main branch",
-    async (command) => {
-      const output = await getOutput(mockInput(command), testRepo);
-      expect(output?.permissionDecision).toBe("deny");
-    },
-  );
+  test.each<[string]>([
+    ['git commit -m "test"'],
+    ['git commit -a -m "test"'],
+  ])("blocks %p on main branch", async (command) => {
+    const output = await getOutput(mockInput(command), testRepo);
+    expect(output?.permissionDecision).toBe("deny");
+  });
 
   it("allows commit in detached HEAD state", async () => {
     await $`git checkout -q --detach HEAD`.cwd(testRepo).quiet();

--- a/plugins/git/scripts/block-default-branch-commit.test.ts
+++ b/plugins/git/scripts/block-default-branch-commit.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -71,17 +71,13 @@ describe("processInput", () => {
     expect(output).toBeNull();
   });
 
-  it("blocks commit on main branch", async () => {
-    const output = await getOutput(mockInput('git commit -m "test"'), testRepo);
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toContain("Cannot commit directly to main");
-    expect(output?.permissionDecisionReason).toContain("Create a topic branch first");
-  });
-
-  it("blocks commit with additional flags", async () => {
-    const output = await getOutput(mockInput('git commit -a -m "test"'), testRepo);
-    expect(output?.permissionDecision).toBe("deny");
-  });
+  test.each<[string]>([['git commit -m "test"'], ['git commit -a -m "test"']])(
+    "blocks %p on main branch",
+    async (command) => {
+      const output = await getOutput(mockInput(command), testRepo);
+      expect(output?.permissionDecision).toBe("deny");
+    },
+  );
 
   it("allows commit in detached HEAD state", async () => {
     await $`git checkout -q --detach HEAD`.cwd(testRepo).quiet();


### PR DESCRIPTION
Applies the repo testing conventions to the `git` plugin's unit tests.

The two `processInput` blocks that both blocked a commit on `main` differed only in the command string, so they collapse into a single `test.each` table over `git commit -m "test"` and `git commit -a -m "test"`. The dropped `permissionDecisionReason` substring assertions on the merged block are already covered exhaustively by the dedicated `formatDenyOutput` test, which asserts the full reason string, and `processInput` returns `formatDenyOutput(branch)` directly.

This is a pure `test.each` collapse. It adds no output snapshots and no property tests.

Test LOC (`wc -l` over `*.test.ts` in the unit): 229 before, 225 after.
