### PR TITLE
ci: dedicated matrix job and narrower always-paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,6 @@ jobs:
 
   validate:
     runs-on: ubuntu-latest
-    outputs:
-      plugins: ${{ steps.list.outputs.plugins }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -102,17 +100,27 @@ jobs:
           Consider adding these to \`enabledPlugins\` if they should be active." || true
           fi
 
+  plugins-list:
+    runs-on: ubuntu-latest
+    outputs:
+      plugins: ${{ steps.list.outputs.plugins }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - uses: ./.github/actions/bun-install
+
       - name: List local plugins
         id: list
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           always_args=(
-            --always=schemas/
-            --always=scripts/
+            --always=scripts/list-plugins.ts
+            --always=packages/marketplace/
+            --always=packages/skill-lint/
             --always=.github/workflows/test.yml
             --always=.claude-plugin/marketplace.json
-            --always=.claude/settings.json
           )
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             readarray -t files < <(gh pr view ${{ github.event.pull_request.number }} --json files -q '.files[].path')
@@ -123,14 +131,14 @@ jobs:
           echo "plugins=$plugins" >> "$GITHUB_OUTPUT"
 
   plugin:
-    needs: validate
-    if: needs.validate.outputs.plugins != '[]'
+    needs: plugins-list
+    if: needs.plugins-list.outputs.plugins != '[]'
     runs-on: ${{ matrix.plugin.runner }}
     timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
-        plugin: ${{ fromJson(needs.validate.outputs.plugins) }}
+        plugin: ${{ fromJson(needs.plugins-list.outputs.plugins) }}
     env:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     steps:
@@ -217,13 +225,13 @@ jobs:
         run: find "./plugins/${{ matrix.plugin.name }}" -name '*.integration.ts' -exec bun test {} +
 
   plugins:
-    needs: [validate, plugin]
+    needs: [plugins-list, plugin]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:
       - name: Check plugin results
         run: |
-          if [[ "${{ needs.validate.outputs.plugins }}" == "[]" ]]; then
+          if [[ "${{ needs.plugins-list.outputs.plugins }}" == "[]" ]]; then
             echo "No plugins to test"
             exit 0
           fi
@@ -284,6 +292,8 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install Claude Code CLI
+        id: cli
+        background: true
         run: curl -fsSL https://claude.ai/install.sh | bash
 
       - name: Setup Claude configuration
@@ -292,6 +302,9 @@ jobs:
           for item in user/*; do
             ln -sfn "$GITHUB_WORKSPACE/$item" "$HOME/.claude/$(basename "$item")"
           done
+
+      - name: Wait for CLI
+        wait: cli
 
       - name: Generate context report
         run: |


### PR DESCRIPTION
Cuts PR CI wall-clock by starting the plugin matrix earlier and scheduling it far less often. Timing over the last 27 runs showed a serial chain (`validate` ~25–32s → matrix → gate) on every plugin-touching PR, and a 282s worst case caused entirely by a queued macOS runner on a full-matrix run.

The always-paths that force all 36 plugin jobs were stale: `scripts/`, `schemas/`, and `.claude/settings.json` only feed checks in `validate`, which runs unconditionally anyway. The blanket `scripts/` entry dates from #216 when the matrix generator lived there. Meanwhile `packages/marketplace` and `packages/skill-lint`, which matrix generation and the per-plugin lint actually depend on, were not always-paths at all. The new list covers the real dependencies, so script/schema/settings-only PRs now run zero plugin jobs (and zero macOS jobs, which is where the queue tail lives). Pushes to `main` still run the full matrix via the no-args path in `list-plugins.ts`, so integrated coverage is unchanged.

Matrix generation moves into a minimal `plugins-list` job so the matrix starts after checkout plus install instead of behind `validate`'s twelve check steps. Plugin jobs are independent validations, so nothing depended on that ordering. Failure semantics of the `plugins` gate are unchanged: a failed `plugins-list` produces an empty output and a skipped matrix, which the gate still fails on. The `context` job also gets the same `background: true` CLI-install overlap the `plugin` job already uses.

Verified locally that `list-plugins.ts` with the new always-paths returns `[]` for a script-only change, the full list for a `packages/marketplace` change, and the single plugin for a plugin change. This PR touches `test.yml` (an always-path), so its own run exercises `plugins-list`, the full matrix, and the gate end to end.

Considered and deferred: consolidating the three macOS matrix entries into one job (loses per-plugin feedback, and after this change PRs rarely schedule macOS jobs at all) and shallow-cloning `coverage` (its diff needs the merge base).
