### PR TITLE
issue: put agent context in a collapsed block

### DIFF
--- a/plugins/issue/skills/refine/SKILL.md
+++ b/plugins/issue/skills/refine/SKILL.md
@@ -64,13 +64,13 @@ For a substantial issue, the opening summary plus one type section is the floor.
 
 ## Agent Context
 
-What you learned exploring the codebase, so the implementing agent doesn't explore it again. Last in the body, under a `## 🤖 Agent Context` heading. The platform skill turns that heading into a collapsible, collapsed by default. Without one, wrap it in GFM `<details>`.
+What you learned exploring the codebase, so the implementing agent doesn't explore it again. Last in the body, under a `## 🤖 Agent Context` heading. The platform skill turns that heading into a collapsible. Where no platform skill covers the tracker, wrap it in GFM `<details>` at save time.
 
 Write for an agent. Use lists of paths, symbols, and commands. [Style](#style) does not apply. Line numbers, ranges, and bare enumeration are fine when they save a search.
 
 Emit only what exploration produced. Drop subsections you can't fill, and the whole section when you explored nothing.
 
-Pin the block to the commit you read (`git rev-parse --short HEAD`) and pair every line number with its symbol, which survives drift.
+Open the block with the commit you read (`git rev-parse --short HEAD`) and today's date. Pair every line number with its symbol, which survives drift.
 
 ```markdown
 ## 🤖 Agent Context

--- a/plugins/issue/skills/refine/SKILL.md
+++ b/plugins/issue/skills/refine/SKILL.md
@@ -49,24 +49,56 @@ time out, so downstream jobs read a partial snapshot as if it were complete.
 
 [Type-specific sections from guide (select, don't fill)]
 
-## Context
-
-### Related Code
-
-Files that need changes or inform the work.
+## 🤖 Agent Context
 ```
 
 Populate only the keys you can infer: `title`, `type`, `labels`, `priority`, `relations`. Omit any optional key you can't fill, and drop empty relation lists. The platform skill fills routing and workspace fields (team, assignee, state, estimate) at save time.
 
-A related issue you found belongs under `relations` as a tracker link, kept out of the body. Mention another issue in the body only when it tells the reader something the relation can't: what a prior attempt tried, why upstream work matters. Never append a standalone Related Issues section. It just restates links the relation already expresses.
+A related issue you found belongs under `relations` as a tracker link, kept out of the body. Mention another issue in the body only when it tells the reader something the relation can't: what a prior attempt tried, why upstream work matters. Never append a standalone Related Issues section. It just restates links the relation already expresses. Put links the tracker has no field for (cross-tracker issues, upstream bug reports) under [Agent Context](#agent-context).
 
 ## Section Selection
 
 Every section must tell the reader something they couldn't have guessed. Cut sections whose content is tautological ("tests must pass"), template residue ("no behavior change"), or obvious given the issue's size.
 
-For a substantial issue, the opening summary plus one type section plus `## Context` is the floor. Grow only when content demands. A trivial issue needs none of that frame: a sentence or two that names the problem and points at the code is enough.
+For a substantial issue, the opening summary plus one type section is the floor. Grow only when content demands. A trivial issue needs none of that frame: a sentence or two that names the problem and points at the code is enough.
+
+## Agent Context
+
+What you learned exploring the codebase, so the implementing agent doesn't explore it again. Last in the body, under a `## 🤖 Agent Context` heading. The platform skill turns that heading into a collapsible, collapsed by default. Without one, wrap it in GFM `<details>`.
+
+Write for an agent. Use lists of paths, symbols, and commands. [Style](#style) does not apply. Line numbers, ranges, and bare enumeration are fine when they save a search.
+
+Emit only what exploration produced. Drop subsections you can't fill, and the whole section when you explored nothing.
+
+Pin the block to the commit you read (`git rev-parse --short HEAD`) and pair every line number with its symbol, which survives drift.
+
+```markdown
+## 🤖 Agent Context
+
+Gathered at `a1b2c3d` on 1970-01-01.
+
+### Related Code
+
+- `acquire` at `src/pool.ts:88` blocks on an exhausted pool with no deadline
+- `release` at `src/pool.ts:140` early-returns on a closed connection, leaking the slot
+
+### Prior Art
+
+- `f0e9d8c` added the same deadline to the write pool. Mirror its test setup.
+```
+
+Subsections, in order:
+
+| Section | Content |
+|---------|---------|
+| Related Code | Files to change or read, with the symbol and why it matters |
+| Prior Art | Commits, PRs, or issues that solved a similar problem, and what to take |
+| Verification | Test file to extend, suite to run, gate covering this area |
+| Search Hints | Search patterns and entry points that found the code |
 
 ## Style
+
+Human-facing body only. [Agent Context](#agent-context) has its own rules.
 
 State facts and drop the hedging. Name the function, file, or behavior rather than describing it vaguely. Every sentence should add information.
 

--- a/plugins/issue/skills/refine/feature.md
+++ b/plugins/issue/skills/refine/feature.md
@@ -24,7 +24,7 @@ High-level implementation. Reference existing patterns. Skip for trivially-desig
 
 #### Changes
 
-Files and components to modify. Skip when Related Code already names the files.
+Files and components to modify. Skip when Agent Context already names the files.
 
 #### Open Questions
 

--- a/plugins/linear/skills/linear/references/conventions.md
+++ b/plugins/linear/skills/linear/references/conventions.md
@@ -22,6 +22,23 @@ This matters when content moves between the two paths:
 - Moving connector output to the CLI requires converting node markup to GFM first. Raw node markup written through the CLI is stored literally and corrupted. Reading the same issue via CLI/API returns GFM directly.
 - A `[ENG-123](url)` link read through the CLI loses its chip when written back through the connector, which `<>`-wraps it. To edit through the connector and keep chips, reference issues by bare identifier, or write through the CLI/API.
 
+## Collapsible Sections
+
+A collapsible renders collapsed, and its marker differs by write path the way an issue reference does. The title sits on the opening marker, the closing marker is bare, and both need a blank line against the content. Markdown inside behaves normally, headings included.
+
+- **Connector `save_issue`**: `>>>`
+- **CLI / GraphQL API**: `+++` (the stored GFM form)
+
+```markdown
++++ 🤖 Agent Context
+
+Gathered at `a1b2c3d` on 1970-01-01.
+
++++
+```
+
+Issue refinement marks its collapsible as a `## 🤖 Agent Context` heading. Replace the heading with the opening marker for your path, keeping its text as the title, and close the block at the end of the body.
+
 ## Issue Status
 
 When creating issues, set status based on assignment:

--- a/plugins/linear/skills/linear/references/conventions.md
+++ b/plugins/linear/skills/linear/references/conventions.md
@@ -24,7 +24,7 @@ This matters when content moves between the two paths:
 
 ## Collapsible Sections
 
-A collapsible renders collapsed, and its marker differs by write path the way an issue reference does. The title sits on the opening marker, the closing marker is bare, and both need a blank line against the content. Markdown inside behaves normally, headings included.
+A collapsible renders collapsed, and its marker differs by write path the way [Issue References](#issue-references) do. The title sits on the opening marker. The closing marker is bare. Both need a blank line against the content. Markdown inside behaves normally, headings included.
 
 - **Connector `save_issue`**: `>>>`
 - **CLI / GraphQL API**: `+++` (the stored GFM form)

--- a/plugins/linear/skills/linear/references/structured-file.md
+++ b/plugins/linear/skills/linear/references/structured-file.md
@@ -17,7 +17,7 @@ Map the metadata keys these files tend to carry onto the connector `save_issue` 
 
 Relation params take the issue identifier from each entry's tracker URL. `blocks`, `blockedBy`, and `relatedTo` accept arrays. `duplicateOf` takes a single identifier. Each is append-only. A save never removes relations you did not name. For keys the file omits, or ones this table does not name, map them when Linear has a matching field and ask when the mapping is unclear.
 
-When the body ends in a `## 🤖 Agent Context` heading, rewrite it as a collapsible before saving, per [Collapsible Sections](conventions.md#collapsible-sections).
+When the body ends with a `## 🤖 Agent Context` section, rewrite its heading as a collapsible before saving, per [Collapsible Sections](conventions.md#collapsible-sections).
 
 Routing fields (team, assignee, state) are not in the file. Take them from the user at save time. Default the state from assignment as in [Issue Status](conventions.md#issue-status). `getDefaultState` in `hooks/save-issue.ts` encodes that rule.
 

--- a/plugins/linear/skills/linear/references/structured-file.md
+++ b/plugins/linear/skills/linear/references/structured-file.md
@@ -17,6 +17,8 @@ Map the metadata keys these files tend to carry onto the connector `save_issue` 
 
 Relation params take the issue identifier from each entry's tracker URL. `blocks`, `blockedBy`, and `relatedTo` accept arrays. `duplicateOf` takes a single identifier. Each is append-only. A save never removes relations you did not name. For keys the file omits, or ones this table does not name, map them when Linear has a matching field and ask when the mapping is unclear.
 
+When the body ends in a `## 🤖 Agent Context` heading, rewrite it as a collapsible before saving, per [Collapsible Sections](conventions.md#collapsible-sections).
+
 Routing fields (team, assignee, state) are not in the file. Take them from the user at save time. Default the state from assignment as in [Issue Status](conventions.md#issue-status). `getDefaultState` in `hooks/save-issue.ts` encodes that rule.
 
 ## Saving


### PR DESCRIPTION
Exploration findings are worth keeping on an issue, since they save the implementing agent from re-deriving which files matter. They also read as filler to a human, and a `## Context` section sitting open at the bottom of every refined issue makes each one look run-on. Renaming it `## 🤖 Agent Context` and collapsing it separates the two audiences: the emoji marks who it's for, the collapse keeps it out of the way of everyone else.

Scoping `## Style` to the human-facing body is what makes the block worth having. Those rules ban line ranges because they go stale, which is correct for prose a person reads and wrong for a pointer an agent follows. Inside the block they're lifted, so line numbers, ranges, and bare enumeration are all allowed. Staleness is handled instead of avoided: the block opens with the short SHA and date it was gathered at, and every line number is paired with the symbol it points at, which survives drift the number won't.

`Related Code` carries over. `Prior Art`, `Verification`, and `Search Hints` are new. The block is emitted only when exploration actually produced something, so an issue refined from its description alone still gets no block at all, and `--compact` is unaffected.

Collapsible syntax is path-dependent on Linear, the same way issue references already are, so `linear:linear` owns it rather than `issue:refine` guessing. Verified against BEN-5, which already contained one: stored GFM is `+++ Title` … `+++`, and the connector projects and parses `>>>`. Refine emits a plain heading and the platform skill rewrites it at save time.

Two things left out deliberately. `issue:issue` still doesn't read the block or refresh it after implementing, so nothing consumes this yet beyond a human pasting the issue to an agent. And there's no GitHub issue skill in this repo to own `<details>`, so refine names it inline as the fallback rather than deferring to a skill that doesn't exist.

The `.md`-only diff gated out every review pass but prose. `writing:review` ran across content, style, and artifacts. Its findings are in b378f1d2. The Greptile local pass couldn't run, returning `free_reviews_limit_reached`, which may also affect the required hosted check.
