### PR TITLE
atuin: shell-history plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -178,6 +178,11 @@
       "name": "activitywatch",
       "description": "Query local ActivityWatch usage data: per-app time, window titles, and active vs idle spans",
       "source": "./plugins/activitywatch"
+    },
+    {
+      "name": "atuin",
+      "description": "Query local shell history from atuin: recent commands, usage stats, and ad-hoc SQL over the history db",
+      "source": "./plugins/atuin"
     }
   ]
 }

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -37,7 +37,7 @@ Treat this section as a trust model, not an exhaustive mirror of `settings.json`
 
 - `allowUnixSockets` should be local IPC endpoints where secret material never leaves a dedicated agent (for example, signing daemons or tmux sockets).
 - `allowLocalBinding` should stay loopback-only.
-- `filesystem.allowWrite` should allow only scratch/cache/worktree paths that tools must mutate, and never credential stores or broad home-directory globs.
+- `filesystem.allowWrite` should allow only scratch/cache/worktree paths that tools must mutate, and never credential stores or broad home-directory globs. `~/.local/share/atuin` is a deliberate exception to the credential-store clause: the dir holds atuin's sync encryption key and the session tokens in `meta.db`. Atuin opens `meta.db` read-write on every command, including the history reads behind the `atuin:history` skill, and SQLite creates journal and WAL files beside its dbs, so a file-level grant would fail intermittently. The sandbox grants no egress to atuin's sync hosts, so the risk is local tampering: a swapped key or token surfaces in a later unsandboxed `atuin sync` rather than exfiltrating directly.
 
 ### Escaped Commands (`excludedCommands`)
 

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -37,7 +37,7 @@ Treat this section as a trust model, not an exhaustive mirror of `settings.json`
 
 - `allowUnixSockets` should be local IPC endpoints where secret material never leaves a dedicated agent (for example, signing daemons or tmux sockets).
 - `allowLocalBinding` should stay loopback-only.
-- `filesystem.allowWrite` should allow only scratch/cache/worktree paths that tools must mutate, and never credential stores or broad home-directory globs. `~/.local/share/atuin` is a deliberate exception to the credential-store clause: the dir holds atuin's sync encryption key and the session tokens in `meta.db`. Atuin opens `meta.db` read-write on every command, including the history reads behind the `atuin:history` skill, and SQLite creates journal and WAL files beside its dbs, so a file-level grant would fail intermittently. The sandbox grants no egress to atuin's sync hosts, so the risk is local tampering: a swapped key or token surfaces in a later unsandboxed `atuin sync` rather than exfiltrating directly.
+- `filesystem.allowWrite` should allow only scratch/cache/worktree paths that tools must mutate, and never credential stores or broad home-directory globs. `~/.local/share/atuin` is a deliberate exception to the credential-store clause: the dir holds atuin's sync encryption key and the session tokens in `meta.db`. Atuin opens `meta.db` read-write on every command, including the history reads behind the `atuin:history` skill, and SQLite creates journal and WAL files beside its dbs, so a file-level grant would fail intermittently. The sandbox grants no egress to atuin's sync hosts, so the risk is local tampering: a swapped key or token would first reach the network through a later unsandboxed `atuin sync`.
 
 ### Escaped Commands (`excludedCommands`)
 

--- a/plugins/atuin/.claude-plugin/plugin.json
+++ b/plugins/atuin/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "atuin",
+  "description": "Query local shell history from atuin: recent commands, usage stats, and ad-hoc SQL over the history db",
+  "author": {
+    "name": "Ben Drucker",
+    "email": "bvdrucker@gmail.com"
+  }
+}

--- a/plugins/atuin/README.md
+++ b/plugins/atuin/README.md
@@ -1,0 +1,19 @@
+# Atuin Plugin
+
+Shell history for Claude Code, from [atuin](https://atuin.sh)'s local capture.
+
+## Contents
+
+- **Skill `history`**: answer "what did I run" questions from atuin's local capture.
+
+## How It Works
+
+Atuin records every shell command (with directory, exit code, duration, and hostname) into a SQLite db at `~/.local/share/atuin/history.db`. The skill queries that capture directly: `atuin search` and `atuin stats` for the common shapes, and a read-only DuckDB `ATTACH` for anything the CLI can't express. No ingest step and no separate index.
+
+## Capture Setup
+
+Capture is provisioned separately by the `atuin` dotfiles topic. This plugin is read-only and assumes capture is already running.
+
+## Curation
+
+The always-on cost is one skill description. If the session index shows `atuin:history` never invoked over a few weeks of "recent activity" questions, drop the plugin from `enabledPlugins`.

--- a/plugins/atuin/skills/history/SKILL.md
+++ b/plugins/atuin/skills/history/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: atuin:history
+description: Report shell history from atuin's local capture. Covers what commands ran, when, where, and how they exited. Use when asked "what commands did I run", "what was I working on in the terminal", "have I ever run X", "how do I usually invoke X", or about recent shell activity, command frequency, or failed commands.
+argument-hint: "[query]"
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Shell History
+
+Report shell activity from atuin's local capture. This skill only reads. Never run subcommands that modify history (`atuin delete`, `atuin search --delete`, `atuin import`).
+
+Arguments are search terms: start with `atuin search $ARGUMENTS`.
+
+## CLI Queries
+
+The default path. `atuin search [query]` prints matching commands, newest first. Useful flags:
+
+- `--after "2 days ago"` / `--before "2026-07-01"`: date bounds, human phrases work
+- `-c/--cwd <dir>`: commands run in a directory (`--exclude-cwd` to invert)
+- `-e/--exit <code>` / `--exclude-exit <code>`: filter by exit code (`--exclude-exit 0` finds failures)
+- `--limit <n>`: cap the result count
+- `-r`: oldest first instead of newest first
+- `-f/--format '{time} {command}'`: also `{directory}`, `{exit}`, `{duration}`, `{relativetime}`, `{user}`, `{host}`
+- `--cmd-only`: bare command text
+- `--search-mode <prefix|full-text|fuzzy|skim>`: `full-text` for exact substring matches, overriding the fuzzy default
+- `--include-duplicates`: repeated identical commands otherwise collapse to the latest
+
+`atuin stats [today|week|month|year]` aggregates the period: top commands with counts. `-c <n>` sets top-N, `-n 2` counts command pairs (sequences) instead of single commands.
+
+`atuin history list` dumps everything, and takes `--cmd-only` and `-f` too.
+
+## Sandbox
+
+Query subcommands work sandboxed: the sandbox grants writes to `~/.local/share/atuin` because atuin opens its metadata db read-write even for searches. Network subcommands (`atuin status`, `sync`, `login`) fail sandboxed. They are never needed to answer history questions, so don't escalate.
+
+## DuckDB
+
+For aggregations the CLI can't express (frequency by directory, time-bucketed histograms, joins against other data):
+
+```bash
+duckdb -c "INSTALL sqlite; LOAD sqlite;
+ATTACH '$HOME/.local/share/atuin/history.db' AS atuin (TYPE sqlite, READ_ONLY);
+SELECT ...;"
+```
+
+Use `$HOME`, not `~` (DuckDB does not expand tildes). `READ_ONLY` is mandatory: the db is WAL-mode with live writers. `INSTALL sqlite` is a local no-op once the extension is cached. A machine without the cache must run it unsandboxed once, since the extension host is not sandbox-reachable.
+
+### Schema
+
+One table, `atuin.history`, one row per invocation:
+
+- `timestamp`: **nanoseconds** since epoch. Convert with `to_timestamp(timestamp / 1e9)`, bound with `timestamp > (epoch(now()) - 86400) * 1e9`
+- `duration`: also nanoseconds
+- `command`, `cwd`, `exit`, `session`, `hostname`: what ran, where, and how
+- `deleted_at`: deletions keep the row. Filter `deleted_at IS NULL`
+- `author`, `intent`: agent attribution, populated only when an agent's shell is hooked

--- a/user/settings.json
+++ b/user/settings.json
@@ -252,7 +252,8 @@
     "bun@bendrucker": true,
     "mermaid@bendrucker": true,
     "typescript-lsp@claude-plugins-official": true,
-    "gopls-lsp@claude-plugins-official": true
+    "gopls-lsp@claude-plugins-official": true,
+    "atuin@bendrucker": true
   },
   "extraKnownMarketplaces": {
     "bendrucker": {
@@ -330,7 +331,8 @@
         "~/.bun/install",
         "~/.npm",
         "~/.local/share/uv",
-        "~/.local/share/graphite"
+        "~/.local/share/graphite",
+        "~/.local/share/atuin"
       ]
     },
     "excludedCommands": [


### PR DESCRIPTION
Adds an `atuin` plugin with one skill, `atuin:history`, so shell-history questions ("what did I run", "what was I working on in the terminal") route to atuin. The skill covers `atuin search` and `atuin stats` as the default path and a read-only DuckDB `ATTACH` for aggregations the CLI can't express. It's modeled on `activitywatch`, minus the wrapper scripts and named queries. It also ships enabled in `enabledPlugins`. That's the step activitywatch skipped, and why it routes nothing today.

## Sandbox Write Grant

atuin 18.17 opens `meta.db` read-write and chmods it on every command, including reads (`crates/atuin-client/src/meta.rs:70`). Every sandboxed query fails with EPERM. This adds `~/.local/share/atuin` to `sandbox.filesystem.allowWrite`, a deliberate divergence from the approved plan, which verified a sandboxed `atuin search` before the 18.17 upgrade introduced `meta.db`.

The grant is directory-scoped rather than `meta.db` alone because SQLite creates journal and WAL files beside its dbs, so a file-level grant would fail intermittently whenever atuin writes its version-check or sync timestamps. The directory holds atuin's sync key and session tokens, which the trust-model rule says never to make writable. The rule now documents the exception and its boundary: the sandbox grants no egress to atuin's sync hosts, so the residual risk is local tampering, and a swapped key or token would first reach the network through a later unsandboxed `atuin sync`.

## Verification

- Routing: a headless `claude --plugin-dir ./plugins/atuin --setting-sources local -p "what was I working on in the terminal yesterday?"` session invoked `atuin:history` as its first action and ran correctly-bounded `atuin search` commands. The permission denials it then hit are artifacts of the stripped-down harness, which loads no sandbox config.
- Every documented flag was checked against `atuin search --help` and `atuin stats --help`, and the schema claims (nanosecond `timestamp` and `duration`, `deleted_at`, `author`/`intent`) against the live db.
- The DuckDB path runs sandboxed today because the `sqlite` extension is already cached. `INSTALL sqlite` resolves against `extensions.duckdb.org`, which is not sandbox-reachable, so the skill documents a one-time unsandboxed install instead of widening egress.
- The sandboxed `atuin search` fix is only observable after this merges: the live `~/.claude` symlinks to the main checkout, so current sessions still run the old sandbox profile.
