### PR TITLE
writing: narrow numbering detection to explicit step headings

### DIFF
--- a/plugins/writing/README.md
+++ b/plugins/writing/README.md
@@ -4,7 +4,7 @@ Writing style enforcement and slop detection for prose output (PR descriptions, 
 
 ## Contents
 
-- **Hooks**: Numbered heading detection, heading style enforcement, AI writing trope detection (em dashes, vocabulary, copula avoidance, promotional language, parallelism, connector density)
+- **Hooks**: Step and phase numbering detection, heading style enforcement, AI writing trope detection (em dashes, vocabulary, copula avoidance, promotional language, parallelism, connector density)
 - **Skills**: `writing` system reminder for prose writing guidelines, `writing:analyze` session-history-based trope ruleset curation, `writing:rewrite` user-invoked text rewriter, `writing:scan` user-invoked trope detector (`audit` gates a directory, `score` measures one input's density), `writing:review` multi-agent document review
 - **Agents**: `content`, `style`, `artifacts` (conditional review lenses)
 

--- a/plugins/writing/README.md
+++ b/plugins/writing/README.md
@@ -4,7 +4,7 @@ Writing style enforcement and slop detection for prose output (PR descriptions, 
 
 ## Contents
 
-- **Hooks**: Step and phase numbering detection, heading style enforcement, AI writing trope detection (em dashes, vocabulary, copula avoidance, promotional language, parallelism, connector density)
+- **Hooks**: Step, phase, and part numbering detection, heading style enforcement, AI writing trope detection (em dashes, vocabulary, copula avoidance, promotional language, parallelism, connector density)
 - **Skills**: `writing` system reminder for prose writing guidelines, `writing:analyze` session-history-based trope ruleset curation, `writing:rewrite` user-invoked text rewriter, `writing:scan` user-invoked trope detector (`audit` gates a directory, `score` measures one input's density), `writing:review` multi-agent document review
 - **Agents**: `content`, `style`, `artifacts` (conditional review lenses)
 

--- a/plugins/writing/hooks/numbering.test.ts
+++ b/plugins/writing/hooks/numbering.test.ts
@@ -72,10 +72,15 @@ describe("formatDecision", () => {
 // checks.
 describe("hasNumberingHint", () => {
   test.each<{ name: string; content: string; hinted: boolean }>([
-    { name: "markdown numbered heading", content: "## 1. Setup\n\nBody\n", hinted: true },
+    { name: "markdown numbered heading", content: "## 1. Setup\n\nBody\n", hinted: false },
     { name: "markdown Step heading", content: "# Step 1\n", hinted: true },
     { name: "markdown Phase heading, wide gap", content: "# Phase    2\n", hinted: true },
-    { name: "tab after heading number", content: "## 3.\tSetup\n", hinted: true },
+    { name: "tab after heading number", content: "## 3.\tSetup\n", hinted: false },
+    {
+      name: "ranked findings heading",
+      content: "## 1. Append-Only Artifacts and Full-Document Regrowth (8 of 8 sessions)\n",
+      hinted: false,
+    },
     { name: "code identifier step1", content: "function step1() {}\n", hinted: true },
     { name: "code identifier Phase2", content: "class Phase2:\n    pass\n", hinted: true },
     {
@@ -93,11 +98,22 @@ describe("hasNumberingHint", () => {
 
 describe("checkMarkdown", () => {
   test.each<[string, string, string | null]>([
-    ['detects "# 1. Introduction"', "# 1. Introduction", "1. Introduction"],
     ['detects "## Step 2: Setup"', "## Step 2: Setup", "Step 2"],
     ['detects "### Phase 3"', "### Phase 3", "Phase 3"],
+    ['detects "#### Part 4: Rollout"', "#### Part 4: Rollout", "Part 4"],
     ["allows descriptive headings", "# Introduction", null],
     ["allows headings with numbers mid-text", "# Using OAuth2 for Authentication", null],
+    ["allows a bare numbered heading", "# 1. Introduction", null],
+    [
+      "allows a ranked findings heading",
+      "## 1. Append-Only Artifacts and Full-Document Regrowth (8 of 8 sessions)",
+      null,
+    ],
+    [
+      "allows a ranked findings heading with a count",
+      "## 2. AskUserQuestion Misalignment (7 of 8)",
+      null,
+    ],
   ])("%s", (_name, content, expected) => {
     const match = checkMarkdown(content);
     expected === null ? expect(match).toBeNull() : expect(match).toContain(expected);
@@ -275,10 +291,10 @@ describe.skipIf(!hasSg())("processInput with code (requires sg)", () => {
 
 describe("processInput with markdown", () => {
   test.each<[string, string, string, boolean, string | null]>([
-    ['detects "# 1. Introduction"', "README.md", "# 1. Introduction", true, "1. Introduction"],
     ['detects "## Step 2: Setup"', "docs.md", "## Step 2: Setup", true, "Step 2"],
     ['detects "### Phase 3"', "guide.markdown", "### Phase 3", true, "Phase 3"],
     ["allows descriptive headings", "README.md", "# Introduction", false, null],
+    ["allows a bare numbered heading", "README.md", "# 1. Introduction", false, null],
     [
       "allows headings with numbers mid-text",
       "README.md",
@@ -299,8 +315,8 @@ describe("processInput with markdown", () => {
   });
 
   it("prefixes the edit-mode reminder", async () => {
-    const output = await getOutput(mockEditInput("README.md", "# 1. Introduction"), "edit");
-    expect(output?.additionalContext).toContain("This edit introduces numbered sequences.");
+    const output = await getOutput(mockEditInput("README.md", "## Step 2: Setup"), "edit");
+    expect(output?.additionalContext).toContain("This edit introduces step or phase numbering.");
   });
 });
 
@@ -345,30 +361,30 @@ describe("already-numbered files", () => {
 
   it("allows Edit when the file already has numbered headings", async () => {
     const filePath = join(dir, "review.md");
-    await Bun.write(filePath, "# Findings\n\n## 1. First issue\n\nDetails.\n");
-    const output = await getOutput(mockEditInput(filePath, "## 2. Second issue"), "edit");
+    await Bun.write(filePath, "# Findings\n\n## Step 1: First issue\n\nDetails.\n");
+    const output = await getOutput(mockEditInput(filePath, "## Step 2: Second issue"), "edit");
     expect(output).toBeNull();
   });
 
   it("reminds when Edit introduces numbering into a clean file", async () => {
     const filePath = join(dir, "clean.md");
     await Bun.write(filePath, "# Findings\n\nDetails.\n");
-    const output = await getOutput(mockEditInput(filePath, "## 1. First issue"), "edit");
-    expect(output?.additionalContext).toContain("numbered sequences");
+    const output = await getOutput(mockEditInput(filePath, "## Step 1: First issue"), "edit");
+    expect(output?.additionalContext).toContain("step or phase numbering");
   });
 
   it("allows non-numbered Edit to an already-numbered file", async () => {
     const filePath = join(dir, "review.md");
-    await Bun.write(filePath, "# Findings\n\n## 1. First issue\n");
+    await Bun.write(filePath, "# Findings\n\n## Step 1: First issue\n");
     const output = await getOutput(mockEditInput(filePath, "More details."), "edit");
     expect(output).toBeNull();
   });
 
   it("allows Write overwriting a file that already has numbered headings", async () => {
     const filePath = join(dir, "review.md");
-    await Bun.write(filePath, "## 1. First issue\n");
+    await Bun.write(filePath, "## Step 1: First issue\n");
     const output = await getOutput(
-      mockWriteInput(filePath, "## 1. First issue\n\n## 2. Second issue\n"),
+      mockWriteInput(filePath, "## Step 1: First issue\n\n## Step 2: Second issue\n"),
       "write",
     );
     expect(output).toBeNull();
@@ -376,8 +392,8 @@ describe("already-numbered files", () => {
 
   it("reminds when Write creates a new numbered file", async () => {
     const filePath = join(dir, "new.md");
-    const output = await getOutput(mockWriteInput(filePath, "# 1. Introduction"), "write");
-    expect(output?.additionalContext).toContain("numbered sequences");
+    const output = await getOutput(mockWriteInput(filePath, "# Step 1: Introduction"), "write");
+    expect(output?.additionalContext).toContain("step or phase numbering");
   });
 
   describe.skipIf(!hasSg())("code files (requires sg)", () => {
@@ -399,8 +415,8 @@ describe("already-numbered files", () => {
 
 describe("markdown context tier", () => {
   it("reminds rather than blocks on markdown Write", async () => {
-    const output = await getOutput(mockWriteInput("README.md", "# 1. Introduction"), "write");
+    const output = await getOutput(mockWriteInput("README.md", "# Step 1: Introduction"), "write");
     expect(output).not.toHaveProperty("permissionDecision");
-    expect(output?.additionalContext).toContain("numbered sequences");
+    expect(output?.additionalContext).toContain("step or phase numbering");
   });
 });

--- a/plugins/writing/hooks/numbering.ts
+++ b/plugins/writing/hooks/numbering.ts
@@ -19,9 +19,10 @@ import {
 
 export type Mode = "write" | "edit";
 
-// Cheap prefilter covering every shape checkMarkdown or a numbering.yml rule
-// can flag. It gates the expensive path (mdast parse, sg spawn) in-process.
-const NUMBER_HINT = /(step|phase|part).{0,8}[0-9]|[0-9]\.( |\t)/i;
+// Every shape checkMarkdown or a numbering.yml rule can flag carries a
+// step/phase/part token near a digit, so this prefilter gates the expensive
+// path (mdast parse, sg spawn) in-process.
+const NUMBER_HINT = /(step|phase|part).{0,8}[0-9]/i;
 
 export function hasNumberingHint(content: string): boolean {
   return NUMBER_HINT.test(content);
@@ -39,6 +40,10 @@ type AstGrepMatch = {
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// Bare `N. ` headings are usually rankings or enumerations, not process steps,
+// so only explicit step labels count.
+const STEP_HEADING = /^(Step|Phase|Part)\s+[0-9]+/i;
+
 export function checkMarkdown(content: string): string | null {
   const ast = fromMarkdown(content);
   const matches: MarkdownMatch[] = [];
@@ -49,7 +54,7 @@ export function checkMarkdown(content: string): string | null {
       .map((child) => child.value)
       .join("");
 
-    if (/^[0-9]+\.\s/.test(text) || /^(Step|Phase|Part)\s+[0-9]+/i.test(text)) {
+    if (STEP_HEADING.test(text)) {
       matches.push({
         text: text.trim(),
         line: node.position?.start?.line || 0,
@@ -59,7 +64,7 @@ export function checkMarkdown(content: string): string | null {
   });
 
   if (matches.length > 0) {
-    return `Numbered heading: ${matches[0]?.text}`;
+    return `Numbered step heading: ${matches[0]?.text}`;
   }
 
   return null;
@@ -162,7 +167,7 @@ export async function check(input: PreToolUseHookInput, mode: Mode): Promise<Hoo
     return null;
   }
 
-  const reason = `Detected numbered sequences that create tight coupling.
+  const reason = `Detected step or phase numbering that creates tight coupling.
 ${match}
 
 Use descriptive names instead. See CLAUDE.md Organization guidelines.`;
@@ -171,7 +176,8 @@ Use descriptive names instead. See CLAUDE.md Organization guidelines.`;
   // prompts and 0 rejections, and an ask stalls background jobs. Code keeps
   // deny because blocking before the write is cheap and effective.
   if (isMarkdownFile(ext)) {
-    const message = mode === "edit" ? `This edit introduces numbered sequences. ${reason}` : reason;
+    const message =
+      mode === "edit" ? `This edit introduces step or phase numbering. ${reason}` : reason;
     return { output: formatContext(message), category: "numbering" };
   }
 

--- a/plugins/writing/hooks/pretooluse.test.ts
+++ b/plugins/writing/hooks/pretooluse.test.ts
@@ -42,9 +42,9 @@ function mockInput(
   } as PreToolUseHookInput;
 }
 
-// Trips all three checkers at context tier: a numbered lowercase heading
+// Trips all three checkers at context tier: a lowercase step heading
 // (numbering + headings) and a spaced em dash (tropes).
-const MULTI_VIOLATION = "# 1. introduction\n\nThis — is bad\n";
+const MULTI_VIOLATION = "# step 1: introduction\n\nThis — is bad\n";
 
 function contextOf(output: unknown): string {
   return (output as { hookSpecificOutput: { additionalContext: string } }).hookSpecificOutput
@@ -57,7 +57,7 @@ describe("single output per tool call", () => {
       mockInput("Write", { file_path: "docs/draft.md", content: MULTI_VIOLATION }),
     );
     expect(output).not.toBeNull();
-    expect(contextOf(output)).toContain("numbered sequences");
+    expect(contextOf(output)).toContain("step or phase numbering");
     const { ts, session_id, duration_ms, ...stable } = log;
     expect(typeof duration_ms).toBe("number");
     expect(stable).toMatchInlineSnapshot(`
@@ -113,8 +113,8 @@ describe("code files", () => {
 });
 
 describe("session-scoped repeat suppression", () => {
-  // Numbered heading only: title-cased so headings stays silent, no tropes.
-  const NUMBERED_ONLY = "# 1. Introduction\n\nPlain prose here.\n";
+  // Step heading only: title-cased so headings stays silent, no tropes.
+  const NUMBERED_ONLY = "# Step 1: Introduction\n\nPlain prose here.\n";
 
   it("suppresses a repeat of the same category within the window", async () => {
     const sessionId = crypto.randomUUID();


### PR DESCRIPTION
`checkMarkdown` flagged any heading starting `N. `. That is the shape of ranked findings, enumerations, and tool inventories, not the process-step numbering the CLAUDE.md rule is about. The rule text names `Phase 1:` and `Step 2:`, so the matcher now does too.

The original finding framed this as a blocking problem. It isn't anymore: #1035 demoted markdown numbering from `ask` to `context` and #928 added the already-numbered suppression, so the hook has injected no `ask` or `deny` for markdown since 2026-07-09. What survives is a precision problem. Every markdown numbering fire in the recent run log was a bare-numbered heading of the ranked-findings kind, and each one spent context on advice that did not apply. The justification here is noise, not unblocking.

Narrowing gives up detection of bare-numbered headings in genuinely procedural documents. The session sample supports the trade: of the bare-number fires in July, all were rankings, enumerations, or inventories, and none were process steps.

Dropping the `[0-9]\.( |\t)` alternative from `NUMBER_HINT` is the other half. It existed only to admit bare-numbered headings, and it matched any ordered list or `1. ` in prose on the hot path, so every such write paid an mdast parse before the checker declined. The remaining `step|phase|part` alternative still covers all of `numbering.yml`, which is identifier-scoped and untouched.

The reason string changed wording, which intentionally resets the `hook_blocks` signature that groups these fires in session queries. The old signature belonged to a checker with different semantics.

Verified end to end through `pretooluse.ts`: a ranked heading now produces no numbering injection, `## Step 2: Setup` still does. The 17 unrelated failures in `bun test` (cross-machine session DB, `upstream.ts`) reproduce unchanged on `main`.

Removal criterion: the next `hook-health.ts` run after merge should show `numbering` at or near zero markdown fires while still firing on real `Step N` headings. Zero fires over a month is evidence to retire the markdown half rather than keep narrowing it.

Automated code review did not run on this branch, so it warrants a medium-effort review pass.

Original Task: [[discovery] numbering.ts over-fires on ranked finding lists](https://things.bendrucker.me/show?id=XdibY61asb6YuryeDbynnR)
