### PR TITLE
claude-code: bring the skill-authoring frontmatter reference current

### DIFF
--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -39,7 +39,6 @@ With neither flag, use the skill as an authoring reference. See [Validation](#va
 
 - **Conciseness**: Keep `SKILL.md` under 500 lines. Use progressive disclosure.
 - **Appropriate Freedom**: Text for flexible tasks, pseudocode for moderate variation, scripts for error-prone operations.
-- **Cross-Model Testing**: Validate across Haiku, Sonnet, and Opus.
 
 ## Skill Structure
 
@@ -49,7 +48,8 @@ name: plugin-name:skill-name
 description: Third-person capability description with trigger terms
 argument-hint: "[--flag] [<positional>]"  # Optional: arguments shown in slash menu
 allowed-tools: [Read, Grep, Glob]         # Optional: tool restrictions
-model: claude-sonnet-4-20250514           # Optional: override model
+model: sonnet                             # Optional: override model
+effort: low                               # Optional: reasoning effort
 context: fork                             # Optional: run in isolated subagent
 agent: Explore                            # Optional: agent type for fork
 user-invocable: false                     # Optional: hide from slash menu
@@ -70,7 +70,8 @@ hooks:                                    # Optional: skill-scoped hooks
 **Optional Fields**:
 - `argument-hint`: Arguments the skill accepts, shown in the slash menu after the skill name. See [Argument Hints](#argument-hints).
 - `allowed-tools`: Tools Claude can use without permission when skill is active
-- `model`: Override the conversation's model
+- `model`: Override the conversation's model. Prefer a tier alias (`haiku`, `sonnet`, `opus`, `fable`) or `inherit` over a dated model ID.
+- `effort`: Reasoning effort while the skill is active. Pin `low` on mechanical skills such as monitoring, execution, and formatting. Defaults to the conversation's effort.
 - `context`: Set to `fork` to run in isolated subagent context
 - `agent`: Agent type when `context: fork` (`Explore`, `Plan`, `general-purpose`, or custom)
 - `user-invocable`: Hide from slash menu when `false` (default: `true`)

--- a/plugins/claude-code/skills/skill/references/patterns.md
+++ b/plugins/claude-code/skills/skill/references/patterns.md
@@ -265,7 +265,7 @@ The sub-agent starts with a **clean context** — it does not inherit the parent
 
 ### When Not to Fork
 
-`context: fork` loses all conversation history. If the skill needs awareness of what the user has been working on, run it inline and use Task agents to offload verbose work. The inline skill retains full context while keeping the heavy lifting out of the main conversation.
+`context: fork` loses all conversation history. If the skill needs awareness of what the user has been working on, run it inline and use `Agent` subagents to offload verbose work. The inline skill retains full context while keeping the heavy lifting out of the main conversation.
 
 ## Skill-Scoped Hooks
 

--- a/plugins/claude-code/skills/skill/references/troubleshooting.md
+++ b/plugins/claude-code/skills/skill/references/troubleshooting.md
@@ -6,7 +6,7 @@
 - Check YAML syntax (no tabs, proper `---` delimiters)
 - Confirm file location (`~/.claude/skills/` or `.claude/skills/`)
 - Test with explicit trigger phrases
-- For syntax questions, use Task tool with `subagent_type='claude-code-guide'`
+- For syntax questions, use the `Agent` tool with `subagent_type='claude-code-guide'`
 
 ## YAML Errors
 
@@ -58,5 +58,4 @@ Before deploying:
 - [ ] Clear workflows with steps
 - [ ] Scripts with explicit error handling
 - [ ] All package dependencies listed
-- [ ] Tested across Haiku/Sonnet/Opus
 - [ ] Real-world scenario validation


### PR DESCRIPTION
The `model` example in the skill-authoring reference was `claude-sonnet-4-20250514`, which is not in the current lineup. The reference's own guidance says the value is a tier alias, so the example was teaching the pattern the prose warns against, and a dated snapshot ID re-rots at every model release. It is now the bare alias `sonnet`.

`effort` was undocumented despite six skills in this repo setting it. The prose deliberately does not enumerate its values: the CLI's description string and the repo's schema disagree on whether `xhigh` and bare integers are accepted, and this change has no evidence to settle that.

Cross-model testing (`SKILL.md` principle plus its deployment-checklist twin) is gone. Nothing here can run a skill across models, so it was an unenforceable instruction, and the lineup it named omits Fable. The two `Task` tool names that survived #1097 become `Agent`.

Frontmatter facts were read from the installed CLI's own frontmatter schema at 2.1.218. The `background` field and `schemas/skill.schema.json` are covered by parallel changes and deliberately untouched here.

Follow-up, out of scope: `user/skills/agent-browser/SKILL.md:7` sets `hidden: true`, which is not a valid frontmatter key.

https://claude.ai/code/session_01JwSBM8AdjwpMgZPhzJ9dKx
