### PR TITLE
writing: remove command shims that shadow their own skills

### DIFF
--- a/plugins/writing/README.md
+++ b/plugins/writing/README.md
@@ -5,7 +5,7 @@ Writing style enforcement and slop detection for prose output (PR descriptions, 
 ## Contents
 
 - **Hooks**: Step, phase, and part numbering detection, heading style enforcement, AI writing trope detection (em dashes, vocabulary, copula avoidance, promotional language, parallelism, connector density)
-- **Skills**: `writing` system reminder for prose writing guidelines, `writing:analyze` session-history-based trope ruleset curation, `writing:rewrite` user-invoked text rewriter, `writing:scan` user-invoked trope detector (`audit` gates a directory, `score` measures one input's density), `writing:review` multi-agent document review
+- **Skills**: `writing:writing` system reminder for prose writing guidelines, `writing:analyze` session-history-based trope ruleset curation, `writing:rewrite` user-invoked text rewriter, `writing:scan` user-invoked trope detector (`audit` gates a directory, `score` measures one input's density), `writing:review` multi-agent document review
 - **Agents**: `content`, `style`, `artifacts` (conditional review lenses)
 
 ## Wordlists

--- a/plugins/writing/commands/review.md
+++ b/plugins/writing/commands/review.md
@@ -1,6 +1,0 @@
----
-description: Review a document through parallel agents for content, style, and artifacts
-argument-hint: <path>
----
-
-Invoke the `writing:review` skill with: $ARGUMENTS

--- a/plugins/writing/commands/writing.md
+++ b/plugins/writing/commands/writing.md
@@ -1,5 +1,0 @@
----
-description: Inject writing style rules into the current context
----
-
-Invoke the `writing:writing` skill with: $ARGUMENTS

--- a/plugins/writing/skills/writing/SKILL.md
+++ b/plugins/writing/skills/writing/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: writing
+name: writing:writing
 description: >-
   Enforce direct, concise prose style and catch writing slop. Use when writing or editing PR descriptions,
   issue bodies, commit messages, documentation, Slack messages, or any human-facing text.


### PR DESCRIPTION
The `writing:writing` skill has been silently failing to load since 5f36801a. Invoking it returned the text `Invoke the `writing:writing` skill with: ...` instead of the style rules, so prose got written without them.

The cause is a name collision. `commands/writing.md` and `skills/writing/` both namespace to `writing:writing`, and the command wins resolution. The command's body was a shim delegating to the skill, so once #673 qualified that delegation to the skill's full name, the command began pointing at itself. `writing:review` had the same collision, undetected because its shim still named a target that resolved elsewhere.

Removing both shims is the fix rather than renaming them. Skills are user-invocable by default, so `/writing:writing` and `/writing:review` keep working from the slash menu with no command file at all, and the shims never did anything else. `plugin.json` declares no `commands` key, so dropping the directory doesn't trip plugin manifest validation.

## Evidence

The session index dates the break precisely. Counting shim echoes against loads of the real skill body:

| Month | Shim echo | Real skill body |
|---|---|---|
| 2026-07 | 284 | 90 |
| 2026-06 | 330 | 132 |
| 2026-05 | 0 | 34 |

One transcript captures the whole failure in sequence: the skill call returns the shim, a retry with arguments returns it again, and the model concludes `The writing skill didn't return content, so I'll apply the style rules directly.` Eight other sessions recovered differently, falling back to `find` to hunt for `SKILL.md` on disk.

## Verification

Neither `skill-lint` nor `check-marketplace` catches this class of bug. They validate skills and plugin directories in isolation, and nothing compares command names against skill names. A check for that collision is worth adding, but it belongs in `skill-lint` alongside the existing namespace rules rather than here.

Confirming the skill loads takes a fresh session, since plugin state is read at session start and this session still has the shim resolved.

Also qualifies the skill's `name` from `writing` to `writing:writing`, matching its siblings. That's cosmetic. Auto-namespacing already produced the same result.
