### PR TITLE
improve-claude-code: rename the Task tool to Agent

### DIFF
--- a/user/skills/improve-claude-code/SKILL.md
+++ b/user/skills/improve-claude-code/SKILL.md
@@ -38,7 +38,7 @@ Run the session skill's `scripts/refresh.ts --refresh` once, alone (a refresh wi
 
 #### Fan-Out
 
-Launch one `Task` agent per dimension (hook latency, hook blocks, permissions and sandbox, context tax, tokens, turns and compaction, skill economy), the same mining fan-out `agent-ideas` uses. The DB path is stable (the session skill states it), so agent prompts reference it directly; point each agent at `references/discovery.md`. Each agent runs its dimension's named queries (by name, read-only) plus any inline rollups, and returns structured candidate findings **plus the exact SQL it ran**. Read-only opens share the lock, so agents never contend with each other.
+Launch one `Agent` call per dimension (hook latency, hook blocks, permissions and sandbox, context tax, tokens, turns and compaction, skill economy), the same mining fan-out `agent-ideas` uses. The DB path is stable (the session skill states it), so agent prompts reference it directly; point each agent at `references/discovery.md`. Each agent runs its dimension's named queries (by name, read-only) plus any inline rollups, and returns structured candidate findings **plus the exact SQL it ran**. Read-only opens share the lock, so agents never contend with each other.
 
 #### Grounding
 


### PR DESCRIPTION
Renames the harness subagent tool from `Task` to `Agent` in the Discover fan-out step of `improve-claude-code`. 29138036 renamed the other sites, and this one was missed.

Phrased as "one `Agent` call per dimension" rather than a direct word swap, which would have produced "one `Agent` agent per dimension". This matches how the sibling `agent-ideas` skill already reads.

Remaining `Task` references live in `plugins/claude-code/skills/skill/references/` and `plugins/review/skills/follow-up/`. Both are being renamed in their own PRs.

https://claude.ai/code/session_01JwSBM8AdjwpMgZPhzJ9dKx
