### PR TITLE
eval(writing): scaffold writing:rewrite mining and labeling

### DIFF
--- a/evals/writing/.gitignore
+++ b/evals/writing/.gitignore
@@ -1,0 +1,4 @@
+# Generated and local-only. Mined pairs may reconstruct work-host draft text,
+# so the assembled sample and reviewer feedback never leave this machine.
+data/
+feedback/

--- a/evals/writing/README.md
+++ b/evals/writing/README.md
@@ -1,0 +1,125 @@
+# `writing:writing` Rubric
+
+A local harness for evaluating the writing style rules, following the structure
+of [`evals/pr-body`](../pr-body). The aim is a rubric: a concrete list of what
+makes a rewrite good or bad, derived from labeling real outputs, then used to
+score the rules before and after edits.
+
+The eval unit is the [`writing:rewrite`](../../plugins/writing/skills/rewrite)
+transform. `writing:writing` only injects the style rules into context and emits
+no artifact. It has nothing observable to label. `rewrite` applies the same
+rules to a draft and produces a cleaned version. Its `(input, output)` pair is
+the proxy for whether the rules do their job.
+
+This scaffold delivers the mining script and the labeling UI. The rubric,
+scorer, and judge come after a labeling session, since the rubric is derived
+from the labels.
+
+## Privacy
+
+`rewrite` runs on arbitrary text, including drafts written on work hosts.
+`scripts/mine.ts` hardcodes `host = 'local'` in its probe SQL, so imported work
+sessions are never read. `data/` and `feedback/` are gitignored regardless. The
+only content that ships is the synthetic `drafts/` set.
+
+## Dataset
+
+The rubric wants real `(input, output)` pairs. They can't be reconstructed from
+the session index. `rewrite` runs in a fork and displays its result rather than
+writing a file, and the rewritten text is gone the moment that fork returns. The
+index keeps the input, which arrives as the skill args in `skill_calls`. It
+never sees the output.
+
+So the labelable set is synthetic. `drafts/` holds hand-authored pairs, each a
+sloppy `input` and a plausible but imperfect `output`, seeded with the two
+failure modes a labeler needs to catch:
+
+- Over-stripping: the rewrite drops a functional fact the input carried.
+- Residual slop: a trope survives into the output.
+
+The drafts are tracked and reproducible, the way
+[`evals/issue-refine/briefs`](../issue-refine/briefs) seeds its A/B scenarios
+with the tropes its rubric targets. `mine.ts` still probes the index and reports
+how many real `writing:rewrite` invocations exist. A future owner needs that
+real-corpus size even though the outputs aren't recoverable.
+
+## Workflow
+
+### 1. Mine
+
+Build the session index first if it is stale (the session skill owns it):
+
+```bash
+bun plugins/claude-code/skills/session/scripts/refresh.ts
+```
+
+Then assemble the labelable sample:
+
+```bash
+bun evals/writing/scripts/mine.ts                      # writes data/samples.json
+bun evals/writing/scripts/mine.ts --limit 30
+```
+
+`mine.ts` probes the index for the real invocation count, loads the synthetic
+`drafts/`, and selects a category-balanced sample that interleaves the longer
+rewrites with the tight one-liners.
+
+### 2. Label
+
+```bash
+bun evals/writing/label/server.ts                      # http://localhost:4320
+```
+
+Open the URL and review each pair. Input and output render side by side. Per
+item you can:
+
+- Select any span in either panel to attach an inline comment with a severity
+  (critical / minor / praise). Mark lost meaning on the input, residual slop on
+  the output. Highlights persist across reloads.
+- Set a verdict (good / ok / bad), toggle quality tags, and write freeform notes.
+
+Everything autosaves to `feedback/<id>.json`.
+
+The UI is copied from `evals/pr-body/label/` and adapted for the paired view.
+Copying is the current convention across `evals/`; extracting a shared harness
+package is a known deferred refactor.
+
+### 3. Derive the rubric (after labeling)
+
+Once a batch is labeled, the recurring critical spans and tags become
+`RUBRIC.md`: the failure modes the rules should stop producing (over-stripping,
+residual slop) and the traits to preserve. That feeds concrete edits to
+`plugins/writing/` and a mechanical `score.ts`.
+
+The scorer will not re-implement pattern matching. It wraps the plugin's own
+engine: [`plugins/writing/detection/scan.ts`](../../plugins/writing/detection/scan.ts)
+(`scanAll`) or the `writing:score` skill's `--json` density output. Residual slop
+is whatever the engine still finds in the output.
+
+### 4. A/B test a rules change (after the rubric)
+
+An A/B run takes each synthetic draft's input, rewrites it through two versions
+of the rules (committed via `git show HEAD:...` versus the working tree), and
+scores both outputs. `ab-report.ts` gives the mechanical score, a blinded
+`judge.ts` handles the meaning-loss findings the engine can't measure.
+
+The scorer is the plugin's own detection engine, so an A/B run must pin that
+engine and its wordlists to one revision across both sides. Scoring the new
+rules with the new engine would let a wordlist edit flatter itself. Pin to the
+committed revision so both outputs are judged by the same detector.
+
+## Status
+
+- Done: `scripts/mine.ts`, `drafts/`, `label/` UI, this loop definition.
+- Next (owner): run the labeler over the drafts, expand `drafts/` toward ~30
+  pairs spanning more categories, label them.
+- After labeling: `RUBRIC.md`, `score.ts` (wrapping `scan.ts`), `judge.ts`,
+  `ab-report.ts`, and a gate on `plugins/writing/` edits.
+
+## Layout
+
+- `scripts/mine.ts`: probes the index, builds `data/samples.json` from `drafts/`
+- `scripts/mine.test.ts`: property and table tests over the pure helpers
+- `drafts/`: synthetic `(input, output)` pairs, seeded with both failure modes (tracked)
+- `label/server.ts`, `label/index.html`: the paired review UI (inline span comments, verdict, tags, notes)
+- `data/`, `feedback/`: generated or local-only (gitignored)

--- a/evals/writing/drafts/commit-message.json
+++ b/evals/writing/drafts/commit-message.json
@@ -1,0 +1,6 @@
+{
+  "category": "commit-message",
+  "note": "output over-strips: drops the reason the retry cap exists (the input's 'because the API rate-limits us') and keeps residual hedging ('should').",
+  "input": "This commit basically leverages a brand new retry helper in order to robustly handle the flaky upstream calls that we were seeing. We cap retries at 3 because the API rate-limits us pretty aggressively after that. It should hopefully resolve the intermittent 429s that have been plaguing the nightly job.",
+  "output": "Add a retry helper for flaky upstream calls, capped at 3 attempts. This should resolve the intermittent 429s in the nightly job."
+}

--- a/evals/writing/drafts/doc-paragraph.json
+++ b/evals/writing/drafts/doc-paragraph.json
@@ -1,0 +1,6 @@
+{
+  "category": "doc-paragraph",
+  "note": "output over-strips: drops the '5 minute' default and the env-var override name, both functional facts a reader needs. Voice is clean, so this isolates meaning loss from residual slop.",
+  "input": "The cache is designed to significantly improve performance by storing computed results. By default, entries live for 5 minutes, but you can override this by setting the CACHE_TTL environment variable to a number of seconds. When an entry expires, the next request recomputes it and repopulates the cache seamlessly.",
+  "output": "The cache stores computed results to improve performance. Entries expire after a timeout, and the next request recomputes and repopulates them."
+}

--- a/evals/writing/drafts/pr-comment.json
+++ b/evals/writing/drafts/pr-comment.json
@@ -1,0 +1,6 @@
+{
+  "category": "pr-comment",
+  "note": "clean rewrite: strips filler and hedging, preserves the concrete ask and the file reference. A near-good baseline so labeling has a positive case.",
+  "input": "I think it might potentially be worth considering whether we should maybe extract this validation logic into its own function? It's currently duplicated in a couple of places (handleCreate and handleUpdate) and it feels like it could get out of sync over time. Just a thought, not a blocker or anything.",
+  "output": "This validation logic is duplicated in handleCreate and handleUpdate and could drift out of sync. Consider extracting it into a shared function. Not a blocker."
+}

--- a/evals/writing/drafts/slack-update.json
+++ b/evals/writing/drafts/slack-update.json
@@ -1,0 +1,6 @@
+{
+  "category": "slack-update",
+  "note": "output keeps residual slop (em dash, 'delve', 'seamless') and preserves meaning; a good rewrite would strip the vocabulary without dropping the blocker.",
+  "input": "Hey team! Just wanted to give a quick update on the migration. We've made great progress and things are moving along nicely. The one blocker is that the staging DB creds expired, so I'm waiting on ops to rotate them before I can run the final cutover. Should be unblocked by EOD tomorrow.",
+  "output": "Migration update — we're moving along and I want to delve into the remaining work for a seamless cutover. The one blocker: staging DB creds expired, so I'm waiting on ops to rotate them before the final cutover. Unblocked by EOD tomorrow."
+}

--- a/evals/writing/label/index.html
+++ b/evals/writing/label/index.html
@@ -1,0 +1,394 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>writing:rewrite review</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
+    <style>
+      :root {
+        --bg: #0f1115;
+        --panel: #171a21;
+        --panel2: #1f242d;
+        --border: #2a313c;
+        --text: #d8dee9;
+        --muted: #8a94a6;
+        --accent: #6aa6ff;
+        --critical: #ff5d5d;
+        --minor: #ffb454;
+        --praise: #4ec88a;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+        display: grid;
+        grid-template-columns: 290px 1fr;
+        height: 100vh;
+      }
+      a { color: var(--accent); }
+      /* Sidebar */
+      #sidebar { background: var(--panel); border-right: 1px solid var(--border); overflow-y: auto; }
+      #progress { padding: 12px 14px; border-bottom: 1px solid var(--border); font-size: 13px; color: var(--muted); position: sticky; top: 0; background: var(--panel); }
+      #progress b { color: var(--text); }
+      .navitem { padding: 10px 14px; border-bottom: 1px solid var(--border); cursor: pointer; }
+      .navitem:hover { background: var(--panel2); }
+      .navitem.active { background: var(--panel2); border-left: 3px solid var(--accent); padding-left: 11px; }
+      .navitem .row1 { display: flex; gap: 6px; align-items: center; font-size: 12px; color: var(--muted); }
+      .navitem .title { color: var(--text); font-size: 13px; margin-top: 3px; }
+      .badge { font-size: 10px; text-transform: uppercase; letter-spacing: .04em; padding: 1px 6px; border-radius: 999px; background: var(--panel2); border: 1px solid var(--border); color: #8fd6ff; }
+      .verdict-dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; margin-left: auto; background: #3a414c; }
+      .verdict-dot.good { background: var(--praise); }
+      .verdict-dot.ok { background: var(--minor); }
+      .verdict-dot.bad { background: var(--critical); }
+      .navitem .anncount { font-size: 11px; color: var(--muted); }
+      /* Main */
+      #main { overflow-y: auto; padding: 22px 30px 120px; }
+      .hd { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+      .hd h1 { font-size: 19px; margin: 0; flex: 1 1 100%; }
+      .meta { color: var(--muted); font-size: 12px; }
+      .section-label { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); margin: 22px 0 8px; }
+      .pair { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+      .doc { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 6px 22px; }
+      .doc.input { opacity: .92; }
+      .doc h1, .doc h2 { font-size: 17px; border-bottom: 1px solid var(--border); padding-bottom: 5px; }
+      .doc h3 { font-size: 14px; color: #c7d0dd; }
+      .doc code { background: #11151b; padding: 1px 5px; border-radius: 4px; font-size: 12.5px; }
+      .doc pre { background: #11151b; padding: 12px; border-radius: 6px; overflow-x: auto; }
+      .doc pre code { background: none; padding: 0; }
+      .doc a { word-break: break-all; }
+      ::highlight(critical) { background: rgba(255,93,93,.30); text-decoration: underline wavy var(--critical); }
+      ::highlight(minor) { background: rgba(255,180,84,.26); text-decoration: underline wavy var(--minor); }
+      ::highlight(praise) { background: rgba(78,200,138,.24); }
+      /* Selection popover */
+      #pop { position: absolute; z-index: 50; display: none; background: var(--panel2); border: 1px solid var(--border); border-radius: 8px; padding: 8px; box-shadow: 0 8px 24px rgba(0,0,0,.5); width: 280px; }
+      #pop textarea { width: 100%; height: 54px; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 6px; padding: 6px; font: inherit; resize: vertical; }
+      #pop .quote { font-size: 11px; color: var(--muted); margin-bottom: 6px; max-height: 40px; overflow: hidden; font-style: italic; }
+      .sevrow { display: flex; gap: 6px; margin: 6px 0; }
+      .sevbtn { flex: 1; cursor: pointer; border: 1px solid var(--border); background: var(--bg); color: var(--text); border-radius: 6px; padding: 4px; font-size: 12px; }
+      .sevbtn[data-sev="critical"].on { background: var(--critical); color: #1a0000; border-color: var(--critical); }
+      .sevbtn[data-sev="minor"].on { background: var(--minor); color: #241500; border-color: var(--minor); }
+      .sevbtn[data-sev="praise"].on { background: var(--praise); color: #00200f; border-color: var(--praise); }
+      #pop .actions { display: flex; gap: 6px; justify-content: flex-end; margin-top: 6px; }
+      button.btn { cursor: pointer; border: 1px solid var(--border); background: var(--panel); color: var(--text); border-radius: 6px; padding: 5px 12px; font-size: 12px; }
+      button.btn.primary { background: var(--accent); color: #06121f; border-color: var(--accent); }
+      /* Right rail (verdict/tags/notes/annotations) */
+      .rail { margin-top: 26px; display: grid; grid-template-columns: 1fr 1fr; gap: 22px; }
+      .card { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 14px; }
+      .card h3 { margin: 0 0 10px; font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); }
+      .verdicts { display: flex; gap: 8px; }
+      .verdicts button { flex: 1; }
+      .verdicts button.on[data-v="good"] { background: var(--praise); color: #00200f; border-color: var(--praise); }
+      .verdicts button.on[data-v="ok"] { background: var(--minor); color: #241500; border-color: var(--minor); }
+      .verdicts button.on[data-v="bad"] { background: var(--critical); color: #1a0000; border-color: var(--critical); }
+      .tags { display: flex; flex-wrap: wrap; gap: 6px; }
+      .tag { cursor: pointer; border: 1px solid var(--border); border-radius: 999px; padding: 3px 10px; font-size: 12px; color: var(--muted); user-select: none; }
+      .tag.on { background: var(--accent); color: #06121f; border-color: var(--accent); }
+      #notes { width: 100%; min-height: 90px; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 6px; padding: 8px; font: inherit; resize: vertical; }
+      .annlist { grid-column: 1 / -1; }
+      .ann { border-left: 3px solid var(--border); padding: 6px 10px; margin-bottom: 8px; background: var(--bg); border-radius: 0 6px 6px 0; }
+      .ann.critical { border-color: var(--critical); }
+      .ann.minor { border-color: var(--minor); }
+      .ann.praise { border-color: var(--praise); }
+      .ann .fieldtag { font-size: 10px; text-transform: uppercase; letter-spacing: .04em; color: #8fd6ff; margin-right: 6px; }
+      .ann .q { font-style: italic; color: var(--muted); font-size: 12px; }
+      .ann .c { margin-top: 3px; }
+      .ann .del { float: right; cursor: pointer; color: var(--muted); }
+      .saved { font-size: 11px; color: var(--praise); }
+      .topbar { display: flex; gap: 10px; align-items: center; margin-bottom: 4px; }
+      .topbar .spacer { flex: 1; }
+    </style>
+  </head>
+  <body>
+    <div id="sidebar">
+      <div id="progress"></div>
+      <div id="nav"></div>
+    </div>
+    <div id="main"></div>
+    <div id="pop">
+      <div class="quote" id="popQuote"></div>
+      <div class="sevrow">
+        <button class="sevbtn on" data-sev="critical">critical</button>
+        <button class="sevbtn" data-sev="minor">minor</button>
+        <button class="sevbtn" data-sev="praise">praise</button>
+      </div>
+      <textarea id="popText" placeholder="What's wrong with this span? (optional)"></textarea>
+      <div class="actions">
+        <button class="btn" id="popCancel">cancel</button>
+        <button class="btn primary" id="popSave">comment</button>
+      </div>
+    </div>
+
+    <script>
+      // Two failure axes the rewrite transform can hit: over-stripping (meaning
+      // lost vs the input) and residual slop (trope survived into the output).
+      const TAGS = [
+        "over-stripping", "meaning-loss", "residual-slop", "hedging-remains",
+        "filler-remains", "vocabulary-remains", "voice-clean", "faithful", "good",
+      ];
+      let samples = [];
+      let feedback = {}; // id -> {verdict, tags[], notes, annotations[]}
+      let current = null;
+      let pending = null; // pending new annotation {field, start, end, quote}
+      let pendingSev = "critical";
+
+      const $ = (s, r = document) => r.querySelector(s);
+      const $$ = (s, r = document) => [...r.querySelectorAll(s)];
+      const el = (t, props = {}, kids = []) => {
+        const n = Object.assign(document.createElement(t), props);
+        for (const k of [].concat(kids)) n.append(k);
+        return n;
+      };
+
+      async function boot() {
+        samples = await (await fetch("/api/samples")).json();
+        feedback = await (await fetch("/api/feedback")).json();
+        for (const s of samples) feedback[s.id] ??= { verdict: null, tags: [], notes: "", annotations: [] };
+        renderNav();
+        select(samples[0].id);
+        wirePopover();
+      }
+
+      function fb(id) { return feedback[id]; }
+
+      function renderNav() {
+        const done = samples.filter((s) => {
+          const f = fb(s.id);
+          return f.verdict || f.annotations.length || f.notes.trim() || f.tags.length;
+        }).length;
+        $("#progress").innerHTML = `<b>${done}</b> / ${samples.length} reviewed &nbsp;·&nbsp; <a href="#" id="exportLink">export</a>`;
+        $("#exportLink").onclick = (e) => { e.preventDefault(); exportAll(); };
+        const nav = $("#nav");
+        nav.innerHTML = "";
+        for (const s of samples) {
+          const f = fb(s.id);
+          const item = el("div", { className: "navitem" + (s.id === current ? " active" : "") });
+          item.onclick = () => select(s.id);
+          const dot = el("span", { className: "verdict-dot " + (f.verdict || "") });
+          item.append(
+            el("div", { className: "row1" }, [
+              el("span", { className: "badge", textContent: s.category }),
+              el("span", { textContent: s.id }),
+              dot,
+            ]),
+            el("div", { className: "title", textContent: s.input.slice(0, 70) }),
+            el("div", { className: "anncount", textContent: `${f.annotations.length} inline · ${f.tags.length} tags` }),
+          );
+          nav.append(item);
+        }
+      }
+
+      function select(id) {
+        current = id;
+        renderNav();
+        renderMain();
+      }
+
+      function renderMain() {
+        const s = samples.find((x) => x.id === current);
+        const f = fb(current);
+        const main = $("#main");
+        main.innerHTML = "";
+
+        const topbar = el("div", { className: "topbar" }, [
+          el("span", { className: "badge", textContent: s.category }),
+          el("span", { className: "meta" }, [
+            `${s.id} · ${s.source} · ${s.size} · in ${s.input.length} / out ${s.output.length} chars`,
+          ]),
+          el("span", { className: "spacer" }),
+          el("span", { className: "saved", id: "savedFlag" }),
+        ]);
+        main.append(topbar, el("div", { className: "hd" }, [
+          el("h1", { textContent: `${s.category} rewrite` }),
+        ]));
+
+        main.append(el("div", { className: "section-label", textContent: "Left: original draft · Right: rewrite. Select any span to comment." }));
+        const pair = el("div", { className: "pair" });
+        pair.append(renderDoc("input", s.input), renderDoc("output", s.output));
+        main.append(pair);
+
+        renderRail(main, s, f);
+        requestAnimationFrame(() => applyHighlights());
+      }
+
+      function renderDoc(field, text) {
+        const wrap = el("div");
+        wrap.append(el("div", {
+          className: "section-label",
+          textContent: field === "input" ? "Input (mark meaning that must survive)" : "Output (mark residual slop + lost meaning)",
+        }));
+        const doc = el("div", { className: `doc ${field}`, id: `doc-${field}` });
+        doc.innerHTML = marked.parse(text);
+        doc.dataset.field = field;
+        wrap.append(doc);
+        return wrap;
+      }
+
+      function renderRail(main, s, f) {
+        const rail = el("div", { className: "rail" });
+
+        const vCard = el("div", { className: "card" });
+        vCard.append(el("h3", { textContent: "Verdict" }));
+        const vrow = el("div", { className: "verdicts" });
+        for (const v of ["good", "ok", "bad"]) {
+          const b = el("button", { className: "btn" + (f.verdict === v ? " on" : ""), textContent: v });
+          b.dataset.v = v;
+          b.onclick = () => { f.verdict = f.verdict === v ? null : v; save(); renderMain(); renderNav(); };
+          vrow.append(b);
+        }
+        vCard.append(vrow);
+
+        const tCard = el("div", { className: "card" });
+        tCard.append(el("h3", { textContent: "Tags" }));
+        const tags = el("div", { className: "tags" });
+        for (const t of TAGS) {
+          const on = f.tags.includes(t);
+          const chip = el("span", { className: "tag" + (on ? " on" : ""), textContent: t });
+          chip.onclick = () => {
+            f.tags = on ? f.tags.filter((x) => x !== t) : [...f.tags, t];
+            save(); renderMain(); renderNav();
+          };
+          tags.append(chip);
+        }
+        tCard.append(tags);
+
+        const nCard = el("div", { className: "card", style: "grid-column: 1 / -1" });
+        nCard.append(el("h3", { textContent: "Notes" }));
+        const ta = el("textarea", { id: "notes", value: f.notes, placeholder: "Freeform: what meaning was lost, what slop survived, what the rewrite should have produced." });
+        ta.oninput = () => { f.notes = ta.value; save(); };
+        nCard.append(ta);
+
+        const aCard = el("div", { className: "card annlist" });
+        aCard.append(el("h3", { textContent: `Inline comments (${f.annotations.length})` }));
+        if (!f.annotations.length) aCard.append(el("div", { className: "meta", textContent: "Select text in either panel above to add one." }));
+        f.annotations.forEach((a, i) => {
+          const row = el("div", { className: "ann " + a.severity });
+          const del = el("span", { className: "del", textContent: "✕" });
+          del.onclick = () => { f.annotations.splice(i, 1); save(); renderMain(); renderNav(); };
+          row.append(
+            del,
+            el("div", { className: "q" }, [
+              el("span", { className: "fieldtag", textContent: a.field }),
+              `“${a.quote}”`,
+            ]),
+          );
+          if (a.comment) row.append(el("div", { className: "c", textContent: a.comment }));
+          aCard.append(row);
+        });
+
+        rail.append(vCard, tCard, nCard, aCard);
+        main.append(rail);
+      }
+
+      // ---- inline annotation engine (stable char offsets into rendered text) ----
+      function textNodes(container) {
+        const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+        const nodes = [];
+        let pos = 0, n;
+        while ((n = walker.nextNode())) {
+          nodes.push({ node: n, start: pos, len: n.nodeValue.length });
+          pos += n.nodeValue.length;
+        }
+        return nodes;
+      }
+      function globalOffset(nodes, node, offset) {
+        const e = nodes.find((x) => x.node === node);
+        return e ? e.start + offset : null;
+      }
+      function rangeFor(container, start, end) {
+        const nodes = textNodes(container);
+        const find = (off) => {
+          for (const e of nodes) if (off >= e.start && off <= e.start + e.len) return { node: e.node, offset: off - e.start };
+          return null;
+        };
+        const a = find(start), b = find(end);
+        if (!a || !b) return null;
+        const r = document.createRange();
+        r.setStart(a.node, a.offset);
+        r.setEnd(b.node, b.offset);
+        return r;
+      }
+      function applyHighlights() {
+        if (!window.Highlight || !CSS.highlights) return;
+        CSS.highlights.clear();
+        const buckets = { critical: [], minor: [], praise: [] };
+        for (const a of fb(current).annotations) {
+          const doc = $(`#doc-${a.field}`);
+          if (!doc) continue;
+          const r = rangeFor(doc, a.start, a.end);
+          if (r) buckets[a.severity]?.push(r);
+        }
+        for (const sev of Object.keys(buckets)) {
+          if (buckets[sev].length) CSS.highlights.set(sev, new Highlight(...buckets[sev]));
+        }
+      }
+
+      function wirePopover() {
+        const pop = $("#pop");
+        document.addEventListener("mouseup", (ev) => {
+          if (pop.contains(ev.target)) return;
+          const sel = window.getSelection();
+          if (!sel.rangeCount || sel.isCollapsed) return;
+          const r = sel.getRangeAt(0);
+          const doc = [$("#doc-input"), $("#doc-output")].find((d) => d && d.contains(r.commonAncestorContainer));
+          if (!doc) { pop.style.display = "none"; return; }
+          const nodes = textNodes(doc);
+          const start = globalOffset(nodes, r.startContainer, r.startOffset);
+          const end = globalOffset(nodes, r.endContainer, r.endOffset);
+          if (start == null || end == null || end <= start) return;
+          pending = { field: doc.dataset.field, start, end, quote: sel.toString().trim() };
+          pendingSev = "critical";
+          $("#popQuote").textContent = `“${pending.quote.slice(0, 140)}”`;
+          $("#popText").value = "";
+          setSev("critical");
+          const rect = r.getBoundingClientRect();
+          pop.style.display = "block";
+          pop.style.top = window.scrollY + rect.bottom + 8 + "px";
+          pop.style.left = Math.min(window.scrollX + rect.left, window.innerWidth - 300) + "px";
+          $("#popText").focus();
+        });
+        $$(".sevbtn").forEach((b) => (b.onclick = () => setSev(b.dataset.sev)));
+        $("#popCancel").onclick = () => { pop.style.display = "none"; window.getSelection().removeAllRanges(); };
+        $("#popSave").onclick = commitPending;
+        $("#popText").addEventListener("keydown", (e) => { if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) commitPending(); });
+      }
+      function setSev(s) { pendingSev = s; $$(".sevbtn").forEach((b) => b.classList.toggle("on", b.dataset.sev === s)); }
+      function commitPending() {
+        if (!pending) return;
+        fb(current).annotations.push({ ...pending, severity: pendingSev, comment: $("#popText").value.trim() });
+        fb(current).annotations.sort((a, b) => a.field.localeCompare(b.field) || a.start - b.start);
+        pending = null;
+        $("#pop").style.display = "none";
+        window.getSelection().removeAllRanges();
+        save(); renderMain(); renderNav();
+      }
+
+      let saveTimer = null;
+      function save() {
+        const id = current;
+        const flag = $("#savedFlag");
+        if (flag) flag.textContent = "saving…";
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(async () => {
+          await fetch("/api/feedback", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ id, feedback: fb(id) }),
+          });
+          const f2 = $("#savedFlag");
+          if (f2) { f2.textContent = "saved ✓"; setTimeout(() => { if ($("#savedFlag") === f2) f2.textContent = ""; }, 1200); }
+        }, 350);
+      }
+
+      function exportAll() {
+        const blob = new Blob([JSON.stringify(feedback, null, 2)], { type: "application/json" });
+        const a = el("a", { href: URL.createObjectURL(blob), download: "writing-rewrite-feedback.json" });
+        a.click();
+      }
+
+      boot();
+    </script>
+  </body>
+</html>

--- a/evals/writing/label/server.ts
+++ b/evals/writing/label/server.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env bun
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { cli } from "cleye";
+
+// Local labeling server. Serves the review UI, hands the browser the assembled
+// (input, output) pairs, and persists reviewer feedback to feedback/<id>.json so
+// a later analysis pass can read it back off disk.
+//
+// Copied from evals/pr-body/label/server.ts; a shared harness package is a known
+// deferred refactor (see README).
+
+const argv = cli({
+  name: "label-server",
+  flags: {
+    port: { type: Number, default: 4320, description: "Port to listen on" },
+    data: {
+      type: String,
+      default: `${import.meta.dir}/../data/samples.json`,
+      description: "Assembled pairs to review",
+    },
+    feedback: {
+      type: String,
+      default: `${import.meta.dir}/../feedback`,
+      description: "Directory for saved feedback",
+    },
+  },
+});
+
+const html = join(import.meta.dir, "index.html");
+
+async function readAllFeedback(): Promise<Record<string, unknown>> {
+  const out: Record<string, unknown> = {};
+  let names: string[] = [];
+  try {
+    names = await readdir(argv.flags.feedback);
+  } catch {
+    return out;
+  }
+  for (const n of names) {
+    if (!n.endsWith(".json")) continue;
+    try {
+      out[n.replace(/\.json$/, "")] = await Bun.file(join(argv.flags.feedback, n)).json();
+    } catch {}
+  }
+  return out;
+}
+
+const server = Bun.serve({
+  port: argv.flags.port,
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/" || url.pathname === "/index.html") {
+      return new Response(Bun.file(html), {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
+
+    if (url.pathname === "/api/samples") {
+      return new Response(Bun.file(argv.flags.data), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (url.pathname === "/api/feedback" && req.method === "GET") {
+      return Response.json(await readAllFeedback());
+    }
+
+    if (url.pathname === "/api/feedback" && req.method === "POST") {
+      const body = (await req.json()) as { id?: string; feedback?: unknown };
+      if (!body.id || !/^[\w-]+$/.test(body.id)) return new Response("bad id", { status: 400 });
+      const path = join(argv.flags.feedback, `${body.id}.json`);
+      await Bun.write(path, JSON.stringify(body.feedback, null, 2));
+      return Response.json({ ok: true });
+    }
+
+    return new Response("not found", { status: 404 });
+  },
+});
+
+console.log(`Labeling UI: http://localhost:${server.port}`);
+console.log(`Samples:     ${argv.flags.data}`);
+console.log(`Feedback:    ${argv.flags.feedback}/`);

--- a/evals/writing/label/server.ts
+++ b/evals/writing/label/server.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { readdir } from "node:fs/promises";
+import { mkdir, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { cli } from "cleye";
 
@@ -28,6 +28,8 @@ const argv = cli({
 });
 
 const html = join(import.meta.dir, "index.html");
+
+await mkdir(argv.flags.feedback, { recursive: true });
 
 async function readAllFeedback(): Promise<Record<string, unknown>> {
   const out: Record<string, unknown> = {};

--- a/evals/writing/scripts/mine.test.ts
+++ b/evals/writing/scripts/mine.test.ts
@@ -56,9 +56,7 @@ test.each<{ name: string; counts: Record<string, number>; limit: number; expecte
   },
 ])("selectSample $name", ({ counts, limit, expected }) => {
   const candidates = Object.entries(counts).flatMap(([category, n]) =>
-    Array.from({ length: n }, (_, i) =>
-      makeItem({ category, output: "x".repeat(10 * (i + 1)) }),
-    ),
+    Array.from({ length: n }, (_, i) => makeItem({ category, output: "x".repeat(10 * (i + 1)) })),
   );
   const selected = selectSample(candidates, limit);
   expect(selected.map((s) => s.category)).toEqual(expected);

--- a/evals/writing/scripts/mine.test.ts
+++ b/evals/writing/scripts/mine.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "bun:test";
+import fc from "fast-check";
+import { type Item, type RewriteDraft, selectSample, toItem, weave } from "./mine";
+
+function makeItem(overrides: Partial<Item>): Item {
+  return {
+    id: "",
+    category: "commit-message",
+    size: "compact",
+    source: "synthetic",
+    input: "an input",
+    output: "an output",
+    ...overrides,
+  };
+}
+
+test("weave interleaves longest and shortest", () => {
+  const lengths = [1, 2, 3, 4, 5];
+  const woven = weave(lengths, (n) => n);
+  expect(woven).toEqual([5, 1, 4, 2, 3]);
+});
+
+test("weave preserves the multiset", () => {
+  fc.assert(
+    fc.property(fc.array(fc.integer({ min: 0, max: 100 })), (lengths) => {
+      const woven = weave(lengths, (n) => n);
+      expect([...woven].sort((a, b) => a - b)).toEqual([...lengths].sort((a, b) => a - b));
+    }),
+  );
+});
+
+test.each<{ name: string; counts: Record<string, number>; limit: number; expected: string[] }>([
+  {
+    name: "round-robins across categories before repeating one",
+    counts: { "commit-message": 3, "slack-update": 1 },
+    limit: 3,
+    expected: ["commit-message", "slack-update", "commit-message"],
+  },
+  {
+    name: "drains small categories and keeps filling from large ones",
+    counts: { "commit-message": 4, "slack-update": 1 },
+    limit: 5,
+    expected: [
+      "commit-message",
+      "slack-update",
+      "commit-message",
+      "commit-message",
+      "commit-message",
+    ],
+  },
+  {
+    name: "returns everything when under the limit",
+    counts: { "commit-message": 2 },
+    limit: 50,
+    expected: ["commit-message", "commit-message"],
+  },
+])("selectSample $name", ({ counts, limit, expected }) => {
+  const candidates = Object.entries(counts).flatMap(([category, n]) =>
+    Array.from({ length: n }, (_, i) =>
+      makeItem({ category, output: "x".repeat(10 * (i + 1)) }),
+    ),
+  );
+  const selected = selectSample(candidates, limit);
+  expect(selected.map((s) => s.category)).toEqual(expected);
+});
+
+test("selectSample assigns sequential ids", () => {
+  const candidates = [makeItem({ input: "a" }), makeItem({ input: "b" })];
+  const ids = selectSample(candidates, 10).map((s) => s.id);
+  expect(ids).toEqual(["rw-001", "rw-002"]);
+});
+
+test("toItem carries the category and sizes by output length", () => {
+  const draft: RewriteDraft = {
+    category: "doc-paragraph",
+    input: "a".repeat(100),
+    output: "b".repeat(800),
+  };
+  expect(toItem(draft)).toMatchInlineSnapshot(
+    { input: expect.any(String), output: expect.any(String) },
+    `
+    {
+      "category": "doc-paragraph",
+      "id": "",
+      "input": Any<String>,
+      "output": Any<String>,
+      "size": "full",
+      "source": "synthetic",
+    }
+  `,
+  );
+});

--- a/evals/writing/scripts/mine.ts
+++ b/evals/writing/scripts/mine.ts
@@ -1,0 +1,204 @@
+#!/usr/bin/env bun
+import { mkdir, readdir } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { cli } from "cleye";
+
+// Assemble a labelable set of writing:rewrite (input, output) pairs.
+//
+// The eval unit is the writing:rewrite transform: it is the observable proxy
+// for writing:writing, which only injects rules into context and emits no
+// artifact. rewrite takes a sloppy draft and displays a cleaned version.
+//
+// Mining source: the session index records every writing:rewrite invocation
+// (skill_calls carries skill_name + args, i.e. the input), but the skill runs
+// in a fork and DISPLAYS its output rather than writing a file, so the rewritten
+// text is not recoverable as a clean pair. This script probes the index to
+// report how many real invocations exist, then builds the labelable sample from
+// the tracked synthetic drafts in drafts/ (seeded like issue-refine's briefs/).
+//
+// Egress rule: rewrite operates on arbitrary text, including work-host content.
+// The probe SQL is hardcoded to host = 'local'; keep it that way. The synthetic
+// drafts are the only content that ships.
+
+export interface RewriteDraft {
+  category: string;
+  input: string;
+  output: string;
+}
+
+export interface Item {
+  id: string;
+  category: string;
+  size: "compact" | "full";
+  source: "synthetic";
+  input: string;
+  output: string;
+}
+
+const PROBE_SQL = `
+SELECT count(*) AS invocations
+FROM skill_calls
+WHERE host = 'local'
+  AND skill_name = 'writing:rewrite'
+`;
+
+export function sizeOf(output: string): "compact" | "full" {
+  return output.length < 600 ? "compact" : "full";
+}
+
+export function toItem(draft: RewriteDraft): Item {
+  return {
+    id: "",
+    category: draft.category,
+    size: sizeOf(draft.output),
+    source: "synthetic",
+    input: draft.input,
+    output: draft.output,
+  };
+}
+
+// Interleave longest and shortest so a truncated labeling session still spans
+// both the multi-paragraph rewrites and the tight one-liners.
+export function weave<T>(items: T[], length: (item: T) => number): T[] {
+  const sorted = [...items].sort((a, b) => length(b) - length(a));
+  const woven: T[] = [];
+  let lo = 0;
+  let hi = sorted.length - 1;
+  while (lo <= hi) {
+    const first = sorted[lo++];
+    if (first !== undefined) woven.push(first);
+    if (lo <= hi) {
+      const last = sorted[hi--];
+      if (last !== undefined) woven.push(last);
+    }
+  }
+  return woven;
+}
+
+// Category-balanced round-robin so one draft category doesn't crowd out the
+// rest of the sample.
+export function selectSample(candidates: Item[], limit: number): Item[] {
+  const buckets = new Map<string, Item[]>();
+  for (const c of candidates) {
+    const arr = buckets.get(c.category) ?? [];
+    arr.push(c);
+    buckets.set(c.category, arr);
+  }
+  for (const [category, arr] of buckets) {
+    buckets.set(
+      category,
+      weave(arr, (i) => i.output.length),
+    );
+  }
+  const order = [...buckets.keys()].sort();
+  const selected: Item[] = [];
+  let added = true;
+  while (added && selected.length < limit) {
+    added = false;
+    for (const category of order) {
+      const next = buckets.get(category)?.shift();
+      if (next && selected.length < limit) {
+        selected.push(next);
+        added = true;
+      }
+    }
+  }
+  selected.forEach((s, i) => {
+    s.id = `rw-${String(i + 1).padStart(3, "0")}`;
+  });
+  return selected;
+}
+
+function resolveDbPath(db: string | undefined): string {
+  if (db) return db;
+  const dataDir =
+    process.env.CLAUDE_PLUGIN_DATA || join(process.env.TMPDIR || "/tmp", "claude-session");
+  return join(dataDir, "session.duckdb");
+}
+
+async function probeInvocations(dbPath: string): Promise<number | null> {
+  if (!(await Bun.file(dbPath).exists())) return null;
+  const proc = Bun.spawn(["duckdb", "-readonly", "-json", dbPath], {
+    stdin: new TextEncoder().encode(PROBE_SQL),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0) throw new Error(`duckdb failed (${code}): ${err.trim()}`);
+  const rows = JSON.parse(out.trim() || "[]") as Array<{ invocations: number }>;
+  return rows[0]?.invocations ?? 0;
+}
+
+async function loadDrafts(dir: string): Promise<RewriteDraft[]> {
+  const names = (await readdir(dir)).filter((n) => n.endsWith(".json")).sort();
+  const drafts: RewriteDraft[] = [];
+  for (const name of names) {
+    const draft = (await Bun.file(join(dir, name)).json()) as Partial<RewriteDraft>;
+    if (typeof draft.input !== "string" || typeof draft.output !== "string") {
+      throw new Error(`${name}: missing input/output string`);
+    }
+    drafts.push({
+      category: draft.category ?? basename(name, ".json"),
+      input: draft.input,
+      output: draft.output,
+    });
+  }
+  return drafts;
+}
+
+async function main() {
+  const argv = cli({
+    name: "mine",
+    help: {
+      description:
+        "Assemble writing:rewrite (input, output) pairs into a labelable set. " +
+        "Probes the session index for real invocation count, then builds the " +
+        "sample from tracked synthetic drafts (outputs display in-fork and are " +
+        "not recoverable as clean pairs).",
+    },
+    flags: {
+      db: {
+        type: String,
+        description: "session.duckdb path (defaults to the session skill's data dir)",
+      },
+      drafts: {
+        type: String,
+        default: join(import.meta.dirname, "..", "drafts"),
+        description: "Directory of tracked synthetic (input, output) drafts",
+      },
+      out: {
+        type: String,
+        default: join(import.meta.dirname, "..", "data", "samples.json"),
+        description: "Output path for the labelable sample",
+      },
+      limit: { type: Number, default: 50, description: "Max items to keep" },
+    },
+  });
+
+  const invocations = await probeInvocations(resolveDbPath(argv.flags.db));
+  if (invocations === null) {
+    console.log("Session index absent; skipping the real-invocation probe.");
+  } else {
+    console.log(`Session index: ${invocations} local writing:rewrite invocations.`);
+    console.log("Outputs display in-fork and are not persisted, so pairs come from drafts/.");
+  }
+
+  const drafts = await loadDrafts(argv.flags.drafts);
+  const candidates = drafts.map(toItem);
+  const selected = selectSample(candidates, argv.flags.limit);
+
+  await mkdir(dirname(argv.flags.out), { recursive: true });
+  await Bun.write(argv.flags.out, `${JSON.stringify(selected, null, 2)}\n`);
+
+  const byCategory: Record<string, number> = {};
+  for (const s of selected) byCategory[s.category] = (byCategory[s.category] ?? 0) + 1;
+
+  console.log(`Wrote ${selected.length} samples to ${argv.flags.out}`);
+  for (const [category, n] of Object.entries(byCategory)) console.log(`  ${category}: ${n}`);
+}
+
+if (import.meta.main) main();


### PR DESCRIPTION
Adds a local eval harness for the writing style rules under `evals/writing/`.

This is scaffold-only, mirroring evals/pr-body PR #977: it delivers the miner, the label UI, a synthetic dataset, and the README loop definition. The rubric, scorer, judge, and A/B runner are deferred to owner work after a labeling session, since the rubric is derived from the labels.

## Why the Proxy

`writing:writing` only injects the style rules into context and emits no artifact, so it has nothing observable to score. The eval unit is instead the `writing:rewrite` transform: it applies the same rules to a draft and produces a cleaned version, so its `(input, output)` pair is the proxy for whether the rules work.

## Dataset Decision

Mining real pairs from the session index doesn't work. `rewrite` runs in a fork and displays its result rather than writing a file, so the rewritten text is gone once the fork returns. The index keeps the input (the skill args in `skill_calls`) but never sees the output. `mine.ts` therefore probes the index for the real invocation count, then assembles the labelable sample from tracked synthetic drafts in `drafts/`, seeded with the two failure modes a labeler needs to catch: over-stripping (a functional fact dropped from the input) and residual slop (a trope that survived into the output). This follows how evals/issue-refine seeds its A/B briefs with the tropes its rubric targets.

## Scorer Note

The future mechanical scorer will wrap the plugin's own detection engine, `plugins/writing/detection/scan.ts` (`scanAll`) or the `writing:score` skill's `--json` density, rather than re-implement pattern matching. Because the scorer is the plugin's own engine, a later A/B must pin the engine and its wordlists to one revision across both sides, or a wordlist edit would score itself.

## Testing

`bun test evals/writing` covers the pure helpers (`weave`, `selectSample`, `toItem`) with fast-check properties and a table, copied from pr-body. Ran `mine.ts` end to end (probe reports the invocation count, writes a category-balanced `data/samples.json`) and booted `label/server.ts` on port 4320, confirming it serves the pair view and roundtrips feedback. `data/` and `feedback/` are gitignored. Only the harness and synthetic drafts ship.

Original Task: [[discovery] Eval coverage for writing:writing (copy issue-refine harness)](https://things.bendrucker.me/show?id=7WBS8unbFHHRXXN8jdjQ9p)
