### PR TITLE
feat(claude-code): add index-health self-audit query

### DIFF
--- a/plugins/claude-code/skills/session/SKILL.md
+++ b/plugins/claude-code/skills/session/SKILL.md
@@ -103,6 +103,7 @@ Every query also takes an optional `host` param. Omit it to span every machine (
 - `plan-iterations`: one row per ExitPlanMode present, ordered within a session. Measures growth (`chars_delta`, `lines_added`), removal (`lines_removed`), and carry-over (`lines_carried`, `carry_over_ratio`) against the previous present via set comparison of normalized plan text, plus time to the first present (`secs_to_first_plan`) and the session's human-authored prompt count (`human_msgs`). High carry-over paired with growth and near-zero removal is the append-only re-present signature. Params: `min_plans` (default 2, since the query is about re-presents), `after_date`, `before_date`, `project`, `host`.
 - `outcomes`: session terminal states, the outcome side the activity-centric queries never measure. Classifies every session as shipped (pr-link or a ship-signal Bash command: `git push`, `gh pr create/merge`, `glab mr create/merge`), ongoing (too fresh to call), handed-off (last plan rejected, implement-elsewhere), abandoned-with-edits (edits but nothing shipped, the loss signal), or no-artifact (Q&A/analysis), plus distinct PRs opened and PRs that took multiple sessions. Shipped means opened or pushed, not merged; PR fate lives outside the index. Params: `after_date`, `before_date`, `project`, `host`, `ongoing_hours` (default 48).
 - `hook-config-vs-observed`: hooks CONFIGURED on disk (plugin `hooks.json`, `~/.claude/settings.json`, `.claude/settings.json`) left-joined against DISTINCT hooks OBSERVED in `hook_events`, surfacing `observed_fires = 0` rows: hooks that never left a trace, the blind spot every other hook query misses because a silently-succeeding hook produces no event at all. Params: `after_date`, `before_date`, `project`, `host` (scopes the observed side only), `hook` (glob on configured command), `hook_config_glob` (override the plugin-cache glob).
+- `index-health`: the index auditing itself; run it FIRST in any analysis pass. One row per issue (`check_name`, `status`, `subject`, `detail`), alerts before info: `stream-silent` (a record kind that posted regularly then went quiet longer than its own worst historical gap, the signature of an upstream rename/removal that leaves consumers returning confidently stale results), `stream-new` (kinds first seen recently, shipping unconsumed), `host-staleness` (an imported host whose newest record lags the corpus, so cross-host queries read it as idle), `null-timestamp-kinds` (rows date filters silently exclude), `disk-not-indexed`/`indexed-not-on-disk` (index vs `~/.claude/projects` drift), `corpus-window` (the span each host actually covers). Deliberately takes no date/project/host scoping: health is corpus-level. Params: `min_active_days` (default 5), `new_days` (default 14), `stale_days` (default 2), `projects_glob` (default `~/.claude/projects/**/*.jsonl`).
 
 ### Markdown and YAML on Disk
 
@@ -213,6 +214,17 @@ Every table and view carries a `host` column (`local` for this machine, the labe
 - `project_filter(path, pattern)`: match the last path component against a glob pattern.
 - `host_filter(host_col, host_val)`: pass through when `host_val` is NULL, else match the host column.
 - `project_id(host, path)`: `host || ':' || path`, a cross-host project identity.
+
+## Known Blind Spots
+
+The `index-health` query detects drift the corpus can show; these absences are structural, so no query can surface them. State them when an analysis depends on what they hide.
+
+- **Thinking text**: Claude Code persists thinking blocks as signature-only stubs. `content_items` rows with `type = 'thinking'` exist but carry no text; reasoning is unsearchable from transcripts and must be intercepted at runtime (hooks) if needed.
+- **Retention floor**: `cleanupPeriodDays` deletes old session files, and the index rebuilds from surviving JSONL on migration, so the corpus floor ratchets forward (see `corpus-window`). `~/.claude/history.jsonl` holds prompt-level history much further back but is not ingested.
+- **Cloud and mobile sessions**: claude.ai web/mobile chats and cloud routines write no local JSONL. A `bridge-session` record marks only that a cloud bridge existed; the cloud side's content stays remote.
+- **Approved permission prompts**: only rejections leave a trace (`"User rejected tool use"` results). A prompt the user approved is indistinguishable from a call that never prompted, so prompting friction is undercountable.
+- **Offloaded tool results**: large outputs are truncated to a `<persisted-output>` preview pointing at a sidecar file under `tool-results/`; the full output never enters the index.
+- **Other machines**: only imported hosts exist. A machine never imported, or one gone stale (see `host-staleness`), is invisible rather than empty.
 
 ## Discovery
 

--- a/plugins/claude-code/skills/session/fixtures/sessions/-Users-test-health/health.jsonl
+++ b/plugins/claude-code/skills/session/fixtures/sessions/-Users-test-health/health.jsonl
@@ -1,0 +1,9 @@
+{"type":"attachment","attachment":{"type":"health-quiet","note":"daily stream that stops"},"sessionId":"health-session","cwd":"/Users/test/health","timestamp":"2024-01-16T09:00:00.000Z","uuid":"hq-1"}
+{"type":"attachment","attachment":{"type":"health-quiet","note":"daily stream that stops"},"sessionId":"health-session","cwd":"/Users/test/health","timestamp":"2024-01-17T09:00:00.000Z","uuid":"hq-2"}
+{"type":"attachment","attachment":{"type":"health-quiet","note":"daily stream that stops"},"sessionId":"health-session","cwd":"/Users/test/health","timestamp":"2024-01-18T09:00:00.000Z","uuid":"hq-3"}
+{"type":"attachment","attachment":{"type":"health-quiet","note":"daily stream that stops"},"sessionId":"health-session","cwd":"/Users/test/health","timestamp":"2024-01-19T09:00:00.000Z","uuid":"hq-4"}
+{"type":"attachment","attachment":{"type":"health-quiet","note":"daily stream that stops"},"sessionId":"health-session","cwd":"/Users/test/health","timestamp":"2024-01-20T09:00:00.000Z","uuid":"hq-5"}
+{"type":"attachment","attachment":{"type":"health-quiet","note":"daily stream that stops"},"sessionId":"health-session","cwd":"/Users/test/health","timestamp":"2024-01-21T09:00:00.000Z","uuid":"hq-6"}
+{"type":"attachment","attachment":{"type":"health-fresh","note":"kind that appears late in the corpus"},"sessionId":"health-session","cwd":"/Users/test/health","timestamp":"2024-01-31T09:00:00.000Z","uuid":"hf-1"}
+{"type":"health-marker","sessionId":"health-session","cwd":"/Users/test/health","uuid":"hm-1"}
+{"type":"health-marker","sessionId":"health-session","cwd":"/Users/test/health","uuid":"hm-2"}

--- a/plugins/claude-code/skills/session/references/discovery.md
+++ b/plugins/claude-code/skills/session/references/discovery.md
@@ -7,9 +7,10 @@ Fan out read-only analysts over the session index to mine config-change candidat
 Mirror the "Parallel Queries (Workflows)" pattern in [`SKILL.md`](../SKILL.md): refresh once, then every agent opens the index read-only.
 
 1. Refresh once, alone. `scripts/refresh.ts --refresh` takes an exclusive write lock, so it must finish before any agent starts. Capture the printed `$DB` path and hand it to the agents. Never let a fanned-out agent call `refresh.ts`.
-2. Fan out one agent per dimension below. Each runs its named queries (`duckdb -readonly "$DB" < resources/queries/<name>.sql`, scoped with `SET VARIABLE`) plus any inline rollups, all read-only, all against the one shared file. Read-only opens take no lock, so the agents never contend.
-3. Each agent returns structured candidate findings plus the exact SQL it ran. The SQL travels with the finding so the grounding pass and the digest can both cite it.
-4. One or more grounding agents re-check every candidate against the live config (see [Grounding](#grounding)). Drop or downgrade anything that does not hold.
+2. Audit the instrument before trusting it: `duckdb -readonly "$DB" < resources/queries/index-health.sql`. Every alert constrains the run: a `stream-silent` kind means the dimensions reading it (e.g. diagnostics) return stale or empty results with no error; a stale host means cross-host numbers read that machine as idle; `null-timestamp-kinds` lists rows every date-scoped query excludes. Pass the alerts to the agents alongside `$DB`, and cite them in the digest wherever they cap a finding's confidence.
+3. Fan out one agent per dimension below. Each runs its named queries (`duckdb -readonly "$DB" < resources/queries/<name>.sql`, scoped with `SET VARIABLE`) plus any inline rollups, all read-only, all against the one shared file. Read-only opens take no lock, so the agents never contend.
+4. Each agent returns structured candidate findings plus the exact SQL it ran. The SQL travels with the finding so the grounding pass and the digest can both cite it.
+5. One or more grounding agents re-check every candidate against the live config (see [Grounding](#grounding)). Drop or downgrade anything that does not hold.
 
 ## Dimension Cheat Sheet
 

--- a/plugins/claude-code/skills/session/resources/queries/index-health.sql
+++ b/plugins/claude-code/skills/session/resources/queries/index-health.sql
@@ -1,0 +1,227 @@
+-- Index self-audit: checks the instrument before trusting its readings. Every other
+-- named query assumes the index reflects reality; this one checks the index against
+-- its own history and against the disk, surfacing the ways a query can return a
+-- confidently wrong answer with no error. Run it FIRST in any discovery or analysis
+-- pass (references/discovery.md wires it in as the opening step).
+--
+-- One row per issue: check_name, status ('alert' or 'info'), subject, detail.
+-- Alerts sort first. An empty alert set means the checks below found nothing; it does
+-- not mean the index is complete. Thinking text, cloud sessions, and pre-retention
+-- history are structurally absent; see SKILL.md "Known Blind Spots".
+--
+-- Checks:
+--   stream-silent (alert): a record kind that posted regularly and then went silent
+--     longer than its own worst historical gap. The signature of an upstream rename
+--     or removal: every query reading that kind now returns stale or empty results
+--     with no staleness signal (e.g. attachment:diagnostics after CLI 2.1.198,
+--     system:api_error after 2.1.179). Silence is judged against the kind's own gap
+--     distribution so bursty-by-nature kinds don't false-positive.
+--   stream-new (info): a kind first seen recently. New surfaces ship unconsumed;
+--     each is a triage prompt (add a view/query, or document it as noise).
+--   host-staleness (alert): an imported host whose newest record lags the corpus.
+--     Cross-host queries silently read a dead snapshot and conclude that machine
+--     went idle; re-sync per SKILL.md "Re-syncing".
+--   null-timestamp-kinds (info): kinds whose rows carry no timestamp. date_filter
+--     excludes them from EVERY date-scoped query (NULL >= x is NULL), so a date
+--     window hides these rows entirely.
+--   disk-not-indexed (alert): JSONL files on disk missing from the index. Files
+--     created since the last refresh land here too (refresh.ts marks a session
+--     refreshed once and skips subsequent runs), so run refresh.ts --refresh and
+--     re-check; entries that persist mean refresh failure or glob drift. Local host
+--     only; imported hosts' files live under session-imports/ and are covered by
+--     their own refresh watermark.
+--   indexed-not-on-disk (info): indexed files deleted from disk, expected once
+--     cleanupPeriodDays reaps old sessions. The index is their only surviving copy,
+--     so a forced rebuild (migration) permanently loses them.
+--   corpus-window (info): per host, the span the index actually covers. Any
+--     "all-time" claim is bounded below by this floor.
+--
+-- Params (all optional): min_active_days (stream-silent eligibility, default 5),
+-- new_days (stream-new window, default 14), stale_days (host-staleness
+-- threshold, default 2), projects_glob (disk check, default
+-- '~/.claude/projects/**/*.jsonl'; pass the same override given to refresh.ts if
+-- CLAUDE_PROJECTS_DIR is customized).
+WITH corpus AS (
+  SELECT MIN(timestamp) AS min_ts, MAX(timestamp) AS max_ts
+  FROM records
+  WHERE timestamp IS NOT NULL
+),
+-- Highest CLI version in the corpus, by numeric segment order (string MAX would put
+-- 2.1.99 above 2.1.198).
+corpus_version AS (
+  SELECT version
+  FROM records
+  WHERE version IS NOT NULL
+  GROUP BY version
+  ORDER BY list_transform(string_split(version, '.'), lambda x: TRY_CAST(x AS INTEGER)) DESC
+  LIMIT 1
+),
+active_days AS (
+  SELECT kind, timestamp::DATE AS day
+  FROM records
+  WHERE timestamp IS NOT NULL
+  GROUP BY kind, day
+),
+gaps AS (
+  SELECT
+    kind,
+    day,
+    DATE_DIFF('day', LAG(day) OVER (PARTITION BY kind ORDER BY day), day) AS gap
+  FROM active_days
+),
+kind_stats AS (
+  SELECT
+    kind,
+    COUNT(*) AS active_day_count,
+    MIN(day) AS first_seen,
+    MAX(day) AS last_seen,
+    COALESCE(MAX(gap), 1) AS max_gap
+  FROM gaps
+  GROUP BY kind
+),
+kind_rows AS (
+  SELECT
+    kind,
+    COUNT(*) AS total,
+    arg_max(version, timestamp) AS last_version
+  FROM records
+  WHERE timestamp IS NOT NULL
+  GROUP BY kind
+),
+silent_streams AS (
+  SELECT
+    'stream-silent' AS check_name,
+    'alert' AS status,
+    ks.kind AS subject,
+    'silent ' || DATE_DIFF('day', ks.last_seen::TIMESTAMP, c.max_ts)
+      || ' days (worst historical gap ' || ks.max_gap
+      || '); last seen ' || ks.last_seen
+      || ' on version ' || COALESCE(kr.last_version, 'unknown')
+      || ' (corpus now ' || (SELECT version FROM corpus_version)
+      || '); ' || kr.total || ' rows over ' || ks.active_day_count
+      || ' active days' AS detail
+  FROM kind_stats ks
+  JOIN kind_rows kr USING (kind), corpus c
+  WHERE ks.active_day_count >= COALESCE(TRY_CAST(getvariable('min_active_days') AS INTEGER), 5)
+    AND DATE_DIFF('day', ks.last_seen::TIMESTAMP, c.max_ts) > GREATEST(ks.max_gap, 2)
+),
+new_kinds AS (
+  SELECT
+    'stream-new' AS check_name,
+    'info' AS status,
+    ks.kind AS subject,
+    'first seen ' || ks.first_seen || ', ' || kr.total
+      || ' rows so far; a new record kind to triage (consume it in a view or query, '
+      || 'or document it as noise)' AS detail
+  FROM kind_stats ks
+  JOIN kind_rows kr USING (kind), corpus c
+  WHERE DATE_DIFF('day', ks.first_seen::TIMESTAMP, c.max_ts)
+        <= COALESCE(TRY_CAST(getvariable('new_days') AS INTEGER), 14)
+    -- A kind present since (near) the start of the corpus is as old as the index
+    -- itself, not new; without this, a young corpus reports every kind as new.
+    AND DATE_DIFF('day', c.min_ts, ks.first_seen::TIMESTAMP)
+        > COALESCE(TRY_CAST(getvariable('new_days') AS INTEGER), 14)
+),
+host_span AS (
+  SELECT
+    host,
+    COUNT(*) AS row_count,
+    COUNT(DISTINCT source_file) AS file_count,
+    MIN(timestamp) AS first_ts,
+    MAX(timestamp) AS last_ts
+  FROM raw
+  GROUP BY host
+),
+stale_hosts AS (
+  SELECT
+    'host-staleness' AS check_name,
+    'alert' AS status,
+    h.host AS subject,
+    'last record ' || h.last_ts::DATE || ', '
+      || DATE_DIFF('day', h.last_ts, c.max_ts)
+      || ' days behind the corpus; cross-host queries read this host as idle. '
+      || 'Re-sync it (SKILL.md "Re-syncing")' AS detail
+  FROM host_span h, corpus c
+  WHERE DATE_DIFF('day', h.last_ts, c.max_ts)
+        > COALESCE(TRY_CAST(getvariable('stale_days') AS INTEGER), 2)
+),
+null_ts AS (
+  SELECT kind, COUNT(*) AS n
+  FROM records
+  GROUP BY kind
+  HAVING COUNT(timestamp) = 0
+),
+null_ts_summary AS (
+  SELECT
+    'null-timestamp-kinds' AS check_name,
+    'info' AS status,
+    COUNT(*) || ' kinds' AS subject,
+    SUM(n) || ' rows carry no timestamp and are invisible to every date-filtered '
+      || 'query; largest: '
+      || (SELECT string_agg(kind || ' (' || n || ')', ', ' ORDER BY n DESC)
+          FROM (SELECT kind, n FROM null_ts ORDER BY n DESC LIMIT 5)) AS detail
+  FROM null_ts
+  HAVING COUNT(*) > 0
+),
+disk AS (
+  SELECT file
+  FROM glob(COALESCE(
+    TRY_CAST(getvariable('projects_glob') AS VARCHAR),
+    '~/.claude/projects/**/*.jsonl'
+  ))
+),
+indexed AS (
+  SELECT DISTINCT source_file FROM raw WHERE host = 'local'
+),
+disk_missing AS (
+  SELECT
+    'disk-not-indexed' AS check_name,
+    'alert' AS status,
+    COUNT(*) || ' files' AS subject,
+    'on disk but absent from the index; expected for files created since the last '
+      || 'refresh (run refresh.ts --refresh and re-check), persistent entries mean '
+      || 'refresh failure or glob drift, e.g. '
+      || (SELECT string_agg(file, ', ')
+          FROM (SELECT d2.file
+                FROM disk d2
+                LEFT JOIN indexed i2 ON i2.source_file = d2.file
+                WHERE i2.source_file IS NULL
+                LIMIT 3)) AS detail
+  FROM disk d
+  LEFT JOIN indexed i ON i.source_file = d.file
+  WHERE i.source_file IS NULL
+  HAVING COUNT(*) > 0
+),
+disk_vanished AS (
+  SELECT
+    'indexed-not-on-disk' AS check_name,
+    'info' AS status,
+    COUNT(*) || ' files' AS subject,
+    'indexed but deleted from disk (expected under cleanupPeriodDays); the index is '
+      || 'their only surviving copy, and a forced rebuild loses them' AS detail
+  FROM indexed i
+  LEFT JOIN disk d ON d.file = i.source_file
+  WHERE d.file IS NULL
+  HAVING COUNT(*) > 0
+),
+window_info AS (
+  SELECT
+    'corpus-window' AS check_name,
+    'info' AS status,
+    host AS subject,
+    file_count || ' files, ' || row_count || ' rows, '
+      || first_ts::DATE || ' to ' || last_ts::DATE AS detail
+  FROM host_span
+),
+combined AS (
+  SELECT check_name, status, subject, detail FROM silent_streams
+  UNION ALL SELECT * FROM stale_hosts
+  UNION ALL SELECT * FROM disk_missing
+  UNION ALL SELECT * FROM new_kinds
+  UNION ALL SELECT * FROM null_ts_summary
+  UNION ALL SELECT * FROM disk_vanished
+  UNION ALL SELECT * FROM window_info
+)
+SELECT check_name, status, subject, detail
+FROM combined
+ORDER BY status = 'alert' DESC, check_name, subject;

--- a/plugins/claude-code/skills/session/resources/queries/index-health.sql
+++ b/plugins/claude-code/skills/session/resources/queries/index-health.sql
@@ -142,7 +142,10 @@ stale_hosts AS (
       || ' days behind the corpus; cross-host queries read this host as idle. '
       || 'Re-sync it (SKILL.md "Re-syncing")' AS detail
   FROM host_span h, corpus c
-  WHERE DATE_DIFF('day', h.last_ts, c.max_ts)
+  -- Imported hosts only: the remediation is a re-sync, which does not apply to
+  -- local. A lagging local corpus shows up as disk-not-indexed instead.
+  WHERE h.host != 'local'
+    AND DATE_DIFF('day', h.last_ts, c.max_ts)
         > COALESCE(TRY_CAST(getvariable('stale_days') AS INTEGER), 2)
 ),
 null_ts AS (

--- a/plugins/claude-code/skills/session/scripts/db.test.ts
+++ b/plugins/claude-code/skills/session/scripts/db.test.ts
@@ -1375,6 +1375,96 @@ describe("skill-config-vs-observed query", () => {
   });
 });
 
+describe("index-health query", () => {
+  const projectsGlob = path.join(fixturesDir, "**", "*.jsonl");
+
+  type Health = { check_name: string; status: string; subject: string; detail: string };
+
+  function healthParams(overrides: Record<string, string | null> = {}) {
+    return {
+      projects_glob: projectsGlob,
+      min_active_days: null,
+      new_days: null,
+      stale_days: null,
+      ...overrides,
+    };
+  }
+
+  it("flags a kind that went silent beyond its own historical gap", async () => {
+    const rows = await runQuery<Health>(db, "index-health", healthParams());
+    const silent = rows.filter((r) => r.check_name === "stream-silent");
+    expect(silent.map((r) => r.subject)).toEqual(["attachment:health-quiet"]);
+    expect(silent[0]?.status).toBe("alert");
+    expect(silent[0]?.detail).toContain("worst historical gap 1");
+  });
+
+  it("reports a kind first seen late in the corpus as new, not kinds as old as the index", async () => {
+    const rows = await runQuery<Health>(db, "index-health", healthParams());
+    const fresh = rows.filter((r) => r.check_name === "stream-new");
+    expect(fresh.map((r) => r.subject)).toEqual(["attachment:health-fresh"]);
+    expect(fresh[0]?.status).toBe("info");
+  });
+
+  it("summarizes kinds whose rows carry no timestamp", async () => {
+    const rows = await runQuery<Health>(db, "index-health", healthParams());
+    const nullTs = rows.find((r) => r.check_name === "null-timestamp-kinds");
+    expect(nullTs?.status).toBe("info");
+    expect(nullTs?.detail).toContain("health-marker (2)");
+  });
+
+  it("reports the corpus window per host and no disk gap when the glob matches", async () => {
+    const rows = await runQuery<Health>(db, "index-health", healthParams());
+    const windows = rows.filter((r) => r.check_name === "corpus-window");
+    expect(windows.map((r) => r.subject)).toEqual(["local"]);
+    expect(rows.some((r) => r.check_name === "disk-not-indexed")).toBe(false);
+    expect(rows.some((r) => r.check_name === "indexed-not-on-disk")).toBe(false);
+  });
+
+  it("alerts on disk files missing from the index", async () => {
+    const extraDir = path.join(tmpDir, "extra-projects", "-Users-test-extra");
+    mkdirSync(extraDir, { recursive: true });
+    await Bun.write(
+      path.join(extraDir, "unindexed.jsonl"),
+      '{"type":"user","message":{"role":"user","content":"hi"},"sessionId":"extra","timestamp":"2024-02-01T00:00:00.000Z","uuid":"ex-1"}\n',
+    );
+    const rows = await runQuery<Health>(
+      db,
+      "index-health",
+      healthParams({ projects_glob: path.join(tmpDir, "extra-projects", "**", "*.jsonl") }),
+    );
+    const missing = rows.find((r) => r.check_name === "disk-not-indexed");
+    expect(missing?.status).toBe("alert");
+    expect(missing?.subject).toBe("1 files");
+    expect(missing?.detail).toContain("unindexed.jsonl");
+    // With the glob pointed away from the fixtures, every indexed file reads as deleted.
+    expect(rows.find((r) => r.check_name === "indexed-not-on-disk")?.status).toBe("info");
+  });
+
+  it("alerts on an imported host whose newest record lags the corpus", async () => {
+    const staleProjects = path.join(importsDir, "stale", "projects", "-Users-test-stale");
+    mkdirSync(staleProjects, { recursive: true });
+    await Bun.write(
+      path.join(staleProjects, "old.jsonl"),
+      '{"type":"user","message":{"role":"user","content":"old work"},"sessionId":"stale-session","timestamp":"2023-12-01T00:00:00.000Z","uuid":"st-1"}\n',
+    );
+    await Bun.write(
+      path.join(importsDir, "stale", "manifest.json"),
+      `${JSON.stringify({
+        host: "stale",
+        source: "stale:.claude/projects/",
+        imported_at: "2024-01-01T00:00:00Z",
+        policy: { block_egress: true },
+      })}\n`,
+    );
+    await reindex();
+    const rows = await runQuery<Health>(db, "index-health", healthParams());
+    const stale = rows.find((r) => r.check_name === "host-staleness");
+    expect(stale?.status).toBe("alert");
+    expect(stale?.subject).toBe("stale");
+    expect(stale?.detail).toContain("days behind the corpus");
+  });
+});
+
 describe("frontmatter query", () => {
   it("parses name and description from a SKILL.md frontmatter", async () => {
     await loadExtensions(db);

--- a/plugins/claude-code/skills/session/scripts/db.test.ts
+++ b/plugins/claude-code/skills/session/scripts/db.test.ts
@@ -1458,10 +1458,12 @@ describe("index-health query", () => {
     );
     await reindex();
     const rows = await runQuery<Health>(db, "index-health", healthParams());
-    const stale = rows.find((r) => r.check_name === "host-staleness");
-    expect(stale?.status).toBe("alert");
-    expect(stale?.subject).toBe("stale");
-    expect(stale?.detail).toContain("days behind the corpus");
+    const staleness = rows.filter((r) => r.check_name === "host-staleness");
+    // exactly the imported host: local never alerts, its remediation (re-sync)
+    // does not apply
+    expect(staleness.map((r) => r.subject)).toEqual(["stale"]);
+    expect(staleness[0]?.status).toBe("alert");
+    expect(staleness[0]?.detail).toContain("days behind the corpus");
   });
 });
 


### PR DESCRIPTION
Adds `index-health`, a self-audit query for the session index: every other named query trusts the index to reflect reality, and nothing checked the instrument itself. When an upstream CLI release renames or drops a record kind, the queries reading it keep returning results that are stale or empty with no error. This query makes those failure modes visible as first-class rows.

Seven checks, one row per issue (`check_name`, `status`, `subject`, `detail`, alerts sorted first):

- `stream-silent` (alert): a record kind that posted regularly and then went quiet longer than its own worst historical gap. Judging silence against each kind's own gap distribution keeps bursty-by-nature kinds from false-positiving. On the live corpus this immediately caught real drift: `attachment:diagnostics` stopped after CLI 2.1.197 and `system:api_error` after 2.1.179, so the `diagnostics` query and `activity`'s API-error column have been silently reading dead streams.
- `stream-new` (info): kinds first seen recently, each a triage prompt to consume in a view or document as noise. Guarded so a young corpus doesn't report every kind as new.
- `host-staleness` (alert): an imported host whose newest record lags the corpus, which cross-host queries otherwise read as the machine going idle.
- `null-timestamp-kinds` (info): kinds whose rows carry no timestamp. `date_filter` evaluates `NULL >= x` to NULL, so these rows are invisible to every date-scoped query. The live corpus has 15 such kinds totaling ~133k rows.
- `disk-not-indexed` (alert) and `indexed-not-on-disk` (info): drift between `~/.claude/projects/**/*.jsonl` and the index in both directions. The detail text distinguishes expected churn (files created since the last refresh, `cleanupPeriodDays` reaping) from genuine refresh failure or glob drift.
- `corpus-window` (info): the span the index actually covers per host, the floor under any "all-time" claim.

Beyond the query, this PR wires self-audit into how the skill is used. `references/discovery.md` now runs `index-health` as the opening step of every discovery pass, so agents learn what the corpus cannot show them before drawing conclusions from it. SKILL.md gains a `Known Blind Spots` section for the gaps no query can detect (thinking text stored as signature-only stubs, cloud-side session content, history predating the retention floor, approved permission prompts, offloaded tool output), since an empty alert set must not read as "the index is complete."

Two decisions worth flagging. Silence detection deliberately takes no date/project/host scoping because index health is a corpus-level property; scoping it would reintroduce the blind spots it exists to catch. And the check names went through a rename (originally stream-death/stream-birth): the lifecycle metaphor read oddly for data, so they landed as stream-silent/stream-new.

Tests cover each check against a purpose-built fixture host (a daily kind that stops, a late-arriving kind, timestamp-less rows) plus hand-built cases for host staleness and disk drift, asserting exact subject sets so the thresholds can't silently widen.
