### PR TITLE
feat(plan): ask on append-only plan re-presents

### DIFF
--- a/plugins/plan/hooks/gate.test.ts
+++ b/plugins/plan/hooks/gate.test.ts
@@ -119,6 +119,57 @@ describe("size advisory", () => {
   });
 });
 
+describe("append-only re-present", () => {
+  const lines = (count: number, prefix = "line") =>
+    Array.from({ length: count }, (_, i) => `${prefix} ${i}`);
+
+  const initial = lines(10).join("\n");
+
+  it("asks when a re-present keeps nearly all prior lines and only adds new ones", async () => {
+    await decision(initial);
+    const appended = `${initial}\nline 10`;
+    expect(await decision(appended)).toEqual({
+      hookEventName: "PreToolUse",
+      permissionDecision: "ask",
+      permissionDecisionReason: expect.stringContaining("append-only"),
+    });
+  });
+
+  it("returns null for a genuine revision with low carry-over", async () => {
+    await decision(initial);
+    const revised = lines(10, "revised").join("\n");
+    expect(await decision(revised)).toBeNull();
+  });
+
+  it("does not ask when growth is zero even with full carry-over", async () => {
+    await decision(initial);
+    // Same lines, reordered: full carry-over but no net new lines.
+    const reordered = [...lines(10)].reverse().join("\n");
+    expect(await decision(reordered)).toBeNull();
+  });
+
+  it("does not ask when more than the incidental-drop allowance is removed", async () => {
+    const big = lines(20).join("\n");
+    await decision(big);
+    // Drop 2 prior lines and add 3 new ones: carry-over is still >= 0.9, but
+    // removal exceeds the incidental-drop allowance, so this is a real edit.
+    const trimmedAndGrown = [...lines(18), ...lines(3, "new")].join("\n");
+    expect(await decision(trimmedAndGrown)).toBeNull();
+  });
+
+  it("allows and skips state when the stored line set is corrupt", async () => {
+    await decision(initial);
+    await Bun.write(join(stateRoot, "session-1", "exit-plan-lines"), "not json");
+    expect(await decision(`${initial}\nline 10`)).toBeNull();
+  });
+
+  it("prefers deny when the append-only re-present is byte-identical", async () => {
+    await decision(initial);
+    await decision(`${initial}\nline 10`);
+    expect((await decision(`${initial}\nline 10`))?.permissionDecision).toBe("deny");
+  });
+});
+
 describe("fail open", () => {
   it("allows and skips state when session_id is missing", async () => {
     const input = mockInput("My plan");

--- a/plugins/plan/hooks/gate.test.ts
+++ b/plugins/plan/hooks/gate.test.ts
@@ -168,6 +168,26 @@ describe("append-only re-present", () => {
     await decision(`${initial}\nline 10`);
     expect((await decision(`${initial}\nline 10`))?.permissionDecision).toBe("deny");
   });
+
+  it("asks once for append-only, not size, when the re-present is also oversized", async () => {
+    const pad = "x".repeat(120);
+    const padded = (count: number, prefix: string) =>
+      Array.from({ length: count }, (_, i) => `${prefix} ${i} ${pad}`);
+    const base = padded(90, "line").join("\n");
+    expect(base.length).toBeLessThan(12_000);
+    await decision(base);
+
+    const grown = [...padded(90, "line"), ...padded(5, "new")].join("\n");
+    expect(grown.length).toBeGreaterThan(12_000);
+    expect(await decision(grown)).toEqual({
+      hookEventName: "PreToolUse",
+      permissionDecision: "ask",
+      permissionDecisionReason: expect.stringContaining("append-only"),
+    });
+    // Append-only asks before the size check, so the size branch never runs and
+    // records no marker: one prompt for append-only, no second prompt for size.
+    expect(readdirSync(join(stateRoot, "session-1"))).not.toContain("exit-plan-size-asked");
+  });
 });
 
 describe("fail open", () => {

--- a/plugins/plan/hooks/gate.ts
+++ b/plugins/plan/hooks/gate.ts
@@ -8,10 +8,25 @@ import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runn
 
 const SIZE_THRESHOLD = 12_000;
 
+// A re-present that keeps nearly every prior line and drops almost none regrew
+// the document instead of consolidating superseded design and revising it.
+const APPEND_ONLY_MIN_CARRYOVER = 0.9;
+// Zero net growth is a no-op edit (or whitespace-only), not the regrowth pattern.
+const APPEND_ONLY_MIN_GROWTH = 1;
+// Allow one incidental drop (e.g. a stray line) without losing the append-only signal.
+const APPEND_ONLY_MAX_REMOVED = 1;
+
 const DENY_REASON =
   "Plan text is unchanged since the last presentation. Incorporate the redirect " +
   "feedback with a targeted revision of the affected sections (do not regrow the " +
   "document), lead with a short 'Changed since last plan' block, and re-present.";
+
+const APPEND_ONLY_ASK_REASON =
+  "This re-present keeps nearly all prior lines and only adds new ones: append-only " +
+  "growth, not a revision. Consolidate superseded design into a two-line pointer " +
+  "(what it was, why it was parked, where it lives), lead with a 'Changed since " +
+  "last plan' block, and re-present the delta, not the regrown document. Approve " +
+  "to present anyway.";
 
 const ASK_REASON =
   "This plan exceeds 12k characters. Plans this large are rarely approved; " +
@@ -44,6 +59,43 @@ async function writeState(path: string, content: string): Promise<void> {
   }
 }
 
+function normalizeLines(plan: string): Set<string> {
+  const lines = new Set<string>();
+  for (const rawLine of plan.split("\n")) {
+    const line = rawLine.trim();
+    if (line) lines.add(line);
+  }
+  return lines;
+}
+
+function parseLineSet(raw: string): Set<string> | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed) || !parsed.every((item) => typeof item === "string")) return null;
+    return new Set(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function isAppendOnlyRevision(previous: Set<string>, current: Set<string>): boolean {
+  if (previous.size === 0) return false;
+
+  let carriedOver = 0;
+  for (const line of previous) {
+    if (current.has(line)) carriedOver++;
+  }
+  const carryOverRatio = carriedOver / previous.size;
+  const removed = previous.size - carriedOver;
+  const growth = current.size - previous.size;
+
+  return (
+    carryOverRatio >= APPEND_ONLY_MIN_CARRYOVER &&
+    growth >= APPEND_ONLY_MIN_GROWTH &&
+    removed <= APPEND_ONLY_MAX_REMOVED
+  );
+}
+
 export async function processInput(
   input: PreToolUseHookInput,
   stateRoot = process.env.CLAUDE_PLAN_MARKER_ROOT || "/tmp/claude",
@@ -62,14 +114,24 @@ export async function processInput(
   }
 
   const hashPath = join(dir, "exit-plan-hash");
+  const linesPath = join(dir, "exit-plan-lines");
   const askedPath = join(dir, "exit-plan-size-asked");
 
   const hash = createHash("sha256").update(plan).digest("hex");
   const previous = await readState(hashPath);
   await writeState(hashPath, hash);
 
+  const currentLines = normalizeLines(plan);
+  const previousLinesRaw = await readState(linesPath);
+  await writeState(linesPath, JSON.stringify(Array.from(currentLines)));
+
   if (previous !== null && previous === hash) {
     return formatDecision("deny", DENY_REASON);
+  }
+
+  const previousLines = previousLinesRaw === null ? null : parseLineSet(previousLinesRaw);
+  if (previousLines !== null && isAppendOnlyRevision(previousLines, currentLines)) {
+    return formatDecision("ask", APPEND_ONLY_ASK_REASON);
   }
 
   if (plan.length > SIZE_THRESHOLD && (await readState(askedPath)) === null) {


### PR DESCRIPTION
The plan re-present gate only caught byte-identical re-presents. A plan that grows append-only (keeps nearly all prior lines, adds new ones, removes almost none) is not byte-identical, so it sailed through with `null` even though it never consolidated superseded design.

This adds a second signal alongside the existing hash check: the previous plan's normalized line set (trimmed, deduped, blank lines dropped) is persisted next to the hash. On a non-identical re-present, we compute carry-over ratio, net line growth, and lines removed against that prior set, and `ask` when carry-over >= 0.9, growth > 0, and removed <= 1. Byte-identical `deny` still wins if it also applies.

The ask reason names the append-only pattern and points at the guidelines' Revision rules: consolidate superseded design into a two-line pointer, lead with "Changed since last plan", re-present the delta.

Complements #1038 but is independent, only touches `gate.ts` (and its test).
