### PR TITLE
feat(ship): finishing coordinator skill

### DIFF
--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -18,8 +18,6 @@ allowed-tools:
   - Skill(writing:review)
   - Skill(pull-request:create)
   - Skill(pull-request:babysit)
-  - Skill(pull-request:update)
-  - Skill(pull-request:follow-up)
 ---
 
 # Ship
@@ -40,20 +38,17 @@ PR all the way to merged.
 
 ## Context
 
-Gathered at invocation with bang-execution, so the decide step reads it without
-spending a tool call:
+Gathered at invocation with bang-execution, so the decide step reads it without a
+tool call:
 
 - Working tree and untracked files: !`git status --short`
 
-This signal is base-independent. The committed diff needs a base, which the decide
-step resolves first.
+This is base-independent. The committed diff needs a base, resolved below.
 
 ## Decide What Applies
 
 Resolve the base before diffing. It defaults to `main`. On a stacked branch pass
-`--base <parent>` so gating sees only the tip layer. Diffing against `main` from
-inside a stack pulls in every layer beneath the tip and inflates the file set,
-which can mis-gate a docs-only tip as a code change. Diff the tip against the base
+`--base <parent>` so gating sees only the tip layer. Diff the tip against the base
 with `git diff <base>...HEAD`.
 
 Gate each pass on what the change contains. Read the Context above for the
@@ -107,8 +102,7 @@ Order:
    its trims through a branch fast-forward (see [Comment
    Trims](#comment-trims)). The other fix passes dirty the tree, so running the
    comment pass first keeps the tree clean for it. This pass pauses at preflight
-   to show an agent-count summary and wait for approval, so it interrupts the
-   otherwise unattended flow. That is expected.
+   for an agent-count approval, so it interrupts the otherwise unattended flow.
 2. **Correctness and quality**: `code-review <effort> --fix` or `simplify`. These
    apply their own fixes to the working tree.
 3. **`writing:review`** over the touched prose. It surfaces prose findings.
@@ -136,10 +130,10 @@ git merge --ff-only comments/audit-<hash>
 git branch -d comments/audit-<hash>
 ```
 
-The audit commit is a single commit off the same `HEAD`, so the fast-forward is
-always clean. The merge lives in the dispatched Agent to keep ship's own command
-surface to `git diff` and `git status`. See [`references/passes.md`](references/passes.md)
-for why this resolution over the alternatives.
+The fast-forward is always clean, since the audit commit sits directly on `HEAD`.
+The merge runs in the dispatched Agent so ship's own commands stay `git diff` and
+`git status`. See [`references/passes.md`](references/passes.md) for the rejected
+alternatives.
 
 ## Create
 
@@ -162,32 +156,17 @@ Babysit owns the follow-up loop and the CI waits. Ship does not poll on its own.
 
 ## Refresh the Body
 
-Dispatch a background `general-purpose` Agent to run `pull-request:update <url>`.
-It reads the final PR and the merged diff, not this session's transcript. Use
-`general-purpose`, never `fork`: a fork inherits this session's context and would
-reintroduce the diary narration this step exists to remove.
+Dispatch a background `general-purpose` Agent to run `pull-request:update <url>`,
+on a cheaper model when one is set. It reads the final PR and the merged diff, not
+this session's transcript. Use `general-purpose`, never `fork`: a fork inherits
+this context and would reintroduce the diary narration.
 
-This is the mechanism that kills the diary effect. The rewriter never saw the
-review back-and-forth, so it describes the merged diff as a finished change. No
-"initially", no "after review", no narration of passes that ran. The clean
-context is the point, so backgrounding is a convenience, not a requirement. This
-is the last step, so blocking on it costs little.
-
-Run the Agent on a cheaper model when one is set. Out-of-context on a cheaper
-model serves both goals at once: it removes the diary narration and cuts the cost
-of the rewrite.
+This is what kills the diary effect. The rewriter never saw the review
+back-and-forth, so it describes the merged diff as a finished change, with no
+"initially" or "after review". The cheaper out-of-context model also cuts the
+rewrite's cost.
 
 ## Report
 
-Close with:
-
-- The PR link.
-- Which passes ran, and which were gated out.
-- The final state: green and ready, or merging.
-
-## Cost Levers
-
-Gating the optional passes is the biggest saver. A docs-only diff never spends
-context on `code-review` or `verify`. A code-only diff never spends it on
-`writing:review`. Effort tracks the diff rather than defaulting high, and the
-body-refresh Agent runs out of context on a cheaper model.
+Close with the PR link, which passes ran and which were gated out, and the final
+state (green and ready, or merging).

--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -40,21 +40,27 @@ PR all the way to merged.
 
 ## Context
 
-Gathered at invocation with bang-execution, so the decide step reads them without
+Gathered at invocation with bang-execution, so the decide step reads it without
 spending a tool call:
 
 - Working tree and untracked files: !`git status --short`
-- Committed changes vs `main`: !`git diff --stat main...HEAD`
 
-Untracked files appear only in the first list, so union both for the full
-changed-file set. `main` is the assumed base.
+This signal is base-independent. The committed diff needs a base, which the decide
+step resolves first.
 
 ## Decide What Applies
 
-Gate each pass on what the change contains. Read the Context above for the file
-set and its size, and run `git diff` on the relevant paths only where a judgment
-call needs the content (whether the diff introduces code comments, whether a code
-change is a pure refactor). The full matrix, the effort-inference table, and the
+Resolve the base before diffing. In a Worktrunk stack the parent is the branch
+recorded in `.git/wt/stack`, so diff against that. Otherwise the base is `main`.
+Diffing the tip against its own parent (`git diff <base>...HEAD`) keeps a stacked
+branch gated on its own layer instead of every layer beneath it. A hardcoded
+`main` would pull the whole stack in and inflate the file set.
+
+Gate each pass on what the change contains. Read the Context above for the
+working-tree state, then run `git diff <base>...HEAD` (plus a plain `git diff` for
+uncommitted work) for the file set, its size, and the content behind any judgment
+call: whether the diff introduces code comments, whether a code change is a pure
+refactor. The full matrix, the effort-inference table, and the
 `code-review`-versus-`simplify` heuristic live in
 [`references/passes.md`](references/passes.md). The short version:
 
@@ -98,7 +104,9 @@ Order:
 1. **`comments:audit`** first, because it needs a clean working tree and lands
    its trims through a branch fast-forward (see [Comment
    Trims](#comment-trims)). The other fix passes dirty the tree, so running the
-   comment pass first keeps the tree clean for it.
+   comment pass first keeps the tree clean for it. This pass pauses at preflight
+   to show an agent-count summary and wait for approval, so it interrupts the
+   otherwise unattended flow. That is expected.
 2. **Correctness and quality**: `code-review <effort> --fix` or `simplify`. These
    apply their own fixes to the working tree.
 3. **`writing:review`** over the touched prose. It surfaces prose findings.
@@ -113,10 +121,13 @@ working tree, so the branch's changes must be committed for it to land the trims
 
 `comments:audit` commits its trims to a fresh `comments/audit-<hash>` branch off
 `HEAD` and leaves the working tree untouched. Ship needs those trims on the
-shipping branch. Run `comments:audit --base <base> --fix` and capture the exact
-branch name it prints. Then dispatch a short-lived `general-purpose` Agent,
-passing it that branch name, to fast-forward the shipping branch onto the audit
-commit and delete the temp branch:
+shipping branch. Run `comments:audit --base <base> --fix` and capture the branch
+name it prints.
+
+When the audit finds nothing to trim it writes no branch. There is nothing to
+fast-forward, so skip this step. Only when a branch name was printed, dispatch a
+short-lived `general-purpose` Agent, passing it that name, to fast-forward the
+shipping branch onto the audit commit and delete the temp branch:
 
 ```
 git merge --ff-only comments/audit-<hash>

--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -2,7 +2,7 @@
 name: ship
 disable-model-invocation: true
 description: >-
-  Finish a branch: infer which review passes the diff warrants, run them, open
+  Finish a branch: infer which review passes the change warrants, run them, open
   the PR, babysit CI to green, triage bot comments, and refresh the body from a
   clean context. Invoke as /ship when a change is ready to send.
 argument-hint: "[--merge] [--effort <level>] [--simplify] [--skip <pass>] [--base <ref>]"
@@ -11,6 +11,7 @@ allowed-tools:
   - AskUserQuestion
   - Bash(git diff:*)
   - Bash(git status:*)
+  - Skill(plan:review)
   - Skill(code-review)
   - Skill(simplify)
   - Skill(verify)
@@ -59,6 +60,9 @@ refactor. The full matrix, the effort-inference table, and the
 `code-review`-versus-`simplify` heuristic live in
 [`references/passes.md`](references/passes.md). The short version:
 
+- **`plan:review`** runs when the work was built against an approved plan, meaning
+  Claude Code injected a `~/.claude/plans/` file into this session. The trigger is
+  the plan's presence, so a session with no approved plan skips it.
 - **Correctness and quality** runs when the diff changes code, as exactly one of
   `code-review <effort> --fix` (default) or `simplify` (pure refactor with no new
   behavior). A docs-only or config-only diff skips it.
@@ -85,8 +89,8 @@ be a refactor or a behavior change, or an effort that could be `medium` or
 - `--effort <low|medium|high|max|ultra>` overrides the inferred `code-review`
   effort.
 - `--simplify` forces the `simplify` path over `code-review`.
-- `--skip <pass>` drops a gated pass. Repeatable. Pass names: `code-review`,
-  `simplify`, `comments`, `writing`, `verify`.
+- `--skip <pass>` drops a gated pass. Repeatable. Pass names: `plan`,
+  `code-review`, `simplify`, `comments`, `writing`, `verify`.
 - `--base <ref>` sets the diff base for gating. Default `main`. On a stack, pass
   the parent branch so gating sees only the tip layer.
 
@@ -98,16 +102,21 @@ apply in parallel.
 
 Order:
 
-1. **`comments:audit`** first, because it needs a clean working tree and lands
-   its trims through a branch fast-forward (see [Comment
-   Trims](#comment-trims)). The other fix passes dirty the tree, so running the
-   comment pass first keeps the tree clean for it. This pass pauses at preflight
-   for an agent-count approval, so it interrupts the otherwise unattended flow.
-2. **Correctness and quality**: `code-review <effort> --fix` or `simplify`. These
+1. **`plan:review`** first, when a plan gated it in. It is read-only: it forks a
+   clean-context agent over the plan and the diff and reports divergence and
+   follow-ups without touching the tree. Surface its findings and handle any
+   fix-before-merge drift before moving on, so the passes below cover whatever
+   those fixes produce.
+2. **`comments:audit`**, because it needs a clean working tree and lands its trims
+   through a branch fast-forward (see [Comment Trims](#comment-trims)). The other
+   fix passes dirty the tree, so running the comment pass before them keeps the
+   tree clean for it. This pass pauses at preflight for an agent-count approval, so
+   it interrupts the otherwise unattended flow.
+3. **Correctness and quality**: `code-review <effort> --fix` or `simplify`. These
    apply their own fixes to the working tree.
-3. **`writing:review`** over the touched prose. It surfaces prose findings.
+4. **`writing:review`** over the touched prose. It surfaces prose findings.
    Address the salient ones before the body is written.
-4. **`verify`** to exercise the change end to end.
+5. **`verify`** to exercise the change end to end.
 
 If the working tree is dirty when ship reaches the comment pass, say so and ask
 whether to commit first. `comments:audit` operates on `HEAD` and requires a clean

--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: ship
+disable-model-invocation: true
+description: >-
+  Finish a branch: infer which review passes the diff warrants, run them, open
+  the PR, babysit CI to green, triage bot comments, and refresh the body from a
+  clean context. Invoke as /ship when a change is ready to send.
+argument-hint: "[--merge] [--effort <level>] [--simplify] [--skip <pass>]"
+allowed-tools:
+  - Agent
+  - AskUserQuestion
+  - Bash(git diff:*)
+  - Bash(git status:*)
+  - Skill(code-review)
+  - Skill(simplify)
+  - Skill(verify)
+  - Skill(comments:audit)
+  - Skill(writing:review)
+  - Skill(pull-request:create)
+  - Skill(pull-request:babysit)
+  - Skill(pull-request:update)
+  - Skill(pull-request:follow-up)
+---
+
+# Ship
+
+Finish the current branch with one command. Ship reads the diff, decides which
+review passes it warrants, runs them in sequence, opens the PR, watches CI to
+green, and refreshes the body from a clean context.
+
+Ship is a decider and sequencer, not a worker. Each pass it runs fans out on its
+own (`code-review`, `simplify`, `comments:audit`, `writing:review`, `verify`, and
+`pull-request:babysit` all dispatch their own agents or watchers). Ship's job is
+to gate the optional passes so the diff only pays for the reviewers it earns, then
+run the finishing sequence in the right order.
+
+The default end state is **green and ready**: CI passing, bot comments triaged,
+body refreshed, stopped for your own web review. `--merge` opts into driving the
+PR all the way to merged.
+
+## Context
+
+Gathered at invocation with bang-execution, so the decide step reads them without
+spending a tool call:
+
+- Working tree and untracked files: !`git status --short`
+- Committed changes vs `main`: !`git diff --stat main...HEAD`
+
+Untracked files appear only in the first list, so union both for the full
+changed-file set. `main` is the assumed base.
+
+## Decide What Applies
+
+Gate each pass on what the change contains. Read the Context above for the file
+set and its size, and run `git diff` on the relevant paths only where a judgment
+call needs the content (whether the diff introduces code comments, whether a code
+change is a pure refactor). The full matrix, the effort-inference table, and the
+`code-review`-versus-`simplify` heuristic live in
+[`references/passes.md`](references/passes.md). The short version:
+
+- **Correctness and quality** runs when the diff changes code, as exactly one of
+  `code-review <effort> --fix` (default) or `simplify` (pure refactor with no new
+  behavior). A docs-only or config-only diff skips it.
+- **`comments:audit`** runs when the diff introduces code comments.
+- **`writing:review`** runs when the diff touches prose (`.md`, `.mdx`, `.rst`,
+  docs).
+- **`verify`** runs when the diff has a runtime surface. It declines tests-only
+  and docs-only diffs on its own, so passing it a docs change is a no-op, not a
+  failure.
+
+Infer, don't interrogate. Present the plan in one line and proceed:
+
+> Ship plan: `code-review medium --fix` → `verify` → create → babysit. Skipping
+> comments (no new comments) and writing (no prose).
+
+Use `AskUserQuestion` only when a call is genuinely ambiguous: a diff that could
+be a refactor or a behavior change, or an effort that could be `medium` or
+`high`. One question, then run.
+
+## Flags
+
+- `--merge` drives the PR to merged (babysit `--merge`). Default is green and
+  ready.
+- `--effort <low|medium|high|max|ultra>` overrides the inferred `code-review`
+  effort.
+- `--simplify` forces the `simplify` path over `code-review`.
+- `--skip <pass>` drops a gated pass. Repeatable. Pass names: `code-review`,
+  `simplify`, `comments`, `writing`, `verify`.
+
+## Pre-PR Reviews
+
+Run the gated review passes before creating the PR, serialized. `code-review
+--fix`, `simplify`, and the comment trims all write to the branch, so they cannot
+apply in parallel.
+
+Order:
+
+1. **`comments:audit`** first, because it needs a clean working tree and lands
+   its trims through a branch fast-forward (see [Comment
+   Trims](#comment-trims)). The other fix passes dirty the tree, so running the
+   comment pass first keeps the tree clean for it.
+2. **Correctness and quality**: `code-review <effort> --fix` or `simplify`. These
+   apply their own fixes to the working tree.
+3. **`writing:review`** over the touched prose. It surfaces prose findings.
+   Address the salient ones before the body is written.
+4. **`verify`** to exercise the change end to end.
+
+If the working tree is dirty when ship reaches the comment pass, say so and ask
+whether to commit first. `comments:audit` operates on `HEAD` and requires a clean
+working tree, so the branch's changes must be committed for it to land the trims.
+
+#### Comment Trims
+
+`comments:audit` commits its trims to a fresh `comments/audit-<hash>` branch off
+`HEAD` and leaves the working tree untouched. Ship needs those trims on the
+shipping branch. Run `comments:audit --base <base> --fix` and capture the exact
+branch name it prints. Then dispatch a short-lived `general-purpose` Agent,
+passing it that branch name, to fast-forward the shipping branch onto the audit
+commit and delete the temp branch:
+
+```
+git merge --ff-only comments/audit-<hash>
+git branch -d comments/audit-<hash>
+```
+
+The audit commit is a single commit off the same `HEAD`, so the fast-forward is
+always clean. The merge lives in the dispatched Agent to keep ship's own command
+surface to `git diff` and `git status`. See [`references/passes.md`](references/passes.md)
+for why this resolution over the alternatives.
+
+## Create
+
+Run `pull-request:create` to commit the accumulated working-tree fixes, push, and
+open the PR. Capture the PR URL it prints. The babysit and body-refresh steps
+both need it.
+
+## Babysit
+
+Run `pull-request:babysit <url>` to watch CI and fix trivial failures until
+green.
+
+- Add `--reviews` so babysit hands bot comments to `pull-request:follow-up
+  --auto` after the first green. Default this on: bot review triage is part of
+  finishing.
+- Add `--merge` only when `/ship --merge` was passed. Without it, babysit stops
+  at green and ready.
+
+Babysit owns the follow-up loop and the CI waits. Ship does not poll on its own.
+
+## Refresh the Body
+
+Dispatch a background `general-purpose` Agent to run `pull-request:update <url>`.
+It reads the final PR and the merged diff, not this session's transcript. Use
+`general-purpose`, never `fork`: a fork inherits this session's context and would
+reintroduce the diary narration this step exists to remove.
+
+This is the mechanism that kills the diary effect. The rewriter never saw the
+review back-and-forth, so it describes the merged diff as a finished change. No
+"initially", no "after review", no narration of passes that ran. The clean
+context is the point, so backgrounding is a convenience, not a requirement. This
+is the last step, so blocking on it costs little.
+
+Run the Agent on a cheaper model when one is set. Out-of-context on a cheaper
+model serves both goals at once: it removes the diary narration and cuts the cost
+of the rewrite.
+
+## Report
+
+Close with:
+
+- The PR link.
+- Which passes ran, and which were gated out.
+- The final state: green and ready, or merging.
+
+## Cost Levers
+
+Gating the optional passes is the biggest saver. A docs-only diff never spends
+context on `code-review` or `verify`. A code-only diff never spends it on
+`writing:review`. Effort tracks the diff rather than defaulting high, and the
+body-refresh Agent runs out of context on a cheaper model.

--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Finish a branch: infer which review passes the diff warrants, run them, open
   the PR, babysit CI to green, triage bot comments, and refresh the body from a
   clean context. Invoke as /ship when a change is ready to send.
-argument-hint: "[--merge] [--effort <level>] [--simplify] [--skip <pass>]"
+argument-hint: "[--merge] [--effort <level>] [--simplify] [--skip <pass>] [--base <ref>]"
 allowed-tools:
   - Agent
   - AskUserQuestion
@@ -50,11 +50,11 @@ step resolves first.
 
 ## Decide What Applies
 
-Resolve the base before diffing. In a Worktrunk stack the parent is the branch
-recorded in `.git/wt/stack`, so diff against that. Otherwise the base is `main`.
-Diffing the tip against its own parent (`git diff <base>...HEAD`) keeps a stacked
-branch gated on its own layer instead of every layer beneath it. A hardcoded
-`main` would pull the whole stack in and inflate the file set.
+Resolve the base before diffing. It defaults to `main`. On a stacked branch pass
+`--base <parent>` so gating sees only the tip layer. Diffing against `main` from
+inside a stack pulls in every layer beneath the tip and inflates the file set,
+which can mis-gate a docs-only tip as a code change. Diff the tip against the base
+with `git diff <base>...HEAD`.
 
 Gate each pass on what the change contains. Read the Context above for the
 working-tree state, then run `git diff <base>...HEAD` (plus a plain `git diff` for
@@ -92,6 +92,8 @@ be a refactor or a behavior change, or an effort that could be `medium` or
 - `--simplify` forces the `simplify` path over `code-review`.
 - `--skip <pass>` drops a gated pass. Repeatable. Pass names: `code-review`,
   `simplify`, `comments`, `writing`, `verify`.
+- `--base <ref>` sets the diff base for gating. Default `main`. On a stack, pass
+  the parent branch so gating sees only the tip layer.
 
 ## Pre-PR Reviews
 

--- a/user/skills/ship/references/passes.md
+++ b/user/skills/ship/references/passes.md
@@ -1,0 +1,89 @@
+# Ship Passes
+
+The decision matrix ship uses to gate each pre-PR review, infer `code-review`
+effort, choose between `code-review` and `simplify`, and land comment trims on
+the shipping branch.
+
+## Gating Matrix
+
+Read the diff against the base plus the working tree. Gate each pass on what the
+diff actually contains:
+
+| Diff contains | Pass | Notes |
+|---|---|---|
+| Code changes | `code-review <effort> --fix` or `simplify` | Exactly one of the two. Skipped on a docs-only or config-only diff |
+| New code comments | `comments:audit` | See [Comment Trims](#comment-trims) |
+| Prose (`.md`, `.mdx`, `.rst`, docs) | `writing:review` | Prose-gated |
+| A runtime surface | `verify` | Skips tests-only and docs-only diffs itself |
+
+The gating is what saves context. A docs-only change skips `code-review` and
+`verify`. A code-only change skips `writing:review`. Never run a reviewer the
+diff does not warrant.
+
+`--skip <pass>` drops any gated pass. `code-review`, `simplify`, `comments`,
+`writing`, `verify`.
+
+## Effort Inference
+
+`code-review` runs at an inferred effort unless `--effort` overrides it. Session
+history spreads fairly evenly across the low three (roughly `low` 63, `medium` 49,
+`high` 47), with `max` and `ultra` rare (2 and 0). Match the effort to the diff.
+`high` is a routine outcome for risky work. Reserve `max` and `ultra` for explicit
+requests.
+
+| Diff shape | Effort |
+|---|---|
+| Tiny: one file, a handful of lines | `low` |
+| Ordinary change | `medium` |
+| Risky: touches multiple plugins, hooks, permissions, sandbox, or auth-shaped code | `high` |
+| Explicit request only | `max`, `ultra` |
+
+`ultra` is a deep multi-agent cloud review. Never infer it. Run it only when the
+user passes `--effort ultra`.
+
+## Code-Review Versus Simplify
+
+They are alternatives, not a pair. Session history bears this out: many runs did
+one or the other, few did both. Choose one.
+
+Pick `simplify` when the change is a pure refactor or cleanup with no new
+behavior: extraction, renaming, dedup, dead-code removal, moving code without
+changing what it does. `simplify` covers reuse, simplification, efficiency, and
+altitude. It does not hunt for bugs.
+
+Pick `code-review` for everything else. Any new behavior, bug fix, or feature
+needs correctness coverage, which `simplify` does not provide.
+
+`--simplify` forces the `simplify` path regardless of the inference.
+
+## Comment Trims
+
+`comments:audit` does not write to the working tree. It commits its trims to a
+fresh `comments/audit-<hash>` branch off `HEAD` via git plumbing, and its apply
+step requires a clean working tree. Ship needs those trims on the shipping
+branch, not on a side branch.
+
+Resolution: run `comments:audit` as the **first** pre-PR pass, while the tree is
+still clean, then fast-forward the shipping branch onto the audit commit.
+
+```
+comments:audit --base <base> --fix
+git merge --ff-only comments/audit-<hash>
+git branch -d comments/audit-<hash>
+```
+
+The audit commit is a single commit off the same `HEAD`, so the fast-forward
+never conflicts. Ship dispatches the merge to a short-lived `general-purpose`
+Agent so ship's own command surface stays limited to `git diff` and `git status`.
+
+Two alternatives were rejected:
+
+- **`--report` plus inline apply**: pulls the full findings into ship's context,
+  which defeats the whole point of keeping the bulk verdicts on disk and off the
+  conversation.
+- **Running it after `code-review --fix`**: the fix pass dirties the tree, and
+  `comments:audit` apply then fails its clean-tree check. Reordering it first
+  avoids a commit step mid-sequence.
+
+Running the audit first also means the later `code-review --fix` pass sees the
+already-trimmed comments, which is the better ordering anyway.

--- a/user/skills/ship/references/passes.md
+++ b/user/skills/ship/references/passes.md
@@ -6,22 +6,42 @@ the shipping branch.
 
 ## Gating Matrix
 
-Read the diff against the base plus the working tree. Gate each pass on what the
-diff actually contains:
+Most passes gate on the diff. Read it against the base plus the working tree, and
+gate each on what it contains. `plan:review` is the exception: it gates on whether
+the session was built against an approved plan.
 
-| Diff contains | Pass | Notes |
+| Trigger | Pass | Notes |
 |---|---|---|
+| An approved plan for the session | `plan:review` | Context-gated. See [Plan Review](#plan-review) |
 | Code changes | `code-review <effort> --fix` or `simplify` | Exactly one of the two. Skipped on a docs-only or config-only diff |
 | New code comments | `comments:audit` | See [Comment Trims](#comment-trims) |
 | Prose (`.md`, `.mdx`, `.rst`, docs) | `writing:review` | Prose-gated |
 | A runtime surface | `verify` | Skips tests-only and docs-only diffs itself |
 
 The gating is what saves context. A docs-only change skips `code-review` and
-`verify`. A code-only change skips `writing:review`. Never run a reviewer the
-diff does not warrant.
+`verify`. A code-only change skips `writing:review`. An ad-hoc change with no plan
+skips `plan:review`. Never run a reviewer the change does not warrant.
 
-`--skip <pass>` drops any gated pass. `code-review`, `simplify`, `comments`,
-`writing`, `verify`.
+`--skip <pass>` drops any gated pass. `plan`, `code-review`, `simplify`,
+`comments`, `writing`, `verify`.
+
+## Plan Review
+
+`plan:review` gates on whether the session was built against an approved plan. Run
+it when Claude Code injected one (`~/.claude/plans/<name>.md`) into the session. An
+ad-hoc change with no plan has nothing to review against, so skip it.
+
+It is read-only. It forks a clean-context agent over the plan and the diff and
+reports divergences, requirements drift, and ranked follow-ups. It writes nothing
+to the tree. That is why it runs first, ahead of the fix passes: its follow-ups
+frame what the rest of the sequence and the author still need to address, and any
+drift fix it prompts then flows through `code-review` and `verify` like the rest of
+the change.
+
+Forking a clean context is what the review depends on. The session that built the
+change carries a justification for every departure, so drift reads as normal from
+inside it. A reviewer starting clean judges the delta on its merits. `plan:review`
+owns sourcing the plan and diffing it, so ship only decides whether to run it.
 
 ## Effort Inference
 

--- a/user/skills/ship/references/passes.md
+++ b/user/skills/ship/references/passes.md
@@ -76,6 +76,10 @@ The audit commit is a single commit off the same `HEAD`, so the fast-forward
 never conflicts. Ship dispatches the merge to a short-lived `general-purpose`
 Agent so ship's own command surface stays limited to `git diff` and `git status`.
 
+A clean audit writes no branch. When `comments:audit` reports nothing to trim,
+there is no `comments/audit-<hash>` to merge, so skip the fast-forward rather than
+running it against a branch that does not exist.
+
 Two alternatives were rejected:
 
 - **`--report` plus inline apply**: pulls the full findings into ship's context,


### PR DESCRIPTION
Adds `/ship`, a user-level coordinator that finishes the current branch in one command. It reads the diff, gates each review pass on what the change warrants, runs the gated passes, opens the PR, babysits CI to green, triages bot comments, and refreshes the PR body from a clean context.

## Why a Coordinator

The finishing sequence was already a habit, hand-typed as `then /…` chains across many sessions: `[code-review OR simplify] → create → babysit → triage → refresh`. `/ship` puts it behind one dictated command without losing the per-change judgment calls. It stays a lightweight decider and sequencer rather than a Workflow. The sub-skills (`code-review`, `comments:audit`, `writing:review`, `babysit`) already fan out internally, so the coordinator only decides and orders.

## Decisions

- **Gating over blanket runs.** Optional passes run only when the diff warrants them: prose-gated `writing:review`, comment-gated `comments:audit`, runtime-gated `verify`. This is the main cost lever.
- **`plan:review` catches requirements drift.** Now that it is on `main`, ship composes it as the first pre-PR pass, gated on whether an approved plan drove the work (a `~/.claude/plans/` file injected into the session). It is read-only, forking a clean-context agent to report divergence, so its follow-ups frame the fix passes that follow. A clean context surfaces drift the implementing session has already rationalized.
- **`code-review` and `simplify` are alternatives.** Session history shows the two are almost never run together, so ship picks one. `--simplify` forces the refactor path.
- **Effort tracks the diff.** Effort is inferred from the diff shape (`low` for tiny, `medium` default, `high` for risky or multi-plugin changes), matching the observed distribution. `max` and `ultra` run only on explicit request.
- **Explicit base flag.** Gating diffs against `--base <ref>` (default `main`) rather than inspecting the worktree's stack metadata, since ship's allowed tools don't include a read of arbitrary files. An explicit flag keeps the command surface to `git diff`/`git status` while still supporting stacked branches, where gating needs only the tip layer.
- **Forked body refresh.** The final `pull-request:update` runs in a background `general-purpose` agent with clean context, so the rewritten body describes the merged change instead of narrating the review back-and-forth. Never a `fork`, which would inherit this session's context and defeat the point.
- **Default green-and-ready.** Ship stops at green with bot comments triaged, leaving the final web review to you. `--merge` opts into the auto-merge path.

`comments:audit` commits its trims to a side branch off `HEAD`, so ship runs it first on a clean tree and fast-forwards those trims onto the shipping branch. The reasoning and the rejected alternatives live in `references/passes.md`.

## Verification

`bun run skill-lint "user/skills/ship"` checks the frontmatter and reference depth. Gating was exercised on a throwaway docs-only branch, where the plan selects `writing:review` alone and omits `code-review` and `verify`.

Incubating as a user-level skill under `user/skills/ship`, not a plugin.

