### PR TITLE
docs(agent-team): add model-selection guidance for spawned agents

### DIFF
--- a/plugins/claude-code/skills/agent-team/SKILL.md
+++ b/plugins/claude-code/skills/agent-team/SKILL.md
@@ -70,6 +70,6 @@ Teammates inherit the lead's permission settings at spawn. Each loads project co
 ## References
 
 - [references/hooks.md](references/hooks.md) — `TeammateIdle` and `TaskCompleted` quality gate hooks
-- [references/practices.md](references/practices.md) — task sizing, spawn prompts, file conflicts, team structures
+- [references/practices.md](references/practices.md) — task sizing, spawn prompts, file conflicts, team structures, model selection
 - [references/interaction.md](references/interaction.md) — display modes, keyboard shortcuts, direct teammate interaction
 - [Agent Teams Documentation](https://code.claude.com/docs/en/agent-teams)

--- a/plugins/claude-code/skills/agent-team/references/practices.md
+++ b/plugins/claude-code/skills/agent-team/references/practices.md
@@ -72,6 +72,8 @@ Teams add coordination overhead. Use them when parallelism savings exceed that c
 
 Each agent consumes a full context window. Prefer fewer agents with well-scoped tasks over many agents with thin tasks.
 
+Each agent also runs a model, and teammates and Agent-tool subagents inherit the session model unless you set `model` explicitly. For mechanical, well-scoped work (fixes with clear specs, finders, verifiers, formatting passes), pass a cheaper model (`model: "sonnet"`, or `haiku` for trivial extraction) rather than billing fan-out at a premium session model's rate. Keep the premium tier for the orchestrator and judgment-heavy verification. In Workflow scripts, pin `model` on `agent()` calls or per-phase in `meta.phases` for the same reason.
+
 ## Task Decomposition
 
 Decompose by **independence**, not by phase or layer.

--- a/plugins/claude-code/skills/agent-team/references/practices.md
+++ b/plugins/claude-code/skills/agent-team/references/practices.md
@@ -72,7 +72,7 @@ Teams add coordination overhead. Use them when parallelism savings exceed that c
 
 Each agent consumes a full context window. Prefer fewer agents with well-scoped tasks over many agents with thin tasks.
 
-Each agent also runs a model, and teammates and Agent-tool subagents inherit the session model unless you set `model` explicitly. For mechanical, well-scoped work (fixes with clear specs, finders, verifiers, formatting passes), pass a cheaper model (`model: "sonnet"`, or `haiku` for trivial extraction) rather than billing fan-out at a premium session model's rate. Keep the premium tier for the orchestrator and judgment-heavy verification. In Workflow scripts, pin `model` on `agent()` calls or per-phase in `meta.phases` for the same reason.
+Each agent also runs a model, and teammates and Agent-tool subagents inherit the session model unless you set `model` explicitly. For mechanical, well-scoped work (fixes with clear specs, finders, verifiers, formatting passes), pass a cheaper model (`model: "sonnet"`, or `haiku` for trivial extraction) rather than billing fan-out at a premium session model's rate. Keep the premium tier for the orchestrator and judgment-heavy verification. The `model` value is a bare tier alias (`opus`, `sonnet`, `haiku`, `fable`), not a full model ID like `claude-sonnet-4-5`. Both the Agent tool and Workflow `agent()` accept these shorthands as-is. In Workflow scripts, pin `model` on `agent()` calls or per-phase in `meta.phases` for the same reason.
 
 ## Task Decomposition
 


### PR DESCRIPTION
Adds a paragraph to the agent-team practices reference on choosing a model for spawned agents.

Teammates and Agent-tool subagents inherit the session model unless you set `model` explicitly. When the orchestrator runs a premium tier, mechanical fan-out (fix agents, finders, verifiers, mining and formatting passes) silently bills at premium rates for work that needs no premium capability. Session history over the last two weeks shows this happening in practice: over a thousand general-purpose subagent messages on the premium model, with a multi-agent audit workflow costing several times what the same run would on a cheaper tier. The healthy pattern already appears in other sessions that pin subagents to a cheaper model while keeping the orchestrator premium.

The guidance lands in the existing per-agent cost section (Team Sizing), which already covers context-window cost per agent. It recommends passing a cheaper model for well-scoped mechanical work and reserving the premium tier for the orchestrator and judgment-heavy verification, and notes the same applies to Workflow scripts via `model` on `agent()` calls or per-phase in `meta.phases`. The SKILL.md reference line gains "model selection" so the topic is discoverable without opening the file.

Kept deliberately terse: this is always-on prompt material, so the numbers stay in this PR body rather than the skill text.

Ran `bun run skill-lint "plugins/claude-code/skills/agent-team"`, which validates the SKILL.md frontmatter, namespace, and reference depth; it passes clean.
