### PR TITLE
github: add a Copilot cross-model review skill

### DIFF
--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -6,6 +6,7 @@ GitHub workflow, Actions monitoring, and rulesets management for Claude Code.
 
 - **Skills**:
   - `actions-monitor`: Watch a PR's CI and stream state events; invokes the logs agent on failures
+  - `copilot`: Cross-model review of the current diff through the Copilot CLI. Slash-invocable only, one call by default and three at most, because the Copilot plan is a fixed budget
   - `notifications`: Inbox management (list, filter, mark read/done, unsubscribe)
   - `pr-comments`: Fetch unresolved review comments from a pull request
   - `stack`: Build, publish, and merge native stacked PRs with the `gh stack` extension

--- a/plugins/github/scripts/copilot-review.test.ts
+++ b/plugins/github/scripts/copilot-review.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { ANGLES, buildPrompt, type Diff, splitPaths } from "./copilot-review";
+
+describe("splitPaths", () => {
+  // git only emits these intact with -z. Newline splitting turns each into a path that
+  // does not exist, and the file silently drops out of the review.
+  test.each([
+    ["plain", "a.ts\0b.ts\0", ["a.ts", "b.ts"]],
+    ["non-ascii", "café.ts\0", ["café.ts"]],
+    ["newline in name", "we\nird.ts\0ok.ts\0", ["we\nird.ts", "ok.ts"]],
+    ["no trailing separator", "only.ts", ["only.ts"]],
+    ["empty", "", []],
+  ])("%s", (_name, output, expected) => {
+    expect(splitPaths(output)).toEqual(expected);
+  });
+});
+
+describe("buildPrompt", () => {
+  const diff: Diff = { base: "origin/main", patch: "@@ -1 +1 @@\n-old\n+new", files: ["a.ts"] };
+
+  test("carries the diff, the focus, and the file body", () => {
+    const prompt = buildPrompt(diff, new Map([["a.ts", "export const x = 1;"]]), [], "FOCUS HERE");
+
+    expect(prompt).toContain("FOCUS HERE");
+    expect(prompt).toContain("## Diff (against origin/main)");
+    expect(prompt).toContain("+new");
+    expect(prompt).toContain("### a.ts");
+    expect(prompt).toContain("export const x = 1;");
+    expect(prompt).toContain("Do NOT summarize the change");
+  });
+
+  test("names omitted files so the model knows its view is partial", () => {
+    const prompt = buildPrompt(diff, new Map(), ["huge.ts"], "FOCUS");
+
+    expect(prompt).toContain("Not included in full because of size: huge.ts");
+    expect(prompt).not.toContain("## Full contents");
+  });
+});
+
+describe("angles", () => {
+  test("stay disjoint so extra calls buy coverage rather than agreement", () => {
+    expect(ANGLES).toHaveLength(3);
+    expect(new Set(ANGLES.map((angle) => angle.id)).size).toBe(3);
+    for (const angle of ANGLES) {
+      expect(angle.focus).toContain("Look ONLY for these two classes");
+    }
+  });
+});

--- a/plugins/github/scripts/copilot-review.ts
+++ b/plugins/github/scripts/copilot-review.ts
@@ -1,0 +1,413 @@
+#!/usr/bin/env bun
+
+import { mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, sep } from "node:path";
+import { $ } from "bun";
+import { cli } from "cleye";
+
+const DEFAULT_MODEL = "gpt-5.6-terra";
+const MAX_ANGLES = 3;
+
+// Copilot takes the prompt as an argv value, so the cap has to stay clear of ARG_MAX
+// as well as of the plan's credit budget. The budget is the tighter of the two.
+const DEFAULT_MAX_BYTES = 120_000;
+
+// --force lifts the budget guard, not the operating-system one. Past this the spawn fails
+// with E2BIG and no review runs at all, so refuse with an explanation instead.
+const ABSOLUTE_MAX_BYTES = 400_000;
+
+const DIM = "\x1b[2m";
+const RED = "\x1b[31m";
+const YELLOW = "\x1b[33m";
+const CYAN = "\x1b[36m";
+const BOLD = "\x1b[1m";
+const RESET = "\x1b[0m";
+
+export interface Diff {
+  base: string;
+  patch: string;
+  files: string[];
+}
+
+export interface Angle {
+  id: string;
+  title: string;
+  focus: string;
+}
+
+interface Result {
+  angle: Angle;
+  exitCode: number;
+  output: string;
+  credits: number | null;
+}
+
+function git(args: string[], cwd: string): string {
+  const result = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+  if (result.exitCode !== 0) {
+    throw new Error(`git ${args.join(" ")}: ${result.stderr.toString().trim()}`);
+  }
+  return result.stdout.toString();
+}
+
+function gitOk(args: string[], cwd: string): boolean {
+  return (
+    Bun.spawnSync(["git", ...args], { cwd, stdout: "ignore", stderr: "ignore" }).exitCode === 0
+  );
+}
+
+/** Prefer the remote tracking ref so the review sees what the PR would merge. */
+function resolveBase(cwd: string): string {
+  for (const ref of ["@{upstream}", "origin/main", "origin/master", "main", "master"]) {
+    if (gitOk(["rev-parse", "--verify", "--quiet", ref], cwd)) return ref;
+  }
+  return "HEAD~1";
+}
+
+/**
+ * Read NUL-delimited git output. Plain newline output is unusable here: with the default
+ * core.quotePath, git escapes a name like café.ts and wraps it in quotes, and a filename
+ * may legally contain a newline. Either one yields a path that does not exist on disk.
+ */
+export function splitPaths(output: string): string[] {
+  return output.split("\0").filter((path) => path.length > 0);
+}
+
+function collectDiff(base: string, cwd: string): Diff {
+  const committed = git(["diff", `${base}...HEAD`], cwd);
+  const working = git(["diff", "HEAD"], cwd);
+  const patch = [committed, working].filter((part) => part.trim()).join("\n");
+
+  const names = new Set<string>();
+  for (const range of [[`${base}...HEAD`], ["HEAD"]]) {
+    for (const path of splitPaths(git(["diff", "--name-only", "-z", ...range], cwd))) {
+      names.add(path);
+    }
+  }
+  // git diff never lists untracked files, so a pre-commit review would miss new files entirely.
+  for (const path of splitPaths(git(["ls-files", "--others", "--exclude-standard", "-z"], cwd))) {
+    names.add(path);
+  }
+
+  return { base, patch, files: [...names].sort() };
+}
+
+const PREAMBLE = `You are reviewing a code change as a second opinion. The author already reviewed it with a different model, so repeating what that model would notice is worthless. Your value is the defect it missed.
+
+Report only defects. For each one give the file and line, what is wrong, and a concrete failure scenario: the inputs or state that trigger it and the wrong result. A finding with no nameable failure is not a finding.`;
+
+const RULES = `Rules:
+
+- Do NOT summarize the change. Do not restate what the diff does. Do not open with an overview.
+- Do NOT praise anything or comment on style, naming, or formatting unless it causes a defect.
+- Do not speculate about code you cannot see. Everything you are given is below.
+- You have no filesystem or network access. Do not attempt to read files or run commands.
+- If you genuinely find no defect, say exactly: NO DEFECTS FOUND, then name the two or three places you consider most likely to hide one and why you cleared them.`;
+
+const ALL_CLASSES = `Prioritize, in this order:
+
+1. Unchecked failure. A read, write, fetch, parse, or subprocess whose success is never tested, so a partial or empty result flows onward as if it were real data. Look hard at anything that streams or concatenates without checking each source succeeded.
+2. Correctness. Off-by-one, inverted conditions, null or undefined on a reachable path, falsy-zero treated as missing, wrong variable, lost error context.
+3. Data loss and destructive behavior. Overwrites, truncation, deletes, and any path that can clobber user state.
+4. Concurrency and resource handling. Races, unreleased handles, unbounded growth.
+5. Security. Injection, path traversal, secrets in output or arguments, unsafe defaults.
+6. API and contract misuse. Wrong argument order, ignored return values, violated invariants stated in nearby comments or docs.`;
+
+/**
+ * Distinct lenses rather than repeated passes. Three identical reviews mostly agree, which
+ * costs three times as much for one review's worth of coverage.
+ */
+export const ANGLES: Angle[] = [
+  {
+    id: "failure",
+    title: "Unchecked failure and correctness",
+    focus: `Look ONLY for these two classes and ignore everything else:
+
+1. Unchecked failure. A read, write, fetch, parse, or subprocess whose success is never tested, so a partial or empty result flows onward as if it were real data. Look hard at anything that streams or concatenates without checking each source succeeded.
+2. Correctness. Off-by-one, inverted conditions, null or undefined on a reachable path, falsy-zero treated as missing, wrong variable, lost error context.`,
+  },
+  {
+    id: "safety",
+    title: "Data loss and security",
+    focus: `Look ONLY for these two classes and ignore everything else:
+
+1. Data loss and destructive behavior. Overwrites, truncation, deletes, and any path that can clobber user state. Include anything that discards data on an error path.
+2. Security. Injection, path traversal, symlink following, secrets reaching output, arguments, logs, or a third-party service, and unsafe defaults.`,
+  },
+  {
+    id: "contract",
+    title: "Contracts, concurrency, and resources",
+    focus: `Look ONLY for these two classes and ignore everything else:
+
+1. API and contract misuse. Wrong argument order, ignored return values, a call whose documented preconditions are not met, and invariants stated in nearby comments or docs that the code violates.
+2. Concurrency and resource handling. Races, ordering assumptions between concurrent operations, unreleased handles, unbounded growth.`,
+  },
+];
+
+export function buildPrompt(
+  diff: Diff,
+  contents: Map<string, string>,
+  skipped: string[],
+  focus: string,
+): string {
+  const parts = [
+    PREAMBLE,
+    "",
+    focus,
+    "",
+    RULES,
+    "",
+    `## Diff (against ${diff.base})`,
+    "",
+    "```diff",
+    diff.patch,
+    "```",
+  ];
+
+  if (contents.size > 0) {
+    parts.push("", "## Full contents of the changed files", "");
+    for (const [path, body] of contents) {
+      parts.push(`### ${path}`, "", "```", body, "```", "");
+    }
+  }
+
+  if (skipped.length > 0) {
+    parts.push(
+      "",
+      `Not included in full because of size: ${skipped.join(", ")}. Review those from the diff alone and say so if that limits a finding.`,
+    );
+  }
+
+  return parts.join("\n");
+}
+
+/**
+ * Copilot refuses to write to ~/.copilot under the sandbox. A throwaway HOME keeps the
+ * sandbox intact, and starting it empty also means no hooks, custom instructions, or
+ * session history reach the review. No tools are enabled and cwd is outside the repo, so
+ * this is one turn against inlined text: Copilot never fans out on its own.
+ */
+async function runCopilot(prompt: string, model: string, angle: Angle): Promise<Result> {
+  const home = mkdtempSync(join(tmpdir(), "copilot-review-"));
+  try {
+    const child = Bun.spawn(
+      [
+        "copilot",
+        "--model",
+        model,
+        "--disable-builtin-mcps",
+        "--no-ask-user",
+        "--no-custom-instructions",
+        "-p",
+        prompt,
+      ],
+      {
+        cwd: "/",
+        env: { ...process.env, HOME: home },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+      child.exited,
+    ]);
+
+    const output = [stdout, stderr].filter((part) => part.trim()).join("\n");
+    const credits = output.match(/AI Credits\s+([\d.]+)/);
+
+    return { angle, exitCode, output, credits: credits ? Number(credits[1]) : null };
+  } finally {
+    await $`rm -rf ${home}`.quiet().nothrow();
+  }
+}
+
+async function collectContents(diff: Diff, cwd: string, maxBytes: number) {
+  // One file at a time so a single large file loses its body rather than the whole set.
+  const perFileCap = Math.floor(maxBytes / 3);
+  const contents = new Map<string, string>();
+  const skipped: string[] = [];
+  const root = realpathSync(cwd);
+
+  let running = 0;
+  for (const path of diff.files) {
+    let resolved: string;
+    try {
+      resolved = realpathSync(join(cwd, path));
+    } catch {
+      // Deleted in this change. The diff already carries what it used to say.
+      continue;
+    }
+    // The prompt goes to a third-party service, and a repo symlink can point anywhere:
+    // a dotfiles checkout linking to ~/.ssh would otherwise inline a private key. The diff
+    // still shows the link itself, which is the reviewable part.
+    if (resolved !== root && !resolved.startsWith(root + sep)) continue;
+
+    const file = Bun.file(resolved);
+    if (file.size === 0) continue;
+    // Stop at the budget rather than reading every file first. A thousand small changed
+    // files can each sit under perFileCap and still blow the prompt in aggregate.
+    if (file.size > perFileCap || running + file.size > maxBytes) {
+      skipped.push(path);
+      continue;
+    }
+    running += file.size;
+    contents.set(path, await file.text());
+  }
+
+  return { contents, skipped };
+}
+
+async function main(): Promise<void> {
+  const argv = cli({
+    name: "copilot-review",
+    flags: {
+      base: {
+        type: String,
+        description: "Base ref to diff against (default: upstream, then origin/main)",
+      },
+      model: {
+        type: String,
+        description: "Copilot model",
+        default: DEFAULT_MODEL,
+      },
+      angles: {
+        type: Number,
+        description: `Independent review angles to run, 1 to ${MAX_ANGLES}. Each is one more billed call`,
+        default: 1,
+      },
+      maxBytes: {
+        type: Number,
+        description: "Refuse a prompt larger than this many bytes",
+        default: DEFAULT_MAX_BYTES,
+      },
+      dryRun: {
+        type: Boolean,
+        description: "Print the prompts and their size, spend nothing",
+        default: false,
+      },
+      force: {
+        type: Boolean,
+        description: "Run even when a prompt exceeds --max-bytes",
+        default: false,
+      },
+    },
+  });
+
+  const angleCount = Math.trunc(argv.flags.angles);
+  if (!Number.isFinite(angleCount) || angleCount < 1 || angleCount > MAX_ANGLES) {
+    console.error(`${RED}--angles must be between 1 and ${MAX_ANGLES}.${RESET}`);
+    process.exit(1);
+  }
+
+  const maxBytes = Math.trunc(argv.flags.maxBytes);
+  if (!Number.isFinite(maxBytes) || maxBytes < 1) {
+    console.error(`${RED}--max-bytes must be a positive number.${RESET}`);
+    process.exit(1);
+  }
+
+  const cwd = process.cwd();
+  const base = argv.flags.base ?? resolveBase(cwd);
+  // An unverified base reaches git as an option, not a revision: --base=--output=/tmp/x
+  // turns the diff into a file write. rev-parse rejects anything that is not a revision.
+  if (!gitOk(["rev-parse", "--verify", "--quiet", `${base}^{commit}`], cwd)) {
+    console.error(`${RED}--base ${base} is not a revision in this repository.${RESET}`);
+    process.exit(1);
+  }
+  const diff = collectDiff(base, cwd);
+
+  if (!diff.patch.trim() && diff.files.length === 0) {
+    console.error(`Nothing to review against ${base}.`);
+    process.exit(1);
+  }
+
+  const { contents, skipped } = await collectContents(diff, cwd, maxBytes);
+
+  // One angle reviews everything. More than one splits the classes so the calls do not overlap.
+  const angles =
+    angleCount === 1
+      ? [{ id: "all", title: "All defect classes", focus: ALL_CLASSES }]
+      : ANGLES.slice(0, angleCount);
+
+  const prompts = angles.map((angle) => ({
+    angle,
+    prompt: buildPrompt(diff, contents, skipped, angle.focus),
+  }));
+  const largest = Math.max(...prompts.map(({ prompt }) => Buffer.byteLength(prompt, "utf8")));
+  const total = prompts.reduce((sum, { prompt }) => sum + Buffer.byteLength(prompt, "utf8"), 0);
+
+  console.error(`${CYAN}copilot review${RESET}`);
+  console.error(`  model      ${argv.flags.model}`);
+  console.error(`  base       ${base}`);
+  console.error(
+    `  files      ${diff.files.length}${skipped.length ? ` (${skipped.length} body omitted)` : ""}`,
+  );
+  console.error(`  angles     ${angles.length} (${angles.map((angle) => angle.id).join(", ")})`);
+  console.error(
+    `  prompt     ${total.toLocaleString()} bytes total, roughly ${Math.round(total / 4).toLocaleString()} tokens`,
+  );
+  console.error(
+    `${DIM}  ${angles.length} billed call${angles.length === 1 ? "" : "s"} against a fixed plan budget. Credits spent print below.${RESET}`,
+  );
+
+  if (argv.flags.dryRun) {
+    for (const { angle, prompt } of prompts) {
+      console.error("");
+      console.error(`${BOLD}--- ${angle.id} ---${RESET}`);
+      console.log(prompt);
+    }
+    return;
+  }
+
+  if (largest > ABSOLUTE_MAX_BYTES) {
+    console.error("");
+    console.error(
+      `${RED}Refusing: largest prompt is ${largest.toLocaleString()} bytes, past the ${ABSOLUTE_MAX_BYTES.toLocaleString()} argv ceiling that --force cannot lift.${RESET}`,
+    );
+    console.error(`${YELLOW}Narrow the diff with --base.${RESET}`);
+    process.exit(1);
+  }
+
+  if (largest > maxBytes && !argv.flags.force) {
+    console.error("");
+    console.error(
+      `${RED}Refusing: largest prompt is ${largest.toLocaleString()} bytes, over the ${maxBytes.toLocaleString()} cap.${RESET}`,
+    );
+    console.error(
+      `${YELLOW}Narrow the diff with --base, or pass --force if this review is worth the spend.${RESET}`,
+    );
+    process.exit(1);
+  }
+
+  console.error("");
+  const results = await Promise.all(
+    prompts.map(({ angle, prompt }) => runCopilot(prompt, argv.flags.model, angle)),
+  );
+
+  let spent = 0;
+  let failed = false;
+  for (const result of results) {
+    if (angles.length > 1) {
+      console.log(`\n${BOLD}## ${result.angle.title}${RESET}\n`);
+    }
+    console.log(result.output.trim());
+    if (result.credits !== null) spent += result.credits;
+    if (result.exitCode !== 0) failed = true;
+  }
+
+  if (angles.length > 1) {
+    console.error("");
+    console.error(
+      `${CYAN}Total AI credits ${spent.toFixed(2)} across ${angles.length} calls${RESET}`,
+    );
+  }
+
+  process.exit(failed ? 1 : 0);
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/plugins/github/skills/copilot/SKILL.md
+++ b/plugins/github/skills/copilot/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: github:copilot
+description: Get a second-model code review of the current diff from GPT via the Copilot CLI, then triage its findings. Use when a change is worth a cross-model check that Claude reviewing its own work cannot give.
+argument-hint: "[--base <ref>] [--model <name>] [--dry-run] [--force]"
+disable-model-invocation: true
+allowed-tools:
+  - Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/copilot-review.ts:*)
+  - Bash(git diff:*)
+  - Bash(git log:*)
+  - Bash(git status:*)
+  - Read
+  - Grep
+  - Glob
+  - Edit
+---
+
+# Copilot Review
+
+A second model reads the diff. The point is not a better reviewer, it is a different one: Claude re-reading its own work shares the blind spot that produced it. This has already paid for itself once, catching a `compose` function that streamed two files to stdout without checking either read succeeded, which two Claude passes both cleared.
+
+## Spend This Deliberately
+
+Copilot Pro is a fixed budget and one careless review can eat a visible share of it. That constraint is why this skill exists in the shape it does:
+
+- It is `disable-model-invocation`, so nothing can reach it by natural-language routing or delegation from another skill. `/github:copilot` typed by the user is the only entry point. Do not invoke it because a change "looks worth reviewing" and do not wire it into `ship` or any hook.
+- One call by default, three at the absolute most. `--angles` is the only knob and it is capped at 3.
+- Copilot itself never fans out. It runs with no tools, no MCP servers, and a working directory outside the repo, so every call is one turn against text inlined in the prompt. Any fan-out is the script's, bounded and countable.
+- It reviews a diff, never a repository.
+- The script prints the prompt size and the number of billed calls before it spends, and the credits actually used after. Read both out.
+
+## Arguments
+
+Everything is optional and forwards to the script.
+
+- `--base <ref>`: what to diff against. Defaults to the upstream tracking ref, then `origin/main`.
+- `--angles <1-3>`: how many independent review calls to make. Defaults to 1. See [Angles](#angles).
+- `--model <name>`: see [Models](#models). Defaults to `gpt-5.6-terra`.
+- `--dry-run`: print the assembled prompts and their size, spend nothing. Use this when the diff might be large.
+- `--force`: run even when a prompt exceeds the size cap.
+
+## Run It
+
+```bash
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/copilot-review.ts [--base <ref>] [--angles <n>] [--model <name>]
+```
+
+The script resolves the diff, inlines the changed files, runs the Copilot calls concurrently, and prints each angle's findings. It refuses a prompt over 120 KB rather than quietly spending on it. When that happens, prefer narrowing the scope with `--base` over passing `--force`.
+
+## Angles
+
+One angle asks for every defect class in one call, which is the right default. Above that, the script splits the classes so the calls do not overlap, because three identical reviews mostly agree and cost three times as much for one review's worth of coverage.
+
+| angles | coverage |
+| --- | --- |
+| 1 | every class, one call |
+| 2 | unchecked failure and correctness, then data loss and security |
+| 3 | adds contracts, concurrency, and resources |
+
+Use 3 only when the change genuinely warrants the max-effort profile: something security-sensitive, destructive, or concurrent. It triples the spend.
+
+## Triage the Findings
+
+The output is a claim from a model that cannot see the repository, so treat it the way you would a review bot rather than an oracle. For each finding, read the actual code and decide:
+
+- **Real** → fix it, or say precisely why you are deferring.
+- **Wrong** → say what the model missed. It reviews from inlined text and does not know the surrounding codebase, so a finding that depends on a caller or invariant it never saw is a common and expected miss.
+- **Unsure** → put it to the user rather than guessing.
+
+Report what you accepted and what you rejected, with the reason in both directions. A silent drop looks identical to a miss.
+
+Never re-run to get a second opinion on a rejected finding. That doubles the spend for a judgment you have already made.
+
+## Models
+
+Measured on one trivial call each, so treat these as relative rather than absolute:
+
+| model | AI credits | notes |
+| --- | --- | --- |
+| `gpt-5.6-terra` | 3.89 | default, newest generation |
+| `gpt-5.3-codex` | 2.73 | code-tuned, older generation |
+| `gpt-5.6-luna` | 0.39 | roughly a tenth the cost, for a cheap look |
+
+`copilot help config` lists every model name the CLI accepts. That list is the discovery method: there is no `models` subcommand, and the names are not guessable. It is also broader than what this account can reach, so a listed name can still come back "not available". Probing costs nothing when a model is rejected, because the CLI fails before inference.
+
+`gpt-5.6-codex` does not exist. The GPT-5.6 family is `sol`, `terra`, and `luna`, and `sol` is not reachable on this plan.
+
+## Gotchas
+
+The sandbox blocks Copilot writing to `~/.copilot`, which kills the run with `I/O error: Operation not permitted (os error 1)`. The script gives it a throwaway empty `HOME` instead, which keeps the sandbox intact. Do not solve this by disabling the sandbox. Auth does not live in `~/.copilot`, so an empty one costs nothing and also keeps hooks, custom instructions, and session history out of the review.
+
+The prompt travels as an argv value, so it is bounded by `ARG_MAX` as well as by cost. The 120 KB cap sits well under both, and a second ceiling at 400 KB refuses even under `--force`, because past that the spawn fails with `E2BIG` and no review runs at all.
+
+**The diff and the changed files go to GitHub.** That is the whole mechanism, and there is no redaction. A changed file holding a token or a key sends it. The script will not follow a symlink out of the repository, so a link to `~/.ssh` inlines nothing, but anything genuinely committed or staged in the tree is fair game. Check what is in the diff before reviewing a change that touches secrets or fixtures.
+
+Copilot runs with no tools and its cwd outside the repo, so it cannot read the code it is reviewing. Everything it sees is inlined in the prompt. A finding that assumes it read a file is confused, not informed.
+
+Default framing gets you a thin pass that ignores most of what you asked for. The script's prompt names the defect classes in priority order and forbids summarizing the change back. Keep that if you edit it.


### PR DESCRIPTION
Adds `/github:copilot`, a cross-model review of the current diff through the Copilot CLI.

The case for it is a defect it already caught. Reviewing a change in `bendrucker/dotfiles`, Copilot ran alongside two Claude reviewers and was the only one to notice a `compose` function that streamed two files to stdout without checking either read succeeded, which could install a config file missing its entire upstream half. A model re-reading its own work shares the blind spot that produced it, and no amount of re-reading fixes that.

## The Budget Shapes Everything

The Copilot Pro plan is a fixed allowance that one high fan-out review over a large repository would exhaust. Every design choice here follows from that:

- **`disable-model-invocation`.** Natural-language routing and skill-to-skill delegation cannot reach it, so `ship`, `review:peer`, and a stray "this looks worth reviewing" all bounce off. A typed `/github:copilot` is the only entry point. It also means the skill costs zero recurring context when unused. Nothing was added to `~/.claude/CLAUDE.md`, deliberately, since an entry there invites the automatic invocation this is built to prevent.
- **One call by default, three at most.** `--angles` is the only knob and is capped at 3.
- **Copilot itself never fans out.** No tools, no MCP servers, working directory outside the repo, everything inlined in the prompt. Each call is one turn against text. Any fan-out is the script's, bounded and countable.
- **Diff-scoped, never whole-repo.** A 120 KB prompt cap refuses rather than quietly spending, and a second ceiling at 400 KB holds even under `--force`.
- **Cost is visible at the call site.** Prompt size and billed-call count print before the spend, per-call credits after, with a total across angles.

## Reaching GPT-5.6

The target was `gpt-5.6-codex`. It does not exist, and neither do the other names probed while scoping this. The CLI has no `models` subcommand, but `copilot help config` enumerates every accepted name, which turns discovery from guesswork into a lookup.

The GPT-5.6 family is `sol`, `terra`, and `luna`. Probing which are actually entitled costs nothing, because a rejected model fails before inference with the same error as a nonsense string. On this account `terra` and `luna` work, `sol` does not, and `gpt-5.3-codex` is the only reachable codex variant. Measured on one trivial call each:

| model | AI credits |
| --- | --- |
| `gpt-5.6-terra` | 3.89 |
| `gpt-5.3-codex` | 2.73 |
| `gpt-5.6-luna` | 0.39 |

`terra` is the default. So the earlier read that `gpt-5.4` was the only reachable GPT-5.x was wrong: the probes had used names the CLI never offered.

## Angles Are Disjoint

Above one angle the script splits the defect classes rather than repeating the review, because three identical passes mostly agree and cost three times as much for one pass worth of coverage. Two angles cover unchecked failure and correctness, then data loss and security. Three adds contracts, concurrency, and resources.

## What the Tool Found in Itself

Both passes were run against this branch, and the findings are why several of these guards exist.

The single-angle pass caught two defects in the first draft. Paths were parsed as newline-delimited text, so with the default `core.quotePath` a file named `café.ts` came back quoted and escaped, failed to stat, and was silently treated as deleted. And changed files were read through symlinks with no containment check, so a repository linking to `~/.ssh` would have inlined a private key into a prompt bound for a third party. Fixed with `-z` throughout and a `realpathSync` containment test, which also handles the in-repo relative links a dotfiles checkout is full of.

The three-angle pass found four more, one per angle plus a duplicate class. `--max-bytes` was never validated, so a non-numeric value produced `NaN` and every comparison against it went false, disabling the cap entirely. `--base` reached git unverified, so `--base=--output=/tmp/x` turned a diff into a file write. `--force` bypassed the only size guard even though the prompt travels as an argv value, trading a clear refusal for an opaque `E2BIG`. And content accumulated with no running total, so many small files could each pass the per-file cap and still blow the prompt together.

All four are fixed and the guards are exercised directly. One finding was accepted rather than fixed: the diff and changed-file contents go to GitHub with no redaction, which is the mechanism rather than a bug, and is now documented as something to check before reviewing a change that touches secrets.

## Notes

The sandbox blocks Copilot writing to `~/.copilot`, which kills a run with `I/O error: Operation not permitted`. The script gives it a throwaway empty `HOME` instead, leaving the sandbox intact. Auth turns out not to live there, so an empty one costs nothing and also keeps hooks, custom instructions, and session history out of the review.

Default framing returns a thin pass that ignores most of what it was asked. The prompt names the defect classes in priority order and forbids summarizing the change back, which is what produced the findings above.

The skill sits in `github` rather than `review` because the vendor mechanics belong with the platform, leaving the review workflows vendor-free.
