### PR TITLE
refactor(session): move query catalogs to references/catalog.md

### DIFF
--- a/plugins/claude-code/skills/session/SKILL.md
+++ b/plugins/claude-code/skills/session/SKILL.md
@@ -77,33 +77,50 @@ The `project` param matches against the directory name (last path component) usi
 
 Every query also takes an optional `host` param. Omit it to span every machine (including `local`); pass `host=work` to scope to one imported machine. See [Cross-Machine History](#cross-machine-history).
 
-- `search`: find sessions by keyword (ILIKE on `content_text` and `summary`). Params: `query`, `limit`, `after_date`, `before_date`, `project`
-- `stats`: tool usage breakdown with error rates and aggregate totals. Params: `after_date`, `before_date`, `project`
-- `errors`: recent tool errors with type filtering. Params: `error_type` (`rejection` or `failure`), `limit`, `after_date`, `before_date`, `project`
-- `permissions`: tool calls the user rejected. Params: `limit`, `after_date`, `before_date`, `project`
-- `sandbox`: Bash calls that bypassed the sandbox (`dangerouslyDisableSandbox`), with back-links to prior failed sandboxed calls of the same command. Params: `limit`, `after_date`, `before_date`, `project`
-- `skills`: skill invocation counts by name. Params: `skill`, `after_date`, `before_date`, `project`
-- `text-export`: dump cleaned prose from `text_content` (TSV-friendly). Params: `role`, `model` (glob), `after_date`, `before_date`, `project`, `min_chars`.
-- `phrase-lift`: count a phrase per role/model with per-1M-char rate and assistant-vs-user lift. Params: `phrase`, `after_date`, `before_date`.
-- `model-summary`: assistant text item/message/char counts per model. Params: `after_date`, `before_date`, `project`.
-- `schema`: list every column in every table/view. Use this first when you don't know what's available.
-- `keys`: sample which top-level JSON keys appear in `raw.data` (the unstructured part), with occurrence counts.
-- `hooks`: hook activity and performance, one row per hook (keyed by command). Runs, blocks, asks, errors, cancelled, context injections, friction rate, p50/p95 duration. Params: `event` (hook event filter), `hook` (glob on command/name), `after_date`, `before_date`, `project`.
-- `hook-blocks`: hook overfiring analysis. Blocking events grouped by hook and normalized reason signature, with `storm_sessions` (sessions blocked 2+ times by the same signature) and `max_burst`. Params: `hook` (glob), `after_date`, `before_date`, `project`.
-- `activity`: session interaction profile, separating human signals (prompts, interruptions) from automated ones (auto-continuations, scheduled fires, queued goals), plus compactions, API retries, hook friction, and permission-mode distribution. Params: `after_date`, `before_date`, `project`.
-- `diagnostics`: recurring type-checker/linter/LSP diagnostics grouped by source/severity/code, with file and session spread. The signal for systematic mistakes. Params: `after_date`, `before_date`, `project`.
-- `files`: file hotspots, the files read and edited most across sessions. Params: `limit`, `after_date`, `before_date`, `project`.
-- `skill-activity`: work attributed to each skill (assistant turns, sessions, input/output/cache tokens). Swap `attribution_skill` for `attribution_plugin`/`attribution_agent` in the SQL to re-cut. Params: `after_date`, `before_date`, `project`.
-- `fields`: schema discovery by inference. Enumerates JSON keys at a path for records of a kind, with each value's JSON type and a count (divergent types appear as multiple rows). Params: `kind` (glob on `records.kind`, or null for all), `path` (JSON path, e.g. `$` or `$.attachment`), `after_date`, `before_date`, `project`.
-- `hook-block-then-retry-success`: per hook, blocks that were retried away by a same-hook success in the same session within N seconds (noise vs genuine redirect). Params: `hook` (glob on command/name), `within_seconds` (default 300), `after_date`, `before_date`, `project`, `host`.
-- `repeat-read-waste`: repeat Reads (same file re-read within a session) decomposed by cause: paginated (`offset`/`limit` chunking), sidechain (subagent fan-out), after-own-edit, and true repeats (the actionable context tax), with char/token cost. Params: `after_date`, `before_date`, `project`, `host`.
-- `skill-auto-vs-explicit`: per skill, model-auto (empty args) vs explicit/slash invocations, the core `disable-model-invocation` lever. Params: `min_calls` (default 1), `after_date`, `before_date`, `project`, `host`.
-- `sandbox-bypass-effective-command`: top `dangerouslyDisableSandbox` commands normalized to their real verb after stripping leading `cd <path>` wrappers, `echo` lines, and env-assignment prefixes (`excludedCommands` candidates). Params: `min_count` (default 5), `after_date`, `before_date`, `project`, `host`.
-- `plans`: sessions that used plan mode (ExitPlanMode), with per-session plan count, redirect/approved/handoff breakdown, and a `replan_tier` label keyed on mid-session redirects (`single` / `replan` for 1 / `off-rails` for 2+). A terminal rejection with no file edits afterward counts as a handoff (plan here, implement in a fresh session), never as a redirect. Sorted by plan_count descending. Params: `min_plans` (default 1), `after_date`, `before_date`, `project`, `host`.
-- `plan-iterations`: one row per ExitPlanMode present, ordered within a session. Measures growth (`chars_delta`, `lines_added`), removal (`lines_removed`), and carry-over (`lines_carried`, `carry_over_ratio`) against the previous present via set comparison of normalized plan text, plus time to the first present (`secs_to_first_plan`) and the session's human-authored prompt count (`human_msgs`). High carry-over paired with growth and near-zero removal is the append-only re-present signature. Params: `min_plans` (default 2, since the query is about re-presents), `after_date`, `before_date`, `project`, `host`.
-- `outcomes`: session terminal states, the outcome side the activity-centric queries never measure. Classifies every session as shipped (pr-link or a ship-signal Bash command: `git push`, `gh pr create/merge`, `glab mr create/merge`), ongoing (too fresh to call), handed-off (last plan rejected, implement-elsewhere), abandoned-with-edits (edits but nothing shipped, the loss signal), or no-artifact (Q&A/analysis), plus distinct PRs opened and PRs that took multiple sessions. Shipped means opened or pushed, not merged; PR fate lives outside the index. Params: `after_date`, `before_date`, `project`, `host`, `ongoing_hours` (default 48).
-- `hook-config-vs-observed`: hooks CONFIGURED on disk (plugin `hooks.json`, `~/.claude/settings.json`, `.claude/settings.json`) left-joined against DISTINCT hooks OBSERVED in `hook_events`, surfacing `observed_fires = 0` rows: hooks that never left a trace, the blind spot every other hook query misses because a silently-succeeding hook produces no event at all. Params: `after_date`, `before_date`, `project`, `host` (scopes the observed side only), `hook` (glob on configured command), `hook_config_glob` (override the plugin-cache glob).
-- `index-health`: the index auditing itself; run it FIRST in any analysis pass. One row per issue (`check_name`, `status`, `subject`, `detail`), alerts before info: `stream-silent` (a record kind that posted regularly then went quiet longer than its own worst historical gap, the signature of an upstream rename/removal that leaves consumers returning confidently stale results), `stream-new` (kinds first seen recently, shipping unconsumed), `host-staleness` (an imported host whose newest record lags the corpus, so cross-host queries read it as idle), `null-timestamp-kinds` (rows date filters silently exclude), `disk-not-indexed`/`indexed-not-on-disk` (index vs `~/.claude/projects` drift), `corpus-window` (the span each host actually covers). Deliberately takes no date/project/host scoping: health is corpus-level. Params: `min_active_days` (default 5), `new_days` (default 14), `stale_days` (default 2), `projects_glob` (default `~/.claude/projects/**/*.jsonl`).
+Every query, grouped by category with a one-line gloss:
+
+#### Sessions and Prose
+- `search`: find sessions by keyword
+- `text-export`: dump cleaned prose
+- `phrase-lift`: phrase rate, assistant-vs-user lift
+- `model-summary`: assistant text per model
+
+#### Tool Use and Friction
+- `stats`: tool usage breakdown
+- `errors`: recent tool errors
+- `permissions`: tool calls the user rejected
+- `sandbox`: sandbox-bypassing Bash calls
+- `sandbox-bypass-effective-command`: normalized bypass verbs
+
+#### Hooks
+- `hooks`: hook activity and performance
+- `hook-blocks`: hook overfiring analysis
+- `hook-block-then-retry-success`: blocks retried away
+- `hook-config-vs-observed`: configured vs observed hooks
+
+#### Skills
+- `skills`: skill invocation counts
+- `skill-activity`: work attributed per skill
+- `skill-auto-vs-explicit`: auto vs explicit invocations
+
+#### Files, Tokens, Activity
+- `files`: most-read and edited file hotspots
+- `repeat-read-waste`: repeat-Read context tax
+- `activity`: session interaction profile
+- `diagnostics`: recurring type/lint diagnostics
+
+#### Planning and Outcomes
+- `plans`: sessions using plan mode
+- `plan-iterations`: per-plan growth and carry-over
+- `outcomes`: session terminal states
+
+#### Schema and Index
+- `schema`: list every column
+- `keys`: sample raw JSON keys
+- `fields`: infer JSON keys at a path
+- `index-health`: the index auditing itself
+
+Full params and descriptions in [`references/catalog.md`](references/catalog.md). Load it before running a query you have not used.
 
 ### Markdown and YAML on Disk
 
@@ -114,21 +131,7 @@ duckdb -readonly -init ${CLAUDE_SKILL_DIR}/resources/extensions.sql "$DB" \
   < ${CLAUDE_SKILL_DIR}/resources/queries/plan-sections.sql
 ```
 
-- `plan-sections`: one row per markdown section across plan files on disk, joined to the session that produced each plan (outcome, replan sequence). The glob self-defaults to `~/.claude/plans/*.md` and takes an optional `plans_glob` override. Reads plan structure rather than re-parsing headings by hand, e.g. "which plans have no Verification section":
-
-  ```sql
-  -- prepend SET VARIABLE plans_glob = '...'; to scope
-  WITH s AS (
-    SELECT file_path, bool_or(title = 'Verification') AS has_verification
-    FROM read_markdown_sections('~/.claude/plans/*.md', filename=true)
-    GROUP BY file_path
-  )
-  SELECT file_path FROM s WHERE NOT has_verification;
-  ```
-
-  Local-host caveat: plans are read from the local disk, so a `plan_calls.plan_file` from an imported host (or a deleted plan) has no file to read. The `LEFT JOIN` simply omits its sections, so session-side data is unaffected. Embedded `$.input.plan` (via `plan_calls.plan_chars` / `content_items`) stays the source for cross-host and point-in-time needs.
-- `frontmatter`: one row per markdown file with YAML frontmatter, returning typed `name`/`description` and `content_chars`. The glob self-defaults to the memory corpus (`~/.claude/projects/*/memory/*.md`), where the nested `metadata` frontmatter auto-expands into a typed struct. Override with `frontmatter_glob` for skills, which live under `~/.claude/plugins` (not `~/.claude/skills`) and are duplicated across cache version-hashes, so pin one copy: `plugins/*/skills/*/SKILL.md` for repo skills.
-- `skill-config-vs-observed`: skills CONFIGURED on disk (plugin cache, `~/.claude/skills`, `.claude/skills` relative to cwd) left-joined against observed `skill_calls`, zero-fire first, with `description_chars` (the always-on cost) and `disable-model-invocation` (a zero there is normal). The curation instrument: which installed skills never fire. Params: `after_date`, `before_date`, `project`, `host` (observed side only), `skill` (glob on configured name), `plugin_skill_glob`/`user_skill_glob`/`project_skill_glob` (override a source, required when one is absent on disk).
+Three queries use this path: `plan-sections`, `frontmatter`, and `skill-config-vs-observed`. Params and per-query notes are in [`references/catalog.md`](references/catalog.md).
 
 The reusable pattern for markdown/YAML on disk: a self-defaulting glob (`~` expands to home, override via `SET VARIABLE`) feeding a table function over files (`read_markdown_sections` for body structure, `read_yaml_frontmatter` for frontmatter), never materializing file bodies into a column, with extension setup centralized in `resources/extensions.sql` and pulled in via `-init`. Follow it for new markdown-on-disk needs rather than reinventing regex parsing.
 
@@ -182,38 +185,9 @@ Importing another machine's history is a data-ownership decision: raise it once,
 
 Imported corpora are a hot place for secrets in tool output and pasted text. Patterns worth watching before anything leaves the machine: `sk_live_`, `xoxb-`, `ghp_`, `AKIA`, `eyJhbGciOi`. This is a signal to review, not a redactor.
 
-## Tables and Views
+## Tables, Views, and Macros
 
-Every table and view carries a `host` column (`local` for this machine, the label for imported ones). The `sessions` view adds `project_id` (`host || ':' || project_path`) for cross-host project identity.
-
-- `raw`: one row per JSONL line, **every record type** (chat, attachments, system events, permission modes, titles, queue ops, snapshots, and more), not just user/assistant. Pinned scalar columns (`host`, `session_id`, `type`, `project_path`, `git_branch`, `is_meta`, `is_sidechain`, `duration_ms`, `timestamp`, `summary`, `input_tokens`, `output_tokens`, `source_file`, `source_line`) plus a `data JSON` column that holds the full original line. Pinned numerics use `TRY_CAST`, so a divergent value type yields NULL rather than failing the import.
-- `records`: universal union over `raw`, one row per line, with a normalized `kind` label (`type`, plus `subtype`/attachment kind when present) and the cross-cutting dimensions (`uuid`, `parent_uuid`, `permission_mode`, `version`, `slug`, `is_meta`, `is_sidechain`) every record may carry, plus full `data`. The anti-blindness backbone: `SELECT kind, COUNT(*) FROM records GROUP BY kind` is the whole taxonomy; reach into `data->>'$.path'` for anything not pinned. Use the `fields` query to discover those paths.
-- `attachments`: one row per `attachment` record (the richest non-chat category: hooks, diagnostics, skill/tool listings, plan/auto mode, queued commands, command permissions). Columns: `kind` (attachment subtype), `hook_name`, `hook_event`, `tool_use_id`, `attachment JSON` (full payload), `data`.
-- `system_events`: one row per `system` record. `subtype`, `level`, `content`, `duration_ms`, `message_count`, and per-subtype fields: stop-hook (`hook_count`, `prevented_continuation`, `stop_reason`), compaction (`compact_trigger`, `compact_pre_tokens`, `compact_duration_ms`), API errors (`error_code`, `retry_attempt`).
-- `hook_events`: one row per `hook_*` attachment (every event: PreToolUse, PostToolUse, Stop, SessionStart, UserPromptSubmit, PermissionRequest), with replayed lines deduped. `kind`, `hook_event`, `hook_name`, `command` (exact script; NULL for a `hook_blocking_error`), `exit_code`, `duration_ms`, `decision` (allow/ask/deny, parsed from the stdout JSON of a hook_success when the hook returns a permission decision), `reason`, `additional_context`, `blocked` (boolean), plus `stdout`/`stderr`/`content`/`blocking_error`.
-- `hook_blocks`: the friction surface, `hook_events` filtered to events that stopped or interrupted a tool call or the model. `decision` is deny/ask/block; `reason` is the surfaced message. Find overfiring hooks here (high counts, repeated blocks within a session).
-- `messages`: view over `raw` filtered to `type IN ('user', 'assistant')`, with a derived `content_text` (string-form messages only), `model`, token columns (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`), attribution columns (`attribution_skill`, `attribution_plugin`, `attribution_agent`, `attribution_mcp_server`, `attribution_mcp_tool`), and a `summary` joined from summary rows.
-- `message_usage`: one row per assistant message with deduped token columns (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens` as MAX per message id), plus `model`, attribution columns, and `content_rows` (raw row count). **Sum tokens from here, not from `raw`/`messages`**: every content-block row repeats the parent message's usage, so per-row sums inflate totals 2-3.5x.
-- `content_items`: one row per element of `data->'$.message.content'`, with pinned columns (`type`, `name`, `id`, `tool_use_id`, `text`, `content`, `is_error`), the parent's attribution (`attribution_skill`/`plugin`/`agent`), plus `data JSON` (the content item) and `tool_use_result JSON` (merged from the parent message). Replayed lines from session rewind/resume are deduped (by record uuid, then by tool id), so tool_use/tool_result counts are one row per event.
-- `diagnostics`: one row per type-checker/linter/LSP diagnostic surfaced in-session. Columns: `file`, `severity`, `source`, `code`, `message`. Unnested from `diagnostics` attachments.
-- `file_operations`: one row per `Read`/`Write`/`Edit`/`MultiEdit`/`NotebookEdit`, with `operation`, `file_path`, and attribution. What you work on, and under which skill/plugin/agent.
-- `pr_links`: pull requests opened from a session, one row per distinct link (the harness re-emits the record across turns; the view dedupes and keeps the first emission's timestamp). Columns: `pr_number`, `repository`, `url`, `session_id`. Join to `sessions` to connect work to shipped outcomes.
-- `text_content`: one row per prose text item across user and assistant messages. Columns: `session_id`, `timestamp`, `role`, `model` (NULL for user), `project_path`, `text` (fenced and inline-backtick code stripped), `raw_text`, `source_file`, `source_line`.
-- `sessions`: aggregated session-level stats (start/end time, duration, message counts).
-- `tool_calls`: one row per tool use, with `file_path` and `command` (from the tool input) and attribution (`attribution_skill`/`plugin`/`agent`).
-- `tool_errors`: tool results where `is_error` is true, joined with the originating tool call. `error_type` is `rejection` or `failure`.
-- `permission_requests`: tool calls the user rejected.
-- `sandbox_bypasses`: Bash calls that used `dangerouslyDisableSandbox=true`, with back-links to retried failures.
-- `skill_calls`: one row per `Skill` tool invocation.
-- `plan_calls`: one row per `ExitPlanMode` tool use. Columns: `tool_use_id`, `plan_file`, `plan_chars` (length of plan text; fetch the full text via `json_extract_string(data, '$.input.plan')` from `content_items` when needed), `outcome` (`approved` / `redirected` / `handoff` / `unknown`), `plan_seq` (1-based ordinal within the session). `handoff` is a rejection of the session's last plan with no file edits after it: the deliberate reject-and-implement-elsewhere workflow. `redirected` is any other rejection (mid-session churn).
-- `plan_sessions`: one row per session that used plan mode. Columns: `plan_count`, `redirect_count`, `approved_count`, `handoff_count`, `unknown_count`, `first_plan_ts`, `last_plan_ts`.
-
-## Macros
-
-- `date_filter(ts, after, before)`: filter a timestamp column by optional date bounds.
-- `project_filter(path, pattern)`: match the last path component against a glob pattern.
-- `host_filter(host_col, host_val)`: pass through when `host_val` is NULL, else match the host column.
-- `project_id(host, path)`: `host || ':' || path`, a cross-host project identity.
+Every table and view carries a `host` column (`local` for this machine, the label for imported ones). The `sessions` view adds `project_id` (`host || ':' || project_path`) for cross-host project identity. [`references/catalog.md`](references/catalog.md) documents every table, view, and filter macro. Load it before writing SQL against a surface you have not used, or ask DuckDB directly (see [Discovery](#discovery)).
 
 ## Known Blind Spots
 

--- a/plugins/claude-code/skills/session/references/catalog.md
+++ b/plugins/claude-code/skills/session/references/catalog.md
@@ -1,0 +1,84 @@
+# Session Query Catalog
+
+Full parameters and descriptions for every named query, the on-disk markdown/YAML queries, and the tables, views, and macros the [`SKILL.md`](../SKILL.md) name index points to. Load this before running a query you have not used.
+
+## Named Queries
+
+- `search`: find sessions by keyword (ILIKE on `content_text` and `summary`). Params: `query`, `limit`, `after_date`, `before_date`, `project`
+- `stats`: tool usage breakdown with error rates and aggregate totals. Params: `after_date`, `before_date`, `project`
+- `errors`: recent tool errors with type filtering. Params: `error_type` (`rejection` or `failure`), `limit`, `after_date`, `before_date`, `project`
+- `permissions`: tool calls the user rejected. Params: `limit`, `after_date`, `before_date`, `project`
+- `sandbox`: Bash calls that bypassed the sandbox (`dangerouslyDisableSandbox`), with back-links to prior failed sandboxed calls of the same command. Params: `limit`, `after_date`, `before_date`, `project`
+- `skills`: skill invocation counts by name. Params: `skill`, `after_date`, `before_date`, `project`
+- `text-export`: dump cleaned prose from `text_content` (TSV-friendly). Params: `role`, `model` (glob), `after_date`, `before_date`, `project`, `min_chars`.
+- `phrase-lift`: count a phrase per role/model with per-1M-char rate and assistant-vs-user lift. Params: `phrase`, `after_date`, `before_date`.
+- `model-summary`: assistant text item/message/char counts per model. Params: `after_date`, `before_date`, `project`.
+- `schema`: list every column in every table/view. Use this first when you don't know what's available.
+- `keys`: sample which top-level JSON keys appear in `raw.data` (the unstructured part), with occurrence counts.
+- `hooks`: hook activity and performance, one row per hook (keyed by command). Runs, blocks, asks, errors, cancelled, context injections, friction rate, p50/p95 duration. Params: `event` (hook event filter), `hook` (glob on command/name), `after_date`, `before_date`, `project`.
+- `hook-blocks`: hook overfiring analysis. Blocking events grouped by hook and normalized reason signature, with `storm_sessions` (sessions blocked 2+ times by the same signature) and `max_burst`. Params: `hook` (glob), `after_date`, `before_date`, `project`.
+- `activity`: session interaction profile, separating human signals (prompts, interruptions) from automated ones (auto-continuations, scheduled fires, queued goals), plus compactions, API retries, hook friction, and permission-mode distribution. Params: `after_date`, `before_date`, `project`.
+- `diagnostics`: recurring type-checker/linter/LSP diagnostics grouped by source/severity/code, with file and session spread. The signal for systematic mistakes. Params: `after_date`, `before_date`, `project`.
+- `files`: file hotspots, the files read and edited most across sessions. Params: `limit`, `after_date`, `before_date`, `project`.
+- `skill-activity`: work attributed to each skill (assistant turns, sessions, input/output/cache tokens). Swap `attribution_skill` for `attribution_plugin`/`attribution_agent` in the SQL to re-cut. Params: `after_date`, `before_date`, `project`.
+- `fields`: schema discovery by inference. Enumerates JSON keys at a path for records of a kind, with each value's JSON type and a count (divergent types appear as multiple rows). Params: `kind` (glob on `records.kind`, or null for all), `path` (JSON path, e.g. `$` or `$.attachment`), `after_date`, `before_date`, `project`.
+- `hook-block-then-retry-success`: per hook, blocks that were retried away by a same-hook success in the same session within N seconds (noise vs genuine redirect). Params: `hook` (glob on command/name), `within_seconds` (default 300), `after_date`, `before_date`, `project`, `host`.
+- `repeat-read-waste`: repeat Reads (same file re-read within a session) decomposed by cause: paginated (`offset`/`limit` chunking), sidechain (subagent fan-out), after-own-edit, and true repeats (the actionable context tax), with char/token cost. Params: `after_date`, `before_date`, `project`, `host`.
+- `skill-auto-vs-explicit`: per skill, model-auto (empty args) vs explicit/slash invocations, the core `disable-model-invocation` lever. Params: `min_calls` (default 1), `after_date`, `before_date`, `project`, `host`.
+- `sandbox-bypass-effective-command`: top `dangerouslyDisableSandbox` commands normalized to their real verb after stripping leading `cd <path>` wrappers, `echo` lines, and env-assignment prefixes (`excludedCommands` candidates). Params: `min_count` (default 5), `after_date`, `before_date`, `project`, `host`.
+- `plans`: sessions that used plan mode (ExitPlanMode), with per-session plan count, redirect/approved/handoff breakdown, and a `replan_tier` label keyed on mid-session redirects (`single` / `replan` for 1 / `off-rails` for 2+). A terminal rejection with no file edits afterward counts as a handoff (plan here, implement in a fresh session), never as a redirect. Sorted by plan_count descending. Params: `min_plans` (default 1), `after_date`, `before_date`, `project`, `host`.
+- `plan-iterations`: one row per ExitPlanMode present, ordered within a session. Measures growth (`chars_delta`, `lines_added`), removal (`lines_removed`), and carry-over (`lines_carried`, `carry_over_ratio`) against the previous present via set comparison of normalized plan text, plus time to the first present (`secs_to_first_plan`) and the session's human-authored prompt count (`human_msgs`). High carry-over paired with growth and near-zero removal is the append-only re-present signature. Params: `min_plans` (default 2, since the query is about re-presents), `after_date`, `before_date`, `project`, `host`.
+- `outcomes`: session terminal states, the outcome side the activity-centric queries never measure. Classifies every session as shipped (pr-link or a ship-signal Bash command: `git push`, `gh pr create/merge`, `glab mr create/merge`), ongoing (too fresh to call), handed-off (last plan rejected, implement-elsewhere), abandoned-with-edits (edits but nothing shipped, the loss signal), or no-artifact (Q&A/analysis), plus distinct PRs opened and PRs that took multiple sessions. Shipped means opened or pushed, not merged; PR fate lives outside the index. Params: `after_date`, `before_date`, `project`, `host`, `ongoing_hours` (default 48).
+- `hook-config-vs-observed`: hooks CONFIGURED on disk (plugin `hooks.json`, `~/.claude/settings.json`, `.claude/settings.json`) left-joined against DISTINCT hooks OBSERVED in `hook_events`, surfacing `observed_fires = 0` rows: hooks that never left a trace, the blind spot every other hook query misses because a silently-succeeding hook produces no event at all. Params: `after_date`, `before_date`, `project`, `host` (scopes the observed side only), `hook` (glob on configured command), `hook_config_glob` (override the plugin-cache glob).
+- `index-health`: the index auditing itself; run it FIRST in any analysis pass. One row per issue (`check_name`, `status`, `subject`, `detail`), alerts before info: `stream-silent` (a record kind that posted regularly then went quiet longer than its own worst historical gap, the signature of an upstream rename/removal that leaves consumers returning confidently stale results), `stream-new` (kinds first seen recently, shipping unconsumed), `host-staleness` (an imported host whose newest record lags the corpus, so cross-host queries read it as idle), `null-timestamp-kinds` (rows date filters silently exclude), `disk-not-indexed`/`indexed-not-on-disk` (index vs `~/.claude/projects` drift), `corpus-window` (the span each host actually covers). Deliberately takes no date/project/host scoping: health is corpus-level. Params: `min_active_days` (default 5), `new_days` (default 14), `stale_days` (default 2), `projects_glob` (default `~/.claude/projects/**/*.jsonl`).
+
+## Markdown and YAML on Disk
+
+- `plan-sections`: one row per markdown section across plan files on disk, joined to the session that produced each plan (outcome, replan sequence). The glob self-defaults to `~/.claude/plans/*.md` and takes an optional `plans_glob` override. Reads plan structure rather than re-parsing headings by hand, e.g. "which plans have no Verification section":
+
+  ```sql
+  -- prepend SET VARIABLE plans_glob = '...'; to scope
+  WITH s AS (
+    SELECT file_path, bool_or(title = 'Verification') AS has_verification
+    FROM read_markdown_sections('~/.claude/plans/*.md', filename=true)
+    GROUP BY file_path
+  )
+  SELECT file_path FROM s WHERE NOT has_verification;
+  ```
+
+  Local-host caveat: plans are read from the local disk, so a `plan_calls.plan_file` from an imported host (or a deleted plan) has no file to read. The `LEFT JOIN` simply omits its sections, so session-side data is unaffected. Embedded `$.input.plan` (via `plan_calls.plan_chars` / `content_items`) stays the source for cross-host and point-in-time needs.
+- `frontmatter`: one row per markdown file with YAML frontmatter, returning typed `name`/`description` and `content_chars`. The glob self-defaults to the memory corpus (`~/.claude/projects/*/memory/*.md`), where the nested `metadata` frontmatter auto-expands into a typed struct. Override with `frontmatter_glob` for skills, which live under `~/.claude/plugins` (not `~/.claude/skills`) and are duplicated across cache version-hashes, so pin one copy: `plugins/*/skills/*/SKILL.md` for repo skills.
+- `skill-config-vs-observed`: skills CONFIGURED on disk (plugin cache, `~/.claude/skills`, `.claude/skills` relative to cwd) left-joined against observed `skill_calls`, zero-fire first, with `description_chars` (the always-on cost) and `disable-model-invocation` (a zero there is normal). The curation instrument: which installed skills never fire. Params: `after_date`, `before_date`, `project`, `host` (observed side only), `skill` (glob on configured name), `plugin_skill_glob`/`user_skill_glob`/`project_skill_glob` (override a source, required when one is absent on disk).
+
+## Tables and Views
+
+Every table and view carries a `host` column (`local` for this machine, the label for imported ones). The `sessions` view adds `project_id` (`host || ':' || project_path`) for cross-host project identity.
+
+- `raw`: one row per JSONL line, **every record type** (chat, attachments, system events, permission modes, titles, queue ops, snapshots, and more), not just user/assistant. Pinned scalar columns (`host`, `session_id`, `type`, `project_path`, `git_branch`, `is_meta`, `is_sidechain`, `duration_ms`, `timestamp`, `summary`, `input_tokens`, `output_tokens`, `source_file`, `source_line`) plus a `data JSON` column that holds the full original line. Pinned numerics use `TRY_CAST`, so a divergent value type yields NULL rather than failing the import.
+- `records`: universal union over `raw`, one row per line, with a normalized `kind` label (`type`, plus `subtype`/attachment kind when present) and the cross-cutting dimensions (`uuid`, `parent_uuid`, `permission_mode`, `version`, `slug`, `is_meta`, `is_sidechain`) every record may carry, plus full `data`. The anti-blindness backbone: `SELECT kind, COUNT(*) FROM records GROUP BY kind` is the whole taxonomy; reach into `data->>'$.path'` for anything not pinned. Use the `fields` query to discover those paths.
+- `attachments`: one row per `attachment` record (the richest non-chat category: hooks, diagnostics, skill/tool listings, plan/auto mode, queued commands, command permissions). Columns: `kind` (attachment subtype), `hook_name`, `hook_event`, `tool_use_id`, `attachment JSON` (full payload), `data`.
+- `system_events`: one row per `system` record. `subtype`, `level`, `content`, `duration_ms`, `message_count`, and per-subtype fields: stop-hook (`hook_count`, `prevented_continuation`, `stop_reason`), compaction (`compact_trigger`, `compact_pre_tokens`, `compact_duration_ms`), API errors (`error_code`, `retry_attempt`).
+- `hook_events`: one row per `hook_*` attachment (every event: PreToolUse, PostToolUse, Stop, SessionStart, UserPromptSubmit, PermissionRequest), with replayed lines deduped. `kind`, `hook_event`, `hook_name`, `command` (exact script; NULL for a `hook_blocking_error`), `exit_code`, `duration_ms`, `decision` (allow/ask/deny, parsed from the stdout JSON of a hook_success when the hook returns a permission decision), `reason`, `additional_context`, `blocked` (boolean), plus `stdout`/`stderr`/`content`/`blocking_error`.
+- `hook_blocks`: the friction surface, `hook_events` filtered to events that stopped or interrupted a tool call or the model. `decision` is deny/ask/block; `reason` is the surfaced message. Find overfiring hooks here (high counts, repeated blocks within a session).
+- `messages`: view over `raw` filtered to `type IN ('user', 'assistant')`, with a derived `content_text` (string-form messages only), `model`, token columns (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`), attribution columns (`attribution_skill`, `attribution_plugin`, `attribution_agent`, `attribution_mcp_server`, `attribution_mcp_tool`), and a `summary` joined from summary rows.
+- `message_usage`: one row per assistant message with deduped token columns (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens` as MAX per message id), plus `model`, attribution columns, and `content_rows` (raw row count). **Sum tokens from here, not from `raw`/`messages`**: every content-block row repeats the parent message's usage, so per-row sums inflate totals 2-3.5x.
+- `content_items`: one row per element of `data->'$.message.content'`, with pinned columns (`type`, `name`, `id`, `tool_use_id`, `text`, `content`, `is_error`), the parent's attribution (`attribution_skill`/`plugin`/`agent`), plus `data JSON` (the content item) and `tool_use_result JSON` (merged from the parent message). Replayed lines from session rewind/resume are deduped (by record uuid, then by tool id), so tool_use/tool_result counts are one row per event.
+- `diagnostics`: one row per type-checker/linter/LSP diagnostic surfaced in-session. Columns: `file`, `severity`, `source`, `code`, `message`. Unnested from `diagnostics` attachments.
+- `file_operations`: one row per `Read`/`Write`/`Edit`/`MultiEdit`/`NotebookEdit`, with `operation`, `file_path`, and attribution. What you work on, and under which skill/plugin/agent.
+- `pr_links`: pull requests opened from a session, one row per distinct link (the harness re-emits the record across turns; the view dedupes and keeps the first emission's timestamp). Columns: `pr_number`, `repository`, `url`, `session_id`. Join to `sessions` to connect work to shipped outcomes.
+- `text_content`: one row per prose text item across user and assistant messages. Columns: `session_id`, `timestamp`, `role`, `model` (NULL for user), `project_path`, `text` (fenced and inline-backtick code stripped), `raw_text`, `source_file`, `source_line`.
+- `sessions`: aggregated session-level stats (start/end time, duration, message counts).
+- `tool_calls`: one row per tool use, with `file_path` and `command` (from the tool input) and attribution (`attribution_skill`/`plugin`/`agent`).
+- `tool_errors`: tool results where `is_error` is true, joined with the originating tool call. `error_type` is `rejection` or `failure`.
+- `permission_requests`: tool calls the user rejected.
+- `sandbox_bypasses`: Bash calls that used `dangerouslyDisableSandbox=true`, with back-links to retried failures.
+- `skill_calls`: one row per `Skill` tool invocation.
+- `plan_calls`: one row per `ExitPlanMode` tool use. Columns: `tool_use_id`, `plan_file`, `plan_chars` (length of plan text; fetch the full text via `json_extract_string(data, '$.input.plan')` from `content_items` when needed), `outcome` (`approved` / `redirected` / `handoff` / `unknown`), `plan_seq` (1-based ordinal within the session). `handoff` is a rejection of the session's last plan with no file edits after it: the deliberate reject-and-implement-elsewhere workflow. `redirected` is any other rejection (mid-session churn).
+- `plan_sessions`: one row per session that used plan mode. Columns: `plan_count`, `redirect_count`, `approved_count`, `handoff_count`, `unknown_count`, `first_plan_ts`, `last_plan_ts`.
+
+## Macros
+
+- `date_filter(ts, after, before)`: filter a timestamp column by optional date bounds.
+- `project_filter(path, pattern)`: match the last path component against a glob pattern.
+- `host_filter(host_col, host_val)`: pass through when `host_val` is NULL, else match the host column.
+- `project_id(host, path)`: `host || ':' || path`, a cross-host project identity.

--- a/plugins/claude-code/skills/session/references/discovery.md
+++ b/plugins/claude-code/skills/session/references/discovery.md
@@ -14,7 +14,7 @@ Mirror the "Parallel Queries (Workflows)" pattern in [`SKILL.md`](../SKILL.md): 
 
 ## Dimension Cheat Sheet
 
-Each dimension maps to the named queries that answer it (Tier-1 listed in `SKILL.md`'s catalog, Tier-2 documented in [Tier-2 Catalog](#tier-2-catalog) below) plus the survey surfaces to start from. Simple `GROUP BY ... COUNT/SUM` rollups (tokens by host, turns by project, hook time by event) stay inline; an agent writes them in seconds.
+Each dimension maps to the named queries that answer it (Tier-1 listed in [`catalog.md`](catalog.md), Tier-2 documented in [Tier-2 Catalog](#tier-2-catalog) below) plus the survey surfaces to start from. Simple `GROUP BY ... COUNT/SUM` rollups (tokens by host, turns by project, hook time by event) stay inline; an agent writes them in seconds.
 
 | Dimension | Named queries | Survey surfaces |
 |-----------|---------------|-----------------|


### PR DESCRIPTION
Moves the session skill's reference catalogs out of the always-loaded `SKILL.md` body into a new `references/catalog.md`. The named-query params/descriptions, the markdown/YAML query bullets, `## Tables and Views`, and `## Macros` were all loaded on every session that touched the skill, for ~6,211 estimated tokens. They now defer to the reference, dropping the `SKILL.md` estimate to ~3,300.

Routing is preserved in the body. A compact name index lists every query by name, grouped by category with a 3-5 word gloss, so the model still knows which queries exist and keeps preferring them over writing SQL from scratch. The bulky params and descriptions are the only part that defers, behind a pointer to `catalog.md`. The query mechanics that guide correct invocation stay in the body: the `SET VARIABLE` / project / host semantics, the markdown `-init resources/extensions.sql` setup and example, and the whole `## Cross-Machine History` section.

Nothing executable moved. `references/discovery.md` had one stale pointer ("Tier-1 listed in `SKILL.md`'s catalog"), now repointed at `catalog.md`; a grep confirmed it was the only one.

`bun run skill-lint` covers frontmatter, body line count, and reference depth for both `discovery.md` and `catalog.md`. The `db.test.ts` suite exercises the index build unaffected by the doc move. A smoke test drove `refresh.ts` into a named query (`stats.sql`) and `DESCRIBE messages` to confirm the executable query path still resolves after the move.

Original Task: [[discovery] Move session skill catalogs into references/](https://things.bendrucker.me/show?id=PUcwD9k1Zup6mmR5XaNw9V)
