### PR TITLE
ship: reach xhigh, stop restating the review cell table, and report the body refresh

### DIFF
--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -47,7 +47,7 @@ Infer, don't interrogate. Present the plan in one line, then proceed. `AskUserQu
 ## Flags
 
 - `--merge`: drive to merged (babysit `--merge`). Default: green and ready.
-- `--effort <low|medium|high|max|ultra>`: override inferred `review:code` effort. `ultra` is a billed cloud review only a user-typed `/code-review ultra` can start, so ship stops and hands it back instead of substituting a local level.
+- `--effort <low|medium|high|xhigh|max|ultra>`: override inferred `review:code` effort. `ultra` is a billed cloud review only a user-typed `/code-review ultra` can start, so ship stops and hands it back instead of substituting a local level.
 - `--simplify`: force `simplify` over `review:code`.
 - `--skip <pass>` (repeatable): drop a gated pass. Names: `plan`, `review:code` (the old `code-review` is accepted as an alias), `simplify`, `comments`, `bot`, `writing`, `verify`.
 - `--base <ref>`: base branch for gating. Default `main`; on a stack, the parent branch. Resolved to its upstream tracking ref (e.g. `origin/...`) before diffing.
@@ -92,8 +92,8 @@ Babysit owns the CI waits. Follow-up owns the wait for an expected review and it
 
 ## Refresh the Body
 
-Dispatch a background `general-purpose` Agent (cheaper model if set) to run `pull-request:update <url>`. Never `fork`: it must read the final PR and diff cold, not this session's transcript, so the body describes the finished change with no review narration.
+Dispatch a background `general-purpose` Agent (cheaper model if set) to run `pull-request:update <url>` on every run that opened a PR. Never `fork`: it must read the final PR and diff cold, not this session's transcript, so the body describes the finished change with no review narration. Rewriting the body inside this session is not a substitute.
 
 ## Report
 
-PR link, passes run and gated out, final state (green and ready, or merging).
+PR link, passes run and gated out, final state (green and ready, or merging), and whether the body refresh was dispatched.

--- a/user/skills/ship/references/passes.md
+++ b/user/skills/ship/references/passes.md
@@ -40,7 +40,7 @@ flowchart TD
 
 ## Effort Inference
 
-Infer `review:code` effort from the diff unless `--effort` overrides. `high` is routine for risky work. Reserve `max` for explicit requests.
+Infer `review:code` effort from the diff unless `--effort` overrides. `high` is routine for risky work. Reserve `xhigh` and `max` for explicit requests.
 
 | Diff shape | Effort |
 |---|---|
@@ -49,7 +49,7 @@ Infer `review:code` effort from the diff unless `--effort` overrides. `high` is 
 | Risky: multiple plugins, hooks, permissions, sandbox, or auth-shaped code | `high` |
 | Explicit request only | `max` |
 
-On Opus 4.8, only `max` fans out subagents. `medium`, `high`, and `xhigh` run every angle inline in one context with dedup and no verify pass, so stepping from `medium` to `high` buys two more findings' worth of cap rather than a separate verifier fleet. Budget `--effort high` accordingly and use `max` when a change genuinely warrants independent verification.
+`review:code` picks its fan-out shape from its own cell table, keyed on model family as well as effort level, which is why the same `--effort` can mean one inline pass in one family and a fleet of finders plus per-candidate verifiers in another. Do not infer cost from the effort name.
 
 `--effort ultra` is not inferrable and `review:code` cannot run it. It is a billed cloud review that only a user-typed `/code-review ultra` can launch. On `--effort ultra`, stop and say so rather than substituting a local level.
 


### PR DESCRIPTION
Three stale facts in the `ship` skill.

Ship's documented `--effort` enum listed `low|medium|high|max|ultra`, omitting `xhigh`. `review:code` advertises `xhigh` in its own argument hint, parses the `xhi` prefix, and defines an `xhigh` column for every model family, so the level was reachable through `review:code` directly but not through ship. The effort inference note now marks `xhigh` as explicit-request-only alongside `max`. The inference table is unchanged, so nothing moves for a run that passes no `--effort`.

`references/passes.md` restated one model family's row of `plugins/review/skills/code/efforts.md` verbatim. That duplicated a fact owned by another plugin with its own refresh trigger, and it was scoped to a single family, so it said nothing about any other. It now states that fan-out shape varies by family and level and that `review:code` owns the table. It names no family and cites no path, since ship has no `Read` in `allowed-tools` and runs in repos other than this one.

`SKILL.md` declares "body refreshed" as part of ship's default end state, but `## Report` never accounted for it. The dispatch is now explicit on every run that opened a PR, and the report says whether it happened.

`efforts.md` is deliberately untouched. Its unknown-family fallthrough to the `default` row is documented, and the trigger for a new row is an upstream recalibration that `scripts/check-review-drift.ts` already watches.

## Known follow-up

The effort inference table still maps "Explicit request only" to `max` alone, while the prose above it now reserves both `xhigh` and `max` for explicit requests. Two reviewers flagged the gap. It is left alone here on purpose: that table drives what ship picks when no `--effort` is passed, and this change is a reachability fix, not a defaults change. `xhigh` is discoverable from the `--effort` enum and from the prose directly above the table, so nothing is unreachable. Whether the table should describe explicit-request levels at all is a separate question.

https://claude.ai/code/session_01JwSBM8AdjwpMgZPhzJ9dKx
