### PR TITLE
fix(biome-hook): skip generated workflow scripts

### DIFF
--- a/.claude/hooks/biome/index.test.ts
+++ b/.claude/hooks/biome/index.test.ts
@@ -187,6 +187,17 @@ describe("biome hook", () => {
       expect(files).toEqual([]);
     });
 
+    it("ignores generated workflow scripts", async () => {
+      const wfDir = join(tempDir, "workflows", "scripts");
+      const wfPath = join(wfDir, "sweep-wf_123.js");
+      await Bun.write(wfPath, "export const meta = {};\nreturn { done: true };\n");
+      const transcriptPath = join(tempDir, `transcript-wf-${Date.now()}.jsonl`);
+      await Bun.write(transcriptPath, createTranscriptContent([{ path: wfPath, tool: "Edit" }]));
+
+      const files = await parseTranscript(transcriptPath);
+      expect(files).toEqual([]);
+    });
+
     it("ignores non-Edit/Write tools", async () => {
       const filePath = await copyFixture("valid.ts", tempDir);
       const transcriptPath = join(tempDir, `transcript-read-${Date.now()}.jsonl`);

--- a/.claude/hooks/biome/index.ts
+++ b/.claude/hooks/biome/index.ts
@@ -34,7 +34,16 @@ function getExtension(filePath: string): string {
   return parts.length > 1 ? (parts.at(-1) ?? "") : "";
 }
 
+// Workflow scripts persisted under session state (<transcript dir>/workflows/
+// scripts/) are generated runtime artifacts: the workflow runner wraps them in
+// an async function body, so their top-level `return` is valid at runtime but
+// can never parse as a standalone module.
+const WORKFLOW_SCRIPT_SEGMENT = "/workflows/scripts/";
+
 function isBiomeFile(filePath: string): boolean {
+  if (filePath.includes(WORKFLOW_SCRIPT_SEGMENT)) {
+    return false;
+  }
   const ext = getExtension(filePath);
   return BIOME_EXTENSIONS.has(ext);
 }


### PR DESCRIPTION
The Biome Stop hook lints every `.js`/`.ts` file the session edited, including workflow scripts persisted under session state (`~/.claude/projects/<project>/<session>/workflows/scripts/`). Those files are generated runtime artifacts: the workflow runner wraps them in an async function body, so their top-level `return` is valid at runtime but can never parse as a standalone module. Editing one (to fix an args bug and resume the run) left this session permanently blocked at Stop on a parse error Biome auto-fix can never resolve.

Excludes the `/workflows/scripts/` path segment in `isBiomeFile`, which covers both the Stop transcript scan and the PostToolUse check. Excluding in the hook beats editing the artifact: the file is runtime state that the workflow engine may replay on resume, and it never lands in a commit.

A new `parseTranscript` regression test covers the exclusion: a transcript editing a workflow script with a top-level `return` no longer surfaces the file for linting.
