### PR TITLE
Enable comments plugin from bendrucker marketplace

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -264,7 +264,8 @@
     "mermaid@bendrucker": true,
     "typescript-lsp@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
-    "atuin@bendrucker": true
+    "atuin@bendrucker": true,
+    "comments@bendrucker": true
   },
   "extraKnownMarketplaces": {
     "bendrucker": {


### PR DESCRIPTION
Enables the `comments` plugin from the bendrucker marketplace in user-level settings.

## Changes

- Added `"comments@bendrucker": true` to the enabled plugins list in `user/settings.json`

This makes the comments plugin available for use across all Claude Code sessions using this configuration.

https://claude.ai/code/session_01Cq7ZtpABRuta52EaJxCAFk