### PR TITLE
feat(skill-lint): flag line-start bold labels

### DIFF
--- a/packages/skill-lint/format.ts
+++ b/packages/skill-lint/format.ts
@@ -10,7 +10,8 @@ function statusIcon(result: RuleResult): string {
 }
 
 function formatResult(result: RuleResult): string {
-  return `  [${statusIcon(result)}] ${result.rule}: ${result.message}`;
+  const location = result.line === undefined ? "" : ` (line ${result.line})`;
+  return `  [${statusIcon(result)}] ${result.rule}${location}: ${result.message}`;
 }
 
 function formatReference(ref: ReferenceResult): string {

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/rules/headers.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/rules/headers.ts
@@ -1,0 +1,71 @@
+import type { Rule, RuleResult, SkillContent } from "../types";
+
+const FENCE_OPEN = /^\s*(`{3,}|~{3,})/;
+const FENCE_CLOSE = /^\s*(`{3,}|~{3,})\s*$/;
+const LINE_START_LABEL = /^\*\*[^*]+\*\*:/;
+
+interface Fence {
+  marker: string;
+  length: number;
+}
+
+function frontmatterOffset(content: SkillContent): number {
+  const prefixLength = content.raw.length - content.body.length;
+  if (prefixLength <= 0) return 0;
+  return content.raw.slice(0, prefixLength).split("\n").length - 1;
+}
+
+function closes(line: string, fence: Fence): boolean {
+  const match = line.match(FENCE_CLOSE);
+  if (!match?.[1]) return false;
+  const marker = match[1];
+  return marker[0] === fence.marker && marker.length >= fence.length;
+}
+
+export const preferHeaders: Rule = {
+  name: "prefer-headers",
+  severity: "warn",
+  check(content: SkillContent): RuleResult[] {
+    const results: RuleResult[] = [];
+    const offset = frontmatterOffset(content);
+    let fence: Fence | null = null;
+
+    content.body.split("\n").forEach((line, index) => {
+      if (fence) {
+        if (closes(line, fence)) fence = null;
+        return;
+      }
+
+      const open = line.match(FENCE_OPEN);
+      if (open?.[1]) {
+        fence = { marker: open[1][0] ?? "", length: open[1].length };
+        return;
+      }
+
+      if (!LINE_START_LABEL.test(line)) return;
+
+      results.push({
+        rule: "prefer-headers",
+        severity: "warn",
+        passed: false,
+        message: `line-start bold label. Use a #### header for the subsection instead`,
+        line: offset + index + 1,
+      });
+    });
+
+    if (results.length === 0) {
+      return [
+        {
+          rule: "prefer-headers",
+          severity: "warn",
+          passed: true,
+          message: "no line-start bold labels",
+        },
+      ];
+    }
+
+    return results;
+  },
+};
+
+export const headerRules: Rule[] = [preferHeaders];

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/rules/index.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/rules/index.ts
@@ -2,6 +2,7 @@ import type { Rule } from "../types";
 import { bangExecutionRules } from "./bang-execution";
 import { bodyRules } from "./body";
 import { frontmatterRules } from "./frontmatter";
+import { headerRules } from "./headers";
 import { namespaceRules } from "./namespace";
 import { tokenRules } from "./tokens";
 
@@ -9,6 +10,7 @@ export const allRules: Rule[] = [
   ...frontmatterRules,
   ...namespaceRules,
   ...bodyRules,
+  ...headerRules,
   ...bangExecutionRules,
   ...tokenRules,
 ];

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/test/fixtures/prefer-headers/SKILL.md
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/test/fixtures/prefer-headers/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: prefer-headers
+description: Fixture exercising the prefer-headers rule across its boundary cases.
+---
+
+# Fixture
+
+**Config**: a line-start bold label should flag.
+
+- **Item**: a list-item label should not flag.
+1. **Step**: a numbered list-item label should not flag.
+
+A sentence carrying **inline bold**: should not flag mid-sentence.
+
+```md
+**Fenced**: a bold label inside a fenced block should not flag.
+```

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { lintSkill } from "../index";
 import { parseSkill } from "../parse";
 import { bangExecutionMatcher } from "../rules/bang-execution";
+import { preferHeaders } from "../rules/headers";
 import {
   allowedToolsFormat,
   descriptionLength,
@@ -254,6 +255,43 @@ describe("bangExecutionMatcher", () => {
   });
 });
 
+describe("preferHeaders", () => {
+  const failing = (body: string) => {
+    const result = preferHeaders.check(parseSkill(body), "");
+    const results = Array.isArray(result) ? result : [result];
+    return results.filter((r) => !r.passed);
+  };
+
+  test.each<{ name: string; body: string; flagged: boolean }>([
+    { name: "flags a line-start bold label", body: "**Config**: value", flagged: true },
+    { name: "passes a hyphen list-item label", body: "- **Item**: value", flagged: false },
+    { name: "passes a numbered list-item label", body: "1. **Step**: value", flagged: false },
+    {
+      name: "passes mid-sentence bold",
+      body: "A line carrying **inline bold**: continues here",
+      flagged: false,
+    },
+    {
+      name: "passes a bold label inside a fenced block",
+      body: "```md\n**Fenced**: value\n```",
+      flagged: false,
+    },
+    {
+      name: "passes a label inside a block that nests a different fence marker",
+      body: "```md\n~~~\n**Inner**: value\n~~~\n```",
+      flagged: false,
+    },
+  ])("$name", ({ body, flagged }) => {
+    expect(failing(body).length > 0).toBe(flagged);
+  });
+
+  it("reports the offending line number and warn severity", () => {
+    const [offender] = failing("intro\n\n**Config**: value");
+    expect(offender?.severity).toBe("warn");
+    expect(offender?.line).toBe(3);
+  });
+});
+
 describe("namespace rules", () => {
   const pluginPath = (plugin: string) => `plugins/${plugin}/skills/some-skill`;
 
@@ -346,6 +384,14 @@ describe("lintSkill", () => {
     expect(result.errors).toBeGreaterThan(0);
     const descError = result.results.find((r) => r.rule === "description-required");
     expect(descError?.passed).toBe(false);
+  });
+
+  it("warns on line-start bold labels without failing", async () => {
+    const result = await lintSkill(path.join(fixturesDir, "prefer-headers"));
+    expect(result.errors).toBe(0);
+    const offenders = result.results.filter((r) => r.rule === "prefer-headers" && !r.passed);
+    expect(offenders).toHaveLength(1);
+    expect(offenders[0]?.line).toBe(8);
   });
 
   it("detects references", async () => {

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
@@ -3,7 +3,6 @@ import * as path from "node:path";
 import { lintSkill } from "../index";
 import { parseSkill } from "../parse";
 import { bangExecutionMatcher } from "../rules/bang-execution";
-import { preferHeaders } from "../rules/headers";
 import {
   allowedToolsFormat,
   descriptionLength,
@@ -13,6 +12,7 @@ import {
   nameFormat,
   nameLength,
 } from "../rules/frontmatter";
+import { preferHeaders } from "../rules/headers";
 import { namespaceMismatch, namespaceStutter } from "../rules/namespace";
 import type { RuleResult, Severity } from "../types";
 


### PR DESCRIPTION
Adds a `prefer-headers` skill-lint rule that flags line-start markdown bold labels (`**Label**:` at column 0) in skill body text, steering authors toward `####` subsection headers for clearer document structure.

The rule scans the body line by line while tracking fenced-code state, so labels inside fenced blocks are left alone. It anchors on column 0, which is what separates a subsection header from the cases that must pass: hyphen and numbered list-item labels (`- **x**:`, `1. **x**:`) and mid-sentence bold both carry leading characters, so the anchor excludes them without extra logic. A label needs a colon after the closing `**`, so bare bold and the `**Why:**` form (colon inside the markers) are not flagged.

It ships at `warn` severity, matching the other advisory rules. Several existing SKILL.md files still use line-start bold labels, and a blocking rule would turn CI red on unrelated skills. Warnings surface the pattern without gating, and the offenders can be converted separately. This PR does not convert them.

Because the rule can now report several results for one file (one per offending line), the text formatter renders the `line` number alongside each result so a warning points at a specific line.

## Testing

Covers the boundary directly: a column-0 label flags, while hyphen and numbered list items, mid-sentence bold, and a label inside a fenced block all pass. A fixture drives the same cases through `lintSkill` and asserts the reported line number, confirming warnings are counted without producing errors. The fixture is force-added because `**/fixtures/` is gitignored in this repo; without it CI would run the integration test against a missing file.

## Memory Retirement

This encodes the `feedback_prefer_headers` memory as a lint check but does not delete the memory file. Retiring a memory is a separate propose-for-approval step under the "always propose, delete on approval" policy. The two earlier memories that graduated to rules (`no_double_assertion`, `no_async_import`) were in fact never deleted, so keeping the memory is the consistent default and deletion is out of scope here.

Original Task: [[discovery] Encode encodable feedback memories as lint rules](https://things.bendrucker.me/show?id=SHdCFE75Y1egea4yMZfMbN)
