### PR TITLE
plan: add a ⏰ check-in marker for future work

### DIFF
--- a/plugins/plan/references/guidelines.md
+++ b/plugins/plan/references/guidelines.md
@@ -87,10 +87,11 @@ Before naming symbols, files, directories, or headings, check what already gover
 
 ## Checkpoints
 
-A checkpoint is a line the plan marks with an emoji so execution stops at it and does something before continuing past. Two kinds, each with its own marker and discipline:
+A checkpoint is a line the plan marks with an emoji. Three kinds, each with its own marker and discipline:
 
 - `✋` a human checkpoint: hand back for a read.
 - `🧪` a verification checkpoint: run a named check and confirm its signal.
+- `⏰` a check-in checkpoint: schedule a future look at work that needs time to prove out.
 
 Every marker is load-bearing in both directions, not decoration. When execution reaches a marked line it honors the marker before continuing past. Because each line states its instruction in plain words, a session that executes the plan without this guidance in context still honors it. The user may add a marker by hand, including on a line the plan did not mark, to insert a checkpoint the plan missed. A hand-added checkpoint is honored exactly like an authored one. These emoji are the only ones the plan carries. Add a new marker type only by defining its discipline here first.
 
@@ -111,12 +112,20 @@ Do not defer every check to the end. When a slice must hold before the next is b
 - Write each as a runnable check naming its signal, the same before/after shape as `Verification`: `🧪 Verify: <signal> via <command> before <what continues>`.
 - When execution reaches the line, run the check. If the signal matches, continue. If it does not, stop and surface the gap instead of building on it.
 
+### `⏰` Check-in Checkpoints
+
+Some outcomes cannot be known by the time execution ends because they need elapsed time. Mark the point where the work is done but unproven and schedule the look, so the intent does not die with the session.
+
+- Place one only where waiting is the point: a rollout soaking under real traffic, a migration settling, an upstream fix landing. If the check can run now, it is a `🧪`.
+- Write each as `⏰ Check in: schedule <what to look at> in your task manager for <absolute date>`. The date is when to look again, not an estimate of how long the work takes. Execution creates the item at that line and continues past without stopping.
+- Give the scheduled item what a fresh session needs to re-enter: where the work lives and how to resume it. It fires with none of this context.
+
 ## Pauses
 
 A pause or bare interrupt in plan mode is a stop signal. Present and wait. Do not edit silently and re-submit.
 
 ## Carryovers
 
-- No time estimates.
+- No time estimates. A `⏰` check-in date is not one (see `Checkpoints`).
 - Reference skills inline where they run ("use `pull-request:create` after committing", "load `git:conflicts` when a rebase or merge hits conflicts") rather than in a separate list.
 - Document out-of-scope observations separately. Keep them out of the change.

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -46,10 +46,10 @@ Schedule `⏰` plan check-ins in Things with `things:url add`, which unlike inbo
 Notes carry what to check, the plan path, the repo, and a launch URL:
 
 ```
-claude-cli://open?q=<encoded prompt>&cwd=<absolute main repo path>
+claude-cli://open?q=<url-encoded prompt>&cwd=<absolute main repo path>
 ```
 
-- `open` is the only action. Use `q` for the prompt and `cwd` for the working directory.
+- `open` is the only action. Use `q` for the prompt and `cwd` for the working directory. Both are ordinary percent-encoded query params. The handler base64-encodes them itself when it builds the session's argv.
 - The URL prefills a new session's prompt without submitting it, and cannot resume the original session.
 - Point `cwd` at the main repo, never a worktree. Worktrees get pruned.
 

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -39,6 +39,20 @@ Every customization costs tokens on every session. Before adding one, define how
 
 The Bash tool escapes `!` to `\!` on every path, including single quotes and heredocs, breaking `jq !=`, `awk !~`, and similar operators ([#2941](https://github.com/anthropics/claude-code/issues/2941), [#10335](https://github.com/anthropics/claude-code/issues/10335)). For `jq`, use `| not` instead of `!=`. For anything else, author the content with the Write tool, then run it. No shell quoting or heredoc bypasses the escape.
 
+## Check-ins
+
+Schedule `⏰` plan check-ins in Things with `things:url add`, which unlike inbox capture can set `when=<yyyy-mm-dd>`. Tag them `claude-code`. Things is the only tracker that can raise work on a future date, so work-tracked check-ins go there too, linking their Linear issue in the notes.
+
+Notes carry what to check, the plan path, the repo, and a launch URL:
+
+```
+claude-cli://open?q=<encoded prompt>&cwd=<absolute main repo path>
+```
+
+- `open` is the only action. Use `q` for the prompt and `cwd` for the working directory.
+- The URL prefills a new session's prompt without submitting it, and cannot resume the original session.
+- Point `cwd` at the main repo, never a worktree. Worktrees get pruned.
+
 ## Git
 
 - Never `git push` to the default branch (usually `main` or `master`) unless I explicitly instruct you.


### PR DESCRIPTION
Adds `⏰`, a third checkpoint marker in `plugins/plan/references/guidelines.md`, for work whose outcome needs elapsed time to prove out: a rollout soaking, a migration settling, an upstream fix landing. It follows `✋` and `🧪`'s discipline, plain language a session honors even without the guidelines file in context. Execution creates the scheduled item and moves on, no stopping.

The routing that delivers a `⏰` lives elsewhere, in `user/CLAUDE.md`. Both plan-mode injectors gate on `permission_mode == "plan"`, so `guidelines.md` has left context by the time a `⏰` fires at execution. `user/CLAUDE.md` stays always-on, so it survives to that moment. `plugins/plan` ships through the marketplace too, so its marker text just says "your task manager" and names nothing specific.

Things is the unconditional target. Linear's issue `dueDate` marks lateness, and Linear has no field for a future activation date on an issue. `snoozedUntilAt` sits scoped to Triage, unreachable through the connector or `linear-cli`. Things `when=<yyyy-mm-dd>` is the only primitive that raises work on a future date, so every check-in goes to that single backend. Work-tracked check-ins land there too, with their Linear issue linked in the notes.

The scheduled Things item carries a `claude-cli://open` launch URL. `q` holds the prompt, `cwd` the working directory. Both are ordinary percent-encoded query params, and the handler base64url-encodes them itself when building argv. The URL prefills a new session's prompt without submitting it, and it cannot resume the original session. `cwd` points at the main repo, never a worktree, since worktrees get pruned.

Nothing here builds the removal signal the Curation rule expects. The `claude-code` tag makes `⏰` usage queryable, through `things:jxa` or the session index. The real dogfood is simpler: a genuine check-in on whether this marker earns its context cost.
