### PR TITLE
biome: enforce useTemplate as an error

### DIFF
--- a/.claude/hooks/biome/index.ts
+++ b/.claude/hooks/biome/index.ts
@@ -338,7 +338,7 @@ async function main(): Promise<void> {
 
   const output = await processInput(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/.claude/hooks/coverage/index.ts
+++ b/.claude/hooks/coverage/index.ts
@@ -90,7 +90,7 @@ async function main(): Promise<void> {
 
   const output = await processPostToolUse(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/.claude/hooks/plugin-deps/index.ts
+++ b/.claude/hooks/plugin-deps/index.ts
@@ -48,7 +48,7 @@ async function main(): Promise<void> {
   if (input.hook_event_name !== "Stop") return;
 
   const output = await processStop(input);
-  if (output) process.stdout.write(JSON.stringify(output) + "\n");
+  if (output) process.stdout.write(`${JSON.stringify(output)}\n`);
 }
 
 if (import.meta.main) {

--- a/.claude/hooks/plugin-imports/index.ts
+++ b/.claude/hooks/plugin-imports/index.ts
@@ -55,7 +55,7 @@ async function main(): Promise<void> {
   if (input.hook_event_name !== "Stop") return;
 
   const output = await processStop(input);
-  if (output) process.stdout.write(JSON.stringify(output) + "\n");
+  if (output) process.stdout.write(`${JSON.stringify(output)}\n`);
 }
 
 if (import.meta.main) {

--- a/.claude/hooks/stop/index.ts
+++ b/.claude/hooks/stop/index.ts
@@ -135,7 +135,7 @@ async function main(): Promise<void> {
 
   const output = await processStop(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/biome.json
+++ b/biome.json
@@ -10,6 +10,7 @@
     "rules": {
       "recommended": true,
       "style": {
+        "useTemplate": "error",
         "noRestrictedImports": {
           "level": "error",
           "options": {
@@ -78,7 +79,7 @@
       }
     },
     {
-      "includes": ["**/scripts/jxa/**/*.js"],
+      "includes": ["**/jxa/**/*.js"],
       "linter": {
         "enabled": false
       }

--- a/evals/review-voice/scripts/report.ts
+++ b/evals/review-voice/scripts/report.ts
@@ -90,7 +90,7 @@ async function main() {
     if (!wanted.includes(label.label)) continue;
     const c = byId.get(id);
     if (!c) continue;
-    const head = `${label.label.toUpperCase()} ${dim(`[${c.host}] ${c.source}${c.line ? ":" + c.line : ""}`)}`;
+    const head = `${label.label.toUpperCase()} ${dim(`[${c.host}] ${c.source}${c.line ? `:${c.line}` : ""}`)}`;
     console.log(label.label === "bad" ? red(head) : green(head));
     if (label.note) console.log(dim(`note: ${label.note}`));
     console.log(c.body);

--- a/plugins/claude-code/skills/skill/scripts/check-lint.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-lint.ts
@@ -50,7 +50,7 @@ async function main(): Promise<void> {
 
   const output = await processPostToolUse(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/plugins/git/scripts/block-default-branch-commit.ts
+++ b/plugins/git/scripts/block-default-branch-commit.ts
@@ -56,7 +56,7 @@ async function main(): Promise<void> {
 
   const output = await processInput(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/plugins/git/skills/conflicts/scripts/check-markers.ts
+++ b/plugins/git/skills/conflicts/scripts/check-markers.ts
@@ -37,7 +37,7 @@ async function main(): Promise<void> {
     const denial = formatOutput(
       `Conflict markers in staged files: ${markers || "run 'git diff --cached --check' for details"}`,
     );
-    process.stdout.write(JSON.stringify(denial) + "\n");
+    process.stdout.write(`${JSON.stringify(denial)}\n`);
   }
 }
 

--- a/plugins/github/scripts/fetch.ts
+++ b/plugins/github/scripts/fetch.ts
@@ -165,7 +165,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/plugins/gitlab/hooks/auth.ts
+++ b/plugins/gitlab/hooks/auth.ts
@@ -30,7 +30,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/plugins/gitlab/scripts/fetch.ts
+++ b/plugins/gitlab/scripts/fetch.ts
@@ -143,7 +143,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/plugins/go/scripts/check.ts
+++ b/plugins/go/scripts/check.ts
@@ -75,7 +75,7 @@ async function main(): Promise<void> {
 
   const output = await processInput(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/plugins/linear/hooks/save-issue.ts
+++ b/plugins/linear/hooks/save-issue.ts
@@ -113,7 +113,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/plugins/linear/scripts/fetch.ts
+++ b/plugins/linear/scripts/fetch.ts
@@ -46,7 +46,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/plugins/mac/hooks/sandbox.ts
+++ b/plugins/mac/hooks/sandbox.ts
@@ -100,7 +100,7 @@ async function main(): Promise<void> {
 
   const output = await processInput(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/plugins/newline/scripts/ensure.ts
+++ b/plugins/newline/scripts/ensure.ts
@@ -61,7 +61,7 @@ async function main(): Promise<void> {
   try {
     const output = await processInput(input);
     if (output) {
-      process.stdout.write(JSON.stringify(output) + "\n");
+      process.stdout.write(`${JSON.stringify(output)}\n`);
     }
   } catch (error) {
     console.error(`[newline/ensure] ${error instanceof Error ? error.message : String(error)}`);

--- a/plugins/newline/scripts/preserve.ts
+++ b/plugins/newline/scripts/preserve.ts
@@ -75,7 +75,7 @@ async function main(): Promise<void> {
   try {
     const output = await processInput(input);
     if (output) {
-      process.stdout.write(JSON.stringify(output) + "\n");
+      process.stdout.write(`${JSON.stringify(output)}\n`);
     }
   } catch (error) {
     console.error(`[newline/preserve] ${error instanceof Error ? error.message : String(error)}`);

--- a/plugins/plan/hooks/gate.ts
+++ b/plugins/plan/hooks/gate.ts
@@ -154,7 +154,7 @@ async function main(): Promise<void> {
 
   const output = await processInput(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/plugins/pull-request/scripts/validate.ts
+++ b/plugins/pull-request/scripts/validate.ts
@@ -11,7 +11,7 @@ function denyWithError(reason: string): void {
       permissionDecisionReason: reason,
     },
   } satisfies SyncHookJSONOutput;
-  process.stdout.write(JSON.stringify(output) + "\n");
+  process.stdout.write(`${JSON.stringify(output)}\n`);
 }
 
 async function main(): Promise<void> {
@@ -27,7 +27,7 @@ async function main(): Promise<void> {
 
   const output = await processInput(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/plugins/shortcuts/hooks/open.ts
+++ b/plugins/shortcuts/hooks/open.ts
@@ -70,7 +70,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/plugins/tmux/hooks/target.ts
+++ b/plugins/tmux/hooks/target.ts
@@ -81,7 +81,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input, process.env.TMUX_PANE);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/plugins/type-ignore/hooks/detect.ts
+++ b/plugins/type-ignore/hooks/detect.ts
@@ -163,7 +163,7 @@ async function main(): Promise<void> {
 
   const output = await processInput(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/plugins/ui-design/skills/wireframe/scripts/validate-hook.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/validate-hook.ts
@@ -56,7 +56,7 @@ async function main(): Promise<void> {
 
   const output = await processInput(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/plugins/writing/hooks/pretooluse.ts
+++ b/plugins/writing/hooks/pretooluse.ts
@@ -114,7 +114,7 @@ async function main(): Promise<void> {
   const { output, log } = await dispatch(input);
   appendRunLog(log);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/user/hooks/session-limit/index.ts
+++ b/user/hooks/session-limit/index.ts
@@ -204,7 +204,7 @@ async function main(): Promise<void> {
 
   const output = await processInput(input, Date.now());
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/user/hooks/webfetch-block/index.ts
+++ b/user/hooks/webfetch-block/index.ts
@@ -69,7 +69,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/user/hooks/worktree/index.ts
+++ b/user/hooks/worktree/index.ts
@@ -91,7 +91,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 


### PR DESCRIPTION
`useTemplate` sat at `recommended: true`, which makes it a warning. `bun run check` (`biome check`) exits 0 on warnings, so nothing enforced it and the violation count drifted up over time. This promotes it to `error` and clears the existing sites, so it stays at zero.

## What changed

- Set `style.useTemplate` to `"error"` in `biome.json`.
- Converted the existing string-concatenation sites to template literals via `biome --write --unsafe --only=style/useTemplate`. Biome marks the fix "unsafe" because it can't prove the left operand's type statically, but every converted site here has a string literal or `JSON.stringify(...)` on the left, so the output is byte-identical. I read every hunk to confirm.
- Broadened the JXA linter exemption from `**/scripts/jxa/**/*.js` to `**/jxa/**/*.js`.

## Why the JXA exemption moved

JXA scripts concatenate macOS object specifiers like `list.name()` and `t.name()`. String concatenation coerces via `valueOf` first, template interpolation via `toString` first, and for a specifier those can return different values. Converting JXA sites is a real behavior change, so they stay exempt.

The old pattern only matched `plugins/things/scripts/jxa/`. A second JXA layout exists at `plugins/things/skills/jxa/scripts/export-markdown.js`, which the pattern missed, so that file was being linted and flagged. The broadened pattern covers both layouts. `export-markdown.js` is now exempt and untouched.

## Verification

- `bun run check` is clean: `useTemplate` reports no errors, and the remaining warnings are unrelated rules that predate this branch.
- Each touched plugin's `bun test` suite covers the converted files, run in isolation the way the CI matrix runs them.
- The full-suite flaky failures (DuckDB cross-machine and `compactDatabase`) reproduce on `main` and touch none of these files, so they are unrelated to this change.
