### PR TITLE
feat(rules): add no-terminal-width ast-grep rule

### DIFF
--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -19,6 +19,7 @@ When writing scripts (hooks, skill CLIs, etc.) that accept arguments:
 
 - **Argument parsing**: Use [cleye](https://github.com/privatenumber/cleye) for type-safe argument parsing with automatic `--help` generation. Load the `cleye` skill for usage patterns (parameters, flags, subcommands) instead of reading existing scripts.
 - **Table output**: Use the `table` package for terminal table output. Do not use `markdown-table` or similar GFM-oriented packages, script output is displayed in a terminal, not rendered as markdown.
+- **Output width**: Use a fixed default width with a flag override (e.g. `--truncate <n>`) for truncation or layout. Do not read `process.stdout.columns` or gate on `process.stdout.isTTY`. The column count is undefined when piped, and even in a terminal the output lands in Claude's context as text, so a fixed width stays predictable across both. The `no-terminal-width` prek hook enforces this.
 - **Ancestor paths**: Use `join(import.meta.dirname, "..")` to resolve parent directories. Avoid chaining `dirname()` calls; explicit `".."` is clearer.
 
 # Terminal Colors

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,14 @@ repos:
         pass_filenames: false
         entry: ast-grep scan --rule rules/no-double-assertion.yaml
 
+      - id: no-terminal-width
+        name: No terminal-width output sizing
+        language: system
+        files: \.ts$
+        exclude: \.test\.ts$
+        pass_filenames: false
+        entry: ast-grep scan --rule rules/no-terminal-width.yaml
+
       - id: marketplace-check
         name: Marketplace completeness
         language: system

--- a/rules/no-terminal-width.yaml
+++ b/rules/no-terminal-width.yaml
@@ -1,0 +1,15 @@
+id: no-terminal-width
+language: TypeScript
+severity: error
+message: >-
+  Do not size CLI output to terminal width. Claude is usually a TTY but sometimes
+  runs piped, where the column count is zero or undefined. Even in a terminal the
+  output lands in context as text, so a fixed width reads the same in both cases.
+  Use a fixed default width with a flag override instead of process.stdout.columns
+  or an isTTY gate.
+rule:
+  any:
+    - pattern: process.stdout.columns
+    - pattern: process.stdout.isTTY
+ignores:
+  - "**/*.test.ts"


### PR DESCRIPTION
Adds `rules/no-terminal-width.yaml`, an ast-grep rule that flags `process.stdout.columns` and `process.stdout.isTTY` in TypeScript sources, plus a matching `local` prek hook and a prose note in `.claude/rules/scripts.md`.

Sizing CLI output to terminal width is an anti-pattern here for two reasons. When a script runs piped the column count is undefined or zero, so the width logic breaks exactly when it matters. Even in an interactive session the output lands in Claude's context as text rather than a human-sized terminal, so adapting to the terminal width does not serve the reader. A fixed default with a flag override (e.g. `--truncate <n>`) stays predictable across both. The rule covers `isTTY` alongside `columns` because gating output on `isTTY` is the same anti-pattern.

This mirrors the existing `no-double-assertion` rule: same file shape, same `ignores` for `*.test.ts`, and the same commit-time enforcement through prek only. It is deliberately not wired into CI, because ast-grep is not installed on the CI runners. That parity with `no-double-assertion` is intentional.

## Testing

Verified the rule against a scratch file: it matches both `process.stdout.columns` and `process.stdout.isTTY`, ignores unrelated `process.stdout` access such as `process.stdout.write`, and respects the `*.test.ts` exclusion. The current tree has no source using either pattern, so the new prek hook lands green.

## Memory Retirement

This encodes the `feedback_no_terminal_width_cli_output` memory as a lint rule but does not delete the memory file. Retiring a memory is a separate propose-for-approval step under the "always propose, delete on approval" policy. The two earlier memories that graduated to rules (`no_double_assertion`, `no_async_import`) were in fact never deleted, so keeping the memory is the consistent default and deletion is out of scope here.

Original Task: [[discovery] Encode encodable feedback memories as lint rules](https://things.bendrucker.me/show?id=SHdCFE75Y1egea4yMZfMbN)
