### PR TITLE
Add agent-browser skill documentation

### DIFF
--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -27,6 +27,7 @@ Every customization costs tokens on every session. Before adding one, define how
 
 - The user has carefully curated skills for their common workflows. Load skills when possible to adhere to the user's preferences and navigate their projects efficiently.
 - For questions about Claude Code features or usage, use the Task tool with `subagent_type='claude-code-guide'` to consult official documentation.
+- Prefer the `agent-browser` skill over `WebFetch`/`WebSearch` when a task needs a real browser — interacting with a page, screenshots, scraping JS-rendered content, or web-app QA/dogfooding. It loads the CLI's version-matched `skills get` workflows. Plain `WebFetch` stays fine for static page fetches.
 - Finish a branch with `/ship`: it runs the warranted review passes, opens the PR, babysits CI to green, triages bot comments, and refreshes the body. Don't hand-chain `EnterWorktree` + `pull-request:create` for a branch finish.
 - `pull-request:create` remains the skill for opening a PR directly (it is what `/ship` calls). If it's unavailable, create the PR with an empty body.
 - Open PRs ready for review by default. Reserve `--draft` for speculative changes that need deep human review before merge. Draft status can suppress bot review.

--- a/user/skills/agent-browser/SKILL.md
+++ b/user/skills/agent-browser/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: agent-browser
+description: Real-browser automation via the `agent-browser` CLI. Use when a task needs an actual browser — navigating pages, filling forms, clicking, taking screenshots, scraping or extracting page data — or for exploratory testing, QA, and dogfooding of web apps. Pulls version-matched workflow instructions from the CLI itself.
+allowed-tools:
+  - Bash(agent-browser:*)
+  - Bash(npx agent-browser:*)
+hidden: true
+---
+
+# agent-browser
+
+Native browser-automation CLI (Chrome via CDP, accessibility-tree snapshots, compact `@eN` element refs).
+
+This stub holds no usage details on purpose — load the version-matched workflow from the CLI before running any `agent-browser` command:
+
+```bash
+agent-browser skills get core          # start here: workflows, patterns, troubleshooting
+agent-browser skills get core --full   # full command reference + templates
+agent-browser skills get dogfood       # exploratory testing / QA / bug hunts
+agent-browser skills list              # everything on the installed version
+```
+
+Slack automation exists via `agent-browser skills get slack`, but prefer the Slack MCP tools for reads/sends/searches.


### PR DESCRIPTION
Adds the `agent-browser` skill stub to the user skills directory. This provides documentation and guidance for using the agent-browser CLI for real-browser automation tasks.

## Changes

- Added `user/skills/agent-browser/SKILL.md` with skill metadata and usage instructions
  - Declares the skill as hidden (not listed in marketplace)
  - Permits `Bash(agent-browser:*)` and `Bash(npx agent-browser:*)` tool invocations
  - Provides guidance to load version-matched workflows from the CLI itself via `agent-browser skills get` commands
  - References available skill modules: `core` (workflows and patterns), `dogfood` (QA/testing), and `slack` (with note to prefer Slack MCP tools)

## Implementation Details

The skill stub intentionally contains no detailed usage documentation, instead directing users to load version-matched instructions from the installed CLI. This keeps the documentation in sync with the CLI version and avoids duplication.

https://claude.ai/code/session_01HBsSCqHhDFQ6MCBZW2evDp