### PR TITLE
settings: allowlist the live docs hosts and track the schemastore grant

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -5,7 +5,7 @@ paths:
 
 # Settings
 
-User-level settings live in `user/settings.json` (plugins, permissions, sandbox). Project-level settings live in `.claude/settings.json` (biome hook). See the [settings documentation](https://docs.anthropic.com/en/docs/claude-code/settings) for available options.
+User-level settings live in `user/settings.json` (plugins, permissions, sandbox). Project-level settings live in `.claude/settings.json` (biome hook). See the [settings documentation](https://code.claude.com/docs/en/settings) for available options.
 
 ## Permission Paths
 
@@ -44,8 +44,10 @@ The sandbox is egress control, not filesystem lockdown. Credentials stay outside
 ### Hosts (`WebFetch(domain:...)` Permissions)
 
 - Package registries: `registry.npmjs.org`, `www.npmjs.com`, `pypi.org`, `rubygems.org`, `proxy.golang.org`, `sum.golang.org`, `community-extensions.duckdb.org` (DuckDB community extensions `markdown`/`yaml`, fetched on first `INSTALL ... FROM community`).
-- Docs and source: `docs.anthropic.com`, `code.claude.com`, `modelcontextprotocol.io`, `pkg.go.dev`, `bun.sh`, `bun.com`, `github.com`, `raw.githubusercontent.com`.
+- Docs and source: `platform.claude.com`, `code.claude.com`, `modelcontextprotocol.io`, `pkg.go.dev`, `bun.sh`, `bun.com`, `github.com`, `raw.githubusercontent.com`. `docs.anthropic.com` stays as the legacy host that 301-redirects to the first two, so the first leg of a redirect still resolves without a prompt.
 - Credentialed APIs: `api.github.com`, `api.linear.app`, `api.anthropic.com`, `claude.ai`, `gitlab.com`, `*.greptile.com`, `*.coderabbit.ai`. Trusted only because each secret lives outside the sandbox, except `gitlab.com`, `*.greptile.com`, and `*.coderabbit.ai` (see below).
+
+`www.schemastore.org` is granted in `.claude/settings.json` rather than here, because only this repo fetches it, through `schemas/overlays/sources.json`. It is unauthenticated and read-only, so the secrets-outside rule needs no caveat for it.
 
 `api.anthropic.com` is the known exfil-capable host (it accepts uploads). It stays because the agent needs the model API.
 

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -47,7 +47,23 @@ The sandbox is egress control, not filesystem lockdown. Credentials stay outside
 - Docs and source: `platform.claude.com`, `code.claude.com`, `modelcontextprotocol.io`, `pkg.go.dev`, `bun.sh`, `bun.com`, `github.com`, `raw.githubusercontent.com`. `docs.anthropic.com` stays as the legacy host that 301-redirects to the first two, so the first leg of a redirect still resolves without a prompt.
 - Credentialed APIs: `api.github.com`, `api.linear.app`, `api.anthropic.com`, `claude.ai`, `gitlab.com`, `*.greptile.com`, `*.coderabbit.ai`. Trusted only because each secret lives outside the sandbox, except `gitlab.com`, `*.greptile.com`, and `*.coderabbit.ai` (see below).
 
+**Removal criterion.** The grant only buys the first leg of a redirect, so it dies with the redirect:
+
+```
+curl -s -o /dev/null -w '%{http_code} %{redirect_url}\n' https://docs.anthropic.com/en/docs/claude-code/settings
+```
+
+Today: `301 https://code.claude.com/docs/en/settings`. Once that is no longer a 3xx into a host already listed above, drop it.
+
 `www.schemastore.org` is granted in `.claude/settings.json` rather than here, because only this repo fetches it, through `schemas/overlays/sources.json`. It is unauthenticated and read-only, so the secrets-outside rule needs no caveat for it.
+
+**Removal criterion.** Drop it when no overlay resolves its base live:
+
+```
+jq -r '.schemas[].url' schemas/overlays/sources.json | grep schemastore.org
+```
+
+The overlay design fetches every base at validation time, so this only empties if the upstream-backed schemas become hand-authored or vendored. See [`schemas.md`](schemas.md).
 
 `api.anthropic.com` is the known exfil-capable host (it accepts uploads). It stays because the agent needs the model API.
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,7 @@
       "Bash(npm view:*)",
       "Bash(shellcheck:*)",
       "Bash(brew info:*)",
+      "WebFetch(domain:www.schemastore.org)",
       "Skill(bun:bun)",
       "Skill(claude-code:agent-team)",
       "Skill(claude-code:hook)",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # claude
 
-> My personal plugin marketplace for [Claude Code](https://docs.anthropic.com/en/docs/claude-code), Anthropic's AI coding assistant.
+> My personal plugin marketplace for [Claude Code](https://code.claude.com/docs), Anthropic's AI coding assistant.
 
 ## Overview
 

--- a/user/settings.json
+++ b/user/settings.json
@@ -33,6 +33,7 @@
       "Bash(wt config:*)",
       "WebFetch(domain:modelcontextprotocol.io)",
       "WebFetch(domain:docs.anthropic.com)",
+      "WebFetch(domain:platform.claude.com)",
       "WebFetch(domain:registry.npmjs.org)",
       "WebFetch(domain:www.npmjs.com)",
       "WebFetch(domain:pypi.org)",


### PR DESCRIPTION
`docs.anthropic.com` now 301-redirects, and it splits: Claude Code docs land on `code.claude.com`, platform and API docs land on `platform.claude.com`. Neither successor host was in any tracked settings file. Verified with `curl -sI https://docs.anthropic.com/en/docs/claude-code/settings`, whose first hop is `HTTP/2 301`, and with `curl -sL` on each link to see where its own chain terminates.

`docs.anthropic.com` stays in `user/settings.json`. `WebFetch` does not follow cross-host redirects, so the legacy host has to be granted for the first leg to resolve without a prompt. The two entries are the two halves of one hop, not a duplicate.

Adding `platform.claude.com` widens the derived sandbox network allowlist for every sandboxed process on every project, since `user/settings.json` is symlinked to `~/.claude`. Accepted because no CLI in this setup stores a credential for that host and `WebFetch` sends no cookies. That is a narrower claim than the host being inert.

Separately, `bun run schemas check` and the `packages/validate/*.ts` entrypoints fetch `https://www.schemastore.org/...` through `schemas/overlays/sources.json`. The only allowlist entry for that host lived in `.claude/settings.local.json`, which is gitignored, so a fresh clone carried no tracked declaration of the network dependency. The grant goes in `.claude/settings.json` rather than user scope because only this repo fetches schemastore and the project file is what a fresh clone loads. `json.schemastore.org` is deliberately not granted: it appears only as `$schema` string values that editors resolve, never through Claude Code.

## Removal criteria

Drop `docs.anthropic.com` from `user/settings.json` and from the docs-and-source bullet in `.claude/rules/settings.md` once `curl -sI https://docs.anthropic.com/en/docs/claude-code/settings` stops returning a redirect.

Drop `www.schemastore.org` from `.claude/settings.json` when `schemas/overlays/sources.json` no longer targets schemastore, or when overlay bases stop being fetched live.

https://claude.ai/code/session_01JwSBM8AdjwpMgZPhzJ9dKx
