### PR TITLE
test(.claude): apply testing conventions

### DIFF
--- a/.claude/hooks/biome/index.test.ts
+++ b/.claude/hooks/biome/index.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import { exec } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -117,23 +117,27 @@ describe("biome hook", () => {
   });
 
   describe("runBiomeCheck", () => {
-    it("returns null for valid files", async () => {
-      const filePath = await copyFixture("valid.ts", tempDir);
-      expect(await runBiomeCheck(filePath)).toBeNull();
-    });
-
-    it("returns errors for files with fixable issues", async () => {
-      const filePath = await copyFixture("fixable.ts", tempDir);
+    test.each<{ name: string; fixture: string; expected: string | null }>([
+      { name: "returns null for valid files", fixture: "valid.ts", expected: null },
+      {
+        name: "returns errors for files with fixable issues",
+        fixture: "fixable.ts",
+        expected: "format",
+      },
+      {
+        name: "returns errors for files with unfixable issues",
+        fixture: "unfixable.ts",
+        expected: "noDuplicateObjectKeys",
+      },
+    ])("$name", async ({ fixture, expected }) => {
+      const filePath = await copyFixture(fixture, tempDir);
       const result = await runBiomeCheck(filePath);
-      expect(result).not.toBeNull();
-      expect(result).toContain("format");
-    });
-
-    it("returns errors for files with unfixable issues", async () => {
-      const filePath = await copyFixture("unfixable.ts", tempDir);
-      const result = await runBiomeCheck(filePath);
-      expect(result).not.toBeNull();
-      expect(result).toContain("noDuplicateObjectKeys");
+      if (expected === null) {
+        expect(result).toBeNull();
+      } else {
+        expect(result).not.toBeNull();
+        expect(result).toContain(expected);
+      }
     });
 
     it("returns null for files the Biome config ignores", async () => {
@@ -143,18 +147,19 @@ describe("biome hook", () => {
   });
 
   describe("runBiomeFix", () => {
-    it("fixes auto-fixable issues", async () => {
-      const filePath = await copyFixture("fixable.ts", tempDir);
+    test.each<{ name: string; fixture: string; fixedAfter: boolean }>([
+      { name: "fixes auto-fixable issues", fixture: "fixable.ts", fixedAfter: true },
+      { name: "does not fix unsafe issues", fixture: "unfixable.ts", fixedAfter: false },
+    ])("$name", async ({ fixture, fixedAfter }) => {
+      const filePath = await copyFixture(fixture, tempDir);
       expect(await runBiomeCheck(filePath)).not.toBeNull();
       await runBiomeFix(filePath);
-      expect(await runBiomeCheck(filePath)).toBeNull();
-    });
-
-    it("does not fix unsafe issues", async () => {
-      const filePath = await copyFixture("unfixable.ts", tempDir);
-      expect(await runBiomeCheck(filePath)).not.toBeNull();
-      await runBiomeFix(filePath);
-      expect(await runBiomeCheck(filePath)).not.toBeNull();
+      const result = await runBiomeCheck(filePath);
+      if (fixedAfter) {
+        expect(result).toBeNull();
+      } else {
+        expect(result).not.toBeNull();
+      }
     });
   });
 
@@ -163,19 +168,10 @@ describe("biome hook", () => {
       expect(await parseTranscript("/nonexistent/path.jsonl")).toEqual([]);
     });
 
-    it("extracts file paths from Edit tool uses", async () => {
+    test.each(["Edit", "Write"])("extracts file paths from %s tool uses", async (tool) => {
       const filePath = await copyFixture("valid.ts", tempDir);
-      const transcriptPath = join(tempDir, `transcript-edit-${Date.now()}.jsonl`);
-      await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Edit" }]));
-
-      const files = await parseTranscript(transcriptPath);
-      expect(files).toContain(filePath);
-    });
-
-    it("extracts file paths from Write tool uses", async () => {
-      const filePath = await copyFixture("valid.ts", tempDir);
-      const transcriptPath = join(tempDir, `transcript-write-${Date.now()}.jsonl`);
-      await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Write" }]));
+      const transcriptPath = join(tempDir, `transcript-${tool}-${Date.now()}.jsonl`);
+      await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool }]));
 
       const files = await parseTranscript(transcriptPath);
       expect(files).toContain(filePath);
@@ -245,9 +241,22 @@ describe("biome hook", () => {
       expect(await processPostToolUse(input)).toBeNull();
     });
 
-    it("returns additionalContext for fixable issues", async () => {
-      const filePath = await copyFixture("fixable.ts", tempDir);
-      const input = mockPostToolUseInput("Write", { file_path: filePath });
+    test.each<{ name: string; fixture: string; tool: string; expected: string }>([
+      {
+        name: "returns additionalContext for fixable issues",
+        fixture: "fixable.ts",
+        tool: "Write",
+        expected: "Biome found issues",
+      },
+      {
+        name: "returns additionalContext for unfixable issues",
+        fixture: "unfixable.ts",
+        tool: "Edit",
+        expected: "noDuplicateObjectKeys",
+      },
+    ])("$name", async ({ fixture, tool, expected }) => {
+      const filePath = await copyFixture(fixture, tempDir);
+      const input = mockPostToolUseInput(tool, { file_path: filePath });
       const result = await processPostToolUse(input);
 
       expect(result).not.toBeNull();
@@ -257,18 +266,7 @@ describe("biome hook", () => {
 
       const additionalContext = (result?.hookSpecificOutput as { additionalContext: string })
         .additionalContext;
-      expect(additionalContext).toContain("Biome found issues");
-    });
-
-    it("returns additionalContext for unfixable issues", async () => {
-      const filePath = await copyFixture("unfixable.ts", tempDir);
-      const input = mockPostToolUseInput("Edit", { file_path: filePath });
-      const result = await processPostToolUse(input);
-
-      expect(result).not.toBeNull();
-      const additionalContext = (result?.hookSpecificOutput as { additionalContext: string })
-        .additionalContext;
-      expect(additionalContext).toContain("noDuplicateObjectKeys");
+      expect(additionalContext).toContain(expected);
     });
   });
 

--- a/.claude/hooks/coverage/index.test.ts
+++ b/.claude/hooks/coverage/index.test.ts
@@ -73,20 +73,18 @@ describe("formatHint", () => {
 });
 
 describe("processPostToolUse", () => {
-  test("ignores non-edit tools", async () => {
+  test.each<{ name: string; toolName: string; filePath: string }>([
+    { name: "ignores non-edit tools", toolName: "Read", filePath: sourceFile },
+    {
+      name: "ignores test files",
+      toolName: "Edit",
+      filePath: join(workDir, "sample.test.ts"),
+    },
+  ])("$name", async ({ toolName, filePath }) => {
     const result = await processPostToolUse({
       hook_event_name: "PostToolUse",
-      tool_name: "Read",
-      tool_input: { file_path: sourceFile },
-    } as Parameters<typeof processPostToolUse>[0]);
-    expect(result).toBeNull();
-  });
-
-  test("ignores test files", async () => {
-    const result = await processPostToolUse({
-      hook_event_name: "PostToolUse",
-      tool_name: "Edit",
-      tool_input: { file_path: join(workDir, "sample.test.ts") },
+      tool_name: toolName,
+      tool_input: { file_path: filePath },
     } as Parameters<typeof processPostToolUse>[0]);
     expect(result).toBeNull();
   });

--- a/.claude/hooks/plugin-deps/index.test.ts
+++ b/.claude/hooks/plugin-deps/index.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -57,19 +57,18 @@ process.exit(${VIOLATION_EXIT});`,
     expect(output?.reason).toContain('missing dependency "cleye"');
   });
 
-  it("reports a non-blocking systemMessage when the checker crashes", async () => {
-    const checker = await fakeChecker(
-      "crash.ts",
-      `throw new Error("Cannot find module '@bendrucker/claude-marketplace'");`,
-    );
+  test.each<{ name: string; crashes: boolean }>([
+    { name: "reports a non-blocking systemMessage when the checker crashes", crashes: true },
+    { name: "does not block when the checker script is missing", crashes: false },
+  ])("$name", async ({ crashes }) => {
+    const checker = crashes
+      ? await fakeChecker(
+          "crash.ts",
+          `throw new Error("Cannot find module '@bendrucker/claude-marketplace'");`,
+        )
+      : join(tempDir, "missing.ts");
 
     const output = await processStop(stopInput(), checker);
-    expect(output?.decision).toBeUndefined();
-    expect(output?.systemMessage).toContain("checker could not run");
-  });
-
-  it("does not block when the checker script is missing", async () => {
-    const output = await processStop(stopInput(), join(tempDir, "missing.ts"));
     expect(output?.decision).toBeUndefined();
     expect(output?.systemMessage).toContain("checker could not run");
   });

--- a/.claude/hooks/plugin-imports/index.test.ts
+++ b/.claude/hooks/plugin-imports/index.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -57,19 +57,18 @@ process.exit(${VIOLATION_EXIT});`,
     expect(output?.reason).toContain("imports outside plugin boundary");
   });
 
-  it("reports a non-blocking systemMessage when the checker crashes", async () => {
-    const checker = await fakeChecker(
-      "crash.ts",
-      `throw new Error("Cannot find module '@bendrucker/claude-marketplace'");`,
-    );
+  test.each<{ name: string; crashes: boolean }>([
+    { name: "reports a non-blocking systemMessage when the checker crashes", crashes: true },
+    { name: "does not block when the checker script is missing", crashes: false },
+  ])("$name", async ({ crashes }) => {
+    const checker = crashes
+      ? await fakeChecker(
+          "crash.ts",
+          `throw new Error("Cannot find module '@bendrucker/claude-marketplace'");`,
+        )
+      : join(tempDir, "missing.ts");
 
     const output = await processStop(stopInput(), checker);
-    expect(output?.decision).toBeUndefined();
-    expect(output?.systemMessage).toContain("checker could not run");
-  });
-
-  it("does not block when the checker script is missing", async () => {
-    const output = await processStop(stopInput(), join(tempDir, "missing.ts"));
     expect(output?.decision).toBeUndefined();
     expect(output?.systemMessage).toContain("checker could not run");
   });

--- a/.claude/hooks/stop/index.test.ts
+++ b/.claude/hooks/stop/index.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -14,6 +14,18 @@ beforeAll(async () => {
 afterAll(async () => {
   await rm(tempDir, { recursive: true, force: true });
 });
+
+function stopInput(overrides?: Partial<StopHookInput>): StopHookInput {
+  return {
+    hook_event_name: "Stop",
+    session_id: "test",
+    transcript_path: "/dev/null",
+    cwd: tempDir,
+    stop_hook_active: false,
+    permission_mode: "default",
+    ...overrides,
+  };
+}
 
 function createTranscriptContent(files: Array<{ path: string; tool: string }>): string {
   return files
@@ -97,30 +109,15 @@ describe("parseTranscript", () => {
 });
 
 describe("scopePaths", () => {
-  it("returns a clean relative path for a file inside cwd", () => {
-    const cwd = join(tempDir, "repo");
-    const file = join(cwd, "plugins", "mac", "plugin.json");
-    expect(scopePaths([file], cwd)).toEqual([join("plugins", "mac", "plugin.json")]);
-  });
-
-  it("excludes an absolute path in a sibling worktree", () => {
-    const cwd = join(tempDir, "repo");
-    const sibling = join(tempDir, "other-worktree", "plugins", "mac", "plugin.json");
-    expect(scopePaths([sibling], cwd)).toEqual([]);
-  });
-
-  it("excludes a path whose relative form starts with ..", () => {
-    const cwd = join(tempDir, "a", "b", "c");
-    const outside = join(tempDir, "a", "elsewhere.ts");
-    const scoped = scopePaths([outside], cwd);
-    expect(scoped.every((p) => !p.startsWith(".."))).toBe(true);
-    expect(scoped).toEqual([]);
-  });
-
-  it("keeps a sibling file literally named ..foo.ts directly under cwd", () => {
-    const cwd = join(tempDir, "repo");
-    const file = join(cwd, "..foo.ts");
-    expect(scopePaths([file], cwd)).toEqual(["..foo.ts"]);
+  test.each<[string[], string[], string[]]>([
+    [["repo"], ["repo", "plugins", "mac", "plugin.json"], [join("plugins", "mac", "plugin.json")]],
+    [["repo"], ["other-worktree", "plugins", "mac", "plugin.json"], []],
+    [["a", "b", "c"], ["a", "elsewhere.ts"], []],
+    [["repo"], ["repo", "..foo.ts"], ["..foo.ts"]],
+  ])("cwd=%p file=%p -> %p", (cwdParts, fileParts, expected) => {
+    const cwd = join(tempDir, ...cwdParts);
+    const file = join(tempDir, ...fileParts);
+    expect(scopePaths([file], cwd)).toEqual(expected);
   });
 });
 
@@ -144,16 +141,7 @@ describe("processStop", () => {
 
     process.env.CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE = "cloud_default";
 
-    const input: StopHookInput = {
-      hook_event_name: "Stop",
-      session_id: "test",
-      transcript_path: transcriptPath,
-      cwd: tempDir,
-      stop_hook_active: false,
-      permission_mode: "default",
-    };
-
-    expect(await processStop(input)).toBeNull();
+    expect(await processStop(stopInput({ transcript_path: transcriptPath }))).toBeNull();
   });
 
   it("returns null when every collected file is out-of-tree", async () => {
@@ -167,15 +155,6 @@ describe("processStop", () => {
     const transcriptPath = join(tempDir, "transcript-out-of-tree.jsonl");
     await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Edit" }]));
 
-    const input: StopHookInput = {
-      hook_event_name: "Stop",
-      session_id: "test",
-      transcript_path: transcriptPath,
-      cwd,
-      stop_hook_active: false,
-      permission_mode: "default",
-    };
-
-    expect(await processStop(input)).toBeNull();
+    expect(await processStop(stopInput({ transcript_path: transcriptPath, cwd }))).toBeNull();
   });
 });

--- a/.claude/skills/agent-ideas/scripts/fetch.test.ts
+++ b/.claude/skills/agent-ideas/scripts/fetch.test.ts
@@ -33,26 +33,35 @@ const rss = `<?xml version="1.0"?>
 
 describe("parseFeed", () => {
   test("parses Atom entries with alternate links and HTML-stripped excerpts", () => {
-    const posts = parseFeed(atom);
-    expect(posts).toHaveLength(2);
-    expect(posts[0]).toMatchObject({
-      title: "Agentic coding with Claude",
-      url: "https://example.com/post-1",
-      date: "2026-05-28T12:00:00.000Z",
-    });
-    expect(posts[0]?.excerpt).toBe("A post about & MCP tooling.");
-    expect(posts[1]?.url).toBe("https://example.com/post-2");
+    expect(parseFeed(atom)).toMatchInlineSnapshot(`
+      [
+        {
+          "date": "2026-05-28T12:00:00.000Z",
+          "excerpt": "A post about & MCP tooling.",
+          "title": "Agentic coding with Claude",
+          "url": "https://example.com/post-1",
+        },
+        {
+          "date": "2026-05-20T08:00:00.000Z",
+          "excerpt": "Body content here.",
+          "title": "Second post",
+          "url": "https://example.com/post-2",
+        },
+      ]
+    `);
   });
 
   test("parses RSS items and normalizes pubDate to ISO", () => {
-    const posts = parseFeed(rss);
-    expect(posts).toHaveLength(1);
-    expect(posts[0]).toMatchObject({
-      title: "RSS item one",
-      url: "https://example.com/rss-1",
-      date: "2026-05-28T12:00:00.000Z",
-    });
-    expect(posts[0]?.excerpt).toBe("HTML stripped description.");
+    expect(parseFeed(rss)).toMatchInlineSnapshot(`
+      [
+        {
+          "date": "2026-05-28T12:00:00.000Z",
+          "excerpt": "HTML stripped description.",
+          "title": "RSS item one",
+          "url": "https://example.com/rss-1",
+        },
+      ]
+    `);
   });
 
   test("returns no posts for an unrecognized document", () => {


### PR DESCRIPTION
Applies the repo's testing conventions to six `.claude` test suites: collapse near-duplicate cases into `test.each` tables and snapshot formatted output instead of hand-asserting each field.

Test LOC across these suites drops from 897 to 879. Every refactor preserves the original assertions.

## Changes

- `biome/index.test.ts`: `runBiomeCheck`, `runBiomeFix`, the `Edit`/`Write` transcript extraction, and the `processPostToolUse` fixable/unfixable cases become `test.each` tables.
- `coverage`, `plugin-deps`, `plugin-imports`: fold each suite's two sibling cases into a single table.
- `stop/index.test.ts`: add a `stopInput` helper for the repeated `StopHookInput` literal and parametrize `scopePaths` over `[cwd, file, expected]` rows. The dropped `startsWith("..")` assertion is subsumed by the exact `toEqual([])` on the excluded rows.
- `fetch.test.ts`: replace partial `toMatchObject` checks with full `toMatchInlineSnapshot` of the parsed feed, which asserts the whole shape rather than a few fields.

This tables no cases and drops none. It adds no property tests, so every change is a pure refactor and the two inline snapshots are the only new lines.
