### PR TITLE
curation: add the harmony-with-native-behavior test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ The [`user/`](user/) directory contains user-level Claude Code configuration tha
 
 Every customization (skill, hook, wordlist entry, agent, rule, permission) costs tokens on every session that touches it. Adding is cheap, accumulation is silent, and removal has no natural trigger. Before adding one, define how it gets removed: what evidence shows it's earning its cost, what evidence shows it isn't, and where that evidence surfaces. Detectors of model behavior need particular care: models drift and rules lose value, so pair detection with a path to evolve or retire.
 
+A customization must also stay harmonious with Claude Code's native behavior. When the harness changes a default or an application-level behavior, assume the change encodes aggregate usage data and evaluation knowledge you do not have, and default to accommodating that direction rather than overriding it. So before adding a customization that touches native behavior, apply the harmony test: ask whether it works with the harness's intent or against it, and prefer accommodation. Add a customization that pushes back on a native behavior only as a light-touch experiment, carrying explicit forward evaluation criteria and a removal trigger. When Claude Code v2.1.198 made the built-in `Explore` agent inherit the conversation model (capped at Opus) instead of running on Haiku, hard-pinning it back to Haiku would contravene that intent, so any Explore steering stays a soft default and gets removed if it proves inert after a couple of weeks.
+
 ## Rules
 
 Path-specific guidance lives in [`.claude/rules/`](.claude/rules/) and auto-injects when you touch matching files (via `paths` frontmatter), so it stays out of this always-on file:

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -23,6 +23,8 @@
 
 Every customization costs tokens on every session. Before adding one, define how it gets removed: what shows it's working, what shows it isn't, and where that signal surfaces.
 
+Prefer accommodating Claude Code's native defaults over overriding them, since a changed default encodes usage and eval data you lack. Add a customization that fights one only as a light-touch experiment with evaluation and removal criteria.
+
 ## Workflow
 
 - The user has carefully curated skills for their common workflows. Load skills when possible to adhere to the user's preferences and navigate their projects efficiently.

--- a/user/skills/improve-claude-code/SKILL.md
+++ b/user/skills/improve-claude-code/SKILL.md
@@ -42,7 +42,7 @@ Launch one `Agent` call per dimension (hook latency, hook blocks, permissions an
 
 #### Grounding
 
-Mandatory. Launch one or more grounding agents that re-check every candidate against the live files under `/Users/ben/src/bendrucker/claude`. Drop anything the config already addresses. Downgrade anything thin or host-skewed. Carry `grounded` (boolean) and `confidence` (high/medium/low) per candidate. Raw query findings go stale within a week against a config that changes weekly: a prior run overturned four of its own headline findings. See the grounding rules in `references/discovery.md` (hooks run in parallel, so never sum durations as wall-clock, and split friction into what a setting can fix and what it cannot).
+Mandatory. Launch one or more grounding agents that re-check every candidate against the live files under `/Users/ben/src/bendrucker/claude`. Drop anything the config already addresses. Downgrade anything thin or host-skewed. Apply the harmony test from the repo's `CLAUDE.md`: a candidate that would fight a native Claude Code behavior gets reframed as an accommodation or a light-touch experiment with forward evaluation and removal criteria, since the harness's defaults encode aggregate usage and eval knowledge the finding lacks (Claude Code v2.1.198 moving `Explore` off Haiku onto the conversation model is the canonical case). Carry `grounded` (boolean) and `confidence` (high/medium/low) per candidate. Raw query findings go stale within a week against a config that changes weekly: a prior run overturned four of its own headline findings. See the grounding rules in `references/discovery.md` (hooks run in parallel, so never sum durations as wall-clock, and split friction into what a setting can fix and what it cannot).
 
 #### Dedup
 


### PR DESCRIPTION
Encodes a durable design principle into the Curation discipline: a customization should stay harmonious with Claude Code's native behavior rather than fight it.

When the harness changes a default or an application-level behavior, that change encodes aggregate usage data and evaluation knowledge (model performance, eval results) an individual user does not have. So the default response is to accommodate the new direction. A customization that pushes back on a native behavior stays a light-touch experiment, carrying explicit forward evaluation criteria and a removal trigger.

This extends the existing rule (define how a customization gets removed before adding it) with a harmony test that runs first: whether the customization works with the harness's intent, and whether it can be reframed as an accommodation instead of an override.

The motivating case is Claude Code v2.1.198, which changed the built-in `Explore` agent to inherit the main conversation's model (capped at Opus) instead of running on Haiku. That is a deliberate architectural choice, most likely because Haiku Explore underperformed on real evals. Hard-pinning Explore back to Haiku would contravene that intent. A soft, evaluated default is the right response. If Explore steering stays inert (Explore still resolves to Opus on essentially every call) about two weeks after adding it, remove it as wasted tokens. If it shifts exploration back toward Haiku, compare the Opus-run and Haiku-run cases to inform a real trade-off rather than a blind pin.

Three placements, kept tight since every always-on line costs tokens:

- `CLAUDE.md` Curation section carries the authoritative harmony test.
- `user/skills/improve-claude-code/SKILL.md` grounding step reframes mined candidates that would fight a native behavior before they reach triage.
- `user/CLAUDE.md` Curation section echoes the principle in one cross-repo line.
