### PR TITLE
plan: add a checkpoint marker system (human + verification) to guidelines

### DIFF
--- a/plugins/plan/references/guidelines.md
+++ b/plugins/plan/references/guidelines.md
@@ -85,7 +85,7 @@ Before naming symbols, files, directories, or headings, check what already gover
 
 ## Human Checkpoints
 
-When the spec was not fully settled before plan mode opened, build in points where the plan hands back for a look before it runs on. A plan that sequences every slice with no return point commits the user to an approach they cannot correct until it is all built, which is where an unclear spec goes off the rails.
+When the approach carries uncertainty that convergence cannot settle in advance because only building resolves it, build in points where the plan hands back for a look before it runs on. This is not a license to skip convergence: settle everything you can before plan mode, then checkpoint what only building can. A plan that sequences every slice with no return point commits the user to an approach they cannot correct until it is all built, which is where an unsettled approach goes off the rails.
 
 - Place a checkpoint where a wrong assumption is expensive to unwind: after the first vertical slice proves the approach, at an interface or schema the rest builds on, before a one-way door (a migration, a public rename, a destructive or outward-facing step).
 - Do not checkpoint mechanical fan-out (one pattern across many files, a rename across call sites). Reserve checkpoints for decisions, not volume.

--- a/plugins/plan/references/guidelines.md
+++ b/plugins/plan/references/guidelines.md
@@ -83,6 +83,20 @@ Before naming symbols, files, directories, or headings, check what already gover
 - `ls` the sibling layout and match it (for skills, a `references/` subdir).
 - Honor standing `CLAUDE.md` rules. Numbered `Step`/`Phase` headings are banned everywhere, plan files included.
 
+## Human Checkpoints
+
+When the spec was not fully settled before plan mode opened, build in points where the plan hands back for a look before it runs on. A plan that sequences every slice with no return point commits the user to an approach they cannot correct until it is all built, which is where an unclear spec goes off the rails.
+
+- Place a checkpoint where a wrong assumption is expensive to unwind: after the first vertical slice proves the approach, at an interface or schema the rest builds on, before a one-way door (a migration, a public rename, a destructive or outward-facing step).
+- Do not checkpoint mechanical fan-out (one pattern across many files, a rename across call sites). Reserve checkpoints for decisions, not volume.
+
+Write each checkpoint as a visible stop instruction marked with `✋`, naming what the user confirms: `✋ Checkpoint: stop and confirm <what> before <what continues>`. The marker is load-bearing in both directions, not decoration:
+
+- When execution reaches a `✋` line, stop there. Present what is built and wait for the user's read before continuing past it, the same stop discipline as `Pauses`. Because the line states the stop in plain words, a session that executes the plan without this guidance in context still honors it.
+- The user may add `✋` to the plan by hand, including on a line the plan did not mark, to insert a checkpoint the plan missed. A hand-added checkpoint is honored exactly like an authored one.
+
+`✋` is the only marker the plan uses and the only emoji it should carry. Do not introduce others.
+
 ## Pauses
 
 A pause or bare interrupt in plan mode is a stop signal. Present and wait. Do not edit silently and re-submit.

--- a/plugins/plan/references/guidelines.md
+++ b/plugins/plan/references/guidelines.md
@@ -65,6 +65,8 @@ Aim for at least one criterion that fails when the change is wrong while the sui
 
 Without the before/after contrast, a criterion only restates intent. Mechanical checks (`make test`, lint, typecheck, build) are necessary but not sufficient: list them once and confirm a named target exists before citing it. A criterion must be able to fail for a reason other than the edit not applying, so do not verify by asserting the diff landed (deleted attribute absent, added clause present).
 
+Layer verification through the plan. A criterion parked only at the end catches the break after the whole plan is built, not at the slice that caused it. Where a slice must hold before the next builds on it, place a `🧪` verification checkpoint at the proving point (see `Checkpoints`).
+
 ## Revision
 
 A redirect is new input scoped to what it names. On each iteration:
@@ -83,19 +85,31 @@ Before naming symbols, files, directories, or headings, check what already gover
 - `ls` the sibling layout and match it (for skills, a `references/` subdir).
 - Honor standing `CLAUDE.md` rules. Numbered `Step`/`Phase` headings are banned everywhere, plan files included.
 
-## Human Checkpoints
+## Checkpoints
+
+A checkpoint is a line the plan marks with an emoji so execution stops at it and does something before continuing past. Two kinds, each with its own marker and discipline:
+
+- `✋` a human checkpoint: hand back for a read.
+- `🧪` a verification checkpoint: run a named check and confirm its signal.
+
+Every marker is load-bearing in both directions, not decoration. When execution reaches a marked line it honors the marker before continuing past. Because each line states its instruction in plain words, a session that executes the plan without this guidance in context still honors it. The user may add a marker by hand, including on a line the plan did not mark, to insert a checkpoint the plan missed. A hand-added checkpoint is honored exactly like an authored one. These emoji are the only ones the plan carries. Add a new marker type only by defining its discipline here first.
+
+### `✋` Human Checkpoints
 
 When the approach carries uncertainty that convergence cannot settle in advance because only building resolves it, build in points where the plan hands back for a look before it runs on. This is not a license to skip convergence: settle everything you can before plan mode, then checkpoint what only building can. A plan that sequences every slice with no return point commits the user to an approach they cannot correct until it is all built, which is where an unsettled approach goes off the rails.
 
 - Place a checkpoint where a wrong assumption is expensive to unwind: after the first vertical slice proves the approach, at an interface or schema the rest builds on, before a one-way door (a migration, a public rename, a destructive or outward-facing step).
 - Do not checkpoint mechanical fan-out (one pattern across many files, a rename across call sites). Reserve checkpoints for decisions, not volume.
 
-Write each checkpoint as a visible stop instruction marked with `✋`, naming what the user confirms: `✋ Checkpoint: stop and confirm <what> before <what continues>`. The marker is load-bearing in both directions, not decoration:
+Write each as a visible stop instruction: `✋ Checkpoint: stop and confirm <what> before <what continues>`. When execution reaches the line, stop there. Present what is built and wait for the user's read before continuing past it, the same stop discipline as `Pauses`.
 
-- When execution reaches a `✋` line, stop there. Present what is built and wait for the user's read before continuing past it, the same stop discipline as `Pauses`. Because the line states the stop in plain words, a session that executes the plan without this guidance in context still honors it.
-- The user may add `✋` to the plan by hand, including on a line the plan did not mark, to insert a checkpoint the plan missed. A hand-added checkpoint is honored exactly like an authored one.
+### `🧪` Verification Checkpoints
 
-`✋` is the only marker the plan uses and the only emoji it should carry. Do not introduce others.
+Do not defer every check to the end. When a slice must hold before the next is built on top of it, mark the point where it is proven, so a broken assumption surfaces at the slice that introduced it rather than after the whole plan is built.
+
+- Place one after a slice whose correctness the rest depends on: a schema the later slices read, a parser the pipeline feeds, a migration the next step assumes has run.
+- Write each as a runnable check naming its signal, the same before/after shape as `Verification`: `🧪 Verify: <signal> via <command> before <what continues>`.
+- When execution reaches the line, run the check. If the signal matches, continue. If it does not, stop and surface the gap instead of building on it.
 
 ## Pauses
 


### PR DESCRIPTION
Adds a `## Checkpoints` marker system to the always-on plan-mode guidelines. A checkpoint is a line the plan marks with an emoji so execution stops there and does something before continuing. Two marker types, each with its own discipline:

- `✋` a human checkpoint: hand back for a read.
- `🧪` a verification checkpoint: run a named check and confirm its signal before the next slice builds on it.

Every marker is load-bearing in both directions. The user scans for it and can hand-add it (even on a line the plan didn't mark) to insert a checkpoint the plan missed. When execution reaches a marked line it honors the marker before continuing, and because each line states its instruction in plain words, a session executing the plan without this guidance in context still obeys it. Adding a new marker type requires defining its discipline in this section first.

The two disciplines target different failure modes:

- **Human checkpoints** cover uncertainty convergence cannot settle in advance because only building resolves it. A plan that sequences every slice with no return point commits the user to an approach they can't correct until it's all built. The opening is scoped to say this is not a license to skip convergence: settle what you can before plan mode, then checkpoint what only building can.
- **Verification checkpoints** counter deferring every check to the end. When a slice must hold before the next builds on it, the checkpoint marks the proving point so a broken assumption surfaces at the slice that introduced it. A layering directive added to `## Verification` connects the two: place checks inline at the proving point, not stacked at the end.

Started as human-checkpoints-only, then generalized in-session into the marker system. No wiring or test changes: `injection-content.sh` always `cat`s this file, and the hook tests assert only `.toContain("Planning Guidelines")`.
