### PR TITLE
docs: drop the dead Bash bang-escaping workaround and stale tool names

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -16,7 +16,7 @@ After making changes to plugin scripts, run them directly to verify they work en
 - **`bun test` runs all unit tests**: Bun auto-discovers `*.test.ts` files. Integration tests (`*.integration.ts`) are not auto-discovered and can be run by passing paths explicitly (e.g., `bun test plugins/<name>/tests/file.integration.ts`).
 - **Prefix dotdir paths with `./` in `bun test`**: A positional arg is a *filter* (substring match against discovered test paths), not a path. Discovery skips dotdirs, so `bun test .claude/hooks` matches nothing and silently runs 0 tests. Writing `bun test ./.claude/hooks` makes bun read it as a path and run the tests under it. Always use a `./` prefix for hidden-dir paths in CI and local test commands.
 - **No `.js` imports in TypeScript**: Import from `./module` not `./module.js`. The bundler/runtime handles resolution.
-- **Prefer skills over agents**: Skills are invocable via the Skill tool. Agents require the Task tool. If something should be directly invocable, make it a skill.
+- **Prefer skills over agents**: Skills are invocable via the `Skill` tool. Agents require the `Agent` tool. If something should be directly invocable, make it a skill.
 
 ## Technique Selection
 

--- a/.claude/skills/agent-ideas/SKILL.md
+++ b/.claude/skills/agent-ideas/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools:
   - Grep
   - Glob
   - WebFetch
-  - Task
+  - Agent
   - Write
   - Skill(things:url)
   - mcp__claude_ai_Zapier__things_create_to-do
@@ -46,7 +46,7 @@ bun ${CLAUDE_SKILL_DIR}/scripts/fetch.ts --days 14 --source simon --source mario
 
 Turn posts into repo-mappable idea cards. The bar is high: a card must name a real surface in this repo it would refine, or make a clear case for a net-new artifact. See [references/mining.md](references/mining.md) for the card schema, the proven heuristics (per-source cap by depth, auto-demote 404 sources, dedupe against existing repo surfaces), and the fan-out flow.
 
-Fan out one mining `Task` agent per source (batch thin sources together). Give each the source's posts, the schema, the heuristics, and a read-only view of the repo so it can fill `repoOverlap` and dedupe. Collect the cards, verify each `sourceUrl` resolves (demote 404s), then dedupe across agents.
+Fan out one mining `Agent` call per source (batch thin sources together). Give each the source's posts, the schema, the heuristics, and a read-only view of the repo so it can fill `repoOverlap` and dedupe. Collect the cards, verify each `sourceUrl` resolves (demote 404s), then dedupe across agents.
 
 ## Synthesize
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,9 +44,6 @@ jobs:
           additional_permissions: |
             actions: read
           
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
           

--- a/plugins/claude-code/skills/hook/SKILL.md
+++ b/plugins/claude-code/skills/hook/SKILL.md
@@ -13,7 +13,7 @@ allowed-tools:
 
 # Claude Code Hooks
 
-Reference for creating and configuring Claude Code hooks. When uncertain about syntax or features, use the Task tool with `subagent_type='claude-code-guide'` to consult official docs.
+Reference for creating and configuring Claude Code hooks. When uncertain about syntax or features, use the `Agent` tool with `subagent_type='claude-code-guide'` to consult official docs.
 
 ## Hook Types
 

--- a/plugins/comments/workflow/judge.workflow.js
+++ b/plugins/comments/workflow/judge.workflow.js
@@ -37,7 +37,7 @@ function judgeShard(shard) {
     'It contains { "id": <shard id>, "comments": [{ "id", "path", "language", "kind", "text", "context" }] }.',
     'Judge every comment in the shard against the rubric. Produce exactly one verdict per comment, keyed by its "id".',
     `Write the object { "verdicts": [{ "id": <comment id>, "verdict": { ... } }] } to this exact path with the Write tool: ${job.verdictsDir}/verdict-${shard.id}.json`,
-    'Use the Write tool, not a Bash heredoc: the Bash tool escapes "!" to "\\!", which is not a valid JSON escape and corrupts the file.',
+    "Use the Write tool, not a Bash heredoc.",
     "Per verdict include: action (keep | trim | rewrite), category (the failing shape, null for keep), confidence (low | medium | high), rationale (one sentence), rewrite (the de-voiced comment text, only when action is rewrite, else null), and trimTo (only for a partial trim: the kept comment rewritten to read as complete sentences, delimiters included, no leading indentation; omit it to delete the whole comment).",
     'Your structured output is only the summary: { "total": <comments judged>, "flagged": <verdicts with action other than keep> }.',
   ].join("\n");

--- a/plugins/linear/skills/linear/api.md
+++ b/plugins/linear/skills/linear/api.md
@@ -20,9 +20,9 @@ Pass a query as the argument. Output is JSON on stdout; pipe through `jq` to ext
 linear api 'query { viewer { id name email } }' | jq '.data.viewer'
 ```
 
-## Non-null markers and the `!` escaping bug
+## Multi-line queries
 
-GraphQL non-null markers (`String!`) contain `!`, which the Bash tool escapes and corrupts inline. Pass any query containing `!` through a quoted heredoc on stdin so the marker survives verbatim:
+Pass multi-line queries through a quoted heredoc on stdin:
 
 ```bash
 linear api --variable id=ISSUE_ID <<'GRAPHQL'

--- a/plugins/meme/skills/image/SKILL.md
+++ b/plugins/meme/skills/image/SKILL.md
@@ -61,7 +61,6 @@ On success the script prints the absolute output path. Fit problems are warnings
 
 ## Gotchas
 
-- The Bash tool escapes `!` to `\!`, which corrupts flag values. If any text contains `!`, Write a spec file to `tmp/` and render with `--spec` instead of text flags.
 - Web search returns template *pages*, not image files, and meme-site pages are often JS-rendered so the image URL is not in the static HTML. Imgflip: the direct image is `https://i.imgflip.com/<id36>.jpg` where `<id36>` is the numeric template ID from the page URL in base36 (`(55311130).toString(36)` → `wxica`). Always `file` the download to confirm it is an image before rendering.
 - Multi-panel formats: set `"linkFontSizes": true` in the spec so all panels share one font size instead of each fitting independently.
 - Images narrower than 400px are auto-upscaled 2x before drawing, so tiny templates still get readable text. Expect output dimensions to differ from the input.

--- a/plugins/pull-request/skills/babysit/SKILL.md
+++ b/plugins/pull-request/skills/babysit/SKILL.md
@@ -141,8 +141,6 @@ The monitor script delivers structured JSON events. Do not pipe CLI output to `p
 
 CI may run on synthetic merge commits whose SHA never matches the branch tip. The watcher reports the source branch SHA in each event; compare against `git rev-parse HEAD`.
 
-The Bash tool escapes `!` to `\!`. Use `| not` in jq filters (e.g. `select(.x == null | not)`), or pass filters via heredoc.
-
 The watcher dedupes by `(sha, state)`. A `failing` event for a SHA older than `git rev-parse HEAD` means a fix was already pushed; ignore it.
 
 Babysit is session-scoped. If the session ends, the watcher process ends with it. Re-invoke this skill from a new session to resume.

--- a/plugins/research/skills/prior-art/SKILL.md
+++ b/plugins/research/skills/prior-art/SKILL.md
@@ -27,7 +27,7 @@ Run searches in parallel. Infer the ecosystem from:
 Start with 2-3 most promising projects:
 1. Read README and high-level docs to assess relevance
 2. Examine code only when relevance is confirmed AND implementation details matter
-3. Dispatch parallel Task agents per project, with explicit focus areas
+3. Dispatch parallel `Agent` calls per project, with explicit focus areas
 
 If results don't satisfy the query, expand to more projects.
 

--- a/plugins/review/skills/follow-up/SKILL.md
+++ b/plugins/review/skills/follow-up/SKILL.md
@@ -104,7 +104,7 @@ status.
 
 Use the `github:pr-comments` skill's script with `--role reviewer --include-resolved` to get every thread you started, resolved and unresolved, each with its full comment chain so silent resolves are visible. Do not pass `--since`. Follow-up needs the whole history.
 
-If a query ever needs hand-authoring (fetching `reviewThreads` is the usual case), write it to a `.graphql` file with the Write tool and pass `gh api graphql -F query=@query.graphql`. Capital `-F` reads the query from a file. An inline `-f query=...` or a shell heredoc breaks because a `!` in a GraphQL non-null marker gets mangled by the Bash tool's escaping.
+If a query ever needs hand-authoring (fetching `reviewThreads` is the usual case), write it to a `.graphql` file with the Write tool and pass `gh api graphql -F query=@query.graphql`. Capital `-F` reads the query from a file, which keeps a long multi-line query out of the command line.
 
 #### GitLab
 

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -26,7 +26,7 @@ Every customization costs tokens on every session. Before adding one, define how
 ## Workflow
 
 - The user has carefully curated skills for their common workflows. Load skills when possible to adhere to the user's preferences and navigate their projects efficiently.
-- For questions about Claude Code features or usage, use the Task tool with `subagent_type='claude-code-guide'` to consult official documentation.
+- For questions about Claude Code features or usage, use the `Agent` tool with `subagent_type='claude-code-guide'` to consult official documentation.
 - Prefer the `agent-browser` skill over `WebFetch`/`WebSearch` when a task needs a real browser — interacting with a page, screenshots, scraping JS-rendered content, or web-app QA/dogfooding. It loads the CLI's version-matched `skills get` workflows. Plain `WebFetch` stays fine for static page fetches.
 - Finish a branch with `/ship`: it runs the warranted review passes, opens the PR, babysits CI to green, triages bot comments, and refreshes the body. Don't hand-chain `EnterWorktree` + `pull-request:create` for a branch finish.
 - `pull-request:create` remains the skill for opening a PR directly (it is what `/ship` calls). If it's unavailable, create the PR with an empty body.
@@ -35,10 +35,6 @@ Every customization costs tokens on every session. Before adding one, define how
 - Store temporary files in `tmp/` directory.
 - The sandbox can write `/tmp`, `$TMPDIR`, and the repo. Never disable the sandbox for file writes; only bypass after a sandboxed run of that command actually failed.
 - Use `pbcopy` and `pbpaste` for clipboard interaction.
-
-### Bash `!` Escaping Bug
-
-The Bash tool escapes `!` to `\!` on every path, including single quotes and heredocs, breaking `jq !=`, `awk !~`, and similar operators ([#2941](https://github.com/anthropics/claude-code/issues/2941), [#10335](https://github.com/anthropics/claude-code/issues/10335)). For `jq`, use `| not` instead of `!=`. For anything else, author the content with the Write tool, then run it. No shell quoting or heredoc bypasses the escape.
 
 ## Check-ins
 

--- a/user/rules/json.md
+++ b/user/rules/json.md
@@ -9,4 +9,3 @@ paths:
 - Use `jq` to parse JSON input. If you know the structure, use `jq` filters to extract specific fields. JSON is often token-heavy, so optimize for size.
   - Use `jq` filters like `keys`, `type`, and length to inspect JSON structures.
   - When fetching from the internet, output JSON to temporary files in `tmp/` directory to allow for inspection.
-- The Bash tool escapes `!` to `\!` on every path (heredocs included), breaking jq `!=`. Use `| not` instead (e.g., `select(.x == null | not)`). For a filter that needs a literal `!`, write it to a `.jq` file with the Write tool and run `jq -f`.


### PR DESCRIPTION
Removes the Bash `!`-escaping workaround and every mirror of the claim. Claude Code `2.1.75` fixed the bug and the installed CLI is `2.1.218`, so the always-on note in `user/CLAUDE.md` and the six copies of it were steering sessions away from `jq !=` and `awk !~` toward a Write-then-run detour. Reproduced through direct Bash tool calls: `jq 'if .a != 2 then ... end'` and `awk '$0 !~ /foo/'` both behave.

Advice that only existed to route around the bug goes with it. Advice that stands on its own stays: the heredoc in `plugins/linear/skills/linear/api.md` still keeps the shell from expanding `$id`, `-F query=@query.graphql` still keeps a long query off the command line, and `judge.workflow.js` still tells the judge agent to use the Write tool. Only the false premises are gone.

Separately, the subagent spawner is named `Agent`, not `Task`, which this repo already uses in seven `allowed-tools` lists and two call examples. The commented-out `model:` block in `.github/workflows/claude.yml` named `claude-opus-4-20250514`, no longer in the model roster, and asserted a default for `anthropics/claude-code-action@beta` that nothing here establishes. Deleting it drops the stale claim without adding an unverified replacement.

Left for a separate change: `plugins/claude-code/skills/skill/references/troubleshooting.md:9`, `user/skills/improve-claude-code/SKILL.md:41`, and `plugins/review/skills/follow-up/SKILL.md:134` with its `evals/evals.json` fixture, which have to move together.

Removal criterion for the deletion: a Bash call containing `!` failing with a shell error, or a literal `\!` reaching output. That surfaces on the next turn and re-adding the note is a three-line edit.

https://claude.ai/code/session_01JwSBM8AdjwpMgZPhzJ9dKx
