### PR TITLE
fix(session): cap image reads in repeat-read-waste token estimate

### DIFF
--- a/plugins/claude-code/skills/session/resources/queries/repeat-read-waste.sql
+++ b/plugins/claude-code/skills/session/resources/queries/repeat-read-waste.sql
@@ -12,6 +12,13 @@
 -- Only `true_repeats` (and arguably `after_own_edit`) is actionable waste; a headline
 -- repeat percentage without this split mostly measures pagination and fan-out
 -- architecture.
+-- Token estimate: text results use the chars/4 proxy, but an image Read returns the file
+-- as a base64 image content block, whose real cost is the model's fixed image tokenization
+-- (~1,600 tokens/image), not a quarter of the base64 length. Left uncapped the proxy
+-- overstates image reads by orders of magnitude: one session's 31 image reads scored ~2.2M
+-- tokens on base64 length vs ~50K real. So image results are capped at a flat per-image
+-- budget: a re-read image still costs those ~1,600 tokens, so it stays in the estimate at
+-- that bounded rate.
 -- Params: after_date, before_date, project, host.
 WITH reads AS (
   SELECT
@@ -21,7 +28,15 @@ WITH reads AS (
     ((tc.data->'$.input.offset') IS NOT NULL
       OR (tc.data->'$.input.limit') IS NOT NULL) AS paginated,
     COALESCE(m.is_sidechain, FALSE) AS is_sidechain,
-    length(tr.content)              AS chars,
+    CASE
+      WHEN tr.content LIKE '%"type":"image"%'
+      -- flat 1,600 tokens per image content block in the result (count the blocks by
+      -- how many times the marker drops out of the string), so a base64 payload can't
+      -- masquerade as millions of text tokens
+      THEN 1600 * (length(tr.content) - length(replace(tr.content, '"type":"image"', '')))
+                  / length('"type":"image"')
+      ELSE length(tr.content) / 4.0
+    END                             AS est_tokens,
     tc.timestamp,
     tc.source_line
   FROM content_items tc
@@ -81,9 +96,9 @@ SELECT
     AS after_own_edit,
   COUNT(*) FILTER (WHERE prior_main_reads >= 1 AND NOT paginated AND NOT is_sidechain AND NOT after_own_edit)
     AS true_repeats,
-  ROUND(SUM(chars) FILTER (WHERE prior_main_reads >= 1 AND NOT paginated AND NOT is_sidechain AND NOT after_own_edit) / 4.0 / 1000.0, 1)
+  ROUND(SUM(est_tokens) FILTER (WHERE prior_main_reads >= 1 AND NOT paginated AND NOT is_sidechain AND NOT after_own_edit) / 1000.0, 1)
     AS true_repeat_ktokens,
-  ROUND(SUM(chars) FILTER (WHERE rn > 1) / 4.0 / 1000.0, 1) AS repeat_ktokens
+  ROUND(SUM(est_tokens) FILTER (WHERE rn > 1) / 1000.0, 1) AS repeat_ktokens
 FROM classified
 GROUP BY host
 ORDER BY host;


### PR DESCRIPTION
Fixes a measurement artifact in `repeat-read-waste.sql`. The query estimated tokens as `length(content)/4`, a chars-per-token proxy. That proxy is meaningless for an image Read: the tool result is a base64 image content block, and the model tokenizes an image to a fixed budget (~1,600 tokens on the models these sessions ran), not to a quarter of the base64 length. So every image Read inflated the waste estimate by orders of magnitude.

Found while dogfooding: on the live local index, one `claude.meme-generator` session (`f496141b`, 2026-07-07) topped the per-session ranking at ~2,238K read tokens, ~2,235K of which came from just 31 image reads scored on their base64 length. Real cost is closer to ~50K tokens. That single session dominated the local host's `repeat_ktokens` headline.

## Approach

Image results are detected by the image content-block marker in the joined tool result rather than by file extension. Both detectors agreed exactly on the live index (112 image reads, zero divergence either way), and the content-block marker is the more direct signal: it identifies actual image results regardless of file naming, and it catches results whose content array does not lead with the image block.

Image results are capped at a flat per-image budget rather than excluded. A re-read image still costs those ~1,600 tokens, so it belongs in the estimate, just at a bounded rate instead of the runaway base64 proxy. The cap counts image blocks in the result (via the marker drop-out trick) so a multi-image result scales, then the `/4` text scaling folds into a single per-row `est_tokens` column.

## Verification

Ran the modified query read-only against the live index (`duckdb -readonly`). Row counts (`total_reads`, `repeat_reads`, per-cause splits) are unchanged. Only the token columns move: local `repeat_ktokens` drops 9253.0 to 8722.5 and `true_repeat_ktokens` 615.5 to 85.0. Per-session, the meme session falls from ~2,238K (dominating) to ~52.7K, well below the text-heavy sessions that were previously buried under it. Text-only sessions are untouched.

`bun run skill-lint "plugins/claude-code/skills/session"` passes and all 101 tests in `scripts/db.test.ts` pass.

Scoped to avoid conflicts with the open #1000, which touches this skill but not this query.
