### PR TITLE
feat(pull-request): route bot-review wait through babysit/follow-up

### DIFF
--- a/plugins/pull-request/skills/babysit/SKILL.md
+++ b/plugins/pull-request/skills/babysit/SKILL.md
@@ -129,7 +129,7 @@ Report the event (include `minutes`) and the work done since the start SHA, then
 
 ## Reviews Hand-off
 
-With `--reviews`, after the first green invoke `pull-request:follow-up --auto <pr-url>` to triage AI-reviewer threads (fix, reply, resolve, loop until the reviewer is satisfied). follow-up calls back into babysit for each post-push CI wait, so let it own the review loop.
+With `--reviews`, after the first green invoke `pull-request:follow-up --auto <pr-url>` to triage AI-reviewer threads (fix, reply, resolve, loop until the reviewer is satisfied). follow-up calls back into babysit for each post-push CI wait, so let it own the review loop. When a bot review is expected but hasn't landed at green, follow-up waits for its first pass rather than reporting nothing to do.
 
 When it returns satisfied, re-request the **human** reviewers whose approval a push (follow-up's fixes or babysit's own) invalidated. Don't re-request bots; follow-up owns the `@bot` re-trigger.
 

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -107,7 +107,7 @@ Parse `$ARGUMENTS` for these flags. With none, create a normal PR/MR that is rea
 
 - `--draft`: open the PR/MR as a draft. Default: ready for review.
 - `--auto`: after creating, enable auto-merge so it merges once checks pass and required approvals land. Default: off.
-- `--watch`: after creating, spawn `pull-request:babysit` to actively shepherd the PR/MR (fix trivial red CI, drive the merge). Distinct from `--auto`, which only flips on the platform's passive auto-merge. Default: off.
+- `--watch`: after creating, spawn `pull-request:babysit` to actively shepherd the PR/MR (fix trivial red CI, drive the merge). When a bot review should gate the merge (asked to wait for a reviewer, or one is expected), add `--reviews` so babysit hands the wait to `follow-up --auto`, which reads each reviewer's documented signal before merging. Distinct from `--auto`, which only flips on the platform's passive auto-merge. Default: off.
 - `--dry-run` (alias `--body-only`): produce the body without creating anything. See [Dry Run](#dry-run). Default: off.
 
 ## Dry Run
@@ -131,7 +131,7 @@ If `--dry-run` (or `--body-only`) is set, follow the Dry Run section instead of 
    - **GitHub**: `gh pr merge --auto` (add `--squash` or `--rebase` to match the repo's merge method when known)
    - **GitLab**: load `gitlab:merge-request` and run its `merge.ts --auto-merge`, which handles merge trains and falls back to `glab mr merge` as needed
 1. Suggest reviewers on corporate repos (see [Reviewers](#reviewers)). Skip this step for OSS. The PR/MR already exists, so reviewer ranking runs after creation and adds no latency to it.
-1. Watch the PR/MR when `--watch` is set. Spawn a background `Agent` that invokes the `pull-request:babysit <url> --merge` skill on the PR/MR url created earlier. Babysit is session-scoped and owns its own `Monitor` watcher, so running it inside a backgrounded Agent gives it a session to live in: the create session returns immediately while the watch persists in the background. This mirrors the babysit -> follow-up handoff, where babysit delegates the review loop to another skill that owns its own watchers.
+1. Watch the PR/MR when `--watch` is set. Spawn a background `Agent` that invokes the `pull-request:babysit <url> --merge` skill (add `--reviews` when a bot review should gate the merge, per the flag above) on the PR/MR url created earlier. Babysit is session-scoped and owns its own `Monitor` watcher, so running it inside a backgrounded Agent gives it a session to live in: the create session returns immediately while the watch persists in the background. This mirrors the babysit -> follow-up handoff, where babysit delegates the review loop to another skill that owns its own watchers.
 
 ## GitLab Notes
 

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -107,7 +107,7 @@ Parse `$ARGUMENTS` for these flags. With none, create a normal PR/MR that is rea
 
 - `--draft`: open the PR/MR as a draft. Default: ready for review.
 - `--auto`: after creating, enable auto-merge so it merges once checks pass and required approvals land. Default: off.
-- `--watch`: after creating, spawn `pull-request:babysit` to actively shepherd the PR/MR (fix trivial red CI, drive the merge). When a bot review should gate the merge (asked to wait for a reviewer, or one is expected), add `--reviews` so babysit hands the wait to `follow-up --auto`, which reads each reviewer's documented signal before merging. Distinct from `--auto`, which only flips on the platform's passive auto-merge. Default: off.
+- `--watch`: after creating, spawn `pull-request:babysit` to actively shepherd the PR/MR (fix trivial red CI, drive the merge). When a bot review should gate the merge (asked to wait for a reviewer, or a review bot is configured on the repo), add `--reviews` so babysit hands the wait to `follow-up --auto`, which reads each reviewer's documented signal before merging. At creation time the pending-status-check signal does not exist yet, so lean on the configured-reviewer signal here and let follow-up re-check the live PR; a needless `--reviews` costs only one no-op hand-off. Distinct from `--auto`, which only flips on the platform's passive auto-merge. Default: off.
 - `--dry-run` (alias `--body-only`): produce the body without creating anything. See [Dry Run](#dry-run). Default: off.
 
 ## Dry Run

--- a/plugins/pull-request/skills/follow-up/SKILL.md
+++ b/plugins/pull-request/skills/follow-up/SKILL.md
@@ -57,7 +57,7 @@ Then run each round:
 
 Loop until: the reviewer's satisfaction signal hits on HEAD ([reviewers.md](reviewers.md)); no new bot threads for two rounds after a green push; max 4 rounds (oscillation guard); the idle timeout outlasts the re-trigger; or the PR closes/merges.
 
-When a bot review is **expected** (a reviewer bot assigned or already commenting, a pending bot-review status check, a configured reviewer per [reviewers.md](reviewers.md), or a bot that auto-reviews this repo) but no summary has landed on HEAD, an empty thread list means the review is still pending. The two-round satisfied exit above doesn't apply yet: wait through the same wake and re-trigger for the first summary. The idle-timeout backstop still bounds that wait, so a review that never runs times out instead of looping past the round cap. With no bot reviewer expected, an empty result is nothing to do: stop.
+When a bot review is **expected** ([reviewers.md](reviewers.md) defines the signals) but no summary has landed on HEAD, an empty thread list means the review is still pending. The two-round satisfied exit above doesn't apply yet: wait through the same wake and re-trigger for the first summary. The idle-timeout backstop still bounds that wait, so a review that never runs times out instead of looping past the round cap. With no bot reviewer expected, an empty result is nothing to do: stop.
 
 babysit and follow-up compose both directions: `babysit --reviews` hands off to this loop after its first green, and this loop calls babysit between rounds. The entry point is the outer one. "Wait for a bot review before merging" is exactly this pairing (`babysit --reviews --merge`, or this loop then merge), keyed on each reviewer's signal ([reviewers.md](reviewers.md)).
 

--- a/plugins/pull-request/skills/follow-up/SKILL.md
+++ b/plugins/pull-request/skills/follow-up/SKILL.md
@@ -57,7 +57,9 @@ Then run each round:
 
 Loop until: the reviewer's satisfaction signal hits on HEAD ([reviewers.md](reviewers.md)); no new bot threads for two rounds after a green push; max 4 rounds (oscillation guard); the idle timeout outlasts the re-trigger; or the PR closes/merges.
 
-babysit and follow-up compose both directions: `babysit --reviews` hands off to this loop after its first green, and this loop calls babysit between rounds. The entry point is the outer one.
+When a bot review is **expected** (a reviewer bot assigned or already commenting, a pending bot-review status check, a configured reviewer per [reviewers.md](reviewers.md), or a bot that auto-reviews this repo) but no summary has landed on HEAD, an empty thread list means the review is still pending. The two-round satisfied exit above doesn't apply yet: wait through the same wake and re-trigger for the first summary. The idle-timeout backstop still bounds that wait, so a review that never runs times out instead of looping past the round cap. With no bot reviewer expected, an empty result is nothing to do: stop.
+
+babysit and follow-up compose both directions: `babysit --reviews` hands off to this loop after its first green, and this loop calls babysit between rounds. The entry point is the outer one. "Wait for a bot review before merging" is exactly this pairing (`babysit --reviews --merge`, or this loop then merge), keyed on each reviewer's signal ([reviewers.md](reviewers.md)).
 
 On stop, report fixes, replies/resolves, and escalations. If the reviewer is satisfied, suggest the next action (human review, merge train, auto-merge) but don't perform it unless asked. `pull-request:babysit --merge` drives to merged.
 

--- a/plugins/pull-request/skills/follow-up/reviewers.md
+++ b/plugins/pull-request/skills/follow-up/reviewers.md
@@ -4,12 +4,12 @@ Per-reviewer "satisfied" signals for the `--auto` loop, plus how to add a review
 
 ## Satisfaction Signals
 
-Third-party reviewers converge on one shape: each leaves a single summary comment, edited in place across review cycles, holding the satisfaction signal and sometimes actionable items that never become inline threads. Read the summary, not just the thread list:
+Third-party reviewers converge on one shape: each leaves a single summary comment, edited in place across review cycles, holding the satisfaction signal and sometimes actionable items that never become inline threads. These bots deliver the verdict by editing that comment in place and submit no native GitHub review, so the reviews list (`gh api .../pulls/N/reviews` filtered to the bot) never populates and polling it hangs until timeout. Read the summary, not just the thread list or the reviews list:
 
 - Select the summary comment by `updated_at`, not `created_at`. The current signal is an edit to a comment created rounds ago, so newest-created points at the wrong one.
 - Treat the summary body as a thread source. A thread-count check alone reads an unfinished review, with actionable items parked in the summary, as satisfied.
 
-A reviewer is done when its latest summary on the current HEAD reports nothing actionable and no unresolved bot threads remain. A stale signal from an earlier SHA does not count. Each vendor phrases "none left" differently; use the string as a fast path, fall back to the thread count:
+A reviewer is done when its latest summary on the current HEAD reports nothing actionable and no unresolved bot threads remain. A stale signal from an earlier SHA does not count. An **absent** summary on HEAD means the review is still pending, so when a review is expected, wait for the summary to land before reading it. Each vendor phrases "none left" differently; use the string as a fast path, fall back to the thread count:
 
 - **CodeRabbit** (GitHub `coderabbitai`, GitLab `group_<id>_bot_<hash>`): `Actionable comments posted: 0`. Nitpick and LGTM notes are noise unless obviously correct.
 - **Greptile** (GitHub `greptile-apps[bot]` / `greptileai`): top confidence score (e.g. `5/5`); actionable items live in its "fix all with AI" section.
@@ -18,7 +18,7 @@ A reviewer is done when its latest summary on the current HEAD reports nothing a
 
 #### Copilot
 
-GitHub Copilot (`copilot-pull-request-reviewer` / `github-copilot[bot]`) diverges: it posts a fresh native GitHub review each cycle instead of editing one comment in place, so take its latest review by submission, not `updated_at`. Satisfied when that review on the current HEAD adds no actionable threads ("reviewed N files and found no issues" / "no further comments").
+GitHub Copilot (`copilot-pull-request-reviewer` / `github-copilot[bot]`) diverges and is the one exception to the reviews-list warning above: it posts a fresh native GitHub review each cycle instead of editing one comment in place, so take its latest review by submission, not `updated_at`. Satisfied when that review on the current HEAD adds no actionable threads ("reviewed N files and found no issues" / "no further comments").
 
 ## Re-triggering an Idle Reviewer
 

--- a/plugins/pull-request/skills/follow-up/reviewers.md
+++ b/plugins/pull-request/skills/follow-up/reviewers.md
@@ -20,6 +20,16 @@ A reviewer is done when its latest summary on the current HEAD reports nothing a
 
 GitHub Copilot (`copilot-pull-request-reviewer` / `github-copilot[bot]`) diverges and is the one exception to the reviews-list warning above: it posts a fresh native GitHub review each cycle instead of editing one comment in place, so take its latest review by submission, not `updated_at`. Satisfied when that review on the current HEAD adds no actionable threads ("reviewed N files and found no issues" / "no further comments").
 
+## When a Review Is Expected
+
+Whether a review is expected decides how to read an absent summary: pending (keep waiting) versus nothing-to-do (stop). This is the one definition every entry path shares. A bot review is expected when any of these hold:
+
+- a review bot is assigned or already present as a reviewer,
+- a bot-review status check is pending on HEAD,
+- a reviewer in the list above is configured for the repo, shown by its app or webhook being installed or by recent review activity.
+
+The status-check signal only appears after the PR exists and the bot's webhook has fired, so a check made at creation time sees only the first and third. Re-evaluate against the live PR before merging, where the pending check has appeared. With none of these signals present, no review is expected: an empty result is nothing to do.
+
 ## Re-triggering an Idle Reviewer
 
 If a reviewer doesn't re-review within ~5 minutes of a green push, post **one** top-level comment mentioning it to re-trigger, then reset the idle timer:

--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -84,7 +84,7 @@ The commit sits on `HEAD`, so the fast-forward is clean. It runs in the Agent to
 - `--reviews` (default on): after first green, hand bot comments to `pull-request:follow-up --auto`.
 - `--merge`: only when `/ship --merge` was passed; else stop at green.
 
-A bot review often lands after the green push with no CI event to key off. `--reviews` covers this: follow-up waits for an expected review's first pass, then triages it. A review is expected when a review bot is configured on the repo, assigned or present as a reviewer, a bot-review status check is pending, or the repo shows recent bot review activity. With none of these, the hand-off returns at once and ship stops at green.
+A bot review often lands after the green push with no CI event to key off. `--reviews` covers this: follow-up waits for an expected review's first pass, then triages it. Follow-up owns which reviews are expected, keyed on the signals in its `reviewers.md`, so ship never restates them. With none expected, the hand-off returns at once and ship stops at green.
 
 Babysit owns the CI waits. Follow-up owns the wait for an expected review and its per-reviewer signal. Ship delegates the review wait and never hand-rolls a reviews-API poll.
 

--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -84,7 +84,9 @@ The commit sits on `HEAD`, so the fast-forward is clean. It runs in the Agent to
 - `--reviews` (default on): after first green, hand bot comments to `pull-request:follow-up --auto`.
 - `--merge`: only when `/ship --merge` was passed; else stop at green.
 
-Babysit owns the CI waits and the follow-up loop. Ship never polls.
+A bot review often lands after the green push with no CI event to key off. `--reviews` covers this: follow-up waits for an expected review's first pass, then triages it. A review is expected when a review bot is configured on the repo, assigned or present as a reviewer, a bot-review status check is pending, or the repo shows recent bot review activity. With none of these, the hand-off returns at once and ship stops at green.
+
+Babysit owns the CI waits. Follow-up owns the wait for an expected review and its per-reviewer signal. Ship delegates the review wait and never hand-rolls a reviews-API poll.
 
 ## Refresh the Body
 


### PR DESCRIPTION
Wires one contract across ship and the pull-request skills: when a bot review is expected, wait for it via `babysit --reviews` / `follow-up --auto` keyed on reviewers.md's summary signal, then merge. Producer (ship) and consumers (create, babysit, follow-up) now agree on the same handoff, and the wrong signal (a poll of the native reviews API) is called out as unreachable everywhere the choice comes up.

## Why

Asked to "wait for Greptile to review before merging," an agent hand-rolled a poll against `gh api .../pulls/N/reviews` filtered to the bot. That signal never fires: Greptile (like CodeRabbit) delivers its verdict as a commit status check plus an in-place summary comment, and submits no native GitHub review, so the poll hangs until timeout. The correct machinery already existed in `babysit --reviews` / `follow-up --auto` but nothing routed the "wait before merge" request to it, and nothing named the reviews-API poll as the trap it is.

A parallel gap in ship: it opened the PR, drove CI to green, and stopped. A bot review that lands after green has no CI event to key off, so ship never waited for it and its actionable comments went untriaged.

## What Changed

- `follow-up/reviewers.md`: names the reviews-API poll as the wrong signal (the bots submit no native review), and distinguishes an absent summary on HEAD (pending, keep waiting) from a satisfied one. Copilot flagged as the one exception that does post native reviews.
- `follow-up/SKILL.md`: when a bot review is expected but no summary has landed, an empty thread list is a pending review, not "nothing to do"; the loop waits for the first pass. States that "wait for a bot review before merging" is `babysit --reviews --merge`, never a reviews-API poll.
- `babysit/SKILL.md`: notes follow-up waits for an expected review's first pass at green rather than reporting nothing to do.
- `create/SKILL.md`: `--watch` adds `--reviews` when a bot review should gate the merge, so babysit waits for the reviewer's summary signal before merging.
- `ship/SKILL.md`: after green, `--reviews` waits for an expected review (bot configured, assigned, a pending bot-review check, or prior bot activity), then hands to `follow-up --auto`. Reuses the babysit/follow-up waiter rather than inventing one.

## Removal Signal (Ship's Expected-Review Wait)

This is a detector of "a bot review is coming," and detectors drift as bots change how they publish. It earns its cost if ship sessions on bot-configured repos catch review comments that previously went untriaged, visible as follow-up activity in the session index after a green push. It should be retired or narrowed if it routinely waits on repos where no review lands (the expected-signal over-fires) or if the summary-signal detection in reviewers.md goes stale and the wait times out without triaging. Both surface in the session history for ship runs; if the wait stops paying off there, drop the expected-review paragraph and let `--reviews` trigger only on comments already present at green.

Original Task: [Route 'wait for bot review before merge' through babysit/follow-up (Greptile signal)](https://things.bendrucker.me/show?id=EjuyYLSP1otq55SAAFtdWZ)
Original Task: [Ship skill: monitor for expected bot review comments and auto-follow-up](https://things.bendrucker.me/show?id=HM9fvGojWZTjea7pGAssDg)
