### PR TITLE
github,pull-request: support GitHub stacked pull requests

### DIFF
--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -8,6 +8,7 @@ GitHub workflow, Actions monitoring, and rulesets management for Claude Code.
   - `actions-monitor`: Watch a PR's CI and stream state events; invokes the logs agent on failures
   - `notifications`: Inbox management (list, filter, mark read/done, unsubscribe)
   - `pr-comments`: Fetch unresolved review comments from a pull request
+  - `stack`: Publish and merge native stacked PRs via `gh stack link` and `gh stack merge`
 - **Agents**:
   - `github-rulesets-manager`: Configure repository rulesets and branch protection
   - `logs`: Extracts relevant lines from failing-job logs (invoked by `actions-monitor`)

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -8,7 +8,7 @@ GitHub workflow, Actions monitoring, and rulesets management for Claude Code.
   - `actions-monitor`: Watch a PR's CI and stream state events; invokes the logs agent on failures
   - `notifications`: Inbox management (list, filter, mark read/done, unsubscribe)
   - `pr-comments`: Fetch unresolved review comments from a pull request
-  - `stack`: Publish and merge native stacked PRs via `gh stack link` and `gh stack merge`
+  - `stack`: Build, publish, and merge native stacked PRs with the `gh stack` extension
 - **Agents**:
   - `github-rulesets-manager`: Configure repository rulesets and branch protection
   - `logs`: Extracts relevant lines from failing-job logs (invoked by `actions-monitor`)

--- a/plugins/github/skills/stack/SKILL.md
+++ b/plugins/github/skills/stack/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: github:stack
+description: Publish and merge GitHub native stacked pull requests with the `gh stack` extension. Use when a branch is stacked on another branch rather than the default branch, when linking a chain of branches into a stack on GitHub, or when merging a PR that belongs to a stack. Load before running any `gh stack` command.
+allowed-tools:
+  - Bash(gh stack:*)
+  - Bash(gh pr:*)
+  - Bash(gh api:*)
+---
+
+# Stacked Pull Requests
+
+`gh stack` (the `github/gh-stack` extension) drives GitHub's native stacked PRs. It has two halves, and only one fits a layout where each branch lives in its own worktree.
+
+The remote half (`link`, `merge`, `unstack`) goes through the GitHub API and writes no local state. Use it. The local-tracking half (`init`, `add`, `submit`, `push`, `sync`, `rebase`, `checkout`, `modify`, and the navigation commands) assumes every layer is checked out in one working tree. Skip it and let whatever manages the branches own the rebases. `gh stack rebase` prints `✓ Rebased <branch>` and changes nothing when that branch is checked out in another worktree ([gh-stack#35](https://github.com/github/gh-stack/issues/35)).
+
+Exit code 9 means the repository doesn't have stacked PRs enabled.
+
+## Detection
+
+Stack membership lives on the API, and this query answers with nothing checked out. `gh pr view` has no stack field, and `gh stack view` reads local tracking state a worktree layout never has.
+
+```bash
+gh api graphql -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){stack{number size}}}}' \
+  -F owner=OWNER -F repo=REPO -F number=N
+```
+
+`"stack": null` means the PR isn't stacked. Otherwise `number` is the stack number and `size` its PR count.
+
+## Publishing
+
+`gh stack link` takes branches, PR numbers, or PR URLs bottom to top. It pushes each branch, opens a PR for any branch missing one, corrects the base of any PR whose base breaks the chain, and creates or updates the stack object.
+
+```bash
+gh stack link auth-layer api-routes ui-components   # create or update a stack
+gh stack link 7 ui-polish                           # append to stack 7
+gh stack link --base develop auth-layer api-routes  # non-default trunk
+```
+
+`link` needs at least two arguments, or a stack number plus what to append, and only ever adds to a stack.
+
+Rebase and push the whole stack first. `link` pushes without force. A freshly rebased branch is rejected.
+
+Open the PR yourself with `gh pr create --base <parent>` before linking whenever the title and body matter. `link` reuses an open PR when it finds one, and auto-generates a title from the commit subject or branch name for the ones it creates.
+
+## Merging
+
+`gh pr merge` does not work on a stacked PR. Use `gh stack merge`, which takes a stack number or a PR number (not a URL), resolving a bare number as a stack first.
+
+```bash
+gh stack merge 42 --yes --squash  # everything up to and including PR #42
+gh stack merge 7 --yes --squash   # stack 7, no local checkout needed
+```
+
+`--yes` runs it headlessly. Name the method too, since the default is whichever one you used last. With no argument it takes the stack for the current branch. Give it a number instead. The merge should not turn on what happens to be checked out.
+
+The merge is all-or-nothing across every PR at or below the target. One layer that can't merge sinks the call, and the reason comes back on stderr. Layers above stay open, and GitHub retargets and rebases them onto the new base.
+
+Only open-and-not-draft state is checked before submitting. GitHub evaluates branch protection and repository rules when the merge runs, and those requirements can't be bypassed for a stack.
+
+When the base branch uses a merge queue, the stack goes on the queue instead of merging directly. The queue picks the method and ignores any method flag with a warning, and the PRs enter together but land as the queue processes them, possibly in separate groups.

--- a/plugins/github/skills/stack/SKILL.md
+++ b/plugins/github/skills/stack/SKILL.md
@@ -13,7 +13,9 @@ allowed-tools:
 
 The remote half (`link`, `merge`, `unstack`) goes through the GitHub API and writes no local state. Use it. The local-tracking half (`init`, `add`, `submit`, `push`, `sync`, `rebase`, `checkout`, `modify`, and the navigation commands) assumes every layer is checked out in one working tree. Skip it and let whatever manages the branches own the rebases. `gh stack rebase` prints `✓ Rebased <branch>` and changes nothing when that branch is checked out in another worktree ([gh-stack#35](https://github.com/github/gh-stack/issues/35)).
 
-Exit code 9 means the repository doesn't have stacked PRs enabled.
+Exit code 9 means the repository doesn't have stacked PRs enabled. Code 6 means a branch belongs to more than one stack, or more than one remote is configured with no `remote.pushDefault` set. `link` takes `--remote` for that second case.
+
+Stack numbers and PR numbers come from one sequence per repository and never overlap. A bare number is unambiguous wherever a command takes either.
 
 ## Detection
 
@@ -21,10 +23,19 @@ Stack membership lives on the API, and this query answers with nothing checked o
 
 ```bash
 gh api graphql -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){stack{number size}}}}' \
-  -F owner=OWNER -F repo=REPO -F number=N
+  -F owner=<owner> -F repo=<repo> -F number=<n>
 ```
 
 `"stack": null` means the PR isn't stacked. Otherwise `number` is the stack number and `size` its PR count.
+
+To read the other layers, ask for the entries. `position` counts up from the base, so position 1 is the bottom of the stack and the layers below yours are the ones with a lower position.
+
+```bash
+gh api graphql -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){stackEntry{position stack{entries(first:50){nodes{position pullRequest{number state isDraft reviewDecision mergeStateStatus}}}}}}}}' \
+  -F owner=<owner> -F repo=<repo> -F number=<n>
+```
+
+There is no CI field here. `mergeStateStatus` is the proxy. `CLEAN` is mergeable and passing. `BLOCKED` is blocked by a rule or a missing review, `UNSTABLE` is a non-passing commit status, `DIRTY` is a conflict, and `BEHIND` is a stale head ref.
 
 ## Publishing
 
@@ -44,14 +55,14 @@ Open the PR yourself with `gh pr create --base <parent>` before linking whenever
 
 ## Merging
 
-`gh pr merge` does not work on a stacked PR. Use `gh stack merge`, which takes a stack number or a PR number (not a URL), resolving a bare number as a stack first.
+`gh pr merge` does not work on a stacked PR. Use `gh stack merge`, which takes a stack number or a PR number, never a URL.
 
 ```bash
-gh stack merge 42 --yes --squash  # everything up to and including PR #42
-gh stack merge 7 --yes --squash   # stack 7, no local checkout needed
+gh stack merge 42 --yes --<method>  # everything up to and including PR #42
+gh stack merge 7 --yes --<method>   # stack 7, no local checkout needed
 ```
 
-`--yes` runs it headlessly. Name the method too, since the default is whichever one you used last. With no argument it takes the stack for the current branch. Give it a number instead. The merge should not turn on what happens to be checked out.
+`--yes` runs it headlessly. Name the method rather than inheriting the default, which is whichever one you used last, and take it from the repo (`gh repo view --json squashMergeAllowed,mergeCommitAllowed,rebaseMergeAllowed`). With no argument it takes the stack for the current branch. Give it a number instead. The merge should not turn on what happens to be checked out.
 
 The merge is all-or-nothing across every PR at or below the target. One layer that can't merge sinks the call, and the reason comes back on stderr. Layers above stay open, and GitHub retargets and rebases them onto the new base.
 

--- a/plugins/github/skills/stack/SKILL.md
+++ b/plugins/github/skills/stack/SKILL.md
@@ -9,35 +9,69 @@ allowed-tools:
 
 # Stacked Pull Requests
 
-`gh stack` (the `github/gh-stack` extension) drives GitHub's native stacked PRs. It has two halves, and only one fits a layout where each branch lives in its own worktree.
+`gh stack` (the `github/gh-stack` extension) drives GitHub's native stacked PRs. The stack object on GitHub is the same either way, and so is the merge. What differs is where the branches live locally, which decides how the stack gets built and published.
 
-The remote half (`link`, `merge`, `unstack`) goes through the GitHub API and writes no local state. Use it. The local-tracking half (`init`, `add`, `submit`, `push`, `sync`, `rebase`, `checkout`, `modify`, and the navigation commands) assumes every layer is checked out in one working tree. Skip it and let whatever manages the branches own the rebases. `gh stack rebase` prints `✓ Rebased <branch>` and changes nothing when that branch is checked out in another worktree ([gh-stack#35](https://github.com/github/gh-stack/issues/35)).
+## Layouts
 
-Exit code 9 means the repository doesn't have stacked PRs enabled. Code 6 means a branch belongs to more than one stack, or more than one remote is configured with no `remote.pushDefault` set. `link` takes `--remote` for that second case.
+**Native tracking** keeps every layer checked out in one working tree. `gh stack` owns the branches, the rebases, and the publish. This is what the extension is built for, and it gets the interactive PR editor, cascading rebase, and one-command sync.
+
+**External tracking** keeps each layer somewhere else, typically its own worktree. Another tool owns the rebases and `gh stack link` publishes the result. `link` is documented for exactly this and writes no local state.
+
+Pick per stack. The choice can differ across stacks in one repository. Native tracking fits a stack you are actively reshaping, where reordering and folding layers matters more than working two layers at once. External tracking fits a stack whose layers are worked on in parallel or over a long stretch, where each layer wants its own checkout, editor, and running services.
+
+Read the current state with `gh stack view --short` (add `--json` to parse it). It answers from local tracking. Output means native tracking, and an error means the stack is not tracked here. That is a statement about this clone, not about GitHub: a stack published by `link` is real on GitHub and still absent from `view`.
+
+Don't mix them for one stack. The local-tracking commands silently under-perform against branches they can't check out. `gh stack rebase` prints `✓ Rebased <branch>` and changes nothing when that branch is checked out in a different worktree ([gh-stack#35](https://github.com/github/gh-stack/issues/35)).
+
+Exit code 9 means the repository doesn't have stacked PRs enabled. Code 6 means a branch belongs to more than one stack, or more than one remote is configured with no `remote.pushDefault` set. `link`, `submit`, `push`, and `sync` take `--remote` for that second case.
 
 Stack numbers and PR numbers come from one sequence per repository and never overlap. A bare number is unambiguous wherever a command takes either.
 
 ## Detection
 
-Stack membership lives on the API, and this query answers with nothing checked out. `gh pr view` has no stack field, and `gh stack view` reads local tracking state a worktree layout never has.
+Stack membership lives on the API. This query answers with nothing checked out and under either layout, which makes it the right check for anything holding a PR number rather than a branch.
 
 ```bash
 gh api graphql -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){stack{number size}}}}' \
   -F owner=<owner> -F repo=<repo> -F number=<n>
 ```
 
-`"stack": null` means the PR isn't stacked. Otherwise `number` is the stack number and `size` its PR count.
+`"stack": null` means the PR isn't stacked. Otherwise `number` is the stack number and `size` its PR count. `gh pr view` has no stack field. This query is the only PR-level answer.
 
-To read the other layers, ask for the entries. `position` counts up from the base, so position 1 is the bottom of the stack and the layers below yours are the ones with a lower position.
+To read the other layers, ask for the entries. `position` counts up from the base, so position 1 is the bottom and the layers below yours are the ones with a lower position.
 
 ```bash
 gh api graphql -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){stackEntry{position stack{entries(first:50){nodes{position pullRequest{number state isDraft reviewDecision mergeStateStatus}}}}}}}}' \
   -F owner=<owner> -F repo=<repo> -F number=<n>
 ```
 
-There is no CI field here. `mergeStateStatus` is the proxy. `CLEAN` is mergeable and passing. `BLOCKED` is blocked by a rule or a missing review, `UNSTABLE` is a non-passing commit status, `DIRTY` is a conflict, and `BEHIND` is a stale head ref.
+There is no CI field here. `mergeStateStatus` is the proxy. `CLEAN` is mergeable with checks passing. `BLOCKED` is blocked by a rule or a missing review, `UNSTABLE` is a non-passing commit status, `DIRTY` is a conflict, and `BEHIND` is a stale head ref.
 
-## Publishing
+## Native Tracking
+
+Build the stack with `init` and `add`. `init` adopts branches that exist and creates the ones that don't, bottom to top.
+
+```bash
+gh stack init auth-layer api-routes ui-components  # adopt or create a whole stack
+gh stack init --base develop my-feature            # non-default trunk
+gh stack add -Am "Add rate limiting" rate-limits   # new layer on top, committing staged work
+```
+
+`gh stack submit` pushes every branch, opens the missing PRs, fixes the bases, and creates or updates the stack object. Interactively it opens a single-screen editor to write each new PR's title, description, and draft state before submitting them together. Use it whenever the bodies matter, which is most of the time.
+
+Non-interactively, and with `--auto`, it skips the editor and auto-generates titles. It also creates new PRs as **drafts**. Pass `--open` to get PRs that are ready for review.
+
+`gh stack sync` is the maintenance command: fetch, reconcile against the stack on GitHub, fast-forward the trunk, cascade-rebase each branch onto its parent, push atomically with `--force-with-lease`, and link the open PRs into a stack once two exist. It never opens PRs. `--prune` deletes local branches for merged PRs, which is the cleanup after a stack lands.
+
+Use the narrower commands when sync is too much: `gh stack rebase` for the cascading rebase alone (`--downstack`, `--upstack`, `--no-trunk`, and `--continue` / `--abort` around conflicts), and `gh stack push` to push without rebasing. `push` is per-branch and not atomic. A rejected branch leaves the ones before it already updated.
+
+`gh stack modify` restructures the stack interactively: drop, fold, insert, reorder, rename. Run `submit` afterward, since it changes local branches and leaves GitHub behind.
+
+Move around with `gh stack checkout` (bare, for a picker over local and remote stacks), plus `up`, `down`, `top`, `bottom`, `trunk`, and `switch`.
+
+## External Tracking
+
+Let the other tool rebase and push the whole stack first. `link` pushes without force. It rejects a branch whose remote copy has diverged, which is every branch immediately after a rebase.
 
 `gh stack link` takes branches, PR numbers, or PR URLs bottom to top. It pushes each branch, opens a PR for any branch missing one, corrects the base of any PR whose base breaks the chain, and creates or updates the stack object.
 
@@ -47,15 +81,13 @@ gh stack link 7 ui-polish                           # append to stack 7
 gh stack link --base develop auth-layer api-routes  # non-default trunk
 ```
 
-`link` needs at least two arguments, or a stack number plus what to append, and only ever adds to a stack.
+It needs at least two arguments, or a stack number plus what to append, and only ever adds to a stack. `--open` marks new and existing PRs ready for review.
 
-Rebase and push the whole stack first. `link` pushes without force. A freshly rebased branch is rejected.
-
-Open the PR yourself with `gh pr create --base <parent>` before linking whenever the title and body matter. `link` reuses an open PR when it finds one, and auto-generates a title from the commit subject or branch name for the ones it creates.
+Open the PR yourself with `gh pr create --base <parent>` before linking whenever the title and body matter. `link` reuses an open PR when it finds one, and auto-generates a title from the commit subject or branch name for the ones it creates. There is no editor here, which is the main thing `submit` has that `link` doesn't.
 
 ## Merging
 
-`gh pr merge` does not work on a stacked PR. Use `gh stack merge`, which takes a stack number or a PR number, never a URL.
+`gh pr merge` does not work on a stacked PR. Use `gh stack merge`, which takes a stack number or a PR number, never a URL, and works under either layout.
 
 ```bash
 gh stack merge 42 --yes --<method>  # everything up to and including PR #42
@@ -64,8 +96,14 @@ gh stack merge 7 --yes --<method>   # stack 7, no local checkout needed
 
 `--yes` runs it headlessly. Name the method rather than inheriting the default, which is whichever one you used last, and take it from the repo (`gh repo view --json squashMergeAllowed,mergeCommitAllowed,rebaseMergeAllowed`). With no argument it takes the stack for the current branch. Give it a number instead. The merge should not turn on what happens to be checked out.
 
-The merge is all-or-nothing across every PR at or below the target. One layer that can't merge sinks the call, and the reason comes back on stderr. Layers above stay open, and GitHub retargets and rebases them onto the new base.
+The merge is all-or-nothing across every PR at or below the target. One layer that can't merge sinks the call, and the reason comes back on stderr. Layers above stay open, and GitHub retargets and rebases them onto the new base. Pull that down afterward (`gh stack sync` under native tracking, the external tool otherwise), because every open layer is stale locally until you do.
 
 Only open-and-not-draft state is checked before submitting. GitHub evaluates branch protection and repository rules when the merge runs, and those requirements can't be bypassed for a stack.
 
 When the base branch uses a merge queue, the stack goes on the queue instead of merging directly. The queue picks the method and ignores any method flag with a warning, and the PRs enter together but land as the queue processes them, possibly in separate groups.
+
+## Switching Layouts
+
+`gh stack checkout <stack-number>` adopts a stack that exists only on GitHub: it queries the API, fetches the branches, and sets up local tracking. This is how a stack published by `link` becomes natively tracked, and it wants a working tree the branches can all be checked out in.
+
+`gh stack unstack --local` drops local tracking and leaves the stack on GitHub, which is the reverse. Without `--local`, `unstack` also unstacks on GitHub, and takes a stack number to do that from anywhere. GitHub keeps PRs stacked when they are queued or have auto-merge enabled.

--- a/plugins/pull-request/skills/babysit/SKILL.md
+++ b/plugins/pull-request/skills/babysit/SKILL.md
@@ -12,6 +12,7 @@ allowed-tools:
   - Bash(bunx:*)
   - Bash(gh:*)
   - Skill(pull-request:follow-up)
+  - Skill(github:stack)
   - Skill(gitlab:merge-request)
   - Skill(git:conflicts)
   - mcp__github

--- a/plugins/pull-request/skills/babysit/merge-mode.md
+++ b/plugins/pull-request/skills/babysit/merge-mode.md
@@ -22,21 +22,17 @@ Submit by the most automated path the repo allows (merge queue/train, else auto-
 
 Load `github:stack` for the full command surface. Submit with `gh stack merge <pr-number> --yes --squash`, which merges every PR at or below this one atomically and leaves the layers above open for GitHub to retarget and rebase. Match the method to the repo the same way as the unstacked path.
 
-Run the pre-flight block check against every PR at or below this one. The merge is all-or-nothing. A lower layer that is red, draft, or short an approval sinks the whole call. Read the members from the stack `entries` and check each with `position` at or below yours:
-
-```
-gh api graphql -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){stackEntry{position stack{entries(first:50){nodes{position pullRequest{number state isDraft reviewDecision mergeStateStatus}}}}}}}}' -F owner=<owner> -F repo=<repo> -F number=<n>
-```
+Run the pre-flight block check against every PR at or below this one. The merge is all-or-nothing. A lower layer that is draft, short an approval, or blocked on its own checks sinks the whole call. `github:stack` has the entries query and what `position` and `mergeStateStatus` mean.
 
 A block on another layer is unrecoverable from here: babysit watches one PR and can't fix a sibling's CI. Report which layer blocks and `TaskStop`.
 
-The watcher still follows this PR alone. `merged` means this PR landed and stays the success terminal. Under a merge queue the stack enters as a unit and lands as the queue processes it, possibly in separate groups. Treat lower layers merging first as progress and keep waiting for the watcher's own terminal. A warning that the queue ignored the method flag reports the queue picking its own method, and the submit stands.
+The watcher still follows this PR alone. `merged` means this PR landed and stays the success terminal. Under a merge queue the stack enters as a unit and lands as the queue processes it, possibly in separate groups. Treat lower layers merging first as progress and keep waiting for the watcher's own terminal. The queue also picks its own merge method and warns that it ignored the flag you passed, which is a successful submit rather than a rejection.
 
 ## Re-arm
 
 A push drops the PR from the merge mechanism (GitLab: off the train; GitHub: clears queued auto-merge) and fires **no monitor event**. So after **every** push in Merge Mode, re-submit by the same path as the initial submit above instead of waiting. Each re-arm counts toward the 3-attempt oscillation guard below.
 
-A stacked PR re-arms on the next `status: success` instead. `gh stack merge` submits immediately and has no `--auto` to arm ahead of green. Run it straight after a push and it either fails the branch-protection check or lands unverified code. The push has already dropped the stack from any queue it was in and nothing is waiting on it. The delay costs only the CI wait that would have happened anyway. It still counts as an attempt.
+On a stacked PR, don't re-submit after the push. Wait for the watcher's next `status: success` and re-submit there. `gh stack merge` submits immediately and has no `--auto` to arm ahead of green, so running it straight after a push either fails the branch-protection check or lands unverified code. The push has already dropped the stack from any queue it was in and nothing is waiting on it. The wait still counts as an attempt.
 
 Then watch the merge through the monitor rather than polling by hand: invoke the provider's monitor skill again on the PR and react to its events. The watcher enforces the interval and the wall clock, so this phase stays bounded like the CI wait (see [Bounds](SKILL.md#bounds)) and babysit owns no loop here. React to:
 

--- a/plugins/pull-request/skills/babysit/merge-mode.md
+++ b/plugins/pull-request/skills/babysit/merge-mode.md
@@ -4,14 +4,39 @@ Load this when babysit runs with `--merge`. Don't stop at green: drive the PR to
 
 First confirm the PR can merge on its own. Don't bypass blocks you can't resolve: missing **human** approval (you can't self-approve; if a bot was the blocker and `--reviews` ran, it's already handled), branch protection, draft state, or requested changes. Report and `TaskStop`. Read state via `gh pr view --json mergeable,mergeStateStatus,reviewDecision,state` (GitLab: `gitlab:merge-request`).
 
+On GitHub, check stack membership before submitting, because `gh pr merge` does not work on a stacked PR:
+
+```
+gh api graphql -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){stack{number size}}}}' -F owner=<owner> -F repo=<repo> -F number=<n>
+```
+
+`"stack": null` takes the unstacked path below. Anything else routes to [Stacked PRs](#stacked-prs).
+
 Submit by the most automated path the repo allows (merge queue/train, else auto-merge, else direct, valid since CI is green):
 
-- **GitHub**: `gh pr merge <pr-url> --auto --squash` enables auto-merge or queues the PR. If `--auto` is rejected, merge directly: `gh pr merge <pr-url> --squash`. Prefer squash → merge → rebase per `gh repo view --json squashMergeAllowed,mergeCommitAllowed,rebaseMergeAllowed`.
+- **GitHub, unstacked**: `gh pr merge <pr-url> --auto --squash` enables auto-merge or queues the PR. If `--auto` is rejected, merge directly: `gh pr merge <pr-url> --squash`. Prefer squash → merge → rebase per `gh repo view --json squashMergeAllowed,mergeCommitAllowed,rebaseMergeAllowed`.
+- **GitHub, stacked**: see [Stacked PRs](#stacked-prs).
 - **GitLab**: delegate to the `gitlab:merge-request` skill.
+
+## Stacked PRs
+
+Load `github:stack` for the full command surface. Submit with `gh stack merge <pr-number> --yes --squash`, which merges every PR at or below this one atomically and leaves the layers above open for GitHub to retarget and rebase. Match the method to the repo the same way as the unstacked path.
+
+Run the pre-flight block check against every PR at or below this one. The merge is all-or-nothing. A lower layer that is red, draft, or short an approval sinks the whole call. Read the members from the stack `entries` and check each with `position` at or below yours:
+
+```
+gh api graphql -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){stackEntry{position stack{entries(first:50){nodes{position pullRequest{number state isDraft reviewDecision mergeStateStatus}}}}}}}}' -F owner=<owner> -F repo=<repo> -F number=<n>
+```
+
+A block on another layer is unrecoverable from here: babysit watches one PR and can't fix a sibling's CI. Report which layer blocks and `TaskStop`.
+
+The watcher still follows this PR alone. `merged` means this PR landed and stays the success terminal. Under a merge queue the stack enters as a unit and lands as the queue processes it, possibly in separate groups. Treat lower layers merging first as progress and keep waiting for the watcher's own terminal. A warning that the queue ignored the method flag reports the queue picking its own method, and the submit stands.
 
 ## Re-arm
 
 A push drops the PR from the merge mechanism (GitLab: off the train; GitHub: clears queued auto-merge) and fires **no monitor event**. So after **every** push in Merge Mode, re-submit by the same path as the initial submit above instead of waiting. Each re-arm counts toward the 3-attempt oscillation guard below.
+
+A stacked PR re-arms on the next `status: success` instead. `gh stack merge` submits immediately and has no `--auto` to arm ahead of green. Run it straight after a push and it either fails the branch-protection check or lands unverified code. The push has already dropped the stack from any queue it was in and nothing is waiting on it. The delay costs only the CI wait that would have happened anyway. It still counts as an attempt.
 
 Then watch the merge through the monitor rather than polling by hand: invoke the provider's monitor skill again on the PR and react to its events. The watcher enforces the interval and the wall clock, so this phase stays bounded like the CI wait (see [Bounds](SKILL.md#bounds)) and babysit owns no loop here. React to:
 

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -110,14 +110,18 @@ If `--dry-run` (or `--body-only`) is set, follow [Dry Run](#dry-run) instead of 
 
 A branch whose parent is another topic branch rather than the default branch is a stack layer, and its PR has to target that parent. `--base <ref>` names the parent, and so does the user saying what this branch sits on. Nothing else does: the branch's own upstream ref points at its remote copy, not its parent. Without either signal, open against the default branch.
 
-On GitHub, create the PR with `--base <parent>`, then chain it into the stack:
+On GitHub, create the PR with `--base <parent>`, then chain it into the stack. Which form to use depends on whether the parent is already stacked, so run `github:stack`'s detection query against the parent's PR first:
 
 ```
-gh stack link <bottom> ... <this-branch>   # bottom to top, creates or updates the stack
-gh stack link <stack-number> <this-branch> # append to an existing stack
+gh stack link <stack-number> <this-branch> # parent is in a stack: append to it
+gh stack link <bottom> ... <this-branch>   # parent isn't: list the chain bottom to top
 ```
 
-Creating the PR first preserves the drafted title and body. `link` reuses the open PR it finds and would otherwise auto-generate both. Load `github:stack` for detection, merge behavior, and the local-tracking commands to avoid.
+Under one worktree per branch there's no local view of the chain, so the query is the only way to tell. Creating the PR first preserves the drafted title and body. `link` reuses the open PR it finds and would otherwise auto-generate both.
+
+Exit code 9 means the repo doesn't have stacked PRs enabled. Leave the PR as it is: `--base <parent>` already targets the right branch, and with no stack object the merge takes the ordinary `gh pr merge` path. Say so and move on.
+
+Load `github:stack` for the queries, merge behavior, and the local-tracking commands to avoid.
 
 ## GitLab Notes
 

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -110,18 +110,20 @@ If `--dry-run` (or `--body-only`) is set, follow [Dry Run](#dry-run) instead of 
 
 A branch whose parent is another topic branch rather than the default branch is a stack layer, and its PR has to target that parent. `--base <ref>` names the parent, and so does the user saying what this branch sits on. Nothing else does: the branch's own upstream ref points at its remote copy, not its parent. Without either signal, open against the default branch.
 
-On GitHub, create the PR with `--base <parent>`, then chain it into the stack. Which form to use depends on whether the parent is already stacked, so run `github:stack`'s detection query against the parent's PR first:
+On GitHub, create the PR with `--base <parent>`, then chain it into the stack with `gh stack link`. Creating it first is what preserves the drafted title and body: `link` reuses the open PR it finds, and auto-generates both for PRs it opens itself. The native alternative, `gh stack submit`, prompts for them in a full-screen editor no tool call can drive.
+
+Which form of `link` to use depends on whether the parent is already stacked. `gh stack view --short` answers when the stack is tracked in this working tree, and `github:stack`'s detection query answers against the parent's PR either way.
 
 ```
 gh stack link <stack-number> <this-branch> # parent is in a stack: append to it
 gh stack link <bottom> ... <this-branch>   # parent isn't: list the chain bottom to top
 ```
 
-Under one worktree per branch there's no local view of the chain, so the query is the only way to tell. Creating the PR first preserves the drafted title and body. `link` reuses the open PR it finds and would otherwise auto-generate both.
+`link` writes no local tracking state. It works whether or not `gh stack` owns the branches here. On a tracked stack the next `gh stack sync` reconciles the new PR into local state.
 
 Exit code 9 means the repo doesn't have stacked PRs enabled. Leave the PR as it is: `--base <parent>` already targets the right branch, and with no stack object the merge takes the ordinary `gh pr merge` path. Say so and move on.
 
-Load `github:stack` for the queries, merge behavior, and the local-tracking commands to avoid.
+Load `github:stack` for the two layouts, the queries, and the merge behavior.
 
 ## GitLab Notes
 

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -4,17 +4,19 @@ description: |
   Create a pull request, merge request, or change request with proper formatting and content guidelines.
   Invoke when the user wants to create, open, or submit a PR, MR, or CR, including after committing changes.
 
-argument-hint: "[--draft] [--auto] [--watch] [--dry-run]"
+argument-hint: "[--draft] [--auto] [--watch] [--base <ref>] [--dry-run]"
 allowed-tools:
   - mcp__github
   - Agent
   - Skill(pull-request:babysit)
   - Skill(pull-request:follow-up)
+  - Skill(github:stack)
   - "Bash(git add:*)"
   - "Bash(git commit:*)"
   - "Bash(git push:*)"
   - "Bash(git remote get-url:*)"
   - "Bash(gh pr:*)"
+  - "Bash(gh stack:*)"
   - "Bash(glab mr:*)"
   - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/*)"
 ---
@@ -72,6 +74,7 @@ Parse `$ARGUMENTS` for these flags. With none, create a normal PR/MR that is rea
 - `--draft`: open the PR/MR as a draft. Default: ready for review.
 - `--auto`: after creating, enable auto-merge so it merges once checks pass and required approvals land. Default: off.
 - `--watch`: after creating, spawn `pull-request:babysit` to actively shepherd the PR/MR (fix trivial red CI, drive the merge). When a bot review should gate the merge (asked to wait for a reviewer, or a review bot is configured on the repo), add `--reviews` so babysit hands the wait to `follow-up --auto`; a needless `--reviews` costs only one no-op hand-off. Distinct from `--auto`, which only flips on the platform's passive auto-merge. Default: off.
+- `--base <ref>`: parent branch for a stack layer. See [Stacking](#stacking). Default: the repo's default branch.
 - `--dry-run` (alias `--body-only`): produce the body without creating anything. See [Dry Run](#dry-run). Default: off.
 
 ## Dry Run
@@ -94,11 +97,27 @@ If `--dry-run` (or `--body-only`) is set, follow [Dry Run](#dry-run) instead of 
    - Write the body in its own Bash call, then create in a second call that starts with `gh`/`glab`. The body-validation hook matches on that leading verb, so anything in front of it (a `cd`, a chained heredoc that writes the body, an env assignment) skips validation silently. Never `cd` to the directory you are already in
    - **GitHub**: `gh pr create --title "..." --body-file tmp/pr-body-<branch>.md`
    - **GitLab**: `glab mr create --title "..." --description "$(cat tmp/pr-body-<branch>.md)"`
+   - Add `--base <parent>` on either when the branch is a stack layer (see [Stacking](#stacking))
+1. Link the stack when the branch is a GitHub stack layer, after the PR exists. See [Stacking](#stacking).
 1. Enable auto-merge when `--auto` is set, after the PR/MR exists:
    - **GitHub**: `gh pr merge --auto` (add `--squash` or `--rebase` to match the repo's merge method when known)
+   - **GitHub, stacked**: auto-merge has no equivalent. Say so and suggest `--watch`, which drives the stack merge at green.
    - **GitLab**: load `gitlab:merge-request` and run its `merge.ts --auto-merge`, which handles merge trains and falls back to `glab mr merge` as needed
 1. Suggest reviewers on corporate repos (see [Reviewers](#reviewers)). Skip this step for OSS.
 1. Watch the PR/MR when `--watch` is set. Spawn a background `Agent` that invokes `pull-request:babysit <url> --merge` (add `--reviews` per the flag above). Babysit is session-scoped and owns its own `Monitor` watcher, so the backgrounded Agent gives it a session to live in while create returns immediately.
+
+## Stacking
+
+A branch whose parent is another topic branch rather than the default branch is a stack layer, and its PR has to target that parent. `--base <ref>` names the parent, and so does the user saying what this branch sits on. Nothing else does: the branch's own upstream ref points at its remote copy, not its parent. Without either signal, open against the default branch.
+
+On GitHub, create the PR with `--base <parent>`, then chain it into the stack:
+
+```
+gh stack link <bottom> ... <this-branch>   # bottom to top, creates or updates the stack
+gh stack link <stack-number> <this-branch> # append to an existing stack
+```
+
+Creating the PR first preserves the drafted title and body. `link` reuses the open PR it finds and would otherwise auto-generate both. Load `github:stack` for detection, merge behavior, and the local-tracking commands to avoid.
 
 ## GitLab Notes
 

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -70,7 +70,7 @@ I use Worktrunk (the `wt` CLI) for git worktrees, exposed through two skills:
 
 I work in stacks routinely. Each branch lives in its own Worktrunk worktree (see Worktrees above). Restack with `wt sync`, a custom extension that rebases each branch onto its parent in dependency order. Useful flags: `--fetch` to pull the base first, `--push` to update remotes after rebasing, `--prune` to remove integrated worktrees. Run `wt sync --dry-run` to preview the plan.
 
-`wt sync` owns the local side and GitHub owns the published side. `gh stack link <bottom> ... <top>` chains the PR bases and creates the stack object without writing local tracking state, which is what makes it fit one worktree per branch. Run `wt sync --push` first, since `link` pushes without force. `gh stack merge <pr-number>` lands everything up to that PR atomically and leaves the layers above for GitHub to retarget, and a stack number works with nothing checked out. `gh pr merge` does not work on a stacked PR. Skip the local-tracking half of `gh stack` (`init`, `add`, `checkout`, `sync`, `rebase`, `submit`, and the navigation commands): it assumes the whole stack sits in one working tree. Load `github:stack` before any `gh stack` command, `gitlab:merge-request` for the GitLab equivalent.
+`wt sync` owns the local side. GitHub owns the published side, through `gh stack link` and `gh stack merge`. Run `wt sync --push` before linking, and `wt sync --fetch` after a merge, since GitHub rebases the layers left open and every one of them is a stale worktree until you pull. Most of `gh stack` assumes the whole stack sits in one working tree and is wrong here, so load `github:stack` before any `gh stack` command. `gitlab:merge-request` is the GitLab equivalent.
 
 ## Personal Details
 

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -68,9 +68,12 @@ I use Worktrunk (the `wt` CLI) for git worktrees, exposed through two skills:
 
 ## Stacked PRs
 
-I work in stacks routinely. Each branch lives in its own Worktrunk worktree (see Worktrees above). Restack with `wt sync`, a custom extension that rebases each branch onto its parent in dependency order. Useful flags: `--fetch` to pull the base first, `--push` to update remotes after rebasing, `--prune` to remove integrated worktrees. Run `wt sync --dry-run` to preview the plan.
+I work in stacks routinely, in one of two layouts, chosen per stack. Load `github:stack` before any `gh stack` command. `gitlab:merge-request` is the GitLab equivalent.
 
-`wt sync` owns the local side. GitHub owns the published side, through `gh stack link` and `gh stack merge`. Run `wt sync --push` before linking, and `wt sync --fetch` after a merge, since GitHub rebases the layers left open and every one of them is a stale worktree until you pull. Most of `gh stack` assumes the whole stack sits in one working tree and is wrong here, so load `github:stack` before any `gh stack` command. `gitlab:merge-request` is the GitLab equivalent.
+- A worktree per branch (see Worktrees above) suits layers I work on in parallel or over a long stretch. `wt sync` rebases each branch onto its parent in dependency order: `--fetch` to pull the base first, `--push` to update remotes, `--prune` to remove integrated worktrees, `--dry-run` to preview the plan. Publish with `gh stack link`, after `wt sync --push`, because `link` pushes without force.
+- One worktree holding the whole stack suits a stack I'm actively reshaping, where reordering and folding layers matters more than working two layers at once. `gh stack` owns it end to end, and `gh stack sync` covers what `wt sync` and `gh stack link` do together in the other layout.
+
+Don't mix the two within one stack. The local-tracking commands silently do nothing to a branch checked out in another worktree. `gh stack merge` merges either layout. Pull the surviving layers afterward, since GitHub rebases everything left open above the merge.
 
 ## Personal Details
 

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -70,6 +70,8 @@ I use Worktrunk (the `wt` CLI) for git worktrees, exposed through two skills:
 
 I work in stacks routinely. Each branch lives in its own Worktrunk worktree (see Worktrees above). Restack with `wt sync`, a custom extension that rebases each branch onto its parent in dependency order. Useful flags: `--fetch` to pull the base first, `--push` to update remotes after rebasing, `--prune` to remove integrated worktrees. Run `wt sync --dry-run` to preview the plan.
 
+`wt sync` owns the local side and GitHub owns the published side. `gh stack link <bottom> ... <top>` chains the PR bases and creates the stack object without writing local tracking state, which is what makes it fit one worktree per branch. Run `wt sync --push` first, since `link` pushes without force. `gh stack merge <pr-number>` lands everything up to that PR atomically and leaves the layers above for GitHub to retarget, and a stack number works with nothing checked out. `gh pr merge` does not work on a stacked PR. Skip the local-tracking half of `gh stack` (`init`, `add`, `checkout`, `sync`, `rebase`, `submit`, and the navigation commands): it assumes the whole stack sits in one working tree. Load `github:stack` before any `gh stack` command, `gitlab:merge-request` for the GitLab equivalent.
+
 ## Personal Details
 
 - Standard username: `@bendrucker`. Refer to any actions performed by this user as "you."

--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -79,6 +79,8 @@ The commit sits on `HEAD`, so the fast-forward is clean. It runs in the Agent to
 
 Join the background `plan:review` first if it was gated in. Act on fix-worthy drift before the PR exists, and carry any deferred follow-ups into the report. Then `pull-request:create` commits the working-tree fixes, pushes, opens the PR. Capture the URL: babysit and body-refresh need it.
 
+Pass `--base <parent>` through when `/ship --base` named a stack parent. Create needs it to target the PR at the parent and to link the layer into the stack on GitHub. Without it the PR opens against the default branch and carries every lower layer's diff.
+
 ## Babysit
 
 `pull-request:babysit <url>` watches CI and fixes trivial failures to green.


### PR DESCRIPTION
GitHub shipped [stacked pull requests](https://github.blog/changelog/2026-07-30-stacked-pull-requests-are-now-in-public-preview/) on 2026-07-30. `gh pr merge` does not work on a stacked PR, and it is the primary merge path in both babysit's merge mode and `pull-request:create`, so either would have failed the first time a stack existed on GitHub.

## Two Layouts

`gh stack` splits into a remote half (`link`, `merge`, `unstack`) that goes through the API and writes no local state, and a local-tracking half (`init`, `add`, `submit`, `push`, `sync`, `rebase`, `checkout`, `modify`, navigation) that assumes every layer of the stack is checked out in one working tree.

Both are supported here, chosen per stack rather than per repository. Native tracking fits a stack under active reshaping, where reordering and folding layers matters more than working two layers at once. External tracking fits layers worked on in parallel or over a long stretch, where each wants its own checkout and running services. `gh stack checkout <stack-number>` adopts a stack that exists only on GitHub, and `gh stack unstack --local` drops tracking without touching it, so a stack can move between them.

What doesn't work is mixing them within one stack. `gh stack rebase` prints `✓ Rebased <branch>` and does nothing when that branch is checked out elsewhere ([gh-stack#35](https://github.com/github/gh-stack/issues/35), still open at v0.1.0).

`user/CLAUDE.md` previously stated one worktree per branch as a flat fact and `wt sync` as the only restack path. It now presents both layouts with what each is good for. `wt sync` plus `gh stack link` and `gh stack sync` are the two halves of the same job.

## Skill Placement

The reference lives at `plugins/github/skills/stack/` as a skill, not as a `stack.md` under `plugins/pull-request/skills/create/`. Two skills in different plugins consume it: `create` publishes the stack and `babysit` merges it, and a reference file under `create/` would need a cross-skill relative path to reach babysit. It mirrors the split this repo already has on GitLab, where `glab stack` mechanics live in `gitlab:merge-request` and the platform-agnostic `pull-request` plugin delegates per platform. A skill is also model-invocable, so "stack these branches" routes to it directly.

## Detection

Under native tracking `gh stack view --short` answers locally. Anything holding a PR number instead of a branch needs the API, and `gh pr view` has no stack field, so detection goes through GraphQL: `pullRequest.stack` returns null when unstacked, and `pullRequest.stackEntry.stack.entries` enumerates the other layers for babysit's pre-flight check. That query is layout-independent, which is why babysit uses it.

## Merge Mode

`gh stack merge` is all-or-nothing across every PR at or below the target, so the pre-flight block check widens from the watched PR to every layer below it. A sibling that is draft or short an approval sinks the whole call, and babysit can't fix another layer's CI, so that case reports and stops.

Re-arm splits by stack membership. `gh stack merge` submits immediately and has no `--auto` to arm ahead of green, so re-submitting straight after a push either fails the branch-protection check or lands unverified code. A stacked PR re-arms at the next `status: success`.

Under a merge queue the stack enters as a unit but lands as the queue processes it, possibly in separate groups. The watcher follows one PR, so its `merged` still means that PR landed and stays the terminal. Lower layers landing first counts as progress and the wait continues.

## Base Branch

`--base <parent>` now threads from `/ship` through `pull-request:create` to `gh pr create`, which a stack layer needs so its PR targets the parent and carries only its own diff. Create opens the PR before calling `gh stack link` so the drafted title and body survive. `link` auto-generates both for PRs it opens itself, and `gh stack submit` collects them in a full-screen editor no tool call can drive, so `gh pr create` stays the path under either layout. On a repo without stacked PRs enabled `link` exits 9, and create leaves the PR alone: the base is already right and the merge takes the ordinary `gh pr merge` path.

Every command and flag is checked against `gh stack <cmd> --help` at v0.1.0, and the GraphQL fields against live schema introspection. Worth knowing from that pass: `gh stack sync` also links open PRs into a stack once two exist, and both `gh stack submit --auto` and `gh stack link` create PRs as drafts unless passed `--open`.
