### PR TITLE
renovate: link commit compare view on plugin digest bumps

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -33,5 +33,14 @@
       additionalBranchPrefix: "plugin-",
       semanticCommits: "disabled",
     },
+    {
+      // Digest bumps track a moving branch, so Renovate's version-delta changelog
+      // engine has no release range to render. Link the GitHub compare view instead
+      // so the commit list between the old and new SHA is one click away.
+      matchDatasources: ["git-refs"],
+      prBodyNotes: [
+        "📜 **Changelog**: [`{{{currentDigestShort}}}` → `{{{newDigestShort}}}`](https://github.com/{{{depName}}}/compare/{{{currentDigest}}}...{{{newDigest}}})",
+      ],
+    },
   ],
 }


### PR DESCRIPTION
Digest bumps for the third-party marketplaces (`anthropics/claude-plugins-official`, `astral-sh/claude-code-plugins`, `ast-grep/claude-skill`) open with an empty changelog. #1045 is the motivating case: a single-line SHA bump that actually spanned 239 upstream commits, none of them visible without cloning the repo and assembling the compare by hand.

This is not fixable by picking a different datasource. Renovate's changelog engine is version-delta based: it filters releases between `currentVersion` and `newVersion` and never inspects digests, so `getChangeLogJSON` returns null the moment there is no version range. These marketplaces pin a moving branch (`ref` resolves against `main`), so `currentValue` stays `main` across every update and no delta exists. Tracking tags instead would give Renovate a real range, but the repos publish no releases or tags, so that path is closed too.

The pragmatic equivalent is a compare link. A `prBodyNotes` entry scoped to the `git-refs` datasource renders `github.com/<repo>/compare/<old>...<new>` into the PR body, putting the full commit list one click away. Scoping by datasource keeps it off the semver-pinned marketplaces (`worktrunk`, `linear-cli`, `agent-browser`), which resolve through `github-releases` and already get native release notes.

Validated with `renovate-config-validator` (passes) and confirmed each template field (`currentDigestShort`, `newDigestShort`, `currentDigest`, `newDigest`, `depName`) against the Renovate templates docs. The link only renders once Renovate reruns and opens the next digest PR.

#1045
