### PR TITLE
perf(tmux): guard notification --clear behind an inline shell check

### DIFF
--- a/plugins/tmux/hooks/hooks.json
+++ b/plugins/tmux/hooks/hooks.json
@@ -25,7 +25,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/notification.ts\" --clear"
+            "command": "[ -z \"$TMUX\" ] || { [ -n \"$TMUX_PANE\" ] && [ -z \"$(tmux show-options -gqv \"@claude_notification_${TMUX_PANE#%}\")\" ]; } || bun \"${CLAUDE_PLUGIN_ROOT}/hooks/notification.ts\" --clear"
           }
         ]
       },

--- a/plugins/tmux/hooks/notification-clear.test.ts
+++ b/plugins/tmux/hooks/notification-clear.test.ts
@@ -4,10 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import hooks from "./hooks.json";
 
-const clearCommand = hooks.hooks.PreToolUse.flatMap((matcher) => matcher.hooks)
+const found = hooks.hooks.PreToolUse.flatMap((matcher) => matcher.hooks)
   .map((hook) => hook.command)
   .find((command) => command.includes("--clear"));
-if (!clearCommand) throw new Error("hooks.json is missing the PreToolUse --clear command");
+if (!found) throw new Error("hooks.json is missing the PreToolUse --clear command");
+const clearCommand = found;
 
 describe("PreToolUse --clear guard", () => {
   let binDir: string;

--- a/plugins/tmux/hooks/notification-clear.test.ts
+++ b/plugins/tmux/hooks/notification-clear.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import hooks from "./hooks.json";
+
+const clearCommand = hooks.hooks.PreToolUse.flatMap((matcher) => matcher.hooks)
+  .map((hook) => hook.command)
+  .find((command) => command.includes("--clear"));
+if (!clearCommand) throw new Error("hooks.json is missing the PreToolUse --clear command");
+
+describe("PreToolUse --clear guard", () => {
+  let binDir: string;
+
+  beforeAll(async () => {
+    binDir = mkdtempSync(join(tmpdir(), "tmux-clear-test-"));
+    const stubs: Record<string, string> = {
+      tmux: 'if [ "$1" = "show-options" ]; then printf \'%s\' "$FAKE_MARKER"; fi',
+      bun: "",
+    };
+    for (const [name, body] of Object.entries(stubs)) {
+      const path = join(binDir, name);
+      await Bun.write(path, `#!/bin/sh\necho "${name} $*" >> "$CALL_LOG"\n${body}`);
+      Bun.spawnSync(["chmod", "+x", path]);
+    }
+  });
+
+  afterAll(() => {
+    Bun.spawnSync(["rm", "-rf", binDir]);
+  });
+
+  async function runClear(
+    env: Record<string, string>,
+  ): Promise<{ exitCode: number | null; calls: string[] }> {
+    const log = join(binDir, `calls-${Math.random().toString(36).slice(2)}.log`);
+    const proc = Bun.spawnSync(["sh", "-c", clearCommand], {
+      env: {
+        PATH: `${binDir}:/usr/bin:/bin`,
+        CALL_LOG: log,
+        CLAUDE_PLUGIN_ROOT: "/plugin",
+        ...env,
+      },
+    });
+    const file = Bun.file(log);
+    const calls = (await file.exists()) ? (await file.text()).trim().split("\n") : [];
+    return { exitCode: proc.exitCode, calls };
+  }
+
+  test.each<{ name: string; env: Record<string, string>; calls: string[] }>([
+    {
+      name: "outside tmux: no subprocess at all",
+      env: {},
+      calls: [],
+    },
+    {
+      name: "no marker for this pane: checks tmux, skips bun",
+      env: { TMUX: "/tmp/tmux-1/default,1,0", TMUX_PANE: "%5" },
+      calls: ["tmux show-options -gqv @claude_notification_5"],
+    },
+    {
+      name: "marker set for this pane: runs bun --clear",
+      env: { TMUX: "/tmp/tmux-1/default,1,0", TMUX_PANE: "%5", FAKE_MARKER: "3:Bash" },
+      calls: [
+        "tmux show-options -gqv @claude_notification_5",
+        "bun /plugin/hooks/notification.ts --clear",
+      ],
+    },
+    {
+      name: "TMUX_PANE unset: falls through to bun for pane resolution",
+      env: { TMUX: "/tmp/tmux-1/default,1,0" },
+      calls: ["bun /plugin/hooks/notification.ts --clear"],
+    },
+  ])("$name", async ({ env, calls }) => {
+    const result = await runClear(env);
+    expect(result.exitCode).toBe(0);
+    expect(result.calls).toEqual(calls);
+  });
+});

--- a/plugins/tmux/hooks/notification.ts
+++ b/plugins/tmux/hooks/notification.ts
@@ -109,6 +109,9 @@ async function main(): Promise<void> {
   const pane = process.env.TMUX_PANE ?? tmuxQuery("display-message", "-p", "#{pane_id}");
   if (!pane) return;
 
+  // hooks.json wraps the --clear invocation in an inline shell guard that
+  // skips the bun startup entirely when this pane has no notification marker,
+  // so this arm only runs when there is actually something to clear.
   if (argv.flags.clear) {
     tmux("set-option", "-gu", paneOptionKey(pane));
     updateSummary();


### PR DESCRIPTION
Guards the tmux notification `--clear` hook behind an inline shell check so the universal PreToolUse matcher no longer pays a bun cold start on every tool call.

## Evidence

`plugins/tmux/hooks/notification.ts --clear` fires on the universal blocking PreToolUse matcher (`Bash|Edit|Write|MultiEdit|mcp__.*`). Its only job is clearing a tmux status-bar notification marker, yet it paid a ~50ms bun cold start plus two synchronous `Bun.spawnSync` tmux subprocess calls on every tool call (local-host telemetry). Combined with the writing check-tropes hook, every Bash command paid two bun cold starts before executing.

The marker is only set after a permission prompt, so nearly every invocation had nothing to clear. The hook command now runs an inline shell guard: exit immediately outside tmux, check this pane's `@claude_notification_<N>` option with one `tmux show-options -gqv`, and only launch the bun script when a marker is actually set. When `TMUX_PANE` is unset it falls through to bun, which retains the pane-id query fallback. Skipping is behavior-equivalent: with no marker for the pane, the script unset a nonexistent option and rebuilt an identical summary.

Local timing over 20 runs: ~4.5ms per invocation for the guard vs ~25ms for the bun script with a warm cache (cold starts are worse). The Notification and Stop arms are unchanged, so marker setting and bell behavior are untouched.

Tests drive the actual `hooks.json` command through `sh -c` with stubbed `tmux` and `bun` binaries, asserting exactly which subprocesses run in each case.

Discovery: f1619f97bd23
