### PR TITLE
feat(agents): add user-scope agents scaffold with scout template

### DIFF
--- a/user/agents/README.md
+++ b/user/agents/README.md
@@ -1,0 +1,9 @@
+# Agents
+
+User-scope [subagents](https://docs.anthropic.com/en/docs/claude-code/sub-agents). `install.sh` symlinks this directory to `~/.claude/agents/`, so every `*.md` here is available to any project as a named agent.
+
+These are reusable, named background agents, one per file, named by basename. Dispatch one with `claude --bg --agent <name> "<task>"`, or pick it from the agent step in the `claude-launch` launcher (in the dotfiles repo).
+
+`scout.md` is a concrete starting point. It investigates read-only and reports findings without touching the tree. Copy it to add your own, keeping `tools` scoped to what the agent needs and `model` matched to the work.
+
+The global default subagent (the `agent` key in `settings.json`) is intentionally left unset. Setting it would run every main session as that subagent.

--- a/user/agents/scout.md
+++ b/user/agents/scout.md
@@ -1,0 +1,24 @@
+---
+name: scout
+description: Read-only codebase investigator. Use to answer "how does X work" or "where is Y handled" by reading across many files and returning a findings summary, without modifying anything. A good default for background dispatch (claude --bg --agent scout).
+tools: Read, Grep, Glob
+model: sonnet
+---
+
+You are a read-only scout. You investigate a codebase and report what you find. You never modify files, run commands, or make changes of any kind.
+
+## Approach
+
+- Start broad, then narrow. Use Glob and Grep to locate the relevant files before reading them.
+- Read only what you need. Prefer targeted reads over whole files once you know where the answer lives.
+- Follow the real call paths. Trace how the pieces connect rather than guessing from names.
+
+## Report
+
+Return a self-contained summary for someone who has not opened the code:
+
+- The direct answer to the question, up front.
+- The key files and symbols, cited as `path:line`.
+- How the pieces fit together, and any caveats or loose ends worth a second look.
+
+Keep it tight. Report the findings and skip the play-by-play.


### PR DESCRIPTION
Adds `user/agents/`, a home for reusable named background agents. `install.sh` already symlinks every top-level entry under `user/` into `~/.claude/`, so this directory becomes `~/.claude/agents/` with no installer change.

The companion dotfiles PR wires up `claude agents` (the background-agent view): launch aliases, a gum launcher, a tmux popup, and a status chip. Its launcher enumerates `~/.claude/agents/*.md` for its `--agent` picker, and this scaffold gives that picker something to offer out of the box.

`scout.md` is a concrete, safe template. A read-only investigator scoped to `Read, Grep, Glob`, it returns a findings summary without touching the tree, and doubles as a copyable example of the `description`/`tools`/`model` frontmatter. The `agent` key in `settings.json` stays unset on purpose. A global default subagent would run every main session as that agent.

## Verification

Simulating the installer symlink (`user/agents` → a target `agents/`, the same directory-symlink path already used for `rules/`, `hooks/`, and `skills/`) resolves cleanly, and the launcher's frontmatter-gated enumeration offers `scout` while skipping the `README`.
