### PR TITLE
improve-claude-code: paginate the Discover dedup PR scan

### DIFF
--- a/user/skills/improve-claude-code/SKILL.md
+++ b/user/skills/improve-claude-code/SKILL.md
@@ -53,9 +53,12 @@ For Things, query via `things:jxa` for every `claude-code`-tagged todo and recen
 For PR bodies, scan every PR on the config repo:
 
 ```bash
-gh pr list --repo bendrucker/claude --state all --limit 1000 --json state,body \
-  --jq '.[] | .state as $s | (.body // "") | scan("Discovery: [0-9a-f]{12}") | "\($s) \(.)"'
+gh api --paginate '/repos/bendrucker/claude/pulls?state=all&per_page=100' \
+  --jq '.[] | (if .merged_at then "MERGED" elif .state == "closed" then "CLOSED" else "OPEN" end) as $s
+        | (.body // "") | scan("Discovery: [0-9a-f]{12}") | "\($s) \(.)"'
 ```
+
+Paginate rather than passing `gh pr list --limit <n>`, which silently drops every PR past the limit once the repo outgrows it.
 
 Each line is `<STATE> Discovery: <fp>`, where `STATE` is `OPEN`, `MERGED`, or `CLOSED`. Build a fingerprint-to-state map, strongest state wins (`MERGED` over `OPEN`). Then mark each candidate:
 


### PR DESCRIPTION
The Discover dedup step scans PR bodies for `Discovery:` fingerprints with `gh pr list --limit 1000`. The repo is at 1019 PRs, so the scan now drops the overflow with no error. Impact today is zero because the missed PRs predate the marker convention, but from here the ledger degrades silently and a shipped finding resurfaces as `new`.

Raising the constant only moves the ceiling, so this paginates instead. `gh pr list` has no `--paginate` flag (only `-L/--limit`), so the scan moves to `gh api --paginate` over the pulls endpoint. That payload reports `state` as `open`/`closed` only, so `merged_at` is what separates `MERGED` from `CLOSED`. The emitted shape stays `<STATE> Discovery: <fp>`, which the strongest-state-wins mapping below the snippet depends on.

## Evidence

Both commands run against the live repo, sorted and diffed:

```
$ gh pr list --repo bendrucker/claude --state all --limit 1000 --json state,body \
    --jq '...' | sort > tmp/disc-old.txt
$ gh api --paginate '/repos/bendrucker/claude/pulls?state=all&per_page=100' \
    --jq '...' | sort > tmp/disc-new.txt
$ diff tmp/disc-old.txt tmp/disc-new.txt
$ wc -l tmp/disc-old.txt tmp/disc-new.txt
      35 tmp/disc-old.txt
      35 tmp/disc-new.txt
```

Identical output, 35 lines: 31 `MERGED`, 2 `CLOSED`, 2 `OPEN`. Runtime is ~8.9s paginated against ~6.5s for the capped command over 11 pages.

Automated code review did not run on this branch (`/code-review` is `disable-model-invocation`), so the diff got a manual self-review instead.

Original Task: [[discovery] Discover dedup PR scan truncates at 1000 PRs](https://things.bendrucker.me/show?id=MVsPmPCS5GDLjnGeMjuzTC)

Discovery: 2873edb31bd0
