### PR TITLE
feat(plan): inject on first plan-mode tool call + model-gated delegation guidance

### DIFF
--- a/plugins/plan/README.md
+++ b/plugins/plan/README.md
@@ -5,12 +5,14 @@ Planning mode guidelines and context injection for Claude Code.
 ## Contents
 
 - **Skill** `plan:review`: reviews how an implementation diverged from its approved plan, forking a clean-context agent over the plan and the diff to surface drift and follow-ups
-- **Hook**: Automatically injects planning guidelines when entering plan mode (via Shift+Tab or EnterPlanMode tool)
+- **Hook**: Injects planning guidelines the first time a session is in plan mode, whether that first signal is a prompt or a tool call, and appends delegation guidance when the orchestrator runs on an expensive model
 - **Hook**: Gates `ExitPlanMode`, denying byte-identical plan re-presents and asking once per session before presenting a plan over 12k characters
 
 ## How It Works
 
-The `UserPromptSubmit` hook checks `permission_mode` in the hook input. When the mode is `plan`, it injects the planning guidelines into the conversation context. A marker file prevents duplicate injection on subsequent prompts within the same session.
+Two hooks share one job: inject the guidelines exactly once per plan-mode session. The `UserPromptSubmit` hook (`scripts/context.sh`) catches a prompt submitted while already in plan mode. A `PreToolUse` hook (`scripts/plan-inject.sh`, matcher `*`) catches the case where a session toggles into plan mode after its last prompt, so no `UserPromptSubmit` fires before `ExitPlanMode`. `permission_mode` rides on every `PreToolUse`, so the first tool call in plan mode is a reliable injection point. Both read `permission_mode` and share a `plan-injected` marker under `$CLAUDE_PLAN_MARKER_ROOT/<session_id>/`, so whichever fires first wins and the other short-circuits.
+
+Both paths call `scripts/injection-content.sh` to assemble the content. It emits `references/guidelines.md` always, and reads the latest assistant `model` from the transcript. When that model is an expensive orchestrator (opus, fable), it appends `references/delegation.md`, which requires the plan to carry a Delegation section laying out the agent/model/effort DAG. `UserPromptSubmit` returns the content on stdout; `PreToolUse` returns it as `hookSpecificOutput.additionalContext`. Any read or parse problem falls back to the guidelines alone.
 
 The `PreToolUse` gate hook hashes each presented plan under `/tmp/claude/<session_id>/` and denies a resubmission whose text is unchanged since the last presentation, with instructions to revise instead of regrow. Plans over 12k characters trigger a one-time confirmation prompt. Infrastructure weirdness (missing session id, unreadable state) fails open.
 

--- a/plugins/plan/hooks/gate.test.ts
+++ b/plugins/plan/hooks/gate.test.ts
@@ -88,6 +88,50 @@ describe("unchanged re-present", () => {
   });
 });
 
+describe("append-only re-present", () => {
+  const basePlan = [
+    "# Add retry to the fetch client",
+    "## Approach",
+    "- Wrap the fetch call in a retry loop",
+    "- Back off exponentially between attempts",
+    "- Cap retries at 3",
+    "## Files",
+    "- src/client.ts",
+    "- src/client.test.ts",
+    "## Testing",
+    "- Add a test for the backoff schedule",
+  ].join("\n");
+
+  it("asks when the re-present keeps nearly all prior lines and only adds new ones", async () => {
+    await decision(basePlan);
+    const grown = `${basePlan}\n## Rollout\n- Ship behind a flag\n- Monitor error rates`;
+    expect(await decision(grown)).toEqual({
+      hookEventName: "PreToolUse",
+      permissionDecision: "ask",
+      permissionDecisionReason: expect.stringContaining("append-only growth"),
+    });
+  });
+
+  it("allows a genuine revision that rewrites most of the plan", async () => {
+    await decision(basePlan);
+    const rewritten = [
+      "# Add retry to the fetch client",
+      "## Approach",
+      "- Use a circuit breaker instead of unbounded retries",
+      "- Fail fast after 2 consecutive errors",
+      "## Files",
+      "- src/circuit-breaker.ts",
+      "## Testing",
+      "- Add a test for the open/closed transitions",
+    ].join("\n");
+    expect(await decision(rewritten)).toBeNull();
+  });
+
+  it("does not ask on the first presentation of a plan that would otherwise qualify", async () => {
+    expect(await decision(basePlan)).toBeNull();
+  });
+});
+
 describe("size advisory", () => {
   const bigPlan = (seed: string) => seed + "x".repeat(12_001);
 

--- a/plugins/plan/hooks/hooks.json
+++ b/plugins/plan/hooks/hooks.json
@@ -13,6 +13,15 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/plan-inject.sh\""
+          }
+        ]
+      },
+      {
         "matcher": "ExitPlanMode",
         "hooks": [
           {

--- a/plugins/plan/references/delegation.md
+++ b/plugins/plan/references/delegation.md
@@ -1,0 +1,24 @@
+# Delegation
+
+Claude Code ships no auto-downgrade. A subagent inherits the orchestrator's model unless a lever sets otherwise, so an expensive orchestrator spawns expensive subagents by default. A review of a month of spawns found the generic path (`general-purpose`, `Plan`, bare `claude`) almost never delegated down: reasoning-grade tokens went to log reading and mechanical edits.
+
+When the orchestrator runs on an expensive model (Opus, Fable), the plan must carry a Delegation section that lays out the agent/model/effort DAG:
+
+- Which slices delegate to which `model` and `effort`, and which stay on the orchestrator.
+- Where checkpoints sit. A checkpoint is a slice whose output the orchestrator reads before the next slice starts.
+- What runs in sequence versus parallel.
+
+## Defaults
+
+Match the model to the work, not to the orchestrator:
+
+- Narrow, well-specified, high-token, low-reasoning work (reading logs, mechanical edits, grep sweeps) goes to **Haiku**.
+- General-purpose work (bounded implementation, research with a settled question) goes to **Sonnet**.
+- Coding under a Fable orchestrator goes to **Opus**.
+- Reserve the orchestrator's own model for genuine reasoning: design forks, cross-slice synthesis, judgment a subagent cannot hold.
+
+## Levers
+
+- **Task-tool `model` override**: set `model` on the spawn. It wins over the subagent's frontmatter.
+- **Subagent frontmatter** `model:` (`haiku`/`sonnet`/`opus`/`fable`) and `effort:` (`low`/`medium`/`high`/`xhigh`/`max`): the default when a spawn sets neither.
+- **`subagent_type`**: a purpose-built agent that already pins a cheaper model (for example `Explore` on Haiku) delegates down with no per-spawn override.

--- a/plugins/plan/scripts/context.sh
+++ b/plugins/plan/scripts/context.sh
@@ -19,7 +19,8 @@ if [ -n "$session_id" ]; then
   fi
 fi
 
-cat "$(dirname "$0")/../references/guidelines.md"
+transcript=$(printf '%s' "$input" | jq -r '.transcript_path // empty')
+"$(dirname "$0")/injection-content.sh" "$transcript"
 
 if [ -n "$marker" ]; then
   touch "$marker"

--- a/plugins/plan/scripts/injection-content.sh
+++ b/plugins/plan/scripts/injection-content.sh
@@ -7,9 +7,12 @@ here=$(dirname "$0")
 
 cat "$here/../references/guidelines.md"
 
+# The tail bounds cost on a large transcript. It counts JSONL entries, not lines
+# of one record, and the last assistant turn sits at the tail, so a generous
+# ceiling keeps it in range even in a long session. Empty model falls open.
 model=""
 if [ -n "$transcript" ] && [ -f "$transcript" ]; then
-  model=$(tail -n 500 "$transcript" | jq -rs '[.[] | select(.type == "assistant") | .message.model // empty] | last // empty' 2>/dev/null)
+  model=$(tail -n 2000 "$transcript" | jq -rs '[.[] | select(.type == "assistant") | .message.model // empty] | last // empty' 2>/dev/null)
 fi
 
 case "$model" in

--- a/plugins/plan/scripts/injection-content.sh
+++ b/plugins/plan/scripts/injection-content.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Emit the plan-mode injection: guidelines always, plus delegation guidance when
+# the session's latest assistant model is an expensive orchestrator (opus/fable).
+# Fails open: any read/parse problem falls back to guidelines alone.
+transcript="$1"
+here=$(dirname "$0")
+
+cat "$here/../references/guidelines.md"
+
+model=""
+if [ -n "$transcript" ] && [ -f "$transcript" ]; then
+  model=$(tail -n 500 "$transcript" | jq -rs '[.[] | select(.type == "assistant") | .message.model // empty] | last // empty' 2>/dev/null)
+fi
+
+case "$model" in
+  *opus* | *fable*)
+    printf '\n'
+    cat "$here/../references/delegation.md"
+    ;;
+esac

--- a/plugins/plan/scripts/injection-content.test.ts
+++ b/plugins/plan/scripts/injection-content.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const scriptPath = join(import.meta.dirname, "injection-content.sh");
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "plan-inject-content-"));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+async function transcriptWith(models: string[]): Promise<string> {
+  const lines = models.map((model) =>
+    JSON.stringify({ type: "assistant", message: { role: "assistant", model, content: [] } }),
+  );
+  const path = join(dir, "transcript.jsonl");
+  await Bun.write(path, `${lines.join("\n")}\n`);
+  return path;
+}
+
+async function assemble(transcript: string | null): Promise<string> {
+  const args = transcript === null ? [scriptPath] : [scriptPath, transcript];
+  const proc = Bun.spawn(["bash", ...args], { stdout: "pipe", stderr: "pipe" });
+  const stdout = await new Response(proc.stdout).text();
+  await proc.exited;
+  return stdout;
+}
+
+test.each<{ name: string; models: string[]; delegation: boolean }>([
+  { name: "opus includes delegation", models: ["claude-opus-4-8"], delegation: true },
+  { name: "fable includes delegation", models: ["claude-fable-5"], delegation: true },
+  { name: "sonnet excludes delegation", models: ["claude-sonnet-5"], delegation: false },
+  { name: "haiku excludes delegation", models: ["claude-haiku-4-5-20251001"], delegation: false },
+  {
+    name: "last assistant model wins (ends sonnet)",
+    models: ["claude-opus-4-8", "claude-sonnet-5"],
+    delegation: false,
+  },
+  {
+    name: "last assistant model wins (ends opus)",
+    models: ["claude-sonnet-5", "claude-opus-4-8"],
+    delegation: true,
+  },
+])("$name", async ({ models, delegation }) => {
+  const out = await assemble(await transcriptWith(models));
+  expect(out).toContain("Planning Guidelines");
+  expect(out.includes("# Delegation")).toBe(delegation);
+});
+
+describe("fail open", () => {
+  test("guidelines only when no transcript is given", async () => {
+    const out = await assemble(null);
+    expect(out).toContain("Planning Guidelines");
+    expect(out).not.toContain("# Delegation");
+  });
+
+  test("guidelines only when the transcript path is missing", async () => {
+    const out = await assemble(join(dir, "does-not-exist.jsonl"));
+    expect(out).toContain("Planning Guidelines");
+    expect(out).not.toContain("# Delegation");
+  });
+
+  test("guidelines only when the transcript is malformed", async () => {
+    const path = join(dir, "bad.jsonl");
+    await Bun.write(path, "not json\n{also not\n");
+    const out = await assemble(path);
+    expect(out).toContain("Planning Guidelines");
+    expect(out).not.toContain("# Delegation");
+  });
+});

--- a/plugins/plan/scripts/plan-inject.sh
+++ b/plugins/plan/scripts/plan-inject.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# PreToolUse injection: closes the gap where a session toggles into plan mode
+# after its last prompt, so no UserPromptSubmit fires before ExitPlanMode.
+# permission_mode rides on every PreToolUse, so the first tool call in plan mode
+# is a reliable injection point. Shares the plan-injected marker with context.sh,
+# so whichever fires first wins and the other short-circuits.
+input=$(cat)
+
+mode=$(printf '%s' "$input" | jq -r '.permission_mode // empty')
+if [ "$mode" != "plan" ]; then
+  exit 0
+fi
+
+session_id=$(printf '%s' "$input" | jq -r '.session_id // empty')
+marker_root="${CLAUDE_PLAN_MARKER_ROOT:-/tmp/claude}"
+
+marker=""
+if [ -n "$session_id" ]; then
+  dir="$marker_root/$session_id"
+  mkdir -p "$dir"
+  marker="$dir/plan-injected"
+  if [ -f "$marker" ]; then
+    exit 0
+  fi
+fi
+
+transcript=$(printf '%s' "$input" | jq -r '.transcript_path // empty')
+content=$("$(dirname "$0")/injection-content.sh" "$transcript")
+
+jq -n --arg ctx "$content" \
+  '{hookSpecificOutput: {hookEventName: "PreToolUse", additionalContext: $ctx}}'
+
+if [ -n "$marker" ]; then
+  touch "$marker"
+fi

--- a/plugins/plan/scripts/plan-inject.sh
+++ b/plugins/plan/scripts/plan-inject.sh
@@ -11,17 +11,20 @@ if [ "$mode" != "plan" ]; then
   exit 0
 fi
 
+# PreToolUse fires on every tool call, so without a session_id to dedup against
+# we would re-inject on each one. Require it here (context.sh, once per prompt,
+# can afford to inject without dedup).
 session_id=$(printf '%s' "$input" | jq -r '.session_id // empty')
-marker_root="${CLAUDE_PLAN_MARKER_ROOT:-/tmp/claude}"
+if [ -z "$session_id" ]; then
+  exit 0
+fi
 
-marker=""
-if [ -n "$session_id" ]; then
-  dir="$marker_root/$session_id"
-  mkdir -p "$dir"
-  marker="$dir/plan-injected"
-  if [ -f "$marker" ]; then
-    exit 0
-  fi
+marker_root="${CLAUDE_PLAN_MARKER_ROOT:-/tmp/claude}"
+dir="$marker_root/$session_id"
+mkdir -p "$dir"
+marker="$dir/plan-injected"
+if [ -f "$marker" ]; then
+  exit 0
 fi
 
 transcript=$(printf '%s' "$input" | jq -r '.transcript_path // empty')
@@ -30,6 +33,4 @@ content=$("$(dirname "$0")/injection-content.sh" "$transcript")
 jq -n --arg ctx "$content" \
   '{hookSpecificOutput: {hookEventName: "PreToolUse", additionalContext: $ctx}}'
 
-if [ -n "$marker" ]; then
-  touch "$marker"
-fi
+touch "$marker"

--- a/plugins/plan/scripts/plan-inject.test.ts
+++ b/plugins/plan/scripts/plan-inject.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const scriptPath = join(import.meta.dirname, "plan-inject.sh");
+
+let markerRoot: string;
+
+beforeEach(() => {
+  markerRoot = mkdtempSync(join(tmpdir(), "plan-inject-"));
+});
+
+afterEach(async () => {
+  await rm(markerRoot, { recursive: true, force: true });
+});
+
+async function run(input: unknown): Promise<string> {
+  const proc = Bun.spawn(["bash", scriptPath], {
+    stdin: Buffer.from(JSON.stringify(input)),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, CLAUDE_PLAN_MARKER_ROOT: markerRoot },
+  });
+  const stdout = await new Response(proc.stdout).text();
+  await proc.exited;
+  return stdout;
+}
+
+async function opusTranscript(): Promise<string> {
+  const line = JSON.stringify({
+    type: "assistant",
+    message: { role: "assistant", model: "claude-opus-4-8", content: [] },
+  });
+  const path = join(markerRoot, "transcript.jsonl");
+  await Bun.write(path, `${line}\n`);
+  return path;
+}
+
+test("emits additionalContext JSON on first plan-mode tool call", async () => {
+  const stdout = await run({ permission_mode: "plan", session_id: "t1" });
+  const parsed = JSON.parse(stdout);
+  expect(parsed.hookSpecificOutput.hookEventName).toBe("PreToolUse");
+  expect(parsed.hookSpecificOutput.additionalContext).toContain("Planning Guidelines");
+});
+
+test("touches the marker so a second call short-circuits", async () => {
+  await run({ permission_mode: "plan", session_id: "t1" });
+  expect(await Bun.file(join(markerRoot, "t1", "plan-injected")).exists()).toBe(true);
+  const second = await run({ permission_mode: "plan", session_id: "t1" });
+  expect(second).toBe("");
+});
+
+test("stays silent outside plan mode", async () => {
+  const stdout = await run({ permission_mode: "default", session_id: "t1" });
+  expect(stdout).toBe("");
+});
+
+test("re-injects for a different session id", async () => {
+  await run({ permission_mode: "plan", session_id: "t1" });
+  const stdout = await run({ permission_mode: "plan", session_id: "t2" });
+  expect(stdout.length).toBeGreaterThan(0);
+});
+
+test("includes delegation guidance when the model is expensive", async () => {
+  const transcript_path = await opusTranscript();
+  const stdout = await run({ permission_mode: "plan", session_id: "t1", transcript_path });
+  const parsed = JSON.parse(stdout);
+  expect(parsed.hookSpecificOutput.additionalContext).toContain("# Delegation");
+});

--- a/plugins/plan/scripts/plan-inject.test.ts
+++ b/plugins/plan/scripts/plan-inject.test.ts
@@ -57,6 +57,11 @@ test("stays silent outside plan mode", async () => {
   expect(stdout).toBe("");
 });
 
+test("stays silent without a session_id, since a high-frequency hook cannot dedup", async () => {
+  const stdout = await run({ permission_mode: "plan" });
+  expect(stdout).toBe("");
+});
+
 test("re-injects for a different session id", async () => {
   await run({ permission_mode: "plan", session_id: "t1" });
   const stdout = await run({ permission_mode: "plan", session_id: "t2" });


### PR DESCRIPTION
Two hook changes in the `plan` plugin.

**Injection timing.** The guidelines-injection hook only fired on a `UserPromptSubmit` in plan mode, so a session that toggled into plan mode after its last prompt never got it (no `UserPromptSubmit` before `ExitPlanMode`). A new `PreToolUse(*)` hook injects on the first tool call in plan mode, sharing the `plan-injected` marker with `context.sh` so whichever fires first wins. It requires a `session_id` to dedup, since `PreToolUse` fires on every tool call.

**Model-gated delegation.** Both paths call a shared `injection-content.sh` assembler that reads the latest assistant model from the transcript and appends a new `references/delegation.md` when the orchestrator is opus/fable, requiring the plan to lay out the agent/model/effort DAG. Fails open to the guidelines alone.

Stack base for #1040 (plan:grill) and the append-only gate PR.
