### PR TITLE
statusline: add model and reasoning-effort indicators

### DIFF
--- a/user/scripts/__snapshots__/statusline.test.ts.snap
+++ b/user/scripts/__snapshots__/statusline.test.ts.snap
@@ -57,3 +57,7 @@ exports[`rendered output combined-60 1`] = `"\x1B[91m󰪣\x1B[39m \x1B[32m+120\x
 exports[`rendered output combined-80 1`] = `"\x1B[91m󰪣\x1B[39m \x1B[32m+120\x1B[39m \x1B[31m-45\x1B[39m \x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/long-branch-name-that-needs-eliding-eventually\x1B]8;;\x1B\\\x1B[39m \x1B[2m↑2\x1B[22m"`;
 
 exports[`rendered output combined-120 1`] = `"\x1B[91m󰪣\x1B[39m \x1B[32m+120\x1B[39m \x1B[31m-45\x1B[39m \x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/long-branch-name-that-needs-eliding-eventually\x1B]8;;\x1B\\\x1B[39m \x1B[2m↑2\x1B[22m"`;
+
+exports[`rendered output model-leads 1`] = `"\x1B[2mF\x1B[22m \x1B[32m󰪠\x1B[39m myrepo"`;
+
+exports[`rendered output model-only 1`] = `"\x1B[2mO\x1B[22m"`;

--- a/user/scripts/__snapshots__/statusline.test.ts.snap
+++ b/user/scripts/__snapshots__/statusline.test.ts.snap
@@ -26,6 +26,12 @@ exports[`rendered output dial-exceeds-70 1`] = `"\x1B[91m󰪢\x1B[39m"`;
 
 exports[`rendered output no-dial 1`] = `""`;
 
+exports[`rendered output model-effort-leads 1`] = `"\x1B[2mF\x1B[22m \x1B[2m⠧\x1B[22m \x1B[32m󰪠\x1B[39m myrepo"`;
+
+exports[`rendered output model-only 1`] = `"\x1B[2mO\x1B[22m"`;
+
+exports[`rendered output effort-only 1`] = `"\x1B[2m⠿\x1B[22m"`;
+
 exports[`rendered output lines-added 1`] = `"\x1B[32m+5\x1B[39m"`;
 
 exports[`rendered output lines-removed 1`] = `"\x1B[31m-3\x1B[39m"`;
@@ -57,7 +63,3 @@ exports[`rendered output combined-60 1`] = `"\x1B[91m󰪣\x1B[39m \x1B[32m+120\x
 exports[`rendered output combined-80 1`] = `"\x1B[91m󰪣\x1B[39m \x1B[32m+120\x1B[39m \x1B[31m-45\x1B[39m \x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/long-branch-name-that-needs-eliding-eventually\x1B]8;;\x1B\\\x1B[39m \x1B[2m↑2\x1B[22m"`;
 
 exports[`rendered output combined-120 1`] = `"\x1B[91m󰪣\x1B[39m \x1B[32m+120\x1B[39m \x1B[31m-45\x1B[39m \x1B]8;;https://github.com/ben/myrepo\x1B\\myrepo\x1B]8;;\x1B\\\x1B[2m/\x1B[22m\x1B[36m\x1B]8;;https://github.com/ben/myrepo/actions/runs/1\x1B\\feature/long-branch-name-that-needs-eliding-eventually\x1B]8;;\x1B\\\x1B[39m \x1B[2m↑2\x1B[22m"`;
-
-exports[`rendered output model-leads 1`] = `"\x1B[2mF\x1B[22m \x1B[32m󰪠\x1B[39m myrepo"`;
-
-exports[`rendered output model-only 1`] = `"\x1B[2mO\x1B[22m"`;

--- a/user/scripts/effort.test.ts
+++ b/user/scripts/effort.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { effortGlyph } from "./effort";
+
+describe("effortGlyph", () => {
+  test.each<[string | null | undefined, string | null]>([
+    ["low", "⠂"],
+    ["medium", "⠆"],
+    ["high", "⠇"],
+    ["xhigh", "⠧"],
+    ["max", "⠿"],
+    ["unknown", null],
+    ["", null],
+    [null, null],
+    [undefined, null],
+  ])("level %p -> %p", (level, expected) => {
+    expect(effortGlyph(level)).toBe(expected);
+  });
+});

--- a/user/scripts/effort.ts
+++ b/user/scripts/effort.ts
@@ -1,0 +1,15 @@
+// Braille dot-ramp for the reasoning effort level, low to max. More dots is more
+// effort. Null when the level is unknown or the model reports no effort, so the
+// segment simply drops rather than rendering a placeholder.
+const EFFORT_GLYPHS: Record<string, string> = {
+  low: "⠂",
+  medium: "⠆",
+  high: "⠇",
+  xhigh: "⠧",
+  max: "⠿",
+};
+
+export function effortGlyph(level?: string | null): string | null {
+  if (!level) return null;
+  return EFFORT_GLYPHS[level] ?? null;
+}

--- a/user/scripts/model.test.ts
+++ b/user/scripts/model.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { modelLetter } from "./model";
+
+describe("modelLetter", () => {
+  test.each<[string, string | null, string | null]>([
+    ["claude-opus-4-8", null, "O"],
+    ["claude-opus-4-8[1m]", null, "O"],
+    ["claude-sonnet-5", null, "S"],
+    ["claude-haiku-4-5-20251001", null, "H"],
+    ["claude-fable-5", null, "F"],
+    ["claude-newmodel-1", "NewModel 1", "N"],
+    ["", "Opus", "O"],
+    ["", "", null],
+    ["", null, null],
+  ])("id %p / name %p -> %p", (id, name, expected) => {
+    expect(modelLetter(id, name)).toBe(expected);
+  });
+
+  test("undefined id falls back to display name", () => {
+    expect(modelLetter(undefined, "Haiku")).toBe("H");
+  });
+});

--- a/user/scripts/model.ts
+++ b/user/scripts/model.ts
@@ -1,0 +1,19 @@
+// Single-letter model indicator for the status lines. The family token in the
+// model id is authoritative. display_name is the fallback for ids whose family
+// we don't recognize, so a future model still gets a letter.
+
+const FAMILY_LETTERS: Record<string, string> = {
+  opus: "O",
+  sonnet: "S",
+  haiku: "H",
+  fable: "F",
+};
+
+export function modelLetter(id?: string | null, displayName?: string | null): string | null {
+  const hay = (id ?? "").toLowerCase();
+  for (const [family, letter] of Object.entries(FAMILY_LETTERS)) {
+    if (hay.includes(family)) return letter;
+  }
+  const fallback = (displayName ?? id ?? "").match(/[a-z]/i);
+  return fallback ? fallback[0].toUpperCase() : null;
+}

--- a/user/scripts/statusline.test.ts
+++ b/user/scripts/statusline.test.ts
@@ -12,6 +12,7 @@ import {
   emitRateLimits,
   exceeds200k,
   formatWorktree,
+  modelSegment,
   type Span,
   type WorktreeData,
 } from "./statusline";
@@ -78,6 +79,21 @@ const cases: RenderCase[] = [
   })),
   { name: "no-dial", columns: 80, stdin: {}, worktree: null },
   {
+    name: "model-leads",
+    columns: 80,
+    stdin: {
+      model: { id: "claude-fable-5", display_name: "Fable" },
+      context_window: { used_percentage: 30 },
+    },
+    worktree: mainWt,
+  },
+  {
+    name: "model-only",
+    columns: 80,
+    stdin: { model: { id: "claude-opus-4-8", display_name: "Opus" } },
+    worktree: null,
+  },
+  {
     name: "lines-added",
     columns: 80,
     stdin: { cost: { total_lines_added: 5, total_lines_removed: 0 } },
@@ -124,6 +140,15 @@ const cases: RenderCase[] = [
 describe("rendered output", () => {
   test.each(cases)("$name", (c) => {
     expect(buildStatusLine(c.stdin, c.columns, c.worktree)).toMatchSnapshot();
+  });
+});
+
+describe("modelSegment", () => {
+  test("renders the family letter, null when absent", () => {
+    expect(strip(modelSegment({ model: { id: "claude-fable-5" } }) ?? "")).toBe("F");
+    expect(strip(modelSegment({ model: { id: "claude-opus-4-8[1m]" } }) ?? "")).toBe("O");
+    expect(modelSegment({})).toBeNull();
+    expect(modelSegment({ model: null })).toBeNull();
   });
 });
 

--- a/user/scripts/statusline.test.ts
+++ b/user/scripts/statusline.test.ts
@@ -8,6 +8,7 @@ import {
   dialColor,
   dialIndex,
   dialSegment,
+  effortSegment,
   elideSpans,
   emitRateLimits,
   exceeds200k,
@@ -79,10 +80,11 @@ const cases: RenderCase[] = [
   })),
   { name: "no-dial", columns: 80, stdin: {}, worktree: null },
   {
-    name: "model-leads",
+    name: "model-effort-leads",
     columns: 80,
     stdin: {
       model: { id: "claude-fable-5", display_name: "Fable" },
+      effort: { level: "xhigh" },
       context_window: { used_percentage: 30 },
     },
     worktree: mainWt,
@@ -91,6 +93,12 @@ const cases: RenderCase[] = [
     name: "model-only",
     columns: 80,
     stdin: { model: { id: "claude-opus-4-8", display_name: "Opus" } },
+    worktree: null,
+  },
+  {
+    name: "effort-only",
+    columns: 80,
+    stdin: { effort: { level: "max" } },
     worktree: null,
   },
   {
@@ -149,6 +157,16 @@ describe("modelSegment", () => {
     expect(strip(modelSegment({ model: { id: "claude-opus-4-8[1m]" } }) ?? "")).toBe("O");
     expect(modelSegment({})).toBeNull();
     expect(modelSegment({ model: null })).toBeNull();
+  });
+});
+
+describe("effortSegment", () => {
+  test("renders the effort glyph, null when absent or unsupported", () => {
+    expect(strip(effortSegment({ effort: { level: "max" } }) ?? "")).toBe("⠿");
+    expect(strip(effortSegment({ effort: { level: "low" } }) ?? "")).toBe("⠂");
+    expect(effortSegment({ effort: { level: "bogus" } })).toBeNull();
+    expect(effortSegment({})).toBeNull();
+    expect(effortSegment({ effort: null })).toBeNull();
   });
 });
 

--- a/user/scripts/statusline.ts
+++ b/user/scripts/statusline.ts
@@ -3,6 +3,7 @@ import { mkdirSync } from "node:fs";
 import { basename, dirname } from "node:path";
 import { styleText } from "node:util";
 import { dialGlyph } from "./glyphs";
+import { modelLetter } from "./model";
 import { expandTilde, type RateLimits } from "./rate-limits";
 
 interface CurrentUsage {
@@ -13,6 +14,7 @@ interface CurrentUsage {
 }
 
 interface StatusInput {
+  model?: { id?: string; display_name?: string } | null;
   context_window?: { used_percentage?: number | null; current_usage?: CurrentUsage | null };
   cost?: { total_lines_added?: number; total_lines_removed?: number };
   rate_limits?: RateLimits | null;
@@ -89,6 +91,13 @@ export function exceeds200k(input: StatusInput): boolean {
     (usage.cache_creation_input_tokens ?? 0) +
     (usage.cache_read_input_tokens ?? 0);
   return total > 200_000;
+}
+
+// A leading dim letter for the active model so Fable-vs-Opus reads at a glance.
+// Always shown: absence would be ambiguous once more than one model is in play.
+export function modelSegment(input: StatusInput): string | null {
+  const letter = modelLetter(input.model?.id, input.model?.display_name);
+  return letter ? styleText(["dim"], letter) : null;
 }
 
 export function dialSegment(input: StatusInput): string | null {
@@ -223,6 +232,8 @@ export function buildStatusLine(
 ): string {
   const segments: string[] = [];
 
+  const model = modelSegment(input);
+  if (model) segments.push(model);
   const dial = dialSegment(input);
   if (dial) segments.push(dial);
   const lines = linesSegment(input);

--- a/user/scripts/statusline.ts
+++ b/user/scripts/statusline.ts
@@ -2,6 +2,7 @@
 import { mkdirSync } from "node:fs";
 import { basename, dirname } from "node:path";
 import { styleText } from "node:util";
+import { effortGlyph } from "./effort";
 import { dialGlyph } from "./glyphs";
 import { modelLetter } from "./model";
 import { expandTilde, type RateLimits } from "./rate-limits";
@@ -15,6 +16,7 @@ interface CurrentUsage {
 
 interface StatusInput {
   model?: { id?: string; display_name?: string } | null;
+  effort?: { level?: string } | null;
   context_window?: { used_percentage?: number | null; current_usage?: CurrentUsage | null };
   cost?: { total_lines_added?: number; total_lines_removed?: number };
   rate_limits?: RateLimits | null;
@@ -98,6 +100,13 @@ export function exceeds200k(input: StatusInput): boolean {
 export function modelSegment(input: StatusInput): string | null {
   const letter = modelLetter(input.model?.id, input.model?.display_name);
   return letter ? styleText(["dim"], letter) : null;
+}
+
+// A braille dot-ramp for the reasoning effort, dim like the model letter so the
+// two session-config markers read alike. Absent when the model has no effort.
+export function effortSegment(input: StatusInput): string | null {
+  const glyph = effortGlyph(input.effort?.level);
+  return glyph ? styleText(["dim"], glyph) : null;
 }
 
 export function dialSegment(input: StatusInput): string | null {
@@ -234,6 +243,8 @@ export function buildStatusLine(
 
   const model = modelSegment(input);
   if (model) segments.push(model);
+  const effort = effortSegment(input);
+  if (effort) segments.push(effort);
   const dial = dialSegment(input);
   if (dial) segments.push(dial);
   const lines = linesSegment(input);

--- a/user/scripts/subagent-statusline.test.ts
+++ b/user/scripts/subagent-statusline.test.ts
@@ -3,11 +3,13 @@ import { styleText } from "node:util";
 import { genericGlyph, purposeGlyphs } from "./glyphs";
 import {
   extractActivity,
+  extractModel,
   formatDescription,
   formatElapsed,
   formatTokens,
   humanizeTool,
   renderTask,
+  subagentModelLetter,
   type Task,
 } from "./subagent-statusline";
 
@@ -124,8 +126,57 @@ describe("extractActivity", () => {
   });
 });
 
+describe("extractModel", () => {
+  const withModel = (model?: string) => ({
+    message: { role: "assistant", content: [], ...(model ? { model } : {}) },
+  });
+
+  test("returns the newest assistant model", () => {
+    expect(extractModel([withModel("claude-opus-4-8"), withModel("claude-fable-5")])).toBe(
+      "claude-fable-5",
+    );
+  });
+
+  test("skips entries without a model", () => {
+    expect(extractModel([withModel("claude-opus-4-8"), withModel(undefined)])).toBe(
+      "claude-opus-4-8",
+    );
+  });
+
+  test("null when no entry carries a model", () => {
+    expect(extractModel([])).toBeNull();
+    expect(extractModel([withModel(undefined)])).toBeNull();
+  });
+});
+
+describe("subagentModelLetter", () => {
+  test.each<[string | null, string | null, string | null]>([
+    ["claude-fable-5", "claude-opus-4-8", "F"],
+    ["claude-opus-4-8", "claude-opus-4-8", null],
+    ["claude-opus-4-8[1m]", "claude-opus-4-8", null],
+    ["claude-opus-4-8", "claude-fable-5", "O"],
+    [null, "claude-opus-4-8", null],
+    ["claude-fable-5", null, null],
+  ])("sub %p / session %p -> %p", (sub, session, expected) => {
+    expect(subagentModelLetter(sub, session)).toBe(expected);
+  });
+});
+
 describe("renderTask", () => {
   const now = 65_000;
+
+  test("model letter joins the dim meta before the type name", () => {
+    const out = renderTask(
+      { id: "a", description: "search", startTime: 0, tokenCount: 1500 },
+      null,
+      now,
+      "Explore",
+      null,
+      null,
+      "F",
+    );
+    expect(strip(out.content)).toContain("· 1m 5s · 1.5k · F · Explore");
+  });
 
   test("activity wins over the description and is not sentence-cased", () => {
     const out = renderTask(

--- a/user/scripts/subagent-statusline.ts
+++ b/user/scripts/subagent-statusline.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { styleText } from "node:util";
 import { genericGlyph, purposeGlyphs, remoteGlyph } from "./glyphs";
+import { modelLetter } from "./model";
 
 export interface Task {
   id: string;
@@ -92,6 +93,7 @@ export function renderTask(
   agentType: string | null,
   activity: string | null = null,
   description: string | null = null,
+  model: string | null = null,
 ): { id: string; content: string } {
   const icon = typeIcon(agentType, task.status ?? "running");
   const marker = remoteMarker(task.type);
@@ -99,6 +101,7 @@ export function renderTask(
   const metaParts: string[] = [];
   if (task.startTime != null) metaParts.push(formatElapsed(task.startTime, now));
   if ((task.tokenCount ?? 0) > 0) metaParts.push(formatTokens(task.tokenCount ?? 0));
+  if (model) metaParts.push(model);
 
   // The type name trails as dim text after the meta. The icon already conveys
   // the kind, so a narrow terminal can drop the name without losing it.
@@ -156,7 +159,7 @@ interface ContentBlock {
 }
 
 interface TranscriptEntry {
-  message?: { role?: string; content?: ContentBlock[] };
+  message?: { role?: string; content?: ContentBlock[]; model?: string };
 }
 
 const basename = (p: unknown): string =>
@@ -230,16 +233,42 @@ export function extractActivity(entries: TranscriptEntry[]): string | null {
   return null;
 }
 
+// The newest assistant model in a transcript tail. Both the subagent's own model
+// and its parent session's model come from here. Comparing the two decides
+// whether a subagent is running off-default and warrants a letter.
+export function extractModel(entries: TranscriptEntry[]): string | null {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const model = entries[i]?.message?.model;
+    if (typeof model === "string" && model) return model;
+  }
+  return null;
+}
+
+// A subagent's model letter, shown only when it differs from the session it was
+// spawned from. Same model (or either unknown) yields no letter, keeping the
+// line quiet unless a cheaper model is actually in play.
+export function subagentModelLetter(
+  subModel: string | null,
+  sessionModel: string | null,
+): string | null {
+  if (!subModel || !sessionModel) return null;
+  const sub = modelLetter(subModel);
+  if (!sub || sub === modelLetter(sessionModel)) return null;
+  return sub;
+}
+
 // Each task id keys a sidecar pair the harness writes next to the subagent
 // transcript, scoped to the current project's sessions (derived from cwd). The
-// path prefix locates both the `.meta.json` and the `.jsonl`. A miss yields no
-// glyph or activity (the prune signal if the harness changes this layout).
-function subagentBase(id: string, projectDir: string): string | null {
+// path prefix locates both the `.meta.json` and the `.jsonl`. Its first segment
+// is the parent session id. A miss yields no glyph or activity (the prune signal
+// if the harness changes this layout).
+function subagentBase(id: string, projectDir: string): { base: string; sessionId: string } | null {
   try {
     for (const rel of new Bun.Glob(`*/subagents/agent-${id}.meta.json`).scanSync({
       cwd: projectDir,
     })) {
-      return join(projectDir, rel).slice(0, -".meta.json".length);
+      const sessionId = rel.split("/")[0] ?? "";
+      return { base: join(projectDir, rel).slice(0, -".meta.json".length), sessionId };
     }
   } catch {
     // Project directory unreadable: skip enrichment.
@@ -255,14 +284,14 @@ async function readMeta(base: string): Promise<AgentMeta | null> {
   }
 }
 
-// Transcripts grow to megabytes; only the tail holds the latest events. Read a
-// bounded suffix and drop the first line, which a mid-file slice splits.
+// Transcripts grow to megabytes. Only the tail holds the latest events, so read
+// a bounded suffix and drop the first line, which a mid-file slice splits.
 const TAIL_BYTES = 65_536;
-async function readActivity(base: string): Promise<string | null> {
+async function readEntries(path: string): Promise<TranscriptEntry[]> {
   try {
-    const file = Bun.file(`${base}.jsonl`);
+    const file = Bun.file(path);
     const size = file.size;
-    if (!size) return null;
+    if (!size) return [];
     const start = Math.max(0, size - TAIL_BYTES);
     const lines = (await file.slice(start).text()).split("\n");
     if (start > 0) lines.shift();
@@ -275,9 +304,9 @@ async function readActivity(base: string): Promise<string | null> {
         // Skip malformed lines.
       }
     }
-    return extractActivity(entries);
+    return entries;
   } catch {
-    return null;
+    return [];
   }
 }
 
@@ -297,11 +326,25 @@ if (import.meta.main) {
   const projectDir = join(homedir(), ".claude", "projects", slug);
   const now = Date.now();
 
+  // All tasks on this line share one parent session, so its model is read once.
+  const sessionModels = new Map<string, string | null>();
+  const sessionModel = async (sessionId: string): Promise<string | null> => {
+    if (!sessionModels.has(sessionId)) {
+      const entries = await readEntries(join(projectDir, `${sessionId}.jsonl`));
+      sessionModels.set(sessionId, extractModel(entries));
+    }
+    return sessionModels.get(sessionId) ?? null;
+  };
+
   const lines: string[] = [];
   for (const task of input.tasks ?? []) {
-    const base = subagentBase(task.id, projectDir);
-    const meta = base ? await readMeta(base) : null;
-    const activity = base ? await readActivity(base) : null;
+    const located = subagentBase(task.id, projectDir);
+    const meta = located ? await readMeta(located.base) : null;
+    const entries = located ? await readEntries(`${located.base}.jsonl`) : [];
+    const activity = extractActivity(entries);
+    const model = located
+      ? subagentModelLetter(extractModel(entries), await sessionModel(located.sessionId))
+      : null;
     lines.push(
       JSON.stringify(
         renderTask(
@@ -311,6 +354,7 @@ if (import.meta.main) {
           meta?.agentType ?? null,
           activity,
           meta?.description ?? null,
+          model,
         ),
       ),
     );


### PR DESCRIPTION
Adds two session-config markers to the status line so I can tell at a glance what is running and how hard it is thinking, now that I switch between Fable and Opus and vary reasoning effort per task. Both are compact and sit at the left of the line, ahead of the runtime state (context dial, line counts) and location (worktree). The dividing principle: config markers render dim, runtime state keeps its color.

## Model Indicator

A single uppercase letter keyed off the model family (`O`/`S`/`H`/`F`), dim. A single letter stays compact enough for the subagent rows, and the four current families are unambiguous by first letter. The family token in the model id is authoritative, with `display_name` as a fallback so an unrecognized future model still gets a letter.

The two lines differ in when they show it:

- Main line: always shown. Once more than one model is in play, absence would be ambiguous, so the letter is always present to name the active one.
- Subagent line: shown in the dim meta only when the subagent's model differs from the session it was spawned from. An Opus session spawning Opus subagents stays quiet. A dispatched Fable or Haiku stands out by presence. This compares by family letter, so the `[1m]` context variant of a model doesn't read as a different model.

The main status input carries `model.id`/`model.display_name` directly. Subagent task objects carry no model, so each subagent's model is read from its transcript tail (`message.model`), and the parent session's model is read the same way, once per line and memoized across the tasks that share it. I refactored the existing tail read to parse entries once and feed both activity and model extraction.

## Effort Indicator

A braille dot-ramp for the reasoning effort, dim, placed after the model letter. There are five effort levels (`low`, `medium`, `high`, `xhigh`, `max`), which ruled out the four-state gauge glyphs. Dots scale to any count and read as intensity: `⠂ ⠆ ⠇ ⠧ ⠿`. It reads from `effort.level` in the status input and is absent when the model reports no effort parameter.

Main line only. The subagent status input exposes effort only at the session level, which is identical for every row and already shown on the main line, so a per-subagent effort marker would carry no information.

## Layout

The line reads left to right as config, then runtime, then location: model, effort, context dial, `+/-` lines, worktree. Each is its own evenly-spaced segment. Model and effort are fixed-width markers measured before the worktree label, so they never elide and the worktree takes whatever width remains, the same treatment the context dial already had.

## Verification

Beyond the unit tests, I drove both scripts end-to-end. The main line renders the model letter and the effort ramp across all five levels, drops the effort segment when the model doesn't support it, and drops the model letter when it's absent. The subagent line shows the letter for a Fable subagent under an Opus session and stays blank for an Opus subagent, driven against fixture transcripts under a temporary `HOME`.
