### PR TITLE
things: pass the plugin data dir to the x-callback-url bridge

### DIFF
--- a/plugins/things/CLAUDE.md
+++ b/plugins/things/CLAUDE.md
@@ -31,6 +31,8 @@ Biome linting is disabled for `scripts/jxa/` files via the root `biome.json` ove
 
 `reorder.ts` and `inbox.ts` are bun TypeScript scripts (not `osascript`). Their Launch Services handoff runs outside the command sandbox via the `claude:dangerouslyDisableSandbox` marker.
 
+The x-callback-url bridge needs `CLAUDE_PLUGIN_DATA` to locate its `.app` bundle, and Claude Code does not export it to Bash tool calls. The `things:url` skill sets it on every documented invocation, where the substitution has already resolved it, and the three scripts inherit it. Keep that prefix on any new documented command, or the callback is lost and `dispatch` silently falls back to `open`.
+
 ## What NOT to Do
 
 - **Don't use `tag.toDos().length`** for tag metadata — includes logbook items (13K+), extremely slow

--- a/plugins/things/skills/url/SKILL.md
+++ b/plugins/things/skills/url/SKILL.md
@@ -4,10 +4,9 @@ description: Create, update, and manage Things 3 tasks and projects, including q
 argument-hint: "<add | update | show | search | json | capture> [key=value ...]"
 effort: low
 allowed-tools:
-  - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts:*)"
-  - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts:*)"
-  - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/reorder.ts:*)"
-  - Bash
+  - "Bash(CLAUDE_PLUGIN_DATA=${CLAUDE_PLUGIN_DATA} bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts:*)"
+  - "Bash(CLAUDE_PLUGIN_DATA=${CLAUDE_PLUGIN_DATA} bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts:*)"
+  - "Bash(CLAUDE_PLUGIN_DATA=${CLAUDE_PLUGIN_DATA} bun ${CLAUDE_PLUGIN_ROOT}/scripts/reorder.ts:*)"
   - Read
 ---
 
@@ -23,11 +22,13 @@ Write operations for Things 3 via the `things:///` URL scheme.
 
 Use `url.ts` for most operations — it handles auth tokens and URL encoding.
 
+Keep the `CLAUDE_PLUGIN_DATA=` prefix on every invocation. Claude Code exports that variable to hooks and MCP servers but not to Bash tool calls, and the x-callback-url bridge needs it to locate its `.app` bundle. Dropping it costs the callback, so `url.ts` falls back to a fire-and-forget `open` and returns no todo id.
+
 ```bash
-bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts <command> [key=value ...]
+CLAUDE_PLUGIN_DATA=${CLAUDE_PLUGIN_DATA} bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts <command> [key=value ...]
 
 # Bulk update: pass multiple id= params to batch via JSON command
-bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts update id=X id=Y id=Z when=tomorrow
+CLAUDE_PLUGIN_DATA=${CLAUDE_PLUGIN_DATA} bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts update id=X id=Y id=Z when=tomorrow
 ```
 
 For raw URL scheme access: `open -g "things:///add?title=Buy%20milk&when=today"`
@@ -51,7 +52,7 @@ See [examples.md](examples.md) for detailed usage of each command.
 ## Reorder Items
 
 ```bash
-bun ${CLAUDE_PLUGIN_ROOT}/scripts/reorder.ts [--list today|anytime|someday] <id1> <id2> <id3> ...
+CLAUDE_PLUGIN_DATA=${CLAUDE_PLUGIN_DATA} bun ${CLAUDE_PLUGIN_ROOT}/scripts/reorder.ts [--list today|anytime|someday] <id1> <id2> <id3> ...
 ```
 
 Items appear at the top of the list in the order specified. Default list is `today`. Also works for items within a project. Use the `--list` value matching the items' current scheduling state.
@@ -61,14 +62,14 @@ Items appear at the top of the list in the order specified. Default list is `tod
 For quick captures to the inbox, use `inbox.ts`. It tags each todo `Claude` and appends session attribution, so prefer it over `url.ts add` when delegating a task mid-session.
 
 ```bash
-bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts --session-id ${CLAUDE_SESSION_ID} title="Buy milk"
+CLAUDE_PLUGIN_DATA=${CLAUDE_PLUGIN_DATA} bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts --session-id ${CLAUDE_SESSION_ID} title="Buy milk"
 ```
 
 `title` captures one todo. `titles` (newline-separated) captures several at once. Add tags with `--tag` (repeatable). Other params: `notes` (max 10,000 chars), `tags` (comma-separated), `checklist-items` (newline-separated, max 100). The script handles URL encoding, session attribution, and the `Claude` tag.
 
 ```bash
 # Multiple todos, each with the claude-code tag
-bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts --session-id ${CLAUDE_SESSION_ID} --tag claude-code titles="Buy milk
+CLAUDE_PLUGIN_DATA=${CLAUDE_PLUGIN_DATA} bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts --session-id ${CLAUDE_SESSION_ID} --tag claude-code titles="Buy milk
 Walk dog"
 ```
 

--- a/plugins/x-callback-url/README.md
+++ b/plugins/x-callback-url/README.md
@@ -13,3 +13,5 @@ Call x-callback-url schemes from the CLI and receive responses synchronously.
 - `scripts/main.swift` — Swift source for the xcall bridge
 - `scripts/build.sh` — Compiles Swift source into `.app` bundle with URL scheme registration
 - `scripts/run.sh` — Build-if-needed + invoke wrapper
+
+The bundle is installed to `$CLAUDE_PLUGIN_DATA`. Claude Code does not export that variable to Bash tool calls, so a consuming skill sets it on the command it documents.

--- a/plugins/x-callback-url/scripts/build.sh
+++ b/plugins/x-callback-url/scripts/build.sh
@@ -6,21 +6,24 @@ set -euo pipefail
 # The .app bundle is required because macOS only delivers URL scheme
 # callbacks to registered applications with CFBundleURLTypes in Info.plist.
 #
-# Installs into ${CLAUDE_PLUGIN_DATA}. Marketplace installs put plugin
-# sources in a content-addressed cache directory whose hash rotates per
-# plugin version; building xcall.app there would leave Launch Services
-# pointing at a deleted path after any plugin update.
+# Installs into ${CLAUDE_PLUGIN_DATA}. Marketplace installs put plugin sources
+# in a content-addressed cache directory whose hash rotates per plugin version,
+# so a bundle built beside the source would leave Launch Services pointing at a
+# deleted path after any plugin update.
 #
 # Output (stdout): path to the compiled binary inside the .app bundle.
 # Cached: only recompiles if main.swift is newer than the existing binary.
 
-if [[ -z "${CLAUDE_PLUGIN_DATA:-}" ]]; then
-  echo "CLAUDE_PLUGIN_DATA is not set; this script must be invoked from a Claude Code plugin context" >&2
-  exit 1
-fi
-
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SOURCE="$SCRIPT_DIR/main.swift"
+
+# Claude Code exports CLAUDE_PLUGIN_DATA to hooks and MCP servers but not to
+# Bash tool calls. A caller reached from a Bash invocation passes it explicitly,
+# taking the value from its own skill, where the variable is substituted.
+if [[ -z "${CLAUDE_PLUGIN_DATA:-}" ]]; then
+  echo "CLAUDE_PLUGIN_DATA is not set; pass it explicitly, as the things:url skill does" >&2
+  exit 1
+fi
 
 APP_DIR="$CLAUDE_PLUGIN_DATA/xcall.app"
 CONTENTS_DIR="$APP_DIR/Contents"
@@ -30,16 +33,31 @@ BINARY="$MACOS_DIR/xcall"
 LEGACY_APP_DIR="$SCRIPT_DIR/xcall.app"
 LSREGISTER=/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister
 
+# Launch Services reports bundle paths with symlinks resolved, so comparing its
+# answer against an unresolved path (a data dir under /var, say) reads as a
+# binding failure when the registration is correct.
+canonical_path() {
+  local target="$1"
+  if [[ -d "$target" ]]; then
+    (cd "$target" && pwd -P)
+  else
+    printf '%s\n' "$target"
+  fi
+}
+
 scheme_handler_path() {
   "$LSREGISTER" -dump 2>/dev/null \
     | awk 'BEGIN { RS = "--------------------------------------------------------------------------------" } /com\.bendrucker\.xcall-claude/' \
     | awk '/^path:/ { sub(/^path:[[:space:]]+/, ""); sub(/[[:space:]]+\([^)]+\)$/, ""); print; exit }'
 }
 
+# Deleting an already-unregistered bundle is best effort: the plugin tree can be
+# read-only under the sandbox, and failing to clean it up should not take down a
+# callback that is otherwise working.
 unregister_legacy_bundle() {
   if [[ -d "$LEGACY_APP_DIR" && "$LEGACY_APP_DIR" != "$APP_DIR" ]]; then
     "$LSREGISTER" -u "$LEGACY_APP_DIR" >/dev/null 2>&1 || true
-    rm -rf "$LEGACY_APP_DIR"
+    rm -rf "$LEGACY_APP_DIR" || true
   fi
 }
 
@@ -89,12 +107,34 @@ build_bundle() {
 PLIST
 }
 
+# A bundle can survive at a path an earlier version of this script built into.
+# Launch Services keeps delivering xcall-claude:// to that copy, and
+# `lsregister -f` on the new bundle does not take the scheme back, so the
+# waiting process never sees its callback and times out. Retire the stale copy
+# instead. Only paths ending in xcall.app are removed, and scheme_handler_path
+# only ever reports bundles carrying this plugin's identifier.
+retire_stale_handler() {
+  local handler="$1"
+  [[ "$handler" == */xcall.app ]] || return 1
+
+  "$LSREGISTER" -u "$handler" >/dev/null 2>&1 || true
+  rm -rf "$handler" || true
+  "$LSREGISTER" -f "$APP_DIR"
+}
+
 register_bundle() {
   "$LSREGISTER" -f "$APP_DIR"
 
-  local handler
-  handler="$(scheme_handler_path)"
-  if [[ "$handler" != "$APP_DIR" ]]; then
+  local want handler
+  want="$(canonical_path "$APP_DIR")"
+
+  handler="$(canonical_path "$(scheme_handler_path)")"
+  if [[ -n "$handler" && "$handler" != "$want" ]]; then
+    retire_stale_handler "$handler" || true
+    handler="$(canonical_path "$(scheme_handler_path)")"
+  fi
+
+  if [[ "$handler" != "$want" ]]; then
     echo "lsregister did not bind xcall-claude:// to $APP_DIR (got: ${handler:-<none>})" >&2
     exit 1
   fi

--- a/plugins/x-callback-url/scripts/run.sh
+++ b/plugins/x-callback-url/scripts/run.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
+# Exit 3 separates a build failure from xcall's own exit codes (0 success,
+# 1 x-error, 2 x-cancel). Callers treat any non-zero status as "no result", so
+# without it a broken build is indistinguishable from the target app rejecting
+# the request.
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-BINARY="$("$SCRIPT_DIR/build.sh")"
+
+if ! BINARY="$("$SCRIPT_DIR/build.sh")"; then
+  echo "xcall build failed; see errors above" >&2
+  exit 3
+fi
+
 exec "$BINARY" "$@"

--- a/plugins/x-callback-url/skills/xcall/SKILL.md
+++ b/plugins/x-callback-url/skills/xcall/SKILL.md
@@ -15,6 +15,8 @@ Send [x-callback-url](https://x-callback-url.com/) requests from the command lin
 
 `xcall` is a Swift CLI that builds into a macOS `.app` bundle. The `.app` is required because macOS only delivers URL scheme callbacks to registered applications. On first use, `run.sh` compiles the source into `${CLAUDE_PLUGIN_DATA}/xcall.app` and registers the callback scheme (`xcall-claude://`) with Launch Services. Installing into the plugin's data directory (not the plugin source/cache tree) keeps the registered path stable across plugin updates: the marketplace cache is content-addressed, so building xcall.app inside it would orphan the Launch Services registration on the next update.
 
+Claude Code exports `CLAUDE_PLUGIN_DATA` to hooks and MCP servers but not to Bash tool calls, and `run.sh` is reached both ways. A consuming skill closes that gap by setting the variable on the command it documents, where the substitution has already resolved it. `things:url` does this on every `url.ts`, `inbox.ts`, and `reorder.ts` invocation. `build.sh` never guesses a location of its own, because a second bundle would take the `xcall-claude://` scheme from the first and `lsregister -f` does not take it back.
+
 ## Usage
 
 ```bash
@@ -23,7 +25,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/run.sh "<url>"
 
 **stdout**: `x-success` query string on success
 **stderr**: `x-error` query string or timeout message
-**Exit codes**: 0 = success, 1 = error, 2 = cancel
+**Exit codes**: 0 = success, 1 = error, 2 = cancel, 3 = build failed
 
 ## Examples
 
@@ -75,10 +77,10 @@ Apps with their own CLI (e.g., Shortcuts via `shortcuts run`) don't need xcall â
 ## Build Details
 
 - Source: `scripts/main.swift` (~100 lines)
-- Build: `scripts/build.sh` compiles to `${CLAUDE_PLUGIN_DATA}/xcall.app/`. The script exits non-zero if `CLAUDE_PLUGIN_DATA` is unset.
+- Build: `scripts/build.sh` compiles to `${CLAUDE_PLUGIN_DATA}/xcall.app/`. It exits non-zero when the variable is unset
 - Bundle ID: `com.bendrucker.xcall-claude`
 - Callback scheme: `xcall-claude://`
 - `Info.plist`: `CFBundleTypeRole=Editor`, `LSUIElement=true`. `LSBackgroundOnly` is intentionally not set: combining it with `LSUIElement` causes macOS to refuse to route URL scheme callbacks to the app, surfacing as a "no application set" dialog.
-- After building, `build.sh` calls `lsregister -f` and verifies the scheme handler is the freshly built bundle. If verification fails it exits non-zero.
+- After building, `build.sh` calls `lsregister -f` and verifies the scheme handler is the freshly built bundle. A bundle left behind at a path an earlier version built into keeps the scheme, and `lsregister -f` does not take it back, so `build.sh` unregisters and deletes that copy before verifying. If verification still fails it exits non-zero.
 - Build is cached â€” recompiles only if `main.swift` is newer than the binary
 - Timeout: 10 seconds


### PR DESCRIPTION
`build.sh` requires `CLAUDE_PLUGIN_DATA` to locate the `xcall.app` bundle, but Claude Code exports that variable to hooks and MCP servers only, never to Bash tool calls. Every Bash-invoked caller hit the guard: `build.sh` exited 1, `run.sh` died under `set -e`, and `plugins/things/scripts/url.ts` swallowed the failure and fell through to a plain `open -g`. The write landed, so nothing looked broken, but the callback never ran and no todo id, batch id, or `show?id=` link ever came back. The entire callback feature was dark from the model's side.

The variable is only missing at the Bash boundary, and the skill sitting on that boundary already has it: `${CLAUDE_PLUGIN_DATA}` is substituted in skill content. So `things:url` sets it on the commands it documents, and `url.ts`, `inbox.ts`, and `reorder.ts` inherit it down to `run.sh`. No script changes, and `build.sh` keeps its original hard requirement rather than learning to guess a location.

Two things that could have broken this and do not:

- The `mac` sandbox marker hook parses the command to find the script it should read for `claude:dangerouslyDisableSandbox`. It already skips leading `VAR=` assignments, so the bypass still fires with the prefix.
- Permission patterns match the command from its start, so the three `Bash(...)` entries in `allowed-tools` carry the prefix too. `${CLAUDE_PLUGIN_DATA}` is substituted there the same as in the body.

Bare `Bash` comes out of `allowed-tools` in the same change. It was covering one thing, the raw `open -g "things:///..."` escape hatch, which is a Launch Services handoff that should ask rather than run unprompted.

The bundle moves from the `x-callback-url` data dir to the `things` one, which is where the working consumer is. That exposed a hazard worth naming, because it also fires on merge for anyone whose bundle is at the old path: a bundle outlives the path it was built in, keeps the `xcall-claude://` scheme, and `lsregister -f` on the new bundle does **not** take it back. macOS then delivers the callback to a bundle no process is waiting on and the caller sits until its 10s timeout. `register_bundle` unregisters and deletes the stale holder before verifying, guarded to paths ending in `xcall.app` (`scheme_handler_path` only ever reports bundles carrying this plugin's identifier). Handler comparison also canonicalizes symlinks, since Launch Services reports resolved paths and an unresolved `/var` data dir read as a binding failure when the registration was correct.

One rough edge left as is: the invocation that performs the migration loses its own callback, because the retirement happens while that call is already waiting. The next call is fine, and the retirement runs once.

`run.sh` now exits 3 when the build fails. Callers treat any non-zero status as "no result", so a broken build was indistinguishable from the target app returning an `x-error`, which is how this stayed silent for so long.

## Evidence

Fails closed with the variable absent, which is the behavior on `main` and stays:

```
$ env -u CLAUDE_PLUGIN_DATA bash plugins/x-callback-url/scripts/run.sh "things:///version"
CLAUDE_PLUGIN_DATA is not set; pass it explicitly, as the things:url skill does
xcall build failed; see errors above
EXIT=3
```

The command the skill now renders, run sandboxed through the Bash tool, marker hook firing, read-only `version`:

```
$ CLAUDE_PLUGIN_DATA=~/.claude/plugins/data/things-bendrucker bun plugins/things/scripts/url.ts version
x-things-scheme-version=2&x-things-client-version=32212515
EXIT=0
```

The first run of that command returned empty at exit 0, which is the migration edge above: it built the bundle and retired the previous holder while its own callback was already in flight. Every run after it returns the payload.

No Things todo was created, updated, or canceled. `version` is read-only.

Covered by `bun test plugins/things plugins/x-callback-url`, `biome check`, and `skill-lint` on both plugins. CI never runs `build.sh`, it only `swiftc -parse`s the source.

`review:code` did not run: #1084 landed after this session's plugin cache was built, so the skill is not loadable here. I self-reviewed the diff. It changes a build script and touches Launch Services registration, so a `medium` human pass is worth it.

Discovery: 5f8d2e14b7a9

## References

Documentation for the precondition landed separately in #1078.
