### PR TITLE
user,review: treat a skill's fan-out as requested

### DIFF
--- a/plugins/review/skills/code/SKILL.md
+++ b/plugins/review/skills/code/SKILL.md
@@ -60,7 +60,7 @@ Otherwise run the selected angles from [angles.md](angles.md). Each surfaces up 
 
 #### Fan-out cells
 
-`medium`, `high`, `xhigh`, and `max` on the default and Sonnet families, plus `max` on Opus 4.8. Run each angle as an independent `Agent`. Give every agent the scope block, its single angle text, and the cleanup-precedence block if it carries a cleanup lens.
+`medium`, `high`, `xhigh`, and `max` on the default and Sonnet families, plus `max` on Opus 4.8. Run each angle as an independent `Agent`. Invoking this skill is the request for that fan-out, so run it whenever `Agent` is in the tool set. Give every agent the scope block, its single angle text, and the cleanup-precedence block if it carries a cleanup lens.
 
 #### Inline cells
 
@@ -68,7 +68,7 @@ Otherwise run the selected angles from [angles.md](angles.md). Each surfaces up 
 
 #### No `Agent` tool
 
-Every fan-out cell degrades to a single inline pass. Work through every angle yourself in one pass. Do not skip angles for lack of fan-out. Say in the summary that this was a single-pass review, not the full multi-agent fan-out, so nobody is misled about what ran.
+Only a missing `Agent` tool degrades a fan-out cell to a single inline pass. Work through every angle yourself in one pass. Do not skip angles for lack of fan-out. Say in the summary that this was a single-pass review, not the full multi-agent fan-out, so nobody is misled about what ran.
 
 Pass every candidate with a nameable failure scenario through. Finders that silently drop half-believed candidates bypass the verify step and are the dominant cause of misses.
 

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -28,6 +28,7 @@ Prefer accommodating Claude Code's native defaults over overriding them, since a
 ## Workflow
 
 - The user has carefully curated skills for their common workflows. Load skills when possible to adhere to the user's preferences and navigate their projects efficiently.
+- A skill that instructs a subagent fan-out or a background dispatch already carries the user's authorization for `Agent`. Run the dispatch as the skill writes it, and degrade to an inline pass only when `Agent` is absent from the tool set, saying in the output that it ran inline.
 - For questions about Claude Code features or usage, use the `Agent` tool with `subagent_type='claude-code-guide'` to consult official documentation.
 - Prefer the `agent-browser` skill over `WebFetch`/`WebSearch` when a task needs a real browser — interacting with a page, screenshots, scraping JS-rendered content, or web-app QA/dogfooding. It loads the CLI's version-matched `skills get` workflows. Plain `WebFetch` stays fine for static page fetches.
 - Finish a branch with `/ship`: it runs the warranted review passes, opens the PR, babysits CI to green, triages bot comments, and refreshes the body. Don't hand-chain `EnterWorktree` + `pull-request:create` for a branch finish.


### PR DESCRIPTION
Claude Code 2.1.220's system prompt carries two lines: "Do not call the AgentTool unless the user requested it" and "Do not use workflows or deep-research unless the user requested it." Neither lives in a config file. `grep -a` against the installed binary finds both compiled directly into it, absent from every settings file, hook, and rule in this repo. Nothing here can disable them.

That gate recently beat a skill's own dispatch instruction. `/ship`'s reviewer pass ran inline instead of fanning out, even though the skill it invoked said to fan out. Since the lines can't be edited, the fix has to work with the gate rather than override it.

The resolution: invoking a skill that instructs a fan-out or a background dispatch is itself the user's request for `Agent`. `user/CLAUDE.md` states that once, globally, so `ship`, `writing:review`, `pull-request:create`, and `review:follow-up` all pick it up without a skill-local edit.

`plugins/review/skills/code/SKILL.md` gets a change on top of that, because it held the actual trapdoor. Its "No `Agent` tool" cell described "every fan-out cell degrades to a single inline pass." That language was broad enough to double as an excuse for a model already inclined to skip the fan-out. That cell now degrades only when `Agent` is genuinely missing from the tool set. The reinforcement sentence itself sits under the "Fan-out cells" heading rather than the degrade cell, so a model resolving to a real fan-out cell reads it before deciding what to run, while a model landing on the degrade cell reads the narrower trigger instead.

Removal criteria: a release that stops shipping the gate, or `review:code` summaries that stop declaring single-pass runs while `Agent` was available. The skill already requires stating when a review went inline. That's the signal this stopped working.
