### PR TITLE
test(plugins/linear): apply testing conventions

### DIFF
--- a/plugins/linear/hooks/save-issue.test.ts
+++ b/plugins/linear/hooks/save-issue.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { getDefaultState, normalizeInput, processInput } from "./save-issue";
 
@@ -18,16 +18,12 @@ function mockInput(
 }
 
 describe("getDefaultState", () => {
-  it("returns Backlog when no assignee", () => {
-    expect(getDefaultState(undefined)).toBe("Backlog");
-  });
-
-  it("returns Todo when assignee is set", () => {
-    expect(getDefaultState("me")).toBe("Todo");
-  });
-
-  it("returns Backlog when assignee is empty string", () => {
-    expect(getDefaultState("")).toBe("Backlog");
+  test.each<[string, string | undefined, string]>([
+    ["returns Backlog when no assignee", undefined, "Backlog"],
+    ["returns Todo when assignee is set", "me", "Todo"],
+    ["returns Backlog when assignee is empty string", "", "Backlog"],
+  ])("%s", (_name, assignee, expected) => {
+    expect(getDefaultState(assignee)).toBe(expected);
   });
 });
 
@@ -72,17 +68,10 @@ describe("processInput", () => {
     expect(processInput(mockInput(toolInput))).toMatchSnapshot();
   });
 
-  it("works with the local MCP create_issue tool name", () => {
-    expect(
-      processInput(mockInput({ title: "x", team: "ENG" }, "mcp__linear__create_issue")),
-    ).toMatchSnapshot();
-  });
-
-  it("works with the plugin MCP create_issue tool name", () => {
-    expect(
-      processInput(
-        mockInput({ title: "x", team: "ENG" }, "mcp__plugin_linear_linear__create_issue"),
-      ),
-    ).toMatchSnapshot();
+  test.each<[string, string]>([
+    ["local MCP create_issue tool name", "mcp__linear__create_issue"],
+    ["plugin MCP create_issue tool name", "mcp__plugin_linear_linear__create_issue"],
+  ])("works with the %s", (_name, toolName) => {
+    expect(processInput(mockInput({ title: "x", team: "ENG" }, toolName))).toMatchSnapshot();
   });
 });

--- a/plugins/linear/scripts/fetch.test.ts
+++ b/plugins/linear/scripts/fetch.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import type {
   PreToolUseHookInput,
   PreToolUseHookSpecificOutput,
@@ -24,44 +24,35 @@ function getOutput(input: PreToolUseHookInput): PreToolUseHookSpecificOutput | n
 }
 
 describe("isPublicUrl", () => {
-  it("allows docs URLs", () => {
-    expect(isPublicUrl("https://linear.app/docs")).toBe(true);
-    expect(isPublicUrl("https://linear.app/docs/due-dates")).toBe(true);
-    expect(isPublicUrl("https://linear.app/docs/due-dates.md")).toBe(true);
-  });
-
-  it("allows developers URLs", () => {
-    expect(isPublicUrl("https://linear.app/developers")).toBe(true);
-    expect(isPublicUrl("https://linear.app/developers/api")).toBe(true);
-  });
-
-  it("allows changelog URLs", () => {
-    expect(isPublicUrl("https://linear.app/changelog")).toBe(true);
-    expect(isPublicUrl("https://linear.app/changelog/2024")).toBe(true);
-  });
-
-  it("blocks workspace URLs", () => {
-    expect(isPublicUrl("https://linear.app/myteam/issue/ABC-123")).toBe(false);
-    expect(isPublicUrl("https://linear.app/myteam/project/abc")).toBe(false);
+  test.each<[string, boolean]>([
+    ["https://linear.app/docs", true],
+    ["https://linear.app/docs/due-dates", true],
+    ["https://linear.app/docs/due-dates.md", true],
+    ["https://linear.app/developers", true],
+    ["https://linear.app/developers/api", true],
+    ["https://linear.app/changelog", true],
+    ["https://linear.app/changelog/2024", true],
+    ["https://linear.app/myteam/issue/ABC-123", false],
+    ["https://linear.app/myteam/project/abc", false],
+  ])("%s is public: %p", (url, expected) => {
+    expect(isPublicUrl(url)).toBe(expected);
   });
 });
 
 describe("processInput", () => {
-  it("allows public docs URLs", () => {
-    expect(processInput(mockInput("https://linear.app/docs/due-dates"))).toBeNull();
-    expect(processInput(mockInput("https://linear.app/developers"))).toBeNull();
-    expect(processInput(mockInput("https://linear.app/changelog"))).toBeNull();
-  });
-
-  it("denies workspace issue URLs", () => {
-    const output = getOutput(mockInput("https://linear.app/myteam/issue/ABC-123"));
+  test.each<[string, string, string | null]>([
+    ["allows public docs URL", "https://linear.app/docs/due-dates", null],
+    ["allows public developers URL", "https://linear.app/developers", null],
+    ["allows public changelog URL", "https://linear.app/changelog", null],
+    ["denies workspace issue URLs", "https://linear.app/myteam/issue/ABC-123", "Linear MCP"],
+    ["denies workspace project URLs", "https://linear.app/myteam/project/abc123", "Linear MCP"],
+  ])("%s", (_name, url, expectedReason) => {
+    const output = getOutput(mockInput(url));
+    if (expectedReason === null) {
+      expect(output).toBeNull();
+      return;
+    }
     expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toContain("Linear MCP");
-  });
-
-  it("denies workspace project URLs", () => {
-    const output = getOutput(mockInput("https://linear.app/myteam/project/abc123"));
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toContain("Linear MCP");
+    expect(output?.permissionDecisionReason).toContain(expectedReason);
   });
 });


### PR DESCRIPTION
Applies the repo's testing conventions to the `linear` plugin's unit tests, collapsing repetitive per-case `it()` blocks into `test.each` tables.

The behavior under test is unchanged. Every assertion from the original tests survives: `getDefaultState` still maps assignee presence to `Backlog`/`Todo`, `processInput` snapshots still cover both the local and plugin MCP tool names, and the `fetch` hook still allows public docs/developers/changelog URLs while denying workspace issue and project URLs with a reason containing `Linear MCP`. The 21 snapshots are untouched.

## Tables and Snapshots

- `getDefaultState`: three cases tabled over `(assignee, expected)`.
- `processInput` in `save-issue`: the two MCP-tool-name cases tabled, each still asserting against `toMatchSnapshot()`.
- `isPublicUrl`: nine URL cases tabled over `(url, expected boolean)`.
- `processInput` in `fetch`: the allow and deny cases merged into one table; null-expectation rows assert `toBeNull()`, reason rows assert `permissionDecision === "deny"` and the reason contains the expected substring.

This change adds no property tests. These are pure table refactors. Test LOC drops from 155 to 135.
