### PR TITLE
settings: restore moshi-hook agent hooks

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -109,6 +109,15 @@
             "timeout": 86400
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "async": false,
+            "command": "'/opt/homebrew/bin/moshi-hook' claude-hook",
+            "type": "command"
+          }
+        ]
       }
     ],
     "PostCompact": [
@@ -130,6 +139,26 @@
             "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "'/opt/homebrew/bin/moshi-hook' claude-hook",
+            "type": "command"
+          }
+        ],
+        "matcher": "AskUserQuestion"
+      },
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "'/opt/homebrew/bin/moshi-hook' claude-hook",
+            "type": "command"
+          }
+        ],
+        "matcher": "ExitPlanMode"
       }
     ],
     "PreCompact": [
@@ -170,6 +199,26 @@
             "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "'/opt/homebrew/bin/moshi-hook' claude-hook",
+            "type": "command"
+          }
+        ],
+        "matcher": "AskUserQuestion"
+      },
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "'/opt/homebrew/bin/moshi-hook' claude-hook",
+            "type": "command"
+          }
+        ],
+        "matcher": "ExitPlanMode"
       }
     ],
     "SessionEnd": [
@@ -178,6 +227,15 @@
           {
             "type": "command",
             "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "'/opt/homebrew/bin/moshi-hook' claude-hook",
+            "type": "command"
           }
         ]
       }
@@ -201,6 +259,15 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "'/opt/homebrew/bin/moshi-hook' claude-hook",
+            "type": "command"
+          }
+        ]
       }
     ],
     "Stop": [
@@ -209,6 +276,15 @@
           {
             "type": "command",
             "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "'/opt/homebrew/bin/moshi-hook' claude-hook",
+            "type": "command"
           }
         ]
       }
@@ -263,6 +339,15 @@
           {
             "type": "command",
             "command": "bun ~/.claude/hooks/session-limit"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "'/opt/homebrew/bin/moshi-hook' claude-hook",
+            "type": "command"
           }
         ]
       }


### PR DESCRIPTION
Restores the hook entries `moshi-hook install` writes for Claude Code, removed in #842 because the phone notifications were too noisy. moshi is worth another try: it detects herdr as a first-class terminal environment (`$HERDR_ENV=1` → `kind=herdr` in `moshi-hook context`), which makes it the only iOS client that understands the multiplexer I actually use.

Regenerated against moshi-hook 0.2.68 instead of reverting #842, since the hook set has grown since #748. New: `PreToolUse` matchers for `AskUserQuestion` and `ExitPlanMode`, and `SessionEnd`. The `PermissionRequest` entry no longer carries a 300s timeout, so it falls back to the harness default.

The installer still can't write through the `~/.claude/settings.json` symlink. It creates a temp file next to the target and renames over it, replacing the symlink with a forked copy, the same trap #748 hit. I ran the installer against a backup, extracted the nine moshi entries, restored the symlink, and hand-ported them here in the installer's key order so the drift check compares equal.

Notification volume is not tunable from this file. `moshi-hook set` exposes only `always-on-discovery`, and installing a subset of the hooks makes `moshi-hook status` report the config stale, which invites the installer to clobber the symlink again. Muting has to happen in the iOS app.

## Testing

- Deployed the file and confirmed `moshi-hook status` reports `claude current` against `~/.claude/settings.json`, with the symlink intact
- `jq` comparison of the nine moshi entries against the installer's own output shows no structural difference
- `bun run format:check` and `bun run schemas check` pass

The `rjyo/moshi` tap and formula are already back in the dotfiles Brewfile, and the daemon is paired and running. One caveat surfaced by `moshi-hook status`: the host is attached to an inactive Moshi Pro license, so approval round-trips may not work until that's reactivated.
