### PR TITLE
job: add personal inbox and reaction disposition

### DIFF
--- a/user/skills/job/SKILL.md
+++ b/user/skills/job/SKILL.md
@@ -34,9 +34,9 @@ Arguments beyond the mode are a focus hint ($ARGUMENTS). Weight the brief toward
 
 ## Delegation
 
-This skill never names platforms. The config declares which version-control platform, issue tracker, worktree tool, messaging platform, and email account the user works with. For each task:
+This skill never names platforms. The config declares which version-control platform, issue tracker, worktree tool, messaging platform, email account, and optional personal capture inbox the user works with. For each task:
 
-1. Find the installed skill covering the configured tool's task (the skill for the configured platform's merge requests, the skill for the configured tracker's issues, the skill or MCP for the configured messaging and email inboxes, the skill that runs a review queue) and load it for mechanics.
+1. Find the installed skill covering the configured tool's task (the skill for the configured platform's merge requests, the skill for the configured tracker's issues, the skill or MCP for the configured messaging and email inboxes, the personal inbox's configured `access` for its captures, the skill that runs a review queue) and load it for mechanics.
 2. If no installed skill matches, use the configured CLI or MCP directly. Stay read-only until the user confirms actions.
 
 Platforms, hostnames, and usernames come only from the config or the user, never from this skill.
@@ -61,10 +61,10 @@ Close with the mode's cross-project synthesis: the day's sequence, or the night'
 
 Split recommended actions into two groups:
 
-- Safe: reversible or expected. Assign a reviewer, retry CI, post a reply the user has seen drafted, update tracker status, archive a handled notification or email.
+- Safe: reversible or expected. Assign a reviewer, retry CI, add a reaction or brief acknowledgement, post a reply the user has seen drafted, update tracker status, archive a handled notification or email.
 - Ask-first: approve, close, merge, anything hard to walk back. Each needs its own confirmation.
 
-Drive inbound to zero. Every review request, message, notification, and email leaves the run with a terminal disposition: handled, deferred to a tracked task or issue, or archived. Nothing stays in an ambiguous unread state.
+Drive inbound to zero. Every review request, message, notification, and email leaves the run with a terminal disposition: handled, reacted to or briefly acknowledged, deferred to the work tracker as a team-backlog item or to the personal inbox for your own next-steps and reminders when one is configured, or archived. Never stand up a tracker issue in place of a personal capture: when the user says "my inbox" that means the personal inbox, and when the destination is unclear, ask. Nothing stays in an ambiguous unread state.
 
 Present safe actions via AskUserQuestion (execute all, pick a subset, or none). Execute through the delegated skills, then give a short summary of what changed.
 

--- a/user/skills/job/references/end.md
+++ b/user/skills/job/references/end.md
@@ -28,7 +28,7 @@ Flag items that need collaboration lead time (a reviewer in another timezone, a 
 
 Review debt is inbound requests you did not reach today, unanswered threads on others' PRs/MRs, and any message, notification, or email still awaiting your reply or filing. Choose one path per item:
 
-- Reply now: draft the reply and include it in the brief. Posting a draft the user approved is safe.
+- Reply now: judge whether the thread needs a substantive response first. Where a reaction or brief acknowledgement closes it, prefer that. Draft a reply only when it carries real content, keep it terse, and include it in the brief. Posting a draft the user approved is safe.
 - Carry to tomorrow: record it explicitly so it appears in tomorrow's start brief.
 
 Never silently drop an item.
@@ -47,7 +47,7 @@ Offer per worktree: commit and push as WIP (safe on your own branch), or record 
 ## Tracker Hygiene and Tomorrow
 
 - Make states match reality: merged work marked done, in-progress only for what is actually in progress. Corrections are safe actions.
-- Capture next steps as issue comments or new issues, including monitor and follow-up intents like "when X merges, rebase Y", so tomorrow's start run has a starting point instead of a memory.
+- Capture next steps where they belong. Work for the team backlog lands as tracker comments or new issues, including monitor and follow-up intents like "when X merges, rebase Y", so tomorrow's start run has a starting point instead of a memory. Personal next-steps and reminders go to the personal inbox when one is configured. When the user says "my inbox" that means the personal inbox, so route there rather than opening a tracker issue in its place, and ask when the destination is unclear.
 
 ## Brief and Act
 

--- a/user/skills/job/references/setup.md
+++ b/user/skills/job/references/setup.md
@@ -6,7 +6,7 @@ First-run interview. Produces `~/.config/claude-job-skill/config.json`. The skil
 
 Build candidate answers from the environment rather than a hardcoded tool list:
 
-- Scan the installed-skills list already in context for version-control, issue-tracker, code-review, worktree, messaging, and email coverage. Messaging and email often arrive as MCP servers rather than skills or CLIs, so check the connected MCP servers too.
+- Scan the installed-skills list already in context for version-control, issue-tracker, code-review, worktree, messaging, email, and personal task-manager coverage. Messaging, email, and a personal task-manager often arrive as MCP servers rather than skills or CLIs, so check the connected MCP servers too.
 - Probe for CLIs read-only: `command -v`, then the CLI's authenticated-user query (its `whoami` or `me` equivalent) to learn the username, which doubles as verification for the interview's version-control answer.
 - Check `git config --get remote.origin.url` in likely repos for a host hint.
 
@@ -21,6 +21,7 @@ Ask via AskUserQuestion with detected candidates as options, relying on the buil
 - Worktrees: the tool used, if any, plus every root directory the end-of-day sweep should walk when it checks for uncommitted changes and unpushed commits.
 - Messaging: the platform, how it is reached (an installed skill, an MCP server, or a CLI), and the work handle. Used to sweep inbound direct messages and mentions. Optional.
 - Email: the account, how it is reached (an installed skill, an MCP server, or a CLI), and the work address. Used to sweep unhandled mail. Optional.
+- Personal inbox: a personal capture destination distinct from the work tracker, how it is reached (an installed skill, an MCP server, or a CLI), for your own next-steps and reminders. Kept separate so "track this to my inbox" never lands a team-backlog issue. Optional.
 - Working hours: optional, default 09:00 to 17:00, used only to suggest a mode when `/job` runs with no argument.
 - Notes: optional free-form text for reviewer conventions and team norms, where employer specifics belong rather than anywhere in the skill.
 
@@ -35,6 +36,7 @@ Run `mkdir -p ~/.config/claude-job-skill`, then write `config.json`:
   "tracker": { "platform": "...", "username": "...", "team": "..." },
   "chat": { "platform": "...", "access": "...", "username": "..." },
   "email": { "platform": "...", "access": "...", "address": "..." },
+  "inbox": { "platform": "...", "access": "..." },
   "worktrees": { "tool": "...", "roots": ["~/src/..."] },
   "hours": { "start": "09:00", "end": "17:00" },
   "notes": "free-form conventions"

--- a/user/skills/job/references/start.md
+++ b/user/skills/job/references/start.md
@@ -34,7 +34,7 @@ Triage covers the whole queue before any review begins. Reviews are session-leng
 For each of your open PRs/MRs, flag:
 
 - Failing or stuck CI. Retrying a flaky job is safe. A real failure becomes a candidate focus item. Before planning around a red pipeline, confirm the failure is yours to fix. A shared build break or an upstream outage is not work, and the same job failing identically across several of your MRs is the tell.
-- Reviewer threads awaiting your reply. Draft replies and include them in the brief.
+- Reviewer threads awaiting your reply. Judge first whether the thread needs a substantive response. Where a reaction or brief acknowledgement closes it, prefer that. Draft a reply only when it carries real content, keep it terse, and include it in the brief.
 - Ready for review but no reviewer assigned. Assigning per the config notes is safe.
 - Stale drafts. Recommend one of: finish today (focus item), send as-is (safe), or close (ask-first).
 
@@ -42,7 +42,9 @@ For each of your open PRs/MRs, flag:
 
 Triage each inbound item, whether a message, a tracker notification, or an email, into an action: a review handoff, a decision you owe someone, a question to answer, or a new task. An item often carries the only signal for a focus item, so a thread that names an MR or issue belongs with that work in the brief, not stranded in a separate inbox list. Map every item to the project it concerns, or to `Misc`.
 
-Inbox zero is the target. Each item leaves the day in a terminal state: handled, deferred to a tracked task, or archived. Drafting a reply the user has read is safe, as is archiving something already handled. Sending a reply without review is ask-first.
+Inbox zero is the target. Each item leaves the day in a terminal state: handled, reacted to or briefly acknowledged, deferred, or archived. Before drafting a reply, judge whether the thread needs a substantive response. Where a reaction or brief acknowledgement closes it, prefer that over filler. Draft a reply only when it carries real content, and keep it terse.
+
+Route what gets deferred by where it belongs. Work for the team backlog goes to the tracker, while personal next-steps and reminders go to the personal inbox when one is configured. "My inbox" means the personal inbox. When the destination is ambiguous, ask rather than defaulting to a tracker issue, and never create a tracker issue in place of a personal capture. Drafting a reply the user has read is safe, as is archiving something already handled. Sending a reply without review is ask-first.
 
 ## Today Plan
 


### PR DESCRIPTION
Two behavioral fixes to the `/job` skill ahead of dogfooding it on the work machine today. Both come from the 06-23 work-side run, and both post-date the June gap fixes in #864/#865/#868.

## Tracker vs Personal Inbox

On 06-23, "track something to my inbox" made the skill open tracker issues (which were then deleted). The skill conflated the configured work *tracker* with a personal capture inbox. This adds an optional `inbox` to the config (same `platform`/`access` shape as `chat`/`email`), a detection source, and an interview question. `vcs` and `tracker` stay the only required keys. The mode bodies now route by destination: team-backlog work goes to the tracker, personal next-steps and reminders go to the personal inbox, "my inbox" means the personal inbox, and an ambiguous destination gets a question rather than a defaulted tracker issue. The skill never names the underlying tool. Config declares it, the body refers to roles only.

## Reaction Disposition

On 06-23 the skill drafted a peer-MR reply the user rejected as slop ("just thumbs up react"). Every inbound path defaulted to composing reply text. This adds a reaction / brief-acknowledgement disposition to the safe-actions and terminal-disposition sets, and gates drafted replies behind a substance check: prefer a reaction where it closes the thread, draft only when the reply carries real content. "Reaction" stays generic across platforms.

## Verification

`skill-lint` covers the skill after the edits, and the `setup.md` config block parses as JSON with the optional `inbox` key alongside the existing required keys.

For the writing gate, `writing:scan audit` on the edited files reports only findings that are already present in the pre-edit versions at `HEAD`, on the same lines and columns. The edits introduce no new tropes, so the pre-existing findings sit in prose outside this change's scope and I left those untouched lines alone. My additions carry no em-dashes or "X, not Y" constructs, the patterns the writing hook caught on 06-22.

The real proof is the next `/job` run: "track this to my inbox" should reach the personal inbox, and a low-content thread should get a reaction rather than a drafted reply.

Switching review dispatch from tmux panes to background agents was considered and deferred. It belongs to the review plugin as its own effort and depends on the unmerged `review` named-agent persona. This skill's handoff is already mechanism-agnostic and stays as-is.
