### PR TITLE
hooks: drop @constellos/claude-code-kit

### DIFF
--- a/.claude/hooks/biome/index.ts
+++ b/.claude/hooks/biome/index.ts
@@ -10,7 +10,6 @@ import type {
   StopHookInput,
   SyncHookJSONOutput,
 } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 const execAsync = promisify(exec);
 
@@ -329,7 +328,7 @@ export async function processInput(input: HookInput): Promise<SyncHookJSONOutput
 async function main(): Promise<void> {
   let input: HookInput;
   try {
-    input = await readStdinJson<HookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as HookInput;
   } catch (error) {
     console.error(
       `[biome] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -339,7 +338,7 @@ async function main(): Promise<void> {
 
   const output = await processInput(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/.claude/hooks/coverage/index.ts
+++ b/.claude/hooks/coverage/index.ts
@@ -2,7 +2,6 @@
 
 import { join, relative } from "node:path";
 import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import { parseLcov, uncoveredLines } from "../../../scripts/coverage/lcov";
 
 const repoRoot = join(import.meta.dirname, "..", "..", "..");
@@ -81,7 +80,7 @@ export async function processPostToolUse(
 async function main(): Promise<void> {
   let input: PostToolUseHookInput;
   try {
-    input = await readStdinJson<PostToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PostToolUseHookInput;
   } catch (error) {
     console.error(
       `[coverage] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -91,7 +90,7 @@ async function main(): Promise<void> {
 
   const output = await processPostToolUse(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/.claude/hooks/plugin-deps/index.ts
+++ b/.claude/hooks/plugin-deps/index.ts
@@ -2,7 +2,6 @@
 
 import { join } from "node:path";
 import type { StopHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 // Mirrors VIOLATION_EXIT in scripts/check-plugin-deps.ts. Deliberately a
 // literal rather than an import: importing the checker would pull its module
@@ -45,11 +44,11 @@ export async function processStop(
 }
 
 async function main(): Promise<void> {
-  const input = await readStdinJson<StopHookInput>();
+  const input = JSON.parse(await Bun.stdin.text()) as StopHookInput;
   if (input.hook_event_name !== "Stop") return;
 
   const output = await processStop(input);
-  if (output) writeStdoutJson(output);
+  if (output) process.stdout.write(JSON.stringify(output) + "\n");
 }
 
 if (import.meta.main) {

--- a/.claude/hooks/plugin-imports/index.ts
+++ b/.claude/hooks/plugin-imports/index.ts
@@ -2,7 +2,6 @@
 
 import { join } from "node:path";
 import type { StopHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 // Mirrors VIOLATION_EXIT in scripts/check-plugin-imports.ts. Deliberately a
 // literal rather than an import: importing the checker would pull its module
@@ -52,11 +51,11 @@ export async function processStop(
 }
 
 async function main(): Promise<void> {
-  const input = await readStdinJson<StopHookInput>();
+  const input = JSON.parse(await Bun.stdin.text()) as StopHookInput;
   if (input.hook_event_name !== "Stop") return;
 
   const output = await processStop(input);
-  if (output) writeStdoutJson(output);
+  if (output) process.stdout.write(JSON.stringify(output) + "\n");
 }
 
 if (import.meta.main) {

--- a/.claude/hooks/stop/index.ts
+++ b/.claude/hooks/stop/index.ts
@@ -4,7 +4,6 @@ import { execFile } from "node:child_process";
 import { isAbsolute, relative, sep } from "node:path";
 import { promisify } from "node:util";
 import type { StopHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 const execFileAsync = promisify(execFile);
 const PREK_TIMEOUT = 120_000;
@@ -127,7 +126,7 @@ export async function processStop(input: StopHookInput): Promise<SyncHookJSONOut
 async function main(): Promise<void> {
   let input: StopHookInput;
   try {
-    input = await readStdinJson<StopHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as StopHookInput;
   } catch {
     return;
   }
@@ -136,7 +135,7 @@ async function main(): Promise<void> {
 
   const output = await processStop(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,6 @@
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
         "@biomejs/biome": "^2.3.13",
-        "@constellos/claude-code-kit": "^0.4.0",
         "@types/bun": "^1.3.12",
         "@types/mdast": "^4.0.4",
         "ajv": "^8.17.1",
@@ -53,7 +52,7 @@
     "plugins/claude-code": {
       "name": "claude-code",
       "dependencies": {
-        "@constellos/claude-code-kit": "^0.4.0",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.0",
       },
     },
     "plugins/claude-code/skills/session": {
@@ -91,7 +90,6 @@
       "name": "git",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-        "@constellos/claude-code-kit": "^0.4.0",
       },
     },
     "plugins/github": {
@@ -99,7 +97,6 @@
       "version": "1.0.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-        "@constellos/claude-code-kit": "^0.4.0",
         "cleye": "^2.0.0",
         "url-pattern": "^1.0.3",
       },
@@ -109,7 +106,6 @@
       "version": "1.0.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-        "@constellos/claude-code-kit": "^0.4.0",
         "cleye": "^2.2.1",
         "table": "^6.9.0",
         "url-pattern": "^1.0.3",
@@ -119,7 +115,6 @@
       "name": "go",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-        "@constellos/claude-code-kit": "^0.4.0",
       },
     },
     "plugins/issue": {
@@ -133,14 +128,12 @@
       "name": "linear",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-        "@constellos/claude-code-kit": "^0.4.0",
       },
     },
     "plugins/mac": {
       "name": "mac",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-        "@constellos/claude-code-kit": "^0.4.0",
         "acorn": "^8.15.0",
         "cleye": "^2.0.0",
       },
@@ -170,21 +163,18 @@
       "name": "newline",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-        "@constellos/claude-code-kit": "^0.4.0",
       },
     },
     "plugins/plan": {
       "name": "@bendrucker/claude-plan",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-        "@constellos/claude-code-kit": "^0.4.0",
       },
     },
     "plugins/pull-request": {
       "name": "pull-request",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-        "@constellos/claude-code-kit": "^0.4.0",
         "ap-style-title-case": "^2.0.0",
         "mdast-util-from-markdown": "^2.0.2",
         "unist-util-visit": "^5.1.0",
@@ -204,7 +194,6 @@
       "name": "shortcuts",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-        "@constellos/claude-code-kit": "^0.4.0",
       },
     },
     "plugins/things": {
@@ -212,7 +201,6 @@
       "version": "1.0.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-        "@constellos/claude-code-kit": "^0.4.0",
         "cleye": "^2.0.0",
         "table": "^6.9.0",
       },
@@ -229,7 +217,6 @@
       "name": "@bendrucker/claude-tmux",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-        "@constellos/claude-code-kit": "^0.4.0",
         "cleye": "^2.0.0",
         "table": "^6.9.0",
       },
@@ -238,7 +225,6 @@
       "name": "@bendrucker/type-ignore",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-        "@constellos/claude-code-kit": "^0.4.0",
       },
     },
     "plugins/ui-design": {
@@ -246,7 +232,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-        "@constellos/claude-code-kit": "^0.4.0",
         "@xmldom/xmldom": "^0.9.8",
         "cleye": "^2.2.1",
         "playwright": "^1.50.1",
@@ -258,7 +243,6 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
         "@anthropic-ai/sdk": "^0.105.0",
-        "@constellos/claude-code-kit": "^0.4.0",
         "@duckdb/node-api": "1.5.0-r.1",
         "ap-style-title-case": "^2.0.0",
         "cleye": "^2.2.1",
@@ -277,7 +261,6 @@
       "name": "x-callback-url",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-        "@constellos/claude-code-kit": "^0.4.0",
       },
     },
   },
@@ -360,8 +343,6 @@
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
     "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
-
-    "@constellos/claude-code-kit": ["@constellos/claude-code-kit@0.4.0", "", { "dependencies": { "zod": "^3.23.0" }, "optionalDependencies": { "gray-matter": "^4.0.3", "minimatch": "^10.0.1" }, "peerDependencies": { "@modelcontextprotocol/sdk": ">=1.0.0" }, "optionalPeers": ["@modelcontextprotocol/sdk"], "bin": { "cck": "bin/cck.js", "claude-code-kit": "bin/cck.js", "cck-hook": "bin/cck-hook.js", "cck-sync-mcp": "bin/cck-sync-mcp.js" } }, "sha512-dS7gOlUiHNYV8RMmU5KqxKi3Q9OUPCWPfZ/nvWRnymjO3JogGUgQL56C2av270oowbMpCXuw1PXVAiySlQ0gwg=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
 
@@ -721,13 +702,9 @@
 
     "babel-runtime": ["babel-runtime@6.26.0", "", { "dependencies": { "core-js": "^2.4.0", "regenerator-runtime": "^0.11.0" } }, "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g=="],
 
-    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
-
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
-
-    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "bson": ["bson@7.2.0", "", {}, "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ=="],
 
@@ -1189,8 +1166,6 @@
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
-    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
-
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minimist-options": ["minimist-options@4.1.0", "", { "dependencies": { "arrify": "^1.0.1", "is-plain-obj": "^1.1.0", "kind-of": "^6.0.3" } }, "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A=="],
@@ -1566,8 +1541,6 @@
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@bendrucker/claude-writing/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.105.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-sDyu+aM9cE6uZE+HgRjjHRb+qqb87GHZOx+8bE0YlWetdL1YcVLxn8h9ltxGOflyChTe6PMEo50kMQV4cw0hfg=="],
-
-    "@constellos/claude-code-kit/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "cli-color/ansi-regex": ["ansi-regex@2.1.1", "", {}, "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="],
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   "devDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
     "@biomejs/biome": "^2.3.13",
-    "@constellos/claude-code-kit": "^0.4.0",
     "@types/bun": "^1.3.12",
     "@types/mdast": "^4.0.4",
     "ajv": "^8.17.1",

--- a/plugins/claude-code/package.json
+++ b/plugins/claude-code/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@constellos/claude-code-kit": "^0.4.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
   }
 }

--- a/plugins/claude-code/skills/hook/SKILL.md
+++ b/plugins/claude-code/skills/hook/SKILL.md
@@ -86,10 +86,10 @@ input=$(cat)
 file_path=$(echo "$input" | jq -r '.tool_input.file_path')
 ```
 
-Or use `@constellos/claude-code-kit/runners`:
+Parse in TypeScript:
 ```typescript
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
-const input = await readStdinJson<PreToolUseHookInput>();
+import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+const input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
 ```
 
 ## Hook Output

--- a/plugins/claude-code/skills/skill/scripts/check-lint.test.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-lint.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { PostToolUseInput } from "@constellos/claude-code-kit";
+import type { PostToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { processPostToolUse } from "./check-lint";
 import type { SkillLintResult } from "./skill-lint/types";
 
@@ -47,7 +47,7 @@ function postToolUseInput(filePath: string) {
 }
 
 describe("processPostToolUse", () => {
-  test.each<{ name: string; input: PostToolUseInput; expectLint: boolean }>([
+  test.each<{ name: string; input: PostToolUseHookInput; expectLint: boolean }>([
     {
       name: "returns lint issues for SKILL.md writes",
       input: postToolUseInput("/plugins/gitlab/skills/ci/SKILL.md"),

--- a/plugins/claude-code/skills/skill/scripts/check-lint.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-lint.ts
@@ -30,7 +30,6 @@ export async function processPostToolUse(
   if (messages.length === 0) return null;
 
   return {
-    decision: undefined,
     hookSpecificOutput: {
       hookEventName: "PostToolUse",
       additionalContext: `skill-lint found issues in ${filePath}:\n\n${messages.join("\n")}`,

--- a/plugins/claude-code/skills/skill/scripts/check-lint.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-lint.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env bun
 
 import { basename, dirname } from "node:path";
-import type { PostToolUseHookOutput, PostToolUseInput } from "@constellos/claude-code-kit";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
+import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { lintSkill as defaultLintSkill } from "./skill-lint";
 import type { SkillLintResult } from "./skill-lint/types";
 
@@ -21,9 +20,9 @@ async function lintMessages(skillDir: string, lintSkill: LintSkillFn): Promise<s
 }
 
 export async function processPostToolUse(
-  input: PostToolUseInput,
+  input: PostToolUseHookInput,
   lintSkill: LintSkillFn = defaultLintSkill,
-): Promise<PostToolUseHookOutput | null> {
+): Promise<SyncHookJSONOutput | null> {
   const filePath = (input.tool_input as { file_path?: string }).file_path;
   if (!filePath || basename(filePath) !== "SKILL.md") return null;
 
@@ -40,9 +39,9 @@ export async function processPostToolUse(
 }
 
 async function main(): Promise<void> {
-  let input: PostToolUseInput;
+  let input: PostToolUseHookInput;
   try {
-    input = await readStdinJson<PostToolUseInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PostToolUseHookInput;
   } catch (error) {
     console.error(
       `[skill-lint] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -52,7 +51,7 @@ async function main(): Promise<void> {
 
   const output = await processPostToolUse(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/plugins/claude-code/skills/skill/scripts/check-namespace.test.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-namespace.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { PostToolUseInput } from "@constellos/claude-code-kit";
+import type { PostToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import {
   checkSkillNamespace,
   checkStuttering,
@@ -14,7 +14,7 @@ import {
 } from "./check-namespace";
 import { makePostToolUseInput } from "./test-support";
 
-function mockWriteInput(filePath: string): PostToolUseInput {
+function mockWriteInput(filePath: string): PostToolUseHookInput {
   return makePostToolUseInput({ tool_input: { file_path: filePath, content: "" } });
 }
 

--- a/plugins/claude-code/skills/skill/scripts/check-namespace.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-namespace.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env bun
 
 import { basename } from "node:path";
-import type { PostToolUseInput } from "@constellos/claude-code-kit";
-import { readStdinJson } from "@constellos/claude-code-kit/runners";
+import type { PostToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 
 export function extractPluginName(filePath: string): string | null {
   const match = filePath.match(/plugins\/([^/]+)\//);
@@ -67,11 +66,11 @@ export function checkSkillNamespace(name: string, pluginName: string): string[] 
   return warnings;
 }
 
-export async function processHookInput(input: PostToolUseInput): Promise<string[]> {
+export async function processHookInput(input: PostToolUseHookInput): Promise<string[]> {
   const warnings: string[] = [];
 
   if (input.tool_name !== "Write" && input.tool_name !== "Edit") return warnings;
-  const filePath = input.tool_input.file_path;
+  const filePath = (input.tool_input as { file_path?: string }).file_path;
   if (!filePath) return warnings;
 
   const pluginName = extractPluginName(filePath);
@@ -98,9 +97,9 @@ export async function processHookInput(input: PostToolUseInput): Promise<string[
 }
 
 async function main(): Promise<void> {
-  let input: PostToolUseInput;
+  let input: PostToolUseHookInput;
   try {
-    input = await readStdinJson<PostToolUseInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PostToolUseHookInput;
   } catch {
     return;
   }

--- a/plugins/claude-code/skills/skill/scripts/check-structure.test.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-structure.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, test } from "bun:test";
-import type { PostToolUseInput } from "@constellos/claude-code-kit";
+import type { PostToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { extractSkillRoot, processHookInput, validateSkillPath } from "./check-structure";
 import { makePostToolUseInput } from "./test-support";
 
-function mockWriteInput(filePath: string): PostToolUseInput {
+function mockWriteInput(filePath: string): PostToolUseHookInput {
   return makePostToolUseInput({ tool_input: { file_path: filePath, content: "" } });
 }
 

--- a/plugins/claude-code/skills/skill/scripts/check-structure.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-structure.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env bun
 
 import { relative } from "node:path";
-import type { PostToolUseInput } from "@constellos/claude-code-kit";
-import { readStdinJson } from "@constellos/claude-code-kit/runners";
+import type { PostToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 
 const SPEC_URL = "https://agentskills.io/specification#optional-directories";
 
@@ -35,10 +34,10 @@ export function validateSkillPath(filePath: string, skillRoot: string): string |
   return `'${rel}' is outside the standard skill structure. Allowed paths: ${allowed}. See ${SPEC_URL}`;
 }
 
-export function processHookInput(input: PostToolUseInput): string[] {
+export function processHookInput(input: PostToolUseHookInput): string[] {
   if (input.tool_name !== "Write" && input.tool_name !== "Edit") return [];
 
-  const filePath = input.tool_input.file_path;
+  const filePath = (input.tool_input as { file_path?: string }).file_path;
   if (!filePath) return [];
 
   const skillRoot = extractSkillRoot(filePath);
@@ -49,9 +48,9 @@ export function processHookInput(input: PostToolUseInput): string[] {
 }
 
 async function main(): Promise<void> {
-  let input: PostToolUseInput;
+  let input: PostToolUseHookInput;
   try {
-    input = await readStdinJson<PostToolUseInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PostToolUseHookInput;
   } catch {
     return;
   }

--- a/plugins/claude-code/skills/skill/scripts/test-support.ts
+++ b/plugins/claude-code/skills/skill/scripts/test-support.ts
@@ -1,6 +1,8 @@
-import type { PostToolUseInput } from "@constellos/claude-code-kit";
+import type { PostToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 
-export function makePostToolUseInput(overrides: Partial<PostToolUseInput> = {}): PostToolUseInput {
+export function makePostToolUseInput(
+  overrides: Partial<PostToolUseHookInput> = {},
+): PostToolUseHookInput {
   return {
     session_id: "test",
     transcript_path: "/tmp/transcript.jsonl",
@@ -10,7 +12,7 @@ export function makePostToolUseInput(overrides: Partial<PostToolUseInput> = {}):
     tool_use_id: "test-id",
     tool_name: "Write",
     tool_input: { file_path: "/tmp/file", content: "" },
-    tool_response: { message: "ok", bytes_written: 0 },
+    tool_response: { type: "create", filePath: "/tmp/file", content: "" },
     ...overrides,
-  } as PostToolUseInput;
+  } as PostToolUseHookInput;
 }

--- a/plugins/git/package.json
+++ b/plugins/git/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-    "@constellos/claude-code-kit": "^0.4.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
   }
 }

--- a/plugins/git/scripts/block-default-branch-commit.ts
+++ b/plugins/git/scripts/block-default-branch-commit.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import { $ } from "bun";
 import { getDefaultBranch } from "./default-branch";
 
@@ -47,7 +46,7 @@ export async function processInput(
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = await readStdinJson<PreToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
   } catch (error) {
     console.error(
       `[git/block-default-branch-commit] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -57,7 +56,7 @@ async function main(): Promise<void> {
 
   const output = await processInput(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/plugins/git/skills/conflicts/scripts/check-markers.ts
+++ b/plugins/git/skills/conflicts/scripts/check-markers.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import { $ } from "bun";
 
 function formatOutput(reason: string): SyncHookJSONOutput {
@@ -17,7 +16,7 @@ function formatOutput(reason: string): SyncHookJSONOutput {
 async function main(): Promise<void> {
   let _input: PreToolUseHookInput;
   try {
-    _input = await readStdinJson<PreToolUseHookInput>();
+    _input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
   } catch (error) {
     console.error(
       `[git/conflicts/check-markers] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -35,11 +34,10 @@ async function main(): Promise<void> {
       .slice(0, 5)
       .join(", ");
 
-    writeStdoutJson(
-      formatOutput(
-        `Conflict markers in staged files: ${markers || "run 'git diff --cached --check' for details"}`,
-      ),
+    const denial = formatOutput(
+      `Conflict markers in staged files: ${markers || "run 'git diff --cached --check' for details"}`,
     );
+    process.stdout.write(JSON.stringify(denial) + "\n");
   }
 }
 

--- a/plugins/github/package.json
+++ b/plugins/github/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-    "@constellos/claude-code-kit": "^0.4.0",
     "cleye": "^2.0.0",
     "url-pattern": "^1.0.3"
   }

--- a/plugins/github/scripts/fetch.ts
+++ b/plugins/github/scripts/fetch.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import UrlPattern from "url-pattern";
 
 export type WebFetchInput = { url: string; prompt: string };
@@ -156,7 +155,7 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = await readStdinJson<PreToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
   } catch (error) {
     console.error(
       `[github/fetch] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -166,7 +165,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/plugins/gitlab/hooks/auth.ts
+++ b/plugins/gitlab/hooks/auth.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 export function processInput(input: PostToolUseHookInput): SyncHookJSONOutput | null {
   const command = (input.tool_input as { command?: string }).command;
@@ -22,7 +21,7 @@ export function processInput(input: PostToolUseHookInput): SyncHookJSONOutput | 
 async function main(): Promise<void> {
   let input: PostToolUseHookInput;
   try {
-    input = await readStdinJson<PostToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PostToolUseHookInput;
   } catch {
     return;
   }
@@ -31,7 +30,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/plugins/gitlab/package.json
+++ b/plugins/gitlab/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-    "@constellos/claude-code-kit": "^0.4.0",
     "cleye": "^2.2.1",
     "table": "^6.9.0",
     "url-pattern": "^1.0.3"

--- a/plugins/gitlab/scripts/fetch.ts
+++ b/plugins/gitlab/scripts/fetch.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import UrlPattern from "url-pattern";
 
 export type WebFetchInput = { url: string; prompt: string };
@@ -134,7 +133,7 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = await readStdinJson<PreToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
   } catch (error) {
     console.error(
       `[gitlab/fetch] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -144,7 +143,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/plugins/go/package.json
+++ b/plugins/go/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-    "@constellos/claude-code-kit": "^0.4.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
   }
 }

--- a/plugins/go/scripts/check.ts
+++ b/plugins/go/scripts/check.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 export type FileInput = {
   file_path?: string;
@@ -66,7 +65,7 @@ export async function processInput(input: PreToolUseHookInput): Promise<SyncHook
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = await readStdinJson<PreToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
   } catch (error) {
     console.error(
       `[go/check] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -76,7 +75,7 @@ async function main(): Promise<void> {
 
   const output = await processInput(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/plugins/linear/hooks/save-issue.ts
+++ b/plugins/linear/hooks/save-issue.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 export type CreateIssueInput = {
   id?: string;
@@ -104,7 +103,7 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = await readStdinJson<PreToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
   } catch (error) {
     console.error(
       `[linear/save-issue] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -114,7 +113,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/plugins/linear/package.json
+++ b/plugins/linear/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-    "@constellos/claude-code-kit": "^0.4.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
   }
 }

--- a/plugins/linear/scripts/fetch.ts
+++ b/plugins/linear/scripts/fetch.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 export type WebFetchInput = { url: string };
 
@@ -37,7 +36,7 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = await readStdinJson<PreToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
   } catch (error) {
     console.error(
       `[linear/fetch] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -47,7 +46,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/plugins/mac/hooks/sandbox.ts
+++ b/plugins/mac/hooks/sandbox.ts
@@ -2,7 +2,6 @@
 
 import { basename } from "node:path";
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 type ToolInput = { command: string };
 
@@ -91,7 +90,7 @@ export async function processInput(
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = await readStdinJson<PreToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
   } catch (error) {
     console.error(
       `[mac/sandbox] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -101,7 +100,7 @@ async function main(): Promise<void> {
 
   const output = await processInput(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/plugins/mac/package.json
+++ b/plugins/mac/package.json
@@ -4,7 +4,6 @@
   "type": "module",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-    "@constellos/claude-code-kit": "^0.4.0",
     "acorn": "^8.15.0",
     "cleye": "^2.0.0"
   }

--- a/plugins/newline/package.json
+++ b/plugins/newline/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-    "@constellos/claude-code-kit": "^0.4.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
   }
 }

--- a/plugins/newline/scripts/check.ts
+++ b/plugins/newline/scripts/check.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson } from "@constellos/claude-code-kit/runners";
 import { isMemoryPath } from "./memory-path";
 import { setState } from "./state";
 
@@ -40,7 +39,7 @@ export async function processInput(input: PreToolUseHookInput): Promise<void> {
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = await readStdinJson<PreToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
   } catch (error) {
     console.error(
       `[newline/check] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/newline/scripts/ensure.ts
+++ b/plugins/newline/scripts/ensure.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import { isMemoryPath } from "./memory-path";
 
 type ToolInput = {
@@ -51,7 +50,7 @@ export async function processInput(
 async function main(): Promise<void> {
   let input: PostToolUseHookInput;
   try {
-    input = await readStdinJson<PostToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PostToolUseHookInput;
   } catch (error) {
     console.error(
       `[newline/ensure] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -62,7 +61,7 @@ async function main(): Promise<void> {
   try {
     const output = await processInput(input);
     if (output) {
-      writeStdoutJson(output);
+      process.stdout.write(JSON.stringify(output) + "\n");
     }
   } catch (error) {
     console.error(`[newline/ensure] ${error instanceof Error ? error.message : String(error)}`);

--- a/plugins/newline/scripts/preserve.ts
+++ b/plugins/newline/scripts/preserve.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import { isMemoryPath } from "./memory-path";
 import { clearState, getState } from "./state";
 
@@ -65,7 +64,7 @@ export async function processInput(
 async function main(): Promise<void> {
   let input: PostToolUseHookInput;
   try {
-    input = await readStdinJson<PostToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PostToolUseHookInput;
   } catch (error) {
     console.error(
       `[newline/preserve] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -76,7 +75,7 @@ async function main(): Promise<void> {
   try {
     const output = await processInput(input);
     if (output) {
-      writeStdoutJson(output);
+      process.stdout.write(JSON.stringify(output) + "\n");
     }
   } catch (error) {
     console.error(`[newline/preserve] ${error instanceof Error ? error.message : String(error)}`);

--- a/plugins/plan/hooks/gate.ts
+++ b/plugins/plan/hooks/gate.ts
@@ -4,7 +4,6 @@ import { createHash } from "node:crypto";
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 const SIZE_THRESHOLD = 12_000;
 
@@ -145,7 +144,7 @@ export async function processInput(
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = await readStdinJson<PreToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
   } catch (error) {
     console.error(
       `[plan/gate] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -155,7 +154,7 @@ async function main(): Promise<void> {
 
   const output = await processInput(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/plugins/plan/package.json
+++ b/plugins/plan/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-    "@constellos/claude-code-kit": "^0.4.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
   }
 }

--- a/plugins/pull-request/package.json
+++ b/plugins/pull-request/package.json
@@ -4,7 +4,6 @@
   "type": "module",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-    "@constellos/claude-code-kit": "^0.4.0",
     "ap-style-title-case": "^2.0.0",
     "mdast-util-from-markdown": "^2.0.2",
     "unist-util-visit": "^5.1.0"

--- a/plugins/pull-request/scripts/validate.ts
+++ b/plugins/pull-request/scripts/validate.ts
@@ -1,23 +1,23 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import { processInput } from "./validate-body";
 
 function denyWithError(reason: string): void {
-  writeStdoutJson({
+  const output = {
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       permissionDecision: "deny",
       permissionDecisionReason: reason,
     },
-  } satisfies SyncHookJSONOutput);
+  } satisfies SyncHookJSONOutput;
+  process.stdout.write(JSON.stringify(output) + "\n");
 }
 
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = await readStdinJson<PreToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`[pull-request/validate] Failed to parse hook input: ${message}`);
@@ -27,7 +27,7 @@ async function main(): Promise<void> {
 
   const output = await processInput(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/plugins/shortcuts/hooks/open.ts
+++ b/plugins/shortcuts/hooks/open.ts
@@ -2,7 +2,6 @@
 
 import { extname } from "node:path";
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 type BashInput = { command: string };
 
@@ -61,7 +60,7 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = await readStdinJson<PreToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
   } catch (error) {
     console.error(
       `[shortcuts/open] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -71,7 +70,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/plugins/shortcuts/package.json
+++ b/plugins/shortcuts/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-    "@constellos/claude-code-kit": "^0.4.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
   }
 }

--- a/plugins/things/package-lock.json
+++ b/plugins/things/package-lock.json
@@ -9,9 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.25",
-        "@constellos/claude-code-kit": "^0.4.0",
-        "cleye": "^1.3.2",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+        "cleye": "^2.0.0",
         "table": "^6.9.0"
       },
       "devDependencies": {
@@ -20,39 +19,37 @@
         "@jxa/sdef-to-dts": "^1.4.0",
         "@types/node": "^25.1.0",
         "esbuild": "^0.28.1",
-        "typescript": "^5.7.3"
+        "typescript": "^6.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.141.tgz",
-      "integrity": "sha512-AIBacMWGcZIUcXlUoObqjwJ6pmJI3BayAqPAFXuvSq3DHJXdiuZVs7l/zTB5l3nRhRv5cqSrI2XbiDeHgZWizw==",
+      "version": "0.3.210",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.210.tgz",
+      "integrity": "sha512-siEV0CMN8N02wA3r1kUsiBc5Il1Qv2M761eFKq5q2vsAbsWSicjQI6mCVFj73tge4CuDy51oRSXz3CLrjtjSNA==",
       "license": "SEE LICENSE IN README.md",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.93.0",
-        "@modelcontextprotocol/sdk": "^1.29.0"
-      },
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.141",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.141"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.210",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.210",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.210",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.210",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.210",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.210",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.210",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.210"
       },
       "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.141.tgz",
-      "integrity": "sha512-9HZ0ot6+FwOfQ1aeMqQLH4IJGMm/DcP08SysDxscVjBm6l2JjqleHohxi3zid0DurfGweqT+4x9GScJffwg55g==",
+      "version": "0.3.210",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.210.tgz",
+      "integrity": "sha512-twQYlDQvVf0ilWQuvwZ8RcglizPNZt9Xyi10IhxDQEGm7bmYFTB0OUAIVKsYMlL1vjI9ZLCdNyPovo9FCaiehw==",
       "cpu": [
         "arm64"
       ],
@@ -63,9 +60,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.141.tgz",
-      "integrity": "sha512-4iAdarJaQ+2R58s6QJswZCzUdz2WQmL5lYG7Y+FLzWbRSROFfcH0QYpmOqSaPXd2KRQhIJwEacqecDZd/Q1XKQ==",
+      "version": "0.3.210",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.210.tgz",
+      "integrity": "sha512-QcBJIphqHbPJtV0f9UOU8KJPeDLKjgNmPUMQZCW/aVYs09b2rFGTp6x0QqJ6qGzDc0MDRa3gZre07TjklGES5g==",
       "cpu": [
         "x64"
       ],
@@ -76,11 +73,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.141.tgz",
-      "integrity": "sha512-Jdf0ZEwJzOP8sE6rPqdJN+SxMb0/L8sxJg4twCv/7S+Qzk0hJtls+wxSi+0Tjh6EEMaNxJqEGc7S3fx99Wi99Q==",
+      "version": "0.3.210",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.210.tgz",
+      "integrity": "sha512-jY+7Thi+XJREKOSPfW4zr95XNIInHOkzgZ7/jIL6I9v5YQlbmcaYiBjh/zXNDPnjwZHeZkbudsaiF8Lxfej6ww==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -89,11 +89,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.141.tgz",
-      "integrity": "sha512-6H1AJ/AVaWNnV22kubUPkOTRzZFH0+qP9k7WlhriHMN9gtgZcVAsITMddDeGjQsQJMCAdhXFd6sgi7TM1LdeOQ==",
+      "version": "0.3.210",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.210.tgz",
+      "integrity": "sha512-PSI9VzaYxhmkNdyiICknGRHA7xPARTXn8rHjhcOqGgMv2gRipxeFIBa/bZAhc+bG6rLFSG9P6S71c1n1hg630w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -102,11 +105,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.141.tgz",
-      "integrity": "sha512-DVjp72f3HmrRYpbneWZZWIqkUht5kTZXS7wXGFiwzLz6eNYEgjjh+GcsnhIi8UOwZUtNiKUrjZnoP38ovFqV8A==",
+      "version": "0.3.210",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.210.tgz",
+      "integrity": "sha512-uk+tVP0fJm9e2PTyW2ps1WSl3BrABcqTT6vhZVUMX0ccMFoAGEsIpBTyc5BjyFYLkCRWCK+i6GCT4+0MDiWnEQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -115,11 +121,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.141.tgz",
-      "integrity": "sha512-fTI1YuM4cxOa4nSgsyMAdB5ELizkWp+w5Ispo4JnnYtcczMAL4D9GBNjWPW0sUzKvjsJOUVim68SmWLWhUOpXQ==",
+      "version": "0.3.210",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.210.tgz",
+      "integrity": "sha512-OVlYOr3rZIQhue4cuwe/185Uw+eKhPpNSYk873QcI/39nEtGe51aKQvjccKxedEQedt9lDpBwv0hegyfw0/99w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -128,9 +137,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.141.tgz",
-      "integrity": "sha512-Wm10J6kfbufbPGFELokiJ/7Y5Oqug4Uag3HXFsV8g7TWCpaItx/oqVaJoiGptuAtXQB7xGLQVTuk082wER+Y5w==",
+      "version": "0.3.210",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.210.tgz",
+      "integrity": "sha512-IHgcG7wx72AVV3UpJgnTIJYL1sbl9wjPUieEEBCzytwkLEhuRnN009dXxt6RGc3F9gOtmE4Dct7iFae3OPjvsA==",
       "cpu": [
         "arm64"
       ],
@@ -141,9 +150,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.2.141",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.141.tgz",
-      "integrity": "sha512-IXuP29YJuWbR5Q6xOHrjFVGG54V2s1FC61UVNwEN5fpxL09MwPnbwtQL6fqgzt/U1MP7vWAwpXZriYAklkH/mg==",
+      "version": "0.3.210",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.210.tgz",
+      "integrity": "sha512-FwhWDbNpbSJWHZ7e4Y62J1TEy1mUeDXbJ22RgSfh423UCFztGPhgUlz/YDEjFx30x/CDU7g9YsViqjGeN4PlAg==",
       "cpu": [
         "x64"
       ],
@@ -158,6 +167,7 @@
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.93.0.tgz",
       "integrity": "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
       },
@@ -203,47 +213,9 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@constellos/claude-code-kit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@constellos/claude-code-kit/-/claude-code-kit-0.4.0.tgz",
-      "integrity": "sha512-dS7gOlUiHNYV8RMmU5KqxKi3Q9OUPCWPfZ/nvWRnymjO3JogGUgQL56C2av270oowbMpCXuw1PXVAiySlQ0gwg==",
-      "license": "MIT",
-      "dependencies": {
-        "zod": "^3.23.0"
-      },
-      "bin": {
-        "cck": "bin/cck.js",
-        "cck-hook": "bin/cck-hook.js",
-        "cck-sync-mcp": "bin/cck-sync-mcp.js",
-        "claude-code-kit": "bin/cck.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "gray-matter": "^4.0.3",
-        "minimatch": "^10.0.1"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@constellos/claude-code-kit/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -693,6 +665,7 @@
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.14.1"
       },
@@ -753,6 +726,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -793,6 +767,7 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -807,6 +782,7 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -816,6 +792,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -828,6 +805,7 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -837,6 +815,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -934,6 +913,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -963,6 +943,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -1011,7 +992,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -1047,21 +1028,12 @@
         "regenerator-runtime": "^0.11.0"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
@@ -1086,6 +1058,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1098,24 +1071,12 @@
         }
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1125,6 +1086,7 @@
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -1138,6 +1100,7 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -1185,13 +1148,13 @@
       }
     },
     "node_modules/cleye": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/cleye/-/cleye-1.3.4.tgz",
-      "integrity": "sha512-Rd6M8ecBDtdYdPR22h6gG37lPqqJ3hSOaplaGwuGYey9xKmEElOvTgupqfyLSlISshroRpVhYjDtW3vwNUNBaQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/cleye/-/cleye-2.6.0.tgz",
+      "integrity": "sha512-u0SQCsega/ox+2GSuUlG6wvA9c2FtH8sPmv9G9Q3JRTs7FK6+LtaziRAQgx7lrJ1J7bOd3palhwgZKMg8R6JbQ==",
       "license": "MIT",
       "dependencies": {
-        "terminal-columns": "^1.4.1",
-        "type-flag": "^3.0.0"
+        "terminal-columns": "^2.0.0",
+        "type-flag": "^4.1.0"
       },
       "funding": {
         "url": "https://github.com/privatenumber/cleye?sponsor=1"
@@ -1235,6 +1198,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1248,6 +1212,7 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1257,6 +1222,7 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1266,6 +1232,7 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -1284,6 +1251,7 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -1379,6 +1347,7 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1388,6 +1357,7 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -1401,7 +1371,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1414,6 +1385,7 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1443,6 +1415,7 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -1452,6 +1425,7 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -1461,6 +1435,7 @@
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -1570,7 +1545,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/esniff": {
       "version": "2.0.1",
@@ -1592,7 +1568,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -1607,6 +1583,7 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1627,6 +1604,7 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -1639,6 +1617,7 @@
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
       "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -1667,6 +1646,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1710,6 +1690,7 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
       "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "^10.2.0"
       },
@@ -1728,6 +1709,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1748,19 +1730,6 @@
       "license": "ISC",
       "dependencies": {
         "type": "^2.7.2"
-      }
-    },
-    "node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1790,6 +1759,7 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -1811,6 +1781,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1849,6 +1820,7 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1858,6 +1830,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1876,6 +1849,7 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -1900,6 +1874,7 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -1926,27 +1901,12 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gray-matter": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
-      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "js-yaml": "^3.13.1",
-        "kind-of": "^6.0.2",
-        "section-matter": "^1.0.0",
-        "strip-bom-string": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.0"
       }
     },
     "node_modules/hard-rejection": {
@@ -1964,6 +1924,7 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -1988,6 +1949,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2010,6 +1972,7 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "depd": "~2.0.0",
         "inherits": "~2.0.4",
@@ -2030,6 +1993,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -2055,13 +2019,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -2071,6 +2037,7 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -2096,16 +2063,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -2172,6 +2129,7 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
       "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -2187,7 +2145,7 @@
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
       "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -2223,6 +2181,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -2278,7 +2237,8 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -2291,7 +2251,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2387,6 +2347,7 @@
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2396,6 +2357,7 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2452,6 +2414,7 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2464,6 +2427,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2473,6 +2437,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -2492,22 +2457,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -2558,6 +2507,7 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2632,6 +2582,7 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2644,6 +2595,7 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -2743,6 +2695,7 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2779,6 +2732,7 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -2796,6 +2750,7 @@
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -2818,6 +2773,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -2842,6 +2798,7 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
       "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -2867,6 +2824,7 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2876,6 +2834,7 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -3026,6 +2985,7 @@
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -3042,6 +3002,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -3058,27 +3019,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
-    },
-    "node_modules/section-matter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
-      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
       "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
+      "peer": true
     },
     "node_modules/semver": {
       "version": "5.7.2",
@@ -3095,6 +3044,7 @@
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -3121,6 +3071,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -3138,6 +3089,7 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -3156,7 +3108,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/shebang-command": {
       "version": "1.2.0",
@@ -3186,6 +3139,7 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -3205,6 +3159,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.4"
@@ -3221,6 +3176,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -3239,6 +3195,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -3317,7 +3274,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/statuses": {
@@ -3325,6 +3282,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3368,16 +3326,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-bom-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-eof": {
@@ -3433,9 +3381,9 @@
       }
     },
     "node_modules/terminal-columns": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/terminal-columns/-/terminal-columns-1.4.1.tgz",
-      "integrity": "sha512-IKVL/itiMy947XWVv4IHV7a0KQXvKjj4ptbi7Ew9MPMcOLzkiQeyx3Gyvh62hKrfJ0RZc4M1nbhzjNM39Kyujw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/terminal-columns/-/terminal-columns-2.0.0.tgz",
+      "integrity": "sha512-6IByuUjyNZJXUtwDNm+OIe62zgwwaRbH+WMNTcx05O2G5V9WhvluAAHJY8OvUdwmzMPpqAD/7EUpGdI6ae1aiQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/terminal-columns?sponsor=1"
@@ -3483,6 +3431,7 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -3501,7 +3450,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/type": {
       "version": "2.7.3",
@@ -3524,9 +3474,9 @@
       }
     },
     "node_modules/type-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/type-flag/-/type-flag-3.0.0.tgz",
-      "integrity": "sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/type-flag/-/type-flag-4.5.0.tgz",
+      "integrity": "sha512-1aLzxcL6u1O9XHieAJBBX9U4QzwzDTWN0ER9M7QQSvS24NBmGM+N8FcghlgHAzOvDlEEpOx4hEml9CVcDnflcw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/type-flag?sponsor=1"
@@ -3537,6 +3487,7 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "content-type": "^1.0.5",
         "media-typer": "^1.1.0",
@@ -3547,9 +3498,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3572,6 +3523,7 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3592,6 +3544,7 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3637,6 +3590,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -3646,6 +3600,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }

--- a/plugins/things/package.json
+++ b/plugins/things/package.json
@@ -14,7 +14,6 @@
   "type": "commonjs",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-    "@constellos/claude-code-kit": "^0.4.0",
     "cleye": "^2.0.0",
     "table": "^6.9.0"
   },

--- a/plugins/tmux/hooks/target.ts
+++ b/plugins/tmux/hooks/target.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 const targetableCommands = new Set([
   "split-window",
@@ -72,7 +71,7 @@ export function processInput(input: PreToolUseHookInput, pane?: string): SyncHoo
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = await readStdinJson<PreToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
   } catch (error) {
     console.error(
       `[tmux/target] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -82,7 +81,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input, process.env.TMUX_PANE);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/plugins/tmux/package.json
+++ b/plugins/tmux/package.json
@@ -4,7 +4,6 @@
   "type": "module",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-    "@constellos/claude-code-kit": "^0.4.0",
     "cleye": "^2.0.0",
     "table": "^6.9.0"
   }

--- a/plugins/type-ignore/hooks/detect.ts
+++ b/plugins/type-ignore/hooks/detect.ts
@@ -3,7 +3,6 @@
 import { mkdirSync } from "node:fs";
 import * as path from "node:path";
 import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import { EXTENSION_MAP, LANGUAGES, TARGET_EXTENSIONS } from "./languages";
 
 export type WriteInput = { file_path: string; content: string };
@@ -154,7 +153,7 @@ export async function processInput(
 async function main(): Promise<void> {
   let input: PostToolUseHookInput;
   try {
-    input = await readStdinJson<PostToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PostToolUseHookInput;
   } catch (error) {
     console.error(
       `[type-ignore] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -164,7 +163,7 @@ async function main(): Promise<void> {
 
   const output = await processInput(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/plugins/type-ignore/package.json
+++ b/plugins/type-ignore/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-    "@constellos/claude-code-kit": "^0.4.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
   }
 }

--- a/plugins/ui-design/package.json
+++ b/plugins/ui-design/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-    "@constellos/claude-code-kit": "^0.4.0",
     "@xmldom/xmldom": "^0.9.8",
     "cleye": "^2.2.1",
     "playwright": "^1.50.1",

--- a/plugins/ui-design/skills/wireframe/scripts/validate-hook.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/validate-hook.ts
@@ -2,7 +2,6 @@
 
 import { extname } from "node:path";
 import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 import { validate } from "./validate";
 
@@ -50,14 +49,14 @@ Fix these layout issues before rendering.`);
 async function main(): Promise<void> {
   let input: PostToolUseHookInput;
   try {
-    input = await readStdinJson<PostToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PostToolUseHookInput;
   } catch {
     return;
   }
 
   const output = await processInput(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/plugins/writing/hooks/pretooluse.ts
+++ b/plugins/writing/hooks/pretooluse.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import { getExtension, isMemoryPath, isPlanPath, isScratchPath } from "../detection/paths";
 import * as tropes from "./check-tropes";
 import * as headings from "./headings";
@@ -104,7 +103,7 @@ export async function dispatch(
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = await readStdinJson<PreToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
   } catch (error) {
     console.error(
       `[writing/pretooluse] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -115,7 +114,7 @@ async function main(): Promise<void> {
   const { output, log } = await dispatch(input);
   appendRunLog(log);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/plugins/writing/package.json
+++ b/plugins/writing/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
     "@anthropic-ai/sdk": "^0.105.0",
-    "@constellos/claude-code-kit": "^0.4.0",
     "@duckdb/node-api": "1.5.0-r.1",
     "ap-style-title-case": "^2.0.0",
     "cleye": "^2.2.1",

--- a/plugins/x-callback-url/package.json
+++ b/plugins/x-callback-url/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
-    "@constellos/claude-code-kit": "^0.4.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
   }
 }

--- a/user/hooks/session-limit/index.ts
+++ b/user/hooks/session-limit/index.ts
@@ -3,7 +3,6 @@
 import { mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { SyncHookJSONOutput, UserPromptSubmitHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 import { expandTilde, type RateLimits } from "../../scripts/rate-limits";
 
 // Highest announced band per window, keyed to the block it applies to. A changed
@@ -195,7 +194,7 @@ export async function processInput(
 async function main(): Promise<void> {
   let input: UserPromptSubmitHookInput;
   try {
-    input = await readStdinJson<UserPromptSubmitHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as UserPromptSubmitHookInput;
   } catch (error) {
     console.error(
       `[session-limit] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -205,7 +204,7 @@ async function main(): Promise<void> {
 
   const output = await processInput(input, Date.now());
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/user/hooks/webfetch-block/index.ts
+++ b/user/hooks/webfetch-block/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 export type WebFetchInput = { url: string; prompt: string };
 
@@ -60,7 +59,7 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = await readStdinJson<PreToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
   } catch (error) {
     console.error(
       `[webfetch-block] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -70,7 +69,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 

--- a/user/hooks/worktree/index.ts
+++ b/user/hooks/worktree/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env npx tsx
 
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { readStdinJson, writeStdoutJson } from "@constellos/claude-code-kit/runners";
 
 export type BashInput = {
   command?: string;
@@ -82,7 +81,7 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = await readStdinJson<PreToolUseHookInput>();
+    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
   } catch (error) {
     console.error(
       `[worktree] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
@@ -92,7 +91,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input);
   if (output) {
-    writeStdoutJson(output);
+    process.stdout.write(JSON.stringify(output) + "\n");
   }
 }
 


### PR DESCRIPTION
Removes `@constellos/claude-code-kit`. We referenced it in 34 TypeScript files but used exactly two things from it: `readStdinJson` and `writeStdoutJson`, plus a few hook types. The runner, logger, loader, transcript parser, and MCP generator went unused.

This started as the opposite question: could we wrap our hooks in the kit's `cck hook` runner, or does a Bun/Node mismatch block it? Neither holds. The kit's loader calls `isRunningUnderBun()` and skips tsx registration, so we already ran its code under Bun on every hook invocation. But the runner is the one piece that actively would not fit: it requires `export default fn` where our hooks use the `processInput()` + `import.meta.main` split so tests can import them, it always emits JSON where ours return `null` to emit nothing, it `process.chdir()`s as a side effect, and it returns `stopReason` instead of `permissionDecisionReason` when a format hook denies.

Having looked, four things argued for removing it instead:

- **An optional-dependency landmine, reproduced.** The package declares `gray-matter` and `minimatch` in both `dependencies` and `optionalDependencies`. Optional wins, so `bun.lock` recorded them as optional, while `dist/runners/index.js` imports both unconditionally for a markdown validator we never used. Installed with `--omit=optional`, importing `/runners` throws `ERR_MODULE_NOT_FOUND: Cannot find package 'minimatch'`. That is every hook in the repo, on exactly the plugin-cache install path that already broke once.
- **Fabricated `tool_response` types.** It typed Bash as `{output, exit_code}` and Read as `{content, total_lines, offset}`. Real transcripts carry `{stdout, stderr, interrupted, ...}` and `{type, file: {filePath, content, numLines, ...}}`. `test-support.ts` built its fixtures from the fiction.
- **A better source was already a dependency.** `@anthropic-ai/claude-agent-sdk` covers 30 hook events to the kit's 10 and has `PostCompact`, which the kit lacks. Most hooks already imported SDK types alongside the kit's helpers. `plugins/type-ignore/hooks/detect.ts` took `PostToolUseHookInput` from the SDK and `readStdinJson` from the kit in the same file.
- **A frozen artifact with public blast radius.** npm last published 2025-12-06, 12 of 14 versions were unpublished, and `claudeCodeCompat.tested` is pinned at `1.0.35`. This repo is a marketplace others install, so an unpublish breaks every consumer.

The helpers are replaced inline rather than by a shared package: the plugin rules forbid `workspace:*` specifiers and reaching into `packages/`, which is why this was an external package to begin with. That leaves 28 copies of a one-line `process.stdout.write`, which is the deliberate trade.

Three judgment calls worth flagging.

`plugins/claude-code/package.json` listed only the kit, so its entry became the SDK rather than an empty `dependencies` block.

`plugins/things/package-lock.json` had the agent SDK pinned at 0.2.141 while its manifest declares `^0.3.0`, so that lock was already invalid against its own manifest. Regenerating reconciled it to 0.3.210, which inflates that diff. Hand-editing the lock back is the antipattern the repo's lockfile rule warns against, so the correction stands.

`bun.lock` was regenerated by running `bun install` over main's existing lock, which drops the kit and leaves every other pin alone. The rule in `.claude/rules/lockfile.md` says to `rm bun.lock && bun install`. Doing that here floated `bson` from 7.2.0 to 7.3.1, which breaks writing CI: bson 7.3.x calls `node:v8`'s `isBuildingSnapshot`, which Bun has not implemented. The rule is written for conflict resolution and is right for that case, but it needs a caveat for a scoped dependency removal.

One deliberate behavior change: parse-failure text now comes from Bun's raw `SyntaxError` instead of the kit's `Failed to parse JSON input:` wrapper. It surfaces in `pull-request/scripts/validate.ts`'s deny reason. Error text only, no control flow.

## Testing

Beyond CI:

- Captured stdout for real hook input on `main` and again after the change, across four output modes: `PostToolUse` `additionalContext`, a read-only hook that emits nothing, `PreToolUse` `additionalContext`, and a `permissionDecision` deny. Byte-identical on all four.
- Installed `plugins/type-ignore` into a scratch dir with `--omit=optional` and ran its hook end-to-end. It emits its normal JSON where the pre-fix tree threw `ERR_MODULE_NOT_FOUND`. This is the check that catches a partial migration while `bun test` still passes.
- Drove the two hooks whose emit paths only run in narrow conditions: `git/skills/conflicts/scripts/check-markers.ts` against a repo with staged conflict markers, and `validate.ts` against unparseable stdin.
- Ran `writing/hooks/pretooluse.ts` through its real `grep` prefilter, which pipes via `printf '%s'` with no trailing newline. That is the one stdin shape the direct tests miss.

The suite has pre-existing failures in the session-index DuckDB tests and `upstream.ts`. `main` fails the identical set, so they are not from this change.

Rebased onto #1056, which touched `plugins/pull-request/`. Its new `validate.ts` code merged with this migration cleanly, and the checks above were re-run against the rebased tree.

## Out of scope

- `plugins/type-ignore/hooks/detect.ts` and `user/hooks/worktree/index.ts` carry stale `#!/usr/bin/env npx tsx` shebangs. Inert, since both are invoked as `bun <path>` and `tsx` is not a dependency anywhere, but they contradict the Bun-everywhere rule.
- `packages/launch` has committed `node_modules`, no source, and is absent from the root `workspaces` array.


