### PR TITLE
ship,comments: make ship's review passes reachable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Check skill hook path variables
         run: bun scripts/check-skill-hook-vars.ts
 
+      - name: Check skill invocability
+        run: bun scripts/check-skill-invocability.ts
+
       - name: Check embedded markdown code
         run: bun scripts/check-md-code.ts
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,13 @@ repos:
         files: ^plugins/[^/]+/skills/
         entry: scripts/prek-check.sh skill-lint
 
+      - id: skill-invocability
+        name: Skill invocability
+        language: system
+        files: ^(plugins/[^/]+/skills/|user/skills/|\.claude/skills/)
+        pass_filenames: false
+        entry: bun scripts/check-skill-invocability.ts
+
       - id: hook-test
         name: Hook tests
         language: system

--- a/plugins/comments/skills/audit/SKILL.md
+++ b/plugins/comments/skills/audit/SKILL.md
@@ -5,9 +5,10 @@ description: >-
   self-praise, docstring-scope, and section-divider banners. Audits a diff (the
   comments a change introduced) or a whole repo, ranks by intrinsic complexity,
   fans out judging agents, and applies the trims to a fresh branch. Use when
-  reviewing a branch or merge request, or sweeping a slop-heavy codebase.
+  asked to audit, trim, or clean up code comments, or as the comment pass of a
+  branch-finishing flow. Not a general code review: skip it when the change
+  added no comments.
 argument-hint: "[--all] [--base <ref>] [--mr <iid>] [--path <glob>] [--sort <key>] [--limit <n>] [--report] [--fix] [--format <template>]"
-disable-model-invocation: true
 allowed-tools:
   - Bash
   - Read
@@ -25,6 +26,9 @@ fact, delete or shorten it), or `rewrite` (it carries a real fact under AI voice
 strip the voice and keep the fact). A comment earns its place when it adds
 information not readily available in the adjacent code. See
 [`judge/prompt.md`](../../judge/prompt.md) for the full model and carve-outs.
+
+Model-invocable so `ship` can run it as its comment pass. The consent gate at
+[Preflight](#preflight) caps the cost of a misfire at one cheap extraction.
 
 The pipeline is three steps: `preflight` (extract, rank, build the job), the
 Workflow tool (judge), and `apply` (write the trims or report them).

--- a/scripts/check-skill-invocability.test.ts
+++ b/scripts/check-skill-invocability.test.ts
@@ -1,0 +1,95 @@
+import { expect, it, test } from "bun:test";
+import {
+  SKILL_SCOPES,
+  type SkillFile,
+  skillFiles,
+  skillGrants,
+  skillName,
+  violations,
+} from "./check-skill-invocability";
+
+test.each(SKILL_SCOPES)("discovers skills under $dir", async ({ dir }) => {
+  const paths = (await skillFiles()).map((file) => file.path);
+
+  expect(paths.filter((path) => path.startsWith(`${dir}/`))).not.toBeEmpty();
+});
+
+test.each<{ name: string; path: string; frontmatterName?: string; expected: string }>([
+  {
+    name: "plugin skill namespaces on its plugin",
+    path: "plugins/comments/skills/audit/SKILL.md",
+    expected: "comments:audit",
+  },
+  {
+    name: "entry skill collapses to the plugin name",
+    path: "plugins/writing/skills/writing/SKILL.md",
+    expected: "writing",
+  },
+  {
+    name: "frontmatter name wins over derivation",
+    path: "plugins/review/skills/code/SKILL.md",
+    frontmatterName: "review:code",
+    expected: "review:code",
+  },
+  { name: "user skill carries no namespace", path: "user/skills/ship/SKILL.md", expected: "ship" },
+  {
+    name: "project skill carries no namespace",
+    path: ".claude/skills/coverage/SKILL.md",
+    expected: "coverage",
+  },
+])("$name", ({ path, frontmatterName, expected }) => {
+  expect(skillName(path, frontmatterName)).toBe(expected);
+});
+
+test.each<{ name: string; allowedTools: string[]; expected: string[] }>([
+  { name: "bare grant", allowedTools: ["Skill(comments:audit)"], expected: ["comments:audit"] },
+  {
+    name: "surrounding whitespace",
+    allowedTools: [" Skill(review:code) "],
+    expected: ["review:code"],
+  },
+  {
+    name: "grant with arguments",
+    allowedTools: ["Skill(mac:jxa-run Things3:*)"],
+    expected: ["mac:jxa-run"],
+  },
+  {
+    name: "non-Skill entries",
+    allowedTools: ["Bash(git diff:*)", "Agent", "AskUserQuestion"],
+    expected: [],
+  },
+  { name: "empty parens", allowedTools: ["Skill()"], expected: [] },
+])("$name", ({ allowedTools, expected }) => {
+  expect(skillGrants(allowedTools)).toEqual(expected);
+});
+
+it("reports only grants whose target cannot be reached", () => {
+  const skill = (overrides: Partial<SkillFile>): SkillFile => ({
+    path: "user/skills/caller/SKILL.md",
+    name: "caller",
+    disabled: false,
+    grants: [],
+    ...overrides,
+  });
+
+  const files: SkillFile[] = [
+    skill({
+      path: "plugins/comments/skills/audit/SKILL.md",
+      name: "comments:audit",
+      disabled: true,
+    }),
+    skill({ path: "plugins/review/skills/code/SKILL.md", name: "review:code" }),
+    skill({
+      path: "user/skills/ship/SKILL.md",
+      name: "ship",
+      grants: ["comments:audit", "verify", "review:code", "third-party:thing"],
+    }),
+  ];
+
+  expect(violations(files)).toMatchInlineSnapshot(`
+    [
+      "user/skills/ship/SKILL.md: Skill(comments:audit) (disable-model-invocation in plugins/comments/skills/audit/SKILL.md)",
+      "user/skills/ship/SKILL.md: Skill(verify) (user-invocable-only built-in)",
+    ]
+  `);
+});

--- a/scripts/check-skill-invocability.ts
+++ b/scripts/check-skill-invocability.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env bun
+
+import { globSync } from "node:fs";
+import { join } from "node:path";
+import matter from "gray-matter";
+import { runCheck } from "./check";
+
+// Bundled built-ins registered with `disableModelInvocation: true`, per section
+// 8.3 of plugins/review/skills/code/references/upstream-2.1.215.md. Only
+// `code-review` has a drift probe (scripts/check-review-drift.ts), so an entry
+// upstream later makes model-invocable goes stale as a false positive here.
+const USER_INVOCABLE_BUILTINS = new Set(["code-review", "verify", "batch"]);
+
+// Each scope globs from its own directory because node:fs globSync refuses to
+// descend into a dot directory even when the pattern names it literally:
+// globSync(".claude/skills/*/SKILL.md") matches nothing.
+export const SKILL_SCOPES = [
+  { dir: "plugins", pattern: "*/skills/*/SKILL.md" },
+  { dir: "user/skills", pattern: "*/SKILL.md" },
+  { dir: ".claude/skills", pattern: "*/SKILL.md" },
+];
+
+const root = join(import.meta.dirname, "..");
+
+export interface SkillFile {
+  path: string;
+  name: string;
+  disabled: boolean;
+  grants: string[];
+}
+
+/**
+ * The name a skill is reachable by, which `Skill()` grants have to match.
+ *
+ * Frontmatter wins. Derivation covers the rest: a plugin skill namespaces as
+ * `<plugin>:<skill>`, collapsing to `<plugin>` for the entry-skill pattern
+ * where the two match. User and project skills carry no namespace.
+ */
+export function skillName(path: string, frontmatterName?: string): string {
+  if (frontmatterName) return frontmatterName;
+
+  const segments = path.split("/");
+  const skill = segments.at(-2) ?? "";
+  if (segments[0] !== "plugins") return skill;
+
+  const plugin = segments[1];
+  return skill === plugin ? plugin : `${plugin}:${skill}`;
+}
+
+/** Skill names an `allowed-tools` list grants, dropping any trailing arguments. */
+export function skillGrants(allowedTools: string[]): string[] {
+  return allowedTools.flatMap((entry) => {
+    const match = /^Skill\(([^)]*)\)$/.exec(entry.trim());
+    if (!match) return [];
+
+    const [target] = match[1].trim().split(/\s+/);
+    return target ? [target] : [];
+  });
+}
+
+function unreachable(target: string, byName: Map<string, SkillFile>): string | undefined {
+  if (USER_INVOCABLE_BUILTINS.has(target)) return "user-invocable-only built-in";
+
+  const targeted = byName.get(target);
+  if (targeted?.disabled) return `disable-model-invocation in ${targeted.path}`;
+
+  // Unresolvable names are third-party plugin skills this repo cannot see.
+  return undefined;
+}
+
+export function violations(files: SkillFile[]): string[] {
+  const byName = new Map(files.map((file) => [file.name, file]));
+
+  return files.flatMap((file) =>
+    file.grants.flatMap((target) => {
+      const reason = unreachable(target, byName);
+      return reason ? [`${file.path}: Skill(${target}) (${reason})`] : [];
+    }),
+  );
+}
+
+async function read(path: string): Promise<SkillFile> {
+  const { data } = matter(await Bun.file(join(root, path)).text());
+  const allowedTools = data["allowed-tools"] as unknown;
+
+  return {
+    path,
+    name: skillName(path, data.name as string | undefined),
+    disabled: data["disable-model-invocation"] === true,
+    grants: skillGrants(Array.isArray(allowedTools) ? allowedTools : []),
+  };
+}
+
+export async function skillFiles(): Promise<SkillFile[]> {
+  const paths = SKILL_SCOPES.flatMap(({ dir, pattern }) =>
+    globSync(pattern, { cwd: join(root, dir) }).map((match) => `${dir}/${match}`),
+  ).filter((path) => !path.includes("/test/"));
+
+  return Promise.all(paths.map(read));
+}
+
+if (import.meta.main) {
+  await runCheck(
+    async () => ({
+      header: [
+        "These skills grant Skill() on a target that cannot be reached through the Skill tool.",
+        "The delegation fails at runtime:",
+      ],
+      violations: violations(await skillFiles()),
+    }),
+    { success: "All Skill() grants target model-invocable skills" },
+  );
+}

--- a/scripts/check-skill-invocability.ts
+++ b/scripts/check-skill-invocability.ts
@@ -53,7 +53,7 @@ export function skillGrants(allowedTools: string[]): string[] {
     const match = /^Skill\(([^)]*)\)$/.exec(entry.trim());
     if (!match) return [];
 
-    const [target] = match[1].trim().split(/\s+/);
+    const [target] = (match[1] ?? "").trim().split(/\s+/);
     return target ? [target] : [];
   });
 }

--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -13,7 +13,7 @@ allowed-tools:
   - Skill(plan:review)
   - Skill(review:code)
   - Skill(simplify)
-  - Skill(verify)
+  - Skill(run)
   - Skill(comments:audit)
   - Skill(writing:review)
   - Skill(pull-request:create)
@@ -40,7 +40,7 @@ Resolve the base to a **remote** ref so ship's view matches what the PR merges a
 - **`comments:audit`**: diff adds code comments.
 - **`pull-request:follow-up --local`**: a supported review bot is detected for the repo. Follow-up's `local.md` owns detection (repo config fast path, hosted signals when no config is committed) and exits early when nothing is detected. Runs the hosted reviewer locally before the PR exists.
 - **`writing:review`**: diff touches prose (`.md`, `.mdx`, `.rst`, docs).
-- **`verify`**: diff has a runtime surface. Declines tests-only and docs-only itself.
+- **`run`**: diff has a runtime surface. Drive the change in the real app, not just tests. Skip on docs-only and tests-only.
 
 Infer, don't interrogate. Present the plan in one line, then proceed. `AskUserQuestion` only on a real toss-up: refactor versus behavior change, or `medium` versus `high` effort.
 
@@ -49,7 +49,7 @@ Infer, don't interrogate. Present the plan in one line, then proceed. `AskUserQu
 - `--merge`: drive to merged (babysit `--merge`). Default: green and ready.
 - `--effort <low|medium|high|xhigh|max|ultra>`: override inferred `review:code` effort. `ultra` is a billed cloud review only a user-typed `/code-review ultra` can start, so ship stops and hands it back instead of substituting a local level.
 - `--simplify`: force `simplify` over `review:code`.
-- `--skip <pass>` (repeatable): drop a gated pass. Names: `plan`, `review:code` (the old `code-review` is accepted as an alias), `simplify`, `comments`, `bot`, `writing`, `verify`.
+- `--skip <pass>` (repeatable): drop a gated pass. Names: `plan`, `review:code` (the old `code-review` is accepted as an alias), `simplify`, `comments`, `bot`, `writing`, `run` (the old `verify` is accepted as an alias).
 - `--base <ref>`: base branch for gating. Default `main`; on a stack, the parent branch. Resolved to its upstream tracking ref (e.g. `origin/...`) before diffing.
 
 ## Pre-PR Reviews
@@ -60,7 +60,7 @@ Serialized before create: `review:code --fix`, `simplify`, and comment trims all
 2. **`pull-request:follow-up --local`**: reviews committed work only and commits its own fixes, so it runs while the tree is still clean, before the fix passes. Pass the resolved base.
 3. **Correctness and quality**: `review:code <effort> --fix` or `simplify`.
 4. **`writing:review`** over touched prose. Address salient findings before the body is written.
-5. **`verify`** end to end.
+5. **`run`** to drive the change end to end.
 
 Dirty tree at the comment pass: ask whether to commit first. `comments:audit` operates on `HEAD` and needs a clean tree.
 

--- a/user/skills/ship/references/passes.md
+++ b/user/skills/ship/references/passes.md
@@ -13,9 +13,9 @@ Most passes gate on the diff against the resolved base (the upstream tracking re
 | New code comments | `comments:audit` | See [Comment Trims](#comment-trims) |
 | A supported review bot detected for the repo (config fast path, hosted signals otherwise; follow-up's `local.md` owns detection) | `pull-request:follow-up --local` | Reviews committed work, commits its fixes. Runs before the fix passes dirty the tree |
 | Prose (`.md`, `.mdx`, `.rst`, docs) | `writing:review` | |
-| A runtime surface | `verify` | Declines tests-only and docs-only itself |
+| A runtime surface | `run` | Ship declines docs-only and tests-only |
 
-Gating is the cost lever: never run a reviewer the change does not warrant. `--skip <pass>` drops any of them (`plan`, `review:code`, `simplify`, `comments`, `bot`, `writing`, `verify`). `code-review` is still accepted for `review:code` so an old invocation does not silently run the pass it meant to skip.
+Gating is the cost lever: never run a reviewer the change does not warrant. `--skip <pass>` drops any of them (`plan`, `review:code`, `simplify`, `comments`, `bot`, `writing`, `run`). `code-review` is still accepted for `review:code`, and `verify` for `run`, so an old invocation does not silently run the pass it meant to skip.
 
 ## Plan Review
 
@@ -26,10 +26,10 @@ It is read-only and writes nothing, so it runs as a background dispatch rather t
 ```mermaid
 flowchart TD
     S([ship start]) --> G{plan:review gated in?}
-    G -->|no| F1[fix passes: comments-audit, local bot, review:code or simplify, writing, verify]
+    G -->|no| F1[fix passes: comments-audit, local bot, review:code or simplify, writing, run]
     F1 --> C([create PR])
     G -->|yes| D[dispatch plan:review in background]
-    D --> F2[fix passes: comments-audit, local bot, review:code or simplify, writing, verify]
+    D --> F2[fix passes: comments-audit, local bot, review:code or simplify, writing, run]
     D -. concurrent .-> R[plan:review reasons over plan + diff]
     F2 --> J{join: findings?}
     R -.-> J
@@ -65,3 +65,4 @@ Rejected:
 
 - **`--report` plus inline apply**: pulls the full findings into ship's context, defeating the point of keeping bulk verdicts off the conversation.
 - **Running it after `review:code --fix`**: the fix pass dirties the tree, failing `comments:audit`'s clean-tree check.
+- **Invoking the audit's scripts directly from ship**: ship cannot resolve the comments plugin's install path, it would duplicate the three-step runbook, and it would widen ship's tool grant past `git diff` and `git status`. `comments:audit` was made model-invocable instead, the same remedy `review:code` applies to the built-in `/code-review`.


### PR DESCRIPTION
`ship` granted `Skill(comments:audit)` and `Skill(verify)` and gated a pass on each, but the Skill tool refuses both targets. The audit set `disable-model-invocation`, and `verify` is a bundled built-in registered user-invocable-only. So ship's comment pass and its end-to-end pass were no-ops on every run, and nothing here could catch that: the grant looks valid, the skill file lints, and CI stayed green.

The audit gets the flag deleted rather than a route around it. Ship is a user-level skill and cannot resolve the comments plugin's install path, copying the three-step `preflight` / judge / `apply` runbook into ship would create a second call site to rot, and it would widen ship's tool grant past `git diff` and `git status`. Pushing the invocation into a subagent breaks the preflight consent gate too, since a subagent cannot ask the user. What re-enabling costs is an always-on description, so the description now names comment-specific triggers and drops the "reviewing a branch or merge request" hook that would pull the skill into generic review requests. A misfire costs one `preflight` run plus a question, because the consent gate stops before any fan-out. `review:code` already answered this question the same way for the built-in `/code-review`: build a reachable path instead of tunneling under the gate.

`verify` has no in-repo remedy, so ship gates `run` instead. `run` is model-invocable and its stated purpose is driving the change in the real app. It does not decline docs-only and tests-only diffs the way `verify` did, so ship now owns that gate, and `--skip verify` is kept as an alias so an old invocation still drops the pass it meant to drop. The tradeoff accepted here: `run` will not bootstrap a project verify skill when none exists. A backgrounded ship run that can reach the pass beats one that hands it back.

`scripts/check-skill-invocability.ts` is the durable half. It resolves every `Skill()` grant under `plugins/`, `user/`, and `.claude/` against the repo's own skill graph plus the three built-ins upstream registers as user-invocable-only, then reports the granting file, the grant, and why the target is out of reach. Unresolvable names are third-party skills this repo cannot see, so they pass. Writing it surfaced a trap worth naming: `globSync` refuses to descend into a dot directory even when the pattern names it literally, so `.claude/skills/*/SKILL.md` matched nothing and the check was blind to project skills. Each scope now globs from its own directory, with a test asserting every scope contributes at least one file.

One caveat on verification. A running session loads the comments plugin from the marketplace clone, not from this working copy, so `Skill(comments:audit)` keeps refusing until this lands and the clone updates. What is checkable now is the checker itself: it reported both grants before the fix and reports nothing after, and restoring the flag makes it fail again.

Removal path for the new check: delete it if upstream ever makes `Skill()` on a disabled skill work, or if `skill-lint` grows a cross-skill view. If `comments:audit` starts firing on changes that added no comments, narrow the description further before restoring the flag. If the flag ever does come back, ship's comment pass and its grant have to go in the same change, since that pairing is the defect this fixes.

Original Task: [[discovery] ship's comments:audit pass is a broken delegation (Unknown skill)](https://things.bendrucker.me/show?id=EVrZxmNhRiNr5AKT4ScyAs)
