### PR TITLE
eval(pr-body): scaffold mining and labeling for pull-request:create bodies

### DIFF
--- a/evals/pr-body/.gitignore
+++ b/evals/pr-body/.gitignore
@@ -1,0 +1,3 @@
+# Generated and local-only: mined samples and reviewer feedback.
+data/
+feedback/

--- a/evals/pr-body/README.md
+++ b/evals/pr-body/README.md
@@ -1,0 +1,90 @@
+# `pull-request:create` Rubric
+
+A local harness for evaluating the PR bodies that `pull-request:create`
+produces, following the structure of [`evals/issue-refine`](../issue-refine).
+The aim is the same: label real outputs, derive a rubric from the labels, then
+score the skill before and after edits so changes to
+`plugins/pull-request/skills/create/` are gated on output quality instead of
+lint alone.
+
+This scaffold delivers the mining script and the labeling UI. The rubric,
+scorer, and judge come after a labeling session, since the rubric is derived
+from the labels.
+
+## Privacy
+
+The session index includes an imported `work` host marked block-egress, and
+work PR bodies live on private hosts anyway. `scripts/mine.ts` hardcodes
+`host = 'local'` and `repository LIKE 'bendrucker/%'` in its SQL, so only
+public personal PRs are ever mined. Keep those filters if you touch the query.
+`data/` and `feedback/` are gitignored regardless.
+
+## Workflow
+
+### 1. Mine
+
+Build the session index first if it is stale (the session skill owns it):
+
+```bash
+bun plugins/claude-code/skills/session/scripts/refresh.ts
+```
+
+Then mine PR bodies:
+
+```bash
+bun evals/pr-body/scripts/mine.ts                      # writes data/samples.json
+bun evals/pr-body/scripts/mine.ts --limit 80
+```
+
+`mine.ts` enumerates PRs opened from local sessions via the index's `pr_links`
+table, fetches their bodies with `gh pr list`, drops empty bodies, and selects
+a repo-balanced sample that interleaves long sectioned bodies with tight
+one-paragraph ones. Each item records repo, PR number, URL, date, state, and
+the originating session id.
+
+### 2. Label
+
+```bash
+bun evals/pr-body/label/server.ts                      # http://localhost:4319
+```
+
+Open the URL and review each body. Per PR you can:
+
+- Select any span in the rendered body to attach an inline comment with a
+  severity (critical / minor / praise). Highlights persist across reloads.
+- Set a verdict (good / ok / bad), toggle quality tags, and write freeform notes.
+
+Everything autosaves to `feedback/<id>.json`. The header links to the PR on
+GitHub so the diff is one click away while judging the body.
+
+The UI is copied from `evals/issue-refine/label/` and adapted. Copying is the
+current convention across `evals/`; extracting a shared harness package is a
+known deferred refactor.
+
+### 3. Derive the rubric (after labeling)
+
+Once a batch is labeled, the recurring critical spans and tags become
+`RUBRIC.md`: the failure modes the skill should stop producing and the traits
+to preserve. That feeds concrete edits to `plugins/pull-request/skills/create/`
+and a mechanical `score.ts` (rubric-as-code), mirroring issue-refine.
+
+### 4. A/B test a skill change (after the rubric)
+
+The skill's `--dry-run` flag already produces a body without creating anything,
+which is the natural hook: run synthetic change scenarios through the committed
+skill (`git show HEAD:...`) and the working tree, then compare with an
+`ab-report.ts` mechanical score plus a blinded `judge.ts` for the
+judgment-call findings, as issue-refine does.
+
+## Status
+
+- Done: `scripts/mine.ts`, `label/` UI, this loop definition.
+- Next (owner): run the miner and the labeler, label ~50 items.
+- After labeling: `RUBRIC.md`, `score.ts`, `judge.ts`, `ab-report.ts`, and a
+  gate on `pull-request:create` edits.
+
+## Layout
+
+- `scripts/mine.ts`: builds `data/samples.json` from `pr_links` + `gh pr list`
+- `label/server.ts`, `label/index.html`: the review UI (inline span comments, verdict, tags, notes)
+- `data/`, `feedback/`: generated or local-only (gitignored)

--- a/evals/pr-body/label/index.html
+++ b/evals/pr-body/label/index.html
@@ -1,0 +1,375 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>pull-request:create review</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
+    <style>
+      :root {
+        --bg: #0f1115;
+        --panel: #171a21;
+        --panel2: #1f242d;
+        --border: #2a313c;
+        --text: #d8dee9;
+        --muted: #8a94a6;
+        --accent: #6aa6ff;
+        --critical: #ff5d5d;
+        --minor: #ffb454;
+        --praise: #4ec88a;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+        display: grid;
+        grid-template-columns: 290px 1fr;
+        height: 100vh;
+      }
+      a { color: var(--accent); }
+      /* Sidebar */
+      #sidebar { background: var(--panel); border-right: 1px solid var(--border); overflow-y: auto; }
+      #progress { padding: 12px 14px; border-bottom: 1px solid var(--border); font-size: 13px; color: var(--muted); position: sticky; top: 0; background: var(--panel); }
+      #progress b { color: var(--text); }
+      .navitem { padding: 10px 14px; border-bottom: 1px solid var(--border); cursor: pointer; }
+      .navitem:hover { background: var(--panel2); }
+      .navitem.active { background: var(--panel2); border-left: 3px solid var(--accent); padding-left: 11px; }
+      .navitem .row1 { display: flex; gap: 6px; align-items: center; font-size: 12px; color: var(--muted); }
+      .navitem .title { color: var(--text); font-size: 13px; margin-top: 3px; }
+      .badge { font-size: 10px; text-transform: uppercase; letter-spacing: .04em; padding: 1px 6px; border-radius: 999px; background: var(--panel2); border: 1px solid var(--border); color: #8fd6ff; }
+      .verdict-dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; margin-left: auto; background: #3a414c; }
+      .verdict-dot.good { background: var(--praise); }
+      .verdict-dot.ok { background: var(--minor); }
+      .verdict-dot.bad { background: var(--critical); }
+      .navitem .anncount { font-size: 11px; color: var(--muted); }
+      /* Main */
+      #main { overflow-y: auto; padding: 22px 30px 120px; }
+      .hd { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+      .hd h1 { font-size: 19px; margin: 0; flex: 1 1 100%; }
+      .meta { color: var(--muted); font-size: 12px; }
+      .section-label { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); margin: 22px 0 8px; }
+      #doc { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 6px 22px; }
+      #doc h1, #doc h2 { font-size: 17px; border-bottom: 1px solid var(--border); padding-bottom: 5px; }
+      #doc h3 { font-size: 14px; color: #c7d0dd; }
+      #doc code { background: #11151b; padding: 1px 5px; border-radius: 4px; font-size: 12.5px; }
+      #doc pre { background: #11151b; padding: 12px; border-radius: 6px; overflow-x: auto; }
+      #doc pre code { background: none; padding: 0; }
+      #doc table { border-collapse: collapse; }
+      #doc th, #doc td { border: 1px solid var(--border); padding: 5px 9px; }
+      #doc a { word-break: break-all; }
+      ::highlight(critical) { background: rgba(255,93,93,.30); text-decoration: underline wavy var(--critical); }
+      ::highlight(minor) { background: rgba(255,180,84,.26); text-decoration: underline wavy var(--minor); }
+      ::highlight(praise) { background: rgba(78,200,138,.24); }
+      /* Selection popover */
+      #pop { position: absolute; z-index: 50; display: none; background: var(--panel2); border: 1px solid var(--border); border-radius: 8px; padding: 8px; box-shadow: 0 8px 24px rgba(0,0,0,.5); width: 280px; }
+      #pop textarea { width: 100%; height: 54px; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 6px; padding: 6px; font: inherit; resize: vertical; }
+      #pop .quote { font-size: 11px; color: var(--muted); margin-bottom: 6px; max-height: 40px; overflow: hidden; font-style: italic; }
+      .sevrow { display: flex; gap: 6px; margin: 6px 0; }
+      .sevbtn { flex: 1; cursor: pointer; border: 1px solid var(--border); background: var(--bg); color: var(--text); border-radius: 6px; padding: 4px; font-size: 12px; }
+      .sevbtn[data-sev="critical"].on { background: var(--critical); color: #1a0000; border-color: var(--critical); }
+      .sevbtn[data-sev="minor"].on { background: var(--minor); color: #241500; border-color: var(--minor); }
+      .sevbtn[data-sev="praise"].on { background: var(--praise); color: #00200f; border-color: var(--praise); }
+      #pop .actions { display: flex; gap: 6px; justify-content: flex-end; margin-top: 6px; }
+      button.btn { cursor: pointer; border: 1px solid var(--border); background: var(--panel); color: var(--text); border-radius: 6px; padding: 5px 12px; font-size: 12px; }
+      button.btn.primary { background: var(--accent); color: #06121f; border-color: var(--accent); }
+      /* Right rail (verdict/tags/notes/annotations) */
+      .rail { margin-top: 26px; display: grid; grid-template-columns: 1fr 1fr; gap: 22px; }
+      .card { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 14px; }
+      .card h3 { margin: 0 0 10px; font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); }
+      .verdicts { display: flex; gap: 8px; }
+      .verdicts button { flex: 1; }
+      .verdicts button.on[data-v="good"] { background: var(--praise); color: #00200f; border-color: var(--praise); }
+      .verdicts button.on[data-v="ok"] { background: var(--minor); color: #241500; border-color: var(--minor); }
+      .verdicts button.on[data-v="bad"] { background: var(--critical); color: #1a0000; border-color: var(--critical); }
+      .tags { display: flex; flex-wrap: wrap; gap: 6px; }
+      .tag { cursor: pointer; border: 1px solid var(--border); border-radius: 999px; padding: 3px 10px; font-size: 12px; color: var(--muted); user-select: none; }
+      .tag.on { background: var(--accent); color: #06121f; border-color: var(--accent); }
+      #notes { width: 100%; min-height: 90px; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 6px; padding: 8px; font: inherit; resize: vertical; }
+      .annlist { grid-column: 1 / -1; }
+      .ann { border-left: 3px solid var(--border); padding: 6px 10px; margin-bottom: 8px; background: var(--bg); border-radius: 0 6px 6px 0; }
+      .ann.critical { border-color: var(--critical); }
+      .ann.minor { border-color: var(--minor); }
+      .ann.praise { border-color: var(--praise); }
+      .ann .q { font-style: italic; color: var(--muted); font-size: 12px; }
+      .ann .c { margin-top: 3px; }
+      .ann .del { float: right; cursor: pointer; color: var(--muted); }
+      .saved { font-size: 11px; color: var(--praise); }
+      .topbar { display: flex; gap: 10px; align-items: center; margin-bottom: 4px; }
+      .topbar .spacer { flex: 1; }
+    </style>
+  </head>
+  <body>
+    <div id="sidebar">
+      <div id="progress"></div>
+      <div id="nav"></div>
+    </div>
+    <div id="main"></div>
+    <div id="pop">
+      <div class="quote" id="popQuote"></div>
+      <div class="sevrow">
+        <button class="sevbtn on" data-sev="critical">critical</button>
+        <button class="sevbtn" data-sev="minor">minor</button>
+        <button class="sevbtn" data-sev="praise">praise</button>
+      </div>
+      <textarea id="popText" placeholder="What's wrong with this span? (optional)"></textarea>
+      <div class="actions">
+        <button class="btn" id="popCancel">cancel</button>
+        <button class="btn primary" id="popSave">comment</button>
+      </div>
+    </div>
+
+    <script>
+      const TAGS = [
+        "restates-diff", "too-long", "filler", "missing-why", "missing-testing",
+        "vacuous-specificity", "over-structured", "bad-title", "inaccurate", "good",
+      ];
+      let samples = [];
+      let feedback = {}; // id -> {verdict, tags[], notes, annotations[]}
+      let current = null;
+      let pending = null; // pending new annotation {field, start, end, quote}
+      let pendingSev = "critical";
+
+      const $ = (s, r = document) => r.querySelector(s);
+      const el = (t, props = {}, kids = []) => {
+        const n = Object.assign(document.createElement(t), props);
+        for (const k of [].concat(kids)) n.append(k);
+        return n;
+      };
+
+      const repoShort = (repo) => repo.replace(/^bendrucker\//, "");
+
+      async function boot() {
+        samples = await (await fetch("/api/samples")).json();
+        feedback = await (await fetch("/api/feedback")).json();
+        for (const s of samples) feedback[s.id] ??= { verdict: null, tags: [], notes: "", annotations: [] };
+        renderNav();
+        select(samples[0].id);
+        wirePopover();
+      }
+
+      function fb(id) { return feedback[id]; }
+
+      function renderNav() {
+        const done = samples.filter((s) => {
+          const f = fb(s.id);
+          return f.verdict || f.annotations.length || f.notes.trim() || f.tags.length;
+        }).length;
+        $("#progress").innerHTML = `<b>${done}</b> / ${samples.length} reviewed &nbsp;·&nbsp; <a href="#" id="exportLink">export</a>`;
+        $("#exportLink").onclick = (e) => { e.preventDefault(); exportAll(); };
+        const nav = $("#nav");
+        nav.innerHTML = "";
+        for (const s of samples) {
+          const f = fb(s.id);
+          const item = el("div", { className: "navitem" + (s.id === current ? " active" : "") });
+          item.onclick = () => select(s.id);
+          const dot = el("span", { className: "verdict-dot " + (f.verdict || "") });
+          item.append(
+            el("div", { className: "row1" }, [
+              el("span", { className: "badge", textContent: repoShort(s.repo) }),
+              el("span", { textContent: s.id }),
+              dot,
+            ]),
+            el("div", { className: "title", textContent: s.title }),
+            el("div", { className: "anncount", textContent: `${f.annotations.length} inline · ${f.tags.length} tags` }),
+          );
+          nav.append(item);
+        }
+      }
+
+      function select(id) {
+        current = id;
+        renderNav();
+        renderMain();
+      }
+
+      function renderMain() {
+        const s = samples.find((x) => x.id === current);
+        const f = fb(current);
+        const main = $("#main");
+        main.innerHTML = "";
+
+        const link = el("a", { href: s.url, target: "_blank", textContent: `${s.repo}#${s.pr_number}` });
+        const topbar = el("div", { className: "topbar" }, [
+          el("span", { className: "badge", textContent: repoShort(s.repo) }),
+          el("span", { className: "meta" }, [
+            link,
+            ` · ${s.state.toLowerCase()} · ${s.created_at.slice(0, 10)} · ${s.size} · ${s.body.length} chars`,
+          ]),
+          el("span", { className: "spacer" }),
+          el("span", { className: "saved", id: "savedFlag" }),
+        ]);
+        main.append(topbar, el("div", { className: "hd" }, [el("h1", { textContent: s.title })]));
+
+        main.append(el("div", { className: "section-label", textContent: "PR body (select any span to comment)" }));
+        const doc = el("div", { id: "doc" });
+        doc.innerHTML = marked.parse(s.body);
+        doc.dataset.field = "body";
+        main.append(doc);
+
+        renderRail(main, s, f);
+        requestAnimationFrame(() => applyHighlights());
+      }
+
+      function renderRail(main, s, f) {
+        const rail = el("div", { className: "rail" });
+
+        const vCard = el("div", { className: "card" });
+        vCard.append(el("h3", { textContent: "Verdict" }));
+        const vrow = el("div", { className: "verdicts" });
+        for (const v of ["good", "ok", "bad"]) {
+          const b = el("button", { className: "btn" + (f.verdict === v ? " on" : ""), textContent: v });
+          b.dataset.v = v;
+          b.onclick = () => { f.verdict = f.verdict === v ? null : v; save(); renderMain(); renderNav(); };
+          vrow.append(b);
+        }
+        vCard.append(vrow);
+
+        const tCard = el("div", { className: "card" });
+        tCard.append(el("h3", { textContent: "Tags" }));
+        const tags = el("div", { className: "tags" });
+        for (const t of TAGS) {
+          const on = f.tags.includes(t);
+          const chip = el("span", { className: "tag" + (on ? " on" : ""), textContent: t });
+          chip.onclick = () => {
+            f.tags = on ? f.tags.filter((x) => x !== t) : [...f.tags, t];
+            save(); renderMain(); renderNav();
+          };
+          tags.append(chip);
+        }
+        tCard.append(tags);
+
+        const nCard = el("div", { className: "card", style: "grid-column: 1 / -1" });
+        nCard.append(el("h3", { textContent: "Notes" }));
+        const ta = el("textarea", { id: "notes", value: f.notes, placeholder: "Freeform: what's good, what's bad, what the skill should have written instead." });
+        ta.oninput = () => { f.notes = ta.value; save(); };
+        nCard.append(ta);
+
+        const aCard = el("div", { className: "card annlist" });
+        aCard.append(el("h3", { textContent: `Inline comments (${f.annotations.length})` }));
+        if (!f.annotations.length) aCard.append(el("div", { className: "meta", textContent: "Select text in the body above to add one." }));
+        f.annotations.forEach((a, i) => {
+          const row = el("div", { className: "ann " + a.severity });
+          const del = el("span", { className: "del", textContent: "✕" });
+          del.onclick = () => { f.annotations.splice(i, 1); save(); renderMain(); renderNav(); };
+          row.append(del, el("div", { className: "q", textContent: `“${a.quote}”` }));
+          if (a.comment) row.append(el("div", { className: "c", textContent: a.comment }));
+          aCard.append(row);
+        });
+
+        rail.append(vCard, tCard, nCard, aCard);
+        main.append(rail);
+      }
+
+      // ---- inline annotation engine (stable char offsets into rendered text) ----
+      function textNodes(container) {
+        const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+        const nodes = [];
+        let pos = 0, n;
+        while ((n = walker.nextNode())) {
+          nodes.push({ node: n, start: pos, len: n.nodeValue.length });
+          pos += n.nodeValue.length;
+        }
+        return nodes;
+      }
+      function globalOffset(nodes, node, offset) {
+        const e = nodes.find((x) => x.node === node);
+        return e ? e.start + offset : null;
+      }
+      function rangeFor(container, start, end) {
+        const nodes = textNodes(container);
+        const find = (off) => {
+          for (const e of nodes) if (off >= e.start && off <= e.start + e.len) return { node: e.node, offset: off - e.start };
+          return null;
+        };
+        const a = find(start), b = find(end);
+        if (!a || !b) return null;
+        const r = document.createRange();
+        r.setStart(a.node, a.offset);
+        r.setEnd(b.node, b.offset);
+        return r;
+      }
+      function applyHighlights() {
+        if (!window.Highlight || !CSS.highlights) return;
+        CSS.highlights.clear();
+        const doc = $("#doc");
+        if (!doc) return;
+        const buckets = { critical: [], minor: [], praise: [] };
+        for (const a of fb(current).annotations) {
+          const r = rangeFor(doc, a.start, a.end);
+          if (r) buckets[a.severity]?.push(r);
+        }
+        for (const sev of Object.keys(buckets)) {
+          if (buckets[sev].length) CSS.highlights.set(sev, new Highlight(...buckets[sev]));
+        }
+      }
+
+      function wirePopover() {
+        const pop = $("#pop");
+        document.addEventListener("mouseup", (ev) => {
+          if (pop.contains(ev.target)) return;
+          const sel = window.getSelection();
+          if (!sel.rangeCount || sel.isCollapsed) return;
+          const doc = $("#doc");
+          const r = sel.getRangeAt(0);
+          if (!doc || !doc.contains(r.commonAncestorContainer)) { pop.style.display = "none"; return; }
+          const nodes = textNodes(doc);
+          const start = globalOffset(nodes, r.startContainer, r.startOffset);
+          const end = globalOffset(nodes, r.endContainer, r.endOffset);
+          if (start == null || end == null || end <= start) return;
+          pending = { field: "body", start, end, quote: sel.toString().trim() };
+          pendingSev = "critical";
+          $("#popQuote").textContent = `“${pending.quote.slice(0, 140)}”`;
+          $("#popText").value = "";
+          setSev("critical");
+          const rect = r.getBoundingClientRect();
+          pop.style.display = "block";
+          pop.style.top = window.scrollY + rect.bottom + 8 + "px";
+          pop.style.left = Math.min(window.scrollX + rect.left, window.innerWidth - 300) + "px";
+          $("#popText").focus();
+        });
+        $$(".sevbtn").forEach((b) => (b.onclick = () => setSev(b.dataset.sev)));
+        $("#popCancel").onclick = () => { pop.style.display = "none"; window.getSelection().removeAllRanges(); };
+        $("#popSave").onclick = commitPending;
+        $("#popText").addEventListener("keydown", (e) => { if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) commitPending(); });
+      }
+      function setSev(s) { pendingSev = s; $$(".sevbtn").forEach((b) => b.classList.toggle("on", b.dataset.sev === s)); }
+      function commitPending() {
+        if (!pending) return;
+        fb(current).annotations.push({ ...pending, severity: pendingSev, comment: $("#popText").value.trim() });
+        fb(current).annotations.sort((a, b) => a.start - b.start);
+        pending = null;
+        $("#pop").style.display = "none";
+        window.getSelection().removeAllRanges();
+        save(); renderMain(); renderNav();
+      }
+      const $$ = (s, r = document) => [...r.querySelectorAll(s)];
+
+      let saveTimer = null;
+      function save() {
+        const id = current;
+        const flag = $("#savedFlag");
+        if (flag) flag.textContent = "saving…";
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(async () => {
+          await fetch("/api/feedback", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ id, feedback: fb(id) }),
+          });
+          const f2 = $("#savedFlag");
+          if (f2) { f2.textContent = "saved ✓"; setTimeout(() => { if ($("#savedFlag") === f2) f2.textContent = ""; }, 1200); }
+        }, 350);
+      }
+
+      function exportAll() {
+        const blob = new Blob([JSON.stringify(feedback, null, 2)], { type: "application/json" });
+        const a = el("a", { href: URL.createObjectURL(blob), download: "pr-body-feedback.json" });
+        a.click();
+      }
+
+      boot();
+    </script>
+  </body>
+</html>

--- a/evals/pr-body/label/server.ts
+++ b/evals/pr-body/label/server.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env bun
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { cli } from "cleye";
+
+// Local labeling server. Serves the review UI, hands the browser the mined
+// samples, and persists reviewer feedback to feedback/<id>.json so a later
+// analysis pass can read it back off disk.
+//
+// Copied from evals/issue-refine/label/server.ts; a shared harness package is
+// a known deferred refactor (see README).
+
+const argv = cli({
+  name: "label-server",
+  flags: {
+    port: { type: Number, default: 4319, description: "Port to listen on" },
+    data: {
+      type: String,
+      default: `${import.meta.dir}/../data/samples.json`,
+      description: "Mined samples to review",
+    },
+    feedback: {
+      type: String,
+      default: `${import.meta.dir}/../feedback`,
+      description: "Directory for saved feedback",
+    },
+  },
+});
+
+const html = join(import.meta.dir, "index.html");
+
+async function readAllFeedback(): Promise<Record<string, unknown>> {
+  const out: Record<string, unknown> = {};
+  let names: string[] = [];
+  try {
+    names = await readdir(argv.flags.feedback);
+  } catch {
+    return out;
+  }
+  for (const n of names) {
+    if (!n.endsWith(".json")) continue;
+    try {
+      out[n.replace(/\.json$/, "")] = await Bun.file(join(argv.flags.feedback, n)).json();
+    } catch {}
+  }
+  return out;
+}
+
+const server = Bun.serve({
+  port: argv.flags.port,
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/" || url.pathname === "/index.html") {
+      return new Response(Bun.file(html), {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
+
+    if (url.pathname === "/api/samples") {
+      return new Response(Bun.file(argv.flags.data), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (url.pathname === "/api/feedback" && req.method === "GET") {
+      return Response.json(await readAllFeedback());
+    }
+
+    if (url.pathname === "/api/feedback" && req.method === "POST") {
+      const body = (await req.json()) as { id?: string; feedback?: unknown };
+      if (!body.id || !/^[\w-]+$/.test(body.id)) return new Response("bad id", { status: 400 });
+      const path = join(argv.flags.feedback, `${body.id}.json`);
+      await Bun.write(path, JSON.stringify(body.feedback, null, 2));
+      return Response.json({ ok: true });
+    }
+
+    return new Response("not found", { status: 404 });
+  },
+});
+
+console.log(`Labeling UI: http://localhost:${server.port}`);
+console.log(`Samples:     ${argv.flags.data}`);
+console.log(`Feedback:    ${argv.flags.feedback}/`);

--- a/evals/pr-body/scripts/mine.test.ts
+++ b/evals/pr-body/scripts/mine.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "bun:test";
+import fc from "fast-check";
+import { type FetchedPr, type Item, type MinedPr, selectSample, toItem, weave } from "./mine";
+
+function makeItem(overrides: Partial<Item>): Item {
+  return {
+    id: "",
+    repo: "bendrucker/claude",
+    pr_number: 1,
+    url: "https://github.com/bendrucker/claude/pull/1",
+    title: "a title",
+    state: "MERGED",
+    created_at: "2026-01-01T00:00:00Z",
+    session_id: "s-1",
+    size: "compact",
+    body: "a body",
+    ...overrides,
+  };
+}
+
+test("weave interleaves longest and shortest", () => {
+  const lengths = [1, 2, 3, 4, 5];
+  const woven = weave(lengths, (n) => n);
+  expect(woven).toEqual([5, 1, 4, 2, 3]);
+});
+
+test("weave preserves the multiset", () => {
+  fc.assert(
+    fc.property(fc.array(fc.integer({ min: 0, max: 100 })), (lengths) => {
+      const woven = weave(lengths, (n) => n);
+      expect([...woven].sort((a, b) => a - b)).toEqual([...lengths].sort((a, b) => a - b));
+    }),
+  );
+});
+
+test.each<{ name: string; counts: Record<string, number>; limit: number; expected: string[] }>([
+  {
+    name: "round-robins across repos before repeating one",
+    counts: { "bendrucker/claude": 3, "bendrucker/dotfiles": 1 },
+    limit: 3,
+    expected: ["bendrucker/claude", "bendrucker/dotfiles", "bendrucker/claude"],
+  },
+  {
+    name: "drains small repos and keeps filling from large ones",
+    counts: { "bendrucker/claude": 4, "bendrucker/dotfiles": 1 },
+    limit: 5,
+    expected: [
+      "bendrucker/claude",
+      "bendrucker/dotfiles",
+      "bendrucker/claude",
+      "bendrucker/claude",
+      "bendrucker/claude",
+    ],
+  },
+  {
+    name: "returns everything when under the limit",
+    counts: { "bendrucker/claude": 2 },
+    limit: 50,
+    expected: ["bendrucker/claude", "bendrucker/claude"],
+  },
+])("selectSample $name", ({ counts, limit, expected }) => {
+  const candidates = Object.entries(counts).flatMap(([repo, n]) =>
+    Array.from({ length: n }, (_, i) =>
+      makeItem({ repo, pr_number: i + 1, body: "x".repeat(10 * (i + 1)) }),
+    ),
+  );
+  const selected = selectSample(candidates, limit);
+  expect(selected.map((s) => s.repo)).toEqual(expected);
+});
+
+test("selectSample assigns sequential ids", () => {
+  const candidates = [makeItem({ pr_number: 1 }), makeItem({ pr_number: 2 })];
+  const ids = selectSample(candidates, 10).map((s) => s.id);
+  expect(ids).toEqual(["pr-001", "pr-002"]);
+});
+
+test("toItem carries session metadata and sizes the body", () => {
+  const mined: MinedPr = {
+    repository: "bendrucker/claude",
+    pr_number: 42,
+    url: "https://github.com/bendrucker/claude/pull/42",
+    opened_at: "2026-01-02 03:04:05",
+    session_id: "abc-123",
+  };
+  const fetched: FetchedPr = {
+    number: 42,
+    title: "fix: a thing",
+    body: "b".repeat(2000),
+    url: "https://github.com/bendrucker/claude/pull/42",
+    state: "MERGED",
+    createdAt: "2026-01-02T03:04:05Z",
+    author: { login: "bendrucker" },
+  };
+  expect(toItem(mined, fetched)).toMatchInlineSnapshot(
+    { body: expect.any(String) },
+    `
+    {
+      "body": Any<String>,
+      "created_at": "2026-01-02T03:04:05Z",
+      "id": "",
+      "pr_number": 42,
+      "repo": "bendrucker/claude",
+      "session_id": "abc-123",
+      "size": "full",
+      "state": "MERGED",
+      "title": "fix: a thing",
+      "url": "https://github.com/bendrucker/claude/pull/42",
+    }
+  `,
+  );
+});

--- a/evals/pr-body/scripts/mine.ts
+++ b/evals/pr-body/scripts/mine.ts
@@ -1,0 +1,250 @@
+#!/usr/bin/env bun
+import { mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { cli } from "cleye";
+
+// Mine PR bodies authored via Claude Code sessions. The session index's
+// pr_links table maps sessions to the PRs they opened; the bodies themselves
+// live on GitHub, fetched per-repo via `gh pr list`.
+//
+// Egress rule: the index includes an imported `work` host marked block-egress,
+// and work PR bodies live on private hosts anyway. The SQL below is hardcoded
+// to host = 'local' and public bendrucker/* repos; keep it that way.
+
+export interface MinedPr {
+  repository: string;
+  pr_number: number;
+  url: string;
+  opened_at: string;
+  session_id: string;
+}
+
+export interface FetchedPr {
+  number: number;
+  title: string;
+  body: string;
+  url: string;
+  state: string;
+  createdAt: string;
+  author: { login: string };
+}
+
+export interface Item {
+  id: string;
+  repo: string;
+  pr_number: number;
+  url: string;
+  title: string;
+  state: string;
+  created_at: string;
+  session_id: string;
+  size: "compact" | "full";
+  body: string;
+}
+
+const SQL = `
+SELECT repository,
+  pr_number,
+  min(url) AS url,
+  CAST(min(timestamp) AS VARCHAR) AS opened_at,
+  arg_min(session_id, timestamp) AS session_id
+FROM pr_links
+WHERE host = 'local'
+  AND repository LIKE 'bendrucker/%'
+GROUP BY repository, pr_number
+ORDER BY repository, pr_number
+`;
+
+export function sizeOf(body: string): "compact" | "full" {
+  return body.length < 1200 ? "compact" : "full";
+}
+
+export function toItem(mined: MinedPr, fetched: FetchedPr): Item {
+  return {
+    id: "",
+    repo: mined.repository,
+    pr_number: mined.pr_number,
+    url: fetched.url || mined.url,
+    title: fetched.title,
+    state: fetched.state,
+    created_at: fetched.createdAt,
+    session_id: mined.session_id,
+    size: sizeOf(fetched.body),
+    body: fetched.body,
+  };
+}
+
+// Interleave longest and shortest so a truncated labeling session still spans
+// both the sectioned long-form bodies and the tight one-paragraph ones.
+export function weave<T>(items: T[], length: (item: T) => number): T[] {
+  const sorted = [...items].sort((a, b) => length(b) - length(a));
+  const woven: T[] = [];
+  let lo = 0;
+  let hi = sorted.length - 1;
+  while (lo <= hi) {
+    const first = sorted[lo++];
+    if (first !== undefined) woven.push(first);
+    if (lo <= hi) {
+      const last = sorted[hi--];
+      if (last !== undefined) woven.push(last);
+    }
+  }
+  return woven;
+}
+
+// Repo-balanced round-robin so one high-traffic repo doesn't crowd out the
+// rest of the sample.
+export function selectSample(candidates: Item[], limit: number): Item[] {
+  const buckets = new Map<string, Item[]>();
+  for (const c of candidates) {
+    const arr = buckets.get(c.repo) ?? [];
+    arr.push(c);
+    buckets.set(c.repo, arr);
+  }
+  for (const [repo, arr] of buckets) {
+    buckets.set(
+      repo,
+      weave(arr, (i) => i.body.length),
+    );
+  }
+  const order = [...buckets.keys()].sort();
+  const selected: Item[] = [];
+  let added = true;
+  while (added && selected.length < limit) {
+    added = false;
+    for (const repo of order) {
+      const next = buckets.get(repo)?.shift();
+      if (next && selected.length < limit) {
+        selected.push(next);
+        added = true;
+      }
+    }
+  }
+  selected.forEach((s, i) => {
+    s.id = `pr-${String(i + 1).padStart(3, "0")}`;
+  });
+  return selected;
+}
+
+function resolveDbPath(db: string | undefined): string {
+  if (db) return db;
+  const dataDir =
+    process.env.CLAUDE_PLUGIN_DATA || join(process.env.TMPDIR || "/tmp", "claude-session");
+  return join(dataDir, "session.duckdb");
+}
+
+async function queryMined(dbPath: string): Promise<MinedPr[]> {
+  const proc = Bun.spawn(["duckdb", "-readonly", "-json", dbPath], {
+    stdin: new TextEncoder().encode(SQL),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0) throw new Error(`duckdb failed (${code}): ${err.trim()}`);
+  const trimmed = out.trim();
+  if (!trimmed) return [];
+  return JSON.parse(trimmed) as MinedPr[];
+}
+
+async function fetchRepoPrs(repo: string): Promise<Map<number, FetchedPr>> {
+  const proc = Bun.spawn(
+    [
+      "gh",
+      "pr",
+      "list",
+      "--repo",
+      repo,
+      "--author",
+      "bendrucker",
+      "--state",
+      "all",
+      "--limit",
+      "1000",
+      "--json",
+      "number,title,body,url,state,createdAt,author",
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  const [out, err, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0) throw new Error(`gh pr list --repo ${repo} failed (${code}): ${err.trim()}`);
+  const prs = JSON.parse(out) as FetchedPr[];
+  return new Map(prs.map((pr) => [pr.number, pr]));
+}
+
+async function main() {
+  const argv = cli({
+    name: "mine",
+    help: {
+      description: "Mine PR bodies opened from local Claude Code sessions into a labelable set.",
+    },
+    flags: {
+      db: {
+        type: String,
+        description: "session.duckdb path (defaults to the session skill's data dir)",
+      },
+      out: {
+        type: String,
+        default: join(import.meta.dirname, "..", "data", "samples.json"),
+        description: "Output path for the labelable sample",
+      },
+      limit: { type: Number, default: 50, description: "Max items to keep" },
+      minChars: { type: Number, default: 40, description: "Drop bodies shorter than this" },
+    },
+  });
+
+  const dbPath = resolveDbPath(argv.flags.db);
+  if (!(await Bun.file(dbPath).exists())) {
+    console.error(`No session index at ${dbPath}.`);
+    console.error("Build it first: bun plugins/claude-code/skills/session/scripts/refresh.ts");
+    process.exit(1);
+  }
+
+  const mined = await queryMined(dbPath);
+  console.log(`Session index: ${mined.length} distinct local bendrucker/* PRs`);
+
+  const repos = [...new Set(mined.map((m) => m.repository))].sort();
+  const fetched = new Map<string, Map<number, FetchedPr>>();
+  for (const repo of repos) {
+    fetched.set(repo, await fetchRepoPrs(repo));
+  }
+
+  const candidates: Item[] = [];
+  let missing = 0;
+  let short = 0;
+  for (const m of mined) {
+    const pr = fetched.get(m.repository)?.get(m.pr_number);
+    if (!pr) {
+      missing++;
+      continue;
+    }
+    if (pr.body.trim().length < argv.flags.minChars) {
+      short++;
+      continue;
+    }
+    candidates.push(toItem(m, pr));
+  }
+
+  const selected = selectSample(candidates, argv.flags.limit);
+
+  await mkdir(dirname(argv.flags.out), { recursive: true });
+  await Bun.write(argv.flags.out, `${JSON.stringify(selected, null, 2)}\n`);
+
+  const byRepo: Record<string, number> = {};
+  for (const s of selected) byRepo[s.repo] = (byRepo[s.repo] ?? 0) + 1;
+
+  console.log(
+    `Candidates: ${candidates.length} (${missing} not found on GitHub, ${short} below --min-chars)`,
+  );
+  console.log(`Wrote ${selected.length} samples to ${argv.flags.out}`);
+  for (const [repo, n] of Object.entries(byRepo)) console.log(`  ${repo}: ${n}`);
+}
+
+if (import.meta.main) main();


### PR DESCRIPTION
Adds `evals/pr-body`, a labeling harness for the bodies `pull-request:create` produces, following the `evals/issue-refine` structure. This PR delivers the mining and labeling half of the loop. The rubric, `score.ts`, `judge.ts`, and A/B report come after a labeling session, since the rubric is derived from the labels rather than written up front.

`scripts/mine.ts` enumerates PRs opened from Claude sessions via the session index's `pr_links` table, fetches bodies per-repo with `gh pr list`, and selects a repo-balanced sample that interleaves long sectioned bodies with tight one-paragraph ones (the same weave as issue-refine's `build-dataset.ts`). A fast-check property on the weave caught a real bug during development: the truthiness guard copied from `build-dataset.ts` (where items are always objects) dropped falsy items, fixed with explicit `undefined` checks. `label/` is copied from `evals/issue-refine/label/` and adapted to render PR bodies with a GitHub link in the header and PR-specific quality tags. Copying is the current convention across `evals/`; a shared harness package is a known deferred refactor, noted in the README.

Privacy: the index includes an imported `work` host marked block-egress, and work PR bodies live on private hosts anyway. The mining SQL hardcodes `host = 'local'` and `repository LIKE 'bendrucker/%'` rather than exposing them as flags, and `data/`/`feedback/` are gitignored.

## Evidence

- `pull-request:create` is the highest-traffic skill (553 invocations across 444 sessions in 60 days) with zero eval coverage. Skill edits are gated only by lint, never by output quality.
- `evals/issue-refine` already proves the loop end to end (mine, label, rubric, mechanical score plus blinded judge, A/B against git HEAD), so this reuses its structure directly.
- The local corpus is large enough to label from: the live index holds 400 distinct local-host `bendrucker/*` PRs, of which 394 have non-trivial bodies. The verification run wrote a 50-item sample spanning 14 repos.

## Testing

- Unit tests cover the pure mining logic: a fast-check multiset property plus an interleave-order example for `weave`, `test.each` tables for the repo round-robin selection, and an inline snapshot for the item metadata shape.
- Ran `mine.ts` against the live session index, which produced the 50-item sample described above, then smoke-tested `label/server.ts`: `/api/samples` serves the mined items and the UI loads.

Next action for you: run the miner and labeler, label ~50 items. That session unlocks `RUBRIC.md` and the scoring half.

Discovery: be8e024a6fcf
