### PR TITLE
improve-codebase-architecture: refresh from upstream 697d4ce

### DIFF
--- a/user/skills/improve-codebase-architecture/README.md
+++ b/user/skills/improve-codebase-architecture/README.md
@@ -1,3 +1,3 @@
 # Improve Codebase Architecture
 
-Vendored from [mattpocock/skills](https://github.com/mattpocock/skills) at [`b8be62f`](https://github.com/mattpocock/skills/commit/b8be62ffacb0118fa3eaa29a0923c87c8c11985c), with upstream dependencies on `grill-with-docs` (CONTEXT.md glossary, ADR workflow) removed and the refinement step pointed at `interview:plan`.
+Vendored from [mattpocock/skills](https://github.com/mattpocock/skills) at [`697d4ce`](https://github.com/mattpocock/skills/commit/697d4ce), with upstream dependencies on `grill-with-docs` (CONTEXT.md glossary, ADR workflow) removed and the refinement step pointed at `interview:plan`. The YAGNI scoping in the Explore step was ported from upstream. Its ADR/CONTEXT.md reads and `/grilling` side-effects were intentionally left out to keep this copy standalone.

--- a/user/skills/improve-codebase-architecture/SKILL.md
+++ b/user/skills/improve-codebase-architecture/SKILL.md
@@ -33,10 +33,10 @@ If the project has its own domain vocabulary (in code, types, or docs), use it f
 
 ### 1. Explore
 
-**Scope before you scan — YAGNI.** Deepening a module pays off by making future changes to it easier, so put extra weight on the parts of the codebase that have recently changed. Decide *where* to look before you look:
+**Scope before you scan (YAGNI).** Deepening a module pays off by making future changes to it easier, so put extra weight on the parts of the codebase that have recently changed. Decide *where* to look before you look:
 
-- If the user named a direction — a module, a subsystem, a pain point — take it, and skip the inference below.
-- Otherwise, walk back a good stretch of the commit history (`git log --oneline`) to find the codebase's hot spots — the files and areas that keep coming up — and let those paths pull your attention first. If the changes are scattered with no clear hot spot, widen the net.
+- If the user named a direction (a module, a subsystem, a pain point), take it and skip the inference below.
+- Otherwise, walk back a good stretch of the commit history (`git log --oneline`) to find the codebase's hot spots, the files and areas that keep coming up, and let those paths pull your attention first. If the changes are scattered with no clear hot spot, widen the net.
 
 Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
 

--- a/user/skills/improve-codebase-architecture/SKILL.md
+++ b/user/skills/improve-codebase-architecture/SKILL.md
@@ -33,7 +33,12 @@ If the project has its own domain vocabulary (in code, types, or docs), use it f
 
 ### 1. Explore
 
-Use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+**Scope before you scan — YAGNI.** Deepening a module pays off by making future changes to it easier, so put extra weight on the parts of the codebase that have recently changed. Decide *where* to look before you look:
+
+- If the user named a direction — a module, a subsystem, a pain point — take it, and skip the inference below.
+- Otherwise, walk back a good stretch of the commit history (`git log --oneline`) to find the codebase's hot spots — the files and areas that keep coming up — and let those paths pull your attention first. If the changes are scattered with no clear hot spot, widen the net.
+
+Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
 
 - Where does understanding one concept require bouncing between many small modules?
 - Where are modules **shallow** — interface nearly as complex as the implementation?
@@ -68,6 +73,6 @@ Do NOT propose interfaces yet. After the file is written, ask the user: "Which o
 
 ### 3. Refine the chosen candidate
 
-Once the user picks a candidate, walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive. Load `interview:plan` for a structured interview.
+Once the user picks a candidate, walk the decision tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive. Load `interview:plan` for a structured interview.
 
 If they want to explore alternative interfaces for the deepened module, see [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md).


### PR DESCRIPTION
Refresh the vendored `improve-codebase-architecture` skill from upstream [mattpocock/skills](https://github.com/mattpocock/skills), pulling in the one portable content improvement while keeping the skill standalone.

## What changed

- **`SKILL.md`**: Added the YAGNI "scope before you scan" block at the top of the Explore step (upstream PR #533), adapted to standalone by dropping upstream's `CONTEXT.md`/ADR read. Renamed "design tree" to "decision tree" in the refine step.
- **`README.md`**: Bumped the vendor pin from `b8be62f` to the new sync point `697d4ce` and noted that the YAGNI scoping was ported while upstream's ADR/CONTEXT/`/grilling` additions were intentionally left out.

## What was deliberately skipped

Ecosystem coupling that contradicts the standalone design: the ADR callout in `HTML-REPORT.md`, the `CONTEXT.md`/ADR reads in Explore, the `/grilling` plus `/domain-modeling` side-effect loop in step 3, and the Codex `agents/openai.yaml` metadata (marketplace is Claude Code-only).

The reference files (`LANGUAGE.md`, `DEEPENING.md`, `INTERFACE-DESIGN.md`, `HTML-REPORT.md`) are content-identical to upstream. The only diffs are the standalone cross-reference plumbing, so nothing to merge there.

## Verification

- `bun run skill-lint "user/skills/improve-codebase-architecture"` passes (0 errors, 0 warnings).
- Grep confirms no stray `CONTEXT.md`/ADR/`grilling`/`domain-modeling`/`codebase-design` references in the skill content files. Matches exist only in the README, documenting what was removed.
- The vendored spaced-em-dash voice is preserved in the ported block per the plan.
