### PR TITLE
ship: make plan:review non-blocking, drift-gated

### DIFF
--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -34,7 +34,7 @@ Default end state **green and ready**: CI green, bot comments triaged, body refr
 
 Resolve the base to a **remote** ref so ship's view matches what the PR merges against. From the base branch (default `main`, or `--base <parent>` on a stack), take its tracking ref via `git rev-parse --abbrev-ref --symbolic-full-name <base>@{u}`, falling back to `origin/<base>`. Fetch it first (`git fetch`) so a stale local `<base>` never inflates the diff with already-merged commits. Diff `git diff <resolved>...HEAD`, plus a plain `git diff` for uncommitted work, and thread the resolved ref as `--base` to every gated pass (including `code-review`). Gate each pass on the file set, its size, and the content behind any judgment call (new comments, refactor or new behavior). Full matrix and heuristics: [`references/passes.md`](references/passes.md).
 
-- **`plan:review`**: an approved plan is in context (Claude Code injects a `~/.claude/plans/` file). No plan, skip.
+- **`plan:review`**: a substantial approved plan is in context (`~/.claude/plans/` file) *and* the session ran long or redirected enough that the diff could have drifted from it. Dispatched in the background alongside the fix passes, joined before create. A small plan in a tight session doesn't warrant it. No plan, skip.
 - **Correctness and quality**: code changed. Exactly one of `code-review <effort> --fix` (default) or `simplify` (pure refactor, no new behavior). Skip on docs/config-only.
 - **`comments:audit`**: diff adds code comments.
 - **`writing:review`**: diff touches prose (`.md`, `.mdx`, `.rst`, docs).
@@ -52,13 +52,12 @@ Infer, don't interrogate. Present the plan in one line, then proceed. `AskUserQu
 
 ## Pre-PR Reviews
 
-Serialized before create: `code-review --fix`, `simplify`, and comment trims all write to the branch.
+Serialized before create: `code-review --fix`, `simplify`, and comment trims all write to the branch. `plan:review`, when gated in, is read-only, so it runs as a background dispatch alongside these and joins before create rather than gating them. Its findings, if any, are acted on before the PR exists. [`references/passes.md`](references/passes.md) has the DAG.
 
-1. **`plan:review`** (if gated in). Read-only, so it runs first. Surface its findings; handle fix-before-merge drift now, so the passes below cover the resulting fixes.
-2. **`comments:audit`**: needs a clean tree (the fix passes dirty it), lands trims via fast-forward (see [Comment Trims](#comment-trims)). Pauses at preflight for an agent-count approval.
-3. **Correctness and quality**: `code-review <effort> --fix` or `simplify`.
-4. **`writing:review`** over touched prose. Address salient findings before the body is written.
-5. **`verify`** end to end.
+1. **`comments:audit`**: needs a clean tree (the fix passes dirty it), lands trims via fast-forward (see [Comment Trims](#comment-trims)). Pauses at preflight for an agent-count approval.
+2. **Correctness and quality**: `code-review <effort> --fix` or `simplify`.
+3. **`writing:review`** over touched prose. Address salient findings before the body is written.
+4. **`verify`** end to end.
 
 Dirty tree at the comment pass: ask whether to commit first. `comments:audit` operates on `HEAD` and needs a clean tree.
 
@@ -75,7 +74,7 @@ The commit sits on `HEAD`, so the fast-forward is clean. It runs in the Agent to
 
 ## Create
 
-`pull-request:create` commits the working-tree fixes, pushes, opens the PR. Capture the URL: babysit and body-refresh need it.
+Join the background `plan:review` first if it was gated in. Act on fix-worthy drift before the PR exists, and carry any deferred follow-ups into the report. Then `pull-request:create` commits the working-tree fixes, pushes, opens the PR. Capture the URL: babysit and body-refresh need it.
 
 ## Babysit
 

--- a/user/skills/ship/references/passes.md
+++ b/user/skills/ship/references/passes.md
@@ -4,17 +4,37 @@ Gating decisions for ship's pre-PR reviews: which pass runs, `code-review` effor
 
 ## Gating Matrix
 
-Most passes gate on the diff (against the base, plus the working tree). The base is its upstream tracking ref (e.g. `origin/<base>`), not a bare local branch, so a stale local `main` never inflates the file set with already-merged commits. `plan:review` gates on whether an approved plan drove the session.
+Most passes gate on the diff (against the base, plus the working tree). The base is its upstream tracking ref (e.g. `origin/<base>`), not a bare local branch, so a stale local `main` never inflates the file set with already-merged commits. `plan:review` gates on the plan and the session, not the diff (see [Plan Review](#plan-review)).
 
 | Trigger | Pass | Notes |
 |---|---|---|
-| An approved plan in context (`~/.claude/plans/` file) | `plan:review` | Read-only, runs first |
+| A substantial plan in context (`~/.claude/plans/` file) and a long or redirected session | `plan:review` | Read-only, non-blocking: background dispatch, joined before create |
 | Code changes | `code-review <effort> --fix` or `simplify` | Exactly one. Skip on docs/config-only |
 | New code comments | `comments:audit` | See [Comment Trims](#comment-trims) |
 | Prose (`.md`, `.mdx`, `.rst`, docs) | `writing:review` | |
 | A runtime surface | `verify` | Declines tests-only and docs-only itself |
 
 Gating is the cost lever: never run a reviewer the change does not warrant. `--skip <pass>` drops any of them (`plan`, `code-review`, `simplify`, `comments`, `writing`, `verify`).
+
+## Plan Review
+
+`plan:review` is the one pass whose trigger is the plan, not the diff, and whose value (an outside-view read of how the implementation drifted from what was approved) only materializes when the session could actually have drifted. So it gates on two things together: a **substantial** approved plan in context, and a session that **ran long or redirected** enough for the diff to wander from it. A small plan executed in a short, direct session is cost without signal, so it skips.
+
+It is read-only and writes nothing, so it runs as a background dispatch rather than a serial pass. The DAG below is the ordering. Its point is to catch fix-worthy drift while the branch is still local, so findings are acted on before create and deferred follow-ups go to the report. No findings is the common outcome, and the join usually adds no wall-clock.
+
+```mermaid
+flowchart TD
+    S([ship start]) --> G{plan:review gated in?}
+    G -->|no| F[fix passes: comments-audit, code-review or simplify, writing, verify]
+    G -->|yes| D[dispatch plan:review in background]
+    D --> F
+    D -. concurrent .-> R[plan:review reasons over plan + diff]
+    F --> J{join plan:review}
+    R -.-> J
+    J -->|fix-worthy drift| A[act before create]
+    J -->|no findings, common| C
+    A --> C([create PR])
+```
 
 ## Effort Inference
 

--- a/user/skills/ship/references/passes.md
+++ b/user/skills/ship/references/passes.md
@@ -25,15 +25,16 @@ It is read-only and writes nothing, so it runs as a background dispatch rather t
 ```mermaid
 flowchart TD
     S([ship start]) --> G{plan:review gated in?}
-    G -->|no| F[fix passes: comments-audit, code-review or simplify, writing, verify]
+    G -->|no| F1[fix passes: comments-audit, code-review or simplify, writing, verify]
+    F1 --> C([create PR])
     G -->|yes| D[dispatch plan:review in background]
-    D --> F
+    D --> F2[fix passes: comments-audit, code-review or simplify, writing, verify]
     D -. concurrent .-> R[plan:review reasons over plan + diff]
-    F --> J{join plan:review}
+    F2 --> J{join: findings?}
     R -.-> J
     J -->|fix-worthy drift| A[act before create]
-    J -->|no findings, common| C
-    A --> C([create PR])
+    J -->|none, common| C
+    A --> C
 ```
 
 ## Effort Inference


### PR DESCRIPTION
`plan:review` ran as a serial front-gate: ship dispatched it first, read-only, and waited on it before the fix passes. Reviewing ship's real-session history surfaced that the pass has never fired, standalone or through ship. Ship is new and no plan-driven finish has come through it yet, so what it has cost is the always-on decision-matrix row and tool grant, not any runtime value.

This keeps the pass but changes when and how it runs.

- **Tighter gate.** It now needs a substantial approved plan *and* a session that ran long or redirected enough for the diff to have drifted from it. A small plan executed in a short, direct session is cost without signal, so it skips. The old gate fired on any plan in context.
- **Non-blocking.** It is read-only and writes nothing to the branch, so it no longer sits in the serial fix chain. Ship dispatches it in the background alongside the fix passes and joins it before create. The point is to catch fix-worthy drift while the branch is still local, so findings are acted on before the PR exists and deferred follow-ups go into the report. The common outcome is no findings, and because it ran alongside the fix passes the join usually adds no wall-clock.
- **Ordering lives in a DAG.** `passes.md` gains a Plan Review section with a mermaid diagram of the dispatch-alongside, join-before-create flow, so the prose describes the *why* and the diagram carries the sequence.

Original Task: [Review /ship skill performance](https://things.bendrucker.me/show?id=EVEv43SFwEJVDk4mSDok8x)
