### PR TITLE
refactor(ship): cut filler, unwrap prose

### DIFF
--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -2,9 +2,7 @@
 name: ship
 disable-model-invocation: true
 description: >-
-  Finish a branch: infer which review passes the change warrants, run them, open
-  the PR, babysit CI to green, triage bot comments, and refresh the body from a
-  clean context. Invoke as /ship when a change is ready to send.
+  Finish a branch: infer which review passes the change warrants, run them, open the PR, babysit CI to green, triage bot comments, and refresh the body from a clean context.
 argument-hint: "[--merge] [--effort <level>] [--simplify] [--skip <pass>] [--base <ref>]"
 allowed-tools:
   - Agent
@@ -23,159 +21,74 @@ allowed-tools:
 
 # Ship
 
-Finish the current branch with one command. Ship reads the diff, decides which
-review passes it warrants, runs them in sequence, opens the PR, watches CI to
-green, and refreshes the body from a clean context.
+Gate review passes on the diff, run them in order, open the PR, babysit CI to green, refresh the body from a clean context. Each pass fans out on its own; ship only gates and orders.
 
-Ship is a decider and sequencer, not a worker. Each pass it runs fans out on its
-own (`code-review`, `simplify`, `comments:audit`, `writing:review`, `verify`, and
-`pull-request:babysit` all dispatch their own agents or watchers). Ship's job is
-to gate the optional passes so the diff only pays for the reviewers it earns, then
-run the finishing sequence in the right order.
-
-The default end state is **green and ready**: CI passing, bot comments triaged,
-body refreshed, stopped for your own web review. `--merge` opts into driving the
-PR all the way to merged.
+Default end state **green and ready**: CI green, bot comments triaged, body refreshed, stopped for your web review. `--merge` drives to merged.
 
 ## Context
 
-Gathered at invocation with bang-execution, so the decide step reads it without a
-tool call:
-
-- Working tree and untracked files: !`git status --short`
-
-This is base-independent. The committed diff needs a base, resolved below.
+- Working tree: !`git status --short`
 
 ## Decide What Applies
 
-Resolve the base before diffing. It defaults to `main`. On a stacked branch pass
-`--base <parent>` so gating sees only the tip layer. Diff the tip against the base
-with `git diff <base>...HEAD`.
+Resolve the base: default `main`, or `--base <parent>` on a stack. Diff `git diff <base>...HEAD`, plus a plain `git diff` for uncommitted work. Gate each pass on the file set, its size, and the content behind any judgment call (new comments, refactor or new behavior). Full matrix and heuristics: [`references/passes.md`](references/passes.md).
 
-Gate each pass on what the change contains. Read the Context above for the
-working-tree state, then run `git diff <base>...HEAD` (plus a plain `git diff` for
-uncommitted work) for the file set, its size, and the content behind any judgment
-call: whether the diff introduces code comments, whether a code change is a pure
-refactor. The full matrix, the effort-inference table, and the
-`code-review`-versus-`simplify` heuristic live in
-[`references/passes.md`](references/passes.md). The short version:
+- **`plan:review`**: an approved plan is in context (Claude Code injects a `~/.claude/plans/` file). No plan, skip.
+- **Correctness and quality**: code changed. Exactly one of `code-review <effort> --fix` (default) or `simplify` (pure refactor, no new behavior). Skip on docs/config-only.
+- **`comments:audit`**: diff adds code comments.
+- **`writing:review`**: diff touches prose (`.md`, `.mdx`, `.rst`, docs).
+- **`verify`**: diff has a runtime surface. Declines tests-only and docs-only itself.
 
-- **`plan:review`** runs when the work was built against an approved plan, meaning
-  Claude Code injected a `~/.claude/plans/` file into this session. The trigger is
-  the plan's presence, so a session with no approved plan skips it.
-- **Correctness and quality** runs when the diff changes code, as exactly one of
-  `code-review <effort> --fix` (default) or `simplify` (pure refactor with no new
-  behavior). A docs-only or config-only diff skips it.
-- **`comments:audit`** runs when the diff introduces code comments.
-- **`writing:review`** runs when the diff touches prose (`.md`, `.mdx`, `.rst`,
-  docs).
-- **`verify`** runs when the diff has a runtime surface. It declines tests-only
-  and docs-only diffs on its own, so passing it a docs change is a no-op, not a
-  failure.
-
-Infer, don't interrogate. Present the plan in one line and proceed:
-
-> Ship plan: `code-review medium --fix` → `verify` → create → babysit. Skipping
-> comments (no new comments) and writing (no prose).
-
-Use `AskUserQuestion` only when a call is genuinely ambiguous: a diff that could
-be a refactor or a behavior change, or an effort that could be `medium` or
-`high`. One question, then run.
+Infer, don't interrogate. Present the plan in one line, then proceed. `AskUserQuestion` only on a real toss-up: refactor versus behavior change, or `medium` versus `high` effort.
 
 ## Flags
 
-- `--merge` drives the PR to merged (babysit `--merge`). Default is green and
-  ready.
-- `--effort <low|medium|high|max|ultra>` overrides the inferred `code-review`
-  effort.
-- `--simplify` forces the `simplify` path over `code-review`.
-- `--skip <pass>` drops a gated pass. Repeatable. Pass names: `plan`,
-  `code-review`, `simplify`, `comments`, `writing`, `verify`.
-- `--base <ref>` sets the diff base for gating. Default `main`. On a stack, pass
-  the parent branch so gating sees only the tip layer.
+- `--merge`: drive to merged (babysit `--merge`). Default: green and ready.
+- `--effort <low|medium|high|max|ultra>`: override inferred `code-review` effort.
+- `--simplify`: force `simplify` over `code-review`.
+- `--skip <pass>` (repeatable): drop a gated pass. Names: `plan`, `code-review`, `simplify`, `comments`, `writing`, `verify`.
+- `--base <ref>`: diff base for gating. Default `main`; on a stack, the parent branch.
 
 ## Pre-PR Reviews
 
-Run the gated review passes before creating the PR, serialized. `code-review
---fix`, `simplify`, and the comment trims all write to the branch, so they cannot
-apply in parallel.
+Serialized before create: `code-review --fix`, `simplify`, and comment trims all write to the branch.
 
-Order:
+1. **`plan:review`** (if gated in). Read-only, so it runs first. Surface its findings; handle fix-before-merge drift now, so the passes below cover the resulting fixes.
+2. **`comments:audit`**: needs a clean tree (the fix passes dirty it), lands trims via fast-forward (see [Comment Trims](#comment-trims)). Pauses at preflight for an agent-count approval.
+3. **Correctness and quality**: `code-review <effort> --fix` or `simplify`.
+4. **`writing:review`** over touched prose. Address salient findings before the body is written.
+5. **`verify`** end to end.
 
-1. **`plan:review`** first, when a plan gated it in. It is read-only: it forks a
-   clean-context agent over the plan and the diff and reports divergence and
-   follow-ups without touching the tree. Surface its findings and handle any
-   fix-before-merge drift before moving on, so the passes below cover whatever
-   those fixes produce.
-2. **`comments:audit`**, because it needs a clean working tree and lands its trims
-   through a branch fast-forward (see [Comment Trims](#comment-trims)). The other
-   fix passes dirty the tree, so running the comment pass before them keeps the
-   tree clean for it. This pass pauses at preflight for an agent-count approval, so
-   it interrupts the otherwise unattended flow.
-3. **Correctness and quality**: `code-review <effort> --fix` or `simplify`. These
-   apply their own fixes to the working tree.
-4. **`writing:review`** over the touched prose. It surfaces prose findings.
-   Address the salient ones before the body is written.
-5. **`verify`** to exercise the change end to end.
-
-If the working tree is dirty when ship reaches the comment pass, say so and ask
-whether to commit first. `comments:audit` operates on `HEAD` and requires a clean
-working tree, so the branch's changes must be committed for it to land the trims.
+Dirty tree at the comment pass: ask whether to commit first. `comments:audit` operates on `HEAD` and needs a clean tree.
 
 #### Comment Trims
 
-`comments:audit` commits its trims to a fresh `comments/audit-<hash>` branch off
-`HEAD` and leaves the working tree untouched. Ship needs those trims on the
-shipping branch. Run `comments:audit --base <base> --fix` and capture the branch
-name it prints.
-
-When the audit finds nothing to trim it writes no branch. There is nothing to
-fast-forward, so skip this step. Only when a branch name was printed, dispatch a
-short-lived `general-purpose` Agent, passing it that name, to fast-forward the
-shipping branch onto the audit commit and delete the temp branch:
+`comments:audit` commits trims to a fresh `comments/audit-<hash>` branch off `HEAD`, leaving the tree untouched. Run `comments:audit --base <base> --fix` and capture the branch name. No branch means nothing to trim: skip. Otherwise dispatch a short-lived `general-purpose` Agent with that name to fast-forward and delete it:
 
 ```
 git merge --ff-only comments/audit-<hash>
 git branch -d comments/audit-<hash>
 ```
 
-The fast-forward is always clean, since the audit commit sits directly on `HEAD`.
-The merge runs in the dispatched Agent so ship's own commands stay `git diff` and
-`git status`. See [`references/passes.md`](references/passes.md) for the rejected
-alternatives.
+The commit sits on `HEAD`, so the fast-forward is clean. It runs in the Agent to keep ship's own commands to `git diff` and `git status`. Rejected alternatives: [`references/passes.md`](references/passes.md).
 
 ## Create
 
-Run `pull-request:create` to commit the accumulated working-tree fixes, push, and
-open the PR. Capture the PR URL it prints. The babysit and body-refresh steps
-both need it.
+`pull-request:create` commits the working-tree fixes, pushes, opens the PR. Capture the URL: babysit and body-refresh need it.
 
 ## Babysit
 
-Run `pull-request:babysit <url>` to watch CI and fix trivial failures until
-green.
+`pull-request:babysit <url>` watches CI and fixes trivial failures to green.
 
-- Add `--reviews` so babysit hands bot comments to `pull-request:follow-up
-  --auto` after the first green. Default this on: bot review triage is part of
-  finishing.
-- Add `--merge` only when `/ship --merge` was passed. Without it, babysit stops
-  at green and ready.
+- `--reviews` (default on): after first green, hand bot comments to `pull-request:follow-up --auto`.
+- `--merge`: only when `/ship --merge` was passed; else stop at green.
 
-Babysit owns the follow-up loop and the CI waits. Ship does not poll on its own.
+Babysit owns the CI waits and the follow-up loop. Ship never polls.
 
 ## Refresh the Body
 
-Dispatch a background `general-purpose` Agent to run `pull-request:update <url>`,
-on a cheaper model when one is set. It reads the final PR and the merged diff, not
-this session's transcript. Use `general-purpose`, never `fork`: a fork inherits
-this context and would reintroduce the diary narration.
-
-This is what kills the diary effect. The rewriter never saw the review
-back-and-forth, so it describes the merged diff as a finished change, with no
-"initially" or "after review". The cheaper out-of-context model also cuts the
-rewrite's cost.
+Dispatch a background `general-purpose` Agent (cheaper model if set) to run `pull-request:update <url>`. Never `fork`: it must read the final PR and diff cold, not this session's transcript, so the body describes the finished change with no review narration.
 
 ## Report
 
-Close with the PR link, which passes ran and which were gated out, and the final
-state (green and ready, or merging).
+PR link, passes run and gated out, final state (green and ready, or merging).

--- a/user/skills/ship/references/passes.md
+++ b/user/skills/ship/references/passes.md
@@ -1,113 +1,43 @@
 # Ship Passes
 
-The decision matrix ship uses to gate each pre-PR review, infer `code-review`
-effort, choose between `code-review` and `simplify`, and land comment trims on
-the shipping branch.
+Gating decisions for ship's pre-PR reviews: which pass runs, `code-review` effort, `code-review` versus `simplify`, and why comment trims land the way they do.
 
 ## Gating Matrix
 
-Most passes gate on the diff. Read it against the base plus the working tree, and
-gate each on what it contains. `plan:review` is the exception: it gates on whether
-the session was built against an approved plan.
+Most passes gate on the diff (against the base, plus the working tree). `plan:review` gates on whether an approved plan drove the session.
 
 | Trigger | Pass | Notes |
 |---|---|---|
-| An approved plan for the session | `plan:review` | Context-gated. See [Plan Review](#plan-review) |
-| Code changes | `code-review <effort> --fix` or `simplify` | Exactly one of the two. Skipped on a docs-only or config-only diff |
+| An approved plan in context (`~/.claude/plans/` file) | `plan:review` | Read-only, runs first |
+| Code changes | `code-review <effort> --fix` or `simplify` | Exactly one. Skip on docs/config-only |
 | New code comments | `comments:audit` | See [Comment Trims](#comment-trims) |
-| Prose (`.md`, `.mdx`, `.rst`, docs) | `writing:review` | Prose-gated |
-| A runtime surface | `verify` | Skips tests-only and docs-only diffs itself |
+| Prose (`.md`, `.mdx`, `.rst`, docs) | `writing:review` | |
+| A runtime surface | `verify` | Declines tests-only and docs-only itself |
 
-The gating is what saves context. A docs-only change skips `code-review` and
-`verify`. A code-only change skips `writing:review`. An ad-hoc change with no plan
-skips `plan:review`. Never run a reviewer the change does not warrant.
-
-`--skip <pass>` drops any gated pass. `plan`, `code-review`, `simplify`,
-`comments`, `writing`, `verify`.
-
-## Plan Review
-
-`plan:review` gates on whether the session was built against an approved plan. Run
-it when Claude Code injected one (`~/.claude/plans/<name>.md`) into the session. An
-ad-hoc change with no plan has nothing to review against, so skip it.
-
-It is read-only. It forks a clean-context agent over the plan and the diff and
-reports divergences, requirements drift, and ranked follow-ups. It writes nothing
-to the tree. That is why it runs first, ahead of the fix passes: its follow-ups
-frame what the rest of the sequence and the author still need to address, and any
-drift fix it prompts then flows through `code-review` and `verify` like the rest of
-the change.
-
-Forking a clean context is what the review depends on. The session that built the
-change carries a justification for every departure, so drift reads as normal from
-inside it. A reviewer starting clean judges the delta on its merits. `plan:review`
-owns sourcing the plan and diffing it, so ship only decides whether to run it.
+Gating is the cost lever: never run a reviewer the change does not warrant. `--skip <pass>` drops any of them (`plan`, `code-review`, `simplify`, `comments`, `writing`, `verify`).
 
 ## Effort Inference
 
-`code-review` runs at an inferred effort unless `--effort` overrides it. Session
-history spreads fairly evenly across the low three (roughly `low` 63, `medium` 49,
-`high` 47), with `max` and `ultra` rare (2 and 0). Match the effort to the diff.
-`high` is a routine outcome for risky work. Reserve `max` and `ultra` for explicit
-requests.
+Infer `code-review` effort from the diff unless `--effort` overrides. `high` is routine for risky work. Reserve `max` and `ultra` for explicit requests.
 
 | Diff shape | Effort |
 |---|---|
 | Tiny: one file, a handful of lines | `low` |
 | Ordinary change | `medium` |
-| Risky: touches multiple plugins, hooks, permissions, sandbox, or auth-shaped code | `high` |
+| Risky: multiple plugins, hooks, permissions, sandbox, or auth-shaped code | `high` |
 | Explicit request only | `max`, `ultra` |
 
-`ultra` is a deep multi-agent cloud review. Never infer it. Run it only when the
-user passes `--effort ultra`.
+`ultra` is a deep multi-agent cloud review. Never infer it: run it only on `--effort ultra`.
 
 ## Code-Review Versus Simplify
 
-They are alternatives, not a pair. Session history bears this out: many runs did
-one or the other, few did both. Choose one.
-
-Pick `simplify` when the change is a pure refactor or cleanup with no new
-behavior: extraction, renaming, dedup, dead-code removal, moving code without
-changing what it does. `simplify` covers reuse, simplification, efficiency, and
-altitude. It does not hunt for bugs.
-
-Pick `code-review` for everything else. Any new behavior, bug fix, or feature
-needs correctness coverage, which `simplify` does not provide.
-
-`--simplify` forces the `simplify` path regardless of the inference.
+Alternatives, not a pair. Pick `simplify` for a pure refactor or cleanup with no new behavior: extraction, renaming, dedup, dead-code removal, moving code. It covers reuse, simplification, efficiency, and altitude, and does not hunt bugs. Pick `code-review` for anything with new behavior, a bug fix, or a feature, which need the correctness coverage `simplify` skips. `--simplify` forces the `simplify` path.
 
 ## Comment Trims
 
-`comments:audit` does not write to the working tree. It commits its trims to a
-fresh `comments/audit-<hash>` branch off `HEAD` via git plumbing, and its apply
-step requires a clean working tree. Ship needs those trims on the shipping
-branch, not on a side branch.
+`comments:audit` commits trims to a fresh `comments/audit-<hash>` branch off `HEAD` via git plumbing, and its apply requires a clean tree. Ship needs the trims on the shipping branch, so it runs the audit first (clean tree) and fast-forwards the shipping branch onto the audit commit. A clean audit writes no branch, so skip the fast-forward when none was printed.
 
-Resolution: run `comments:audit` as the **first** pre-PR pass, while the tree is
-still clean, then fast-forward the shipping branch onto the audit commit.
+Rejected:
 
-```
-comments:audit --base <base> --fix
-git merge --ff-only comments/audit-<hash>
-git branch -d comments/audit-<hash>
-```
-
-The audit commit is a single commit off the same `HEAD`, so the fast-forward
-never conflicts. Ship dispatches the merge to a short-lived `general-purpose`
-Agent so ship's own command surface stays limited to `git diff` and `git status`.
-
-A clean audit writes no branch. When `comments:audit` reports nothing to trim,
-there is no `comments/audit-<hash>` to merge, so skip the fast-forward rather than
-running it against a branch that does not exist.
-
-Two alternatives were rejected:
-
-- **`--report` plus inline apply**: pulls the full findings into ship's context,
-  which defeats the whole point of keeping the bulk verdicts on disk and off the
-  conversation.
-- **Running it after `code-review --fix`**: the fix pass dirties the tree, and
-  `comments:audit` apply then fails its clean-tree check. Reordering it first
-  avoids a commit step mid-sequence.
-
-Running the audit first also means the later `code-review --fix` pass sees the
-already-trimmed comments, which is the better ordering anyway.
+- **`--report` plus inline apply**: pulls the full findings into ship's context, defeating the point of keeping bulk verdicts off the conversation.
+- **Running it after `code-review --fix`**: the fix pass dirties the tree, failing `comments:audit`'s clean-tree check.


### PR DESCRIPTION
Trims the `/ship` skill from #984. A skill is instructions for Claude, so exposition, connective tissue, and rationale it does not act on are pure token cost. This cuts `SKILL.md` and `passes.md` by roughly half with no instruction lost.

The cuts are duplicated or inert prose: the forked-context rationale for `plan:review` (it already lives in that skill, which ship invokes), the session-history counts that justified the effort and pass heuristics to a human reader without changing what Claude does, restatements of the description, and the worked example plan. The files are also unwrapped to one line per paragraph, matching the surrounding markdown.

Follow-up to #984.
