### PR TITLE
fix(statusline): align model/effort markers and accent non-defaults

### DIFF
--- a/user/scripts/__snapshots__/statusline.test.ts.snap
+++ b/user/scripts/__snapshots__/statusline.test.ts.snap
@@ -26,11 +26,11 @@ exports[`rendered output dial-exceeds-70 1`] = `"\x1B[91m󰪢\x1B[39m"`;
 
 exports[`rendered output no-dial 1`] = `""`;
 
-exports[`rendered output model-effort-leads 1`] = `"\x1B[2mF\x1B[22m \x1B[2m⠧\x1B[22m \x1B[32m󰪠\x1B[39m myrepo"`;
+exports[`rendered output model-effort-leads 1`] = `"\x1B[35m\x1B[1mf\x1B[22m\x1B[39m \x1B[35m\x1B[1m⁞\x1B[22m\x1B[39m \x1B[32m󰪠\x1B[39m myrepo"`;
 
-exports[`rendered output model-only 1`] = `"\x1B[2mO\x1B[22m"`;
+exports[`rendered output model-only 1`] = `"\x1B[2mo\x1B[22m"`;
 
-exports[`rendered output effort-only 1`] = `"\x1B[2m⠿\x1B[22m"`;
+exports[`rendered output effort-only 1`] = `"\x1B[35m\x1B[1m⁙\x1B[22m\x1B[39m"`;
 
 exports[`rendered output lines-added 1`] = `"\x1B[32m+5\x1B[39m"`;
 

--- a/user/scripts/effort.test.ts
+++ b/user/scripts/effort.test.ts
@@ -1,18 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import { effortGlyph } from "./effort";
+import { type EffortMarker, effortMarker } from "./effort";
 
-describe("effortGlyph", () => {
-  test.each<[string | null | undefined, string | null]>([
-    ["low", "⠂"],
-    ["medium", "⠆"],
-    ["high", "⠇"],
-    ["xhigh", "⠧"],
-    ["max", "⠿"],
+describe("effortMarker", () => {
+  test.each<[string | null | undefined, EffortMarker | null]>([
+    ["low", { glyph: "∙", isDefault: false }],
+    ["medium", { glyph: "⁚", isDefault: false }],
+    ["high", { glyph: "⁝", isDefault: true }],
+    ["xhigh", { glyph: "⁞", isDefault: false }],
+    ["max", { glyph: "⁙", isDefault: false }],
     ["unknown", null],
     ["", null],
     [null, null],
     [undefined, null],
   ])("level %p -> %p", (level, expected) => {
-    expect(effortGlyph(level)).toBe(expected);
+    expect(effortMarker(level)).toEqual(expected);
   });
 });

--- a/user/scripts/effort.ts
+++ b/user/scripts/effort.ts
@@ -1,15 +1,28 @@
-// Braille dot-ramp for the reasoning effort level, low to max. More dots is more
-// effort. Null when the level is unknown or the model reports no effort, so the
-// segment simply drops rather than rendering a placeholder.
+// Baseline vertical-dot ramp for the reasoning effort level, low to max. Dot
+// count grows with effort, and the dots sit on the text baseline so the glyph
+// aligns with the model letter rather than floating like braille.
 const EFFORT_GLYPHS: Record<string, string> = {
-  low: "⠂",
-  medium: "⠆",
-  high: "⠇",
-  xhigh: "⠧",
-  max: "⠿",
+  low: "∙",
+  medium: "⁚",
+  high: "⁝",
+  xhigh: "⁞",
+  max: "⁙",
 };
 
-export function effortGlyph(level?: string | null): string | null {
+// The un-highlighted level. Effort at any other level renders in the accent
+// color so an off-default session config stands out.
+const DEFAULT_EFFORT = "high";
+
+export interface EffortMarker {
+  glyph: string;
+  isDefault: boolean;
+}
+
+// Null when the level is unknown or the model reports no effort, so the segment
+// simply drops rather than rendering a placeholder.
+export function effortMarker(level?: string | null): EffortMarker | null {
   if (!level) return null;
-  return EFFORT_GLYPHS[level] ?? null;
+  const glyph = EFFORT_GLYPHS[level];
+  if (!glyph) return null;
+  return { glyph, isDefault: level === DEFAULT_EFFORT };
 }

--- a/user/scripts/model.test.ts
+++ b/user/scripts/model.test.ts
@@ -1,23 +1,23 @@
 import { describe, expect, test } from "bun:test";
-import { modelLetter } from "./model";
+import { type ModelMarker, modelMarker } from "./model";
 
-describe("modelLetter", () => {
-  test.each<[string, string | null, string | null]>([
-    ["claude-opus-4-8", null, "O"],
-    ["claude-opus-4-8[1m]", null, "O"],
-    ["claude-sonnet-5", null, "S"],
-    ["claude-haiku-4-5-20251001", null, "H"],
-    ["claude-fable-5", null, "F"],
-    ["claude-newmodel-1", "NewModel 1", "N"],
+describe("modelMarker", () => {
+  test.each<[string, string | null, ModelMarker | null]>([
+    ["claude-opus-4-8", null, { letter: "o", isDefault: true }],
+    ["claude-opus-4-8[1m]", null, { letter: "o", isDefault: true }],
+    ["claude-sonnet-5", null, { letter: "s", isDefault: false }],
+    ["claude-haiku-4-5-20251001", null, { letter: "h", isDefault: false }],
+    ["claude-fable-5", null, { letter: "f", isDefault: false }],
+    ["claude-newmodel-1", "NewModel 1", { letter: "n", isDefault: false }],
     ["claude-unknown-1", null, null],
-    ["", "Opus", "O"],
+    ["", "Opus", { letter: "o", isDefault: false }],
     ["", "", null],
     ["", null, null],
   ])("id %p / name %p -> %p", (id, name, expected) => {
-    expect(modelLetter(id, name)).toBe(expected);
+    expect(modelMarker(id, name)).toEqual(expected);
   });
 
   test("undefined id falls back to display name", () => {
-    expect(modelLetter(undefined, "Haiku")).toBe("H");
+    expect(modelMarker(undefined, "Haiku")).toEqual({ letter: "h", isDefault: false });
   });
 });

--- a/user/scripts/model.ts
+++ b/user/scripts/model.ts
@@ -3,17 +3,26 @@
 // we don't recognize, so a future model still gets a letter.
 
 const FAMILY_LETTERS: Record<string, string> = {
-  opus: "O",
-  sonnet: "S",
-  haiku: "H",
-  fable: "F",
+  opus: "o",
+  sonnet: "s",
+  haiku: "h",
+  fable: "f",
 };
 
-export function modelLetter(id?: string | null, displayName?: string | null): string | null {
+// The un-highlighted family. Any other model renders in the accent color so a
+// non-default model stands out.
+const DEFAULT_FAMILY = "opus";
+
+export interface ModelMarker {
+  letter: string;
+  isDefault: boolean;
+}
+
+export function modelMarker(id?: string | null, displayName?: string | null): ModelMarker | null {
   const hay = (id ?? "").toLowerCase();
   for (const [family, letter] of Object.entries(FAMILY_LETTERS)) {
-    if (hay.includes(family)) return letter;
+    if (hay.includes(family)) return { letter, isDefault: family === DEFAULT_FAMILY };
   }
   const fallback = (displayName ?? "").match(/[a-z]/i);
-  return fallback ? fallback[0].toUpperCase() : null;
+  return fallback ? { letter: fallback[0].toLowerCase(), isDefault: false } : null;
 }

--- a/user/scripts/statusline.test.ts
+++ b/user/scripts/statusline.test.ts
@@ -151,22 +151,39 @@ describe("rendered output", () => {
   });
 });
 
+// SGR fragments the accent (magenta) and default (dim) styles emit, so tests can
+// assert which style a marker used without matching the whole escape sequence.
+const MAGENTA = "\x1b[35m";
+const DIM = "\x1b[2m";
+
 describe("modelSegment", () => {
-  test("renders the family letter, null when absent", () => {
-    expect(strip(modelSegment({ model: { id: "claude-fable-5" } }) ?? "")).toBe("F");
-    expect(strip(modelSegment({ model: { id: "claude-opus-4-8[1m]" } }) ?? "")).toBe("O");
+  test("renders the lowercase family letter, null when absent", () => {
+    expect(strip(modelSegment({ model: { id: "claude-fable-5" } }) ?? "")).toBe("f");
+    expect(strip(modelSegment({ model: { id: "claude-opus-4-8[1m]" } }) ?? "")).toBe("o");
     expect(modelSegment({})).toBeNull();
     expect(modelSegment({ model: null })).toBeNull();
+  });
+
+  test("accents non-default models, dims the default (opus)", () => {
+    expect(modelSegment({ model: { id: "claude-opus-4-8[1m]" } })).toContain(DIM);
+    expect(modelSegment({ model: { id: "claude-fable-5" } })).toContain(MAGENTA);
+    expect(modelSegment({ model: { id: "claude-sonnet-5" } })).toContain(MAGENTA);
   });
 });
 
 describe("effortSegment", () => {
   test("renders the effort glyph, null when absent or unsupported", () => {
-    expect(strip(effortSegment({ effort: { level: "max" } }) ?? "")).toBe("⠿");
-    expect(strip(effortSegment({ effort: { level: "low" } }) ?? "")).toBe("⠂");
+    expect(strip(effortSegment({ effort: { level: "max" } }) ?? "")).toBe("⁙");
+    expect(strip(effortSegment({ effort: { level: "low" } }) ?? "")).toBe("∙");
     expect(effortSegment({ effort: { level: "bogus" } })).toBeNull();
     expect(effortSegment({})).toBeNull();
     expect(effortSegment({ effort: null })).toBeNull();
+  });
+
+  test("accents non-default effort, dims the default (high)", () => {
+    expect(effortSegment({ effort: { level: "high" } })).toContain(DIM);
+    expect(effortSegment({ effort: { level: "max" } })).toContain(MAGENTA);
+    expect(effortSegment({ effort: { level: "low" } })).toContain(MAGENTA);
   });
 });
 

--- a/user/scripts/statusline.ts
+++ b/user/scripts/statusline.ts
@@ -2,9 +2,9 @@
 import { mkdirSync } from "node:fs";
 import { basename, dirname } from "node:path";
 import { styleText } from "node:util";
-import { effortGlyph } from "./effort";
+import { effortMarker } from "./effort";
 import { dialGlyph } from "./glyphs";
-import { modelLetter } from "./model";
+import { modelMarker } from "./model";
 import { expandTilde, type RateLimits } from "./rate-limits";
 
 interface CurrentUsage {
@@ -95,18 +95,26 @@ export function exceeds200k(input: StatusInput): boolean {
   return total > 200_000;
 }
 
-// A leading dim letter for the active model so Fable-vs-Opus reads at a glance.
-// Always shown: absence would be ambiguous once more than one model is in play.
-export function modelSegment(input: StatusInput): string | null {
-  const letter = modelLetter(input.model?.id, input.model?.display_name);
-  return letter ? styleText(["dim"], letter) : null;
+// Session-config markers (model, effort) render dim at their default and switch
+// to this accent when off-default, so a non-standard session reads at a glance.
+const ACCENT: Parameters<typeof styleText>[0] = ["magenta", "bold"];
+
+function configMarker(text: string, isDefault: boolean): string {
+  return styleText(isDefault ? ["dim"] : ACCENT, text);
 }
 
-// A braille dot-ramp for the reasoning effort, dim like the model letter so the
-// two session-config markers read alike. Absent when the model has no effort.
+// A leading letter for the active model so Fable-vs-Opus reads at a glance.
+// Always shown: absence would be ambiguous once more than one model is in play.
+export function modelSegment(input: StatusInput): string | null {
+  const marker = modelMarker(input.model?.id, input.model?.display_name);
+  return marker ? configMarker(marker.letter, marker.isDefault) : null;
+}
+
+// A baseline dot-ramp for the reasoning effort, styled like the model letter so
+// the two session-config markers read alike. Absent when the model has no effort.
 export function effortSegment(input: StatusInput): string | null {
-  const glyph = effortGlyph(input.effort?.level);
-  return glyph ? styleText(["dim"], glyph) : null;
+  const marker = effortMarker(input.effort?.level);
+  return marker ? configMarker(marker.glyph, marker.isDefault) : null;
 }
 
 export function dialSegment(input: StatusInput): string | null {

--- a/user/scripts/subagent-statusline.test.ts
+++ b/user/scripts/subagent-statusline.test.ts
@@ -173,9 +173,9 @@ describe("renderTask", () => {
       "Explore",
       null,
       null,
-      "F",
+      "f",
     );
-    expect(strip(out.content)).toContain("· 1m 5s · 1.5k · F · Explore");
+    expect(strip(out.content)).toContain("· 1m 5s · 1.5k · f · Explore");
   });
 
   test("activity wins over the description and is not sentence-cased", () => {

--- a/user/scripts/subagent-statusline.test.ts
+++ b/user/scripts/subagent-statusline.test.ts
@@ -151,10 +151,10 @@ describe("extractModel", () => {
 
 describe("subagentModelLetter", () => {
   test.each<[string | null, string | null, string | null]>([
-    ["claude-fable-5", "claude-opus-4-8", "F"],
+    ["claude-fable-5", "claude-opus-4-8", "f"],
     ["claude-opus-4-8", "claude-opus-4-8", null],
     ["claude-opus-4-8[1m]", "claude-opus-4-8", null],
-    ["claude-opus-4-8", "claude-fable-5", "O"],
+    ["claude-opus-4-8", "claude-fable-5", "o"],
     [null, "claude-opus-4-8", null],
     ["claude-fable-5", null, null],
   ])("sub %p / session %p -> %p", (sub, session, expected) => {

--- a/user/scripts/subagent-statusline.ts
+++ b/user/scripts/subagent-statusline.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { styleText } from "node:util";
 import { genericGlyph, purposeGlyphs, remoteGlyph } from "./glyphs";
-import { modelLetter } from "./model";
+import { modelMarker } from "./model";
 
 export interface Task {
   id: string;
@@ -252,8 +252,8 @@ export function subagentModelLetter(
   sessionModel: string | null,
 ): string | null {
   if (!subModel || !sessionModel) return null;
-  const sub = modelLetter(subModel);
-  if (!sub || sub === modelLetter(sessionModel)) return null;
+  const sub = modelMarker(subModel)?.letter ?? null;
+  if (!sub || sub === (modelMarker(sessionModel)?.letter ?? null)) return null;
   return sub;
 }
 


### PR DESCRIPTION
The status line put three unrelated glyph systems side by side: a text model letter, a braille effort ramp, and the Nerd-Font context dial. They report the same cell width, so layout was fine, but their baselines and weights don't match. The braille dots in particular float above the baseline, so the row read as ragged.

Two changes fix it. The braille effort ramp `⠂⠆⠇⠧⠿` becomes a baseline vertical-dot ramp `∙ ⁚ ⁝ ⁞ ⁙` that sits on the text baseline next to the letter, and it grows monotonically 1→5 dots low→max where the braille set dipped at max (so higher effort could read as fewer dots). The one shape break is `max`, a 5-dot square rather than a vertical column, which is acceptable because `max` is essentially only reached via `ultrathink`. The model letter is lowercased to `o/s/h/f`, since lowercase x-height lines up with the dots noticeably better than full-cap letters.

On top of alignment, off-default session config now stands out. The model letter and effort glyph render dim at their defaults and switch to bold magenta otherwise, so a non-standard session is visible at a glance. The defaults are hard-coded constants (`opus`, `high`) rather than derived, since the default model here is always Opus. One shared accent color rather than per-model colors: no color reliably evokes a specific model, so a single override reads more clearly than an arbitrary mapping. Magenta was chosen over yellow (reads as a warning) and blue (too close to the cyan branch label).

`modelLetter`/`effortGlyph` become `modelMarker`/`effortMarker`, returning the glyph plus an `isDefault` flag so the caller applies dim-vs-accent in one place.

Verified by rendering the real `statusline.ts` in a terminal across every model and effort combination, since the alignment is a font property that no text-capture tool can show. Unit and snapshot tests updated for the new glyphs, lowercase letters, and accent styling.
