### PR TITLE
agents: remove unreachable user-consultation branches and dead tool names

### DIFF
--- a/plugins/github/agents/rulesets-manager.md
+++ b/plugins/github/agents/rulesets-manager.md
@@ -2,7 +2,7 @@
 name: rulesets-manager
 description: >-
   Manages GitHub repository rulesets. Use when creating or modifying rulesets, adding required status checks, or configuring branch protection.
-tools: Task, Bash(gh:*), Glob, Grep, LS, Read, TodoWrite, mcp__github
+tools: Bash(gh:*), Glob, Grep, Read, TodoWrite, mcp__github
 model: sonnet
 color: green
 ---
@@ -21,7 +21,7 @@ Core responsibilities:
 2. **Ruleset Selection**: When multiple rulesets exist, pick the most appropriate based on:
    - Target branches (prioritize default branch rulesets)
    - Existing rules and scope
-   - Ask the user to confirm when ambiguous
+   - When more than one ruleset could plausibly be the target, make no change. Return the candidates, the branches each covers, and what you would change in each, and stop.
 
 3. **Status Check Integration**: When adding required status checks:
    - Query recent check runs via `gh api repos/{owner}/{repo}/commits/{sha}/check-runs` or similar endpoints

--- a/plugins/type-ignore/agents/fixer.md
+++ b/plugins/type-ignore/agents/fixer.md
@@ -37,7 +37,7 @@ These changes affect only compile-time behavior:
 - Casting where semantically correct
 - Writing minimal type declarations for untyped libraries
 
-### Requires user consultation
+### Requires approval you cannot obtain
 These changes could affect runtime behavior:
 - Function signature changes
 - Adding/removing parameters
@@ -45,15 +45,12 @@ These changes could affect runtime behavior:
 - Behavioral logic changes
 - Changes to exported APIs
 
-When uncertain, ask the user before making behavioral changes.
+You cannot obtain approval. When a fix would require one of these changes, do not make it. Follow [On Failure](#on-failure) and name the specific signature or API change a human would have to approve.
 
 ### When no upstream types exist
-If a library has no types and you cannot write them, **ASK the user** before proceeding. Present these options:
-1. **Write minimal types** (preferred) — create type declarations for only the APIs used
-2. **Keep the ignore with explanation** — add a comment explaining why the ignore is necessary
-3. **Add config-level ignore** (last resort) — requires explicit user approval
+If a library has no types, write minimal type declarations covering only the APIs this file uses. If you cannot derive them from the library's runtime shape, follow [On Failure](#on-failure) and name the untyped module.
 
-**NEVER silently add config-level ignores.** Moving an ignore to a config file is not fixing it.
+**NEVER add config-level ignores.** Moving an ignore to a config file is not fixing it.
 
 ## On Failure
 
@@ -68,8 +65,8 @@ Include a brief explanation of why the fix requires manual intervention.
 ## Critical Constraints
 
 1. **Never add type ignores yourself** — only TODOs when fixes fail
-2. **Never add config-level ignores without explicit approval** — this is relocating, not fixing
-3. **Preserve functionality** — fixes must not change runtime behavior unless approved
+2. **Never add config-level ignores.** This is relocating, not fixing.
+3. **Preserve functionality.** Fixes must not change runtime behavior.
 4. **Stay scoped** — only fix ignores in the file you were assigned
 5. **Test after fixing** — run type checking to verify the fix works
 

--- a/plugins/type-ignore/agents/fixer.md
+++ b/plugins/type-ignore/agents/fixer.md
@@ -74,7 +74,7 @@ Include a brief explanation of why the fix requires manual intervention.
 
 1. Read the file and locate the type ignore (from hook: single ignore at specified line; from skill: all ignores in file)
 2. Understand the surrounding code and type error
-3. Determine if the fix is safe or requires consultation
+3. Determine if the fix is safe or requires approval you cannot obtain (follow [On Failure](#on-failure))
 4. Apply the fix or replace with TODO
 5. Run the type checker to verify success
 6. Report what was fixed

--- a/plugins/type-ignore/skills/fix/SKILL.md
+++ b/plugins/type-ignore/skills/fix/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools:
   - Read
   - Grep
   - Glob
-  - Task
+  - Agent
 ---
 
 # Type Ignore Fixer
@@ -32,4 +32,4 @@ If no scope provided, scan the entire codebase.
 2. Run type checking to verify fixes
 3. Report summary: files fixed, ignores resolved, issues remaining
 
-Spawn agents in parallel via multiple Task calls in a single message.
+Spawn agents in parallel via multiple `Agent` calls in a single message.


### PR DESCRIPTION
Two agent prompts routed decisions to the user through `AskUserQuestion`, which every subagent has stripped from its tool set. Those branches were unreachable: an agent that hit one either stalled or silently picked a path the prompt never sanctioned. Each now terminates in that agent's existing failure or stop-and-report path.

In `type-ignore:fixer`, changes that could affect runtime behavior now stop at `## On Failure` and name the signature or API change a human would have to approve. The untyped-library branch drops its three-option menu and instructs the preferred option directly, writing minimal declarations for the APIs the file uses. The config-level-ignore prohibition becomes absolute, since the approval that made it conditional was never obtainable.

`github:rulesets-manager` drops `LS`, which is not a Claude Code tool and appears nowhere in the CLI binary, and `Task`, which resolves to `Agent` but is withheld from non-fork subagents while nested spawning is off. Nothing in its body mentions delegation, so it is not replaced with `Agent`. Its ambiguous-ruleset branch now returns the candidate rulesets and what it would change in each, and stops.

`type-ignore:fix` normalizes `Task` to `Agent` to match the rest of the repo. The CLI still handles `Task` as a legacy synonym, so this is a naming-consistency fix.

Verified against transcripts in `~/.claude/projects/`: 614 `AskUserQuestion` invocations, all on the main thread, none in a sidechain frame.

No recurring context cost changes. Agent and skill bodies load only on invocation. The change is fewer lines of unreachable instruction and two tool names that resolved to nothing.

https://claude.ai/code/session_01JwSBM8AdjwpMgZPhzJ9dKx
