### PR TITLE
writing: reduce PreToolUse hook friction via single dispatcher

### DIFF
--- a/plugins/writing/README.md
+++ b/plugins/writing/README.md
@@ -26,11 +26,15 @@ Used for openers and let-me-verbs where the match depends on position (line star
 
 The loader lives in [`detection/wordlists.ts`](detection/wordlists.ts). Compiled patterns are exposed via the `WORDLISTS` constant and consumed by `tropes.ts`.
 
-## Hook Commands
+## Hook Dispatcher
 
-Each hook command runs `bun install --cwd ${CLAUDE_PLUGIN_ROOT}` before the hook script. Installed plugins have no `node_modules`. Bun auto-installs dependencies from its global cache, but packages like `unist-util-visit-parents` use self-referencing subpath exports that fail without a local `node_modules`. `bun install` restores Node.js-style resolution and completes in ~50ms once installed.
+A single PreToolUse entry script, [`hooks/pretooluse.ts`](hooks/pretooluse.ts), reads stdin once and runs the numbering, headings, and tropes checkers in-process. It emits at most one output per tool call with fixed priority (deny > ask > context, earliest checker wins within a tier). Shared skips apply once up front: plan mode, plan and memory paths, and scratch paths (`tmp/` directories, `$TMPDIR`, background job dirs), where prose is internal handoff text that gets scanned later at the Bash egress surface (`--body-file`, `--body`, `gh api -F body=@file`) instead of at write time.
 
-The `check-tropes.ts` hook skips `bun install`: it has no dependencies requiring local resolution.
+Context-tier findings are suppressed when the same rule category already fired in the session within the last five minutes ([`hooks/session-state.ts`](hooks/session-state.ts)). Deny and ask tiers always fire.
+
+#### Run Log
+
+Every dispatcher run appends one JSONL line to `~/.claude/writing-hooks/log.jsonl` (rotated past 5 MB): timestamp, session, tool, extension, duration, outcome (`silent | context | ask | deny | skipped-scratch`), category, and suppression. This is the evidence surface for auditing the hooks' cost and precision. `WRITING_HOOKS_LOG=0` disables it, and a path value redirects it. Once two consecutive audits show stable behavior, flip the default off.
 
 ## Testing
 

--- a/plugins/writing/README.md
+++ b/plugins/writing/README.md
@@ -34,7 +34,7 @@ Context-tier findings are suppressed when the same rule category already fired i
 
 #### Run Log
 
-Every dispatcher run appends one JSONL line to `~/.claude/writing-hooks/log.jsonl` (rotated past 5 MB): timestamp, session, tool, extension, duration, outcome (`silent | context | ask | deny | skipped-scratch`), category, and suppression. This is the evidence surface for auditing the hooks' cost and precision. `WRITING_HOOKS_LOG=0` disables it, and a path value redirects it. Once two consecutive audits show stable behavior, flip the default off.
+Every dispatcher run appends one JSONL line to `~/.claude/writing-hooks/log.jsonl` (rotated past 5 MB): timestamp, session, tool, extension, duration, outcome (`silent | context | ask | deny | skipped-scratch`), category, and suppression. This is the evidence surface for auditing the hooks' cost and precision. `WRITING_HOOKS_LOG=0` disables it, and a path value redirects it. The `writing:analyze` skill reads it through [`skills/analyze/scripts/hook-health.ts`](skills/analyze/scripts/hook-health.ts), which summarizes volume, latency, and per-rule fire/suppress counts and raises fix opportunities. Once two consecutive health checks come back stable, flip the default off.
 
 ## Testing
 

--- a/plugins/writing/detection/comments.test.ts
+++ b/plugins/writing/detection/comments.test.ts
@@ -14,6 +14,26 @@ describe("extractComments", () => {
   it("does not treat URLs as comments", () => {
     expect(extractComments('fetch("https://example.com/path")')).toBe("");
   });
+
+  it("pulls block comments including JSDoc gutters", () => {
+    const src =
+      "/**\n * Returns the parsed config.\n * Callers own validation.\n */\nfunction parse() {}";
+    const comments = extractComments(src);
+    expect(comments).toContain("Returns the parsed config.");
+    expect(comments).toContain("Callers own validation.");
+    expect(comments).not.toContain("function parse");
+    expect(comments).not.toContain("*");
+  });
+
+  it("pulls HTML comments", () => {
+    const comments = extractComments("<div></div>\n<!-- rendered only on mobile -->");
+    expect(comments).toBe("rendered only on mobile");
+  });
+
+  it("pulls triple-quoted Python docstrings", () => {
+    const src = 'def parse():\n    """Parse the config file."""\n    return 1';
+    expect(extractComments(src)).toContain("Parse the config file.");
+  });
 });
 
 describe("comment splices", () => {

--- a/plugins/writing/detection/comments.ts
+++ b/plugins/writing/detection/comments.ts
@@ -1,12 +1,42 @@
 const SINGLE_LINE_COMMENT = /(?:^|\s)(?:\/\/|#)[^\n]*/g;
+const BLOCK_COMMENT = /\/\*[\s\S]*?\*\//g;
+const HTML_COMMENT = /<!--[\s\S]*?-->/g;
+const TRIPLE_QUOTED = /("""|''')[\s\S]*?\1/g;
 
-// Pull single-line comments (`//`, `#`) out of source so they can be checked
-// as prose. No AST: this catches the common case and treats every comment line
-// as prose regardless of language.
+// Strip a block comment's delimiters and the leading `*` gutter JSDoc-style
+// bodies carry on each line.
+function blockBody(block: string): string {
+  return block
+    .replace(/^\/\*+/, "")
+    .replace(/\*+\/$/, "")
+    .split("\n")
+    .map((line) => line.replace(/^\s*\*\s?/, "").trim())
+    .join("\n")
+    .trim();
+}
+
+// Pull comments out of source so they can be checked as prose: single-line
+// (`//`, `#`), block (`/* */`, including JSDoc), HTML (`<!-- -->`), and
+// triple-quoted Python docstrings. No AST: this catches the common cases and
+// treats every comment as prose regardless of language.
 export function extractComments(text: string): string {
-  const lines: string[] = [];
+  const parts: string[] = [];
   for (const match of text.matchAll(SINGLE_LINE_COMMENT)) {
-    lines.push(match[0].replace(/^\s*(?:\/\/|#)\s?/, ""));
+    parts.push(match[0].replace(/^\s*(?:\/\/|#)\s?/, ""));
   }
-  return lines.join("\n");
+  for (const match of text.matchAll(BLOCK_COMMENT)) {
+    parts.push(blockBody(match[0]));
+  }
+  for (const match of text.matchAll(HTML_COMMENT)) {
+    parts.push(
+      match[0]
+        .replace(/^<!--\s?/, "")
+        .replace(/\s?-->$/, "")
+        .trim(),
+    );
+  }
+  for (const match of text.matchAll(TRIPLE_QUOTED)) {
+    parts.push(match[0].slice(3, -3).trim());
+  }
+  return parts.filter((part) => part.length > 0).join("\n");
 }

--- a/plugins/writing/detection/paths.test.ts
+++ b/plugins/writing/detection/paths.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { isScratchPath } from "./paths";
+
+describe("isScratchPath", () => {
+  test.each<{ name: string; filePath: string; scratch: boolean }>([
+    { name: "repo-relative tmp/", filePath: "tmp/notes.md", scratch: true },
+    { name: "nested working-tree tmp/", filePath: "packages/app/tmp/plan.md", scratch: true },
+    { name: "system /tmp", filePath: "/tmp/pr-body.md", scratch: true },
+    { name: "resolved private tmp", filePath: "/private/tmp/claude/x.md", scratch: true },
+    {
+      name: "background job dir",
+      filePath: `${process.env.HOME}/.claude/jobs/e94f65d4/tmp/query.sh`,
+      scratch: true,
+    },
+    {
+      name: "background job file outside its tmp",
+      filePath: `${process.env.HOME}/.claude/jobs/e94f65d4/notes.md`,
+      scratch: true,
+    },
+    { name: "repo README", filePath: "README.md", scratch: false },
+    { name: "docs file named tmp.md", filePath: "docs/tmp.md", scratch: false },
+    { name: "tmp-prefixed directory", filePath: "/Users/ben/src/tmpfoo/x.md", scratch: false },
+    { name: "skill file", filePath: "plugins/writing/skills/scan/SKILL.md", scratch: false },
+  ])("$name → $scratch", ({ filePath, scratch }) => {
+    expect(isScratchPath(filePath)).toBe(scratch);
+  });
+
+  test("TMPDIR contents are scratch", () => {
+    const tmpDir = process.env.TMPDIR;
+    if (!tmpDir) return;
+    expect(isScratchPath(`${resolve(tmpDir)}/handoff.md`)).toBe(true);
+  });
+});

--- a/plugins/writing/detection/paths.test.ts
+++ b/plugins/writing/detection/paths.test.ts
@@ -26,6 +26,20 @@ describe("isScratchPath", () => {
     expect(isScratchPath(filePath)).toBe(scratch);
   });
 
+  test("a repo checked out under a tmp-named ancestor is not scratch", () => {
+    expect(isScratchPath("/Users/x/tmp/myproject/README.md", "/Users/x/tmp/myproject")).toBe(false);
+  });
+
+  test("a tmp dir below such a repo still is", () => {
+    expect(isScratchPath("/Users/x/tmp/myproject/tmp/note.md", "/Users/x/tmp/myproject")).toBe(
+      true,
+    );
+  });
+
+  test("paths outside the working tree are not scratch by segment", () => {
+    expect(isScratchPath("/Users/x/other/tmp/doc.md", "/Users/x/myproject")).toBe(false);
+  });
+
   test("TMPDIR contents are scratch", () => {
     const tmpDir = process.env.TMPDIR;
     if (!tmpDir) return;

--- a/plugins/writing/detection/paths.ts
+++ b/plugins/writing/detection/paths.ts
@@ -21,14 +21,21 @@ const JOBS_PATH_PATTERN = /\/\.claude\/jobs\//;
 // Scratch prose is internal handoff text (job scripts, worktree tmp/ notes,
 // $TMPDIR files) that no human reads at the write site. Content that matters
 // leaves through an egress surface (--body-file, --field key=@file), where the
-// Bash scan still runs. A bare `tmp` segment covers /tmp, /private/tmp, and any
-// working-tree tmp/ directory. TMPDIR and job dirs need explicit checks.
-export function isScratchPath(filePath: string): boolean {
-  const resolved = resolve(filePath);
+// Bash scan still runs. Only a tmp segment below the working tree counts as
+// scratch: a repository that happens to live under a tmp-named ancestor
+// (~/tmp/myproject) still gets its committed prose scanned.
+export function isScratchPath(filePath: string, cwd: string = process.cwd()): boolean {
+  const resolved = resolve(cwd, filePath);
   const tmpDir = process.env.TMPDIR;
   if (tmpDir && resolved.startsWith(`${resolve(tmpDir)}/`)) return true;
   if (JOBS_PATH_PATTERN.test(resolved)) return true;
-  return resolved.split("/").includes("tmp");
+  if (resolved.startsWith("/tmp/") || resolved.startsWith("/private/tmp/")) return true;
+  const root = resolve(cwd);
+  if (!resolved.startsWith(`${root}/`)) return false;
+  return resolved
+    .slice(root.length + 1)
+    .split("/")
+    .includes("tmp");
 }
 
 export function isMarkdownFile(ext: string): boolean {

--- a/plugins/writing/detection/paths.ts
+++ b/plugins/writing/detection/paths.ts
@@ -16,6 +16,21 @@ export function isPlanPath(filePath: string): boolean {
   return home !== "" && filePath.startsWith(`${home}/.claude/plans/`);
 }
 
+const JOBS_PATH_PATTERN = /\/\.claude\/jobs\//;
+
+// Scratch prose is internal handoff text (job scripts, worktree tmp/ notes,
+// $TMPDIR files) that no human reads at the write site. Content that matters
+// leaves through an egress surface (--body-file, --field key=@file), where the
+// Bash scan still runs. A bare `tmp` segment covers /tmp, /private/tmp, and any
+// working-tree tmp/ directory. TMPDIR and job dirs need explicit checks.
+export function isScratchPath(filePath: string): boolean {
+  const resolved = resolve(filePath);
+  const tmpDir = process.env.TMPDIR;
+  if (tmpDir && resolved.startsWith(`${resolve(tmpDir)}/`)) return true;
+  if (JOBS_PATH_PATTERN.test(resolved)) return true;
+  return resolved.split("/").includes("tmp");
+}
+
 export function isMarkdownFile(ext: string): boolean {
   return ext === "md" || ext === "markdown";
 }

--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -522,8 +522,8 @@ export const PATTERNS: PatternDef[] = [
     layer: "cross-sentence",
     category: "test result reporting",
     test: testResultHits,
-    message: () =>
-      "Do not report test results, counts, or CI status. Describe what is covered instead.",
+    message: (matched) =>
+      `Do not report test results, counts, or CI status ("${matched}"). Describe what is covered instead.`,
     positives: ["All 8 tests pass. Now let me check the linter.", "3/3 passing on Sonnet 4.6."],
     negatives: [
       "The tests fail because processInput is now async.",

--- a/plugins/writing/hooks/check-tropes.test.ts
+++ b/plugins/writing/hooks/check-tropes.test.ts
@@ -61,62 +61,6 @@ function mockBash(command: string): PreToolUseHookInput {
   };
 }
 
-describe("plan files", () => {
-  const planPath = `${process.env.HOME}/.claude/plans/my-plan.md`;
-
-  test.each<["Write" | "Edit"]>([
-    ["Write"],
-    ["Edit"],
-  ])("skips %s to plan file with spaced em dash", async (tool) => {
-    const input =
-      tool === "Write" ? mockWrite("This \u2014 is bad") : mockEdit("This \u2014 is bad");
-    (input.tool_input as Record<string, unknown>).file_path = planPath;
-    expect(await processInput(input)).toBeNull();
-  });
-
-  it("returns reminder for non-plan files with spaced em dash", async () => {
-    const result = await processInput(mockWrite("This \u2014 is bad"));
-    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
-  });
-});
-
-describe("plan mode", () => {
-  it("skips Write in plan mode with spaced em dash", async () => {
-    const input: PreToolUseHookInput = {
-      ...mockWrite("This \u2014 is bad"),
-      permission_mode: "plan",
-    };
-    expect(await processInput(input)).toBeNull();
-  });
-
-  it("skips Edit in plan mode with trope", async () => {
-    const input: PreToolUseHookInput = {
-      ...mockEdit("This \u2014 is bad"),
-      permission_mode: "plan",
-    };
-    expect(await processInput(input)).toBeNull();
-  });
-
-  it("still flags trope in normal mode outside plan path", async () => {
-    const result = await processInput(mockWrite("This \u2014 is bad"));
-    expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
-  });
-});
-
-describe("memory files", () => {
-  const memoryPath = `${process.env.HOME}/.claude/projects/-Users-ben-test/memory/MEMORY.md`;
-
-  test.each<["Write" | "Edit"]>([
-    ["Write"],
-    ["Edit"],
-  ])("skips %s to memory file with spaced em dash", async (tool) => {
-    const input =
-      tool === "Write" ? mockWrite("This \u2014 is bad") : mockEdit("This \u2014 is bad");
-    (input.tool_input as Record<string, unknown>).file_path = memoryPath;
-    expect(await processInput(input)).toBeNull();
-  });
-});
-
 describe("wordlist files", () => {
   const wordlistPath = "/Users/test/plugins/writing/wordlists/vocabulary.txt";
 
@@ -374,6 +318,32 @@ describe("collectText", () => {
     it("extracts inline --title", async () => {
       const texts = await collectText(mockBash('gh issue create --title "My title"'));
       expect(texts).toContain("My title");
+    });
+
+    it("reads gh api -F body=@file content", async () => {
+      await Bun.write(tmpFile, "Reply body");
+      const texts = await collectText(
+        mockBash(`gh api repos/x/issues/1/comments -F body=@${tmpFile}`),
+      );
+      expect(texts).toContain("Reply body");
+    });
+
+    it("reads glab api --field description=@file content", async () => {
+      await Bun.write(tmpFile, "MR description");
+      const texts = await collectText(
+        mockBash(`glab api projects/x/merge_requests --field description=@${tmpFile}`),
+      );
+      expect(texts).toContain("MR description");
+    });
+
+    it("ignores field flags with inline values", async () => {
+      const texts = await collectText(mockBash("gh api repos/x -F state=closed"));
+      expect(texts).toHaveLength(0);
+    });
+
+    it("ignores stdin field files", async () => {
+      const texts = await collectText(mockBash("gh api repos/x -F body=@-"));
+      expect(texts).toHaveLength(0);
     });
 
     it("returns empty for commands without text args", async () => {

--- a/plugins/writing/hooks/check-tropes.test.ts
+++ b/plugins/writing/hooks/check-tropes.test.ts
@@ -3,8 +3,12 @@ import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { collectText, processInput } from "./check-tropes";
+import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { check, collectText } from "./check-tropes";
+
+async function processInput(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
+  return (await check(input))?.output ?? null;
+}
 
 function mockWrite(content: string): PreToolUseHookInput {
   return {
@@ -334,6 +338,29 @@ describe("collectText", () => {
         mockBash(`glab api projects/x/merge_requests --field description=@${tmpFile}`),
       );
       expect(texts).toContain("MR description");
+    });
+
+    it("reads shell-quoted field file paths", async () => {
+      await Bun.write(tmpFile, "Quoted body");
+      const texts = await collectText(mockBash(`gh api repos/x/y/issues -F 'body=@${tmpFile}'`));
+      expect(texts).toContain("Quoted body");
+    });
+
+    it("reads git commit -F message files", async () => {
+      await Bun.write(tmpFile, "Commit message body");
+      const texts = await collectText(mockBash(`git commit -F ${tmpFile}`));
+      expect(texts).toContain("Commit message body");
+    });
+
+    it("reads git tag --file message files", async () => {
+      await Bun.write(tmpFile, "Tag annotation");
+      const texts = await collectText(mockBash(`git tag -a v1.0.0 --file ${tmpFile}`));
+      expect(texts).toContain("Tag annotation");
+    });
+
+    it("ignores bare -F outside git commands", async () => {
+      const texts = await collectText(mockBash("curl -F upload=/tmp/data.bin https://x"));
+      expect(texts).toHaveLength(0);
     });
 
     it("ignores field flags with inline values", async () => {

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -8,7 +8,7 @@ import {
   scanIntroduced,
   semicolonSpliceHits,
 } from "../detection/tropes";
-import { formatContext, formatDecision, type HookResult, type SyncHookJSONOutput } from "./io";
+import { formatContext, formatDecision, type HookResult } from "./io";
 
 const FILE_OP_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
 
@@ -22,18 +22,34 @@ export const BODY_FILE_FLAG = "--body-file";
 // hooks.json verbatim, and hooks.test.ts enforces the sync.
 export const FIELD_FILE_GUARD = "(-F|--field)[= ][^ ]*=@";
 
+// git commit / git tag read their message from a file via -F / --file, with no
+// `key=@` marker. Scoped to git so a bare `-F` in unrelated CLIs (curl) does
+// not trigger file reads. Guard fragment shipped to hooks.json like the above.
+export const GIT_MESSAGE_FILE_GUARD = "git (commit|tag).* (-F|--file)[= ]";
+
 const BODY_FILE_PATTERN = new RegExp(`${BODY_FILE_FLAG}[=\\s](\\S+)`);
-const FIELD_FILE_PATTERN = /(?:^|\s)(?:-F|--field)[= ]([^\s=]+)=@(\S+)/g;
+const FIELD_FILE_PATTERN = /(?:^|\s)['"]?(?:-F|--field)[= ]([^\s=]+)=@(\S+)/g;
+const GIT_MESSAGE_FILE_PATTERN = /\bgit\s+(?:commit|tag)\b[^|;&]*?\s(?:-F|--file)[= ](\S+)/g;
+
+// Shell quoting survives into the raw command string, so a path captured from
+// `-F 'body=@tmp/x.md'` carries the closing quote.
+function stripQuotes(token: string): string {
+  return token.replace(/^['"]+|['"]+$/g, "");
+}
 
 function extractBodyFilePath(command: string): string | null {
   const match = command.match(BODY_FILE_PATTERN);
-  return match?.[1] ?? null;
+  return match?.[1] ? stripQuotes(match[1]) : null;
 }
 
 function extractFieldFilePaths(command: string): string[] {
   const paths: string[] = [];
   for (const match of command.matchAll(FIELD_FILE_PATTERN)) {
-    const path = match[2];
+    const path = stripQuotes(match[2] ?? "");
+    if (path && path !== "-") paths.push(path);
+  }
+  for (const match of command.matchAll(GIT_MESSAGE_FILE_PATTERN)) {
+    const path = stripQuotes(match[1] ?? "");
     if (path && path !== "-") paths.push(path);
   }
   return paths;
@@ -156,14 +172,10 @@ function buildFileOpReminder(
 // the old and new comment text.
 const COMMENT_SPLICE_MIN = 1;
 
-function commentSplice(
-  pair: { newText: string; oldText: string },
-  filePath: string | undefined,
-): string | null {
-  if (!filePath || isProseFile(filePath)) return null;
-  const newHits = semicolonSpliceHits(extractComments(pair.newText), COMMENT_SPLICE_MIN);
+function commentSplice(comments: { newText: string; oldText: string }): string | null {
+  const newHits = semicolonSpliceHits(comments.newText, COMMENT_SPLICE_MIN);
   if (newHits.count === 0) return null;
-  const oldHits = semicolonSpliceHits(extractComments(pair.oldText), COMMENT_SPLICE_MIN);
+  const oldHits = semicolonSpliceHits(comments.oldText, COMMENT_SPLICE_MIN);
   if (newHits.count <= oldHits.count) return null;
   return `A code comment splices clauses with a semicolon ("${newHits.sample}"). Comments can be fragments. Use a period or drop a word.`;
 }
@@ -177,28 +189,29 @@ async function processFileOp(input: PreToolUseHookInput): Promise<HookResult | n
   // comments, so scan those; strings and identifiers are program text the
   // model did not write as prose.
   const prose = !filePath || isProseFile(filePath);
-  const matches = prose
-    ? scanIntroduced(pair.newText, pair.oldText, filePath, "file")
-    : scanIntroduced(
-        extractComments(pair.newText),
-        extractComments(pair.oldText),
-        filePath,
-        "file",
-      );
+  const scanPair = prose
+    ? pair
+    : { newText: extractComments(pair.newText), oldText: extractComments(pair.oldText) };
+  const matches = scanIntroduced(scanPair.newText, scanPair.oldText, filePath, "file");
 
   const deny = firstByTier(matches, "deny");
   if (deny) {
+    // Deny-tier reminders instruct a per-file corrective edit, so repeat
+    // suppression must never mute them even though they emit as context.
     return {
       output: formatContext(buildFileOpReminder(input.tool_name, filePath, deny)),
       category: deny.category,
+      suppressible: false,
     };
   }
 
   const context = firstByTier(matches, "context");
   if (context) return { output: formatContext(context.message), category: context.category };
 
-  const splice = commentSplice(pair, filePath);
-  if (splice) return { output: formatContext(splice), category: "comment splice" };
+  if (!prose) {
+    const splice = commentSplice(scanPair);
+    if (splice) return { output: formatContext(splice), category: "comment splice" };
+  }
 
   return null;
 }
@@ -224,8 +237,4 @@ export async function check(input: PreToolUseHookInput): Promise<HookResult | nu
 
   if (FILE_OP_TOOLS.has(input.tool_name)) return processFileOp(input);
   return processSideEffect(input);
-}
-
-export async function processInput(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
-  return (await check(input))?.output ?? null;
 }

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -1,9 +1,6 @@
-#!/usr/bin/env bun
-
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import { extractComments } from "../detection/comments";
-import { isMemoryPath, isPlanPath, isProseFile } from "../detection/paths";
+import { isProseFile } from "../detection/paths";
 import {
   firstByTier,
   type PatternMatch,
@@ -11,20 +8,35 @@ import {
   scanIntroduced,
   semicolonSpliceHits,
 } from "../detection/tropes";
-import { formatContext, formatDecision, isPlanMode, type SyncHookJSONOutput } from "./io";
+import { formatContext, formatDecision, type HookResult, type SyncHookJSONOutput } from "./io";
 
 const FILE_OP_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
 
 // The full set of Bash prose surfaces this hook scans. The hooks.json Bash
-// guard is derived from these; hooks.test.ts enforces the sync.
+// guard is derived from these. hooks.test.ts enforces the sync.
 export const PROSE_FLAGS = ["--body", "--message", "--description", "--title"] as const;
 export const BODY_FILE_FLAG = "--body-file";
 
+// gh api / glab api carry prose in `-F key=@file` / `--field key=@file` forms
+// that the prose-flag alternation misses. The guard fragment ships to
+// hooks.json verbatim, and hooks.test.ts enforces the sync.
+export const FIELD_FILE_GUARD = "(-F|--field)[= ][^ ]*=@";
+
 const BODY_FILE_PATTERN = new RegExp(`${BODY_FILE_FLAG}[=\\s](\\S+)`);
+const FIELD_FILE_PATTERN = /(?:^|\s)(?:-F|--field)[= ]([^\s=]+)=@(\S+)/g;
 
 function extractBodyFilePath(command: string): string | null {
   const match = command.match(BODY_FILE_PATTERN);
   return match?.[1] ?? null;
+}
+
+function extractFieldFilePaths(command: string): string[] {
+  const paths: string[] = [];
+  for (const match of command.matchAll(FIELD_FILE_PATTERN)) {
+    const path = match[2];
+    if (path && path !== "-") paths.push(path);
+  }
+  return paths;
 }
 
 const INLINE_ARG_PATTERNS = new Map<string, RegExp>(
@@ -101,8 +113,13 @@ export async function collectText(input: PreToolUseHookInput): Promise<string[]>
   if (toolName === "Bash" && typeof toolInput.command === "string") {
     const texts: string[] = [];
     const bodyFile = extractBodyFilePath(toolInput.command);
-    if (bodyFile && (await Bun.file(bodyFile).exists())) {
-      texts.push(await Bun.file(bodyFile).text());
+    const files = bodyFile
+      ? [bodyFile, ...extractFieldFilePaths(toolInput.command)]
+      : extractFieldFilePaths(toolInput.command);
+    for (const path of files) {
+      if (await Bun.file(path).exists()) {
+        texts.push(await Bun.file(path).text());
+      }
     }
     for (const flag of PROSE_FLAGS) {
       const value = extractInlineArg(toolInput.command, flag);
@@ -112,18 +129,6 @@ export async function collectText(input: PreToolUseHookInput): Promise<string[]>
   }
 
   return [];
-}
-
-function isPlanFile(input: PreToolUseHookInput): boolean {
-  const filePath = (input.tool_input as Record<string, unknown>).file_path;
-  if (typeof filePath !== "string") return false;
-  return isPlanPath(filePath);
-}
-
-function isMemoryFile(input: PreToolUseHookInput): boolean {
-  const filePath = (input.tool_input as Record<string, unknown>).file_path;
-  if (typeof filePath !== "string") return false;
-  return isMemoryPath(filePath);
 }
 
 const WORDLIST_PATH_PATTERN = /\/wordlists\/[^/]+\.txt$/;
@@ -163,67 +168,64 @@ function commentSplice(
   return `A code comment splices clauses with a semicolon ("${newHits.sample}"). Comments can be fragments. Use a period or drop a word.`;
 }
 
-async function processFileOp(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
+async function processFileOp(input: PreToolUseHookInput): Promise<HookResult | null> {
   const pair = await collectFileOpPair(input);
   if (!pair) return null;
   const filePath = (input.tool_input as Record<string, unknown>).file_path as string | undefined;
-  const matches = scanIntroduced(pair.newText, pair.oldText, filePath, "file");
+
+  // Prose rules target prose. In a code file the model's prose surface is its
+  // comments, so scan those; strings and identifiers are program text the
+  // model did not write as prose.
+  const prose = !filePath || isProseFile(filePath);
+  const matches = prose
+    ? scanIntroduced(pair.newText, pair.oldText, filePath, "file")
+    : scanIntroduced(
+        extractComments(pair.newText),
+        extractComments(pair.oldText),
+        filePath,
+        "file",
+      );
 
   const deny = firstByTier(matches, "deny");
   if (deny) {
-    return formatContext(buildFileOpReminder(input.tool_name, filePath, deny));
+    return {
+      output: formatContext(buildFileOpReminder(input.tool_name, filePath, deny)),
+      category: deny.category,
+    };
   }
 
   const context = firstByTier(matches, "context");
-  if (context) return formatContext(context.message);
+  if (context) return { output: formatContext(context.message), category: context.category };
 
   const splice = commentSplice(pair, filePath);
-  if (splice) return formatContext(splice);
+  if (splice) return { output: formatContext(splice), category: "comment splice" };
 
   return null;
 }
 
-async function processSideEffect(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
+async function processSideEffect(input: PreToolUseHookInput): Promise<HookResult | null> {
   const texts = await collectText(input);
   if (texts.length === 0) return null;
 
   const matches = scan(texts.join("\n"), undefined, "sideEffect");
   const deny = firstByTier(matches, "deny");
-  if (deny?.structural) return formatDecision("deny", deny.message);
+  if (deny?.structural) {
+    return { output: formatDecision("deny", deny.message), category: deny.category };
+  }
 
   const match = deny ?? firstByTier(matches, "context");
-  if (match) return formatContext(match.message);
+  if (match) return { output: formatContext(match.message), category: match.category };
 
   return null;
 }
 
-export async function processInput(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
-  if (isPlanFile(input)) return null;
-  if (isMemoryFile(input)) return null;
+export async function check(input: PreToolUseHookInput): Promise<HookResult | null> {
   if (isWordlistFile(input)) return null;
-  if (isPlanMode(input)) return null;
 
   if (FILE_OP_TOOLS.has(input.tool_name)) return processFileOp(input);
   return processSideEffect(input);
 }
 
-async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
-  try {
-    input = await readStdinJson<PreToolUseHookInput>();
-  } catch (error) {
-    console.error(
-      `[writing/tropes] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return;
-  }
-
-  const output = await processInput(input);
-  if (output) {
-    writeStdoutJson(output);
-  }
-}
-
-if (import.meta.main) {
-  main().catch(console.error);
+export async function processInput(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
+  return (await check(input))?.output ?? null;
 }

--- a/plugins/writing/hooks/headings.test.ts
+++ b/plugins/writing/hooks/headings.test.ts
@@ -260,35 +260,4 @@ describe("processInput", () => {
     };
     expect(getOutput(input)).toBeNull();
   });
-
-  it("skips memory markdown files", () => {
-    const memoryPath = `${process.env.HOME}/.claude/projects/-Users-ben-test/memory/MEMORY.md`;
-    expect(getOutput(mockWriteInput(memoryPath, "# introduction"))).toBeNull();
-  });
-
-  it("skips Write to plan path", () => {
-    const planPath = `${process.env.HOME}/.claude/plans/my-plan.md`;
-    expect(getOutput(mockWriteInput(planPath, "# introduction"))).toBeNull();
-  });
-
-  it("skips Write in plan mode", () => {
-    const input: PreToolUseHookInput = {
-      ...mockWriteInput("README.md", "# introduction"),
-      permission_mode: "plan",
-    };
-    expect(getOutput(input)).toBeNull();
-  });
-
-  it("skips Write with sentence heading in plan mode", () => {
-    const input: PreToolUseHookInput = {
-      ...mockWriteInput("README.md", "## Latency Is the Main Bottleneck"),
-      permission_mode: "plan",
-    };
-    expect(getOutput(input)).toBeNull();
-  });
-
-  it("still flags lowercase heading outside plan mode and plan path", () => {
-    const output = getOutput(mockWriteInput("README.md", "# introduction"));
-    expect(output?.additionalContext).toContain("AP-style title case");
-  });
 });

--- a/plugins/writing/hooks/headings.test.ts
+++ b/plugins/writing/hooks/headings.test.ts
@@ -3,7 +3,7 @@ import type {
   PreToolUseHookInput,
   PreToolUseHookSpecificOutput,
 } from "@anthropic-ai/claude-agent-sdk";
-import { checkBoldAsHeading, checkSentenceHeading, checkTitleCase, processInput } from "./headings";
+import { check, checkBoldAsHeading, checkSentenceHeading, checkTitleCase } from "./headings";
 
 function mockWriteInput(filePath: string, content: string): PreToolUseHookInput {
   return {
@@ -18,9 +18,9 @@ function mockWriteInput(filePath: string, content: string): PreToolUseHookInput 
 }
 
 function getOutput(input: PreToolUseHookInput): PreToolUseHookSpecificOutput | null {
-  const result = processInput(input);
+  const result = check(input);
   if (!result) return null;
-  return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
+  return result.output.hookSpecificOutput as PreToolUseHookSpecificOutput;
 }
 
 const titleCaseCases: { description: string; content: string; match: boolean }[] = [

--- a/plugins/writing/hooks/headings.ts
+++ b/plugins/writing/hooks/headings.ts
@@ -5,13 +5,7 @@ import { fromMarkdown } from "mdast-util-from-markdown";
 import { visit } from "unist-util-visit";
 import { getExtension, isMarkdownFile } from "../detection/paths";
 import { classifyHeadingBaseline } from "../linguistics/heading";
-import {
-  type EditInput,
-  formatContext,
-  type HookResult,
-  type SyncHookJSONOutput,
-  type WriteInput,
-} from "./io";
+import { type EditInput, formatContext, type HookResult, type WriteInput } from "./io";
 
 const PLACEHOLDER = "\0";
 
@@ -178,8 +172,4 @@ export function check(input: PreToolUseHookInput): HookResult | null {
   }
 
   return null;
-}
-
-export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {
-  return check(input)?.output ?? null;
 }

--- a/plugins/writing/hooks/headings.ts
+++ b/plugins/writing/hooks/headings.ts
@@ -1,17 +1,14 @@
-#!/usr/bin/env bun
-
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import { apStyleTitleCase } from "ap-style-title-case";
 import type { Heading, Paragraph, Strong, Text } from "mdast";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { visit } from "unist-util-visit";
-import { getExtension, isMarkdownFile, isMemoryPath, isPlanPath } from "../detection/paths";
+import { getExtension, isMarkdownFile } from "../detection/paths";
 import { classifyHeadingBaseline } from "../linguistics/heading";
 import {
   type EditInput,
   formatContext,
-  isPlanMode,
+  type HookResult,
   type SyncHookJSONOutput,
   type WriteInput,
 } from "./io";
@@ -134,7 +131,7 @@ export function checkSentenceHeading(content: string): string | null {
   return result;
 }
 
-export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {
+export function check(input: PreToolUseHookInput): HookResult | null {
   const toolName = input.tool_name;
 
   let content: string;
@@ -152,52 +149,37 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
     return null;
   }
 
-  if (isMemoryPath(filePath)) return null;
-  if (isPlanPath(filePath)) return null;
-  if (isPlanMode(input)) return null;
-
   const ext = getExtension(filePath);
   if (!isMarkdownFile(ext)) return null;
 
   const titleCase = checkTitleCase(content);
   if (titleCase) {
-    return formatContext(
-      `${titleCase}. Apply AP-style title case: capitalize major words, lowercase articles/prepositions (a, an, the, in, of, etc.) unless they start the heading.`,
-    );
+    return {
+      output: formatContext(
+        `${titleCase}. Apply AP-style title case: capitalize major words, lowercase articles/prepositions (a, an, the, in, of, etc.) unless they start the heading.`,
+      ),
+      category: "title case heading",
+    };
   }
 
   const boldHeading = checkBoldAsHeading(content);
   if (boldHeading) {
-    return formatContext(
-      `${boldHeading}. Replace the bold-colon pattern with a markdown heading (## ) at the appropriate level.`,
-    );
+    return {
+      output: formatContext(
+        `${boldHeading}. Replace the bold-colon pattern with a markdown heading (## ) at the appropriate level.`,
+      ),
+      category: "bold as heading",
+    };
   }
 
   const sentenceHeading = checkSentenceHeading(content);
   if (sentenceHeading) {
-    return formatContext(sentenceHeading);
+    return { output: formatContext(sentenceHeading), category: "sentence heading" };
   }
 
   return null;
 }
 
-async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
-  try {
-    input = await readStdinJson<PreToolUseHookInput>();
-  } catch (error) {
-    console.error(
-      `[style/headings] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return;
-  }
-
-  const output = processInput(input);
-  if (output) {
-    writeStdoutJson(output);
-  }
-}
-
-if (import.meta.main) {
-  main().catch(console.error);
+export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {
+  return check(input)?.output ?? null;
 }

--- a/plugins/writing/hooks/hooks.json
+++ b/plugins/writing/hooks/hooks.json
@@ -34,7 +34,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "in=$(cat); if printf '%s' \"$in\" | grep -qE -- '--(body|message|description|title)[-= ]|(-F|--field)[= ][^ ]*=@'; then printf '%s' \"$in\" | bun \"${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.ts\"; fi"
+            "command": "in=$(cat); if printf '%s' \"$in\" | grep -qE -- '--(body|message|description|title)[-= ]|(-F|--field)[= ][^ ]*=@|git (commit|tag).* (-F|--file)[= ]'; then printf '%s' \"$in\" | bun \"${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.ts\"; fi"
           }
         ]
       }

--- a/plugins/writing/hooks/hooks.json
+++ b/plugins/writing/hooks/hooks.json
@@ -7,16 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "in=$(cat); if printf '%s' \"$in\" | grep -qiE '(step|phase|part).{0,8}[0-9]|[0-9]\\.( |\\\\t)'; then printf '%s' \"$in\" | bun \"${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts\" write; fi"
-          },
-          {
-            "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts\"",
-            "if": "Write(**/*.md)"
-          },
-          {
-            "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\""
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.ts\""
           }
         ]
       },
@@ -25,16 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "in=$(cat); if printf '%s' \"$in\" | grep -qiE '(step|phase|part).{0,8}[0-9]|[0-9]\\.( |\\\\t)'; then printf '%s' \"$in\" | bun \"${CLAUDE_PLUGIN_ROOT}/hooks/numbering.ts\" edit; fi"
-          },
-          {
-            "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/headings.ts\"",
-            "if": "Edit(**/*.md)"
-          },
-          {
-            "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\""
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.ts\""
           }
         ]
       },
@@ -43,7 +25,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\""
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.ts\""
           }
         ]
       },
@@ -52,7 +34,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "in=$(cat); if printf '%s' \"$in\" | grep -qE -- '--(body|message|description|title)[-= ]'; then printf '%s' \"$in\" | bun \"${CLAUDE_PLUGIN_ROOT}/hooks/check-tropes.ts\"; fi"
+            "command": "in=$(cat); if printf '%s' \"$in\" | grep -qE -- '--(body|message|description|title)[-= ]|(-F|--field)[= ][^ ]*=@'; then printf '%s' \"$in\" | bun \"${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.ts\"; fi"
           }
         ]
       }

--- a/plugins/writing/hooks/hooks.test.ts
+++ b/plugins/writing/hooks/hooks.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { BODY_FILE_FLAG, PROSE_FLAGS } from "./check-tropes";
+import { BODY_FILE_FLAG, FIELD_FILE_GUARD, PROSE_FLAGS } from "./check-tropes";
 import config from "./hooks.json";
 
 type HookCommand = { type: string; command: string; if?: string };
@@ -22,42 +22,29 @@ function findCommand(matcher: string, script: string): string {
 }
 
 describe("PreToolUse gating", () => {
-  test("matchers, guards, and if conditions", () => {
+  test("every matcher routes to the single dispatcher", () => {
     const view = Object.fromEntries(
       preToolUse.map((entry) => [
         entry.matcher,
-        Object.fromEntries(
-          entry.hooks.map((hook) => [
-            scriptName(hook.command),
-            { guarded: hook.command.startsWith("in=$(cat);"), if: hook.if ?? null },
-          ]),
-        ),
+        entry.hooks.map((hook) => ({
+          script: scriptName(hook.command),
+          guarded: hook.command.startsWith("in=$(cat);"),
+        })),
       ]),
     );
     expect(view).toEqual({
-      Write: {
-        numbering: { guarded: true, if: null },
-        headings: { guarded: false, if: "Write(**/*.md)" },
-        "check-tropes": { guarded: false, if: null },
-      },
-      Edit: {
-        numbering: { guarded: true, if: null },
-        headings: { guarded: false, if: "Edit(**/*.md)" },
-        "check-tropes": { guarded: false, if: null },
-      },
-      MultiEdit: {
-        "check-tropes": { guarded: false, if: null },
-      },
-      Bash: {
-        "check-tropes": { guarded: true, if: null },
-      },
+      Write: [{ script: "pretooluse", guarded: false }],
+      Edit: [{ script: "pretooluse", guarded: false }],
+      MultiEdit: [{ script: "pretooluse", guarded: false }],
+      Bash: [{ script: "pretooluse", guarded: true }],
     });
   });
 
   test("Bash guard alternation is derived from the flags check-tropes extracts", () => {
-    const command = findCommand("Bash", "check-tropes");
+    const command = findCommand("Bash", "pretooluse");
     const alternation = `--(${PROSE_FLAGS.map((flag) => flag.slice(2)).join("|")})[-= ]`;
     expect(command).toContain(alternation);
+    expect(command).toContain(FIELD_FILE_GUARD);
     expect(`${BODY_FILE_FLAG} `).toMatch(new RegExp(alternation));
   });
 });
@@ -94,33 +81,6 @@ describe("inline guard behavior", () => {
     return { exitCode: proc.exitCode, calls };
   }
 
-  // Every shape checkMarkdown or a numbering.yml rule can flag must launch the
-  // full check; content that cannot match must skip the bun spawn.
-  test.each<{ name: string; content: string; runs: boolean }>([
-    { name: "markdown numbered heading", content: "## 1. Setup\n\nBody\n", runs: true },
-    { name: "markdown Step heading", content: "# Step 1\n", runs: true },
-    { name: "markdown Phase heading, wide gap", content: "# Phase    2\n", runs: true },
-    { name: "tab after heading number", content: "## 3.\tSetup\n", runs: true },
-    { name: "code identifier step1", content: "function step1() {}\n", runs: true },
-    { name: "code identifier Phase2", content: "class Phase2:\n    pass\n", runs: true },
-    {
-      name: "code identifier part3 in any language",
-      content: "part3 <- function(x) x\n",
-      runs: true,
-    },
-    { name: "plain prose", content: "Descriptive names only.\n", runs: false },
-    { name: "version string", content: "Bump to v1.2.3\n", runs: false },
-    { name: "bare code", content: "const total = sum(items)\n", runs: false },
-  ])("numbering: $name", async ({ content, runs }) => {
-    const command = findCommand("Write", "numbering");
-    const result = await runGuard(command, {
-      tool_name: "Write",
-      tool_input: { file_path: "/repo/example.R", content },
-    });
-    expect(result.exitCode).toBe(0);
-    expect(result.calls).toEqual(runs ? ["bun /plugin/hooks/numbering.ts write"] : []);
-  });
-
   test.each<{ name: string; command: string; runs: boolean }>([
     { name: "no prose flags", command: "git status", runs: false },
     {
@@ -134,14 +94,25 @@ describe("inline guard behavior", () => {
       runs: true,
     },
     { name: "body file", command: "jira update --body-file /tmp/x.md", runs: true },
+    {
+      name: "gh api short field file",
+      command: "gh api repos/x/issues -F body=@tmp/reply.md",
+      runs: true,
+    },
+    {
+      name: "glab api long field file",
+      command: "glab api projects/x/merge_requests --field description=@tmp/mr.md",
+      runs: true,
+    },
+    { name: "field with inline value", command: "gh api repos/x -F state=closed", runs: false },
     { name: "flag-free long command", command: "ls -la && bun test plugins/writing", runs: false },
-  ])("check-tropes bash: $name", async ({ command, runs }) => {
-    const hookCommand = findCommand("Bash", "check-tropes");
+  ])("dispatcher bash: $name", async ({ command, runs }) => {
+    const hookCommand = findCommand("Bash", "pretooluse");
     const result = await runGuard(hookCommand, {
       tool_name: "Bash",
       tool_input: { command },
     });
     expect(result.exitCode).toBe(0);
-    expect(result.calls).toEqual(runs ? ["bun /plugin/hooks/check-tropes.ts"] : []);
+    expect(result.calls).toEqual(runs ? ["bun /plugin/hooks/pretooluse.ts"] : []);
   });
 });

--- a/plugins/writing/hooks/hooks.test.ts
+++ b/plugins/writing/hooks/hooks.test.ts
@@ -2,7 +2,12 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { BODY_FILE_FLAG, FIELD_FILE_GUARD, PROSE_FLAGS } from "./check-tropes";
+import {
+  BODY_FILE_FLAG,
+  FIELD_FILE_GUARD,
+  GIT_MESSAGE_FILE_GUARD,
+  PROSE_FLAGS,
+} from "./check-tropes";
 import config from "./hooks.json";
 
 type HookCommand = { type: string; command: string; if?: string };
@@ -45,6 +50,7 @@ describe("PreToolUse gating", () => {
     const alternation = `--(${PROSE_FLAGS.map((flag) => flag.slice(2)).join("|")})[-= ]`;
     expect(command).toContain(alternation);
     expect(command).toContain(FIELD_FILE_GUARD);
+    expect(command).toContain(GIT_MESSAGE_FILE_GUARD);
     expect(`${BODY_FILE_FLAG} `).toMatch(new RegExp(alternation));
   });
 });
@@ -104,7 +110,15 @@ describe("inline guard behavior", () => {
       command: "glab api projects/x/merge_requests --field description=@tmp/mr.md",
       runs: true,
     },
+    {
+      name: "quoted field file",
+      command: "gh api repos/x/y/issues -F 'body=@tmp/body.md'",
+      runs: true,
+    },
+    { name: "git commit message file", command: "git commit -F tmp/msg.txt", runs: true },
+    { name: "git tag long file flag", command: "git tag -a v1 --file tmp/tag.txt", runs: true },
     { name: "field with inline value", command: "gh api repos/x -F state=closed", runs: false },
+    { name: "git commit inline message", command: "git commit -m 'fix: parser'", runs: false },
     { name: "flag-free long command", command: "ls -la && bun test plugins/writing", runs: false },
   ])("dispatcher bash: $name", async ({ command, runs }) => {
     const hookCommand = findCommand("Bash", "pretooluse");

--- a/plugins/writing/hooks/io.ts
+++ b/plugins/writing/hooks/io.ts
@@ -5,6 +5,18 @@ export type { SyncHookJSONOutput };
 export type WriteInput = { file_path: string; content: string };
 export type EditInput = { file_path: string; new_string: string };
 
+// A checker's finding: the formatted hook output plus the rule category the
+// dispatcher uses for session-scoped repeat suppression and the run log.
+export type HookResult = { output: SyncHookJSONOutput; category: string };
+
+export type PermissionTier = "deny" | "ask" | "context";
+
+export function tierOf(output: SyncHookJSONOutput): PermissionTier {
+  const specific = output.hookSpecificOutput as Record<string, unknown> | undefined;
+  const decision = specific?.permissionDecision;
+  return decision === "deny" || decision === "ask" ? decision : "context";
+}
+
 export function isPlanMode(input: PreToolUseHookInput): boolean {
   return input.permission_mode === "plan";
 }

--- a/plugins/writing/hooks/io.ts
+++ b/plugins/writing/hooks/io.ts
@@ -7,7 +7,9 @@ export type EditInput = { file_path: string; new_string: string };
 
 // A checker's finding: the formatted hook output plus the rule category the
 // dispatcher uses for session-scoped repeat suppression and the run log.
-export type HookResult = { output: SyncHookJSONOutput; category: string };
+// suppressible: false exempts a context-shaped output from repeat suppression
+// (deny-tier findings reformatted as per-file fix-it reminders).
+export type HookResult = { output: SyncHookJSONOutput; category: string; suppressible?: boolean };
 
 export type PermissionTier = "deny" | "ask" | "context";
 

--- a/plugins/writing/hooks/numbering.test.ts
+++ b/plugins/writing/hooks/numbering.test.ts
@@ -9,7 +9,7 @@ import type {
   PreToolUseHookSpecificOutput,
 } from "@anthropic-ai/claude-agent-sdk";
 import { formatDecision } from "./io";
-import { checkCode, checkMarkdown, processInput } from "./numbering";
+import { checkCode, checkMarkdown, hasNumberingHint, processInput } from "./numbering";
 
 function hasSg(): boolean {
   try {
@@ -64,6 +64,30 @@ describe("formatDecision", () => {
         permissionDecisionReason: "Test reason",
       },
     });
+  });
+});
+
+// Ported from the retired hooks.json shell guard: every shape checkMarkdown or
+// a numbering.yml rule can flag must pass the hint, and content that cannot
+// match must short-circuit before the expensive checks.
+describe("hasNumberingHint", () => {
+  test.each<{ name: string; content: string; hinted: boolean }>([
+    { name: "markdown numbered heading", content: "## 1. Setup\n\nBody\n", hinted: true },
+    { name: "markdown Step heading", content: "# Step 1\n", hinted: true },
+    { name: "markdown Phase heading, wide gap", content: "# Phase    2\n", hinted: true },
+    { name: "tab after heading number", content: "## 3.\tSetup\n", hinted: true },
+    { name: "code identifier step1", content: "function step1() {}\n", hinted: true },
+    { name: "code identifier Phase2", content: "class Phase2:\n    pass\n", hinted: true },
+    {
+      name: "code identifier part3 in any language",
+      content: "part3 <- function(x) x\n",
+      hinted: true,
+    },
+    { name: "plain prose", content: "Descriptive names only.\n", hinted: false },
+    { name: "version string", content: "Bump to v1.2.3\n", hinted: false },
+    { name: "bare code", content: "const total = sum(items)\n", hinted: false },
+  ])("$name", ({ content, hinted }) => {
+    expect(hasNumberingHint(content)).toBe(hinted);
   });
 });
 
@@ -191,7 +215,7 @@ describe.skipIf(!hasSg())("processInput with code (requires sg)", () => {
       "deny",
       null,
     ],
-    ["Edit tool: asks instead of deny", "main.go", "func step1() {}", "edit", "ask", null],
+    ["Edit tool: denies like Write", "main.go", "func step1() {}", "edit", "deny", null],
     ["File type filtering: checks Go files", "main.go", "func step1() {}", "write", "deny", null],
     [
       "File type filtering: checks TypeScript files",
@@ -250,28 +274,33 @@ describe.skipIf(!hasSg())("processInput with code (requires sg)", () => {
 });
 
 describe("processInput with markdown", () => {
-  test.each<[string, string, string, "ask" | null, string | null]>([
-    ['detects "# 1. Introduction"', "README.md", "# 1. Introduction", "ask", "1. Introduction"],
-    ['detects "## Step 2: Setup"', "docs.md", "## Step 2: Setup", "ask", "Step 2"],
-    ['detects "### Phase 3"', "guide.markdown", "### Phase 3", "ask", "Phase 3"],
-    ["allows descriptive headings", "README.md", "# Introduction", null, null],
+  test.each<[string, string, string, boolean, string | null]>([
+    ['detects "# 1. Introduction"', "README.md", "# 1. Introduction", true, "1. Introduction"],
+    ['detects "## Step 2: Setup"', "docs.md", "## Step 2: Setup", true, "Step 2"],
+    ['detects "### Phase 3"', "guide.markdown", "### Phase 3", true, "Phase 3"],
+    ["allows descriptive headings", "README.md", "# Introduction", false, null],
     [
       "allows headings with numbers mid-text",
       "README.md",
       "# Using OAuth2 for Authentication",
-      null,
+      false,
       null,
     ],
-  ])("%s", async (_name, filePath, content, expected, reasonContains) => {
+  ])("%s", async (_name, filePath, content, flagged, reasonContains) => {
     const output = await getOutput(mockWriteInput(filePath, content), "write");
-    if (expected === null) {
+    if (!flagged) {
       expect(output).toBeNull();
       return;
     }
-    expect(output?.permissionDecision).toBe(expected);
+    expect(output).not.toHaveProperty("permissionDecision");
     if (reasonContains) {
-      expect(output?.permissionDecisionReason).toContain(reasonContains);
+      expect(output?.additionalContext).toContain(reasonContains);
     }
+  });
+
+  it("prefixes the edit-mode reminder", async () => {
+    const output = await getOutput(mockEditInput("README.md", "# 1. Introduction"), "edit");
+    expect(output?.additionalContext).toContain("This edit introduces numbered sequences.");
   });
 });
 
@@ -303,60 +332,6 @@ describe("processInput edge cases", () => {
   });
 });
 
-describe("memory files", () => {
-  const memoryPath = `${process.env.HOME}/.claude/projects/-Users-ben-test/memory/MEMORY.md`;
-
-  it("skips Write to memory markdown with numbered heading", async () => {
-    const output = await getOutput(mockWriteInput(memoryPath, "# 1. Introduction"), "write");
-    expect(output).toBeNull();
-  });
-
-  it("skips Edit to memory markdown with numbered heading", async () => {
-    const output = await getOutput(mockEditInput(memoryPath, "# 1. Introduction"), "edit");
-    expect(output).toBeNull();
-  });
-
-  it("still asks on non-memory markdown with numbered heading", async () => {
-    const output = await getOutput(mockWriteInput("README.md", "# 1. Introduction"), "write");
-    expect(output?.permissionDecision).toBe("ask");
-  });
-});
-
-describe("plan files", () => {
-  const planPath = `${process.env.HOME}/.claude/plans/feature.md`;
-
-  it("skips Write to plan markdown with numbered heading", async () => {
-    const output = await getOutput(mockWriteInput(planPath, "# 1. Introduction"), "write");
-    expect(output).toBeNull();
-  });
-
-  it("skips Edit to plan markdown with numbered heading", async () => {
-    const output = await getOutput(mockEditInput(planPath, "# 1. Introduction"), "edit");
-    expect(output).toBeNull();
-  });
-
-  it("still asks on non-plan markdown with numbered heading", async () => {
-    const output = await getOutput(mockWriteInput("README.md", "# 1. Introduction"), "write");
-    expect(output?.permissionDecision).toBe("ask");
-  });
-});
-
-describe("plan mode", () => {
-  function mockPlanModeWrite(filePath: string, content: string): PreToolUseHookInput {
-    return { ...mockWriteInput(filePath, content), permission_mode: "plan" };
-  }
-
-  it("skips Write with numbered heading when permission_mode is plan", async () => {
-    const output = await getOutput(mockPlanModeWrite("README.md", "# 1. Introduction"), "write");
-    expect(output).toBeNull();
-  });
-
-  it("still asks when permission_mode is not plan", async () => {
-    const output = await getOutput(mockWriteInput("README.md", "# 1. Introduction"), "write");
-    expect(output?.permissionDecision).toBe("ask");
-  });
-});
-
 describe("already-numbered files", () => {
   let dir: string;
 
@@ -375,11 +350,11 @@ describe("already-numbered files", () => {
     expect(output).toBeNull();
   });
 
-  it("asks when Edit introduces numbering into a clean file", async () => {
+  it("reminds when Edit introduces numbering into a clean file", async () => {
     const filePath = join(dir, "clean.md");
     await Bun.write(filePath, "# Findings\n\nDetails.\n");
     const output = await getOutput(mockEditInput(filePath, "## 1. First issue"), "edit");
-    expect(output?.permissionDecision).toBe("ask");
+    expect(output?.additionalContext).toContain("numbered sequences");
   });
 
   it("allows non-numbered Edit to an already-numbered file", async () => {
@@ -399,10 +374,10 @@ describe("already-numbered files", () => {
     expect(output).toBeNull();
   });
 
-  it("asks when Write creates a new numbered file", async () => {
+  it("reminds when Write creates a new numbered file", async () => {
     const filePath = join(dir, "new.md");
     const output = await getOutput(mockWriteInput(filePath, "# 1. Introduction"), "write");
-    expect(output?.permissionDecision).toBe("ask");
+    expect(output?.additionalContext).toContain("numbered sequences");
   });
 
   describe.skipIf(!hasSg())("code files (requires sg)", () => {
@@ -413,18 +388,19 @@ describe("already-numbered files", () => {
       expect(output).toBeNull();
     });
 
-    it("asks when Edit introduces numbering into a clean code file", async () => {
+    it("denies when Edit introduces numbering into a clean code file", async () => {
       const filePath = join(dir, "main.go");
       await Bun.write(filePath, "package main\nfunc processItems() {}\n");
       const output = await getOutput(mockEditInput(filePath, "func step1() {}"), "edit");
-      expect(output?.permissionDecision).toBe("ask");
+      expect(output?.permissionDecision).toBe("deny");
     });
   });
 });
 
-describe("markdown ask tier", () => {
-  it("asks rather than denies on markdown Write", async () => {
+describe("markdown context tier", () => {
+  it("reminds rather than blocks on markdown Write", async () => {
     const output = await getOutput(mockWriteInput("README.md", "# 1. Introduction"), "write");
-    expect(output?.permissionDecision).toBe("ask");
+    expect(output).not.toHaveProperty("permissionDecision");
+    expect(output?.additionalContext).toContain("numbered sequences");
   });
 });

--- a/plugins/writing/hooks/numbering.test.ts
+++ b/plugins/writing/hooks/numbering.test.ts
@@ -9,7 +9,7 @@ import type {
   PreToolUseHookSpecificOutput,
 } from "@anthropic-ai/claude-agent-sdk";
 import { formatDecision } from "./io";
-import { checkCode, checkMarkdown, hasNumberingHint, processInput } from "./numbering";
+import { check, checkCode, checkMarkdown, hasNumberingHint } from "./numbering";
 
 function hasSg(): boolean {
   try {
@@ -49,9 +49,9 @@ async function getOutput(
   input: PreToolUseHookInput,
   mode: "write" | "edit" = "write",
 ): Promise<PreToolUseHookSpecificOutput | null> {
-  const result = await processInput(input, mode);
+  const result = await check(input, mode);
   if (!result) return null;
-  return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
+  return result.output.hookSpecificOutput as PreToolUseHookSpecificOutput;
 }
 
 describe("formatDecision", () => {
@@ -67,9 +67,9 @@ describe("formatDecision", () => {
   });
 });
 
-// Ported from the retired hooks.json shell guard: every shape checkMarkdown or
-// a numbering.yml rule can flag must pass the hint, and content that cannot
-// match must short-circuit before the expensive checks.
+// Every shape checkMarkdown or a numbering.yml rule can flag must pass the
+// hint. Content that cannot match must short-circuit before the expensive
+// checks.
 describe("hasNumberingHint", () => {
   test.each<{ name: string; content: string; hinted: boolean }>([
     { name: "markdown numbered heading", content: "## 1. Setup\n\nBody\n", hinted: true },

--- a/plugins/writing/hooks/numbering.ts
+++ b/plugins/writing/hooks/numbering.ts
@@ -14,15 +14,13 @@ import {
   formatContext,
   formatDecision,
   type HookResult,
-  type SyncHookJSONOutput,
   type WriteInput,
 } from "./io";
 
 export type Mode = "write" | "edit";
 
 // Cheap prefilter covering every shape checkMarkdown or a numbering.yml rule
-// can flag. It gates the expensive path (mdast parse, sg spawn) in-process,
-// replacing the shell grep guard that hooks.json used to carry.
+// can flag. It gates the expensive path (mdast parse, sg spawn) in-process.
 const NUMBER_HINT = /(step|phase|part).{0,8}[0-9]|[0-9]\.( |\t)/i;
 
 export function hasNumberingHint(content: string): boolean {
@@ -178,11 +176,4 @@ Use descriptive names instead. See CLAUDE.md Organization guidelines.`;
   }
 
   return { output: formatDecision("deny", reason), category: "numbering" };
-}
-
-export async function processInput(
-  input: PreToolUseHookInput,
-  mode: Mode,
-): Promise<SyncHookJSONOutput | null> {
-  return (await check(input, mode))?.output ?? null;
 }

--- a/plugins/writing/hooks/numbering.ts
+++ b/plugins/writing/hooks/numbering.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env bun
-
 import { execSync } from "node:child_process";
 import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
@@ -7,20 +5,29 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import type { Heading, Text } from "mdast";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { visit } from "unist-util-visit";
-import { getExtension, isMarkdownFile, isMemoryPath, isPlanPath } from "../detection/paths";
+import { getExtension, isMarkdownFile } from "../detection/paths";
 import {
   type EditInput,
+  formatContext,
   formatDecision,
-  isPlanMode,
+  type HookResult,
   type SyncHookJSONOutput,
   type WriteInput,
 } from "./io";
 
-type Mode = "write" | "edit";
+export type Mode = "write" | "edit";
+
+// Cheap prefilter covering every shape checkMarkdown or a numbering.yml rule
+// can flag. It gates the expensive path (mdast parse, sg spawn) in-process,
+// replacing the shell grep guard that hooks.json used to carry.
+const NUMBER_HINT = /(step|phase|part).{0,8}[0-9]|[0-9]\.( |\t)/i;
+
+export function hasNumberingHint(content: string): boolean {
+  return NUMBER_HINT.test(content);
+}
 
 type MarkdownMatch = {
   text: string;
@@ -117,10 +124,7 @@ async function fileAlreadyNumbered(filePath: string, ext: string): Promise<boole
   return match !== null;
 }
 
-export async function processInput(
-  input: PreToolUseHookInput,
-  mode: Mode,
-): Promise<SyncHookJSONOutput | null> {
+export async function check(input: PreToolUseHookInput, mode: Mode): Promise<HookResult | null> {
   const toolName = input.tool_name;
 
   let content: string;
@@ -138,9 +142,7 @@ export async function processInput(
     return null;
   }
 
-  if (isMemoryPath(filePath)) return null;
-  if (isPlanPath(filePath)) return null;
-  if (isPlanMode(input)) return null;
+  if (typeof content !== "string" || !hasNumberingHint(content)) return null;
 
   const ext = getExtension(filePath);
   let match: string | null = null;
@@ -167,33 +169,20 @@ ${match}
 
 Use descriptive names instead. See CLAUDE.md Organization guidelines.`;
 
-  if (mode === "edit") {
-    return formatDecision("ask", `This edit introduces numbered sequences. ${reason}`);
+  // Markdown numbering is advice, not a gate: the ask tier collected 52
+  // prompts and 0 rejections, and an ask stalls background jobs. Code keeps
+  // deny because blocking before the write is cheap and effective.
+  if (isMarkdownFile(ext)) {
+    const message = mode === "edit" ? `This edit introduces numbered sequences. ${reason}` : reason;
+    return { output: formatContext(message), category: "numbering" };
   }
 
-  const decision = isMarkdownFile(ext) ? "ask" : "deny";
-  return formatDecision(decision, reason);
+  return { output: formatDecision("deny", reason), category: "numbering" };
 }
 
-async function main(): Promise<void> {
-  const mode = (process.argv[2] || "write") as Mode;
-
-  let input: PreToolUseHookInput;
-  try {
-    input = await readStdinJson<PreToolUseHookInput>();
-  } catch (error) {
-    console.error(
-      `[style/numbering] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return;
-  }
-
-  const output = await processInput(input, mode);
-  if (output) {
-    writeStdoutJson(output);
-  }
-}
-
-if (import.meta.main) {
-  main().catch(console.error);
+export async function processInput(
+  input: PreToolUseHookInput,
+  mode: Mode,
+): Promise<SyncHookJSONOutput | null> {
+  return (await check(input, mode))?.output ?? null;
 }

--- a/plugins/writing/hooks/pretooluse.test.ts
+++ b/plugins/writing/hooks/pretooluse.test.ts
@@ -58,11 +58,16 @@ describe("single output per tool call", () => {
     );
     expect(output).not.toBeNull();
     expect(contextOf(output)).toContain("numbered sequences");
-    expect(log.outcome).toBe("context");
-    expect(log.category).toBe("numbering");
-    expect(log.tool).toBe("Write");
-    expect(log.ext).toBe("md");
-    expect(typeof log.duration_ms).toBe("number");
+    const { ts, session_id, duration_ms, ...stable } = log;
+    expect(typeof duration_ms).toBe("number");
+    expect(stable).toMatchInlineSnapshot(`
+      {
+        "category": "numbering",
+        "ext": "md",
+        "outcome": "context",
+        "tool": "Write",
+      }
+    `);
   });
 
   it("falls through to later checkers when earlier ones are silent", async () => {

--- a/plugins/writing/hooks/pretooluse.test.ts
+++ b/plugins/writing/hooks/pretooluse.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { dispatch } from "./pretooluse";
+
+function mockInput(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  overrides: Partial<PreToolUseHookInput> = {},
+): PreToolUseHookInput {
+  return {
+    hook_event_name: "PreToolUse",
+    session_id: crypto.randomUUID(),
+    transcript_path: "/tmp/test",
+    cwd: "/tmp",
+    tool_name: toolName,
+    tool_input: toolInput,
+    tool_use_id: "test",
+    ...overrides,
+  } as PreToolUseHookInput;
+}
+
+// Trips all three checkers at context tier: a numbered lowercase heading
+// (numbering + headings) and a spaced em dash (tropes).
+const MULTI_VIOLATION = "# 1. introduction\n\nThis — is bad\n";
+
+function contextOf(output: unknown): string {
+  return (output as { hookSpecificOutput: { additionalContext: string } }).hookSpecificOutput
+    .additionalContext;
+}
+
+describe("single output per tool call", () => {
+  it("emits exactly one injection when multiple checkers hit", async () => {
+    const { output, log } = await dispatch(
+      mockInput("Write", { file_path: "docs/draft.md", content: MULTI_VIOLATION }),
+    );
+    expect(output).not.toBeNull();
+    expect(contextOf(output)).toContain("numbered sequences");
+    expect(log.outcome).toBe("context");
+    expect(log.category).toBe("numbering");
+    expect(log.tool).toBe("Write");
+    expect(log.ext).toBe("md");
+    expect(typeof log.duration_ms).toBe("number");
+  });
+
+  it("falls through to later checkers when earlier ones are silent", async () => {
+    const { output, log } = await dispatch(
+      mockInput("Write", { file_path: "docs/draft.md", content: "This — is bad\n" }),
+    );
+    expect(contextOf(output)).toContain("em dash");
+    expect(log.category).toBe("spaced em dash");
+  });
+});
+
+describe("code files", () => {
+  it("stays silent on a trope inside a string literal", async () => {
+    const { output, log } = await dispatch(
+      mockInput("Write", {
+        file_path: "src/args.ts",
+        content: 'const msg = "All 8 tests pass";\n',
+      }),
+    );
+    expect(output).toBeNull();
+    expect(log.outcome).toBe("silent");
+  });
+
+  it("flags the same trope in a comment, quoting the match", async () => {
+    const { output } = await dispatch(
+      mockInput("Write", {
+        file_path: "src/args.ts",
+        content: "// All 8 tests pass\nconst x = 1;\n",
+      }),
+    );
+    expect(contextOf(output)).toContain('"All 8 tests pass"');
+  });
+});
+
+describe("session-scoped repeat suppression", () => {
+  it("suppresses a repeat of the same category within the window", async () => {
+    const sessionId = crypto.randomUUID();
+    const input = mockInput(
+      "Write",
+      { file_path: "docs/draft.md", content: MULTI_VIOLATION },
+      { session_id: sessionId },
+    );
+    const now = 1_000_000;
+
+    const first = await dispatch(input, now);
+    expect(first.output).not.toBeNull();
+    expect(first.log.outcome).toBe("context");
+
+    const second = await dispatch(input, now + 60_000);
+    expect(second.output).toBeNull();
+    expect(second.log.outcome).toBe("silent");
+    expect(second.log.suppressed).toBe(true);
+    expect(second.log.category).toBe("numbering");
+  });
+
+  it("fires again once the window has passed", async () => {
+    const sessionId = crypto.randomUUID();
+    const input = mockInput(
+      "Write",
+      { file_path: "docs/draft.md", content: MULTI_VIOLATION },
+      { session_id: sessionId },
+    );
+    const now = 1_000_000;
+
+    await dispatch(input, now);
+    const later = await dispatch(input, now + 6 * 60_000);
+    expect(later.output).not.toBeNull();
+  });
+
+  it("does not suppress across sessions", async () => {
+    const content = { file_path: "docs/draft.md", content: MULTI_VIOLATION };
+    const now = 1_000_000;
+
+    await dispatch(mockInput("Write", content), now);
+    const other = await dispatch(mockInput("Write", content), now + 60_000);
+    expect(other.output).not.toBeNull();
+  });
+
+  it("never suppresses deny-tier decisions", async () => {
+    const sessionId = crypto.randomUUID();
+    const command = 'gh pr create --body "This feature — which broke — is fixed"';
+    const input = mockInput("Bash", { command }, { session_id: sessionId });
+    const now = 1_000_000;
+
+    const first = await dispatch(input, now);
+    const second = await dispatch(input, now + 1_000);
+    expect(first.log.outcome).toBe("deny");
+    expect(second.log.outcome).toBe("deny");
+    expect(second.output).not.toBeNull();
+  });
+});
+
+describe("scratch paths", () => {
+  test.each<{ name: string; filePath: string }>([
+    { name: "repo tmp/", filePath: "tmp/notes.md" },
+    { name: "system /tmp", filePath: "/tmp/pr-body.md" },
+    { name: "job dir", filePath: `${process.env.HOME}/.claude/jobs/abc123/tmp/handoff.md` },
+  ])("skips all checkers for $name", async ({ filePath }) => {
+    const { output, log } = await dispatch(
+      mockInput("Write", { file_path: filePath, content: MULTI_VIOLATION }),
+    );
+    expect(output).toBeNull();
+    expect(log.outcome).toBe("skipped-scratch");
+  });
+
+  it("still scans scratch content at the Bash egress surface", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "dispatch-egress-"));
+    const bodyFile = join(dir, "pr-body.md");
+    await Bun.write(bodyFile, "We must delve into the issue");
+    const { output, log } = await dispatch(
+      mockInput("Bash", { command: `gh pr create --body-file ${bodyFile}` }),
+    );
+    await rm(dir, { recursive: true, force: true });
+    expect(contextOf(output)).toContain("delve");
+    expect(log.outcome).toBe("context");
+  });
+
+  it("scans gh api field-file egress", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "dispatch-egress-"));
+    const replyFile = join(dir, "reply.md");
+    await Bun.write(replyFile, "We must delve into the issue");
+    const { output } = await dispatch(
+      mockInput("Bash", { command: `gh api repos/x/issues/1/comments -F body=@${replyFile}` }),
+    );
+    await rm(dir, { recursive: true, force: true });
+    expect(contextOf(output)).toContain("delve");
+  });
+});
+
+describe("shared skips", () => {
+  const violating = { file_path: "docs/draft.md", content: MULTI_VIOLATION };
+
+  it("skips plan mode entirely", async () => {
+    const { output, log } = await dispatch(
+      mockInput("Write", violating, { permission_mode: "plan" }),
+    );
+    expect(output).toBeNull();
+    expect(log.outcome).toBe("silent");
+  });
+
+  it("skips plan files", async () => {
+    const { output } = await dispatch(
+      mockInput("Write", { ...violating, file_path: `${process.env.HOME}/.claude/plans/p.md` }),
+    );
+    expect(output).toBeNull();
+  });
+
+  it("skips memory files", async () => {
+    const { output } = await dispatch(
+      mockInput("Write", {
+        ...violating,
+        file_path: `${process.env.HOME}/.claude/projects/-Users-ben-test/memory/MEMORY.md`,
+      }),
+    );
+    expect(output).toBeNull();
+  });
+
+  it("stays silent on clean prose", async () => {
+    const { output, log } = await dispatch(
+      mockInput("Write", { file_path: "docs/draft.md", content: "# Cache Layer\n\nPlain.\n" }),
+    );
+    expect(output).toBeNull();
+    expect(log.outcome).toBe("silent");
+  });
+});

--- a/plugins/writing/hooks/pretooluse.test.ts
+++ b/plugins/writing/hooks/pretooluse.test.ts
@@ -1,10 +1,29 @@
-import { describe, expect, it, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { dispatch } from "./pretooluse";
+
+// Session-state files land in $TMPDIR. Redirect it so test runs do not litter
+// the shared OS temp dir with per-UUID state files.
+const originalTmpdir = process.env.TMPDIR;
+let stateDir: string;
+
+beforeAll(() => {
+  stateDir = mkdtempSync(join(tmpdir(), "dispatch-state-"));
+  process.env.TMPDIR = stateDir;
+});
+
+afterAll(async () => {
+  if (originalTmpdir === undefined) {
+    delete process.env.TMPDIR;
+  } else {
+    process.env.TMPDIR = originalTmpdir;
+  }
+  await rm(stateDir, { recursive: true, force: true });
+});
 
 function mockInput(
   toolName: string,
@@ -15,7 +34,7 @@ function mockInput(
     hook_event_name: "PreToolUse",
     session_id: crypto.randomUUID(),
     transcript_path: "/tmp/test",
-    cwd: "/tmp",
+    cwd: "/Users/test/project",
     tool_name: toolName,
     tool_input: toolInput,
     tool_use_id: "test",
@@ -76,14 +95,27 @@ describe("code files", () => {
     );
     expect(contextOf(output)).toContain('"All 8 tests pass"');
   });
+
+  it("scans block comments, not just single-line ones", async () => {
+    const { output } = await dispatch(
+      mockInput("Write", {
+        file_path: "src/cache.ts",
+        content: "/**\n * The cache — cold at first — warms up.\n */\nconst x = 1;\n",
+      }),
+    );
+    expect(contextOf(output)).toContain("em dash");
+  });
 });
 
 describe("session-scoped repeat suppression", () => {
+  // Numbered heading only: title-cased so headings stays silent, no tropes.
+  const NUMBERED_ONLY = "# 1. Introduction\n\nPlain prose here.\n";
+
   it("suppresses a repeat of the same category within the window", async () => {
     const sessionId = crypto.randomUUID();
     const input = mockInput(
       "Write",
-      { file_path: "docs/draft.md", content: MULTI_VIOLATION },
+      { file_path: "docs/draft.md", content: NUMBERED_ONLY },
       { session_id: sessionId },
     );
     const now = 1_000_000;
@@ -99,7 +131,7 @@ describe("session-scoped repeat suppression", () => {
     expect(second.log.category).toBe("numbering");
   });
 
-  it("fires again once the window has passed", async () => {
+  it("falls through to the next finding when the winner is suppressed", async () => {
     const sessionId = crypto.randomUUID();
     const input = mockInput(
       "Write",
@@ -108,13 +140,32 @@ describe("session-scoped repeat suppression", () => {
     );
     const now = 1_000_000;
 
+    const first = await dispatch(input, now);
+    expect(first.log.category).toBe("numbering");
+
+    const second = await dispatch(input, now + 60_000);
+    expect(second.output).not.toBeNull();
+    expect(second.log.outcome).toBe("context");
+    expect(second.log.category).toBe("title case heading");
+  });
+
+  it("fires again once the window has passed", async () => {
+    const sessionId = crypto.randomUUID();
+    const input = mockInput(
+      "Write",
+      { file_path: "docs/draft.md", content: NUMBERED_ONLY },
+      { session_id: sessionId },
+    );
+    const now = 1_000_000;
+
     await dispatch(input, now);
     const later = await dispatch(input, now + 6 * 60_000);
     expect(later.output).not.toBeNull();
+    expect(later.log.category).toBe("numbering");
   });
 
   it("does not suppress across sessions", async () => {
-    const content = { file_path: "docs/draft.md", content: MULTI_VIOLATION };
+    const content = { file_path: "docs/draft.md", content: NUMBERED_ONLY };
     const now = 1_000_000;
 
     await dispatch(mockInput("Write", content), now);
@@ -133,6 +184,22 @@ describe("session-scoped repeat suppression", () => {
     expect(first.log.outcome).toBe("deny");
     expect(second.log.outcome).toBe("deny");
     expect(second.output).not.toBeNull();
+  });
+
+  it("never suppresses deny-origin fix-it reminders on file ops", async () => {
+    const sessionId = crypto.randomUUID();
+    const input = mockInput(
+      "Write",
+      { file_path: "docs/draft.md", content: "This — is bad\n" },
+      { session_id: sessionId },
+    );
+    const now = 1_000_000;
+
+    const first = await dispatch(input, now);
+    const second = await dispatch(input, now + 60_000);
+    expect(contextOf(first.output)).toContain("follow-up Edit");
+    expect(contextOf(second.output)).toContain("follow-up Edit");
+    expect(second.log.outcome).toBe("context");
   });
 });
 

--- a/plugins/writing/hooks/pretooluse.ts
+++ b/plugins/writing/hooks/pretooluse.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env bun
+
+import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import { getExtension, isMemoryPath, isPlanPath, isScratchPath } from "../detection/paths";
+import * as tropes from "./check-tropes";
+import * as headings from "./headings";
+import { type HookResult, isPlanMode, type SyncHookJSONOutput, tierOf } from "./io";
+import * as numbering from "./numbering";
+import { appendRunLog, type RunLogEntry, type RunOutcome } from "./run-log";
+import { recentlyFired, recordFired } from "./session-state";
+
+const FILE_OP_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
+
+const TIER_RANK = { deny: 0, ask: 1, context: 2 } as const;
+
+export type DispatchResult = {
+  output: SyncHookJSONOutput | null;
+  log: RunLogEntry;
+};
+
+function filePathOf(input: PreToolUseHookInput): string | undefined {
+  if (!FILE_OP_TOOLS.has(input.tool_name)) return undefined;
+  const filePath = (input.tool_input as Record<string, unknown>).file_path;
+  return typeof filePath === "string" ? filePath : undefined;
+}
+
+// One dispatcher run sequences all checkers in-process and emits at most one
+// output. Priority is deny > ask > context, and within a tier the earliest
+// checker in numbering → headings → tropes order wins.
+export async function dispatch(
+  input: PreToolUseHookInput,
+  now: number = Date.now(),
+): Promise<DispatchResult> {
+  const start = performance.now();
+  const filePath = filePathOf(input);
+
+  const base = {
+    ts: new Date(now).toISOString(),
+    session_id: input.session_id,
+    tool: input.tool_name,
+    ext: filePath ? getExtension(filePath) : "",
+  };
+
+  const finish = (
+    output: SyncHookJSONOutput | null,
+    outcome: RunOutcome,
+    extra: Partial<RunLogEntry> = {},
+  ): DispatchResult => ({
+    output,
+    log: { ...base, duration_ms: Math.round(performance.now() - start), outcome, ...extra },
+  });
+
+  if (isPlanMode(input)) return finish(null, "silent");
+  if (filePath && isScratchPath(filePath)) return finish(null, "skipped-scratch");
+  if (filePath && (isPlanPath(filePath) || isMemoryPath(filePath))) return finish(null, "silent");
+
+  const mode: numbering.Mode = input.tool_name === "Edit" ? "edit" : "write";
+  const checkers = [
+    () => numbering.check(input, mode),
+    async () => headings.check(input),
+    () => tropes.check(input),
+  ];
+
+  const results: HookResult[] = [];
+  for (const checker of checkers) {
+    const result = await checker();
+    if (result) results.push(result);
+  }
+  if (results.length === 0) return finish(null, "silent");
+
+  let winner = results[0] as HookResult;
+  for (const result of results.slice(1)) {
+    if (TIER_RANK[tierOf(result.output)] < TIER_RANK[tierOf(winner.output)]) {
+      winner = result;
+    }
+  }
+
+  const tier = tierOf(winner.output);
+  if (tier === "context") {
+    if (await recentlyFired(input.session_id, winner.category, now)) {
+      return finish(null, "silent", { category: winner.category, suppressed: true });
+    }
+    await recordFired(input.session_id, winner.category, now);
+  }
+
+  return finish(winner.output, tier, { category: winner.category });
+}
+
+async function main(): Promise<void> {
+  let input: PreToolUseHookInput;
+  try {
+    input = await readStdinJson<PreToolUseHookInput>();
+  } catch (error) {
+    console.error(
+      `[writing/pretooluse] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  const { output, log } = await dispatch(input);
+  appendRunLog(log);
+  if (output) {
+    writeStdoutJson(output);
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/plugins/writing/hooks/pretooluse.ts
+++ b/plugins/writing/hooks/pretooluse.ts
@@ -52,7 +52,7 @@ export async function dispatch(
   });
 
   if (isPlanMode(input)) return finish(null, "silent");
-  if (filePath && isScratchPath(filePath)) return finish(null, "skipped-scratch");
+  if (filePath && isScratchPath(filePath, input.cwd)) return finish(null, "skipped-scratch");
   if (filePath && (isPlanPath(filePath) || isMemoryPath(filePath))) return finish(null, "silent");
 
   const mode: numbering.Mode = input.tool_name === "Edit" ? "edit" : "write";
@@ -62,29 +62,43 @@ export async function dispatch(
     () => tropes.check(input),
   ];
 
+  // One checker crashing must not take down the others or the run log.
   const results: HookResult[] = [];
   for (const checker of checkers) {
-    const result = await checker();
-    if (result) results.push(result);
+    try {
+      const result = await checker();
+      if (result) results.push(result);
+    } catch (error) {
+      console.error(
+        `[writing/pretooluse] checker failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
   if (results.length === 0) return finish(null, "silent");
 
-  let winner = results[0] as HookResult;
-  for (const result of results.slice(1)) {
-    if (TIER_RANK[tierOf(result.output)] < TIER_RANK[tierOf(winner.output)]) {
-      winner = result;
+  // Stable sort: within a tier the earliest checker keeps priority. A
+  // suppressed winner falls through to the next result rather than muting
+  // findings whose categories never fired.
+  const ordered = [...results].sort(
+    (a, b) => TIER_RANK[tierOf(a.output)] - TIER_RANK[tierOf(b.output)],
+  );
+  let suppressed: HookResult | undefined;
+  for (const result of ordered) {
+    const tier = tierOf(result.output);
+    if (tier === "context" && result.suppressible !== false) {
+      if (await recentlyFired(input.session_id, result.category, now)) {
+        suppressed ??= result;
+        continue;
+      }
+      await recordFired(input.session_id, result.category, now);
     }
+    return finish(result.output, tier, { category: result.category });
   }
-
-  const tier = tierOf(winner.output);
-  if (tier === "context") {
-    if (await recentlyFired(input.session_id, winner.category, now)) {
-      return finish(null, "silent", { category: winner.category, suppressed: true });
-    }
-    await recordFired(input.session_id, winner.category, now);
-  }
-
-  return finish(winner.output, tier, { category: winner.category });
+  return finish(
+    null,
+    "silent",
+    suppressed ? { category: suppressed.category, suppressed: true } : {},
+  );
 }
 
 async function main(): Promise<void> {

--- a/plugins/writing/hooks/pretooluse.ts
+++ b/plugins/writing/hooks/pretooluse.ts
@@ -58,7 +58,7 @@ export async function dispatch(
   const mode: numbering.Mode = input.tool_name === "Edit" ? "edit" : "write";
   const checkers = [
     () => numbering.check(input, mode),
-    async () => headings.check(input),
+    () => headings.check(input),
     () => tropes.check(input),
   ];
 

--- a/plugins/writing/hooks/run-log.test.ts
+++ b/plugins/writing/hooks/run-log.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { appendRunLog, type RunLogEntry, resolveLogPath } from "./run-log";
+
+function entry(overrides: Partial<RunLogEntry> = {}): RunLogEntry {
+  return {
+    ts: "2026-07-09T00:00:00.000Z",
+    session_id: "test-session",
+    tool: "Write",
+    ext: "md",
+    duration_ms: 5,
+    outcome: "silent",
+    ...overrides,
+  };
+}
+
+describe("resolveLogPath", () => {
+  it("defaults to the home-dir log when unset", () => {
+    expect(resolveLogPath(undefined)).toBe(
+      join(homedir(), ".claude", "writing-hooks", "log.jsonl"),
+    );
+  });
+
+  test.each<[string]>([["0"], ["false"], ["off"], ["OFF"]])("disables for %p", (value) => {
+    expect(resolveLogPath(value)).toBeNull();
+  });
+
+  test.each<[string]>([["1"], ["true"], ["on"]])("stays on the default path for %p", (value) => {
+    expect(resolveLogPath(value)).toBe(join(homedir(), ".claude", "writing-hooks", "log.jsonl"));
+  });
+
+  it("treats any other value as a destination override", () => {
+    expect(resolveLogPath("/custom/dir/hooks.jsonl")).toBe("/custom/dir/hooks.jsonl");
+  });
+});
+
+describe("appendRunLog", () => {
+  it("creates the directory and appends one JSONL line per run", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "run-log-"));
+    const path = join(dir, "nested", "log.jsonl");
+
+    appendRunLog(entry({ outcome: "context", category: "numbering" }), path);
+    appendRunLog(entry({ outcome: "silent", suppressed: true, category: "numbering" }), path);
+
+    const lines = (await Bun.file(path).text()).trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0] as string)).toMatchObject({
+      outcome: "context",
+      category: "numbering",
+      tool: "Write",
+    });
+    expect(JSON.parse(lines[1] as string)).toMatchObject({ suppressed: true });
+  });
+
+  it("does nothing when logging is disabled", () => {
+    expect(() => appendRunLog(entry(), null)).not.toThrow();
+  });
+
+  it("rotates once the file exceeds the size cap", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "run-log-"));
+    const path = join(dir, "log.jsonl");
+    const line = `${JSON.stringify(entry())}\n`;
+    const filler = line.repeat(Math.ceil((5 * 1024 * 1024 + 1) / line.length));
+    await Bun.write(path, filler);
+
+    appendRunLog(entry({ outcome: "deny" }), path);
+
+    const rotated = Bun.file(`${path}.1`);
+    expect(await rotated.exists()).toBe(true);
+    expect(rotated.size).toBe(filler.length);
+    const fresh = (await Bun.file(path).text()).trim().split("\n");
+    expect(fresh).toHaveLength(1);
+    expect(JSON.parse(fresh[0] as string)).toMatchObject({ outcome: "deny" });
+  });
+});

--- a/plugins/writing/hooks/run-log.ts
+++ b/plugins/writing/hooks/run-log.ts
@@ -1,0 +1,47 @@
+// biome-ignore lint/style/noRestrictedImports: concurrent sessions append to one log, so writes need O_APPEND atomicity and rotation needs rename. Bun.write read-modify-write would drop lines.
+import { appendFileSync, mkdirSync, renameSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export type RunOutcome = "silent" | "context" | "ask" | "deny" | "skipped-scratch";
+
+export type RunLogEntry = {
+  ts: string;
+  session_id: string;
+  tool: string;
+  ext: string;
+  duration_ms: number;
+  outcome: RunOutcome;
+  category?: string;
+  suppressed?: boolean;
+};
+
+const MAX_LOG_BYTES = 5 * 1024 * 1024;
+const OFF_VALUES = new Set(["0", "false", "off"]);
+const ON_VALUES = new Set(["1", "true", "on"]);
+
+// WRITING_HOOKS_LOG resolves in this one place: unset defaults to on (current
+// phase: collecting evidence), 0/false/off disables, and any other value is a
+// destination path override. A settings `env` entry is enough to turn logging
+// off later.
+export function resolveLogPath(
+  env: string | undefined = process.env.WRITING_HOOKS_LOG,
+): string | null {
+  if (env !== undefined && OFF_VALUES.has(env.toLowerCase())) return null;
+  if (env && !ON_VALUES.has(env.toLowerCase())) return env;
+  return join(homedir(), ".claude", "writing-hooks", "log.jsonl");
+}
+
+export function appendRunLog(entry: RunLogEntry, path: string | null = resolveLogPath()): void {
+  if (!path) return;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    const file = Bun.file(path);
+    if (file.size > MAX_LOG_BYTES) {
+      renameSync(path, `${path}.1`);
+    }
+    appendFileSync(path, `${JSON.stringify(entry)}\n`);
+  } catch {
+    // Observability must never break the hook.
+  }
+}

--- a/plugins/writing/hooks/session-state.ts
+++ b/plugins/writing/hooks/session-state.ts
@@ -1,0 +1,47 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Session-scoped repeat suppression: a context-tier rule that already fired
+// recently in this session gets muted instead of re-injected. The state is one
+// small JSON file per session in the OS temp dir, so it disappears with the
+// machine's temp cleanup and needs no explicit lifecycle.
+export const SUPPRESS_WINDOW_MS = 5 * 60 * 1000;
+
+export type SessionState = Record<string, number>;
+
+function statePath(sessionId: string): string {
+  const safe = sessionId.replace(/[^\w-]/g, "");
+  return join(process.env.TMPDIR ?? tmpdir(), `writing-hooks-${safe}.json`);
+}
+
+async function readState(sessionId: string): Promise<SessionState> {
+  try {
+    const file = Bun.file(statePath(sessionId));
+    if (!(await file.exists())) return {};
+    const parsed: unknown = await file.json();
+    if (!parsed || typeof parsed !== "object") return {};
+    return parsed as SessionState;
+  } catch {
+    return {};
+  }
+}
+
+export async function recentlyFired(
+  sessionId: string,
+  category: string,
+  now: number,
+): Promise<boolean> {
+  const state = await readState(sessionId);
+  const last = state[category];
+  return typeof last === "number" && now - last < SUPPRESS_WINDOW_MS;
+}
+
+export async function recordFired(sessionId: string, category: string, now: number): Promise<void> {
+  try {
+    const state = await readState(sessionId);
+    state[category] = now;
+    await Bun.write(statePath(sessionId), JSON.stringify(state));
+  } catch {
+    // State is an optimization. A failed write must not break the hook.
+  }
+}

--- a/plugins/writing/skills/analyze/SKILL.md
+++ b/plugins/writing/skills/analyze/SKILL.md
@@ -80,6 +80,29 @@ bun ${CLAUDE_SKILL_DIR}/scripts/judge-run.ts headings tmp/heading-labels.tsv
 
 See the "Meaning-Layer Judge" section of [references/methodology.md](references/methodology.md) for the rubric, prompt versioning, gate, and calibration protocol.
 
+## Hook Health
+
+The PreToolUse dispatcher (`hooks/pretooluse.ts`) appends one JSONL line per run to `~/.claude/writing-hooks/log.jsonl` (controlled by `WRITING_HOOKS_LOG`, see the plugin README). That log is the runtime half of this skill's audit: the wordlist analysis judges rule precision from session history, and the health check judges hook behavior from what the dispatcher actually did.
+
+Run it before or alongside the wordlist audit:
+
+```bash
+bun ${CLAUDE_SKILL_DIR}/scripts/hook-health.ts
+bun ${CLAUDE_SKILL_DIR}/scripts/hook-health.ts --since 2026-07-01 --json
+bun ${CLAUDE_SKILL_DIR}/scripts/hook-health.ts --log /path/to/log.jsonl
+```
+
+It reads the default log (plus its `.1` rotation) and reports run volume, outcome and tool breakdowns, latency percentiles for the silent hot path, and per-category fire/suppress counts. The report ends with an opportunities list, each naming a concrete fix:
+
+- a category dominating injections points at a precision audit of that rule (sample its firings from session history, then demote, narrow, or retire)
+- a category suppressed as often as it fires means the reminder is not changing behavior within sessions
+- any `ask` outcome is a regression (the numbering demotion expected zero) and names a rule to demote
+- silent-run p95 over budget points at the dispatcher's checker order and prefilters
+- a high `skipped-scratch` share warrants checking recent Write paths against `isScratchPath` for swallowed durable prose
+- a clean report is itself the signal: after two consecutive stable audits, flip the `WRITING_HOOKS_LOG` default to off
+
+Fixes land in the plugin (wordlists, `detection/`, `hooks/`), then the next audit's log confirms or refutes them.
+
 ## Metrics
 
 **Lift**: how distinctive a phrase is to assistant output vs. user text. `lift = rate_assistant / rate_user_smoothed`, where rates are per-million-token frequencies. A lift of 10.0 means the assistant uses the phrase 10x more per token than the user. The `--min-lift` threshold (default 5.0) gates new candidate phrases only. Rule keep/remove uses a direct rate comparison plus `--min-count`, not lift (see methodology).

--- a/plugins/writing/skills/analyze/scripts/hook-health.test.ts
+++ b/plugins/writing/skills/analyze/scripts/hook-health.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, test } from "bun:test";
+import type { RunLogEntry } from "../../../hooks/run-log";
+import { type HookHealth, opportunities, parseLog, renderReport, summarize } from "./hook-health";
+
+function entry(overrides: Partial<RunLogEntry> = {}): RunLogEntry {
+  return {
+    ts: "2026-07-01T00:00:00.000Z",
+    session_id: "s1",
+    tool: "Write",
+    ext: "md",
+    duration_ms: 5,
+    outcome: "silent",
+    ...overrides,
+  };
+}
+
+function daysApart(entries: RunLogEntry[], days: number): RunLogEntry[] {
+  const start = Date.parse("2026-07-01T00:00:00.000Z");
+  return entries.map((item, index) => ({
+    ...item,
+    ts: new Date(
+      start + (index / Math.max(1, entries.length - 1)) * days * 86_400_000,
+    ).toISOString(),
+  }));
+}
+
+describe("parseLog", () => {
+  it("reads one entry per line and skips torn writes", () => {
+    const text = [
+      JSON.stringify(entry()),
+      '{"ts":"2026-07-01T00:00:00.000Z","session_id":"s1","tool":"Wr',
+      "",
+      JSON.stringify(entry({ outcome: "context", category: "numbering" })),
+    ].join("\n");
+    const entries = parseLog(text);
+    expect(entries).toHaveLength(2);
+    expect(entries[1]?.category).toBe("numbering");
+  });
+});
+
+describe("summarize", () => {
+  it("aggregates outcomes, tools, categories, and latency", () => {
+    const health = summarize([
+      entry({ duration_ms: 2 }),
+      entry({ duration_ms: 4, tool: "Bash", ext: "" }),
+      entry({ outcome: "context", category: "numbering", duration_ms: 10 }),
+      entry({ outcome: "silent", category: "numbering", suppressed: true, duration_ms: 1 }),
+      entry({ outcome: "deny", category: "spaced em dash", duration_ms: 20 }),
+      entry({ outcome: "skipped-scratch", duration_ms: 0 }),
+    ]);
+
+    expect(health.total).toBe(6);
+    expect(health.injections).toBe(2);
+    expect(health.byOutcome.context).toBe(1);
+    expect(health.byOutcome["skipped-scratch"]).toBe(1);
+    expect(health.byTool.Bash).toBe(1);
+    expect(health.categories).toEqual([
+      { category: "numbering", fired: 1, suppressed: 1, share: 0.5 },
+      { category: "spaced em dash", fired: 1, suppressed: 0, share: 0.5 },
+    ]);
+    expect(health.latency.max).toBe(20);
+    expect(health.latency.silentP95).toBe(4);
+  });
+});
+
+describe("opportunities", () => {
+  function baseline(overrides: Partial<HookHealth> = {}): HookHealth {
+    const quiet = summarize(
+      daysApart(
+        Array.from({ length: 100 }, () => entry()),
+        7,
+      ),
+    );
+    return { ...quiet, ...overrides };
+  }
+
+  it("asks for more evidence on a thin log", () => {
+    const found = opportunities(summarize([entry()]));
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("Evidence still accumulating");
+  });
+
+  it("flags a category dominating injections", () => {
+    const health = baseline({
+      injections: 100,
+      categories: [{ category: "test result reporting", fired: 40, suppressed: 2, share: 0.4 }],
+    });
+    expect(opportunities(health).join("\n")).toContain("test result reporting");
+  });
+
+  it("flags a category suppressed as often as it fires", () => {
+    const health = baseline({
+      injections: 100,
+      categories: [{ category: "numbering", fired: 10, suppressed: 15, share: 0.1 }],
+    });
+    expect(opportunities(health).join("\n")).toContain("suppressed as often as it fires");
+  });
+
+  it("flags ask outcomes", () => {
+    const health = baseline();
+    health.byOutcome.ask = 3;
+    expect(opportunities(health).join("\n")).toContain("ask outcomes");
+  });
+
+  it("flags slow silent runs", () => {
+    const health = baseline();
+    health.latency.silentP95 = 250;
+    expect(opportunities(health).join("\n")).toContain("p95 latency");
+  });
+
+  it("flags a scratch-skip share above the ceiling", () => {
+    const health = baseline();
+    health.byOutcome["skipped-scratch"] = Math.round(health.total * 0.7);
+    expect(opportunities(health).join("\n")).toContain("skipped-scratch");
+  });
+
+  it("points at the log retirement trigger when nothing is raised", () => {
+    const found = opportunities(baseline());
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("WRITING_HOOKS_LOG");
+  });
+});
+
+describe("renderReport", () => {
+  test("renders tables and the opportunity list", () => {
+    const health = summarize(
+      daysApart(
+        [
+          ...Array.from({ length: 60 }, () => entry()),
+          entry({ outcome: "context", category: "numbering", duration_ms: 12 }),
+        ],
+        7,
+      ),
+    );
+    const report = renderReport(health);
+    expect(report).toContain("runs/day");
+    expect(report).toContain("numbering");
+    expect(report).toContain("Opportunities:");
+  });
+});

--- a/plugins/writing/skills/analyze/scripts/hook-health.ts
+++ b/plugins/writing/skills/analyze/scripts/hook-health.ts
@@ -1,0 +1,292 @@
+#!/usr/bin/env bun
+
+import { cli } from "cleye";
+import { table } from "table";
+import { type RunLogEntry, type RunOutcome, resolveLogPath } from "../../../hooks/run-log";
+
+export type CategoryHealth = {
+  category: string;
+  fired: number;
+  suppressed: number;
+  share: number;
+};
+
+export type HookHealth = {
+  total: number;
+  spanDays: number;
+  runsPerDay: number;
+  byOutcome: Record<RunOutcome, number>;
+  byTool: Record<string, number>;
+  injections: number;
+  categories: CategoryHealth[];
+  latency: { p50: number; p95: number; max: number; silentP95: number };
+};
+
+export function parseLog(text: string): RunLogEntry[] {
+  const entries: RunLogEntry[] = [];
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (parsed && typeof parsed === "object" && "outcome" in parsed) {
+        entries.push(parsed as RunLogEntry);
+      }
+    } catch {
+      // A torn write from a concurrent session produces a partial line.
+    }
+  }
+  return entries;
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const index = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, index)] ?? 0;
+}
+
+const INJECTION_OUTCOMES = new Set<RunOutcome>(["context", "ask", "deny"]);
+
+export function summarize(entries: RunLogEntry[]): HookHealth {
+  const byOutcome: Record<RunOutcome, number> = {
+    silent: 0,
+    context: 0,
+    ask: 0,
+    deny: 0,
+    "skipped-scratch": 0,
+  };
+  const byTool: Record<string, number> = {};
+  const perCategory = new Map<string, { fired: number; suppressed: number }>();
+  const durations: number[] = [];
+  const silentDurations: number[] = [];
+  let firstTs = Number.POSITIVE_INFINITY;
+  let lastTs = Number.NEGATIVE_INFINITY;
+
+  for (const entry of entries) {
+    byOutcome[entry.outcome] = (byOutcome[entry.outcome] ?? 0) + 1;
+    byTool[entry.tool] = (byTool[entry.tool] ?? 0) + 1;
+    durations.push(entry.duration_ms);
+    if (entry.outcome === "silent" && !entry.suppressed) silentDurations.push(entry.duration_ms);
+
+    if (entry.category) {
+      const bucket = perCategory.get(entry.category) ?? { fired: 0, suppressed: 0 };
+      if (entry.suppressed) {
+        bucket.suppressed += 1;
+      } else if (INJECTION_OUTCOMES.has(entry.outcome)) {
+        bucket.fired += 1;
+      }
+      perCategory.set(entry.category, bucket);
+    }
+
+    const ts = Date.parse(entry.ts);
+    if (!Number.isNaN(ts)) {
+      firstTs = Math.min(firstTs, ts);
+      lastTs = Math.max(lastTs, ts);
+    }
+  }
+
+  const injections = entries.filter((entry) => INJECTION_OUTCOMES.has(entry.outcome)).length;
+  const spanDays =
+    entries.length > 0 && lastTs > firstTs ? (lastTs - firstTs) / (24 * 60 * 60 * 1000) : 0;
+
+  durations.sort((a, b) => a - b);
+  silentDurations.sort((a, b) => a - b);
+
+  const categories = [...perCategory.entries()]
+    .map(([category, counts]) => ({
+      category,
+      ...counts,
+      share: injections > 0 ? counts.fired / injections : 0,
+    }))
+    .sort((a, b) => b.fired - a.fired || b.suppressed - a.suppressed);
+
+  return {
+    total: entries.length,
+    spanDays,
+    runsPerDay: spanDays > 0 ? entries.length / spanDays : entries.length,
+    byOutcome,
+    byTool,
+    injections,
+    categories,
+    latency: {
+      p50: percentile(durations, 50),
+      p95: percentile(durations, 95),
+      max: durations.at(-1) ?? 0,
+      silentP95: percentile(silentDurations, 95),
+    },
+  };
+}
+
+const MIN_RUNS = 50;
+const MIN_SPAN_DAYS = 3;
+const DOMINANT_SHARE = 0.25;
+const MIN_FIRES_FOR_SUPPRESSION_SIGNAL = 5;
+const SILENT_P95_BUDGET_MS = 100;
+const SCRATCH_SHARE_CEILING = 0.6;
+
+// Each opportunity names a concrete fix, mirroring the curation principle:
+// the log exists so audits read over/under-firing directly instead of
+// inferring it from transcripts.
+export function opportunities(health: HookHealth): string[] {
+  const found: string[] = [];
+
+  if (health.total < MIN_RUNS || health.spanDays < MIN_SPAN_DAYS) {
+    found.push(
+      `Evidence still accumulating (${health.total} runs over ${health.spanDays.toFixed(1)} days). Re-run once the log spans at least ${MIN_SPAN_DAYS} days and ${MIN_RUNS} runs.`,
+    );
+    return found;
+  }
+
+  for (const cat of health.categories) {
+    if (cat.share >= DOMINANT_SHARE) {
+      found.push(
+        `"${cat.category}" is ${Math.round(cat.share * 100)}% of injections. Audit its precision: sample recent firings from session history and demote, narrow, or retire the rule if hits are unactionable.`,
+      );
+    }
+    if (cat.fired >= MIN_FIRES_FOR_SUPPRESSION_SIGNAL && cat.suppressed >= cat.fired) {
+      found.push(
+        `"${cat.category}" is suppressed as often as it fires (${cat.fired} fired, ${cat.suppressed} suppressed). The reminder is not changing behavior within sessions. Consider a stronger message or retiring the rule.`,
+      );
+    }
+  }
+
+  if (health.byOutcome.ask > 0) {
+    found.push(
+      `${health.byOutcome.ask} ask outcomes recorded. Asks block background jobs and the numbering demotion expected zero. Find the emitting rule and demote it.`,
+    );
+  }
+
+  if (health.latency.silentP95 > SILENT_P95_BUDGET_MS) {
+    found.push(
+      `Silent-run p95 latency is ${health.latency.silentP95}ms (budget ${SILENT_P95_BUDGET_MS}ms). The no-finding path runs on every file op. Profile the dispatcher's checker order and prefilters.`,
+    );
+  }
+
+  const scratchShare = health.total > 0 ? health.byOutcome["skipped-scratch"] / health.total : 0;
+  if (scratchShare > SCRATCH_SHARE_CEILING) {
+    found.push(
+      `${Math.round(scratchShare * 100)}% of runs are skipped-scratch. Verify the scratch heuristic is not swallowing durable prose (check recent Write paths in session history against isScratchPath).`,
+    );
+  }
+
+  if (found.length === 0) {
+    found.push(
+      "No issues raised. After two consecutive stable audits, flip the WRITING_HOOKS_LOG default to off (see README Run Log).",
+    );
+  }
+
+  return found;
+}
+
+function formatShare(share: number): string {
+  return `${Math.round(share * 100)}%`;
+}
+
+export function renderReport(health: HookHealth): string {
+  const lines: string[] = [];
+
+  lines.push(
+    table([
+      ["runs", String(health.total)],
+      ["span (days)", health.spanDays.toFixed(1)],
+      ["runs/day", health.runsPerDay.toFixed(1)],
+      ["injections", String(health.injections)],
+      [
+        "outcomes",
+        Object.entries(health.byOutcome)
+          .filter(([, count]) => count > 0)
+          .map(([outcome, count]) => `${outcome}=${count}`)
+          .join(" "),
+      ],
+      [
+        "tools",
+        Object.entries(health.byTool)
+          .map(([tool, count]) => `${tool}=${count}`)
+          .join(" "),
+      ],
+      [
+        "latency (ms)",
+        `p50=${health.latency.p50} p95=${health.latency.p95} max=${health.latency.max} silent-p95=${health.latency.silentP95}`,
+      ],
+    ]),
+  );
+
+  if (health.categories.length > 0) {
+    lines.push(
+      table([
+        ["category", "fired", "suppressed", "share of injections"],
+        ...health.categories.map((cat) => [
+          cat.category,
+          String(cat.fired),
+          String(cat.suppressed),
+          formatShare(cat.share),
+        ]),
+      ]),
+    );
+  }
+
+  lines.push("Opportunities:");
+  for (const opportunity of opportunities(health)) {
+    lines.push(`- ${opportunity}`);
+  }
+
+  return lines.join("\n");
+}
+
+async function readLog(path: string, since?: string): Promise<RunLogEntry[]> {
+  const texts: string[] = [];
+  for (const candidate of [`${path}.1`, path]) {
+    const file = Bun.file(candidate);
+    if (await file.exists()) texts.push(await file.text());
+  }
+  let entries = parseLog(texts.join("\n"));
+  if (since) {
+    const cutoff = Date.parse(since);
+    if (!Number.isNaN(cutoff)) {
+      entries = entries.filter((entry) => Date.parse(entry.ts) >= cutoff);
+    }
+  }
+  return entries;
+}
+
+if (import.meta.main) {
+  const argv = cli({
+    name: "hook-health",
+    help: {
+      description:
+        "Read the writing-hooks run log and report volume, latency, per-rule fire/suppress counts, and fix opportunities.",
+    },
+    flags: {
+      log: {
+        type: String,
+        description: "Log path (default: WRITING_HOOKS_LOG or ~/.claude/writing-hooks/log.jsonl)",
+      },
+      since: {
+        type: String,
+        description: "Only count entries at or after this date (ISO)",
+      },
+      json: {
+        type: Boolean,
+        description: "Emit the summary as JSON instead of tables",
+      },
+    },
+  });
+
+  const path = argv.flags.log ?? resolveLogPath();
+  if (!path) {
+    console.error("Logging is disabled (WRITING_HOOKS_LOG). Pass --log <path>.");
+    process.exit(1);
+  }
+
+  const entries = await readLog(path, argv.flags.since);
+  if (entries.length === 0) {
+    console.error(`No log entries at ${path}. The dispatcher writes one line per hook run.`);
+    process.exit(1);
+  }
+
+  const health = summarize(entries);
+  if (argv.flags.json) {
+    console.log(JSON.stringify({ ...health, opportunities: opportunities(health) }, null, 2));
+  } else {
+    console.log(renderReport(health));
+  }
+}


### PR DESCRIPTION
Session-history analysis of the writing plugin's PreToolUse hooks (DuckDB index over `~/.claude/projects`, local and work hosts) found ~3,058 context injections across 804 sessions, and much of that volume was friction rather than enforcement: prose rules firing on raw source code (~15% of file-op injections), the dominant test-result rule (28% of recent injections) omitting the sample that tripped it, up to three simultaneous injections per tool call, same-rule storms (one session absorbed 48 injections), numbering asks with 52 prompts and zero rejections ever, and internal handoff prose in `tmp/` drawing deliverable-grade nagging (repo `tmp/` alone was 43% of recent injections, including one file flagged 108 times).

## Design

Content counts as a deliverable when it leaves through an egress surface, not because of where it was drafted. Write-time scanning now skips scratch paths (working-tree `tmp/` segments, `/tmp`, `$TMPDIR`, background-job dirs), and the Bash egress scan picks the content up where it actually ships: `--body`/`--body-file`/`--message`/`--description`/`--title`, `gh api`/`glab api` `-F`/`--field key=@file` forms, and `git commit`/`git tag` `-F`/`--file` message files. Simulated on 60 days of history, the skip removes roughly half of all injection volume, and most of what it removes was never read by a human. One residual gap is accepted and unchanged: issue bodies posted through MCP Linear tools have been unscanned since #976 removed the `mcp__.*` matcher.

Code files scan comments only (single-line, block/JSDoc, HTML, and Python docstrings). Strings and identifiers are program text the model did not write as prose, and they were the derailment-prone false positives.

The three per-matcher hook commands collapse into one dispatcher (`hooks/pretooluse.ts`): one bun spawn per tool call and at most one injection, with deny > ask > context priority and numbering → headings → tropes order within a tier. Checker crashes are isolated so one failure cannot swallow another checker's finding or the run-log entry. A context-tier category that fired within the last 5 minutes in the same session is suppressed, and a suppressed winner falls through to the next non-suppressed finding. Deny/ask decisions and deny-origin per-file fix-it reminders are never suppressed, since each occurrence demands a corrective edit.

Numbering demotes markdown from ask to context: the ask tier collected 52 prompts and zero rejections, and an ask stalls background jobs. Code files keep deny, and edit-mode code moves from ask to deny, resolving an inconsistency the old code had. Blocking before the write is equally cheap for edits.

Every dispatcher run appends one JSONL line to `~/.claude/writing-hooks/log.jsonl` (ts, session, tool, ext, duration, outcome, category, suppressed), which is the evidence surface the curation principle requires: the next audit reads run volume, latency, and per-rule fire/suppress counts directly instead of inferring from transcripts. `WRITING_HOOKS_LOG=0` disables it and a path value redirects it. Once two consecutive audits show stable behavior, the default flips off via a settings `env` entry.

## Testing

Added dispatcher, scratch-path, comment-extraction, and run-log suites alongside the updated hook tests (`bun test plugins/writing`). Ran the dispatcher end to end through the exact `hooks.json` commands: a multi-violation markdown write produced a single injection and a log line, an immediate repeat suppressed then fell through to the next category, a `.ts` file with "All 8 tests pass" in a string stayed silent while the same text in a comment flagged with the sample quoted, `tmp/` writes logged `skipped-scratch`, and `--body-file`, quoted `-F 'body=@…'`, and `git commit -F` all scanned at egress. A high-effort multi-agent review of the first cut surfaced the coverage gaps fixed in the second commit: the scratch heuristic over-matched repositories cloned under tmp-named ancestors, quoted field arguments broke path extraction, block comments went unscanned, and a suppressed winner muted co-occurring findings.
