### PR TITLE
fix(statusline): drop id fallback in modelLetter

### DIFF
--- a/user/scripts/model.test.ts
+++ b/user/scripts/model.test.ts
@@ -9,6 +9,7 @@ describe("modelLetter", () => {
     ["claude-haiku-4-5-20251001", null, "H"],
     ["claude-fable-5", null, "F"],
     ["claude-newmodel-1", "NewModel 1", "N"],
+    ["claude-unknown-1", null, null],
     ["", "Opus", "O"],
     ["", "", null],
     ["", null, null],

--- a/user/scripts/model.ts
+++ b/user/scripts/model.ts
@@ -14,6 +14,6 @@ export function modelLetter(id?: string | null, displayName?: string | null): st
   for (const [family, letter] of Object.entries(FAMILY_LETTERS)) {
     if (hay.includes(family)) return letter;
   }
-  const fallback = (displayName ?? id ?? "").match(/[a-z]/i);
+  const fallback = (displayName ?? "").match(/[a-z]/i);
   return fallback ? fallback[0].toUpperCase() : null;
 }


### PR DESCRIPTION
Follow-up to #1006. `modelLetter` fell back to `displayName ?? id ?? ""` before running the letter regex, so an unrecognized `claude-*` id with no `display_name` matched against the id itself and returned `"C"` (the first letter of `claude`) instead of `null`. The file comment documents `display_name` as the sole fallback for unrecognized ids, so the id should never feed the regex.

Drops the `id` term from the fallback and adds a `["claude-unknown-1", null, null]` case to the table.
