### PR TITLE
feat(mac): reintroduce trimmed sandbox-skip marker for macOS handoff wrappers

### DIFF
--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -30,4 +30,17 @@ Use ANSI colors (0-15) in scripts that produce terminal output. These are remapp
 
 `excludedCommands` matches only the top-level command of a Bash invocation. Nested commands (e.g., `open` spawned from a `bun scripts/foo.ts` wrapper) inherit the parent's sandbox profile, so adding `open:*` to `excludedCommands` does not exempt nested calls.
 
-Scripts that shell out to Go CLIs (`gh`, `glab`, `terraform`) or hand off to Launch Services (`open`, URL schemes) run sandboxed. The `sandbox.network.allowMachLookup` and `sandbox.allowAppleEvents` keys in `user/settings.json` cover both cases profile-wide. See [`plugins/mac/README.md`](../../plugins/mac/README.md).
+Go CLIs (`gh`, `glab`, `terraform`, `kubectl`, `go`) run fine sandboxed: `sandbox.network.allowMachLookup: ["com.apple.trustd.agent"]` in `user/settings.json` lets Go's `crypto/x509` reach the system `trustd` daemon for TLS verification profile-wide.
+
+Apple Events and Launch Services handoff (`osascript`, `open`, URL schemes) does not survive the sandbox even with `sandbox.allowAppleEvents`, because the child process's TCC attribution changes under the Seatbelt container. These wrappers need a full sandbox skip, provided by the `mac` plugin's marker-based hook.
+
+`${CLAUDE_PLUGIN_ROOT}` does NOT expand in hook `matcher` fields (it only expands in `command` strings). A matcher like `Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/:*)` is compared literally against the resolved cache path (`bun /Users/.../plugins/cache/.../scripts/foo.ts`), never matches, and the hook never fires. Do not use `${CLAUDE_PLUGIN_ROOT}` in matchers.
+
+The marker hook sidesteps this: it uses a broad `Bash|Monitor` matcher and reads the head of the invoked `bun`/`node` script for the comment `claude:dangerouslyDisableSandbox`. When present, it injects `dangerouslyDisableSandbox: true`, running that command fully outside the sandbox. This is layout-independent, so it works regardless of the cache `<hash>` path. Add the marker after the shebang of any top-level script that hands off to Apple Events or Launch Services:
+
+```ts
+#!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: <reason>
+```
+
+The marker requires the `mac` plugin installed and only fires for interpreters in its `SCRIPT_INTERPRETERS` set (`bun`, `node`). See [`plugins/mac/README.md`](../../plugins/mac/README.md) for canonical docs.

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -17,7 +17,7 @@ Permission patterns starting with `/` are relative to the settings file, not abs
 
 ## Sandbox and Nested Commands
 
-`excludedCommands` matches only the top-level command of a Bash invocation. Nested commands (e.g., `open` spawned from a `bun scripts/foo.ts` wrapper) inherit the parent's sandbox profile, so adding `open:*` to `excludedCommands` does not exempt nested calls. Scripts that shell out to Go CLIs or hand off to Launch Services run sandboxed via `sandbox.network.allowMachLookup` and `sandbox.allowAppleEvents`. See [`scripts.md`](scripts.md).
+`excludedCommands` matches only the top-level command of a Bash invocation. Nested commands (e.g., `open` spawned from a `bun scripts/foo.ts` wrapper) inherit the parent's sandbox profile, so adding `open:*` to `excludedCommands` does not exempt nested calls. Go CLIs run sandboxed via `sandbox.network.allowMachLookup`; wrappers that hand off to Apple Events or Launch Services need a full skip via the `mac` plugin's `claude:dangerouslyDisableSandbox` marker hook. See [`scripts.md`](scripts.md).
 
 ## Sandbox Trust Model
 

--- a/plugins/mac/README.md
+++ b/plugins/mac/README.md
@@ -9,6 +9,10 @@ macOS-specific automation and system integration.
 - **jxa** — JXA language guide for writing JavaScript for Automation code
 - **jxa-run** — App-scoped JXA runner with AST-based Application() validation
 
+### Hooks
+
+- **sandbox** — Reads the invoked `bun`/`node` script for the `claude:dangerouslyDisableSandbox` marker and disables the command sandbox when present. Matches both `Bash` and `Monitor` tool calls.
+
 ### Scripts
 
 - `scripts/jxa.ts` — App-scoped JXA runner with AST-based `Application()` validation
@@ -16,10 +20,22 @@ macOS-specific automation and system integration.
 
 ## Sandbox
 
-Go-based CLIs and Launch Services handoffs run sandboxed. Two `sandbox` keys in `user/settings.json` cover them profile-wide:
+Go-based CLIs run fine sandboxed: `sandbox.network.allowMachLookup: ["com.apple.trustd.agent"]` in `user/settings.json` lets Go's `crypto/x509` reach the system `trustd` daemon for TLS verification (`gh`, `glab`, `terraform`, `kubectl`, `go`) profile-wide.
 
-- `sandbox.network.allowMachLookup: ["com.apple.trustd.agent"]` lets Go's `crypto/x509` reach the system `trustd` daemon for TLS verification (`gh`, `glab`, `terraform`, `kubectl`, `go`).
-- `sandbox.allowAppleEvents: true` covers Apple Events and Launch Services `open`/URL-scheme handoff (`open-url.ts`, the Things scripts).
+Apple Events and Launch Services handoff is different. Scripts that shell out to `osascript` (JXA) or `open` (URL schemes) do not survive the sandbox even with `sandbox.allowAppleEvents`, so they need a full skip.
+
+### Sandbox bypass marker
+
+The `sandbox` hook disables the command sandbox for a `bun <script>` or `node <script>` invocation when the script's first 64KB contains the literal string `claude:dangerouslyDisableSandbox`. Add the marker after the shebang of any top-level wrapper that hands off to Apple Events or Launch Services:
+
+```ts
+#!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: hands off to osascript for JXA Apple Events
+```
+
+The marker goes on the top-level entrypoint script only. The hook inspects the `bun`/`node` script argument, not imported modules, so a helper like `things/scripts/ensure-running.ts` carries no marker of its own; its callers do.
+
+The marker is inert on Linux and inert when the `mac` plugin is not installed. It only activates when this hook runs on macOS.
 
 ## Testing
 

--- a/plugins/mac/hooks/hooks.json
+++ b/plugins/mac/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Disables the command sandbox for plugin scripts that hand off to macOS automation (Apple Events, Launch Services)",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Monitor",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/sandbox.ts\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/mac/hooks/sandbox.test.ts
+++ b/plugins/mac/hooks/sandbox.test.ts
@@ -1,0 +1,127 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, sep } from "node:path";
+import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { extractCommands, hasBypassMarker, processInput } from "./sandbox";
+
+let fixtureDir: string;
+let markedScriptPath: string;
+let unmarkedScriptPath: string;
+
+beforeAll(async () => {
+  fixtureDir = await mkdtemp(`${tmpdir()}${sep}sandbox-test-`);
+
+  markedScriptPath = join(fixtureDir, "marked.ts");
+  await Bun.write(
+    markedScriptPath,
+    `#!/usr/bin/env bun\n// claude:dangerouslyDisableSandbox: hands off to Apple Events\nconsole.log("hi");\n`,
+  );
+
+  unmarkedScriptPath = join(fixtureDir, "unmarked.ts");
+  await Bun.write(unmarkedScriptPath, `#!/usr/bin/env bun\nconsole.log("hi");\n`);
+});
+
+afterAll(async () => {
+  const { rm } = await import("node:fs/promises");
+  await rm(fixtureDir, { recursive: true, force: true });
+});
+
+function makeInput(command: string, toolName = "Bash"): PreToolUseHookInput {
+  return {
+    tool_name: toolName,
+    tool_input: { command },
+  } as PreToolUseHookInput;
+}
+
+describe("extractCommands", () => {
+  test("captures bun script arg", () => {
+    expect(extractCommands("bun watch.ts --pr 42")).toEqual([
+      { cmd: "bun", scriptArg: "watch.ts" },
+    ]);
+  });
+
+  test("captures node script arg", () => {
+    expect(extractCommands("node ./scripts/run.js")).toEqual([
+      { cmd: "node", scriptArg: "./scripts/run.js" },
+    ]);
+  });
+
+  test("captures env-prefixed bun script arg", () => {
+    expect(extractCommands("FOO=bar bun watch.ts")).toEqual([
+      { cmd: "bun", scriptArg: "watch.ts" },
+    ]);
+  });
+
+  test("captures bun script arg through a pipe", () => {
+    expect(extractCommands("bun watch.ts | jq .rate")).toEqual([
+      { cmd: "bun", scriptArg: "watch.ts" },
+      { cmd: "jq" },
+    ]);
+  });
+
+  test("skips bun flag-bearing invocation", () => {
+    expect(extractCommands("bun --silent watch.ts")).toEqual([{ cmd: "bun" }]);
+  });
+
+  test("absolute bun script path", () => {
+    expect(extractCommands("bun /abs/path/watch.ts")).toEqual([
+      { cmd: "bun", scriptArg: "/abs/path/watch.ts" },
+    ]);
+  });
+});
+
+describe("hasBypassMarker", () => {
+  test("detects bypass marker in script", async () => {
+    expect(await hasBypassMarker(markedScriptPath)).toBe(true);
+  });
+
+  test("returns false for script without marker", async () => {
+    expect(await hasBypassMarker(unmarkedScriptPath)).toBe(false);
+  });
+
+  test("returns false for nonexistent path", async () => {
+    expect(await hasBypassMarker("/nonexistent/path")).toBe(false);
+  });
+});
+
+describe("processInput", () => {
+  test("returns null on non-darwin", async () => {
+    const result = await processInput(makeInput(`bun ${markedScriptPath}`), "linux");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when command is undefined", async () => {
+    const input = { tool_name: "Bash", tool_input: {} } as PreToolUseHookInput;
+    const result = await processInput(input, "darwin");
+    expect(result).toBeNull();
+  });
+
+  test("disables sandbox for marked bun script", async () => {
+    const input = makeInput(`bun ${markedScriptPath} --pr 42`);
+    const result = await processInput(input, "darwin");
+    expect(result).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        updatedInput: {
+          ...(input.tool_input as Record<string, unknown>),
+          dangerouslyDisableSandbox: true,
+        },
+      },
+    });
+  });
+
+  test("does not disable sandbox for unmarked bun script", async () => {
+    const result = await processInput(makeInput(`bun ${unmarkedScriptPath}`), "darwin");
+    expect(result).toBeNull();
+  });
+
+  test("processes Monitor tool input the same as Bash", async () => {
+    const input = makeInput(`bun ${markedScriptPath}`, "Monitor");
+    const result = await processInput(input, "darwin");
+    expect(result?.hookSpecificOutput).toMatchObject({
+      hookEventName: "PreToolUse",
+      updatedInput: { dangerouslyDisableSandbox: true },
+    });
+  });
+});

--- a/plugins/mac/hooks/sandbox.test.ts
+++ b/plugins/mac/hooks/sandbox.test.ts
@@ -116,6 +116,15 @@ describe("processInput", () => {
     expect(result).toBeNull();
   });
 
+  test("honors marker on second bun invocation in a chain", async () => {
+    const input = makeInput(`bun ${unmarkedScriptPath} && bun ${markedScriptPath}`);
+    const result = await processInput(input, "darwin");
+    expect(result?.hookSpecificOutput).toMatchObject({
+      hookEventName: "PreToolUse",
+      updatedInput: { dangerouslyDisableSandbox: true },
+    });
+  });
+
   test("processes Monitor tool input the same as Bash", async () => {
     const input = makeInput(`bun ${markedScriptPath}`, "Monitor");
     const result = await processInput(input, "darwin");

--- a/plugins/mac/hooks/sandbox.ts
+++ b/plugins/mac/hooks/sandbox.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env bun
+
+import { basename } from "node:path";
+import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+
+type ToolInput = { command: string };
+
+const SHELL_OPERATORS = /\s*(?:&&|\|\||[|;])\s*/;
+const SCRIPT_INTERPRETERS = new Set(["bun", "node"]);
+const SCRIPT_MARKER = "claude:dangerouslyDisableSandbox";
+
+export type Invocation = { cmd: string; scriptArg?: string };
+
+export function extractCommands(command: string): Invocation[] {
+  const segments = command.split(SHELL_OPERATORS);
+  const seen = new Set<string>();
+  const result: Invocation[] = [];
+
+  for (const segment of segments) {
+    const trimmed = segment.trim().replace(/^[()]+|[()]+$/g, "");
+    if (!trimmed) continue;
+
+    const tokens = trimmed.split(/\s+/);
+    let i = 0;
+
+    // skip env var prefixes (FOO=bar)
+    while (i < tokens.length && /^[A-Za-z_]\w*=/.test(tokens[i] as string)) {
+      i++;
+    }
+
+    const cmd = tokens[i];
+    if (!cmd) continue;
+
+    const name = basename(cmd);
+    if (seen.has(name)) continue;
+    seen.add(name);
+
+    const invocation: Invocation = { cmd };
+    if (SCRIPT_INTERPRETERS.has(name)) {
+      const next = tokens[i + 1];
+      if (next && !next.startsWith("-")) {
+        invocation.scriptArg = next;
+      }
+    }
+    result.push(invocation);
+  }
+
+  return result;
+}
+
+async function readHead(path: string, length = 65536): Promise<Buffer | null> {
+  try {
+    const file = Bun.file(path);
+    const slice = file.slice(0, length);
+    return Buffer.from(await slice.arrayBuffer());
+  } catch {
+    return null;
+  }
+}
+
+export async function hasBypassMarker(path: string): Promise<boolean> {
+  const head = await readHead(path);
+  return head ? head.includes(SCRIPT_MARKER) : false;
+}
+
+function disableSandbox(toolInput: Record<string, unknown>): SyncHookJSONOutput {
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      updatedInput: { ...toolInput, dangerouslyDisableSandbox: true },
+    },
+  };
+}
+
+export async function processInput(
+  input: PreToolUseHookInput,
+  platform = process.platform,
+): Promise<SyncHookJSONOutput | null> {
+  if (platform !== "darwin") return null;
+
+  const toolInput = input.tool_input as Record<string, unknown>;
+  const { command } = toolInput as ToolInput;
+  if (!command) return null;
+
+  for (const { scriptArg } of extractCommands(command)) {
+    if (scriptArg && (await hasBypassMarker(scriptArg))) {
+      return disableSandbox(toolInput);
+    }
+  }
+
+  return null;
+}
+
+async function main(): Promise<void> {
+  let input: PreToolUseHookInput;
+  try {
+    input = await readStdinJson<PreToolUseHookInput>();
+  } catch (error) {
+    console.error(
+      `[mac/sandbox] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  const output = await processInput(input);
+  if (output) {
+    writeStdoutJson(output);
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/plugins/mac/hooks/sandbox.ts
+++ b/plugins/mac/hooks/sandbox.ts
@@ -14,7 +14,6 @@ export type Invocation = { cmd: string; scriptArg?: string };
 
 export function extractCommands(command: string): Invocation[] {
   const segments = command.split(SHELL_OPERATORS);
-  const seen = new Set<string>();
   const result: Invocation[] = [];
 
   for (const segment of segments) {
@@ -33,9 +32,6 @@ export function extractCommands(command: string): Invocation[] {
     if (!cmd) continue;
 
     const name = basename(cmd);
-    if (seen.has(name)) continue;
-    seen.add(name);
-
     const invocation: Invocation = { cmd };
     if (SCRIPT_INTERPRETERS.has(name)) {
       const next = tokens[i + 1];

--- a/plugins/mac/scripts/jxa.ts
+++ b/plugins/mac/scripts/jxa.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: hands off to osascript for JXA Apple Events, which the command sandbox blocks
 
 import * as acorn from "acorn";
 

--- a/plugins/mac/scripts/open-url.ts
+++ b/plugins/mac/scripts/open-url.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: hands off to open for Launch Services, which the command sandbox blocks
 
 interface ValidationResult {
   valid: boolean;

--- a/plugins/things/CLAUDE.md
+++ b/plugins/things/CLAUDE.md
@@ -10,7 +10,7 @@ JXA scripts run via `osascript`, which requires Apple Events mach-lookup service
 - Formatter (`scripts/format-output.ts`): reads JSON from stdin, outputs tables or passes through `--json`
 - JXA execution: invoke the `mac:jxa-run` skill, which validates `Application("Things3")` scope via AST
 
-Scripts that hand off to Launch Services (`inbox.ts`, `url.ts`, `reorder.ts`) run sandboxed. The `sandbox.allowAppleEvents` key in `user/settings.json` covers Launch Services `open`/URL-scheme handoff. See [`plugins/mac/README.md`](../mac/README.md).
+Scripts that hand off to Launch Services (`inbox.ts`, `url.ts`, `reorder.ts`) carry the `claude:dangerouslyDisableSandbox` marker so the `mac` plugin's sandbox hook runs them fully outside the command sandbox. `sandbox.allowAppleEvents` alone does not survive the handoff. See [`plugins/mac/README.md`](../mac/README.md).
 
 ## JXA Script Conventions
 
@@ -29,7 +29,7 @@ Biome linting is disabled for `scripts/jxa/` files via the root `biome.json` ove
 
 `scripts/url.ts` owns the URL handoff. `dispatch(command, params)` builds the Things URL, runs it through the x-callback-url runner when available, and falls back to a Launch Services `open` on any xcall failure, returning the parsed todo id when xcall surfaces one. `inbox.ts`, `reorder.ts`, and `url.ts`'s own CLI call `dispatch` rather than re-implementing the runner-selection and fallback. `buildUrl`, `openUrl`, `xcall`, and `findXcallRunner` are internal to `url.ts`. Inject a `DispatchActions` to test runner selection and fallback without real Launch Services or keychain access, mirroring `plugins/gitlab/scripts/merge.ts`.
 
-`reorder.ts` and `inbox.ts` are bun TypeScript scripts (not `osascript`). Their Launch Services handoff runs sandboxed via `sandbox.allowAppleEvents`.
+`reorder.ts` and `inbox.ts` are bun TypeScript scripts (not `osascript`). Their Launch Services handoff runs outside the command sandbox via the `claude:dangerouslyDisableSandbox` marker.
 
 ## What NOT to Do
 

--- a/plugins/things/scripts/inbox.ts
+++ b/plugins/things/scripts/inbox.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: hands off to osascript via ensure-running, which the command sandbox blocks
 
 import { cli } from "cleye";
 import { ensureThingsRunning } from "./ensure-running";

--- a/plugins/things/scripts/reorder.ts
+++ b/plugins/things/scripts/reorder.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: hands off to osascript via ensure-running, which the command sandbox blocks
 
 import { cli } from "cleye";
 import { ensureThingsRunning } from "./ensure-running";

--- a/plugins/things/scripts/url.ts
+++ b/plugins/things/scripts/url.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: hands off to open/xcall for Things URL schemes and osascript via ensure-running, which the command sandbox blocks
 
 import { readdirSync } from "node:fs";
 import { join } from "node:path";

--- a/plugins/things/skills/url/SKILL.md
+++ b/plugins/things/skills/url/SKILL.md
@@ -117,7 +117,7 @@ The write scripts (`url.ts`, `inbox.ts`) print to stdout on success. No output m
 
 #### Sandbox-blocked URL handoff
 
-If stderr mentions `procNotFound`, `-10810`, or `LSOpenURLsWithRole`, the macOS sandbox blocked the URL handoff to Things. `sandbox.allowAppleEvents` in `user/settings.json` covers Launch Services handoff. If it still happens, verify that key is set rather than disabling the sandbox manually.
+If stderr mentions `procNotFound`, `-10810`, or `LSOpenURLsWithRole`, the macOS sandbox blocked the URL handoff to Things. `url.ts` and `inbox.ts` carry the `claude:dangerouslyDisableSandbox` marker so the `mac` plugin's sandbox hook runs them outside the sandbox. If it still happens, verify the `mac` plugin is installed so that hook is active.
 
 ## Documentation
 


### PR DESCRIPTION
JXA automation (`mac:jxa-run`, Things 3) is broken under the command sandbox on `main`. The JXA path is `bun plugins/mac/scripts/jxa.ts Things3 …`, which spawns `osascript` as a child of the sandboxed `bun`. The docs say `sandbox.allowAppleEvents` should propagate to children and leave only a TCC prompt, but for these wrappers it does not: the handoff still fails with an Apple Events denial. The likely reason is TCC responsible-process attribution under the Seatbelt container, but regardless of mechanism these wrappers need a full sandbox skip, not the in-sandbox Apple Events grant.

PR #904 retired the marker hook wholesale, on the theory that `allowAppleEvents` (#838) plus `allowMachLookup` (#903) replaced every case. The Go-TLS case is genuinely covered by `allowMachLookup`. The Apple Events case is not. This brings back only the marker half.

`excludedCommands` can't target this: it keys on the top-level executable (`bun`), so it can't exempt one bun script without exempting all, and `${CLAUDE_PLUGIN_ROOT}` doesn't expand in hook matchers. A broad-matcher `PreToolUse` hook that reads the invoked script's head for a marker comment is the only layout-independent path.

## What changed

- Restores `plugins/mac/hooks/sandbox.ts` and `hooks.json`, trimmed of the Go-binary detection (`hasGoBuildInfo`, `isGoBinary`) that `allowMachLookup` now owns. The loop reduces to a single marker check over `bun`/`node` script arguments. Dropped the old second hook entry that wired `disable-sandbox.ts` to an `open-url.ts` matcher. That matcher never fired (the `${CLAUDE_PLUGIN_ROOT}` non-expansion above), and `open-url.ts` now carries the marker instead.
- Adds the `claude:dangerouslyDisableSandbox` marker to the five top-level handoff wrappers: `jxa.ts`, `open-url.ts`, `things/scripts/url.ts`, `inbox.ts`, `reorder.ts`. The marker goes on entrypoints only. `things/scripts/ensure-running.ts` calls `osascript` but is an imported module, not a top-level script argument, so it carries no marker; its callers do.
- Updates the docs the marker's removal left stale: `.claude/rules/scripts.md`, `.claude/rules/settings.md`, `plugins/mac/README.md`, `plugins/things/CLAUDE.md`, and the `things:url` skill. Each claimed `allowAppleEvents` covered these handoffs profile-wide.

## Verification

- `sandbox.test.ts` covers `extractCommands` parsing (env-prefixed, piped, flag-bearing, absolute-path `bun`/`node` invocations) and `processInput` injecting the skip for a marked temp script while returning null for an unmarked one and on non-darwin. Full `mac` and `things` suites stay green, and `check-hook-quoting.ts` and `skill-lint` pass.
- Fed the hook real stdin against the actual `jxa.ts`: it injects `dangerouslyDisableSandbox: true`. Fed it the unmarked `ensure-running.ts`: it returns nothing, confirming imported helpers don't get the skip.
- The macOS end-to-end signal (a real sandboxed session with the branch installed, running a JXA query against Things 3 to confirm it no longer fails with `-1743`) needs the plugin installed and hasn't been run here.

## Follow-up

Once this lands, `sandbox.allowAppleEvents: true` in `user/settings.json` is redundant for these wrappers, since the skip runs them fully outside the sandbox. Leaving it is harmless. Removing it would narrow the profile-wide isolation loss it causes, but that needs its own trace of any direct top-level Apple Events users before it's safe, so it's out of scope here.
