### PR TITLE
biome: skip gitignored files in the Stop hook

### DIFF
--- a/.claude/hooks/biome/index.test.ts
+++ b/.claude/hooks/biome/index.test.ts
@@ -232,6 +232,28 @@ describe("biome hook", () => {
       const files = await parseTranscript(transcriptPath);
       expect(files).toEqual([]);
     });
+
+    it("filters out gitignored files but keeps tracked siblings", async () => {
+      const repoDir = await mkdtemp(join(tempDir, "ignored-transcript-"));
+      await execAsync("git init", { cwd: repoDir });
+      await Bun.write(join(repoDir, ".gitignore"), "tmp/\n");
+      const tracked = join(repoDir, "kept.ts");
+      const ignored = join(repoDir, "tmp", "scratch.ts");
+      await Bun.write(tracked, "export const a = 1;\n");
+      await Bun.write(ignored, "export const b = 2;\n");
+
+      const transcriptPath = join(tempDir, `transcript-gitignored-${Date.now()}.jsonl`);
+      await Bun.write(
+        transcriptPath,
+        createTranscriptContent([
+          { path: tracked, tool: "Write" },
+          { path: ignored, tool: "Write" },
+        ]),
+      );
+
+      const files = await parseTranscript(transcriptPath);
+      expect(files).toEqual([tracked]);
+    });
   });
 
   describe("processPostToolUse", () => {

--- a/.claude/hooks/biome/index.test.ts
+++ b/.claude/hooks/biome/index.test.ts
@@ -254,6 +254,25 @@ describe("biome hook", () => {
       const files = await parseTranscript(transcriptPath);
       expect(files).toEqual([tracked]);
     });
+
+    it("does not shell-evaluate a path containing a command substitution", async () => {
+      const repoDir = await mkdtemp(join(tempDir, "injection-repo-"));
+      await execAsync("git init", { cwd: repoDir });
+      // isIgnored runs git with cwd = the file's directory, so a bare relative
+      // name is where the injected `touch` would land if a shell evaluated it.
+      const malicious = join(repoDir, "$(touch pwned).ts");
+      await Bun.write(malicious, "export const a = 1;\n");
+
+      const transcriptPath = join(tempDir, `transcript-injection-${Date.now()}.jsonl`);
+      await Bun.write(
+        transcriptPath,
+        createTranscriptContent([{ path: malicious, tool: "Write" }]),
+      );
+
+      const files = await parseTranscript(transcriptPath);
+      expect(files).toEqual([malicious]);
+      expect(await Bun.file(join(repoDir, "pwned")).exists()).toBe(false);
+    });
   });
 
   describe("processPostToolUse", () => {

--- a/.claude/hooks/biome/index.ts
+++ b/.claude/hooks/biome/index.ts
@@ -51,6 +51,20 @@ async function fileExists(filePath: string): Promise<boolean> {
   return Bun.file(filePath).exists();
 }
 
+// A gitignored path (scratch under tmp/, a nested worktree) can never be
+// committed, so gating Stop on its lint errors blocks the session on throwaway
+// content. git check-ignore drops those while keeping new untracked source
+// files in scope, which `git ls-files` would not. Paths outside any repo exit
+// 128 and stay in scope.
+async function isIgnored(filePath: string): Promise<boolean> {
+  try {
+    await execAsync(`git check-ignore -q "${filePath}"`, { cwd: dirname(filePath) });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // Biome ships as a devDependency, so its binary lives in the module graph
 // rather than on PATH (`bun run` adds node_modules/.bin, but `bun test` and
 // direct hook invocation do not). Resolve it through the package and run it
@@ -86,8 +100,7 @@ export async function parseTranscript(transcriptPath: string): Promise<string[]>
   }
 
   const content = await Bun.file(transcriptPath).text();
-  const files = new Set<string>();
-  const existChecks: Array<Promise<{ path: string; exists: boolean }>> = [];
+  const candidates = new Set<string>();
 
   for (const line of content.split("\n")) {
     if (!line.trim()) continue;
@@ -102,20 +115,18 @@ export async function parseTranscript(transcriptPath: string): Promise<string[]>
 
         const filePath = block.input?.file_path;
         if (filePath && isBiomeFile(filePath)) {
-          existChecks.push(fileExists(filePath).then((exists) => ({ path: filePath, exists })));
+          candidates.add(filePath);
         }
       }
     } catch {}
   }
 
-  const results = await Promise.all(existChecks);
-  for (const { path, exists } of results) {
-    if (exists) {
-      files.add(path);
-    }
-  }
-
-  return [...files];
+  const checks = [...candidates].map(async (path) => ({
+    path,
+    keep: (await fileExists(path)) && !(await isIgnored(path)),
+  }));
+  const results = await Promise.all(checks);
+  return results.filter((result) => result.keep).map((result) => result.path);
 }
 
 // Biome derives its project root from the working directory. Running from an

--- a/.claude/hooks/biome/index.ts
+++ b/.claude/hooks/biome/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { exec } from "node:child_process";
+import { exec, execFile } from "node:child_process";
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -12,6 +12,7 @@ import type {
 } from "@anthropic-ai/claude-agent-sdk";
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 const BIOME_EXTENSIONS = new Set(["ts", "tsx", "js", "jsx", "json", "jsonc"]);
 
@@ -58,7 +59,7 @@ async function fileExists(filePath: string): Promise<boolean> {
 // 128 and stay in scope.
 async function isIgnored(filePath: string): Promise<boolean> {
   try {
-    await execAsync(`git check-ignore -q "${filePath}"`, { cwd: dirname(filePath) });
+    await execFileAsync("git", ["check-ignore", "-q", filePath], { cwd: dirname(filePath) });
     return true;
   } catch {
     return false;


### PR DESCRIPTION
Editing a gitignored scratch file gated the biome Stop hook on lint errors for content that can never be committed. The live trigger was a Workflow script written to the repo's `tmp/`: its top-level `return` is valid under the Workflow runner but fails to parse as a standalone module, so `biome check` blocked Stop. The existing `/workflows/scripts/` exclusion only covered scripts under the session directory, not the repo's own `tmp/`.

`parseTranscript` now drops any candidate that `git check-ignore` reports as ignored. `check-ignore` rather than `git ls-files` keeps new, untracked source files in scope (a file the model just created but hasn't committed still gets checked); paths outside any repo exit 128 and stay in scope. This mirrors the git-tracked scoping the check-md-code hook adopted in 9464be23.
