### PR TITLE
plan: make revision guidance standalone, gate sustained growth

### DIFF
--- a/plugins/plan/README.md
+++ b/plugins/plan/README.md
@@ -6,7 +6,7 @@ Planning mode guidelines and context injection for Claude Code.
 
 - **Skill** `plan:review`: reviews how an implementation diverged from its approved plan, forking a clean-context agent over the plan and the diff to surface drift and follow-ups
 - **Hook**: Injects planning guidelines the first time a session is in plan mode, whether that first signal is a prompt or a tool call, and appends delegation guidance when the orchestrator runs on an expensive model
-- **Hook**: Gates `ExitPlanMode`, denying byte-identical plan re-presents and asking once per session before presenting a plan over 12k characters
+- **Hook**: Gates `ExitPlanMode`, denying byte-identical plan re-presents, asking on an append-only re-present, asking once per session when a third or later present exceeds every earlier one, and asking once per session before presenting a plan over 12k characters
 
 ## How It Works
 
@@ -14,7 +14,7 @@ Two hooks share one job: inject the guidelines exactly once per plan-mode sessio
 
 Both paths call `scripts/injection-content.sh` to assemble the content. It emits `references/guidelines.md` always, and reads the latest assistant `model` from the transcript. When that model is an expensive orchestrator (opus, fable), it appends `references/delegation.md`, which requires the plan to carry a Delegation section laying out the agent/model/effort DAG. `UserPromptSubmit` returns the content on stdout; `PreToolUse` returns it as `hookSpecificOutput.additionalContext`. Any read or parse problem falls back to the guidelines alone.
 
-The `PreToolUse` gate hook hashes each presented plan under `/tmp/claude/<session_id>/` and denies a resubmission whose text is unchanged since the last presentation, with instructions to revise instead of regrow. Plans over 12k characters trigger a one-time confirmation prompt. Infrastructure weirdness (missing session id, unreadable state) fails open.
+The `PreToolUse` gate hook keeps per-session state under `/tmp/claude/<session_id>/` and runs four checks in order. It denies a resubmission whose text is byte-identical to the last presentation. It asks when a re-present keeps nearly every prior line and only adds new ones. It asks once per session when the third or later present is longer than every present before it, the shape of a plan that accumulates residue instead of shedding it. The baseline is that high-water mark rather than the first present, because `Direction Before Detail` prescribes a skeletal first plan. It asks once per session for plans over 12k characters. Infrastructure weirdness (missing session id, unreadable state) fails open.
 
 `plan:review` reads the approved plan from the file Claude Code writes under `~/.claude/plans/` and injects into the session on plan exit. It forks a clean-context agent that diffs the plan against the branch's base (resolved from the open PR, not assumed to be `main`) using the rubric in `skills/review/references/divergence.md`.
 

--- a/plugins/plan/hooks/gate.test.ts
+++ b/plugins/plan/hooks/gate.test.ts
@@ -57,7 +57,7 @@ describe("unchanged re-present", () => {
     expect(await decision("My plan")).toEqual({
       hookEventName: "PreToolUse",
       permissionDecision: "deny",
-      permissionDecisionReason: expect.stringContaining("Plan text is unchanged"),
+      permissionDecisionReason: expect.stringContaining("byte-identical"),
     });
   });
 
@@ -108,7 +108,7 @@ describe("append-only re-present", () => {
     expect(await decision(grown)).toEqual({
       hookEventName: "PreToolUse",
       permissionDecision: "ask",
-      permissionDecisionReason: expect.stringContaining("append-only growth"),
+      permissionDecisionReason: expect.stringContaining("keeps nearly every prior line"),
     });
   });
 
@@ -175,7 +175,7 @@ describe("append-only re-present", () => {
     expect(await decision(appended)).toEqual({
       hookEventName: "PreToolUse",
       permissionDecision: "ask",
-      permissionDecisionReason: expect.stringContaining("append-only"),
+      permissionDecisionReason: expect.stringContaining("keeps nearly every prior line"),
     });
   });
 
@@ -226,11 +226,72 @@ describe("append-only re-present", () => {
     expect(await decision(grown)).toEqual({
       hookEventName: "PreToolUse",
       permissionDecision: "ask",
-      permissionDecisionReason: expect.stringContaining("append-only"),
+      permissionDecisionReason: expect.stringContaining("keeps nearly every prior line"),
     });
     // Append-only asks before the size check, so the size branch never runs and
     // records no marker: one prompt for append-only, no second prompt for size.
     expect(readdirSync(join(stateRoot, "session-1"))).not.toContain("exit-plan-size-asked");
+  });
+});
+
+describe("sustained growth", () => {
+  // Each rewrite uses a distinct line prefix so carry-over stays low and the
+  // append-only check, which runs first, never fires.
+  const rewrite = (prefix: string, count: number) =>
+    Array.from({ length: count }, (_, i) => `${prefix} ${i}`).join("\n");
+
+  const skeletal = rewrite("alpha", 4);
+  const grown = rewrite("bravo", 12);
+  const grownAgain = rewrite("charlie", 30);
+
+  it("stays silent on a second present that grows", async () => {
+    await decision(skeletal);
+    expect(await decision(grown)).toBeNull();
+  });
+
+  it("asks on a third present above the high-water mark", async () => {
+    await decision(skeletal);
+    await decision(grown);
+    expect(await decision(grownAgain)).toEqual({
+      hookEventName: "PreToolUse",
+      permissionDecision: "ask",
+      permissionDecisionReason: `Presentation 3 is larger than any before it (${grown.length} -> ${grownAgain.length} chars). If redirects added scope, that growth is right. Otherwise it is residue: delete superseded design, move resolved research to <plan>-decisions.md, and keep only what the implementer builds from. Approve to present anyway.`,
+    });
+  });
+
+  it("stays silent when the third present comes in under the high-water mark", async () => {
+    await decision(skeletal);
+    await decision(grownAgain);
+    expect(await decision(grown)).toBeNull();
+  });
+
+  it("measures against the high-water mark, not the previous present", async () => {
+    await decision(skeletal);
+    await decision(grownAgain);
+    await decision(rewrite("delta", 6));
+    // Larger than the present before it, still under the high-water mark.
+    expect(await decision(rewrite("echo", 10))).toBeNull();
+  });
+
+  it("asks at most once per session", async () => {
+    await decision(skeletal);
+    await decision(grown);
+    expect((await decision(grownAgain))?.permissionDecision).toBe("ask");
+    expect(await decision(rewrite("delta", 60))).toBeNull();
+  });
+
+  it("allows and skips the check when the stored history is corrupt", async () => {
+    await decision(skeletal);
+    await decision(grown);
+    await Bun.write(join(stateRoot, "session-1", "exit-plan-presents"), "not json");
+    expect(await decision(grownAgain)).toBeNull();
+  });
+
+  it("prefers deny when the grown re-present is byte-identical", async () => {
+    await decision(skeletal);
+    await decision(grown);
+    await decision(grownAgain);
+    expect((await decision(grownAgain))?.permissionDecision).toBe("deny");
   });
 });
 

--- a/plugins/plan/hooks/gate.test.ts
+++ b/plugins/plan/hooks/gate.test.ts
@@ -255,7 +255,9 @@ describe("sustained growth", () => {
     expect(await decision(grownAgain)).toEqual({
       hookEventName: "PreToolUse",
       permissionDecision: "ask",
-      permissionDecisionReason: `Presentation 3 is larger than any before it (${grown.length} -> ${grownAgain.length} chars). If redirects added scope, that growth is right. Otherwise it is residue: delete superseded design, move resolved research to <plan>-decisions.md, and keep only what the implementer builds from. Approve to present anyway.`,
+      permissionDecisionReason: expect.stringContaining(
+        `Presentation 3 is larger than any before it (${grown.length} -> ${grownAgain.length} chars)`,
+      ),
     });
   });
 
@@ -278,6 +280,15 @@ describe("sustained growth", () => {
     await decision(grown);
     expect((await decision(grownAgain))?.permissionDecision).toBe("ask");
     expect(await decision(rewrite("delta", 60))).toBeNull();
+  });
+
+  it("counts a present the append-only check asked on, and reports its ordinal", async () => {
+    await decision(skeletal);
+    await decision(grown);
+    // An append-only third present returns before the growth branch, so the
+    // growth ask is still available when a genuine rewrite lands fourth.
+    expect((await decision(`${grown}\nbravo tail`))?.permissionDecision).toBe("ask");
+    expect((await decision(grownAgain))?.permissionDecisionReason).toContain("Presentation 4");
   });
 
   it("allows and skips the check when the stored history is corrupt", async () => {

--- a/plugins/plan/hooks/gate.test.ts
+++ b/plugins/plan/hooks/gate.test.ts
@@ -287,11 +287,20 @@ describe("sustained growth", () => {
     expect(await decision(grownAgain)).toBeNull();
   });
 
-  it("prefers deny when the grown re-present is byte-identical", async () => {
+  it("still denies a byte-identical re-present after the growth ask has fired", async () => {
     await decision(skeletal);
     await decision(grown);
     await decision(grownAgain);
     expect((await decision(grownAgain))?.permissionDecision).toBe("deny");
+  });
+
+  it("does not spend the ask on a plan that barely clears the high-water mark", async () => {
+    await decision(skeletal);
+    await decision(grown);
+    // One character over the high-water mark falls inside the noise margin.
+    expect(await decision(`${grown}x`)).toBeNull();
+    // The ask is still available for growth that reads as accumulation.
+    expect((await decision(grownAgain))?.permissionDecision).toBe("ask");
   });
 });
 

--- a/plugins/plan/hooks/gate.ts
+++ b/plugins/plan/hooks/gate.ts
@@ -18,6 +18,9 @@ const APPEND_ONLY_MAX_REMOVED = 1;
 // Direction Before Detail prescribes a skeletal first plan, so growth into the
 // second present is the workflow working. Sustained growth starts at the third.
 const GROWTH_MIN_PRESENTS = 3;
+// Only one growth ask fires per session, so a plan that lands a hair over the
+// high-water mark must not spend it. Require a margin that reads as accumulation.
+const GROWTH_MIN_EXCESS_RATIO = 0.05;
 
 const DENY_REASON =
   "Plan text is byte-identical to the presentation that was just rejected. Re-read " +
@@ -157,8 +160,9 @@ export async function processInput(
     return formatDecision("deny", DENY_REASON);
   }
 
-  // A denied call never reached the user, so it is not a presentation and does
-  // not advance the count.
+  // Past the deny, so a byte-identical resubmission neither advances the count
+  // nor raises the high-water mark. An ask still does: the hook cannot observe
+  // whether the user approved it.
   const presentsRaw = await readState(presentsPath);
   const history = presentsRaw === null ? null : parsePresentHistory(presentsRaw);
   const ordinal = (history?.count ?? 0) + 1;
@@ -175,7 +179,7 @@ export async function processInput(
   if (
     history !== null &&
     ordinal >= GROWTH_MIN_PRESENTS &&
-    plan.length > history.maxLength &&
+    plan.length > history.maxLength * (1 + GROWTH_MIN_EXCESS_RATIO) &&
     (await readState(growthAskedPath)) === null
   ) {
     await writeState(growthAskedPath, "asked");

--- a/plugins/plan/hooks/gate.ts
+++ b/plugins/plan/hooks/gate.ts
@@ -15,21 +15,34 @@ const APPEND_ONLY_MIN_GROWTH = 1;
 // Allow one incidental drop (e.g. a stray line) without losing the append-only signal.
 const APPEND_ONLY_MAX_REMOVED = 1;
 
+// Direction Before Detail prescribes a skeletal first plan, so growth into the
+// second present is the workflow working. Sustained growth starts at the third.
+const GROWTH_MIN_PRESENTS = 3;
+
 const DENY_REASON =
-  "Plan text is unchanged since the last presentation. Incorporate the redirect " +
-  "feedback with a targeted revision of the affected sections (do not regrow the " +
-  "document), lead with a short 'Changed since last plan' block, and re-present.";
+  "Plan text is byte-identical to the presentation that was just rejected. Re-read " +
+  "the user's messages since that presentation and revise the sections they name, " +
+  "deleting anything they superseded. If the rejection carried no feedback, use " +
+  "AskUserQuestion to get direction instead of resubmitting.";
 
 const APPEND_ONLY_ASK_REASON =
-  "This re-present keeps nearly all prior lines and only adds new ones: append-only " +
-  "growth, not a revision. Consolidate superseded design into a two-line pointer " +
-  "(what it was, why it was parked, where it lives), lead with a 'Changed since " +
-  "last plan' block, and re-present the delta, not the regrown document. Approve " +
-  "to present anyway.";
+  "This re-present keeps nearly every prior line and only adds new ones. Find what " +
+  "the feedback superseded and delete it instead of writing around it. The plan is " +
+  "the standalone execution document, not a record of this conversation. Approve to " +
+  "present anyway.";
+
+function growthAskReason(ordinal: number, previousMax: number, length: number): string {
+  return (
+    `Presentation ${ordinal} is larger than any before it (${previousMax} -> ${length} chars). ` +
+    "If redirects added scope, that growth is right. Otherwise it is residue: delete " +
+    "superseded design, move resolved research to <plan>-decisions.md, and keep only " +
+    "what the implementer builds from. Approve to present anyway."
+  );
+}
 
 const ASK_REASON =
-  "This plan exceeds 12k characters. Plans this large are rarely approved; " +
-  "consolidate superseded content into <plan>.decisions.md or split the scope. " +
+  "This plan exceeds 12k characters. Plans this large are rarely approved. " +
+  "Consolidate superseded content into <plan>-decisions.md or split the scope. " +
   "Approve to present anyway.";
 
 function formatDecision(decision: "deny" | "ask", reason: string): SyncHookJSONOutput {
@@ -77,6 +90,20 @@ function parseLineSet(raw: string): Set<string> | null {
   }
 }
 
+type PresentHistory = { count: number; maxLength: number };
+
+function parsePresentHistory(raw: string): PresentHistory | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const { count, maxLength } = parsed as Record<string, unknown>;
+    if (typeof count !== "number" || typeof maxLength !== "number") return null;
+    return { count, maxLength };
+  } catch {
+    return null;
+  }
+}
+
 function isAppendOnlyRevision(previous: Set<string>, current: Set<string>): boolean {
   if (previous.size === 0) return false;
 
@@ -114,6 +141,8 @@ export async function processInput(
 
   const hashPath = join(dir, "exit-plan-hash");
   const linesPath = join(dir, "exit-plan-lines");
+  const presentsPath = join(dir, "exit-plan-presents");
+  const growthAskedPath = join(dir, "exit-plan-growth-asked");
   const askedPath = join(dir, "exit-plan-size-asked");
 
   const hash = createHash("sha256").update(plan).digest("hex");
@@ -128,9 +157,29 @@ export async function processInput(
     return formatDecision("deny", DENY_REASON);
   }
 
+  // A denied call never reached the user, so it is not a presentation and does
+  // not advance the count.
+  const presentsRaw = await readState(presentsPath);
+  const history = presentsRaw === null ? null : parsePresentHistory(presentsRaw);
+  const ordinal = (history?.count ?? 0) + 1;
+  await writeState(
+    presentsPath,
+    JSON.stringify({ count: ordinal, maxLength: Math.max(history?.maxLength ?? 0, plan.length) }),
+  );
+
   const previousLines = previousLinesRaw === null ? null : parseLineSet(previousLinesRaw);
   if (previousLines !== null && isAppendOnlyRevision(previousLines, currentLines)) {
     return formatDecision("ask", APPEND_ONLY_ASK_REASON);
+  }
+
+  if (
+    history !== null &&
+    ordinal >= GROWTH_MIN_PRESENTS &&
+    plan.length > history.maxLength &&
+    (await readState(growthAskedPath)) === null
+  ) {
+    await writeState(growthAskedPath, "asked");
+    return formatDecision("ask", growthAskReason(ordinal, history.maxLength, plan.length));
   }
 
   if (plan.length > SIZE_THRESHOLD && (await readState(askedPath)) === null) {

--- a/plugins/plan/references/guidelines.md
+++ b/plugins/plan/references/guidelines.md
@@ -69,11 +69,13 @@ Layer verification through the plan. A criterion parked only at the end catches 
 
 ## Revision
 
-A redirect is new input scoped to what it names. On each iteration:
+A redirect is new input scoped to what it names. The plan is the standalone execution document: a session holding only the plan file, with no access to this conversation, must be able to execute it. Every rule below is that test applied.
 
-- Revise the sections the feedback covers. Untouched sections stay untouched. Do not regrow the whole plan or log every decision and revision. Never re-present text unchanged after a rejection.
-- Consolidate before every re-present. A superseded design collapses to a two-line pointer: what it was, why it was parked, where the artifact lives. Resolved research moves to the decisions file. A plan that argues with its earlier self has stopped being a plan.
-- Lead the re-present with a short "Changed since last plan" block. The full document lives in the plan file the user reads at handoff. The re-present is for the delta.
+- Revise the sections the feedback covers. Untouched sections stay untouched. If a rejection arrives with no feedback, ask what to change instead of guessing at a revision.
+- When feedback supersedes a decision, delete the superseded text. Do not write around it, soften it, or annotate it.
+- Cut any content whose reader is the user in this conversation rather than the implementer in a fresh session: research residue, decision narration, restated feedback. Resolved research moves to `<plan>-decisions.md`.
+- A finished plan reads as if it were written once. Any sentence that only makes sense to a reader who saw an earlier draft ("changed since last plan", "previously considered", "now uses") is diary. The chat holds the history and the plan links the transcript.
+- A ruled-out approach survives only when the implementer would otherwise re-propose it: one line under `## Alternatives`, the approach and why it loses. Everything else is deleted, not parked.
 - Treat every AskUserQuestion answer from this session as a constraint. Before ExitPlanMode, verify the plan satisfies each one.
 - Question the axis, not the plan. When feedback or investigation opens an axis with more than one viable position (scope breadth, framework positioning, naming, execution shape), fire one batched AskUserQuestion before drafting into it. An unasked axis question costs full re-present cycles; one batched question is cheaper than one re-present.
 


### PR DESCRIPTION
The revision guidance told a re-presented plan to lead with a "Changed since last plan" block, which turns the plan into a diary of the conversation that produced it. A plan is the standalone execution document a fresh session runs with no access to the chat, and the transcript already ships alongside it, so a changelog inside the plan duplicates a record that already exists. I replaced the delta instruction with an audience test: cut any sentence that only makes sense to a reader who saw an earlier draft, and delete resolved research and superseded design rather than annotate or soften it. The test is an audience check rather than a size limit because the failure observed was research residue and duplicated spec, and a model told to shrink compresses prose while trimming the verification detail that has to stay.

The existing append-only check in `gate.ts` only ever caught one bad round: a plan that churns a few lines each present while still growing overall passes it every time, and a byte-identical re-present was the only hard stop against that shape. I added a third check that asks once per session when the third or later present is longer than every present before it. The baseline is the high-water mark across all presents, not the first one, because the guidance prescribes a skeletal first plan, and a first-present baseline would flag that workflow as growth. The ask requires the excess to clear a 5% margin over the high-water mark, so a revision landing a few characters over the mark doesn't spend the once-per-session budget before real regrowth shows up. It asks rather than denies, since a redirect that adds real scope is legitimate growth and only the user can tell the difference from residue.

Byte-identical resubmissions are denied before the append-only and growth checks run, so they don't advance the present count or raise the high-water mark. An ask that the user rejects does raise the high-water mark anyway, because the hook only sees the plan text, not whether the ask was approved.

`guidelines.md` keeps one "X, not Y" contrast ("deleted, not parked") that the tropes hook otherwise flags. It stays because it's load-bearing here: the rule is specifically about what happens to the alternative that doesn't survive.

Beyond the unit tests, I ran three real `ExitPlanMode` payloads through `bun plugins/plan/hooks/gate.ts` against a scratch state root. A growing sequence asks on the third present with the correct ordinal and both character counts. A skeletal-then-larger-then-smaller sequence, the workflow the guidance recommends, stays silent throughout.

The growth ask should be judged by how often it fires and whether it gets approved past anyway. Frequent approve-anyway means the threshold is wrong. No fires in a month of plan sessions means the guidance landed and the check is dead weight.
