### PR TITLE
test(plugins/ui-design): apply testing conventions

### DIFF
--- a/plugins/ui-design/skills/wireframe/scripts/validate-hook.test.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/validate-hook.test.ts
@@ -18,55 +18,51 @@ function makeInput(toolName: string, filePath: string): PostToolUseHookInput {
 }
 
 describe("isSvgFile", () => {
-  it("returns true for .svg files", () => {
-    expect(isSvgFile("/path/to/file.svg")).toBe(true);
-    expect(isSvgFile("file.svg")).toBe(true);
-  });
-
-  it("returns false for non-svg files", () => {
-    expect(isSvgFile("/path/to/file.png")).toBe(false);
-    expect(isSvgFile("/path/to/file.ts")).toBe(false);
-    expect(isSvgFile("/path/to/file")).toBe(false);
-  });
-
-  it("handles edge cases", () => {
-    expect(isSvgFile(".svg")).toBe(false);
-    expect(isSvgFile("/path/to/.svg")).toBe(false);
-    expect(isSvgFile("/path/to/file.SVG")).toBe(false);
+  it.each<[string, boolean]>([
+    ["/path/to/file.svg", true],
+    ["file.svg", true],
+    ["/path/to/file.png", false],
+    ["/path/to/file.ts", false],
+    ["/path/to/file", false],
+    [".svg", false],
+    ["/path/to/.svg", false],
+    ["/path/to/file.SVG", false],
+  ])("isSvgFile(%p) is %p", (input, expected) => {
+    expect(isSvgFile(input)).toBe(expected);
   });
 });
 
 describe("processInput", () => {
-  it("returns null for non-Write/Edit tools", async () => {
-    const result = await processInput(makeInput("Read", "/path/to/file.svg"));
-    expect(result).toBeNull();
-  });
+  it.each<{ name: string; tool: string; path: string; expected: null | string }>([
+    { name: "non-Write/Edit tools", tool: "Read", path: "/path/to/file.svg", expected: null },
+    { name: "non-SVG files", tool: "Write", path: "/path/to/file.ts", expected: null },
+    {
+      name: "valid SVG",
+      tool: "Write",
+      path: path.join(assetsDir, "login-screen.svg"),
+      expected: null,
+    },
+    {
+      name: "invalid SVG",
+      tool: "Write",
+      path: path.join(fixturesDir, "missing-dimensions.svg"),
+      expected: "missing-dimensions",
+    },
+    {
+      name: "Edit tool",
+      tool: "Edit",
+      path: path.join(fixturesDir, "overlapping-elements.svg"),
+      expected: "overlap",
+    },
+  ])("handles $name", async ({ tool, path: filePath, expected }) => {
+    const result = await processInput(makeInput(tool, filePath));
 
-  it("returns null for non-SVG files", async () => {
-    const result = await processInput(makeInput("Write", "/path/to/file.ts"));
-    expect(result).toBeNull();
-  });
-
-  it("returns null for valid SVG", async () => {
-    const result = await processInput(makeInput("Write", path.join(assetsDir, "login-screen.svg")));
-    expect(result).toBeNull();
-  });
-
-  it("returns violations for invalid SVG", async () => {
-    const result = await processInput(
-      makeInput("Write", path.join(fixturesDir, "missing-dimensions.svg")),
-    );
-    expect(result).not.toBeNull();
-    const output = result?.hookSpecificOutput as PostToolUseHookSpecificOutput | undefined;
-    expect(output?.additionalContext).toContain("missing-dimensions");
-  });
-
-  it("works with Edit tool", async () => {
-    const result = await processInput(
-      makeInput("Edit", path.join(fixturesDir, "overlapping-elements.svg")),
-    );
-    expect(result).not.toBeNull();
-    const output = result?.hookSpecificOutput as PostToolUseHookSpecificOutput | undefined;
-    expect(output?.additionalContext).toContain("overlap");
+    if (expected === null) {
+      expect(result).toBeNull();
+    } else {
+      expect(result).not.toBeNull();
+      const output = result?.hookSpecificOutput as PostToolUseHookSpecificOutput | undefined;
+      expect(output?.additionalContext).toContain(expected);
+    }
   });
 });

--- a/plugins/ui-design/skills/wireframe/scripts/validate.test.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/validate.test.ts
@@ -20,88 +20,55 @@ function findViolation(violations: Violation[], issue: string): Violation | unde
 
 describe("validate", () => {
   describe("example assets", () => {
-    it("accepts a well-formed login screen", async () => {
-      const svg = await loadAsset("login-screen");
-      const violations = validate(svg);
-      expect(violations).toHaveLength(0);
-    });
-
-    it("accepts nested groups within bounds", async () => {
-      const svg = await loadAsset("nested-groups");
-      const violations = validate(svg);
-      expect(violations).toHaveLength(0);
-    });
-
-    it("accepts a two-column layout", async () => {
-      const svg = await loadAsset("two-column");
-      const violations = validate(svg);
-      expect(violations).toHaveLength(0);
-    });
-
-    it("accepts a grid layout", async () => {
-      const svg = await loadAsset("grid");
-      const violations = validate(svg);
-      expect(violations).toHaveLength(0);
-    });
-
-    it("accepts a table layout", async () => {
-      const svg = await loadAsset("table");
-      const violations = validate(svg);
-      expect(violations).toHaveLength(0);
-    });
-
-    it("accepts a form layout", async () => {
-      const svg = await loadAsset("form");
-      const violations = validate(svg);
-      expect(violations).toHaveLength(0);
-    });
-
-    it("accepts a modal dialog", async () => {
-      const svg = await loadAsset("modal");
+    it.each([
+      "login-screen",
+      "nested-groups",
+      "two-column",
+      "grid",
+      "table",
+      "form",
+      "modal",
+    ])("accepts %s", async (name) => {
+      const svg = await loadAsset(name);
       const violations = validate(svg);
       expect(violations).toHaveLength(0);
     });
   });
 
   describe("invalid fixtures", () => {
-    it("rejects SVG without width/height attributes", async () => {
-      const svg = await loadFixture("missing-dimensions");
+    it.each<{ name: string; fixture: string; issue: string; exactCount?: number }>([
+      {
+        name: "missing width/height attributes",
+        fixture: "missing-dimensions",
+        issue: "missing-dimensions",
+        exactCount: 1,
+      },
+      {
+        name: "element extending outside canvas",
+        fixture: "element-out-of-bounds",
+        issue: "out-of-bounds",
+      },
+      { name: "overlapping sibling elements", fixture: "overlapping-elements", issue: "overlap" },
+      {
+        name: "text extending outside container",
+        fixture: "text-outside-container",
+        issue: "out-of-bounds",
+      },
+      {
+        name: "group extending outside canvas",
+        fixture: "group-out-of-bounds",
+        issue: "out-of-bounds",
+      },
+    ])("detects $name", async ({ fixture, issue, exactCount }) => {
+      const svg = await loadFixture(fixture);
       const violations = validate(svg);
 
-      expect(violations).toHaveLength(1);
-      expect(findViolation(violations, "missing-dimensions")).toBeDefined();
-    });
-
-    it("detects elements extending outside canvas", async () => {
-      const svg = await loadFixture("element-out-of-bounds");
-      const violations = validate(svg);
-
-      expect(violations.length).toBeGreaterThan(0);
-      expect(findViolation(violations, "out-of-bounds")).toBeDefined();
-    });
-
-    it("detects overlapping sibling elements", async () => {
-      const svg = await loadFixture("overlapping-elements");
-      const violations = validate(svg);
-
-      expect(violations.length).toBeGreaterThan(0);
-      expect(findViolation(violations, "overlap")).toBeDefined();
-    });
-
-    it("detects text extending outside container", async () => {
-      const svg = await loadFixture("text-outside-container");
-      const violations = validate(svg);
-
-      expect(violations.length).toBeGreaterThan(0);
-      expect(findViolation(violations, "out-of-bounds")).toBeDefined();
-    });
-
-    it("detects group extending outside canvas", async () => {
-      const svg = await loadFixture("group-out-of-bounds");
-      const violations = validate(svg);
-
-      expect(violations.length).toBeGreaterThan(0);
-      expect(findViolation(violations, "out-of-bounds")).toBeDefined();
+      if (exactCount !== undefined) {
+        expect(violations).toHaveLength(exactCount);
+      } else {
+        expect(violations.length).toBeGreaterThan(0);
+      }
+      expect(findViolation(violations, issue)).toBeDefined();
     });
   });
 });
@@ -128,35 +95,41 @@ describe("validateFiles", () => {
 });
 
 describe("circle and ellipse elements", () => {
-  it("accepts circle within bounds", () => {
-    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  it.each<{ name: string; svg: string; expectViolation: boolean }>([
+    {
+      name: "circle within bounds",
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
       <circle cx="50" cy="50" r="40" fill="none" stroke="black"/>
-    </svg>`;
-    const violations = validate(svg);
-    expect(violations).toHaveLength(0);
-  });
-
-  it("detects circle out of bounds", () => {
-    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    </svg>`,
+      expectViolation: false,
+    },
+    {
+      name: "circle out of bounds",
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
       <circle cx="50" cy="50" r="60" fill="none" stroke="black"/>
-    </svg>`;
-    const violations = validate(svg);
-    expect(findViolation(violations, "out-of-bounds")).toBeDefined();
-  });
-
-  it("accepts ellipse within bounds", () => {
-    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    </svg>`,
+      expectViolation: true,
+    },
+    {
+      name: "ellipse within bounds",
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
       <ellipse cx="50" cy="50" rx="40" ry="30" fill="none" stroke="black"/>
-    </svg>`;
-    const violations = validate(svg);
-    expect(violations).toHaveLength(0);
-  });
-
-  it("detects ellipse out of bounds", () => {
-    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    </svg>`,
+      expectViolation: false,
+    },
+    {
+      name: "ellipse out of bounds",
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
       <ellipse cx="50" cy="50" rx="60" ry="30" fill="none" stroke="black"/>
-    </svg>`;
+    </svg>`,
+      expectViolation: true,
+    },
+  ])("$name", ({ svg, expectViolation }) => {
     const violations = validate(svg);
-    expect(findViolation(violations, "out-of-bounds")).toBeDefined();
+    if (expectViolation) {
+      expect(findViolation(violations, "out-of-bounds")).toBeDefined();
+    } else {
+      expect(violations).toHaveLength(0);
+    }
   });
 });


### PR DESCRIPTION
Applies the repo's testing conventions to the `wireframe` skill's test suite, collapsing repetitive single-case `it` blocks into `it.each` tables. Pure refactor, no behavior or coverage change.

Test LOC dropped from 302 to 271. The refactor drops no cases, snapshots nothing, and adds no property tests. Every table row asserts exactly what its predecessor did.

## Changes

- `validate-hook.test.ts`: `isSvgFile` becomes an 8-row table over `[input, expected]`; `processInput` becomes a 5-row table keyed on `expected` (null for pass-through, substring for the violation's `additionalContext`).
- `validate.test.ts`: the example-asset cases collapse to a name list; invalid-fixture cases become a table that preserves the exact-count assertion for `missing-dimensions` (`toHaveLength(1)`) while others assert `> 0`; circle/ellipse cases become a table keyed on `expectViolation`.
