### PR TITLE
session: abort refresh on scan errors instead of wiping host rows

### DIFF
--- a/plugins/claude-code/skills/session/CLAUDE.md
+++ b/plugins/claude-code/skills/session/CLAUDE.md
@@ -13,7 +13,7 @@ JSONL files in `~/.claude/projects/` are the canonical data. The DuckDB database
 
 ### Host Enumeration
 
-`db.ts` enumerates one entry per host: `local` (honoring `CLAUDE_PROJECTS_DIR` / the `projectsDir` option) plus one per `~/.claude/session-imports/*/manifest.json` (override the root with `CLAUDE_SESSION_IMPORTS_DIR` / the `importsDir` option). The filesystem is the registry; there is no host table. `ensureIndex` loops the hosts, scanning each host's root in TypeScript and importing per file. A host whose root directory is missing is skipped, never treated as all-files-deleted, so a typo'd `CLAUDE_PROJECTS_DIR` or unmounted dir cannot wipe a host's rows.
+`db.ts` enumerates one entry per host: `local` (honoring `CLAUDE_PROJECTS_DIR` / the `projectsDir` option) plus one per `~/.claude/session-imports/*/manifest.json` (override the root with `CLAUDE_SESSION_IMPORTS_DIR` / the `importsDir` option). The filesystem is the registry; there is no host table. `ensureIndex` loops the hosts, scanning each host's root in TypeScript and importing per file. A host whose root directory is missing is skipped, never treated as all-files-deleted, so a typo'd `CLAUDE_PROJECTS_DIR` or unmounted dir cannot wipe a host's rows. Any other scan failure (e.g. an unreadable subdirectory) aborts the refresh, because a partial listing is indistinguishable from mass deletion.
 
 ### Tables
 

--- a/plugins/claude-code/skills/session/scripts/db.test.ts
+++ b/plugins/claude-code/skills/session/scripts/db.test.ts
@@ -1055,27 +1055,31 @@ describe("change catalog", () => {
     expect(Number(row?.n)).toBeGreaterThan(0);
   });
 
-  it("aborts and keeps a host's rows when the scan fails mid-walk", async () => {
-    await importFixtureHost("guarded");
-    await reindex();
-    const [before] = await db.query<{ n: bigint }>(
-      "SELECT COUNT(*) AS n FROM raw WHERE host = 'guarded'",
-    );
-    expect(Number(before?.n)).toBeGreaterThan(0);
+  // chmod 000 does not restrict root, so the walk would succeed there
+  it.skipIf(process.getuid?.() === 0)(
+    "aborts and keeps a host's rows when the scan fails mid-walk",
+    async () => {
+      await importFixtureHost("guarded");
+      await reindex();
+      const [before] = await db.query<{ n: bigint }>(
+        "SELECT COUNT(*) AS n FROM raw WHERE host = 'guarded'",
+      );
+      expect(Number(before?.n)).toBeGreaterThan(0);
 
-    const subdir = path.join(importsDir, "guarded", "projects", "-Users-test-project");
-    await $`chmod 000 ${subdir}`.quiet();
-    try {
-      await expect(reindex()).rejects.toThrow();
-    } finally {
-      await $`chmod 755 ${subdir}`.quiet();
-    }
+      const subdir = path.join(importsDir, "guarded", "projects", "-Users-test-project");
+      await $`chmod 000 ${subdir}`.quiet();
+      try {
+        await expect(reindex()).rejects.toThrow();
+      } finally {
+        await $`chmod 755 ${subdir}`.quiet();
+      }
 
-    const [after] = await db.query<{ n: bigint }>(
-      "SELECT COUNT(*) AS n FROM raw WHERE host = 'guarded'",
-    );
-    expect(Number(after?.n)).toBe(Number(before?.n));
-  });
+      const [after] = await db.query<{ n: bigint }>(
+        "SELECT COUNT(*) AS n FROM raw WHERE host = 'guarded'",
+      );
+      expect(Number(after?.n)).toBe(Number(before?.n));
+    },
+  );
 });
 
 describe("view versioning", () => {

--- a/plugins/claude-code/skills/session/scripts/db.test.ts
+++ b/plugins/claude-code/skills/session/scripts/db.test.ts
@@ -1054,6 +1054,28 @@ describe("change catalog", () => {
     );
     expect(Number(row?.n)).toBeGreaterThan(0);
   });
+
+  it("aborts and keeps a host's rows when the scan fails mid-walk", async () => {
+    await importFixtureHost("guarded");
+    await reindex();
+    const [before] = await db.query<{ n: bigint }>(
+      "SELECT COUNT(*) AS n FROM raw WHERE host = 'guarded'",
+    );
+    expect(Number(before?.n)).toBeGreaterThan(0);
+
+    const subdir = path.join(importsDir, "guarded", "projects", "-Users-test-project");
+    await $`chmod 000 ${subdir}`.quiet();
+    try {
+      await expect(reindex()).rejects.toThrow();
+    } finally {
+      await $`chmod 755 ${subdir}`.quiet();
+    }
+
+    const [after] = await db.query<{ n: bigint }>(
+      "SELECT COUNT(*) AS n FROM raw WHERE host = 'guarded'",
+    );
+    expect(Number(after?.n)).toBe(Number(before?.n));
+  });
 });
 
 describe("view versioning", () => {

--- a/plugins/claude-code/skills/session/scripts/db.ts
+++ b/plugins/claude-code/skills/session/scripts/db.ts
@@ -196,17 +196,13 @@ export interface ScannedFile {
   size: number;
 }
 
-function listEntries(root: string) {
-  try {
-    return readdirSync(root, { withFileTypes: true, recursive: true });
-  } catch {
-    return [];
-  }
-}
-
+// Scan errors must propagate, never degrade to an empty listing: ensureIndex
+// reads a missing path as a deleted file, so a swallowed error (e.g. an
+// unreadable subdirectory) would delete every indexed row for the host. The
+// missing-root case is handled by the dirExists guard before the scan.
 export function scanJsonlFiles(root: string): ScannedFile[] {
   const files: ScannedFile[] = [];
-  for (const entry of listEntries(root)) {
+  for (const entry of readdirSync(root, { withFileTypes: true, recursive: true })) {
     if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
     const full = path.join(entry.parentPath, entry.name);
     const file = Bun.file(full);


### PR DESCRIPTION
Follow-up to #1034, fixing the scan-error hole greptile flagged in its review there.

`listEntries` wrapped the recursive directory walk in a catch-all that returned an empty listing on any error. `ensureIndex` reads a path missing from the scan as a deleted file, so a swallowed error became mass deletion: a host root that passes the `dirExists` guard but contains an unreadable subdirectory (Bun's recursive `readdirSync` throws `EACCES` mid-walk, verified by probe) would drop every indexed row for that host. That bypassed the documented guarantee that only `forget.ts` deletes rows explicitly.

The catch protected nothing legitimate. The missing-root case is already handled by the `dirExists` guard immediately before the scan, so scan errors now propagate and abort the refresh. A partial listing is indistinguishable from mass deletion, so aborting is the only safe response.

The regression test makes a fixture host's subdirectory unreadable (`chmod 000`), asserts the reindex rejects, and asserts the host's row count is unchanged afterward.
