### PR TITLE
comments: fix partial trims and harden the apply step

### DIFF
--- a/plugins/comments/apply/edits.test.ts
+++ b/plugins/comments/apply/edits.test.ts
@@ -36,9 +36,12 @@ describe("computeFileEdits", () => {
     source: string;
     items: EditItem[];
     expected: string;
+    options?: { maxWidth?: number };
     skipsEmpty?: boolean;
     skipsLength?: number;
     skipDetail?: RegExp;
+    warningsLength?: number;
+    warningDetail?: RegExp;
   }>([
     {
       name: "case (a): deletes a single full-line comment",
@@ -123,6 +126,202 @@ describe("computeFileEdits", () => {
         }),
       ],
       expected: "x = 1;\ny = 2;",
+    },
+    {
+      name: "trimTo: replaces an indented full-line comment span with the kept text",
+      source:
+        "code();\n    // walk the list and retry each entry, reusing\n    // the same backoff: rate-limited per key\n    more();",
+      items: [
+        item({
+          startLine: 2,
+          endLine: 3,
+          startColumn: 4,
+          endColumn: "    // the same backoff: rate-limited per key".length,
+          verdict: verdict({ trimTo: "// retries reuse the first backoff: rate-limited per key" }),
+        }),
+      ],
+      expected:
+        "code();\n    // retries reuse the first backoff: rate-limited per key\n    more();",
+      skipsEmpty: true,
+    },
+    {
+      name: "trimTo: replaces a docstring block with the kept text",
+      source:
+        "a();\n  /**\n   * Walks the loop and retries.\n   * The broker rate-limits per key.\n   */\n  b();",
+      items: [
+        item({
+          startLine: 2,
+          endLine: 5,
+          startColumn: 2,
+          endColumn: 5,
+          kind: "docstring",
+          verdict: verdict({ trimTo: "/** The broker rate-limits per key. */" }),
+        }),
+      ],
+      expected: "a();\n  /** The broker rate-limits per key. */\n  b();",
+      skipsEmpty: true,
+    },
+    {
+      name: "trimTo: splices the kept text after the code for a trailing line comment",
+      source: "count += 1; // increment the counter, reusing the shared backoff",
+      items: [
+        item({
+          startLine: 1,
+          endLine: 1,
+          startColumn: 12,
+          endColumn: "count += 1; // increment the counter, reusing the shared backoff".length,
+          verdict: verdict({ trimTo: "// reuses the shared backoff" }),
+        }),
+      ],
+      expected: "count += 1; // reuses the shared backoff",
+      skipsEmpty: true,
+    },
+    {
+      name: "trimTo: skips a block interleaved with code on its line",
+      source: "x = 1; /* note */ y = 2;",
+      items: [
+        item({
+          startLine: 1,
+          endLine: 1,
+          startColumn: 7,
+          endColumn: 17,
+          kind: "block",
+          verdict: verdict({ trimTo: "/* fact */" }),
+        }),
+      ],
+      expected: "x = 1; /* note */ y = 2;",
+      skipDetail: /interleaved/,
+    },
+    {
+      name: "fragment guard: skips a trimToLines keep opening with 'the' after an unterminated drop",
+      source:
+        "op();\n# walk the queue and retry each entry, reusing\n# the same backoff: rate-limited per key\ndone();",
+      items: [
+        item({
+          startLine: 2,
+          endLine: 3,
+          startColumn: 0,
+          endColumn: "# the same backoff: rate-limited per key".length,
+          verdict: verdict({ trimToLines: [2] }),
+        }),
+      ],
+      expected:
+        "op();\n# walk the queue and retry each entry, reusing\n# the same backoff: rate-limited per key\ndone();",
+      skipDetail: /mid-sentence fragment/,
+    },
+    {
+      name: "fragment guard: skips a trimToLines keep opening with 'others' after an unterminated drop",
+      source:
+        "op();\n// dedupe entries that repeat and drop\n// others that expired already\ndone();",
+      items: [
+        item({
+          startLine: 2,
+          endLine: 3,
+          startColumn: 0,
+          endColumn: "// others that expired already".length,
+          verdict: verdict({ trimToLines: [2] }),
+        }),
+      ],
+      expected:
+        "op();\n// dedupe entries that repeat and drop\n// others that expired already\ndone();",
+      skipDetail: /mid-sentence fragment/,
+    },
+    {
+      name: "fragment guard: matches a connective carrying trailing punctuation",
+      source:
+        "op();\n# retry each entry with the backoff\n# that, in turn, the broker chose\ndone();",
+      items: [
+        item({
+          startLine: 2,
+          endLine: 3,
+          startColumn: 0,
+          endColumn: "# that, in turn, the broker chose".length,
+          verdict: verdict({ trimToLines: [2] }),
+        }),
+      ],
+      expected:
+        "op();\n# retry each entry with the backoff\n# that, in turn, the broker chose\ndone();",
+      skipDetail: /mid-sentence fragment/,
+    },
+    {
+      name: "fragment guard: strips SQL-style markers before reading the boundary",
+      source:
+        "op();\n-- walk the table and update rows, keeping\n-- the same checksum as before\ndone();",
+      items: [
+        item({
+          startLine: 2,
+          endLine: 3,
+          startColumn: 0,
+          endColumn: "-- the same checksum as before".length,
+          verdict: verdict({ trimToLines: [2] }),
+        }),
+      ],
+      expected:
+        "op();\n-- walk the table and update rows, keeping\n-- the same checksum as before\ndone();",
+      skipDetail: /mid-sentence fragment/,
+    },
+    {
+      name: "fragment guard: does not fire on an identifier-led kept line",
+      source: "op();\n# checks each flag value\n# bool is coerced to int here\ndone();",
+      items: [
+        item({
+          startLine: 2,
+          endLine: 3,
+          startColumn: 0,
+          endColumn: "# bool is coerced to int here".length,
+          verdict: verdict({ trimToLines: [2] }),
+        }),
+      ],
+      expected: "op();\n# bool is coerced to int here\ndone();",
+      skipsEmpty: true,
+    },
+    {
+      name: "fragment guard: does not fire when the dropped boundary ends a sentence",
+      source: "op();\n# The loop retries each entry.\n# The broker rate-limits per key.\ndone();",
+      items: [
+        item({
+          startLine: 2,
+          endLine: 3,
+          startColumn: 0,
+          endColumn: "# The broker rate-limits per key.".length,
+          verdict: verdict({ trimToLines: [2] }),
+        }),
+      ],
+      expected: "op();\n# The broker rate-limits per key.\ndone();",
+      skipsEmpty: true,
+    },
+    {
+      name: "warnings: flags an applier-produced line over maxWidth",
+      source: "count += 1; // note",
+      items: [
+        item({
+          startLine: 1,
+          endLine: 1,
+          startColumn: 12,
+          endColumn: "count += 1; // note".length,
+          verdict: verdict({
+            trimTo: "// a kept clause long enough to overflow the configured width limit",
+          }),
+        }),
+      ],
+      expected: "count += 1; // a kept clause long enough to overflow the configured width limit",
+      options: { maxWidth: 40 },
+      warningsLength: 1,
+      warningDetail: /over 40/,
+    },
+    {
+      name: "blank collapse: drops the blank left under a block opener by a deleted docstring",
+      source: "def f():\n    # says what it does\n\n    return 1",
+      items: [
+        item({
+          startLine: 2,
+          endLine: 2,
+          startColumn: 4,
+          endColumn: "    # says what it does".length,
+        }),
+      ],
+      expected: "def f():\n    return 1",
+      skipsEmpty: true,
     },
     {
       name: "resolution: deletion wins over a replacement on the same line",
@@ -219,8 +418,18 @@ describe("computeFileEdits", () => {
       expected: "x = 1; /* note */ y = 2;",
       skipDetail: /interleaved/,
     },
-  ])("$name", ({ source, items, expected, skipsEmpty, skipsLength, skipDetail }) => {
-    const result = computeFileEdits(source, items);
+  ])("$name", ({
+    source,
+    items,
+    expected,
+    options,
+    skipsEmpty,
+    skipsLength,
+    skipDetail,
+    warningsLength,
+    warningDetail,
+  }) => {
+    const result = computeFileEdits(source, items, options);
     expect(result.content).toBe(expected);
     if (skipsEmpty) {
       expect(result.skips).toEqual([]);
@@ -230,6 +439,10 @@ describe("computeFileEdits", () => {
     }
     if (skipDetail) {
       expect(result.skips[0]?.detail).toMatch(skipDetail);
+    }
+    expect(result.warnings).toHaveLength(warningsLength ?? 0);
+    if (warningDetail) {
+      expect(result.warnings[0]?.detail).toMatch(warningDetail);
     }
   });
 });
@@ -246,17 +459,20 @@ describe("migration-data-migration-mixed convention", () => {
     expect(fixture.trimToLines).toEqual([2]);
 
     const source = [first, second, "op.execute()"].join("\n");
-    const result = computeFileEdits(source, [
+    const editItem = (over: Partial<Verdict>) =>
       item({
         startLine: 1,
         endLine: 2,
         startColumn: first.length - first.trimStart().length,
         endColumn: second.length,
         kind: fixture.kind as CommentKind,
-        verdict: verdict({ trimToLines: fixture.trimToLines }),
-      }),
-    ]);
-    expect(result.content).toContain("Tool calls have tool_args");
-    expect(result.content).not.toContain("Data migration: Convert");
+        verdict: verdict(over),
+      });
+
+    for (const over of [{ trimToLines: fixture.trimToLines }, { trimTo: fixture.trimTo }]) {
+      const result = computeFileEdits(source, [editItem(over)]);
+      expect(result.content).toContain("Tool calls have tool_args");
+      expect(result.content).not.toContain("Data migration: Convert");
+    }
   });
 });

--- a/plugins/comments/apply/edits.test.ts
+++ b/plugins/comments/apply/edits.test.ts
@@ -261,6 +261,21 @@ describe("computeFileEdits", () => {
       skipDetail: /mid-sentence fragment/,
     },
     {
+      name: "fragment guard: does not fire on a sentence-opening preposition",
+      source: "op();\n# walk the queue and rebuild it\n# For each entry, retry once.\ndone();",
+      items: [
+        item({
+          startLine: 2,
+          endLine: 3,
+          startColumn: 0,
+          endColumn: "# For each entry, retry once.".length,
+          verdict: verdict({ trimToLines: [2] }),
+        }),
+      ],
+      expected: "op();\n# For each entry, retry once.\ndone();",
+      skipsEmpty: true,
+    },
+    {
       name: "fragment guard: does not fire on an identifier-led kept line",
       source: "op();\n# checks each flag value\n# bool is coerced to int here\ndone();",
       items: [

--- a/plugins/comments/apply/edits.ts
+++ b/plugins/comments/apply/edits.ts
@@ -38,7 +38,9 @@ export interface FileEditOptions {
 /**
  * Words that continue a sentence rather than start one. A kept line opening
  * with one of these, right after a dropped line that lacks terminal
- * punctuation, is almost certainly a mid-sentence fragment.
+ * punctuation, is almost certainly a mid-sentence fragment. Sentence-opening
+ * prepositions (for, to, from, of, as) are excluded: they routinely start
+ * complete sentences ("For each entry, retry once.") and over-fire the guard.
  */
 export const SENTENCE_CONNECTIVES = new Set([
   "and",
@@ -64,11 +66,6 @@ export const SENTENCE_CONNECTIVES = new Set([
   "while",
   "when",
   "where",
-  "as",
-  "of",
-  "to",
-  "for",
-  "from",
 ]);
 
 /** A line's prose: leading/trailing comment markers and whitespace stripped. */

--- a/plugins/comments/apply/edits.ts
+++ b/plugins/comments/apply/edits.ts
@@ -18,9 +18,66 @@ export interface EditSkip {
   detail: string;
 }
 
+/** A line the applier produced that a human should re-check, not a refusal. */
+export interface EditWarning {
+  line: number;
+  detail: string;
+}
+
 export interface FileEditResult {
   content: string;
   skips: EditSkip[];
+  warnings: EditWarning[];
+}
+
+export interface FileEditOptions {
+  /** Applier-produced lines longer than this are flagged in `warnings`. */
+  maxWidth?: number;
+}
+
+/**
+ * Words that continue a sentence rather than start one. A kept line opening
+ * with one of these, right after a dropped line that lacks terminal
+ * punctuation, is almost certainly a mid-sentence fragment.
+ */
+export const SENTENCE_CONNECTIVES = new Set([
+  "and",
+  "or",
+  "but",
+  "so",
+  "which",
+  "that",
+  "the",
+  "this",
+  "these",
+  "those",
+  "other",
+  "others",
+  "its",
+  "their",
+  "instead",
+  "rather",
+  "with",
+  "without",
+  "because",
+  "since",
+  "while",
+  "when",
+  "where",
+  "as",
+  "of",
+  "to",
+  "for",
+  "from",
+]);
+
+/** A line's prose: leading/trailing comment markers and whitespace stripped. */
+function stripCommentMarkers(line: string): string {
+  return line
+    .trim()
+    .replace(/^(?:\/\*+|\/\/+|#+|--+|;+|"""|'''|\*+)\s*/, "")
+    .replace(/\s*(?:\*+\/|"""|''')$/, "")
+    .trim();
 }
 
 /**
@@ -39,9 +96,31 @@ function keepLines(item: EditItem): number[] | null {
   return keep.length === 0 ? null : keep;
 }
 
+/**
+ * True when a line-range trim would keep a line that continues a sentence begun
+ * on a dropped line: the dropped boundary line does not end a sentence and the
+ * kept line opens with a connective word. `trimToLines` cannot express the
+ * needed mid-line cut, so the trim must go to a human (or a `trimTo` verdict).
+ */
+function strandsFragment(item: EditItem, kept: Set<number>, lines: string[]): boolean {
+  for (const n of kept) {
+    if (n <= item.startLine || kept.has(n - 1)) continue;
+    const dropped = stripCommentMarkers(lines[n - 2] ?? "");
+    if (/[.!?:]$/.test(dropped)) continue;
+    // Match letters only, so a connective with trailing punctuation ("that,")
+    // still resolves to its word.
+    const firstWord = stripCommentMarkers(lines[n - 1] ?? "")
+      .match(/^[A-Za-z']+/)?.[0]
+      ?.toLowerCase();
+    if (firstWord && SENTENCE_CONNECTIVES.has(firstWord)) return true;
+  }
+  return false;
+}
+
 function applyTrim(
   item: EditItem,
   keep: number[],
+  lines: string[],
   deletions: Set<number>,
   skips: EditSkip[],
 ): void {
@@ -54,6 +133,15 @@ function applyTrim(
       startLine: item.startLine,
       reason: "manual",
       detail: "trim would drop the opening or closing delimiter of a block comment",
+    });
+    return;
+  }
+  if (strandsFragment(item, kept, lines)) {
+    skips.push({
+      startLine: item.startLine,
+      reason: "manual",
+      detail:
+        "partial trim would keep a mid-sentence fragment (sentence starts mid-line on a dropped line); rewrite by hand",
     });
     return;
   }
@@ -92,13 +180,51 @@ function applyFull(
 }
 
 /**
- * Replace a comment's span with the judge's de-voiced rewrite. The rewrite text
- * carries the delimiters but no leading indentation; the applier owns it. For a
- * full-line comment the span's lines become the indented rewrite lines. For a
- * trailing line comment the rewrite is spliced after the code, one space apart.
- * Anything else (a trailing block, code interleaved on the line) is skipped and
- * flagged, the same conservative bar trims use.
+ * Replace a comment's span with judge-authored text (a `rewrite` or a partial
+ * trim's `trimTo`). The text carries the delimiters but no leading indentation;
+ * the applier owns it. For a full-line comment the span's lines become the
+ * indented text lines. For a trailing line comment the text is spliced after
+ * the code, one space apart. Anything else (a trailing block, code interleaved
+ * on the line) is skipped and flagged, the same conservative bar trims use.
  */
+function replaceSpan(
+  item: EditItem,
+  text: string,
+  lines: string[],
+  deletions: Set<number>,
+  spanInserts: Map<number, string[]>,
+  skips: EditSkip[],
+): void {
+  const before = (lines[item.startLine - 1] ?? "").slice(0, item.startColumn);
+  const after = (lines[item.endLine - 1] ?? "").slice(item.endColumn);
+  const wsBefore = before.trim().length === 0;
+  const wsAfter = after.trim().length === 0;
+  const textLines = text.split("\n");
+
+  if (wsBefore && wsAfter) {
+    const indent = before;
+    spanInserts.set(
+      item.startLine,
+      textLines.map((line) => `${indent}${line}`.replace(/\s+$/, "")),
+    );
+    for (let n = item.startLine; n <= item.endLine; n++) deletions.add(n);
+    return;
+  }
+
+  if (!wsBefore && wsAfter && item.kind === "line" && item.startLine === item.endLine) {
+    const code = before.replace(/\s+$/, "");
+    spanInserts.set(item.startLine, [`${code} ${textLines.join(" ")}`.replace(/\s+$/, "")]);
+    deletions.add(item.startLine);
+    return;
+  }
+
+  skips.push({
+    startLine: item.startLine,
+    reason: "manual",
+    detail: "comment is interleaved with code on its line",
+  });
+}
+
 function applyRewrite(
   item: EditItem,
   lines: string[],
@@ -115,34 +241,7 @@ function applyRewrite(
     });
     return;
   }
-  const before = (lines[item.startLine - 1] ?? "").slice(0, item.startColumn);
-  const after = (lines[item.endLine - 1] ?? "").slice(item.endColumn);
-  const wsBefore = before.trim().length === 0;
-  const wsAfter = after.trim().length === 0;
-  const rewriteLines = rewrite.split("\n");
-
-  if (wsBefore && wsAfter) {
-    const indent = before;
-    spanInserts.set(
-      item.startLine,
-      rewriteLines.map((line) => `${indent}${line}`.replace(/\s+$/, "")),
-    );
-    for (let n = item.startLine; n <= item.endLine; n++) deletions.add(n);
-    return;
-  }
-
-  if (!wsBefore && wsAfter && item.kind === "line" && item.startLine === item.endLine) {
-    const code = before.replace(/\s+$/, "");
-    spanInserts.set(item.startLine, [`${code} ${rewriteLines.join(" ")}`.replace(/\s+$/, "")]);
-    deletions.add(item.startLine);
-    return;
-  }
-
-  skips.push({
-    startLine: item.startLine,
-    reason: "manual",
-    detail: "comment is interleaved with code on its line",
-  });
+  replaceSpan(item, rewrite, lines, deletions, spanInserts, skips);
 }
 
 /**
@@ -151,7 +250,9 @@ function applyRewrite(
  * them once, never mutating line indices mid-loop. By action:
  *
  * - `keep` → left untouched;
- * - `trim` with `trimToLines` → keep those comment-relative lines, drop the rest;
+ * - `trim` with `trimTo` → replace the comment span with the kept, rewritten text;
+ * - `trim` with `trimToLines` → keep those comment-relative lines, drop the rest,
+ *   unless the cut would strand a mid-sentence fragment (skipped for a human);
  * - `trim` whole, full-line comment → delete its lines;
  * - `trim` whole, trailing line comment after code → strip it, keep the code;
  * - `rewrite` → replace the comment span with the indented de-voiced text;
@@ -159,22 +260,33 @@ function applyRewrite(
  *
  * Overlapping verdicts on one line resolve with deletion winning over a replace.
  * A span insert at a line takes precedence over its own span's deletions.
+ * Applier-produced lines longer than `maxWidth` are flagged in `warnings`.
  */
-export function computeFileEdits(source: string, items: EditItem[]): FileEditResult {
+export function computeFileEdits(
+  source: string,
+  items: EditItem[],
+  options: FileEditOptions = {},
+): FileEditResult {
+  const { maxWidth = 100 } = options;
   const lines = source.split("\n");
   const deletions = new Set<number>();
   const replacements = new Map<number, string>();
   const spanInserts = new Map<number, string[]>();
   const skips: EditSkip[] = [];
+  const warnings: EditWarning[] = [];
 
   for (const item of items) {
     switch (item.verdict.action) {
       case "keep":
         break;
       case "trim": {
+        if (item.verdict.trimTo) {
+          replaceSpan(item, item.verdict.trimTo, lines, deletions, spanInserts, skips);
+          break;
+        }
         const keep = keepLines(item);
         if (keep != null) {
-          applyTrim(item, keep, deletions, skips);
+          applyTrim(item, keep, lines, deletions, skips);
         } else {
           applyFull(item, lines, deletions, replacements, skips);
         }
@@ -186,15 +298,28 @@ export function computeFileEdits(source: string, items: EditItem[]): FileEditRes
     }
   }
 
+  for (const [n, insert] of spanInserts) {
+    for (const line of insert) {
+      if (line.length > maxWidth) {
+        warnings.push({
+          line: n,
+          detail: `applier produced a ${line.length}-character line (over ${maxWidth}); re-wrap by hand`,
+        });
+      }
+    }
+  }
+
   const isBlank = (line: string): boolean => line.trim().length === 0;
   const out: string[] = [];
+  let lastPushed = "";
   let lastPushedBlank = false;
   for (let n = 1; n <= lines.length; n++) {
     const insert = spanInserts.get(n);
     if (insert) {
       if (insert.length > 0) {
         for (const line of insert) out.push(line);
-        lastPushedBlank = isBlank(insert[insert.length - 1] as string);
+        lastPushed = insert[insert.length - 1] as string;
+        lastPushedBlank = isBlank(lastPushed);
       }
       continue;
     }
@@ -206,8 +331,15 @@ export function computeFileEdits(source: string, items: EditItem[]): FileEditRes
     if (isBlank(line) && lastPushedBlank && (deletions.has(n - 1) || deletions.has(n + 1))) {
       continue;
     }
+    // Deleting a docstring directly under a `def f():` or `{` opener can leave a
+    // blank as the block's first line. Drop a blank right after a deleted span
+    // when the surviving line above the span opens a block.
+    if (isBlank(line) && deletions.has(n - 1) && /[:{]$/.test(lastPushed.trimEnd())) {
+      continue;
+    }
     out.push(line);
+    lastPushed = line;
     lastPushedBlank = isBlank(line);
   }
-  return { content: out.join("\n"), skips };
+  return { content: out.join("\n"), skips, warnings };
 }

--- a/plugins/comments/apply/format.test.ts
+++ b/plugins/comments/apply/format.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { type FormatResult, formatContent, renderTemplate } from "./format";
+
+describe("renderTemplate", () => {
+  test.each<[string, string, string]>([
+    ["cat", "src/a.ts", "cat"],
+    ["prettier --stdin-filepath {}", "src/a.ts", "prettier --stdin-filepath 'src/a.ts'"],
+    ["fmt {} {}", "a b.py", "fmt 'a b.py' 'a b.py'"],
+    ["fmt {}", "it's.py", "fmt 'it'\\''s.py'"],
+  ])("%p with %p renders %p", (template, path, expected) => {
+    expect(renderTemplate(template, path)).toBe(expected);
+  });
+});
+
+describe("formatContent", () => {
+  test.each<{ name: string; template: string; content: string; expected: FormatResult }>([
+    {
+      name: "passes content through an identity command",
+      template: "cat",
+      content: "line one\nline two\n",
+      expected: { content: "line one\nline two\n", formatted: true },
+    },
+    {
+      name: "returns the transforming command's stdout",
+      template: "tr 'a-z' 'A-Z'",
+      content: "hello\n",
+      expected: { content: "HELLO\n", formatted: true },
+    },
+    {
+      name: "substitutes {} with the path",
+      template: "cat; printf '%s' {}",
+      content: "content\n",
+      expected: { content: "content\nsrc/a b.ts", formatted: true },
+    },
+    {
+      name: "keeps the original content when the command exits non-zero",
+      template: "echo mangled; echo broken >&2; exit 3",
+      content: "original\n",
+      expected: { content: "original\n", formatted: false, error: "exit 3: broken" },
+    },
+    {
+      name: "keeps the original content when an exit-0 command emits nothing",
+      template: "cat > /dev/null",
+      content: "original\n",
+      expected: {
+        content: "original\n",
+        formatted: false,
+        error: "produced empty output for non-empty input",
+      },
+    },
+  ])("$name", async ({ template, content, expected }) => {
+    expect(await formatContent(template, "src/a b.ts", content)).toEqual(expected);
+  });
+});

--- a/plugins/comments/apply/format.ts
+++ b/plugins/comments/apply/format.ts
@@ -1,0 +1,54 @@
+/**
+ * Formatter pass for applied edits. The applier splices comment text by line,
+ * so the result can carry debris a formatter would fix (stray blanks, long
+ * collapsed lines). The caller supplies a shell command template; nothing is
+ * auto-discovered or auto-executed beyond it.
+ */
+
+export interface FormatResult {
+  content: string;
+  formatted: boolean;
+  /** Why the content was kept unformatted: exit code and stderr. */
+  error?: string;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+/** The template with `{}` replaced by the shell-quoted repo-relative path. */
+export function renderTemplate(template: string, path: string): string {
+  return template.replaceAll("{}", shellQuote(path));
+}
+
+/**
+ * Run the formatter template over one file's content: content on stdin, `{}`
+ * in the template replaced with the file's path, stdout taken as the formatted
+ * content. Runs in the current working directory (the repo root on the apply
+ * path). A non-zero exit returns the original content with `formatted: false`.
+ */
+export async function formatContent(
+  template: string,
+  path: string,
+  content: string,
+): Promise<FormatResult> {
+  const proc = Bun.spawn(["sh", "-c", renderTemplate(template, path)], {
+    stdin: new TextEncoder().encode(content),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    return { content, formatted: false, error: `exit ${exitCode}: ${stderr.trim()}` };
+  }
+  // An in-place formatter (e.g. `ruff format {}` without `-`) exits 0 and prints
+  // nothing. Taking its stdout would empty the file.
+  if (content.trim().length > 0 && stdout.trim().length === 0) {
+    return { content, formatted: false, error: "produced empty output for non-empty input" };
+  }
+  return { content: stdout, formatted: true };
+}

--- a/plugins/comments/apply/report.test.ts
+++ b/plugins/comments/apply/report.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { Verdict } from "../judge/schema";
-import { type ReportItem, renderReport } from "./report";
+import { type ReportItem, renderReport, summarize } from "./report";
 
 const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
 const strip = (s: string) => s.replace(ANSI, "");
@@ -46,13 +46,52 @@ describe("renderReport", () => {
       ),
     );
     expect(out).toMatchInlineSnapshot(`
-"src/a.ts
-  :4  trim  restate-the-what  high
+"2 delete / 0 trim / 0 rewrite across 2 file(s)
+
+src/a.ts
+  :4  delete  restate-the-what  high
       Paraphrases the line.
 
 src/b.ts
-  :9  trim  section-divider  low
+  :9  delete  section-divider  low
       Paraphrases the line."
+`);
+  });
+
+  test("labels a whole-comment trim as delete and a partial trim as trim, with a keep preview", () => {
+    const out = strip(
+      renderReport(
+        [
+          reportItem({ startLine: 2 }),
+          reportItem({
+            startLine: 8,
+            verdict: verdict({ trimTo: "# the broker rate-limits per key" }),
+          }),
+          reportItem({
+            startLine: 14,
+            verdict: verdict({
+              action: "rewrite",
+              category: "voice",
+              rewrite: "// the fact",
+              rationale: "Voice.",
+            }),
+          }),
+        ],
+        { fix: false },
+      ),
+    );
+    expect(out).toMatchInlineSnapshot(`
+"1 delete / 1 trim / 1 rewrite across 1 file(s)
+
+src/a.ts
+  :2  delete  restate-the-what  high
+      Paraphrases the line.
+  :8  trim  restate-the-what  high
+      Paraphrases the line.
+      keep: # the broker rate-limits per key
+  :14  rewrite  voice  high
+      Voice.
+      new: // the fact"
 `);
   });
 
@@ -83,5 +122,21 @@ src/b.ts
     expect(strip(renderReport([item], { fix: true }))).toContain("fix: delete it");
     expect(strip(renderReport([item], { fix: true }))).toContain("keep lines: 2");
     expect(strip(renderReport([item], { fix: false }))).not.toContain("fix: delete it");
+  });
+});
+
+describe("summarize", () => {
+  test("splits flagged verdicts by delete, trim, and rewrite and counts distinct files", () => {
+    const items = [
+      reportItem({ path: "src/a.ts" }),
+      reportItem({ path: "src/a.ts", verdict: verdict({ trimToLines: [1] }) }),
+      reportItem({ path: "src/b.ts", verdict: verdict({ trimTo: "# kept" }) }),
+      reportItem({
+        path: "src/b.ts",
+        verdict: verdict({ action: "rewrite", category: "voice", rewrite: "// fact" }),
+      }),
+      reportItem({ path: "src/c.ts", verdict: verdict({ action: "keep", category: null }) }),
+    ];
+    expect(summarize(items)).toBe("1 delete / 2 trim / 1 rewrite across 2 file(s)");
   });
 });

--- a/plugins/comments/apply/report.test.ts
+++ b/plugins/comments/apply/report.test.ts
@@ -139,4 +139,14 @@ describe("summarize", () => {
     ];
     expect(summarize(items)).toBe("1 delete / 2 trim / 1 rewrite across 2 file(s)");
   });
+
+  test("counts only what applies, moving refused verdicts to a manual-handling tail", () => {
+    const items = [
+      reportItem({ path: "src/a.ts" }),
+      reportItem({ path: "src/b.ts", verdict: verdict({ trimToLines: [2] }), skipped: true }),
+    ];
+    expect(summarize(items)).toBe(
+      "1 delete / 0 trim / 0 rewrite across 1 file(s), 1 to manual handling",
+    );
+  });
 });

--- a/plugins/comments/apply/report.ts
+++ b/plugins/comments/apply/report.ts
@@ -23,9 +23,28 @@ function firstLine(text: string): string {
 }
 
 /**
+ * A `trim` that keeps nothing (no `trimTo`, no `trimToLines`) removes the whole
+ * comment, so it reads as `delete`; a `trim` that keeps part stays `trim`.
+ */
+function actionLabel(verdict: Verdict): string {
+  if (verdict.action !== "trim") return verdict.action;
+  return verdict.trimTo || verdict.trimToLines?.length ? "trim" : "delete";
+}
+
+/** One-line split of the flagged verdicts: `N delete / M trim / K rewrite across F files`. */
+export function summarize(items: ReportItem[]): string {
+  const flagged = items.filter((item) => item.verdict.action !== "keep");
+  const count = (label: string) =>
+    flagged.filter((item) => actionLabel(item.verdict) === label).length;
+  const files = new Set(flagged.map((item) => item.path)).size;
+  return `${count("delete")} delete / ${count("trim")} trim / ${count("rewrite")} rewrite across ${files} file(s)`;
+}
+
+/**
  * Render the flagged comments grouped by file as `path:line  action  category
- * confidence  rationale`. A `rewrite` shows its old → new preview; with `fix`, a
- * suggestion and any keep-lines follow. `keep` items are dropped.
+ * confidence  rationale`, under a delete/trim/rewrite summary line. A `rewrite`
+ * shows its old → new preview; a partial trim shows what it keeps; with `fix`,
+ * a suggestion follows. `keep` items are dropped.
  */
 export function renderReport(items: ReportItem[], options: { fix: boolean }): string {
   const flagged = items.filter((item) => item.verdict.action !== "keep");
@@ -45,7 +64,7 @@ export function renderReport(items: ReportItem[], options: { fix: boolean }): st
       const conf =
         verdict.confidence === "high" ? color.red(verdict.confidence) : verdict.confidence;
       lines.push(
-        `  ${color.dim(`:${startLine}`)}  ${verdict.action}  ${verdict.category}  ${conf}`,
+        `  ${color.dim(`:${startLine}`)}  ${actionLabel(verdict)}  ${verdict.category}  ${conf}`,
       );
       lines.push(`      ${verdict.rationale}`);
       if (verdict.action === "rewrite" && verdict.rewrite) {
@@ -55,11 +74,13 @@ export function renderReport(items: ReportItem[], options: { fix: boolean }): st
       if (options.fix && verdict.suggestedFix) {
         lines.push(color.dim(`      fix: ${verdict.suggestedFix}`));
       }
-      if (verdict.trimToLines?.length) {
+      if (verdict.trimTo) {
+        lines.push(color.dim(`      keep: ${firstLine(verdict.trimTo)}`));
+      } else if (verdict.trimToLines?.length) {
         lines.push(color.dim(`      keep lines: ${verdict.trimToLines.join(", ")}`));
       }
     }
     blocks.push(lines.join("\n"));
   }
-  return blocks.join("\n\n");
+  return [color.bold(summarize(items)), ...blocks].join("\n\n");
 }

--- a/plugins/comments/apply/report.ts
+++ b/plugins/comments/apply/report.ts
@@ -15,6 +15,8 @@ export interface ReportItem {
   verdict: Verdict;
   /** The original comment text, for rendering a rewrite's old → new preview. */
   text?: string;
+  /** True when the applier refused the edit and left it for manual handling. */
+  skipped?: boolean;
 }
 
 /** The first line of a possibly multi-line comment, for a one-line preview. */
@@ -31,13 +33,21 @@ function actionLabel(verdict: Verdict): string {
   return verdict.trimTo || verdict.trimToLines?.length ? "trim" : "delete";
 }
 
-/** One-line split of the flagged verdicts: `N delete / M trim / K rewrite across F files`. */
+/**
+ * One-line split of the flagged verdicts: `N delete / M trim / K rewrite across
+ * F files`. Counts only what the applier will change. Verdicts it refused are
+ * appended as `, J to manual handling` so the split reads without the stderr
+ * skip list.
+ */
 export function summarize(items: ReportItem[]): string {
   const flagged = items.filter((item) => item.verdict.action !== "keep");
+  const applied = flagged.filter((item) => !item.skipped);
   const count = (label: string) =>
-    flagged.filter((item) => actionLabel(item.verdict) === label).length;
-  const files = new Set(flagged.map((item) => item.path)).size;
-  return `${count("delete")} delete / ${count("trim")} trim / ${count("rewrite")} rewrite across ${files} file(s)`;
+    applied.filter((item) => actionLabel(item.verdict) === label).length;
+  const files = new Set(applied.map((item) => item.path)).size;
+  const manual = flagged.length - applied.length;
+  const split = `${count("delete")} delete / ${count("trim")} trim / ${count("rewrite")} rewrite across ${files} file(s)`;
+  return manual > 0 ? `${split}, ${manual} to manual handling` : split;
 }
 
 /**

--- a/plugins/comments/evals/eval.ts
+++ b/plugins/comments/evals/eval.ts
@@ -38,6 +38,8 @@ export interface Fixture {
   category: SlopCategory | null;
   /** For `action: "rewrite"`: the owner's gold de-voiced text, for hand spot-checks. */
   rewrite?: string | null;
+  /** For a partial `trim`: the owner's gold kept-comment text, for hand spot-checks. */
+  trimTo?: string;
   trimToLines?: number[];
   source?: string;
   note?: string;
@@ -90,6 +92,12 @@ function validateFixture(value: unknown, file: string): Fixture {
     action: action as VerdictAction,
     category: category as SlopCategory | null,
   };
+  if (record.trimTo != null) {
+    if (typeof record.trimTo !== "string" || record.trimTo.length === 0 || action !== "trim") {
+      throw new Error(`Fixture ${file} "trimTo" must be a non-empty string on a "trim" fixture`);
+    }
+    fixture.trimTo = record.trimTo;
+  }
   if (typeof record.rewrite === "string") fixture.rewrite = record.rewrite;
   if (Array.isArray(record.trimToLines)) fixture.trimToLines = record.trimToLines as number[];
   if (typeof record.source === "string") fixture.source = record.source;

--- a/plugins/comments/evals/fixtures/README.md
+++ b/plugins/comments/evals/fixtures/README.md
@@ -18,6 +18,7 @@ the voice/rewrite cases.
   "action": "trim",
   "category": "restate-the-what",
   "rewrite": null,
+  "trimTo": "# the kept comment, rewritten to stand alone",
   "trimToLines": [1],
   "source": "jacob/!680 get_records.py:1116",
   "note": "Ben's review note or the rationale for the label"
@@ -32,8 +33,13 @@ the voice/rewrite cases.
 - `rewrite`: for a `rewrite` fixture, the owner's gold de-voiced text, for hand
   spot-checks. The gate scores the predicted action; rewrite text is checked by
   hand. `null` otherwise.
-- `trimToLines`: optional, only for mixed blocks where some lines are a genuine
-  why and others are slop. The lines worth keeping (relative to the comment).
+- `trimTo`: optional, only for mixed blocks where part is a genuine why and the
+  rest is slop: the owner's gold kept-comment text, rewritten to read as complete
+  sentences. Like `rewrite`, it is for hand spot-checks; the gate scores the
+  action.
+- `trimToLines`: the deprecated line-range form of a partial trim, kept where a
+  fixture also exercises the applier's compat path. The lines worth keeping
+  (relative to the comment).
 - `context`: real source, line-numbered, so the judge can answer the
   what-on-dense question.
 

--- a/plugins/comments/evals/fixtures/migration-data-migration-mixed.json
+++ b/plugins/comments/evals/fixtures/migration-data-migration-mixed.json
@@ -7,6 +7,7 @@
   "context": "59: \n60:     # Data migration: Convert tool-{name} types to tool_call/tool_return\n61:     # Tool calls have tool_args, tool returns have tool_content\n62:     op.execute(\"\"\"\n63:         UPDATE message_parts\n64:         SET type = CASE\n65:             WHEN tool_content IS NOT NULL THEN 'tool_return'\n66:             ELSE 'tool_call'\n67:         END\n68:         WHERE type LIKE 'tool-%'\n69:     \"\"\")",
   "action": "trim",
   "category": "restate-the-what",
+  "trimTo": "# Tool calls have tool_args, tool returns have tool_content",
   "trimToLines": [
     2
   ],

--- a/plugins/comments/evals/fixtures/queue-retry-backoff-midline-trim.json
+++ b/plugins/comments/evals/fixtures/queue-retry-backoff-midline-trim.json
@@ -1,0 +1,12 @@
+{
+  "id": "queue-retry-backoff-midline-trim",
+  "path": "src/queue/retry.py",
+  "language": "python",
+  "kind": "line",
+  "comment": "# Walk the pending queue in insertion order and retry each entry, reusing\n    # the same backoff the first attempt chose: the broker rate-limits per key.",
+  "context": "12: def retry_pending(queue: PendingQueue) -> None:\n13:     # Walk the pending queue in insertion order and retry each entry, reusing\n14:     # the same backoff the first attempt chose: the broker rate-limits per key.\n15:     for entry in queue.pending():\n16:         send(entry, backoff=entry.backoff)\n17:",
+  "action": "trim",
+  "category": "restate-the-what",
+  "trimTo": "# Retries reuse the first attempt's backoff: the broker rate-limits per key.",
+  "note": "Mixed block whose sentence boundary lands mid-line. The walk-and-retry clause restates the loop below; the kept why (broker rate-limits per key) starts mid-sentence on line 1 and continues onto line 2, so a line-range trim of either line strands a fragment. The gold trimTo rewrites the kept clause to stand alone."
+}

--- a/plugins/comments/judge/judge.test.ts
+++ b/plugins/comments/judge/judge.test.ts
@@ -47,6 +47,49 @@ describe("parseVerdict", () => {
     expect(() => parseVerdict(raw({ action: "delete" }), "x")).toThrow(/"action" must be one of/);
   });
 
+  test.each<{ name: string; over: Record<string, unknown>; error?: RegExp; trimTo?: string }>([
+    {
+      name: "accepts trimTo on a trim verdict",
+      over: { trimTo: "# the kept why" },
+      trimTo: "# the kept why",
+    },
+    {
+      name: "accepts a trim verdict without trimTo (whole-comment delete)",
+      over: {},
+    },
+    {
+      name: "rejects an empty trimTo",
+      over: { trimTo: "" },
+      error: /"trimTo" must be a non-empty string/,
+    },
+    {
+      name: "rejects a non-string trimTo",
+      over: { trimTo: [2] },
+      error: /"trimTo" must be a non-empty string/,
+    },
+    {
+      name: "rejects trimTo on keep",
+      over: { action: "keep", category: null, trimTo: "# stray" },
+      error: /"trimTo" is only valid when action is "trim"/,
+    },
+    {
+      name: "rejects trimTo on rewrite",
+      over: { action: "rewrite", category: "voice", rewrite: "// fact", trimTo: "# stray" },
+      error: /"trimTo" is only valid when action is "trim"/,
+    },
+  ])("$name", ({ over, error, trimTo }) => {
+    if (error) {
+      expect(() => parseVerdict(raw(over), "x")).toThrow(error);
+      return;
+    }
+    const v = parseVerdict(raw(over), "x");
+    if (trimTo) {
+      expect(v.trimTo).toBe(trimTo);
+    } else {
+      expect(v.trimTo).toBeUndefined();
+    }
+  });
+
   test("preserves suggestedFix and numeric trimToLines", () => {
     const v = parseVerdict(raw({ suggestedFix: "drop it", trimToLines: [1, "x", 3] }), "x");
     expect(v.suggestedFix).toBe("drop it");

--- a/plugins/comments/judge/judge.ts
+++ b/plugins/comments/judge/judge.ts
@@ -70,6 +70,14 @@ export function parseVerdict(value: unknown, label: string | number): Verdict {
   if (action !== "rewrite" && hasRewrite) {
     throw new Error(`Judge verdict ${label} "rewrite" is only valid when action is "rewrite"`);
   }
+  if (record.trimTo != null) {
+    if (typeof record.trimTo !== "string" || record.trimTo.length === 0) {
+      throw new Error(`Judge verdict ${label} "trimTo" must be a non-empty string`);
+    }
+    if (action !== "trim") {
+      throw new Error(`Judge verdict ${label} "trimTo" is only valid when action is "trim"`);
+    }
+  }
   const verdict: Verdict = {
     action,
     category: (record.category ?? null) as SlopCategory | null,
@@ -78,6 +86,7 @@ export function parseVerdict(value: unknown, label: string | number): Verdict {
     rewrite: action === "rewrite" ? (record.rewrite as string) : null,
   };
   if (typeof record.suggestedFix === "string") verdict.suggestedFix = record.suggestedFix;
+  if (typeof record.trimTo === "string") verdict.trimTo = record.trimTo;
   if (Array.isArray(record.trimToLines)) {
     verdict.trimToLines = record.trimToLines.filter(
       (line): line is number => typeof line === "number",

--- a/plugins/comments/judge/prompt.md
+++ b/plugins/comments/judge/prompt.md
@@ -81,7 +81,7 @@ is actually present.
   the query selects, the columns it returns, or the steps it runs is restatement,
   however analytical it reads. Such a header earns `keep` only for the line that
   states a fact the code cannot (a non-obvious data shape, a filter's load-bearing
-  reason). Trim it, or `trimToLines` to that one line, when the rest only
+  reason). Trim it, or keep only that line via `trimTo`, when the rest only
   describes the query in words.
 - **narration**: a diary of the change rather than documentation of the code.
   Migration stories repeated across helpers; roadmap/ticket breadcrumbs
@@ -124,14 +124,17 @@ is actually present.
 
 A single comment block can mix a genuine why with slop restatement. Do not
 keep-or-trim the whole block. When only part is slop, set `action: "trim"` and
-use `trimToLines` to list the 1-based line numbers (within the comment) worth
-keeping; the rest is the slop to drop. When the whole comment should go, omit
-`trimToLines` or leave it empty.
+put the kept comment in `trimTo`: the comment as it should read after the cut,
+rewritten to read as complete sentences, with its delimiters and no leading
+indentation (the same contract as `rewrite`). The cut may land mid-line. A kept
+clause whose sentence started on a dropped line must be rewritten to stand
+alone; never ship a dangling fragment. When the whole comment should go, omit
+`trimTo`.
 
 A genuine why elsewhere in the block does not excuse a clause that restates the
 adjacent code. When a clause paraphrases the mechanics of the code it sits
-against, it is slop even when a neighboring clause is real why. Trim to the
-why-only lines. Reserve `keep` for blocks that are why throughout.
+against, it is slop even when a neighboring clause is real why. Keep only the
+why in `trimTo`. Reserve `keep` for blocks that are why throughout.
 
 ## Output
 
@@ -149,7 +152,7 @@ verdict per comment. Per verdict:
   and the voice you are stripping if rewriting.
 - `rewrite`: for `rewrite` only, the cleaned comment text including its
   delimiters. `null` otherwise.
-- `trimToLines`: only for a partial `trim` of a multi-line block, per above.
+- `trimTo`: only for a partial `trim`, the kept comment rewritten per above.
   `null` otherwise.
 
 When in doubt on a plain comment, keep it: passing a mediocre comment is cheaper

--- a/plugins/comments/judge/schema.ts
+++ b/plugins/comments/judge/schema.ts
@@ -33,8 +33,8 @@ export type SlopCategory = (typeof SLOP_CATEGORIES)[number];
  * What the applier does with a comment.
  *
  * - `keep`: it earns its place and is cleanly written. Leave it.
- * - `trim`: it carries no fact a competent reader lacks. Delete it, or trim to
- *   the worthwhile lines via `trimToLines`.
+ * - `trim`: it carries no fact a competent reader lacks. Delete it, or keep
+ *   only the worthwhile part via `trimTo`.
  * - `rewrite`: it carries a real fact under AI voice. Strip the voice, keep the
  *   fact. `rewrite` holds the de-voiced comment text.
  */
@@ -59,10 +59,18 @@ export interface Verdict {
   /** Present only with `--fix`: a concrete rewrite, trim, or delete suggestion. */
   suggestedFix?: string;
   /**
-   * For a mixed block where only some lines are slop: the lines worth keeping,
-   * numbered 1-based and relative to the comment (line 1 is the comment's first
-   * line). Empty means delete the whole comment. Omitted when the comment is
-   * judged as a single unit.
+   * For a partial `trim`: the kept comment, rewritten as it should read. Same
+   * contract as `rewrite` (delimiters included, no leading indentation), so a
+   * kept clause whose sentence started on a dropped line reads as a complete
+   * sentence, and the cut may land mid-line. Omitted when the whole comment
+   * should go. Preferred over `trimToLines`.
+   */
+  trimTo?: string;
+  /**
+   * Deprecated line-range form of a partial trim, still accepted by the
+   * applier: the lines worth keeping, numbered 1-based and relative to the
+   * comment (line 1 is the comment's first line). Empty means delete the whole
+   * comment. Prefer `trimTo`, which cannot strand a mid-sentence fragment.
    */
   trimToLines?: number[];
 }
@@ -83,6 +91,7 @@ export function verdictSchema(): Record<string, unknown> {
       rationale: { type: "string" },
       rewrite: { anyOf: [{ type: "string" }, { type: "null" }] },
       suggestedFix: { anyOf: [{ type: "string" }, { type: "null" }] },
+      trimTo: { anyOf: [{ type: "string" }, { type: "null" }] },
       trimToLines: {
         anyOf: [{ type: "array", items: { type: "integer" } }, { type: "null" }],
       },

--- a/plugins/comments/skills/audit/SKILL.md
+++ b/plugins/comments/skills/audit/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   comments a change introduced) or a whole repo, ranks by intrinsic complexity,
   fans out judging agents, and applies the trims to a fresh branch. Use when
   reviewing a branch or merge request, or sweeping a slop-heavy codebase.
-argument-hint: "[--all] [--base <ref>] [--mr <iid>] [--path <glob>] [--sort <key>] [--limit <n>] [--report] [--fix]"
+argument-hint: "[--all] [--base <ref>] [--mr <iid>] [--path <glob>] [--sort <key>] [--limit <n>] [--report] [--fix] [--format <template>]"
 disable-model-invocation: true
 allowed-tools:
   - Bash
@@ -48,6 +48,8 @@ compiler directives (`eslint-disable`, `noqa`, `go:generate`), shebang lines,
 and license headers never reach the judge.
 - `--fix`: ask the judge for a concrete suggestion per finding.
 - `--report`: at apply time, print findings instead of writing a branch.
+- `--format <template>`: at apply time, pipe each edited file through a
+  formatter before committing.
 
 ## Preflight
 
@@ -93,7 +95,7 @@ verdicts stay on disk, off the conversation, for `apply` to read.
 ## Apply
 
 ```bash
-bun <plugin-dir>/skills/audit/scripts/audit.ts apply --job <jobDir> [--report] [--fix]
+bun <plugin-dir>/skills/audit/scripts/audit.ts apply --job <jobDir> [--report] [--fix] [--format <template>]
 ```
 
 Default apply re-extracts the judged files and matches verdicts to comments by
@@ -101,13 +103,43 @@ id at their current position, applies the trims and rewrites, and commits to a
 fresh `comments/audit-<hash>` branch off HEAD. The commit is built with git
 plumbing, so the working tree is never modified and the current branch stays
 checked out. A `rewrite` replaces the comment span in place with the de-voiced
-text, so the diff shows the cleaned comment. A comment that moved or changed
+text, so the diff shows the cleaned comment. A partial trim carries the kept
+comment as rewritten text (`trimTo`) and is spliced the same way; a legacy
+line-range trim (`trimToLines`) that would strand a mid-sentence fragment is
+refused and listed for manual handling instead. A comment that moved or changed
 since preflight gets a new id, matches no verdict, and is skipped. Review the
 result with `git diff HEAD..comments/audit-<hash>`. Apply requires a clean
-working tree.
+working tree. The success message and `--report` both open with a
+`N delete / M trim / K rewrite across F files` split: a `trim` that keeps
+nothing is reported as `delete`.
 
 `--report` prints the findings grouped by file (`path:line  action  category
-confidence  rationale`, with an old → new preview for each rewrite) and writes
-nothing. Use it to review before applying, or on a dirty tree. Comments the
-applier cannot change safely (a comment interleaved with code, a trim that would
-break a block delimiter) are left in place and listed for manual handling.
+confidence  rationale`, with an old → new preview for each rewrite and a
+`keep:` preview for each partial trim) and writes nothing. Use it to review
+before applying, or on a dirty tree.
+
+### Formatting
+
+The applier splices lines without running a formatter, which can leave debris a
+formatter would fix (a stray blank, a collapsed trailing comment past the line
+width). `--format` takes a shell command template: `{}` is replaced with the
+repo-relative path, the file's new content is piped on stdin, stdout is taken as
+the formatted content, and the command runs from the repo root. A non-zero exit
+warns and keeps the unformatted content. Examples:
+
+```bash
+--format 'ruff format --stdin-filename {} -'
+--format 'prettier --stdin-filepath {}'
+```
+
+Pick the formatter from the target repo's own configuration and pass it
+explicitly, or omit the flag. NEVER guess at, auto-discover, or auto-execute a
+formatter the repo does not configure.
+
+### Manual Handling
+
+Comments the applier cannot change safely are left in place and listed for
+manual handling: a comment interleaved with code, a trim that would break a
+block delimiter, and a line-range trim whose kept line would open mid-sentence.
+Applier-produced lines that exceed the width limit are applied but listed as
+warnings to re-wrap by hand.

--- a/plugins/comments/skills/audit/SKILL.md
+++ b/plugins/comments/skills/audit/SKILL.md
@@ -110,8 +110,9 @@ refused and listed for manual handling instead. A comment that moved or changed
 since preflight gets a new id, matches no verdict, and is skipped. Review the
 result with `git diff HEAD..comments/audit-<hash>`. Apply requires a clean
 working tree. The success message and `--report` both open with a
-`N delete / M trim / K rewrite across F files` split: a `trim` that keeps
-nothing is reported as `delete`.
+`N delete / M trim / K rewrite across F files` split, counting only what
+auto-applies: a `trim` that keeps nothing is reported as `delete`, and refused
+verdicts appear as a `, J to manual handling` tail.
 
 `--report` prints the findings grouped by file (`path:line  action  category
 confidence  rationale`, with an old → new preview for each rewrite and a

--- a/plugins/comments/skills/audit/scripts/audit.ts
+++ b/plugins/comments/skills/audit/scripts/audit.ts
@@ -6,8 +6,9 @@ import { $ } from "bun";
 import { cli, command } from "cleye";
 import { applyToBranch, isCleanTree } from "../../../apply/branch";
 import { computeFileEdits, type EditItem } from "../../../apply/edits";
+import { formatContent } from "../../../apply/format";
 import { collectVerdicts, matchVerdicts } from "../../../apply/join";
-import { color, type ReportItem, renderReport } from "../../../apply/report";
+import { color, type ReportItem, renderReport, summarize } from "../../../apply/report";
 import {
   type CollectedComment,
   collectDiff,
@@ -213,11 +214,16 @@ const applyCmd = command(
       job: { type: String, description: "The job dir printed by preflight" },
       report: { type: Boolean, default: false, description: "Print findings instead of applying" },
       fix: { type: Boolean, default: false, description: "Include suggestions in the report" },
+      format: {
+        type: String,
+        description:
+          "Format each edited file through this shell template ({} = path, content on stdin)",
+      },
     },
   },
   async (parsed) => {
     await chdirToRepoRoot();
-    const { job, report, fix } = parsed.flags;
+    const { job, report, fix, format } = parsed.flags;
     if (!job) {
       console.error("--job <dir> is required.");
       process.exit(1);
@@ -250,6 +256,8 @@ const applyCmd = command(
     const editsByPath = new Map<string, string>();
     const matched = new Set<string>();
     const manualSkips: string[] = [];
+    const skippedComments = new Set<string>();
+    const editWarnings: { path: string; line: number; detail: string }[] = [];
 
     // Re-extract each judged file and match verdicts by id at the comment's
     // current range. A verdict whose id no longer re-extracts has drifted.
@@ -272,9 +280,30 @@ const applyCmd = command(
       }
       if (editItems.length > 0) {
         const result = computeFileEdits(source, editItems);
-        for (const skip of result.skips)
+        for (const skip of result.skips) {
           manualSkips.push(`${path}:${skip.startLine}  ${skip.detail}`);
+          skippedComments.add(`${path}:${skip.startLine}`);
+        }
+        for (const warning of result.warnings)
+          editWarnings.push({ path, line: warning.line, detail: warning.detail });
         if (result.content !== source) editsByPath.set(path, result.content);
+      }
+    }
+
+    const formattedPaths = new Set<string>();
+    if (format && !report) {
+      for (const [path, content] of editsByPath) {
+        const formatted = await formatContent(format, path, content);
+        if (formatted.formatted) {
+          editsByPath.set(path, formatted.content);
+          formattedPaths.add(path);
+        } else {
+          console.error(
+            color.yellow(
+              `Formatter failed for ${path} (${formatted.error}); keeping unformatted content.`,
+            ),
+          );
+        }
       }
     }
 
@@ -293,8 +322,13 @@ const applyCmd = command(
         process.exit(1);
       } else {
         await applyToBranch(editsByPath, { branch });
+        // Count only what landed. Verdicts skipped for manual handling show up
+        // in the list below.
+        const applied = reportItems.filter(
+          (item) => !skippedComments.has(`${item.path}:${item.startLine}`),
+        );
         console.log(
-          `Trimmed ${editsByPath.size} file(s) on branch ${color.bold(branch)}. Review with git diff HEAD..${branch}.`,
+          `Applied ${summarize(applied)} on branch ${color.bold(branch)}. Review with git diff HEAD..${branch}.`,
         );
       }
     }
@@ -309,6 +343,14 @@ const applyCmd = command(
     if (manualSkips.length > 0) {
       console.error(color.yellow(`Left ${manualSkips.length} comment(s) for manual handling:`));
       for (const skip of manualSkips) console.error(`  ${skip}`);
+    }
+    // A formatter that succeeded owns line wrapping for its file, so its
+    // over-length warnings are stale.
+    const remainingWarnings = editWarnings.filter((warning) => !formattedPaths.has(warning.path));
+    if (remainingWarnings.length > 0) {
+      console.error(color.yellow(`Applied ${remainingWarnings.length} edit(s) worth re-checking:`));
+      for (const warning of remainingWarnings)
+        console.error(`  ${warning.path}:${warning.line}  ${warning.detail}`);
     }
   },
 );

--- a/plugins/comments/skills/audit/scripts/audit.ts
+++ b/plugins/comments/skills/audit/scripts/audit.ts
@@ -307,6 +307,10 @@ const applyCmd = command(
       }
     }
 
+    for (const item of reportItems) {
+      if (skippedComments.has(`${item.path}:${item.startLine}`)) item.skipped = true;
+    }
+
     const driftSkips = [...verdicts.keys()].filter((id) => !matched.has(id));
 
     if (report) {
@@ -322,13 +326,8 @@ const applyCmd = command(
         process.exit(1);
       } else {
         await applyToBranch(editsByPath, { branch });
-        // Count only what landed. Verdicts skipped for manual handling show up
-        // in the list below.
-        const applied = reportItems.filter(
-          (item) => !skippedComments.has(`${item.path}:${item.startLine}`),
-        );
         console.log(
-          `Applied ${summarize(applied)} on branch ${color.bold(branch)}. Review with git diff HEAD..${branch}.`,
+          `Applied ${summarize(reportItems)} on branch ${color.bold(branch)}. Review with git diff HEAD..${branch}.`,
         );
       }
     }

--- a/plugins/comments/workflow/judge.workflow.js
+++ b/plugins/comments/workflow/judge.workflow.js
@@ -38,7 +38,7 @@ function judgeShard(shard) {
     'Judge every comment in the shard against the rubric. Produce exactly one verdict per comment, keyed by its "id".',
     `Write the object { "verdicts": [{ "id": <comment id>, "verdict": { ... } }] } to this exact path with the Write tool: ${job.verdictsDir}/verdict-${shard.id}.json`,
     'Use the Write tool, not a Bash heredoc: the Bash tool escapes "!" to "\\!", which is not a valid JSON escape and corrupts the file.',
-    "Per verdict include: action (keep | trim | rewrite), category (the failing shape, null for keep), confidence (low | medium | high), rationale (one sentence), rewrite (the de-voiced comment text, only when action is rewrite, else null), and trimToLines (only for a partial trim of a multi-line block).",
+    "Per verdict include: action (keep | trim | rewrite), category (the failing shape, null for keep), confidence (low | medium | high), rationale (one sentence), rewrite (the de-voiced comment text, only when action is rewrite, else null), and trimTo (only for a partial trim: the kept comment rewritten to read as complete sentences, delimiters included, no leading indentation; omit it to delete the whole comment).",
     'Your structured output is only the summary: { "total": <comments judged>, "flagged": <verdicts with action other than keep> }.',
   ].join("\n");
   return agent(prompt, {


### PR DESCRIPTION
The first real `/comments:audit` run confirmed a defect in partial trims. `trimToLines` keeps whole lines, so a kept line whose sentence began on a dropped line ships as a dangling fragment, and line granularity can't express the fix because the slop clause often starts mid-line.

The judge now returns a partial trim as `trimTo`: the kept comment rewritten to read as complete sentences, under the same contract as `rewrite` (delimiters included, no leading indentation). The applier splices it through the same span-replacement path as rewrites. Fragments become structurally impossible on the new path. `trimToLines` stays as a deprecated compat path with a sentence-connective guard: a kept line opening with a continuation word after a dropped line that lacks terminal punctuation goes to manual handling.

The apply step picks up the other lessons from that run:

- `--format <template>` pipes each edited file through a repo-configured formatter (`{}` = path, content on stdin, stdout = result). A non-zero exit or empty output keeps the unformatted content. The skill instructs the driving agent to take the formatter from the target repo's config and never auto-discover one.
- Applier-produced lines over a width limit surface as warnings, suppressed for files a formatter handled. A blank left directly under a `def f():`-style opener by a deleted comment is collapsed.
- Reports and the apply message open with a `N delete / M trim / K rewrite across F files` split. A `trim` that keeps nothing renders as `delete`, partial trims show a `keep:` preview, and the applied count excludes verdicts routed to manual handling.

Sanity-checked end to end on a scratch repo: preflight, hand-written verdicts covering a `trimTo` splice, a fragment-trap `trimToLines`, and a full delete, then `apply --report` and `apply --format cat` with the branch diff, manual-handling entry, and summary split verified.

The prompt sha changes and no `ANTHROPIC_API_KEY` was available in this environment, so the eval gate (`bun run plugins/comments/evals/eval.ts --gate`) needs a re-clear before merge.

Original Task: [BUG: comment-audit partial trims produce dangling sentence fragments](https://things.bendrucker.me/show?id=Vfi9KoMc84Y5bKLtxysopf)
Original Task: [Improve comment-audit skill: lessons from first run](https://things.bendrucker.me/show?id=4TLNejiPwhsyGGBahpnt2F)
