### PR TITLE
settings: add PostCompact and TeammateIdle hooks

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -111,6 +111,16 @@
         ]
       }
     ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "*",
@@ -174,6 +184,7 @@
     ],
     "SessionStart": [
       {
+        "matcher": "startup|resume|clear",
         "hooks": [
           {
             "type": "command",
@@ -223,6 +234,16 @@
       }
     ],
     "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+          }
+        ]
+      }
+    ],
+    "TeammateIdle": [
       {
         "hooks": [
           {


### PR DESCRIPTION
Adds the vibe-island bridge to `PostCompact` and `TeammateIdle`, two lifecycle events that landed since the bridge hooks were last written. The island already reports on every other phase of a session. Leaving these two unwired means it goes stale across a compaction and never reflects an idle teammate.

The upstream installer's version of this change also narrowed `PreCompact` to a `manual|auto` matcher and reordered keys. Dropped both. `PreCompactHookInput.trigger` is typed `'manual' | 'auto'` and nothing else, so that matcher constrains nothing, and the reordering is just its serializer.

The `SessionStart` matcher is the one non-obvious piece. `SessionStartHookInput.source` still includes `'compact'` alongside the new `PostCompact` event, so wiring `PostCompact` without narrowing `SessionStart` would fire the bridge twice on every compaction. Scoping that entry to `startup|resume|clear` keeps it to one.

Event names, trigger enums, and `source` values were checked against the agent SDK type definitions shipped with Claude Code 2.1.220 rather than taken on faith from the installer.
