### PR TITLE
test(plugins/type-ignore): apply testing conventions

### DIFF
--- a/plugins/type-ignore/hooks/detect.test.ts
+++ b/plugins/type-ignore/hooks/detect.test.ts
@@ -1,202 +1,134 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { findIgnorePattern, findLineNumber, hasNewIgnore } from "./detect";
+
+type Ignore = { label: string; match: string } | null;
+const ignore = (label: string, match = label): Ignore => ({ label, match });
 
 describe("detect", () => {
   describe("findIgnorePattern", () => {
-    describe("typescript", () => {
-      it("detects @ts-ignore", () => {
-        expect(findIgnorePattern("// @ts-ignore", "typescript")).toEqual({
-          label: "@ts-ignore",
-          match: "@ts-ignore",
-        });
-      });
-
-      it("detects @ts-expect-error", () => {
-        expect(findIgnorePattern("// @ts-expect-error", "typescript")).toEqual({
-          label: "@ts-expect-error",
-          match: "@ts-expect-error",
-        });
-      });
-
-      it("detects eslint-disable", () => {
-        expect(findIgnorePattern("// eslint-disable", "typescript")).toEqual({
-          label: "eslint-disable",
-          match: "eslint-disable",
-        });
-      });
-
-      it("detects eslint-disable-next-line", () => {
-        expect(findIgnorePattern("// eslint-disable-next-line", "typescript")).toEqual({
-          label: "eslint-disable",
-          match: "eslint-disable-next-line",
-        });
-      });
-
-      it("detects biome-ignore", () => {
-        expect(findIgnorePattern("// biome-ignore lint: reason", "typescript")).toEqual({
-          label: "biome-ignore",
-          match: "biome-ignore",
-        });
-      });
-
-      it("returns null for clean TypeScript", () => {
-        expect(findIgnorePattern("const x = 1;", "typescript")).toBeNull();
-      });
-    });
-
-    describe("python", () => {
-      it("detects # type: ignore", () => {
-        expect(findIgnorePattern("# type: ignore", "python")).toEqual({
-          label: "type: ignore",
-          match: "# type: ignore",
-        });
-      });
-
-      it("detects # noqa", () => {
-        expect(findIgnorePattern("# noqa", "python")).toEqual({
-          label: "noqa",
-          match: "# noqa",
-        });
-      });
-
-      it("detects # pylint: disable", () => {
-        expect(findIgnorePattern("# pylint: disable=C0111", "python")).toEqual({
-          label: "pylint: disable",
-          match: "# pylint: disable",
-        });
-      });
-
-      it("returns null for clean Python", () => {
-        expect(findIgnorePattern("x = 1", "python")).toBeNull();
-      });
-    });
-
-    describe("go", () => {
-      it("detects //nolint", () => {
-        expect(findIgnorePattern("//nolint", "go")).toEqual({
-          label: "nolint",
-          match: "//nolint",
-        });
-      });
-
-      it("detects //nolint:errcheck", () => {
-        expect(findIgnorePattern("//nolint:errcheck", "go")).toEqual({
-          label: "nolint",
-          match: "//nolint",
-        });
-      });
-
-      it("does not match // nolint with space", () => {
-        expect(findIgnorePattern("// nolint", "go")).toBeNull();
-      });
-
-      it("detects //lint:ignore", () => {
-        expect(findIgnorePattern("//lint:ignore", "go")).toEqual({
-          label: "lint:ignore",
-          match: "//lint:ignore",
-        });
-      });
-
-      it("returns null for clean Go", () => {
-        expect(findIgnorePattern("func main() {}", "go")).toBeNull();
-      });
-    });
-
-    describe("rust", () => {
-      it("detects #[allow(unused)]", () => {
-        expect(findIgnorePattern("#[allow(unused)]", "rust")).toEqual({
-          label: "#[allow(...)]",
-          match: "#[allow(unused)]",
-        });
-      });
-
-      it("detects #![allow(unused)] inner attribute", () => {
-        expect(findIgnorePattern("#![allow(unused)]", "rust")).toEqual({
-          label: "#[allow(...)]",
-          match: "#![allow(unused)]",
-        });
-      });
-
-      it("detects #[allow(clippy::complexity)]", () => {
-        expect(findIgnorePattern("#[allow(clippy::complexity)]", "rust")).toEqual({
-          label: "#[allow(...)]",
-          match: "#[allow(clippy::complexity)]",
-        });
-      });
-
-      it("returns null for clean Rust", () => {
-        expect(findIgnorePattern("fn main() {}", "rust")).toBeNull();
-      });
-    });
-
-    describe("ruby", () => {
-      it("detects # rubocop:disable", () => {
-        expect(findIgnorePattern("# rubocop:disable Style/FrozenStringLiteral", "ruby")).toEqual({
-          label: "rubocop:disable",
-          match: "# rubocop:disable",
-        });
-      });
-
-      it("returns null for clean Ruby", () => {
-        expect(findIgnorePattern("def hello; end", "ruby")).toBeNull();
-      });
+    test.each<[string, string, string, Ignore]>([
+      ["detects @ts-ignore", "// @ts-ignore", "typescript", ignore("@ts-ignore")],
+      ["detects @ts-expect-error", "// @ts-expect-error", "typescript", ignore("@ts-expect-error")],
+      ["detects eslint-disable", "// eslint-disable", "typescript", ignore("eslint-disable")],
+      [
+        "detects eslint-disable-next-line",
+        "// eslint-disable-next-line",
+        "typescript",
+        ignore("eslint-disable", "eslint-disable-next-line"),
+      ],
+      [
+        "detects biome-ignore",
+        "// biome-ignore lint: reason",
+        "typescript",
+        ignore("biome-ignore"),
+      ],
+      ["returns null for clean TypeScript", "const x = 1;", "typescript", null],
+      [
+        "detects # type: ignore",
+        "# type: ignore",
+        "python",
+        ignore("type: ignore", "# type: ignore"),
+      ],
+      ["detects # noqa", "# noqa", "python", ignore("noqa", "# noqa")],
+      [
+        "detects # pylint: disable",
+        "# pylint: disable=C0111",
+        "python",
+        ignore("pylint: disable", "# pylint: disable"),
+      ],
+      ["returns null for clean Python", "x = 1", "python", null],
+      ["detects //nolint", "//nolint", "go", ignore("nolint", "//nolint")],
+      ["detects //nolint:errcheck", "//nolint:errcheck", "go", ignore("nolint", "//nolint")],
+      ["does not match // nolint with space", "// nolint", "go", null],
+      ["detects //lint:ignore", "//lint:ignore", "go", ignore("lint:ignore", "//lint:ignore")],
+      ["returns null for clean Go", "func main() {}", "go", null],
+      [
+        "detects #[allow(unused)]",
+        "#[allow(unused)]",
+        "rust",
+        ignore("#[allow(...)]", "#[allow(unused)]"),
+      ],
+      [
+        "detects #![allow(unused)] inner attribute",
+        "#![allow(unused)]",
+        "rust",
+        ignore("#[allow(...)]", "#![allow(unused)]"),
+      ],
+      [
+        "detects #[allow(clippy::complexity)]",
+        "#[allow(clippy::complexity)]",
+        "rust",
+        ignore("#[allow(...)]", "#[allow(clippy::complexity)]"),
+      ],
+      ["returns null for clean Rust", "fn main() {}", "rust", null],
+      [
+        "detects # rubocop:disable",
+        "# rubocop:disable Style/FrozenStringLiteral",
+        "ruby",
+        ignore("rubocop:disable", "# rubocop:disable"),
+      ],
+      ["returns null for clean Ruby", "def hello; end", "ruby", null],
+    ])("%s", (_name, content, language, expected) => {
+      expect(findIgnorePattern(content, language)).toEqual(expected);
     });
   });
 
   describe("hasNewIgnore", () => {
-    it("detects new TypeScript ignore", () => {
-      expect(hasNewIgnore("const x = 1;", "// @ts-ignore\nconst x = 1;", "typescript")).toEqual({
-        label: "@ts-ignore",
-        match: "@ts-ignore",
-      });
-    });
-
-    it("returns null when ignore already existed", () => {
-      expect(
-        hasNewIgnore("// @ts-ignore\nconst x = 1;", "// @ts-ignore\nconst y = 2;", "typescript"),
-      ).toBeNull();
-    });
-
-    it("detects new Python ignore", () => {
-      expect(hasNewIgnore("x = 1", "x = 1  # type: ignore", "python")).toEqual({
-        label: "type: ignore",
-        match: "# type: ignore",
-      });
-    });
-
-    it("detects new Go ignore", () => {
-      expect(hasNewIgnore("err := foo()", "err := foo() //nolint:errcheck", "go")).toEqual({
-        label: "nolint",
-        match: "//nolint",
-      });
-    });
-
-    it("detects new Rust ignore", () => {
-      expect(hasNewIgnore("fn foo() {}", "#[allow(unused)]\nfn foo() {}", "rust")).toEqual({
-        label: "#[allow(...)]",
-        match: "#[allow(unused)]",
-      });
-    });
-
-    it("detects new Ruby ignore", () => {
-      expect(hasNewIgnore("def foo; end", "# rubocop:disable\ndef foo; end", "ruby")).toEqual({
-        label: "rubocop:disable",
-        match: "# rubocop:disable",
-      });
+    test.each<[string, string, string, string, Ignore]>([
+      [
+        "detects new TypeScript ignore",
+        "const x = 1;",
+        "// @ts-ignore\nconst x = 1;",
+        "typescript",
+        ignore("@ts-ignore"),
+      ],
+      [
+        "returns null when ignore already existed",
+        "// @ts-ignore\nconst x = 1;",
+        "// @ts-ignore\nconst y = 2;",
+        "typescript",
+        null,
+      ],
+      [
+        "detects new Python ignore",
+        "x = 1",
+        "x = 1  # type: ignore",
+        "python",
+        ignore("type: ignore", "# type: ignore"),
+      ],
+      [
+        "detects new Go ignore",
+        "err := foo()",
+        "err := foo() //nolint:errcheck",
+        "go",
+        ignore("nolint", "//nolint"),
+      ],
+      [
+        "detects new Rust ignore",
+        "fn foo() {}",
+        "#[allow(unused)]\nfn foo() {}",
+        "rust",
+        ignore("#[allow(...)]", "#[allow(unused)]"),
+      ],
+      [
+        "detects new Ruby ignore",
+        "def foo; end",
+        "# rubocop:disable\ndef foo; end",
+        "ruby",
+        ignore("rubocop:disable", "# rubocop:disable"),
+      ],
+    ])("%s", (_name, oldString, newString, language, expected) => {
+      expect(hasNewIgnore(oldString, newString, language)).toEqual(expected);
     });
   });
 
   describe("findLineNumber", () => {
-    it("finds pattern on first line", () => {
-      expect(findLineNumber("@ts-ignore\ncode", "@ts-ignore")).toBe(1);
-    });
-
-    it("finds pattern on third line", () => {
-      expect(findLineNumber("line1\nline2\n@ts-ignore\nline4", "@ts-ignore")).toBe(3);
-    });
-
-    it("returns 1 when pattern not found", () => {
-      expect(findLineNumber("no pattern here", "@ts-ignore")).toBe(1);
+    test.each<[string, string, number]>([
+      ["@ts-ignore\ncode", "@ts-ignore", 1],
+      ["line1\nline2\n@ts-ignore\nline4", "@ts-ignore", 3],
+      ["no pattern here", "@ts-ignore", 1],
+    ])("finds %p in %p at line %d", (content, pattern, expected) => {
+      expect(findLineNumber(content, pattern)).toBe(expected);
     });
   });
 });


### PR DESCRIPTION
Converts the `detect` hook tests from one `it` per case to `test.each` tables, one table per function under test. Every input, language, and expected result carries over verbatim, so the assertions are unchanged.

A small `ignore(label, match = label)` helper builds the expected `{ label, match }` object. It defaults `match` to `label` for the common case where the two coincide, which removes most of the repetition.

Test LOC dropped from 202 to 134. Nothing was tabled out or snapshotted, and the suite adds no property tests. The inputs are a fixed enumeration of comment syntaxes per language, so an exhaustive table is the natural form.

The tables cover `findIgnorePattern` (per-language detection of ignore comments and clean-code null cases across TypeScript, Python, Go, Rust, and Ruby), `hasNewIgnore` (a newly introduced ignore versus one that already existed), and `findLineNumber` (locating a pattern by line and falling back to 1 when absent).
