### PR TITLE
linear: drop the multi-operation CLI version guard

### DIFF
--- a/plugins/linear/skills/linear/SKILL.md
+++ b/plugins/linear/skills/linear/SKILL.md
@@ -15,7 +15,7 @@ Tools and workflows for managing issues, projects, and teams in Linear.
 
 ## Environment
 
-- **`linear` CLI**: !`command -v linear >/dev/null 2>&1 && linear --version 2>/dev/null || echo "not installed"`
+- **`linear` CLI**: !`linear --version 2>/dev/null || echo "not installed"`
 
 The connector and MCP paths need no CLI. The CLI-only operations (relations, bulk work) require `linear`; when it reads "not installed", stay on the connector. The version above tells you which CLI is installed. Confirm its exact subcommands and flags with `linear <cmd> --help` or the `linear-cli:linear-cli` skill rather than assuming them.
 


### PR DESCRIPTION
Invoking `linear:linear` failed outright with `Shell command permission check failed`. Bang execution runs its command through the permission check, which refuses a command composed of multiple operations when any part is unapproved, and the `command -v linear >/dev/null 2>&1 && linear --version` guard is two such parts. The whole skill load aborts on that failure.

The guard was redundant: `2>/dev/null` already swallows the not-found message, so `linear --version 2>/dev/null || echo "not installed"` covers both cases as a single command. Verified by loading the skill, which now injects `linear 2.2.0`.

The repo has 11 other multi-operation injections. A throwaway probe skill exercised each distinct shape among them through the same path: `shortcuts` (`which … && echo || echo`), `gitlab:merge-request` (`mkdir; touch; echo`), `afk` (`ifconfig | grep`), `tuicr` (`tuicr review list || echo`), and `review:peer` (`gh api graphql … | grep || echo`). None hit the check. It tolerates a single operation it cannot pre-approve, handing that one to the classifier. This line carried two of them (`command -v linear` and `linear --version`), which is what put it over.
