### PR TITLE
job: route carryover items and read configured hours

### DIFF
--- a/user/skills/job/SKILL.md
+++ b/user/skills/job/SKILL.md
@@ -28,7 +28,7 @@ Requested mode: `$0`. Local time: !`date "+%A %H:%M"`.
 - `end`: read [references/end.md](references/end.md)
 - `setup`: read [references/setup.md](references/setup.md)
 
-With no argument, suggest a mode from the local time above: before about 13:00 suggests start, after suggests end. On a weekend, suggest nothing and ask. Confirm the suggestion with AskUserQuestion before proceeding.
+With no argument, suggest a mode from the local time above: before the midpoint of the configured working hours (about 13:00 by default) suggests start, after suggests end. On a weekend, suggest nothing and ask. Confirm the suggestion with AskUserQuestion before proceeding.
 
 Arguments beyond the mode are a focus hint ($ARGUMENTS). Weight the brief toward what they name.
 

--- a/user/skills/job/references/end.md
+++ b/user/skills/job/references/end.md
@@ -29,7 +29,7 @@ Flag items that need collaboration lead time (a reviewer in another timezone, a 
 Review debt is inbound requests you did not reach today, unanswered threads on others' PRs/MRs, and any message, notification, or email still awaiting your reply or filing. Choose one path per item:
 
 - Reply now: judge whether the thread needs a substantive response first. Where a reaction or brief acknowledgement closes it, prefer that. Draft a reply only when it carries real content, keep it terse, and include it in the brief. Posting a draft the user approved is safe.
-- Carry to tomorrow: record it explicitly so it appears in tomorrow's start brief.
+- Carry to tomorrow: capture it where it belongs per Tracker Hygiene below (team work to the tracker, personal follow-ups to the personal inbox), so tomorrow's start gather surfaces it rather than a memory.
 
 Never silently drop an item.
 


### PR DESCRIPTION
Fixes two gaps in the job skill found while reviewing session history before this morning's run. Both survived the July 9 audit, whose other findings all shipped (#864, #865, #868, #1023, #1024).

End mode's Review Debt told the model to "record it explicitly" for carryover items without saying where. Destination-less capture gets misrouted (the June 23 run sent a work item to the personal inbox). The line now points at the Tracker Hygiene routing rule already in the same file: team work to the tracker, personal follow-ups to the personal inbox.

The setup interview captures working hours solely to suggest a mode when `/job` runs bare, yet the suggestion logic hardcoded 13:00. The key was written and never read. The suggestion now derives from the midpoint of the configured hours, with 13:00 still the default.

Considered and deferred: deduplicating the inbox-zero and reaction-discipline language repeated across `SKILL.md` and the mode files, which risks behavior loss and needs more than a pre-run window.
