### PR TITLE
writing: make the review lens agents read-only and own their own rules

### DIFF
--- a/plugins/writing/agents/artifacts.md
+++ b/plugins/writing/agents/artifacts.md
@@ -2,6 +2,8 @@
 name: artifacts
 description: |
   Reviews document artifacts: URL validity, citations, Mermaid diagram syntax, and markdown table formatting. Only dispatched when the document contains links, diagrams, or tables.
+disallowedTools: Edit, Write, NotebookEdit, Agent
+model: sonnet
 ---
 
 Review the document's embedded artifacts. Use WebFetch to check URL validity. Verify Mermaid diagram syntax and accuracy against surrounding text. Check markdown table formatting and data consistency.

--- a/plugins/writing/agents/content.md
+++ b/plugins/writing/agents/content.md
@@ -2,6 +2,8 @@
 name: content
 description: |
   Reviews document substance: technical accuracy, factual claims, logical flow, section structure, code examples, and internal consistency.
+disallowedTools: Edit, Write, NotebookEdit, Agent
+model: sonnet
 ---
 
 Review the document for correctness and coherence. Check factual claims, API references, code examples, logical flow, section ordering, and internal consistency.

--- a/plugins/writing/agents/style.md
+++ b/plugins/writing/agents/style.md
@@ -2,8 +2,25 @@
 name: style
 description: |
   Reviews document presentation: voice consistency, audience fit, AI trope detection, readability, and formatting.
+disallowedTools: Edit, Write, NotebookEdit, Agent
+model: sonnet
 ---
 
-Review the document for style and tone. Check voice consistency, audience appropriateness, AI writing tropes (per the writing preferences in your prompt), readability, and markdown formatting.
+Review the document for style and tone. Check voice consistency, audience appropriateness, AI writing tropes, readability, and markdown formatting.
+
+Apply these writing preferences:
+
+- Avoid AI-typical vocabulary: `meticulous`/`meticulously`, `pivotal`, `testament`, `underscore` (figurative), `interplay`, `intricacies`, `bolstered`, `garner`/`garnered`, `foster`/`fostering`
+- Avoid promotional language: `boasts`, `vibrant`, `showcasing`, `nestled`, `groundbreaking`, `renowned`, `diverse array`
+- Avoid copula avoidance ("X is Y" not fancy alternatives)
+- Split connector-joined clauses (semicolons, dashes) into separate sentences
+- Direct, conversational tone
+- Headings are short noun-phrase topic labels, not sentences. Flag a heading that contains a finite verb, reads as a `Topic: explanatory clause`, or is otherwise a full clause. Cut to the noun phrase. Push the explanation into the first sentence.
+
+<!--
+Curation note for maintainers. Skip this block when reviewing a document.
+
+The vocabulary list above is review-only. Apart from `meticulous` (`wordlists/vocabulary.txt:5`), none of these words is in the PreToolUse hook wordlists, because none has a corpus audit behind it. Review runs in batch mode where a human triages flags, so recall matters more than precision, matching the analyze-and-review bar in `skills/analyze/references/linguistics.md`. Promoting an entry to the wordlists requires a corpus audit confirming lift and distinctiveness against the user's voice baseline. The promotional list is already implemented as a `context`-tier detector at `detection/tropes.ts:541` with its own `evidence` and `retire` fields.
+-->
 
 Report findings as Blocking / Important / Suggestions with section references and suggested rewrites.

--- a/plugins/writing/skills/review/SKILL.md
+++ b/plugins/writing/skills/review/SKILL.md
@@ -33,16 +33,6 @@ When `--lens` is set, restrict the dispatch to the named lenses. `artifacts` sti
 
 Spawn all applicable agents in parallel. Each receives the document content, audience, and focus areas.
 
-For `writing:style`, also inject these writing preferences (sub-agents cannot see skills):
-
-- Avoid AI-typical vocabulary: `meticulous`/`meticulously`, `pivotal`, `testament`, `underscore` (figurative), `interplay`, `intricacies`, `bolstered`, `garner`/`garnered`, `foster`/`fostering`
-  - These words are **review-only**. They do not appear in the hook wordlists because none has a corpus audit behind it. The review skill runs in batch mode where a human triages flags (recall matters more than precision), matching the analyze-and-review bar from linguistics.md. Promoting any to the hook wordlists requires a corpus audit confirming lift and distinctiveness versus the user's voice baseline.
-- Avoid promotional language: `boasts`, `vibrant`, `showcasing`, `nestled`, `groundbreaking`, `renowned`, `diverse array`
-- Avoid copula avoidance ("X is Y" not fancy alternatives)
-- Split connector-joined clauses (semicolons, dashes) into separate sentences
-- Direct, conversational tone
-- Headings are short noun-phrase topic labels, not sentences. Flag a heading that contains a finite verb, reads as a `Topic: explanatory clause`, or is otherwise a full clause. Cut to the noun phrase; push the explanation into the first sentence.
-
 ## Synthesize
 
 Merge agent findings per [references/synthesis.md](references/synthesis.md). Deduplicate, rank by severity, and present a unified report.


### PR DESCRIPTION
`writing:review` dispatches `content`, `style`, and `artifacts` in parallel against one document, then merges their findings. Two defects followed from how those agents were defined.

## Read-only lenses

None of the three set `tools:` or `disallowedTools:`, so each inherited the full subagent pool, including `Edit`, `Write`, and `NotebookEdit`. A lens that edits the document instead of reporting on it invalidates the two lenses reviewing the same file in parallel, and the dedup step then reports fixes against text that no longer exists. `user/agents/review.md` already carries this denylist for the same reason.

`Agent` is on the list as forward defense. Nested subagent spawning is off by default on the installed CLI 2.1.218, and the default depth rises to 3 in 2.1.219, so the entry is inert today and becomes load-bearing on upgrade.

`Bash` stays in the pool, so these are not strictly read-only. That residual is accepted on the same terms `user/agents/review.md` accepts it. Closing it would need `isolation: worktree`, which would provision a git worktree per lens on every review run.

`model: sonnet` pins all three. Each body is a single bounded instruction with a fixed output shape. Without a pin a subagent inherits the orchestrator's model, so an expensive orchestrator spawns expensive lenses.

## Style rules move to the agent that applies them

`skills/review/SKILL.md` hand-injected nine lines of style rules into the `writing:style` spawn prompt, justified by the parenthetical "sub-agents cannot see skills". That claim is false, and the placement was wrong regardless: `style.md` deferred to "the writing preferences in your prompt", so the agent's own rules lived in a different file that every caller had to know to inject.

The rules now live in `style.md`. This also changes which context pays for them. They previously loaded on every `writing:review` run, including `--lens content` runs that never spawn the style agent.

The review-only curation note becomes an HTML comment so it does not read as an instruction to the reviewing agent, since wordlist curation policy gives that agent nothing to act on. Its claim that none of these words appears in the hook wordlists was wrong. `meticulous` is at `wordlists/vocabulary.txt:5`. The note also records that the promotional list is already implemented as a `context`-tier detector at `detection/tropes.ts:541`.

This change adds no `skills:` frontmatter. Four of the six relocated bullets already restate `skills/writing/SKILL.md`, so preloading it would duplicate them in the same agent context.

## Verification

`claude plugin validate plugins/writing`, `bun run skill-lint`, `bun test plugins/writing/`, and `bun scripts/check-marketplace.ts`.

https://claude.ai/code/session_01JwSBM8AdjwpMgZPhzJ9dKx
