### PR TITLE
test(plugins/tmux): apply testing conventions

### DIFF
--- a/plugins/tmux/hooks/target.test.ts
+++ b/plugins/tmux/hooks/target.test.ts
@@ -15,20 +15,22 @@ function mockInput(command: string): PreToolUseHookInput {
 }
 
 describe("parseTmuxCommand", () => {
-  test.each<{ name: string; input: string; expected: { subcommand: string; rest: string } | null }>([
-    {
-      name: "extracts subcommand and rest",
-      input: "tmux split-window -h -d",
-      expected: { subcommand: "split-window", rest: " -h -d" },
-    },
-    {
-      name: "handles subcommand with no args",
-      input: "tmux split-window",
-      expected: { subcommand: "split-window", rest: "" },
-    },
-    { name: "returns null for non-tmux command", input: "ls -la", expected: null },
-    { name: "returns null for empty string", input: "", expected: null },
-  ])("$name", ({ input, expected }) => {
+  test.each<{ name: string; input: string; expected: { subcommand: string; rest: string } | null }>(
+    [
+      {
+        name: "extracts subcommand and rest",
+        input: "tmux split-window -h -d",
+        expected: { subcommand: "split-window", rest: " -h -d" },
+      },
+      {
+        name: "handles subcommand with no args",
+        input: "tmux split-window",
+        expected: { subcommand: "split-window", rest: "" },
+      },
+      { name: "returns null for non-tmux command", input: "ls -la", expected: null },
+      { name: "returns null for empty string", input: "", expected: null },
+    ],
+  )("$name", ({ input, expected }) => {
     expect(parseTmuxCommand(input)).toEqual(expected);
   });
 });
@@ -54,8 +56,16 @@ describe("injectTarget", () => {
       command: "tmux split-window -h -d",
       expected: 'tmux split-window -t "%5" -h -d',
     },
-    { name: "injects target for alias", command: "tmux splitw -h", expected: 'tmux splitw -t "%5" -h' },
-    { name: "returns null for non-targetable command", command: "tmux list-sessions", expected: null },
+    {
+      name: "injects target for alias",
+      command: "tmux splitw -h",
+      expected: 'tmux splitw -t "%5" -h',
+    },
+    {
+      name: "returns null for non-targetable command",
+      command: "tmux list-sessions",
+      expected: null,
+    },
     {
       name: "returns null when -t already present",
       command: "tmux split-window -t %3 -h",

--- a/plugins/tmux/hooks/target.test.ts
+++ b/plugins/tmux/hooks/target.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { hasExistingTarget, injectTarget, parseTmuxCommand, processInput } from "./target";
 
@@ -15,112 +15,90 @@ function mockInput(command: string): PreToolUseHookInput {
 }
 
 describe("parseTmuxCommand", () => {
-  it("extracts subcommand and rest", () => {
-    expect(parseTmuxCommand("tmux split-window -h -d")).toEqual({
-      subcommand: "split-window",
-      rest: " -h -d",
-    });
-  });
-
-  it("handles subcommand with no args", () => {
-    expect(parseTmuxCommand("tmux split-window")).toEqual({
-      subcommand: "split-window",
-      rest: "",
-    });
-  });
-
-  it("returns null for non-tmux command", () => {
-    expect(parseTmuxCommand("ls -la")).toBeNull();
-  });
-
-  it("returns null for empty string", () => {
-    expect(parseTmuxCommand("")).toBeNull();
+  test.each<{ name: string; input: string; expected: { subcommand: string; rest: string } | null }>([
+    {
+      name: "extracts subcommand and rest",
+      input: "tmux split-window -h -d",
+      expected: { subcommand: "split-window", rest: " -h -d" },
+    },
+    {
+      name: "handles subcommand with no args",
+      input: "tmux split-window",
+      expected: { subcommand: "split-window", rest: "" },
+    },
+    { name: "returns null for non-tmux command", input: "ls -la", expected: null },
+    { name: "returns null for empty string", input: "", expected: null },
+  ])("$name", ({ input, expected }) => {
+    expect(parseTmuxCommand(input)).toEqual(expected);
   });
 });
 
 describe("hasExistingTarget", () => {
-  it("detects -t mid-args", () => {
-    expect(hasExistingTarget(" -t %5 -h")).toBe(true);
-  });
-
-  it("detects -t at end", () => {
-    expect(hasExistingTarget(" -h -t ")).toBe(true);
-  });
-
-  it("detects standalone -t", () => {
-    expect(hasExistingTarget(" -t ")).toBe(true);
-  });
-
-  it("returns false when absent", () => {
-    expect(hasExistingTarget(" -h -d")).toBe(false);
-  });
-
-  it("does not match -t inside another flag", () => {
-    expect(hasExistingTarget(" -target foo")).toBe(false);
-  });
-
-  it("detects -t with value attached (no space)", () => {
-    expect(hasExistingTarget(" -t%3 -h")).toBe(true);
-  });
-
-  it("detects -t with quoted value attached", () => {
-    expect(hasExistingTarget(' -t"%3" -h')).toBe(true);
+  test.each<{ name: string; input: string; expected: boolean }>([
+    { name: "detects -t mid-args", input: " -t %5 -h", expected: true },
+    { name: "detects -t at end", input: " -h -t ", expected: true },
+    { name: "detects standalone -t", input: " -t ", expected: true },
+    { name: "returns false when absent", input: " -h -d", expected: false },
+    { name: "does not match -t inside another flag", input: " -target foo", expected: false },
+    { name: "detects -t with value attached (no space)", input: " -t%3 -h", expected: true },
+    { name: "detects -t with quoted value attached", input: ' -t"%3" -h', expected: true },
+  ])("$name", ({ input, expected }) => {
+    expect(hasExistingTarget(input)).toBe(expected);
   });
 });
 
 describe("injectTarget", () => {
-  it("injects target after subcommand", () => {
-    expect(injectTarget("tmux split-window -h -d", "%5")).toBe('tmux split-window -t "%5" -h -d');
-  });
-
-  it("injects target for alias", () => {
-    expect(injectTarget("tmux splitw -h", "%5")).toBe('tmux splitw -t "%5" -h');
-  });
-
-  it("returns null for non-targetable command", () => {
-    expect(injectTarget("tmux list-sessions", "%5")).toBeNull();
-  });
-
-  it("returns null when -t already present", () => {
-    expect(injectTarget("tmux split-window -t %3 -h", "%5")).toBeNull();
-  });
-
-  it("returns null for non-tmux command", () => {
-    expect(injectTarget("ls -la", "%5")).toBeNull();
-  });
-
-  it("injects target for send-keys", () => {
-    expect(injectTarget("tmux send-keys C-c", "%5")).toBe('tmux send-keys -t "%5" C-c');
-  });
-
-  it("injects target for capture-pane", () => {
-    expect(injectTarget("tmux capture-pane -p", "%5")).toBe('tmux capture-pane -t "%5" -p');
-  });
-
-  it("does not inject target for display-message", () => {
-    expect(injectTarget("tmux display-message -p '#{pane_id}'", "%5")).toBeNull();
-  });
-
-  it("returns null when -t has value attached (no space)", () => {
-    expect(injectTarget("tmux split-window -t%3 -h", "%5")).toBeNull();
+  test.each<{ name: string; command: string; expected: string | null }>([
+    {
+      name: "injects target after subcommand",
+      command: "tmux split-window -h -d",
+      expected: 'tmux split-window -t "%5" -h -d',
+    },
+    { name: "injects target for alias", command: "tmux splitw -h", expected: 'tmux splitw -t "%5" -h' },
+    { name: "returns null for non-targetable command", command: "tmux list-sessions", expected: null },
+    {
+      name: "returns null when -t already present",
+      command: "tmux split-window -t %3 -h",
+      expected: null,
+    },
+    { name: "returns null for non-tmux command", command: "ls -la", expected: null },
+    {
+      name: "injects target for send-keys",
+      command: "tmux send-keys C-c",
+      expected: 'tmux send-keys -t "%5" C-c',
+    },
+    {
+      name: "injects target for capture-pane",
+      command: "tmux capture-pane -p",
+      expected: 'tmux capture-pane -t "%5" -p',
+    },
+    {
+      name: "does not inject target for display-message",
+      command: "tmux display-message -p '#{pane_id}'",
+      expected: null,
+    },
+    {
+      name: "returns null when -t has value attached (no space)",
+      command: "tmux split-window -t%3 -h",
+      expected: null,
+    },
+  ])("$name", ({ command, expected }) => {
+    expect(injectTarget(command, "%5")).toBe(expected);
   });
 });
 
 describe("processInput", () => {
-  it("returns null when pane is undefined", () => {
-    expect(processInput(mockInput("tmux split-window -h"))).toBeNull();
-  });
-
-  it("returns null when pane is empty", () => {
-    expect(processInput(mockInput("tmux split-window -h"), "")).toBeNull();
-  });
-
-  it("returns null for non-targetable command", () => {
-    expect(processInput(mockInput("tmux list-sessions"), "%5")).toBeNull();
-  });
-
-  it("returns null when -t already present", () => {
-    expect(processInput(mockInput("tmux split-window -t %3 -h"), "%5")).toBeNull();
+  test.each<{ name: string; command: string; pane?: string }>([
+    { name: "returns null when pane is undefined", command: "tmux split-window -h" },
+    { name: "returns null when pane is empty", command: "tmux split-window -h", pane: "" },
+    { name: "returns null for non-targetable command", command: "tmux list-sessions", pane: "%5" },
+    {
+      name: "returns null when -t already present",
+      command: "tmux split-window -t %3 -h",
+      pane: "%5",
+    },
+  ])("$name", ({ command, pane }) => {
+    expect(processInput(mockInput(command), pane)).toBeNull();
   });
 
   it("returns updatedInput and additionalContext for targetable command", () => {

--- a/plugins/tmux/skills/tmux/scripts/safe-command.test.ts
+++ b/plugins/tmux/skills/tmux/scripts/safe-command.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
 
 const script = join(import.meta.dir, "safe-command.sh");
@@ -23,26 +23,19 @@ function isAllow(output: string): boolean {
 }
 
 describe("safe-command", () => {
-  it("auto-allows read-only commands", async () => {
-    expect(isAllow(await run("tmux capture-pane -p"))).toBe(true);
-    expect(isAllow(await run("tmux display-message -p '#{pane_id}'"))).toBe(true);
-    expect(isAllow(await run("tmux list-windows"))).toBe(true);
-  });
-
-  it("auto-allows within-window layout and pane commands", async () => {
-    expect(isAllow(await run("tmux select-pane -t %3"))).toBe(true);
-    expect(isAllow(await run("tmux resize-pane -D 5"))).toBe(true);
-  });
-
-  it("does not auto-allow window-navigation commands", async () => {
-    expect(await run("tmux select-window -t :2")).toBe("");
-    expect(await run("tmux switch-client -t other")).toBe("");
-    expect(await run("tmux next-window")).toBe("");
-    expect(await run("tmux previous-window")).toBe("");
-    expect(await run("tmux last-window")).toBe("");
-  });
-
-  it("does not auto-allow non-tmux commands", async () => {
-    expect(await run("ls -la")).toBe("");
+  test.each<{ command: string; allowed: boolean }>([
+    { command: "tmux capture-pane -p", allowed: true },
+    { command: "tmux display-message -p '#{pane_id}'", allowed: true },
+    { command: "tmux list-windows", allowed: true },
+    { command: "tmux select-pane -t %3", allowed: true },
+    { command: "tmux resize-pane -D 5", allowed: true },
+    { command: "tmux select-window -t :2", allowed: false },
+    { command: "tmux switch-client -t other", allowed: false },
+    { command: "tmux next-window", allowed: false },
+    { command: "tmux previous-window", allowed: false },
+    { command: "tmux last-window", allowed: false },
+    { command: "ls -la", allowed: false },
+  ])("$command -> allowed=$allowed", async ({ command, allowed }) => {
+    expect(isAllow(await run(command))).toBe(allowed);
   });
 });


### PR DESCRIPTION
Applies the repo's testing conventions to the `tmux` plugin's unit tests, converting repetitive single-assertion `it` blocks into `test.each` tables.

Both `target.test.ts` and `safe-command.test.ts` had clusters of near-identical cases that differed only in input and expected value. Tabulating them keeps every case's coverage while cutting the boilerplate. Test LOC dropped from 193 to 164.

In `safe-command.test.ts` the four separate blocks collapse into one table asserting `isAllow(await run(command))` against an `allowed` boolean. This changes the shape of the "not auto-allowed" cases from an exact `toBe("")` on raw output to a derived boolean. It is behaviorally equivalent given the script's outputs: the deny path emits an empty string, and `isAllow("")` short-circuits to `false` before any `JSON.parse`. The script only ever emits allow-JSON or empty, so no non-allow non-empty output exists that the looser check would miss.

No property tests were added. Nothing was tabled or snapshotted.

## Testing

`AGENT=1 bun test ./plugins/tmux/hooks/target.test.ts ./plugins/tmux/skills/tmux/scripts/safe-command.test.ts` reports 37 pass.
