### PR TITLE
feat(skills): pin effort low on mechanical skills

### DIFF
--- a/plugins/github/skills/actions-monitor/SKILL.md
+++ b/plugins/github/skills/actions-monitor/SKILL.md
@@ -2,6 +2,7 @@
 name: github:actions-monitor
 description: Monitor GitHub Actions runs and extract failure diagnostics. Use when watching PR CI, branch builds, or specific workflow runs.
 argument-hint: "[pr-url | branch | run-id] [--max-minutes N] [--interval S]"
+effort: low
 allowed-tools:
   - Monitor
   - TaskStop

--- a/plugins/gitlab/skills/ci-monitor/SKILL.md
+++ b/plugins/gitlab/skills/ci-monitor/SKILL.md
@@ -2,6 +2,7 @@
 name: gitlab:ci-monitor
 description: Investigate GitLab CI pipeline failures and extract diagnostics. Use when watching MR CI, branch builds, or specific pipelines.
 argument-hint: "[mr-url | branch | pipeline-id] [--max-minutes N] [--project group/project]"
+effort: low
 allowed-tools:
   - Monitor
   - TaskStop

--- a/plugins/mac/skills/jxa-run/SKILL.md
+++ b/plugins/mac/skills/jxa-run/SKILL.md
@@ -2,6 +2,7 @@
 name: mac:jxa-run
 description: Execute JXA scripts scoped to a macOS application. Use when running JXA expressions or script files against an app via osascript. Validates Application() scope via AST.
 argument-hint: <app> <expression-or-script-file>
+effort: low
 allowed-tools:
   - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/jxa.ts:*)"
 hooks:

--- a/plugins/pull-request/skills/babysit/SKILL.md
+++ b/plugins/pull-request/skills/babysit/SKILL.md
@@ -2,6 +2,7 @@
 name: pull-request:babysit
 description: Monitor a PR's CI, fix trivial failures, and self-cancel when green; --merge drives to merged, --reviews hands off to AI-review triage.
 argument-hint: "[pr-url] [--merge] [--reviews]"
+effort: low
 allowed-tools:
   - Monitor
   - TaskStop

--- a/plugins/things/skills/url/SKILL.md
+++ b/plugins/things/skills/url/SKILL.md
@@ -2,6 +2,7 @@
 name: things:url
 description: Create, update, and manage Things 3 tasks and projects, including quick inbox captures. Not for reads. Use things:jxa to query data.
 argument-hint: "<add | update | show | search | json | capture> [key=value ...]"
+effort: low
 allowed-tools:
   - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts:*)"
   - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts:*)"

--- a/plugins/tmux/skills/tmux/SKILL.md
+++ b/plugins/tmux/skills/tmux/SKILL.md
@@ -2,6 +2,7 @@
 name: tmux
 description: Tmux session, window, and pane management. Use when capturing output, sending keys, opening processes in panes, or checking notifications.
 argument-hint: "[capture | send | split | notify | list] [target ...]"
+effort: low
 allowed-tools:
   - "Bash(bash ${CLAUDE_SKILL_DIR}/scripts/pane.sh:*)"
   - "Bash(bash ${CLAUDE_SKILL_DIR}/scripts/window.sh:*)"

--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -26,6 +26,11 @@
       "type": "string",
       "description": "Model to use when this skill is active (e.g., claude-sonnet-4-20250514). Defaults to the conversation's model."
     },
+    "effort": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "xhigh", "max"],
+      "description": "Reasoning effort to use when this skill is active. Lower effort is faster and cheaper; use it for mechanical skills. Defaults to the conversation's effort."
+    },
     "context": {
       "type": "string",
       "enum": ["fork"],


### PR DESCRIPTION
Skills can pin a reasoning effort via `effort:` frontmatter, which overrides the session level while the skill is active. Nothing in this setup used that lever. Premium-model sessions run every mechanical flow at the default `high` effort: CI polling, tmux pane commands, URL-scheme calls, all of it burning thinking text that makes up over half of assistant output in the last 14 days of session history.

Candidates came from the session index: 60 days of output tokens attributed per skill on Fable and Opus threads, filtered to skills whose entire activation is mechanical. The six that survived both filters are `tmux:tmux` (~$26 of attributed premium output over the window), `mac:jxa-run` (~$8), `pull-request:babysit` (~$4), `things:url` (~$3), `gitlab:ci-monitor` (~$3), and `github:actions-monitor` (small in this ranking but loop-fired constantly after pushes). The monitors and babysit also run long in wakeup loops, where cheap turns compound.

Several heavier hitters were excluded deliberately. `pull-request:create` and `gitlab:merge-request` compose PR bodies, and prose quality there is under active curation. `git:conflicts` and `claude-code:session` need real reasoning. `worktrunk:wt-switch-create` is mechanical but re-roots the session into substantive work, and it is third-party (max-sixty/worktrunk) anyway, along with `worktrunk:worktrunk`, the single largest mechanical bucket in the ranking.

`skill-lint` validates specific frontmatter fields and has no unknown-key rule, so the new key needs no lint changes to be accepted.

Sizing honestly: output tokens are about a sixth of total estimated spend, so this trims a slice of a slice. But it costs nothing recurring. Removal criteria per the curation rule: the session index can compare per-skill attributed output tokens before and after, and if the numbers don't drop, or a pinned skill starts misbehaving on edge cases, its key goes.
