### PR TITLE
feat(skills): drop near-zero-use skills from always-on catalog

### DIFF
--- a/plugins/research/skills/prior-art/SKILL.md
+++ b/plugins/research/skills/prior-art/SKILL.md
@@ -3,6 +3,7 @@ name: research:prior-art
 description: |
   Research existing solutions when exploring a new problem space. Use when the user mentions "prior art", "existing solutions", "what libraries exist for", or wants to understand the landscape before building.
 argument-hint: <topic>
+disable-model-invocation: true
 ---
 
 Research prior art for: $ARGUMENTS

--- a/plugins/review/skills/inbox/SKILL.md
+++ b/plugins/review/skills/inbox/SKILL.md
@@ -5,6 +5,7 @@ description: >
   Use when reviewing multiple PRs, checking the review queue, batch reviews, or managing your review inbox.
   Pass --queue to spawn an already-ordered queue.
 argument-hint: "[--queue]"
+disable-model-invocation: true
 allowed-tools:
   - Monitor
   - TaskStop


### PR DESCRIPTION
Adds `disable-model-invocation: true` to two slash-workflow skills that the model almost never auto-invokes. The flag drops their name and description from the always-on catalog, so they cost zero recurring context, while staying slash-invocable via `/review:inbox` and `/research:prior-art`.

`review:inbox` is a tmux orchestrator with no cross-skill `Skill()` consumer. `research:prior-art` overlaps the built-in deep-research skill, so this flags it rather than retiring it, keeping it on hand behind the slash menu. A re-grep (excluding `.worktrees` and the plugin cache) confirmed neither is invoked via the `Skill()` tool by any other skill, so flagging them breaks nothing.

`interview:plan` was intentionally left unflagged. Two skills invoke it through the `Skill()` tool (`tech-spec:create` and `improve-codebase-architecture`), and the binary blocks `Skill()` on a model-disabled skill, so flagging it would break those consumers.

`skill-lint` passes for both touched plugins. Names and argument hints are unchanged, so `/review:inbox --queue` and `/research:prior-art <topic>` still parse.

Original Task: [[discovery] DMI flags for near-zero-use skills](https://things.bendrucker.me/show?id=Ef5uRt5c1ZCf1HzoXH4euv)
