### PR TITLE
feat(plan): add plan:review skill

### DIFF
--- a/plugins/plan/README.md
+++ b/plugins/plan/README.md
@@ -4,6 +4,7 @@ Planning mode guidelines and context injection for Claude Code.
 
 ## Contents
 
+- **Skill** `plan:review`: reviews how an implementation diverged from its approved plan, forking a clean-context agent over the plan and the diff to surface drift and follow-ups
 - **Hook**: Automatically injects planning guidelines when entering plan mode (via Shift+Tab or EnterPlanMode tool)
 - **Hook**: Gates `ExitPlanMode`, denying byte-identical plan re-presents and asking once per session before presenting a plan over 12k characters
 
@@ -12,6 +13,8 @@ Planning mode guidelines and context injection for Claude Code.
 The `UserPromptSubmit` hook checks `permission_mode` in the hook input. When the mode is `plan`, it injects the planning guidelines into the conversation context. A marker file prevents duplicate injection on subsequent prompts within the same session.
 
 The `PreToolUse` gate hook hashes each presented plan under `/tmp/claude/<session_id>/` and denies a resubmission whose text is unchanged since the last presentation, with instructions to revise instead of regrow. Plans over 12k characters trigger a one-time confirmation prompt. Infrastructure weirdness (missing session id, unreadable state) fails open.
+
+`plan:review` reads the approved plan from the file Claude Code writes under `~/.claude/plans/` and injects into the session on plan exit. It forks a clean-context agent that diffs the plan against the branch's base (resolved from the open PR, not assumed to be `main`) using the rubric in `skills/review/references/divergence.md`.
 
 ## Testing
 

--- a/plugins/plan/skills/review/SKILL.md
+++ b/plugins/plan/skills/review/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: plan:review
+description: >-
+  Review how an implementation diverged from its approved plan. Forks a
+  clean-context agent over the plan and the diff to surface requirements drift
+  and warranted follow-ups. Use at finish time or before opening a PR.
+allowed-tools:
+  - Agent
+---
+
+# Plan Review
+
+Compare what shipped against the plan that was approved. Surface where the implementation drifted and what follow-ups that warrants.
+
+The review runs in a forked agent with a clean context. An implementing session accumulates a justification for every departure as it happens, so drift goes unseen from inside it. A reviewer handed only the plan and the diff judges the delta cold. That outside view is the point: re-emphasizing the same prompt in the implementing context would not substitute for it.
+
+## Fork the Review
+
+Claude Code writes the approved plan to a file under `~/.claude/plans/` and injects that file's path into the session when plan mode exits. That file is the plan. Use the path already in this session's context. If none was injected, the session built against no approved plan and there is nothing to review: say so and stop.
+
+Dispatch a background `general-purpose` Agent. Never `fork`: a fork inherits this session's context and defeats the outside view. The agent starts clean and has no idea where this skill lives, so hand it absolute paths: the plan file, and the rubric `references/divergence.md` resolved against this skill's base directory (that directory is in your context). A bare relative path resolves against the repo root in the agent's context and misses. Tell it to:
+
+- read the plan file.
+- work out the base branch this change targets, then diff what shipped against it. The branch's open PR is authoritative (`gh pr view --json baseRefName -q .baseRefName`). With no PR yet, fall back to the repository default (`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`). Don't assume `main`: a stacked branch targets its parent. Capture both committed and uncommitted work: `git diff <base>...HEAD`, plus `git diff HEAD` and `git status --short` for anything not yet committed. The review can run mid-implementation, so uncommitted changes are in scope.
+- read the rubric it was handed, and return the report that rubric asks for.
+
+Run it on a cheaper model when one is set. The review reasons over two documents, so it does not need the top tier.
+
+## Report
+
+Relay the agent's report: the divergences and their classification, the drift, the ranked follow-ups (fix-before-merge against later), and the verdict. Add nothing of your own. The value is the outside view, not a second opinion filtered back through this context.

--- a/plugins/plan/skills/review/references/divergence.md
+++ b/plugins/plan/skills/review/references/divergence.md
@@ -1,0 +1,36 @@
+# Divergence Rubric
+
+The lens for judging an implementation against its approved plan.
+
+## Inputs
+
+- The approved plan (a file path).
+- The diff of what shipped: `git diff <base>...HEAD` against the branch's base, plus the working tree for uncommitted work.
+
+Read the plan first, then the diff. Judge the delta on its merits, not the plan's letter. A plan can be internally inconsistent or wrong, so a departure that corrects it counts as an improvement. Anchor every claim in the plan text or the diff.
+
+## Report
+
+#### Divergences
+
+Where the implementation departs from the plan. For each: what the plan said, what shipped, a file and line anchor, and a classification.
+
+- `justified`: a correction of the plan, or a well-earned improvement.
+- `neutral`: an acceptable equivalent the plan did not mandate either way.
+- `drift`: an unjustified departure, or a requirement quietly dropped.
+
+#### Requirements Drift
+
+What the plan required that is missing, weakened, or silently dropped. Then what was added that the plan never called for, with a judgment on whether the addition earns its place or is scope creep.
+
+#### Follow-Ups
+
+Concrete, actionable items the divergence warrants, ranked by importance. Split `fix before merge` from `later`. Name the file and the change for each.
+
+#### Verdict
+
+One paragraph. Does the outcome honor the plan's intent, even where it departs from the letter? Say so plainly, and name the one thing most worth the author's attention.
+
+## Stance
+
+Neutral third party. You did not write this code, so do not defend it, and do not assume the plan was right. Where the plan and the diff disagree, report the disagreement rather than resolving it in either's favor by default.


### PR DESCRIPTION
Adds `plan:review`, a skill that checks how an implementation diverged from the plan it was built against.

Requirements drift is where a lot of finishing sloppiness comes from, and it hides in the worst possible place: the implementing session. That session accumulates a justification for every departure as it happens, so by the end no single divergence registers as drift. Reading the diff back from inside that context can't surface it. `plan:review` forks a `general-purpose` agent with a clean context and hands it only the plan and the diff, so it judges the delta cold. The forked context is the whole mechanism, which is why re-emphasizing the same prompt in the implementing session would not substitute for it.

## Decisions

- **The plan comes from the file Claude Code already writes.** Every approved plan lands as plain markdown under `~/.claude/plans/`, and its path is injected into the session when plan mode exits. The skill reads that file. No new persisted state, no transcript parsing, and no helper script: the plan is already extracted and already on disk.
- **No flags, thin skill.** The skill gathers the injected path and the diff against the branch's base, then dispatches. The base is resolved from the branch's open PR rather than assumed to be `main`, so a stacked branch is reviewed against its parent. The classification scheme (justified / neutral / drift), the drift and follow-up framing, and the neutral stance live in `references/divergence.md`.
- **Forked agent, never `fork`.** A `fork` inherits the parent context, which reintroduces exactly the bias the review exists to escape. The skill uses `general-purpose` and says so explicitly.
- **Model-invokable.** A finishing coordinator like `/ship` composes it by name, and the model can invoke it at finish time on its own. That earns a recurring description cost, kept small by a compact description.

## Why Not the Transcript

An earlier cut of this read the plan back out of the session transcript by scanning `~/.claude/projects/` for a matching `<session>.jsonl`. That was the wrong source. A session's transcript is stored under a directory munged from the path it started in, which does not survive a worktree re-root: this branch's own transcript lives under one munged path while the session reports another. Scanning to paper over that is guesswork. The plan file sidesteps it entirely.

## Verification

The skill passes `skill-lint`. Run end-to-end, the forked-review agent turned a plan and its diff into a ranked divergence report that separated justified corrections from genuine follow-ups.

Not yet wired into `/ship`. Folding it in there is a follow-up once this lands.
