### PR TITLE
perf(writing): gate hot-path hooks at the matcher level

### DIFF
--- a/plugins/writing/hooks/check-tropes.test.ts
+++ b/plugins/writing/hooks/check-tropes.test.ts
@@ -61,18 +61,6 @@ function mockBash(command: string): PreToolUseHookInput {
   };
 }
 
-function mockMcp(toolName: string, toolInput: Record<string, unknown>): PreToolUseHookInput {
-  return {
-    hook_event_name: "PreToolUse",
-    session_id: "test",
-    transcript_path: "/tmp/test",
-    cwd: "/tmp",
-    tool_name: toolName,
-    tool_input: toolInput,
-    tool_use_id: "test",
-  };
-}
-
 describe("plan files", () => {
   const planPath = `${process.env.HOME}/.claude/plans/my-plan.md`;
 
@@ -339,55 +327,14 @@ describe("collectText", () => {
       expect(texts).toHaveLength(0);
     });
   });
-
-  describe("MCP tools", () => {
-    it("extracts prose strings, skipping short values", async () => {
-      const texts = await collectText(
-        mockMcp("mcp__linear__save_issue", {
-          title: "Fix the bug in authentication flow",
-          description: "Users are unable to log in when using SSO",
-          team: "ENG",
-        }),
-      );
-      expect(texts).toContain("Fix the bug in authentication flow");
-      expect(texts).toContain("Users are unable to log in when using SSO");
-      expect(texts).not.toContain("ENG");
-    });
-
-    it("skips URLs and identifiers", async () => {
-      const texts = await collectText(
-        mockMcp("mcp__claude_ai_Slack__slack_send_message", {
-          channel_id: "C123ABC456",
-          text: "The deploy finished successfully and all tests pass",
-        }),
-      );
-      expect(texts).toContain("The deploy finished successfully and all tests pass");
-      expect(texts).not.toContain("C123ABC456");
-    });
-
-    it("handles empty input", async () => {
-      const texts = await collectText(mockMcp("mcp__test", {}));
-      expect(texts).toHaveLength(0);
-    });
-  });
 });
 
-describe("Bash/MCP processInput", () => {
-  it("denies MCP tool input with spaced em dash", async () => {
+describe("Bash processInput", () => {
+  it("denies Bash inline arg with spaced em dash", async () => {
     const result = await processInput(
-      mockMcp("mcp__linear__save_issue", {
-        title: "Fix the bug",
-        description: "This feature \u2014 which was added last week \u2014 is broken",
-      }),
-    );
-    expect(result?.hookSpecificOutput).toHaveProperty("permissionDecision", "deny");
-  });
-
-  it("denies a spaced em dash even on a non-prose tool", async () => {
-    const result = await processInput(
-      mockMcp("mcp__db__execute", {
-        statement: "Filter the rows \u2014 the pending ones \u2014 before the update runs",
-      }),
+      mockBash(
+        'gh pr create --body "This feature \u2014 which was added last week \u2014 is broken"',
+      ),
     );
     expect(result?.hookSpecificOutput).toHaveProperty("permissionDecision", "deny");
   });
@@ -409,77 +356,7 @@ describe("Bash/MCP processInput", () => {
     }
   });
 
-  it("flags AI vocabulary on a prose-bearing tool as context", async () => {
-    const result = await processInput(
-      mockMcp("mcp__linear__save_issue", {
-        title: "Login fails",
-        summary: "We delve into the intricacies of the auth flow here",
-      }),
-    );
-    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
-    expect(result?.hookSpecificOutput).not.toHaveProperty("permissionDecision");
-  });
-
-  it("ignores AI vocabulary on a non-prose tool with a non-prose key", async () => {
-    const result = await processInput(
-      mockMcp("mcp__db__execute", {
-        statement: "We delve into the rows and underscore the totals here",
-      }),
-    );
-    expect(result).toBeNull();
-  });
-
-  it("flags AI vocabulary on a non-prose tool with a prose key", async () => {
-    const result = await processInput(
-      mockMcp("mcp__db__execute", {
-        description: "We delve into the rows and underscore the totals here",
-      }),
-    );
-    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
-    expect(result?.hookSpecificOutput).not.toHaveProperty("permissionDecision");
-  });
-
-  it("returns null for clean MCP input", async () => {
-    const result = await processInput(
-      mockMcp("mcp__claude_ai_Slack__slack_send_message", {
-        text: "The deploy finished successfully.",
-      }),
-    );
-    expect(result).toBeNull();
-  });
-
   it("returns null for non-text Bash commands", async () => {
     expect(await processInput(mockBash("git push origin main"))).toBeNull();
-  });
-
-  it("ignores flagged content in nested old_str fields", async () => {
-    const flagged = "We should delve into the codebase to understand it.";
-    const result = await processInput(
-      mockMcp("mcp__example_tool", {
-        command: "update_content",
-        content_updates: [{ old_str: flagged, new_str: "Clean replacement text here." }],
-      }),
-    );
-    expect(result).toBeNull();
-  });
-
-  it("ignores blocklisted query fields but scans remaining prose", async () => {
-    const result = await processInput(
-      mockMcp("mcp__search_tool", {
-        query: "delve into the codebase and find issues",
-        result_description: "A straightforward summary of the findings.",
-      }),
-    );
-    expect(result).toBeNull();
-  });
-
-  it("still flags nested prose in non-blocklisted keys", async () => {
-    const result = await processInput(
-      mockMcp("mcp__some_tool", {
-        payload: { body: "We delve into the system for a while longer" },
-      }),
-    );
-    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
-    expect(result?.hookSpecificOutput).not.toHaveProperty("permissionDecision");
   });
 });

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -8,69 +8,6 @@ import { formatContext, formatDecision, isPlanMode, type SyncHookJSONOutput } fr
 
 const FILE_OP_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
 
-const MIN_PROSE_LENGTH = 20;
-
-const SKIPPED_KEYS = new Set([
-  "old_string",
-  "oldstring",
-  "old_str",
-  "pattern",
-  "match",
-  "search",
-  "search_query",
-  "query",
-]);
-
-function shouldSkipKey(key: string | undefined): boolean {
-  if (!key) return false;
-  const lower = key.toLowerCase();
-  if (SKIPPED_KEYS.has(lower)) return true;
-  return lower.startsWith("old_");
-}
-
-function isProse(value: string): boolean {
-  if (value.length < MIN_PROSE_LENGTH) return false;
-  if (/^https?:\/\//.test(value)) return false;
-  if (/^[A-Za-z0-9_-]+$/.test(value)) return false;
-  return /\s/.test(value);
-}
-
-type ProseEntry = { key: string | undefined; value: string };
-
-function extractProseEntries(value: unknown, key?: string): ProseEntry[] {
-  if (shouldSkipKey(key)) return [];
-  if (typeof value === "string") return isProse(value) ? [{ key, value }] : [];
-  if (Array.isArray(value)) return value.flatMap((item) => extractProseEntries(item, key));
-  if (typeof value === "object" && value !== null) {
-    return Object.entries(value).flatMap(([childKey, childValue]) =>
-      extractProseEntries(childValue, childKey),
-    );
-  }
-  return [];
-}
-
-function extractProse(value: unknown, key?: string): string[] {
-  return extractProseEntries(value, key).map((entry) => entry.value);
-}
-
-const PROSE_TOOL_PATTERN =
-  /\b(?:issue|ticket|story|epic|document|doc|page|wiki|note|comment|message|post|reply|thread|discussion|review|article|memo)\b/;
-
-const PROSE_KEY_PATTERN =
-  /\b(?:description|body|content|text|title|summary|comment|message|note|details)\b/;
-
-function tokenize(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9]+/g, " ");
-}
-
-function isProseTool(toolName: string): boolean {
-  return PROSE_TOOL_PATTERN.test(tokenize(toolName));
-}
-
-function isProseKey(key: string | undefined): boolean {
-  return key !== undefined && PROSE_KEY_PATTERN.test(tokenize(key));
-}
-
 function extractBodyFilePath(command: string): string | null {
   const match = command.match(/--body-file[=\s](\S+)/);
   return match?.[1] ?? null;
@@ -162,18 +99,7 @@ export async function collectText(input: PreToolUseHookInput): Promise<string[]>
     return texts;
   }
 
-  return extractProse(toolInput);
-}
-
-async function collectLexicalText(input: PreToolUseHookInput): Promise<string[]> {
-  const toolName = input.tool_name;
-
-  if (toolName === "Bash") return collectText(input);
-
-  const toolInput = input.tool_input as Record<string, unknown>;
-  const entries = extractProseEntries(toolInput);
-  if (isProseTool(toolName)) return entries.map((entry) => entry.value);
-  return entries.filter((entry) => isProseKey(entry.key)).map((entry) => entry.value);
+  return [];
 }
 
 function isPlanFile(input: PreToolUseHookInput): boolean {
@@ -229,13 +155,11 @@ async function processSideEffect(input: PreToolUseHookInput): Promise<SyncHookJS
   const texts = await collectText(input);
   if (texts.length === 0) return null;
 
-  const structural = firstByTier(scan(texts.join("\n"), undefined, "sideEffect"), "deny");
-  if (structural?.structural) return formatDecision("deny", structural.message);
+  const matches = scan(texts.join("\n"), undefined, "sideEffect");
+  const deny = firstByTier(matches, "deny");
+  if (deny?.structural) return formatDecision("deny", deny.message);
 
-  const lexical = await collectLexicalText(input);
-  if (lexical.length === 0) return null;
-  const matches = scan(lexical.join("\n"), undefined, "sideEffect");
-  const match = firstByTier(matches, "deny") ?? firstByTier(matches, "context");
+  const match = deny ?? firstByTier(matches, "context");
   if (match) return formatContext(match.message);
 
   return null;

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -8,15 +8,20 @@ import { formatContext, formatDecision, isPlanMode, type SyncHookJSONOutput } fr
 
 const FILE_OP_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
 
+// The full set of Bash prose surfaces this hook scans. The hooks.json Bash
+// guard is derived from these; hooks.test.ts enforces the sync.
+export const PROSE_FLAGS = ["--body", "--message", "--description", "--title"] as const;
+export const BODY_FILE_FLAG = "--body-file";
+
+const BODY_FILE_PATTERN = new RegExp(`${BODY_FILE_FLAG}[=\\s](\\S+)`);
+
 function extractBodyFilePath(command: string): string | null {
-  const match = command.match(/--body-file[=\s](\S+)/);
+  const match = command.match(BODY_FILE_PATTERN);
   return match?.[1] ?? null;
 }
 
-const INLINE_ARG_PATTERNS = new Map(
-  ["--body", "--message", "--description", "--title"].map(
-    (flag) => [flag, new RegExp(`${flag}[= ](?:"([^"]+)"|'([^']+)')`)] as const,
-  ),
+const INLINE_ARG_PATTERNS = new Map<string, RegExp>(
+  PROSE_FLAGS.map((flag) => [flag, new RegExp(`${flag}[= ](?:"([^"]+)"|'([^']+)')`)]),
 );
 
 function extractInlineArg(command: string, flag: string): string | null {
@@ -92,7 +97,7 @@ export async function collectText(input: PreToolUseHookInput): Promise<string[]>
     if (bodyFile && (await Bun.file(bodyFile).exists())) {
       texts.push(await Bun.file(bodyFile).text());
     }
-    for (const flag of ["--body", "--message", "--description", "--title"]) {
+    for (const flag of PROSE_FLAGS) {
       const value = extractInlineArg(toolInput.command, flag);
       if (value) texts.push(value);
     }

--- a/plugins/writing/hooks/hooks.json
+++ b/plugins/writing/hooks/hooks.json
@@ -7,7 +7,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts\" write"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts\" write",
+            "if": "Write(**/*.md)|Write(**/*.markdown)|Write(**/*.go)|Write(**/*.js)|Write(**/*.jsx)|Write(**/*.mjs)|Write(**/*.cjs)|Write(**/*.ts)|Write(**/*.tsx)|Write(**/*.mts)|Write(**/*.cts)|Write(**/*.py)"
           },
           {
             "type": "command",
@@ -25,7 +26,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts\" edit"
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts\" edit",
+            "if": "Edit(**/*.md)|Edit(**/*.markdown)|Edit(**/*.go)|Edit(**/*.js)|Edit(**/*.jsx)|Edit(**/*.mjs)|Edit(**/*.cjs)|Edit(**/*.ts)|Edit(**/*.tsx)|Edit(**/*.mts)|Edit(**/*.cts)|Edit(**/*.py)"
           },
           {
             "type": "command",
@@ -48,11 +50,12 @@
         ]
       },
       {
-        "matcher": "Bash|mcp__.*",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\""
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\"",
+            "if": "Bash(gh *)|Bash(glab *)|Bash(linear *)"
           }
         ]
       }

--- a/plugins/writing/hooks/hooks.json
+++ b/plugins/writing/hooks/hooks.json
@@ -7,8 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts\" write",
-            "if": "Write(**/*.md)|Write(**/*.markdown)|Write(**/*.go)|Write(**/*.js)|Write(**/*.jsx)|Write(**/*.mjs)|Write(**/*.cjs)|Write(**/*.ts)|Write(**/*.tsx)|Write(**/*.mts)|Write(**/*.cts)|Write(**/*.py)"
+            "command": "in=$(cat); if printf '%s' \"$in\" | grep -qiE '(step|phase|part).{0,8}[0-9]|[0-9]\\.( |\\\\t)'; then printf '%s' \"$in\" | bun \"${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts\" write; fi"
           },
           {
             "type": "command",
@@ -26,8 +25,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts\" edit",
-            "if": "Edit(**/*.md)|Edit(**/*.markdown)|Edit(**/*.go)|Edit(**/*.js)|Edit(**/*.jsx)|Edit(**/*.mjs)|Edit(**/*.cjs)|Edit(**/*.ts)|Edit(**/*.tsx)|Edit(**/*.mts)|Edit(**/*.cts)|Edit(**/*.py)"
+            "command": "in=$(cat); if printf '%s' \"$in\" | grep -qiE '(step|phase|part).{0,8}[0-9]|[0-9]\\.( |\\\\t)'; then printf '%s' \"$in\" | bun \"${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts\" edit; fi"
           },
           {
             "type": "command",
@@ -54,8 +52,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\"",
-            "if": "Bash(gh *)|Bash(glab *)|Bash(linear *)"
+            "command": "in=$(cat); if printf '%s' \"$in\" | grep -qE -- '--(body|message|description|title)[-= ]'; then printf '%s' \"$in\" | bun \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\"; fi"
           }
         ]
       }

--- a/plugins/writing/hooks/hooks.test.ts
+++ b/plugins/writing/hooks/hooks.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { SG_EXTENSIONS } from "./numbering";
+
+type HookCommand = { type: string; command: string; if?: string };
+type HookEntry = { matcher: string; hooks: HookCommand[] };
+
+const config = (await Bun.file(join(import.meta.dirname, "hooks.json")).json()) as {
+  hooks: { PreToolUse: HookEntry[] };
+};
+
+const preToolUse = config.hooks.PreToolUse;
+
+function scriptName(command: string): string {
+  return command.match(/hooks\/([\w-]+)\.ts/)?.[1] ?? command;
+}
+
+describe("PreToolUse gating", () => {
+  test("matchers and if conditions", () => {
+    const view = preToolUse.map((entry) => ({
+      matcher: entry.matcher,
+      hooks: entry.hooks.map((hook) => ({
+        script: scriptName(hook.command),
+        if: hook.if ?? null,
+      })),
+    }));
+    expect(view).toMatchInlineSnapshot(`
+      [
+        {
+          "hooks": [
+            {
+              "if": "Write(**/*.md)|Write(**/*.markdown)|Write(**/*.go)|Write(**/*.js)|Write(**/*.jsx)|Write(**/*.mjs)|Write(**/*.cjs)|Write(**/*.ts)|Write(**/*.tsx)|Write(**/*.mts)|Write(**/*.cts)|Write(**/*.py)",
+              "script": "numbering",
+            },
+            {
+              "if": "Write(**/*.md)",
+              "script": "headings",
+            },
+            {
+              "if": null,
+              "script": "check-tropes",
+            },
+          ],
+          "matcher": "Write",
+        },
+        {
+          "hooks": [
+            {
+              "if": "Edit(**/*.md)|Edit(**/*.markdown)|Edit(**/*.go)|Edit(**/*.js)|Edit(**/*.jsx)|Edit(**/*.mjs)|Edit(**/*.cjs)|Edit(**/*.ts)|Edit(**/*.tsx)|Edit(**/*.mts)|Edit(**/*.cts)|Edit(**/*.py)",
+              "script": "numbering",
+            },
+            {
+              "if": "Edit(**/*.md)",
+              "script": "headings",
+            },
+            {
+              "if": null,
+              "script": "check-tropes",
+            },
+          ],
+          "matcher": "Edit",
+        },
+        {
+          "hooks": [
+            {
+              "if": null,
+              "script": "check-tropes",
+            },
+          ],
+          "matcher": "MultiEdit",
+        },
+        {
+          "hooks": [
+            {
+              "if": "Bash(gh *)|Bash(glab *)|Bash(linear *)",
+              "script": "check-tropes",
+            },
+          ],
+          "matcher": "Bash",
+        },
+      ]
+    `);
+  });
+
+  test("numbering matcher gates cover exactly the extensions numbering.ts scans", () => {
+    const gates = preToolUse
+      .flatMap((entry) => entry.hooks)
+      .filter((hook) => hook.command.includes("numbering.ts"));
+    expect(gates).toHaveLength(2);
+    for (const hook of gates) {
+      const extensions = [...(hook.if ?? "").matchAll(/\*\*\/\*\.(\w+)\)/g)].map(
+        (match) => match[1],
+      );
+      expect(new Set(extensions)).toEqual(new Set(["md", "markdown", ...SG_EXTENSIONS]));
+    }
+  });
+});

--- a/plugins/writing/hooks/hooks.test.ts
+++ b/plugins/writing/hooks/hooks.test.ts
@@ -23,78 +23,35 @@ function findCommand(matcher: string, script: string): string {
 
 describe("PreToolUse gating", () => {
   test("matchers, guards, and if conditions", () => {
-    const view = preToolUse.map((entry) => ({
-      matcher: entry.matcher,
-      hooks: entry.hooks.map((hook) => ({
-        script: scriptName(hook.command),
-        guarded: hook.command.startsWith("in=$(cat);"),
-        if: hook.if ?? null,
-      })),
-    }));
-    expect(view).toMatchInlineSnapshot(`
-      [
-        {
-          "hooks": [
-            {
-              "guarded": true,
-              "if": null,
-              "script": "numbering",
-            },
-            {
-              "guarded": false,
-              "if": "Write(**/*.md)",
-              "script": "headings",
-            },
-            {
-              "guarded": false,
-              "if": null,
-              "script": "check-tropes",
-            },
-          ],
-          "matcher": "Write",
-        },
-        {
-          "hooks": [
-            {
-              "guarded": true,
-              "if": null,
-              "script": "numbering",
-            },
-            {
-              "guarded": false,
-              "if": "Edit(**/*.md)",
-              "script": "headings",
-            },
-            {
-              "guarded": false,
-              "if": null,
-              "script": "check-tropes",
-            },
-          ],
-          "matcher": "Edit",
-        },
-        {
-          "hooks": [
-            {
-              "guarded": false,
-              "if": null,
-              "script": "check-tropes",
-            },
-          ],
-          "matcher": "MultiEdit",
-        },
-        {
-          "hooks": [
-            {
-              "guarded": true,
-              "if": null,
-              "script": "check-tropes",
-            },
-          ],
-          "matcher": "Bash",
-        },
-      ]
-    `);
+    const view = Object.fromEntries(
+      preToolUse.map((entry) => [
+        entry.matcher,
+        Object.fromEntries(
+          entry.hooks.map((hook) => [
+            scriptName(hook.command),
+            { guarded: hook.command.startsWith("in=$(cat);"), if: hook.if ?? null },
+          ]),
+        ),
+      ]),
+    );
+    expect(view).toEqual({
+      Write: {
+        numbering: { guarded: true, if: null },
+        headings: { guarded: false, if: "Write(**/*.md)" },
+        "check-tropes": { guarded: false, if: null },
+      },
+      Edit: {
+        numbering: { guarded: true, if: null },
+        headings: { guarded: false, if: "Edit(**/*.md)" },
+        "check-tropes": { guarded: false, if: null },
+      },
+      MultiEdit: {
+        "check-tropes": { guarded: false, if: null },
+      },
+      Bash: {
+        "check-tropes": { guarded: true, if: null },
+      },
+    });
   });
 
   test("Bash guard alternation is derived from the flags check-tropes extracts", () => {

--- a/plugins/writing/hooks/hooks.test.ts
+++ b/plugins/writing/hooks/hooks.test.ts
@@ -1,26 +1,33 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { SG_EXTENSIONS } from "./numbering";
+import { BODY_FILE_FLAG, PROSE_FLAGS } from "./check-tropes";
+import config from "./hooks.json";
 
 type HookCommand = { type: string; command: string; if?: string };
 type HookEntry = { matcher: string; hooks: HookCommand[] };
 
-const config = (await Bun.file(join(import.meta.dirname, "hooks.json")).json()) as {
-  hooks: { PreToolUse: HookEntry[] };
-};
-
-const preToolUse = config.hooks.PreToolUse;
+const preToolUse = config.hooks.PreToolUse as HookEntry[];
 
 function scriptName(command: string): string {
   return command.match(/hooks\/([\w-]+)\.ts/)?.[1] ?? command;
 }
 
+function findCommand(matcher: string, script: string): string {
+  const entry = preToolUse.find((candidate) => candidate.matcher === matcher);
+  const hook = entry?.hooks.find((candidate) => scriptName(candidate.command) === script);
+  if (!hook) throw new Error(`hooks.json is missing ${script} under matcher ${matcher}`);
+  return hook.command;
+}
+
 describe("PreToolUse gating", () => {
-  test("matchers and if conditions", () => {
+  test("matchers, guards, and if conditions", () => {
     const view = preToolUse.map((entry) => ({
       matcher: entry.matcher,
       hooks: entry.hooks.map((hook) => ({
         script: scriptName(hook.command),
+        guarded: hook.command.startsWith("in=$(cat);"),
         if: hook.if ?? null,
       })),
     }));
@@ -29,14 +36,17 @@ describe("PreToolUse gating", () => {
         {
           "hooks": [
             {
-              "if": "Write(**/*.md)|Write(**/*.markdown)|Write(**/*.go)|Write(**/*.js)|Write(**/*.jsx)|Write(**/*.mjs)|Write(**/*.cjs)|Write(**/*.ts)|Write(**/*.tsx)|Write(**/*.mts)|Write(**/*.cts)|Write(**/*.py)",
+              "guarded": true,
+              "if": null,
               "script": "numbering",
             },
             {
+              "guarded": false,
               "if": "Write(**/*.md)",
               "script": "headings",
             },
             {
+              "guarded": false,
               "if": null,
               "script": "check-tropes",
             },
@@ -46,14 +56,17 @@ describe("PreToolUse gating", () => {
         {
           "hooks": [
             {
-              "if": "Edit(**/*.md)|Edit(**/*.markdown)|Edit(**/*.go)|Edit(**/*.js)|Edit(**/*.jsx)|Edit(**/*.mjs)|Edit(**/*.cjs)|Edit(**/*.ts)|Edit(**/*.tsx)|Edit(**/*.mts)|Edit(**/*.cts)|Edit(**/*.py)",
+              "guarded": true,
+              "if": null,
               "script": "numbering",
             },
             {
+              "guarded": false,
               "if": "Edit(**/*.md)",
               "script": "headings",
             },
             {
+              "guarded": false,
               "if": null,
               "script": "check-tropes",
             },
@@ -63,6 +76,7 @@ describe("PreToolUse gating", () => {
         {
           "hooks": [
             {
+              "guarded": false,
               "if": null,
               "script": "check-tropes",
             },
@@ -72,7 +86,8 @@ describe("PreToolUse gating", () => {
         {
           "hooks": [
             {
-              "if": "Bash(gh *)|Bash(glab *)|Bash(linear *)",
+              "guarded": true,
+              "if": null,
               "script": "check-tropes",
             },
           ],
@@ -82,16 +97,94 @@ describe("PreToolUse gating", () => {
     `);
   });
 
-  test("numbering matcher gates cover exactly the extensions numbering.ts scans", () => {
-    const gates = preToolUse
-      .flatMap((entry) => entry.hooks)
-      .filter((hook) => hook.command.includes("numbering.ts"));
-    expect(gates).toHaveLength(2);
-    for (const hook of gates) {
-      const extensions = [...(hook.if ?? "").matchAll(/\*\*\/\*\.(\w+)\)/g)].map(
-        (match) => match[1],
-      );
-      expect(new Set(extensions)).toEqual(new Set(["md", "markdown", ...SG_EXTENSIONS]));
-    }
+  test("Bash guard alternation is derived from the flags check-tropes extracts", () => {
+    const command = findCommand("Bash", "check-tropes");
+    const alternation = `--(${PROSE_FLAGS.map((flag) => flag.slice(2)).join("|")})[-= ]`;
+    expect(command).toContain(alternation);
+    expect(`${BODY_FILE_FLAG} `).toMatch(new RegExp(alternation));
+  });
+});
+
+describe("inline guard behavior", () => {
+  let binDir: string;
+
+  beforeAll(async () => {
+    binDir = mkdtempSync(join(tmpdir(), "writing-guard-test-"));
+    const stub = join(binDir, "bun");
+    await Bun.write(stub, '#!/bin/sh\necho "bun $*" >> "$CALL_LOG"\ncat > /dev/null\n');
+    Bun.spawnSync(["chmod", "+x", stub]);
+  });
+
+  afterAll(() => {
+    Bun.spawnSync(["rm", "-rf", binDir]);
+  });
+
+  async function runGuard(
+    command: string,
+    input: Record<string, unknown>,
+  ): Promise<{ exitCode: number | null; calls: string[] }> {
+    const log = join(binDir, `calls-${Math.random().toString(36).slice(2)}.log`);
+    const proc = Bun.spawnSync(["sh", "-c", command], {
+      stdin: Buffer.from(JSON.stringify(input)),
+      env: {
+        PATH: `${binDir}:/usr/bin:/bin`,
+        CALL_LOG: log,
+        CLAUDE_PLUGIN_ROOT: "/plugin",
+      },
+    });
+    const file = Bun.file(log);
+    const calls = (await file.exists()) ? (await file.text()).trim().split("\n") : [];
+    return { exitCode: proc.exitCode, calls };
+  }
+
+  // Every shape checkMarkdown or a numbering.yml rule can flag must launch the
+  // full check; content that cannot match must skip the bun spawn.
+  test.each<{ name: string; content: string; runs: boolean }>([
+    { name: "markdown numbered heading", content: "## 1. Setup\n\nBody\n", runs: true },
+    { name: "markdown Step heading", content: "# Step 1\n", runs: true },
+    { name: "markdown Phase heading, wide gap", content: "# Phase    2\n", runs: true },
+    { name: "tab after heading number", content: "## 3.\tSetup\n", runs: true },
+    { name: "code identifier step1", content: "function step1() {}\n", runs: true },
+    { name: "code identifier Phase2", content: "class Phase2:\n    pass\n", runs: true },
+    {
+      name: "code identifier part3 in any language",
+      content: "part3 <- function(x) x\n",
+      runs: true,
+    },
+    { name: "plain prose", content: "Descriptive names only.\n", runs: false },
+    { name: "version string", content: "Bump to v1.2.3\n", runs: false },
+    { name: "bare code", content: "const total = sum(items)\n", runs: false },
+  ])("numbering: $name", async ({ content, runs }) => {
+    const command = findCommand("Write", "numbering");
+    const result = await runGuard(command, {
+      tool_name: "Write",
+      tool_input: { file_path: "/repo/example.R", content },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.calls).toEqual(runs ? ["bun /plugin/hooks/numbering.ts write"] : []);
+  });
+
+  test.each<{ name: string; command: string; runs: boolean }>([
+    { name: "no prose flags", command: "git status", runs: false },
+    {
+      name: "gh with title and body",
+      command: 'gh pr create --title "Hi" --body "There"',
+      runs: true,
+    },
+    {
+      name: "arbitrary CLI with description",
+      command: "mycli publish --description 'x'",
+      runs: true,
+    },
+    { name: "body file", command: "jira update --body-file /tmp/x.md", runs: true },
+    { name: "flag-free long command", command: "ls -la && bun test plugins/writing", runs: false },
+  ])("check-tropes bash: $name", async ({ command, runs }) => {
+    const hookCommand = findCommand("Bash", "check-tropes");
+    const result = await runGuard(hookCommand, {
+      tool_name: "Bash",
+      tool_input: { command },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.calls).toEqual(runs ? ["bun /plugin/hooks/check-tropes.ts"] : []);
   });
 });

--- a/plugins/writing/hooks/numbering.test.ts
+++ b/plugins/writing/hooks/numbering.test.ts
@@ -112,9 +112,23 @@ describe.skipIf(!hasSg())("checkCode (requires sg)", () => {
     ["detects Python class Phase2", "class Phase2:\n    pass", "py", "Phase2"],
     ["allows descriptive Python names", "def process_items():\n    pass", "py", null],
     ["detects TypeScript function step1()", "function step1() {}", "ts", "step1"],
+    ["detects TSX function step1()", "function step1() {}", "tsx", "step1"],
   ])("%s", async (_name, content, lang, expected) => {
     const match = await checkCode(content, lang);
     expected === null ? expect(match).toBeNull() : expect(match).toContain(expected);
+  });
+});
+
+describe("checkCode extension gating", () => {
+  test.each<[string]>([
+    ["sh"],
+    ["json"],
+    ["yml"],
+    ["txt"],
+    ["sql"],
+    [""],
+  ])("returns null for uncovered extension %p without scanning", async (ext) => {
+    expect(await checkCode("function step1() {}", ext)).toBeNull();
   });
 });
 

--- a/plugins/writing/hooks/numbering.test.ts
+++ b/plugins/writing/hooks/numbering.test.ts
@@ -119,15 +119,13 @@ describe.skipIf(!hasSg())("checkCode (requires sg)", () => {
   });
 });
 
-describe("checkCode extension gating", () => {
+describe.skipIf(!hasSg())("checkCode uncovered languages (requires sg)", () => {
   test.each<[string]>([
     ["sh"],
     ["json"],
     ["yml"],
-    ["txt"],
     ["sql"],
-    [""],
-  ])("returns null for uncovered extension %p without scanning", async (ext) => {
+  ])("returns null for extension %p with no numbering.yml rules", async (ext) => {
     expect(await checkCode("function step1() {}", ext)).toBeNull();
   });
 });

--- a/plugins/writing/hooks/numbering.ts
+++ b/plugins/writing/hooks/numbering.ts
@@ -60,7 +60,24 @@ export function checkMarkdown(content: string): string | null {
   return null;
 }
 
+// Extensions the numbering.yml languages cover. Gates subprocess spawns and
+// must stay in sync with the numbering matchers in hooks.json (see hooks.test.ts).
+export const SG_EXTENSIONS = new Set([
+  "go",
+  "js",
+  "jsx",
+  "mjs",
+  "cjs",
+  "ts",
+  "tsx",
+  "mts",
+  "cts",
+  "py",
+]);
+
 export async function checkCode(content: string, ext: string): Promise<string | null> {
+  if (!SG_EXTENSIONS.has(ext)) return null;
+
   try {
     execSync("command -v sg", { stdio: ["pipe", "pipe", "pipe"] });
   } catch {

--- a/plugins/writing/hooks/numbering.ts
+++ b/plugins/writing/hooks/numbering.ts
@@ -60,24 +60,7 @@ export function checkMarkdown(content: string): string | null {
   return null;
 }
 
-// Extensions the numbering.yml languages cover. Gates subprocess spawns and
-// must stay in sync with the numbering matchers in hooks.json (see hooks.test.ts).
-export const SG_EXTENSIONS = new Set([
-  "go",
-  "js",
-  "jsx",
-  "mjs",
-  "cjs",
-  "ts",
-  "tsx",
-  "mts",
-  "cts",
-  "py",
-]);
-
 export async function checkCode(content: string, ext: string): Promise<string | null> {
-  if (!SG_EXTENSIONS.has(ext)) return null;
-
   try {
     execSync("command -v sg", { stdio: ["pipe", "pipe", "pipe"] });
   } catch {

--- a/plugins/writing/hooks/numbering.yml
+++ b/plugins/writing/hooks/numbering.yml
@@ -47,6 +47,23 @@ constraints:
     regex: "(?i)(step|phase|part)[0-9]+"
 ---
 id: numbering
+language: tsx
+severity: error
+message: "Numbered identifier creates tight coupling: $NAME"
+note: "Use descriptive names instead. See CLAUDE.md Organization guidelines."
+rule:
+  any:
+    - pattern: "function $NAME($$$) { $$$ }"
+    - pattern: "const $NAME = $$$"
+    - pattern: "let $NAME = $$$"
+    - pattern: "var $NAME = $$$"
+    - pattern: "type $NAME = $$$"
+    - pattern: "interface $NAME { $$$ }"
+constraints:
+  NAME:
+    regex: "(?i)(step|phase|part)[0-9]+"
+---
+id: numbering
 language: python
 severity: error
 message: "Numbered identifier creates tight coupling: $NAME"


### PR DESCRIPTION
Gates the two hottest blocking PreToolUse hooks in the writing plugin so they only spawn when they can act. Gating is by content and by flag, never by extension or tool name, so no language or CLI is silently excluded.

## Changes

#### `check-tropes.ts`

- Drops the `mcp__.*` matcher arm. The Bash arm now runs behind an inline guard that greps hook stdin for the prose flags the script extracts (`--body`, `--body-file`, `--message`, `--description`, `--title`). Any CLI carrying prose is scanned; commands with no prose surface skip the bun cold start. The flag list is exported as `PROSE_FLAGS` and a sync test derives the guard alternation from it, so the gate and the scanner cannot drift.
- Body files are authored with the Write tool (per the global `!`-escaping rule) and check-tropes already fires on Write, so `--body-file` content is scanned at authoring time. The guarded Bash arm keeps coverage for inline args, the one prose path that never flows through Write.
- Removes the MCP prose-extraction code and tests that the matcher change made unreachable.

#### `numbering.ts`

- An inline guard greps hook stdin for a superset of every shape the checker can flag (`step`/`phase`/`part` near a digit, numbered-heading forms including tab and JSON-escaped whitespace). Any file type passes through on content, so languages without `numbering.yml` rules today still activate the moment rules are added, and no edit is excluded by extension. Session data: 13% of Write/Edit calls in the last 60 days touch extensions outside the yml-covered set (json 2.3%, sql 1.6%, sh 1.2%, java 1.0%, yml+yaml 1.3%, cpp, rs, and a long tail).
- Adds a `tsx` rule block: ast-grep treats tsx as a separate language, so `.tsx` files previously spawned `sg` and could never match.

#### Tests

- `hooks.test.ts` snapshots the matcher/guard structure, runs the real guard commands against a stubbed `bun` to assert every flaggable shape launches the check and non-matching content skips it, and enforces the `PROSE_FLAGS` sync.

## Evidence

Session-history hook telemetry (30 days, local machine): `check-tropes.ts` ran 1,026 times at p50 81ms / p95 111ms. Its matcher included `Bash` and `mcp__.*`, so every Bash command and MCP call paid a ~50ms bun cold start (measured floor: bun + SDK imports) before the tool ran. `numbering.ts` fired on every Edit/Write with no path gate and shelled out to ast-grep on every non-markdown edit (~93ms measured). These were the two hottest blocking hooks in the config. The inline guard's skip path measures ~10ms.

Discovery: 13721cb7f556
Discovery: 7be0e659731b
