### PR TITLE
docs(issue): batch issue searches in refine context gathering

### DIFF
--- a/plugins/issue/skills/refine/SKILL.md
+++ b/plugins/issue/skills/refine/SKILL.md
@@ -27,7 +27,7 @@ Parse `$ARGUMENTS`:
 ## Workflow
 
 1. Identify type and read the corresponding guide. When `--type` is set, use it and skip identification.
-2. Gather context from code and related issues
+2. Gather context from code and related issues. Consolidate keyword variants into one or two broader searches per topic rather than a separate call per phrasing. Scan results by title and summary with a small result limit, and fetch full issue bodies only for the issues that will inform the refinement.
 3. Draft refinement following the type-specific structure. Under `--compact`, produce the tight output described in [Section Selection](#section-selection).
 4. Write `tmp/issue-<slug>.md`, output it for approval, then hand the file to the platform skill.
 


### PR DESCRIPTION
During refinement, the context-gathering step tends to fire near-duplicate tracker searches, one per keyword variant, and pull full issue bodies just to browse for relevance. Those payloads then re-read as session context on every subsequent turn, so the cost compounds well past the original search. Session history over two weeks showed hundreds of thousands of tokens of search and issue-fetch payloads, with single bursts large enough to dominate a turn, recurring across many refinement sessions.

This adds two sentences to step 2 of the workflow: consolidate keyword variants into one or two broader searches per topic, and scan titles and summaries with a small result limit before fetching full bodies only for the issues that will inform the refinement. The guidance stays vendor-neutral so it applies across GitHub, Linear, and GitLab.
