### PR TITLE
feat(improve-claude-code): scheduled discover mode with launchd agent

### DIFF
--- a/user/launchd/README.md
+++ b/user/launchd/README.md
@@ -1,0 +1,39 @@
+# `launchd`
+
+Launch agents for scheduled Claude Code runs. These are per-machine: install only on the always-on Mac Studio.
+
+## `me.bendrucker.claude.discover.plist`
+
+Runs `claude -p "/improve-claude-code discover --scheduled" --permission-mode acceptEdits` every Monday at 07:23 in the config repo. The scheduled Discover mode mines session history, writes the weekly digest, and auto-files high-confidence grounded candidates as `claude-code` Things todos. See the Scheduled section of `user/skills/improve-claude-code/SKILL.md`.
+
+It runs through `/bin/zsh -lc` so the login shell resolves `claude` from PATH (Homebrew install location changes across versions).
+
+## Install
+
+Copy the plist into `~/Library/LaunchAgents`, including in dotfiles setup. Symlinks break persistence: launchd on macOS 14+ ignores symlinked plists at login, so a symlinked agent loads once via `launchctl` and then never reloads after a reboot.
+
+```sh
+cp ~/.claude/launchd/me.bendrucker.claude.discover.plist ~/Library/LaunchAgents/
+launchctl bootstrap gui/$UID ~/Library/LaunchAgents/me.bendrucker.claude.discover.plist
+```
+
+After editing the source plist, re-copy and reload:
+
+```sh
+launchctl bootout gui/$UID/me.bendrucker.claude.discover
+cp ~/.claude/launchd/me.bendrucker.claude.discover.plist ~/Library/LaunchAgents/
+launchctl bootstrap gui/$UID ~/Library/LaunchAgents/me.bendrucker.claude.discover.plist
+```
+
+## Verify
+
+```sh
+launchctl list | grep bendrucker
+tail -f ~/Library/Logs/claude-discover.log ~/Library/Logs/claude-discover.err.log
+```
+
+Trigger a run immediately without waiting for Monday:
+
+```sh
+launchctl kickstart gui/$UID/me.bendrucker.claude.discover
+```

--- a/user/launchd/me.bendrucker.claude.discover.plist
+++ b/user/launchd/me.bendrucker.claude.discover.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>me.bendrucker.claude.discover</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/zsh</string>
+		<string>-lc</string>
+		<string>claude -p "/improve-claude-code discover --scheduled" --permission-mode acceptEdits</string>
+	</array>
+	<key>WorkingDirectory</key>
+	<string>/Users/ben/src/bendrucker/claude</string>
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Weekday</key>
+		<integer>1</integer>
+		<key>Hour</key>
+		<integer>7</integer>
+		<key>Minute</key>
+		<integer>23</integer>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>/Users/ben/Library/Logs/claude-discover.log</string>
+	<key>StandardErrorPath</key>
+	<string>/Users/ben/Library/Logs/claude-discover.err.log</string>
+	<key>ProcessType</key>
+	<string>Background</string>
+</dict>
+</plist>

--- a/user/skills/improve-claude-code/SKILL.md
+++ b/user/skills/improve-claude-code/SKILL.md
@@ -28,7 +28,7 @@ All Things interaction goes through the `things:jxa` and `things:url` skills (ne
 
 ## Discover
 
-Mine session history for improvement candidates, ground them against the live config, write a digest, and file the keepers. Discover never auto-files: filing is an explicit user choice. Implementing is a separate run of the loop below, unless the user opts into [Direct Implementation](#direct-implementation) for the run. The engine is the `claude-code:session` skill's fan-out, whose `references/discovery.md` carries the recipe (dimension cheat sheet, grounding mandate, host safety, Tier-2 catalog). Load that skill to read it.
+Mine session history for improvement candidates, ground them against the live config, write a digest, and file the keepers. Interactive Discover never auto-files: filing is an explicit user choice. The one exception is [Scheduled](#scheduled), the unattended variant, which auto-files high-confidence grounded candidates. Implementing is a separate run of the loop below, unless the user opts into [Direct Implementation](#direct-implementation) for the run. The engine is the `claude-code:session` skill's fan-out, whose `references/discovery.md` carries the recipe (dimension cheat sheet, grounding mandate, host safety, Tier-2 catalog). Load that skill to read it.
 
 #### Refresh
 
@@ -54,7 +54,7 @@ Suppress `already-filed` and `already-shipped` from the actionable set; still co
 
 #### Digest
 
-The only guaranteed output. Write `tmp/claude-discovery-digest-<YYYY-Www>.md`, ranked and grouped high to low confidence. Each entry shows the finding, its grounding note, the SQL that produced it, and its dedup status. Default `host=local` for config-change candidates; cite imported hosts as corroborating counts only, never pasting raw `content`/`command`/`stdout` from an egress-blocked host (see host safety in `references/discovery.md`). **Never auto-file from this step.**
+The only guaranteed output. Write `tmp/claude-discovery-digest-<YYYY-Www>.md`, ranked and grouped high to low confidence. Each entry shows the finding, its grounding note, the SQL that produced it, and its dedup status. Default `host=local` for config-change candidates; cite imported hosts as corroborating counts only, never pasting raw `content`/`command`/`stdout` from an egress-blocked host (see host safety in `references/discovery.md`). **Never auto-file from this step in an interactive run.** Only the [Scheduled](#scheduled) path files without asking, and it files after the digest lands.
 
 #### File the Keepers
 
@@ -75,9 +75,15 @@ Implement-as-you-go is an opt-in alternative to filing, chosen explicitly by the
 
 These PRs have no backing Things todo, so skip the `Original Task` link. Instead the body carries an Evidence section (local-host evidence only, never content from an egress-blocked host) plus one `Discovery: <fingerprint>` line per finding. Dedup today scans only Things notes, so these markers stay invisible until that scan is extended to PR bodies. Until then, a finding implemented this way can resurface as `new` on the next run.
 
+#### Scheduled
+
+Invoked as `discover --scheduled`, this is the unattended weekly variant. It runs the same refresh, fan-out, grounding, dedup, and digest pipeline as an interactive run. After the digest is written, it auto-files every candidate that is `new`, `grounded`, and `confidence == high` as a `claude-code` Things todo via `things:url`, using the exact title, notes, and `Discovery: <fingerprint>` format from [File the Keepers](#file-the-keepers). Medium and low confidence candidates land in the digest only. Because dismissal is not tracked, they resurface as `new` on the next run, where an interactive pass can file them.
+
+A scheduled run never prompts (no `AskUserQuestion`), never implements ([Direct Implementation](#direct-implementation) is interactive-only), and ends after reporting how many todos it filed. Everything downstream is unchanged: the filed todos wait in the same backlog for a later interactive triage and implement pass.
+
 #### Cadence
 
-On-demand is primary: invoke this skill in Discover mode at your terminal. A weekly run is optional and must run **locally** (a `/loop` or `/schedule` trigger on this machine). The session DB and the `duckdb` CLI live here, so the `agent-ideas` headless-then-teleport bridge does not apply (that works only because RSS is public). A documented option, not built infrastructure.
+On-demand is primary: invoke this skill in Discover mode at your terminal. The weekly run is committed infrastructure: `user/launchd/me.bendrucker.claude.discover.plist` runs `discover --scheduled` Mondays at 07:23 on the always-on Mac Studio (install and log instructions in `user/launchd/README.md`). It must run **locally** because the session DB and the `duckdb` CLI live on that machine, so the `agent-ideas` headless-then-teleport bridge does not apply (that works only because RSS is public).
 
 #### Fingerprint
 


### PR DESCRIPTION
Adds a `--scheduled` variant to `improve-claude-code` Discover mode and a committed launchd agent to run it weekly, giving the discovery loop an actual motor.

## Changes

- `user/skills/improve-claude-code/SKILL.md`: new `Scheduled` section. `discover --scheduled` runs the normal refresh, fan-out, grounding, dedup, and digest pipeline unattended, then auto-files every `new` + `grounded` + high-confidence candidate as a `claude-code` Things todo via `things:url`, using the File the Keepers title/notes/fingerprint format. Medium and low confidence stay digest-only. The run never prompts and never implements. Digest and Cadence sections updated to carve out the scheduled path.
- `user/launchd/me.bendrucker.claude.discover.plist`: launchd agent running `claude -p "/improve-claude-code discover --scheduled" --permission-mode acceptEdits` Mondays at 07:23 in the config repo, via `/bin/zsh -lc` so the login shell resolves `claude`. Logs to `~/Library/Logs/claude-discover.{log,err.log}`.
- `user/launchd/README.md`: install, reload, verify, and log-tailing instructions. Install copies the plist rather than symlinking, since launchd on macOS 14+ ignores symlinked plists at login.

## Evidence

- The discovery loop is fully instrumented but has no motor: Discover mode said "never auto-files," Cadence called the weekly run "a documented option, not built infrastructure," and `disable-model-invocation: true` blocks self-triggering.
- The manual cadence slips in practice: digests exist for 2026-W23, W24, W25, and W27, with W26 missing.
- You asked for the scheduling to be committed and declarative. Cloud routines are out because the session DB and `duckdb` CLI exist only locally, so the artifact is a launchd plist targeting the always-on Mac Studio, distributed through the existing `user/` symlink mechanism.

## Verification

- `plutil -lint user/launchd/*.plist` passes.
- `bun run skill-lint "user/skills/*"` passes.
- `bun run check` exits 0 (remaining warnings are pre-existing).
- `claude --help` confirms `-p/--print` and `--permission-mode`; the unattended invocation itself is unverified until a run on the Mac Studio.

Discovery: d976d87de78e
