### PR TITLE
docs(gitlab): add MR review-base guidance and route draft notes through the script

### DIFF
--- a/plugins/gitlab/skills/merge-request/review.md
+++ b/plugins/gitlab/skills/merge-request/review.md
@@ -2,9 +2,22 @@
 
 Submit review feedback as draft notes that accumulate before publishing. Comments stay private until bulk-published, mirroring GitHub's pending review workflow.
 
+## Determine the Review Base
+
+Review the MR's actual diff, not whatever a local branch name resolves to. GitLab diffs an MR against the merge-base of its source and target branches. A local `git diff main...HEAD` diverges from that whenever local `main` lags `origin/main`: commits already on `origin/main` but missing from your stale local `main` fall into the range, so the review picks up changes the MR never made (the "bundled changes" false positive).
+
+Fetch first, then diff against the remote tracking ref, never a bare branch name:
+
+```bash
+git fetch origin
+git diff origin/<target-branch>...HEAD   # three-dot diffs from the merge-base
+```
+
+Read `<target-branch>` from `glab mr view <iid>` (usually `main`). For the exact diff GitLab renders, use `glab mr diff <iid>` or the API-fetched refs the script below relies on.
+
 ## Draft Notes Script
 
-`${CLAUDE_SKILL_DIR}/scripts/draft-note.ts` handles JSON construction and `glab api` calls. It fetches diff refs automatically when creating positioned comments, avoiding manual SHA management.
+Always create and anchor inline draft notes through `${CLAUDE_SKILL_DIR}/scripts/draft-note.ts`, never raw `glab api .../draft_notes` calls. The script builds the JSON payload, sets the required `Content-Type`, and fetches diff refs so positioned comments anchor to the right SHAs. Hand-rolling drops the `position` object (the note lands as a summary comment instead of inline) and hits the failures in [API Pitfalls](#api-pitfalls).
 
 ### Create
 


### PR DESCRIPTION
Two related fixes to the gitlab `merge-request` review skill, both from pitfalls hit while reviewing real MRs.

The review flow had no guidance on which base to diff against. Reviewing off a bare local `main` that lagged `origin/main` pulled already-merged commits into `main...HEAD` and produced a wrong "bundled changes" conclusion, since the MR never touched those commits. The new "Determine the Review Base" section in `review.md` resolves the base against the remote tracking ref (`origin/<target-branch>`, three-dot from the merge-base), mirroring how GitLab itself diffs the MR. This is the same root lesson as the ship-skill base fix, applied to the GitLab review flow.

The "Draft Notes Script" section only described what `draft-note.ts` does; it never told authors to use it over raw `glab api draft_notes`. Hand-rolling that call hits pitfalls the script already solves: HTTP 415 without a `Content-Type`, `position[...]` bracket fields silently dropped (so notes land as summary comments instead of inline), and PUT stripping position on re-anchor. The section now directs authors to the script and points at the existing API Pitfalls list rather than duplicating it.

Docs-only change to skill prose.

Original Task: [Commit review-base guidance to gitlab merge-request review.md](https://things.bendrucker.me/show?id=XFnNmmT8SGAyJjpF5NnF2i)
Original Task: [GitLab MR reviews: use draft-note.ts, don't hand-roll glab api](https://things.bendrucker.me/show?id=MZVqyDcohp1opNiDb8SLxZ)
