### PR TITLE
test(plugins/review): apply testing conventions

### DIFF
--- a/plugins/review/skills/inbox/scripts/layout.test.ts
+++ b/plugins/review/skills/inbox/scripts/layout.test.ts
@@ -17,20 +17,15 @@ describe("layoutArgs", () => {
     }
   });
 
-  test("first pane: horizontal split at 70% against orchestrator", () => {
-    expect(layoutArgs(0, undefined)).toEqual(["-h", "-d", "-l", "70%", "-t", "%0"]);
-  });
-
-  test("second pane: vertical split against last pane", () => {
-    expect(layoutArgs(1, "%1")).toEqual(["-v", "-d", "-t", "%1"]);
-  });
-
-  test("third pane: vertical split against last pane", () => {
-    expect(layoutArgs(2, "%2")).toEqual(["-v", "-d", "-t", "%2"]);
-  });
-
-  test("fourth pane: new horizontal split column", () => {
-    expect(layoutArgs(3, "%3")).toEqual(["-h", "-d", "-t", "%3"]);
+  test.each<[number, string | undefined, string | undefined, string[]]>([
+    [0, undefined, undefined, ["-h", "-d", "-l", "70%", "-t", "%0"]],
+    [1, "%1", undefined, ["-v", "-d", "-t", "%1"]],
+    [2, "%2", undefined, ["-v", "-d", "-t", "%2"]],
+    [3, "%3", undefined, ["-h", "-d", "-t", "%3"]],
+    [0, undefined, "reviews", ["-h", "-d", "-t", "reviews"]],
+    [1, "%1", "reviews", ["-v", "-d", "-t", "%1"]],
+  ])("index=%p lastPane=%p target=%p", (index, lastPane, target, expected) => {
+    expect(layoutArgs(index, lastPane, target)).toEqual(expected);
   });
 
   test("throws when TMUX_PANE is not set", () => {
@@ -40,16 +35,8 @@ describe("layoutArgs", () => {
     );
   });
 
-  test("first pane with target session: split that session, no sidebar carve-out", () => {
-    expect(layoutArgs(0, undefined, "reviews")).toEqual(["-h", "-d", "-t", "reviews"]);
-  });
-
   test("target session does not require TMUX_PANE for the first pane", () => {
     delete process.env.TMUX_PANE;
     expect(layoutArgs(0, undefined, "reviews")).toEqual(["-h", "-d", "-t", "reviews"]);
-  });
-
-  test("subsequent panes chain off the last pane even with a target session", () => {
-    expect(layoutArgs(1, "%1", "reviews")).toEqual(["-v", "-d", "-t", "%1"]);
   });
 });

--- a/plugins/review/skills/inbox/scripts/parse.test.ts
+++ b/plugins/review/skills/inbox/scripts/parse.test.ts
@@ -2,23 +2,19 @@ import { describe, expect, test } from "bun:test";
 import { derivePaneName, deriveRepo } from "./parse";
 
 describe("deriveRepo", () => {
-  test("extracts owner/repo from GitHub PR URL", () => {
-    expect(deriveRepo("https://github.com/owner/repo/pull/42")).toBe("owner/repo");
-  });
-
-  test("extracts group/repo from GitLab MR URL", () => {
-    expect(deriveRepo("https://gitlab.com/group/repo/-/merge_requests/1")).toBe("group/repo");
+  test.each<[string, string]>([
+    ["https://github.com/owner/repo/pull/42", "owner/repo"],
+    ["https://gitlab.com/group/repo/-/merge_requests/1", "group/repo"],
+  ])("%s -> %s", (url, expected) => {
+    expect(deriveRepo(url)).toBe(expected);
   });
 });
 
 describe("derivePaneName", () => {
-  test("GitHub PR URL", () => {
-    expect(derivePaneName("https://github.com/owner/repo/pull/42")).toBe("review-owner-repo-42");
-  });
-
-  test("GitLab MR URL", () => {
-    expect(derivePaneName("https://gitlab.com/group/repo/-/merge_requests/7")).toBe(
-      "review-group-repo-7",
-    );
+  test.each<[string, string]>([
+    ["https://github.com/owner/repo/pull/42", "review-owner-repo-42"],
+    ["https://gitlab.com/group/repo/-/merge_requests/7", "review-group-repo-7"],
+  ])("%s -> %s", (url, expected) => {
+    expect(derivePaneName(url)).toBe(expected);
   });
 });

--- a/plugins/review/skills/inbox/scripts/poll.test.ts
+++ b/plugins/review/skills/inbox/scripts/poll.test.ts
@@ -1,30 +1,22 @@
 import { describe, expect, test } from "bun:test";
-import { fetchUrls, newUrls } from "./poll";
+import { type FetchResult, fetchUrls, newUrls } from "./poll";
 
 describe("fetchUrls", () => {
-  test("returns ok:true with extracted URLs on success", async () => {
-    const result = await fetchUrls(
+  test.each<[string, string, FetchResult]>([
+    [
+      "success",
       `echo '[{"url":"https://example.test/1"},{"url":"https://example.test/2"}]'`,
-    );
-    expect(result).toEqual({
-      ok: true,
-      urls: ["https://example.test/1", "https://example.test/2"],
-    });
-  });
-
-  test("returns ok:true with empty array when queue is empty", async () => {
-    const result = await fetchUrls("echo '[]'");
-    expect(result).toEqual({ ok: true, urls: [] });
-  });
-
-  test("returns ok:false with stderr reason when command exits non-zero", async () => {
-    const result = await fetchUrls("echo 'auth failed' >&2; exit 1");
-    expect(result).toEqual({ ok: false, reason: "auth failed" });
-  });
-
-  test("returns ok:false with exit-code reason when command fails with no stderr", async () => {
-    const result = await fetchUrls("exit 2");
-    expect(result).toEqual({ ok: false, reason: "exited with code 2" });
+      { ok: true, urls: ["https://example.test/1", "https://example.test/2"] },
+    ],
+    ["empty queue", "echo '[]'", { ok: true, urls: [] }],
+    [
+      "non-zero exit with stderr",
+      "echo 'auth failed' >&2; exit 1",
+      { ok: false, reason: "auth failed" },
+    ],
+    ["non-zero exit with no stderr", "exit 2", { ok: false, reason: "exited with code 2" }],
+  ])("%s", async (_name, cmd, expected) => {
+    expect(await fetchUrls(cmd)).toEqual(expected);
   });
 
   test("returns ok:false when output is not valid JSON", async () => {
@@ -37,27 +29,12 @@ describe("fetchUrls", () => {
 });
 
 describe("newUrls", () => {
-  test("keeps only URLs not already tracked", () => {
-    const tracked = new Set(["https://example.test/1"]);
-    expect(newUrls(["https://example.test/1", "https://example.test/2"], tracked)).toEqual([
-      "https://example.test/2",
-    ]);
-  });
-
-  test("dedupes a URL that appears on more than one platform", () => {
-    expect(newUrls(["https://example.test/2", "https://example.test/2"], new Set())).toEqual([
-      "https://example.test/2",
-    ]);
-  });
-
-  test("preserves fetch order", () => {
-    expect(newUrls(["https://example.test/3", "https://example.test/2"], new Set())).toEqual([
-      "https://example.test/3",
-      "https://example.test/2",
-    ]);
-  });
-
-  test("returns nothing when every fetched URL is tracked", () => {
-    expect(newUrls(["https://example.test/1"], new Set(["https://example.test/1"]))).toEqual([]);
+  test.each<[string, string[], Set<string>, string[]]>([
+    ["keeps only untracked URLs", ["u1", "u2"], new Set(["u1"]), ["u2"]],
+    ["dedupes a URL seen on more than one platform", ["u2", "u2"], new Set(), ["u2"]],
+    ["preserves fetch order", ["u3", "u2"], new Set(), ["u3", "u2"]],
+    ["returns nothing when every URL is tracked", ["u1"], new Set(["u1"]), []],
+  ])("%s", (_name, urls, tracked, expected) => {
+    expect(newUrls(urls, tracked)).toEqual(expected);
   });
 });

--- a/plugins/review/skills/tuicr/scripts/comment.test.ts
+++ b/plugins/review/skills/tuicr/scripts/comment.test.ts
@@ -17,22 +17,19 @@ function comment(overrides: Partial<TuicrComment>): TuicrComment {
 }
 
 describe("deriveAnchor", () => {
-  test("uses the new side when tuicr stamps it", () => {
-    expect(deriveAnchor(comment({ start_line: 150, end_line: 150, side: "new" }))).toEqual({
-      side: "new",
-      line: 150,
-      path: "user/settings.json",
-    });
-  });
-
-  test("uses the old side for a removed line", () => {
-    expect(
-      deriveAnchor(comment({ path: "old.txt", start_line: 11, end_line: 11, side: "old" })),
-    ).toEqual({
-      side: "old",
-      line: 11,
-      path: "old.txt",
-    });
+  test.each<[string, Partial<TuicrComment>, ReturnType<typeof deriveAnchor>]>([
+    [
+      "uses the new side when tuicr stamps it",
+      { start_line: 150, end_line: 150, side: "new" },
+      { side: "new", line: 150, path: "user/settings.json" },
+    ],
+    [
+      "uses the old side for a removed line",
+      { path: "old.txt", start_line: 11, end_line: 11, side: "old" },
+      { side: "old", line: 11, path: "old.txt" },
+    ],
+  ])("%s", (_name, overrides, expected) => {
+    expect(deriveAnchor(comment(overrides))).toEqual(expected);
   });
 
   test("defaults to the new side when side is omitted on a line comment", () => {
@@ -47,13 +44,11 @@ describe("deriveAnchor", () => {
 });
 
 describe("decodeComments", () => {
-  test("decodes a bare array of comments", () => {
-    const comments = decodeComments(JSON.stringify([comment({ id: "c1" })]));
+  test.each<[string, unknown]>([
+    ["decodes a bare array of comments", [comment({ id: "c1" })]],
+    ["decodes a { comments: [...] } envelope", { comments: [comment({ id: "c1" })] }],
+  ])("%s", (_name, payload) => {
+    const comments = decodeComments(JSON.stringify(payload));
     expect(comments.map((c) => c.id)).toEqual(["c1"]);
-  });
-
-  test("decodes a { comments: [...] } envelope", () => {
-    const comments = decodeComments(JSON.stringify({ comments: [comment({ id: "c2" })] }));
-    expect(comments.map((c) => c.id)).toEqual(["c2"]);
   });
 });

--- a/plugins/review/skills/tuicr/scripts/platform.test.ts
+++ b/plugins/review/skills/tuicr/scripts/platform.test.ts
@@ -117,92 +117,70 @@ index 1111111..2222222 100644
 });
 
 describe("toGitHubComment", () => {
-  test("maps a new-side comment to RIGHT", () => {
-    expect(
-      toGitHubComment(comment({ start_line: 150, end_line: 150, side: "new" }), {
-        commitId: "abc123",
-      }),
-    ).toEqual({
-      path: "user/settings.json",
-      line: 150,
-      side: "RIGHT",
-      commit_id: "abc123",
-      body: "comment",
-    });
-  });
-
-  test("maps an old-side deletion to LEFT", () => {
-    expect(
-      toGitHubComment(comment({ path: "old.txt", start_line: 11, end_line: 11, side: "old" }), {
-        commitId: "abc123",
-      }),
-    ).toEqual({
-      path: "old.txt",
-      line: 11,
-      side: "LEFT",
-      commit_id: "abc123",
-      body: "comment",
-    });
+  test.each<[string, Partial<TuicrComment>, ReturnType<typeof toGitHubComment>]>([
+    [
+      "maps a new-side comment to RIGHT",
+      { start_line: 150, end_line: 150, side: "new" },
+      {
+        path: "user/settings.json",
+        line: 150,
+        side: "RIGHT",
+        commit_id: "abc123",
+        body: "comment",
+      },
+    ],
+    [
+      "maps an old-side deletion to LEFT",
+      { path: "old.txt", start_line: 11, end_line: 11, side: "old" },
+      { path: "old.txt", line: 11, side: "LEFT", commit_id: "abc123", body: "comment" },
+    ],
+  ])("%s", (_name, overrides, expected) => {
+    expect(toGitHubComment(comment(overrides), { commitId: "abc123" })).toEqual(expected);
   });
 });
 
 describe("toGitLabPosition", () => {
   const refs = { base_sha: "base", head_sha: "head", start_sha: "start" };
 
-  test("sets new_line for a new-side comment and defaults old_path to new_path", () => {
-    expect(
-      toGitLabPosition(comment({ start_line: 150, end_line: 150, side: "new" }), refs, {
-        newPath: "user/settings.json",
-      }),
-    ).toEqual({
-      position_type: "text",
-      base_sha: "base",
-      head_sha: "head",
-      start_sha: "start",
-      new_path: "user/settings.json",
-      old_path: "user/settings.json",
-      new_line: 150,
-    });
-  });
-
-  test("sets old_line for an old-side deletion", () => {
-    expect(
-      toGitLabPosition(
-        comment({ path: "old.txt", start_line: 11, end_line: 11, side: "old" }),
-        refs,
-        {
-          newPath: "old.txt",
-        },
-      ),
-    ).toEqual({
-      position_type: "text",
-      base_sha: "base",
-      head_sha: "head",
-      start_sha: "start",
-      new_path: "old.txt",
-      old_path: "old.txt",
-      old_line: 11,
-    });
-  });
-
-  test("carries distinct old_path for a rename", () => {
-    expect(
-      toGitLabPosition(
-        comment({ path: "src/new-name.ts", start_line: 7, end_line: 7, side: "new" }),
-        refs,
-        {
-          newPath: "src/new-name.ts",
-          oldPath: "src/old-name.ts",
-        },
-      ),
-    ).toEqual({
-      position_type: "text",
-      base_sha: "base",
-      head_sha: "head",
-      start_sha: "start",
-      new_path: "src/new-name.ts",
-      old_path: "src/old-name.ts",
-      new_line: 7,
-    });
+  test.each<
+    [
+      string,
+      Partial<TuicrComment>,
+      Parameters<typeof toGitLabPosition>[2],
+      ReturnType<typeof toGitLabPosition>,
+    ]
+  >([
+    [
+      "sets new_line for a new-side comment and defaults old_path to new_path",
+      { start_line: 150, end_line: 150, side: "new" },
+      { newPath: "user/settings.json" },
+      {
+        ...refs,
+        position_type: "text",
+        new_path: "user/settings.json",
+        old_path: "user/settings.json",
+        new_line: 150,
+      },
+    ],
+    [
+      "sets old_line for an old-side deletion",
+      { path: "old.txt", start_line: 11, end_line: 11, side: "old" },
+      { newPath: "old.txt" },
+      { ...refs, position_type: "text", new_path: "old.txt", old_path: "old.txt", old_line: 11 },
+    ],
+    [
+      "carries distinct old_path for a rename",
+      { path: "src/new-name.ts", start_line: 7, end_line: 7, side: "new" },
+      { newPath: "src/new-name.ts", oldPath: "src/old-name.ts" },
+      {
+        ...refs,
+        position_type: "text",
+        new_path: "src/new-name.ts",
+        old_path: "src/old-name.ts",
+        new_line: 7,
+      },
+    ],
+  ])("%s", (_name, overrides, options, expected) => {
+    expect(toGitLabPosition(comment(overrides), refs, options)).toEqual(expected);
   });
 });

--- a/plugins/review/skills/tuicr/scripts/watch.test.ts
+++ b/plugins/review/skills/tuicr/scripts/watch.test.ts
@@ -32,19 +32,13 @@ describe("describeComment", () => {
 });
 
 describe("newComments", () => {
-  test("returns only comments whose IDs are not yet seen", () => {
-    const seen = new Set(["c1"]);
-    const comments = [comment({ id: "c1" }), comment({ id: "c2" })];
-    expect(newComments(seen, comments).map((c) => c.id)).toEqual(["c2"]);
-  });
-
-  test("skips comments without an ID", () => {
-    const comments = [comment({ id: "" }), comment({ id: "c2" })];
-    expect(newComments(new Set(), comments).map((c) => c.id)).toEqual(["c2"]);
-  });
-
-  test("returns nothing when all are seen", () => {
-    const comments = [comment({ id: "c1" }), comment({ id: "c2" })];
-    expect(newComments(new Set(["c1", "c2"]), comments)).toEqual([]);
+  test.each<[string, string[], string[], string[]]>([
+    ["returns only comments whose IDs are not yet seen", ["c1"], ["c1", "c2"], ["c2"]],
+    ["skips comments without an ID", [], ["", "c2"], ["c2"]],
+    ["returns nothing when all are seen", ["c1", "c2"], ["c1", "c2"], []],
+  ])("%s", (_name, seenIds, commentIds, expected) => {
+    const seen = new Set(seenIds);
+    const comments = commentIds.map((id) => comment({ id }));
+    expect(newComments(seen, comments).map((c) => c.id)).toEqual(expected);
   });
 });


### PR DESCRIPTION
Folds the point-probe tests across the `review` plugin's `inbox` and `tuicr` script suites into `test.each` tables. Each converted `describe` now drives its cases from one table, so the assertion body is written once and the rows carry only the varying inputs and expected output. The assertions are unchanged: every row asserts what its former standalone test asserted.

Test LOC across the unit went from 1020 to 947. This adds no property tests, so it is a pure refactor and the LOC drop reflects the removed boilerplate.

## Tabled

- `inbox/layout.test.ts`: the six `layoutArgs` point tests, including the two target-session cases, collapse into one table. The `TMUX_PANE`-mutating cases (the throw and the no-`TMUX_PANE` target case) stay standalone because they manipulate `process.env`.
- `inbox/parse.test.ts`: `deriveRepo` and `derivePaneName` URL cases.
- `inbox/poll.test.ts`: `fetchUrls` success/empty/error cases and `newUrls` filtering cases. The invalid-JSON case stays standalone.
- `tuicr/comment.test.ts`: `deriveAnchor` new/old-side cases and `decodeComments` array/envelope cases. The side-defaulting case stays standalone.
- `tuicr/platform.test.ts`: `toGitHubComment` and `toGitLabPosition` mapping cases. The GitLab expectations spread the shared `refs` object.
- `tuicr/watch.test.ts`: `newComments` filtering cases.

## Tabled but Reverted

`tuicr/diff.test.ts` was flagged for a `toMatchInlineSnapshot()` conversion of five `parseDiff` boundary-probe tests. The conversion preserves (and slightly strengthens) the probes, but each snapshot renders as a ~15-line block, growing the file from 113 to 184 lines. That is a material per-file LOC regression against a set of deliberate single-line boundary probes, so the file is left in its original state. The unit stays net LOC-negative without it.
