### PR TITLE
test(plugins/plan): apply testing conventions

### DIFF
--- a/plugins/plan/hooks/gate.test.ts
+++ b/plugins/plan/hooks/gate.test.ts
@@ -68,14 +68,12 @@ describe("unchanged re-present", () => {
     expect(await decision("My plan, revised")).toBeNull();
   });
 
-  it("allows a changed plan", async () => {
+  it.each<{ name: string; changedPlan: string }>([
+    { name: "allows a changed plan", changedPlan: "My revised plan" },
+    { name: "treats trailing-whitespace-only changes as changed", changedPlan: "My plan \n" },
+  ])("$name", async ({ changedPlan }) => {
     await decision("My plan");
-    expect(await decision("My revised plan")).toBeNull();
-  });
-
-  it("treats trailing-whitespace-only changes as changed", async () => {
-    await decision("My plan");
-    expect(await decision("My plan \n")).toBeNull();
+    expect(await decision(changedPlan)).toBeNull();
   });
 
   it("updates the stored hash on allow, so re-presenting the new text denies", async () => {


### PR DESCRIPTION
Applies the repo's testing conventions to the `plugins/plan` unit (`gate.test.ts`, `context.test.ts`).

The two `unchanged re-present` cases that shared a body (allow a changed plan, treat a trailing-whitespace-only change as changed) collapse into one `it.each` table. Both assert the same invariant they did before: after storing a hash for `"My plan"`, presenting different text returns a null decision (allowed). No behavior or assertion changed.

This refactor adds no property tests, so there are no invariants to record. Nothing was snapshotted.

Test LOC: 211 before, 209 after.
