### PR TITLE
fix(linear): replace fictional SDK examples with real tool inputs

### DIFF
--- a/plugins/linear/skills/linear/SKILL.md
+++ b/plugins/linear/skills/linear/SKILL.md
@@ -23,11 +23,11 @@ The connector and MCP paths need no CLI. The CLI-only operations (relations, bul
 
 `$0` (optional verb) routes to an operation; pass the rest (issue id, title, filters) as its params. With no verb, infer the operation from the request.
 
-- `create`: create an issue. See [Creating vs Updating](#creating-vs-updating) and [Issue Status](#issue-status).
+- `create`: create an issue. See [Creating vs Updating](#creating-vs-updating) and Issue Status in [references/conventions.md](references/conventions.md).
 - `update`: update an issue by id. See [Creating vs Updating](#creating-vs-updating).
-- `list`: query issues. See [Querying Issues](#querying-issues).
+- `list`: query issues. See Querying Issues in [references/conventions.md](references/conventions.md).
 - `view`: fetch a single issue; include its `url` for anything you may reference.
-- `comment`: comment on an issue, using full URLs per [Issue References](#issue-references).
+- `comment`: comment on an issue, using full URLs per Issue References in [references/conventions.md](references/conventions.md).
 
 Pick a tool path per [Tool Selection](#tool-selection).
 
@@ -70,110 +70,15 @@ Update (`id` present, change only what you need):
 }
 ```
 
-The local and plugin MCP variants split these into `create_issue` and `update_issue`, shown in the examples below. The create precondition (`title` required) applies to both paths.
+The local and plugin MCP variants split these into `create_issue` and `update_issue` with the same flat field shapes. The create precondition (`title` required) applies to both paths.
 
 ## Saving a Structured Issue File
 
-Several skills hand off a Markdown file with YAML frontmatter for issue metadata and a body below the closing `---`. Issue refinement emits one, project planning emits a similar file, and others will follow. This section maps that shape to a Linear issue. The schema varies by producer, so read the file's frontmatter to see which keys it actually carries, extract them with whatever fits that file, and write the body to its own file so it passes by path and stays out of context.
-
-Map the metadata keys these files tend to carry onto the `linear` CLI:
-
-| Frontmatter | Linear |
-|-------------|--------|
-| `title` | `--title` |
-| body (below the closing `---`) | `--description-file <path>` |
-| `labels` | one `--label` per entry |
-| `priority` (`urgent`, `high`, `medium`, `low`) | `--priority` `1`..`4` |
-| `relations` (`blocks`, `blocked-by`, `related`, `duplicate-of`) | `linear issue relation add <id> <type> <relatedId>` |
-
-A relation's `type` is the frontmatter key, except `duplicate-of` maps to `duplicate`. Its `relatedId` is the issue identifier in the relation's tracker URL. For keys the file omits, or ones this table does not name, map them when Linear has a matching field and ask when the mapping is unclear.
-
-Routing fields (team, assignee, state) are not in the file. Take them from the user at save time. Default the state from assignment as in [Issue Status](#issue-status). `getDefaultState` in `hooks/save-issue.ts` encodes that rule.
-
-### Simple Saves
-
-When the file declares no relations, the connector `save_issue` is enough: pass the title, the body as `description`, the labels, and the routing fields, per [Creating vs Updating](#creating-vs-updating). This is the default.
-
-### Relations
-
-The connector and MCP tools cannot set relations, so a file that declares any needs the `linear` CLI. When the Environment block shows it is not installed, save through the connector and report the relation targets you skipped so the user can add them by hand.
-
-With the CLI present, create the issue with the body by file, then add one relation per entry from the parsed frontmatter:
-
-```bash
-new_id=$(linear issue create --title "$title" --description-file "$body_file" \
-  --team "$team" --state "$state" | grep -oE '[A-Z][A-Z0-9]*-[0-9]+' | head -1)
-linear issue relation add "$new_id" blocked-by ENG-100
-```
-
-Add `--label`, `--assignee`, and `--priority` when the file carries them. The `linear-cli:linear-cli` skill documents the full CLI surface.
+Skills that emit a Markdown file with YAML frontmatter (issue refinement, project planning) hand off here. [references/structured-file.md](references/structured-file.md) maps that frontmatter onto Linear fields, covers routing fields taken from the user at save time, and shows the `linear` CLI commands required when the file declares relations.
 
 ## Conventions
 
-### Issue References
-
-When writing text that references other issues (descriptions, comments, updates), never use bare identifiers like `ENG-123`. Linear auto-renders issue URLs as inline previews, so use the full URL:
-
-- **Bare URL**: `https://linear.app/workspace/issue/ENG-123` (renders as an inline preview)
-- **Hyperlinked text**: `[the auth bug](https://linear.app/workspace/issue/ENG-123)` (when linking specific words is more natural)
-
-Both MCP tools and GraphQL queries return a `url` field on issues. Always include `url` when querying issues you may reference in writing.
-
-### Issue Status
-
-When creating issues, set status based on assignment:
-
-- **Assigned to me** (`assignee: "me"`): Set `state: "Todo"`
-- **Unassigned**: Set `state: "Backlog"`
-
-Example:
-```typescript
-// Issue for myself
-await linear.create_issue({
-  team: "ENG",
-  title: "Fix authentication bug",
-  assignee: "me",
-  state: "Todo"
-})
-
-// Unassigned issue
-await linear.create_issue({
-  team: "ENG",
-  title: "Research API performance",
-  state: "Backlog"
-})
-```
-
-### Querying Issues
-
-Use `assignee: "me"` to filter issues assigned to the authenticated user:
-
-```typescript
-// My issues
-await linear.list_issues({ assignee: "me" })
-
-// Team backlog
-await linear.list_issues({ team: "ENG", state: "Backlog" })
-```
-
-### Labels
-
-Use label names directly in `create_issue` and `update_issue` — no need to look up IDs:
-
-```typescript
-await linear.create_issue({
-  team: "ENG",
-  title: "Update documentation",
-  labels: ["documentation", "high-priority"]
-})
-```
-
-**Label Lookup**: Labels can exist at the workspace or team level. Check both:
-
-1. Workspace labels: `list_issue_labels()` (no team filter)
-2. Team labels: `list_issue_labels({ team: "TEAM" })`
-
-If a label isn't found at the workspace level, check the team before concluding it doesn't exist.
+[references/conventions.md](references/conventions.md) holds the house rules: reference issues by full URL (never bare `ENG-123`), default state from assignment (assigned to me is `Todo`, unassigned is `Backlog`), query with `assignee: "me"`, and pass label names directly (checking workspace then team when looking one up). Apply it whenever you create, update, comment, or query.
 
 ## GraphQL API
 

--- a/plugins/linear/skills/linear/references/conventions.md
+++ b/plugins/linear/skills/linear/references/conventions.md
@@ -1,0 +1,75 @@
+# Conventions
+
+House rules for writing to and querying Linear. Tool inputs below are JSON arguments for the connector and MCP tools named in [Tool Selection](../SKILL.md#tool-selection).
+
+## Issue References
+
+When writing text that references other issues (descriptions, comments, updates), never use bare identifiers like `ENG-123`. Linear auto-renders issue URLs as inline previews, so use the full URL:
+
+- **Bare URL**: `https://linear.app/workspace/issue/ENG-123` (renders as an inline preview)
+- **Hyperlinked text**: `[the auth bug](https://linear.app/workspace/issue/ENG-123)` (when linking specific words is more natural)
+
+Both MCP tools and GraphQL queries return a `url` field on issues. Always include `url` when querying issues you may reference in writing.
+
+## Issue Status
+
+When creating issues, set status based on assignment:
+
+- **Assigned to me** (`assignee: "me"`): Set `state: "Todo"`
+- **Unassigned**: Set `state: "Backlog"`
+
+Input for the connector `save_issue` or MCP `create_issue`:
+
+```json
+{
+  "team": "ENG",
+  "title": "Fix authentication bug",
+  "assignee": "me",
+  "state": "Todo"
+}
+```
+
+Unassigned:
+
+```json
+{
+  "team": "ENG",
+  "title": "Research API performance",
+  "state": "Backlog"
+}
+```
+
+## Querying Issues
+
+Use `assignee: "me"` to filter issues assigned to the authenticated user. Input for the MCP `list_issues` tool:
+
+```json
+{ "assignee": "me" }
+```
+
+Team backlog:
+
+```json
+{ "team": "ENG", "state": "Backlog" }
+```
+
+When no MCP list tool is available, fall back to GraphQL per [GraphQL API](../SKILL.md#graphql-api).
+
+## Labels
+
+Use label names directly when creating or updating; no need to look up IDs:
+
+```json
+{
+  "team": "ENG",
+  "title": "Update documentation",
+  "labels": ["documentation", "high-priority"]
+}
+```
+
+Labels can exist at the workspace or team level. Check both with the MCP `list_issue_labels` tool:
+
+1. Workspace labels: no `team` filter (empty input `{}`)
+2. Team labels: `{ "team": "TEAM" }`
+
+If a label isn't found at the workspace level, check the team before concluding it doesn't exist.

--- a/plugins/linear/skills/linear/references/structured-file.md
+++ b/plugins/linear/skills/linear/references/structured-file.md
@@ -1,0 +1,35 @@
+# Saving a Structured Issue File
+
+Several skills hand off a Markdown file with YAML frontmatter for issue metadata and a body below the closing `---`. Issue refinement emits one, project planning emits a similar file, and others will follow. This document maps that shape to a Linear issue. The schema varies by producer, so read the file's frontmatter to see which keys it actually carries, extract them with whatever fits that file, and write the body to its own file so it passes by path and stays out of context.
+
+Map the metadata keys these files tend to carry onto the `linear` CLI:
+
+| Frontmatter | Linear |
+|-------------|--------|
+| `title` | `--title` |
+| body (below the closing `---`) | `--description-file <path>` |
+| `labels` | one `--label` per entry |
+| `priority` (`urgent`, `high`, `medium`, `low`) | `--priority` `1`..`4` |
+| `relations` (`blocks`, `blocked-by`, `related`, `duplicate-of`) | `linear issue relation add <id> <type> <relatedId>` |
+
+A relation's `type` is the frontmatter key, except `duplicate-of` maps to `duplicate`. Its `relatedId` is the issue identifier in the relation's tracker URL. For keys the file omits, or ones this table does not name, map them when Linear has a matching field and ask when the mapping is unclear.
+
+Routing fields (team, assignee, state) are not in the file. Take them from the user at save time. Default the state from assignment as in [Issue Status](conventions.md#issue-status). `getDefaultState` in `hooks/save-issue.ts` encodes that rule.
+
+## Simple Saves
+
+When the file declares no relations, the connector `save_issue` is enough: pass the title, the body as `description`, the labels, and the routing fields, per [Creating vs Updating](../SKILL.md#creating-vs-updating). This is the default.
+
+## Relations
+
+The connector and MCP tools cannot set relations, so a file that declares any needs the `linear` CLI. When the Environment block shows it is not installed, save through the connector and report the relation targets you skipped so the user can add them by hand.
+
+With the CLI present, create the issue with the body by file, then add one relation per entry from the parsed frontmatter:
+
+```bash
+new_id=$(linear issue create --title "$title" --description-file "$body_file" \
+  --team "$team" --state "$state" | grep -oE '[A-Z][A-Z0-9]*-[0-9]+' | head -1)
+linear issue relation add "$new_id" blocked-by ENG-100
+```
+
+Add `--label`, `--assignee`, and `--priority` when the file carries them. The `linear-cli:linear-cli` skill documents the full CLI surface.


### PR DESCRIPTION
The linear skill's Conventions section taught a fictional TypeScript SDK. This replaces those examples with the real invocation surfaces and moves the inlined reference material into `references/`.

## Changes

- Rewrite the Issue Status, Querying Issues, and Labels examples as JSON tool inputs for the connector `save_issue` and MCP `create_issue`/`list_issues`/`list_issue_labels` tools, matching the surfaces the skill's Tool Selection section documents. No SDK-style usage remains.
- Move the structured-issue-file workflow to `references/structured-file.md` and the conventions to `references/conventions.md`, leaving pointers at the point of use (following the `review:peer` structure).
- SKILL.md body drops from 212 to 108 lines.

## Evidence

`plugins/linear/skills/linear/SKILL.md` (~212 lines, near-zero reference files) contained TypeScript examples around lines 130-169 (`await linear.create_issue({...})`, `await linear.list_issues({...})`) describing a fictional SDK matching none of the real tool paths the skill enumerates (claude.ai connector `save_issue`/`get_issue` MCP tools, and the `linear` CLI). A model reading it could attempt calls that don't exist. The body also inlined pure reference material (Saving a Structured Issue File, Conventions) that progressive disclosure says belongs in `references/`.

`skill-lint` validates the reference links resolve and stay within depth 1.

Discovery: a190eb8c1fef
