### PR TITLE
hooks: background pure side-effect hooks

### DIFF
--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -12,6 +12,18 @@ Raw `git worktree add` is denied in favor of the `worktrunk` skill, except under
 
 Wrap `${CLAUDE_PLUGIN_ROOT}` in double quotes in shell-form hook commands: `bun "${CLAUDE_PLUGIN_ROOT}/scripts/foo.ts"`. Matcher fields are not shell commands and should not be quoted. Run `bun scripts/check-hook-quoting.ts` to validate.
 
+## Async
+
+The `claude-code:hook` skill covers `async` and `asyncRewake`: what they drop, which events kill or outlive a backgrounded process, and when to use them. Read it before marking a hook async here.
+
+In this repo only the vibe-island bridge and the herdr state export in `user/settings.json` qualify. Everything else gates a call or emits `hookSpecificOutput`, including every hook in `plugins/*/hooks/hooks.json`. Three of the bridge's 14 entries stay synchronous:
+
+- `Stop`, because backgrounded `Stop` hooks are killed before they finish. Measured, and the reason the skill calls the event out.
+- `StopFailure`, which shares the same stop path. Left synchronous for that reason rather than a measurement of its own.
+- `PermissionRequest`, because the bridge blocks there to return a remote `permissionDecision`. That is what its 86400s timeout is for, and it follows from the general rule against backgrounding a hook that emits output.
+
+`plugins/tmux/hooks/notification.ts` is not a notifier, despite the name. Its three hooks do a read-modify-write on shared tmux options and depend on completing in event order, so backgrounding any of them races the others.
+
 ## MCP Matchers
 
 Hook matchers for MCP tools must include all three naming patterns (local, plugin, Claude AI). Run `bun scripts/check-mcp-matchers.ts` to validate. See [`plugins.md`](plugins.md) for the patterns and known display-name mappings.

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -7,6 +7,8 @@ paths:
 
 User-level settings live in `user/settings.json` (plugins, permissions, sandbox). Project-level settings live in `.claude/settings.json` (biome hook). See the [settings documentation](https://code.claude.com/docs/en/settings) for available options.
 
+Read [`hooks.md`](hooks.md) before adding or changing a hook entry in either file. Its `paths` globs cover `hooks.json` only, so it does not auto-inject here, and roughly half this repo's hook entries live in these two files.
+
 ## Permission Paths
 
 Permission patterns starting with `/` are relative to the settings file, not absolute filesystem paths. Use `//` for absolute paths:

--- a/plugins/claude-code/skills/hook/SKILL.md
+++ b/plugins/claude-code/skills/hook/SKILL.md
@@ -22,10 +22,14 @@ Reference for creating and configuring Claude Code hooks. When uncertain about s
 | PreToolUse | Before tool execution | Validate inputs, block operations, modify parameters |
 | PostToolUse | After tool completes | Check results, run linters, provide feedback |
 | UserPromptSubmit | When user sends message | Pre-process input, add context |
-| Stop | Session ends | Cleanup, save state |
-| SubagentStop | Subagent completes | Process results |
-| PreCompact | Before context compaction | Save important state |
+| PermissionRequest | Permission dialog appears | Return a decision, notify a remote approver |
+| Stop | Agent finishes a turn | Cleanup, save state |
+| StopFailure | Agent stops on failure | Report the failure |
+| SubagentStart / SubagentStop | Subagent spawns / completes | Process results |
+| SessionStart / SessionEnd | Session begins / ends | Inject context, export state |
+| PreCompact / PostCompact | Around context compaction | Save important state |
 | Notification | System notification | Log events |
+| TeammateIdle | Teammate about to go idle | Hand off work |
 
 ## Configuration Files
 
@@ -104,6 +108,21 @@ const input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
 ```
 
 Exit with no output to allow without modification.
+
+## Async
+
+`"async": true` on a command hook backgrounds it so the turn does not wait. Nothing above reaches the model: no `permissionDecision`, no `updatedInput`, no `additionalContext`, and exit code 2 does not block. Verified on 2.1.220 that stderr and a nonzero exit are both dropped. `"asyncRewake": true` backgrounds the hook but wakes the model on exit code 2, delivering stderr (or stdout when stderr is empty) as a system reminder. Neither field applies to `prompt` or `agent` hooks.
+
+Use `async` only for a hook that is a pure side effect: a notifier, a status bridge, a terminal bell, a state export. Keep it off when the hook returns any of the output above, mutates state a later step reads, or gates a tool call.
+
+Two events behave differently from the rest, measured on 2.1.220:
+
+- `Stop` kills the backgrounded process almost immediately. Anything past a few milliseconds never finishes. A `Stop` notifier must stay synchronous.
+- `SessionEnd` outlives the CLI. A backgrounded hook there runs to completion after the process exits, making it safe to background.
+
+`SubagentStop`, `SessionStart`, `UserPromptSubmit`, and `PostToolUse` all run to completion when backgrounded.
+
+Hooks on the same event already run concurrently with each other, so `async` only shortens the turn when the side-effect hook is the slowest one on its event. It is still worth setting on a hook that qualifies, because the payoff moves as sibling hooks change.
 
 ## Script Storage
 

--- a/schemas/hook.schema.json
+++ b/schemas/hook.schema.json
@@ -215,7 +215,12 @@
             "async": {
               "type": "boolean",
               "default": false,
-              "description": "Run the hook in the background without blocking"
+              "description": "Run this hook asynchronously without blocking Claude Code"
+            },
+            "asyncRewake": {
+              "type": "boolean",
+              "default": false,
+              "description": "When true, the hook runs in the background and wakes the model when it exits with code 2. Implies async."
             },
             "if": {
               "type": "string",

--- a/user/settings.json
+++ b/user/settings.json
@@ -94,7 +94,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'",
+            "async": true
           }
         ]
       }
@@ -116,7 +117,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'",
+            "async": true
           }
         ]
       }
@@ -127,7 +129,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'",
+            "async": true
           }
         ]
       }
@@ -137,7 +140,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'",
+            "async": true
           }
         ]
       }
@@ -167,7 +171,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'",
+            "async": true
           }
         ]
       }
@@ -177,7 +182,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'",
+            "async": true
           }
         ]
       }
@@ -188,7 +194,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'",
+            "async": true
           }
         ]
       },
@@ -198,7 +205,8 @@
           {
             "type": "command",
             "command": "bash \"$HOME/.claude/hooks/herdr-agent-state.sh\" session",
-            "timeout": 10
+            "timeout": 10,
+            "async": true
           }
         ]
       }
@@ -228,7 +236,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'",
+            "async": true
           }
         ]
       }
@@ -238,7 +247,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'",
+            "async": true
           }
         ]
       }
@@ -248,7 +258,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'",
+            "async": true
           }
         ]
       }
@@ -258,7 +269,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'"
+            "command": "/bin/sh -c '[ -x \"$HOME/.vibe-island/bin/vibe-island-bridge\" ] && \"$HOME/.vibe-island/bin/vibe-island-bridge\" --source claude; exit 0'",
+            "async": true
           },
           {
             "type": "command",


### PR DESCRIPTION
Marks the vibe-island bridge and the herdr state export in `user/settings.json` as `async`. Nothing reads their output. A turn should not wait on them.

Two things I assumed going in were wrong, and both changed the diff.

I expected `SessionEnd` to be unsafe to background, on the theory that teardown kills the process first. It is the reverse. A 1s async `SessionEnd` hook completes 2.7s after the CLI has already exited, while an async `Stop` hook is killed almost immediately and never reaches its end marker. `Stop` is alone in this. So `SessionEnd` is async here and `Stop` is not, the opposite of how it reads.

I also recorded `PermissionRequest` as staying synchronous because the bridge's process lifetime signals the pending-approval state. That was a guess, and it was wrong. Probing the bridge per event shows it returns empty stdout and exits 0 immediately everywhere except `PermissionRequest`, where it blocked the full 5s timeout (`rc=124`). Its binary carries `permissionDecision` and `hookSpecificOutput`. It blocks to return a remote approval, which is what the 86400s timeout buys. Same outcome, correct reason.

## Payoff

Hooks on one event already run concurrently, which I measured before touching anything: three 2s `PreToolUse` hooks add 2.0s, not 6.0s. So `async` only shortens a turn where the side-effect hook is the slowest on its event. On `PostToolUse` the bridge is the only hook that always fires, because biome, coverage and type-ignore are each `if`-gated to file edits, which leaves its ~38ms sitting on every single tool call. That is where this pays.

## Dropped Scope

I first marked the four tmux hooks async and then reverted all of them. `notification.ts` reads like a notifier but does a read-modify-write on shared tmux options from three call sites, and those hooks depend on completing in event order. Backgrounding the `PreToolUse` clear lets it land after the `Notification` hook has already set the pane marker. A pane blocked on approval then shows nothing in the status bar.

The one tmux hook without that problem is a `tmux set-option` one-liner that shares `SessionStart` with a synchronous `bun` script dominating it, so marking it bought nothing.

## Documentation

Async guidance went into the `claude-code:hook` skill rather than `.claude/rules/hooks.md`. It is general harness knowledge, and the skill ships to marketplace users while a rules file does not. The rules files keep only the repo-specific decisions.

`.claude/rules/settings.md` now points at `hooks.md`, whose `paths` globs cover `hooks.json` only and so never inject while editing the two files where most of these flags live. Schema descriptions now match upstream SchemaStore verbatim rather than restating the prose in a second place.

## Known Limitation

Vibe Island owns those 14 hook entries. Its launcher rewrites `~/.claude/settings.json` when the app has been missing for five minutes, stripping every hook whose command contains `vibe-island`. That file is a symlink to the tracked `user/settings.json`, so an app update or absence can silently revert these flags or reformat the file. Nothing here can prevent that.

One thing I left alone: `schemas/hook.schema.json` is `additionalProperties: false` but omits `shell`, `args`, `continueOnBlock`, and the `http` and `mcp_tool` hook types that upstream's settings schema defines. A plugin using any of them fails CI validation for a field Claude Code supports. Real, but outside this change.
