### PR TITLE
scripts,settings: fail CI when an enabled plugin id does not resolve

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Check marketplace completeness
         run: bun scripts/check-marketplace.ts
 
+      - name: Check enabled plugin ids
+        run: bun scripts/check-plugin-ids.ts
+
       - name: Check MCP hook matchers
         run: bun scripts/check-mcp-matchers.ts
 

--- a/packages/marketplace/index.ts
+++ b/packages/marketplace/index.ts
@@ -85,8 +85,9 @@ interface MarketplaceFile {
   plugins: Array<{ name: string; source: PluginSource; description?: string }>;
 }
 
-interface SettingsFile {
+export interface SettingsFile {
   enabledPlugins?: Record<string, boolean>;
+  extraKnownMarketplaces?: Record<string, { source: unknown }>;
 }
 
 const PACKAGE_ROOT = join(import.meta.dirname, "..", "..");
@@ -166,6 +167,12 @@ export async function loadPlugins(opts?: LoadOptions): Promise<Plugin[]> {
   }
 
   return [...plugins.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** The settings file read for enabled state, or an empty object when absent. */
+export async function loadSettings(opts?: LoadOptions): Promise<SettingsFile> {
+  const root = repoRoot(opts);
+  return (await readJson<SettingsFile>(settingsPathFor(root, opts))) ?? {};
 }
 
 /**

--- a/scripts/check-plugin-ids.test.ts
+++ b/scripts/check-plugin-ids.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { type PluginId, parseId, sources, violations } from "./check-plugin-ids";
+
+test.each<{ name: string; id: string; expected: PluginId | null }>([
+  {
+    name: "plugin and marketplace",
+    id: "linear@bendrucker",
+    expected: { name: "linear", marketplace: "bendrucker" },
+  },
+  { name: "no marketplace", id: "linear", expected: null },
+  { name: "empty marketplace", id: "linear@", expected: null },
+  { name: "empty plugin", id: "@bendrucker", expected: null },
+])("$name", ({ id, expected }) => {
+  expect(parseId(id)).toEqual(expected);
+});
+
+const marketplaces = new Set(["bendrucker", "worktrunk"]);
+const listed = new Set(["linear", "review"]);
+
+test.each<{ name: string; ids: string[]; expected: number }>([
+  { name: "own marketplace, listed", ids: ["linear@bendrucker"], expected: 0 },
+  { name: "own marketplace, renamed away", ids: ["lienar@bendrucker"], expected: 1 },
+  { name: "third party, declared", ids: ["worktrunk@worktrunk"], expected: 0 },
+  { name: "third party, undeclared marketplace", ids: ["ast-grep@ast-grep"], expected: 1 },
+  { name: "malformed id", ids: ["linear"], expected: 1 },
+])("$name", ({ ids, expected }) => {
+  expect(violations({ ids, marketplaces, listed })).toHaveLength(expected);
+});
+
+test("a third-party name is not resolved", () => {
+  expect(violations({ ids: ["no-such-plugin@worktrunk"], marketplaces, listed })).toBeEmpty();
+});
+
+test("every enabled plugin in this repo resolves", async () => {
+  expect(violations(await sources())).toBeEmpty();
+});

--- a/scripts/check-plugin-ids.ts
+++ b/scripts/check-plugin-ids.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env bun
+
+import { loadPlugins, loadSettings } from "../packages/marketplace/index";
+import { runCheck } from "./check";
+
+/** The marketplace `.claude-plugin/marketplace.json` publishes. */
+const OWN = "bendrucker";
+
+export interface PluginId {
+  name: string;
+  marketplace: string;
+}
+
+/**
+ * Splits an `enabledPlugins` key into its plugin name and marketplace, or null
+ * when it does not carry both. Claude Code silently ignores a key it cannot
+ * resolve, so a malformed one disables the plugin without saying so.
+ */
+export function parseId(id: string): PluginId | null {
+  const at = id.lastIndexOf("@");
+  if (at <= 0 || at === id.length - 1) return null;
+  return { name: id.slice(0, at), marketplace: id.slice(at + 1) };
+}
+
+export interface Sources {
+  /** Every key of `enabledPlugins`, in file order. */
+  ids: string[];
+  /** Marketplace keys declared in `extraKnownMarketplaces`. */
+  marketplaces: Set<string>;
+  /** Plugin names this repo's marketplace offers. */
+  listed: Set<string>;
+}
+
+/**
+ * Enabled ids that cannot resolve.
+ *
+ * Third-party names are unverifiable offline: resolving them means fetching
+ * each remote marketplace manifest, so those ids are checked only as far as
+ * their marketplace being declared.
+ */
+export function violations({ ids, marketplaces, listed }: Sources): string[] {
+  const messages: string[] = [];
+
+  for (const id of ids) {
+    const parsed = parseId(id);
+    if (!parsed) {
+      messages.push(`${id}: not of the form <plugin>@<marketplace>`);
+      continue;
+    }
+    if (!marketplaces.has(parsed.marketplace)) {
+      messages.push(`${id}: marketplace "${parsed.marketplace}" is not in extraKnownMarketplaces`);
+      continue;
+    }
+    if (parsed.marketplace === OWN && !listed.has(parsed.name)) {
+      messages.push(`${id}: no plugin named "${parsed.name}" in .claude-plugin/marketplace.json`);
+    }
+  }
+
+  return messages;
+}
+
+export async function sources(): Promise<Sources> {
+  const [settings, plugins] = await Promise.all([loadSettings(), loadPlugins()]);
+  return {
+    ids: Object.keys(settings.enabledPlugins ?? {}),
+    marketplaces: new Set(Object.keys(settings.extraKnownMarketplaces ?? {})),
+    listed: new Set(plugins.filter((plugin) => plugin.listing).map((plugin) => plugin.name)),
+  };
+}
+
+if (import.meta.main) {
+  await runCheck(
+    async () => ({
+      header: "Enabled plugins that do not resolve:",
+      violations: violations(await sources()),
+    }),
+    { success: "Every enabled plugin id resolves" },
+  );
+}

--- a/user/settings.json
+++ b/user/settings.json
@@ -436,8 +436,7 @@
     "claude-plugins-official": {
       "source": {
         "source": "github",
-        "repo": "anthropics/claude-plugins-official",
-        "ref": "87644d1355e6f08d55eb98dc2264d68fa226b6ac"
+        "repo": "anthropics/claude-plugins-official"
       }
     },
     "astral-sh": {


### PR DESCRIPTION
Claude Code ignores an `enabledPlugins` key it cannot resolve. There is no warning, so a plugin that gets renamed in a marketplace stays listed in settings and quietly stops loading. The installed state on my machine has 15 of these.

`scripts/check-plugin-ids.ts` resolves every key and fails CI on the ones that don't. It runs in the `validate` job alongside the other `check-*` scripts.

## Scope

The check is offline, so its coverage is uneven and worth stating plainly:

- Every key must parse as `<plugin>@<marketplace>`.
- Every marketplace must be declared in `extraKnownMarketplaces`.
- A `@bendrucker` plugin name must appear in `.claude-plugin/marketplace.json`.

Third-party plugin names are not resolved. Doing that means fetching each remote marketplace manifest from GitHub during CI, which trades a deterministic check for network flakiness and unauthenticated rate limits. Those ids are covered only as far as their marketplace being declared. This is the weaker half, and it's the half where the rename risk actually lives, since I control the `bendrucker` names.

## Official Marketplace Pin

Dropped, because it never did anything. That marketplace is materialized from a GCS tarball rather than cloned, and three SHAs disagree about it on my machine:

| Source | SHA |
| --- | --- |
| `user/settings.json` `ref` | `87644d1` |
| `known_marketplaces.json` recorded ref | `27d2b86` |
| Installed content's `.gcs-sha` | `7217edc` |

Every git-cloned marketplace matches its recorded ref exactly (`ast-grep-marketplace` at `c2a9bc1`, `astral-sh` at `f8034678`). This one has no `.git` directory and matches nothing. Renovate's digest `customManager` was bumping a value with no effect on what gets installed.

The `astral-sh` and `ast-grep-marketplace` pins stay. Renovate maintains them and they are honored.

Verified with `bun run check`, `bun run build`, both validate scripts, and `bun test`.
