### PR TITLE
test(scripts): apply testing conventions

### DIFF
--- a/scripts/coverage/lcov.test.ts
+++ b/scripts/coverage/lcov.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
 import {
   coveredLines,
+  type FileCoverage,
   formatLcov,
   formatRanges,
   lineCoverage,
@@ -8,6 +10,21 @@ import {
   parseLcov,
   uncoveredLines,
 } from "./lcov";
+
+const pathChar = fc.constantFrom(
+  ..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/._-".split(""),
+);
+
+const fileCoverage = fc.record<FileCoverage>({
+  file: fc.array(pathChar, { minLength: 1 }).map((chars) => chars.join("")),
+  lineHits: fc
+    .uniqueArray(fc.tuple(fc.integer({ min: 1 }), fc.nat()), {
+      selector: ([line]) => line,
+    })
+    .map((entries) => new Map(entries)),
+  functionsFound: fc.nat(),
+  functionsHit: fc.nat(),
+});
 
 function defined<T>(value: T | undefined): T {
   if (value === undefined) throw new Error("expected a value");
@@ -41,11 +58,21 @@ end_of_record
 describe("parseLcov", () => {
   test("extracts file, line hits, and function totals", () => {
     const a = defined(parseLcov(SINGLE)[0]);
-    expect(a.file).toBe("src/a.ts");
-    expect(a.functionsFound).toBe(2);
-    expect(a.functionsHit).toBe(1);
-    expect(a.lineHits.get(1)).toBe(5);
-    expect(a.lineHits.get(2)).toBe(0);
+    expect(a).toMatchInlineSnapshot(`
+      {
+        "file": "src/a.ts",
+        "functionsFound": 2,
+        "functionsHit": 1,
+        "lineHits": 
+      Map {
+          1 => 5,
+          2 => 0,
+          3 => 0,
+          4 => 2,
+        }
+      ,
+      }
+    `);
   });
 
   test("parses multiple records", () => {
@@ -110,9 +137,20 @@ end_of_record
 });
 
 describe("formatLcov", () => {
-  test("round-trips through the parser", () => {
-    const records = parseLcov(MULTI);
+  test.each<{ name: string; text: string }>([
+    { name: "single record", text: SINGLE },
+    { name: "multiple records", text: MULTI },
+  ])("round-trips $name through the parser", ({ text }) => {
+    const records = parseLcov(text);
     expect(parseLcov(formatLcov(records))).toEqual(records);
+  });
+
+  test("round-trips any records through the parser", () => {
+    fc.assert(
+      fc.property(fc.array(fileCoverage), (records) => {
+        expect(parseLcov(formatLcov(records))).toEqual(records);
+      }),
+    );
   });
 
   test("emits empty string for no records", () => {

--- a/scripts/coverage/report.test.ts
+++ b/scripts/coverage/report.test.ts
@@ -17,14 +17,17 @@ describe("terminalReport", () => {
   });
 
   test("lists files, percentages, and uncovered ranges", () => {
-    // Color codes wrap the percentage and detail file name, so assert on
-    // substrings that survive between the escapes.
     const out = terminalReport([fileCoverage("a.ts", { 1: 1, 2: 0, 3: 0, 4: 1 })]);
-    expect(out).toContain("a.ts");
-    expect(out).toContain("50.0%");
-    expect(out).toContain("2-3");
-    expect(out).toContain("Uncovered lines:");
-    expect(out).toContain(": 2, 3");
+    expect(out).toMatchInlineSnapshot(`
+      "╔══════╤═════════╤═══════════╗
+      ║ File │ % Lines │ Uncovered ║
+      ╟──────┼─────────┼───────────╢
+      ║ a.ts │ \x1B[31m50.0%\x1B[39m   │ 2-3       ║
+      ╚══════╧═════════╧═══════════╝
+
+      Uncovered lines:
+      \x1B[31ma.ts\x1B[0m: 2, 3"
+    `);
   });
 
   test("omits the uncovered detail section when everything is covered", () => {
@@ -37,9 +40,13 @@ describe("terminalReport", () => {
 describe("githubReport", () => {
   test("builds a markdown summary table", () => {
     const summary = githubReport([fileCoverage("a.ts", { 1: 1, 2: 0, 3: 0 })]);
-    expect(summary).toContain("## Coverage");
-    expect(summary).toContain("| `a.ts` |");
-    expect(summary).toContain("33.3%");
+    expect(summary).toMatchInlineSnapshot(`
+      "## Coverage
+
+      | File | % Lines | Uncovered |
+      | --- | --- | --- |
+      | \`a.ts\` | 33.3% | 2-3 |"
+    `);
   });
 
   test("reports no data for an empty set", () => {

--- a/scripts/coverage/run.test.ts
+++ b/scripts/coverage/run.test.ts
@@ -10,16 +10,10 @@ describe("resolveScope", () => {
     [".claude/hooks/biome/index.ts", "./.claude"],
     [".claude/skills/agent-ideas/sources.ts", "./.claude"],
     ["user/rules/typescript.md", "./user"],
+    [join(repoRoot, "packages/validate/run.ts"), "packages/validate/"],
+    ["scripts/coverage/run.ts", "./scripts/coverage"],
   ])("%s -> %s", (file, expected) => {
     expect(resolveScope(file)).toBe(expected);
-  });
-
-  test("accepts absolute paths", () => {
-    expect(resolveScope(join(repoRoot, "packages/validate/run.ts"))).toBe("packages/validate/");
-  });
-
-  test("falls back to the nearest ancestor dir containing tests", () => {
-    expect(resolveScope("scripts/coverage/run.ts")).toBe("./scripts/coverage");
   });
 });
 

--- a/scripts/prek-check.test.ts
+++ b/scripts/prek-check.test.ts
@@ -22,7 +22,10 @@ async function run(...args: string[]): Promise<RunResult> {
 
 describe("prek-check plugin-validate", () => {
   it.each<[string, string]>([
-    ["relative path pointing outside the tree", "../../other/plugins/foo/.claude-plugin/plugin.json"],
+    [
+      "relative path pointing outside the tree",
+      "../../other/plugins/foo/.claude-plugin/plugin.json",
+    ],
     ["absolute path", "/abs/plugins/foo/.claude-plugin/plugin.json"],
   ])("skips a %s without ENOENT", async (_name, path) => {
     const { exitCode, stderr } = await run("plugin-validate", path);

--- a/scripts/prek-check.test.ts
+++ b/scripts/prek-check.test.ts
@@ -21,20 +21,11 @@ async function run(...args: string[]): Promise<RunResult> {
 }
 
 describe("prek-check plugin-validate", () => {
-  it("skips a relative path pointing outside the tree without ENOENT", async () => {
-    const { exitCode, stderr } = await run(
-      "plugin-validate",
-      "../../other/plugins/foo/.claude-plugin/plugin.json",
-    );
-    expect(exitCode).toBe(0);
-    expect(stderr).not.toContain("ENOENT");
-  });
-
-  it("skips an absolute path", async () => {
-    const { exitCode, stderr } = await run(
-      "plugin-validate",
-      "/abs/plugins/foo/.claude-plugin/plugin.json",
-    );
+  it.each<[string, string]>([
+    ["relative path pointing outside the tree", "../../other/plugins/foo/.claude-plugin/plugin.json"],
+    ["absolute path", "/abs/plugins/foo/.claude-plugin/plugin.json"],
+  ])("skips a %s without ENOENT", async (_name, path) => {
+    const { exitCode, stderr } = await run("plugin-validate", path);
     expect(exitCode).toBe(0);
     expect(stderr).not.toContain("ENOENT");
   });


### PR DESCRIPTION
Applies the repo's testing conventions to the coverage and prek-check script tests: parameterized tables for repeated cases, inline snapshots for structured output, and a fast-check property for the lcov round-trip.

Test LOC (`wc -l` over the four `*.test.ts` files) went from 259 to 289. The pure refactors dropped LOC as expected: `run.test.ts` folded two one-off `resolveScope` cases into the existing `test.each` table (-6), and `prek-check.test.ts` collapsed two near-identical `plugin-validate` cases into one `it.each` (-9). The net rose because the snapshot and property work adds lines while asserting strictly more.

## Snapshots

Three assertions built from `toContain`/`toBe` substring checks became `toMatchInlineSnapshot`:

- `parseLcov` in `lcov.test.ts`: the full `FileCoverage` record, including the `lineHits` Map, instead of five field spot-checks.
- `terminalReport` in `report.test.ts`: the whole box-drawn table plus the uncovered-lines detail, including the color escapes, instead of five surviving substrings.
- `githubReport` in `report.test.ts`: the entire markdown summary table instead of three substrings.

These outputs are short (well under the file-snapshot threshold) but multi-line and structured, so the inline block is longer than the substring calls it replaces even though it pins the entire shape.

## Property

`formatLcov` in `lcov.test.ts` gains a fast-check property asserting the round-trip invariant `parseLcov(formatLcov(records)) === records` over arbitrary coverage records (generated file paths, unique-keyed line-hit Maps, function totals). The existing example test also became a `test.each` covering the single- and multi-record fixtures.
