### PR TITLE
job: focus a live session's herdr pane

### DIFF
--- a/user/skills/job/SKILL.md
+++ b/user/skills/job/SKILL.md
@@ -12,6 +12,8 @@ allowed-tools:
   - Read(${CLAUDE_SKILL_DIR}/references/*)
   - Bash(claude agents:*)
   - Bash(claude --bg:*)
+  - Bash(herdr agent list:*)
+  - Bash(herdr agent focus:*)
 ---
 
 # Job
@@ -54,6 +56,8 @@ Read-only first. The sources are independent (review queue, own PRs, tracker, me
 
 Background Claude sessions may already be working items in the brief. Run `claude agents --json --all` inline in the orchestrator rather than in a sub-agent: it is one command, and the join needs the raw records that a sub-agent summary would flatten. Each record carries `id`, `sessionId`, `name`, `cwd`, `kind`, `startedAt`, `status`, `state`, and, when blocked, `waitingFor`. `state` is `working`, `blocked`, `done`, or `failed`, and is null for interactive sessions.
 
+When `HERDR_PANE_ID` is set, a second inline call, `herdr agent list`, maps live sessions to the terminal panes running them. Join its agents to the `claude agents` records on `sessionId == agent_session.value` and record the matched `pane_id` on the brief item. That join is exact, so never fall back to a title or `cwd` comparison. When `HERDR_PANE_ID` is unset there is no herdr server to ask, so skip the call and the resume command below carries the handoff. Load the `herdr` skill for the mechanics and for which commands answer with JSON.
+
 Join each record to a brief item in this order:
 
 1. A `name` matching the `job:<identifier>` convention below. Exact and structural, so it is the only join that never guesses.
@@ -78,7 +82,7 @@ An item with a matched agent gains one line under its existing entry:
 agent `<short id>` · <state>[ (<waitingFor>)] · <age>
 ```
 
-A live session (`working`, `blocked`, or an interactive session whose `state` is null) adds a second line, `→ claude --resume <sessionId>`, because resuming it is the action. A `done` or `failed` session gets no resume line. It is history, so the item keeps the action it already had, and the entry carries the `sessionId` as the prior attempt worth reading.
+A live session (`working`, `blocked`, or an interactive session whose `state` is null) adds a second line naming how to get back into it, because that is the action. With a matched pane the line is `→ herdr agent focus <pane_id>`, and `herdr agent attach <pane_id>` is the variant that connects to the pane directly. Without one it is `→ claude --resume <sessionId>`. A `done` or `failed` session gets no action line either way. It is history, so the item keeps the action it already had, and the entry carries the `sessionId` as the prior attempt worth reading.
 
 An unmatched agent becomes its own entry only when it still wants something: `blocked`, `failed`, or `working`. Since gather runs with `--all`, unmatched `done` records are completed history and get dropped. Keeping them would fill a prioritized brief with finished work. Group what remains by the repo `cwd` resolves to, or `Misc` when it resolves to none. A blocked agent is blocking work and sorts with it under the ordering rule above.
 
@@ -97,7 +101,7 @@ Present safe actions via AskUserQuestion (execute all, pick a subset, or none). 
 
 Run the quick safe actions and tracker corrections first. Session-length work like a review starts only at the end of the run, after the rest is cleared, and never before the approved order from triage.
 
-Never dispatch over an item with a live session. Resuming it is a handoff: surface the resume command and let the user run it, since this skill runs in its own session and cannot attach to another.
+Never dispatch over an item with a live session. When the item's session resolved to a herdr pane, `herdr agent focus <pane_id>` hands the user the running session rather than a command to paste. Confirm before focusing, since it moves the user's foreground away from this session, and treat it as the last action in the run for that item. Without a matched pane, surface the resume command and let the user run it.
 
 A prior session that is `done` or `failed` does not block a fresh dispatch, but when the work needs another pass, name that `sessionId` in the new prompt so the new session can look up what already happened.
 

--- a/user/skills/job/references/end.md
+++ b/user/skills/job/references/end.md
@@ -48,7 +48,7 @@ Offer per worktree: commit and push as WIP (safe on your own branch), or record 
 
 ## Unattended Agents
 
-Every blocked or failed agent leaves the day resumed, stopped, or captured as a follow-up. Route captures per Tracker Hygiene below. A blocked agent carries what it is waiting on in `waitingFor`, and that belongs in the capture, since tomorrow's answer is worthless without the question.
+Every blocked or failed agent leaves the day resumed, focused into its herdr pane when one matched, stopped, or captured as a follow-up. Route captures per Tracker Hygiene below. A blocked agent carries what it is waiting on in `waitingFor`, and that belongs in the capture, since tomorrow's answer is worthless without the question.
 
 A `working` agent can be left running overnight. That is a choice, so record it in the completion summary along with what it is expected to have finished by morning.
 

--- a/user/skills/job/references/start.md
+++ b/user/skills/job/references/start.md
@@ -46,7 +46,7 @@ Triage each inbound item, whether a message, a tracker notification, or an email
 
 Read is not handled. Notification state records only what the user has seen, so judge each thread by who spoke last and what remains open, never by unread flags. Two states never collapse into background noise: a thread where the user's own most recent comment is unanswered, which is live work awaiting a reply rather than a closed loop, and active discussion on work that also has an open MR in the user's review queue, which is review context and merges into that review's entry, since the thread may be converging on a different fix than the diff shows.
 
-A blocked agent is an inbound item like any message or notification, and it gets the same terminal disposition: resumed by you, or deferred with a note recording what it is waiting on. Read is not handled applies here too. An agent you saw in `claude agents` and walked away from is still open work.
+A blocked agent is an inbound item like any message or notification, and it gets the same terminal disposition: resumed by you, focused into its herdr pane when one matched, or deferred with a note recording what it is waiting on. Read is not handled applies here too. An agent you saw in `claude agents` and walked away from is still open work.
 
 Route deferrals per the contract in `SKILL.md`: team work to the tracker, personal next-steps and reminders to the personal inbox. Drafting a reply the user has read is safe, as is archiving something already handled. Sending a reply without review is ask-first.
 


### PR DESCRIPTION
The `job` skill handed you `claude --resume <sessionId>` for every item with a live session, justified by the skill "runs in its own session and cannot attach to another." Off herdr that holds. Under herdr it doesn't: `herdr agent list` returns `agent_session.value` per pane, so the join to a `claude agents` record is exact on session UUID with no title guessing, and `herdr agent focus <pane_id>` puts you in the running session instead of in a command to paste.

Gather makes one extra inline call when `HERDR_PANE_ID` is set. A matched pane turns the brief's action line into `herdr agent focus <pane_id>`, and Act can run that itself after confirming, since focus moves your foreground off the `job` session. `herdr agent attach` stays out of `allowed-tools`. It takes over the terminal, so the brief names it and you run it.

Every branch is guarded on `HERDR_PANE_ID`. On the tmux work machine nothing calls herdr, and the resume path reads complete on its own rather than as a degraded reference to the herdr branch.

Original Task: [job: focus a live session with herdr instead of handing over a resume command](https://things.bendrucker.me/show?id=R69VFoDJLT64QVGmMjbaNz)
