### PR TITLE
settings: report WorktreeRemove success when the worktree is already gone

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -76,6 +76,16 @@
     "deny": []
   },
   "hooks": {
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'p=$(jq -er .worktree_path) || exit 1; [ -e \"$p\" ] && exit 1; exit 0'"
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "matcher": "*",


### PR DESCRIPTION
Removing a worktree out of band (`wt sync --prune`, a post-merge hook, `wt remove` from inside it) permanently stranded its agent session in the fleet view, which refused to delete it with "could not be removed".

The removal fails precisely because the worktree is already gone. `removeAgentWorktree` branches on the job's `worktreeHookBased` flag. The plain git branch runs `git worktree remove --force`, then re-checks with `lstat` when that fails, so a missing directory falls through and reports success. It self-heals. The hook branch has no such check: `executeWorktreeRemoveHook` is driven purely by exit code and never stats the path. The worktrunk plugin's hook runs `wt remove` against a path that no longer resolves to a worktree, worktrunk falls back to treating the argument as a branch name, and it exits 1. The job keeps its stale `worktreePath` forever, so no amount of retrying can clear it.

Hook results are OR'd across every configured hook. A guard that succeeds only when the path is already absent therefore recovers the stranded job without masking a real failure, since it claims success only when the directory genuinely is not there and contributes nothing when it is.

Updating the worktrunk plugin does not fix this. v0.65.0 drops the `-D` and quotes the path properly, but fails identically against an absent path.

Verified against the command as stored here, fed real hook payloads:

- gone path exits 0
- existing path exits 1
- malformed input exits 1
- path containing spaces stays quoted

Remove this once either upstream fix lands: hook-based removal statting the path the way the git path already does, or `wt remove` exiting 0 for an already-absent worktree.
