### PR TITLE
feat(hooks): add session-limit awareness hook

### DIFF
--- a/user/hooks/session-limit/index.test.ts
+++ b/user/hooks/session-limit/index.test.ts
@@ -11,13 +11,13 @@ import type {
   UserPromptSubmitHookSpecificOutput,
 } from "@anthropic-ai/claude-agent-sdk";
 import {
-  band,
+  crossedBand,
   evaluate,
-  FIVE_HOUR_THRESHOLDS,
+  FIVE_HOUR_BANDS,
   formatResetTime,
   type Marker,
   processInput,
-  SEVEN_DAY_THRESHOLDS,
+  SEVEN_DAY_BANDS,
 } from "./index";
 
 const FIVE_RESETS = 1783503000; // Wed 9:30 AM UTC
@@ -41,7 +41,7 @@ function marker(over: Partial<Marker> = {}): Marker {
   };
 }
 
-describe("band", () => {
+describe("crossedBand", () => {
   test.each([
     [89, 0],
     [90, 90],
@@ -50,7 +50,7 @@ describe("band", () => {
     [99, 95],
     [100, 100],
   ])("five-hour %i%% -> band %i", (pct, expected) => {
-    expect(band(pct, FIVE_HOUR_THRESHOLDS)).toBe(expected);
+    expect(crossedBand(pct, FIVE_HOUR_BANDS)?.threshold ?? 0).toBe(expected);
   });
 
   test.each([
@@ -58,7 +58,7 @@ describe("band", () => {
     [95, 95],
     [100, 95],
   ])("seven-day %i%% -> band %i", (pct, expected) => {
-    expect(band(pct, SEVEN_DAY_THRESHOLDS)).toBe(expected);
+    expect(crossedBand(pct, SEVEN_DAY_BANDS)?.threshold ?? 0).toBe(expected);
   });
 });
 

--- a/user/hooks/session-limit/index.test.ts
+++ b/user/hooks/session-limit/index.test.ts
@@ -122,6 +122,12 @@ describe("evaluate", () => {
     expect(result?.messages[0]).not.toContain("schedule a wake-up");
   });
 
+  it("defers rather than scheduling when a stale reset is already in the past", () => {
+    const result = evaluate(limits(100), null, FIVE_RESETS_MS + 60 * 1000);
+    expect(result?.messages[0]).toContain("tell the user to return");
+    expect(result?.messages[0]).not.toContain("schedule a wake-up");
+  });
+
   it("announces the seven-day band independently", () => {
     const result = evaluate(limits(50, 96), null, 0);
     expect(result?.messages).toHaveLength(1);

--- a/user/hooks/session-limit/index.test.ts
+++ b/user/hooks/session-limit/index.test.ts
@@ -5,7 +5,11 @@ import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { UserPromptSubmitHookInput } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  SyncHookJSONOutput,
+  UserPromptSubmitHookInput,
+  UserPromptSubmitHookSpecificOutput,
+} from "@anthropic-ai/claude-agent-sdk";
 import {
   band,
   evaluate,
@@ -189,10 +193,14 @@ describe("processInput", () => {
     await Bun.write(rlPath, JSON.stringify(limits(fivePct, sevenPct)));
   }
 
+  function context(output: SyncHookJSONOutput | null): string {
+    const specific = output?.hookSpecificOutput as UserPromptSubmitHookSpecificOutput | undefined;
+    return specific?.additionalContext ?? "";
+  }
+
   it("injects context when a band is crossed", async () => {
     await writeLimits(92);
-    const output = await processInput(input("s1"), 0);
-    const ctx = output?.hookSpecificOutput?.additionalContext ?? "";
+    const ctx = context(await processInput(input("s1"), 0));
     expect(ctx).toContain("90%");
     expect(ctx).toContain("Wed 9:30 AM");
   });
@@ -203,8 +211,7 @@ describe("processInput", () => {
     expect(await processInput(input("s2"), 0)).toBeNull();
 
     await writeLimits(96);
-    const escalated = await processInput(input("s2"), 0);
-    expect(escalated?.hookSpecificOutput?.additionalContext).toContain("95%");
+    expect(context(await processInput(input("s2"), 0))).toContain("95%");
   });
 
   it("resets the band after a block rollover", async () => {

--- a/user/hooks/session-limit/index.test.ts
+++ b/user/hooks/session-limit/index.test.ts
@@ -1,9 +1,10 @@
 process.env.TZ = "UTC";
 
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, test } from "bun:test";
 import type { UserPromptSubmitHookInput } from "@anthropic-ai/claude-agent-sdk";
 import {
   band,
@@ -138,10 +139,14 @@ describe("message content", () => {
     expect(evaluate(limits(95), null, 0)?.messages[0]).toMatchInlineSnapshot(
       `"You are at 95% of the current 5-hour usage block (resets Wed 9:30 AM). Prefer finishing in-flight work over starting anything new, and batch tool calls."`,
     );
-    expect(evaluate(limits(100), null, FIVE_RESETS_MS - 10 * 60 * 1000)?.messages[0]).toMatchInlineSnapshot(
+    expect(
+      evaluate(limits(100), null, FIVE_RESETS_MS - 10 * 60 * 1000)?.messages[0],
+    ).toMatchInlineSnapshot(
       `"The 5-hour usage block is exhausted (resets Wed 9:30 AM). Every further request now spends overage credits. Finish only in-flight work, then schedule a wake-up for just after Wed 9:30 AM (no need to ask) so work resumes on a fresh block, and stop. Start no new work."`,
     );
-    expect(evaluate(limits(100), null, FIVE_RESETS_MS - 2 * 60 * 60 * 1000)?.messages[0]).toMatchInlineSnapshot(
+    expect(
+      evaluate(limits(100), null, FIVE_RESETS_MS - 2 * 60 * 60 * 1000)?.messages[0],
+    ).toMatchInlineSnapshot(
       `"The 5-hour usage block is exhausted (resets Wed 9:30 AM). Every further request now spends overage credits. Finish only in-flight work, then tell the user to return at Wed 9:30 AM to resume on a fresh block, and stop. Start no new work."`,
     );
   });
@@ -164,8 +169,8 @@ describe("processInput", () => {
     process.env.CLAUDE_SESSION_LIMIT_MARKER_ROOT = join(dir, "markers");
   });
 
-  afterEach(() => {
-    rmSync(dir, { recursive: true, force: true });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
     delete process.env.CLAUDE_STATUSLINE_RATE_LIMITS_PATH;
     delete process.env.CLAUDE_SESSION_LIMIT_MARKER_ROOT;
   });
@@ -180,54 +185,54 @@ describe("processInput", () => {
     };
   }
 
-  function writeLimits(fivePct: number, sevenPct = 0) {
-    writeFileSync(rlPath, JSON.stringify(limits(fivePct, sevenPct)));
+  async function writeLimits(fivePct: number, sevenPct = 0) {
+    await Bun.write(rlPath, JSON.stringify(limits(fivePct, sevenPct)));
   }
 
-  it("injects context when a band is crossed", () => {
-    writeLimits(92);
-    const output = processInput(input("s1"), 0);
+  it("injects context when a band is crossed", async () => {
+    await writeLimits(92);
+    const output = await processInput(input("s1"), 0);
     const ctx = output?.hookSpecificOutput?.additionalContext ?? "";
     expect(ctx).toContain("90%");
     expect(ctx).toContain("Wed 9:30 AM");
   });
 
-  it("dedups across invocations and escalates on the next band", () => {
-    writeLimits(92);
-    expect(processInput(input("s2"), 0)).not.toBeNull();
-    expect(processInput(input("s2"), 0)).toBeNull();
+  it("dedups across invocations and escalates on the next band", async () => {
+    await writeLimits(92);
+    expect(await processInput(input("s2"), 0)).not.toBeNull();
+    expect(await processInput(input("s2"), 0)).toBeNull();
 
-    writeLimits(96);
-    const escalated = processInput(input("s2"), 0);
+    await writeLimits(96);
+    const escalated = await processInput(input("s2"), 0);
     expect(escalated?.hookSpecificOutput?.additionalContext).toContain("95%");
   });
 
-  it("resets the band after a block rollover", () => {
-    writeLimits(96);
-    expect(processInput(input("s3"), 0)).not.toBeNull();
+  it("resets the band after a block rollover", async () => {
+    await writeLimits(96);
+    expect(await processInput(input("s3"), 0)).not.toBeNull();
 
-    writeFileSync(
+    await Bun.write(
       rlPath,
       JSON.stringify({
         five_hour: { used_percentage: 30, resets_at: FIVE_RESETS + 18000 },
         seven_day: { used_percentage: 0, resets_at: SEVEN_RESETS },
       }),
     );
-    expect(processInput(input("s3"), 0)).toBeNull();
+    expect(await processInput(input("s3"), 0)).toBeNull();
 
-    const stored = JSON.parse(
-      readFileSync(join(dir, "markers", "s3", "session-limit.json"), "utf8"),
-    ) as Marker;
+    const stored = (await Bun.file(
+      join(dir, "markers", "s3", "session-limit.json"),
+    ).json()) as Marker;
     expect(stored.fiveHourBand).toBe(0);
     expect(stored.fiveHourResetsAt).toBe(FIVE_RESETS + 18000);
   });
 
-  it("emits nothing when the rate-limit file is missing", () => {
-    expect(processInput(input("s4"), 0)).toBeNull();
+  it("emits nothing when the rate-limit file is missing", async () => {
+    expect(await processInput(input("s4"), 0)).toBeNull();
   });
 
-  it("emits nothing when the rate-limit file is empty", () => {
-    writeFileSync(rlPath, "");
-    expect(processInput(input("s5"), 0)).toBeNull();
+  it("emits nothing when the rate-limit file is empty", async () => {
+    await Bun.write(rlPath, "");
+    expect(await processInput(input("s5"), 0)).toBeNull();
   });
 });

--- a/user/hooks/session-limit/index.test.ts
+++ b/user/hooks/session-limit/index.test.ts
@@ -1,0 +1,233 @@
+process.env.TZ = "UTC";
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, test } from "bun:test";
+import type { UserPromptSubmitHookInput } from "@anthropic-ai/claude-agent-sdk";
+import {
+  band,
+  evaluate,
+  FIVE_HOUR_THRESHOLDS,
+  formatResetTime,
+  type Marker,
+  processInput,
+  SEVEN_DAY_THRESHOLDS,
+} from "./index";
+
+const FIVE_RESETS = 1783503000; // Wed 9:30 AM UTC
+const SEVEN_RESETS = 1783922400; // Mon 6:00 AM UTC
+const FIVE_RESETS_MS = FIVE_RESETS * 1000;
+
+function limits(fivePct: number, sevenPct = 0) {
+  return {
+    five_hour: { used_percentage: fivePct, resets_at: FIVE_RESETS },
+    seven_day: { used_percentage: sevenPct, resets_at: SEVEN_RESETS },
+  };
+}
+
+function marker(over: Partial<Marker> = {}): Marker {
+  return {
+    fiveHourBand: 0,
+    fiveHourResetsAt: FIVE_RESETS,
+    sevenDayBand: 0,
+    sevenDayResetsAt: SEVEN_RESETS,
+    ...over,
+  };
+}
+
+describe("band", () => {
+  test.each([
+    [89, 0],
+    [90, 90],
+    [94, 90],
+    [95, 95],
+    [99, 95],
+    [100, 100],
+  ])("five-hour %i%% -> band %i", (pct, expected) => {
+    expect(band(pct, FIVE_HOUR_THRESHOLDS)).toBe(expected);
+  });
+
+  test.each([
+    [94, 0],
+    [95, 95],
+    [100, 95],
+  ])("seven-day %i%% -> band %i", (pct, expected) => {
+    expect(band(pct, SEVEN_DAY_THRESHOLDS)).toBe(expected);
+  });
+});
+
+describe("formatResetTime", () => {
+  it("renders local weekday and time", () => {
+    expect(formatResetTime(FIVE_RESETS)).toBe("Wed 9:30 AM");
+    expect(formatResetTime(SEVEN_RESETS)).toBe("Mon 6:00 AM");
+  });
+});
+
+describe("evaluate", () => {
+  it("returns null when five_hour percentage is absent", () => {
+    expect(evaluate({ seven_day: { used_percentage: 99 } }, null, 0)).toBeNull();
+    expect(evaluate({}, null, 0)).toBeNull();
+  });
+
+  it("emits nothing below the first threshold", () => {
+    const result = evaluate(limits(89), null, 0);
+    expect(result?.messages).toEqual([]);
+    expect(result?.marker.fiveHourBand).toBe(0);
+  });
+
+  it("announces the 90 band on first crossing", () => {
+    const result = evaluate(limits(92), null, 0);
+    expect(result?.marker.fiveHourBand).toBe(90);
+    expect(result?.messages).toHaveLength(1);
+    expect(result?.messages[0]).toContain("90%");
+    expect(result?.messages[0]).toContain("Wed 9:30 AM");
+  });
+
+  it("suppresses a band already announced for the same block", () => {
+    const result = evaluate(limits(92), marker({ fiveHourBand: 90 }), 0);
+    expect(result?.messages).toEqual([]);
+    expect(result?.marker.fiveHourBand).toBe(90);
+  });
+
+  it("escalates to the next band", () => {
+    const result = evaluate(limits(96), marker({ fiveHourBand: 90 }), 0);
+    expect(result?.messages).toHaveLength(1);
+    expect(result?.messages[0]).toContain("95%");
+    expect(result?.marker.fiveHourBand).toBe(95);
+  });
+
+  it("resets the band when the block rolls over", () => {
+    const prev = marker({ fiveHourBand: 95, fiveHourResetsAt: FIVE_RESETS - 18000 });
+    const result = evaluate(limits(30), prev, 0);
+    expect(result?.messages).toEqual([]);
+    expect(result?.marker.fiveHourBand).toBe(0);
+    expect(result?.marker.fiveHourResetsAt).toBe(FIVE_RESETS);
+  });
+
+  it("schedules a wake-up when the reset is within the wake-up horizon", () => {
+    const result = evaluate(limits(100), null, FIVE_RESETS_MS - 10 * 60 * 1000);
+    expect(result?.messages[0]).toContain("schedule a wake-up");
+    expect(result?.messages[0]).not.toContain("tell the user to return");
+  });
+
+  it("defers to the user when the reset is beyond the wake-up horizon", () => {
+    const result = evaluate(limits(100), null, FIVE_RESETS_MS - 2 * 60 * 60 * 1000);
+    expect(result?.messages[0]).toContain("tell the user to return");
+    expect(result?.messages[0]).not.toContain("schedule a wake-up");
+  });
+
+  it("announces the seven-day band independently", () => {
+    const result = evaluate(limits(50, 96), null, 0);
+    expect(result?.messages).toHaveLength(1);
+    expect(result?.messages[0]).toContain("7-day");
+    expect(result?.marker.sevenDayBand).toBe(95);
+  });
+
+  it("announces both windows in one evaluation", () => {
+    const result = evaluate(limits(90, 96), null, 0);
+    expect(result?.messages).toHaveLength(2);
+  });
+});
+
+describe("message content", () => {
+  it("matches the five-hour snapshots", () => {
+    expect(evaluate(limits(90), null, 0)?.messages[0]).toMatchInlineSnapshot(
+      `"You are at 90% of the current 5-hour usage block (resets Wed 9:30 AM). Favor efficient work and avoid starting large non-essential tasks."`,
+    );
+    expect(evaluate(limits(95), null, 0)?.messages[0]).toMatchInlineSnapshot(
+      `"You are at 95% of the current 5-hour usage block (resets Wed 9:30 AM). Prefer finishing in-flight work over starting anything new, and batch tool calls."`,
+    );
+    expect(evaluate(limits(100), null, FIVE_RESETS_MS - 10 * 60 * 1000)?.messages[0]).toMatchInlineSnapshot(
+      `"The 5-hour usage block is exhausted (resets Wed 9:30 AM). Every further request now spends overage credits. Finish only in-flight work, then schedule a wake-up for just after Wed 9:30 AM (no need to ask) so work resumes on a fresh block, and stop. Start no new work."`,
+    );
+    expect(evaluate(limits(100), null, FIVE_RESETS_MS - 2 * 60 * 60 * 1000)?.messages[0]).toMatchInlineSnapshot(
+      `"The 5-hour usage block is exhausted (resets Wed 9:30 AM). Every further request now spends overage credits. Finish only in-flight work, then tell the user to return at Wed 9:30 AM to resume on a fresh block, and stop. Start no new work."`,
+    );
+  });
+
+  it("matches the seven-day snapshot", () => {
+    expect(evaluate(limits(50, 95), null, 0)?.messages[0]).toMatchInlineSnapshot(
+      `"You are at 95% of the 7-day usage limit. A 5-hour wait will not restore this. Minimize spend until the weekly reset (Mon 6:00 AM)."`,
+    );
+  });
+});
+
+describe("processInput", () => {
+  let dir: string;
+  let rlPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "session-limit-"));
+    rlPath = join(dir, "rl.json");
+    process.env.CLAUDE_STATUSLINE_RATE_LIMITS_PATH = rlPath;
+    process.env.CLAUDE_SESSION_LIMIT_MARKER_ROOT = join(dir, "markers");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    delete process.env.CLAUDE_STATUSLINE_RATE_LIMITS_PATH;
+    delete process.env.CLAUDE_SESSION_LIMIT_MARKER_ROOT;
+  });
+
+  function input(sessionId: string): UserPromptSubmitHookInput {
+    return {
+      hook_event_name: "UserPromptSubmit",
+      session_id: sessionId,
+      transcript_path: "/tmp/test",
+      cwd: "/tmp",
+      prompt: "hi",
+    };
+  }
+
+  function writeLimits(fivePct: number, sevenPct = 0) {
+    writeFileSync(rlPath, JSON.stringify(limits(fivePct, sevenPct)));
+  }
+
+  it("injects context when a band is crossed", () => {
+    writeLimits(92);
+    const output = processInput(input("s1"), 0);
+    const ctx = output?.hookSpecificOutput?.additionalContext ?? "";
+    expect(ctx).toContain("90%");
+    expect(ctx).toContain("Wed 9:30 AM");
+  });
+
+  it("dedups across invocations and escalates on the next band", () => {
+    writeLimits(92);
+    expect(processInput(input("s2"), 0)).not.toBeNull();
+    expect(processInput(input("s2"), 0)).toBeNull();
+
+    writeLimits(96);
+    const escalated = processInput(input("s2"), 0);
+    expect(escalated?.hookSpecificOutput?.additionalContext).toContain("95%");
+  });
+
+  it("resets the band after a block rollover", () => {
+    writeLimits(96);
+    expect(processInput(input("s3"), 0)).not.toBeNull();
+
+    writeFileSync(
+      rlPath,
+      JSON.stringify({
+        five_hour: { used_percentage: 30, resets_at: FIVE_RESETS + 18000 },
+        seven_day: { used_percentage: 0, resets_at: SEVEN_RESETS },
+      }),
+    );
+    expect(processInput(input("s3"), 0)).toBeNull();
+
+    const stored = JSON.parse(
+      readFileSync(join(dir, "markers", "s3", "session-limit.json"), "utf8"),
+    ) as Marker;
+    expect(stored.fiveHourBand).toBe(0);
+    expect(stored.fiveHourResetsAt).toBe(FIVE_RESETS + 18000);
+  });
+
+  it("emits nothing when the rate-limit file is missing", () => {
+    expect(processInput(input("s4"), 0)).toBeNull();
+  });
+
+  it("emits nothing when the rate-limit file is empty", () => {
+    writeFileSync(rlPath, "");
+    expect(processInput(input("s5"), 0)).toBeNull();
+  });
+});

--- a/user/hooks/session-limit/index.ts
+++ b/user/hooks/session-limit/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { SyncHookJSONOutput, UserPromptSubmitHookInput } from "@anthropic-ai/claude-agent-sdk";
@@ -126,31 +126,31 @@ function markerPath(sessionId: string): string {
   return join(root, sessionId, "session-limit.json");
 }
 
-function readJson<T>(path: string): T | null {
+async function readJson<T>(path: string): Promise<T | null> {
   try {
-    return JSON.parse(readFileSync(path, "utf8")) as T;
+    return JSON.parse(await Bun.file(path).text()) as T;
   } catch {
     return null;
   }
 }
 
-export function processInput(
+export async function processInput(
   input: UserPromptSubmitHookInput,
   nowMs: number,
-): SyncHookJSONOutput | null {
+): Promise<SyncHookJSONOutput | null> {
   const sessionId = input.session_id;
   if (!sessionId) return null;
 
-  const rl = readJson<RateLimits>(rateLimitsPath());
+  const rl = await readJson<RateLimits>(rateLimitsPath());
   if (!rl) return null;
 
   const path = markerPath(sessionId);
-  const result = evaluate(rl, readJson<Marker>(path), nowMs);
+  const result = evaluate(rl, await readJson<Marker>(path), nowMs);
   if (!result) return null;
 
   try {
     mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, `${JSON.stringify(result.marker)}\n`);
+    await Bun.write(path, `${JSON.stringify(result.marker)}\n`);
   } catch {
     return null;
   }
@@ -176,7 +176,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const output = processInput(input, Date.now());
+  const output = await processInput(input, Date.now());
   if (output) {
     writeStdoutJson(output);
   }

--- a/user/hooks/session-limit/index.ts
+++ b/user/hooks/session-limit/index.ts
@@ -1,20 +1,10 @@
 #!/usr/bin/env bun
 
 import { mkdirSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { SyncHookJSONOutput, UserPromptSubmitHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
-
-interface RateLimitWindow {
-  used_percentage?: number;
-  resets_at?: number;
-}
-
-interface RateLimits {
-  five_hour?: RateLimitWindow;
-  seven_day?: RateLimitWindow;
-}
+import { expandTilde, type RateLimits } from "../../scripts/rate-limits";
 
 // Highest announced band per window, keyed to the block it applies to. A changed
 // resets_at means the block rolled over, so the band no longer applies.
@@ -25,18 +15,55 @@ export interface Marker {
   sevenDayResetsAt: number;
 }
 
-export const FIVE_HOUR_THRESHOLDS = [90, 95, 100];
-export const SEVEN_DAY_THRESHOLDS = [95];
+// A band pairs its threshold with the message emitted on crossing, so a threshold
+// can never exist without a message (no silent empty injection). Adding one is a
+// single entry.
+interface Band {
+  threshold: number;
+  message: (resetsAt: number, nowMs: number) => string;
+}
 
 // Auto-scheduling a wake-up caps out around an hour. Past this horizon the model
 // defers to the user instead of scheduling.
 const WAKEUP_HORIZON_MS = 55 * 60 * 1000;
 
-// Highest crossed threshold, or 0 when the percentage is below all of them.
-export function band(pct: number, thresholds: readonly number[]): number {
-  let crossed = 0;
-  for (const threshold of thresholds) {
-    if (pct >= threshold) crossed = threshold;
+export const FIVE_HOUR_BANDS: Band[] = [
+  {
+    threshold: 90,
+    message: (resetsAt) =>
+      `You are at 90% of the current 5-hour usage block (resets ${formatResetTime(resetsAt)}). Favor efficient work and avoid starting large non-essential tasks.`,
+  },
+  {
+    threshold: 95,
+    message: (resetsAt) =>
+      `You are at 95% of the current 5-hour usage block (resets ${formatResetTime(resetsAt)}). Prefer finishing in-flight work over starting anything new, and batch tool calls.`,
+  },
+  {
+    threshold: 100,
+    message: (resetsAt, nowMs) => {
+      const reset = formatResetTime(resetsAt);
+      const withinHorizon = resetsAt * 1000 - nowMs <= WAKEUP_HORIZON_MS;
+      const resume = withinHorizon
+        ? `then schedule a wake-up for just after ${reset} (no need to ask) so work resumes on a fresh block, and stop`
+        : `then tell the user to return at ${reset} to resume on a fresh block, and stop`;
+      return `The 5-hour usage block is exhausted (resets ${reset}). Every further request now spends overage credits. Finish only in-flight work, ${resume}. Start no new work.`;
+    },
+  },
+];
+
+export const SEVEN_DAY_BANDS: Band[] = [
+  {
+    threshold: 95,
+    message: (resetsAt) =>
+      `You are at 95% of the 7-day usage limit. A 5-hour wait will not restore this. Minimize spend until the weekly reset (${formatResetTime(resetsAt)}).`,
+  },
+];
+
+// Highest band whose threshold the percentage has crossed, or null when below all.
+export function crossedBand(pct: number, bands: Band[]): Band | null {
+  let crossed: Band | null = null;
+  for (const band of bands) {
+    if (pct >= band.threshold) crossed = band;
   }
   return crossed;
 }
@@ -47,29 +74,6 @@ export function formatResetTime(resetsAt: number): string {
     hour: "numeric",
     minute: "2-digit",
   });
-}
-
-function fiveHourMessage(bandValue: number, resetsAt: number, nowMs: number): string {
-  const reset = formatResetTime(resetsAt);
-  switch (bandValue) {
-    case 90:
-      return `You are at 90% of the current 5-hour usage block (resets ${reset}). Favor efficient work and avoid starting large non-essential tasks.`;
-    case 95:
-      return `You are at 95% of the current 5-hour usage block (resets ${reset}). Prefer finishing in-flight work over starting anything new, and batch tool calls.`;
-    case 100: {
-      const withinHorizon = resetsAt * 1000 - nowMs <= WAKEUP_HORIZON_MS;
-      const resume = withinHorizon
-        ? `then schedule a wake-up for just after ${reset} (no need to ask) so work resumes on a fresh block, and stop`
-        : `then tell the user to return at ${reset} to resume on a fresh block, and stop`;
-      return `The 5-hour usage block is exhausted (resets ${reset}). Every further request now spends overage credits. Finish only in-flight work, ${resume}. Start no new work.`;
-    }
-    default:
-      return "";
-  }
-}
-
-function sevenDayMessage(resetsAt: number): string {
-  return `You are at 95% of the 7-day usage limit. A 5-hour wait will not restore this. Minimize spend until the weekly reset (${formatResetTime(resetsAt)}).`;
 }
 
 export function evaluate(
@@ -89,19 +93,19 @@ export function evaluate(
   const messages: string[] = [];
 
   let fiveBand = priorFiveBand;
-  const currentFive = band(fivePct, FIVE_HOUR_THRESHOLDS);
-  if (currentFive > priorFiveBand) {
-    messages.push(fiveHourMessage(currentFive, fiveResetsAt, nowMs));
-    fiveBand = currentFive;
+  const crossedFive = crossedBand(fivePct, FIVE_HOUR_BANDS);
+  if (crossedFive && crossedFive.threshold > priorFiveBand) {
+    messages.push(crossedFive.message(fiveResetsAt, nowMs));
+    fiveBand = crossedFive.threshold;
   }
 
   let sevenBand = priorSevenBand;
   const sevenPct = rl.seven_day?.used_percentage;
   if (typeof sevenPct === "number") {
-    const currentSeven = band(sevenPct, SEVEN_DAY_THRESHOLDS);
-    if (currentSeven > priorSevenBand) {
-      messages.push(sevenDayMessage(sevenResetsAt));
-      sevenBand = currentSeven;
+    const crossedSeven = crossedBand(sevenPct, SEVEN_DAY_BANDS);
+    if (crossedSeven && crossedSeven.threshold > priorSevenBand) {
+      messages.push(crossedSeven.message(sevenResetsAt, nowMs));
+      sevenBand = crossedSeven.threshold;
     }
   }
 
@@ -117,8 +121,9 @@ export function evaluate(
 }
 
 function rateLimitsPath(): string {
-  const target = process.env.CLAUDE_STATUSLINE_RATE_LIMITS_PATH ?? "~/.vibe-island/cache/rl.json";
-  return target.startsWith("~/") ? join(homedir(), target.slice(2)) : target;
+  return expandTilde(
+    process.env.CLAUDE_STATUSLINE_RATE_LIMITS_PATH ?? "~/.vibe-island/cache/rl.json",
+  );
 }
 
 function markerPath(sessionId: string): string {
@@ -134,6 +139,16 @@ async function readJson<T>(path: string): Promise<T | null> {
   }
 }
 
+function markerChanged(prev: Marker | null, next: Marker): boolean {
+  return (
+    !prev ||
+    prev.fiveHourBand !== next.fiveHourBand ||
+    prev.fiveHourResetsAt !== next.fiveHourResetsAt ||
+    prev.sevenDayBand !== next.sevenDayBand ||
+    prev.sevenDayResetsAt !== next.sevenDayResetsAt
+  );
+}
+
 export async function processInput(
   input: UserPromptSubmitHookInput,
   nowMs: number,
@@ -145,14 +160,19 @@ export async function processInput(
   if (!rl) return null;
 
   const path = markerPath(sessionId);
-  const result = evaluate(rl, await readJson<Marker>(path), nowMs);
+  const prev = await readJson<Marker>(path);
+  const result = evaluate(rl, prev, nowMs);
   if (!result) return null;
 
-  try {
-    mkdirSync(dirname(path), { recursive: true });
-    await Bun.write(path, `${JSON.stringify(result.marker)}\n`);
-  } catch {
-    return null;
+  // Below thresholds and within the same block the marker is unchanged, so skip
+  // the write. This keeps the hook near-zero cost on the common per-prompt path.
+  if (markerChanged(prev, result.marker)) {
+    try {
+      mkdirSync(dirname(path), { recursive: true });
+      await Bun.write(path, `${JSON.stringify(result.marker)}\n`);
+    } catch {
+      return null;
+    }
   }
 
   if (result.messages.length === 0) return null;

--- a/user/hooks/session-limit/index.ts
+++ b/user/hooks/session-limit/index.ts
@@ -42,7 +42,11 @@ export const FIVE_HOUR_BANDS: Band[] = [
     threshold: 100,
     message: (resetsAt, nowMs) => {
       const reset = formatResetTime(resetsAt);
-      const withinHorizon = resetsAt * 1000 - nowMs <= WAKEUP_HORIZON_MS;
+      // A stale rl.json can hold a resets_at already in the past. A negative
+      // remaining time must not read as "within horizon" and schedule a
+      // wake-up for a moment that has elapsed.
+      const msUntilReset = resetsAt * 1000 - nowMs;
+      const withinHorizon = msUntilReset > 0 && msUntilReset <= WAKEUP_HORIZON_MS;
       const resume = withinHorizon
         ? `then schedule a wake-up for just after ${reset} (no need to ask) so work resumes on a fresh block, and stop`
         : `then tell the user to return at ${reset} to resume on a fresh block, and stop`;
@@ -81,6 +85,9 @@ export function evaluate(
   prev: Marker | null,
   nowMs: number,
 ): { marker: Marker; messages: string[] } | null {
+  // five_hour presence is the signal that this session exposes rate-limit data
+  // at all, so its absence skips both windows. A seven_day-only account would
+  // then go unwarned, but no such account is known to exist.
   const fivePct = rl.five_hour?.used_percentage;
   if (typeof fivePct !== "number") return null;
 

--- a/user/hooks/session-limit/index.ts
+++ b/user/hooks/session-limit/index.ts
@@ -1,0 +1,187 @@
+#!/usr/bin/env bun
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type { SyncHookJSONOutput, UserPromptSubmitHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+
+interface RateLimitWindow {
+  used_percentage?: number;
+  resets_at?: number;
+}
+
+interface RateLimits {
+  five_hour?: RateLimitWindow;
+  seven_day?: RateLimitWindow;
+}
+
+// Highest announced band per window, keyed to the block it applies to. A changed
+// resets_at means the block rolled over, so the band no longer applies.
+export interface Marker {
+  fiveHourBand: number;
+  fiveHourResetsAt: number;
+  sevenDayBand: number;
+  sevenDayResetsAt: number;
+}
+
+export const FIVE_HOUR_THRESHOLDS = [90, 95, 100];
+export const SEVEN_DAY_THRESHOLDS = [95];
+
+// Auto-scheduling a wake-up caps out around an hour. Past this horizon the model
+// defers to the user instead of scheduling.
+const WAKEUP_HORIZON_MS = 55 * 60 * 1000;
+
+// Highest crossed threshold, or 0 when the percentage is below all of them.
+export function band(pct: number, thresholds: readonly number[]): number {
+  let crossed = 0;
+  for (const threshold of thresholds) {
+    if (pct >= threshold) crossed = threshold;
+  }
+  return crossed;
+}
+
+export function formatResetTime(resetsAt: number): string {
+  return new Date(resetsAt * 1000).toLocaleString([], {
+    weekday: "short",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function fiveHourMessage(bandValue: number, resetsAt: number, nowMs: number): string {
+  const reset = formatResetTime(resetsAt);
+  switch (bandValue) {
+    case 90:
+      return `You are at 90% of the current 5-hour usage block (resets ${reset}). Favor efficient work and avoid starting large non-essential tasks.`;
+    case 95:
+      return `You are at 95% of the current 5-hour usage block (resets ${reset}). Prefer finishing in-flight work over starting anything new, and batch tool calls.`;
+    case 100: {
+      const withinHorizon = resetsAt * 1000 - nowMs <= WAKEUP_HORIZON_MS;
+      const resume = withinHorizon
+        ? `then schedule a wake-up for just after ${reset} (no need to ask) so work resumes on a fresh block, and stop`
+        : `then tell the user to return at ${reset} to resume on a fresh block, and stop`;
+      return `The 5-hour usage block is exhausted (resets ${reset}). Every further request now spends overage credits. Finish only in-flight work, ${resume}. Start no new work.`;
+    }
+    default:
+      return "";
+  }
+}
+
+function sevenDayMessage(resetsAt: number): string {
+  return `You are at 95% of the 7-day usage limit. A 5-hour wait will not restore this. Minimize spend until the weekly reset (${formatResetTime(resetsAt)}).`;
+}
+
+export function evaluate(
+  rl: RateLimits,
+  prev: Marker | null,
+  nowMs: number,
+): { marker: Marker; messages: string[] } | null {
+  const fivePct = rl.five_hour?.used_percentage;
+  if (typeof fivePct !== "number") return null;
+
+  const fiveResetsAt = rl.five_hour?.resets_at ?? 0;
+  const sevenResetsAt = rl.seven_day?.resets_at ?? 0;
+
+  const priorFiveBand = prev && prev.fiveHourResetsAt === fiveResetsAt ? prev.fiveHourBand : 0;
+  const priorSevenBand = prev && prev.sevenDayResetsAt === sevenResetsAt ? prev.sevenDayBand : 0;
+
+  const messages: string[] = [];
+
+  let fiveBand = priorFiveBand;
+  const currentFive = band(fivePct, FIVE_HOUR_THRESHOLDS);
+  if (currentFive > priorFiveBand) {
+    messages.push(fiveHourMessage(currentFive, fiveResetsAt, nowMs));
+    fiveBand = currentFive;
+  }
+
+  let sevenBand = priorSevenBand;
+  const sevenPct = rl.seven_day?.used_percentage;
+  if (typeof sevenPct === "number") {
+    const currentSeven = band(sevenPct, SEVEN_DAY_THRESHOLDS);
+    if (currentSeven > priorSevenBand) {
+      messages.push(sevenDayMessage(sevenResetsAt));
+      sevenBand = currentSeven;
+    }
+  }
+
+  return {
+    marker: {
+      fiveHourBand: fiveBand,
+      fiveHourResetsAt: fiveResetsAt,
+      sevenDayBand: sevenBand,
+      sevenDayResetsAt: sevenResetsAt,
+    },
+    messages,
+  };
+}
+
+function rateLimitsPath(): string {
+  const target = process.env.CLAUDE_STATUSLINE_RATE_LIMITS_PATH ?? "~/.vibe-island/cache/rl.json";
+  return target.startsWith("~/") ? join(homedir(), target.slice(2)) : target;
+}
+
+function markerPath(sessionId: string): string {
+  const root = process.env.CLAUDE_SESSION_LIMIT_MARKER_ROOT ?? "/tmp/claude";
+  return join(root, sessionId, "session-limit.json");
+}
+
+function readJson<T>(path: string): T | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function processInput(
+  input: UserPromptSubmitHookInput,
+  nowMs: number,
+): SyncHookJSONOutput | null {
+  const sessionId = input.session_id;
+  if (!sessionId) return null;
+
+  const rl = readJson<RateLimits>(rateLimitsPath());
+  if (!rl) return null;
+
+  const path = markerPath(sessionId);
+  const result = evaluate(rl, readJson<Marker>(path), nowMs);
+  if (!result) return null;
+
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, `${JSON.stringify(result.marker)}\n`);
+  } catch {
+    return null;
+  }
+
+  if (result.messages.length === 0) return null;
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext: result.messages.join("\n\n"),
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  let input: UserPromptSubmitHookInput;
+  try {
+    input = await readStdinJson<UserPromptSubmitHookInput>();
+  } catch (error) {
+    console.error(
+      `[session-limit] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  const output = processInput(input, Date.now());
+  if (output) {
+    writeStdoutJson(output);
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/user/scripts/rate-limits.ts
+++ b/user/scripts/rate-limits.ts
@@ -1,0 +1,18 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// The rate-limit contract Claude Code pipes to the statusline. `statusline.ts`
+// mirrors it to `rl.json` (the writer); the session-limit hook reads it back.
+export interface RateLimitWindow {
+  used_percentage?: number;
+  resets_at?: number;
+}
+
+export interface RateLimits {
+  five_hour?: RateLimitWindow;
+  seven_day?: RateLimitWindow;
+}
+
+export function expandTilde(target: string): string {
+  return target.startsWith("~/") ? join(homedir(), target.slice(2)) : target;
+}

--- a/user/scripts/statusline.ts
+++ b/user/scripts/statusline.ts
@@ -1,25 +1,15 @@
 #!/usr/bin/env bun
 import { mkdirSync } from "node:fs";
-import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname } from "node:path";
 import { styleText } from "node:util";
 import { dialGlyph } from "./glyphs";
+import { expandTilde, type RateLimits } from "./rate-limits";
 
 interface CurrentUsage {
   input_tokens?: number;
   output_tokens?: number;
   cache_creation_input_tokens?: number;
   cache_read_input_tokens?: number;
-}
-
-interface RateLimitWindow {
-  used_percentage?: number;
-  resets_at?: number;
-}
-
-interface RateLimits {
-  five_hour?: RateLimitWindow;
-  seven_day?: RateLimitWindow;
 }
 
 interface StatusInput {
@@ -221,7 +211,7 @@ export async function emitRateLimits(input: StatusInput, target: string): Promis
   const limits = input.rate_limits;
   if (!limits) return;
 
-  const path = target.startsWith("~/") ? join(homedir(), target.slice(2)) : target;
+  const path = expandTilde(target);
   mkdirSync(dirname(path), { recursive: true });
   await Bun.write(path, `${JSON.stringify(limits)}\n`);
 }

--- a/user/settings.json
+++ b/user/settings.json
@@ -259,6 +259,10 @@
           {
             "type": "command",
             "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+          },
+          {
+            "type": "command",
+            "command": "bun ~/.claude/hooks/session-limit"
           }
         ]
       }


### PR DESCRIPTION
Adds a `UserPromptSubmit` hook that makes a session aware of its own rate-limit standing and injects escalating warnings as it nears the 5-hour block limit. On a work account with overage billing, crossing that limit silently burns credits. Today the wrap-up is manual: notice you're close, tell the session to stop, schedule a wake-up for after the block resets. This automates the noticing and the guidance.

## Mechanism

Claude Code exposes exact rate-limit data (`used_percentage`, `resets_at`) only to the statusline command's stdin, never to hooks. So the model can't see it directly. `statusline.ts` already mirrors the live `rate_limits` object to `~/.vibe-island/cache/rl.json` every turn (for the menu-bar app). The hook reads that same file and, when a threshold is crossed, injects guidance via `additionalContext`. No new statusline, no change to `statusline.ts`.

## Behavior

Awareness only. It injects context and lets the model act; it never blocks a prompt or a tool call. Five-hour bands at 90 / 95 / 100 escalate from "favor efficient work" to "wind down" to overage. The overage message tells the model to finish in-flight work and either schedule a wake-up (when the reset is within the ~1-hour wake-up horizon) or ask the user to return at the reset time (when it's further out). A separate 7-day band at 95 warns that a 5-hour wait won't help. Thresholds are a single edited const.

## Token Cost

This is the point of the design, so it can't become the background usage-eater it's meant to prevent. Below every threshold the hook does a file read plus a compare and emits nothing. A per-session marker at `/tmp/claude/<session_id>/session-limit.json` caps each band at one injection per block, so a full 5-hour block costs at most a few short injections. When a window's `resets_at` advances the block has rolled over, so that window's band resets to 0.

Fail-open everywhere: missing, empty, stale, or unparseable `rl.json`, no `five_hour` data, or a marker-write failure all emit nothing. That means API-key sessions and any account that doesn't receive `rate_limits` are silently unaffected.

## Verification

Unit tests cover the band table around each threshold, marker dedup, block rollover resetting the band, the message snapshots, and the fail-open paths. Exercised end-to-end via the documented pipe: a 92% fixture injects the 90% message with the reset time; a second call at 92% is suppressed by the marker; 96% escalates to the 95% message; a changed `resets_at` at 30% emits nothing and resets the marker band; a missing file produces no output.

## Open item

`rl.json` is confirmed populating on my personal account. The primary target is the work account, and it's unconfirmed whether Team subscriptions receive `rate_limits` in the statusline stdin. If they don't, the hook safely no-ops there (fail-open). Worth checking a work session's `~/.vibe-island/cache/rl.json` before relying on it. The deferred fallback, out of scope here, is to populate `rl.json` from `ccusage blocks --active --json` as a separate populator.
