### PR TITLE
ship: resolve review base to remote tracking ref

### DIFF
--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -48,7 +48,7 @@ Infer, don't interrogate. Present the plan in one line, then proceed. `AskUserQu
 - `--effort <low|medium|high|max|ultra>`: override inferred `code-review` effort.
 - `--simplify`: force `simplify` over `code-review`.
 - `--skip <pass>` (repeatable): drop a gated pass. Names: `plan`, `code-review`, `simplify`, `comments`, `writing`, `verify`.
-- `--base <ref>`: base branch for gating. Default `main`; on a stack, the parent branch. Resolved to its remote tracking ref (`origin/...`) before diffing.
+- `--base <ref>`: base branch for gating. Default `main`; on a stack, the parent branch. Resolved to its upstream tracking ref (e.g. `origin/...`) before diffing.
 
 ## Pre-PR Reviews
 

--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -8,6 +8,8 @@ allowed-tools:
   - AskUserQuestion
   - Bash(git diff:*)
   - Bash(git status:*)
+  - Bash(git fetch:*)
+  - Bash(git rev-parse:*)
   - Skill(plan:review)
   - Skill(code-review)
   - Skill(simplify)
@@ -30,7 +32,7 @@ Default end state **green and ready**: CI green, bot comments triaged, body refr
 
 ## Decide What Applies
 
-Resolve the base: default `main`, or `--base <parent>` on a stack. Diff `git diff <base>...HEAD`, plus a plain `git diff` for uncommitted work. Gate each pass on the file set, its size, and the content behind any judgment call (new comments, refactor or new behavior). Full matrix and heuristics: [`references/passes.md`](references/passes.md).
+Resolve the base to a **remote** ref so ship's view matches what the PR merges against. From the base branch (default `main`, or `--base <parent>` on a stack), take its tracking ref via `git rev-parse --abbrev-ref --symbolic-full-name <base>@{u}`, falling back to `origin/<base>`. Fetch it first (`git fetch`) so a stale local `<base>` never inflates the diff with already-merged commits. Diff `git diff <resolved>...HEAD`, plus a plain `git diff` for uncommitted work, and thread the resolved ref as `--base` to every gated pass (including `code-review`). Gate each pass on the file set, its size, and the content behind any judgment call (new comments, refactor or new behavior). Full matrix and heuristics: [`references/passes.md`](references/passes.md).
 
 - **`plan:review`**: an approved plan is in context (Claude Code injects a `~/.claude/plans/` file). No plan, skip.
 - **Correctness and quality**: code changed. Exactly one of `code-review <effort> --fix` (default) or `simplify` (pure refactor, no new behavior). Skip on docs/config-only.
@@ -46,7 +48,7 @@ Infer, don't interrogate. Present the plan in one line, then proceed. `AskUserQu
 - `--effort <low|medium|high|max|ultra>`: override inferred `code-review` effort.
 - `--simplify`: force `simplify` over `code-review`.
 - `--skip <pass>` (repeatable): drop a gated pass. Names: `plan`, `code-review`, `simplify`, `comments`, `writing`, `verify`.
-- `--base <ref>`: diff base for gating. Default `main`; on a stack, the parent branch.
+- `--base <ref>`: base branch for gating. Default `main`; on a stack, the parent branch. Resolved to its remote tracking ref (`origin/...`) before diffing.
 
 ## Pre-PR Reviews
 

--- a/user/skills/ship/references/passes.md
+++ b/user/skills/ship/references/passes.md
@@ -4,7 +4,7 @@ Gating decisions for ship's pre-PR reviews: which pass runs, `code-review` effor
 
 ## Gating Matrix
 
-Most passes gate on the diff (against the base, plus the working tree). `plan:review` gates on whether an approved plan drove the session.
+Most passes gate on the diff (against the base, plus the working tree). The base is a remote tracking ref (`origin/<base>`), not a bare local branch, so a stale local `main` never inflates the file set with already-merged commits. `plan:review` gates on whether an approved plan drove the session.
 
 | Trigger | Pass | Notes |
 |---|---|---|

--- a/user/skills/ship/references/passes.md
+++ b/user/skills/ship/references/passes.md
@@ -4,7 +4,7 @@ Gating decisions for ship's pre-PR reviews: which pass runs, `code-review` effor
 
 ## Gating Matrix
 
-Most passes gate on the diff (against the base, plus the working tree). The base is a remote tracking ref (`origin/<base>`), not a bare local branch, so a stale local `main` never inflates the file set with already-merged commits. `plan:review` gates on whether an approved plan drove the session.
+Most passes gate on the diff (against the base, plus the working tree). The base is its upstream tracking ref (e.g. `origin/<base>`), not a bare local branch, so a stale local `main` never inflates the file set with already-merged commits. `plan:review` gates on whether an approved plan drove the session.
 
 | Trigger | Pass | Notes |
 |---|---|---|


### PR DESCRIPTION
Original Task: [ship/code-review skills: diff base uses stale local main](https://things.bendrucker.me/show?id=MLHeRTKnHy4ktEnfE29fGx)

The `ship` skill resolved its gating base as the bare local branch `main` and diffed `main...HEAD`. In a worktree branched from the fetched `origin/main`, the local `main` ref is usually behind, so `main...HEAD` folded every already-merged `origin/main` commit into the diff. The dispatched review passes then scanned files the branch never touched, and the body-refresh and pass gating saw an inflated file set. The GitHub PR was unaffected because it diffs against remote `main`, so ship's local view diverged from what actually merges.

Ship now resolves the base to its remote tracking ref: `git rev-parse --abbrev-ref --symbolic-full-name <base>@{u}` (which turns `main` into `origin/main`), falling back to `origin/<base>` when no upstream is configured. It fetches that ref first so the comparison is current, then threads the resolved ref through the gating diff and the `--base` handoff to every pass, including the built-in `code-review`. `git diff <resolved>...HEAD` keeps the merge-base semantics that match the PR.

The change is prose-only in `user/skills/ship/`, kept surgical so a follow-up building on ship's flow rebases cleanly. `allowed-tools` gains `git fetch` and `git rev-parse` for the resolution, which happens in ship's own context since the resolved ref feeds every pass.
