### PR TITLE
gitlab:ci-monitor: stop reporting false greens

### DIFF
--- a/plugins/gitlab/skills/ci-monitor/SKILL.md
+++ b/plugins/gitlab/skills/ci-monitor/SKILL.md
@@ -43,13 +43,15 @@ Launch the watch script via the `Monitor` tool with `persistent: true`:
 
 Exactly one of `--mr`, `--branch`, or `--pipeline-id` is required. In branch and pipeline-id modes, `--project` is inferred from the current git remote when omitted. Pipeline-id mode queries `glab api projects/:id/pipelines/:pid` directly; if the pipeline does not exist the watcher exits non-zero on the first call.
 
+MR mode resolves the pipeline from `projects/:id/merge_requests/:iid/pipelines` and branch mode from `projects/:id/pipelines?ref=<branch>`. Both ignore `external` pipelines (commit statuses posted by other tools, which carry no CI jobs) and `parent_pipeline` pipelines (children the parent already aggregates), and each prefers its own kind: `merge_request_event` in MR mode, branch pipelines in branch mode.
+
 The script emits one JSON object per line on stdout. When the first probe is already green, it emits a single `status: success` event and exits, so there is no separate initial-green path. In pipeline-id mode it also exits after emitting `status: failing`, because a specific pipeline has a finite lifetime and will not restart on its own.
 
 #### Event schema
 
 Each line is one of:
 
-- `{"type":"status","state":"running|failing|success","sha":"...","run_id":"..."}`: `run_id` is the GitLab pipeline ID.
+- `{"type":"status","state":"running|failing|success","sha":"...","run_id":"..."}`: `run_id` is the GitLab pipeline ID. A `success` is confirmed against the pipeline's jobs before it is emitted, so a pipeline reporting `success` while a required job failed is reported as `failing`.
 - `{"type":"conflicts","sha":"..."}`: MR reports merge conflicts against the target branch. MR mode only.
 - `{"type":"mergeable-unknown","sha":"..."}`: GitLab could not settle merge status after bounded re-polling. MR mode only.
 - `{"type":"queued-timeout","minutes":N}`: pipeline has been queued longer than the threshold.
@@ -61,7 +63,7 @@ Each line is one of:
 
 In branch and pipeline-id modes, `conflicts`, `mergeable-unknown`, `pr-closed`, and `merged` are never emitted (there is no MR metadata to derive them from). `merged` and `pr-closed` are distinct terminal events: `merged` means the MR landed, `pr-closed` means it closed without merging.
 
-The script exits on `status: success` in every mode. In pipeline-id mode it also exits on `status: failing` (the pipeline is terminal).
+The script exits on `status: success` in every mode, but only once that success survives the job-level confirmation above. A pipeline whose jobs cannot be read keeps the watcher polling rather than exiting green, surfacing as `api-error` if it persists. In pipeline-id mode it also exits on `status: failing` (the pipeline is terminal).
 
 #### React to events
 

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
@@ -18,6 +18,7 @@ import {
   parseMrUrl,
   parsePipelineList,
   parseProject,
+  pipelineDurations,
   probeBranch,
   probeMr,
   probePipelineId,
@@ -217,6 +218,119 @@ describe("isNotFoundError", () => {
     ["500 internal server error", false],
   ])("%p is %p", (message, expected) => {
     expect(isNotFoundError(message)).toBe(expected);
+  });
+});
+
+describe("pipelineDurations", () => {
+  // The pipeline list endpoint returns none of `finished_at`, `started_at`, or
+  // `duration`, so the original `select(.finished_at != null)` filter matched
+  // nothing and every watch polled at the no-history rate. The fractional
+  // seconds below guard the trap underneath it: `fromdateiso8601` rejects them,
+  // so restoring the timing fields without moving the date math out of jq would
+  // have swapped a silent empty result for a hard jq failure.
+  test.each<{ name: string; raw: unknown[]; expected: number[] }>([
+    {
+      name: "measures elapsed wall time across fractional-second timestamps",
+      raw: [
+        {
+          status: "success",
+          created_at: "2026-07-30T19:00:00.123Z",
+          updated_at: "2026-07-30T19:02:05.456Z",
+        },
+      ],
+      expected: [125.333],
+    },
+    {
+      name: "keeps failed and canceled pipelines",
+      raw: [
+        {
+          status: "failed",
+          created_at: "2026-07-30T19:00:00Z",
+          updated_at: "2026-07-30T19:01:00Z",
+        },
+        {
+          status: "canceled",
+          created_at: "2026-07-30T19:00:00Z",
+          updated_at: "2026-07-30T19:00:30Z",
+        },
+      ],
+      expected: [60, 30],
+    },
+    {
+      name: "drops skipped and manual pipelines that never ran",
+      raw: [
+        {
+          status: "skipped",
+          created_at: "2026-07-30T19:00:00Z",
+          updated_at: "2026-07-30T19:00:01Z",
+        },
+        {
+          status: "manual",
+          created_at: "2026-07-30T19:00:00Z",
+          updated_at: "2026-07-30T19:00:01Z",
+        },
+      ],
+      expected: [],
+    },
+    {
+      name: "drops still-running pipelines",
+      raw: [
+        {
+          status: "running",
+          created_at: "2026-07-30T19:00:00Z",
+          updated_at: "2026-07-30T19:00:20Z",
+        },
+      ],
+      expected: [],
+    },
+    {
+      name: "drops entries with missing, malformed, or non-positive timing",
+      raw: [
+        { status: "success", created_at: "2026-07-30T19:00:00Z" },
+        { status: "success", created_at: "not a date", updated_at: "2026-07-30T19:01:00Z" },
+        {
+          status: "success",
+          created_at: "2026-07-30T19:01:00Z",
+          updated_at: "2026-07-30T19:01:00Z",
+        },
+        null,
+        "not an object",
+      ],
+      expected: [],
+    },
+  ])("$name", ({ raw, expected }) => {
+    const durations = pipelineDurations(raw);
+    expect(durations).toHaveLength(expected.length);
+    durations.forEach((seconds, index) => {
+      expect(seconds).toBeCloseTo(expected[index] as number, 2);
+    });
+  });
+
+  test("never yields a duration the clamped interval cannot consume", () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            status: fc.constantFrom("success", "failed", "canceled", "skipped", "running"),
+            createdMs: fc.integer({ min: 0, max: 4e12 }),
+            elapsedMs: fc.integer({ min: -5000, max: 3_600_000 }),
+          }),
+        ),
+        (entries) => {
+          const raw = entries.map(({ status, createdMs, elapsedMs }) => ({
+            status,
+            created_at: new Date(createdMs).toISOString(),
+            updated_at: new Date(createdMs + elapsedMs).toISOString(),
+          }));
+          const durations = pipelineDurations(raw);
+          expect(durations.every((seconds) => seconds > 0)).toBe(true);
+          expect(durations.length).toBeLessThanOrEqual(raw.length);
+          const interval = computeInterval(durations);
+          expect(interval).toBeGreaterThanOrEqual(30);
+          expect(interval).toBeLessThanOrEqual(600);
+        },
+      ),
+    );
   });
 });
 

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
@@ -10,12 +10,20 @@ import {
   type InternalState,
   initialState,
   isNotFoundError,
+  type JobRecord,
+  jobsContradictSuccess,
   normalizePipelineStatus,
+  type PipelineRecord,
   type Probe,
   parseMrUrl,
+  parsePipelineList,
   parseProject,
+  probeBranch,
+  probeMr,
+  probePipelineId,
   registerApiError,
   resolveMergeStatus,
+  selectPipeline,
 } from "./watch";
 
 function makeProbe(overrides: Partial<Probe> = {}): Probe {
@@ -56,7 +64,21 @@ function makeExec(scripted: Array<{ match: string; result: ExecResult }>): {
 }
 
 const ok = (stdout: string): ExecResult => ({ ok: true, stdout });
+const fail = (stderr: string): ExecResult => ({
+  ok: false,
+  stderr,
+  rateLimited: false,
+  retryAfter: "",
+});
 const noopSleep = (): Promise<void> => Promise.resolve();
+
+function makeRecord(overrides: Partial<PipelineRecord> = {}): PipelineRecord {
+  return { id: 1, status: "running", sha: "sha1", source: "push", ...overrides };
+}
+
+function makeJob(overrides: Partial<JobRecord> = {}): JobRecord {
+  return { name: "test", status: "success", allowFailure: false, ...overrides };
+}
 
 describe("parseMrUrl", () => {
   test.each<{
@@ -647,5 +669,365 @@ describe("resolveMergeStatus", () => {
       detailedMergeStatus: "checking",
     });
     expect(remaining()).toEqual([]);
+  });
+});
+
+describe("parsePipelineList", () => {
+  test.each<{ name: string; raw: unknown; expected: PipelineRecord[] | null }>([
+    {
+      name: "returns null for a non-array body",
+      raw: { message: "403 Forbidden" },
+      expected: null,
+    },
+    { name: "returns null for a null body", raw: null, expected: null },
+    { name: "returns an empty list for an empty array", raw: [], expected: [] },
+    {
+      name: "parses numeric and string ids alike",
+      raw: [
+        { id: 10, status: "success", sha: "abc", source: "push" },
+        { id: "11", status: "failed", sha: "def", source: "merge_request_event" },
+      ],
+      expected: [
+        { id: 10, status: "success", sha: "abc", source: "push" },
+        { id: 11, status: "failing", sha: "def", source: "merge_request_event" },
+      ],
+    },
+    {
+      name: "drops entries without a usable id",
+      raw: [{ status: "success" }, { id: null }, { id: "not-a-number" }, { id: "" }, { id: 12 }],
+      expected: [{ id: 12, status: "running", sha: "", source: "" }],
+    },
+    {
+      name: "defaults a missing sha and source to empty strings",
+      raw: [{ id: 13, status: "running" }],
+      expected: [{ id: 13, status: "running", sha: "", source: "" }],
+    },
+  ])("$name", ({ raw, expected }) => {
+    expect(parsePipelineList(raw)).toEqual(expected);
+  });
+});
+
+describe("selectPipeline", () => {
+  test.each<{
+    name: string;
+    records: PipelineRecord[];
+    prefer: "merge-request" | "branch";
+    expectedId: number | null;
+  }>([
+    {
+      name: "ignores a newer external success in favour of the MR pipeline",
+      records: [
+        makeRecord({ id: 200, status: "success", source: "external" }),
+        makeRecord({ id: 199, status: "failing", source: "merge_request_event" }),
+      ],
+      prefer: "merge-request",
+      expectedId: 199,
+    },
+    {
+      name: "prefers a running MR pipeline over a newer skipped push pipeline",
+      records: [
+        makeRecord({ id: 300, status: "success", source: "push" }),
+        makeRecord({ id: 299, status: "running", source: "merge_request_event" }),
+      ],
+      prefer: "merge-request",
+      expectedId: 299,
+    },
+    {
+      name: "prefers the push pipeline in branch mode when both kinds are present",
+      records: [
+        makeRecord({ id: 300, status: "success", source: "push" }),
+        makeRecord({ id: 299, status: "running", source: "merge_request_event" }),
+      ],
+      prefer: "branch",
+      expectedId: 300,
+    },
+    {
+      name: "ignores parent_pipeline children whose status the parent aggregates",
+      records: [
+        makeRecord({ id: 400, status: "success", source: "parent_pipeline" }),
+        makeRecord({ id: 398, status: "failing", source: "merge_request_event" }),
+      ],
+      prefer: "merge-request",
+      expectedId: 398,
+    },
+    {
+      name: "returns null when every candidate has an excluded source",
+      records: [
+        makeRecord({ id: 500, source: "external" }),
+        makeRecord({ id: 501, source: "parent_pipeline" }),
+      ],
+      prefer: "merge-request",
+      expectedId: null,
+    },
+    { name: "returns null for an empty list", records: [], prefer: "branch", expectedId: null },
+    {
+      name: "falls back to branch pipelines in MR mode when the project runs none",
+      records: [makeRecord({ id: 600, source: "push" }), makeRecord({ id: 601, source: "web" })],
+      prefer: "merge-request",
+      expectedId: 601,
+    },
+    {
+      name: "falls back to MR pipelines in branch mode when the project runs none",
+      records: [
+        makeRecord({ id: 700, source: "merge_request_event" }),
+        makeRecord({ id: 701, source: "merge_request_event" }),
+      ],
+      prefer: "branch",
+      expectedId: 701,
+    },
+    {
+      name: "orders single-digit against double-digit ids numerically",
+      records: [makeRecord({ id: 9, source: "push" }), makeRecord({ id: 10, source: "push" })],
+      prefer: "branch",
+      expectedId: 10,
+    },
+    {
+      name: "orders realistic ten-digit ids numerically",
+      records: [
+        makeRecord({ id: 2712763426, source: "push" }),
+        makeRecord({ id: 2712702628, source: "push" }),
+      ],
+      prefer: "branch",
+      expectedId: 2712763426,
+    },
+  ])("$name", ({ records, prefer, expectedId }) => {
+    expect(selectPipeline(records, prefer)?.id ?? null).toBe(expectedId);
+  });
+
+  const pipelineRecord = fc.record<PipelineRecord>({
+    id: fc.integer({ min: 1, max: 3_000_000_000 }),
+    status: fc.constantFrom<InternalState>("running", "queued", "failing", "success"),
+    sha: fc.string(),
+    source: fc.constantFrom(
+      "push",
+      "merge_request_event",
+      "external",
+      "parent_pipeline",
+      "web",
+      "schedule",
+    ),
+  });
+
+  test("picks an input record that is eligible and highest-id within its partition", () => {
+    fc.assert(
+      fc.property(
+        fc.array(pipelineRecord),
+        fc.constantFrom<"merge-request" | "branch">("merge-request", "branch"),
+        (records, prefer) => {
+          const selected = selectPipeline(records, prefer);
+          const eligible = records.filter(
+            (record) => record.source !== "external" && record.source !== "parent_pipeline",
+          );
+          if (eligible.length === 0) {
+            expect(selected).toBeNull();
+            return;
+          }
+          expect(selected).not.toBeNull();
+          if (!selected) return;
+          expect(records).toContain(selected);
+          const isMergeRequest = (record: PipelineRecord) =>
+            record.source === "merge_request_event";
+          const preferred = eligible.filter((record) =>
+            prefer === "merge-request" ? isMergeRequest(record) : !isMergeRequest(record),
+          );
+          if (preferred.length > 0) {
+            expect(preferred).toContain(selected);
+          }
+          const partition = eligible.filter(
+            (record) => isMergeRequest(record) === isMergeRequest(selected),
+          );
+          expect(selected.id).toBe(Math.max(...partition.map((record) => record.id)));
+        },
+      ),
+    );
+  });
+});
+
+describe("jobsContradictSuccess", () => {
+  test.each<{ name: string; jobs: JobRecord[]; contradicting: string[] }>([
+    {
+      name: "a failed required job contradicts the pipeline's success",
+      jobs: [makeJob(), makeJob({ name: "rspec", status: "failed" })],
+      contradicting: ["rspec"],
+    },
+    {
+      name: "a failed allow_failure job does not contradict",
+      jobs: [makeJob({ name: "flaky", status: "failed", allowFailure: true })],
+      contradicting: [],
+    },
+    {
+      name: "success, manual, and skipped jobs do not contradict",
+      jobs: [
+        makeJob({ name: "build" }),
+        makeJob({ name: "deploy", status: "manual" }),
+        makeJob({ name: "docs", status: "skipped" }),
+      ],
+      contradicting: [],
+    },
+    {
+      name: "an empty job list does not contradict (bridge jobs are absent from the jobs endpoint)",
+      jobs: [],
+      contradicting: [],
+    },
+    {
+      name: "a canceled job does not contradict (cancellation already turns the pipeline canceled)",
+      jobs: [makeJob({ name: "lint", status: "canceled" })],
+      contradicting: [],
+    },
+  ])("$name", ({ jobs, contradicting }) => {
+    expect(jobsContradictSuccess(jobs).map((job) => job.name)).toEqual(contradicting);
+  });
+});
+
+describe("probe pipeline selection", () => {
+  const mrJson = JSON.stringify({
+    sha: "head-sha",
+    source_branch: "feature",
+    merge_status: "can_be_merged",
+    detailed_merge_status: "mergeable",
+    state: "opened",
+  });
+
+  const pipelinesJson = (records: Array<Record<string, unknown>>): string =>
+    JSON.stringify(records);
+
+  // Regression: an `external` pipeline is a commit status posted by another tool.
+  // It is created green and carries no jobs, and because it is created last it
+  // wins any newest-first selection. Resolving the MR's pipeline by that ordering
+  // reported success while the real CI run was red, so the watcher exited green
+  // on a failing MR.
+  it("reports failing when an external success outranks the real MR pipeline", () => {
+    const { exec } = makeExec([
+      { match: "merge_requests/7", result: ok(mrJson) },
+      {
+        match: "merge_requests/7/pipelines",
+        result: ok(
+          pipelinesJson([
+            { id: 902, status: "success", sha: "head-sha", source: "external" },
+            { id: 901, status: "failed", sha: "merge-sha", source: "merge_request_event" },
+          ]),
+        ),
+      },
+    ]);
+    const probed = probeMr("group%2Fproject", 7, exec);
+    expect(probed.ok).toBe(true);
+    if (!probed.ok) return;
+    expect(probed.probe.state).toBe("failing");
+    expect(probed.probe.runId).toBe("901");
+    expect(probed.probe.sha).toBe("head-sha");
+  });
+
+  it("downgrades a claimed success when a required job failed", () => {
+    const { exec } = makeExec([
+      { match: "merge_requests/7", result: ok(mrJson) },
+      {
+        match: "merge_requests/7/pipelines",
+        result: ok(
+          pipelinesJson([{ id: 901, status: "success", sha: "s", source: "merge_request_event" }]),
+        ),
+      },
+      {
+        match: "pipelines/901/jobs",
+        result: ok(
+          JSON.stringify([
+            { name: "build", status: "success", allow_failure: false },
+            { name: "rspec", status: "failed", allow_failure: false },
+          ]),
+        ),
+      },
+    ]);
+    const probed = probeMr("group%2Fproject", 7, exec);
+    expect(probed.ok).toBe(true);
+    if (!probed.ok) return;
+    expect(probed.probe.state).toBe("failing");
+    expect(probed.probe.runId).toBe("901");
+  });
+
+  it("confirms a success against the jobs endpoint with exactly one extra call", () => {
+    const { exec, remaining } = makeExec([
+      { match: "merge_requests/7", result: ok(mrJson) },
+      {
+        match: "merge_requests/7/pipelines",
+        result: ok(
+          pipelinesJson([{ id: 901, status: "success", sha: "s", source: "merge_request_event" }]),
+        ),
+      },
+      {
+        match: "pipelines/901/jobs",
+        result: ok(JSON.stringify([{ name: "build", status: "success", allow_failure: false }])),
+      },
+    ]);
+    const probed = probeMr("group%2Fproject", 7, exec);
+    expect(probed.ok).toBe(true);
+    if (!probed.ok) return;
+    expect(probed.probe.state).toBe("success");
+    expect(remaining()).toEqual([]);
+  });
+
+  it("fails the probe rather than emitting a success it could not confirm", () => {
+    const { exec } = makeExec([
+      { match: "merge_requests/7", result: ok(mrJson) },
+      {
+        match: "merge_requests/7/pipelines",
+        result: ok(
+          pipelinesJson([{ id: 901, status: "success", sha: "s", source: "merge_request_event" }]),
+        ),
+      },
+      { match: "pipelines/901/jobs", result: fail("HTTP 500") },
+    ]);
+    expect(probeMr("group%2Fproject", 7, exec).ok).toBe(false);
+  });
+
+  it("keeps polling when every pipeline on the page is excluded", () => {
+    const { exec } = makeExec([
+      { match: "merge_requests/7", result: ok(mrJson) },
+      {
+        match: "merge_requests/7/pipelines",
+        result: ok(pipelinesJson([{ id: 902, status: "success", sha: "s", source: "external" }])),
+      },
+    ]);
+    const probed = probeMr("group%2Fproject", 7, exec);
+    expect(probed.ok).toBe(true);
+    if (!probed.ok) return;
+    expect(probed.probe.runId).toBeNull();
+    expect(probed.probe.state).toBe("running");
+  });
+
+  it("applies the job gate in pipeline-id mode as well", () => {
+    const { exec, remaining } = makeExec([
+      {
+        match: "pipelines/901'",
+        result: ok(JSON.stringify({ id: 901, status: "success", sha: "s" })),
+      },
+      {
+        match: "pipelines/901/jobs",
+        result: ok(JSON.stringify([{ name: "rspec", status: "failed", allow_failure: false }])),
+      },
+    ]);
+    const probed = probePipelineId("group%2Fproject", "901", exec);
+    expect(probed.ok).toBe(true);
+    if (!probed.ok) return;
+    expect(probed.probe.state).toBe("failing");
+    expect(remaining()).toEqual([]);
+  });
+
+  it("ignores an external success in branch mode too", () => {
+    const { exec } = makeExec([
+      {
+        match: "pipelines?ref=main",
+        result: ok(
+          pipelinesJson([
+            { id: 902, status: "success", sha: "a", source: "external" },
+            { id: 901, status: "failed", sha: "b", source: "push" },
+          ]),
+        ),
+      },
+    ]);
+    const probed = probeBranch("group%2Fproject", "main", exec);
+    expect(probed.ok).toBe(true);
+    if (!probed.ok) return;
+    expect(probed.probe.state).toBe("failing");
+    expect(probed.probe.runId).toBe("901");
+    expect(probed.probe.sha).toBe("b");
   });
 });

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
@@ -258,6 +258,79 @@ export function normalizePipelineStatus(status: string): InternalState {
   }
 }
 
+export type PipelineRecord = {
+  id: number;
+  status: InternalState;
+  sha: string;
+  source: string;
+};
+
+// `external` pipelines are commit-status reports posted by other tools: they
+// carry no CI jobs and go green the moment they are created. `parent_pipeline`
+// pipelines are children whose status the parent already aggregates, so a green
+// child says nothing about the run as a whole. Either one can outrank the real
+// pipeline by id and produce a false green.
+const EXCLUDED_PIPELINE_SOURCES = ["external", "parent_pipeline"];
+
+export function parsePipelineList(raw: unknown): PipelineRecord[] | null {
+  if (!Array.isArray(raw)) return null;
+  const records: PipelineRecord[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const fields = entry as Record<string, unknown>;
+    const rawId = fields.id;
+    if (typeof rawId !== "number" && typeof rawId !== "string") continue;
+    const id = Number(rawId);
+    // `Number("")` is 0, so an empty id would otherwise become a `run_id` of
+    // "0" and get handed to the logs agent as if it were a real pipeline.
+    if (!Number.isFinite(id) || id <= 0) continue;
+    records.push({
+      id,
+      status: normalizePipelineStatus(typeof fields.status === "string" ? fields.status : ""),
+      sha: typeof fields.sha === "string" ? fields.sha : "",
+      source: typeof fields.source === "string" ? fields.source : "",
+    });
+  }
+  return records;
+}
+
+// Both pipeline list endpoints mix pipeline kinds: the MR endpoint returns the
+// source branch's push pipelines alongside the MR's own, and the branch-ref
+// endpoint returns merge-request pipelines whose stored ref is that branch,
+// including ones belonging to other MRs. Preferring the caller's own kind, and
+// falling back to the other only when the preferred kind is absent, keeps
+// projects that run just one kind working.
+export function selectPipeline(
+  records: PipelineRecord[],
+  prefer: "merge-request" | "branch",
+): PipelineRecord | null {
+  const eligible = records.filter((record) => !EXCLUDED_PIPELINE_SOURCES.includes(record.source));
+  const mergeRequestPipelines = eligible.filter(
+    (record) => record.source === "merge_request_event",
+  );
+  const branchPipelines = eligible.filter((record) => record.source !== "merge_request_event");
+  const [preferred, fallback] =
+    prefer === "merge-request"
+      ? [mergeRequestPipelines, branchPipelines]
+      : [branchPipelines, mergeRequestPipelines];
+  const partition = preferred.length > 0 ? preferred : fallback;
+  return partition.reduce<PipelineRecord | null>(
+    (best, record) => (best === null || record.id > best.id ? record : best),
+    null,
+  );
+}
+
+export type JobRecord = { name: string; status: string; allowFailure: boolean };
+
+// Job data can only ever downgrade a claimed success, never confirm one: the
+// jobs endpoint omits bridge (trigger) jobs, so a pipeline whose work lives in
+// child pipelines legitimately reports zero jobs, as does a `skipped` pipeline.
+// A `canceled` job is left out on purpose, since cancellation already turns the
+// pipeline `canceled` and widening the rule risks rejecting healthy greens.
+export function jobsContradictSuccess(jobs: JobRecord[]): JobRecord[] {
+  return jobs.filter((job) => job.status === "failed" && !job.allowFailure);
+}
+
 export function computeInterval(durationsSeconds: number[]): number {
   if (durationsSeconds.length === 0) return NO_HISTORY_INTERVAL_SECONDS;
   const avg = durationsSeconds.reduce((a, b) => a + b, 0) / durationsSeconds.length;
@@ -388,12 +461,6 @@ export async function resolveMergeStatus(
   return current;
 }
 
-type PipelineSummary = { id: string; status: InternalState; sha: string } | null;
-
-type PipelineResult =
-  | { ok: true; pipeline: PipelineSummary }
-  | { ok: false; rateLimited: boolean; retryAfter: string };
-
 function parsePipeline(
   parsed: Record<string, unknown>,
 ): { id: string; status: InternalState; sha: string } | null {
@@ -405,56 +472,170 @@ function parsePipeline(
   return { id, status: normalizePipelineStatus(status), sha };
 }
 
-function fetchPipeline(projectEncoded: string, branch: string): PipelineResult {
-  const filter = "[.[] | {id, status, sha}] | .[0] // null";
-  const result = exec(
-    `glab api 'projects/${projectEncoded}/pipelines?ref=${encodeURIComponent(branch)}&per_page=1' | jq -c '${filter}'`,
+export type PipelineTarget = { kind: "mr"; iid: number } | { kind: "branch"; branch: string };
+
+function pipelineListPath(projectEncoded: string, target: PipelineTarget, perPage: number): string {
+  return target.kind === "mr"
+    ? `projects/${projectEncoded}/merge_requests/${target.iid}/pipelines?per_page=${perPage}`
+    : `projects/${projectEncoded}/pipelines?ref=${encodeURIComponent(target.branch)}&per_page=${perPage}`;
+}
+
+function describeTarget(target: PipelineTarget): string {
+  return target.kind === "mr" ? `MR !${target.iid}` : `branch ${target.branch}`;
+}
+
+type PipelineListResult =
+  | { ok: true; records: PipelineRecord[] }
+  | { ok: false; rateLimited: boolean; retryAfter: string };
+
+function fetchPipelineList(
+  projectEncoded: string,
+  target: PipelineTarget,
+  run: ExecFn = exec,
+): PipelineListResult {
+  const filter = "[.[] | {id, status, sha, source}]";
+  const result = run(
+    `glab api '${pipelineListPath(projectEncoded, target, 20)}' | jq -c '${filter}'`,
   );
   if (!result.ok) {
     return { ok: false, rateLimited: result.rateLimited, retryAfter: result.retryAfter };
   }
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(result.stdout || "null") as Record<string, unknown> | null;
-    return { ok: true, pipeline: parsed ? parsePipeline(parsed) : null };
+    parsed = JSON.parse(result.stdout || "null");
   } catch (err) {
     console.error(
-      `glab api returned unparseable JSON for pipelines on ${branch}: ${err instanceof Error ? err.message : String(err)}`,
+      `glab api returned unparseable JSON for pipelines on ${describeTarget(target)}: ${err instanceof Error ? err.message : String(err)}`,
     );
     return { ok: false, rateLimited: false, retryAfter: "" };
   }
+  const records = parsePipelineList(parsed);
+  if (!records) {
+    console.error(
+      `glab api returned non-array JSON for pipelines on ${describeTarget(target)}; treating as probe failure`,
+    );
+    return { ok: false, rateLimited: false, retryAfter: "" };
+  }
+  return { ok: true, records };
 }
 
-type Probed =
-  | { ok: true; probe: Probe; sourceBranch: string }
+type JobsResult = { ok: true; jobs: JobRecord[] } | { ok: false };
+
+function fetchJobs(projectEncoded: string, pipelineId: string, run: ExecFn = exec): JobsResult {
+  const filter = "[.[] | {name, status, allow_failure}]";
+  const result = run(
+    `glab api 'projects/${projectEncoded}/pipelines/${encodeURIComponent(pipelineId)}/jobs?per_page=100' | jq -c '${filter}'`,
+  );
+  if (!result.ok) {
+    console.error(
+      `glab api failed while confirming success for pipeline ${pipelineId}: ${result.stderr.trim()}`,
+    );
+    return { ok: false };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result.stdout || "null");
+  } catch (err) {
+    console.error(
+      `glab api returned unparseable JSON for jobs on pipeline ${pipelineId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { ok: false };
+  }
+  if (!Array.isArray(parsed)) {
+    console.error(`glab api returned non-array JSON for jobs on pipeline ${pipelineId}`);
+    return { ok: false };
+  }
+  const jobs: JobRecord[] = [];
+  for (const entry of parsed) {
+    if (!entry || typeof entry !== "object") continue;
+    const fields = entry as Record<string, unknown>;
+    jobs.push({
+      name: typeof fields.name === "string" ? fields.name : "",
+      status: typeof fields.status === "string" ? fields.status : "",
+      allowFailure: fields.allow_failure === true,
+    });
+  }
+  return { ok: true, jobs };
+}
+
+type VerifiedState = { ok: true; state: InternalState } | { ok: false };
+
+// Confirm a claimed success against the pipeline's jobs before letting it end
+// the watch. Only a claimed success pays for the extra call, so a watch that
+// ends green spends exactly one. An unreadable jobs response fails closed: the
+// caller turns it into a probe failure and re-polls rather than emitting an
+// unverified green.
+function verifyState(
+  projectEncoded: string,
+  pipeline: { id: string; status: InternalState },
+  run: ExecFn = exec,
+): VerifiedState {
+  if (pipeline.status !== "success") {
+    return { ok: true, state: pipeline.status };
+  }
+  const jobs = fetchJobs(projectEncoded, pipeline.id, run);
+  if (!jobs.ok) {
+    return { ok: false };
+  }
+  const contradicting = jobsContradictSuccess(jobs.jobs);
+  if (contradicting.length > 0) {
+    console.error(
+      `pipeline ${pipeline.id} reports success but required jobs failed: ${contradicting.map((job) => job.name).join(", ")}`,
+    );
+    return { ok: true, state: "failing" };
+  }
+  return { ok: true, state: "success" };
+}
+
+type Probed = { ok: true; probe: Probe } | { ok: false; rateLimited: boolean; retryAfter: string };
+
+type SelectedPipeline =
+  | { ok: true; runId: string | null; state: InternalState; sha: string }
   | { ok: false; rateLimited: boolean; retryAfter: string };
 
-function probeMr(projectEncoded: string, iid: number, cachedBranch: string | null): Probed {
-  const mr = fetchMrMetadata(projectEncoded, iid);
+function resolvePipeline(
+  projectEncoded: string,
+  target: PipelineTarget,
+  prefer: "merge-request" | "branch",
+  run: ExecFn,
+): SelectedPipeline {
+  const pipelines = fetchPipelineList(projectEncoded, target, run);
+  if (!pipelines.ok) {
+    return { ok: false, rateLimited: pipelines.rateLimited, retryAfter: pipelines.retryAfter };
+  }
+  const selected = selectPipeline(pipelines.records, prefer);
+  // No eligible pipeline leaves the state `running`, so a page of nothing but
+  // excluded sources degrades to "keep polling" instead of to a green.
+  if (!selected) {
+    return { ok: true, runId: null, state: "running", sha: "" };
+  }
+  const id = String(selected.id);
+  const verified = verifyState(projectEncoded, { id, status: selected.status }, run);
+  if (!verified.ok) {
+    return { ok: false, rateLimited: false, retryAfter: "" };
+  }
+  return { ok: true, runId: id, state: verified.state, sha: selected.sha };
+}
+
+export function probeMr(projectEncoded: string, iid: number, run: ExecFn = exec): Probed {
+  const mr = fetchMrMetadata(projectEncoded, iid, run);
   if (!mr.ok) {
     return { ok: false, rateLimited: mr.rateLimited, retryAfter: mr.retryAfter };
   }
-  const branch = mr.metadata.sourceBranch || cachedBranch || "";
 
-  let runId: string | null = null;
-  let pipelineState: InternalState = "running";
-  if (branch) {
-    const pipeline = fetchPipeline(projectEncoded, branch);
-    if (!pipeline.ok) {
-      return { ok: false, rateLimited: pipeline.rateLimited, retryAfter: pipeline.retryAfter };
-    }
-    if (pipeline.pipeline) {
-      runId = pipeline.pipeline.id;
-      pipelineState = pipeline.pipeline.status;
-    }
+  const pipeline = resolvePipeline(projectEncoded, { kind: "mr", iid }, "merge-request", run);
+  if (!pipeline.ok) {
+    return { ok: false, rateLimited: pipeline.rateLimited, retryAfter: pipeline.retryAfter };
   }
 
   return {
     ok: true,
-    sourceBranch: branch,
     probe: {
+      // The MR head sha, not the pipeline sha: a merged-results pipeline reports
+      // the ephemeral merge commit, and this sha keys event dedup.
       sha: mr.metadata.sha,
-      state: pipelineState,
-      runId,
+      state: pipeline.state,
+      runId: pipeline.runId,
       hasConflicts: mr.metadata.hasConflicts,
       mergeStatus: mr.metadata.mergeStatus,
       detailedMergeStatus: mr.metadata.detailedMergeStatus,
@@ -467,9 +648,13 @@ type PipelineByIdResult =
   | { ok: true; pipeline: { id: string; status: InternalState; sha: string } }
   | { ok: false; rateLimited: boolean; retryAfter: string; notFound: boolean };
 
-function fetchPipelineById(projectEncoded: string, pipelineId: string): PipelineByIdResult {
+function fetchPipelineById(
+  projectEncoded: string,
+  pipelineId: string,
+  run: ExecFn = exec,
+): PipelineByIdResult {
   const filter = "{id, status, sha}";
-  const result = exec(
+  const result = run(
     `glab api 'projects/${projectEncoded}/pipelines/${encodeURIComponent(pipelineId)}' | jq -c '${filter}'`,
   );
   if (!result.ok) {
@@ -505,8 +690,12 @@ type ProbedById =
   | { ok: true; probe: Probe }
   | { ok: false; rateLimited: boolean; retryAfter: string; notFound: boolean };
 
-function probePipelineId(projectEncoded: string, pipelineId: string): ProbedById {
-  const pipeline = fetchPipelineById(projectEncoded, pipelineId);
+export function probePipelineId(
+  projectEncoded: string,
+  pipelineId: string,
+  run: ExecFn = exec,
+): ProbedById {
+  const pipeline = fetchPipelineById(projectEncoded, pipelineId, run);
   if (!pipeline.ok) {
     return {
       ok: false,
@@ -515,11 +704,15 @@ function probePipelineId(projectEncoded: string, pipelineId: string): ProbedById
       notFound: pipeline.notFound,
     };
   }
+  const verified = verifyState(projectEncoded, pipeline.pipeline, run);
+  if (!verified.ok) {
+    return { ok: false, rateLimited: false, retryAfter: "", notFound: false };
+  }
   return {
     ok: true,
     probe: {
       sha: pipeline.pipeline.sha,
-      state: pipeline.pipeline.status,
+      state: verified.state,
       runId: pipeline.pipeline.id,
       hasConflicts: false,
       mergeStatus: "",
@@ -529,19 +722,17 @@ function probePipelineId(projectEncoded: string, pipelineId: string): ProbedById
   };
 }
 
-function probeBranch(projectEncoded: string, branch: string): Probed {
-  const pipeline = fetchPipeline(projectEncoded, branch);
+export function probeBranch(projectEncoded: string, branch: string, run: ExecFn = exec): Probed {
+  const pipeline = resolvePipeline(projectEncoded, { kind: "branch", branch }, "branch", run);
   if (!pipeline.ok) {
     return { ok: false, rateLimited: pipeline.rateLimited, retryAfter: pipeline.retryAfter };
   }
-  const p = pipeline.pipeline;
   return {
     ok: true,
-    sourceBranch: branch,
     probe: {
-      sha: p?.sha ?? "",
-      state: p?.status ?? "running",
-      runId: p?.id ?? null,
+      sha: pipeline.sha,
+      state: pipeline.state,
+      runId: pipeline.runId,
       hasConflicts: false,
       mergeStatus: "",
       detailedMergeStatus: "",
@@ -550,15 +741,16 @@ function probeBranch(projectEncoded: string, branch: string): Probed {
   };
 }
 
-function fetchInterval(projectEncoded: string, branch: string): number {
+function fetchInterval(projectEncoded: string, target: PipelineTarget): number {
   const filter =
-    "[.[] | select(.finished_at != null) | ((.finished_at | fromdateiso8601) - (.started_at // .created_at | fromdateiso8601))]";
+    '[.[] | select(.source != "external" and .source != "parent_pipeline") | select(.finished_at != null) | ((.finished_at | fromdateiso8601) - (.started_at // .created_at | fromdateiso8601))]';
+  const label = describeTarget(target);
   const result = exec(
-    `glab api 'projects/${projectEncoded}/pipelines?ref=${encodeURIComponent(branch)}&per_page=5' | jq -c '${filter}'`,
+    `glab api '${pipelineListPath(projectEncoded, target, 5)}' | jq -c '${filter}'`,
   );
   if (!result.ok) {
     console.error(
-      `glab api failed while computing poll interval for ${branch}; defaulting to ${DEFAULT_INTERVAL_SECONDS}s: ${result.stderr.trim()}`,
+      `glab api failed while computing poll interval for ${label}; defaulting to ${DEFAULT_INTERVAL_SECONDS}s: ${result.stderr.trim()}`,
     );
     return DEFAULT_INTERVAL_SECONDS;
   }
@@ -569,11 +761,11 @@ function fetchInterval(projectEncoded: string, branch: string): number {
       return computeInterval(numbers);
     }
     console.error(
-      `glab api returned non-array JSON while computing poll interval for ${branch}; defaulting to ${DEFAULT_INTERVAL_SECONDS}s`,
+      `glab api returned non-array JSON while computing poll interval for ${label}; defaulting to ${DEFAULT_INTERVAL_SECONDS}s`,
     );
   } catch (err) {
     console.error(
-      `glab api returned unparseable JSON while computing poll interval for ${branch}; defaulting to ${DEFAULT_INTERVAL_SECONDS}s: ${err instanceof Error ? err.message : String(err)}`,
+      `glab api returned unparseable JSON while computing poll interval for ${label}; defaulting to ${DEFAULT_INTERVAL_SECONDS}s: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
   return DEFAULT_INTERVAL_SECONDS;
@@ -603,7 +795,7 @@ type RunOptions = {
 };
 
 type ProbeOutcome =
-  | { ok: true; probe: Probe; sourceBranch: string | null }
+  | { ok: true; probe: Probe }
   | { ok: false; rateLimited: boolean; retryAfter: string; notFound: boolean };
 
 function isTerminal(events: Event[], mode: RunTarget["mode"]): boolean {
@@ -628,20 +820,20 @@ async function run(options: RunOptions): Promise<void> {
     projectEncoded = encodeURIComponent(target.project);
   }
 
-  const doProbe = (cachedBranch: string | null): ProbeOutcome => {
+  const doProbe = (): ProbeOutcome => {
     if (target.mode === "mr" && iid !== null) {
-      const r = probeMr(projectEncoded, iid, cachedBranch);
+      const r = probeMr(projectEncoded, iid);
       if (!r.ok) {
         return { ok: false, rateLimited: r.rateLimited, retryAfter: r.retryAfter, notFound: false };
       }
-      return { ok: true, probe: r.probe, sourceBranch: r.sourceBranch };
+      return { ok: true, probe: r.probe };
     }
     if (target.mode === "branch") {
       const r = probeBranch(projectEncoded, target.branch);
       if (!r.ok) {
         return { ok: false, rateLimited: r.rateLimited, retryAfter: r.retryAfter, notFound: false };
       }
-      return { ok: true, probe: r.probe, sourceBranch: r.sourceBranch };
+      return { ok: true, probe: r.probe };
     }
     if (target.mode === "pipeline-id") {
       const r = probePipelineId(projectEncoded, target.pipelineId);
@@ -653,13 +845,19 @@ async function run(options: RunOptions): Promise<void> {
           notFound: r.notFound,
         };
       }
-      return { ok: true, probe: r.probe, sourceBranch: null };
+      return { ok: true, probe: r.probe };
     }
     throw new Error("Invalid watcher target state");
   };
 
+  const intervalTarget: PipelineTarget | null =
+    target.mode === "mr" && iid !== null
+      ? { kind: "mr", iid }
+      : target.mode === "branch"
+        ? { kind: "branch", branch: target.branch }
+        : null;
+
   let state = initialState();
-  let branch: string | null = null;
   let intervalSeconds: number | null = options.intervalSeconds;
   const deadline = Date.now() + options.maxMinutes * 60 * 1000;
 
@@ -670,7 +868,7 @@ async function run(options: RunOptions): Promise<void> {
       return;
     }
 
-    const result = doProbe(branch);
+    const result = doProbe();
     if (!result.ok) {
       if (target.mode === "pipeline-id" && result.notFound) {
         console.error(`Pipeline ${target.pipelineId} not found in project ${target.project}`);
@@ -684,7 +882,6 @@ async function run(options: RunOptions): Promise<void> {
       for (const event of errOutcome.events) emit(event);
     } else {
       state = clearApiErrors(state);
-      if (result.sourceBranch) branch = result.sourceBranch;
       // Settle merge status before deriving events so `conflicts` lands in the
       // same cycle as a stale `success`, ahead of the terminal return below.
       let probe = result.probe;
@@ -702,10 +899,9 @@ async function run(options: RunOptions): Promise<void> {
       for (const event of outcome.events) emit(event);
       if (isTerminal(outcome.events, target.mode)) return;
 
-      intervalSeconds ??=
-        target.mode === "pipeline-id" || !branch
-          ? DEFAULT_INTERVAL_SECONDS
-          : fetchInterval(projectEncoded, branch);
+      intervalSeconds ??= intervalTarget
+        ? fetchInterval(projectEncoded, intervalTarget)
+        : DEFAULT_INTERVAL_SECONDS;
     }
 
     await sleep((intervalSeconds ?? DEFAULT_INTERVAL_SECONDS) * 1000);

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
@@ -331,6 +331,36 @@ export function jobsContradictSuccess(jobs: JobRecord[]): JobRecord[] {
   return jobs.filter((job) => job.status === "failed" && !job.allowFailure);
 }
 
+// Statuses whose elapsed time reflects CI work actually running. `skipped` and
+// `manual` pipelines finish in about a second without doing anything, so
+// averaging them in would collapse the interval toward the floor.
+const TIMED_PIPELINE_STATUSES = new Set(["success", "failed", "canceled"]);
+
+// The pipeline list endpoint carries no `finished_at`, `started_at`, or
+// `duration`, so elapsed time has to come from `updated_at - created_at`. On a
+// finished pipeline the two agree to within about three seconds, and `duration`
+// would be wrong here regardless: it excludes queue time, which a poller waits
+// through. Dates are parsed here rather than in jq because `fromdateiso8601`
+// rejects the fractional seconds GitLab sends.
+export function pipelineDurations(raw: unknown[]): number[] {
+  const durations: number[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const record = entry as Record<string, unknown>;
+    const status = record.status;
+    const createdAt = record.created_at;
+    const updatedAt = record.updated_at;
+    if (typeof status !== "string" || !TIMED_PIPELINE_STATUSES.has(status)) continue;
+    if (typeof createdAt !== "string" || typeof updatedAt !== "string") continue;
+    const started = Date.parse(createdAt);
+    const ended = Date.parse(updatedAt);
+    if (Number.isNaN(started) || Number.isNaN(ended)) continue;
+    const seconds = (ended - started) / 1000;
+    if (seconds > 0) durations.push(seconds);
+  }
+  return durations;
+}
+
 export function computeInterval(durationsSeconds: number[]): number {
   if (durationsSeconds.length === 0) return NO_HISTORY_INTERVAL_SECONDS;
   const avg = durationsSeconds.reduce((a, b) => a + b, 0) / durationsSeconds.length;
@@ -743,10 +773,10 @@ export function probeBranch(projectEncoded: string, branch: string, run: ExecFn 
 
 function fetchInterval(projectEncoded: string, target: PipelineTarget): number {
   const filter =
-    '[.[] | select(.source != "external" and .source != "parent_pipeline") | select(.finished_at != null) | ((.finished_at | fromdateiso8601) - (.started_at // .created_at | fromdateiso8601))]';
+    '[.[] | select(.source != "external" and .source != "parent_pipeline") | {status, created_at, updated_at}]';
   const label = describeTarget(target);
   const result = exec(
-    `glab api '${pipelineListPath(projectEncoded, target, 5)}' | jq -c '${filter}'`,
+    `glab api '${pipelineListPath(projectEncoded, target, 20)}' | jq -c '${filter}'`,
   );
   if (!result.ok) {
     console.error(
@@ -757,8 +787,7 @@ function fetchInterval(projectEncoded: string, target: PipelineTarget): number {
   try {
     const parsed = JSON.parse(result.stdout || "[]");
     if (Array.isArray(parsed)) {
-      const numbers = parsed.filter((n): n is number => typeof n === "number" && n > 0);
-      return computeInterval(numbers);
+      return computeInterval(pipelineDurations(parsed));
     }
     console.error(
       `glab api returned non-array JSON while computing poll interval for ${label}; defaulting to ${DEFAULT_INTERVAL_SECONDS}s`,


### PR DESCRIPTION
The watcher resolved every pipeline with `projects/:id/pipelines?ref=<branch>&per_page=1` and took whatever GitLab listed first. That query does not express the intent in either mode. It matches on the pipeline's stored ref, so it returns merge-request pipelines belonging to other MRs on the same branch, child pipelines that share their parent's ref, and `external` pipelines. An `external` pipeline is a commit status posted by another tool: it carries no CI jobs and is green the moment it is created. Any of those can hold the highest id and win, and `isTerminal` ends the watch on any `status: success`, so a green belonging to something else exited the watch on a red MR.

MR mode now reads `projects/:id/merge_requests/:iid/pipelines` and branch mode keeps the branch-ref query. Both funnel through `selectPipeline`, which drops `external` and `parent_pipeline` sources, prefers the caller's own pipeline kind, falls back to the other kind only when the preferred one is absent (so a project that runs just one kind still works), and takes the highest id numerically. Source filtering alone would not have been enough: a `skipped` push pipeline normalizes to `success` and can outrank a `running` merge-request pipeline, which is why the preference exists rather than plain newest-by-id. When nothing is eligible the state stays `running`, so an all-excluded page keeps polling rather than degrading to a green.

A claimed `success` is then confirmed against the pipeline's jobs, in all three modes. A failed job with `allow_failure: false` downgrades the state to `failing`. The check can only ever downgrade, never confirm: the jobs endpoint omits bridge (trigger) jobs, so a parent whose work lives in child pipelines legitimately reports zero jobs, as does a `skipped` pipeline. Requiring that jobs exist would break both. `canceled` jobs are deliberately out of scope, since a cancellation already turns the pipeline `canceled` and widening the rule risks rejecting healthy greens. An unreadable jobs response fails closed as a probe failure and re-polls, so an unverifiable success is never emitted, and the wall clock plus the `api-error` event bound the downside.

Two alternatives were rejected. `head_pipeline` on the MR detail response looks like a one-call replacement, but GitLab derives it from the pipelines on the head sha ordered by id, so an `external` pipeline can become `head_pipeline` and reproduce the bug. The pipeline `sha` looked usable as a staleness check, but a merged-results pipeline reports the ephemeral merge commit rather than the MR head, so MR mode still sources `Probe.sha` from the MR metadata, which is what keys event dedup and the per-sha conflict suppression.

MR mode no longer needs the source branch to find its pipeline, so the cached-branch plumbing is gone and the poll-interval query follows the same target.

Found while verifying and left alone: neither pipeline list endpoint returns `finished_at` or `started_at`, so `fetchInterval`'s duration filter has always produced an empty array and the computed interval has always been the 30s floor. That predates this change and wants its own fix.

Unit tests cover the selection and job-gate logic, including a property that the selected pipeline is always an eligible input record holding the highest id in its partition, plus scripted-`exec` tests over each probe path. End to end, the CLI ran in all three modes against a stub `glab` on `PATH`, which exercises the real shell and `jq` pipeline: an `external` success is ignored in favor of the failing merge-request pipeline, a green pipeline whose required job failed reports `failing`, and a genuinely green one emits `status: success` and exits. `glab` auth is unavailable on this machine, so no live watch against a real project ran. The API response shapes this depends on were re-confirmed with unauthenticated `curl` against a public project.

Original Task: [Bug: gitlab ci-monitor reports a false green from external-source pipelines](https://things.bendrucker.me/show?id=ADogEAGGbiKqzAK2zuSLub)
