### PR TITLE
settings: re-enable the claude-in-chrome skill

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -2,7 +2,6 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "theme": "auto",
   "skillOverrides": {
-    "claude-in-chrome": "off",
     "dataviz": "user-invocable-only"
   },
   "fallbackModel": ["sonnet"],


### PR DESCRIPTION
Removes the `claude-in-chrome: off` entry from `skillOverrides` so the skill returns to default full visibility. The Chrome connector loads regardless of this override, and usage went from zero to heavy since it was disabled in #937, so the config should match how the skill is actually used. Absence of the key restores default full visibility. `skillOverrides` is upstream-backed with no overlay, so this is a pure config edit.

This does not eliminate the ~176-schema MCP-reconnect re-bill. That is a separate upstream issue.

Original Task: [Re-enable the claude-in-chrome skill](https://things.bendrucker.me/show?id=27nnwzUZqmwh3EfHRHATkB)
