### PR TITLE
feat(meme): add meme plugin with image skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -168,6 +168,11 @@
       "name": "comments",
       "description": "Detect AI slop code comments in a diff and steer clean comment generation",
       "source": "./plugins/comments"
+    },
+    {
+      "name": "meme",
+      "description": "Generate memes from images: classic Impact macros, labels, and TV-subtitle captions",
+      "source": "./plugins/meme"
     }
   ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -142,6 +142,15 @@
         "cleye": "^2.0.0",
       },
     },
+    "plugins/meme": {
+      "name": "meme",
+      "version": "0.1.0",
+      "dependencies": {
+        "@napi-rs/canvas": "^0.1.65",
+        "cleye": "^2.2.1",
+        "sharp": "^0.35.0",
+      },
+    },
     "plugins/mermaid/skills/diagram": {
       "name": "mermaid-diagram",
       "version": "0.1.0",
@@ -502,6 +511,30 @@
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.11", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA=="],
+
+    "@napi-rs/canvas": ["@napi-rs/canvas@0.1.100", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "0.1.100", "@napi-rs/canvas-darwin-arm64": "0.1.100", "@napi-rs/canvas-darwin-x64": "0.1.100", "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100", "@napi-rs/canvas-linux-arm64-gnu": "0.1.100", "@napi-rs/canvas-linux-arm64-musl": "0.1.100", "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100", "@napi-rs/canvas-linux-x64-gnu": "0.1.100", "@napi-rs/canvas-linux-x64-musl": "0.1.100", "@napi-rs/canvas-win32-arm64-msvc": "0.1.100", "@napi-rs/canvas-win32-x64-msvc": "0.1.100" } }, "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA=="],
+
+    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@0.1.100", "", { "os": "android", "cpu": "arm64" }, "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ=="],
+
+    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@0.1.100", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A=="],
+
+    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@0.1.100", "", { "os": "darwin", "cpu": "x64" }, "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw=="],
+
+    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@0.1.100", "", { "os": "linux", "cpu": "arm" }, "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA=="],
+
+    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@0.1.100", "", { "os": "linux", "cpu": "arm64" }, "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw=="],
+
+    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@0.1.100", "", { "os": "linux", "cpu": "arm64" }, "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ=="],
+
+    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@0.1.100", "", { "os": "linux", "cpu": "none" }, "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw=="],
+
+    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@0.1.100", "", { "os": "linux", "cpu": "x64" }, "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg=="],
+
+    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@0.1.100", "", { "os": "linux", "cpu": "x64" }, "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA=="],
+
+    "@napi-rs/canvas-win32-arm64-msvc": ["@napi-rs/canvas-win32-arm64-msvc@0.1.100", "", { "os": "win32", "cpu": "arm64" }, "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw=="],
+
+    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.100", "", { "os": "win32", "cpu": "x64" }, "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA=="],
 
     "@nodable/entities": ["@nodable/entities@2.2.0", "", {}, "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg=="],
 
@@ -1082,6 +1115,8 @@
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "meme": ["meme@workspace:plugins/meme"],
 
     "memjs": ["memjs@1.3.2", "", {}, "sha512-qUEg2g8vxPe+zPn09KidjIStHPtoBO8Cttm8bgJFWWabbsjQ9Av9Ky+6UcvKx6ue0LLb/LEhtcyQpRyKfzeXcg=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "plugins/x-callback-url",
     "plugins/review",
     "plugins/comments",
+    "plugins/meme",
     ".claude/skills/agent-ideas"
   ],
   "scripts": {

--- a/plugins/meme/.claude-plugin/plugin.json
+++ b/plugins/meme/.claude-plugin/plugin.json
@@ -1,0 +1,4 @@
+{
+  "name": "meme",
+  "description": "Generate memes from images: classic Impact macros, labels, and TV-subtitle captions"
+}

--- a/plugins/meme/README.md
+++ b/plugins/meme/README.md
@@ -1,0 +1,13 @@
+# Meme
+
+Generate memes from images: classic Impact macros, labels, and TV-subtitle captions.
+
+## Skills
+
+- `image`: overlay meme text on an image (classic top/bottom, subtitle, caption bar, or multi-label spec)
+
+## Tests
+
+```sh
+bun test plugins/meme
+```

--- a/plugins/meme/package.json
+++ b/plugins/meme/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "meme",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@napi-rs/canvas": "^0.1.65",
+    "cleye": "^2.2.1",
+    "sharp": "^0.35.0"
+  }
+}

--- a/plugins/meme/skills/image/.gitignore
+++ b/plugins/meme/skills/image/.gitignore
@@ -1,0 +1,3 @@
+.bun-cache/
+node_modules/
+tmp/

--- a/plugins/meme/skills/image/SKILL.md
+++ b/plugins/meme/skills/image/SKILL.md
@@ -19,7 +19,7 @@ Overlay meme text on an image with a deterministic renderer. You judge layout, p
 
 ## Workflow
 
-1. Resolve the image. Use the user's path directly. If they only describe an image, WebSearch for it and download with `curl -L -o tmp/<name>.jpg <url>`. Never pass a URL to the renderer.
+1. Resolve the image. Use the user's path directly. If they name a meme format instead of a path, check the template library first (below). Otherwise WebSearch for the image and download with `curl -L -o tmp/<name>.jpg <url>`. Never pass a URL to the renderer.
 2. Read the image. Note the subjects, where faces and action are, contrast, and aspect ratio.
 3. Choose a mode:
    - Top/bottom macro text: `--top` / `--bottom`
@@ -35,6 +35,13 @@ Overlay meme text on an image with a deterministic renderer. You judge layout, p
    ```
 
    Report the path. If the clipboard copy is declined or fails, reveal the file instead: `open -R <path>`.
+
+## Template Library
+
+`${CLAUDE_PLUGIN_DATA}/templates/` holds the user's meme templates, synced outside git. Never copy its images into the repo. Each image may have a sidecar spec of the same basename (`drake.jpg` + `drake.json`): a ready-made layout whose `text` values are `<slot descriptions>` and whose `description` says how the format works.
+
+- User names a format: `ls` the library and match by filename. With a sidecar, copy it to `tmp/`, replace each slot with the actual joke, and render with `--spec`. Panel counts matter: fill every slot the joke needs and drop boxes the format leaves empty.
+- No sidecar (new template): Read the image, trace regions, render, iterate. Once the layout looks right, save it back as a sidecar with `<slot description>` placeholders so the next use skips the tracing.
 
 ## Rendering
 

--- a/plugins/meme/skills/image/SKILL.md
+++ b/plugins/meme/skills/image/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: image
+description: Generate a meme by overlaying text on an image. Use when asked to make a meme, caption an image, add meme text, or produce classic Impact macros, TV-subtitle stills, white-bar captions, or multi-label formats (Drake, distracted boyfriend, whiteboard).
+argument-hint: "[image-path] [meme text or idea]"
+allowed-tools:
+  - "Bash(bun ${CLAUDE_SKILL_DIR}/scripts/render.ts:*)"
+hooks:
+  PreToolUse:
+    - matcher: "Bash(bun ${CLAUDE_SKILL_DIR}/scripts/render.ts:*)"
+      hooks:
+        - type: command
+          command: "bun ${CLAUDE_PLUGIN_ROOT}/skills/image/scripts/setup.ts"
+          once: true
+---
+
+# Meme Image
+
+Overlay meme text on an image with a deterministic renderer. You judge layout, placement, and legibility; the script guarantees the classic look (Impact stroke, subtitle yellow, caption bars).
+
+## Workflow
+
+1. Resolve the image. Use the user's path directly. If they only describe an image, WebSearch for it and download with `curl -L -o tmp/<name>.jpg <url>`. Never pass a URL to the renderer.
+2. Read the image. Note the subjects, where faces and action are, contrast, and aspect ratio.
+3. Choose a mode:
+   - Top/bottom macro text: `--top` / `--bottom`
+   - TV-subtitle quote (yellow, bottom center): `--subtitle`
+   - White bar above or below the image: `--caption` (optionally `--caption-position top|bottom`, default top)
+   - Multi-label formats or custom placement: write a JSON spec file. Read [references/spec.md](references/spec.md) first.
+4. Pick the output filename. It is part of the joke: witty and meme-relevant, kebab or snake case, `.png`. Never `meme.png` or another generic name. If the user supplies a filename, use theirs.
+5. Render, then Read the output PNG. Check legibility, that text does not cover key subjects, line-break placement, and any fit warnings on stderr. Adjust and re-render until it reads well.
+6. Deliver: copy the file reference to the clipboard so a paste keeps the filename:
+
+   ```sh
+   osascript -e 'set the clipboard to POSIX file "<absolute output path>"'
+   ```
+
+   Report the path. If the clipboard copy is declined or fails, reveal the file instead: `open -R <path>`.
+
+## Rendering
+
+```sh
+bun ${CLAUDE_SKILL_DIR}/scripts/render.ts <image> [flags] -o tmp/<joke-name>.png
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--top`, `--bottom` | Classic Impact macro text |
+| `--subtitle` | TV-subtitle text at the bottom |
+| `--caption` | White-bar caption (expands the canvas); `--caption-position top\|bottom` |
+| `--spec`, `-s` | JSON layout spec file (mutually exclusive with the text flags) |
+| `--out`, `-o` | Output PNG path (always required) |
+
+On success the script prints the absolute output path. Fit problems are warnings, not errors: the text still renders at the shrink floor. Treat every warning as a cue to shorten text or enlarge its region.
+
+## Gotchas
+
+- The Bash tool escapes `!` to `\!`, which corrupts flag values. If any text contains `!`, Write a spec file to `tmp/` and render with `--spec` instead of text flags.
+- Images narrower than 400px are auto-upscaled 2x before drawing, so tiny templates still get readable text. Expect output dimensions to differ from the input.
+- Spec coordinates and font sizes are normalized (0-1 fractions of image dimensions). Judge placement from the Read image in fractions, not pixels: Read may downscale.

--- a/plugins/meme/skills/image/SKILL.md
+++ b/plugins/meme/skills/image/SKILL.md
@@ -62,5 +62,7 @@ On success the script prints the absolute output path. Fit problems are warnings
 ## Gotchas
 
 - The Bash tool escapes `!` to `\!`, which corrupts flag values. If any text contains `!`, Write a spec file to `tmp/` and render with `--spec` instead of text flags.
+- Web search returns template *pages*, not image files, and meme-site pages are often JS-rendered so the image URL is not in the static HTML. Imgflip: the direct image is `https://i.imgflip.com/<id36>.jpg` where `<id36>` is the numeric template ID from the page URL in base36 (`(55311130).toString(36)` → `wxica`). Always `file` the download to confirm it is an image before rendering.
+- Multi-panel formats: set `"linkFontSizes": true` in the spec so all panels share one font size instead of each fitting independently.
 - Images narrower than 400px are auto-upscaled 2x before drawing, so tiny templates still get readable text. Expect output dimensions to differ from the input.
 - Spec coordinates and font sizes are normalized (0-1 fractions of image dimensions). Judge placement from the Read image in fractions, not pixels: Read may downscale.

--- a/plugins/meme/skills/image/references/spec.md
+++ b/plugins/meme/skills/image/references/spec.md
@@ -37,7 +37,9 @@ At least one box or caption is required. `style` fields are sparse overrides on 
 |--------|------|----------|
 | `classic` | Impact, uppercase, white fill, thick black stroke | anchor top, max size 0.10 x H |
 | `label` | Helvetica bold, mixed case, black fill, thin white stroke | anchor center, max size 0.06 x H |
-| `subtitle` | Helvetica bold, mixed case, yellow `#ffe400`, thin black outline | anchor bottom, max size 0.045 x H |
+| `subtitle` | Helvetica bold, mixed case, yellow `#ffe400`, black outline | anchor bottom, max size 0.045 x H |
+
+Yellow reads as closed captions. For quoted dialogue or stylized show text (song lyrics, character lines) that is not meant to look like captioning, override to white: `"style": { "fill": "#ffffff" }`.
 
 Anchors map to canned regions: top `{x: 0.05, y: 0.02, w: 0.9, h: 0.3}`, bottom `{x: 0.05, y: 0.68, w: 0.9, h: 0.3}`, center `{x: 0.05, y: 0.35, w: 0.9, h: 0.3}`.
 

--- a/plugins/meme/skills/image/references/spec.md
+++ b/plugins/meme/skills/image/references/spec.md
@@ -25,11 +25,12 @@ JSON file passed via `--spec`. Use it for multi-label formats, custom placement,
   ],
   "captions": [
     { "text": "required", "position": "top | bottom (default top)" }
-  ]
+  ],
+  "linkFontSizes": false
 }
 ```
 
-At least one box or caption is required. `style` fields are sparse overrides on the preset; `fontSize` sets the starting size, and text still shrinks if it does not fit.
+At least one box or caption is required. `style` fields are sparse overrides on the preset; `fontSize` sets the starting size, and text still shrinks if it does not fit. `linkFontSizes: true` re-fits every box at the smallest fitted size; use it for multi-panel formats (Drake, Gru) where mismatched panel text reads wrong.
 
 ## Presets
 

--- a/plugins/meme/skills/image/references/spec.md
+++ b/plugins/meme/skills/image/references/spec.md
@@ -1,0 +1,103 @@
+# Layout Spec
+
+JSON file passed via `--spec`. Use it for multi-label formats, custom placement, style overrides, or any text containing `!`. All coordinates and font sizes are normalized: positions and sizes are fractions of the image dimensions (font sizes are fractions of image height). Caption bars are added outside the image, so box coordinates always refer to the original image area.
+
+## Schema
+
+```json
+{
+  "boxes": [
+    {
+      "text": "required non-empty string",
+      "preset": "classic | label | subtitle (default classic)",
+      "anchor": "top | bottom | center (mutually exclusive with region)",
+      "region": { "x": 0.1, "y": 0.2, "w": 0.5, "h": 0.25 },
+      "align": "left | center | right (default center)",
+      "valign": "top | middle | bottom (default follows anchor; regions default middle)",
+      "style": {
+        "fill": "#rrggbb",
+        "stroke": "#rrggbb",
+        "fontSize": 0.08,
+        "font": "font family name",
+        "uppercase": true
+      }
+    }
+  ],
+  "captions": [
+    { "text": "required", "position": "top | bottom (default top)" }
+  ]
+}
+```
+
+At least one box or caption is required. `style` fields are sparse overrides on the preset; `fontSize` sets the starting size, and text still shrinks if it does not fit.
+
+## Presets
+
+| Preset | Look | Defaults |
+|--------|------|----------|
+| `classic` | Impact, uppercase, white fill, thick black stroke | anchor top, max size 0.10 x H |
+| `label` | Helvetica bold, mixed case, black fill, thin white stroke | anchor center, max size 0.06 x H |
+| `subtitle` | Helvetica bold, mixed case, yellow `#ffe400`, thin black outline | anchor bottom, max size 0.045 x H |
+
+Anchors map to canned regions: top `{x: 0.05, y: 0.02, w: 0.9, h: 0.3}`, bottom `{x: 0.05, y: 0.68, w: 0.9, h: 0.3}`, center `{x: 0.05, y: 0.35, w: 0.9, h: 0.3}`.
+
+Fixed constants (not spec surface): line height 1.15, region padding 4% per side, shrink floor (classic 0.028 x H, absolute floor 12px). Text wraps automatically; explicit newlines collapse to spaces.
+
+## Worked Examples
+
+### Classic Macro (Flags, No Spec Needed)
+
+```sh
+render.ts photo.jpg --top "I'm telling you" --bottom "the tests pass on my machine" -o tmp/pepe-silvia-works-on-my-machine.png
+```
+
+### TV Subtitle (Flags)
+
+```sh
+render.ts still.jpeg --subtitle "♪ workin' hard for the money ♪" -o tmp/dolly-would-approve.png
+```
+
+Renders yellow bottom-center subtitle text. Unicode like ♪ works in both flags and specs.
+
+### Two-Panel Labels (Jim's Whiteboard, 421x475)
+
+One label box per whiteboard panel, regions traced from the Read image:
+
+```json
+{
+  "boxes": [
+    {
+      "text": "just one more refactor",
+      "preset": "label",
+      "region": { "x": 0.06, "y": 0.07, "w": 0.44, "h": 0.3 }
+    },
+    {
+      "text": "and the codebase will be clean",
+      "preset": "label",
+      "region": { "x": 0.08, "y": 0.57, "w": 0.46, "h": 0.26 }
+    }
+  ]
+}
+```
+
+### Drake Format (Two Right-Half Rows)
+
+```json
+{
+  "boxes": [
+    { "text": "rejected option", "preset": "label", "region": { "x": 0.52, "y": 0.05, "w": 0.45, "h": 0.4 } },
+    { "text": "preferred option", "preset": "label", "region": { "x": 0.52, "y": 0.55, "w": 0.45, "h": 0.4 } }
+  ]
+}
+```
+
+### Caption Bar Plus Overlay Text
+
+```json
+{
+  "captions": [{ "text": "staging and production", "position": "top" }],
+  "boxes": [{ "text": "They're the same picture.", "preset": "subtitle" }]
+}
+```
+
+The caption bar expands the canvas; the subtitle box still positions relative to the original image.

--- a/plugins/meme/skills/image/scripts/__snapshots__/spec.test.ts.snap
+++ b/plugins/meme/skills/image/scripts/__snapshots__/spec.test.ts.snap
@@ -21,3 +21,5 @@ exports[`validateSpec rejects bad caption position 1`] = `"spec.captions[0].posi
 exports[`specFromFlags rejects no flags 1`] = `"flags: requires at least one of --top, --bottom, --subtitle, --caption, or --spec"`;
 
 exports[`specFromFlags rejects bad caption position 1`] = `"--caption-position: expected top or bottom"`;
+
+exports[`validateSpec rejects non-boolean linkFontSizes 1`] = `"spec.linkFontSizes: expected a boolean"`;

--- a/plugins/meme/skills/image/scripts/__snapshots__/spec.test.ts.snap
+++ b/plugins/meme/skills/image/scripts/__snapshots__/spec.test.ts.snap
@@ -1,0 +1,23 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`validateSpec rejects not an object 1`] = `"spec: expected an object with boxes and/or captions"`;
+
+exports[`validateSpec rejects empty object 1`] = `"spec: requires at least one of boxes or captions"`;
+
+exports[`validateSpec rejects empty arrays 1`] = `"spec: requires at least one box or caption"`;
+
+exports[`validateSpec rejects box missing text 1`] = `"spec.boxes[0].text: required non-empty string"`;
+
+exports[`validateSpec rejects bad preset 1`] = `"spec.boxes[0].preset: expected one of classic, label, subtitle"`;
+
+exports[`validateSpec rejects anchor and region together 1`] = `"spec.boxes[0]: anchor and region are mutually exclusive"`;
+
+exports[`validateSpec rejects region out of range 1`] = `"spec.boxes[0].region.w: expected a number between 0 and 1, got 2"`;
+
+exports[`validateSpec rejects bad fontSize override 1`] = `"spec.boxes[0].style.fontSize: expected a number between 0 and 1, got 40"`;
+
+exports[`validateSpec rejects bad caption position 1`] = `"spec.captions[0].position: expected top or bottom"`;
+
+exports[`specFromFlags rejects no flags 1`] = `"flags: requires at least one of --top, --bottom, --subtitle, --caption, or --spec"`;
+
+exports[`specFromFlags rejects bad caption position 1`] = `"--caption-position: expected top or bottom"`;

--- a/plugins/meme/skills/image/scripts/__snapshots__/spec.test.ts.snap
+++ b/plugins/meme/skills/image/scripts/__snapshots__/spec.test.ts.snap
@@ -16,7 +16,7 @@ exports[`validateSpec rejects region out of range 1`] = `"spec.boxes[0].region.w
 
 exports[`validateSpec rejects bad fontSize override 1`] = `"spec.boxes[0].style.fontSize: expected a number between 0 and 1, got 40"`;
 
-exports[`validateSpec rejects bad caption position 1`] = `"spec.captions[0].position: expected top or bottom"`;
+exports[`validateSpec rejects bad caption position 1`] = `"spec.captions[0].position: expected one of top, bottom"`;
 
 exports[`specFromFlags rejects no flags 1`] = `"flags: requires at least one of --top, --bottom, --subtitle, --caption, or --spec"`;
 

--- a/plugins/meme/skills/image/scripts/layout.test.ts
+++ b/plugins/meme/skills/image/scripts/layout.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+import {
+  captionBarHeight,
+  defaultValign,
+  fitText,
+  type Measure,
+  padRegion,
+  resolveRegion,
+  wrapText,
+} from "./layout";
+
+const measure: Measure = (text, fontPx) => text.length * fontPx * 0.6;
+
+describe("wrapText", () => {
+  test.each([
+    ["empty string", "", 100, []],
+    ["single word that fits", "hello", 100, ["hello"]],
+    ["exact fit stays on one line", "abcdefgh", 48, ["abcdefgh"]],
+    ["forced break", "one two three four five", 60, ["one two", "three four", "five"]],
+    [
+      "overlong word on its own line",
+      "hi supercalifragilistic yo",
+      60,
+      ["hi", "supercalifragilistic", "yo"],
+    ],
+    ["collapses whitespace", "a  b \n c", 100, ["a b c"]],
+  ])("%s", (_name, text, maxWidth, expected) => {
+    expect(wrapText(text, maxWidth, 10, measure)).toEqual(expected);
+  });
+});
+
+describe("fitText", () => {
+  test("fits at max size", () => {
+    expect(
+      fitText("short", { maxWidth: 300, maxHeight: 100, maxFontPx: 60, minFontPx: 12, measure }),
+    ).toMatchInlineSnapshot(`
+        {
+          "fontPx": 60,
+          "lines": [
+            "short",
+          ],
+          "overflow": false,
+        }
+      `);
+  });
+
+  test("shrinks to fit width", () => {
+    expect(
+      fitText("a somewhat longer line of text", {
+        maxWidth: 300,
+        maxHeight: 200,
+        maxFontPx: 60,
+        minFontPx: 12,
+        measure,
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "fontPx": 44,
+        "lines": [
+          "a somewhat",
+          "longer line",
+          "of text",
+        ],
+        "overflow": false,
+      }
+    `);
+  });
+
+  test("floors with overflow", () => {
+    expect(
+      fitText("way too much text to ever fit inside such a tiny little region honestly", {
+        maxWidth: 60,
+        maxHeight: 30,
+        maxFontPx: 60,
+        minFontPx: 12,
+        measure,
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "fontPx": 12,
+        "lines": [
+          "way too",
+          "much",
+          "text to",
+          "ever fit",
+          "inside",
+          "such a",
+          "tiny",
+          "little",
+          "region",
+          "honestly",
+        ],
+        "overflow": true,
+      }
+    `);
+  });
+});
+
+describe("resolveRegion", () => {
+  test.each([
+    ["top anchor", { anchor: "top" as const }, { x: 50, y: 10, w: 900, h: 150 }],
+    ["bottom anchor", { anchor: "bottom" as const }, { x: 50, y: 340, w: 900, h: 150 }],
+    ["center anchor", { anchor: "center" as const }, { x: 50, y: 175, w: 900, h: 150 }],
+    ["defaults to top", {}, { x: 50, y: 10, w: 900, h: 150 }],
+    [
+      "explicit region",
+      { region: { x: 0.25, y: 0.5, w: 0.5, h: 0.25 } },
+      { x: 250, y: 250, w: 500, h: 125 },
+    ],
+  ])("%s", (_name, placement, expected) => {
+    expect(resolveRegion(placement, 1000, 500)).toEqual(expected);
+  });
+});
+
+describe("defaultValign", () => {
+  test.each([
+    [
+      "explicit valign wins",
+      { text: "x", valign: "middle" as const },
+      "top" as const,
+      "middle" as const,
+    ],
+    ["top anchor", { text: "x" }, "top" as const, "top" as const],
+    ["bottom anchor", { text: "x" }, "bottom" as const, "bottom" as const],
+    ["center anchor", { text: "x" }, "center" as const, "middle" as const],
+    [
+      "region defaults to middle",
+      { text: "x", region: { x: 0, y: 0, w: 1, h: 1 } },
+      "top" as const,
+      "middle" as const,
+    ],
+  ])("%s", (_name, box, anchor, expected) => {
+    expect(defaultValign(box, anchor)).toBe(expected);
+  });
+});
+
+test("padRegion insets 4% per side", () => {
+  expect(padRegion({ x: 100, y: 200, w: 500, h: 250 })).toEqual({
+    x: 120,
+    y: 210,
+    w: 460,
+    h: 230,
+  });
+});
+
+test("captionBarHeight", () => {
+  expect(captionBarHeight(2, 40, 20)).toBe(Math.ceil(2 * 40 * 1.15 + 40));
+});

--- a/plugins/meme/skills/image/scripts/layout.ts
+++ b/plugins/meme/skills/image/scripts/layout.ts
@@ -1,0 +1,114 @@
+import { type Anchor, LINE_HEIGHT, MIN_FONT_PX, REGION_PADDING } from "./presets";
+import type { Region, TextBox } from "./spec";
+
+/** Returns the rendered width in px of text at the given font size. */
+export type Measure = (text: string, fontPx: number) => number;
+
+export interface PxRegion {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+const anchorRegions: Record<Anchor, Region> = {
+  top: { x: 0.05, y: 0.02, w: 0.9, h: 0.3 },
+  bottom: { x: 0.05, y: 0.68, w: 0.9, h: 0.3 },
+  center: { x: 0.05, y: 0.35, w: 0.9, h: 0.3 },
+};
+
+export function resolveRegion(
+  placement: { anchor?: Anchor | undefined; region?: Region | undefined },
+  width: number,
+  height: number,
+): PxRegion {
+  const region = placement.region ?? anchorRegions[placement.anchor ?? "top"];
+  return {
+    x: region.x * width,
+    y: region.y * height,
+    w: region.w * width,
+    h: region.h * height,
+  };
+}
+
+export function defaultValign(box: TextBox, anchor: Anchor): "top" | "middle" | "bottom" {
+  if (box.valign) return box.valign;
+  if (box.region) return "middle";
+  if (anchor === "center") return "middle";
+  return anchor;
+}
+
+export function padRegion(region: PxRegion): PxRegion {
+  const padX = region.w * REGION_PADDING;
+  const padY = region.h * REGION_PADDING;
+  return {
+    x: region.x + padX,
+    y: region.y + padY,
+    w: region.w - 2 * padX,
+    h: region.h - 2 * padY,
+  };
+}
+
+export function wrapText(
+  text: string,
+  maxWidth: number,
+  fontPx: number,
+  measure: Measure,
+): string[] {
+  const words = text.split(/\s+/).filter((word) => word.length > 0);
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    const candidate = current === "" ? word : `${current} ${word}`;
+    if (current !== "" && measure(candidate, fontPx) > maxWidth) {
+      lines.push(current);
+      current = word;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current !== "") lines.push(current);
+  return lines;
+}
+
+export interface FitOptions {
+  maxWidth: number;
+  maxHeight: number;
+  /** Font size bounds in px. */
+  maxFontPx: number;
+  minFontPx: number;
+  measure: Measure;
+}
+
+export interface FitResult {
+  fontPx: number;
+  lines: string[];
+  overflow: boolean;
+}
+
+function fits(lines: string[], fontPx: number, opts: FitOptions): boolean {
+  const height = lines.length * fontPx * LINE_HEIGHT;
+  if (height > opts.maxHeight) return false;
+  return lines.every((line) => opts.measure(line, fontPx) <= opts.maxWidth);
+}
+
+/**
+ * Wrap text at the largest font size that fits the region, shrinking in 5%
+ * steps to the floor. Past the floor, returns the floor layout with
+ * overflow: true so the caller can warn instead of erroring.
+ */
+export function fitText(text: string, opts: FitOptions): FitResult {
+  const minFontPx = Math.max(MIN_FONT_PX, opts.minFontPx);
+  let fontPx = Math.max(minFontPx, opts.maxFontPx);
+  while (fontPx > minFontPx) {
+    const lines = wrapText(text, opts.maxWidth, fontPx, opts.measure);
+    if (fits(lines, fontPx, opts)) return { fontPx, lines, overflow: false };
+    fontPx = Math.max(minFontPx, fontPx - Math.max(1, Math.round(fontPx * 0.05)));
+  }
+  const lines = wrapText(text, opts.maxWidth, minFontPx, opts.measure);
+  return { fontPx: minFontPx, lines, overflow: !fits(lines, minFontPx, opts) };
+}
+
+export function captionBarHeight(lineCount: number, fontPx: number, padPx: number): number {
+  return Math.ceil(lineCount * fontPx * LINE_HEIGHT + 2 * padPx);
+}

--- a/plugins/meme/skills/image/scripts/presets.ts
+++ b/plugins/meme/skills/image/scripts/presets.ts
@@ -1,0 +1,70 @@
+export type PresetName = "classic" | "label" | "subtitle";
+export type Anchor = "top" | "bottom" | "center";
+
+export interface PresetStyle {
+  fontFamily: string;
+  fontWeight: "normal" | "bold";
+  fill: string;
+  stroke: string;
+  /** Stroke width as a fraction of the rendered font size. */
+  strokeWidthRatio: number;
+  uppercase: boolean;
+  /** Font size bounds as fractions of image height. */
+  maxFontSize: number;
+  minFontSize: number;
+  defaultAnchor: Anchor;
+}
+
+export const LINE_HEIGHT = 1.15;
+/** Inner padding on each side, as a fraction of the region dimension. */
+export const REGION_PADDING = 0.04;
+/** Absolute shrink floor in pixels, below which text is unreadable. */
+export const MIN_FONT_PX = 12;
+
+export const presets: Record<PresetName, PresetStyle> = {
+  classic: {
+    fontFamily: "Impact",
+    fontWeight: "normal",
+    fill: "#ffffff",
+    stroke: "#000000",
+    strokeWidthRatio: 1 / 12,
+    uppercase: true,
+    maxFontSize: 0.1,
+    minFontSize: 0.028,
+    defaultAnchor: "top",
+  },
+  label: {
+    fontFamily: "Helvetica",
+    fontWeight: "bold",
+    fill: "#000000",
+    stroke: "#ffffff",
+    strokeWidthRatio: 1 / 18,
+    uppercase: false,
+    maxFontSize: 0.06,
+    minFontSize: 0.02,
+    defaultAnchor: "center",
+  },
+  subtitle: {
+    fontFamily: "Helvetica",
+    fontWeight: "bold",
+    fill: "#ffe400",
+    stroke: "#000000",
+    strokeWidthRatio: 1 / 14,
+    uppercase: false,
+    maxFontSize: 0.045,
+    minFontSize: 0.02,
+    defaultAnchor: "bottom",
+  },
+};
+
+export const caption = {
+  fontFamily: "Helvetica",
+  fontWeight: "bold" as const,
+  fill: "#000000",
+  background: "#ffffff",
+  /** Font size as a fraction of image height. */
+  fontSize: 0.05,
+  minFontSize: 0.025,
+  /** Bar padding as a fraction of image width. */
+  padding: 0.04,
+};

--- a/plugins/meme/skills/image/scripts/presets.ts
+++ b/plugins/meme/skills/image/scripts/presets.ts
@@ -20,6 +20,12 @@ export const LINE_HEIGHT = 1.15;
 export const REGION_PADDING = 0.04;
 /** Absolute shrink floor in pixels, below which text is unreadable. */
 export const MIN_FONT_PX = 12;
+/**
+ * Strokes straddle the glyph edge and the fill covers the inner half, so
+ * below this lineWidth the visible outline drops under a pixel and reads
+ * as no outline at all.
+ */
+export const MIN_STROKE_PX = 3;
 
 export const presets: Record<PresetName, PresetStyle> = {
   classic: {
@@ -49,7 +55,7 @@ export const presets: Record<PresetName, PresetStyle> = {
     fontWeight: "bold",
     fill: "#ffe400",
     stroke: "#000000",
-    strokeWidthRatio: 1 / 14,
+    strokeWidthRatio: 1 / 7,
     uppercase: false,
     maxFontSize: 0.045,
     minFontSize: 0.02,

--- a/plugins/meme/skills/image/scripts/render.test.ts
+++ b/plugins/meme/skills/image/scripts/render.test.ts
@@ -1,0 +1,84 @@
+import { beforeAll, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import sharp from "sharp";
+import { render } from "./render";
+
+const dir = mkdtempSync(join(tmpdir(), "meme-render-"));
+const png = join(dir, "input.png");
+const jpeg = join(dir, "input.jpeg");
+const tiny = join(dir, "tiny.png");
+
+beforeAll(async () => {
+  const base = sharp({
+    create: { width: 800, height: 600, channels: 3, background: { r: 40, g: 80, b: 160 } },
+  });
+  await base.clone().png().toFile(png);
+  await base.clone().jpeg().toFile(jpeg);
+  await sharp({
+    create: { width: 120, height: 90, channels: 3, background: { r: 200, g: 60, b: 60 } },
+  })
+    .png()
+    .toFile(tiny);
+});
+
+test("classic macro renders a decodable PNG at input dimensions", async () => {
+  const out = join(dir, "classic.png");
+  const result = await render(
+    { boxes: [{ text: "one does not simply", anchor: "top" }] },
+    png,
+    out,
+  );
+  expect(result.warnings).toEqual([]);
+  const meta = await sharp(out).metadata();
+  expect({ format: meta.format, width: meta.width, height: meta.height }).toEqual({
+    format: "png",
+    width: 800,
+    height: 600,
+  });
+});
+
+test("caption bar grows the canvas by the computed bar height", async () => {
+  const out = join(dir, "caption.png");
+  const result = await render(
+    { captions: [{ text: "me explaining the joke", position: "top" }] },
+    png,
+    out,
+  );
+  expect(result.bars.top).toBeGreaterThan(0);
+  const meta = await sharp(out).metadata();
+  expect(meta.height).toBe(600 + result.bars.top);
+  expect(result.height).toBe(600 + result.bars.top);
+});
+
+test("jpeg input produces png output", async () => {
+  const out = join(dir, "from-jpeg.png");
+  await render({ boxes: [{ text: "still a png" }] }, jpeg, out);
+  const meta = await sharp(out).metadata();
+  expect(meta.format).toBe("png");
+});
+
+test("images narrower than 400px upscale 2x", async () => {
+  const out = join(dir, "tiny.png");
+  const result = await render({ boxes: [{ text: "tiny" }] }, tiny, out);
+  expect({ width: result.width, height: result.height }).toEqual({ width: 240, height: 180 });
+});
+
+test("text that cannot fit warns instead of erroring", async () => {
+  const out = join(dir, "overflow.png");
+  const result = await render(
+    {
+      boxes: [
+        {
+          text: "an extremely long string of meme text that has no hope of fitting here",
+          region: { x: 0.45, y: 0.45, w: 0.1, h: 0.05 },
+        },
+      ],
+    },
+    png,
+    out,
+  );
+  expect(result.warnings.length).toBe(1);
+  expect(result.warnings[0]).toContain("does not fit");
+});

--- a/plugins/meme/skills/image/scripts/render.test.ts
+++ b/plugins/meme/skills/image/scripts/render.test.ts
@@ -2,8 +2,9 @@ import { beforeAll, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createCanvas } from "@napi-rs/canvas";
 import sharp from "sharp";
-import { render } from "./render";
+import { layoutBoxes, render } from "./render";
 
 const dir = mkdtempSync(join(tmpdir(), "meme-render-"));
 const png = join(dir, "input.png");
@@ -63,6 +64,31 @@ test("images narrower than 400px upscale 2x", async () => {
   const out = join(dir, "tiny.png");
   const result = await render({ boxes: [{ text: "tiny" }] }, tiny, out);
   expect({ width: result.width, height: result.height }).toEqual({ width: 240, height: 180 });
+});
+
+test("linkFontSizes re-fits every box at the smallest fitted size", () => {
+  const ctx = createCanvas(1, 1).getContext("2d");
+  const boxes = [
+    { text: "hi", preset: "label" as const, region: { x: 0, y: 0, w: 0.4, h: 0.3 } },
+    {
+      text: "a considerably longer run of text that must shrink to fit",
+      preset: "label" as const,
+      region: { x: 0.5, y: 0, w: 0.2, h: 0.12 },
+    },
+  ];
+  const [short, long] = layoutBoxes(ctx, { boxes }, 800, 600, "sans-serif");
+  if (!short || !long) throw new Error("expected two layouts");
+  expect(short.fit.fontPx).toBeGreaterThan(long.fit.fontPx);
+  const [shortLinked, longLinked] = layoutBoxes(
+    ctx,
+    { boxes, linkFontSizes: true },
+    800,
+    600,
+    "sans-serif",
+  );
+  if (!shortLinked || !longLinked) throw new Error("expected two layouts");
+  expect(shortLinked.fit.fontPx).toBe(longLinked.fit.fontPx);
+  expect(longLinked.fit.fontPx).toBe(long.fit.fontPx);
 });
 
 test("text that cannot fit warns instead of erroring", async () => {

--- a/plugins/meme/skills/image/scripts/render.ts
+++ b/plugins/meme/skills/image/scripts/render.ts
@@ -13,12 +13,21 @@ import sharp from "sharp";
 import {
   captionBarHeight,
   defaultValign,
+  type FitResult,
   fitText,
   type Measure,
+  type PxRegion,
   padRegion,
   resolveRegion,
 } from "./layout";
-import { caption as captionStyle, LINE_HEIGHT, MIN_STROKE_PX, presets } from "./presets";
+import {
+  type Anchor,
+  caption as captionStyle,
+  LINE_HEIGHT,
+  MIN_STROKE_PX,
+  type PresetStyle,
+  presets,
+} from "./presets";
 import { type Caption, type Spec, specFromFlags, type TextBox, validateSpec } from "./spec";
 
 /** Below this width, text at readable px sizes crowds the image; upscale 2x first. */
@@ -108,16 +117,23 @@ function drawCaption(ctx: SKRSContext2D, layout: CaptionLayout, y: number, width
   });
 }
 
-function drawBox(
+interface BoxLayout {
+  box: TextBox;
+  preset: PresetStyle;
+  font: ResolvedFont;
+  region: PxRegion;
+  anchor: Anchor;
+  fit: FitResult;
+}
+
+function layoutBox(
   ctx: SKRSContext2D,
   box: TextBox,
   imageWidth: number,
   imageHeight: number,
-  offsetY: number,
-  warnings: string[],
-  index: number,
   classicFamily: string,
-): void {
+  fontPxCap?: number,
+): BoxLayout {
   const preset = presets[box.preset ?? "classic"];
   const family =
     box.style?.font ?? (preset.fontFamily === "Impact" ? classicFamily : preset.fontFamily);
@@ -129,13 +145,46 @@ function drawBox(
   const uppercase = box.style?.uppercase ?? preset.uppercase;
   const text = uppercase ? box.text.toUpperCase() : box.text;
 
+  const maxFontPx = (box.style?.fontSize ?? preset.maxFontSize) * imageHeight;
   const fit = fitText(text, {
     maxWidth: region.w,
     maxHeight: region.h,
-    maxFontPx: (box.style?.fontSize ?? preset.maxFontSize) * imageHeight,
+    maxFontPx: fontPxCap === undefined ? maxFontPx : Math.min(maxFontPx, fontPxCap),
     minFontPx: preset.minFontSize * imageHeight,
     measure,
   });
+  return { box, preset, font, region, anchor, fit };
+}
+
+/**
+ * Multi-panel formats read wrong when each panel fits its text independently,
+ * so linkFontSizes re-lays every box at the smallest fitted size.
+ */
+export function layoutBoxes(
+  ctx: SKRSContext2D,
+  spec: Spec,
+  imageWidth: number,
+  imageHeight: number,
+  classicFamily: string,
+): BoxLayout[] {
+  const layouts = (spec.boxes ?? []).map((box) =>
+    layoutBox(ctx, box, imageWidth, imageHeight, classicFamily),
+  );
+  if (!spec.linkFontSizes || layouts.length < 2) return layouts;
+  const minPx = Math.min(...layouts.map((l) => l.fit.fontPx));
+  return layouts.map((l) =>
+    l.fit.fontPx > minPx ? layoutBox(ctx, l.box, imageWidth, imageHeight, classicFamily, minPx) : l,
+  );
+}
+
+function drawBox(
+  ctx: SKRSContext2D,
+  layout: BoxLayout,
+  offsetY: number,
+  warnings: string[],
+  index: number,
+): void {
+  const { box, preset, font, region, anchor, fit } = layout;
   if (fit.overflow) {
     warnings.push(
       `box ${index}: text does not fit at the minimum font size; it renders anyway but may spill out of its region. Shorten the text or enlarge the region.`,
@@ -209,8 +258,8 @@ export async function render(
 
   const warnings: string[] = [];
   const classic = await classicFontFamily();
-  (spec.boxes ?? []).forEach((box, i) => {
-    drawBox(ctx, box, image.width, image.height, bars.top, warnings, i, classic);
+  layoutBoxes(ctx, spec, image.width, image.height, classic).forEach((layout, i) => {
+    drawBox(ctx, layout, bars.top, warnings, i);
   });
 
   const absolute = resolve(outPath);

--- a/plugins/meme/skills/image/scripts/render.ts
+++ b/plugins/meme/skills/image/scripts/render.ts
@@ -1,0 +1,269 @@
+#!/usr/bin/env bun
+
+import { resolve } from "node:path";
+import {
+  createCanvas,
+  GlobalFonts,
+  type Image,
+  loadImage,
+  type SKRSContext2D,
+} from "@napi-rs/canvas";
+import { cli } from "cleye";
+import sharp from "sharp";
+import {
+  captionBarHeight,
+  defaultValign,
+  fitText,
+  type Measure,
+  padRegion,
+  resolveRegion,
+} from "./layout";
+import { caption as captionStyle, LINE_HEIGHT, presets } from "./presets";
+import { type Caption, type Spec, specFromFlags, type TextBox, validateSpec } from "./spec";
+
+/** Below this width, text at readable px sizes crowds the image; upscale 2x first. */
+const MIN_WIDTH = 400;
+
+const IMPACT_PATH = "/System/Library/Fonts/Supplemental/Impact.ttf";
+
+let classicFamily: string | undefined;
+
+async function classicFontFamily(): Promise<string> {
+  if (classicFamily) return classicFamily;
+  if (await Bun.file(IMPACT_PATH).exists()) {
+    GlobalFonts.registerFromPath(IMPACT_PATH, "Impact");
+    classicFamily = "Impact";
+  } else if (GlobalFonts.has("Arial Black")) {
+    classicFamily = "Arial Black";
+  } else {
+    classicFamily = "sans-serif";
+  }
+  return classicFamily;
+}
+
+interface ResolvedFont {
+  family: string;
+  weight: "normal" | "bold";
+}
+
+function fontString(font: ResolvedFont, px: number): string {
+  return `${font.weight} ${px}px ${JSON.stringify(font.family)}`;
+}
+
+function measurer(ctx: SKRSContext2D, font: ResolvedFont): Measure {
+  return (text, fontPx) => {
+    ctx.font = fontString(font, fontPx);
+    return ctx.measureText(text).width;
+  };
+}
+
+export interface RenderResult {
+  outPath: string;
+  width: number;
+  height: number;
+  bars: { top: number; bottom: number };
+  warnings: string[];
+}
+
+interface CaptionLayout {
+  caption: Caption;
+  lines: string[];
+  fontPx: number;
+  barHeight: number;
+}
+
+function layoutCaptions(
+  captions: Caption[],
+  imageWidth: number,
+  imageHeight: number,
+  ctx: SKRSContext2D,
+): CaptionLayout[] {
+  const font: ResolvedFont = { family: captionStyle.fontFamily, weight: captionStyle.fontWeight };
+  const measure = measurer(ctx, font);
+  const padPx = captionStyle.padding * imageWidth;
+  return captions.map((caption) => {
+    const fontPx = Math.round(captionStyle.fontSize * imageHeight);
+    const lines = fitText(caption.text, {
+      maxWidth: imageWidth - 2 * padPx,
+      maxHeight: Number.POSITIVE_INFINITY,
+      maxFontPx: fontPx,
+      minFontPx: fontPx,
+      measure,
+    }).lines;
+    return { caption, lines, fontPx, barHeight: captionBarHeight(lines.length, fontPx, padPx) };
+  });
+}
+
+function drawCaption(ctx: SKRSContext2D, layout: CaptionLayout, y: number, width: number): void {
+  const font: ResolvedFont = { family: captionStyle.fontFamily, weight: captionStyle.fontWeight };
+  const padPx = captionStyle.padding * width;
+  ctx.fillStyle = captionStyle.background;
+  ctx.fillRect(0, y, width, layout.barHeight);
+  ctx.fillStyle = captionStyle.fill;
+  ctx.font = fontString(font, layout.fontPx);
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+  layout.lines.forEach((line, i) => {
+    ctx.fillText(line, width / 2, y + padPx + i * layout.fontPx * LINE_HEIGHT);
+  });
+}
+
+function drawBox(
+  ctx: SKRSContext2D,
+  box: TextBox,
+  imageWidth: number,
+  imageHeight: number,
+  offsetY: number,
+  warnings: string[],
+  index: number,
+  classicFamily: string,
+): void {
+  const preset = presets[box.preset ?? "classic"];
+  const family =
+    box.style?.font ?? (preset.fontFamily === "Impact" ? classicFamily : preset.fontFamily);
+  const font: ResolvedFont = { family, weight: preset.fontWeight };
+  const measure = measurer(ctx, font);
+
+  const anchor = box.anchor ?? preset.defaultAnchor;
+  const region = padRegion(resolveRegion({ anchor, region: box.region }, imageWidth, imageHeight));
+  const uppercase = box.style?.uppercase ?? preset.uppercase;
+  const text = uppercase ? box.text.toUpperCase() : box.text;
+
+  const fit = fitText(text, {
+    maxWidth: region.w,
+    maxHeight: region.h,
+    maxFontPx: (box.style?.fontSize ?? preset.maxFontSize) * imageHeight,
+    minFontPx: preset.minFontSize * imageHeight,
+    measure,
+  });
+  if (fit.overflow) {
+    warnings.push(
+      `box ${index}: text does not fit at the minimum font size; it renders anyway but may spill out of its region. Shorten the text or enlarge the region.`,
+    );
+  }
+
+  const align = box.align ?? "center";
+  const x =
+    align === "left" ? region.x : align === "right" ? region.x + region.w : region.x + region.w / 2;
+  const blockHeight = fit.lines.length * fit.fontPx * LINE_HEIGHT;
+  const valign = defaultValign(box, anchor);
+  const yStart =
+    valign === "top"
+      ? region.y
+      : valign === "bottom"
+        ? region.y + region.h - blockHeight
+        : region.y + (region.h - blockHeight) / 2;
+
+  ctx.font = fontString(font, fit.fontPx);
+  ctx.textAlign = align;
+  ctx.textBaseline = "top";
+  ctx.lineJoin = "round";
+  ctx.lineWidth = fit.fontPx * preset.strokeWidthRatio;
+  ctx.strokeStyle = box.style?.stroke ?? preset.stroke;
+  ctx.fillStyle = box.style?.fill ?? preset.fill;
+  fit.lines.forEach((line, i) => {
+    const y = offsetY + yStart + i * fit.fontPx * LINE_HEIGHT;
+    ctx.strokeText(line, x, y);
+    ctx.fillText(line, x, y);
+  });
+}
+
+export async function render(
+  spec: Spec,
+  inputPath: string,
+  outPath: string,
+): Promise<RenderResult> {
+  let buffer = await sharp(inputPath).rotate().png().toBuffer();
+  let image: Image = await loadImage(buffer);
+  if (image.width < MIN_WIDTH) {
+    buffer = await sharp(buffer)
+      .resize(image.width * 2)
+      .png()
+      .toBuffer();
+    image = await loadImage(buffer);
+  }
+
+  const scratch = createCanvas(1, 1).getContext("2d");
+  const captionLayouts = layoutCaptions(spec.captions ?? [], image.width, image.height, scratch);
+  const topCaptions = captionLayouts.filter((l) => (l.caption.position ?? "top") === "top");
+  const bottomCaptions = captionLayouts.filter((l) => (l.caption.position ?? "top") === "bottom");
+  const bars = {
+    top: topCaptions.reduce((sum, l) => sum + l.barHeight, 0),
+    bottom: bottomCaptions.reduce((sum, l) => sum + l.barHeight, 0),
+  };
+
+  const canvas = createCanvas(image.width, image.height + bars.top + bars.bottom);
+  const ctx = canvas.getContext("2d");
+  ctx.drawImage(image, 0, bars.top);
+
+  let y = 0;
+  for (const layout of topCaptions) {
+    drawCaption(ctx, layout, y, image.width);
+    y += layout.barHeight;
+  }
+  y = bars.top + image.height;
+  for (const layout of bottomCaptions) {
+    drawCaption(ctx, layout, y, image.width);
+    y += layout.barHeight;
+  }
+
+  const warnings: string[] = [];
+  const classic = await classicFontFamily();
+  (spec.boxes ?? []).forEach((box, i) => {
+    drawBox(ctx, box, image.width, image.height, bars.top, warnings, i, classic);
+  });
+
+  const absolute = resolve(outPath);
+  await Bun.write(absolute, await canvas.encode("png"));
+  return { outPath: absolute, width: canvas.width, height: canvas.height, bars, warnings };
+}
+
+if (import.meta.main) {
+  const argv = cli({
+    name: "render",
+    parameters: ["<image>"],
+    help: {
+      description: "Overlay meme text on an image and write a PNG.",
+    },
+    flags: {
+      top: { type: String, description: "Classic Impact macro text at the top" },
+      bottom: { type: String, description: "Classic Impact macro text at the bottom" },
+      subtitle: { type: String, description: "TV-subtitle text at the bottom" },
+      caption: { type: String, description: "White-bar caption text (expands the canvas)" },
+      captionPosition: {
+        type: String,
+        description: "Caption bar placement: top or bottom (default: top)",
+      },
+      spec: {
+        type: String,
+        alias: "s",
+        description: "Path to a JSON layout spec file (mutually exclusive with text flags)",
+      },
+      out: { type: String, alias: "o", description: "Output PNG path (required)" },
+    },
+  });
+
+  const { top, bottom, subtitle, caption, captionPosition, spec: specPath, out } = argv.flags;
+  if (!out) {
+    console.error("error: --out is required");
+    process.exit(1);
+  }
+  if (specPath && (top || bottom || subtitle || caption || captionPosition)) {
+    console.error("error: --spec is mutually exclusive with --top/--bottom/--subtitle/--caption");
+    process.exit(1);
+  }
+
+  try {
+    const spec = specPath
+      ? validateSpec(await Bun.file(specPath).json())
+      : specFromFlags({ top, bottom, subtitle, caption, captionPosition });
+    const result = await render(spec, argv._.image, out);
+    for (const warning of result.warnings) {
+      console.error(`warning: ${warning}`);
+    }
+    console.log(result.outPath);
+  } catch (error) {
+    console.error(`error: ${error instanceof Error ? error.message : error}`);
+    process.exit(1);
+  }
+}

--- a/plugins/meme/skills/image/scripts/render.ts
+++ b/plugins/meme/skills/image/scripts/render.ts
@@ -18,7 +18,7 @@ import {
   padRegion,
   resolveRegion,
 } from "./layout";
-import { caption as captionStyle, LINE_HEIGHT, presets } from "./presets";
+import { caption as captionStyle, LINE_HEIGHT, MIN_STROKE_PX, presets } from "./presets";
 import { type Caption, type Spec, specFromFlags, type TextBox, validateSpec } from "./spec";
 
 /** Below this width, text at readable px sizes crowds the image; upscale 2x first. */
@@ -158,7 +158,7 @@ function drawBox(
   ctx.textAlign = align;
   ctx.textBaseline = "top";
   ctx.lineJoin = "round";
-  ctx.lineWidth = fit.fontPx * preset.strokeWidthRatio;
+  ctx.lineWidth = Math.max(MIN_STROKE_PX, fit.fontPx * preset.strokeWidthRatio);
   ctx.strokeStyle = box.style?.stroke ?? preset.stroke;
   ctx.fillStyle = box.style?.fill ?? preset.fill;
   fit.lines.forEach((line, i) => {

--- a/plugins/meme/skills/image/scripts/setup.ts
+++ b/plugins/meme/skills/image/scripts/setup.ts
@@ -1,0 +1,19 @@
+import { execSync } from "node:child_process";
+import { join } from "node:path";
+
+const skillRoot = join(import.meta.dirname, "..");
+
+// bun install is a fast no-op when deps are already installed
+try {
+  execSync("bun install", {
+    cwd: skillRoot,
+    env: {
+      ...process.env,
+      BUN_INSTALL_CACHE_DIR: join(skillRoot, ".bun-cache"),
+    },
+    stdio: "inherit",
+  });
+} catch {
+  console.error("Failed to install dependencies. Is bun installed? https://bun.sh");
+  process.exit(1);
+}

--- a/plugins/meme/skills/image/scripts/spec.test.ts
+++ b/plugins/meme/skills/image/scripts/spec.test.ts
@@ -15,6 +15,7 @@ describe("validateSpec", () => {
     ["region out of range", { boxes: [{ text: "hi", region: { x: 0, y: 0, w: 2, h: 1 } }] }],
     ["bad fontSize override", { boxes: [{ text: "hi", style: { fontSize: 40 } }] }],
     ["bad caption position", { captions: [{ text: "hi", position: "left" }] }],
+    ["non-boolean linkFontSizes", { linkFontSizes: "yes", boxes: [{ text: "hi" }] }],
   ])("rejects %s", (_name, spec) => {
     expect(() => validateSpec(spec)).toThrowErrorMatchingSnapshot();
   });

--- a/plugins/meme/skills/image/scripts/spec.test.ts
+++ b/plugins/meme/skills/image/scripts/spec.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { specFromFlags, validateSpec } from "./spec";
+
+describe("validateSpec", () => {
+  test.each([
+    ["not an object", "nope"],
+    ["empty object", {}],
+    ["empty arrays", { boxes: [], captions: [] }],
+    ["box missing text", { boxes: [{ preset: "classic" }] }],
+    ["bad preset", { boxes: [{ text: "hi", preset: "comic-sans" }] }],
+    [
+      "anchor and region together",
+      { boxes: [{ text: "hi", anchor: "top", region: { x: 0, y: 0, w: 1, h: 1 } }] },
+    ],
+    ["region out of range", { boxes: [{ text: "hi", region: { x: 0, y: 0, w: 2, h: 1 } }] }],
+    ["bad fontSize override", { boxes: [{ text: "hi", style: { fontSize: 40 } }] }],
+    ["bad caption position", { captions: [{ text: "hi", position: "left" }] }],
+  ])("rejects %s", (_name, spec) => {
+    expect(() => validateSpec(spec)).toThrowErrorMatchingSnapshot();
+  });
+
+  test("accepts a full spec unchanged", () => {
+    const spec = {
+      boxes: [
+        { text: "top text", preset: "classic", anchor: "top" },
+        {
+          text: "a label",
+          preset: "label",
+          region: { x: 0.1, y: 0.2, w: 0.3, h: 0.1 },
+          align: "left",
+          valign: "top",
+          style: { fill: "#ff0000", fontSize: 0.05 },
+        },
+      ],
+      captions: [{ text: "a caption", position: "bottom" }],
+    };
+    expect(validateSpec(spec)).toEqual(spec as ReturnType<typeof validateSpec>);
+  });
+});
+
+describe("specFromFlags", () => {
+  test("classic top and bottom", () => {
+    expect(
+      specFromFlags({ top: "one does not simply", bottom: "ship on friday" }),
+    ).toMatchInlineSnapshot(`
+        {
+          "boxes": [
+            {
+              "anchor": "top",
+              "preset": "classic",
+              "text": "one does not simply",
+            },
+            {
+              "anchor": "bottom",
+              "preset": "classic",
+              "text": "ship on friday",
+            },
+          ],
+        }
+      `);
+  });
+
+  test("subtitle", () => {
+    expect(specFromFlags({ subtitle: "♪ Fable Five, Fable Five ♪" })).toMatchInlineSnapshot(`
+      {
+        "boxes": [
+          {
+            "preset": "subtitle",
+            "text": "♪ Fable Five, Fable Five ♪",
+          },
+        ],
+      }
+    `);
+  });
+
+  test("caption defaults to top", () => {
+    expect(specFromFlags({ caption: "me explaining memes" })).toMatchInlineSnapshot(`
+      {
+        "captions": [
+          {
+            "position": "top",
+            "text": "me explaining memes",
+          },
+        ],
+      }
+    `);
+  });
+
+  test("caption position bottom", () => {
+    expect(specFromFlags({ caption: "hmm", captionPosition: "bottom" })).toMatchInlineSnapshot(`
+      {
+        "captions": [
+          {
+            "position": "bottom",
+            "text": "hmm",
+          },
+        ],
+      }
+    `);
+  });
+
+  test.each([
+    ["no flags", {}],
+    ["bad caption position", { caption: "x", captionPosition: "middle" }],
+  ])("rejects %s", (_name, flags) => {
+    expect(() => specFromFlags(flags)).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/plugins/meme/skills/image/scripts/spec.ts
+++ b/plugins/meme/skills/image/scripts/spec.ts
@@ -34,6 +34,8 @@ export interface Caption {
 export interface Spec {
   boxes?: TextBox[];
   captions?: Caption[];
+  /** Re-fit all boxes at the smallest fitted font size so panels match. */
+  linkFontSizes?: boolean;
 }
 
 const anchors: Anchor[] = ["top", "bottom", "center"];
@@ -138,6 +140,12 @@ export function validateSpec(value: unknown): Spec {
     fail("spec.captions", "expected an array");
   }
   const spec: Spec = {};
+  if (value.linkFontSizes !== undefined) {
+    if (typeof value.linkFontSizes !== "boolean") {
+      fail("spec.linkFontSizes", "expected a boolean");
+    }
+    spec.linkFontSizes = value.linkFontSizes;
+  }
   if (Array.isArray(boxes)) {
     spec.boxes = boxes.map((box, i) => validateBox(box, `spec.boxes[${i}]`));
   }

--- a/plugins/meme/skills/image/scripts/spec.ts
+++ b/plugins/meme/skills/image/scripts/spec.ts
@@ -56,53 +56,74 @@ function validateFraction(value: unknown, path: string): number {
   return value;
 }
 
+function validateString(value: unknown, path: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    fail(path, "required non-empty string");
+  }
+  return value;
+}
+
+function oneOf<T extends string>(value: unknown, options: readonly T[], path: string): T {
+  if (typeof value !== "string" || !(options as readonly string[]).includes(value)) {
+    fail(path, `expected one of ${options.join(", ")}`);
+  }
+  return value as T;
+}
+
 function validateRegion(value: unknown, path: string): Region {
   if (!isRecord(value)) fail(path, "expected an object {x, y, w, h}");
-  for (const key of ["x", "y", "w", "h"]) {
-    validateFraction(value[key], `${path}.${key}`);
+  return {
+    x: validateFraction(value.x, `${path}.x`),
+    y: validateFraction(value.y, `${path}.y`),
+    w: validateFraction(value.w, `${path}.w`),
+    h: validateFraction(value.h, `${path}.h`),
+  };
+}
+
+function validateStyle(value: unknown, path: string): StyleOverrides {
+  if (!isRecord(value)) fail(path, "expected an object");
+  const style: StyleOverrides = {};
+  if (value.fill !== undefined) style.fill = validateString(value.fill, `${path}.fill`);
+  if (value.stroke !== undefined) style.stroke = validateString(value.stroke, `${path}.stroke`);
+  if (value.fontSize !== undefined) {
+    style.fontSize = validateFraction(value.fontSize, `${path}.fontSize`);
   }
-  return value as unknown as Region;
+  if (value.font !== undefined) style.font = validateString(value.font, `${path}.font`);
+  if (value.uppercase !== undefined) {
+    if (typeof value.uppercase !== "boolean") fail(`${path}.uppercase`, "expected a boolean");
+    style.uppercase = value.uppercase;
+  }
+  return style;
 }
 
 function validateBox(value: unknown, path: string): TextBox {
   if (!isRecord(value)) fail(path, "expected an object");
-  if (typeof value.text !== "string" || value.text.length === 0) {
-    fail(`${path}.text`, "required non-empty string");
-  }
-  if (value.preset !== undefined && !presetNames.includes(value.preset as PresetName)) {
-    fail(`${path}.preset`, `expected one of ${presetNames.join(", ")}`);
-  }
   if (value.anchor !== undefined && value.region !== undefined) {
     fail(path, "anchor and region are mutually exclusive");
   }
-  if (value.anchor !== undefined && !anchors.includes(value.anchor as Anchor)) {
-    fail(`${path}.anchor`, `expected one of ${anchors.join(", ")}`);
+  const box: TextBox = { text: validateString(value.text, `${path}.text`) };
+  if (value.preset !== undefined) {
+    box.preset = oneOf(value.preset, presetNames, `${path}.preset`);
   }
-  if (value.region !== undefined) validateRegion(value.region, `${path}.region`);
-  if (value.align !== undefined && !["left", "center", "right"].includes(value.align as string)) {
-    fail(`${path}.align`, "expected left, center, or right");
+  if (value.anchor !== undefined) box.anchor = oneOf(value.anchor, anchors, `${path}.anchor`);
+  if (value.region !== undefined) box.region = validateRegion(value.region, `${path}.region`);
+  if (value.align !== undefined) {
+    box.align = oneOf(value.align, ["left", "center", "right"], `${path}.align`);
   }
-  if (value.valign !== undefined && !["top", "middle", "bottom"].includes(value.valign as string)) {
-    fail(`${path}.valign`, "expected top, middle, or bottom");
+  if (value.valign !== undefined) {
+    box.valign = oneOf(value.valign, ["top", "middle", "bottom"], `${path}.valign`);
   }
-  if (value.style !== undefined) {
-    if (!isRecord(value.style)) fail(`${path}.style`, "expected an object");
-    if (value.style.fontSize !== undefined) {
-      validateFraction(value.style.fontSize, `${path}.style.fontSize`);
-    }
-  }
-  return value as unknown as TextBox;
+  if (value.style !== undefined) box.style = validateStyle(value.style, `${path}.style`);
+  return box;
 }
 
 function validateCaption(value: unknown, path: string): Caption {
   if (!isRecord(value)) fail(path, "expected an object");
-  if (typeof value.text !== "string" || value.text.length === 0) {
-    fail(`${path}.text`, "required non-empty string");
+  const caption: Caption = { text: validateString(value.text, `${path}.text`) };
+  if (value.position !== undefined) {
+    caption.position = oneOf(value.position, ["top", "bottom"], `${path}.position`);
   }
-  if (value.position !== undefined && !["top", "bottom"].includes(value.position as string)) {
-    fail(`${path}.position`, "expected top or bottom");
-  }
-  return value as unknown as Caption;
+  return caption;
 }
 
 export function validateSpec(value: unknown): Spec {

--- a/plugins/meme/skills/image/scripts/spec.ts
+++ b/plugins/meme/skills/image/scripts/spec.ts
@@ -1,0 +1,158 @@
+import { type Anchor, type PresetName, presets } from "./presets";
+
+export interface Region {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface StyleOverrides {
+  fill?: string;
+  stroke?: string;
+  /** Font size as a fraction of image height. */
+  fontSize?: number;
+  font?: string;
+  uppercase?: boolean;
+}
+
+export interface TextBox {
+  text: string;
+  preset?: PresetName;
+  anchor?: Anchor;
+  region?: Region;
+  align?: "left" | "center" | "right";
+  valign?: "top" | "middle" | "bottom";
+  style?: StyleOverrides;
+}
+
+export interface Caption {
+  text: string;
+  position?: "top" | "bottom";
+}
+
+export interface Spec {
+  boxes?: TextBox[];
+  captions?: Caption[];
+}
+
+const anchors: Anchor[] = ["top", "bottom", "center"];
+const presetNames = Object.keys(presets) as PresetName[];
+
+class SpecError extends Error {}
+
+function fail(path: string, message: string): never {
+  throw new SpecError(`${path}: ${message}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && Array.isArray(value) === false;
+}
+
+function validateFraction(value: unknown, path: string): number {
+  if (typeof value !== "number" || Number.isNaN(value) || value < 0 || value > 1) {
+    fail(path, `expected a number between 0 and 1, got ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function validateRegion(value: unknown, path: string): Region {
+  if (!isRecord(value)) fail(path, "expected an object {x, y, w, h}");
+  for (const key of ["x", "y", "w", "h"]) {
+    validateFraction(value[key], `${path}.${key}`);
+  }
+  return value as unknown as Region;
+}
+
+function validateBox(value: unknown, path: string): TextBox {
+  if (!isRecord(value)) fail(path, "expected an object");
+  if (typeof value.text !== "string" || value.text.length === 0) {
+    fail(`${path}.text`, "required non-empty string");
+  }
+  if (value.preset !== undefined && !presetNames.includes(value.preset as PresetName)) {
+    fail(`${path}.preset`, `expected one of ${presetNames.join(", ")}`);
+  }
+  if (value.anchor !== undefined && value.region !== undefined) {
+    fail(path, "anchor and region are mutually exclusive");
+  }
+  if (value.anchor !== undefined && !anchors.includes(value.anchor as Anchor)) {
+    fail(`${path}.anchor`, `expected one of ${anchors.join(", ")}`);
+  }
+  if (value.region !== undefined) validateRegion(value.region, `${path}.region`);
+  if (value.align !== undefined && !["left", "center", "right"].includes(value.align as string)) {
+    fail(`${path}.align`, "expected left, center, or right");
+  }
+  if (value.valign !== undefined && !["top", "middle", "bottom"].includes(value.valign as string)) {
+    fail(`${path}.valign`, "expected top, middle, or bottom");
+  }
+  if (value.style !== undefined) {
+    if (!isRecord(value.style)) fail(`${path}.style`, "expected an object");
+    if (value.style.fontSize !== undefined) {
+      validateFraction(value.style.fontSize, `${path}.style.fontSize`);
+    }
+  }
+  return value as unknown as TextBox;
+}
+
+function validateCaption(value: unknown, path: string): Caption {
+  if (!isRecord(value)) fail(path, "expected an object");
+  if (typeof value.text !== "string" || value.text.length === 0) {
+    fail(`${path}.text`, "required non-empty string");
+  }
+  if (value.position !== undefined && !["top", "bottom"].includes(value.position as string)) {
+    fail(`${path}.position`, "expected top or bottom");
+  }
+  return value as unknown as Caption;
+}
+
+export function validateSpec(value: unknown): Spec {
+  if (!isRecord(value)) fail("spec", "expected an object with boxes and/or captions");
+  const boxes = value.boxes;
+  const captions = value.captions;
+  if (boxes === undefined && captions === undefined) {
+    fail("spec", "requires at least one of boxes or captions");
+  }
+  if (boxes !== undefined && !Array.isArray(boxes)) fail("spec.boxes", "expected an array");
+  if (captions !== undefined && !Array.isArray(captions)) {
+    fail("spec.captions", "expected an array");
+  }
+  const spec: Spec = {};
+  if (Array.isArray(boxes)) {
+    spec.boxes = boxes.map((box, i) => validateBox(box, `spec.boxes[${i}]`));
+  }
+  if (Array.isArray(captions)) {
+    spec.captions = captions.map((c, i) => validateCaption(c, `spec.captions[${i}]`));
+  }
+  if ((spec.boxes?.length ?? 0) + (spec.captions?.length ?? 0) === 0) {
+    fail("spec", "requires at least one box or caption");
+  }
+  return spec;
+}
+
+export interface TextFlags {
+  top?: string | undefined;
+  bottom?: string | undefined;
+  subtitle?: string | undefined;
+  caption?: string | undefined;
+  captionPosition?: string | undefined;
+}
+
+export function specFromFlags(flags: TextFlags): Spec {
+  const spec: Spec = {};
+  const boxes: TextBox[] = [];
+  if (flags.top) boxes.push({ text: flags.top, preset: "classic", anchor: "top" });
+  if (flags.bottom) boxes.push({ text: flags.bottom, preset: "classic", anchor: "bottom" });
+  if (flags.subtitle) boxes.push({ text: flags.subtitle, preset: "subtitle" });
+  if (boxes.length > 0) spec.boxes = boxes;
+  if (flags.caption) {
+    const position = flags.captionPosition ?? "top";
+    if (position !== "top" && position !== "bottom") {
+      fail("--caption-position", "expected top or bottom");
+    }
+    spec.captions = [{ text: flags.caption, position }];
+  }
+  if (!spec.boxes && !spec.captions) {
+    fail("flags", "requires at least one of --top, --bottom, --subtitle, --caption, or --spec");
+  }
+  return spec;
+}


### PR DESCRIPTION
Adds a `meme` plugin whose `image` skill overlays text on an image in three preset styles: classic Impact macro (white fill, thick black stroke, uppercase), `label` (bold black with a thin white stroke, for Drake and whiteboard formats), and `subtitle` (TV-style yellow bottom-center, tuned against real Office and Simpsons subtitle stills). Claude handles the judgment calls, reading the image, choosing a layout, and iterating on the rendered output. A Bun script owns the rendering so wrapping, shrink-to-fit, and stroke styling are always correct.

The renderer is `@napi-rs/canvas`, chosen over sharp+SVG because `measureText` gives exact text metrics for the wrap and shrink math. sharp is still in the dependency set, but only as the input normalizer: it applies EXIF rotation (which `loadImage` ignores) and converts jpeg and webp to PNG. Impact loads from the macOS system font path with an Arial Black then bold sans fallback, so Linux CI stays green without bundling font files.

Common cases go through flags (`--top`/`--bottom`, `--subtitle`, `--caption` with a canvas-expanding white bar). Multi-label and custom placement go through a JSON spec file; the flags desugar into the same spec type, so there is one render path. Spec coordinates and font sizes are normalized 0-1 fractions because Claude judges placement from a Read that may be downscaled. The spec-file route also sidesteps the Bash tool's `!` escaping bug, and the SKILL.md routes any `!`-bearing text there. Fit failures warn and render anyway rather than erroring, since a visible-but-cramped render is something Claude can see and fix on the next iteration.

A few skill-level choices: the output filename is treated as part of the joke (the skill forbids generic names like `meme.png`), and delivery copies the file reference to the clipboard via `osascript` rather than raw pixels, so a paste into Slack or GitHub keeps that filename. Test images stay in Downloads; copyrighted stills are never committed, and the worked examples in `references/spec.md` are spec text only.

Verified by rendering real memes and reading the outputs: a classic macro on a 250x250 template (exercising the 2x upscale for sub-400px images), a subtitle still compared against finished TV-subtitle references, spec-mode labels placed inside both panels of the Jim whiteboard format, and a caption bar over the corporate-needs-you format. Unit tests cover the pure layout math with a fake measurer (wrap, shrink-to-floor, region resolution), spec validation errors, and renderer behavior on programmatic fixtures (caption bar height matches the computed expansion, jpeg in becomes PNG out, upscale threshold). Wrap output from the real measurer is deliberately never snapshotted since font metrics differ on Linux.

The `gif` (captioned video clips) and `emoji` skills discussed for this plugin are out of scope here.
