### PR TITLE
fix(gitlab): make auto-merge re-arm idempotent after push

### DIFF
--- a/plugins/gitlab/scripts/merge.test.ts
+++ b/plugins/gitlab/scripts/merge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { MergeActions } from "./merge";
-import { merge } from "./merge";
+import { arm, merge } from "./merge";
 
 function createActions(overrides: Partial<MergeActions> = {}): MergeActions {
   return {
@@ -72,5 +72,74 @@ describe("merge", () => {
       iid: 10,
       squash: true,
     });
+  });
+});
+
+describe("arm", () => {
+  test("resolves on success without sleeping", async () => {
+    const run = mock(() => Promise.resolve());
+    const sleep = mock(() => Promise.resolve());
+
+    await arm(run, sleep);
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  test("treats already-armed 409 as success", async () => {
+    const run = mock(() =>
+      Promise.reject(new Error('{"message":"Merge request is already set to Auto-Merge"}')),
+    );
+    const sleep = mock(() => Promise.resolve());
+
+    await arm(run, sleep);
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  test("retries through approvals_syncing then succeeds", async () => {
+    let calls = 0;
+    const run = mock(() => {
+      calls++;
+      return calls < 3
+        ? Promise.reject(new Error("approvals_syncing, try again later"))
+        : Promise.resolve();
+    });
+    const sleep = mock(() => Promise.resolve());
+
+    await arm(run, sleep);
+
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  test("throws after exhausting retries on a persistent transient", async () => {
+    const run = mock(() => Promise.reject(new Error("approvals_syncing")));
+    const sleep = mock(() => Promise.resolve());
+
+    await expect(arm(run, sleep)).rejects.toThrow("approvals_syncing");
+    expect(run).toHaveBeenCalledTimes(5);
+    expect(sleep).toHaveBeenCalledTimes(4);
+  });
+
+  test("rethrows a non-transient error immediately", async () => {
+    const run = mock(() => Promise.reject(new Error("404 Not Found")));
+    const sleep = mock(() => Promise.resolve());
+
+    await expect(arm(run, sleep)).rejects.toThrow("404 Not Found");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  test("reads the message from a shell error's stderr", async () => {
+    const run = mock(() =>
+      Promise.reject({ stderr: Buffer.from("... already set to Auto-Merge ...") }),
+    );
+    const sleep = mock(() => Promise.resolve());
+
+    await arm(run, sleep);
+
+    expect(run).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/gitlab/scripts/merge.test.ts
+++ b/plugins/gitlab/scripts/merge.test.ts
@@ -142,4 +142,31 @@ describe("arm", () => {
 
     expect(run).toHaveBeenCalledTimes(1);
   });
+
+  test("reads the error body from stdout when stderr is empty", async () => {
+    const run = mock(() =>
+      Promise.reject({
+        stdout: Buffer.from('{"message":"Merge request is already set to Auto-Merge"}'),
+        stderr: Buffer.from(""),
+      }),
+    );
+    const sleep = mock(() => Promise.resolve());
+
+    await arm(run, sleep);
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  test("falls back to the Error message when both streams are empty", async () => {
+    const run = mock(() =>
+      Promise.reject(
+        Object.assign(new Error("glab exited with code 1"), { stderr: Buffer.from("") }),
+      ),
+    );
+    const sleep = mock(() => Promise.resolve());
+
+    await expect(arm(run, sleep)).rejects.toThrow("glab exited with code 1");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
 });

--- a/plugins/gitlab/scripts/merge.ts
+++ b/plugins/gitlab/scripts/merge.ts
@@ -3,9 +3,48 @@
 import { $ } from "bun";
 import { cli } from "cleye";
 
-// TODO: file upstream glab issue for merge trains 422
-// glab mr merge --auto-merge calls PUT /merge_requests/:iid/merge
-// instead of POST /merge_trains/merge_requests/:iid
+// glab has no merge-train command: `glab mr merge --auto-merge` hits the accept
+// endpoint (PUT .../merge). GitLab 19.1+ resolves that to the train server-side,
+// but we POST .../merge_trains/merge_requests/:iid directly so squash applies to
+// the train add and the outcome doesn't depend on the instance version.
+
+// Re-arming is idempotent: GitLab returns 409 "already set to Auto-Merge" when the
+// MR is already armed, which we treat as success. A push clears the arm and briefly
+// reports approvals_syncing before the arm can land, so retry through that window.
+const ALREADY_ARMED = "already set to Auto-Merge";
+const TRANSIENT = ["approvals_syncing"];
+const MAX_ATTEMPTS = 5;
+const RETRY_DELAY_MS = 2000;
+
+export function errorText(err: unknown): string {
+  const record = err as Record<string, unknown>;
+  if (record?.stderr != null) {
+    return String(record.stderr);
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
+export async function arm(
+  run: () => Promise<unknown>,
+  sleep: (ms: number) => Promise<void> = (ms) => Bun.sleep(ms),
+): Promise<void> {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      await run();
+      return;
+    } catch (err) {
+      const message = errorText(err);
+      if (message.includes(ALREADY_ARMED)) {
+        return;
+      }
+      if (attempt < MAX_ATTEMPTS && TRANSIENT.some((t) => message.includes(t))) {
+        await sleep(RETRY_DELAY_MS);
+        continue;
+      }
+      throw err;
+    }
+  }
+}
 
 interface ProjectConfig {
   id: number;
@@ -43,12 +82,15 @@ export async function addToMergeTrain(opts: MergeTrainOptions): Promise<void> {
     fields.push("--raw-field squash=true");
   }
 
-  await $`glab api projects/${opts.projectId}/merge_trains/merge_requests/${opts.iid} -X POST ${{ raw: fields.join(" ") }}`;
+  await arm(
+    () =>
+      $`glab api projects/${opts.projectId}/merge_trains/merge_requests/${opts.iid} -X POST ${{ raw: fields.join(" ") }}`,
+  );
 }
 
 export async function mergeViaGlab(branch: string, autoMerge: boolean): Promise<void> {
   const flags = autoMerge ? "--auto-merge" : "";
-  await $`glab mr merge ${branch} ${{ raw: flags }} -y`;
+  await arm(() => $`glab mr merge ${branch} ${{ raw: flags }} -y`);
 }
 
 export interface MergeActions {
@@ -69,7 +111,7 @@ export async function merge(
 
   if (project.merge_trains_enabled && opts.autoMerge) {
     const iid = await actions.getMrIid(branch);
-    console.log(`Merge trains enabled — adding !${iid} (${branch}) to merge train`);
+    console.log(`Merge trains enabled: adding !${iid} (${branch}) to merge train`);
     await actions.addToMergeTrain({
       projectId: project.id,
       iid,

--- a/plugins/gitlab/scripts/merge.ts
+++ b/plugins/gitlab/scripts/merge.ts
@@ -17,16 +17,22 @@ const MAX_ATTEMPTS = 5;
 const RETRY_DELAY_MS = 2000;
 
 export function errorText(err: unknown): string {
+  // glab spreads a failure across both streams: `glab api` prints the HTTP error body
+  // (the JSON message) to stdout and a `glab: <message> (HTTP <code>)` line to stderr.
+  // Read both so the already-armed guard matches and callers see the full error text.
   const record = err as Record<string, unknown>;
-  if (record?.stderr != null) {
-    return String(record.stderr);
+  const streams = [record?.stdout, record?.stderr]
+    .map((stream) => (stream == null ? "" : String(stream).trim()))
+    .filter((text) => text.length > 0);
+  if (streams.length > 0) {
+    return streams.join("\n");
   }
   return err instanceof Error ? err.message : String(err);
 }
 
 export async function arm(
   run: () => Promise<unknown>,
-  sleep: (ms: number) => Promise<void> = (ms) => Bun.sleep(ms),
+  sleep: (ms: number) => Promise<void> = Bun.sleep,
 ): Promise<void> {
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     try {

--- a/plugins/gitlab/scripts/stack-merge.ts
+++ b/plugins/gitlab/scripts/stack-merge.ts
@@ -3,7 +3,7 @@
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
-import { merge } from "./merge";
+import { errorText, merge } from "./merge";
 
 interface StackRef {
   prev: string;
@@ -72,7 +72,7 @@ for (const ref of refs) {
   try {
     await merge(ref.branch, { autoMerge: true });
     console.log(`auto-merge enabled: ${ref.branch}`);
-  } catch {
-    console.error(`failed: ${ref.branch}`);
+  } catch (err) {
+    console.error(`failed: ${ref.branch}: ${errorText(err)}`);
   }
 }

--- a/plugins/gitlab/skills/merge-request/SKILL.md
+++ b/plugins/gitlab/skills/merge-request/SKILL.md
@@ -45,6 +45,25 @@ bun ${CLAUDE_PLUGIN_ROOT}/scripts/merge.ts --auto-merge
 bun ${CLAUDE_PLUGIN_ROOT}/scripts/merge.ts feature-branch --auto-merge --squash
 ```
 
+### Re-Arm Auto-Merge After a Push
+
+Pushing new commits cancels queued auto-merge and drops the MR from the merge train. GitLab does this deliberately so the new commits get a fresh pipeline and review. To keep auto-merge, re-run `merge.ts --auto-merge` after every push that intends to stay armed. The script is idempotent: it treats an already-armed MR as success and retries through the brief `approvals_syncing` window that follows a push, so re-running it is always safe.
+
+A push also resets approvals when `reset_approvals_on_push` is on. Re-trigger review in the same pass, see [Re-request reviewers](#re-request-reviewers).
+
+### Inspect or Recover a Train
+
+`glab` has no merge-train command, so use the API directly:
+
+```bash
+# Active train for the project
+glab api "projects/:id/merge_trains?scope=active" | jq '.[] | {iid: .merge_request.iid, status, target_branch}'
+
+# Clear a stuck entry, then re-arm
+glab api --method DELETE "projects/:id/merge_trains/merge_requests/<iid>"
+glab api --method POST  "projects/:id/merge_trains/merge_requests/<iid>" --raw-field auto_merge=true
+```
+
 ## Patterns
 
 **Always push before creating:**


### PR DESCRIPTION
Pushing to a GitLab MR cancels queued auto-merge and drops the MR from the merge train, so auto-merge has to be re-armed after every push. Re-running `merge.ts` to re-arm failed two ways in practice (both seen repeatedly in past sessions): a 409 `"already set to Auto-Merge"` threw as an error, and the arm hit the transient `approvals_syncing` state that GitLab reports for a few seconds right after a push.

The core fix makes re-arming idempotent and safe to run after any push:

- `merge.ts` now wraps the arm in a helper that treats an already-armed MR as success and retries through `approvals_syncing`. Re-running `merge.ts --auto-merge` is always safe, which is what makes "re-arm after every push" reliable.
- `gitlab:merge-request` documents the push -> reset -> re-arm cycle (mirroring the existing approval-reset guidance) plus the train inspect/recover commands (`scope=active` listing, DELETE + re-add for a stuck entry) that had no `glab` equivalent and were hand-rolled each time.
- `stack-merge` surfaces the real error instead of a bare `failed:`, so an actual failure is no longer indistinguishable from the already-armed no-op across a stack.

Kept the GitLab specifics inside `gitlab:merge-request`. The GitHub-primary skills (`babysit`, `create`, `follow-up`) already delegate all GitLab merge behavior to it, so nothing leaked into them. `babysit --merge` already re-arms after every push via its Re-arm step, and that delegation now benefits from the idempotent script.

On the `glab` question: `glab` 1.107.0 still has no merge-train command. `glab mr merge --auto-merge` hits the accept endpoint, and GitLab 19.1+ resolves that to the train server-side, but the direct `merge_trains` endpoint stays worthwhile for applying squash on the train add and for not depending on the instance version. Replaced the stale `422` TODO comment with that rationale.

## Testing

`bun test plugins/gitlab` (189 pass), including new coverage for the idempotency/retry helper: already-armed as success, retry-through-transient, exhausted-retry, non-transient rethrow, and stderr extraction. `skill-lint` and `biome` clean on the changes.
