### PR TITLE
test(plugins/github): apply testing conventions

### DIFF
--- a/plugins/github/scripts/fetch.test.ts
+++ b/plugins/github/scripts/fetch.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import type {
   PreToolUseHookInput,
   PreToolUseHookSpecificOutput,
@@ -24,102 +24,64 @@ function getOutput(input: PreToolUseHookInput): PreToolUseHookSpecificOutput | n
 }
 
 describe("isGitHubUrl", () => {
-  it("returns true for GitHub URLs", () => {
-    expect(isGitHubUrl("https://github.com/owner/repo")).toBe(true);
-    expect(isGitHubUrl("https://github.com/bendrucker/deployments")).toBe(true);
-  });
-
-  it("returns false for non-GitHub URLs", () => {
-    expect(isGitHubUrl("https://example.com")).toBe(false);
-    expect(isGitHubUrl("https://gitlab.com/owner/repo")).toBe(false);
-    expect(isGitHubUrl("http://github.com/owner/repo")).toBe(false);
+  test.each<[string, boolean]>([
+    ["https://github.com/owner/repo", true],
+    ["https://github.com/bendrucker/deployments", true],
+    ["https://example.com", false],
+    ["https://gitlab.com/owner/repo", false],
+    ["http://github.com/owner/repo", false],
+  ])("isGitHubUrl(%p) -> %p", (url, expected) => {
+    expect(isGitHubUrl(url)).toBe(expected);
   });
 });
 
 describe("parseGitHubUrl", () => {
-  it("returns null for non-repo GitHub URLs", () => {
-    expect(parseGitHubUrl("https://github.com/explore")).toBeNull();
-    expect(parseGitHubUrl("https://github.com/settings")).toBeNull();
+  test.each([
+    "https://github.com/explore",
+    "https://github.com/settings",
+  ])("returns null for %p", (url) => {
+    expect(parseGitHubUrl(url)).toBeNull();
   });
 
-  it("detects repo root", () => {
-    const result = parseGitHubUrl("https://github.com/bendrucker/deployments");
-    expect(result?.type).toBe("repo");
-    expect(result?.suggestion).toContain("gh repo view");
+  test.each<[string, string, string]>([
+    ["https://github.com/bendrucker/deployments", "repo", "gh repo view"],
+    ["https://github.com/bendrucker/deployments/", "repo", "gh repo view"],
+    ["https://github.com/bendrucker/bendrucker.me/blob/master/astro.config.ts", "file", "gh api"],
+    ["https://github.com/owner/repo/tree/main/src", "file", "gh api"],
+    ["https://github.com/owner/repo/tree/main", "file", "gh api"],
+  ])("detects %p -> type %p", (url, type, suggestionContains) => {
+    const result = parseGitHubUrl(url);
+    expect(result?.type).toBe(type);
+    expect(result?.suggestion).toContain(suggestionContains);
   });
 
-  it("handles repo root with trailing slash", () => {
-    const result = parseGitHubUrl("https://github.com/bendrucker/deployments/");
-    expect(result?.type).toBe("repo");
-    expect(result?.suggestion).toContain("gh repo view");
-  });
-
-  it("detects file content (blob URL)", () => {
-    const result = parseGitHubUrl(
-      "https://github.com/bendrucker/bendrucker.me/blob/master/astro.config.ts",
-    );
-    expect(result?.type).toBe("file");
-    expect(result?.suggestion).toContain("gh api");
-  });
-
-  it("detects directory (tree URL)", () => {
-    const result = parseGitHubUrl("https://github.com/owner/repo/tree/main/src");
-    expect(result?.type).toBe("file");
-    expect(result?.suggestion).toContain("gh api");
-  });
-
-  it("handles root directory tree", () => {
-    const result = parseGitHubUrl("https://github.com/owner/repo/tree/main");
-    expect(result?.type).toBe("file");
-    expect(result?.suggestion).toContain("gh api");
-  });
-
-  it("detects issues", () => {
-    const result = parseGitHubUrl("https://github.com/owner/repo/issues/123");
-    expect(result?.type).toBe("issue");
-    expect(result?.suggestion).toBe("Use: gh issue view 123.");
-  });
-
-  it("detects PRs", () => {
-    const result = parseGitHubUrl("https://github.com/owner/repo/pull/456");
-    expect(result?.type).toBe("pr");
-    expect(result?.suggestion).toBe("Use: gh pr view 456.");
-  });
-
-  it("detects Actions run", () => {
-    const result = parseGitHubUrl("https://github.com/owner/repo/actions/runs/12345");
-    expect(result?.type).toBe("run");
-    expect(result?.suggestion).toBe("Use: gh run view 12345.");
-  });
-
-  it("detects Actions job", () => {
-    const result = parseGitHubUrl(
+  test.each<[string, string, string]>([
+    ["https://github.com/owner/repo/issues/123", "issue", "Use: gh issue view 123."],
+    ["https://github.com/owner/repo/pull/456", "pr", "Use: gh pr view 456."],
+    ["https://github.com/owner/repo/actions/runs/12345", "run", "Use: gh run view 12345."],
+    [
       "https://github.com/terraform-linters/tflint/actions/runs/19917285716/job/57098829490",
-    );
-    expect(result?.type).toBe("job");
-    expect(result?.suggestion).toBe("Use: gh run view --job 57098829490 --log.");
+      "job",
+      "Use: gh run view --job 57098829490 --log.",
+    ],
+  ])("detects %p -> type %p", (url, type, suggestion) => {
+    const result = parseGitHubUrl(url);
+    expect(result?.type).toBe(type);
+    expect(result?.suggestion).toBe(suggestion);
   });
 });
 
 describe("formatOutput", () => {
-  it("formats deny decision", () => {
-    const output = formatOutput("deny", "Use gh instead");
+  test.each<["deny" | "ask", string]>([
+    ["deny", "Use gh instead"],
+    ["ask", "Unknown pattern"],
+  ])("formats %p decision", (decision, reason) => {
+    const output = formatOutput(decision, reason);
     expect(output).toEqual({
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
-        permissionDecision: "deny",
-        permissionDecisionReason: "Use gh instead",
-      },
-    });
-  });
-
-  it("formats ask decision", () => {
-    const output = formatOutput("ask", "Unknown pattern");
-    expect(output).toEqual({
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        permissionDecision: "ask",
-        permissionDecisionReason: "Unknown pattern",
+        permissionDecision: decision,
+        permissionDecisionReason: reason,
       },
     });
   });
@@ -130,68 +92,30 @@ describe("processInput", () => {
     expect(processInput(mockInput("https://example.com"))).toBeNull();
   });
 
-  it("denies repo root with gh repo view suggestion", () => {
-    const output = getOutput(mockInput("https://github.com/bendrucker/deployments"));
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: gh repo view [<repository>].");
-  });
-
-  it("handles repository URL with trailing slash", () => {
-    const output = getOutput(mockInput("https://github.com/bendrucker/deployments/"));
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: gh repo view [<repository>].");
-  });
-
-  it("denies file content with gh api suggestion", () => {
-    const output = getOutput(
-      mockInput("https://github.com/bendrucker/bendrucker.me/blob/master/astro.config.ts"),
-    );
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: gh api to fetch file contents.");
-  });
-
-  it("denies directory with gh api suggestion", () => {
-    const output = getOutput(mockInput("https://github.com/owner/repo/tree/main/src"));
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: gh api to fetch file contents.");
-  });
-
-  it("handles root directory tree", () => {
-    const output = getOutput(mockInput("https://github.com/owner/repo/tree/main"));
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: gh api to fetch file contents.");
-  });
-
-  it("denies issues with gh issue view suggestion", () => {
-    const output = getOutput(mockInput("https://github.com/owner/repo/issues/123"));
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: gh issue view 123.");
-  });
-
-  it("denies PRs with gh pr view suggestion", () => {
-    const output = getOutput(mockInput("https://github.com/owner/repo/pull/456"));
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: gh pr view 456.");
-  });
-
-  it("denies Actions run with gh run view suggestion", () => {
-    const output = getOutput(mockInput("https://github.com/owner/repo/actions/runs/12345"));
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: gh run view 12345.");
-  });
-
-  it("denies Actions job with gh run view --job suggestion", () => {
-    const output = getOutput(
-      mockInput(
-        "https://github.com/terraform-linters/tflint/actions/runs/19917285716/job/57098829490",
-      ),
-    );
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: gh run view --job 57098829490 --log.");
-  });
-
   it("passes through unknown GitHub URL patterns", () => {
     const output = getOutput(mockInput("https://github.com/explore"));
     expect(output).toBeNull();
+  });
+
+  test.each<[string, string]>([
+    ["https://github.com/bendrucker/deployments", "Use: gh repo view [<repository>]."],
+    ["https://github.com/bendrucker/deployments/", "Use: gh repo view [<repository>]."],
+    [
+      "https://github.com/bendrucker/bendrucker.me/blob/master/astro.config.ts",
+      "Use: gh api to fetch file contents.",
+    ],
+    ["https://github.com/owner/repo/tree/main/src", "Use: gh api to fetch file contents."],
+    ["https://github.com/owner/repo/tree/main", "Use: gh api to fetch file contents."],
+    ["https://github.com/owner/repo/issues/123", "Use: gh issue view 123."],
+    ["https://github.com/owner/repo/pull/456", "Use: gh pr view 456."],
+    ["https://github.com/owner/repo/actions/runs/12345", "Use: gh run view 12345."],
+    [
+      "https://github.com/terraform-linters/tflint/actions/runs/19917285716/job/57098829490",
+      "Use: gh run view --job 57098829490 --log.",
+    ],
+  ])("denies %p", (url, reason) => {
+    const output = getOutput(mockInput(url));
+    expect(output?.permissionDecision).toBe("deny");
+    expect(output?.permissionDecisionReason).toBe(reason);
   });
 });

--- a/plugins/github/scripts/pr-comments.test.ts
+++ b/plugins/github/scripts/pr-comments.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import {
   type Comment,
   detectRole,
@@ -45,14 +45,14 @@ function makeReview(login: string, date: string, state = "CHANGES_REQUESTED"): R
 }
 
 describe("parseUrl", () => {
-  it("parses a valid GitHub PR URL", () => {
-    const result = parseUrl("https://github.com/pydantic/pydantic-ai/pull/3772");
-    expect(result).toEqual({ owner: "pydantic", repo: "pydantic-ai", number: 3772 });
-  });
-
-  it("parses PR URL with trailing path segments", () => {
-    const result = parseUrl("https://github.com/owner/repo/pull/123/files");
-    expect(result).toEqual({ owner: "owner", repo: "repo", number: 123 });
+  test.each<[string, { owner: string; repo: string; number: number }]>([
+    [
+      "https://github.com/pydantic/pydantic-ai/pull/3772",
+      { owner: "pydantic", repo: "pydantic-ai", number: 3772 },
+    ],
+    ["https://github.com/owner/repo/pull/123/files", { owner: "owner", repo: "repo", number: 123 }],
+  ])("parses %p", (url, expected) => {
+    expect(parseUrl(url)).toEqual(expected);
   });
 
   it("throws on non-PR GitHub URL", () => {
@@ -65,12 +65,11 @@ describe("parseUrl", () => {
 });
 
 describe("detectRole", () => {
-  it("returns author when viewer is the PR author", () => {
-    expect(detectRole("bendrucker", "bendrucker")).toBe("author");
-  });
-
-  it("returns reviewer when viewer is not the PR author", () => {
-    expect(detectRole("DouweM", "bendrucker")).toBe("reviewer");
+  test.each<[string, string, Role]>([
+    ["bendrucker", "bendrucker", "author"],
+    ["DouweM", "bendrucker", "reviewer"],
+  ])("detectRole(viewer=%p, author=%p) -> %p", (viewer, author, expected) => {
+    expect(detectRole(viewer, author)).toBe(expected);
   });
 });
 

--- a/plugins/github/scripts/review-threads.test.ts
+++ b/plugins/github/scripts/review-threads.test.ts
@@ -7,25 +7,30 @@ import {
 } from "./review-threads";
 
 describe("mutations", () => {
-  test("reply targets the review thread and posts a body", () => {
-    expect(REPLY_MUTATION).toContain("addPullRequestReviewThreadReply");
-    expect(REPLY_MUTATION).toContain("pullRequestReviewThreadId: $threadId");
-    expect(REPLY_MUTATION).toContain("body: $body");
-  });
-
-  test("resolve targets the review thread", () => {
-    expect(RESOLVE_MUTATION).toContain("resolveReviewThread");
-    expect(RESOLVE_MUTATION).toContain("threadId: $threadId");
-  });
-
-  test("react adds a reaction to a subject", () => {
-    expect(REACT_MUTATION).toContain("addReaction");
-    expect(REACT_MUTATION).toContain("subjectId: $subjectId");
-    expect(REACT_MUTATION).toContain("content: $content");
-  });
-
-  test("thread comment query reads the first comment of a thread", () => {
-    expect(THREAD_COMMENT_QUERY).toContain("PullRequestReviewThread");
-    expect(THREAD_COMMENT_QUERY).toContain("comments(first: 1)");
+  test.each<[string, string, string[]]>([
+    [
+      "reply targets the review thread and posts a body",
+      REPLY_MUTATION,
+      ["addPullRequestReviewThreadReply", "pullRequestReviewThreadId: $threadId", "body: $body"],
+    ],
+    [
+      "resolve targets the review thread",
+      RESOLVE_MUTATION,
+      ["resolveReviewThread", "threadId: $threadId"],
+    ],
+    [
+      "react adds a reaction to a subject",
+      REACT_MUTATION,
+      ["addReaction", "subjectId: $subjectId", "content: $content"],
+    ],
+    [
+      "thread comment query reads the first comment of a thread",
+      THREAD_COMMENT_QUERY,
+      ["PullRequestReviewThread", "comments(first: 1)"],
+    ],
+  ])("%s", (_name, constant, substrings) => {
+    for (const substring of substrings) {
+      expect(constant).toContain(substring);
+    }
   });
 });

--- a/plugins/github/scripts/reviewers.test.ts
+++ b/plugins/github/scripts/reviewers.test.ts
@@ -1,23 +1,16 @@
 import { describe, expect, test } from "bun:test";
-import { isBot, isReviewTarget, parseReviewers } from "./reviewers";
+import { type Author, isBot, isReviewTarget, parseReviewers } from "./reviewers";
 
 describe("isBot", () => {
-  test("matches accounts the API typed as Bot", () => {
-    expect(isBot({ login: "copilot-pull-request-reviewer", __typename: "Bot" })).toBe(true);
-    expect(isBot({ login: "coderabbitai[bot]", __typename: "Bot" })).toBe(true);
-  });
-
-  test("rejects accounts typed as User even with a bot-like login", () => {
-    expect(isBot({ login: "bendrucker", __typename: "User" })).toBe(false);
-    expect(isBot({ login: "coderabbitai", __typename: "User" })).toBe(false);
-  });
-
-  test("rejects an author with no typename", () => {
-    expect(isBot({ login: "mystery" })).toBe(false);
-  });
-
-  test("rejects null", () => {
-    expect(isBot(null)).toBe(false);
+  test.each<[Author | null, boolean]>([
+    [{ login: "copilot-pull-request-reviewer", __typename: "Bot" }, true],
+    [{ login: "coderabbitai[bot]", __typename: "Bot" }, true],
+    [{ login: "bendrucker", __typename: "User" }, false],
+    [{ login: "coderabbitai", __typename: "User" }, false],
+    [{ login: "mystery" }, false],
+    [null, false],
+  ])("isBot(%p) -> %p", (account, expected) => {
+    expect(isBot(account)).toBe(expected);
   });
 });
 
@@ -29,21 +22,12 @@ describe("parseReviewers", () => {
 });
 
 describe("isReviewTarget", () => {
-  test("includes API bots", () => {
-    expect(isReviewTarget({ login: "x", __typename: "Bot" })).toBe(true);
-  });
-
-  test("includes listed accounts the API types as User", () => {
-    expect(isReviewTarget({ login: "Jacob", __typename: "User" }, new Set(["jacob"]))).toBe(true);
-  });
-
-  test("excludes unlisted humans", () => {
-    expect(isReviewTarget({ login: "bendrucker", __typename: "User" }, new Set(["jacob"]))).toBe(
-      false,
-    );
-  });
-
-  test("rejects null", () => {
-    expect(isReviewTarget(null)).toBe(false);
+  test.each<[Author | null, Set<string> | undefined, boolean]>([
+    [{ login: "x", __typename: "Bot" }, undefined, true],
+    [{ login: "Jacob", __typename: "User" }, new Set(["jacob"]), true],
+    [{ login: "bendrucker", __typename: "User" }, new Set(["jacob"]), false],
+    [null, undefined, false],
+  ])("isReviewTarget(%p, %p) -> %p", (account, set, expected) => {
+    expect(isReviewTarget(account, set)).toBe(expected);
   });
 });

--- a/plugins/github/skills/actions-monitor/scripts/watch.test.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import {
   clearApiErrors,
   computeInterval,
@@ -8,6 +8,7 @@ import {
   type Event,
   type ExecFn,
   type ExecResult,
+  type InternalState,
   initialState,
   type Probe,
   parsePrUrl,
@@ -110,77 +111,73 @@ describe("parsePrUrl", () => {
 //   - queued (action):   { state: "QUEUED",      bucket: "pending" }
 //   - pending (status):  { state: "PENDING",     bucket: "pending" }
 describe("deriveChecksState", () => {
-  it("returns running on empty checks", () => {
-    expect(deriveChecksState([])).toBe("running");
-  });
-
-  it("returns failing when any check is in fail bucket", () => {
-    expect(
-      deriveChecksState([
+  test.each<[string, Array<{ state: string; bucket: string; name: string }>, InternalState]>([
+    ["empty checks", [], "running"],
+    [
+      "any check in fail bucket",
+      [
         { state: "SUCCESS", bucket: "pass", name: "a" },
         { state: "FAILURE", bucket: "fail", name: "b" },
-      ]),
-    ).toBe("failing");
-  });
-
-  it("returns failing when any check is in cancel bucket", () => {
-    expect(
-      deriveChecksState([
+      ],
+      "failing",
+    ],
+    [
+      "any check in cancel bucket",
+      [
         { state: "SUCCESS", bucket: "pass", name: "a" },
         { state: "CANCELLED", bucket: "cancel", name: "b" },
-      ]),
-    ).toBe("failing");
-  });
-
-  it("returns running when any check is IN_PROGRESS", () => {
-    expect(
-      deriveChecksState([
+      ],
+      "failing",
+    ],
+    [
+      "any check is IN_PROGRESS",
+      [
         { state: "IN_PROGRESS", bucket: "pending", name: "a" },
         { state: "QUEUED", bucket: "pending", name: "b" },
-      ]),
-    ).toBe("running");
-  });
-
-  it("returns queued when all checks are queued", () => {
-    expect(
-      deriveChecksState([
+      ],
+      "running",
+    ],
+    [
+      "all checks are queued",
+      [
         { state: "QUEUED", bucket: "pending", name: "a" },
         { state: "QUEUED", bucket: "pending", name: "b" },
-      ]),
-    ).toBe("queued");
-  });
-
-  it("returns running when some checks are queued and others have completed", () => {
-    expect(
-      deriveChecksState([
+      ],
+      "queued",
+    ],
+    [
+      "some checks queued and others have completed",
+      [
         { state: "QUEUED", bucket: "pending", name: "a" },
         { state: "SUCCESS", bucket: "pass", name: "b" },
-      ]),
-    ).toBe("running");
-  });
-
-  it("returns success when all checks pass or skip", () => {
-    expect(
-      deriveChecksState([
+      ],
+      "running",
+    ],
+    [
+      "all checks pass or skip",
+      [
         { state: "SUCCESS", bucket: "pass", name: "a" },
         { state: "SKIPPED", bucket: "skipping", name: "b" },
-      ]),
-    ).toBe("success");
-  });
-
-  it("returns success on the canonical all-green payload (regression: bucket+state schema)", () => {
+      ],
+      "success",
+    ],
     // Exact shape captured from `gh pr checks <num> --json state,bucket,name`
     // against a fully-green PR. If this assertion ever flips back to "running"
     // it means deriveChecksState has drifted from gh's actual JSON schema —
     // the same drift that caused the silent-hang on initial-green PRs.
-    const allGreen = [
-      { bucket: "pass", name: "plugins", state: "SUCCESS" },
-      { bucket: "pass", name: "lint", state: "SUCCESS" },
-      { bucket: "pass", name: "build", state: "SUCCESS" },
-      { bucket: "pass", name: "hooks", state: "SUCCESS" },
-      { bucket: "pass", name: "validate", state: "SUCCESS" },
-    ];
-    expect(deriveChecksState(allGreen)).toBe("success");
+    [
+      "canonical all-green payload (regression: bucket+state schema)",
+      [
+        { bucket: "pass", name: "plugins", state: "SUCCESS" },
+        { bucket: "pass", name: "lint", state: "SUCCESS" },
+        { bucket: "pass", name: "build", state: "SUCCESS" },
+        { bucket: "pass", name: "hooks", state: "SUCCESS" },
+        { bucket: "pass", name: "validate", state: "SUCCESS" },
+      ],
+      "success",
+    ],
+  ])("%s -> %s", (_name, checks, expected) => {
+    expect(deriveChecksState(checks)).toBe(expected);
   });
 });
 
@@ -455,114 +452,51 @@ describe("pr-closed", () => {
 });
 
 describe("computeInterval", () => {
-  it("returns fast poll floor when no durations (first PR on branch)", () => {
-    expect(computeInterval([])).toBe(30);
-  });
-
-  it("adds buffer and clamps to minimum", () => {
-    expect(computeInterval([10, 10, 10])).toBe(40);
-  });
-
-  it("clamps to maximum", () => {
-    expect(computeInterval([1000, 1000, 1000])).toBe(600);
+  test.each<[number[], number]>([
+    [[], 30],
+    [[10, 10, 10], 40],
+    [[1000, 1000, 1000], 600],
+  ])("computeInterval(%p) -> %p", (durations, expected) => {
+    expect(computeInterval(durations)).toBe(expected);
   });
 });
 
 describe("parseRepo", () => {
-  it("parses HTTPS URLs", () => {
-    expect(parseRepo("https://github.com/bendrucker/deployments")).toEqual({
-      owner: "bendrucker",
-      repo: "deployments",
-    });
-  });
-
-  it("parses HTTPS URLs with .git suffix", () => {
-    expect(parseRepo("https://github.com/bendrucker/deployments.git")).toEqual({
-      owner: "bendrucker",
-      repo: "deployments",
-    });
-  });
-
-  it("parses scp-style SSH URLs", () => {
-    expect(parseRepo("git@github.com:bendrucker/deployments.git")).toEqual({
-      owner: "bendrucker",
-      repo: "deployments",
-    });
-  });
-
-  it("parses scp-style SSH URLs without .git", () => {
-    expect(parseRepo("git@github.com:bendrucker/deployments")).toEqual({
-      owner: "bendrucker",
-      repo: "deployments",
-    });
-  });
-
-  it("parses ssh:// protocol URLs", () => {
-    expect(parseRepo("ssh://git@github.com/bendrucker/deployments.git")).toEqual({
-      owner: "bendrucker",
-      repo: "deployments",
-    });
-  });
-
-  it("trims surrounding whitespace", () => {
-    expect(parseRepo("  https://github.com/owner/repo.git\n")).toEqual({
-      owner: "owner",
-      repo: "repo",
-    });
-  });
-
-  it("returns null on an unknown URL", () => {
-    expect(parseRepo("https://gitlab.com/owner/repo")).toBeNull();
-  });
-
-  it("returns null on empty input", () => {
-    expect(parseRepo("")).toBeNull();
+  test.each<[string, { owner: string; repo: string } | null]>([
+    ["https://github.com/bendrucker/deployments", { owner: "bendrucker", repo: "deployments" }],
+    ["https://github.com/bendrucker/deployments.git", { owner: "bendrucker", repo: "deployments" }],
+    ["git@github.com:bendrucker/deployments.git", { owner: "bendrucker", repo: "deployments" }],
+    ["git@github.com:bendrucker/deployments", { owner: "bendrucker", repo: "deployments" }],
+    [
+      "ssh://git@github.com/bendrucker/deployments.git",
+      { owner: "bendrucker", repo: "deployments" },
+    ],
+    ["  https://github.com/owner/repo.git\n", { owner: "owner", repo: "repo" }],
+    ["https://gitlab.com/owner/repo", null],
+    ["", null],
+  ])("parses %p", (url, expected) => {
+    expect(parseRepo(url)).toEqual(expected);
   });
 });
 
 describe("deriveRunListState", () => {
-  it("maps conclusion=failure to failing", () => {
-    expect(deriveRunListState({ status: "completed", conclusion: "failure" })).toBe("failing");
+  test.each<[string, string, InternalState]>([
+    ["completed", "failure", "failing"],
+    ["completed", "cancelled", "failing"],
+    ["completed", "timed_out", "failing"],
+    ["completed", "success", "success"],
+    ["completed", "neutral", "success"],
+    ["completed", "skipped", "success"],
+    ["in_progress", "", "running"],
+    ["queued", "", "queued"],
+    ["waiting", "", "queued"],
+    ["pending", "", "queued"],
+    ["wat", "", "running"],
+  ])("maps status=%p conclusion=%p to %p", (status, conclusion, expected) => {
+    expect(deriveRunListState({ status, conclusion })).toBe(expected);
   });
 
-  it("maps conclusion=cancelled to failing", () => {
-    expect(deriveRunListState({ status: "completed", conclusion: "cancelled" })).toBe("failing");
-  });
-
-  it("maps conclusion=timed_out to failing", () => {
-    expect(deriveRunListState({ status: "completed", conclusion: "timed_out" })).toBe("failing");
-  });
-
-  it("maps conclusion=success to success", () => {
-    expect(deriveRunListState({ status: "completed", conclusion: "success" })).toBe("success");
-  });
-
-  it("maps conclusion=neutral to success", () => {
-    expect(deriveRunListState({ status: "completed", conclusion: "neutral" })).toBe("success");
-  });
-
-  it("maps conclusion=skipped to success", () => {
-    expect(deriveRunListState({ status: "completed", conclusion: "skipped" })).toBe("success");
-  });
-
-  it("maps status=in_progress (no conclusion) to running", () => {
-    expect(deriveRunListState({ status: "in_progress", conclusion: "" })).toBe("running");
-  });
-
-  it("maps status=queued to queued", () => {
-    expect(deriveRunListState({ status: "queued", conclusion: "" })).toBe("queued");
-  });
-
-  it("maps status=waiting to queued", () => {
-    expect(deriveRunListState({ status: "waiting", conclusion: "" })).toBe("queued");
-  });
-
-  it("maps status=pending to queued", () => {
-    expect(deriveRunListState({ status: "pending", conclusion: "" })).toBe("queued");
-  });
-
-  it("falls back to running on unknown inputs", () => {
-    expect(deriveRunListState({ status: "wat", conclusion: "" })).toBe("running");
+  it("falls back to running on empty input", () => {
     expect(deriveRunListState({})).toBe("running");
   });
 });


### PR DESCRIPTION
Applies the repo's testing conventions to the `github` plugin's unit tests, collapsing repetitive one-case-per-`it` blocks into `test.each` tables. The behavior under test is unchanged: each table row carries the same input and expected value the original assertion used, so every case covered before is still covered.

Test LOC (`wc -l` over the unit's `*.test.ts`) drops from 1576 to 1422.

## Tabled

- `fetch.test.ts`: `isGitHubUrl`, `parseGitHubUrl` (null, repo/file, issue/pr/run/job), `formatOutput`, and `processInput` deny cases. The non-GitHub passthrough and unknown-pattern cases stay as standalone `it` blocks since they assert `null` rather than a decision.
- `pr-comments.test.ts`: `parseUrl` success cases and `detectRole`.
- `review-threads.test.ts`: the four mutation/query shape checks, each row pairing a constant with its expected substrings.
- `reviewers.test.ts`: `isBot` and `isReviewTarget`.
- `watch.test.ts`: `deriveChecksState`, `computeInterval`, `parseRepo`, and `deriveRunListState`. The `deriveRunListState` `{}` empty-input case stays a standalone `it` since it exercises a defaulted-object path distinct from the status/conclusion rows.

## Snapshotted

No new snapshots. The canonical all-green `deriveChecksState` regression payload moved into the table as a row, keeping its explanatory comment.

## Notes

No property tests were added; every change is a table refactor. `review-threads.test.ts` grew 31 to 36 lines because its rows pack multi-substring expectation arrays that don't compact below the original while staying readable. The group total is still net -154.
