### PR TITLE
test(plugins/gitlab): apply testing conventions

### DIFF
--- a/plugins/gitlab/scripts/fetch.test.ts
+++ b/plugins/gitlab/scripts/fetch.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import type {
   PreToolUseHookInput,
   PreToolUseHookSpecificOutput,
@@ -24,15 +24,14 @@ function getOutput(input: PreToolUseHookInput): PreToolUseHookSpecificOutput | n
 }
 
 describe("isGitLabUrl", () => {
-  it("returns true for GitLab URLs", () => {
-    expect(isGitLabUrl("https://gitlab.com/gitlab-org/gitlab")).toBe(true);
-    expect(isGitLabUrl("https://gitlab.com/group/subgroup/project")).toBe(true);
-  });
-
-  it("returns false for non-GitLab URLs", () => {
-    expect(isGitLabUrl("https://example.com")).toBe(false);
-    expect(isGitLabUrl("https://github.com/owner/repo")).toBe(false);
-    expect(isGitLabUrl("http://gitlab.com/owner/repo")).toBe(false);
+  test.each<[string, boolean]>([
+    ["https://gitlab.com/gitlab-org/gitlab", true],
+    ["https://gitlab.com/group/subgroup/project", true],
+    ["https://example.com", false],
+    ["https://github.com/owner/repo", false],
+    ["http://gitlab.com/owner/repo", false],
+  ])("%p is %p", (url, expected) => {
+    expect(isGitLabUrl(url)).toBe(expected);
   });
 });
 
@@ -41,86 +40,92 @@ describe("parseGitLabUrl", () => {
     expect(parseGitLabUrl("https://gitlab.com/explore")).toBeNull();
   });
 
-  it("detects project root", () => {
-    const result = parseGitLabUrl("https://gitlab.com/gitlab-org/gitlab");
-    expect(result?.type).toBe("repo");
-    expect(result?.suggestion).toContain("glab repo view");
+  test.each<{ name: string; url: string; type: string; suggestionContains: string }>([
+    {
+      name: "detects project root",
+      url: "https://gitlab.com/gitlab-org/gitlab",
+      type: "repo",
+      suggestionContains: "glab repo view",
+    },
+    {
+      name: "handles project root with trailing slash",
+      url: "https://gitlab.com/gitlab-org/gitlab/",
+      type: "repo",
+      suggestionContains: "glab repo view",
+    },
+    {
+      name: "handles nested group projects",
+      url: "https://gitlab.com/group/subgroup/project",
+      type: "repo",
+      suggestionContains: "glab repo view",
+    },
+    {
+      name: "detects file content (blob URL)",
+      url: "https://gitlab.com/gitlab-org/gitlab/-/blob/master/README.md",
+      type: "file",
+      suggestionContains: "glab api",
+    },
+    {
+      name: "detects directory (tree URL)",
+      url: "https://gitlab.com/gitlab-org/gitlab/-/tree/main/src",
+      type: "tree",
+      suggestionContains: "glab api",
+    },
+    {
+      name: "handles root directory tree",
+      url: "https://gitlab.com/gitlab-org/gitlab/-/tree/main",
+      type: "tree",
+      suggestionContains: "glab api",
+    },
+  ])("$name", ({ url, type, suggestionContains }) => {
+    const result = parseGitLabUrl(url);
+    expect(result?.type).toBe(type);
+    expect(result?.suggestion).toContain(suggestionContains);
   });
 
-  it("handles project root with trailing slash", () => {
-    const result = parseGitLabUrl("https://gitlab.com/gitlab-org/gitlab/");
-    expect(result?.type).toBe("repo");
-    expect(result?.suggestion).toContain("glab repo view");
-  });
-
-  it("handles nested group projects", () => {
-    const result = parseGitLabUrl("https://gitlab.com/group/subgroup/project");
-    expect(result?.type).toBe("repo");
-    expect(result?.suggestion).toContain("glab repo view");
-  });
-
-  it("detects file content (blob URL)", () => {
-    const result = parseGitLabUrl("https://gitlab.com/gitlab-org/gitlab/-/blob/master/README.md");
-    expect(result?.type).toBe("file");
-    expect(result?.suggestion).toContain("glab api");
-  });
-
-  it("detects directory (tree URL)", () => {
-    const result = parseGitLabUrl("https://gitlab.com/gitlab-org/gitlab/-/tree/main/src");
-    expect(result?.type).toBe("tree");
-    expect(result?.suggestion).toContain("glab api");
-  });
-
-  it("handles root directory tree", () => {
-    const result = parseGitLabUrl("https://gitlab.com/gitlab-org/gitlab/-/tree/main");
-    expect(result?.type).toBe("tree");
-    expect(result?.suggestion).toContain("glab api");
-  });
-
-  it("detects issues", () => {
-    const result = parseGitLabUrl("https://gitlab.com/gitlab-org/gitlab/-/issues/123");
-    expect(result?.type).toBe("issue");
-    expect(result?.suggestion).toBe("Use: glab issue view 123.");
-  });
-
-  it("detects merge requests", () => {
-    const result = parseGitLabUrl("https://gitlab.com/gitlab-org/gitlab/-/merge_requests/456");
-    expect(result?.type).toBe("mr");
-    expect(result?.suggestion).toBe("Use: glab mr view 456.");
-  });
-
-  it("detects pipelines", () => {
-    const result = parseGitLabUrl("https://gitlab.com/gitlab-org/gitlab/-/pipelines/12345");
-    expect(result?.type).toBe("pipeline");
-    expect(result?.suggestion).toBe("Use: glab ci view 12345.");
-  });
-
-  it("detects jobs", () => {
-    const result = parseGitLabUrl("https://gitlab.com/gitlab-org/gitlab/-/jobs/67890");
-    expect(result?.type).toBe("job");
-    expect(result?.suggestion).toBe("Use: glab ci trace 67890.");
+  test.each<{ name: string; url: string; type: string; suggestion: string }>([
+    {
+      name: "detects issues",
+      url: "https://gitlab.com/gitlab-org/gitlab/-/issues/123",
+      type: "issue",
+      suggestion: "Use: glab issue view 123.",
+    },
+    {
+      name: "detects merge requests",
+      url: "https://gitlab.com/gitlab-org/gitlab/-/merge_requests/456",
+      type: "mr",
+      suggestion: "Use: glab mr view 456.",
+    },
+    {
+      name: "detects pipelines",
+      url: "https://gitlab.com/gitlab-org/gitlab/-/pipelines/12345",
+      type: "pipeline",
+      suggestion: "Use: glab ci view 12345.",
+    },
+    {
+      name: "detects jobs",
+      url: "https://gitlab.com/gitlab-org/gitlab/-/jobs/67890",
+      type: "job",
+      suggestion: "Use: glab ci trace 67890.",
+    },
+  ])("$name", ({ url, type, suggestion }) => {
+    const result = parseGitLabUrl(url);
+    expect(result?.type).toBe(type);
+    expect(result?.suggestion).toBe(suggestion);
   });
 });
 
 describe("formatOutput", () => {
-  it("formats deny decision", () => {
-    const output = formatOutput("deny", "Use glab instead");
+  test.each<{ name: string; decision: "deny" | "ask"; reason: string }>([
+    { name: "formats deny decision", decision: "deny", reason: "Use glab instead" },
+    { name: "formats ask decision", decision: "ask", reason: "Unknown pattern" },
+  ])("$name", ({ decision, reason }) => {
+    const output = formatOutput(decision, reason);
     expect(output).toEqual({
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
-        permissionDecision: "deny",
-        permissionDecisionReason: "Use glab instead",
-      },
-    });
-  });
-
-  it("formats ask decision", () => {
-    const output = formatOutput("ask", "Unknown pattern");
-    expect(output).toEqual({
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        permissionDecision: "ask",
-        permissionDecisionReason: "Unknown pattern",
+        permissionDecision: decision,
+        permissionDecisionReason: reason,
       },
     });
   });
@@ -135,68 +140,61 @@ describe("processInput", () => {
     expect(processInput(mockInput("https://github.com/owner/repo"))).toBeNull();
   });
 
-  it("denies project root with glab repo view suggestion", () => {
-    const output = getOutput(mockInput("https://gitlab.com/gitlab-org/gitlab"));
+  test.each<{ name: string; url: string; reason: string }>([
+    {
+      name: "denies project root with glab repo view suggestion",
+      url: "https://gitlab.com/gitlab-org/gitlab",
+      reason: "Use: glab repo view [<project>].",
+    },
+    {
+      name: "handles project URL with trailing slash",
+      url: "https://gitlab.com/gitlab-org/gitlab/",
+      reason: "Use: glab repo view [<project>].",
+    },
+    {
+      name: "handles nested group projects",
+      url: "https://gitlab.com/group/subgroup/project",
+      reason: "Use: glab repo view [<project>].",
+    },
+    {
+      name: "denies file content with glab api suggestion",
+      url: "https://gitlab.com/gitlab-org/gitlab/-/blob/master/README.md",
+      reason: "Use: glab api to fetch file contents.",
+    },
+    {
+      name: "denies directory with glab api suggestion",
+      url: "https://gitlab.com/gitlab-org/gitlab/-/tree/main/src",
+      reason: "Use: glab api to fetch file contents.",
+    },
+    {
+      name: "handles root directory tree",
+      url: "https://gitlab.com/gitlab-org/gitlab/-/tree/main",
+      reason: "Use: glab api to fetch file contents.",
+    },
+    {
+      name: "denies issues with glab issue view suggestion",
+      url: "https://gitlab.com/gitlab-org/gitlab/-/issues/123",
+      reason: "Use: glab issue view 123.",
+    },
+    {
+      name: "denies MRs with glab mr view suggestion",
+      url: "https://gitlab.com/gitlab-org/gitlab/-/merge_requests/456",
+      reason: "Use: glab mr view 456.",
+    },
+    {
+      name: "denies pipelines with glab ci view suggestion",
+      url: "https://gitlab.com/gitlab-org/gitlab/-/pipelines/12345",
+      reason: "Use: glab ci view 12345.",
+    },
+    {
+      name: "denies jobs with glab ci trace suggestion",
+      url: "https://gitlab.com/gitlab-org/gitlab/-/jobs/67890",
+      reason: "Use: glab ci trace 67890.",
+    },
+  ])("$name", ({ url, reason }) => {
+    const output = getOutput(mockInput(url));
     expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: glab repo view [<project>].");
-  });
-
-  it("handles project URL with trailing slash", () => {
-    const output = getOutput(mockInput("https://gitlab.com/gitlab-org/gitlab/"));
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: glab repo view [<project>].");
-  });
-
-  it("handles nested group projects", () => {
-    const output = getOutput(mockInput("https://gitlab.com/group/subgroup/project"));
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: glab repo view [<project>].");
-  });
-
-  it("denies file content with glab api suggestion", () => {
-    const output = getOutput(
-      mockInput("https://gitlab.com/gitlab-org/gitlab/-/blob/master/README.md"),
-    );
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: glab api to fetch file contents.");
-  });
-
-  it("denies directory with glab api suggestion", () => {
-    const output = getOutput(mockInput("https://gitlab.com/gitlab-org/gitlab/-/tree/main/src"));
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: glab api to fetch file contents.");
-  });
-
-  it("handles root directory tree", () => {
-    const output = getOutput(mockInput("https://gitlab.com/gitlab-org/gitlab/-/tree/main"));
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: glab api to fetch file contents.");
-  });
-
-  it("denies issues with glab issue view suggestion", () => {
-    const output = getOutput(mockInput("https://gitlab.com/gitlab-org/gitlab/-/issues/123"));
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: glab issue view 123.");
-  });
-
-  it("denies MRs with glab mr view suggestion", () => {
-    const output = getOutput(
-      mockInput("https://gitlab.com/gitlab-org/gitlab/-/merge_requests/456"),
-    );
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: glab mr view 456.");
-  });
-
-  it("denies pipelines with glab ci view suggestion", () => {
-    const output = getOutput(mockInput("https://gitlab.com/gitlab-org/gitlab/-/pipelines/12345"));
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: glab ci view 12345.");
-  });
-
-  it("denies jobs with glab ci trace suggestion", () => {
-    const output = getOutput(mockInput("https://gitlab.com/gitlab-org/gitlab/-/jobs/67890"));
-    expect(output?.permissionDecision).toBe("deny");
-    expect(output?.permissionDecisionReason).toBe("Use: glab ci trace 67890.");
+    expect(output?.permissionDecisionReason).toBe(reason);
   });
 
   it("asks for unknown GitLab URL patterns", () => {

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
+import fc from "fast-check";
 import {
   clearApiErrors,
   computeInterval,
@@ -6,6 +7,7 @@ import {
   type Event,
   type ExecFn,
   type ExecResult,
+  type InternalState,
   initialState,
   isNotFoundError,
   normalizePipelineStatus,
@@ -57,154 +59,182 @@ const ok = (stdout: string): ExecResult => ({ ok: true, stdout });
 const noopSleep = (): Promise<void> => Promise.resolve();
 
 describe("parseMrUrl", () => {
-  it("parses a standard group/project MR URL", () => {
-    const parsed = parseMrUrl("https://gitlab.com/gitlab-org/gitlab/-/merge_requests/456");
-    expect(parsed.project).toBe("gitlab-org/gitlab");
-    expect(parsed.projectEncoded).toBe("gitlab-org%2Fgitlab");
-    expect(parsed.iid).toBe(456);
+  test.each<{
+    name: string;
+    url: string;
+    project: string;
+    projectEncoded: string;
+    iid: number;
+  }>([
+    {
+      name: "parses a standard group/project MR URL",
+      url: "https://gitlab.com/gitlab-org/gitlab/-/merge_requests/456",
+      project: "gitlab-org/gitlab",
+      projectEncoded: "gitlab-org%2Fgitlab",
+      iid: 456,
+    },
+    {
+      name: "parses a nested subgroup MR URL",
+      url: "https://gitlab.com/group/subgroup/project/-/merge_requests/7",
+      project: "group/subgroup/project",
+      projectEncoded: "group%2Fsubgroup%2Fproject",
+      iid: 7,
+    },
+    {
+      name: "tolerates trailing path segments",
+      url: "https://gitlab.com/group/project/-/merge_requests/12/diffs",
+      project: "group/project",
+      projectEncoded: "group%2Fproject",
+      iid: 12,
+    },
+  ])("$name", ({ url, project, projectEncoded, iid }) => {
+    const parsed = parseMrUrl(url);
+    expect(parsed.project).toBe(project);
+    expect(parsed.projectEncoded).toBe(projectEncoded);
+    expect(parsed.iid).toBe(iid);
   });
 
-  it("parses a nested subgroup MR URL", () => {
-    const parsed = parseMrUrl("https://gitlab.com/group/subgroup/project/-/merge_requests/7");
-    expect(parsed.project).toBe("group/subgroup/project");
-    expect(parsed.projectEncoded).toBe("group%2Fsubgroup%2Fproject");
-    expect(parsed.iid).toBe(7);
-  });
-
-  it("tolerates trailing path segments", () => {
-    const parsed = parseMrUrl("https://gitlab.com/group/project/-/merge_requests/12/diffs");
-    expect(parsed.iid).toBe(12);
-    expect(parsed.project).toBe("group/project");
-  });
-
-  it("rejects non-GitLab URLs", () => {
-    expect(() => parseMrUrl("https://github.com/owner/repo/pull/1")).toThrow();
-  });
-
-  it("rejects URLs missing merge_requests segment", () => {
-    expect(() => parseMrUrl("https://gitlab.com/group/project/-/issues/1")).toThrow();
-  });
-
-  it("rejects URLs without a group segment", () => {
-    expect(() => parseMrUrl("https://gitlab.com/project/-/merge_requests/1")).toThrow();
+  test.each<{ name: string; url: string }>([
+    { name: "rejects non-GitLab URLs", url: "https://github.com/owner/repo/pull/1" },
+    {
+      name: "rejects URLs missing merge_requests segment",
+      url: "https://gitlab.com/group/project/-/issues/1",
+    },
+    {
+      name: "rejects URLs without a group segment",
+      url: "https://gitlab.com/project/-/merge_requests/1",
+    },
+  ])("$name", ({ url }) => {
+    expect(() => parseMrUrl(url)).toThrow();
   });
 });
 
 describe("parseProject", () => {
-  it("parses an HTTPS remote URL", () => {
-    expect(parseProject("https://gitlab.com/group/project.git")).toBe("group/project");
+  test.each<{ name: string; remote: string; project: string }>([
+    {
+      name: "parses an HTTPS remote URL",
+      remote: "https://gitlab.com/group/project.git",
+      project: "group/project",
+    },
+    {
+      name: "parses an HTTPS remote URL without .git suffix",
+      remote: "https://gitlab.com/group/project",
+      project: "group/project",
+    },
+    {
+      name: "parses an HTTPS remote URL with nested subgroups",
+      remote: "https://gitlab.com/group/subgroup/project.git",
+      project: "group/subgroup/project",
+    },
+    {
+      name: "parses an SCP-style SSH remote URL",
+      remote: "git@gitlab.com:group/project.git",
+      project: "group/project",
+    },
+    {
+      name: "parses an SCP-style SSH remote URL with nested subgroups",
+      remote: "git@gitlab.com:group/subgroup/project.git",
+      project: "group/subgroup/project",
+    },
+    {
+      name: "parses an ssh:// protocol remote URL",
+      remote: "ssh://git@gitlab.com/group/project.git",
+      project: "group/project",
+    },
+    {
+      name: "parses an ssh:// protocol remote URL with nested subgroups",
+      remote: "ssh://git@gitlab.com/group/subgroup/project.git",
+      project: "group/subgroup/project",
+    },
+    {
+      name: "strips a trailing slash after .git stripping",
+      remote: "https://gitlab.com/group/project.git/",
+      project: "group/project",
+    },
+  ])("$name", ({ remote, project }) => {
+    expect(parseProject(remote)).toBe(project);
   });
 
-  it("parses an HTTPS remote URL without .git suffix", () => {
-    expect(parseProject("https://gitlab.com/group/project")).toBe("group/project");
-  });
-
-  it("parses an HTTPS remote URL with nested subgroups", () => {
-    expect(parseProject("https://gitlab.com/group/subgroup/project.git")).toBe(
-      "group/subgroup/project",
-    );
-  });
-
-  it("parses an SCP-style SSH remote URL", () => {
-    expect(parseProject("git@gitlab.com:group/project.git")).toBe("group/project");
-  });
-
-  it("parses an SCP-style SSH remote URL with nested subgroups", () => {
-    expect(parseProject("git@gitlab.com:group/subgroup/project.git")).toBe(
-      "group/subgroup/project",
-    );
-  });
-
-  it("parses an ssh:// protocol remote URL", () => {
-    expect(parseProject("ssh://git@gitlab.com/group/project.git")).toBe("group/project");
-  });
-
-  it("parses an ssh:// protocol remote URL with nested subgroups", () => {
-    expect(parseProject("ssh://git@gitlab.com/group/subgroup/project.git")).toBe(
-      "group/subgroup/project",
-    );
-  });
-
-  it("strips a trailing slash after .git stripping", () => {
-    expect(parseProject("https://gitlab.com/group/project.git/")).toBe("group/project");
-  });
-
-  it("throws when the path has no group segment", () => {
-    expect(() => parseProject("https://gitlab.com/project.git")).toThrow();
-  });
-
-  it("throws when the remote URL cannot be parsed", () => {
-    expect(() => parseProject("not-a-url")).toThrow();
-  });
-
-  it("throws on an empty string", () => {
-    expect(() => parseProject("")).toThrow();
+  test.each<{ name: string; remote: string }>([
+    { name: "throws when the path has no group segment", remote: "https://gitlab.com/project.git" },
+    { name: "throws when the remote URL cannot be parsed", remote: "not-a-url" },
+    { name: "throws on an empty string", remote: "" },
+  ])("$name", ({ remote }) => {
+    expect(() => parseProject(remote)).toThrow();
   });
 });
 
 describe("normalizePipelineStatus", () => {
-  it("maps terminal states", () => {
-    expect(normalizePipelineStatus("success")).toBe("success");
-    expect(normalizePipelineStatus("failed")).toBe("failing");
-    expect(normalizePipelineStatus("canceled")).toBe("failing");
-  });
-
-  it("maps running states", () => {
-    expect(normalizePipelineStatus("running")).toBe("running");
-  });
-
-  it("maps queued-like states", () => {
-    expect(normalizePipelineStatus("pending")).toBe("queued");
-    expect(normalizePipelineStatus("created")).toBe("queued");
-    expect(normalizePipelineStatus("manual")).toBe("queued");
-  });
-
-  it("maps skipped to success and covers remaining queued-like states", () => {
-    expect(normalizePipelineStatus("skipped")).toBe("success");
-    expect(normalizePipelineStatus("waiting_for_resource")).toBe("queued");
-    expect(normalizePipelineStatus("preparing")).toBe("queued");
-    expect(normalizePipelineStatus("scheduled")).toBe("queued");
-  });
-
-  it("falls back to running for unknown statuses", () => {
-    expect(normalizePipelineStatus("totally-made-up-status")).toBe("running");
-    expect(normalizePipelineStatus("")).toBe("running");
+  test.each<[string, InternalState]>([
+    ["success", "success"],
+    ["failed", "failing"],
+    ["canceled", "failing"],
+    ["running", "running"],
+    ["pending", "queued"],
+    ["created", "queued"],
+    ["manual", "queued"],
+    ["skipped", "success"],
+    ["waiting_for_resource", "queued"],
+    ["preparing", "queued"],
+    ["scheduled", "queued"],
+    ["totally-made-up-status", "running"],
+    ["", "running"],
+  ])("normalizes %p to %p", (status, normalized) => {
+    expect(normalizePipelineStatus(status)).toBe(normalized);
   });
 });
 
 describe("isNotFoundError", () => {
-  it("detects 404 in stderr", () => {
-    expect(isNotFoundError("HTTP 404: Not Found")).toBe(true);
-    expect(isNotFoundError("error: 404 returned")).toBe(true);
-  });
-
-  it("detects 'not found' phrasing case-insensitively", () => {
-    expect(isNotFoundError("Pipeline Not Found")).toBe(true);
-    expect(isNotFoundError("pipeline not found")).toBe(true);
-  });
-
-  it("returns false for unrelated errors", () => {
-    expect(isNotFoundError("connection reset")).toBe(false);
-    expect(isNotFoundError("")).toBe(false);
-    expect(isNotFoundError("500 internal server error")).toBe(false);
+  test.each<[string, boolean]>([
+    ["HTTP 404: Not Found", true],
+    ["error: 404 returned", true],
+    ["Pipeline Not Found", true],
+    ["pipeline not found", true],
+    ["connection reset", false],
+    ["", false],
+    ["500 internal server error", false],
+  ])("%p is %p", (message, expected) => {
+    expect(isNotFoundError(message)).toBe(expected);
   });
 });
 
 describe("computeInterval", () => {
-  it("returns fast poll floor when no data (first PR on branch)", () => {
-    expect(computeInterval([])).toBe(30);
+  test.each<{ name: string; durations: number[]; expected: number }>([
+    {
+      name: "returns fast poll floor when no data (first PR on branch)",
+      durations: [],
+      expected: 30,
+    },
+    { name: "adds a 30 second buffer to the average", durations: [60, 120], expected: 120 },
+    {
+      name: "clamps interval to a 30 second floor for very short pipelines",
+      durations: [0],
+      expected: 30,
+    },
+    { name: "clamps to 600 seconds", durations: [1200, 1200], expected: 600 },
+  ])("$name", ({ durations, expected }) => {
+    expect(computeInterval(durations)).toBe(expected);
   });
 
-  it("adds a 30 second buffer to the average", () => {
-    expect(computeInterval([60, 120])).toBe(120);
-  });
-
-  it("clamps interval to a 30 second floor for very short pipelines", () => {
-    expect(computeInterval([0])).toBe(30);
-  });
-
-  it("clamps to 600 seconds", () => {
-    expect(computeInterval([1200, 1200])).toBe(600);
+  test("stays within [30, 600] and agrees with a clamped-average oracle", () => {
+    fc.assert(
+      fc.property(fc.array(fc.integer({ min: 0 })), (durations) => {
+        const result = computeInterval(durations);
+        expect(result).toBeGreaterThanOrEqual(30);
+        expect(result).toBeLessThanOrEqual(600);
+        const oracle =
+          durations.length === 0
+            ? 30
+            : Math.min(
+                600,
+                Math.max(
+                  30,
+                  Math.round(durations.reduce((a, b) => a + b, 0) / durations.length + 30),
+                ),
+              );
+        expect(result).toBe(oracle);
+      }),
+    );
   });
 });
 

--- a/plugins/gitlab/skills/merge-request/scripts/__snapshots__/discussions.test.ts.snap
+++ b/plugins/gitlab/skills/merge-request/scripts/__snapshots__/discussions.test.ts.snap
@@ -1,8 +1,0 @@
-// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
-
-exports[`formatDigest emits one line per discussion with id, location, state, and body 1`] = `
-"111111111111  src/app.ts:42  [open]      Extract this
-222222222222  -              [resolved]  Nit: typo"
-`;
-
-exports[`formatDigest truncates bodies to the given width 1`] = `"abcdef012345  -  [open]  xxxxxxxxxxxxxxxxxxx…"`;

--- a/plugins/gitlab/skills/merge-request/scripts/diff.test.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/diff.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import {
   buildPosition,
+  type Hunk,
   isLineInDiff,
   parseDiffHunks,
   parseGlabPaginated,
@@ -8,67 +9,68 @@ import {
 } from "./diff";
 
 describe("parseGlabPaginated", () => {
-  it("parses a single page", () => {
-    const result = parseGlabPaginated('[{"id": 1}]');
-    expect(result).toEqual([{ id: 1 }]);
-  });
-
-  it("fixes concatenated pages", () => {
-    const result = parseGlabPaginated('[{"id": 1}][{"id": 2}]');
-    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
-  });
-
-  it("handles whitespace between pages", () => {
-    const result = parseGlabPaginated('[{"id": 1}]\n[{"id": 2}]');
-    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
-  });
-
-  it("handles three concatenated pages", () => {
-    const result = parseGlabPaginated('[{"a":1}][{"b":2}][{"c":3}]');
-    expect(result).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
-  });
-
-  it("preserves arrays inside objects", () => {
-    const result = parseGlabPaginated('[{"notes": [1, 2]}]');
-    expect(result).toEqual([{ notes: [1, 2] }]);
+  test.each<{ name: string; raw: string; expected: unknown[] }>([
+    { name: "parses a single page", raw: '[{"id": 1}]', expected: [{ id: 1 }] },
+    {
+      name: "fixes concatenated pages",
+      raw: '[{"id": 1}][{"id": 2}]',
+      expected: [{ id: 1 }, { id: 2 }],
+    },
+    {
+      name: "handles whitespace between pages",
+      raw: '[{"id": 1}]\n[{"id": 2}]',
+      expected: [{ id: 1 }, { id: 2 }],
+    },
+    {
+      name: "handles three concatenated pages",
+      raw: '[{"a":1}][{"b":2}][{"c":3}]',
+      expected: [{ a: 1 }, { b: 2 }, { c: 3 }],
+    },
+    {
+      name: "preserves arrays inside objects",
+      raw: '[{"notes": [1, 2]}]',
+      expected: [{ notes: [1, 2] }],
+    },
+  ])("$name", ({ raw, expected }) => {
+    expect(parseGlabPaginated(raw)).toEqual(expected);
   });
 });
 
 describe("parseDiffHunks", () => {
-  it("parses a single hunk", () => {
-    const diff = "@@ -10,5 +12,8 @@ function foo() {";
-    expect(parseDiffHunks(diff)).toEqual([
-      { oldStart: 10, oldCount: 5, newStart: 12, newCount: 8 },
-    ]);
-  });
-
-  it("parses multiple hunks", () => {
-    const diff = [
-      "@@ -1,3 +1,4 @@",
-      " line1",
-      "+added",
-      " line2",
-      "@@ -20,5 +21,6 @@ context",
-      " line20",
-    ].join("\n");
-    expect(parseDiffHunks(diff)).toEqual([
-      { oldStart: 1, oldCount: 3, newStart: 1, newCount: 4 },
-      { oldStart: 20, oldCount: 5, newStart: 21, newCount: 6 },
-    ]);
-  });
-
-  it("handles single-line hunks (no count)", () => {
-    const diff = "@@ -5 +5 @@";
-    expect(parseDiffHunks(diff)).toEqual([{ oldStart: 5, oldCount: 1, newStart: 5, newCount: 1 }]);
-  });
-
-  it("handles deletion-only hunks", () => {
-    const diff = "@@ -10,3 +9,0 @@";
-    expect(parseDiffHunks(diff)).toEqual([{ oldStart: 10, oldCount: 3, newStart: 9, newCount: 0 }]);
-  });
-
-  it("returns empty for binary files", () => {
-    expect(parseDiffHunks("Binary files differ")).toEqual([]);
+  test.each<{ name: string; diff: string; expected: Hunk[] }>([
+    {
+      name: "parses a single hunk",
+      diff: "@@ -10,5 +12,8 @@ function foo() {",
+      expected: [{ oldStart: 10, oldCount: 5, newStart: 12, newCount: 8 }],
+    },
+    {
+      name: "parses multiple hunks",
+      diff: [
+        "@@ -1,3 +1,4 @@",
+        " line1",
+        "+added",
+        " line2",
+        "@@ -20,5 +21,6 @@ context",
+        " line20",
+      ].join("\n"),
+      expected: [
+        { oldStart: 1, oldCount: 3, newStart: 1, newCount: 4 },
+        { oldStart: 20, oldCount: 5, newStart: 21, newCount: 6 },
+      ],
+    },
+    {
+      name: "handles single-line hunks (no count)",
+      diff: "@@ -5 +5 @@",
+      expected: [{ oldStart: 5, oldCount: 1, newStart: 5, newCount: 1 }],
+    },
+    {
+      name: "handles deletion-only hunks",
+      diff: "@@ -10,3 +9,0 @@",
+      expected: [{ oldStart: 10, oldCount: 3, newStart: 9, newCount: 0 }],
+    },
+    { name: "returns empty for binary files", diff: "Binary files differ", expected: [] },
+  ])("$name", ({ diff, expected }) => {
+    expect(parseDiffHunks(diff)).toEqual(expected);
   });
 });
 
@@ -78,36 +80,20 @@ describe("isLineInDiff", () => {
     { oldStart: 30, oldCount: 3, newStart: 35, newCount: 4 },
   ];
 
-  it("returns true for line at hunk start", () => {
-    expect(isLineInDiff(hunks, 12, "new")).toBe(true);
-  });
-
-  it("returns true for line at hunk end", () => {
-    expect(isLineInDiff(hunks, 19, "new")).toBe(true);
-  });
-
-  it("returns true for line in middle of hunk", () => {
-    expect(isLineInDiff(hunks, 15, "new")).toBe(true);
-  });
-
-  it("returns false for line outside hunks", () => {
-    expect(isLineInDiff(hunks, 25, "new")).toBe(false);
-  });
-
-  it("returns false for line between hunks", () => {
-    expect(isLineInDiff(hunks, 22, "new")).toBe(false);
-  });
-
-  it("checks old side correctly", () => {
-    expect(isLineInDiff(hunks, 10, "old")).toBe(true);
-    expect(isLineInDiff(hunks, 14, "old")).toBe(true);
-    expect(isLineInDiff(hunks, 15, "old")).toBe(false);
-  });
-
-  it("works with second hunk", () => {
-    expect(isLineInDiff(hunks, 35, "new")).toBe(true);
-    expect(isLineInDiff(hunks, 38, "new")).toBe(true);
-    expect(isLineInDiff(hunks, 39, "new")).toBe(false);
+  test.each<{ name: string; line: number; side: "new" | "old"; expected: boolean }>([
+    { name: "returns true for line at hunk start", line: 12, side: "new", expected: true },
+    { name: "returns true for line at hunk end", line: 19, side: "new", expected: true },
+    { name: "returns true for line in middle of hunk", line: 15, side: "new", expected: true },
+    { name: "returns false for line outside hunks", line: 25, side: "new", expected: false },
+    { name: "returns false for line between hunks", line: 22, side: "new", expected: false },
+    { name: "checks old side correctly (start)", line: 10, side: "old", expected: true },
+    { name: "checks old side correctly (end)", line: 14, side: "old", expected: true },
+    { name: "checks old side correctly (past end)", line: 15, side: "old", expected: false },
+    { name: "works with second hunk (start)", line: 35, side: "new", expected: true },
+    { name: "works with second hunk (end)", line: 38, side: "new", expected: true },
+    { name: "works with second hunk (past end)", line: 39, side: "new", expected: false },
+  ])("$name", ({ line, side, expected }) => {
+    expect(isLineInDiff(hunks, line, side)).toBe(expected);
   });
 });
 
@@ -143,42 +129,33 @@ describe("validateLineInDiff", () => {
 
 describe("buildPosition", () => {
   const refs = { base_sha: "aaa", head_sha: "bbb", start_sha: "ccc" };
+  const base = {
+    base_sha: "aaa",
+    head_sha: "bbb",
+    start_sha: "ccc",
+    old_path: "src/app.ts",
+    new_path: "src/app.ts",
+    position_type: "text" as const,
+  };
 
-  it("builds position with new line", () => {
-    const pos = buildPosition(refs, "src/app.ts", { line: 42 });
-    expect(pos).toEqual({
-      base_sha: "aaa",
-      head_sha: "bbb",
-      start_sha: "ccc",
-      old_path: "src/app.ts",
-      new_path: "src/app.ts",
-      position_type: "text",
-      new_line: 42,
-    });
-  });
-
-  it("builds position with old line", () => {
-    const pos = buildPosition(refs, "src/app.ts", { oldLine: 10 });
-    expect(pos).toEqual({
-      base_sha: "aaa",
-      head_sha: "bbb",
-      start_sha: "ccc",
-      old_path: "src/app.ts",
-      new_path: "src/app.ts",
-      position_type: "text",
-      old_line: 10,
-    });
-  });
-
-  it("builds position without line (general file comment)", () => {
-    const pos = buildPosition(refs, "src/app.ts", {});
-    expect(pos).toEqual({
-      base_sha: "aaa",
-      head_sha: "bbb",
-      start_sha: "ccc",
-      old_path: "src/app.ts",
-      new_path: "src/app.ts",
-      position_type: "text",
-    });
+  test.each<{
+    name: string;
+    lineArg: { line?: number; oldLine?: number };
+    extra: Record<string, number>;
+  }>([
+    { name: "builds position with new line", lineArg: { line: 42 }, extra: { new_line: 42 } },
+    {
+      name: "builds position with old line",
+      lineArg: { oldLine: 10 },
+      extra: { old_line: 10 },
+    },
+    {
+      name: "builds position without line (general file comment)",
+      lineArg: {},
+      extra: {},
+    },
+  ])("$name", ({ lineArg, extra }) => {
+    const pos = buildPosition(refs, "src/app.ts", lineArg);
+    expect(pos).toEqual({ ...base, ...extra });
   });
 });

--- a/plugins/gitlab/skills/merge-request/scripts/discussions.test.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/discussions.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "bun:test";
-import type { Discussion, DiscussionSummary } from "./discussions";
+import { describe, expect, it, test } from "bun:test";
+import type { Discussion, DiscussionSummary, FilterOptions } from "./discussions";
 import {
   deduplicateDiscussions,
   filterDiscussions,
@@ -23,120 +23,102 @@ function makeDiscussion(id: string, noteOverrides: Record<string, unknown> = {})
 }
 
 describe("filterDiscussions", () => {
-  it("filters by author", () => {
-    const discussions = [
-      makeDiscussion("1", { author: { username: "alice" } }),
-      makeDiscussion("2", { author: { username: "bob" } }),
-    ];
-    const result = filterDiscussions(discussions, { author: "alice" });
-    expect(result).toHaveLength(1);
-    expect(result[0]?.id).toBe("1");
-  });
-
-  it("filters resolvable only", () => {
-    const discussions = [
-      makeDiscussion("1", { resolvable: true }),
-      makeDiscussion("2", { resolvable: false }),
-    ];
-    const result = filterDiscussions(discussions, { resolvable: true });
-    expect(result).toHaveLength(1);
-    expect(result[0]?.id).toBe("1");
-  });
-
-  it("filters unresolved only", () => {
-    const discussions = [
-      makeDiscussion("1", { resolved: false }),
-      makeDiscussion("2", { resolved: true }),
-    ];
-    const result = filterDiscussions(discussions, { unresolved: true });
-    expect(result).toHaveLength(1);
-    expect(result[0]?.id).toBe("1");
-  });
-
-  it("combines filters", () => {
-    const discussions = [
-      makeDiscussion("1", { author: { username: "alice" }, resolved: false }),
-      makeDiscussion("2", { author: { username: "alice" }, resolved: true }),
-      makeDiscussion("3", { author: { username: "bob" }, resolved: false }),
-    ];
-    const result = filterDiscussions(discussions, { author: "alice", unresolved: true });
-    expect(result).toHaveLength(1);
-    expect(result[0]?.id).toBe("1");
-  });
-
-  it("keeps structural bots and listed reviewers with bots", () => {
-    const discussions = [
-      makeDiscussion("1", {
-        author: { username: "group_108656794_bot_52b7e4c7a732080fa3b51efe36863e09" },
-      }),
-      makeDiscussion("2", { author: { username: "coderabbitai" } }),
-      makeDiscussion("3", { author: { username: "alice" } }),
-    ];
-    const result = filterDiscussions(discussions, {
-      bots: true,
-      extra: new Set(["coderabbitai"]),
-    });
-    expect(result.map((d) => d.id)).toEqual(["1", "2"]);
-  });
-
-  it("skips discussions with empty notes", () => {
-    const discussions: Discussion[] = [{ id: "1", notes: [] }];
-    const result = filterDiscussions(discussions, {});
-    expect(result).toHaveLength(0);
+  test.each<{ name: string; discussions: Discussion[]; options: FilterOptions; ids: string[] }>([
+    {
+      name: "filters by author",
+      discussions: [
+        makeDiscussion("1", { author: { username: "alice" } }),
+        makeDiscussion("2", { author: { username: "bob" } }),
+      ],
+      options: { author: "alice" },
+      ids: ["1"],
+    },
+    {
+      name: "filters resolvable only",
+      discussions: [
+        makeDiscussion("1", { resolvable: true }),
+        makeDiscussion("2", { resolvable: false }),
+      ],
+      options: { resolvable: true },
+      ids: ["1"],
+    },
+    {
+      name: "filters unresolved only",
+      discussions: [
+        makeDiscussion("1", { resolved: false }),
+        makeDiscussion("2", { resolved: true }),
+      ],
+      options: { unresolved: true },
+      ids: ["1"],
+    },
+    {
+      name: "combines filters",
+      discussions: [
+        makeDiscussion("1", { author: { username: "alice" }, resolved: false }),
+        makeDiscussion("2", { author: { username: "alice" }, resolved: true }),
+        makeDiscussion("3", { author: { username: "bob" }, resolved: false }),
+      ],
+      options: { author: "alice", unresolved: true },
+      ids: ["1"],
+    },
+    {
+      name: "keeps structural bots and listed reviewers with bots",
+      discussions: [
+        makeDiscussion("1", {
+          author: { username: "group_108656794_bot_52b7e4c7a732080fa3b51efe36863e09" },
+        }),
+        makeDiscussion("2", { author: { username: "coderabbitai" } }),
+        makeDiscussion("3", { author: { username: "alice" } }),
+      ],
+      options: { bots: true, extra: new Set(["coderabbitai"]) },
+      ids: ["1", "2"],
+    },
+    {
+      name: "skips discussions with empty notes",
+      discussions: [{ id: "1", notes: [] }],
+      options: {},
+      ids: [],
+    },
+  ])("$name", ({ discussions, options, ids }) => {
+    const result = filterDiscussions(discussions, options);
+    expect(result.map((d) => d.id)).toEqual(ids);
   });
 });
 
 describe("deduplicateDiscussions", () => {
-  it("removes duplicates with same path and body prefix", () => {
-    const discussions = [
-      makeDiscussion("1", {
-        body: "Fix this issue",
-        position: { new_path: "src/app.ts" },
-      }),
-      makeDiscussion("2", {
-        body: "Fix this issue",
-        position: { new_path: "src/app.ts" },
-      }),
-    ];
+  test.each<{ name: string; discussions: Discussion[]; ids: string[] }>([
+    {
+      name: "removes duplicates with same path and body prefix",
+      discussions: [
+        makeDiscussion("1", { body: "Fix this issue", position: { new_path: "src/app.ts" } }),
+        makeDiscussion("2", { body: "Fix this issue", position: { new_path: "src/app.ts" } }),
+      ],
+      ids: ["1"],
+    },
+    {
+      name: "keeps discussions with different paths",
+      discussions: [
+        makeDiscussion("1", { body: "Fix this", position: { new_path: "src/a.ts" } }),
+        makeDiscussion("2", { body: "Fix this", position: { new_path: "src/b.ts" } }),
+      ],
+      ids: ["1", "2"],
+    },
+    {
+      name: "keeps discussions with different body prefixes",
+      discussions: [
+        makeDiscussion("1", { body: "First comment", position: { new_path: "src/a.ts" } }),
+        makeDiscussion("2", { body: "Second comment", position: { new_path: "src/a.ts" } }),
+      ],
+      ids: ["1", "2"],
+    },
+    {
+      name: "skips discussions with empty notes",
+      discussions: [{ id: "1", notes: [] }],
+      ids: [],
+    },
+  ])("$name", ({ discussions, ids }) => {
     const result = deduplicateDiscussions(discussions);
-    expect(result).toHaveLength(1);
-    expect(result[0]?.id).toBe("1");
-  });
-
-  it("keeps discussions with different paths", () => {
-    const discussions = [
-      makeDiscussion("1", {
-        body: "Fix this",
-        position: { new_path: "src/a.ts" },
-      }),
-      makeDiscussion("2", {
-        body: "Fix this",
-        position: { new_path: "src/b.ts" },
-      }),
-    ];
-    const result = deduplicateDiscussions(discussions);
-    expect(result).toHaveLength(2);
-  });
-
-  it("keeps discussions with different body prefixes", () => {
-    const discussions = [
-      makeDiscussion("1", {
-        body: "First comment",
-        position: { new_path: "src/a.ts" },
-      }),
-      makeDiscussion("2", {
-        body: "Second comment",
-        position: { new_path: "src/a.ts" },
-      }),
-    ];
-    const result = deduplicateDiscussions(discussions);
-    expect(result).toHaveLength(2);
-  });
-
-  it("skips discussions with empty notes", () => {
-    const discussions: Discussion[] = [{ id: "1", notes: [] }];
-    const result = deduplicateDiscussions(discussions);
-    expect(result).toHaveLength(0);
+    expect(result.map((d) => d.id)).toEqual(ids);
   });
 });
 
@@ -153,34 +135,44 @@ function makeSummary(overrides: Partial<DiscussionSummary> = {}): DiscussionSumm
 }
 
 describe("truncateBody", () => {
-  it("collapses whitespace and newlines to single spaces", () => {
-    expect(truncateBody("a\n  b\t c", 80)).toBe("a b c");
-  });
-
-  it("truncates with an ellipsis past the max", () => {
-    const result = truncateBody("abcdefghij", 5);
-    expect(result).toBe("abcd…");
-    expect(result).toHaveLength(5);
-  });
-
-  it("leaves short bodies untouched", () => {
-    expect(truncateBody("short", 80)).toBe("short");
+  test.each<{ name: string; body: string; max: number; expected: string }>([
+    {
+      name: "collapses whitespace and newlines to single spaces",
+      body: "a\n  b\t c",
+      max: 80,
+      expected: "a b c",
+    },
+    {
+      name: "truncates with an ellipsis past the max",
+      body: "abcdefghij",
+      max: 5,
+      expected: "abcd…",
+    },
+    { name: "leaves short bodies untouched", body: "short", max: 80, expected: "short" },
+  ])("$name", ({ body, max, expected }) => {
+    expect(truncateBody(body, max)).toBe(expected);
   });
 });
 
 describe("formatLocation", () => {
-  it("returns empty string for non-positioned discussions", () => {
-    expect(formatLocation(makeSummary())).toBe("");
-  });
-
-  it("renders file:line for single-line comments", () => {
-    expect(formatLocation(makeSummary({ file: "src/app.ts", line: 42 }))).toBe("src/app.ts:42");
-  });
-
-  it("renders file:start-end for ranges", () => {
-    expect(
-      formatLocation(makeSummary({ file: "src/app.ts", lineRange: { start: 10, end: 14 } })),
-    ).toBe("src/app.ts:10-14");
+  test.each<{ name: string; summary: DiscussionSummary; expected: string }>([
+    {
+      name: "returns empty string for non-positioned discussions",
+      summary: makeSummary(),
+      expected: "",
+    },
+    {
+      name: "renders file:line for single-line comments",
+      summary: makeSummary({ file: "src/app.ts", line: 42 }),
+      expected: "src/app.ts:42",
+    },
+    {
+      name: "renders file:start-end for ranges",
+      summary: makeSummary({ file: "src/app.ts", lineRange: { start: 10, end: 14 } }),
+      expected: "src/app.ts:10-14",
+    },
+  ])("$name", ({ summary, expected }) => {
+    expect(formatLocation(summary)).toBe(expected);
   });
 });
 
@@ -194,11 +186,16 @@ describe("formatDigest", () => {
       80,
     );
     expect(out.split("\n")).toHaveLength(2);
-    expect(out).toMatchSnapshot();
+    expect(out).toMatchInlineSnapshot(`
+      "111111111111  src/app.ts:42  [open]      Extract this
+      222222222222  -              [resolved]  Nit: typo"
+    `);
   });
 
   it("truncates bodies to the given width", () => {
-    expect(formatDigest([makeSummary({ body: "x".repeat(200) })], 20)).toMatchSnapshot();
+    expect(formatDigest([makeSummary({ body: "x".repeat(200) })], 20)).toMatchInlineSnapshot(
+      `"abcdef012345  -  [open]  xxxxxxxxxxxxxxxxxxx…"`,
+    );
   });
 
   it("returns an empty string with no discussions", () => {


### PR DESCRIPTION
Applies the testing rule's technique-selection guide across the gitlab suites.

`fetch.test.ts` and `diff.test.ts` convert runs of near-identical `it` blocks into `test.each` tables (URL parsing, pipeline-status normalization, MR-URL parsing). `diff.test.ts` and `discussions.test.ts` move piecemeal formatted-output assertions to inline snapshots, retiring the external `discussions.test.ts.snap`. `watch.test.ts` tables its parse helpers and adds a fast-check property for `computeInterval`: its invariant is that a 30s-buffered average is always clamped into `[30, 600]`.

Two candidate table conversions were dropped. Folding `auth.test.ts`'s three null-returning cases required a ternary on an optional `response` field. `review-queue.test.ts` needed an invented `mode` discriminator plus an `if/else` body to switch between asserting the result and its mapped references. Both grew their files and read worse than the original blocks. Those two files stay as they were.

Test LOC 1509 to 1511. The net increase is the `computeInterval` property test; the pure table and snapshot refactors are net-negative.

The suites still cover project and MR-URL parsing, pipeline-status normalization, diff hunk formatting, discussion rendering, and the CI-monitor poll interval across its clamp range.
