### PR TITLE
test(plugins/claude-code): apply testing conventions

### DIFF
--- a/plugins/claude-code/skills/skill/scripts/check-lint.test.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-lint.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import type { PostToolUseInput } from "@constellos/claude-code-kit";
 import { processPostToolUse } from "./check-lint";
 import type { SkillLintResult } from "./skill-lint/types";
 
@@ -46,38 +47,25 @@ function postToolUseInput(filePath: string) {
 }
 
 describe("processPostToolUse", () => {
-  it("returns lint issues for SKILL.md writes", async () => {
-    const output = await processPostToolUse(
-      postToolUseInput("/plugins/gitlab/skills/ci/SKILL.md"),
-      fakeLintSkill,
-    );
-    expect(output).toMatchObject({
-      hookSpecificOutput: {
-        hookEventName: "PostToolUse",
-        additionalContext: expect.stringContaining("name-format"),
-      },
-    });
-  });
-
-  it("returns null for passing lint", async () => {
-    const output = await processPostToolUse(
-      postToolUseInput("/passing/skills/ci/SKILL.md"),
-      fakeLintSkill,
-    );
-    expect(output).toBeNull();
-  });
-
-  it("ignores non-SKILL.md files", async () => {
-    const output = await processPostToolUse(
-      postToolUseInput("/plugins/gitlab/skills/ci/scripts/run.ts"),
-      fakeLintSkill,
-    );
-    expect(output).toBeNull();
-  });
-
-  it("ignores non-file tools", async () => {
-    const output = await processPostToolUse(
-      {
+  test.each<{ name: string; input: PostToolUseInput; expectLint: boolean }>([
+    {
+      name: "returns lint issues for SKILL.md writes",
+      input: postToolUseInput("/plugins/gitlab/skills/ci/SKILL.md"),
+      expectLint: true,
+    },
+    {
+      name: "returns null for passing lint",
+      input: postToolUseInput("/passing/skills/ci/SKILL.md"),
+      expectLint: false,
+    },
+    {
+      name: "ignores non-SKILL.md files",
+      input: postToolUseInput("/plugins/gitlab/skills/ci/scripts/run.ts"),
+      expectLint: false,
+    },
+    {
+      name: "ignores non-file tools",
+      input: {
         session_id: "test",
         transcript_path: "/tmp/transcript.jsonl",
         cwd: "/tmp",
@@ -88,8 +76,19 @@ describe("processPostToolUse", () => {
         tool_input: { command: "ls" },
         tool_response: { output: "", exit_code: 0 },
       },
-      fakeLintSkill,
-    );
-    expect(output).toBeNull();
+      expectLint: false,
+    },
+  ])("$name", async ({ input, expectLint }) => {
+    const output = await processPostToolUse(input, fakeLintSkill);
+    if (expectLint) {
+      expect(output).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: "PostToolUse",
+          additionalContext: expect.stringContaining("name-format"),
+        },
+      });
+    } else {
+      expect(output).toBeNull();
+    }
   });
 });

--- a/plugins/claude-code/skills/skill/scripts/check-namespace.test.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-namespace.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, test } from "bun:test";
 import { mkdirSync, mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -12,46 +12,28 @@ import {
   getResourceType,
   processHookInput,
 } from "./check-namespace";
+import { makePostToolUseInput } from "./test-support";
 
 function mockWriteInput(filePath: string): PostToolUseInput {
-  return {
-    session_id: "test",
-    transcript_path: "/tmp/transcript.jsonl",
-    cwd: "/tmp",
-    permission_mode: "default",
-    hook_event_name: "PostToolUse",
-    tool_use_id: "test-id",
-    tool_name: "Write",
-    tool_input: { file_path: filePath, content: "" },
-    tool_response: { message: "ok", bytes_written: 0 },
-  };
+  return makePostToolUseInput({ tool_input: { file_path: filePath, content: "" } });
 }
 
-describe("extractPluginName", () => {
-  it("extracts plugin name from path", () => {
-    expect(extractPluginName("/path/to/plugins/gitlab/skills/ci/SKILL.md")).toBe("gitlab");
-    expect(extractPluginName("/plugins/claude-code/agents/foo.md")).toBe("claude-code");
-  });
-
-  it("returns null for non-plugin paths", () => {
-    expect(extractPluginName("/path/to/src/file.ts")).toBeNull();
-    expect(extractPluginName("/Users/ben/project/SKILL.md")).toBeNull();
-  });
+test.each<[string, string | null]>([
+  ["/path/to/plugins/gitlab/skills/ci/SKILL.md", "gitlab"],
+  ["/plugins/claude-code/agents/foo.md", "claude-code"],
+  ["/path/to/src/file.ts", null],
+  ["/Users/ben/project/SKILL.md", null],
+])("extractPluginName(%p) -> %p", (path, expected) => {
+  expect(extractPluginName(path)).toBe(expected);
 });
 
-describe("getResourceType", () => {
-  it("identifies agents", () => {
-    expect(getResourceType("/plugins/gitlab/agents/reviewer.md")).toBe("agent");
-  });
-
-  it("identifies commands", () => {
-    expect(getResourceType("/plugins/gitlab/commands/merge.md")).toBe("command");
-  });
-
-  it("defaults to skill", () => {
-    expect(getResourceType("/plugins/gitlab/skills/ci/SKILL.md")).toBe("skill");
-    expect(getResourceType("/plugins/gitlab/foo.md")).toBe("skill");
-  });
+test.each<[string, "agent" | "command" | "skill"]>([
+  ["/plugins/gitlab/agents/reviewer.md", "agent"],
+  ["/plugins/gitlab/commands/merge.md", "command"],
+  ["/plugins/gitlab/skills/ci/SKILL.md", "skill"],
+  ["/plugins/gitlab/foo.md", "skill"],
+])("getResourceType(%p) -> %p", (path, expected) => {
+  expect(getResourceType(path)).toBe(expected);
 });
 
 describe("getResourceName", () => {
@@ -87,62 +69,76 @@ describe("getResourceName", () => {
   });
 });
 
-describe("checkStuttering", () => {
-  it("detects prefix stuttering", () => {
-    expect(checkStuttering("gitlab-ci", "gitlab")).toContain("stutters");
-    expect(checkStuttering("github-actions", "github")).toContain("stutters");
-  });
-
-  it("detects suffix stuttering", () => {
-    expect(checkStuttering("ci-gitlab", "gitlab")).toContain("stutters");
-  });
-
-  it("detects exact match", () => {
-    expect(checkStuttering("gitlab", "gitlab")).toContain("stutters");
-  });
-
-  it("handles hyphenated plugin names", () => {
-    expect(checkStuttering("claude-code-helper", "claude-code")).toContain("stutters");
-    expect(checkStuttering("claude_code_helper", "claude-code")).toContain("stutters");
-  });
-
-  it("allows proper names", () => {
-    expect(checkStuttering("ci", "gitlab")).toBeNull();
-    expect(checkStuttering("actions", "github")).toBeNull();
-    expect(checkStuttering("hooks", "claude-code")).toBeNull();
-  });
+test.each<[string, string, string | null]>([
+  ["gitlab-ci", "gitlab", "stutters"],
+  ["github-actions", "github", "stutters"],
+  ["ci-gitlab", "gitlab", "stutters"],
+  ["gitlab", "gitlab", "stutters"],
+  ["claude-code-helper", "claude-code", "stutters"],
+  ["claude_code_helper", "claude-code", "stutters"],
+  ["ci", "gitlab", null],
+  ["actions", "github", null],
+  ["hooks", "claude-code", null],
+])("checkStuttering(%p, %p) -> %p", (name, plugin, expected) => {
+  if (expected === null) {
+    expect(checkStuttering(name, plugin)).toBeNull();
+  } else {
+    expect(checkStuttering(name, plugin)).toContain(expected);
+  }
 });
 
-describe("checkSkillNamespace", () => {
-  it("allows name matching plugin name (primary skill)", () => {
-    expect(checkSkillNamespace("git", "git")).toEqual([]);
-  });
-
-  it("allows properly prefixed names", () => {
-    expect(checkSkillNamespace("gitlab:ci", "gitlab")).toEqual([]);
-    expect(checkSkillNamespace("claude-code:hook", "claude-code")).toEqual([]);
-  });
-
-  it("allows plugin:plugin (primary skill with prefix)", () => {
-    expect(checkSkillNamespace("git:git", "git")).toEqual([]);
-  });
-
-  it("warns on missing prefix", () => {
-    const warnings = checkSkillNamespace("ci", "gitlab");
-    expect(warnings.length).toBeGreaterThan(0);
-    expect(warnings[0]).toContain("should be prefixed");
-    expect(warnings[1]).toContain("gitlab:ci");
-  });
-
-  it("detects stuttering after prefix", () => {
-    const warnings = checkSkillNamespace("gitlab:gitlab-ci", "gitlab");
-    expect(warnings.length).toBeGreaterThan(0);
-    expect(warnings[0]).toContain("stutters");
-  });
-
-  it("allows plugin:plugin without stuttering warning", () => {
-    expect(checkSkillNamespace("gitlab:gitlab", "gitlab")).toEqual([]);
-  });
+test.each<{ name: string; skillName: string; plugin: string; substrings: string[] }>([
+  {
+    name: "allows name matching plugin name (primary skill)",
+    skillName: "git",
+    plugin: "git",
+    substrings: [],
+  },
+  {
+    name: "allows properly prefixed names (gitlab:ci)",
+    skillName: "gitlab:ci",
+    plugin: "gitlab",
+    substrings: [],
+  },
+  {
+    name: "allows properly prefixed names (claude-code:hook)",
+    skillName: "claude-code:hook",
+    plugin: "claude-code",
+    substrings: [],
+  },
+  {
+    name: "allows plugin:plugin (primary skill with prefix)",
+    skillName: "git:git",
+    plugin: "git",
+    substrings: [],
+  },
+  {
+    name: "warns on missing prefix",
+    skillName: "ci",
+    plugin: "gitlab",
+    substrings: ["should be prefixed", "gitlab:ci"],
+  },
+  {
+    name: "detects stuttering after prefix",
+    skillName: "gitlab:gitlab-ci",
+    plugin: "gitlab",
+    substrings: ["stutters"],
+  },
+  {
+    name: "allows plugin:plugin without stuttering warning",
+    skillName: "gitlab:gitlab",
+    plugin: "gitlab",
+    substrings: [],
+  },
+])("checkSkillNamespace: $name", ({ skillName, plugin, substrings }) => {
+  const warnings = checkSkillNamespace(skillName, plugin);
+  if (substrings.length === 0) {
+    expect(warnings).toEqual([]);
+  } else {
+    substrings.forEach((substring, i) => {
+      expect(warnings[i]).toContain(substring);
+    });
+  }
 });
 
 describe("processHookInput", () => {
@@ -218,17 +214,11 @@ describe("processHookInput", () => {
   });
 
   it("returns empty for non-file tools", async () => {
-    const input: PostToolUseInput = {
-      session_id: "test",
-      transcript_path: "/tmp/transcript.jsonl",
-      cwd: "/tmp",
-      permission_mode: "default",
-      hook_event_name: "PostToolUse",
-      tool_use_id: "test-id",
+    const input = makePostToolUseInput({
       tool_name: "Bash",
       tool_input: { command: "ls" },
       tool_response: { output: "", exit_code: 0 },
-    };
+    });
     const warnings = await processHookInput(input);
     expect(warnings).toEqual([]);
   });

--- a/plugins/claude-code/skills/skill/scripts/check-structure.test.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-structure.test.ts
@@ -1,85 +1,59 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import type { PostToolUseInput } from "@constellos/claude-code-kit";
 import { extractSkillRoot, processHookInput, validateSkillPath } from "./check-structure";
+import { makePostToolUseInput } from "./test-support";
 
 function mockWriteInput(filePath: string): PostToolUseInput {
-  return {
-    session_id: "test",
-    transcript_path: "/tmp/transcript.jsonl",
-    cwd: "/tmp",
-    permission_mode: "default",
-    hook_event_name: "PostToolUse",
-    tool_use_id: "test-id",
-    tool_name: "Write",
-    tool_input: { file_path: filePath, content: "" },
-    tool_response: { message: "ok", bytes_written: 0 },
-  };
+  return makePostToolUseInput({ tool_input: { file_path: filePath, content: "" } });
 }
 
-describe("extractSkillRoot", () => {
-  it("extracts root from plugin skill paths", () => {
-    expect(extractSkillRoot("/path/to/plugins/gitlab/skills/ci/SKILL.md")).toBe(
-      "/path/to/plugins/gitlab/skills/ci",
-    );
-  });
-
-  it("extracts root from personal skill paths", () => {
-    expect(extractSkillRoot("/Users/ben/.claude/skills/my-skill/SKILL.md")).toBe(
-      "/Users/ben/.claude/skills/my-skill",
-    );
-  });
-
-  it("extracts root from project skill paths", () => {
-    expect(extractSkillRoot("/project/.claude/skills/review/scripts/lint.sh")).toBe(
-      "/project/.claude/skills/review",
-    );
-  });
-
-  it("returns null for non-skill paths", () => {
-    expect(extractSkillRoot("/path/to/src/file.ts")).toBeNull();
-    expect(extractSkillRoot("/Users/ben/project/README.md")).toBeNull();
-  });
+test.each<[string, string | null]>([
+  ["/path/to/plugins/gitlab/skills/ci/SKILL.md", "/path/to/plugins/gitlab/skills/ci"],
+  ["/Users/ben/.claude/skills/my-skill/SKILL.md", "/Users/ben/.claude/skills/my-skill"],
+  ["/project/.claude/skills/review/scripts/lint.sh", "/project/.claude/skills/review"],
+  ["/path/to/src/file.ts", null],
+  ["/Users/ben/project/README.md", null],
+])("extractSkillRoot(%p) -> %p", (path, expected) => {
+  expect(extractSkillRoot(path)).toBe(expected);
 });
 
 describe("validateSkillPath", () => {
   const root = "/plugins/gitlab/skills/ci";
 
-  it("allows SKILL.md", () => {
-    expect(validateSkillPath(`${root}/SKILL.md`, root)).toBeNull();
-  });
-
-  it("allows files in scripts/", () => {
-    expect(validateSkillPath(`${root}/scripts/run.sh`, root)).toBeNull();
-  });
-
-  it("allows files in references/", () => {
-    expect(validateSkillPath(`${root}/references/api.md`, root)).toBeNull();
-  });
-
-  it("allows files in assets/", () => {
-    expect(validateSkillPath(`${root}/assets/template.html`, root)).toBeNull();
-  });
-
-  it("allows nested files within allowed directories", () => {
-    expect(validateSkillPath(`${root}/scripts/lib/helpers.ts`, root)).toBeNull();
-  });
-
-  it("rejects files in non-standard directories", () => {
-    const result = validateSkillPath(`${root}/utils/helper.ts`, root);
-    expect(result).toContain("utils/helper.ts");
-    expect(result).toContain("outside the standard skill structure");
-    expect(result).toContain("agentskills.io");
-  });
-
-  it("rejects top-level files other than SKILL.md", () => {
-    const result = validateSkillPath(`${root}/README.md`, root);
-    expect(result).toContain("README.md");
-    expect(result).toContain("outside the standard skill structure");
-  });
-
-  it("rejects src/ directory", () => {
-    const result = validateSkillPath(`${root}/src/index.ts`, root);
-    expect(result).toContain("src/index.ts");
+  test.each<{ name: string; path: string; substrings: string[] }>([
+    { name: "allows SKILL.md", path: `${root}/SKILL.md`, substrings: [] },
+    { name: "allows files in scripts/", path: `${root}/scripts/run.sh`, substrings: [] },
+    { name: "allows files in references/", path: `${root}/references/api.md`, substrings: [] },
+    { name: "allows files in assets/", path: `${root}/assets/template.html`, substrings: [] },
+    {
+      name: "allows nested files within allowed directories",
+      path: `${root}/scripts/lib/helpers.ts`,
+      substrings: [],
+    },
+    {
+      name: "rejects files in non-standard directories",
+      path: `${root}/utils/helper.ts`,
+      substrings: ["utils/helper.ts", "outside the standard skill structure", "agentskills.io"],
+    },
+    {
+      name: "rejects top-level files other than SKILL.md",
+      path: `${root}/README.md`,
+      substrings: ["README.md", "outside the standard skill structure"],
+    },
+    {
+      name: "rejects src/ directory",
+      path: `${root}/src/index.ts`,
+      substrings: ["src/index.ts"],
+    },
+  ])("$name", ({ path, substrings }) => {
+    const result = validateSkillPath(path, root);
+    if (substrings.length === 0) {
+      expect(result).toBeNull();
+    } else {
+      for (const substring of substrings) {
+        expect(result).toContain(substring);
+      }
+    }
   });
 });
 
@@ -113,17 +87,11 @@ describe("processHookInput", () => {
   });
 
   it("ignores non-file tools", () => {
-    const input: PostToolUseInput = {
-      session_id: "test",
-      transcript_path: "/tmp/transcript.jsonl",
-      cwd: "/tmp",
-      permission_mode: "default",
-      hook_event_name: "PostToolUse",
-      tool_use_id: "test-id",
+    const input = makePostToolUseInput({
       tool_name: "Bash",
       tool_input: { command: "ls" },
       tool_response: { output: "", exit_code: 0 },
-    };
+    });
     expect(processHookInput(input)).toEqual([]);
   });
 });

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import * as path from "node:path";
 import { lintSkill } from "../index";
 import { parseSkill } from "../parse";
@@ -13,7 +13,7 @@ import {
   nameLength,
 } from "../rules/frontmatter";
 import { namespaceMismatch, namespaceStutter } from "../rules/namespace";
-import type { RuleResult } from "../types";
+import type { RuleResult, Severity } from "../types";
 
 const fixturesDir = path.join(import.meta.dirname, "fixtures");
 
@@ -49,170 +49,150 @@ Content here.`);
 });
 
 describe("frontmatter rules", () => {
-  describe("nameFormat", () => {
-    it("passes for valid names", () => {
-      const content = parseSkill("---\nname: valid-name\n---\n");
-      const result = single(nameFormat.check(content, ""));
-      expect(result.passed).toBe(true);
-    });
-
-    it("fails for uppercase", () => {
-      const content = parseSkill("---\nname: Invalid\n---\n");
-      const result = single(nameFormat.check(content, ""));
-      expect(result.passed).toBe(false);
-    });
-
-    it("fails for underscores", () => {
-      const content = parseSkill("---\nname: invalid_name\n---\n");
-      const result = single(nameFormat.check(content, ""));
-      expect(result.passed).toBe(false);
-    });
-
-    it("allows numbers", () => {
-      const content = parseSkill("---\nname: skill123\n---\n");
-      const result = single(nameFormat.check(content, ""));
-      expect(result.passed).toBe(true);
-    });
-
-    it("allows namespaced names", () => {
-      const content = parseSkill("---\nname: github:actions\n---\n");
-      const result = single(nameFormat.check(content, ""));
-      expect(result.passed).toBe(true);
-    });
-
-    it("allows same-name namespace", () => {
-      const content = parseSkill("---\nname: git:git\n---\n");
-      const result = single(nameFormat.check(content, ""));
-      expect(result.passed).toBe(true);
-    });
+  test.each<{ name: string; frontmatter: string; passed: boolean }>([
+    { name: "passes for valid names", frontmatter: "---\nname: valid-name\n---\n", passed: true },
+    { name: "fails for uppercase", frontmatter: "---\nname: Invalid\n---\n", passed: false },
+    {
+      name: "fails for underscores",
+      frontmatter: "---\nname: invalid_name\n---\n",
+      passed: false,
+    },
+    { name: "allows numbers", frontmatter: "---\nname: skill123\n---\n", passed: true },
+    {
+      name: "allows namespaced names",
+      frontmatter: "---\nname: github:actions\n---\n",
+      passed: true,
+    },
+    { name: "allows same-name namespace", frontmatter: "---\nname: git:git\n---\n", passed: true },
+  ])("nameFormat: $name", ({ frontmatter, passed }) => {
+    const content = parseSkill(frontmatter);
+    const result = single(nameFormat.check(content, ""));
+    expect(result.passed).toBe(passed);
   });
 
-  describe("nameLength", () => {
-    it("passes for short names", () => {
-      const content = parseSkill("---\nname: short\n---\n");
-      const result = single(nameLength.check(content, ""));
-      expect(result.passed).toBe(true);
-    });
-
-    it("fails for names over 64 chars", () => {
-      const longName = "a".repeat(65);
-      const content = parseSkill(`---\nname: ${longName}\n---\n`);
-      const result = single(nameLength.check(content, ""));
-      expect(result.passed).toBe(false);
-    });
+  test.each<{ name: string; frontmatter: string; passed: boolean }>([
+    { name: "passes for short names", frontmatter: "---\nname: short\n---\n", passed: true },
+    {
+      name: "fails for names over 64 chars",
+      frontmatter: `---\nname: ${"a".repeat(65)}\n---\n`,
+      passed: false,
+    },
+  ])("nameLength: $name", ({ frontmatter, passed }) => {
+    const content = parseSkill(frontmatter);
+    const result = single(nameLength.check(content, ""));
+    expect(result.passed).toBe(passed);
   });
 
-  describe("nameEdgeHyphens", () => {
-    it("passes for valid names", () => {
-      const content = parseSkill("---\nname: valid-name\n---\n");
-      const result = single(nameEdgeHyphens.check(content, ""));
-      expect(result.passed).toBe(true);
-    });
-
-    it("fails for leading hyphen", () => {
-      const content = parseSkill("---\nname: -invalid\n---\n");
-      const result = single(nameEdgeHyphens.check(content, ""));
-      expect(result.passed).toBe(false);
-    });
-
-    it("fails for trailing hyphen", () => {
-      const content = parseSkill("---\nname: invalid-\n---\n");
-      const result = single(nameEdgeHyphens.check(content, ""));
-      expect(result.passed).toBe(false);
-    });
-
-    it("fails for leading hyphen in namespace prefix", () => {
-      const content = parseSkill("---\nname: -github:actions\n---\n");
-      const result = single(nameEdgeHyphens.check(content, ""));
-      expect(result.passed).toBe(false);
-    });
-
-    it("fails for trailing hyphen in namespaced part", () => {
-      const content = parseSkill("---\nname: github:actions-\n---\n");
-      const result = single(nameEdgeHyphens.check(content, ""));
-      expect(result.passed).toBe(false);
-    });
-
-    it("passes for valid namespaced names", () => {
-      const content = parseSkill("---\nname: github:actions\n---\n");
-      const result = single(nameEdgeHyphens.check(content, ""));
-      expect(result.passed).toBe(true);
-    });
+  test.each<{ name: string; frontmatter: string; passed: boolean }>([
+    { name: "passes for valid names", frontmatter: "---\nname: valid-name\n---\n", passed: true },
+    { name: "fails for leading hyphen", frontmatter: "---\nname: -invalid\n---\n", passed: false },
+    {
+      name: "fails for trailing hyphen",
+      frontmatter: "---\nname: invalid-\n---\n",
+      passed: false,
+    },
+    {
+      name: "fails for leading hyphen in namespace prefix",
+      frontmatter: "---\nname: -github:actions\n---\n",
+      passed: false,
+    },
+    {
+      name: "fails for trailing hyphen in namespaced part",
+      frontmatter: "---\nname: github:actions-\n---\n",
+      passed: false,
+    },
+    {
+      name: "passes for valid namespaced names",
+      frontmatter: "---\nname: github:actions\n---\n",
+      passed: true,
+    },
+  ])("nameEdgeHyphens: $name", ({ frontmatter, passed }) => {
+    const content = parseSkill(frontmatter);
+    const result = single(nameEdgeHyphens.check(content, ""));
+    expect(result.passed).toBe(passed);
   });
 
-  describe("nameConsecutiveHyphens", () => {
-    it("passes for single hyphens", () => {
-      const content = parseSkill("---\nname: valid-name\n---\n");
-      const result = single(nameConsecutiveHyphens.check(content, ""));
-      expect(result.passed).toBe(true);
-    });
-
-    it("fails for consecutive hyphens", () => {
-      const content = parseSkill("---\nname: invalid--name\n---\n");
-      const result = single(nameConsecutiveHyphens.check(content, ""));
-      expect(result.passed).toBe(false);
-    });
+  test.each<{ name: string; frontmatter: string; passed: boolean }>([
+    {
+      name: "passes for single hyphens",
+      frontmatter: "---\nname: valid-name\n---\n",
+      passed: true,
+    },
+    {
+      name: "fails for consecutive hyphens",
+      frontmatter: "---\nname: invalid--name\n---\n",
+      passed: false,
+    },
+  ])("nameConsecutiveHyphens: $name", ({ frontmatter, passed }) => {
+    const content = parseSkill(frontmatter);
+    const result = single(nameConsecutiveHyphens.check(content, ""));
+    expect(result.passed).toBe(passed);
   });
 
-  describe("descriptionRequired", () => {
-    it("passes when description exists", () => {
-      const content = parseSkill("---\ndescription: Some description\n---\n");
-      const result = single(descriptionRequired.check(content, ""));
-      expect(result.passed).toBe(true);
-    });
-
-    it("fails when description is missing", () => {
-      const content = parseSkill("---\nname: test\n---\n");
-      const result = single(descriptionRequired.check(content, ""));
-      expect(result.passed).toBe(false);
-    });
-
-    it("fails when description is empty", () => {
-      const content = parseSkill("---\ndescription: ''\n---\n");
-      const result = single(descriptionRequired.check(content, ""));
-      expect(result.passed).toBe(false);
-    });
+  test.each<{ name: string; frontmatter: string; passed: boolean }>([
+    {
+      name: "passes when description exists",
+      frontmatter: "---\ndescription: Some description\n---\n",
+      passed: true,
+    },
+    {
+      name: "fails when description is missing",
+      frontmatter: "---\nname: test\n---\n",
+      passed: false,
+    },
+    {
+      name: "fails when description is empty",
+      frontmatter: "---\ndescription: ''\n---\n",
+      passed: false,
+    },
+  ])("descriptionRequired: $name", ({ frontmatter, passed }) => {
+    const content = parseSkill(frontmatter);
+    const result = single(descriptionRequired.check(content, ""));
+    expect(result.passed).toBe(passed);
   });
 
-  describe("descriptionLength", () => {
-    it("passes for short descriptions", () => {
-      const content = parseSkill("---\ndescription: Short\n---\n");
-      const result = single(descriptionLength.check(content, ""));
-      expect(result.passed).toBe(true);
-    });
-
-    it("fails for descriptions over 1024 chars", () => {
-      const longDesc = "a".repeat(1025);
-      const content = parseSkill(`---\ndescription: ${longDesc}\n---\n`);
-      const result = single(descriptionLength.check(content, ""));
-      expect(result.passed).toBe(false);
-    });
+  test.each<{ name: string; frontmatter: string; passed: boolean }>([
+    {
+      name: "passes for short descriptions",
+      frontmatter: "---\ndescription: Short\n---\n",
+      passed: true,
+    },
+    {
+      name: "fails for descriptions over 1024 chars",
+      frontmatter: `---\ndescription: ${"a".repeat(1025)}\n---\n`,
+      passed: false,
+    },
+  ])("descriptionLength: $name", ({ frontmatter, passed }) => {
+    const content = parseSkill(frontmatter);
+    const result = single(descriptionLength.check(content, ""));
+    expect(result.passed).toBe(passed);
   });
 
-  describe("allowedToolsFormat", () => {
-    it("passes when allowed-tools is not set", () => {
-      const content = parseSkill("---\nname: test\n---\n");
-      const result = single(allowedToolsFormat.check(content, ""));
-      expect(result.passed).toBe(true);
-    });
-
-    it("passes when allowed-tools is an array", () => {
-      const content = parseSkill("---\nallowed-tools:\n  - Bash\n  - Read\n---\n");
-      const result = single(allowedToolsFormat.check(content, ""));
-      expect(result.passed).toBe(true);
-    });
-
-    it("passes when allowed-tools is an inline array", () => {
-      const content = parseSkill("---\nallowed-tools: [Bash, Read]\n---\n");
-      const result = single(allowedToolsFormat.check(content, ""));
-      expect(result.passed).toBe(true);
-    });
-
-    it("fails when allowed-tools is a comma-separated string", () => {
-      const content = parseSkill("---\nallowed-tools: Bash(gh:*), mcp__github\n---\n");
-      const result = single(allowedToolsFormat.check(content, ""));
-      expect(result.passed).toBe(false);
-    });
+  test.each<{ name: string; frontmatter: string; passed: boolean }>([
+    {
+      name: "passes when allowed-tools is not set",
+      frontmatter: "---\nname: test\n---\n",
+      passed: true,
+    },
+    {
+      name: "passes when allowed-tools is an array",
+      frontmatter: "---\nallowed-tools:\n  - Bash\n  - Read\n---\n",
+      passed: true,
+    },
+    {
+      name: "passes when allowed-tools is an inline array",
+      frontmatter: "---\nallowed-tools: [Bash, Read]\n---\n",
+      passed: true,
+    },
+    {
+      name: "fails when allowed-tools is a comma-separated string",
+      frontmatter: "---\nallowed-tools: Bash(gh:*), mcp__github\n---\n",
+      passed: false,
+    },
+  ])("allowedToolsFormat: $name", ({ frontmatter, passed }) => {
+    const content = parseSkill(frontmatter);
+    const result = single(allowedToolsFormat.check(content, ""));
+    expect(result.passed).toBe(passed);
   });
 });
 
@@ -221,115 +201,129 @@ describe("bangExecutionMatcher", () => {
   const skill = (allowedTools: string, body: string) =>
     parseSkill(`---\nname: test\nallowed-tools:\n${allowedTools}\n---\n\n${body}\n`);
 
-  it("passes when the open-glob shape matches a bang command", () => {
-    const content = skill(
-      `  - "Bash(bun ${root}/scripts/*)"`,
-      `- Out: !\`bun ${root}/scripts/context.ts\``,
-    );
+  test.each<{
+    name: string;
+    allowedTools: string;
+    body: string;
+    passed: boolean;
+    severity?: Severity;
+    message?: string;
+  }>([
+    {
+      name: "passes when the open-glob shape matches a bang command",
+      allowedTools: `  - "Bash(bun ${root}/scripts/*)"`,
+      body: `- Out: !\`bun ${root}/scripts/context.ts\``,
+      passed: true,
+    },
+    {
+      name: "warns when a :* glob matcher matches a bang command",
+      allowedTools: `  - "Bash(bun ${root}/scripts/*:*)"`,
+      body: `- Out: !\`bun ${root}/scripts/context.ts\``,
+      passed: false,
+      severity: "warn",
+      message: `Bash(bun ${root}/scripts/*:*)`,
+    },
+    {
+      name: "passes when there is no bang execution",
+      allowedTools: `  - "Bash(bun ${root}/scripts/*:*)"`,
+      body: "Run the script when needed.",
+      passed: true,
+    },
+    {
+      name: "ignores a :* glob matcher that no bang command uses",
+      allowedTools: '  - "Bash(git show :*:*)"\n  - "Bash(jq:*)"',
+      body: "- List: !`tuicr review list`",
+      passed: true,
+    },
+    {
+      name: "passes when a bang command is matched by a command-prefix matcher",
+      allowedTools: '  - "Bash(uname:*)"',
+      body: "- OS: !`uname -s`",
+      passed: true,
+    },
+  ])("$name", ({ allowedTools, body, passed, severity, message }) => {
+    const content = skill(allowedTools, body);
     const result = single(bangExecutionMatcher.check(content, ""));
-    expect(result.passed).toBe(true);
-  });
-
-  it("warns when a :* glob matcher matches a bang command", () => {
-    const content = skill(
-      `  - "Bash(bun ${root}/scripts/*:*)"`,
-      `- Out: !\`bun ${root}/scripts/context.ts\``,
-    );
-    const result = single(bangExecutionMatcher.check(content, ""));
-    expect(result.passed).toBe(false);
-    expect(result.severity).toBe("warn");
-    expect(result.message).toContain(`Bash(bun ${root}/scripts/*:*)`);
-  });
-
-  it("passes when there is no bang execution", () => {
-    const content = skill(`  - "Bash(bun ${root}/scripts/*:*)"`, "Run the script when needed.");
-    const result = single(bangExecutionMatcher.check(content, ""));
-    expect(result.passed).toBe(true);
-  });
-
-  it("ignores a :* glob matcher that no bang command uses", () => {
-    const content = skill(
-      '  - "Bash(git show :*:*)"\n  - "Bash(jq:*)"',
-      "- List: !`tuicr review list`",
-    );
-    const result = single(bangExecutionMatcher.check(content, ""));
-    expect(result.passed).toBe(true);
-  });
-
-  it("passes when a bang command is matched by a command-prefix matcher", () => {
-    const content = skill('  - "Bash(uname:*)"', "- OS: !`uname -s`");
-    const result = single(bangExecutionMatcher.check(content, ""));
-    expect(result.passed).toBe(true);
+    expect(result.passed).toBe(passed);
+    if (severity) {
+      expect(result.severity).toBe(severity);
+    }
+    if (message) {
+      expect(result.message).toContain(message);
+    }
   });
 });
 
 describe("namespace rules", () => {
   const pluginPath = (plugin: string) => `plugins/${plugin}/skills/some-skill`;
 
-  describe("namespaceMismatch", () => {
-    it("passes when prefix matches plugin", () => {
-      const content = parseSkill("---\nname: github:actions\n---\n");
-      const result = single(namespaceMismatch.check(content, pluginPath("github")));
-      expect(result.passed).toBe(true);
-    });
-
-    it("passes when no prefix", () => {
-      const content = parseSkill("---\nname: actions\n---\n");
-      const result = single(namespaceMismatch.check(content, pluginPath("github")));
-      expect(result.passed).toBe(true);
-    });
-
-    it("fails when prefix mismatches plugin", () => {
-      const content = parseSkill("---\nname: gitlab:foo\n---\n");
-      const result = single(namespaceMismatch.check(content, pluginPath("github")));
-      expect(result.passed).toBe(false);
-    });
-
-    it("skips when not in a plugin directory", () => {
-      const content = parseSkill("---\nname: gitlab:foo\n---\n");
-      const result = single(namespaceMismatch.check(content, "/some/other/path"));
-      expect(result.passed).toBe(true);
-    });
+  test.each<{ name: string; skillName: string; plugin: string; passed: boolean }>([
+    {
+      name: "passes when prefix matches plugin",
+      skillName: "github:actions",
+      plugin: "github",
+      passed: true,
+    },
+    { name: "passes when no prefix", skillName: "actions", plugin: "github", passed: true },
+    {
+      name: "fails when prefix mismatches plugin",
+      skillName: "gitlab:foo",
+      plugin: "github",
+      passed: false,
+    },
+  ])("namespaceMismatch: $name", ({ skillName, plugin, passed }) => {
+    const content = parseSkill(`---\nname: ${skillName}\n---\n`);
+    const result = single(namespaceMismatch.check(content, pluginPath(plugin)));
+    expect(result.passed).toBe(passed);
   });
 
-  describe("namespaceStutter", () => {
-    it("passes for non-stuttering names", () => {
-      const content = parseSkill("---\nname: gitlab:ci\n---\n");
-      const result = single(namespaceStutter.check(content, pluginPath("gitlab")));
-      expect(result.passed).toBe(true);
-    });
+  it("namespaceMismatch: skips when not in a plugin directory", () => {
+    const content = parseSkill("---\nname: gitlab:foo\n---\n");
+    const result = single(namespaceMismatch.check(content, "/some/other/path"));
+    expect(result.passed).toBe(true);
+  });
 
-    it("warns on stuttering suffix", () => {
-      const content = parseSkill("---\nname: gitlab:gitlab-ci\n---\n");
-      const result = single(namespaceStutter.check(content, pluginPath("gitlab")));
-      expect(result.passed).toBe(false);
+  test.each<{ name: string; skillName: string; plugin: string; passed: boolean; warn?: boolean }>([
+    {
+      name: "passes for non-stuttering names",
+      skillName: "gitlab:ci",
+      plugin: "gitlab",
+      passed: true,
+    },
+    {
+      name: "warns on stuttering suffix",
+      skillName: "gitlab:gitlab-ci",
+      plugin: "gitlab",
+      passed: false,
+      warn: true,
+    },
+    {
+      name: "passes when suffix equals plugin name",
+      skillName: "git:git",
+      plugin: "git",
+      passed: true,
+    },
+    {
+      name: "permits the entry-skill convention (plugin:plugin)",
+      skillName: "writing:writing",
+      plugin: "writing",
+      passed: true,
+    },
+    {
+      name: "warns on redundant-suffix stutter (plugin:plugin-foo)",
+      skillName: "writing:writing-analyze",
+      plugin: "writing",
+      passed: false,
+      warn: true,
+    },
+    { name: "passes when no prefix", skillName: "actions", plugin: "github", passed: true },
+  ])("namespaceStutter: $name", ({ skillName, plugin, passed, warn }) => {
+    const content = parseSkill(`---\nname: ${skillName}\n---\n`);
+    const result = single(namespaceStutter.check(content, pluginPath(plugin)));
+    expect(result.passed).toBe(passed);
+    if (warn) {
       expect(result.severity).toBe("warn");
-    });
-
-    it("passes when suffix equals plugin name", () => {
-      const content = parseSkill("---\nname: git:git\n---\n");
-      const result = single(namespaceStutter.check(content, pluginPath("git")));
-      expect(result.passed).toBe(true);
-    });
-
-    it("permits the entry-skill convention (plugin:plugin)", () => {
-      const content = parseSkill("---\nname: writing:writing\n---\n");
-      const result = single(namespaceStutter.check(content, pluginPath("writing")));
-      expect(result.passed).toBe(true);
-    });
-
-    it("warns on redundant-suffix stutter (plugin:plugin-foo)", () => {
-      const content = parseSkill("---\nname: writing:writing-analyze\n---\n");
-      const result = single(namespaceStutter.check(content, pluginPath("writing")));
-      expect(result.passed).toBe(false);
-      expect(result.severity).toBe("warn");
-    });
-
-    it("passes when no prefix", () => {
-      const content = parseSkill("---\nname: actions\n---\n");
-      const result = single(namespaceStutter.check(content, pluginPath("github")));
-      expect(result.passed).toBe(true);
-    });
+    }
   });
 });
 

--- a/plugins/claude-code/skills/skill/scripts/test-support.ts
+++ b/plugins/claude-code/skills/skill/scripts/test-support.ts
@@ -1,0 +1,16 @@
+import type { PostToolUseInput } from "@constellos/claude-code-kit";
+
+export function makePostToolUseInput(overrides: Partial<PostToolUseInput> = {}): PostToolUseInput {
+  return {
+    session_id: "test",
+    transcript_path: "/tmp/transcript.jsonl",
+    cwd: "/tmp",
+    permission_mode: "default",
+    hook_event_name: "PostToolUse",
+    tool_use_id: "test-id",
+    tool_name: "Write",
+    tool_input: { file_path: "/tmp/file", content: "" },
+    tool_response: { message: "ok", bytes_written: 0 },
+    ...overrides,
+  } as PostToolUseInput;
+}


### PR DESCRIPTION
Applies the repo's testing conventions to the `claude-code` plugin's script tests, converting repetitive single-assertion `it` blocks into `test.each` tables and factoring out a shared `PostToolUseInput` builder.

## Changes

- `check-lint.test.ts`, `check-namespace.test.ts`, `check-structure.test.ts`, `skill-lint/test/rules.test.ts`: collapse families of near-identical `it` cases into `test.each` tables. Each table preserves the original assertions. Boolean/`null` expectations map to a `passed`/`expectLint` flag, and `toContain` message checks map to a `substrings` list checked in order.
- New `test-support.ts` provides `makePostToolUseInput(overrides)`, replacing three copies of the full `PostToolUseInput` literal across `check-namespace` and `check-structure`.

## Tabled

`session/scripts/db.test.ts` left unchanged. Its six worklist assertions (permission_requests, two sandbox_bypasses, the permissions and sandbox queries, the diagnostics view, and the second/third plan-iterations rows) are single-row checks against queries that `SELECT *` or return extra columns. Converting them to `toMatchInlineSnapshot` while preserving the exact asserted fields forces narrowing to a subset object, which duplicates the field list once in the object and again in the printed snapshot. That measurably raised LOC (+67 net in isolation, driven by multi-line pretty-printed strings like the sandbox `retried_error` text). Snapshotting the full row would avoid the duplication but change the contract (new columns become part of the exact match, and the sandbox timestamp is a DB-native Date/bigint whose printed form is less portable). Neither tradeoff fits the constraint of net-lower LOC with no change to what is asserted, so the file was reverted.

No fast-check property tests were introduced. All conversions are table-driven refactors, so there are no new invariants.

## Testing

The refactored suites cover the same cases as before: name/description frontmatter rules, edge and consecutive hyphens, allowed-tools format, the bang-execution matcher, namespace mismatch and stutter, skill-path structure validation, plugin-name extraction, and the lint hook's SKILL.md handling.

Unit test LOC (`wc -l` over `*.test.ts`): 2088 before, 2039 after.
