### PR TITLE
check-md-code: scope to git-tracked markdown

### DIFF
--- a/.claude/skills/cleye/SKILL.md
+++ b/.claude/skills/cleye/SKILL.md
@@ -53,7 +53,7 @@ Access: `argv._.required`, `argv._.optional`, `argv._.files`.
 
 Flags accept a type constructor or a config object:
 
-```ts
+```ts fragment
 flags: {
   name: String,                    // shorthand
   count: {
@@ -79,7 +79,7 @@ Kebab-case flags (`--dry-run`) become camelCase properties (`argv.flags.dryRun`)
 
 Set `help.description` on `cli()` for a summary line above the generated usage block:
 
-```ts
+```ts fragment
 const argv = cli({
   name: "scan",
   parameters: ["<path>"],

--- a/scripts/check-md-code.test.ts
+++ b/scripts/check-md-code.test.ts
@@ -1,20 +1,38 @@
 import { afterEach, expect, it } from "bun:test";
 import { rm } from "node:fs/promises";
 import { join } from "node:path";
-import { findViolations } from "./check-md-code";
+import { checkFile, findViolations } from "./check-md-code";
 
-const fixture = join(import.meta.dir, "..", "tmp", "check-md-code-fixture.md");
+const root = join(import.meta.dir, "..");
+const name = "check-md-code-fixture.md";
+const fixture = join(root, name);
+
+const block = (lang: string) => [`\`\`\`${lang}`, "{ not json }", "```", ""].join("\n");
 
 afterEach(async () => {
   await rm(fixture, { force: true });
 });
 
-it("ignores untracked markdown", async () => {
-  await Bun.write(fixture, ["```json", "{ not json }", "```", ""].join("\n"));
+it("skips markdown that git does not track", async () => {
+  await Bun.write(fixture, block("json"));
+
   const violations = await findViolations();
-  expect(violations.filter((violation) => violation.includes("check-md-code-fixture"))).toEqual([]);
+
+  expect(violations.filter((violation) => violation.startsWith(name))).toEqual([]);
 });
 
-it("finds no violations in tracked markdown", async () => {
-  expect(await findViolations()).toEqual([]);
+it("reports a code block that fails to parse", async () => {
+  await Bun.write(fixture, block("json"));
+
+  expect(await checkFile(name)).toHaveLength(1);
+});
+
+it("skips a block tagged fragment", async () => {
+  await Bun.write(fixture, block("json fragment"));
+
+  expect(await checkFile(name)).toEqual([]);
+});
+
+it("reads a tracked file that has been deleted from the working tree as empty", async () => {
+  expect(await checkFile("does-not-exist.md")).toEqual([]);
 });

--- a/scripts/check-md-code.test.ts
+++ b/scripts/check-md-code.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, expect, it } from "bun:test";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { findViolations } from "./check-md-code";
+
+const fixture = join(import.meta.dir, "..", "tmp", "check-md-code-fixture.md");
+
+afterEach(async () => {
+  await rm(fixture, { force: true });
+});
+
+it("ignores untracked markdown", async () => {
+  await Bun.write(fixture, ["```json", "{ not json }", "```", ""].join("\n"));
+  const violations = await findViolations();
+  expect(violations.filter((violation) => violation.includes("check-md-code-fixture"))).toEqual([]);
+});
+
+it("finds no violations in tracked markdown", async () => {
+  expect(await findViolations()).toEqual([]);
+});

--- a/scripts/check-md-code.ts
+++ b/scripts/check-md-code.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import type { Code } from "mdast";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { visit } from "unist-util-visit";
-import { runCheck, tracked } from "./check";
+import { readTracked, runCheck, tracked } from "./check";
 
 const root = join(import.meta.dirname, "..");
 
@@ -66,8 +66,10 @@ function checkBlock(node: Code): string | null {
   }
 }
 
-async function checkFile(file: string): Promise<string[]> {
-  const text = await Bun.file(join(root, file)).text();
+export async function checkFile(file: string): Promise<string[]> {
+  const text = await readTracked(file, root);
+  if (text === null) return [];
+
   const ast = fromMarkdown(text);
   const violations: string[] = [];
 
@@ -82,15 +84,7 @@ async function checkFile(file: string): Promise<string[]> {
 }
 
 export async function findViolations(): Promise<string[]> {
-  const files = await tracked("*.md", root);
-
-  // `git ls-files` reports tracked files that have been deleted in the working
-  // tree, so read only the ones still on disk.
-  const present = await Promise.all(
-    files.map(async (file) => ((await Bun.file(join(root, file)).exists()) ? file : null)),
-  );
-
-  const results = await Promise.all(present.filter((file) => file !== null).map(checkFile));
+  const results = await Promise.all((await tracked("*.md", root)).map(checkFile));
   return results.flat();
 }
 

--- a/scripts/check-md-code.ts
+++ b/scripts/check-md-code.ts
@@ -1,11 +1,10 @@
 #!/usr/bin/env bun
 
 import { join } from "node:path";
-import { Glob } from "bun";
 import type { Code } from "mdast";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { visit } from "unist-util-visit";
-import { runCheck } from "./check";
+import { runCheck, tracked } from "./check";
 
 const root = join(import.meta.dirname, "..");
 
@@ -82,15 +81,16 @@ async function checkFile(file: string): Promise<string[]> {
   return violations;
 }
 
-async function findViolations(): Promise<string[]> {
-  const glob = new Glob("**/*.md");
-  const files: string[] = [];
-  for await (const file of glob.scan({ cwd: root })) {
-    if (file.includes("node_modules") || file.includes(".bun-cache")) continue;
-    files.push(file);
-  }
+export async function findViolations(): Promise<string[]> {
+  const files = await tracked("*.md", root);
 
-  const results = await Promise.all(files.map(checkFile));
+  // `git ls-files` reports tracked files that have been deleted in the working
+  // tree, so read only the ones still on disk.
+  const present = await Promise.all(
+    files.map(async (file) => ((await Bun.file(join(root, file)).exists()) ? file : null)),
+  );
+
+  const results = await Promise.all(present.filter((file) => file !== null).map(checkFile));
   return results.flat();
 }
 

--- a/scripts/check-permission-rules.ts
+++ b/scripts/check-permission-rules.ts
@@ -2,7 +2,7 @@
 
 import { join } from "node:path";
 import matter from "gray-matter";
-import { runCheck, tracked } from "./check";
+import { readTracked, runCheck, tracked } from "./check";
 
 // Claude Code warns on startup about Write(path), NotebookEdit(path), and
 // Glob(path) permission rules: the permission system routes file writes
@@ -38,7 +38,10 @@ async function checkSettings(): Promise<string[]> {
   const violations: string[] = [];
 
   for (const file of await tracked("*settings*.json", root)) {
-    const parsed: unknown = await Bun.file(join(root, file)).json();
+    const raw = await readTracked(file, root);
+    if (raw === null) continue;
+
+    const parsed: unknown = JSON.parse(raw);
     if (typeof parsed !== "object" || parsed === null) continue;
 
     const permissions = (parsed as Record<string, unknown>).permissions as Permissions | undefined;
@@ -64,8 +67,8 @@ async function checkFrontmatter(): Promise<string[]> {
   const violations: string[] = [];
 
   for (const file of await tracked("*.md", root)) {
-    const raw = await Bun.file(join(root, file)).text();
-    if (!raw.startsWith("---")) continue;
+    const raw = await readTracked(file, root);
+    if (raw === null || !raw.startsWith("---")) continue;
 
     let data: Record<string, unknown>;
     try {

--- a/scripts/check-permission-rules.ts
+++ b/scripts/check-permission-rules.ts
@@ -1,9 +1,8 @@
 #!/usr/bin/env bun
 
 import { join } from "node:path";
-import { $ } from "bun";
 import matter from "gray-matter";
-import { runCheck } from "./check";
+import { runCheck, tracked } from "./check";
 
 // Claude Code warns on startup about Write(path), NotebookEdit(path), and
 // Glob(path) permission rules: the permission system routes file writes
@@ -29,11 +28,6 @@ function describe(file: string, context: string, rule: string): string {
   return `${file} (${context}): ${rule} (use ${REPLACEMENT[tool]}(...) instead)`;
 }
 
-async function tracked(pattern: string): Promise<string[]> {
-  const output = await $`git ls-files -z ${pattern}`.cwd(root).text();
-  return output.split("\0").filter(Boolean);
-}
-
 interface Permissions {
   allow?: string[];
   deny?: string[];
@@ -43,7 +37,7 @@ interface Permissions {
 async function checkSettings(): Promise<string[]> {
   const violations: string[] = [];
 
-  for (const file of await tracked("*settings*.json")) {
+  for (const file of await tracked("*settings*.json", root)) {
     const parsed: unknown = await Bun.file(join(root, file)).json();
     if (typeof parsed !== "object" || parsed === null) continue;
 
@@ -69,7 +63,7 @@ function frontmatterRules(value: unknown): string[] {
 async function checkFrontmatter(): Promise<string[]> {
   const violations: string[] = [];
 
-  for (const file of await tracked("*.md")) {
+  for (const file of await tracked("*.md", root)) {
     const raw = await Bun.file(join(root, file)).text();
     if (!raw.startsWith("---")) continue;
 

--- a/scripts/check.ts
+++ b/scripts/check.ts
@@ -1,4 +1,16 @@
 import { exit } from "node:process";
+import { $ } from "bun";
+
+/**
+ * Repo-relative paths of git-tracked files matching a pathspec.
+ *
+ * The pathspec must stay interpolated: `Bun.$` glob-expands literal template
+ * text, which would reduce `*.md` to root-level files before git sees it.
+ */
+export async function tracked(pattern: string, cwd: string): Promise<string[]> {
+  const output = await $`git ls-files -z ${pattern}`.cwd(cwd).text();
+  return output.split("\0").filter(Boolean);
+}
 
 export interface CheckResult {
   /** Lines printed before the violation list when violations exist. */

--- a/scripts/check.ts
+++ b/scripts/check.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { exit } from "node:process";
 import { $ } from "bun";
 
@@ -10,6 +11,23 @@ import { $ } from "bun";
 export async function tracked(pattern: string, cwd: string): Promise<string[]> {
   const output = await $`git ls-files -z ${pattern}`.cwd(cwd).text();
   return output.split("\0").filter(Boolean);
+}
+
+/**
+ * Contents of a tracked file, or null when it is absent from the working tree.
+ *
+ * `git ls-files` lists files deleted locally but not yet staged, so every
+ * caller iterating a tracked list has to tolerate a missing file. Reading and
+ * catching beats checking existence first, which doubles the syscalls and still
+ * races: the file can vanish between the check and the read.
+ */
+export async function readTracked(file: string, cwd: string): Promise<string | null> {
+  try {
+    return await Bun.file(join(cwd, file)).text();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
 }
 
 export interface CheckResult {


### PR DESCRIPTION
`check-md-code.ts` globbed `**/*.md` across the whole repo, so it failed on markdown that will never be committed. The Stop hook runs `prek run --files <edited paths>` and the `md-code` hook sets `pass_filenames: false`, so editing any `.md` (including a scratch file under `tmp/`) triggered a full-repo scan. At HEAD that scan reports five violations, all in gitignored `tmp/` plan and draft files.

Scoping to `git ls-files` fixes the class rather than the instance. An `exclude:` for `tmp/` in `.pre-commit-config.yaml` would only cover the paths I happen to use today, and `.worktrees/` has the same problem. The `tracked()` helper already existed privately in `check-permission-rules.ts`, so it moves to `scripts/check.ts` and both scripts share it.

This is not purely subtractive. `Bun.Glob.scan` skips dot-directories by default, so the old glob never scanned `.claude/**` or `.github/**`. The tracked set is smaller overall (260 vs 388 files) but includes 14 dot-directory files for the first time, which surfaced two pre-existing violations in `.claude/skills/cleye/SKILL.md`. Both are deliberately partial snippets (a bare `flags: {}` object literal and a `cli({ ... })` call with a literal `...` placeholder), so they get the existing `fragment` fence tag rather than a rewrite.

`git ls-files` also reports tracked files deleted in the working tree, hence the existence guard before reading. Without it the Stop hook would throw mid-session on any branch with a deleted markdown file.

Verified locally: the check exits 0 in a dirty tree with a broken `tmp/scratch.md` present, `prek run --files tmp/scratch.md` passes, and `prek run --all-files` is green.

Original Task: [[discovery] Scope md-code hook to tracked files](https://things.bendrucker.me/show?id=DHr3CWfcUpsVy4Xrr47PnX)
