### PR TITLE
writing: lint code embedded in markdown fences

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Check skill hook path variables
         run: bun scripts/check-skill-hook-vars.ts
 
+      - name: Check embedded markdown code
+        run: bun scripts/check-md-code.ts
+
       - name: Check for unenabled plugins
         if: github.event_name == 'pull_request'
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,3 +61,10 @@ repos:
         files: ^(plugins/|\.claude-plugin/marketplace\.json)
         pass_filenames: false
         entry: bun scripts/check-marketplace.ts
+
+      - id: md-code
+        name: Markdown embedded code
+        language: system
+        files: \.md$
+        pass_filenames: false
+        entry: bun scripts/check-md-code.ts

--- a/bun.lock
+++ b/bun.lock
@@ -15,10 +15,13 @@
         "@biomejs/biome": "^2.3.13",
         "@constellos/claude-code-kit": "^0.4.0",
         "@types/bun": "^1.3.12",
+        "@types/mdast": "^4.0.4",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "fast-check": "^4.8.0",
         "gray-matter": "^4.0.3",
+        "mdast-util-from-markdown": "^2.0.2",
+        "unist-util-visit": "^5.1.0",
       },
     },
     ".claude/skills/agent-ideas": {

--- a/package.json
+++ b/package.json
@@ -50,10 +50,13 @@
     "@biomejs/biome": "^2.3.13",
     "@constellos/claude-code-kit": "^0.4.0",
     "@types/bun": "^1.3.12",
+    "@types/mdast": "^4.0.4",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "fast-check": "^4.8.0",
-    "gray-matter": "^4.0.3"
+    "gray-matter": "^4.0.3",
+    "mdast-util-from-markdown": "^2.0.2",
+    "unist-util-visit": "^5.1.0"
   },
   "dependencies": {
     "cleye": "^2.2.1",

--- a/plugins/claude-code/skills/hook/SKILL.md
+++ b/plugins/claude-code/skills/hook/SKILL.md
@@ -122,7 +122,7 @@ Store complex hooks in `.claude/hooks/` or project `hooks/` directory:
 ```
 
 Reference with:
-```json
+```json fragment
 "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/my-hook.ts"
 ```
 

--- a/plugins/things/skills/jxa/jxa.md
+++ b/plugins/things/skills/jxa/jxa.md
@@ -162,7 +162,7 @@ JSON.stringify(todos, null, 2);
 ```
 
 **Querying Todos:**
-```javascript
+```javascript fragment
 // Get all todos
 const allTodos = app.toDos();
 

--- a/plugins/things/skills/url/url-scheme.md
+++ b/plugins/things/skills/url/url-scheme.md
@@ -256,7 +256,7 @@ open -g "things:///json?data=$(echo "$data" | jq -sRr @uri)"
 ### Operations
 
 **Create (default):**
-```json
+```json fragment
 {
   "type": "to-do",
   "operation": "create",
@@ -265,7 +265,7 @@ open -g "things:///json?data=$(echo "$data" | jq -sRr @uri)"
 ```
 
 **Update:**
-```json
+```json fragment
 {
   "type": "to-do",
   "operation": "update",

--- a/scripts/check-md-code.ts
+++ b/scripts/check-md-code.ts
@@ -1,0 +1,105 @@
+#!/usr/bin/env bun
+
+import { join } from "node:path";
+import { Glob } from "bun";
+import type { Code } from "mdast";
+import { fromMarkdown } from "mdast-util-from-markdown";
+import { visit } from "unist-util-visit";
+import { runCheck } from "./check";
+
+const root = join(import.meta.dirname, "..");
+
+// Embedded JS/TS is illustrative, not runnable: fences routinely use top-level
+// await, export, and undefined globals. Bun.Transpiler in module mode checks
+// syntax only. It tolerates all of that but throws on a genuine syntax error.
+type Loader = "js" | "jsx" | "ts" | "tsx";
+
+const LOADERS: Record<string, Loader> = {
+  js: "js",
+  javascript: "js",
+  jsx: "jsx",
+  ts: "ts",
+  typescript: "ts",
+  tsx: "tsx",
+};
+
+const transpilers = new Map<Loader, Bun.Transpiler>();
+
+function transpilerFor(loader: Loader): Bun.Transpiler {
+  let transpiler = transpilers.get(loader);
+  if (!transpiler) {
+    transpiler = new Bun.Transpiler({ loader });
+    transpilers.set(loader, transpiler);
+  }
+  return transpiler;
+}
+
+function firstLine(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.split("\n")[0]?.trim() ?? "Parse error";
+}
+
+function checkBlock(node: Code): string | null {
+  const lang = node.lang?.toLowerCase();
+  if (!lang) return null;
+
+  // A `fragment` token in the info string opts a deliberately-partial or
+  // multi-example block out of single-module parsing.
+  if (node.meta?.split(/\s+/).includes("fragment")) return null;
+
+  if (lang === "json") {
+    try {
+      JSON.parse(node.value);
+      return null;
+    } catch (error) {
+      return firstLine(error);
+    }
+  }
+
+  const loader = LOADERS[lang];
+  if (!loader) return null;
+
+  try {
+    transpilerFor(loader).transformSync(node.value);
+    return null;
+  } catch (error) {
+    return firstLine(error);
+  }
+}
+
+async function checkFile(file: string): Promise<string[]> {
+  const text = await Bun.file(join(root, file)).text();
+  const ast = fromMarkdown(text);
+  const violations: string[] = [];
+
+  visit(ast, "code", (node: Code) => {
+    const error = checkBlock(node);
+    if (error === null) return;
+    const line = node.position?.start.line ?? 0;
+    violations.push(`${file}:${line} [${node.lang}] ${error}`);
+  });
+
+  return violations;
+}
+
+async function findViolations(): Promise<string[]> {
+  const glob = new Glob("**/*.md");
+  const files: string[] = [];
+  for await (const file of glob.scan({ cwd: root })) {
+    if (file.includes("node_modules") || file.includes(".bun-cache")) continue;
+    files.push(file);
+  }
+
+  const results = await Promise.all(files.map(checkFile));
+  return results.flat();
+}
+
+if (import.meta.main) {
+  await runCheck(
+    async () => ({
+      header: "Fenced code blocks with syntax errors (tag the fence `fragment` to skip):",
+      violations: await findViolations(),
+    }),
+    { success: "All fenced JS/TS/JSON code blocks parse" },
+  );
+}


### PR DESCRIPTION
Adds `scripts/check-md-code.ts`, which syntax-checks fenced code blocks in every `*.md`. The motivation was PR #1053, which added a real Workflow script to `improve-claude-code/SKILL.md` for the model to author from. It nearly shipped syntactically broken, and the only thing that caught it was a manual note in the PR body. Nothing in CI or pre-commit parses code inside markdown, so a broken snippet in a skill would ship and then be handed to the model as a template.

## Syntax-only, by measurement

A probe over the 91 JS/TS-family fences in the repo found only one that failed a strict parse. Embedded JS/TS is illustrative, not runnable: fences routinely use top-level `await`, `export`, and undefined globals (`agent`, `pipeline`, `args`, `expect`, `Application`). So the checker validates syntax and nothing else. It never resolves symbols, types, or imports. JS/TS parse through `Bun.Transpiler` in module mode, which tolerates all of the above but throws on a genuine syntax error. JSON goes through `JSON.parse`. Every other language is ignored (bash alone is ~1300 fences), as are language-less fences, which sometimes hold pseudo-code object literals.

I verified the ceiling holds against the actual #1053 case: the un-corrupted script (top-level `await` + `export` + undefined `pipeline`/`agent`/`args`) passes, and reintroducing the brace bug that nearly shipped is flagged with a parse error at the right line.

## Opting a block out

A block opts out with a `fragment` token in its info string: <code>```ts fragment</code>. This covers deliberately-partial snippets and multi-example blocks that don't parse as one module. GitHub still highlights by the first token, so syntax highlighting is unaffected. Adopting the checker surfaced four such pre-existing fences, now tagged: the jxa querying example (two `const todo` bindings in one block), two Things URL JSON examples using `{...}` placeholders, and the hook-command JSON reference (a single object property, not a whole object).

## Wiring

One step in the CI `validate` job alongside the other `check-*.ts` scripts, and a `local` pre-commit hook. The three mdast dependencies (`mdast-util-from-markdown`, `unist-util-visit`, `@types/mdast`) are added to the root `package.json`, matching what `plugins/writing` already vendors. Extraction uses mdast rather than regex so tilde fences, indented fences, and nesting are handled correctly.

A `PostToolUse` hook that runs the same check on a touched `*.md` at authoring time would be the earliest signal. I left it out of this cut; the pre-commit hook is the gate and CI is the backstop.
