### PR TITLE
skills: disambiguate review vs pull-request follow-up

### DIFF
--- a/plugins/pull-request/skills/follow-up/SKILL.md
+++ b/plugins/pull-request/skills/follow-up/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: pull-request:follow-up
 description: >
-  Follow up on review feedback you received on a PR/MR: check what review comments need
-  responses, investigate how threads were resolved (including silent resolves), and draft
-  replies. With --auto, autonomously triage AI-reviewer (bot) threads and loop until the
-  reviewer is satisfied, clearing a bot review hands-off.
+  Follow up as the author on review feedback left on your own PR/MR: check which reviewer
+  comments still need a response, investigate how threads were resolved (including silent
+  resolves), and draft replies. With --auto, autonomously triage AI-reviewer (bot) threads and
+  loop until the reviewer is satisfied, clearing a bot review hands-off. Use when reviewers
+  commented on your PR and you need to respond or satisfy them. Triggers: "respond to review
+  comments on my PR", "address reviewer feedback", "make the bot reviewer pass".
 argument-hint: "[pr-url] [--auto] [--include-human-nits]"
 allowed-tools:
   - Bash(git:*)

--- a/plugins/review/skills/follow-up/SKILL.md
+++ b/plugins/review/skills/follow-up/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: review:follow-up
 description: >
-  Follow up on a PR/MR you reviewed: assess whether the author's fixes actually grasped each
-  concern, find silently resolved or mechanically-fixed threads, and get a graded re-review call.
-  Use after leaving review feedback to see if the author acted on it.
+  Follow up as the reviewer on a PR/MR you reviewed: did the author's fixes actually grasp
+  each concern you raised, or just go through the motions? Finds silently resolved or
+  mechanically-fixed threads and returns a graded re-review call. Use when you left review
+  comments and want to verify the author acted on them before re-approving. Triggers: "did they
+  fix my review comments", "re-review this PR", "check whether the author addressed my feedback".
 argument-hint: "[pr-url] [--on-behalf-of <reviewer>]"
 allowed-tools:
   - Bash(gh:*)


### PR DESCRIPTION
`review:follow-up` and `pull-request:follow-up` both read as "follow up on review feedback" and point in opposite directions, so the model activated one or the other as a coin flip. `review:follow-up` is for the reviewer checking whether their concerns were addressed. `pull-request:follow-up` is for the author responding to feedback on their own PR.

Rewrites both `description` fields to lead with the role (reviewer vs author) and adds concrete trigger phrases a user would actually say, so the model resolves the direction from intent.

Scope is deliberately description-only. A full rename of the skills, directories, and slugs was considered and deferred to a separate change. This edits only the YAML frontmatter `description`, not the SKILL.md bodies (another PR concurrently edits `review:follow-up`'s body), permissions, or cross-references.

`skill-lint` passes on both skills.

Original Task: [Disambiguate review:follow-up vs pull-request:follow-up](https://things.bendrucker.me/show?id=VTpYQK9jyWgfyzX39fs3tz)
