### PR TITLE
fix(user): route branch finishes through /ship

### DIFF
--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -27,7 +27,9 @@ Every customization costs tokens on every session. Before adding one, define how
 
 - The user has carefully curated skills for their common workflows. Load skills when possible to adhere to the user's preferences and navigate their projects efficiently.
 - For questions about Claude Code features or usage, use the Task tool with `subagent_type='claude-code-guide'` to consult official documentation.
-- Always use the `pull-request:create` skill to create pull requests. If the skill is unavailable, create the PR with an empty body.
+- Finish a branch with `/ship`: it runs the warranted review passes, opens the PR, babysits CI to green, triages bot comments, and refreshes the body. Don't hand-chain `EnterWorktree` + `pull-request:create` for a branch finish.
+- `pull-request:create` remains the skill for opening a PR directly (it is what `/ship` calls). If it's unavailable, create the PR with an empty body.
+- Open PRs ready for review by default. Reserve `--draft` for speculative changes that need deep human review before merge. Draft status can suppress bot review.
 - When executing build commands, output to `/dev/null` to avoid creating binaries.
 - Store temporary files in `tmp/` directory.
 - The sandbox can write `/tmp`, `$TMPDIR`, and the repo. Never disable the sandbox for file writes; only bypass after a sandboxed run of that command actually failed.
@@ -47,7 +49,7 @@ The Bash tool escapes `!` to `\!` on every path, including single quotes and her
 
 I use Worktrunk (the `wt` CLI) for git worktrees, exposed through two skills:
 
-- For creating or entering a worktree, use the `worktrunk:wt-switch-create` skill. It re-roots the session into a new worktree (optionally in another repo), runs an optional task, and acts as a targeted command for the common case. Prefer it over the generic skill whenever the task is worktree creation, including anywhere you would otherwise delegate worktree creation to Worktrunk.
+- For creating or entering a worktree, use the `worktrunk:wt-switch-create` skill. It re-roots the session into a new worktree (optionally in another repo), runs an optional task, and acts as a targeted command for the common case. Prefer it over the generic skill whenever the task is worktree creation, including anywhere you would otherwise delegate worktree creation to Worktrunk. This preference holds even when a background-job or harness context suggests the generic `EnterWorktree` tool for isolation.
 - For everything else (pruning, listing, removing, running hooks, editing config, and general `wt` questions), use the generic `worktrunk:worktrunk` skill.
 - Disposable verification worktrees may be created with `git worktree add tmp/<name>`; everything persistent goes through the worktrunk skills.
 

--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: ship
-disable-model-invocation: true
 description: >-
   Finish a branch: infer which review passes the change warrants, run them, open the PR, babysit CI to green, triage bot comments, and refresh the body from a clean context.
 argument-hint: "[--merge] [--effort <level>] [--simplify] [--skip <pass>] [--base <ref>]"


### PR DESCRIPTION
Corrects the finishing-workflow guidance so plans stop defaulting to `EnterWorktree` plus a draft `pull-request:create` finish. A recent plan closed with exactly that step, and each cause traced to a specific line of standing guidance rather than the one-off plan.

Three edits:

- `user/skills/ship/SKILL.md`: drop `disable-model-invocation: true`. The flag hid `/ship` from the model's catalog, which is why no plan-generating session ever routed to it. Removing it makes `/ship` visible and invocable.
- `user/CLAUDE.md` finishing directive: replace "always use `pull-request:create`" with a finish-via-`/ship` default. `pull-request:create` stays the skill for opening a PR directly (it is what `/ship` calls). PRs now default to ready for review, with `--draft` reserved for speculative changes needing deep human review, since draft status can suppress bot review.
- `user/CLAUDE.md` worktree bullet: note the `worktrunk:wt-switch-create` preference holds even when a background-job or harness context suggests the generic `EnterWorktree` tool. That harness default was what beat the standing preference.

The distributed `plan` plugin's `guidelines.md` stays untouched: naming `/ship` or `worktrunk:wt-switch-create` there would leak personal `user/` skills to installers.

## Tradeoff

Flipping `disable-model-invocation` is a real behavior change. `/ship`'s description now loads in every session (no longer zero recurring cost), and the model may auto-invoke this heavy finish at the end of any task. This was directed deliberately, so plans can route to `/ship`. The removal criteria memory for the skill now accounts for both.
