### PR TITLE
pull-request: lint PR body heading case in the validate hook

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -185,6 +185,12 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
         "@constellos/claude-code-kit": "^0.4.0",
+        "ap-style-title-case": "^2.0.0",
+        "mdast-util-from-markdown": "^2.0.2",
+        "unist-util-visit": "^5.1.0",
+      },
+      "devDependencies": {
+        "@types/mdast": "^4.0.4",
       },
     },
     "plugins/review": {

--- a/plugins/pull-request/package.json
+++ b/plugins/pull-request/package.json
@@ -4,6 +4,12 @@
   "type": "module",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-    "@constellos/claude-code-kit": "^0.4.0"
+    "@constellos/claude-code-kit": "^0.4.0",
+    "ap-style-title-case": "^2.0.0",
+    "mdast-util-from-markdown": "^2.0.2",
+    "unist-util-visit": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/mdast": "^4.0.4"
   }
 }

--- a/plugins/pull-request/scripts/heading-case.test.ts
+++ b/plugins/pull-request/scripts/heading-case.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { extractHeadings, headingCaseViolations } from "./heading-case";
+
+describe("headingCaseViolations", () => {
+  test.each<[string, string, { text: string; suggested: string }[]]>([
+    [
+      "flags a sentence-case heading",
+      "## Two fixes found while testing",
+      [{ text: "Two fixes found while testing", suggested: "Two Fixes Found While Testing" }],
+    ],
+    [
+      "flags over-capitalized stopwords",
+      "## Changes To The Parser",
+      [{ text: "Changes To The Parser", suggested: "Changes to the Parser" }],
+    ],
+    ["ignores an already AP-cased heading", "## Changes to the Parser", []],
+    ["preserves an all-caps acronym", "## API Changes", []],
+    ["preserves a mixed-case identifier", "## gitLab Integration", []],
+    ["excludes an inline-code word", "## Changes to `validate.ts`", []],
+    ["ignores a heading that is only code", "## `foo.ts`", []],
+  ])("%s", (_name, body, expected) => {
+    expect(headingCaseViolations(body)).toEqual(expected);
+  });
+
+  test("flags each heading in a multi-heading body", () => {
+    const body = "## Two fixes found\n\nSome prose.\n\n## Changes To The Parser";
+    expect(headingCaseViolations(body)).toEqual([
+      { text: "Two fixes found", suggested: "Two Fixes Found" },
+      { text: "Changes To The Parser", suggested: "Changes to the Parser" },
+    ]);
+  });
+
+  test("suggests re-casing around a preserved inline-code word", () => {
+    expect(headingCaseViolations("## changes to `validate.ts`")).toEqual([
+      { text: "changes to `validate.ts`", suggested: "Changes to `validate.ts`" },
+    ]);
+  });
+
+  test("ignores a `#` line inside a fenced code block", () => {
+    const body = "Prose about the change.\n\n```md\n## two words lower\n```";
+    expect(headingCaseViolations(body)).toEqual([]);
+  });
+});
+
+describe("extractHeadings", () => {
+  test("reconstructs heading text and keeps inline code", () => {
+    const headings = extractHeadings("## Changes to `validate.ts`\n\n### Plain Heading");
+    expect(headings.map((heading) => heading.text)).toEqual([
+      "Changes to `validate.ts`",
+      "Plain Heading",
+    ]);
+  });
+
+  test("skips a `#` line inside a fenced code block", () => {
+    expect(extractHeadings("```\n## fake\n```")).toEqual([]);
+  });
+});

--- a/plugins/pull-request/scripts/heading-case.ts
+++ b/plugins/pull-request/scripts/heading-case.ts
@@ -75,20 +75,32 @@ function isIdentifier(word: string): boolean {
   return /[A-Z]/.test(letters.slice(1));
 }
 
-export function extractHeadings(body: string): Heading[] {
+interface ParsedHeading {
+  children: PhrasingContent[];
+  combined: string;
+  codeSpans: string[];
+}
+
+function parseHeadings(body: string): ParsedHeading[] {
   const tree = fromMarkdown(body);
-  const headings: Heading[] = [];
+  const headings: ParsedHeading[] = [];
   visit(tree, "heading", (node: MdastHeading) => {
     const { combined, codeSpans } = reconstruct(node.children);
-    headings.push({ children: node.children, text: restore(combined.trim(), codeSpans) });
+    headings.push({ children: node.children, combined, codeSpans });
   });
   return headings;
 }
 
+export function extractHeadings(body: string): Heading[] {
+  return parseHeadings(body).map(({ children, combined, codeSpans }) => ({
+    children,
+    text: restore(combined.trim(), codeSpans),
+  }));
+}
+
 export function headingCaseViolations(body: string): { text: string; suggested: string }[] {
   const violations: { text: string; suggested: string }[] = [];
-  for (const heading of extractHeadings(body)) {
-    const { combined, codeSpans } = reconstruct(heading.children);
+  for (const { combined, codeSpans } of parseHeadings(body)) {
     const trimmed = combined.trim();
     if (trimmed.length === 0) continue;
 

--- a/plugins/pull-request/scripts/heading-case.ts
+++ b/plugins/pull-request/scripts/heading-case.ts
@@ -1,0 +1,114 @@
+import { apStyleTitleCase } from "ap-style-title-case";
+import type { Heading as MdastHeading, PhrasingContent } from "mdast";
+import { fromMarkdown } from "mdast-util-from-markdown";
+import { visit } from "unist-util-visit";
+
+// ap-style-title-case ships a stopword list missing two words AP lowercases:
+// `as` (a short conjunction/preposition) and `vs`/`vs.` (versus). The library
+// splits on commas and colons but not periods, so `vs.` is one token.
+const AP_STOPWORDS = [
+  "a",
+  "an",
+  "and",
+  "as",
+  "at",
+  "but",
+  "by",
+  "for",
+  "in",
+  "nor",
+  "of",
+  "on",
+  "or",
+  "so",
+  "the",
+  "to",
+  "up",
+  "vs",
+  "vs.",
+  "yet",
+];
+
+// A single Private Use Area codepoint stands in for each inline-code span while
+// AP casing runs. It carries no whitespace, so it reads as one word and keeps
+// the code span's position (first/last-word rules stay correct), and it is never
+// a stopword, so casing leaves it untouched.
+const PLACEHOLDER = String.fromCharCode(0xe000);
+
+export interface Heading {
+  children: PhrasingContent[];
+  text: string;
+}
+
+function reconstruct(children: PhrasingContent[]): { combined: string; codeSpans: string[] } {
+  const parts: string[] = [];
+  const codeSpans: string[] = [];
+  const walk = (nodes: PhrasingContent[]) => {
+    for (const node of nodes) {
+      if (node.type === "inlineCode") {
+        codeSpans.push(node.value);
+        parts.push(PLACEHOLDER);
+      } else if (node.type === "text") {
+        parts.push(node.value);
+      } else if ("children" in node) {
+        walk(node.children);
+      } else if ("value" in node) {
+        parts.push(node.value);
+      }
+    }
+  };
+  walk(children);
+  return { combined: parts.join(""), codeSpans };
+}
+
+function restore(text: string, codeSpans: string[]): string {
+  let i = 0;
+  return text.replaceAll(PLACEHOLDER, () => `\`${codeSpans[i++]}\``);
+}
+
+// AP casing preserves all-caps acronyms on its own, but it title-cases
+// identifiers with a lowercase first letter (`gitLab` -> `GitLab`, `iOS` ->
+// `IOS`). Skip any word with an internal capital so those aren't re-cased.
+function isIdentifier(word: string): boolean {
+  const letters = word.replace(/[^A-Za-z]/g, "");
+  if (letters.length < 2) return false;
+  return /[A-Z]/.test(letters.slice(1));
+}
+
+export function extractHeadings(body: string): Heading[] {
+  const tree = fromMarkdown(body);
+  const headings: Heading[] = [];
+  visit(tree, "heading", (node: MdastHeading) => {
+    const { combined, codeSpans } = reconstruct(node.children);
+    headings.push({ children: node.children, text: restore(combined.trim(), codeSpans) });
+  });
+  return headings;
+}
+
+export function headingCaseViolations(body: string): { text: string; suggested: string }[] {
+  const violations: { text: string; suggested: string }[] = [];
+  for (const heading of extractHeadings(body)) {
+    const { combined, codeSpans } = reconstruct(heading.children);
+    const trimmed = combined.trim();
+    if (trimmed.length === 0) continue;
+
+    const original = trimmed.split(/\s+/);
+    const cased = apStyleTitleCase(trimmed, { stopwords: AP_STOPWORDS }).trim().split(/\s+/);
+    if (original.length !== cased.length) continue;
+
+    let differs = false;
+    const suggested = original.map((word, i) => {
+      if (word.includes(PLACEHOLDER) || isIdentifier(word)) return word;
+      if (word !== cased[i]) differs = true;
+      return cased[i];
+    });
+
+    if (differs) {
+      violations.push({
+        text: restore(original.join(" "), codeSpans),
+        suggested: restore(suggested.join(" "), codeSpans),
+      });
+    }
+  }
+  return violations;
+}

--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -1,4 +1,5 @@
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { headingCaseViolations } from "./heading-case";
 
 function hasBashCommand(input: unknown): input is { command: string } {
   return (
@@ -231,6 +232,15 @@ function structuralReasons(body: string): string[] {
   }
   if (hasBacktickedRef(body)) {
     reasons.push(AUTOLINK_REASON);
+  }
+  const headingViolations = headingCaseViolations(body);
+  if (headingViolations.length > 0) {
+    const suggestions = headingViolations
+      .map((violation) => `\`${violation.text}\` → \`${violation.suggested}\``)
+      .join("; ");
+    reasons.push(
+      `Section headings should use AP title case. Suggested: ${suggestions}. Adjust unless a heading is intentionally cased (proper noun, code identifier).`,
+    );
   }
   return reasons;
 }

--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -236,7 +236,7 @@ function structuralReasons(body: string): string[] {
   const headingViolations = headingCaseViolations(body);
   if (headingViolations.length > 0) {
     const suggestions = headingViolations
-      .map((violation) => `\`${violation.text}\` → \`${violation.suggested}\``)
+      .map((violation) => `"${violation.text}" → "${violation.suggested}"`)
       .join("; ");
     reasons.push(
       `Section headings should use AP title case. Suggested: ${suggestions}. Adjust unless a heading is intentionally cased (proper noun, code identifier).`,

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -57,7 +57,7 @@ describe("extractBodyFilePath", () => {
 describe("validateBody", () => {
   it("returns null for valid body without test counts", () => {
     expect(
-      validateBody("## Summary\nFixes a bug\n\n## Test plan\nUnit tests cover the fix"),
+      validateBody("## Summary\nFixes a bug\n\n## Test Plan\nUnit tests cover the fix"),
     ).toBeNull();
   });
 
@@ -138,6 +138,19 @@ describe("validateBody", () => {
       "## Changes\n\n- **Caching**: stores records in memory\n- **Eviction**: drops the oldest entry",
     );
     expect(result).toBeNull();
+  });
+
+  it("warns on a sentence-case section heading", () => {
+    const result = validateBody("## Two fixes found while testing\n\nReshapes the resolver.");
+    expect(getPermissionDecision(result)).toBeUndefined();
+    expect(getAdditionalContext(result)).toContain("AP title case");
+    expect(getAdditionalContext(result)).toContain("Two Fixes Found While Testing");
+  });
+
+  it("does not warn on AP-cased headings with an acronym", () => {
+    expect(
+      validateBody("## API Changes\n\nAdds an endpoint.\n\n## Changes to the Parser\n\nRewrites it."),
+    ).toBeNull();
   });
 });
 
@@ -343,6 +356,16 @@ describe("processInput", () => {
       createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
     );
     expect(result).toBeNull();
+  });
+
+  it("warns on a sentence-case heading in a body file", async () => {
+    const bodyFile = path.join(tempDir, "body.md");
+    await Bun.write(bodyFile, "## Two fixes found while testing\n\nReshapes the resolver.");
+    const result = await processInput(
+      createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
+    );
+    expect(getPermissionDecision(result)).toBeUndefined();
+    expect(getAdditionalContext(result)).toContain("Two Fixes Found While Testing");
   });
 
   it("lets a test-count deny precede a backticked SHA warning", async () => {

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -149,7 +149,9 @@ describe("validateBody", () => {
 
   it("does not warn on AP-cased headings with an acronym", () => {
     expect(
-      validateBody("## API Changes\n\nAdds an endpoint.\n\n## Changes to the Parser\n\nRewrites it."),
+      validateBody(
+        "## API Changes\n\nAdds an endpoint.\n\n## Changes to the Parser\n\nRewrites it.",
+      ),
     ).toBeNull();
   });
 });

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -147,6 +147,14 @@ describe("validateBody", () => {
     expect(getAdditionalContext(result)).toContain("Two Fixes Found While Testing");
   });
 
+  it("keeps a heading's inline code intact in the suggestion", () => {
+    const result = validateBody("## changes to `validate.ts`\n\nReshapes the resolver.");
+    expect(getPermissionDecision(result)).toBeUndefined();
+    expect(getAdditionalContext(result)).toContain(
+      '"changes to `validate.ts`" → "Changes to `validate.ts`"',
+    );
+  });
+
   it("does not warn on AP-cased headings with an acronym", () => {
     expect(
       validateBody(


### PR DESCRIPTION
The `pull-request:create` skill asks for Title-Case section headings, but prompting alone doesn't hold and bodies keep shipping sentence-case. This adds a deterministic backstop to the existing `validate-body` warn path: extract headings with MDAST, compare each against AP title case, and surface mismatches as a warning the model can accept or override.

MDAST extraction ignores `#` lines inside fenced code blocks, which the structural regexes it sits beside don't. Two guards keep the check off acronyms and identifiers:

- A word inside an inline-code span is never re-cased, and the span holds its position so first/last-word rules stay correct, so a heading ending in a code path isn't flagged.
- Mixed-case identifiers like `gitLab` and `iOS` are skipped, since AP casing would mangle their tails. All-caps acronyms (`API`, `CI`) the library already preserves.

It stays a warning, never a deny, so an intentionally-cased heading (a proper noun) can be kept. The check runs through `structuralReasons`, so `pull-request:update` bodies are covered too.
