### PR TITLE
feat(agents): add user-level review persona

### DIFF
--- a/user/agents/review.md
+++ b/user/agents/review.md
@@ -1,0 +1,19 @@
+---
+name: review
+description: >
+  Review a pull request end to end (research, code-quality analysis, and curated
+  comment submission) in an isolated worktree, never editing the code under review.
+  Dispatch with a PR URL or number.
+disallowedTools: Edit, Write, NotebookEdit
+isolation: worktree
+color: cyan
+initialPrompt: >
+  Review this pull request with the review:peer skill, which owns the full
+  workflow. Check out the PR branch into this isolated worktree first.
+---
+
+You review pull requests as me. Dispatched with a PR URL or number, you produce a curated set of review comments for me to approve, never code changes.
+
+The `review:peer` skill owns the workflow: research, context, delegating code-quality analysis to `code-review`, staging comments in `review:tuicr` for me to curate, and posting on my go. Load it and follow it rather than reimplementing its steps.
+
+You run in an isolated worktree branched from the default branch. Check out the PR branch here with `gh pr checkout` instead of touching my working copy. You comment on the code, never modify it. File-editing tools are disabled to hold that boundary, so stage and post through the review tooling.

--- a/user/agents/review.md
+++ b/user/agents/review.md
@@ -1,19 +1,24 @@
 ---
 name: review
 description: >
-  Review a pull request end to end (research, code-quality analysis, and curated
-  comment submission) in an isolated worktree, never editing the code under review.
-  Dispatch with a PR URL or number.
+  Review a pushed pull request with fresh eyes in an isolated worktree, never
+  editing the code under review. A peer's PR gets curated comments; my own gets a
+  cold intent-and-expressiveness audit reported back. Dispatch with a PR URL or number.
 disallowedTools: Edit, Write, NotebookEdit
 isolation: worktree
 color: cyan
 initialPrompt: >
-  Review this pull request with the review:peer skill, which owns the full
-  workflow. Check out the PR branch into this isolated worktree first.
+  Review this pull request with fresh eyes in your isolated worktree. Check out
+  its branch first, then follow your workflow for whether it is mine or a peer's.
 ---
 
-You review pull requests as me. Dispatched with a PR URL or number, you produce a curated set of review comments for me to approve, never code changes.
+You review pushed pull requests with fresh eyes, whether mine or a peer's. You are dispatched with a PR URL or number. Your clean context is the point: you never saw the reasoning that produced the code, so you can judge whether the intent survives in the code alone.
 
-The `review:peer` skill owns the workflow: research, context, delegating code-quality analysis to `code-review`, staging comments in `review:tuicr` for me to curate, and posting on my go. Load it and follow it rather than reimplementing its steps.
+You run in an isolated worktree branched from the default branch. Check out the PR branch here with `gh pr checkout` instead of touching my working copy. You assess the code, never modify it.
 
-You run in an isolated worktree branched from the default branch. Check out the PR branch here with `gh pr checkout` instead of touching my working copy. You comment on the code, never modify it. File-editing tools are disabled to hold that boundary, so stage and post through the review tooling.
+Determine whose PR it is by comparing the reviewing account's login to the author:
+
+- A peer's PR: load `review:peer` and follow it. That skill owns the workflow (research, `code-review` for quality, staging comments in `review:tuicr`, and curated submission on my go). Do not reimplement its steps.
+- My own PR: audit it cold. Read the diff without any authoring rationale and judge whether the intent is clear and the code is expressive on its own. Run `/code-review` for correctness and quality findings, then report everything for me to address. Do not post comments on my own PR.
+
+The `review:self` skill is a different activity, an interactive working-tree pass before I commit. It is not your job. You review pushed PRs.


### PR DESCRIPTION
Adds `review`, the first of a planned family of user-level named agents that bind a whole session to an activity so the harness can label and filter it (`a:review` in the agents view). A skill invoked at session start feeds the model nearly the same prompt, but the harness does not treat the session as bound to it. Named agents are the only mechanism that gives a session a durable, filterable identity, which is the point of using one here.

`review` does fresh-eyes review of a pushed PR, mine or a peer's, and routes by authorship: a peer's PR to `review:peer` for curated comments, my own to a cold `/code-review` audit of intent and expressiveness, reported rather than posted.

## Why an Agent and Not a Skill

Agents and skills overlap heavily. The useful line is where they don't: agents alone express worktree isolation, session labeling, and tool guardrails, while skills alone express progressive disclosure and composition. `review` sits on the agent side of that line and delegates the review logic to skills, which stay the engine.

Two capabilities justify the agent layer, neither available from a bare skill run:

- **Isolation I do by hand every time.** I dedicate a session to review and always set up a worktree first. A bare `/review:peer <url>` instead runs `gh pr checkout` in my current tree and moves my branch. `isolation: worktree` bakes in the worktree I always create and disposes of it after (read-only review leaves it unchanged, so it auto-removes). Agent-native isolation, not Worktrunk, because ephemerality fits disposable review and the `review` plugin needs no `bun install` (only `cleye`/`table`, which Bun auto-installs).
- **Fresh context for self-review.** Reviewing my own PR, a clean session never saw the reasoning that produced the code, so it can judge whether the intent survives in the code alone. My working session cannot: it is saturated with the rationale that biases me. This is a capability the inline skill cannot provide at all, not just toil it removes.

## Decisions

- **Name.** Bare `review`, not `reviewer`. The harness's own agents are bare verbs (`Explore`, `Plan`), so a modifier fights the convention. The only hard collision was `plan` against the built-in `Plan` agent, which is why the planned issue-authoring persona is `issue`, not `plan`.
- **Dual-purpose over pushed PRs.** Peer and self review are the same activity mechanically (a PR URL, isolated checkout, cold read); only the author and posture differ. The agent detects authorship by comparing the reviewing login to the PR author. Self findings are reported, not posted, since review comments on my own PR are noise.
- **`review:self` stays separate.** The existing `review:self` skill is a different activity: an interactive working-tree pass before I commit, where I annotate lines and Claude applies the edits. It needs my dirty tree and edit tools, the inverse of this agent's isolated read-only posture. It stays a skill invoked inline.
- **Guardrail via tools.** `disallowedTools: Edit, Write, NotebookEdit` enforces "assess, never modify" structurally for both modes. Peer comments post through `gh` and the review tooling, which stays available.
- **Plugin-promotable.** The frontmatter avoids `permissionMode`, `hooks`, and `mcpServers`, the three fields plugin agents silently drop. So `review` can later move into the `review` plugin if it proves portable, without losing anything.

## Home and a Dotfiles Caveat

Lives in `user/agents/` to match the `user/` convention (`skills`, `rules`, `hooks`). The `~/.claude/agents` symlink currently points at the dev repo's `.claude/agents` rather than `user/agents`, out of step with its siblings, so it needs repointing to `.claude-repo/user/agents` in the dotfiles `claude` topic before the agent loads at user scope.

## Verification

Frontmatter parses to the documented agent fields and the marketplace check is unaffected (user agents are not plugins). I did not dispatch it end to end: `review:peer` is interactive and needs a live PR, so a real review session (both modes) is the next check once the symlink is repointed.

Draft because this is the reference for the pattern. `issue`, `inbox`, and `outbox` follow once this shape is confirmed in use.
