### PR TITLE
statusline: render subagent effort from the payload

### DIFF
--- a/user/scripts/effort.test.ts
+++ b/user/scripts/effort.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { type EffortMarker, effortMarker } from "./effort";
+import { type EffortMarker, effortGlyph, effortMarker } from "./effort";
 
 describe("effortMarker", () => {
   test.each<[string | null | undefined, EffortMarker | null]>([
@@ -14,5 +14,20 @@ describe("effortMarker", () => {
     [undefined, null],
   ])("level %p -> %p", (level, expected) => {
     expect(effortMarker(level)).toEqual(expected);
+  });
+});
+
+describe("effortGlyph", () => {
+  test.each<[string | number | null | undefined, string | null]>([
+    ["low", "∙"],
+    ["high", "⁝"],
+    ["max", "⁙"],
+    ["unknown", null],
+    [20_000, null],
+    [0, null],
+    [null, null],
+    [undefined, null],
+  ])("effort %p -> %p", (effort, expected) => {
+    expect(effortGlyph(effort)).toBe(expected);
   });
 });

--- a/user/scripts/effort.ts
+++ b/user/scripts/effort.ts
@@ -26,3 +26,11 @@ export function effortMarker(level?: string | null): EffortMarker | null {
   if (!glyph) return null;
   return { glyph, isDefault: level === DEFAULT_EFFORT };
 }
+
+// Agent configs may set effort to an integer token budget instead of a level.
+// Nothing on the ramp represents one, and a bare number in the meta would read
+// as a second token count, so integer efforts render nothing.
+export function effortGlyph(effort?: string | number | null): string | null {
+  if (typeof effort !== "string") return null;
+  return effortMarker(effort)?.glyph ?? null;
+}

--- a/user/scripts/subagent-statusline.test.ts
+++ b/user/scripts/subagent-statusline.test.ts
@@ -178,6 +178,29 @@ describe("renderTask", () => {
     expect(strip(out.content)).toContain("· 1m 5s · 1.5k · f · Explore");
   });
 
+  test.each<[string | number, string]>([
+    ["low", "· 1m 5s · ∙"],
+    ["max", "· 1m 5s · ⁙"],
+    [20_000, "· 1m 5s"],
+    ["turbo", "· 1m 5s"],
+  ])("effort %p renders %p", (effort, expected) => {
+    const out = renderTask({ id: "a", name: "x", startTime: 0, effort }, null, now, null);
+    expect(strip(out.content)).toEndWith(expected);
+  });
+
+  test("effort trails the model letter", () => {
+    const out = renderTask(
+      { id: "a", name: "x", startTime: 0, tokenCount: 1500, effort: "low" },
+      null,
+      now,
+      "Explore",
+      null,
+      null,
+      "f",
+    );
+    expect(strip(out.content)).toContain("· 1m 5s · 1.5k · f · ∙ · Explore");
+  });
+
   test("activity wins over the description and is not sentence-cased", () => {
     const out = renderTask(
       { id: "a", description: "you are implementing the parser" },

--- a/user/scripts/subagent-statusline.ts
+++ b/user/scripts/subagent-statusline.ts
@@ -2,6 +2,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { styleText } from "node:util";
+import { effortGlyph } from "./effort";
 import { genericGlyph, purposeGlyphs, remoteGlyph } from "./glyphs";
 import { modelMarker } from "./model";
 
@@ -13,10 +14,13 @@ export interface Task {
   status?: string;
   startTime?: number;
   tokenCount?: number;
+  model?: string;
+  effort?: string | number;
 }
 
 interface SubagentInput {
   columns?: number;
+  transcript_path?: string;
   tasks?: Task[];
 }
 
@@ -102,6 +106,11 @@ export function renderTask(
   if (task.startTime != null) metaParts.push(formatElapsed(task.startTime, now));
   if ((task.tokenCount ?? 0) > 0) metaParts.push(formatTokens(task.tokenCount ?? 0));
   if (model) metaParts.push(model);
+  // Every declared level renders. The payload carries no session effort to
+  // compare a task's against, and a task's effort is its agent config's
+  // declaration rather than a resolved level, so there is no baseline to hide.
+  const effort = effortGlyph(task.effort);
+  if (effort) metaParts.push(effort);
 
   // The type name trails as dim text after the meta. The icon already conveys
   // the kind, so a narrow terminal can drop the name without losing it.
@@ -233,9 +242,7 @@ export function extractActivity(entries: TranscriptEntry[]): string | null {
   return null;
 }
 
-// The newest assistant model in a transcript tail. Both the subagent's own model
-// and its parent session's model come from here. Comparing the two decides
-// whether a subagent is running off-default and warrants a letter.
+// The newest assistant model in a transcript tail.
 export function extractModel(entries: TranscriptEntry[]): string | null {
   for (let i = entries.length - 1; i >= 0; i--) {
     const model = entries[i]?.message?.model;
@@ -259,16 +266,14 @@ export function subagentModelLetter(
 
 // Each task id keys a sidecar pair the harness writes next to the subagent
 // transcript, scoped to the current project's sessions (derived from cwd). The
-// path prefix locates both the `.meta.json` and the `.jsonl`. Its first segment
-// is the parent session id. A miss yields no glyph or activity (the prune signal
-// if the harness changes this layout).
-function subagentBase(id: string, projectDir: string): { base: string; sessionId: string } | null {
+// path prefix locates both the `.meta.json` and the `.jsonl`. A miss yields no
+// glyph or activity (the prune signal if the harness changes this layout).
+function subagentBase(id: string, projectDir: string): string | null {
   try {
     for (const rel of new Bun.Glob(`*/subagents/agent-${id}.meta.json`).scanSync({
       cwd: projectDir,
     })) {
-      const sessionId = rel.split("/")[0] ?? "";
-      return { base: join(projectDir, rel).slice(0, -".meta.json".length), sessionId };
+      return join(projectDir, rel).slice(0, -".meta.json".length);
     }
   } catch {
     // Project directory unreadable: skip enrichment.
@@ -326,25 +331,22 @@ if (import.meta.main) {
   const projectDir = join(homedir(), ".claude", "projects", slug);
   const now = Date.now();
 
-  // All tasks on this line share one parent session, so its model is read once.
-  const sessionModels = new Map<string, string | null>();
-  const sessionModel = async (sessionId: string): Promise<string | null> => {
-    if (!sessionModels.has(sessionId)) {
-      const entries = await readEntries(join(projectDir, `${sessionId}.jsonl`));
-      sessionModels.set(sessionId, extractModel(entries));
-    }
-    return sessionModels.get(sessionId) ?? null;
-  };
+  // All tasks share the parent session named by stdin, so the model every
+  // subagent letter is compared against is read once.
+  const sessionModel = input.transcript_path
+    ? extractModel(await readEntries(input.transcript_path))
+    : null;
 
   const lines: string[] = [];
   for (const task of input.tasks ?? []) {
-    const located = subagentBase(task.id, projectDir);
-    const meta = located ? await readMeta(located.base) : null;
-    const entries = located ? await readEntries(`${located.base}.jsonl`) : [];
+    const base = subagentBase(task.id, projectDir);
+    const meta = base ? await readMeta(base) : null;
+    const entries = base ? await readEntries(`${base}.jsonl`) : [];
     const activity = extractActivity(entries);
-    const model = located
-      ? subagentModelLetter(extractModel(entries), await sessionModel(located.sessionId))
-      : null;
+    // The payload's model is resolved at spawn and covers a subagent that has
+    // yet to write a turn. Task types that carry none fall back to the
+    // transcript this loop already read for the activity.
+    const model = subagentModelLetter(task.model ?? extractModel(entries), sessionModel);
     lines.push(
       JSON.stringify(
         renderTask(


### PR DESCRIPTION
Claude Code 2.1.215 extends the `subagentStatusLine` payload: each task now carries a resolved `model` and the agent config's `effort`. Renders the effort as the dot ramp the session line already uses, and takes the model letter from the payload instead of scraping it back out of the subagent's transcript.

The two payloads disagree on shape, which is worth knowing before touching this again. The session status line gets `effort: {level}`; a subagent task gets a bare `effort` that is either a level name or an integer token budget. Integers render nothing, since no glyph on the ramp represents one and a bare number sitting next to the token count reads as a second token count.

Effort renders whenever it is declared, with no suppression when it matches the session. That is deliberate but not symmetric with the model letter, which stays hidden when the subagent matches its parent. There is simply no session effort in the payload to compare against, and a task's effort is its agent config's declaration rather than a resolved level, so there is no baseline to hide it against.

The model letter keeps a transcript fallback rather than trusting `model` outright. The payload value is resolved at spawn, so it beats the old scrape for a subagent that has not written a turn yet, but task types that carry no model would otherwise lose a letter they used to get. The fallback reuses the transcript entries the loop already reads for the activity line, so it costs nothing. The parent session's baseline model now comes from the payload's `transcript_path` instead of a path rebuilt from the sidecar's session id.

Verified by piping payloads through the script directly, since the interesting paths live in the `import.meta.main` block that the unit tests don't reach: a haiku subagent under an opus session renders `h · ⁞`, an `opus-4-8[1m]` subagent under opus renders no letter, an integer effort renders nothing, and a task with no `model` falls through to the transcript.

One caveat on dogfooding. Nothing in this repo declares `effort` on an agent definition today, so the glyph won't appear until something does or until a workflow spawns an agent with `opts.effort`. If it stays invisible, that is the signal to pull it back out.
