### PR TITLE
activitywatch: add plugin querying local usage data

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -173,6 +173,11 @@
       "name": "meme",
       "description": "Generate memes from images: classic Impact macros, labels, and TV-subtitle captions",
       "source": "./plugins/meme"
+    },
+    {
+      "name": "activitywatch",
+      "description": "Query local ActivityWatch usage data: per-app time, window titles, and active vs idle spans",
+      "source": "./plugins/activitywatch"
     }
   ]
 }

--- a/plugins/activitywatch/.claude-plugin/plugin.json
+++ b/plugins/activitywatch/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "activitywatch",
+  "description": "Query local ActivityWatch usage data: per-app time, window titles, and active vs idle spans",
+  "author": {
+    "name": "Ben Drucker",
+    "email": "bvdrucker@gmail.com"
+  }
+}

--- a/plugins/activitywatch/README.md
+++ b/plugins/activitywatch/README.md
@@ -1,0 +1,26 @@
+# ActivityWatch Plugin
+
+Local-first visibility into real device usage for Claude Code, from [ActivityWatch](https://activitywatch.net/).
+
+## Contents
+
+- **Skill `activity`**: report per-app time, window titles, and active vs idle spans from ActivityWatch's local capture.
+
+## How It Works
+
+ActivityWatch runs `aw-server-rust` in the background and records the focused app and window title (`aw-watcher-window`) plus active/idle state (`aw-watcher-afk`) into a SQLite db at `~/Library/Application Support/activitywatch/aw-server-rust/sqlite.db`.
+
+The skill attaches that db read-only with DuckDB, which is safe alongside the running server, and answers usage questions from named queries. No ingest step and no separate index: it reads the live capture directly, the same way the [`atuin-query`](https://github.com/bendrucker/dotfiles) idiom reads shell history.
+
+`scripts/aw-query.sh <query> [--recent <dur>] [-n <limit>]` runs a named query from [`skills/activity/resources/queries/`](skills/activity/resources/queries/):
+
+- `top-apps`: total focused time per app
+- `window-titles`: time per window title within each app
+- `app-timeline`: focus events in reverse-chronological order
+- `afk`: active vs idle time
+
+Override the db path with `AW_DB`.
+
+## Capture Setup
+
+Capture is provisioned separately by the `activitywatch` dotfiles topic: it installs the cask, selects `aw-server-rust`, and autostarts `aw-qt` via a LaunchAgent. Window titles need Accessibility granted to ActivityWatch. This plugin is read-only and assumes capture is already running.

--- a/plugins/activitywatch/skills/activity/SKILL.md
+++ b/plugins/activitywatch/skills/activity/SKILL.md
@@ -30,7 +30,7 @@ ${CLAUDE_SKILL_DIR}/scripts/aw-query.sh window-titles --recent 7d -n 40
 ${CLAUDE_SKILL_DIR}/scripts/aw-query.sh afk --recent 1d
 ```
 
-Durations come back both formatted (`duration`, e.g. `1h 23m`) and raw (`seconds`) so results are readable and still sortable/summable.
+The aggregate queries (`top-apps`, `window-titles`, `afk`) return durations both formatted (`duration`, e.g. `1h 23m`) and raw (`seconds`) so results are readable and still sortable/summable. `app-timeline` lists individual focus events and returns raw `seconds` only.
 
 ## Queries
 

--- a/plugins/activitywatch/skills/activity/SKILL.md
+++ b/plugins/activitywatch/skills/activity/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: activitywatch:activity
+description: Report real device usage from ActivityWatch. Covers per-app time, window titles, and active vs idle spans. Use when asked "what apps did I use", "how long was I in X", "what did I work on today", "how much was I active vs idle", or to mine usage patterns for automation.
+argument-hint: "[query] [--recent <1d|7d|4w>] [-n <limit>]"
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Activity
+
+Report how the device was actually used, from ActivityWatch's local capture. This skill only reads. It never writes to the db.
+
+ActivityWatch runs `aw-server-rust` in the background (a LaunchAgent supervises it via `aw-qt`). It records the focused app and window title (`aw-watcher-window`) and active vs idle spans (`aw-watcher-afk`) into a SQLite db. DuckDB attaches that db read-only, which is safe while `aw-server` holds its own write connection.
+
+## Database
+
+`~/Library/Application Support/activitywatch/aw-server-rust/sqlite.db`
+
+Override with `AW_DB` (the wrapper resolves it, since DuckDB cannot expand `~` in `ATTACH`). If the file is missing, ActivityWatch is not installed or has not captured yet.
+
+## Querying
+
+Run a named query with `scripts/aw-query.sh`. Each query supports `--recent <duration>` (`12h`, `1d`, `7d`, `4w`) to scope to a recent window, and `-n <limit>` to cap rows.
+
+```bash
+${CLAUDE_SKILL_DIR}/scripts/aw-query.sh top-apps
+${CLAUDE_SKILL_DIR}/scripts/aw-query.sh top-apps --recent 1d
+${CLAUDE_SKILL_DIR}/scripts/aw-query.sh window-titles --recent 7d -n 40
+${CLAUDE_SKILL_DIR}/scripts/aw-query.sh afk --recent 1d
+```
+
+Durations come back both formatted (`duration`, e.g. `1h 23m`) and raw (`seconds`) so results are readable and still sortable/summable.
+
+## Queries
+
+- **top-apps** — total focused time per app, most first. The headline "what did I use" answer.
+- **window-titles** — time per window title within each app. What you were actually doing, not just which app was open. Needs Accessibility granted to ActivityWatch.
+- **app-timeline** — focus events in reverse-chronological order (when you switched to what, for how long). Pair with `--recent 1d` to reconstruct a day.
+- **afk** — active (`not-afk`) vs idle (`afk`) time. How much of the window was actually at the keyboard.
+
+## Schema
+
+Two tables in the attached `aw` database:
+
+- `buckets(id, name, type, client, hostname, created, data)` — one row per watcher. `type` is `currentwindow` (window watcher) or `afkstatus` (afk watcher).
+- `events(id, bucketrow, starttime, endtime, data)` — `bucketrow` joins to `buckets.id`. `starttime`/`endtime` are **nanoseconds since the Unix epoch** (divide by `1e9` for epoch seconds). `data` is JSON: `{app, title}` for `currentwindow`, `{status}` for `afkstatus`.
+
+Duration of an event is `(endtime - starttime) / 1e9` seconds. The named queries live in [`resources/queries/`](resources/queries/).
+
+## Discovery
+
+For questions the named queries don't cover, attach the db read-only and explore. `DESCRIBE` and a sample surface any watcher's shape (browser, editor, and custom watchers all land in `events.data` as JSON):
+
+```bash
+duckdb -c "INSTALL sqlite; LOAD sqlite; INSTALL json; LOAD json;
+ATTACH '$HOME/Library/Application Support/activitywatch/aw-server-rust/sqlite.db' AS aw (TYPE sqlite, READ_ONLY);
+SELECT type, count(*) FROM aw.buckets GROUP BY 1;
+DESCRIBE aw.events;
+SELECT data FROM aw.events LIMIT 5;"
+```
+
+Write ad-hoc queries in the same shape as the files in `resources/queries/`: join `events` to `buckets`, filter by `buckets.type`, extract fields with `json_extract_string(data, '$.field')`, and measure time as `(endtime - starttime) / 1e9`.

--- a/plugins/activitywatch/skills/activity/resources/queries/afk.sql
+++ b/plugins/activitywatch/skills/activity/resources/queries/afk.sql
@@ -1,0 +1,21 @@
+-- Active (not-afk) vs idle (afk) time from the AFK watcher: how much of the
+-- window was actually at the keyboard.
+-- Params: cutoff (epoch seconds; NULL for all-time).
+WITH afk_events AS (
+  SELECT
+    json_extract_string(e.data, '$.status') AS status,
+    (e.endtime - e.starttime) / 1e9 AS seconds
+  FROM aw.events e
+  JOIN aw.buckets b ON e.bucketrow = b.id
+  WHERE b.type = 'afkstatus'
+    AND (getvariable('cutoff') IS NULL OR e.starttime / 1e9 >= getvariable('cutoff'))
+)
+SELECT
+  CASE status WHEN 'not-afk' THEN 'active' WHEN 'afk' THEN 'idle' ELSE status END AS state,
+  CASE WHEN sum(seconds) >= 3600
+       THEN (sum(seconds) // 3600)::bigint || 'h ' || ((sum(seconds) % 3600) // 60)::bigint || 'm'
+       ELSE (sum(seconds) // 60)::bigint || 'm' END AS duration,
+  round(sum(seconds)) AS seconds
+FROM afk_events
+GROUP BY status
+ORDER BY seconds DESC;

--- a/plugins/activitywatch/skills/activity/resources/queries/app-timeline.sql
+++ b/plugins/activitywatch/skills/activity/resources/queries/app-timeline.sql
@@ -1,0 +1,14 @@
+-- Focus events in reverse-chronological order: when you switched to what and for
+-- how long. Pair with --recent 1d to reconstruct a single day.
+-- Params: cutoff (epoch seconds; NULL for all-time), limit (row cap).
+SELECT
+  to_timestamp(e.starttime / 1e9) AS started,
+  round((e.endtime - e.starttime) / 1e9) AS seconds,
+  json_extract_string(e.data, '$.app') AS app,
+  json_extract_string(e.data, '$.title') AS title
+FROM aw.events e
+JOIN aw.buckets b ON e.bucketrow = b.id
+WHERE b.type = 'currentwindow'
+  AND (getvariable('cutoff') IS NULL OR e.starttime / 1e9 >= getvariable('cutoff'))
+ORDER BY e.starttime DESC
+LIMIT getvariable('limit');

--- a/plugins/activitywatch/skills/activity/resources/queries/top-apps.sql
+++ b/plugins/activitywatch/skills/activity/resources/queries/top-apps.sql
@@ -1,0 +1,23 @@
+-- Time spent focused in each app, most first: the headline "what did I use" view.
+-- Duration = endtime - starttime (nanoseconds) summed per app.
+-- Params: cutoff (epoch seconds; NULL for all-time), limit (row cap).
+WITH app_events AS (
+  SELECT
+    json_extract_string(e.data, '$.app') AS app,
+    (e.endtime - e.starttime) / 1e9 AS seconds
+  FROM aw.events e
+  JOIN aw.buckets b ON e.bucketrow = b.id
+  WHERE b.type = 'currentwindow'
+    AND (getvariable('cutoff') IS NULL OR e.starttime / 1e9 >= getvariable('cutoff'))
+)
+SELECT
+  app,
+  CASE WHEN sum(seconds) >= 3600
+       THEN (sum(seconds) // 3600)::bigint || 'h ' || ((sum(seconds) % 3600) // 60)::bigint || 'm'
+       ELSE (sum(seconds) // 60)::bigint || 'm' END AS duration,
+  round(sum(seconds)) AS seconds,
+  count(*) AS focus_events
+FROM app_events
+GROUP BY app
+ORDER BY seconds DESC
+LIMIT getvariable('limit');

--- a/plugins/activitywatch/skills/activity/resources/queries/window-titles.sql
+++ b/plugins/activitywatch/skills/activity/resources/queries/window-titles.sql
@@ -1,0 +1,25 @@
+-- Time per window title within each app: what you were actually doing, not just
+-- which app was open. Needs Accessibility granted to ActivityWatch for titles.
+-- Params: cutoff (epoch seconds; NULL for all-time), limit (row cap).
+WITH title_events AS (
+  SELECT
+    json_extract_string(e.data, '$.app') AS app,
+    json_extract_string(e.data, '$.title') AS title,
+    (e.endtime - e.starttime) / 1e9 AS seconds
+  FROM aw.events e
+  JOIN aw.buckets b ON e.bucketrow = b.id
+  WHERE b.type = 'currentwindow'
+    AND (getvariable('cutoff') IS NULL OR e.starttime / 1e9 >= getvariable('cutoff'))
+)
+SELECT
+  app,
+  title,
+  CASE WHEN sum(seconds) >= 3600
+       THEN (sum(seconds) // 3600)::bigint || 'h ' || ((sum(seconds) % 3600) // 60)::bigint || 'm'
+       ELSE (sum(seconds) // 60)::bigint || 'm' END AS duration,
+  round(sum(seconds)) AS seconds,
+  count(*) AS focus_events
+FROM title_events
+GROUP BY app, title
+ORDER BY seconds DESC
+LIMIT getvariable('limit');

--- a/plugins/activitywatch/skills/activity/scripts/aw-query.sh
+++ b/plugins/activitywatch/skills/activity/scripts/aw-query.sh
@@ -70,6 +70,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     -n)
       [[ $# -ge 2 ]] || { echo "-n requires an argument" >&2; exit 1; }
+      [[ "$2" =~ ^[0-9]+$ ]] || { echo "-n requires a non-negative integer: '$2'" >&2; exit 1; }
       LIMIT="$2"
       shift 2
       ;;
@@ -117,10 +118,15 @@ fi
 
 [[ -n "$LIMIT" ]] || LIMIT="$(default_limit "$QUERY")"
 
+# Double any single quotes so a db path containing one can't break out of the
+# ATTACH string literal.
+quote="'"
+DB_SQL="${DB//$quote/$quote$quote}"
+
 duckdb <<SQL
 INSTALL sqlite; LOAD sqlite;
 INSTALL json; LOAD json;
-ATTACH '$DB' AS aw (TYPE sqlite, READ_ONLY);
+ATTACH '$DB_SQL' AS aw (TYPE sqlite, READ_ONLY);
 SET VARIABLE cutoff = $CUTOFF;
 SET VARIABLE "limit" = $LIMIT;
 .read $QUERY_FILE

--- a/plugins/activitywatch/skills/activity/scripts/aw-query.sh
+++ b/plugins/activitywatch/skills/activity/scripts/aw-query.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Run a named DuckDB query from resources/queries/ against ActivityWatch's
+# SQLite db.
+#
+# aw-server-rust records device usage in a SQLite db that DuckDB attaches
+# read-only. aw-server keeps its own write connection open, so a read-only
+# attach is safe alongside it. The query files are pure, parameterized SQL
+# (getvariable('cutoff'/'limit')); this wrapper supplies the one thing a .sql
+# file can't: the shell-resolved, absolute db path for ATTACH (DuckDB does not
+# expand ~).
+#
+# Usage:
+#   aw-query.sh <query-name> [--recent <1d|7d|4w>] [-n <limit>]
+#
+#   aw-query.sh top-apps
+#   aw-query.sh top-apps --recent 1d
+#   aw-query.sh window-titles --recent 7d -n 40
+#   aw-query.sh afk --recent 1d
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+QUERY_DIR="$SCRIPT_DIR/../resources/queries"
+
+DB="${AW_DB:-$HOME/Library/Application Support/activitywatch/aw-server-rust/sqlite.db}"
+
+# Convert a human-friendly duration (12h, 1d, 4w) to an epoch cutoff timestamp.
+# Approximate week lengths. Precise enough for usage analysis.
+duration_to_cutoff() {
+  local input="$1"
+  if [[ ! "$input" =~ ^[0-9]+[hHdDwW]?$ ]]; then
+    echo "Invalid duration format: '$input' (expected e.g., 12h, 1d, 4w)" >&2
+    return 1
+  fi
+
+  local val="${input%[hHdDwW]}"
+  local unit="${input: -1}"
+  local seconds
+
+  case "$unit" in
+    h|H) seconds=$((val * 3600)) ;;
+    w|W) seconds=$((val * 7 * 86400)) ;;
+    *)   seconds=$((val * 86400)) ;;
+  esac
+
+  echo $(( $(date +%s) - seconds ))
+}
+
+# Sensible default row cap per query.
+default_limit() {
+  case "$1" in
+    top-apps)      echo 25 ;;
+    app-timeline)  echo 100 ;;
+    window-titles) echo 40 ;;
+    afk)           echo 10 ;;
+    *)             echo 50 ;;
+  esac
+}
+
+QUERY=""
+RECENT=""
+LIMIT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --recent)
+      [[ $# -ge 2 ]] || { echo "--recent requires an argument" >&2; exit 1; }
+      RECENT="$2"
+      shift 2
+      ;;
+    -n)
+      [[ $# -ge 2 ]] || { echo "-n requires an argument" >&2; exit 1; }
+      LIMIT="$2"
+      shift 2
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      if [[ -z "$QUERY" ]]; then
+        QUERY="$1"
+        shift
+      else
+        echo "Unexpected argument: $1" >&2
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$QUERY" ]]; then
+  echo "Usage: aw-query.sh <query-name> [--recent <dur>] [-n <limit>]" >&2
+  exit 1
+fi
+
+QUERY_FILE="$QUERY_DIR/$QUERY.sql"
+if [[ ! -f "$QUERY_FILE" ]]; then
+  echo "Unknown query: '$QUERY'. Available:" >&2
+  for f in "$QUERY_DIR"/*.sql; do
+    echo "  $(basename "$f" .sql)" >&2
+  done
+  exit 1
+fi
+
+if [[ ! -f "$DB" ]]; then
+  echo "ActivityWatch db not found: $DB" >&2
+  echo "Set AW_DB or ensure ActivityWatch (aw-server-rust) is installed and capturing." >&2
+  exit 1
+fi
+
+if [[ -n "$RECENT" ]]; then
+  CUTOFF="$(duration_to_cutoff "$RECENT")"
+else
+  CUTOFF="NULL"
+fi
+
+[[ -n "$LIMIT" ]] || LIMIT="$(default_limit "$QUERY")"
+
+duckdb <<SQL
+INSTALL sqlite; LOAD sqlite;
+INSTALL json; LOAD json;
+ATTACH '$DB' AS aw (TYPE sqlite, READ_ONLY);
+SET VARIABLE cutoff = $CUTOFF;
+SET VARIABLE "limit" = $LIMIT;
+.read $QUERY_FILE
+SQL


### PR DESCRIPTION
## Summary

Adds an `activitywatch` plugin whose `activitywatch:activity` skill reports real device usage from ActivityWatch's local capture: per-app time, window titles, and active vs idle spans. This is the query side of Layer 1 of a local-first observability stack. The capture side (installing ActivityWatch, selecting aw-server-rust, autostarting it) ships separately in the dotfiles repo.

## How it works

The skill attaches ActivityWatch's `aw-server-rust` SQLite db read-only with DuckDB, safe alongside the running server, and answers usage questions from named queries. No ingest and no separate index: it reads the live capture directly, mirroring the atuin-query read-only `ATTACH` idiom.

`scripts/aw-query.sh <query> [--recent <dur>] [-n <limit>]` runs a named query from `resources/queries/`:

- `top-apps`: total focused time per app
- `window-titles`: time per window title within each app
- `app-timeline`: focus events in reverse-chronological order
- `afk`: active vs idle time

Duration comes from `events.starttime`/`endtime` (epoch nanoseconds). App, title, and status live in `events.data` JSON. Window vs afk is selected by `buckets.type`. The db path defaults to the standard location and is overridable with `AW_DB`.

## Schema was confirmed against real data

The queries were authored against the live schema after capture started, not from memory. Confirmed on a running instance: `events.bucketrow` joins `buckets.id`, times are epoch nanoseconds (÷1e9), and payloads are `{app, title}` / `{status}` JSON. The skill documents `DESCRIBE`-based discovery, so watchers added later (browser, editor, or Screen Time imports) are queryable without changing the skill.

## Verification

- All four named queries return real rows through the wrapper against the live db (e.g. `top-apps` → `Ghostty  7m`; `afk` → active/idle split; `window-titles` with captured titles).
- Error paths exit non-zero with clear messages (unknown query, missing db, bad `--recent`).
- `skill-lint`: 0 errors / 0 warnings. `claude plugin validate`: passes. Marketplace validation + completeness pass. `biome check` clean on the JSON. `shellcheck` clean on the wrapper.

## Follow-ups (out of scope)

- Layer 2: [aw-import-screentime](https://github.com/ActivityWatch/aw-import-screentime) to import macOS/iOS Screen Time into the same db, queryable through this skill's discovery path with no changes.
- Generalize the skill to also attach atuin/tmux/session sources.

https://claude.ai/code/session_01DSCcxtJdqGDeAQHGouUd5n
