### PR TITLE
test(plugins/things): apply testing conventions

### DIFF
--- a/plugins/things/scripts/format.test.ts
+++ b/plugins/things/scripts/format.test.ts
@@ -8,39 +8,32 @@ describe("selectColumns", () => {
     ["Task 2", "completed", "2025-02-01", "Project B"],
   ];
 
-  test("returns input unchanged when columns is undefined", () => {
-    const [h, r] = selectColumns(headers, rows, undefined);
-    expect(h).toEqual(headers);
-    expect(r).toEqual(rows);
-  });
-
-  test("returns input unchanged when columns is empty", () => {
-    const [h, r] = selectColumns(headers, rows, []);
-    expect(h).toEqual(headers);
-    expect(r).toEqual(rows);
-  });
-
-  test("filters to selected columns", () => {
-    const [h, r] = selectColumns(headers, rows, ["name", "project"]);
-    expect(h).toEqual(["Name", "Project"]);
-    expect(r).toEqual([
-      ["Task 1", "Project A"],
-      ["Task 2", "Project B"],
-    ]);
-  });
-
-  test("preserves column order from the columns argument", () => {
-    const [h, r] = selectColumns(headers, rows, ["project", "name"]);
-    expect(h).toEqual(["Project", "Name"]);
-    expect(r).toEqual([
-      ["Project A", "Task 1"],
-      ["Project B", "Task 2"],
-    ]);
-  });
-
-  test("normalizes column names with hyphens and case", () => {
-    const [h] = selectColumns(headers, rows, ["due-date"]);
-    expect(h).toEqual(["Due Date"]);
+  test.each<[string, string[] | undefined, string[], string[][] | undefined]>([
+    ["returns input unchanged when columns is undefined", undefined, headers, rows],
+    ["returns input unchanged when columns is empty", [], headers, rows],
+    [
+      "filters to selected columns",
+      ["name", "project"],
+      ["Name", "Project"],
+      [
+        ["Task 1", "Project A"],
+        ["Task 2", "Project B"],
+      ],
+    ],
+    [
+      "preserves column order from the columns argument",
+      ["project", "name"],
+      ["Project", "Name"],
+      [
+        ["Project A", "Task 1"],
+        ["Project B", "Task 2"],
+      ],
+    ],
+    ["normalizes column names with hyphens and case", ["due-date"], ["Due Date"], undefined],
+  ])("%s", (_name, columns, expectedHeaders, expectedRows) => {
+    const [h, r] = selectColumns(headers, rows, columns);
+    expect(h).toEqual(expectedHeaders);
+    if (expectedRows) expect(r).toEqual(expectedRows);
   });
 
   test("exits with error for unknown column", () => {

--- a/plugins/things/scripts/inbox.test.ts
+++ b/plugins/things/scripts/inbox.test.ts
@@ -1,69 +1,53 @@
-import { describe, expect, spyOn, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { printCaptured } from "./inbox";
 
 describe("printCaptured", () => {
-  test("prints title when present", () => {
-    const log = spyOn(console, "log").mockImplementation(() => {});
-    try {
-      printCaptured(new Map([["title", "Buy milk"]]));
-      expect(log).toHaveBeenCalledWith("captured: Buy milk");
-    } finally {
-      log.mockRestore();
-    }
+  let log: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    log = spyOn(console, "log").mockImplementation(() => {});
   });
 
-  test("prints first line and count for multi-line titles", () => {
-    const log = spyOn(console, "log").mockImplementation(() => {});
-    try {
-      printCaptured(new Map([["titles", "Buy milk\nWalk dog\nCall mom"]]));
-      expect(log).toHaveBeenCalledWith("captured: Buy milk (+2 more)");
-    } finally {
-      log.mockRestore();
-    }
+  afterEach(() => {
+    log.mockRestore();
   });
 
-  test("prints titles without suffix when only one line", () => {
-    const log = spyOn(console, "log").mockImplementation(() => {});
-    try {
-      printCaptured(new Map([["titles", "Just one"]]));
-      expect(log).toHaveBeenCalledWith("captured: Just one");
-    } finally {
-      log.mockRestore();
-    }
-  });
-
-  test("ignores blank lines in titles count", () => {
-    const log = spyOn(console, "log").mockImplementation(() => {});
-    try {
-      printCaptured(new Map([["titles", "Buy milk\n\n  \nWalk dog"]]));
-      expect(log).toHaveBeenCalledWith("captured: Buy milk (+1 more)");
-    } finally {
-      log.mockRestore();
-    }
-  });
-
-  test("falls back to (untitled) when neither title nor titles present", () => {
-    const log = spyOn(console, "log").mockImplementation(() => {});
-    try {
-      printCaptured(new Map([["notes", "just notes"]]));
-      expect(log).toHaveBeenCalledWith("captured: (untitled)");
-    } finally {
-      log.mockRestore();
-    }
-  });
-
-  test("prefers title over titles when both present", () => {
-    const log = spyOn(console, "log").mockImplementation(() => {});
-    try {
-      printCaptured(
-        new Map([
-          ["title", "Primary"],
-          ["titles", "Secondary"],
-        ]),
-      );
-      expect(log).toHaveBeenCalledWith("captured: Primary");
-    } finally {
-      log.mockRestore();
-    }
+  test.each<{ name: string; captured: Map<string, string>; expected: string }>([
+    {
+      name: "prints title when present",
+      captured: new Map([["title", "Buy milk"]]),
+      expected: "captured: Buy milk",
+    },
+    {
+      name: "prints first line and count for multi-line titles",
+      captured: new Map([["titles", "Buy milk\nWalk dog\nCall mom"]]),
+      expected: "captured: Buy milk (+2 more)",
+    },
+    {
+      name: "prints titles without suffix when only one line",
+      captured: new Map([["titles", "Just one"]]),
+      expected: "captured: Just one",
+    },
+    {
+      name: "ignores blank lines in titles count",
+      captured: new Map([["titles", "Buy milk\n\n  \nWalk dog"]]),
+      expected: "captured: Buy milk (+1 more)",
+    },
+    {
+      name: "falls back to (untitled) when neither title nor titles present",
+      captured: new Map([["notes", "just notes"]]),
+      expected: "captured: (untitled)",
+    },
+    {
+      name: "prefers title over titles when both present",
+      captured: new Map([
+        ["title", "Primary"],
+        ["titles", "Secondary"],
+      ]),
+      expected: "captured: Primary",
+    },
+  ])("$name", ({ captured, expected }) => {
+    printCaptured(captured);
+    expect(log).toHaveBeenCalledWith(expected);
   });
 });

--- a/plugins/things/scripts/tags.test.ts
+++ b/plugins/things/scripts/tags.test.ts
@@ -2,53 +2,42 @@ import { describe, expect, test } from "bun:test";
 import { mergeTags, parseTags } from "./tags";
 
 describe("parseTags", () => {
-  test("returns empty array for undefined", () => {
-    expect(parseTags(undefined)).toEqual([]);
-  });
-
-  test("returns empty array for empty string", () => {
-    expect(parseTags("")).toEqual([]);
-  });
-
-  test("parses single tag", () => {
-    expect(parseTags("claude-code")).toEqual(["claude-code"]);
-  });
-
-  test("parses comma-separated tags", () => {
-    expect(parseTags("claude-code,work")).toEqual(["claude-code", "work"]);
-  });
-
-  test("trims whitespace", () => {
-    expect(parseTags(" claude-code , work ")).toEqual(["claude-code", "work"]);
-  });
-
-  test("filters empty segments", () => {
-    expect(parseTags("claude-code,,work")).toEqual(["claude-code", "work"]);
+  test.each<{ name: string; input: string | undefined; expected: string[] }>([
+    { name: "undefined", input: undefined, expected: [] },
+    { name: "empty string", input: "", expected: [] },
+    { name: "single tag", input: "claude-code", expected: ["claude-code"] },
+    { name: "comma-separated tags", input: "claude-code,work", expected: ["claude-code", "work"] },
+    { name: "trims whitespace", input: " claude-code , work ", expected: ["claude-code", "work"] },
+    {
+      name: "filters empty segments",
+      input: "claude-code,,work",
+      expected: ["claude-code", "work"],
+    },
+  ])("$name", ({ input, expected }) => {
+    expect(parseTags(input)).toEqual(expected);
   });
 });
 
 describe("mergeTags", () => {
-  test("returns single source as-is", () => {
-    expect(mergeTags(["Claude"])).toEqual(["Claude"]);
-  });
-
-  test("combines multiple sources", () => {
-    expect(mergeTags(["Claude"], ["work"])).toEqual(["Claude", "work"]);
-  });
-
-  test("deduplicates across sources", () => {
-    expect(mergeTags(["Claude"], ["Claude", "work"])).toEqual(["Claude", "work"]);
-  });
-
-  test("preserves insertion order", () => {
-    expect(mergeTags(["Claude", "claude-code"], ["work"])).toEqual([
-      "Claude",
-      "claude-code",
-      "work",
-    ]);
-  });
-
-  test("handles empty sources", () => {
-    expect(mergeTags([], ["Claude"])).toEqual(["Claude"]);
+  test.each<{ name: string; sources: string[][]; expected: string[] }>([
+    { name: "returns single source as-is", sources: [["Claude"]], expected: ["Claude"] },
+    {
+      name: "combines multiple sources",
+      sources: [["Claude"], ["work"]],
+      expected: ["Claude", "work"],
+    },
+    {
+      name: "deduplicates across sources",
+      sources: [["Claude"], ["Claude", "work"]],
+      expected: ["Claude", "work"],
+    },
+    {
+      name: "preserves insertion order",
+      sources: [["Claude", "claude-code"], ["work"]],
+      expected: ["Claude", "claude-code", "work"],
+    },
+    { name: "handles empty sources", sources: [[], ["Claude"]], expected: ["Claude"] },
+  ])("$name", ({ sources, expected }) => {
+    expect(mergeTags(...sources)).toEqual(expected);
   });
 });

--- a/plugins/things/scripts/url.test.ts
+++ b/plugins/things/scripts/url.test.ts
@@ -44,118 +44,102 @@ describe("buildJsonPayload", () => {
     expect(() => buildJsonPayload(["ABC"], {})).toThrow("At least one attribute is required");
   });
 
-  test("coerces boolean attributes to actual booleans", () => {
-    const result = JSON.parse(buildJsonPayload(["ABC"], { completed: "true", canceled: "false" }));
-    expect(result[0].attributes).toEqual({ completed: true, canceled: false });
-  });
-
-  test("leaves non-boolean attributes as strings", () => {
-    const result = JSON.parse(buildJsonPayload(["ABC"], { when: "today", completed: "true" }));
-    expect(result[0].attributes).toEqual({ when: "today", completed: true });
-  });
-
-  test("coerces tags to string array", () => {
-    const result = JSON.parse(buildJsonPayload(["ABC"], { tags: "work,personal" }));
-    expect(result[0].attributes).toEqual({ tags: ["work", "personal"] });
-  });
-
-  test("coerces checklist-items to structured objects", () => {
-    const result = JSON.parse(
-      buildJsonPayload(["ABC"], { "checklist-items": "Buy milk\nWalk dog" }),
-    );
-    expect(result[0].attributes).toEqual({
-      "checklist-items": [
-        { type: "checklist-item", attributes: { title: "Buy milk" } },
-        { type: "checklist-item", attributes: { title: "Walk dog" } },
-      ],
-    });
+  test.each<[string, Record<string, string>, Record<string, unknown>]>([
+    [
+      "coerces boolean attributes to actual booleans",
+      { completed: "true", canceled: "false" },
+      { completed: true, canceled: false },
+    ],
+    [
+      "leaves non-boolean attributes as strings",
+      { when: "today", completed: "true" },
+      { when: "today", completed: true },
+    ],
+    ["coerces tags to string array", { tags: "work,personal" }, { tags: ["work", "personal"] }],
+    [
+      "coerces checklist-items to structured objects",
+      { "checklist-items": "Buy milk\nWalk dog" },
+      {
+        "checklist-items": [
+          { type: "checklist-item", attributes: { title: "Buy milk" } },
+          { type: "checklist-item", attributes: { title: "Walk dog" } },
+        ],
+      },
+    ],
+  ])("%s", (_name, attrs, expected) => {
+    const result = JSON.parse(buildJsonPayload(["ABC"], attrs));
+    expect(result[0].attributes).toEqual(expected);
   });
 });
 
 describe("coerceAttributes", () => {
-  test("coerces all known boolean attributes", () => {
-    const result = coerceAttributes({
-      completed: "true",
-      canceled: "false",
-      reveal: "true",
-      duplicate: "false",
-    });
-    expect(result).toEqual({
-      completed: true,
-      canceled: false,
-      reveal: true,
-      duplicate: false,
-    });
-  });
-
-  test("passes through string attributes unchanged", () => {
-    const result = coerceAttributes({ when: "today" });
-    expect(result).toEqual({ when: "today" });
-  });
-
-  test("does not coerce non-boolean values for boolean attributes", () => {
-    const result = coerceAttributes({ completed: "yes" });
-    expect(result).toEqual({ completed: "yes" });
-  });
-
-  test("coerces tags to string array", () => {
-    const result = coerceAttributes({ tags: "tag1, tag2, tag3" });
-    expect(result).toEqual({ tags: ["tag1", "tag2", "tag3"] });
-  });
-
-  test("coerces add-tags to string array", () => {
-    const result = coerceAttributes({ "add-tags": "Urgent" });
-    expect(result).toEqual({ "add-tags": ["Urgent"] });
-  });
-
-  test("coerces checklist-items to structured objects", () => {
-    const result = coerceAttributes({ "checklist-items": "Item 1\nItem 2" });
-    expect(result).toEqual({
-      "checklist-items": [
-        { type: "checklist-item", attributes: { title: "Item 1" } },
-        { type: "checklist-item", attributes: { title: "Item 2" } },
-      ],
-    });
+  test.each<[string, Record<string, string>, ReturnType<typeof coerceAttributes>]>([
+    [
+      "coerces all known boolean attributes",
+      { completed: "true", canceled: "false", reveal: "true", duplicate: "false" },
+      { completed: true, canceled: false, reveal: true, duplicate: false },
+    ],
+    ["passes through string attributes unchanged", { when: "today" }, { when: "today" }],
+    [
+      "does not coerce non-boolean values for boolean attributes",
+      { completed: "yes" },
+      { completed: "yes" },
+    ],
+    [
+      "coerces tags to string array",
+      { tags: "tag1, tag2, tag3" },
+      { tags: ["tag1", "tag2", "tag3"] },
+    ],
+    ["coerces add-tags to string array", { "add-tags": "Urgent" }, { "add-tags": ["Urgent"] }],
+    [
+      "coerces checklist-items to structured objects",
+      { "checklist-items": "Item 1\nItem 2" },
+      {
+        "checklist-items": [
+          { type: "checklist-item", attributes: { title: "Item 1" } },
+          { type: "checklist-item", attributes: { title: "Item 2" } },
+        ],
+      },
+    ],
+  ])("%s", (_name, attrs, expected) => {
+    expect(coerceAttributes(attrs)).toEqual(expected);
   });
 });
 
 describe("isSandboxBlockedHandoff", () => {
-  test("matches procNotFound message", () => {
-    expect(
-      isSandboxBlockedHandoff(
-        "LSOpenURLsWithRole() failed for the application /Applications/Things3.app with error -10810.\nprocNotFound: no eligible process with specified descriptor",
-      ),
-    ).toBe(true);
-  });
-
-  test("matches bare -10810 code", () => {
-    expect(isSandboxBlockedHandoff("kLSApplicationNotFoundErr (-10810)")).toBe(true);
-  });
-
-  test("matches bare -10673 code", () => {
-    expect(isSandboxBlockedHandoff("NSOSStatusErrorDomain error -10673")).toBe(true);
-  });
-
-  test("matches LSOpenURLsWithRole line on its own", () => {
-    expect(isSandboxBlockedHandoff("LSOpenURLsWithRole failed")).toBe(true);
-  });
-
-  test("does not match unrelated stderr", () => {
-    expect(isSandboxBlockedHandoff("some other error from open")).toBe(false);
-  });
-
-  test("does not match empty stderr", () => {
-    expect(isSandboxBlockedHandoff("")).toBe(false);
-  });
-
-  test("does not match -10810 embedded in a larger number", () => {
-    expect(isSandboxBlockedHandoff("some unrelated number 999-108100 here")).toBe(false);
-    expect(isSandboxBlockedHandoff("error -108101 something else")).toBe(false);
-  });
-
-  test("does not match -10673 embedded in a larger number", () => {
-    expect(isSandboxBlockedHandoff("some unrelated number 999-106730 here")).toBe(false);
-    expect(isSandboxBlockedHandoff("error -106731 something else")).toBe(false);
+  test.each<[string, string, boolean]>([
+    [
+      "matches procNotFound message",
+      "LSOpenURLsWithRole() failed for the application /Applications/Things3.app with error -10810.\nprocNotFound: no eligible process with specified descriptor",
+      true,
+    ],
+    ["matches bare -10810 code", "kLSApplicationNotFoundErr (-10810)", true],
+    ["matches bare -10673 code", "NSOSStatusErrorDomain error -10673", true],
+    ["matches LSOpenURLsWithRole line on its own", "LSOpenURLsWithRole failed", true],
+    ["does not match unrelated stderr", "some other error from open", false],
+    ["does not match empty stderr", "", false],
+    [
+      "does not match -10810 embedded in a larger number (leading digit)",
+      "some unrelated number 999-108100 here",
+      false,
+    ],
+    [
+      "does not match -10810 embedded in a larger number (trailing digit)",
+      "error -108101 something else",
+      false,
+    ],
+    [
+      "does not match -10673 embedded in a larger number (leading digit)",
+      "some unrelated number 999-106730 here",
+      false,
+    ],
+    [
+      "does not match -10673 embedded in a larger number (trailing digit)",
+      "error -106731 something else",
+      false,
+    ],
+  ])("%s", (_name, stderr, expected) => {
+    expect(isSandboxBlockedHandoff(stderr)).toBe(expected);
   });
 });
 


### PR DESCRIPTION
Applies the repo's testing conventions to the `things` plugin's unit tests, collapsing four suites of repetitive one-assertion `test` blocks into `test.each` tables. Behavior coverage is unchanged: every original case survives as a table row asserting the same output.

Test LOC dropped from 435 to 385 across the four `*.test.ts` files. This refactor adds no property tests, so the reduction is straight.

## Notes

- `format.test.ts`: the `selectColumns` cases became one table. The "normalizes column names with hyphens and case" row still asserts headers only (rows left unasserted via an optional `expectedRows`), matching the original.
- `inbox.test.ts`: the repeated `spyOn(console, "log")` + `try/finally` restore in every `printCaptured` case moved to `beforeEach`/`afterEach`, and the cases became a table.
- `url.test.ts`: the two `isSandboxBlockedHandoff` tests that each checked a leading- and trailing-digit variant were split into four explicitly named rows, preserving all four assertions.

Nothing was snapshotted.
