### PR TITLE
things: correct the url.ts success contract

### DIFF
--- a/plugins/things/skills/url/SKILL.md
+++ b/plugins/things/skills/url/SKILL.md
@@ -83,6 +83,8 @@ When the `x-callback-url` plugin is installed, `url.ts` uses xcall to get a resp
 
 Callback is enabled by default. Disable with `--callback=false` to fall back to fire-and-forget via `open -g`. If xcall is unavailable, the script falls back silently.
 
+xcall builds into the plugin data directory and needs `CLAUDE_PLUGIN_DATA` in the environment. A Bash tool call does not carry that variable, so a model-issued `url.ts` run takes the fallback path and stderr carries `CLAUDE_PLUGIN_DATA is not set`.
+
 ## Built-in List IDs (URL Scheme)
 
 For `show` command: `inbox`, `today`, `anytime`, `upcoming`, `someday`, `logbook`, `tomorrow`, `deadlines`, `repeating`, `all-projects`, `logged-projects`
@@ -111,9 +113,13 @@ Things supports [Markdown in notes](https://culturedcode.com/things/support/arti
 
 ## Gotchas
 
-#### Never retry on silent output
+#### Silent Success
 
-The write scripts (`url.ts`, `inbox.ts`) print to stdout on success. No output means the call failed. Read stderr, surface the cause to the user, and only retry once you understand the root cause. Silent retries have created duplicate todos.
+`url.ts` prints only when xcall returns a result. On the fallback path it exits 0 with empty stdout after a successful write, so empty output says nothing about whether the change landed.
+
+Judge failure by a non-zero exit and read stderr for the cause. To confirm a write that printed nothing, query the todo with the `things:jxa` skill. Never retry blind: a repeated `add` creates duplicate todos.
+
+`inbox.ts` and `reorder.ts` do print on success regardless of xcall, so silence from those is a genuine failure.
 
 #### Sandbox-blocked URL handoff
 


### PR DESCRIPTION
The `things:url` gotcha told callers that empty stdout from a write script means the call failed. That is false for `url.ts`. It prints only when xcall returns a result, and on the fallback path it exits 0 with no output after a write that landed. A caller following the old rule reports a false failure, and retrying an `add` on that basis creates the duplicate todos the gotcha itself warns about.

The cause is a missing `CLAUDE_PLUGIN_DATA`. The x-callback-url plugin is installed and `run.sh` resolves fine, but `build.sh` hard-requires that variable to locate the `xcall.app` bundle. That variable is exported for hooks and MCP servers, not for Bash tool calls, so every model-issued `url.ts` run fails the xcall step and silently falls back to `open -g`. The write still succeeds. Documenting that precondition is the fix here; making xcall reachable from a Bash invocation is a separate change.

`inbox.ts` and `reorder.ts` print unconditionally on success, so the old rule held for them. The new text keeps that distinction rather than dropping the retry warning entirely.

## Evidence

The original report, an `update` that succeeded (confirmed via JXA, status became `canceled`):

```
$ bun .../scripts/url.ts update id=UWst2BrzGK838jVLnzhmwc canceled=true 2>&1; echo "exit=$?"
exit=0
```

Reproduced without touching any todo, using the read-only `version` command:

```
$ bun plugins/things/scripts/url.ts version >out 2>err; echo "exit=$?"
exit=0
$ wc -c <out; cat err
0
CLAUDE_PLUGIN_DATA is not set; this script must be invoked from a Claude Code plugin context
```

`env` in a Bash tool call carries no `CLAUDE_PLUGIN_*` variables at all.

`/code-review` was requested but is not available as a skill or command in this agent's context, so the diff went unreviewed beyond `skill-lint`. The two `biome` warnings in `plugins/things/scripts/format.ts` are pre-existing and untouched.

Discovery: c5e0a71b83d4
