### PR TITLE
job: associate in-flight agents with brief items

### DIFF
--- a/user/skills/job/SKILL.md
+++ b/user/skills/job/SKILL.md
@@ -8,6 +8,10 @@ description: >
   tomorrow. Use via /job, /job start, /job end, or /job setup.
 argument-hint: "[start | end | setup]"
 disable-model-invocation: true
+allowed-tools:
+  - Read(${CLAUDE_SKILL_DIR}/references/*)
+  - Bash(claude agents:*)
+  - Bash(claude --bg:*)
 ---
 
 # Job
@@ -49,11 +53,36 @@ Both modes follow this contract.
 
 Read-only first. The sources are independent (review queue, own PRs, tracker, messaging inbox, email inbox), so dispatch parallel read-only sub-agents and merge their results. Merge on shared identifiers: when items from different sources name the same issue or MR, they are one piece of work and become one brief entry carrying every source's state. Sub-agents cannot see each other's results. The join is the orchestrator's job, keyed on the cross-references each sub-agent returns.
 
+#### Agents
+
+Background Claude sessions may already be working items in the brief. Run `claude agents --json --all` inline in the orchestrator rather than in a sub-agent: it is one command, and the join needs the raw records that a sub-agent summary would flatten. Each record carries `id`, `sessionId`, `name`, `cwd`, `kind`, `startedAt`, `status`, `state`, and, when blocked, `waitingFor`. `state` is `working`, `blocked`, `done`, or `failed`, and is null for interactive sessions.
+
+Join each record to a brief item in this order:
+
+1. A `name` matching the `job:<identifier>` convention below. Exact and structural, so it is the only join that never guesses.
+2. An issue key, PR number, or PR URL appearing anywhere in `name`. This covers sessions launched by hand.
+3. `cwd` resolved to a repo, narrowing the candidate items, plus a semantic match of the name text against item titles. Both texts are already in the brief, so this costs nothing extra.
+
+`cwd` is the directory the session launched from. A session that entered a worktree mid-run still reports its launch directory, usually a main checkout, occasionally a path that has since been pruned. Use it to scope candidates by repo. Never derive a branch from it, and never report it as the work.
+
+When an item's session is still unresolved and the user asks about that specific item, fall back to the `claude-code:session` skill's `search` query with the identifier as `query` and the repo as `project`. Never during gather, since it costs a query per item.
+
+Handle three record classes explicitly. Skip any record whose `sessionId` is the current session. Surface `blocked` records, which are waiting on the user and are the reason this source exists. Surface `failed` records, since abandoned work reads as done work otherwise.
+
 ### Brief
 
 One prioritized brief, grouped by project. Resolve each item to its project through the tracker: an issue carries its project, and an MR or message inherits the project of the work it references. Collapse an MR, its issue, and any thread about the same work into one entry. Keep a `Misc` group for project-less items.
 
 Within a group, order blocking items first, then oldest. Each item gets an identifier with a link, a one-line state, and a recommended action. The mode's phases set what to surface and label each item's role within its project.
+
+An item with a matched agent gains one line under its existing entry:
+
+```
+agent `<short id>` · <state>[ (<waitingFor>)] · <age>
+→ claude --resume <sessionId>
+```
+
+Agents that matched no item become their own entries, grouped by the repo their `cwd` resolves to, or `Misc` when it resolves to none. A blocked agent is blocking work and sorts with it under the ordering rule above.
 
 Close with the mode's cross-project synthesis: the day's sequence, or the night's open decisions. This is the triage gate. The brief covers everything gathered, and nothing executes until the user approves the order. Omit empty groups and never pad. An empty queue is a two-line brief.
 
@@ -69,3 +98,11 @@ Drive inbound to zero. Every review request, message, notification, and email le
 Present safe actions via AskUserQuestion (execute all, pick a subset, or none). Execute through the delegated skills, then give a short summary of what changed.
 
 Run the quick safe actions and tracker corrections first. Session-length work like a review starts only at the end of the run, after the rest is cleared, and never before the approved order from triage.
+
+An item with a live session (`working`, `blocked`, or an interactive session whose `state` is null) is never dispatched again. Its recommended action is the resume command, which the user runs. Dispatching over live work is not safe, so do not offer it.
+
+A prior session that is `done` or `failed` does not block a fresh dispatch, but when the work needs another pass, name that `sessionId` in the new prompt so the new session can look up what already happened.
+
+Every session this skill dispatches gets `--name "job:<identifier>"`, reusing the identifier from the brief. That is what lets tomorrow's run join by name alone.
+
+Resuming a blocked agent is a handoff: surface the command, let the user run it. This skill runs in its own session and cannot attach to another.

--- a/user/skills/job/SKILL.md
+++ b/user/skills/job/SKILL.md
@@ -60,7 +60,7 @@ Background Claude sessions may already be working items in the brief. Run `claud
 Join each record to a brief item in this order:
 
 1. A `name` matching the `job:<identifier>` convention below. Exact and structural, so it is the only join that never guesses.
-2. An issue key, PR number, or PR URL appearing anywhere in `name`. This covers sessions launched by hand.
+2. A full PR URL in `name`, or an issue key or `#`-prefixed PR number bounded by non-alphanumeric characters and confirmed against the repo `cwd` resolves to. This covers sessions launched by hand. Do not match a bare substring: `#42` occurs inside `#142`, and every repo has a PR numbered 42.
 3. `cwd` resolved to a repo, narrowing the candidate items, plus a semantic match of the name text against item titles. Both texts are already in the brief, so this costs nothing extra.
 
 `cwd` is the directory the session launched from. A session that entered a worktree mid-run still reports its launch directory, usually a main checkout, occasionally a path that has since been pruned. Use it to scope candidates by repo. Never derive a branch from it, and never report it as the work.
@@ -79,10 +79,11 @@ An item with a matched agent gains one line under its existing entry:
 
 ```
 agent `<short id>` · <state>[ (<waitingFor>)] · <age>
-→ claude --resume <sessionId>
 ```
 
-Agents that matched no item become their own entries, grouped by the repo their `cwd` resolves to, or `Misc` when it resolves to none. A blocked agent is blocking work and sorts with it under the ordering rule above.
+A live session (`working`, `blocked`, or an interactive session whose `state` is null) adds a second line, `→ claude --resume <sessionId>`, because resuming it is the action. A `done` or `failed` session gets no resume line. It is history, so the item keeps the action it already had, and the entry carries the `sessionId` as the prior attempt worth reading.
+
+An unmatched agent becomes its own entry only when it still wants something: `blocked`, `failed`, or `working`. Since gather runs with `--all`, unmatched `done` records are completed history and get dropped. Keeping them would fill a prioritized brief with finished work. Group what remains by the repo `cwd` resolves to, or `Misc` when it resolves to none. A blocked agent is blocking work and sorts with it under the ordering rule above.
 
 Close with the mode's cross-project synthesis: the day's sequence, or the night's open decisions. This is the triage gate. The brief covers everything gathered, and nothing executes until the user approves the order. Omit empty groups and never pad. An empty queue is a two-line brief.
 

--- a/user/skills/job/references/end.md
+++ b/user/skills/job/references/end.md
@@ -1,6 +1,6 @@
 # End
 
-The day ends with decisions. Nothing leaves it unsent, unanswered, unfiled, or unpushed without one.
+The day ends with decisions. Nothing leaves it unsent, unanswered, unfiled, unpushed, or unattended without one.
 
 ## Gather
 
@@ -12,6 +12,8 @@ Dispatch parallel read-only sub-agents:
 - Email (when configured): unhandled mail awaiting your reply or filing, with sender and link.
 - Worktrees: every worktree's uncommitted and unpushed state (details under the sweep below).
 - Tracker: your in-flight issues, their current states, and their projects.
+
+Agents are gathered inline, not by a sub-agent: run `claude agents --json --all` in the orchestrator and join its records per the Agents rules in `SKILL.md`.
 
 ## Outbox Clearing
 
@@ -43,6 +45,12 @@ Enumerate worktrees via the configured worktree tool. Fall back to `git worktree
 - Unpushed commits (`git log @{u}..HEAD --oneline`, or all local commits when no upstream exists)
 
 Offer per worktree: commit and push as WIP (safe on your own branch), or record it as deliberately local in the completion summary.
+
+## Unattended Agents
+
+Every blocked or failed agent leaves the day resumed, stopped, or captured as a follow-up. Route captures per Tracker Hygiene below: team work to the tracker, personal follow-ups to the personal inbox. A blocked agent carries what it is waiting on in `waitingFor`, and that belongs in the capture, since tomorrow's answer is worthless without the question.
+
+A `working` agent can be left running overnight. That is a choice, so record it in the completion summary along with what it is expected to have finished by morning.
 
 ## Tracker Hygiene and Tomorrow
 

--- a/user/skills/job/references/start.md
+++ b/user/skills/job/references/start.md
@@ -12,6 +12,8 @@ Dispatch parallel read-only sub-agents:
 - Messaging (when configured): direct messages and mentions to the configured user since the last working day that imply an action, with sender, link, and the ask.
 - Email (when configured): unhandled mail that needs a reply, an action, or filing, with sender, subject, and link.
 
+In-flight agents are the exception to the fan-out. Run `claude agents --json --all` inline in the orchestrator and join its records to brief items per the Agents rules in `SKILL.md`.
+
 Each sub-agent uses the delegated skill, MCP, or CLI for its source and returns structured state: identifiers, links, and statuses the brief can consume directly, plus every cross-reference an item carries, such as an issue key in an MR title or branch, or an MR named in a comment or message. These cross-references drive the merge in `SKILL.md`, joining one piece of work reported from several sources. Sub-agents report state, not dispositions: who spoke last, when, and what is open. Deciding an item needs nothing is a triage call, and triage happens in the brief.
 
 ## Inbound Review Queue
@@ -46,11 +48,15 @@ Read is not handled. Notification state records only what the user has seen, so 
 
 Inbox zero is the target. Each item leaves the day in a terminal state: handled, reacted to or briefly acknowledged, deferred, or archived. Before drafting a reply, judge whether the thread needs a substantive response. Where a reaction or brief acknowledgement closes it, prefer that over filler. Draft a reply only when it carries real content, and keep it terse.
 
+A blocked agent is an inbound item like any message or notification, and it gets the same terminal disposition: resumed by you, or deferred with a note recording what it is waiting on. Read is not handled applies here too. An agent you saw in `claude agents` and walked away from is still open work.
+
 Route what gets deferred by where it belongs. Work for the team backlog goes to the tracker, while personal next-steps and reminders go to the personal inbox when one is configured. "My inbox" means the personal inbox. When the destination is ambiguous, ask rather than defaulting to a tracker issue, and never create a tracker issue in place of a personal capture. Drafting a reply the user has read is safe, as is archiving something already handled. Sending a reply without review is ask-first.
 
 ## Today Plan
 
 Group everything gathered by project, with a `Misc` group for project-less items. From assignments and the current cycle, propose one to three focus items for the day, folding in anything the earlier phases produced: a real CI failure, a draft to finish, a decision a message asked for.
+
+In-flight agents shape this list. Work that already has a live session is underway, so it never becomes a fresh focus item. Where it needs your attention, the focus item is unblocking the session, not starting the work.
 
 Confirm two things with the user. First, the focus items. Second, the sequence across projects, because working a project at a time and clearing every review first are both reasonable, and only the user knows which they want today.
 


### PR DESCRIPTION
`/job` gathers work from the review queue, your own PRs, the tracker, and messaging, then presents one prioritized brief. It had no idea that background Claude sessions were already working some of those items, so every run reasoned as if nothing was in flight. It could recommend starting work a session was already doing, and an agent blocked waiting on input was invisible to a routine whose whole contract is that nothing leaves the day undecided.

Gather now runs `claude agents --json --all` inline in the orchestrator rather than through a sub-agent, since it is one command and the join needs raw records a summary would flatten.

## The join

There is no branch or PR field on an agent record, and `cwd` is the launch directory. A session that entered a worktree mid-run still reports where it started, usually a main checkout, occasionally a path that has since been pruned. Locally, 8 of 14 background agents report a main checkout despite having entered worktrees. So `cwd` scopes candidates by repo and never identifies the work.

That leaves `name` as the only field carrying meaning, which is why the skill writes it: every session it dispatches gets `--name "job:<identifier>"`, reusing the identifier the brief already shows. The join then falls back through an identifier appearing anywhere in the name, for hand-launched sessions, and finally repo scope plus a semantic match of name text against item titles. The session index is consulted only on demand, when the user asks about a specific unresolved item.

This is the same conclusion `review:inbox` reached. Its `dispatched.ts` keeps a `url → sessionId` store at dispatch precisely because nothing else can recover the link.

## Behavior

An item with a live session is never re-dispatched. The recommended action is a resume command the user runs, since `/job` runs in its own session and cannot attach to another. A `done` or `failed` prior session does not block a fresh dispatch, but the new prompt names the old `sessionId` so it can read the history.

End mode gains an unattended-agents phase alongside the unpushed-work sweep. Every blocked or failed agent leaves the day resumed, stopped, or captured as a follow-up through the existing tracker-vs-personal-inbox routing. A `working` agent left running overnight gets recorded in the summary as a deliberate choice.

## Also

The frontmatter gains `allowed-tools`, which pre-approves reading the skill's own reference files. Those were prompting on every run, since they resolve through `~/.claude/skills/` and fall outside project permissions. `${CLAUDE_SKILL_DIR}` expands in `allowed-tools`, so the pattern stays path-independent. Confirmed against the docs that `allowed-tools` pre-approves rather than restricting, so listing three entries does not cut the skill off from the tools it delegates through.

## Verification

`bun run skill-lint "user/skills/job"` is clean, and the field set the skill assumes matches live `claude agents --json --all` output. The end-to-end checks from the plan are not run here: no agent is currently in `blocked` state locally (states present are null, `done`, `failed`, `working`), so the blocked-agent paths in both modes are unexercised until one occurs naturally.

`claude --from-pr` resumes a session linked to a PR and would subsume the name convention for PR-shaped items. Its link records live in the transcripts themselves (`type: "pr-link"`, GitHub-only), which the session index already exposes as a `pr_links` view. Left for a follow-up rather than depended on here.
