### PR TITLE
settings: exclude pulumi from the sandbox

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -85,7 +85,7 @@ Treat this section as a trust model, not an exhaustive mirror of `settings.json`
 
 Run outside the sandbox; only the top-level command matches (see [Sandbox and Nested Commands](#sandbox-and-nested-commands)).
 
-- Self-authenticating network tools: `git`, `linear`, `aws`, `gcloud`, `az`, `ssh`, `scp`, `rsync`, `docker`. Each carries its own auth and already reaches the network.
+- Self-authenticating network tools: `git`, `linear`, `aws`, `gcloud`, `az`, `pulumi`, `ssh`, `scp`, `rsync`, `docker`. Each carries its own auth and already reaches the network.
 - macOS host integration (`mac` plugin): `open`, `osascript`, `shortcuts`, `pbcopy`, `pbpaste`, `security`, `defaults`, `screencapture`, `say`, `afplay`, `diskutil`, `networksetup`, `dscl`. Host APIs the sandbox cannot model.
 - Local session tooling: `wt`, `claude`, `agent-browser`, `code`. Worktree, session, and editor control that stays local.
 

--- a/user/settings.json
+++ b/user/settings.json
@@ -358,6 +358,7 @@
       "aws:*",
       "gcloud:*",
       "az:*",
+      "pulumi:*",
       "wt:*",
       "claude:*",
       "agent-browser:*",


### PR DESCRIPTION
Adds `pulumi:*` to `sandbox.excludedCommands`. Pulumi self-authenticates to Pulumi Cloud with its own token (`~/.pulumi/credentials.json` or `PULUMI_ACCESS_TOKEN`), and no `*.pulumi.com` host sits in the network allowlist, so it cannot run sandboxed. Every `stack`, `preview`, `up`, and `config` call currently needs an up-front sandbox bypass. It fits the existing self-authenticating network-tools group alongside `aws`, `gcloud`, and `az`, so it goes there and the trust-model doc in `.claude/rules/settings.md` is synced to match.

Original Task: [Add pulumi:* to sandbox.excludedCommands](https://things.bendrucker.me/show?id=4nkNJv97ppVHpMMHYoweQ3)
