### PR TITLE
fix(linear): correct skill from dogfooding

### DIFF
--- a/plugins/linear/skills/linear/SKILL.md
+++ b/plugins/linear/skills/linear/SKILL.md
@@ -35,11 +35,11 @@ Pick a tool path per [Tool Selection](#tool-selection).
 
 Three runtime paths reach Linear, in order of preference:
 
-1. **Claude.ai connector** (`mcp__claude_ai_Linear__save_issue`, `get_issue`) is the primary path. One tool, `save_issue`, handles both create and update. See [Creating vs Updating](#creating-vs-updating).
+1. **Claude.ai connector** (`mcp__claude_ai_Linear__save_issue`, `get_issue`) is the primary path. One tool, `save_issue`, handles both create and update. It also takes relations (`blocks`, `blockedBy`, `relatedTo`, `duplicateOf`), `parentId`, `project`, `milestone`, `cycle`, `estimate`, `dueDate`, and `links` as params. That covers most structured single-issue work end to end. See [Creating vs Updating](#creating-vs-updating).
 2. **Local or plugin MCP** (`create_issue`, `update_issue`, `list_issues`) exposes separate tools for create and update. Use it for simple single-issue operations when the connector is unavailable.
-3. **`linear` CLI and raw GraphQL** is the fallback for what the connector and MCP tools do not cover (complex queries, bulk operations, relations). Defer to the `linear-cli:linear-cli` skill for the CLI surface. See [GraphQL API](#graphql-api).
+3. **`linear` CLI and raw GraphQL** is the fallback for what the connector does not cover (complex queries, bulk operations) and for setting relations when the connector is unavailable. Defer to the `linear-cli:linear-cli` skill for the CLI surface. See [GraphQL API](#graphql-api).
 
-Turning a structured issue file (from issue refinement, project planning, or any skill that emits one) into an issue follows this order. The connector handles a simple save. The CLI path is required only when the file declares relations, which the connector and MCP tools cannot set. See [Saving a Structured Issue File](#saving-a-structured-issue-file).
+Turning a structured issue file (from issue refinement, project planning, or any skill that emits one) into an issue follows this order. The connector handles the whole file, relations included; the CLI is the fallback when the connector is unavailable. See [Saving a Structured Issue File](#saving-a-structured-issue-file).
 
 ## Creating vs Updating
 
@@ -48,7 +48,7 @@ The connector's `save_issue` creates or updates from a single tool, keyed on whe
 - **Create**: omit `id`. `title` is **required** (omitting it produces "title is required when creating an issue").
 - **Update**: pass `id` (from `get_issue`). `title` is optional; send only the fields you change.
 - Use flat top-level keys. No wrapper objects (`issue`, `input`, `parameters`), and the field is `id`, not `issueId`.
-- Omit relation fields the connector does not natively support.
+- Relation params (`blocks`, `blockedBy`, `relatedTo`) are append-only. A save never removes relations you did not name. Pass `duplicateOf`, `parentId`, `project`, or `cycle` as `null` to clear them.
 
 Create (`id` absent, `title` present):
 
@@ -72,13 +72,15 @@ Update (`id` present, change only what you need):
 
 The local and plugin MCP variants split these into `create_issue` and `update_issue` with the same flat field shapes. The create precondition (`title` required) applies to both paths.
 
+The `description` body is GFM and renders Linear's first-class constructs directly: mermaid diagrams, collapsibles, fenced code blocks, and check lists. Author them inline instead of using a workaround.
+
 ## Saving a Structured Issue File
 
-Skills that emit a Markdown file with YAML frontmatter (issue refinement, project planning) hand off here. [references/structured-file.md](references/structured-file.md) maps that frontmatter onto Linear fields, covers routing fields taken from the user at save time, and shows the `linear` CLI commands required when the file declares relations.
+Skills that emit a Markdown file with YAML frontmatter (issue refinement, project planning) hand off here. [references/structured-file.md](references/structured-file.md) maps that frontmatter onto connector `save_issue` params, relations included, covers routing fields taken from the user at save time, and keeps the `linear` CLI as the fallback when the connector is unavailable.
 
 ## Conventions
 
-[references/conventions.md](references/conventions.md) holds the house rules: reference issues by full URL (never bare `ENG-123`), default state from assignment (assigned to me is `Todo`, unassigned is `Backlog`), query with `assignee: "me"`, and pass label names directly (checking workspace then team when looking one up). Apply it whenever you create, update, comment, or query.
+[references/conventions.md](references/conventions.md) holds the house rules: reference issues by the form the write path chips (bare identifier for the connector, URL for the CLI/API, `@displayname` for users on both), default state from assignment (assigned to me is `Todo`, unassigned is `Backlog`), query with `assignee: "me"`, and pass label names directly (checking workspace then team when looking one up). Apply it whenever you create, update, comment, or query.
 
 ## GraphQL API
 

--- a/plugins/linear/skills/linear/SKILL.md
+++ b/plugins/linear/skills/linear/SKILL.md
@@ -48,7 +48,7 @@ The connector's `save_issue` creates or updates from a single tool, keyed on whe
 - **Create**: omit `id`. `title` is **required** (omitting it produces "title is required when creating an issue").
 - **Update**: pass `id` (from `get_issue`). `title` is optional; send only the fields you change.
 - Use flat top-level keys. No wrapper objects (`issue`, `input`, `parameters`), and the field is `id`, not `issueId`.
-- Relation params (`blocks`, `blockedBy`, `relatedTo`) are append-only. A save never removes relations you did not name. Pass `duplicateOf`, `parentId`, `project`, or `cycle` as `null` to clear them.
+- Relation params (`blocks`, `blockedBy`, `relatedTo`) are append-only. A save never removes relations you did not name. Pass `duplicateOf`, `parentId`, `project`, or `cycle` as `null` to clear them. `milestone` and `dueDate` take a value but have no `null` clear.
 
 Create (`id` absent, `title` present):
 

--- a/plugins/linear/skills/linear/api.md
+++ b/plugins/linear/skills/linear/api.md
@@ -2,6 +2,8 @@
 
 Raw GraphQL through the `linear api` subcommand is the fallback for operations the Claude.ai connector and MCP tools do not cover. Use it only after [Tool Selection](SKILL.md#tool-selection) rules out those paths.
 
+Storage is GFM markdown. An issue's raw API `description` returns the portable markdown Linear stores. The CLI/API form is the durable interchange form when moving content between paths.
+
 The `linear-cli:linear-cli` skill is the canonical reference for the full CLI surface and GraphQL mechanics (`--description-file`, schema introspection to a temp file, pagination). It is the recommended companion for non-trivial GraphQL work. The `linear` binary installs via Homebrew:
 
 ```bash

--- a/plugins/linear/skills/linear/references/conventions.md
+++ b/plugins/linear/skills/linear/references/conventions.md
@@ -4,12 +4,23 @@ House rules for writing to and querying Linear. Tool inputs below are JSON argum
 
 ## Issue References
 
-When writing text that references other issues (descriptions, comments, updates), never use bare identifiers like `ENG-123`. Linear auto-renders issue URLs as inline previews, so use the full URL:
+An issue reference renders as an inline chip only when Linear resolves it to a real entity. The two write paths recognize opposite inputs for the same issue. The correct form depends on which path you write through.
 
-- **Bare URL**: `https://linear.app/workspace/issue/ENG-123` (renders as an inline preview)
-- **Hyperlinked text**: `[the auth bug](https://linear.app/workspace/issue/ENG-123)` (when linking specific words is more natural)
+- **Connector `save_issue`**: reference an issue by its bare identifier, `ENG-123`. The connector resolves it to a clean `[ENG-123](url)` chip. A URL renders as a plain link, since the connector wraps it in `<>` and Linear stops recognizing it.
+- **CLI / GraphQL API**: reference an issue by its URL, either bare (`https://linear.app/workspace/issue/ENG-123`) or hyperlinked (`[the auth bug](https://linear.app/workspace/issue/ENG-123)`). A bare identifier stays literal text.
+- **Users, either path**: `@displayname` (for example `@bvdrucker`) chips a user mention on both paths, and is the most portable reference.
 
-Both MCP tools and GraphQL queries return a `url` field on issues. Always include `url` when querying issues you may reference in writing.
+Both connector tools and GraphQL queries return a `url` field on issues. Include `url` when querying issues you may reference in writing. The CLI/API path needs it.
+
+### Serialization and Round-Trip
+
+Storage is GFM markdown. Raw GraphQL `description` and `linear issue view --json` return byte-identical markdown. The CLI is a pass-through of stored content. The connector is a transformer. On read it projects storage into node markup (`<issue>`, `<user>`, `<linear-embed>`), `>>>` collapsibles, and signed image URLs. On write it parses that markup back to GFM. GFM is the canonical interchange form.
+
+This matters when content moves between the two paths:
+
+- Signed image URLs (`?signature=…`) from a connector read expire within minutes and return 401 afterward. Never copy one into stored content. The durable form is the unsigned `uploads.linear.app` URL that the CLI/API return.
+- Moving connector output to the CLI requires converting node markup to GFM first. Raw node markup written through the CLI is stored literally and corrupted. Reading the same issue via CLI/API returns GFM directly.
+- A `[ENG-123](url)` link read through the CLI loses its chip when written back through the connector, which `<>`-wraps it. To edit through the connector and keep chips, reference issues by bare identifier, or write through the CLI/API.
 
 ## Issue Status
 
@@ -38,6 +49,19 @@ Unassigned:
   "state": "Backlog"
 }
 ```
+
+`hooks/save-issue.ts` injects this default only on the connector path, and only when creating without an explicit `state`. On the CLI/API path, set the state yourself.
+
+## CLI Idioms
+
+The CLI addresses the same fields with flags instead of connector JSON:
+
+- **Team** by key: `--team ENG` (the connector takes a team name or ID).
+- **Assignee**: `--assignee self` (the connector uses `"me"`).
+- **State** by name or type: `--state Todo` or `--state started`.
+- **Labels**: one `--label` per entry, repeated.
+
+Pass body text through `--description-file <path>` so it stays out of context and `!` survives the shell. See [Saving a Structured Issue File](structured-file.md) and the `linear-cli:linear-cli` skill.
 
 ## Querying Issues
 

--- a/plugins/linear/skills/linear/references/conventions.md
+++ b/plugins/linear/skills/linear/references/conventions.md
@@ -50,7 +50,7 @@ Unassigned:
 }
 ```
 
-`hooks/save-issue.ts` injects this default only on the connector path, and only when creating without an explicit `state`. On the CLI/API path, set the state yourself.
+`hooks/save-issue.ts` injects this default on the MCP tool paths (the connector `save_issue` and the local or plugin `create_issue`), and only when creating without an explicit `state`. The CLI/API path is not hooked. Set the state yourself there.
 
 ## CLI Idioms
 

--- a/plugins/linear/skills/linear/references/structured-file.md
+++ b/plugins/linear/skills/linear/references/structured-file.md
@@ -2,29 +2,41 @@
 
 Several skills hand off a Markdown file with YAML frontmatter for issue metadata and a body below the closing `---`. Issue refinement emits one, project planning emits a similar file, and others will follow. This document maps that shape to a Linear issue. The schema varies by producer, so read the file's frontmatter to see which keys it actually carries, extract them with whatever fits that file, and write the body to its own file so it passes by path and stays out of context.
 
-Map the metadata keys these files tend to carry onto the `linear` CLI:
+Map the metadata keys these files tend to carry onto the connector `save_issue` params:
 
-| Frontmatter | Linear |
-|-------------|--------|
-| `title` | `--title` |
-| body (below the closing `---`) | `--description-file <path>` |
-| `labels` | one `--label` per entry |
-| `priority` (`urgent`, `high`, `medium`, `low`) | `--priority` `1`..`4` |
-| `relations` (`blocks`, `blocked-by`, `related`, `duplicate-of`) | `linear issue relation add <id> <type> <relatedId>` |
+| Frontmatter | `save_issue` param |
+|-------------|--------------------|
+| `title` | `title` |
+| body (below the closing `---`) | `description` |
+| `labels` | `labels` (array of names) |
+| `priority` (`urgent`, `high`, `medium`, `low`) | `priority` `1`..`4` |
+| `relations.blocks` | `blocks` (array of identifiers) |
+| `relations.blocked-by` | `blockedBy` |
+| `relations.related` | `relatedTo` |
+| `relations.duplicate-of` | `duplicateOf` |
 
-A relation's `type` is the frontmatter key, except `duplicate-of` maps to `duplicate`. Its `relatedId` is the issue identifier in the relation's tracker URL. For keys the file omits, or ones this table does not name, map them when Linear has a matching field and ask when the mapping is unclear.
+Relation params take the issue identifier from each entry's tracker URL. `blocks`, `blockedBy`, and `relatedTo` accept arrays. `duplicateOf` takes a single identifier. Each is append-only. A save never removes relations you did not name. For keys the file omits, or ones this table does not name, map them when Linear has a matching field and ask when the mapping is unclear.
 
 Routing fields (team, assignee, state) are not in the file. Take them from the user at save time. Default the state from assignment as in [Issue Status](conventions.md#issue-status). `getDefaultState` in `hooks/save-issue.ts` encodes that rule.
 
-## Simple Saves
+## Saving
 
-When the file declares no relations, the connector `save_issue` is enough: pass the title, the body as `description`, the labels, and the routing fields, per [Creating vs Updating](../SKILL.md#creating-vs-updating). This is the default.
+The connector `save_issue` handles the whole file in one call, relations included. Pass the title, the body as `description`, the labels, the routing fields, and the relation params from the table above, per [Creating vs Updating](../SKILL.md#creating-vs-updating). This is the default.
 
-## Relations
+```json
+{
+  "team": "ENG",
+  "title": "Fix authentication bug",
+  "description": "…",
+  "state": "Todo",
+  "blockedBy": ["ENG-100"],
+  "relatedTo": ["ENG-42"]
+}
+```
 
-The connector and MCP tools cannot set relations, so a file that declares any needs the `linear` CLI. When the Environment block shows it is not installed, save through the connector and report the relation targets you skipped so the user can add them by hand.
+## CLI Fallback
 
-With the CLI present, create the issue with the body by file, then add one relation per entry from the parsed frontmatter:
+When the connector is unavailable and the Environment block shows the `linear` CLI installed, fall back to it: create the issue with the body by file, then add one relation per entry from the parsed frontmatter.
 
 ```bash
 new_id=$(linear issue create --title "$title" --description-file "$body_file" \
@@ -32,4 +44,4 @@ new_id=$(linear issue create --title "$title" --description-file "$body_file" \
 linear issue relation add "$new_id" blocked-by ENG-100
 ```
 
-Add `--label`, `--assignee`, and `--priority` when the file carries them. The `linear-cli:linear-cli` skill documents the full CLI surface.
+The CLI relation `type` is the frontmatter key, except `duplicate-of` maps to `duplicate`. Add `--label`, `--assignee`, and `--priority` when the file carries them. If neither path can set relations, save the issue and report the relation targets you skipped so the user can add them by hand. The `linear-cli:linear-cli` skill documents the full CLI surface.


### PR DESCRIPTION
Live testing against the `bendrucker` sandbox (the Claude.ai connector and `linear` CLI v2.0.0) proved several `linear` skill claims wrong or backwards. These are failures only surfaced live: how references render, how the two write paths serialize the same content, and what round-trips.

The skill's blanket rule was "never bare `ENG-123`, always full URL." That is right for the CLI/API and exactly backwards for the connector. The connector chips an issue from a bare identifier and `<>`-wraps any URL you hand it (killing the chip); the CLI/API is the reverse. The reference guidance is now path-aware rather than path-blind, keyed on which write path you use, with `@displayname` as the portable user mention on both.

Storage is GFM: raw GraphQL and `linear issue view --json` return byte-identical markdown, so the CLI is a pass-through. The connector is a transformer that projects storage into node markup and signed image URLs on read and parses it back on write. A new serialization subsection in `conventions.md` records this, the one corrupting direction (raw connector node markup written through the CLI), and the footguns (expiring signed URLs, chip loss when a CLI-read link is rewritten through the connector).

`structured-file.md` claimed the connector cannot set relations and mandated a two-step CLI recipe. The connector `save_issue` takes `blocks`, `blockedBy`, `relatedTo`, `duplicateOf`, and `parentId` natively, so relations now flow through one connector call, with the CLI kept as the fallback when the connector is unavailable. `SKILL.md` records the connector's fuller param surface (relations, `project`, `milestone`, `cycle`, `estimate`, `dueDate`, `links`) and keeps it first.

CLI flags in the skill were checked against `linear` v2.0.0 (`--assignee self`, `--state <name|type>`, repeated `--label`, `relation add`, `delete --bulk`); no drift. `hooks/save-issue.ts` needed no change, and its tests stay green.

## Verification

- `bun run skill-lint "plugins/linear/skills/*"`
- `bun test plugins/linear`
- `writing:scan audit` over the skill, with the introduced consequence chains and semicolon splices removed
