### PR TITLE
github: resolve the watched repo from the PR URL

### DIFF
--- a/plugins/github/skills/actions-monitor/SKILL.md
+++ b/plugins/github/skills/actions-monitor/SKILL.md
@@ -25,7 +25,7 @@ Watch a PR, branch, or specific run's GitHub Actions progress and react to failu
 
 Accepted forms:
 
-- A GitHub PR URL (e.g. `https://github.com/owner/repo/pull/42`) runs in **PR mode**.
+- A GitHub PR URL (e.g. `https://github.com/owner/repo/pull/42`) runs in **PR mode**. The owner and repo come from the URL, so PR mode watches the right PR from any working directory.
 - A branch name (e.g. `main`) runs in **branch mode**. The script infers the repo from `git remote get-url origin` in the current directory; pass `--repo <owner/repo>` to override.
 - A run ID (e.g. `12345678`) runs in **run-id mode**, watching a specific workflow run directly. Covers `workflow_dispatch`, manually-triggered, and re-run cases where the run ID is known. The repo is inferred from the git remote; pass `--repo <owner/repo>` to override.
 - No argument: derive the current PR from the current branch with `gh pr view --json url --jq '.url'`. If the branch has no PR, fall back to branch mode with the current branch name.

--- a/plugins/github/skills/actions-monitor/scripts/watch.test.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.test.ts
@@ -379,7 +379,7 @@ describe("resolveMergeable", () => {
       { match: "gh pr view 42", result: ok(mergeJson("UNKNOWN", "UNKNOWN")) },
       { match: "gh pr view 42", result: ok(mergeJson("CONFLICTING", "DIRTY")) },
     ]);
-    const resolved = await resolveMergeable(42, exec, noopSleep);
+    const resolved = await resolveMergeable(42, "owner/repo", exec, noopSleep);
     expect(resolved).toEqual({ mergeable: "CONFLICTING", mergeStateStatus: "DIRTY" });
     expect(remaining()).toEqual([]);
   });
@@ -390,7 +390,7 @@ describe("resolveMergeable", () => {
       result: ok(mergeJson("UNKNOWN", "UNKNOWN")),
     }));
     const { exec, remaining } = makeExec(scripted);
-    const resolved = await resolveMergeable(42, exec, noopSleep);
+    const resolved = await resolveMergeable(42, "owner/repo", exec, noopSleep);
     expect(resolved).toEqual({ mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" });
     expect(remaining()).toEqual([]);
   });
@@ -598,9 +598,9 @@ describe("probePr (gh schema integration)", () => {
     const { exec, remaining } = makeExec([
       { match: "gh pr view 42", result: ok(prJson) },
       { match: "gh pr checks 42", result: ok(checksJson) },
-      { match: "gh run list --branch feature/x", result: ok("999") },
+      { match: "gh run list --repo owner/repo --branch feature/x", result: ok("999") },
     ]);
-    const result = probePr(42, exec);
+    const result = probePr(42, "owner/repo", exec);
     expect(result.kind).toBe("ok");
     if (result.kind !== "ok") return;
     expect(result.probe.state).toBe("success");
@@ -625,11 +625,44 @@ describe("probePr (gh schema integration)", () => {
       if (command.startsWith("gh run list")) return ok("");
       throw new Error(`unexpected: ${command}`);
     };
-    probePr(42, recordingExec);
+    probePr(42, "owner/repo", recordingExec);
     const checksCall = seen.find((c) => c.startsWith("gh pr checks"));
     expect(checksCall).toBeDefined();
     expect(checksCall).toContain("--json state,bucket,name");
     expect(checksCall).not.toContain("conclusion");
+  });
+
+  it("targets the PR's own repo rather than the ambient checkout (regression)", () => {
+    // Every gh call must name the repo. Without --repo, gh resolves the repo
+    // from the working directory's remote, so watching a PR in one repo from a
+    // checkout of another silently reports the wrong PR's state: same number,
+    // different repo. That misfire is indistinguishable from a normal event
+    // stream: a long-merged PR at that number emits success and merged at once.
+    const seen: string[] = [];
+    const recordingExec: ExecFn = (command) => {
+      seen.push(command);
+      if (command.startsWith("gh pr view")) {
+        return ok(
+          JSON.stringify({
+            headRefOid: "abc123",
+            headRefName: "feature/x",
+            state: "OPEN",
+            mergeable: "MERGEABLE",
+            mergeStateStatus: "CLEAN",
+          }),
+        );
+      }
+      if (command.startsWith("gh pr checks")) {
+        return ok(JSON.stringify([{ state: "SUCCESS", bucket: "pass", name: "x" }]));
+      }
+      if (command.startsWith("gh run list")) return ok("999");
+      throw new Error(`unexpected: ${command}`);
+    };
+    probePr(42, "owner/repo", recordingExec);
+    expect(seen).not.toBeEmpty();
+    for (const command of seen) {
+      expect(command).toContain("--repo owner/repo");
+    }
   });
 
   it("emits state=failing when any check is in fail bucket", () => {
@@ -642,7 +675,7 @@ describe("probePr (gh schema integration)", () => {
       { match: "gh pr checks", result: ok(checksJson) },
       { match: "gh run list", result: ok("123") },
     ]);
-    const result = probePr(42, exec);
+    const result = probePr(42, "owner/repo", exec);
     expect(result.kind).toBe("ok");
     if (result.kind !== "ok") return;
     expect(result.probe.state).toBe("failing");
@@ -658,7 +691,7 @@ describe("probePr (gh schema integration)", () => {
       { match: "gh pr checks", result: ok(checksJson) },
       { match: "gh run list", result: ok("123") },
     ]);
-    const result = probePr(42, exec);
+    const result = probePr(42, "owner/repo", exec);
     expect(result.kind).toBe("ok");
     if (result.kind !== "ok") return;
     expect(result.probe.state).toBe("queued");
@@ -674,7 +707,7 @@ describe("probePr (gh schema integration)", () => {
       { match: "gh pr view", result: ok(prJson) },
       { match: "gh pr checks", result: ghError },
     ]);
-    const result = probePr(42, exec);
+    const result = probePr(42, "owner/repo", exec);
     expect(result.kind).toBe("error");
     if (result.kind !== "error") return;
     expect(result.stderr).toContain("Unknown JSON field");
@@ -683,7 +716,7 @@ describe("probePr (gh schema integration)", () => {
 
   it("returns kind=error when gh pr view emits unparseable JSON", () => {
     const { exec } = makeExec([{ match: "gh pr view", result: ok("not json") }]);
-    const result = probePr(42, exec);
+    const result = probePr(42, "owner/repo", exec);
     expect(result.kind).toBe("error");
   });
 
@@ -694,7 +727,7 @@ describe("probePr (gh schema integration)", () => {
       mergeable: "MERGEABLE",
     });
     const { exec } = makeExec([{ match: "gh pr view", result: ok(partialJson) }]);
-    const result = probePr(42, exec);
+    const result = probePr(42, "owner/repo", exec);
     expect(result.kind).toBe("error");
     if (result.kind !== "error") return;
     expect(result.stderr).toContain("headRefName");

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -307,12 +307,13 @@ function mergeabilityUndetermined(m: Mergeability): boolean {
 // the caller should fall back to a local merge dry-run.
 export async function resolveMergeable(
   prNumber: number,
+  repo: string,
   run: ExecFn = exec,
   sleepFn: (ms: number) => Promise<void> = sleep,
 ): Promise<Mergeability> {
   let current: Mergeability = { mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" };
   for (let attempt = 0; attempt < MERGEABLE_UNKNOWN_RETRIES; attempt += 1) {
-    const result = run(`gh pr view ${prNumber} --json mergeable,mergeStateStatus`);
+    const result = run(`gh pr view ${prNumber} --repo ${repo} --json mergeable,mergeStateStatus`);
     if (result.ok) {
       const parsed = parseMergeability(result.stdout);
       if (parsed) {
@@ -377,9 +378,9 @@ export type Probed =
   | { kind: "empty" }
   | { kind: "not-found"; stderr: string };
 
-export function probePr(prNumber: number, run: ExecFn = exec): Probed {
+export function probePr(prNumber: number, repo: string, run: ExecFn = exec): Probed {
   const prResult = run(
-    `gh pr view ${prNumber} --json headRefOid,headRefName,state,mergeable,mergeStateStatus`,
+    `gh pr view ${prNumber} --repo ${repo} --json headRefOid,headRefName,state,mergeable,mergeStateStatus`,
   );
   if (!prResult.ok) {
     return {
@@ -416,7 +417,9 @@ export function probePr(prNumber: number, run: ExecFn = exec): Probed {
     return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
 
-  const checksResult = run(`gh pr checks ${prNumber} --required=false --json state,bucket,name`);
+  const checksResult = run(
+    `gh pr checks ${prNumber} --repo ${repo} --required=false --json state,bucket,name`,
+  );
   if (!checksResult.ok) {
     return {
       kind: "error",
@@ -441,7 +444,7 @@ export function probePr(prNumber: number, run: ExecFn = exec): Probed {
   }
 
   const runIdResult = run(
-    `gh run list --branch ${branch} --limit 1 --json databaseId --jq '.[0].databaseId // ""'`,
+    `gh run list --repo ${repo} --branch ${branch} --limit 1 --json databaseId --jq '.[0].databaseId // ""'`,
   );
   if (!runIdResult.ok) {
     return {
@@ -610,6 +613,7 @@ async function run(options: RunOptions): Promise<void> {
   if (options.mode === "pr") {
     const parsed = parsePrUrl(options.prUrl);
     prNumber = parsed.number;
+    repo = `${parsed.owner}/${parsed.repo}`;
   } else if (options.mode === "branch") {
     repo = options.repo;
     branch = options.branch;
@@ -636,8 +640,8 @@ async function run(options: RunOptions): Promise<void> {
     }
 
     let result: Probed;
-    if (options.mode === "pr" && prNumber !== null) {
-      result = probePr(prNumber);
+    if (options.mode === "pr" && prNumber !== null && repo !== null) {
+      result = probePr(prNumber, repo);
     } else if (options.mode === "branch" && repo !== null && branch !== null) {
       result = probeBranch(repo, branch);
     } else if (options.mode === "run-id" && repo !== null) {
@@ -670,8 +674,13 @@ async function run(options: RunOptions): Promise<void> {
       // Settle mergeability before deriving events so `conflicts` lands in the
       // same cycle as a stale `success`, ahead of the terminal return below.
       let probe = result.probe;
-      if (options.mode === "pr" && prNumber !== null && probeIsUndetermined(probe)) {
-        const resolved = await resolveMergeable(prNumber, exec, sleep);
+      if (
+        options.mode === "pr" &&
+        prNumber !== null &&
+        repo !== null &&
+        probeIsUndetermined(probe)
+      ) {
+        const resolved = await resolveMergeable(prNumber, repo, exec, sleep);
         probe = {
           ...probe,
           mergeable: resolved.mergeable,


### PR DESCRIPTION
PR mode parsed the owner and repo out of the URL, then dropped them and kept only the number:

```ts
const parsed = parsePrUrl(options.prUrl);
prNumber = parsed.number;          // owner/repo discarded
```

Every `gh` call went out bare, so `gh` resolved the repo from the working directory's remote. Watching a PR from a checkout of a *different* repo silently reported a same-numbered PR in the wrong one.

This is not a cosmetic mismatch. It bit me while babysitting `bendrucker.me#541` from a `claude` worktree: the watcher reported `success` and `merged` within seconds, and both were true, of `bendrucker/claude#541`, a PR merged months ago. The event stream is indistinguishable from a real one, and a stale PR at that number reports terminal state on the first poll. I nearly acted on a merge that never happened.

The fix threads `parsePrUrl`'s owner and repo into all four call sites: `gh pr view`, `gh pr checks`, and `gh run list` in `probePr`, plus `gh pr view` in `resolveMergeable`. The `gh run list` call was the one I missed on the first pass, and the regression test is what caught it, so it earns its place. Branch and run-id mode already accepted `--repo` and are untouched.

Worth noting for review: the guard is a loop over every recorded command rather than an assertion per call site, so a fifth `gh` call added later fails the test unless it carries `--repo` too.
