### PR TITLE
skills: fix forked skills whose tools are unavailable in a fork

### DIFF
--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -52,6 +52,7 @@ model: sonnet                             # Optional: override model
 effort: low                               # Optional: reasoning effort
 context: fork                             # Optional: run in isolated subagent
 agent: Explore                            # Optional: agent type for fork
+background: false                         # Optional: block the turn on a fork
 user-invocable: false                     # Optional: hide from slash menu
 hooks:                                    # Optional: skill-scoped hooks
   PreToolUse:
@@ -74,6 +75,7 @@ hooks:                                    # Optional: skill-scoped hooks
 - `effort`: Reasoning effort while the skill is active. Pin `low` on mechanical skills such as monitoring, execution, and formatting. Defaults to the conversation's effort.
 - `context`: Set to `fork` to run in isolated subagent context
 - `agent`: Agent type when `context: fork` (`Explore`, `Plan`, `general-purpose`, or custom)
+- `background`: Only with `context: fork`. `false` waits for the fork's result in the invoking turn instead of backgrounding it. Default `true`.
 - `user-invocable`: Hide from slash menu when `false` (default: `true`)
 - `disable-model-invocation`: Block model (Skill-tool) invocation and drop the skill's name and description from the always-on catalog (zero recurring context cost); still slash-invocable. Opposite of `user-invocable: false`, which hides the slash menu but keeps the description loaded for the model.
 - `hooks`: Skill-scoped hooks (`PreToolUse`, `PostToolUse`, `Stop`)

--- a/plugins/claude-code/skills/skill/references/patterns.md
+++ b/plugins/claude-code/skills/skill/references/patterns.md
@@ -263,6 +263,10 @@ agent: Explore
 
 The sub-agent starts with a **clean context** — it does not inherit the parent conversation. It sees only the skill content (with `!`shell`` injections expanded) and `CLAUDE.md`. Results are summarized and returned to the main conversation.
 
+Forks background by default. The result arrives as a later task notification rather than in the invoking turn, the fork runs with the narrower background-subagent tool set, and its edits fall outside session checkpoints so `/rewind` will not undo them. Set `background: false` when the caller needs the result in the turn that invoked the skill.
+
+A forked skill is a regular subagent. It never receives `AskUserQuestion`. `background: false` does not restore it. A skill whose steps depend on asking the user must run inline.
+
 ### When Not to Fork
 
 `context: fork` loses all conversation history. If the skill needs awareness of what the user has been working on, run it inline and use `Agent` subagents to offload verbose work. The inline skill retains full context while keeping the heavy lifting out of the main conversation.

--- a/plugins/interview/skills/clarify/SKILL.md
+++ b/plugins/interview/skills/clarify/SKILL.md
@@ -3,7 +3,6 @@ name: interview:clarify
 disable-model-invocation: true
 description: |
   Targeted interview for execution-time clarification. Use when you hit an ambiguity or decision point during implementation that needs user input before proceeding.
-context: fork
 ---
 
 # Clarification Interview

--- a/plugins/interview/skills/plan/SKILL.md
+++ b/plugins/interview/skills/plan/SKILL.md
@@ -2,8 +2,6 @@
 name: interview:plan
 description: |
   Comprehensive interview for planning new features or changes. Use when the user wants thorough upfront planning before implementation, or when starting work on a complex feature.
-context: fork
-agent: Plan
 ---
 
 # Planning Interview

--- a/plugins/writing/skills/rewrite/SKILL.md
+++ b/plugins/writing/skills/rewrite/SKILL.md
@@ -7,6 +7,7 @@ description: >-
 argument-hint: "[file path or text; omit to read input from the clipboard]"
 user-invocable: true
 context: fork
+background: false
 allowed-tools:
   - Bash
   - Read


### PR DESCRIPTION
`interview:plan` and `interview:clarify` mandate `AskUserQuestion` in every step while running `context: fork`. A forked skill is a regular subagent, and `AskUserQuestion` is stripped from every subagent. Neither skill can do the one thing it exists to do. A run on 2026-07-15 returned "the tool is not available in this agent context (confirmed via ToolSearch)" and degraded to a prose question list, which both skills explicitly forbid. Removing `context: fork` runs them inline, where the tool exists. `agent: Plan` is meaningless without the fork and goes with it.

`background: false` cannot fix this. The `AskUserQuestion` removal is the first subagent filter and applies foreground or background.

`writing:rewrite` keeps its fork and gains `background: false`. Forks background by default, and its rewritten output lands in a later turn while the user is still waiting on it before sending a message. The justification here is turn timing. Both of its declared tools (`Bash`, `Read`) are in the background subagent set, leaving nothing degraded.

Documents `background` in the skill-authoring reference, which never mentioned it, and corrects `patterns.md`, which described forks as if they still block the turn.

Accepted tradeoff: the interview skills now run inline and inherit the session's permission mode. The prose write-guards at `plan/SKILL.md:38` and `clarify/SKILL.md:27` become the only guard against writes during an interview. Their exploration also lands in the main context window instead of a throwaway fork.

`background` is the repo's first use of that key. It needs no schema entry: #1109 deleted `schemas/skill.schema.json`, and rebasing onto that leaves no frontmatter schema to keep in sync.

https://claude.ai/code/session_01JwSBM8AdjwpMgZPhzJ9dKx

