### PR TITLE
skills: cut token waste in the hottest-path skills

### DIFF
--- a/plugins/gitlab/skills/merge-request/SKILL.md
+++ b/plugins/gitlab/skills/merge-request/SKILL.md
@@ -14,8 +14,6 @@ Working with GitLab merge requests via `glab mr`.
 
 Scripts directory (absolute, for invocations from other skills where `${CLAUDE_SKILL_DIR}` points elsewhere): !`mkdir -p /tmp/claude/gitlab-skill 2>/dev/null; touch "/tmp/claude/gitlab-skill/${CLAUDE_SESSION_ID}" 2>/dev/null; echo "${CLAUDE_SKILL_DIR}/scripts"`
 
-Loading this skill also stamps `/tmp/claude/gitlab-skill/<session>`, which tells the plugin's `hooks/lint.ts` to skip its load-this-skill nudge. Keep the path in sync with `MARKER_DIR` there.
-
 ## Arguments
 
 `$0` (optional verb) routes to a section below. With no verb, infer the operation from the request.
@@ -27,17 +25,6 @@ Loading this skill also stamps `/tmp/claude/gitlab-skill/<session>`, which tells
 - `block`: block an MR until another merges. See [Blocking](#blocking).
 
 Flag defaults: `--draft` off, `--auto` off, `--role reviewer`.
-
-## Key Commands
-
-```bash
-glab mr create --fill      # Create from commits (push branch first!)
-glab mr list               # List MRs
-glab mr view               # View current branch's MR
-glab mr checkout <id>      # Check out MR branch
-```
-
-Use `glab mr --help` and `glab mr <command> --help` for full options.
 
 ## Merging
 
@@ -57,16 +44,7 @@ A push also resets approvals when `reset_approvals_on_push` is on. Re-trigger re
 
 ### Inspect or Recover a Train
 
-`glab` has no merge-train command, so use the API directly:
-
-```bash
-# Active train for the project
-glab api "projects/:id/merge_trains?scope=active" | jq '.[] | {iid: .merge_request.iid, status, target_branch}'
-
-# Clear a stuck entry, then re-arm
-glab api --method DELETE "projects/:id/merge_trains/merge_requests/<iid>"
-glab api --method POST  "projects/:id/merge_trains/merge_requests/<iid>" --raw-field auto_merge=true
-```
+To inspect the active train or clear a stuck entry via the API (`glab` has no merge-train command), see [merge-trains.md](merge-trains.md).
 
 ## Patterns
 
@@ -89,18 +67,7 @@ glab api projects/:id/members/all --paginate | jq '.[] | select(.name | test("<n
 
 ## Blocking
 
-Prevent an MR from merging until another MR merges first. Uses the REST API since `glab mr` has no blocking subcommand.
-
-```bash
-# Block MR !10 until MR !5 merges
-glab api projects/:id/merge_requests/10/blocks -X POST -f blocking_merge_request_iid=5
-
-# List blocks on an MR
-glab api projects/:id/merge_requests/10/blocks
-
-# Remove a block
-glab api projects/:id/merge_requests/10/blocks/<block-id> -X DELETE
-```
+Block an MR from merging until another MR merges first (`block` verb). See [blocking.md](blocking.md) for the REST API commands.
 
 ## Reviews
 
@@ -126,11 +93,4 @@ Fetch, filter, resolve, and summarize MR discussion threads. See [discussions.md
 
 ## Stacking
 
-`glab stack` manages stacked diffs — small changes that build on each other. See [stack.md](stack.md).
-
-## Reference Files
-
-- [review.md](review.md) - Draft notes review workflow
-- [review-state.md](review-state.md) - GraphQL mutations for review decisions, the cross-project review queue, and next-actor triage
-- [discussions.md](discussions.md) - Discussion threads and resolution
-- [stack.md](stack.md) - Stacked diff workflow
+`glab stack` manages stacked diffs, small changes that build on each other. See [stack.md](stack.md).

--- a/plugins/gitlab/skills/merge-request/blocking.md
+++ b/plugins/gitlab/skills/merge-request/blocking.md
@@ -1,0 +1,14 @@
+# Blocking an MR
+
+Prevent an MR from merging until another MR merges first. Uses the REST API since `glab mr` has no blocking subcommand.
+
+```bash
+# Block MR !10 until MR !5 merges
+glab api projects/:id/merge_requests/10/blocks -X POST -f blocking_merge_request_iid=5
+
+# List blocks on an MR
+glab api projects/:id/merge_requests/10/blocks
+
+# Remove a block
+glab api projects/:id/merge_requests/10/blocks/<block-id> -X DELETE
+```

--- a/plugins/gitlab/skills/merge-request/merge-trains.md
+++ b/plugins/gitlab/skills/merge-request/merge-trains.md
@@ -1,0 +1,12 @@
+# Inspect or Recover a Merge Train
+
+`glab` has no merge-train command, so use the API directly.
+
+```bash
+# Active train for the project
+glab api "projects/:id/merge_trains?scope=active" | jq '.[] | {iid: .merge_request.iid, status, target_branch}'
+
+# Clear a stuck entry, then re-arm
+glab api --method DELETE "projects/:id/merge_trains/merge_requests/<iid>"
+glab api --method POST  "projects/:id/merge_trains/merge_requests/<iid>" --raw-field auto_merge=true
+```

--- a/plugins/issue/skills/refine/SKILL.md
+++ b/plugins/issue/skills/refine/SKILL.md
@@ -85,11 +85,17 @@ For a substantial issue, the opening summary plus one type section plus `## Cont
 
 ## Style
 
-Load the `writing` skill for tone and trope rules (hedging, em dashes, marketing vocabulary). The issue-specific rules on top of it:
+State facts and drop the hedging. Name the function, file, or behavior rather than describing it vaguely. Every sentence should add information. A section present only to match the template is filler, so earn each heading.
 
-- Section headings are title-case noun phrases. Keep them free of sentences, slogans, and "X, not Y" antithesis. Write "Connection Lifecycle" rather than "Pin, don't invalidate".
-- Reference code by symbol. Name the function or type and quote the few relevant lines inline. Skip bare line ranges (`file.py:26-56`, `#L26-L56`): they go stale as the file changes. Use a SHA-pinned permalink only when a stable anchor is genuinely needed.
-- Reference issues and PRs as tracker links that expand inline, never as bare numbers (`ENG-1970`, `!578`, `#123`) a reader can't resolve. The platform skill owns the link syntax.
+Section headings are title-case noun phrases. Keep them free of sentences, slogans, and "X, not Y" antithesis. Write "Connection Lifecycle" rather than "Pin, don't invalidate".
+
+Plain words over jargon and marketing. Drop terms like "spike" (as a verb), "seam", "disposition", "reality". Say what the thing does.
+
+Reference code by symbol. Name the function or type and quote the few relevant lines inline. Skip bare line ranges (`file.py:26-56`, `#L26-L56`): they go stale as the file changes. Use a SHA-pinned permalink only when a stable anchor is genuinely needed.
+
+Reference issues and PRs as tracker links that expand inline, never as bare numbers (`ENG-1970`, `!578`, `#123`) a reader can't resolve. The platform skill owns the link syntax.
+
+Don't use spaced em dashes. Split into two sentences without a semicolon or unspaced substitute.
 
 ## Issue Trackers
 

--- a/plugins/issue/skills/refine/SKILL.md
+++ b/plugins/issue/skills/refine/SKILL.md
@@ -68,9 +68,8 @@ Populate only the keys you can infer: `title`, `type`, `labels`, `priority`,
 lists. The platform skill fills routing and workspace fields (team, assignee,
 state, estimate) at save time.
 
-Write the `title` in sentence case: capitalize the first word and proper nouns,
-and leave the rest lowercase. This sets it apart from the title-case body
-headings. Keep it to one line with no long parentheticals.
+Write the `title` in sentence case (not the title case used for body headings),
+one line, no long parentheticals.
 
 A related issue you found belongs under `relations` as a tracker link, kept out
 of the body. Mention another issue in the body only when it tells the reader
@@ -82,23 +81,15 @@ links the relation already expresses.
 
 Every section must tell the reader something they couldn't have guessed. Cut sections whose content is tautological ("tests must pass"), template residue ("no behavior change"), or obvious given the issue's size.
 
-For a substantial issue, the opening summary plus one type section plus `## Context` is the floor. Grow only when content demands. A trivial issue needs none of that frame: a sentence or two that names the problem and points at the code is enough.
-
-`--compact` forces that trivial body regardless of size: name the problem, point at the code, drop the `## Context` frame. Frontmatter is still emitted.
+For a substantial issue, the opening summary plus one type section plus `## Context` is the floor. Grow only when content demands. A trivial issue needs none of that frame: a sentence or two that names the problem and points at the code is enough. `--compact` forces that trivial body regardless of the issue's size.
 
 ## Style
 
-State facts and drop the hedging. Name the function, file, or behavior rather than describing it vaguely. Every sentence should add information. A section present only to match the template is filler, so earn each heading.
+Load the `writing` skill for tone and trope rules (hedging, em dashes, marketing vocabulary). The issue-specific rules on top of it:
 
-Section headings are title-case noun phrases. Keep them free of sentences, slogans, and "X, not Y" antithesis. Write "Connection Lifecycle" rather than "Pin, don't invalidate".
-
-Plain words over jargon and marketing. Drop terms like "spike" (as a verb), "seam", "disposition", "reality". Say what the thing does.
-
-Reference code by symbol. Name the function or type and quote the few relevant lines inline. Skip bare line ranges (`file.py:26-56`, `#L26-L56`): they go stale as the file changes. Use a SHA-pinned permalink only when a stable anchor is genuinely needed.
-
-Reference issues and PRs as tracker links that expand inline, never as bare numbers (`ENG-1970`, `!578`, `#123`) a reader can't resolve. The platform skill owns the link syntax.
-
-Don't use spaced em dashes. Split into two sentences without a semicolon or unspaced substitute.
+- Section headings are title-case noun phrases. Keep them free of sentences, slogans, and "X, not Y" antithesis. Write "Connection Lifecycle" rather than "Pin, don't invalidate".
+- Reference code by symbol. Name the function or type and quote the few relevant lines inline. Skip bare line ranges (`file.py:26-56`, `#L26-L56`): they go stale as the file changes. Use a SHA-pinned permalink only when a stable anchor is genuinely needed.
+- Reference issues and PRs as tracker links that expand inline, never as bare numbers (`ENG-1970`, `!578`, `#123`) a reader can't resolve. The platform skill owns the link syntax.
 
 ## Issue Trackers
 

--- a/plugins/pull-request/skills/babysit/SKILL.md
+++ b/plugins/pull-request/skills/babysit/SKILL.md
@@ -88,7 +88,7 @@ Lockfiles or generated files (`bun.lock`, etc.): regenerate per project conventi
 
 Real source conflicts: rebase on `origin/<base>` and delegate to the `git:conflicts` skill. Resolve, commit, and push where mechanically clear. Where ambiguous or semantic, report the conflicting hunks and call `TaskStop` (this runs unattended, so never guess a merge).
 
-In Merge Mode, after any push here, [re-arm](#re-arm) and count it as a submit attempt.
+In Merge Mode, after any push here, re-arm per [Merge Mode](#merge-mode) and count it as a submit attempt.
 
 #### mergeable-unknown
 
@@ -129,44 +129,11 @@ Report the event (include `minutes`) and the work done since the start SHA, then
 
 ## Reviews Hand-off
 
-With `--reviews`, after the first green invoke `pull-request:follow-up --auto <pr-url>` to triage AI-reviewer threads (fix, reply, resolve, loop until the reviewer is satisfied). follow-up calls back into babysit for each post-push CI wait, so let it own the review loop. When a bot review is expected but hasn't landed at green, follow-up waits for its first pass rather than reporting nothing to do.
-
-When it returns satisfied, re-request the **human** reviewers whose approval a push (follow-up's fixes or babysit's own) invalidated. Don't re-request bots; follow-up owns the `@bot` re-trigger.
-
-- **GitHub**: `gh pr edit <pr-url> --add-reviewer <user>`.
-- **GitLab**: delegate to `gitlab:merge-request` ([Re-request reviewers](../../../gitlab/skills/merge-request/SKILL.md#re-request-reviewers)).
-
-Then branch:
-
-- If `--merge` is also set, proceed to [Merge Mode](#merge-mode).
-- Otherwise report what was addressed and call `TaskStop`.
-
-This human re-request happens only in the `--reviews` flow. Review *threads* stay out of scope: follow-up lists them and leaves them for you.
+With `--reviews`, after the first green, hand off to `pull-request:follow-up --auto` for AI-reviewer triage, then re-request the human reviewers a push invalidated. Load [`reviews.md`](reviews.md) for the hand-off contract and the re-request commands.
 
 ## Merge Mode
 
-With `--merge`, don't stop at green; drive the PR to **merged**. CI green is the entry condition; from here, submit to the repo's merge mechanism and recover from kickouts until it lands. GitHub merges run through `gh` directly; delegate all GitLab merge behavior (trains, endpoint, squash) to `gitlab:merge-request`.
-
-First confirm the PR can merge on its own. Don't bypass blocks you can't resolve: missing **human** approval (you can't self-approve; if a bot was the blocker and `--reviews` ran, it's already handled), branch protection, draft state, or requested changes; report and `TaskStop`. Read state via `gh pr view --json mergeable,mergeStateStatus,reviewDecision,state` (GitLab: `gitlab:merge-request`).
-
-Submit by the most automated path the repo allows (merge queue/train, else auto-merge, else direct, valid since CI is green):
-
-- **GitHub**: `gh pr merge <pr-url> --auto --squash` enables auto-merge or queues the PR. If `--auto` is rejected, merge directly: `gh pr merge <pr-url> --squash`. Prefer squash → merge → rebase per `gh repo view --json squashMergeAllowed,mergeCommitAllowed,rebaseMergeAllowed`.
-- **GitLab**: delegate to the `gitlab:merge-request` skill.
-
-### Re-arm
-
-A push drops the PR from the merge mechanism (GitLab: off the train; GitHub: clears queued auto-merge) and fires **no monitor event**. So in Merge Mode, after **every** push, re-submit by the same path as the initial submit above instead of waiting. Each re-arm counts toward the 3-attempt oscillation guard below.
-
-Then watch the merge through the monitor rather than polling by hand: invoke the provider's monitor skill again on the PR and react to its events. The watcher enforces the interval and the wall clock, so this phase stays bounded like the CI wait (see [Bounds](#bounds)) and babysit owns no loop here. React to:
-
-- `merged`: the PR landed. Report success and `TaskStop`.
-- `conflicts`: route through the [conflicts](#conflicts) handler, then [re-arm](#re-arm). Counts as a submit attempt.
-- `status: failing`: route through the [status: failing](#status-failing) handler; the pushed fix produces a new SHA, then [re-arm](#re-arm). Counts as a submit attempt.
-- `pr-closed`: the PR closed without merging. Report and `TaskStop`.
-- `max-time-reached`: report and `TaskStop`; do not re-arm.
-
-Stop re-submitting after 3 attempts (re-submits included, an oscillation guard) or an unrecoverable block (missing human approval, non-trivial CI failure, non-lockfile conflict, permissions).
+With `--merge`, don't stop at green; drive the PR to **merged**. Load [`merge-mode.md`](merge-mode.md) for the merge-submission paths, the re-arm-after-every-push rule, and the oscillation guard.
 
 ## Gotchas
 

--- a/plugins/pull-request/skills/babysit/merge-mode.md
+++ b/plugins/pull-request/skills/babysit/merge-mode.md
@@ -1,0 +1,24 @@
+# Merge Mode
+
+Load this when babysit runs with `--merge`. Don't stop at green: drive the PR to **merged**. CI green is the entry condition. From here, submit to the repo's merge mechanism and recover from kickouts until it lands. GitHub merges run through `gh` directly. Delegate all GitLab merge behavior (trains, endpoint, squash) to `gitlab:merge-request`.
+
+First confirm the PR can merge on its own. Don't bypass blocks you can't resolve: missing **human** approval (you can't self-approve; if a bot was the blocker and `--reviews` ran, it's already handled), branch protection, draft state, or requested changes. Report and `TaskStop`. Read state via `gh pr view --json mergeable,mergeStateStatus,reviewDecision,state` (GitLab: `gitlab:merge-request`).
+
+Submit by the most automated path the repo allows (merge queue/train, else auto-merge, else direct, valid since CI is green):
+
+- **GitHub**: `gh pr merge <pr-url> --auto --squash` enables auto-merge or queues the PR. If `--auto` is rejected, merge directly: `gh pr merge <pr-url> --squash`. Prefer squash → merge → rebase per `gh repo view --json squashMergeAllowed,mergeCommitAllowed,rebaseMergeAllowed`.
+- **GitLab**: delegate to the `gitlab:merge-request` skill.
+
+## Re-arm
+
+A push drops the PR from the merge mechanism (GitLab: off the train; GitHub: clears queued auto-merge) and fires **no monitor event**. So after **every** push in Merge Mode, re-submit by the same path as the initial submit above instead of waiting. Each re-arm counts toward the 3-attempt oscillation guard below.
+
+Then watch the merge through the monitor rather than polling by hand: invoke the provider's monitor skill again on the PR and react to its events. The watcher enforces the interval and the wall clock, so this phase stays bounded like the CI wait (see [Bounds](SKILL.md#bounds)) and babysit owns no loop here. React to:
+
+- `merged`: the PR landed. Report success and `TaskStop`.
+- `conflicts`: route through the [conflicts](SKILL.md#conflicts) handler, then re-arm. Counts as a submit attempt.
+- `status: failing`: route through the [status: failing](SKILL.md#status-failing) handler; the pushed fix produces a new SHA, then re-arm. Counts as a submit attempt.
+- `pr-closed`: the PR closed without merging. Report and `TaskStop`.
+- `max-time-reached`: report and `TaskStop`; do not re-arm.
+
+Stop re-submitting after 3 attempts (re-submits included, an oscillation guard) or an unrecoverable block (missing human approval, non-trivial CI failure, non-lockfile conflict, permissions).

--- a/plugins/pull-request/skills/babysit/reviews.md
+++ b/plugins/pull-request/skills/babysit/reviews.md
@@ -1,0 +1,15 @@
+# Reviews Hand-off
+
+Load this when babysit runs with `--reviews`. After the first green, invoke `pull-request:follow-up --auto <pr-url>` to triage AI-reviewer threads (fix, reply, resolve, loop until the reviewer is satisfied). follow-up calls back into babysit for each post-push CI wait, so let it own the review loop. When a bot review is expected but hasn't landed at green, follow-up waits for its first pass rather than reporting nothing to do.
+
+When it returns satisfied, re-request the **human** reviewers whose approval a push (follow-up's fixes or babysit's own) invalidated. Don't re-request bots; follow-up owns the `@bot` re-trigger.
+
+- **GitHub**: `gh pr edit <pr-url> --add-reviewer <user>`.
+- **GitLab**: delegate to `gitlab:merge-request` ([Re-request reviewers](../../../gitlab/skills/merge-request/SKILL.md#re-request-reviewers)).
+
+Then branch:
+
+- If `--merge` is also set, proceed to [Merge Mode](merge-mode.md).
+- Otherwise report what was addressed and call `TaskStop`.
+
+This human re-request happens only in the `--reviews` flow. Review *threads* stay out of scope: follow-up lists them and leaves them for you.

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -41,20 +41,13 @@ allowed-tools:
 
 ## Body
 
-The body conveys what the diff cannot: why this change, what you decided along the way, and how you know it works. The reviewer reads the diff for what changed, so don't restate it. Spend the body on intent and the decisions a reviewer can't reconstruct from the code.
+Lead with intent: why this change, the decisions a reviewer can't reconstruct from the diff, and how you know it works. Don't restate what the diff, git, or the status checks already carry. Mine the session for the substance that never reached the code (rejected alternatives, overturned theories, what you observed testing, scope added or dropped) and state each as a self-contained decision, not as a delta against a plan the reviewer never saw.
 
-Mine the conversation that produced this change. The substance lives there: decisions and the alternatives you rejected, the scope you added or dropped, theories you tried and overturned, what you observed testing locally, limitations you ruled out, naming or scope you settled by hand. Put it in the body as a self-contained decision, not as a delta against a plan the reviewer never saw. Keep it out of code comments.
+- Open with a bare verb ("Adds", "Fixes", "Removes") when the change is self-evident, or with the problem when it needs justifying. Don't restate the title.
+- Default to prose. A small PR is a tight paragraph with no headers. Add `##` sections only when length earns them. Length tracks substance, not diff size.
+- Reference the motivating issue at the end of the opening (`Closes #N`, `Fixes #N`, or bare `#N` if not closing). Wrap code identifiers in backticks, but leave bare anything the platform auto-links: commit SHAs and issue/MR refs (`#N`, `!N`, `owner/repo#N`). Backticks kill the link.
 
-- Open with what changed (a bare verb: "Adds", "Fixes", "Removes") when the change is self-evident, or with the problem when the change needs justifying. Don't restate the title.
-- Length tracks substance, not diff size. A subtle one-line fix may need paragraphs. A large mechanical change may need two sentences.
-- Restate nothing another surface already carries. The diff shows what changed, git shows which files, and the status checks show that lint, types, and tests pass. Name a check only when its result is not one CI will post: a manual observation, an intentional exclusion, a pre-existing warning you're leaving in place.
-- Shape prose so it reads. One thread per paragraph, and break a paragraph that runs past three or four sentences. A single sentence stacking clauses behind commas is a wall even when every clause is true. When items are parallel and merely co-occur (findings, cases covered, checks run), make them a list. Prose is for reasoning that connects one point to the next. "Default to prose" means don't add the reflexive scaffold, not cram an enumeration into one sentence.
-- Default to prose. Use `##` sections only when the body is long enough to need them. Small PRs are a tight paragraph with no headers.
-- Audience sets the bar (same owner-and-visibility probe as [Reviewers](#reviewers)). Owner is you: a personal repo you review through Claude, so stay concise and skip background you already hold. Private or org-owned: a corporate repo coworkers skim, so lead with intent at moderate detail. Public and not yours: an open-source repo under external scrutiny with the highest cost for unclear intent, so spend the most on decisions and evidence.
-- Reference the motivating issue at the end of the opening (`Closes #N`, `Fixes #N`, or `#N` if not closing). Related-for-context issues go in a `## References` section, never bare at the bottom.
-- Wrap code identifiers in backticks: function names, class names, file paths, endpoints, status codes. Do not backtick anything the platform auto-links: commit SHAs and issue/MR references (`#N`, `!N`, `owner/repo#N`). Backticks render them as code and kill the link. Write them bare.
-
-See [`sections.md`](sections.md) for the substance catalog (what to surface, by change type), optional-section guidance, how to ground claims in evidence, and the slop patterns to cut. Load the `writing` skill for the full set of tropes to avoid.
+Before drafting anything past a one-paragraph body, load [`sections.md`](sections.md): the substance catalog by change type, audience tiers, density and heading rules, evidence grounding, and slop to cut. Load the `writing` skill for the full set of tropes to avoid.
 
 ## Outline First
 
@@ -66,21 +59,7 @@ A wall of text is easier to prevent than to fix. For a large change, or any open
 
 ## Template
 
-When a PR template is provided in context above, follow its structure instead of the default body format:
-
-- Preserve all template sections, even if some are left empty
-- Leave checklists (checkbox items) untouched for the user to complete manually
-- Remove HTML comments (`<!-- ... -->`) that serve as placeholder instructions
-- Map skill-generated content into corresponding template sections:
-  - Description/summary sections: the opening plus the conversation substance (decisions, scope added or dropped, what you observed testing)
-  - Changes/what sections: follow the `## Changes` guidance in `sections.md`
-  - Testing/verification sections: follow the `## Testing` guidance in `sections.md`
-  - Issue/references sections: the motivating issue ref and `## References` content
-- For template sections with no skill equivalent (e.g., type-of-change dropdowns), fill them based on the diff context
-- Within each template section, follow the style rules from `sections.md`
-- If the template has a free-form description section, place the summary sentences there and add skill subsections within it as needed
-
-When no template is detected, use the default body format from the Body section above.
+When the context above shows a detected PR template, follow its structure instead of the default body format. Load [`template.md`](template.md) for how to preserve sections and map skill-generated content into them. With no template detected, use the default Body format above.
 
 ## Issue Handling
 
@@ -91,28 +70,7 @@ When an issue is referenced:
 
 ## Reviewers
 
-Reviewer suggestion is for corporate and internal work. On OSS the project author or maintainer triages incoming PRs, so suggesting reviewers there only adds noise. Gate this whole section on repository visibility:
-
-- **GitHub**: `gh repo view --json visibility -q .visibility`
-- **GitLab**: `glab api projects/:fullpath --jq .visibility`
-
-A public repository is OSS. Skip the rest of this section and let the maintainer triage. Any other visibility (private, internal) is corporate. Continue below.
-
-Suggest reviewers; never assign them. The user always chooses from the suggestions.
-
-Run the script to rank candidates from the git history of the changed files. It excludes you and needs no arguments:
-
-```bash
-bun ${CLAUDE_PLUGIN_ROOT}/scripts/suggest-reviewers.ts
-```
-
-- **Blame owners**: people who wrote the lines you're changing. Suggest the top one or two.
-- **Sole-author fallback**: when the output reports you're the sole author of the area, use the recent in-area PR/MR refs it prints—look up who you requested review from on those and suggest the recurring names.
-
-This runs after you create the PR/MR, so it never delays creation. Resolve names to platform usernames only after the user accepts, then assign them to the existing PR/MR:
-
-- **GitHub**: `gh pr edit --add-reviewer <user>` (resolve emails to logins with `mcp__github` if needed)
-- **GitLab**: load `gitlab:merge-request` for username resolution, then `glab mr update --reviewer <user>`
+Corporate and internal repos only. On OSS (a public repo you don't own) the maintainer triages, so skip this and add no noise. Suggest reviewers, never assign; the user always chooses. This runs after creation, so it never delays it. Load [`reviewers.md`](reviewers.md) for the visibility gate, the ranking script, and username resolution.
 
 ## Arguments
 

--- a/plugins/pull-request/skills/create/reviewers.md
+++ b/plugins/pull-request/skills/create/reviewers.md
@@ -1,0 +1,26 @@
+# Suggesting Reviewers
+
+Load this after creating the PR/MR on a corporate or internal repo. It runs after creation, so it never delays it.
+
+Gate on repository visibility first:
+
+- **GitHub**: `gh repo view --json visibility -q .visibility`
+- **GitLab**: `glab api projects/:fullpath --jq .visibility`
+
+A public repository is OSS: skip reviewer suggestion and let the maintainer triage. Any other visibility (private, internal) is corporate: continue.
+
+Suggest reviewers, never assign them. The user always chooses from the suggestions.
+
+Rank candidates from the git history of the changed files. The script excludes you and needs no arguments:
+
+```bash
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/suggest-reviewers.ts
+```
+
+- **Blame owners**: people who wrote the lines you're changing. Suggest the top one or two.
+- **Sole-author fallback**: when the output reports you're the sole author of the area, use the recent in-area PR/MR refs it prints. Look up who you requested review from on those and suggest the recurring names.
+
+Resolve names to platform usernames only after the user accepts, then assign them to the existing PR/MR:
+
+- **GitHub**: `gh pr edit --add-reviewer <user>` (resolve emails to logins with `mcp__github` if needed).
+- **GitLab**: load `gitlab:merge-request` for username resolution, then `glab mr update --reviewer <user>`.

--- a/plugins/pull-request/skills/create/template.md
+++ b/plugins/pull-request/skills/create/template.md
@@ -1,0 +1,16 @@
+# PR Template Handling
+
+Load this when the context shows a detected PR template. Follow the template's structure instead of the default body format.
+
+- Preserve all template sections, even if some are left empty.
+- Leave checklists (checkbox items) untouched for the user to complete manually.
+- Remove HTML comments (`<!-- ... -->`) that serve as placeholder instructions.
+- For template sections with no skill equivalent (e.g. type-of-change dropdowns), fill them from the diff context.
+- If the template has a free-form description section, place the summary sentences there and add skill subsections within it as needed.
+
+Map skill-generated content into corresponding template sections, following the style rules in [`sections.md`](sections.md) within each:
+
+- Description/summary sections: the opening plus the conversation substance (decisions, scope added or dropped, what you observed testing).
+- Changes/what sections: the `## Changes` guidance in `sections.md`.
+- Testing/verification sections: the `## Testing` guidance in `sections.md`.
+- Issue/references sections: the motivating issue ref and `## References` content.


### PR DESCRIPTION
Every token in a SKILL.md is paid on each invocation. Ranking this repo's skills by usage from the session index, the four hottest paths are `pull-request:create` (772), `gitlab:merge-request` (232), `issue:refine` (124), and `pull-request:babysit` (115). This trims their token cost two ways: cut prose that re-teaches what Claude or an already-loaded file already knows, and move flag-gated branches into reference files that load only when the branch fires.

## Prose cuts

`create`'s Body section re-derived `sections.md` almost verbatim while its own footer already pointed there, so every invocation paid for both. It now carries the inline gist that serves a small PR plus a hard instruction to load `sections.md` before drafting anything larger, where the audience tiers, density, and heading rules live.

`merge-request` drops marker-plumbing prose (that coupling is already a comment in `lint.ts`), the Key Commands block (redundant with Patterns), and a duplicate reference-file index.

`refine` collapses a three-way `--compact` definition to one line and tightens the title-case guidance. Its Style section stays inline because the eval harness reads those rules in place, so its cut is the smallest of the four by design (866 to 835 words).

## Progressive disclosure

Branches that fire only on a flag or a detected condition move out of the always-loaded path into reference files:

- `create`: Template and Reviewers, gated on a detected template or a corporate repo, move to `template.md` and `reviewers.md`.
- `babysit`: the `--merge` and `--reviews` branches, both off by default, move to `merge-mode.md` and `reviews.md`, so plain CI-watching loads neither.
- `merge-request`: Blocking and merge-train recovery move to `blocking.md` and `merge-trains.md`.

## Result

Always-loaded SKILL.md word counts: `create` 1954 to 1354, `babysit` 1541 to 1093, `merge-request` 809 to 630, `refine` 866 to 835.
