### PR TITLE
schemas: stop the settings overlay from clobbering upstream

### DIFF
--- a/.claude/rules/schemas.md
+++ b/.claude/rules/schemas.md
@@ -17,4 +17,5 @@ paths:
   `schemas/<name>.schema.json` directly.
 
 `bun run schemas check` (CI) fetches current upstream, fails if an overlay stops
-applying, and flags overlay ops upstream has absorbed so they can be dropped.
+applying, and flags overlay ops upstream has absorbed so they can be dropped. It
+also warns when an `add` op overwrites a definition upstream now ships.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Path-specific guidance lives in [`.claude/rules/`](.claude/rules/) and auto-inje
 ## Verification
 
 - `bun scripts/check-marketplace.ts`: verifies all plugin directories are listed in `marketplace.json`. Runs in CI.
-- `bun run schemas check`: fetches current upstream and verifies the upstream-backed schema overlays still apply, flagging overlay edits that upstream has absorbed. Runs in CI.
+- `bun run schemas check`: fetches current upstream and verifies the upstream-backed schema overlays still apply, flagging overlay edits that upstream has absorbed and warning on edits that overwrite an upstream definition. Runs in CI.
 - `bun run skill-lint "plugins/<name>/skills/*"`: validates SKILL.md frontmatter and reference depth. `skill-lint` is a workspace package in `packages/skill-lint`, not an npm registry package.
 
 ## Workflow

--- a/packages/validate/overlay.test.ts
+++ b/packages/validate/overlay.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, test } from "bun:test";
 import type { Operation } from "rfc6902";
-import { applyOverlay, findRedundantOps, getPointer, type RedundantOp } from "./overlay";
+import { applyOverlay, findOverlayConflicts, getPointer, type OverlayConflict } from "./overlay";
 
 describe("applyOverlay", () => {
   it("adds and replaces without mutating the base", () => {
@@ -39,23 +39,35 @@ describe("getPointer", () => {
   });
 });
 
-describe("findRedundantOps", () => {
+describe("findOverlayConflicts", () => {
   const changedReplace: Operation = { op: "replace", path: "/$id", value: "mine" };
   const removeOp: Operation = { op: "remove", path: "/properties/gone" };
 
-  test.each<[string, Record<string, unknown>, Operation[], RedundantOp[]]>([
+  test.each<[string, Record<string, unknown>, Operation[], OverlayConflict[]]>([
     [
-      "flags add/replace ops the base already satisfies",
+      "flags an op the base already satisfies as absorbed",
       { properties: { theme: { type: "string" }, name: { type: "string" } } },
       [
         { op: "add", path: "/properties/theme", value: { type: "string" } },
         { op: "add", path: "/properties/extra", value: { type: "boolean" } },
       ],
-      [{ index: 0, path: "/properties/theme" }],
+      [{ index: 0, path: "/properties/theme", kind: "absorbed" }],
+    ],
+    [
+      "flags an add over a richer upstream definition as diverged",
+      { properties: { theme: { type: "string", enum: ["dark", "light"] } } },
+      [{ op: "add", path: "/properties/theme", value: { type: "string" } }],
+      [{ index: 0, path: "/properties/theme", kind: "diverged" }],
     ],
     ["does not flag a replace that changes the value", { $id: "upstream" }, [changedReplace], []],
     ["ignores remove operations", { properties: {} }, [removeOp], []],
+    [
+      "ignores an add whose target is absent upstream",
+      { properties: {} },
+      [{ op: "add", path: "/properties/new", value: { type: "boolean" } }],
+      [],
+    ],
   ])("%s", (_name, base, patch, expected) => {
-    expect(findRedundantOps(base, patch)).toEqual(expected);
+    expect(findOverlayConflicts(base, patch)).toEqual(expected);
   });
 });

--- a/packages/validate/overlay.ts
+++ b/packages/validate/overlay.ts
@@ -47,26 +47,37 @@ export function getPointer(value: unknown, pointer: string): unknown {
   return current;
 }
 
-export interface RedundantOp {
+/** How an overlay op relates to a base that already defines its target path. */
+export type OverlayConflictKind = "absorbed" | "diverged";
+
+export interface OverlayConflict {
   index: number;
   path: string;
+  kind: OverlayConflictKind;
 }
 
 /**
- * Identify overlay operations the base already satisfies — an add/replace whose
- * target already deep-equals the operation's value. These are edits upstream has
- * absorbed and can be dropped from the patch without changing the merged schema.
+ * Identify overlay operations whose target path the base already defines.
+ *
+ * `absorbed` is a base value deep-equal to the op's value, an edit upstream has
+ * caught up on. `diverged` is an `add` whose value differs, which RFC 6902 `add`
+ * silently replaces, so the overlay overwrites whatever upstream now ships. A
+ * `replace` that changes an existing value is its intended use and is not
+ * reported.
  */
-export function findRedundantOps(base: Schema, patch: Operation[]): RedundantOp[] {
-  const redundant: RedundantOp[] = [];
+export function findOverlayConflicts(base: Schema, patch: Operation[]): OverlayConflict[] {
+  const conflicts: OverlayConflict[] = [];
   for (const [index, op] of patch.entries()) {
     if (op.op !== "add" && op.op !== "replace") continue;
     const existing = getPointer(base, op.path);
-    if (existing !== undefined && Bun.deepEquals(existing, op.value)) {
-      redundant.push({ index, path: op.path });
+    if (existing === undefined) continue;
+    if (Bun.deepEquals(existing, op.value)) {
+      conflicts.push({ index, path: op.path, kind: "absorbed" });
+    } else if (op.op === "add") {
+      conflicts.push({ index, path: op.path, kind: "diverged" });
     }
   }
-  return redundant;
+  return conflicts;
 }
 
 /** Read the overlay registry. The `patch` path in each entry is relative to schemasDir. */

--- a/schemas/overlays/README.md
+++ b/schemas/overlays/README.md
@@ -22,9 +22,11 @@ directly in `schemas/` and have no patch here.
 - **`bun run schemas check`** — CI guard. Fetches current upstream, fails if an
   overlay no longer applies (upstream restructured a path the patch targets) or
   if an overlay op is already in upstream (absorbed — drop the op).
-- It also warns, without failing, when an `add` op targets a path upstream now
-  defines with a different value. RFC 6902 `add` overwrites silently, so the op
-  replaces upstream's definition. Reconcile it against upstream or drop it.
+- **`check`** also warns, without failing, when an `add` op targets a path
+  upstream now defines with a different value. RFC 6902 `add` overwrites
+  silently, so the op replaces upstream's definition. Narrowing upstream this
+  way can be deliberate (see `marketplace.patch.json`), so the warning asks for
+  a decision rather than failing: confirm the override or drop the op.
 
 ## Editing
 

--- a/schemas/overlays/README.md
+++ b/schemas/overlays/README.md
@@ -22,6 +22,9 @@ directly in `schemas/` and have no patch here.
 - **`bun run schemas check`** — CI guard. Fetches current upstream, fails if an
   overlay no longer applies (upstream restructured a path the patch targets) or
   if an overlay op is already in upstream (absorbed — drop the op).
+- It also warns, without failing, when an `add` op targets a path upstream now
+  defines with a different value. RFC 6902 `add` overwrites silently, so the op
+  replaces upstream's definition. Reconcile it against upstream or drop it.
 
 ## Editing
 

--- a/schemas/overlays/settings.patch.json
+++ b/schemas/overlays/settings.patch.json
@@ -1,39 +1,6 @@
 [
   {
     "op": "add",
-    "path": "/properties/sandbox/properties/allowAppleEvents",
-    "value": {
-      "type": "boolean",
-      "description": "Allow sandboxed commands to send macOS Apple Events (osascript, open)"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/properties/sandbox/properties/network/properties/allowMachLookup",
-    "value": {
-      "type": "array",
-      "items": { "type": "string" },
-      "description": "macOS mach services the sandbox may look up (e.g. com.apple.trustd.agent for Go/Security.framework TLS)"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/properties/theme",
-    "value": {
-      "type": "string",
-      "description": "Color theme. \"auto\" follows the OS appearance."
-    }
-  },
-  {
-    "op": "add",
-    "path": "/properties/autoCompactEnabled",
-    "value": {
-      "type": "boolean",
-      "description": "Automatically compact the conversation when context grows large"
-    }
-  },
-  {
-    "op": "add",
     "path": "/properties/skipAutoPermissionPrompt",
     "value": {
       "type": "boolean",
@@ -50,26 +17,12 @@
   },
   {
     "op": "add",
-    "path": "/properties/agentPushNotifEnabled",
+    "path": "/properties/autoCompactWindow",
     "value": {
-      "type": "boolean",
-      "description": "Send push notifications for background agent activity"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/properties/inputNeededNotifEnabled",
-    "value": {
-      "type": "boolean",
-      "description": "Send a notification when Claude is waiting for input"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/properties/preferredNotifChannel",
-    "value": {
-      "type": "string",
-      "description": "Channel used to deliver notifications (e.g. terminal_bell, iterm2)"
+      "type": "integer",
+      "minimum": 100000,
+      "maximum": 1000000,
+      "description": "Auto-compact window size in tokens"
     }
   }
 ]

--- a/scripts/schemas/index.ts
+++ b/scripts/schemas/index.ts
@@ -18,6 +18,7 @@ const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
 
 const check = command({ name: "check" }, async () => {
   let failed = false;
+  let warned = false;
   for (const source of await loadSources(SCHEMAS_DIR)) {
     const [base, patch] = await Promise.all([
       fetchBase(source.url),
@@ -42,12 +43,17 @@ const check = command({ name: "check" }, async () => {
       } else {
         console.log(
           `${yellow("⚠")} ${source.patch} op[${index}] (${path}) replaces a definition ` +
-            `upstream now ships. Reconcile the op against upstream or drop it.`,
+            `upstream now ships. Confirm the override is still intended, otherwise drop the op.`,
         );
+        warned = true;
       }
     }
   }
   if (failed) process.exit(1);
+  if (warned) {
+    console.log(yellow("\nSchema overlays apply, but some ops overwrite an upstream definition."));
+    return;
+  }
   console.log(green("\nAll schema overlays are current with upstream."));
 });
 

--- a/scripts/schemas/index.ts
+++ b/scripts/schemas/index.ts
@@ -5,7 +5,7 @@ import { cli, command } from "cleye";
 import {
   applyOverlay,
   fetchBase,
-  findRedundantOps,
+  findOverlayConflicts,
   loadPatch,
   loadSources,
 } from "../../packages/validate/overlay";
@@ -14,6 +14,7 @@ const SCHEMAS_DIR = join(import.meta.dirname, "../../schemas");
 
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
 
 const check = command({ name: "check" }, async () => {
   let failed = false;
@@ -31,12 +32,19 @@ const check = command({ name: "check" }, async () => {
       failed = true;
     }
 
-    for (const { index, path } of findRedundantOps(base, patch)) {
-      console.log(
-        `${red("✗")} ${source.patch} op[${index}] (${path}) is now in upstream — ` +
-          `drop it from the overlay`,
-      );
-      failed = true;
+    for (const { index, path, kind } of findOverlayConflicts(base, patch)) {
+      if (kind === "absorbed") {
+        console.log(
+          `${red("✗")} ${source.patch} op[${index}] (${path}) is now in upstream. ` +
+            `Drop it from the overlay.`,
+        );
+        failed = true;
+      } else {
+        console.log(
+          `${yellow("⚠")} ${source.patch} op[${index}] (${path}) replaces a definition ` +
+            `upstream now ships. Reconcile the op against upstream or drop it.`,
+        );
+      }
     }
   }
   if (failed) process.exit(1);
@@ -49,7 +57,7 @@ cli(
     commands: [check],
     help: {
       description:
-        "Manage upstream-backed JSON schemas. Each is the upstream SchemaStore base fetched live plus an RFC 6902 overlay of our edits, merged in memory at validation time. `check` fetches current upstream, verifies the overlay still applies, and flags ops upstream has absorbed.",
+        "Manage upstream-backed JSON schemas. Each is the upstream SchemaStore base fetched live plus an RFC 6902 overlay of our edits, merged in memory at validation time. `check` fetches current upstream, verifies the overlay still applies, flags ops upstream has absorbed, and warns on ops that overwrite an upstream definition.",
     },
   },
   (parsed) => parsed.showHelp(),


### PR DESCRIPTION
Seven of the nine ops in `schemas/overlays/settings.patch.json` had stopped being additions and become overwrites. RFC 6902 `add` replaces an existing member, so once SchemaStore defined those paths our stubs silently won. `theme` lost its 7-value enum and `^custom:.+` pattern, `preferredNotifChannel` lost its enum, `sandbox.network.allowMachLookup` lost `items.minLength` and `examples`, and four booleans lost upstream's descriptions and defaults. `theme: "darkk"` and `preferredNotifChannel: "bogus"` both validated clean on `main`.

Each of the nine was checked against the live base before being touched. The seven are present upstream with the same base `type` and strictly more constraint, so dropping them only restores validation. `skipAutoPermissionPrompt` and `skipWorkflowUsageWarning` are still absent upstream and stay.

`autoCompactWindow` is new. `user/settings.json` has been setting it with no schema modeling it, which is what the `unknown property` warning from `bun packages/validate/settings.ts` was reporting. Bounds come from the CLI's own `number().int().min(1e5).max(1e6)` rather than a permissive `exclusiveMinimum: 0`, which would have accepted values the CLI silently drops.

`bun run schemas check` could not see any of this. `findRedundantOps` only fired when the base value deep-equaled the op value, so an op that *differed* from a now-present upstream definition was invisible. That is exactly the clobbering case, so the guard was blind to the failure it existed to catch. `findOverlayConflicts` replaces it with two tiers: `absorbed` (deep-equal, upstream caught up) keeps the old exit-1, and `diverged` (an `add` over a differing value) warns without failing. Run against the old nine-op patch, the new detector flags all seven.

The split is load-bearing rather than cosmetic. `schemas/overlays/marketplace.patch.json` uses `add` at `/properties/name/pattern` and `/properties/name/not` to stay deliberately narrower than upstream. Neither path exists upstream today, so neither reports, but a one-tier detector would fail CI on an intentional narrowing the moment SchemaStore adds a `pattern` there. For the same reason the warning asks whether the override is still intended instead of telling you to drop it, and the run summary no longer prints the green "current with upstream" line after a warning, which would otherwise read as a clean pass in CI.

Verified both tiers end to end by temporarily reintroducing a clobbering op (warns, exit 0) and an upstream-identical op (fails, exit 1). With the three surviving ops, `theme: "darkk"`, `preferredNotifChannel: "bogus"`, and `autoCompactWindow: 50` are now all rejected, and both settings files validate with no warning.

Note that restoring the upstream enums is a real behavior change: a typo in `theme` or `preferredNotifChannel` will now fail `bun packages/validate/settings.ts` where it previously passed.

https://claude.ai/code/session_01JwSBM8AdjwpMgZPhzJ9dKx
