### PR TITLE
test(plugins/writing): apply testing conventions

### DIFF
--- a/plugins/writing/detection/scan.test.ts
+++ b/plugins/writing/detection/scan.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import { scanAll } from "./scan";
 
 describe("scanAll", () => {
@@ -38,19 +38,15 @@ describe("scanAll", () => {
   const dense =
     "The cache starts cold; the first request fills it. The retry logic backs off; later attempts succeed. The parser rejects malformed input; it returns an error. The server validates each field. The client sends a token. The job runs nightly.";
 
-  it("applies fileOnly patterns for prose files", () => {
-    const categories = scanAll(dense, "notes.md").map((r) => r.category);
-    expect(categories).toContain("connector density");
-  });
-
-  it("skips fileOnly patterns for non-prose files", () => {
-    const categories = scanAll(dense, "script.ts").map((r) => r.category);
-    expect(categories).not.toContain("connector density");
-  });
-
-  it("applies fileOnly patterns when no path is given", () => {
-    const categories = scanAll(dense).map((r) => r.category);
-    expect(categories).toContain("connector density");
+  test.each<[string, string | undefined, boolean]>([
+    ["applies fileOnly patterns for prose files", "notes.md", true],
+    ["skips fileOnly patterns for non-prose files", "script.ts", false],
+    ["applies fileOnly patterns when no path is given", undefined, true],
+  ])("%s", (_name, path, contains) => {
+    const categories = scanAll(dense, path).map((r) => r.category);
+    contains
+      ? expect(categories).toContain("connector density")
+      : expect(categories).not.toContain("connector density");
   });
 
   it("reports the position of the connector density sample", () => {

--- a/plugins/writing/detection/tropes.test.ts
+++ b/plugins/writing/detection/tropes.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import fc from "fast-check";
 import { firstByTier, type PatternMatch, regexCatalog, scan, stripCode } from "./tropes";
 
 describe("regexCatalog", () => {
@@ -32,6 +33,33 @@ describe("stripCode", () => {
 
   it("preserves non-code text", () => {
     expect(stripCode("This is plain text")).toBe("This is plain text");
+  });
+
+  // Text whose backticks only form single-line inline spans or well-formed
+  // fenced blocks. That is stripCode's intended domain: inline code that spans
+  // a newline is replaced by equal-width spaces, which drops the newline and
+  // collapses the line count.
+  const plainSegment = fc.string().map((s) => s.replace(/[`\n]/g, ""));
+  const inlineCodeLine = fc
+    .tuple(
+      plainSegment,
+      fc.string().map((s) => s.replace(/[`\n]/g, "") || "x"),
+      plainSegment,
+    )
+    .map(([pre, code, post]) => `${pre}\`${code}\`${post}`);
+  const fencedBlock = fc
+    .array(plainSegment)
+    .map((lines) => `\`\`\`\n${lines.join("\n")}\n\`\`\``);
+  const codeSafeText = fc
+    .array(fc.oneof(plainSegment, inlineCodeLine, fencedBlock))
+    .map((blocks) => blocks.join("\n"));
+
+  it("preserves line count for well-formed code spans", () => {
+    fc.assert(
+      fc.property(codeSafeText, (text) => {
+        expect(stripCode(text).split("\n")).toHaveLength(text.split("\n").length);
+      }),
+    );
   });
 });
 
@@ -399,16 +427,11 @@ describe("scan", () => {
   });
 
   describe("sycophantic acknowledgment", () => {
-    it("flags: You're right", () => {
-      expect(firstByTier(scan("You're right, that was wrong."), "deny")?.category).toBe(
-        "sycophantic acknowledgment",
-      );
-    });
-
-    it("flags: You're absolutely right", () => {
-      expect(firstByTier(scan("You're absolutely right about that."), "deny")?.category).toBe(
-        "sycophantic acknowledgment",
-      );
+    it.each([
+      "You're right, that was wrong.",
+      "You're absolutely right about that.",
+    ])("flags: %j", (text) => {
+      expect(firstByTier(scan(text), "deny")?.category).toBe("sycophantic acknowledgment");
     });
 
     it("allows: turn right", () => {
@@ -582,30 +605,17 @@ describe("scan", () => {
   });
 
   describe("hedging observation", () => {
-    it("flags: looks like", () => {
-      expect(firstByTier(scan("This looks like a regression."), "context")?.category).toBe(
-        "hedging observation",
-      );
-    });
-
-    it("flags: appears to", () => {
-      expect(firstByTier(scan("The fix appears to hold."), "context")?.category).toBe(
-        "hedging observation",
-      );
+    it.each(["This looks like a regression.", "The fix appears to hold."])("flags: %j", (text) => {
+      expect(firstByTier(scan(text), "context")?.category).toBe("hedging observation");
     });
   });
 
   describe("filler", () => {
-    it("flags: 'it's worth noting that'", () => {
-      expect(
-        firstByTier(scan("It's worth noting that the cache is cold."), "context")?.category,
-      ).toBe("filler");
-    });
-
-    it("flags: 'in terms of'", () => {
-      expect(firstByTier(scan("In terms of latency, it improved."), "context")?.category).toBe(
-        "filler",
-      );
+    it.each([
+      "It's worth noting that the cache is cold.",
+      "In terms of latency, it improved.",
+    ])("flags: %j", (text) => {
+      expect(firstByTier(scan(text), "context")?.category).toBe("filler");
     });
 
     it("allows prose without filler markers", () => {

--- a/plugins/writing/detection/tropes.test.ts
+++ b/plugins/writing/detection/tropes.test.ts
@@ -47,9 +47,7 @@ describe("stripCode", () => {
       plainSegment,
     )
     .map(([pre, code, post]) => `${pre}\`${code}\`${post}`);
-  const fencedBlock = fc
-    .array(plainSegment)
-    .map((lines) => `\`\`\`\n${lines.join("\n")}\n\`\`\``);
+  const fencedBlock = fc.array(plainSegment).map((lines) => `\`\`\`\n${lines.join("\n")}\n\`\`\``);
   const codeSafeText = fc
     .array(fc.oneof(plainSegment, inlineCodeLine, fencedBlock))
     .map((blocks) => blocks.join("\n"));

--- a/plugins/writing/hooks/check-tropes.test.ts
+++ b/plugins/writing/hooks/check-tropes.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -74,17 +74,15 @@ function mockMcp(toolName: string, toolInput: Record<string, unknown>): PreToolU
 }
 
 describe("plan files", () => {
-  it("skips Write to plan file with spaced em dash", async () => {
-    const input = mockWrite("This \u2014 is bad");
-    (input.tool_input as Record<string, unknown>).file_path =
-      `${process.env.HOME}/.claude/plans/my-plan.md`;
-    expect(await processInput(input)).toBeNull();
-  });
+  const planPath = `${process.env.HOME}/.claude/plans/my-plan.md`;
 
-  it("skips Edit to plan file with spaced em dash", async () => {
-    const input = mockEdit("This \u2014 is bad");
-    (input.tool_input as Record<string, unknown>).file_path =
-      `${process.env.HOME}/.claude/plans/my-plan.md`;
+  test.each<["Write" | "Edit"]>([
+    ["Write"],
+    ["Edit"],
+  ])("skips %s to plan file with spaced em dash", async (tool) => {
+    const input =
+      tool === "Write" ? mockWrite("This \u2014 is bad") : mockEdit("This \u2014 is bad");
+    (input.tool_input as Record<string, unknown>).file_path = planPath;
     expect(await processInput(input)).toBeNull();
   });
 
@@ -120,31 +118,30 @@ describe("plan mode", () => {
 describe("memory files", () => {
   const memoryPath = `${process.env.HOME}/.claude/projects/-Users-ben-test/memory/MEMORY.md`;
 
-  it("skips Write to memory file with spaced em dash", async () => {
-    const input = mockWrite("This \u2014 is bad");
-    (input.tool_input as Record<string, unknown>).file_path = memoryPath;
-    expect(await processInput(input)).toBeNull();
-  });
-
-  it("skips Edit to memory file with spaced em dash", async () => {
-    const input = mockEdit("This \u2014 is bad");
+  test.each<["Write" | "Edit"]>([
+    ["Write"],
+    ["Edit"],
+  ])("skips %s to memory file with spaced em dash", async (tool) => {
+    const input =
+      tool === "Write" ? mockWrite("This \u2014 is bad") : mockEdit("This \u2014 is bad");
     (input.tool_input as Record<string, unknown>).file_path = memoryPath;
     expect(await processInput(input)).toBeNull();
   });
 });
 
 describe("wordlist files", () => {
-  it("skips Write to wordlist file containing flagged vocabulary", async () => {
-    const input = mockWrite("delve\ntapestry\nbolstered\n");
-    (input.tool_input as Record<string, unknown>).file_path =
-      "/Users/test/plugins/writing/wordlists/vocabulary.txt";
-    expect(await processInput(input)).toBeNull();
-  });
+  const wordlistPath = "/Users/test/plugins/writing/wordlists/vocabulary.txt";
 
-  it("skips Edit to wordlist file", async () => {
-    const input = mockEdit("delve\nadded entry\n");
-    (input.tool_input as Record<string, unknown>).file_path =
-      "/Users/test/plugins/writing/wordlists/vocabulary.txt";
+  test.each<[string, string, string]>([
+    [
+      "skips Write to wordlist file containing flagged vocabulary",
+      "Write",
+      "delve\ntapestry\nbolstered\n",
+    ],
+    ["skips Edit to wordlist file", "Edit", "delve\nadded entry\n"],
+  ])("%s", async (_name, tool, content) => {
+    const input = tool === "Write" ? mockWrite(content) : mockEdit(content);
+    (input.tool_input as Record<string, unknown>).file_path = wordlistPath;
     expect(await processInput(input)).toBeNull();
   });
 

--- a/plugins/writing/hooks/numbering.test.ts
+++ b/plugins/writing/hooks/numbering.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, test } from "bun:test";
 import { execSync } from "node:child_process";
 import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
@@ -55,23 +55,12 @@ async function getOutput(
 }
 
 describe("formatDecision", () => {
-  it("formats deny decision", async () => {
-    const output = formatDecision("deny", "Test reason");
+  test.each<["deny" | "ask"]>([["deny"], ["ask"]])("formats %s decision", (decision) => {
+    const output = formatDecision(decision, "Test reason");
     expect(output).toEqual({
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
-        permissionDecision: "deny",
-        permissionDecisionReason: "Test reason",
-      },
-    });
-  });
-
-  it("formats ask decision", async () => {
-    const output = formatDecision("ask", "Test reason");
-    expect(output).toEqual({
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        permissionDecision: "ask",
+        permissionDecision: decision,
         permissionDecisionReason: "Test reason",
       },
     });
@@ -79,248 +68,198 @@ describe("formatDecision", () => {
 });
 
 describe("checkMarkdown", () => {
-  it('detects "# 1. Introduction"', async () => {
-    const match = checkMarkdown("# 1. Introduction");
-    expect(match).toContain("1. Introduction");
-  });
-
-  it('detects "## Step 2: Setup"', async () => {
-    const match = checkMarkdown("## Step 2: Setup");
-    expect(match).toContain("Step 2");
-  });
-
-  it('detects "### Phase 3"', async () => {
-    const match = checkMarkdown("### Phase 3");
-    expect(match).toContain("Phase 3");
-  });
-
-  it("allows descriptive headings", async () => {
-    const match = checkMarkdown("# Introduction");
-    expect(match).toBeNull();
-  });
-
-  it("allows headings with numbers mid-text", async () => {
-    const match = checkMarkdown("# Using OAuth2 for Authentication");
-    expect(match).toBeNull();
+  test.each<[string, string, string | null]>([
+    ['detects "# 1. Introduction"', "# 1. Introduction", "1. Introduction"],
+    ['detects "## Step 2: Setup"', "## Step 2: Setup", "Step 2"],
+    ['detects "### Phase 3"', "### Phase 3", "Phase 3"],
+    ["allows descriptive headings", "# Introduction", null],
+    ["allows headings with numbers mid-text", "# Using OAuth2 for Authentication", null],
+  ])("%s", (_name, content, expected) => {
+    const match = checkMarkdown(content);
+    expected === null ? expect(match).toBeNull() : expect(match).toContain(expected);
   });
 });
 
 describe.skipIf(!hasSg())("checkCode (requires sg)", () => {
-  it("detects Go func step1()", async () => {
-    const match = await checkCode('package main\nfunc step1() { fmt.Println("test") }', "go");
-    expect(match).toContain("step1");
-  });
-
-  it("detects Go func phase2()", async () => {
-    const match = await checkCode("package main\nfunc phase2() {}", "go");
-    expect(match).toContain("phase2");
-  });
-
-  it("allows descriptive Go function names", async () => {
-    const match = await checkCode(
+  test.each<[string, string, string, string | null]>([
+    [
+      "detects Go func step1()",
+      'package main\nfunc step1() { fmt.Println("test") }',
+      "go",
+      "step1",
+    ],
+    ["detects Go func phase2()", "package main\nfunc phase2() {}", "go", "phase2"],
+    [
+      "allows descriptive Go function names",
       'package main\nfunc processItems() { fmt.Println("test") }',
       "go",
-    );
-    expect(match).toBeNull();
-  });
-
-  it("detects JavaScript function step1()", async () => {
-    const match = await checkCode('function step1() { console.log("test"); }', "js");
-    expect(match).toContain("step1");
-  });
-
-  it("detects JavaScript const part3", async () => {
-    const match = await checkCode("const part3 = () => {};", "js");
-    expect(match).toContain("part3");
-  });
-
-  it("allows descriptive JavaScript names", async () => {
-    const match = await checkCode('function handleSubmit() { console.log("test"); }', "js");
-    expect(match).toBeNull();
-  });
-
-  it("detects Python def step1()", async () => {
-    const match = await checkCode("def step1():\n    pass", "py");
-    expect(match).toContain("step1");
-  });
-
-  it("detects Python class Phase2", async () => {
-    const match = await checkCode("class Phase2:\n    pass", "py");
-    expect(match).toContain("Phase2");
-  });
-
-  it("allows descriptive Python names", async () => {
-    const match = await checkCode("def process_items():\n    pass", "py");
-    expect(match).toBeNull();
-  });
-
-  it("detects TypeScript function step1()", async () => {
-    const match = await checkCode("function step1() {}", "ts");
-    expect(match).toContain("step1");
+      null,
+    ],
+    [
+      "detects JavaScript function step1()",
+      'function step1() { console.log("test"); }',
+      "js",
+      "step1",
+    ],
+    ["detects JavaScript const part3", "const part3 = () => {};", "js", "part3"],
+    [
+      "allows descriptive JavaScript names",
+      'function handleSubmit() { console.log("test"); }',
+      "js",
+      null,
+    ],
+    ["detects Python def step1()", "def step1():\n    pass", "py", "step1"],
+    ["detects Python class Phase2", "class Phase2:\n    pass", "py", "Phase2"],
+    ["allows descriptive Python names", "def process_items():\n    pass", "py", null],
+    ["detects TypeScript function step1()", "function step1() {}", "ts", "step1"],
+  ])("%s", async (_name, content, lang, expected) => {
+    const match = await checkCode(content, lang);
+    expected === null ? expect(match).toBeNull() : expect(match).toContain(expected);
   });
 });
 
 describe.skipIf(!hasSg())("processInput with code (requires sg)", () => {
-  describe("Go numbered identifiers", () => {
-    it("detects func step1()", async () => {
-      const output = await getOutput(
-        mockWriteInput("main.go", 'package main\nfunc step1() { fmt.Println("test") }'),
-        "write",
-      );
-      expect(output?.permissionDecision).toBe("deny");
-      expect(output?.permissionDecisionReason).toContain("step1");
-    });
-
-    it("detects func phase2()", async () => {
-      const output = await getOutput(
-        mockWriteInput("main.go", "package main\nfunc phase2() {}"),
-        "write",
-      );
-      expect(output?.permissionDecision).toBe("deny");
-      expect(output?.permissionDecisionReason).toContain("phase2");
-    });
-
-    it("allows descriptive function names", async () => {
-      const output = await getOutput(
-        mockWriteInput("main.go", 'package main\nfunc processItems() { fmt.Println("test") }'),
-        "write",
-      );
+  test.each<[string, string, string, "write" | "edit", "deny" | "ask" | null, string | null]>([
+    [
+      "Go: detects func step1()",
+      "main.go",
+      'package main\nfunc step1() { fmt.Println("test") }',
+      "write",
+      "deny",
+      "step1",
+    ],
+    [
+      "Go: detects func phase2()",
+      "main.go",
+      "package main\nfunc phase2() {}",
+      "write",
+      "deny",
+      "phase2",
+    ],
+    [
+      "Go: allows descriptive function names",
+      "main.go",
+      'package main\nfunc processItems() { fmt.Println("test") }',
+      "write",
+      null,
+      null,
+    ],
+    [
+      "JavaScript: detects function step1()",
+      "app.js",
+      'function step1() { console.log("test"); }',
+      "write",
+      "deny",
+      null,
+    ],
+    ["JavaScript: detects const part3", "app.js", "const part3 = () => {};", "write", "deny", null],
+    [
+      "JavaScript: allows descriptive names",
+      "app.js",
+      'function handleSubmit() { console.log("test"); }',
+      "write",
+      null,
+      null,
+    ],
+    ["Python: detects def step1()", "script.py", "def step1():\n    pass", "write", "deny", null],
+    ["Python: detects class Phase2", "script.py", "class Phase2:\n    pass", "write", "deny", null],
+    [
+      "Python: allows descriptive names",
+      "script.py",
+      "def process_items():\n    pass",
+      "write",
+      null,
+      null,
+    ],
+    [
+      "Write tool: blocks with deny",
+      "main.go",
+      "package main\nfunc step1() {}",
+      "write",
+      "deny",
+      null,
+    ],
+    ["Edit tool: asks instead of deny", "main.go", "func step1() {}", "edit", "ask", null],
+    ["File type filtering: checks Go files", "main.go", "func step1() {}", "write", "deny", null],
+    [
+      "File type filtering: checks TypeScript files",
+      "app.ts",
+      "function step1() {}",
+      "write",
+      "deny",
+      null,
+    ],
+    [
+      "File type filtering: skips unsupported file types (JSON)",
+      "config.json",
+      '{"step1": "value"}',
+      "write",
+      null,
+      null,
+    ],
+    [
+      "Test files are NOT excluded: checks *_test.go files",
+      "main_test.go",
+      "func step1() {}",
+      "write",
+      "deny",
+      null,
+    ],
+    [
+      "Test files are NOT excluded: checks *.spec.ts files",
+      "app.spec.ts",
+      "function step1() {}",
+      "write",
+      "deny",
+      null,
+    ],
+    [
+      "Test files are NOT excluded: checks test_*.py files",
+      "test_utils.py",
+      "def step1():\n    pass",
+      "write",
+      "deny",
+      null,
+    ],
+  ])("%s", async (_name, filePath, content, mode, expected, reasonContains) => {
+    const output = await getOutput(
+      mode === "write" ? mockWriteInput(filePath, content) : mockEditInput(filePath, content),
+      mode,
+    );
+    if (expected === null) {
       expect(output).toBeNull();
-    });
-  });
-
-  describe("JavaScript numbered identifiers", () => {
-    it("detects function step1()", async () => {
-      const output = await getOutput(
-        mockWriteInput("app.js", 'function step1() { console.log("test"); }'),
-        "write",
-      );
-      expect(output?.permissionDecision).toBe("deny");
-    });
-
-    it("detects const part3", async () => {
-      const output = await getOutput(mockWriteInput("app.js", "const part3 = () => {};"), "write");
-      expect(output?.permissionDecision).toBe("deny");
-    });
-
-    it("allows descriptive names", async () => {
-      const output = await getOutput(
-        mockWriteInput("app.js", 'function handleSubmit() { console.log("test"); }'),
-        "write",
-      );
-      expect(output).toBeNull();
-    });
-  });
-
-  describe("Python numbered identifiers", () => {
-    it("detects def step1()", async () => {
-      const output = await getOutput(
-        mockWriteInput("script.py", "def step1():\n    pass"),
-        "write",
-      );
-      expect(output?.permissionDecision).toBe("deny");
-    });
-
-    it("detects class Phase2", async () => {
-      const output = await getOutput(
-        mockWriteInput("script.py", "class Phase2:\n    pass"),
-        "write",
-      );
-      expect(output?.permissionDecision).toBe("deny");
-    });
-
-    it("allows descriptive names", async () => {
-      const output = await getOutput(
-        mockWriteInput("script.py", "def process_items():\n    pass"),
-        "write",
-      );
-      expect(output).toBeNull();
-    });
-  });
-
-  describe("Write vs Edit mode", () => {
-    it("blocks Write tool with deny", async () => {
-      const output = await getOutput(
-        mockWriteInput("main.go", "package main\nfunc step1() {}"),
-        "write",
-      );
-      expect(output?.permissionDecision).toBe("deny");
-    });
-
-    it("asks for Edit tool instead of deny", async () => {
-      const output = await getOutput(mockEditInput("main.go", "func step1() {}"), "edit");
-      expect(output?.permissionDecision).toBe("ask");
-    });
-  });
-
-  describe("File type filtering", () => {
-    it("checks Go files", async () => {
-      const output = await getOutput(mockWriteInput("main.go", "func step1() {}"), "write");
-      expect(output?.permissionDecision).toBe("deny");
-    });
-
-    it("checks TypeScript files", async () => {
-      const output = await getOutput(mockWriteInput("app.ts", "function step1() {}"), "write");
-      expect(output?.permissionDecision).toBe("deny");
-    });
-
-    it("skips unsupported file types (JSON)", async () => {
-      const output = await getOutput(mockWriteInput("config.json", '{"step1": "value"}'), "write");
-      expect(output).toBeNull();
-    });
-  });
-
-  describe("Test files are NOT excluded", () => {
-    it("checks *_test.go files", async () => {
-      const output = await getOutput(mockWriteInput("main_test.go", "func step1() {}"), "write");
-      expect(output?.permissionDecision).toBe("deny");
-    });
-
-    it("checks *.spec.ts files", async () => {
-      const output = await getOutput(mockWriteInput("app.spec.ts", "function step1() {}"), "write");
-      expect(output?.permissionDecision).toBe("deny");
-    });
-
-    it("checks test_*.py files", async () => {
-      const output = await getOutput(
-        mockWriteInput("test_utils.py", "def step1():\n    pass"),
-        "write",
-      );
-      expect(output?.permissionDecision).toBe("deny");
-    });
+      return;
+    }
+    expect(output?.permissionDecision).toBe(expected);
+    if (reasonContains !== null) {
+      expect(output?.permissionDecisionReason).toContain(reasonContains);
+    }
   });
 });
 
 describe("processInput with markdown", () => {
-  it('detects "# 1. Introduction"', async () => {
-    const output = await getOutput(mockWriteInput("README.md", "# 1. Introduction"), "write");
-    expect(output?.permissionDecision).toBe("ask");
-    expect(output?.permissionDecisionReason).toContain("1. Introduction");
-  });
-
-  it('detects "## Step 2: Setup"', async () => {
-    const output = await getOutput(mockWriteInput("docs.md", "## Step 2: Setup"), "write");
-    expect(output?.permissionDecision).toBe("ask");
-    expect(output?.permissionDecisionReason).toContain("Step 2");
-  });
-
-  it('detects "### Phase 3"', async () => {
-    const output = await getOutput(mockWriteInput("guide.markdown", "### Phase 3"), "write");
-    expect(output?.permissionDecision).toBe("ask");
-    expect(output?.permissionDecisionReason).toContain("Phase 3");
-  });
-
-  it("allows descriptive headings", async () => {
-    const output = await getOutput(mockWriteInput("README.md", "# Introduction"), "write");
-    expect(output).toBeNull();
-  });
-
-  it("allows headings with numbers mid-text", async () => {
-    const output = await getOutput(
-      mockWriteInput("README.md", "# Using OAuth2 for Authentication"),
-      "write",
-    );
-    expect(output).toBeNull();
+  test.each<[string, string, string, "ask" | null, string | null]>([
+    ['detects "# 1. Introduction"', "README.md", "# 1. Introduction", "ask", "1. Introduction"],
+    ['detects "## Step 2: Setup"', "docs.md", "## Step 2: Setup", "ask", "Step 2"],
+    ['detects "### Phase 3"', "guide.markdown", "### Phase 3", "ask", "Phase 3"],
+    ["allows descriptive headings", "README.md", "# Introduction", null, null],
+    [
+      "allows headings with numbers mid-text",
+      "README.md",
+      "# Using OAuth2 for Authentication",
+      null,
+      null,
+    ],
+  ])("%s", async (_name, filePath, content, expected, reasonContains) => {
+    const output = await getOutput(mockWriteInput(filePath, content), "write");
+    if (expected === null) {
+      expect(output).toBeNull();
+      return;
+    }
+    expect(output?.permissionDecision).toBe(expected);
+    if (reasonContains) {
+      expect(output?.permissionDecisionReason).toContain(reasonContains);
+    }
   });
 });
 

--- a/plugins/writing/linguistics/power.test.ts
+++ b/plugins/writing/linguistics/power.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import fc from "fast-check";
 import { powerFromCurrentSample, requiredPositiveCount } from "./power";
 
 describe("requiredPositiveCount", () => {
@@ -35,6 +36,29 @@ describe("requiredPositiveCount", () => {
   it("rejects out-of-range inputs", () => {
     expect(() => requiredPositiveCount({ targetLiftPP: 10, precision: -0.1 })).toThrow("precision");
     expect(() => requiredPositiveCount({ targetLiftPP: 0 })).toThrow("targetLiftPP");
+  });
+
+  it("is non-increasing in lift, non-decreasing in z, and maximal at precision 0.5", () => {
+    const lift = fc.double({ min: 0.1, max: 100, noNaN: true });
+    const zScore = fc.double({ min: 0.1, max: 5, noNaN: true });
+    const prec = fc.double({ min: 0, max: 1, noNaN: true });
+    const count = (inputs: Parameters<typeof requiredPositiveCount>[0]) =>
+      requiredPositiveCount(inputs).requiredPositives;
+    fc.assert(
+      fc.property(lift, lift, zScore, zScore, prec, (lA, lB, zA, zB, precision) => {
+        const [loLift, hiLift] = lA <= lB ? [lA, lB] : [lB, lA];
+        const [loZ, hiZ] = zA <= zB ? [zA, zB] : [zB, zA];
+        expect(count({ targetLiftPP: hiLift })).toBeLessThanOrEqual(
+          count({ targetLiftPP: loLift }),
+        );
+        expect(count({ targetLiftPP: loLift, z: hiZ })).toBeGreaterThanOrEqual(
+          count({ targetLiftPP: loLift, z: loZ }),
+        );
+        expect(count({ targetLiftPP: loLift, precision })).toBeLessThanOrEqual(
+          count({ targetLiftPP: loLift, precision: 0.5 }),
+        );
+      }),
+    );
   });
 });
 

--- a/plugins/writing/linguistics/tricolon.test.ts
+++ b/plugins/writing/linguistics/tricolon.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test";
+import fc from "fast-check";
 import type { CoarseTag } from "./tags";
 import { normalizedDistance, tagShape, tricolonHits } from "./tricolon";
+
+const tagShapeArb = fc.array(
+  fc.constantFrom<CoarseTag>("NOUN", "VERB", "ADJ", "ADV", "PRON", "ADP", "CONJ", "AUX"),
+);
 
 const PARALLEL_TRIPLE =
   "The parser validates the incoming request payload quickly. " +
@@ -23,6 +28,18 @@ describe("normalizedDistance", () => {
 
   it("normalizes by the longer sequence", () => {
     expect(normalizedDistance(["NOUN", "VERB"], ["NOUN", "VERB", "ADV", "ADV"])).toBe(0.5);
+  });
+
+  it("is bounded in [0,1], symmetric, and zero on the diagonal", () => {
+    fc.assert(
+      fc.property(tagShapeArb, tagShapeArb, (a, b) => {
+        const d = normalizedDistance(a, b);
+        expect(d).toBeGreaterThanOrEqual(0);
+        expect(d).toBeLessThanOrEqual(1);
+        expect(normalizedDistance(b, a)).toBe(d);
+        expect(normalizedDistance(a, a)).toBe(0);
+      }),
+    );
   });
 });
 

--- a/plugins/writing/skills/analyze/scripts/analyze.test.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.test.ts
@@ -99,34 +99,48 @@ describe("runAnalysis", () => {
   test("assembles a well-formed ReportInput over the fixture DB", async () => {
     const result = await runAnalysis(db, baseConfig(wordlistsDir));
 
-    // Config-derived fields pass through unchanged.
-    expect(result.generatedAt).toBe("2026-05-24");
-    expect(result.since).toBe("2026-05-01");
-    expect(result.until).toBe("2026-05-31");
-    expect(result.modelFilter).toBe("*opus*");
-    expect(result.projectFilter).toBeNull();
-    expect(result.minLift).toBe(5);
-    expect(result.minCount).toBe(5);
-    expect(result.topN).toBe(10);
+    // Config-derived fields, model summary, and rule-health coverage pass
+    // through deterministically.
+    expect({
+      generatedAt: result.generatedAt,
+      since: result.since,
+      until: result.until,
+      modelFilter: result.modelFilter,
+      projectFilter: result.projectFilter,
+      minLift: result.minLift,
+      minCount: result.minCount,
+      topN: result.topN,
+      modelSummaryLength: result.modelSummary.length,
+      model: result.modelSummary[0]?.model,
+      voiceProfile: result.voiceProfile,
+      ruleHealthLength: result.ruleHealth.length,
+      surfaces: [...new Set(result.ruleHealth.map((r) => r.surface))].sort(),
+    }).toMatchInlineSnapshot(`
+      {
+        "generatedAt": "2026-05-24",
+        "minCount": 5,
+        "minLift": 5,
+        "model": "claude-opus-4",
+        "modelFilter": "*opus*",
+        "modelSummaryLength": 1,
+        "projectFilter": null,
+        "ruleHealthLength": 3,
+        "since": "2026-05-01",
+        "surfaces": [
+          "chat",
+          "deliverable",
+        ],
+        "topN": 10,
+        "until": "2026-05-31",
+        "voiceProfile": null,
+      }
+    `);
 
     // Corpus character totals come from the seeded rows, routed by role and
     // deliverable extraction.
     expect(result.assistantTotalChars).toBeGreaterThan(0);
     expect(result.deliverableTotalChars).toBeGreaterThan(0);
     expect(result.userTotalChars).toBeGreaterThan(0);
-
-    // One assistant model in window.
-    expect(result.modelSummary).toHaveLength(1);
-    expect(result.modelSummary[0]?.model).toBe("claude-opus-4");
-
-    // No profile on disk: voice baseline is absent.
-    expect(result.voiceProfile).toBeNull();
-
-    // Rule health covers every fixture wordlist entry (one per surface kind).
-    expect(result.ruleHealth).toHaveLength(3);
-    const surfaces = new Set(result.ruleHealth.map((r) => r.surface));
-    expect(surfaces.has("chat")).toBe(true);
-    expect(surfaces.has("deliverable")).toBe(true);
 
     // The corrective-feedback query matched the frustration lexicon on the
     // seeded user reply.

--- a/plugins/writing/skills/analyze/scripts/judge.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.test.ts
@@ -259,16 +259,32 @@ describe("judgeCorpus", () => {
       model: "claude-haiku-4-5",
       estimatedCostUsd: 0.01,
     });
-    expect(audit.documents).toBe(3);
-    expect(audit.promptSha256).toBe("abc123");
-    const density = audit.criteria[0];
-    expect(density?.id).toBe("information-density");
-    expect(density?.flagged).toBe(2);
-    expect(density?.total).toBe(3);
-    expect(density?.spans).toEqual(["All tests pass.", "Updated three files."]);
     const sycophancy = audit.criteria.find((c) => c.id === "sycophancy");
-    expect(sycophancy?.flagged).toBe(1);
-    expect(sycophancy?.spans).toEqual([]);
+    expect({
+      documents: audit.documents,
+      promptSha256: audit.promptSha256,
+      density: audit.criteria[0],
+      sycophancy: sycophancy && { flagged: sycophancy.flagged, spans: sycophancy.spans },
+    }).toMatchInlineSnapshot(`
+      {
+        "density": {
+          "flagged": 2,
+          "id": "information-density",
+          "question": "Given that the reviewer has the diff, does this text tell them anything they could not see for themselves?",
+          "spans": [
+            "All tests pass.",
+            "Updated three files.",
+          ],
+          "total": 3,
+        },
+        "documents": 3,
+        "promptSha256": "abc123",
+        "sycophancy": {
+          "flagged": 1,
+          "spans": [],
+        },
+      }
+    `);
   });
 
   test("caps sampled spans", async () => {

--- a/plugins/writing/skills/analyze/scripts/ngram.test.ts
+++ b/plugins/writing/skills/analyze/scripts/ngram.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
 import {
   addNgrams,
   cleanText,
@@ -191,6 +192,19 @@ describe("processRows", () => {
     const fromCorpus = processCorpus(text, [2, 3]);
     expect(fromRows.tokens).toBe(fromCorpus.tokens);
     expect(fromRows.ngrams.get(2)?.get("let me")).toBe(fromCorpus.ngrams.get(2)?.get("let me"));
+  });
+
+  test("single-session stats agree with processCorpus for any text and sizes", () => {
+    fc.assert(
+      fc.property(
+        fc.string(),
+        fc.uniqueArray(fc.integer({ min: 1, max: 5 }), { minLength: 1 }),
+        (text, sizes) => {
+          const fromRows = processRows([{ session_id: "s1", text }], sizes).stats;
+          expect(fromRows).toEqual(processCorpus(text, sizes));
+        },
+      ),
+    );
   });
 });
 

--- a/plugins/writing/skills/analyze/scripts/voice-corpus.test.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-corpus.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import { mergeDocuments, parseCorpus, serializeCorpus } from "./voice-corpus";
+import fc from "fast-check";
+import { mergeDocuments, parseCorpus, serializeCorpus, type VoiceDocument } from "./voice-corpus";
+
+// A document that survives serialize/parse: the source is a single non-empty
+// token (the delimiter captures \S+), meta carries no ")" or newline (it sits
+// inside the (...) group on the single-line delimiter), and body lines never
+// open with "=" so none masquerade as a delimiter after trimming.
+const voiceDocument = fc.record<VoiceDocument>({
+  source: fc.string({ minLength: 1 }).map((s) => s.replace(/\s/g, "") || "x"),
+  meta: fc.string().map((s) => s.replace(/[)\r\n]/g, "")),
+  body: fc
+    .array(fc.string().map((s) => s.replace(/[\r\n]/g, " ").replace(/^[\s=]+/, "")))
+    .map((lines) => lines.join("\n").trim()),
+});
 
 const sample = `===== https://github.com/o/r/pull/1 (2020-01-01T00:00:00Z, +10/-2) =====
 First PR body.
@@ -31,6 +44,17 @@ describe("serializeCorpus", () => {
     const reparsed = parseCorpus(serializeCorpus(docs));
     expect(reparsed.map((d) => d.source)).toEqual(docs.map((d) => d.source));
     expect(reparsed.map((d) => d.body)).toEqual(docs.map((d) => d.body));
+  });
+
+  test("round-trip preserves source and body for any documents", () => {
+    fc.assert(
+      fc.property(fc.array(voiceDocument), (docs) => {
+        const reparsed = parseCorpus(serializeCorpus(docs));
+        const project = (list: VoiceDocument[]) =>
+          list.map((d) => ({ source: d.source, body: d.body }));
+        expect(project(reparsed)).toEqual(project(docs));
+      }),
+    );
   });
 });
 

--- a/plugins/writing/skills/score/scripts/__snapshots__/score.test.ts.snap
+++ b/plugins/writing/skills/score/scripts/__snapshots__/score.test.ts.snap
@@ -1,19 +1,5 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`renderTable header with word count and category rows 1`] = `
-"prose (2 words)
-╔════════════════╤══════╤═════════════╗
-║ Category       │ Hits │ Density /1k ║
-╟────────────────┼──────┼─────────────╢
-║ spaced em dash │ 1    │ 500.0       ║
-╚════════════════╧══════╧═════════════╝"
-`;
-
-exports[`renderTable no patterns for clean prose 1`] = `
-"prose (4 words)
-No patterns detected."
-`;
-
 exports[`renderVoiceDeltaTable rate, baseline, and delta columns for in-register text 1`] = `
 "Voice Delta Features
 ╔═════════════════════════════════════════════════╤══════════════════╤═══════╤═══════════╤════════╗

--- a/plugins/writing/skills/score/scripts/score.test.ts
+++ b/plugins/writing/skills/score/scripts/score.test.ts
@@ -91,13 +91,24 @@ describe("buildReport", () => {
 });
 
 describe("renderTable", () => {
-  const cases: Array<{ name: string; text: string }> = [
-    { name: "header with word count and category rows", text: "a — b" },
-    { name: "no patterns for clean prose", text: "The function reads input." },
-  ];
+  it("header with word count and category rows", () => {
+    expect(renderTable(buildReport("a — b", "doc.md", { comments: false }))).toMatchInlineSnapshot(`
+      "prose (2 words)
+      ╔════════════════╤══════╤═════════════╗
+      ║ Category       │ Hits │ Density /1k ║
+      ╟────────────────┼──────┼─────────────╢
+      ║ spaced em dash │ 1    │ 500.0       ║
+      ╚════════════════╧══════╧═════════════╝"
+    `);
+  });
 
-  it.each(cases)("$name", ({ text }) => {
-    expect(renderTable(buildReport(text, "doc.md", { comments: false }))).toMatchSnapshot();
+  it("no patterns for clean prose", () => {
+    expect(
+      renderTable(buildReport("The function reads input.", "doc.md", { comments: false })),
+    ).toMatchInlineSnapshot(`
+      "prose (4 words)
+      No patterns detected."
+    `);
   });
 });
 


### PR DESCRIPTION
Applies the testing rule's technique-selection guide across the writing plugin's suites.

`numbering.test.ts` was the big one: its language-by-pattern matrix of `checkCode` and `processInput` cases collapses into `test.each` tables keyed on `{content, lang, path, expected}`, shedding 61 lines. `scan.test.ts` and `check-tropes.test.ts` fold sibling cases the same way. The analyze, judge, and score suites move field-by-field and piecemeal assertions to inline snapshots, so each asserts the whole output shape instead of a hand-picked subset; `score`'s external `.snap` shrinks as that content moves inline.

New fast-check properties, each seed-checked against an independent oracle, cover `tropes`, `power`, `tricolon`, `ngram`, and `voice-corpus`. The `stripCode` line-count and idempotence invariants are scoped to the function's real domain (well-formed single-line inline spans and balanced fenced blocks) rather than asserted over arbitrary input, which would not hold.

`grammar.test.ts` was left as-is. Wrapping its eight `finiteVerbWithSubject` one-liners in per-case objects grew the file without adding coverage, so a table there is not worth it.

Test LOC 5864 to 5926. The increase is the property tests plus the inline-snapshot conversions, both of which the rule allows to add lines; the pure table refactors are net-negative.

Coverage spans trope and heading detection, numbering across Go, JS, Python, and TypeScript, the analyze/judge/score pipelines, and the linguistic classifiers over generated arbitraries.
