### PR TITLE
feat: add Greptile config for automatic PR review

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,3 @@
+{
+  "strictness": 2
+}


### PR DESCRIPTION
Adds `.greptile/config.json` to make Greptile the default third-party reviewer for this repo, giving an alternative perspective to local Claude subagent reviews.

Greptile won out over the alternatives on a $0 budget: Codex review and Copilot review are paid, the Gemini Code Assist bot shuts down July 17, CodeRabbit has been middling at work, and Qodo's hosted tier requires 500+ stars. Greptile's free Starter tier (50 credits/month) covers this repo's PR volume, and its open-source program may make it fully free since this repo is public and MIT. It also differs meaningfully from a local Claude diff review despite running on Claude under the hood: full codebase graph indexing, multi-hop investigation, and memory that learns from reactions and replies to suppress noise.

The config is deliberately minimal. `strictness: 2` is the default, stated explicitly so it's visible and tunable. `triggerOnUpdates` stays at its default (false) to conserve credits by reviewing on open rather than every push. No `rules.md` yet, per this repo's curation policy: rules get added only after real reviews show a recurring miss or noise pattern.

This PR is itself the end-to-end test. Once the Greptile GitHub App is installed and the repo is enabled in the dashboard, an automatic review on this PR (triggered by reopening it or by a `@greptileai` mention if the app lands after it opened) confirms the setup works.
