### PR TITLE
chore(agents): trim example blocks from agent descriptions

### DIFF
--- a/plugins/github/agents/logs.md
+++ b/plugins/github/agents/logs.md
@@ -1,7 +1,7 @@
 ---
 name: logs
 description: >-
-  Given a GitHub Actions run ID and PR URL, fetches failing-job logs, writes full logs to a temp file, and returns a structured summary of failures. Invoked by the `github:actions-monitor` skill on failing-status events. Examples: <example>Context: An actions-monitor status event reports a failing run. user: "Run ID 19876543210 failed on https://github.com/owner/repo/pull/42" assistant: "I'll use the logs agent to fetch the failing-job logs, write them to a temp file, and summarize the failures." <commentary>The logs agent is designed exactly for this: extract failure context from a run ID.</commentary></example>
+  Given a GitHub Actions run ID and PR URL, fetches failing-job logs, writes full logs to a temp file, and returns a structured summary of failures. Invoked by the `github:actions-monitor` skill on failing-status events.
 tools: Bash(gh run view:*), Bash(gh run list:*), Bash(jq:*), Bash(mkdir:*), Write, Read, Grep
 model: haiku
 ---

--- a/plugins/github/agents/rulesets-manager.md
+++ b/plugins/github/agents/rulesets-manager.md
@@ -1,7 +1,7 @@
 ---
 name: rulesets-manager
 description: >-
-  Use this agent when you need to manage GitHub repository rulesets, including creating new rulesets, modifying existing ruleset settings, or adding required status checks. Examples: <example>Context: User wants to add a required status check for a linting job. user: "Make the lint job a required status check" assistant: "I'll use the github-rulesets-manager agent to add the lint job as a required status check to your repository's ruleset." <commentary>The user wants to modify GitHub rulesets to require a status check, so use the github-rulesets-manager agent.</commentary></example> <example>Context: User wants to create branch protection rules. user: "Set up branch protection for main branch with required reviews" assistant: "I'll use the github-rulesets-manager agent to create or update a ruleset with required review settings for the main branch." <commentary>The user needs to configure branch protection via rulesets, so use the github-rulesets-manager agent.</commentary></example>
+  Manages GitHub repository rulesets. Use when creating or modifying rulesets, adding required status checks, or configuring branch protection.
 tools: Task, Bash(gh:*), Glob, Grep, LS, Read, TodoWrite, mcp__github
 model: sonnet
 color: green

--- a/plugins/type-ignore/agents/fixer.md
+++ b/plugins/type-ignore/agents/fixer.md
@@ -1,24 +1,7 @@
 ---
 name: fixer
-description: |
+description: >-
   Fixes type errors in a single file instead of ignoring them. Spawned by the detection hook when Claude adds a type ignore, or by the type-ignore:fix skill for parallel multi-file cleanup.
-
-  Examples:
-  - <example>
-    Context: Hook detected a new @ts-ignore added by Claude.
-    assistant: "I'll spawn the type-ignore:fixer agent to fix this type error instead of ignoring it."
-    <commentary>
-    The detection hook triggers this agent automatically when Claude adds a type ignore.
-    </commentary>
-    </example>
-  - <example>
-    Context: User wants to clean up type ignores in a file.
-    user: "Can you fix the type ignores in src/api/client.ts?"
-    assistant: "I'll spawn the type-ignore:fixer agent to fix the type ignores in that file."
-    <commentary>
-    Direct invocation for a single file.
-    </commentary>
-    </example>
 ---
 
 You are a type error resolution specialist. Your job is to fix the underlying type errors that led to ignore comments, not to simply remove or relocate the ignores.


### PR DESCRIPTION
Trims the `<example>`/`<commentary>` blocks out of three agent descriptions. Agent descriptions are injected into every session's always-on context, so example dialogs there are a recurring token tax.

## Evidence

Three agents carried full `<example>` blocks in their descriptions:

- `plugins/github/agents/rulesets-manager.md`: ~996 chars / ~249 tokens
- `plugins/type-ignore/agents/fixer.md`: ~781 chars / ~195 tokens
- `plugins/github/agents/logs.md`: ~618 chars / ~155 tokens

`fixer` is spawned programmatically by the type-ignore detection hook (`plugins/type-ignore/hooks/detect.ts`) and `logs` by the `github:actions-monitor` skill, so model-facing trigger examples are pure waste for them. `rulesets-manager` keeps a description that still names its triggers (rulesets, required status checks, branch protection) without the example dialogs. Estimated savings ~400-500 always-on tokens.

Discovery: 707f17631419
Discovery: a75e68d81ad0
Discovery: ad5d6393c4ce
