### PR TITLE
settings: warn that cd && <verb> forfeits the excludedCommands exemption

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -19,6 +19,8 @@ Permission patterns starting with `/` are relative to the settings file, not abs
 
 `excludedCommands` matches only the top-level command of a Bash invocation. Nested commands (e.g., `open` spawned from a `bun scripts/foo.ts` wrapper) inherit the parent's sandbox profile, so adding `open:*` to `excludedCommands` does not exempt nested calls. Go CLIs run sandboxed via `sandbox.network.allowMachLookup`; wrappers that hand off to Apple Events or Launch Services need a full skip via the `mac` plugin's `claude:dangerouslyDisableSandbox` marker hook. See [`scripts.md`](scripts.md).
 
+The same rule makes a `cd <dir> && <verb>` prefix silently forfeit the exemption. Take `cd <dir> && git push`. Its top-level token is `cd`, so the `git` entry in `excludedCommands` never matches and the whole compound runs sandboxed. The command then fails on egress, and the fallback is a full `dangerouslyDisableSandbox` skip. Prefer a tool's own directory-targeting flag so the exempt verb stays top-level: run `git -C <dir> <subcommand>` instead of `cd <dir> && git <subcommand>`, and the equivalent `-C`/`--cwd`/`--directory` where another tool offers one. This recovers the exemption for the common cross-worktree `git` case. It is guidance rather than enforcement, and it does not cover private-host egress, which belongs in a local-only layer.
+
 ## Plugin Data Dir
 
 The runtime sandbox profile denies writes under `~/.claude/plugins`, and that deny shadows any `filesystem.allowWrite` entry beneath it. `~/.claude/plugins/data` was listed in `allowWrite` for a while and never took effect, so do not re-add it. The failure surfaces as a bare `Operation not permitted`, naming neither the deny rule nor the entry it shadows.


### PR DESCRIPTION
Original Task: [Root-cause the cd && <tool> sandbox-bypass pattern](https://things.bendrucker.me/show?id=UGmsQcNQndCzEaPfhSceqt)

Adds a paragraph to the `Sandbox and Nested Commands` section of `.claude/rules/settings.md` covering a specific way to lose a sandbox exemption. `excludedCommands` matches only the top-level token of a Bash invocation, so prefixing an exempt verb with `cd <dir> &&` makes `cd` the matched token. The verb's exemption never fires, the whole compound runs sandboxed, and when the verb needs egress it fails and escalates to a full `dangerouslyDisableSandbox` skip. In this repo's committed config the exempt verbs are `git` and `linear`, so in practice this is a cross-worktree `git` phenomenon.

The remedy is to keep the exempt verb top-level by using the tool's own directory flag: `git -C <dir> <subcommand>` instead of `cd <dir> && git <subcommand>`, generalized to `-C`/`--cwd`/`--directory` where a tool offers one.

This is the committable ceiling. The structural fix (matching against a compound command's constituent tokens) is upstream and not ownable here. Private-host egress is a separate case that belongs in a local-only layer, so the paragraph is explicit that this is targeted guidance rather than enforcement and does not cover it.
