### PR TITLE
linear: default issue state on the CLI create path

### DIFF
--- a/plugins/linear/README.md
+++ b/plugins/linear/README.md
@@ -11,6 +11,7 @@ Managing Linear issues, projects, and teams for Claude Code.
 ### Hooks
 
 - Guards `save_issue` calls: normalizes input shape, enforces the create/update preconditions, and sets a default state for new issues
+- Guards `linear issue create` Bash calls: appends the same default `--state`, or denies with the flag to add when the command is compound
 
 ## Testing
 

--- a/plugins/linear/hooks/__snapshots__/cli-create.test.ts.snap
+++ b/plugins/linear/hooks/__snapshots__/cli-create.test.ts.snap
@@ -1,0 +1,103 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`processInput bare create injects Backlog 1`] = `
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "updatedInput": {
+      "command": "linear issue create --title x --team BEN --state Backlog",
+    },
+  },
+}
+`;
+
+exports[`processInput create with -a self injects Todo 1`] = `
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "updatedInput": {
+      "command": "linear issue create --title x -a self --state Todo",
+    },
+  },
+}
+`;
+
+exports[`processInput create with --assignee injects Todo 1`] = `
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "updatedInput": {
+      "command": "linear issue create --title x --assignee self --state Todo",
+    },
+  },
+}
+`;
+
+exports[`processInput create with --assignee= injects Todo 1`] = `
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "updatedInput": {
+      "command": "linear issue create --title x --assignee=self --state Todo",
+    },
+  },
+}
+`;
+
+exports[`processInput existing -s passes through 1`] = `null`;
+
+exports[`processInput existing --state= passes through 1`] = `null`;
+
+exports[`processInput --start passes through 1`] = `null`;
+
+exports[`processInput command substitution with a pipe is denied 1`] = `
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "\`linear issue create\` without \`--state\` lands the issue in Triage. Add \`--state Backlog\` to the create command.",
+  },
+}
+`;
+
+exports[`processInput an && chain is denied 1`] = `
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "\`linear issue create\` without \`--state\` lands the issue in Triage. Add \`--state Backlog\` to the create command.",
+  },
+}
+`;
+
+exports[`processInput env-prefixed invocation is rewritten 1`] = `
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "updatedInput": {
+      "command": "LINEAR_API_KEY=abc linear issue create --title x --state Backlog",
+    },
+  },
+}
+`;
+
+exports[`processInput issue update does not fire 1`] = `null`;
+
+exports[`processInput a create mentioned inside a title does not fire 1`] = `null`;
+
+exports[`processInput trailing whitespace is trimmed before the flag 1`] = `
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "updatedInput": {
+      "command": "linear issue create --title x --state Backlog",
+    },
+  },
+}
+`;

--- a/plugins/linear/hooks/__snapshots__/cli-create.test.ts.snap
+++ b/plugins/linear/hooks/__snapshots__/cli-create.test.ts.snap
@@ -101,3 +101,23 @@ exports[`processInput trailing whitespace is trimmed before the flag 1`] = `
   },
 }
 `;
+
+exports[`processInput an || chain is denied 1`] = `
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "\`linear issue create\` without \`--state\` lands the issue in Triage. Add \`--state Backlog\` to the create command.",
+  },
+}
+`;
+
+exports[`processInput a ; sequence is denied 1`] = `
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "\`linear issue create\` without \`--state\` lands the issue in Triage. Add \`--state Backlog\` to the create command.",
+  },
+}
+`;

--- a/plugins/linear/hooks/cli-create.test.ts
+++ b/plugins/linear/hooks/cli-create.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { processInput } from "./cli-create";
+
+function mockInput(command: string): PreToolUseHookInput {
+  return {
+    hook_event_name: "PreToolUse",
+    session_id: "test",
+    transcript_path: "/tmp/test",
+    cwd: "/tmp",
+    tool_name: "Bash",
+    tool_input: { command },
+    tool_use_id: "test",
+  };
+}
+
+describe("processInput", () => {
+  test.each([
+    ["bare create injects Backlog", "linear issue create --title x --team BEN"],
+    ["create with -a self injects Todo", "linear issue create --title x -a self"],
+    ["create with --assignee injects Todo", "linear issue create --title x --assignee self"],
+    ["create with --assignee= injects Todo", "linear issue create --title x --assignee=self"],
+    ["existing -s passes through", "linear issue create --title x -s Todo"],
+    ["existing --state= passes through", "linear issue create --title x --state=Todo"],
+    ["--start passes through", "linear issue create --title x --start"],
+    [
+      "command substitution with a pipe is denied",
+      "id=$(linear issue create --title x --team BEN | grep -oE 'BEN-[0-9]+')",
+    ],
+    [
+      "an && chain is denied",
+      "linear issue create --title x --team BEN && linear issue view BEN-1",
+    ],
+    ["env-prefixed invocation is rewritten", "LINEAR_API_KEY=abc linear issue create --title x"],
+    ["issue update does not fire", "linear issue update BEN-1 --title x"],
+    ["a create mentioned inside a title does not fire", "echo 'linear issue create'"],
+    ["trailing whitespace is trimmed before the flag", "linear issue create --title x  "],
+  ])("%s", (_name, command) => {
+    expect(processInput(mockInput(command))).toMatchSnapshot();
+  });
+});

--- a/plugins/linear/hooks/cli-create.test.ts
+++ b/plugins/linear/hooks/cli-create.test.ts
@@ -31,6 +31,8 @@ describe("processInput", () => {
       "an && chain is denied",
       "linear issue create --title x --team BEN && linear issue view BEN-1",
     ],
+    ["an || chain is denied", "linear issue create --title x --team BEN || exit 1"],
+    ["a ; sequence is denied", "linear issue create --title x --team BEN; echo done"],
     ["env-prefixed invocation is rewritten", "LINEAR_API_KEY=abc linear issue create --title x"],
     ["issue update does not fire", "linear issue update BEN-1 --title x"],
     ["a create mentioned inside a title does not fire", "echo 'linear issue create'"],

--- a/plugins/linear/hooks/cli-create.ts
+++ b/plugins/linear/hooks/cli-create.ts
@@ -16,7 +16,7 @@ const LEADING_CREATE = /^linear\s+issue\s+create(\s|$)/;
 // create, so it supplies a state of its own.
 const HAS_STATE = /(^|\s)(-s|--state)([=\s]|$)/;
 const HAS_START = /(^|\s)--start(\s|$)/;
-const HAS_ASSIGNEE = /(^|\s)(-a|--assignee)[=\s]/;
+const ASSIGNEE = /(?:^|\s)(?:-a|--assignee)[=\s]+(\S+)/;
 
 export function isSingleInvocation(command: string): boolean {
   if (SUBSTITUTION.test(command)) return false;
@@ -30,7 +30,7 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
   if (!command || !CREATE.test(command)) return null;
   if (HAS_STATE.test(command) || HAS_START.test(command)) return null;
 
-  const state = getDefaultState(command.match(HAS_ASSIGNEE)?.[0]);
+  const state = getDefaultState(command.match(ASSIGNEE)?.[1]);
 
   // In a compound command, an appended flag lands on the last segment, so hand
   // the fix back for the author to place.
@@ -66,7 +66,7 @@ async function main(): Promise<void> {
 
   const output = processInput(input);
   if (output) {
-    process.stdout.write(JSON.stringify(output) + "\n");
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   }
 }
 

--- a/plugins/linear/hooks/cli-create.ts
+++ b/plugins/linear/hooks/cli-create.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env bun
+
+import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { getDefaultState } from "./save-issue";
+
+const SHELL_OPERATORS = /\s*(?:&&|\|\||[|;])\s*/;
+const ENV_PREFIX = /^(?:[A-Za-z_]\w*=\S*\s+)*/;
+const SUBSTITUTION = /\$\(|`|\n/;
+
+// `linear issue create` preceded by a shell boundary, so `foo-linear issue
+// create` and a quoted title containing the phrase do not match.
+const CREATE = /(^|[\s;&|("'])linear\s+issue\s+create(\s|$)/;
+const LEADING_CREATE = /^linear\s+issue\s+create(\s|$)/;
+
+// --start self-assigns and moves the issue to a started state right after
+// create, so it supplies a state of its own.
+const HAS_STATE = /(^|\s)(-s|--state)([=\s]|$)/;
+const HAS_START = /(^|\s)--start(\s|$)/;
+const HAS_ASSIGNEE = /(^|\s)(-a|--assignee)[=\s]/;
+
+export function isSingleInvocation(command: string): boolean {
+  if (SUBSTITUTION.test(command)) return false;
+  const segments = command.split(SHELL_OPERATORS);
+  if (segments.length !== 1) return false;
+  return LEADING_CREATE.test(command.trim().replace(ENV_PREFIX, ""));
+}
+
+export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {
+  const { command } = input.tool_input as { command?: string };
+  if (!command || !CREATE.test(command)) return null;
+  if (HAS_STATE.test(command) || HAS_START.test(command)) return null;
+
+  const state = getDefaultState(command.match(HAS_ASSIGNEE)?.[0]);
+
+  // In a compound command, an appended flag lands on the last segment, so hand
+  // the fix back for the author to place.
+  if (!isSingleInvocation(command)) {
+    return {
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: `\`linear issue create\` without \`--state\` lands the issue in Triage. Add \`--state ${state}\` to the create command.`,
+      },
+    };
+  }
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "allow",
+      updatedInput: { command: `${command.trimEnd()} --state ${state}` },
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  let input: PreToolUseHookInput;
+  try {
+    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
+  } catch (error) {
+    console.error(
+      `[linear/cli-create] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  const output = processInput(input);
+  if (output) {
+    process.stdout.write(JSON.stringify(output) + "\n");
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/plugins/linear/hooks/hooks.json
+++ b/plugins/linear/hooks/hooks.json
@@ -21,6 +21,17 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/cli-create.ts\"",
+            "if": "Bash(linear issue create *)",
+            "timeout": 10
+          }
+        ]
       }
     ]
   }

--- a/plugins/linear/skills/linear/references/conventions.md
+++ b/plugins/linear/skills/linear/references/conventions.md
@@ -50,7 +50,9 @@ Unassigned:
 }
 ```
 
-`hooks/save-issue.ts` injects this default on the MCP tool paths (the connector `save_issue` and the local or plugin `create_issue`), and only when creating without an explicit `state`. The CLI/API path is not hooked. Set the state yourself there.
+`hooks/save-issue.ts` injects this default on the MCP tool paths (the connector `save_issue` and the local or plugin `create_issue`), and only when creating without an explicit `state`. `hooks/cli-create.ts` does the same for `linear issue create`, appending `--state` when the command is a single invocation and denying with the flag to add when it is piped or chained.
+
+Raw `linear api` mutations stay unhooked. Set `stateId` yourself there. An issue created through the API with no state lands in Triage on a triage-enabled team.
 
 ## CLI Idioms
 


### PR DESCRIPTION
Issues created through the `linear` CLI were landing in Triage. The MCP hook (`hooks/save-issue.ts`) injects a default workflow state on every create, but its matcher only covers the connector and MCP tools. In flag mode the CLI leaves `stateId` undefined unless `--state` is passed, and Linear routes a stateless API-created issue to Triage on a triage-enabled team. The CLI does pick a default interactively, but interactive mode is gated on `Deno.stdout.isTerminal()`, so an agent under the Bash tool always takes the flag path. `conventions.md` told the reader to set the state themselves there, and that was not holding.

Two things made this cheaper than expected. `--state` matches on state name first and state type second, so the hook can inject the same literal `Todo`/`Backlog` strings `getDefaultState` already returns with no API lookup. And the hook entry's `if` filter (`Bash(linear issue create *)`) keeps the bun process from spawning on unrelated Bash calls, so detection costs one line rather than a matcher hack.

The compound-command case is the reason this isn't a pure rewrite. `id=$(linear issue create ... | grep -oE 'ENG-[0-9]+')` is the documented idiom, and appending a flag to that string lands it on `grep`. Those get a `deny` naming the exact flag to add. Only a single verified `linear` invocation with no operators or substitutions gets `allow` plus a rewritten command, so nothing else is being auto-approved alongside it. An explicit `-s`/`--state` or `--start` passes through untouched.

Flag detection is word-boundary regex over the command, matching how every other hook here parses shell strings. A flag-looking string inside a quoted `--title` is a false positive that only suppresses injection, which is the safe direction.

Verified by driving the hook directly on all three branches: bare create gets `--state Backlog`, the `$( ... | grep )` form is denied with `--state Todo` (picked up from `--assignee self`), and an explicit `--state Todo` produces no output. I did not create real issues against the test workspace, so the end-to-end path through a fresh session is unexercised.

Two gaps left open. `--state Todo` resolves by name only, since there is no `todo` state *type*, so a team with no state literally named "Todo" gets a `NotFoundError`. That is the same string the connector path already sends, so the paths stay consistent. And raw `linear api 'mutation { issueCreate ... }'` stays uncovered, because parsing a GraphQL mutation out of a shell argument is not worth a hook. That one is documented in `conventions.md` instead.
