### PR TITLE
mac: fire the sandbox marker for directly-executed scripts

### DIFF
--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -36,11 +36,11 @@ Apple Events and Launch Services handoff (`osascript`, `open`, URL schemes) does
 
 `${CLAUDE_PLUGIN_ROOT}` does NOT expand in hook `matcher` fields (it only expands in `command` strings). A matcher like `Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/:*)` is compared literally against the resolved cache path (`bun /Users/.../plugins/cache/.../scripts/foo.ts`), never matches, and the hook never fires. Do not use `${CLAUDE_PLUGIN_ROOT}` in matchers.
 
-The marker hook sidesteps this: it uses a broad `Bash|Monitor` matcher and reads the head of the invoked `bun`/`node` script for the comment `claude:dangerouslyDisableSandbox`. When present, it injects `dangerouslyDisableSandbox: true`, running that command fully outside the sandbox. This is layout-independent, so it works regardless of the cache `<hash>` path. Add the marker after the shebang of any top-level script that hands off to Apple Events or Launch Services:
+The marker hook sidesteps this: it uses a broad `Bash|Monitor` matcher and reads the head of the invoked script for the comment `claude:dangerouslyDisableSandbox`. When present, it injects `dangerouslyDisableSandbox: true`, running that command fully outside the sandbox. This is layout-independent, so it works regardless of the cache `<hash>` path. Add the marker after the shebang of any top-level script that hands off to Apple Events or Launch Services, or that writes its plugin data dir under `~/.claude/plugins`:
 
 ```ts
 #!/usr/bin/env bun
 // claude:dangerouslyDisableSandbox: <reason>
 ```
 
-The marker requires the `mac` plugin installed and only fires for interpreters in its `SCRIPT_INTERPRETERS` set (`bun`, `node`). See [`plugins/mac/README.md`](../../plugins/mac/README.md) for canonical docs.
+The marker requires the `mac` plugin installed. It fires for a script passed to an interpreter in the hook's `SCRIPT_INTERPRETERS` set (`bun`, `node`), and for a script executed directly by path when its extension is in `SCRIPT_EXTENSIONS` (`.ts`, `.js`, `.mjs`, `.cjs`, `.sh`). See [`plugins/mac/README.md`](../../plugins/mac/README.md) for canonical docs.

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -19,11 +19,23 @@ Permission patterns starting with `/` are relative to the settings file, not abs
 
 `excludedCommands` matches only the top-level command of a Bash invocation. Nested commands (e.g., `open` spawned from a `bun scripts/foo.ts` wrapper) inherit the parent's sandbox profile, so adding `open:*` to `excludedCommands` does not exempt nested calls. Go CLIs run sandboxed via `sandbox.network.allowMachLookup`; wrappers that hand off to Apple Events or Launch Services need a full skip via the `mac` plugin's `claude:dangerouslyDisableSandbox` marker hook. See [`scripts.md`](scripts.md).
 
-## Plugin Data Dir Is Unwritable
+## Plugin Data Dir
 
 The runtime sandbox profile denies writes under `~/.claude/plugins`, and that deny shadows any `filesystem.allowWrite` entry beneath it. `~/.claude/plugins/data` was listed in `allowWrite` for a while and never took effect, so do not re-add it. The failure surfaces as a bare `Operation not permitted`, naming neither the deny rule nor the entry it shadows.
 
-Plugin scripts that must write their own data dir carry the `mac` plugin's `claude:dangerouslyDisableSandbox` marker instead.
+This is an upstream defect, not a policy we chose. The write profile emits every `allowOnly` rule before every `denyWithinAllow` rule, and Seatbelt takes the last matching rule, so a broad deny always beats a narrow allow no matter how specific. The read profile does not have this problem: it implements `allowWithinDeny`, so a narrower allow can reopen a denied region. Writes have no equivalent primitive, and the [sandboxing docs](https://code.claude.com/docs/en/sandboxing) state the specificity rule only for reads. Confirmed with `sandbox-exec`: given a deny of a parent and an allow of a child, emitting the allow first denies the child, and emitting it last permits the child while the rest of the parent stays denied.
+
+So the fix belongs upstream, and nothing in this repo's settings can express it today.
+
+Meanwhile, the four session-index writers carry the `mac` plugin's `claude:dangerouslyDisableSandbox` marker. That is a bridge around a bug, not the intended design, and it trades real sandbox coverage for a working toolchain.
+
+**Removal criterion.** Drop the markers when this probe succeeds under the sandbox:
+
+```
+touch ~/.claude/plugins/data/.sandbox-probe && rm ~/.claude/plugins/data/.sandbox-probe
+```
+
+Do not wait for an upstream announcement. [#41156](https://github.com/anthropics/claude-code/issues/41156) raised the same conflict at the permission-prompt layer, was wrongly auto-flagged as a duplicate, and was closed `NOT_PLANNED` by a staleness bot after two and a half months. Related: [#51973](https://github.com/anthropics/claude-code/issues/51973), [#34900](https://github.com/anthropics/claude-code/issues/34900). Treat the probe as the only reliable signal.
 
 ## Sandbox Trust Model
 

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -19,6 +19,12 @@ Permission patterns starting with `/` are relative to the settings file, not abs
 
 `excludedCommands` matches only the top-level command of a Bash invocation. Nested commands (e.g., `open` spawned from a `bun scripts/foo.ts` wrapper) inherit the parent's sandbox profile, so adding `open:*` to `excludedCommands` does not exempt nested calls. Go CLIs run sandboxed via `sandbox.network.allowMachLookup`; wrappers that hand off to Apple Events or Launch Services need a full skip via the `mac` plugin's `claude:dangerouslyDisableSandbox` marker hook. See [`scripts.md`](scripts.md).
 
+## Plugin Data Dir Is Unwritable
+
+The runtime sandbox profile denies writes under `~/.claude/plugins`, and that deny shadows any `filesystem.allowWrite` entry beneath it. `~/.claude/plugins/data` was listed in `allowWrite` for a while and never took effect, so do not re-add it. The failure surfaces as a bare `Operation not permitted`, naming neither the deny rule nor the entry it shadows.
+
+Plugin scripts that must write their own data dir carry the `mac` plugin's `claude:dangerouslyDisableSandbox` marker instead.
+
 ## Sandbox Trust Model
 
 The sandbox is egress control, not filesystem lockdown. Credentials stay outside its reach, so a sandboxed process cannot exfiltrate them. Broad filesystem writes are fine, but a new host, socket, or network-reaching escaped command widens the egress surface and needs justification.

--- a/plugins/claude-code/skills/session/CLAUDE.md
+++ b/plugins/claude-code/skills/session/CLAUDE.md
@@ -50,6 +50,8 @@ DuckDB parses `data->>'$.x' = 'y'` as `data->>('$.x' = 'y')` because `=` binds t
 
 `getDb` opens read-write, which needs an exclusive DuckDB file lock: the writers (`refresh.ts` past its stamp, `import.ts`, `forget.ts`, `hosts.ts`) must not run concurrently with each other or with readers. Read-only opens take a shared lock: any number coexist, but none can open mid-refresh and a refresh cannot start while readers hold the file. Either collision fails with `Could not set lock`. The workflow fan-out pattern is therefore "refresh once, then have every agent query with `duckdb -readonly` over the shared file" (documented in SKILL.md "Parallel Queries"). This is why the query path is the bare `duckdb` CLI rather than a wrapper: a read-only open at the stable path is all a caller needs, and a wrapper would force every parallel agent through it for no benefit.
 
+The four writers carry the `claude:dangerouslyDisableSandbox` marker after their shebang. The sandbox denies writes under `~/.claude/plugins`, which covers the plugin data dir holding the index, and the deny shadows any `filesystem.allowWrite` entry beneath it. See [`plugins/mac/README.md`](../../../mac/README.md) for the marker.
+
 ### Callers
 
 - `db.ts`: orchestrates migration, schema, scan, per-file import, view rebuild and versioning, checkpoint, compaction.

--- a/plugins/claude-code/skills/session/scripts/forget.ts
+++ b/plugins/claude-code/skills/session/scripts/forget.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
-// claude:dangerouslyDisableSandbox: opens the DuckDB index read-write in the plugin data dir, which the sandbox's ~/.claude/plugins deny covers
+// claude:dangerouslyDisableSandbox: temporary. Opens the DuckDB index read-write in
+// the plugin data dir, which an upstream sandbox defect makes unwritable. Remove this
+// when the probe in .claude/rules/settings.md succeeds.
 import { rm } from "node:fs/promises";
 import { cli } from "cleye";
 import {

--- a/plugins/claude-code/skills/session/scripts/forget.ts
+++ b/plugins/claude-code/skills/session/scripts/forget.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: opens the DuckDB index read-write in the plugin data dir, which the sandbox's ~/.claude/plugins deny covers
 import { rm } from "node:fs/promises";
 import { cli } from "cleye";
 import {

--- a/plugins/claude-code/skills/session/scripts/hosts.ts
+++ b/plugins/claude-code/skills/session/scripts/hosts.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: opens the DuckDB index read-write in the plugin data dir, which the sandbox's ~/.claude/plugins deny covers
 import * as path from "node:path";
 import { cli } from "cleye";
 import { table } from "table";

--- a/plugins/claude-code/skills/session/scripts/hosts.ts
+++ b/plugins/claude-code/skills/session/scripts/hosts.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
-// claude:dangerouslyDisableSandbox: opens the DuckDB index read-write in the plugin data dir, which the sandbox's ~/.claude/plugins deny covers
+// claude:dangerouslyDisableSandbox: temporary. Opens the DuckDB index read-write in
+// the plugin data dir, which an upstream sandbox defect makes unwritable. Remove this
+// when the probe in .claude/rules/settings.md succeeds.
 import * as path from "node:path";
 import { cli } from "cleye";
 import { table } from "table";

--- a/plugins/claude-code/skills/session/scripts/import.ts
+++ b/plugins/claude-code/skills/session/scripts/import.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
-// claude:dangerouslyDisableSandbox: opens the DuckDB index read-write in the plugin data dir, which the sandbox's ~/.claude/plugins deny covers
+// claude:dangerouslyDisableSandbox: temporary. Opens the DuckDB index read-write in
+// the plugin data dir, which an upstream sandbox defect makes unwritable. Remove this
+// when the probe in .claude/rules/settings.md succeeds.
 import { mkdir } from "node:fs/promises";
 import * as path from "node:path";
 import { $ } from "bun";

--- a/plugins/claude-code/skills/session/scripts/import.ts
+++ b/plugins/claude-code/skills/session/scripts/import.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: opens the DuckDB index read-write in the plugin data dir, which the sandbox's ~/.claude/plugins deny covers
 import { mkdir } from "node:fs/promises";
 import * as path from "node:path";
 import { $ } from "bun";

--- a/plugins/claude-code/skills/session/scripts/refresh.ts
+++ b/plugins/claude-code/skills/session/scripts/refresh.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: opens the DuckDB index read-write in the plugin data dir, which the sandbox's ~/.claude/plugins deny covers
 import { mkdirSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import * as path from "node:path";

--- a/plugins/claude-code/skills/session/scripts/refresh.ts
+++ b/plugins/claude-code/skills/session/scripts/refresh.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
-// claude:dangerouslyDisableSandbox: opens the DuckDB index read-write in the plugin data dir, which the sandbox's ~/.claude/plugins deny covers
+// claude:dangerouslyDisableSandbox: temporary. Opens the DuckDB index read-write in
+// the plugin data dir, which an upstream sandbox defect makes unwritable. Remove this
+// when the probe in .claude/rules/settings.md succeeds.
 import { mkdirSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import * as path from "node:path";

--- a/plugins/mac/README.md
+++ b/plugins/mac/README.md
@@ -11,7 +11,7 @@ macOS-specific automation and system integration.
 
 ### Hooks
 
-- **sandbox** — Reads the invoked `bun`/`node` script for the `claude:dangerouslyDisableSandbox` marker and disables the command sandbox when present. Matches both `Bash` and `Monitor` tool calls.
+- **sandbox** — Reads the invoked script for the `claude:dangerouslyDisableSandbox` marker and disables the command sandbox when present. Matches both `Bash` and `Monitor` tool calls.
 
 ### Scripts
 
@@ -26,14 +26,18 @@ Apple Events and Launch Services handoff is different. Scripts that shell out to
 
 ### Sandbox bypass marker
 
-The `sandbox` hook disables the command sandbox for a `bun <script>` or `node <script>` invocation when the script's first 64KB contains the literal string `claude:dangerouslyDisableSandbox`. Add the marker after the shebang of any top-level wrapper that hands off to Apple Events or Launch Services:
+The `sandbox` hook disables the command sandbox when the invoked script's first 64KB contains the literal string `claude:dangerouslyDisableSandbox`. It finds the script two ways: as the argument to `bun` or `node`, or as the command itself when a script is executed directly by path through its shebang and its extension is `.ts`, `.js`, `.mjs`, `.cjs`, or `.sh`.
+
+Two situations warrant the marker. One is handing off to Apple Events or Launch Services, which does not survive the sandbox. The other is writing a plugin's own data dir: the sandbox profile denies writes under `~/.claude/plugins`, and that deny shadows any `filesystem.allowWrite` entry beneath it, so a plugin script cannot write `~/.claude/plugins/data/<plugin>-<marketplace>/` while sandboxed.
+
+Add the marker after the shebang:
 
 ```ts
 #!/usr/bin/env bun
 // claude:dangerouslyDisableSandbox: hands off to osascript for JXA Apple Events
 ```
 
-The marker goes on the top-level entrypoint script only. The hook inspects the `bun`/`node` script argument, not imported modules, so a helper like `things/scripts/ensure-running.ts` carries no marker of its own; its callers do.
+The marker goes on the top-level entrypoint script only. The hook inspects the invoked script, not imported modules, so a helper like `things/scripts/ensure-running.ts` carries no marker of its own; its callers do.
 
 The marker is inert on Linux and inert when the `mac` plugin is not installed. It only activates when this hook runs on macOS.
 

--- a/plugins/mac/hooks/sandbox.test.ts
+++ b/plugins/mac/hooks/sandbox.test.ts
@@ -69,6 +69,17 @@ describe("extractCommands", () => {
       { cmd: "bun", scriptArg: "/abs/path/watch.ts" },
     ]);
   });
+
+  test.each<[string, string]>([
+    ["/abs/path/refresh.ts --refresh", "/abs/path/refresh.ts"],
+    ["./scripts/run.sh foo", "./scripts/run.sh"],
+  ])("directly executed script %p is its own script arg", (command, expected) => {
+    expect(extractCommands(command)).toEqual([{ cmd: expected, scriptArg: expected }]);
+  });
+
+  test.each<[string]>([["git status"], ["/usr/bin/touch x"]])("no script arg for %p", (command) => {
+    expect(extractCommands(command)).toEqual([{ cmd: command.split(" ")[0] as string }]);
+  });
 });
 
 describe("hasBypassMarker", () => {
@@ -118,6 +129,28 @@ describe("processInput", () => {
 
   test("honors marker on second bun invocation in a chain", async () => {
     const input = makeInput(`bun ${unmarkedScriptPath} && bun ${markedScriptPath}`);
+    const result = await processInput(input, "darwin");
+    expect(result?.hookSpecificOutput).toMatchObject({
+      hookEventName: "PreToolUse",
+      updatedInput: { dangerouslyDisableSandbox: true },
+    });
+  });
+
+  test("disables sandbox for a marked script run directly", async () => {
+    const result = await processInput(makeInput(`${markedScriptPath} --refresh`), "darwin");
+    expect(result?.hookSpecificOutput).toMatchObject({
+      hookEventName: "PreToolUse",
+      updatedInput: { dangerouslyDisableSandbox: true },
+    });
+  });
+
+  test("does not disable sandbox for an unmarked script run directly", async () => {
+    const result = await processInput(makeInput(unmarkedScriptPath), "darwin");
+    expect(result).toBeNull();
+  });
+
+  test("honors marker on second directly-run script in a chain", async () => {
+    const input = makeInput(`${unmarkedScriptPath} && ${markedScriptPath}`);
     const result = await processInput(input, "darwin");
     expect(result?.hookSpecificOutput).toMatchObject({
       hookEventName: "PreToolUse",

--- a/plugins/mac/hooks/sandbox.ts
+++ b/plugins/mac/hooks/sandbox.ts
@@ -1,12 +1,14 @@
 #!/usr/bin/env bun
 
-import { basename } from "node:path";
+import { basename, extname } from "node:path";
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 
 type ToolInput = { command: string };
 
 const SHELL_OPERATORS = /\s*(?:&&|\|\||[|;])\s*/;
 const SCRIPT_INTERPRETERS = new Set(["bun", "node"]);
+// Gating on extensions keeps the hook from reading the head of every binary it sees.
+const SCRIPT_EXTENSIONS = new Set([".ts", ".js", ".mjs", ".cjs", ".sh"]);
 const SCRIPT_MARKER = "claude:dangerouslyDisableSandbox";
 
 export type Invocation = { cmd: string; scriptArg?: string };
@@ -37,6 +39,8 @@ export function extractCommands(command: string): Invocation[] {
       if (next && !next.startsWith("-")) {
         invocation.scriptArg = next;
       }
+    } else if (SCRIPT_EXTENSIONS.has(extname(name))) {
+      invocation.scriptArg = cmd;
     }
     result.push(invocation);
   }

--- a/user/settings.json
+++ b/user/settings.json
@@ -333,7 +333,6 @@
     "filesystem": {
       "allowWrite": [
         "/tmp",
-        "~/.claude/plugins/data",
         "~/.tmux",
         "~/.terraform.d/plugin-cache",
         "~/.cache",


### PR DESCRIPTION
The session index scripts cannot write their DuckDB file while sandboxed. The effective profile puts `/Users/ben/.claude/plugins/data` in `write.allowOnly` and `/Users/ben/.claude/plugins` in `write.denyWithinAllow`, and the deny wins, so a `touch` under the data dir fails with a bare `Operation not permitted` that names neither rule.

**This PR is a bridge around an upstream defect, not a design.** It trades real sandbox coverage for a working session toolchain, and it should be removed rather than built on.

## The Upstream Defect

The write-profile generator emits every `allowOnly` rule before every `denyWithinAllow` rule. Seatbelt takes the last matching rule, so a broad deny beats a narrow allow no matter how specific the allow is. `plugins` is a bare entry in a hardcoded list of protected `~/.claude` subdirectory names, with no carve-out for `data`, even though the runtime designates `CLAUDE_PLUGIN_DATA` as where plugins persist state.

The read profile does not have this problem. It implements `allowWithinDeny`, so a narrower allow reopens a denied region, and it even supports re-denying nested under that. Writes have no equivalent primitive. The [sandboxing docs](https://code.claude.com/docs/en/sandboxing) match the asymmetry: they state "the more specific path wins" for reads and say nothing about write precedence.

Ordering is the entire difference, confirmed with `sandbox-exec` on identical rule sets:

| Rule order | write to `plugins/data` | write to `plugins/other` |
|---|---|---|
| allow(data) only, control | OK | denied |
| allow(data) then deny(plugins), current behavior | **denied** | denied |
| deny(plugins) then allow(data) | **OK** | denied |

So the sandbox can express exactly what is wanted. Nothing in this repo's settings can reach it.

## Removal Criterion

Drop the four markers when this probe succeeds under the sandbox:

```
touch ~/.claude/plugins/data/.sandbox-probe && rm ~/.claude/plugins/data/.sandbox-probe
```

Do not wait for an upstream announcement. [#41156](https://github.com/anthropics/claude-code/issues/41156) raised the same conflict at the permission-prompt layer, was wrongly auto-flagged as a duplicate, argued back, and was then closed `NOT_PLANNED` by a staleness bot after two and a half months. Related: [#51973](https://github.com/anthropics/claude-code/issues/51973), [#34900](https://github.com/anthropics/claude-code/issues/34900). The probe is the only reliable signal.

## The Hook Change

Adding the marker the way `things/scripts/url.ts` does is a no-op for these scripts on its own. `extractCommands` in `plugins/mac/hooks/sandbox.ts` only looked for a script argument when the leading token was `bun` or `node`. The session scripts are invoked as bare shebang executables (`${CLAUDE_SKILL_DIR}/scripts/refresh.ts`), so the hook saw a basename it did not recognize and never read the file. A command token whose extension is `.ts`, `.js`, `.mjs`, `.cjs`, or `.sh` now becomes its own script argument. Keeping it extension-gated matters: the alternative of any path-looking token would read 64KB off every binary the model invokes.

The other option was rewriting every session invocation in `SKILL.md` and `references/cross-machine.md` to `bun ${CLAUDE_SKILL_DIR}/scripts/...`. Smaller diff, but it leaves the trap for the next plugin shipping an executable script and has to stay in sync across docs and callers.

Marked only the four writers (`refresh.ts`, `import.ts`, `forget.ts`, `hosts.ts`). `usage.ts` spawns `duckdb -readonly` and `db.ts` is an imported module, and the marker convention is entrypoint-only. Each marker comment now names itself as temporary and points at the probe.

`~/.claude/plugins/data` comes out of `sandbox.filesystem.allowWrite` in `user/settings.json`. It never took effect, and dead config that reads as authoritative is what made this expensive to diagnose.

## Testing

Verified the hook directly, since it executes from the installed plugin cache rather than the repo checkout:

```
echo '{"tool_name":"Bash","tool_input":{"command":"<abs>/plugins/claude-code/skills/session/scripts/refresh.ts --refresh"}}' | bun plugins/mac/hooks/sandbox.ts
```

It emits `dangerouslyDisableSandbox: true`, including after the marker comments were reworded. `bun test plugins/mac` is green (46 tests).

The end-to-end check, a sandboxed `refresh.ts` actually writing its index, only becomes meaningful once the plugin cache picks up this commit, so it is not verified here.

Unrelated to this change, the full `bun test` run has pre-existing failures in the git-fixture suites and, under parallel load, the session DuckDB suites. Confirmed identical counts on the base commit.

Automated code review did not run: `/code-review` is `disable-model-invocation` and rejects the Skill tool. This warrants a medium-effort pass, since it widens what the sandbox-bypass marker matches.

Original Task: [[discovery] Sandbox deny on ~/.claude/plugins shadows the explicit plugins/data allow](https://things.bendrucker.me/show?id=J2anKt21wVpntKZq59akUS)
