### PR TITLE
gitlab:ci-monitor: fix the adaptive poll interval

### DIFF
--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
@@ -18,6 +18,7 @@ import {
   parseMrUrl,
   parsePipelineList,
   parseProject,
+  pipelineDurations,
   probeBranch,
   probeMr,
   probePipelineId,
@@ -217,6 +218,119 @@ describe("isNotFoundError", () => {
     ["500 internal server error", false],
   ])("%p is %p", (message, expected) => {
     expect(isNotFoundError(message)).toBe(expected);
+  });
+});
+
+describe("pipelineDurations", () => {
+  // The pipeline list endpoint returns none of `finished_at`, `started_at`, or
+  // `duration`, so the original `select(.finished_at != null)` filter matched
+  // nothing and every watch polled at the no-history rate. The fractional
+  // seconds below guard the trap underneath it: `fromdateiso8601` rejects them,
+  // so restoring the timing fields without moving the date math out of jq would
+  // have swapped a silent empty result for a hard jq failure.
+  test.each<{ name: string; raw: unknown[]; expected: number[] }>([
+    {
+      name: "measures elapsed wall time across fractional-second timestamps",
+      raw: [
+        {
+          status: "success",
+          created_at: "2026-07-30T19:00:00.123Z",
+          updated_at: "2026-07-30T19:02:05.456Z",
+        },
+      ],
+      expected: [125.333],
+    },
+    {
+      name: "keeps failed and canceled pipelines",
+      raw: [
+        {
+          status: "failed",
+          created_at: "2026-07-30T19:00:00Z",
+          updated_at: "2026-07-30T19:01:00Z",
+        },
+        {
+          status: "canceled",
+          created_at: "2026-07-30T19:00:00Z",
+          updated_at: "2026-07-30T19:00:30Z",
+        },
+      ],
+      expected: [60, 30],
+    },
+    {
+      name: "drops skipped and manual pipelines that never ran",
+      raw: [
+        {
+          status: "skipped",
+          created_at: "2026-07-30T19:00:00Z",
+          updated_at: "2026-07-30T19:00:01Z",
+        },
+        {
+          status: "manual",
+          created_at: "2026-07-30T19:00:00Z",
+          updated_at: "2026-07-30T19:00:01Z",
+        },
+      ],
+      expected: [],
+    },
+    {
+      name: "drops still-running pipelines",
+      raw: [
+        {
+          status: "running",
+          created_at: "2026-07-30T19:00:00Z",
+          updated_at: "2026-07-30T19:00:20Z",
+        },
+      ],
+      expected: [],
+    },
+    {
+      name: "drops entries with missing, malformed, or non-positive timing",
+      raw: [
+        { status: "success", created_at: "2026-07-30T19:00:00Z" },
+        { status: "success", created_at: "not a date", updated_at: "2026-07-30T19:01:00Z" },
+        {
+          status: "success",
+          created_at: "2026-07-30T19:01:00Z",
+          updated_at: "2026-07-30T19:01:00Z",
+        },
+        null,
+        "not an object",
+      ],
+      expected: [],
+    },
+  ])("$name", ({ raw, expected }) => {
+    const durations = pipelineDurations(raw);
+    expect(durations).toHaveLength(expected.length);
+    durations.forEach((seconds, index) => {
+      expect(seconds).toBeCloseTo(expected[index] as number, 2);
+    });
+  });
+
+  test("never yields a duration the clamped interval cannot consume", () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            status: fc.constantFrom("success", "failed", "canceled", "skipped", "running"),
+            createdMs: fc.integer({ min: 0, max: 4e12 }),
+            elapsedMs: fc.integer({ min: -5000, max: 3_600_000 }),
+          }),
+        ),
+        (entries) => {
+          const raw = entries.map(({ status, createdMs, elapsedMs }) => ({
+            status,
+            created_at: new Date(createdMs).toISOString(),
+            updated_at: new Date(createdMs + elapsedMs).toISOString(),
+          }));
+          const durations = pipelineDurations(raw);
+          expect(durations.every((seconds) => seconds > 0)).toBe(true);
+          expect(durations.length).toBeLessThanOrEqual(raw.length);
+          const interval = computeInterval(durations);
+          expect(interval).toBeGreaterThanOrEqual(30);
+          expect(interval).toBeLessThanOrEqual(600);
+        },
+      ),
+    );
   });
 });
 

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
@@ -331,6 +331,36 @@ export function jobsContradictSuccess(jobs: JobRecord[]): JobRecord[] {
   return jobs.filter((job) => job.status === "failed" && !job.allowFailure);
 }
 
+// Statuses whose elapsed time reflects CI work actually running. `skipped` and
+// `manual` pipelines finish in about a second without doing anything, so
+// averaging them in would collapse the interval toward the floor.
+const TIMED_PIPELINE_STATUSES = new Set(["success", "failed", "canceled"]);
+
+// The pipeline list endpoint carries no `finished_at`, `started_at`, or
+// `duration`, so elapsed time has to come from `updated_at - created_at`. On a
+// finished pipeline the two agree to within about three seconds, and `duration`
+// would be wrong here regardless: it excludes queue time, which a poller waits
+// through. Dates are parsed here rather than in jq because `fromdateiso8601`
+// rejects the fractional seconds GitLab sends.
+export function pipelineDurations(raw: unknown[]): number[] {
+  const durations: number[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const record = entry as Record<string, unknown>;
+    const status = record.status;
+    const createdAt = record.created_at;
+    const updatedAt = record.updated_at;
+    if (typeof status !== "string" || !TIMED_PIPELINE_STATUSES.has(status)) continue;
+    if (typeof createdAt !== "string" || typeof updatedAt !== "string") continue;
+    const started = Date.parse(createdAt);
+    const ended = Date.parse(updatedAt);
+    if (Number.isNaN(started) || Number.isNaN(ended)) continue;
+    const seconds = (ended - started) / 1000;
+    if (seconds > 0) durations.push(seconds);
+  }
+  return durations;
+}
+
 export function computeInterval(durationsSeconds: number[]): number {
   if (durationsSeconds.length === 0) return NO_HISTORY_INTERVAL_SECONDS;
   const avg = durationsSeconds.reduce((a, b) => a + b, 0) / durationsSeconds.length;
@@ -743,10 +773,10 @@ export function probeBranch(projectEncoded: string, branch: string, run: ExecFn 
 
 function fetchInterval(projectEncoded: string, target: PipelineTarget): number {
   const filter =
-    '[.[] | select(.source != "external" and .source != "parent_pipeline") | select(.finished_at != null) | ((.finished_at | fromdateiso8601) - (.started_at // .created_at | fromdateiso8601))]';
+    '[.[] | select(.source != "external" and .source != "parent_pipeline") | {status, created_at, updated_at}]';
   const label = describeTarget(target);
   const result = exec(
-    `glab api '${pipelineListPath(projectEncoded, target, 5)}' | jq -c '${filter}'`,
+    `glab api '${pipelineListPath(projectEncoded, target, 20)}' | jq -c '${filter}'`,
   );
   if (!result.ok) {
     console.error(
@@ -757,8 +787,7 @@ function fetchInterval(projectEncoded: string, target: PipelineTarget): number {
   try {
     const parsed = JSON.parse(result.stdout || "[]");
     if (Array.isArray(parsed)) {
-      const numbers = parsed.filter((n): n is number => typeof n === "number" && n > 0);
-      return computeInterval(numbers);
+      return computeInterval(pipelineDurations(parsed));
     }
     console.error(
       `glab api returned non-array JSON while computing poll interval for ${label}; defaulting to ${DEFAULT_INTERVAL_SECONDS}s`,


### PR DESCRIPTION
Fixes the adaptive poll interval, which has never worked.

`fetchInterval` filtered the pipeline list on `select(.finished_at != null)`, but the pipeline list endpoint returns no `finished_at`, `started_at`, or `duration`. Those fields exist only on the single-pipeline detail endpoint. The filter matched nothing on every call, `computeInterval` always got an empty array, and it returned the no-history rate. Every watch has polled every 30 seconds no matter how long the project's pipelines take.

Verified against the live API on a public project. The old filter returns `[]` where the new one returns 20 records, and feeding that same payload through `computeInterval` yields 404 seconds against the 30 the old path produced.

Stacked on #1131, which rewrites the same function.

#### Elapsed time from `updated_at`

Elapsed time now comes from `updated_at - created_at`, which the list endpoint does return. Sampling finished pipelines showed it tracking true wall time within about three seconds.

`duration` was the obvious alternative and is wrong here even where it is available. It excludes queue time, which a poller waits through like any other. One sampled pipeline queued 47 seconds and ran 90, so `duration` would have understated the wait by a third. Fetching it would also cost one detail request per sampled pipeline.

#### Date math in TypeScript

The date arithmetic moves out of jq. `fromdateiso8601` rejects the fractional seconds GitLab sends, so restoring the timing fields alone would have traded a silent empty result for a hard jq failure. That trap is latent today only because the `finished_at` filter discards every record before any date is parsed. A regression test pins it.

Parsing in TypeScript also makes the logic testable, so `pipelineDurations` gets a table of examples plus a property tying its output to the interval clamp.

#### Sampling

The sample widens from 5 pipelines to 20, and `skipped` and `manual` pipelines are dropped. Both finish in about a second without running CI, so averaging them in pulls the interval toward the floor.

#### Verification

New tests cover the timing fields the API actually returns, fractional-second timestamps, the statuses that count toward the average, and malformed or non-positive entries. A property ties `pipelineDurations` output to the interval clamp.

`glab` auth is expired locally, so the end-to-end run used a stub `glab` serving canned API responses. Over 45 seconds the watcher made three requests: MR metadata, the probe's pipeline list, and the interval's pipeline list. A fourth would have appeared at the 30 second mark under the old behavior. The API response shapes the change depends on were confirmed separately against the real API without auth.

#### Known limitation

`updated_at` reflects the last change to the pipeline, whenever that happened. Retrying a job on an old pipeline bumps it, which inflates that sample. The existing 600 second clamp bounds the effect, so the worst case is a slower poll rather than a wrong one. Worth revisiting with a median instead of a mean if it shows up in practice.
