### PR TITLE
feat(writing): curb semicolon splice drift

### DIFF
--- a/plugins/writing/detection/comments.test.ts
+++ b/plugins/writing/detection/comments.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, test } from "bun:test";
+import { extractComments } from "./comments";
+import { semicolonSpliceHits } from "./tropes";
+
+describe("extractComments", () => {
+  it("pulls single-line // and # comments and drops the markers", () => {
+    const src = ["const x = 1; // warm the cache", "# read the config", "code()"].join("\n");
+    const comments = extractComments(src);
+    expect(comments).toContain("warm the cache");
+    expect(comments).toContain("read the config");
+    expect(comments).not.toContain("code()");
+  });
+
+  it("does not treat URLs as comments", () => {
+    expect(extractComments('fetch("https://example.com/path")')).toBe("");
+  });
+});
+
+describe("comment splices", () => {
+  test.each<{ name: string; src: string; count: number }>([
+    {
+      name: "splice in a // comment",
+      src: "// keep sorted; callers rely on order\nconst x = 1;",
+      count: 1,
+    },
+    {
+      name: "splice in a # comment",
+      src: "# retries twice; the queue drops the job after that\nvalue = 1",
+      count: 1,
+    },
+    {
+      name: "commented-out code does not splice",
+      src: "// foo(); bar()\nconst x = 1;",
+      count: 0,
+    },
+    {
+      name: "splice outside a comment is invisible",
+      src: 'const label = "cold start; warm later";',
+      count: 0,
+    },
+    {
+      name: "fragment comment without a splice",
+      src: "// keep sorted\nconst x = 1;",
+      count: 0,
+    },
+  ])("$name", ({ src, count }) => {
+    expect(semicolonSpliceHits(extractComments(src), 1).count).toBe(count);
+  });
+});

--- a/plugins/writing/detection/comments.ts
+++ b/plugins/writing/detection/comments.ts
@@ -1,0 +1,12 @@
+const SINGLE_LINE_COMMENT = /(?:^|\s)(?:\/\/|#)[^\n]*/g;
+
+// Pull single-line comments (`//`, `#`) out of source so they can be checked
+// as prose. No AST: this catches the common case and treats every comment line
+// as prose regardless of language.
+export function extractComments(text: string): string {
+  const lines: string[] = [];
+  for (const match of text.matchAll(SINGLE_LINE_COMMENT)) {
+    lines.push(match[0].replace(/^\s*(?:\/\/|#)\s?/, ""));
+  }
+  return lines.join("\n");
+}

--- a/plugins/writing/detection/tropes.test.ts
+++ b/plugins/writing/detection/tropes.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import fc from "fast-check";
-import { firstByTier, type PatternMatch, regexCatalog, scan, stripCode } from "./tropes";
+import {
+  firstByTier,
+  type PatternMatch,
+  regexCatalog,
+  scan,
+  semicolonSpliceHits,
+  stripCode,
+} from "./tropes";
 
 describe("regexCatalog", () => {
   it("returns globalized regex patterns for counting", () => {
@@ -396,6 +403,67 @@ describe("scan", () => {
       it(`skips in ${path}`, () => {
         expect(
           scan(semicolons, path).find((m) => m.category === "connector density"),
+        ).toBeUndefined();
+      });
+    }
+  });
+
+  describe("semicolon splice", () => {
+    const twoSplices =
+      "The cache starts cold; the first request fills it. The retry logic backs off; later attempts succeed.";
+    const oneSplice =
+      "The cache starts cold; the first request fills it. The retry logic backs off.";
+
+    test.each<{ name: string; text: string; min: number; count: number }>([
+      { name: "two splices counted at the prose threshold", text: twoSplices, min: 2, count: 2 },
+      { name: "one splice silent at the prose threshold", text: oneSplice, min: 2, count: 0 },
+      { name: "one splice counted at the comment threshold", text: oneSplice, min: 1, count: 1 },
+      {
+        name: "list-item semicolons skipped",
+        text: "- compile the sources; link the objects\n- package the build; ship the artifact",
+        min: 1,
+        count: 0,
+      },
+      {
+        name: "digit before the semicolon is not a splice",
+        text: "The count was 2; see below. The limit was 3; see above.",
+        min: 1,
+        count: 0,
+      },
+      {
+        name: "commented-out code is not a splice",
+        text: "foo(); bar()",
+        min: 1,
+        count: 0,
+      },
+      {
+        name: "uppercase clauses still splice",
+        text: "The cache starts cold; The first request fills it. It retries; It succeeds.",
+        min: 2,
+        count: 2,
+      },
+    ])("$name", ({ text, min, count }) => {
+      expect(semicolonSpliceHits(text, min).count).toBe(count);
+    });
+
+    it("flags two splices in short prose below the density gate", () => {
+      expect(scan(twoSplices).find((m) => m.category === "semicolon splice")).toBeDefined();
+    });
+
+    it("stays silent on a single splice in prose", () => {
+      expect(scan(oneSplice).find((m) => m.category === "semicolon splice")).toBeUndefined();
+    });
+
+    it("detects in prose files", () => {
+      expect(
+        scan(twoSplices, "doc.md").find((m) => m.category === "semicolon splice"),
+      ).toBeDefined();
+    });
+
+    for (const path of ["script.sh", "index.ts"]) {
+      it(`skips in ${path}`, () => {
+        expect(
+          scan(twoSplices, path).find((m) => m.category === "semicolon splice"),
         ).toBeUndefined();
       });
     }

--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -198,6 +198,24 @@ function connectorDensityHits(text: string): Hits {
   return { count: connected.length, sample: first.slice(Math.max(0, i - 20), i + 24).trim() };
 }
 
+// A splice joins clauses with "; " where letters flank the boundary. The
+// letter guards keep commented-out code (`foo(); bar()`), digit-led references
+// ("2; see below"), and bare separators from counting as clause joins. List
+// items are skipped: their semicolons usually separate enumerated fragments,
+// and connector density already covers dense list semicolons.
+const SEMICOLON_SPLICE = /[a-z]; [a-z]/i;
+const PROSE_SPLICE_MIN = 2;
+
+export function semicolonSpliceHits(text: string, minSplices: number): Hits {
+  const spliced = splitSentences(text).filter(
+    (s) => !LIST_ITEM.test(s) && SEMICOLON_SPLICE.test(s),
+  );
+  if (spliced.length < minSplices) return { count: 0, sample: "" };
+  const first = spliced[0] as string;
+  const i = SEMICOLON_SPLICE.exec(first)?.index ?? 0;
+  return { count: spliced.length, sample: first.slice(Math.max(0, i - 20), i + 24).trim() };
+}
+
 const openerPatterns: PatternDef[] = WORDLISTS.openers
   ? [
       {
@@ -476,6 +494,28 @@ export const PATTERNS: PatternDef[] = [
       "Pre-dates the curation principle; no corpus evidence recorded. The 30%-density threshold was set empirically to avoid false positives on definition-list bullets. Validated against the committed test suite.",
     retire:
       "Remove or raise the threshold if corpus analysis shows the pattern fires heavily on user text (not distinctive) or if a powered labeling pass shows precision below the hook bar.",
+  },
+  {
+    tier: "context",
+    layer: "cross-sentence",
+    category: "semicolon splice",
+    test: (text) => semicolonSpliceHits(text, PROSE_SPLICE_MIN),
+    fileOnly: true,
+    message: (matched) =>
+      `Semicolons join independent clauses here (e.g. "${matched}"). This is the em-dash run-on respelled. Split each into two sentences rather than swapping connectors.`,
+    positives: [
+      "The cache starts cold; the first request fills it. The retry logic backs off; later attempts succeed.",
+      "The hook fires on every edit; the scan runs first. The reminder never blocks; it only nudges.",
+    ],
+    negatives: [
+      "The cache starts cold; the first request fills it. The retry logic backs off.",
+      "- compile the sources; link the objects\n- package the build; ship the artifact",
+      "The count was 2; see below. The limit was 3; see above.",
+    ],
+    evidence:
+      "2026-07 session-history analysis found semicolon clause-joins at high rate in assistant deliverables after the em dash ban. Substitution drift relocated the run-on habit instead of fixing sentence structure. Short texts (PR bodies, commit messages) sit below the connector-density gate (5+ sentences, 30% density), so a two-splice floor covers them. An occasional single semicolon never fires.",
+    retire:
+      "Remove when the deliverable corpus shows the splice rate at or below the hand-written baseline for a 30-day window, or when a labeling pass shows precision below the hook bar. The claude-code:session semicolons-per-1000-words query is the evidence stream.",
   },
   {
     tier: "context",

--- a/plugins/writing/hooks/check-tropes.test.ts
+++ b/plugins/writing/hooks/check-tropes.test.ts
@@ -261,6 +261,60 @@ describe("diff-aware filtering", () => {
   });
 });
 
+describe("semicolon splices", () => {
+  function codeEdit(newString: string, oldString: string): PreToolUseHookInput {
+    const input = mockEdit(newString, oldString);
+    (input.tool_input as Record<string, unknown>).file_path = "index.ts";
+    return input;
+  }
+
+  it("flags a code-file edit introducing a spliced comment", async () => {
+    const result = await processInput(
+      codeEdit("// keep sorted; callers rely on order\nconst x = 1;", "const x = 1;"),
+    );
+    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
+    const ctx = (result?.hookSpecificOutput as { additionalContext: string }).additionalContext;
+    expect(ctx).toContain("semicolon");
+  });
+
+  it("ignores a pre-existing spliced comment untouched by the edit", async () => {
+    const result = await processInput(
+      codeEdit(
+        "// keep sorted; callers rely on order\nconst x = 2;",
+        "// keep sorted; callers rely on order\nconst x = 1;",
+      ),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("ignores commented-out code in a code file", async () => {
+    expect(
+      await processInput(codeEdit("// foo(); bar()\nconst x = 1;", "const x = 1;")),
+    ).toBeNull();
+  });
+
+  it("ignores splices in code outside comments", async () => {
+    expect(
+      await processInput(codeEdit('const label = "cold start; warm later";', "const label = 1;")),
+    ).toBeNull();
+  });
+
+  it("flags two splices in a short prose file", async () => {
+    const result = await processInput(
+      mockWrite(
+        "The cache starts cold; the first request fills it. The retry logic backs off; later attempts succeed.",
+      ),
+    );
+    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
+  });
+
+  it("stays silent on a single semicolon in prose", async () => {
+    expect(
+      await processInput(mockWrite("The cache starts cold; the first request fills it.")),
+    ).toBeNull();
+  });
+});
+
 describe("MultiEdit", () => {
   it("returns null when all old_string values are flagged but new_string values are clean", async () => {
     const input = mockMultiEdit([

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -2,8 +2,15 @@
 
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
-import { isMemoryPath, isPlanPath } from "../detection/paths";
-import { firstByTier, type PatternMatch, scan, scanIntroduced } from "../detection/tropes";
+import { extractComments } from "../detection/comments";
+import { isMemoryPath, isPlanPath, isProseFile } from "../detection/paths";
+import {
+  firstByTier,
+  type PatternMatch,
+  scan,
+  scanIntroduced,
+  semicolonSpliceHits,
+} from "../detection/tropes";
 import { formatContext, formatDecision, isPlanMode, type SyncHookJSONOutput } from "./io";
 
 const FILE_OP_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
@@ -139,6 +146,23 @@ function buildFileOpReminder(
   return `${deny.message} You introduced this in your edit to ${target}. Issue a follow-up Edit that targets only the text you just changed. Do not modify unrelated parts of the file, including other pre-existing tropes.`;
 }
 
+// Comments are short, so density gates cannot work there: a single introduced
+// splice fires. Diff-aware like scanIntroduced, comparing splice counts across
+// the old and new comment text.
+const COMMENT_SPLICE_MIN = 1;
+
+function commentSplice(
+  pair: { newText: string; oldText: string },
+  filePath: string | undefined,
+): string | null {
+  if (!filePath || isProseFile(filePath)) return null;
+  const newHits = semicolonSpliceHits(extractComments(pair.newText), COMMENT_SPLICE_MIN);
+  if (newHits.count === 0) return null;
+  const oldHits = semicolonSpliceHits(extractComments(pair.oldText), COMMENT_SPLICE_MIN);
+  if (newHits.count <= oldHits.count) return null;
+  return `A code comment splices clauses with a semicolon ("${newHits.sample}"). Comments can be fragments. Use a period or drop a word.`;
+}
+
 async function processFileOp(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
   const pair = await collectFileOpPair(input);
   if (!pair) return null;
@@ -152,6 +176,9 @@ async function processFileOp(input: PreToolUseHookInput): Promise<SyncHookJSONOu
 
   const context = firstByTier(matches, "context");
   if (context) return formatContext(context.message);
+
+  const splice = commentSplice(pair, filePath);
+  if (splice) return formatContext(splice);
 
   return null;
 }

--- a/plugins/writing/skills/rewrite/references/style-rules.md
+++ b/plugins/writing/skills/rewrite/references/style-rules.md
@@ -11,7 +11,7 @@ Structural rules for rewriting text. Vocabulary and pattern violations are caugh
 
 ## Clause Connectors
 
-Don't join independent clauses with a semicolon or em dash. Split them into two sentences. At most one connector-joined sentence per paragraph, and only when the clauses can't stand alone.
+Don't join independent clauses with a semicolon or em dash. Split them into two sentences. Swapping one connector for another is not a fix. At most one connector-joined sentence per paragraph, and only when the clauses can't stand alone.
 
 ## Filler
 

--- a/plugins/writing/skills/score/scripts/score.test.ts
+++ b/plugins/writing/skills/score/scripts/score.test.ts
@@ -1,14 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { compileStemmedWordlist } from "../../../detection/wordlists";
 import type { VoiceProfile } from "../../analyze/scripts/voice-profile";
-import {
-  buildReport,
-  extractComments,
-  renderTable,
-  renderVoiceDeltaTable,
-  scoreComments,
-  scoreText,
-} from "./score";
+import { buildReport, renderTable, renderVoiceDeltaTable, scoreComments, scoreText } from "./score";
 
 function category(report: ReturnType<typeof buildReport>, group: string, name: string) {
   return report.groups.find((g) => g.group === group)?.categories.find((c) => c.category === name);
@@ -41,16 +34,6 @@ describe("scoreText", () => {
     const score = scoreText("The widget powers the widgets.", undefined, match);
     const custom = score.categories.find((c) => c.category === "custom vocabulary");
     expect(custom?.hits).toBe(2);
-  });
-});
-
-describe("extractComments", () => {
-  it("pulls single-line // and # comments and drops the markers", () => {
-    const src = ["const x = 1; // leverage the cache", "# delve into config", "code()"].join("\n");
-    const comments = extractComments(src);
-    expect(comments).toContain("leverage the cache");
-    expect(comments).toContain("delve into config");
-    expect(comments).not.toContain("code()");
   });
 });
 

--- a/plugins/writing/skills/score/scripts/score.ts
+++ b/plugins/writing/skills/score/scripts/score.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { cli } from "cleye";
 import { table } from "table";
+import { extractComments } from "../../../detection/comments";
 import { isProseFile } from "../../../detection/paths";
 import { scanAll } from "../../../detection/scan";
 import { stripCode } from "../../../detection/tropes";
@@ -58,19 +59,6 @@ function customVocabularyScore(
 ): CategoryScore {
   const hits = match(stripCode(text)).count;
   return { category: CUSTOM_VOCABULARY, hits, density: density(hits, wordCount) };
-}
-
-const SINGLE_LINE_COMMENT = /(?:^|\s)(?:\/\/|#)[^\n]*/g;
-
-// Pull single-line comments (`//`, `#`) out of source so they score as prose.
-// No AST: this catches the common case and treats every comment line as prose
-// regardless of language, which is the point of scoring comments separately.
-export function extractComments(text: string): string {
-  const lines: string[] = [];
-  for (const match of text.matchAll(SINGLE_LINE_COMMENT)) {
-    lines.push(match[0].replace(/^\s*(?:\/\/|#)\s?/, ""));
-  }
-  return lines.join("\n");
 }
 
 export function scoreText(

--- a/plugins/writing/skills/writing/SKILL.md
+++ b/plugins/writing/skills/writing/SKILL.md
@@ -16,7 +16,7 @@ The hook enforces these automatically. Vocabulary and marketing-verb lists are i
 
 - Never use spaced em dashes (` — `).
 - Avoid "not just X, but also Y" parallelism. Simplify.
-- Don't join independent clauses with em dashes, semicolons, or hyphens. Write two sentences. Swapping one connector for another is not a fix.
+- Don't join independent clauses with em dashes, semicolons, or hyphens. Write two sentences. Swapping one connector for another is not a fix. A rare semicolon is fine only when the clauses genuinely can't stand alone.
 - Don't structure bullets as `- **path/to/file**: description`.
 - Use `####` headers instead of `**Label:**` for labeled subsections.
 - Headings name the topic in a couple of words. No verbs, no `Topic: clause`, no sentence-shaped headings. Move the explanation into the body.

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - Prefer concise, direct responses.
 - Minimize unnecessary explanations unless requested.
-- Don't join clauses with semicolons or em dashes. Write two short sentences.
+- Don't join independent clauses with semicolons or em dashes. End the clause with a period. Swapping one connector for another is not a fix. Semicolons only at rare, normal-English cadence.
 - Wrap filenames and code identifiers with `backticks` in any markdown context.
 - Use natural line breaks unless the surrounding code is wrapped at a specific column.
 - Include a trailing newline in all new files.


### PR DESCRIPTION
Session-history analysis showed semicolons severely overused in Claude output: constant clause-joins in short sentences and heavy use in code comments. This is substitution drift. The em dash ban relocated the run-on habit to semicolons instead of fixing sentence structure, and existing coverage missed both surfaces where it landed. The `connector density` detector gates at 5+ sentences and 30% density, so short texts (PR bodies, commit messages) with two splices escaped. Code comments had no detector at all, since `fileOnly` patterns skip non-prose files entirely.

A splice is defined narrowly: a letter-flanked `; ` boundary. Commented-out code (`foo(); bar()`) and digit-led references ("2; see below") never count. List items are skipped too, since their semicolons usually separate enumerated fragments and connector density already covers dense list semicolons. Occasional single semicolons stay legal everywhere. Prose needs two splices to fire, and the new pattern is context tier, so it reminds and never blocks.

Comments get a stricter floor because they are short and density gates cannot work there. The hook extracts `//` and `#` comments from code-file edits and fires on a single introduced splice, diff-aware, so a pre-existing spliced comment untouched by an unrelated edit stays silent. The extraction logic moved from the score skill into `detection/comments.ts` so the hook and score share one implementation. The new pattern sits right after `connector density` in `PATTERNS`, letting the stronger density signal win `firstByTier` when both fire.

The wording layer now states one stance across `user/CLAUDE.md`, `writing:writing`, and `writing:rewrite`: split into two sentences, swapping one connector for another is not a fix, and a semicolon is acceptable only at rare, normal-English cadence. Chat stays wording-only per the tracked chat-voice gap (#828).

The pattern's `retire` clause ties removal to the corpus. Drop it when the deliverable splice rate holds at or below the hand-written baseline for 30 days, measured via the `claude-code:session` semicolons-per-1000-words query.

## Testing

Piped a crafted `PreToolUse` Edit adding `// keep sorted; callers rely on order` to a `.ts` file into `check-tropes.ts`: it returned the comment-splice context output, where before this change it produced nothing. The same edit with a fragment comment stayed silent. Ran `writing:scan` on two fixtures and only the 2-splice file reported `semicolon splice`. Added examples-gate positives/negatives, `semicolonSpliceHits` threshold tables, comment-extraction tests, and hook tests covering the introduced, pre-existing, and commented-out-code cases.
