### PR TITLE
writing: give the analyze judge pricing a family fallback

### DIFF
--- a/plugins/writing/skills/analyze/scripts/judge.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import {
   aggregateVerdicts,
   CHUNK_WORD_LIMIT,
@@ -10,6 +10,7 @@ import {
   HEADING_BATCH_SIZE,
   HEADING_PROMPT_PATH,
   JUDGE_CRITERIA,
+  JUDGE_MODEL,
   type JudgeVerdict,
   judgeCorpus,
   judgeDocument,
@@ -242,6 +243,56 @@ describe("estimateCost", () => {
     const docs = Array(200).fill(Array(1000).fill("word").join(" "));
     const estimate = await estimateCost(docs, { promptText: prompt.text });
     expect(estimate.usd).toBeLessThan(1);
+  });
+});
+
+describe("modelPricing", () => {
+  test.each<[string, number]>([
+    ["claude-haiku-4-5", 0.0025],
+    ["claude-haiku-5-20260901", 0.0025],
+    ["claude-sonnet-4-6", 0.0075],
+    ["claude-sonnet-5", 0.0075],
+    ["claude-opus-5", 0.0125],
+    ["claude-opus-5[1m]", 0.0125],
+    ["claude-fable-5", 0.025],
+    ["claude-mythos-5", 0.025],
+  ])("prices %s from its family", async (model, usd) => {
+    const estimate = await estimateCost(["doc"], {
+      promptText: "prompt",
+      model,
+      countTokens: async () => 1000,
+    });
+    expect(estimate.usd).toBeCloseTo(usd, 6);
+  });
+
+  test("an unrecognized family falls back to haiku rates and warns", async () => {
+    const warn = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const estimate = await estimateCost(["doc"], {
+        promptText: "prompt",
+        model: "some-other-vendor-model",
+        countTokens: async () => 1000,
+      });
+      expect(estimate.usd).toBeCloseTo(0.0025, 6);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0]?.[0]).toContain("some-other-vendor-model");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test("a matched family does not warn", async () => {
+    const warn = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await estimateCost(["doc"], {
+        promptText: "prompt",
+        model: JUDGE_MODEL,
+        countTokens: async () => 1000,
+      });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 });
 

--- a/plugins/writing/skills/analyze/scripts/judge.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.ts
@@ -290,10 +290,26 @@ interface ModelPricing {
 
 const HAIKU_PRICING: ModelPricing = { input: 1, output: 5 };
 
-const PRICING_PER_MTOK: Record<string, ModelPricing> = {
-  "claude-haiku-4-5": HAIKU_PRICING,
-  "claude-sonnet-4-6": { input: 3, output: 15 },
-};
+/**
+ * Per-MTok USD rates matched by family substring, so a new model id in a known
+ * family needs no edit here. The family rows mirror `model_input_rate` and
+ * `model_output_rate` in
+ * `plugins/claude-code/skills/session/resources/schema/03_macros.sql`. Plugins
+ * cannot import across plugin boundaries, so a rate change has to touch both.
+ * Sonnet is held at the 3/15 standard rate rather than a promotional rate, since
+ * an estimate for a known family must not come in under the real bill.
+ *
+ * The no-match fallback in `modelPricing` is the one place the two deliberately
+ * diverge. The SQL defaults an unknown model to Opus rates, this defaults to
+ * Haiku and warns. Raising that floor is a behavioral change, not a rate sync.
+ */
+const FAMILY_PRICING: ReadonlyArray<readonly [string, ModelPricing]> = [
+  ["fable", { input: 10, output: 50 }],
+  ["mythos", { input: 10, output: 50 }],
+  ["opus", { input: 5, output: 25 }],
+  ["sonnet", { input: 3, output: 15 }],
+  ["haiku", HAIKU_PRICING],
+];
 
 /** Rough tokens-per-word multiplier for the offline fallback estimate. */
 const TOKENS_PER_WORD = 1.35;
@@ -350,8 +366,9 @@ export interface CostEstimate {
 }
 
 function modelPricing(model: string): ModelPricing {
-  const pricing = PRICING_PER_MTOK[model];
-  if (pricing) return pricing;
+  const id = model.toLowerCase();
+  const match = FAMILY_PRICING.find(([family]) => id.includes(family));
+  if (match) return match[1];
   console.error(
     `No pricing table entry for model "${model}"; cost estimate assumes Haiku-class rates and may understate the real cost.`,
   );


### PR DESCRIPTION
Prices the `writing:analyze` judge's pre-flight cost estimate by model family instead of by exact model id.

The old `PRICING_PER_MTOK` map was keyed on two literal ids. Anything else fell through to Haiku rates with a stderr warning, and `--judge-model` has no allowlist, so an Opus-class id priced at 1/5 against a real 5/25. The exact-key shape missed even within families the map already held, since a dated id like `claude-haiku-5-20260901` is not the string `claude-haiku-4-5`. Matching on family substring removes the per-release table edit that kept causing this.

This deletes the map rather than extending it. Under family matching both of its rows resolve to exactly what the table returns, so keeping it would be dead weight that reintroduces the maintenance surface this removes. It adds no exact-id rows for newer models either, for the same reason.

Two things a reviewer is likely to read as bugs, both deliberate:

The `sonnet` row holds the 3/15 standard rate even though a promotional 2/10 is live through 2026-08-31. An estimate that comes in under the real bill is worse than one that comes in over, and the promotional rate expires while the code does not.

The no-match fallback stays at Haiku rates, which is the one place this disagrees with `model_input_rate` and `model_output_rate` in the session plugin's `03_macros.sql`, where the `ELSE` branch is Opus-class. Raising that floor changes behavior rather than syncing a rate, so this leaves it alone and records the divergence in the comment so a later sync does not read the two tables as equivalent. Worth doing as a follow-up.

I checked the family rates against the current model catalog rather than carrying them over from the old map. The tests cover the warning in both directions, since the default judge model now resolves through the family path and warning on a match would print on every run.

Scope note: the estimate goes to stderr and lands as `estimatedCostUsd` on the audit record. It gates nothing and blocks no API call, so this keeps the table from going stale at the next release rather than fixing observed harm. The `claude-sonnet-4-6` and `claude-haiku-4-5` judge pins stay as they are.

https://claude.ai/code/session_01JwSBM8AdjwpMgZPhzJ9dKx
