### PR TITLE
settings: commit the herdr claude integration

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -81,7 +81,7 @@ The overlay design fetches every base at validation time, so this only empties i
 
 Treat this section as a trust model, not an exhaustive mirror of `settings.json`.
 
-- `allowUnixSockets` should be local IPC endpoints where secret material never leaves a dedicated agent (for example, signing daemons or tmux sockets).
+- `allowUnixSockets` should be local IPC endpoints where secret material never leaves a dedicated agent (for example, signing daemons or the tmux and herdr sockets). The multiplexer sockets (tmux, herdr) can inject keys into other panes, so they are command execution by another name. Accepted so layout, agent, and notification commands run sandboxed rather than escaped.
 - `allowLocalBinding` should stay loopback-only.
 - `filesystem.allowWrite` should allow only scratch/cache/worktree paths that tools must mutate, and never credential stores or broad home-directory globs. `~/.local/share/atuin` is a deliberate exception to the credential-store clause: the dir holds atuin's sync encryption key and the session tokens in `meta.db`. Atuin opens `meta.db` read-write on every command, including the history reads behind the `atuin:history` skill, and SQLite creates journal and WAL files beside its dbs, so a file-level grant would fail intermittently. The sandbox grants no egress to atuin's sync hosts, so the risk is local tampering: a swapped key or token would first reach the network through a later unsandboxed `atuin sync`.
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .claude/settings.local.json
 .claude/hooks/logs/
+# Managed by `herdr integration install claude`; the settings.json hook entry
+# that invokes it is committed, the script itself is herdr's to overwrite.
+user/hooks/herdr-agent-state.sh
 .prek/
 node_modules/
 .DS_Store

--- a/user/README.md
+++ b/user/README.md
@@ -10,4 +10,6 @@ Run `scripts/install.sh` to create the symlinks.
 - `settings.json` - User settings (plugins, permissions, sandbox, hooks)
 - `hooks/` - User-level hooks that run across all projects
   - `worktree/` - Validates bash commands in worktrunk worktrees
-  - `claude-island-state.py` - Claude Island integration
+  - `webfetch-block/` - Steers WebFetch calls toward better tools
+  - `session-limit/` - Warns when a session approaches its limit
+  - `herdr-agent-state.sh` - Written by `herdr integration install claude` and gitignored; only its `settings.json` hook entry is committed (rewritten to `$HOME` form). Reinstall after cloning or a herdr version bump to restore the script, then discard the installer's `settings.json` edits: it re-sorts the file and appends a duplicate absolute-path entry it can't recognize as already present.

--- a/user/settings.json
+++ b/user/settings.json
@@ -180,6 +180,16 @@
             "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
           }
         ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/herdr-agent-state.sh\" session",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "Stop": [
@@ -329,6 +339,7 @@
       "allowUnixSockets": [
         "~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh",
         "~/.tmux",
+        "~/.config/herdr/herdr.sock",
         "/tmp/claude"
       ]
     },
@@ -399,7 +410,6 @@
   "agentPushNotifEnabled": true,
   "teammateMode": "in-process",
   "env": {
-    "CLAUDE_CODE_DISABLE_TERMINAL_TITLE": "1",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_STATUSLINE_RATE_LIMITS_PATH": "~/.vibe-island/cache/rl.json",
     "TMPDIR": "/tmp",


### PR DESCRIPTION
`herdr integration install claude` writes into the deployed checkout through the `~/.claude` symlinks (a hook script plus a SessionStart entry in `settings.json`), and both sat uncommitted. This commits the wiring while keeping herdr's managed script out of the repo: the installer has no path override, so the script is gitignored and reinstall restores it, matching how the dotfiles herdr topic already owns the plugin installs.

The committed hook entry uses `$HOME` instead of the absolute path the installer writes. Verified against herdr 0.7.5: `herdr integration status` checks only the script file, so the rewrite keeps it green, but a reinstall does not recognize the equivalent entry and appends its own absolute-path duplicate while re-sorting the file. The deploy flow is therefore install, then discard the installer's `settings.json` edits, and installs only recur on integration version bumps. Documented in `user/README.md`.

Dropping `CLAUDE_CODE_DISABLE_TERMINAL_TITLE` fixes agents never showing as working in herdr's sidebar. For Claude, herdr's hooks report only session identity; working/idle/blocked comes from screen scraping against a detection manifest whose only high-priority working rules are the braille spinner prefix in the OSC title and the `/btw` overlay. With title updates suppressed (a tmux-era setting), `herdr agent explain` showed the idle prompt-box rule matching even mid-turn. The socket grant mirrors the tmux one so herdr CLI calls run sandboxed, with the trust-model note extended to cover both multiplexers.
