### PR TITLE
comments: conform judge text to the site's comment syntax

### DIFF
--- a/plugins/comments/apply/comment-syntax.test.ts
+++ b/plugins/comments/apply/comment-syntax.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, test } from "bun:test";
+import type { CommentKind } from "../detection/types";
+import { type CommentStyle, conformToStyle, detectStyle } from "./comment-syntax";
+import type { EditItem } from "./edits";
+
+/**
+ * A span covering whole lines of `source`, the shape `detectStyle` reads. The
+ * columns bracket the comment exactly, as the extractor produces them.
+ */
+function span(source: string, kind: CommentKind = "line"): { lines: string[]; item: EditItem } {
+  const lines = source.split("\n");
+  const first = lines[0] as string;
+  const last = lines[lines.length - 1] as string;
+  return {
+    lines,
+    item: {
+      startLine: 1,
+      endLine: lines.length,
+      startColumn: first.length - first.trimStart().length,
+      endColumn: last.length,
+      kind,
+      verdict: {
+        action: "trim",
+        category: "restate-the-what",
+        confidence: "high",
+        rationale: "r",
+        rewrite: null,
+      },
+    },
+  };
+}
+
+describe("detectStyle", () => {
+  test.each<{
+    name: string;
+    source: string;
+    kind?: CommentKind | undefined;
+    expected: CommentStyle;
+  }>([
+    {
+      name: "javadoc block keeps its star continuation",
+      source: "/**\n * one\n * two\n */",
+      kind: "docstring",
+      expected: { form: "block", open: "/**", close: "*/", continuation: "*" },
+    },
+    {
+      name: "plain block without stars has no continuation",
+      source: "/* one\n   two */",
+      kind: "block",
+      expected: { form: "block", open: "/*", close: "*/", continuation: undefined },
+    },
+    {
+      name: "plain block with stars picks up the continuation",
+      source: "/*\n * one\n */",
+      kind: "block",
+      expected: { form: "block", open: "/*", close: "*/", continuation: "*" },
+    },
+    {
+      name: "python docstring",
+      source: '"""\nDoes a thing.\n"""',
+      kind: "docstring",
+      expected: { form: "block", open: '"""', close: '"""', continuation: undefined },
+    },
+    {
+      name: "slash run",
+      source: "// one\n// two",
+      expected: { form: "line", linePrefix: "//" },
+    },
+    {
+      name: "rust outer doc run is not read as a plain slash run",
+      source: "/// one\n/// two",
+      expected: { form: "line", linePrefix: "///" },
+    },
+    {
+      name: "rust inner doc run is not read as a plain slash run",
+      source: "//! one",
+      expected: { form: "line", linePrefix: "//!" },
+    },
+    { name: "hash run", source: "# one", expected: { form: "line", linePrefix: "#" } },
+    { name: "sql run", source: "-- one", expected: { form: "line", linePrefix: "--" } },
+    {
+      name: "unrecognized markers fall back to the kind with no delimiters",
+      source: "(* ocaml *)",
+      kind: "block",
+      expected: { form: "block" },
+    },
+  ])("$name", ({ source, kind, expected }) => {
+    const { lines, item } = span(source, kind);
+    expect(detectStyle(lines, item)).toEqual(expected);
+  });
+
+  test("reads the comment out of a trailing span, not the code before it", () => {
+    const source = "count += 1; # bumps it";
+    const item = span(source).item;
+    expect(detectStyle([source], { ...item, startColumn: 12 })).toEqual({
+      form: "line",
+      linePrefix: "#",
+    });
+  });
+});
+
+describe("conformToStyle", () => {
+  const javadoc: CommentStyle = { form: "block", open: "/**", close: "*/", continuation: "*" };
+  const pydoc: CommentStyle = { form: "block", open: '"""', close: '"""' };
+  const slash: CommentStyle = { form: "line", linePrefix: "//" };
+  const hash: CommentStyle = { form: "line", linePrefix: "#" };
+
+  test.each<{ name: string; text: string; style: CommentStyle; expected: string | null }>([
+    {
+      name: "javadoc text passes through unchanged",
+      text: "/**\n * Returns the path.\n */",
+      style: javadoc,
+      expected: "/**\n * Returns the path.\n */",
+    },
+    {
+      name: "bare prose gets javadoc delimiters on one line",
+      text: "The broker rate-limits per key.",
+      style: javadoc,
+      expected: "/** The broker rate-limits per key. */",
+    },
+    {
+      name: "multi-line bare prose gets star continuations",
+      text: "The broker rate-limits per key.\nRetries reuse the first backoff.",
+      style: javadoc,
+      expected: "/**\n * The broker rate-limits per key.\n * Retries reuse the first backoff.\n */",
+    },
+    {
+      name: "a blank interior line keeps its continuation marker unpadded",
+      text: "One.\n\nTwo.",
+      style: javadoc,
+      expected: "/**\n * One.\n *\n * Two.\n */",
+    },
+    {
+      name: "bare prose in a python docstring site skips continuations",
+      text: "One.\nTwo.",
+      style: pydoc,
+      expected: '"""\nOne.\nTwo.\n"""',
+    },
+    {
+      name: "bare prose gets a slash prefix on every line",
+      text: "Retries reuse the first backoff.\nThe broker rate-limits per key.",
+      style: slash,
+      expected: "// Retries reuse the first backoff.\n// The broker rate-limits per key.",
+    },
+    {
+      name: "bare prose gets a hash prefix",
+      text: "Rate-limited per key.",
+      style: hash,
+      expected: "# Rate-limited per key.",
+    },
+    {
+      name: "over-indented javadoc text loses its common prefix",
+      text: "    /**\n     * Returns the path.\n     */",
+      style: javadoc,
+      expected: "/**\n * Returns the path.\n */",
+    },
+    {
+      name: "over-indented line text loses its common prefix",
+      text: "    // reuses the shared backoff",
+      style: slash,
+      expected: "// reuses the shared backoff",
+    },
+    {
+      name: "a slash comment landing in a javadoc site is irreconcilable",
+      text: "// Returns the path.",
+      style: javadoc,
+      expected: null,
+    },
+    {
+      name: "a hash comment landing in a slash site is irreconcilable",
+      text: "# Returns the path.",
+      style: slash,
+      expected: null,
+    },
+    {
+      name: "a python docstring landing in a javadoc site is irreconcilable",
+      text: '"""Returns the path."""',
+      style: javadoc,
+      expected: null,
+    },
+    {
+      name: "a plain block is accepted at a javadoc site",
+      text: "/* Returns the path. */",
+      style: javadoc,
+      expected: "/* Returns the path. */",
+    },
+    {
+      name: "bare prose at a rust doc site keeps the doc marker",
+      text: "Retries reuse the first backoff.",
+      style: { form: "line", linePrefix: "///" },
+      expected: "/// Retries reuse the first backoff.",
+    },
+    {
+      name: "a plain slash comment landing in a rust doc site is irreconcilable",
+      text: "// Retries reuse the first backoff.",
+      style: { form: "line", linePrefix: "///" },
+      expected: null,
+    },
+    {
+      name: "a block site with no known delimiters cannot be conformed",
+      text: "Returns the path.",
+      style: { form: "block" },
+      expected: null,
+    },
+    {
+      name: "a line site with no known delimiters cannot be conformed",
+      text: "Returns the path.",
+      style: { form: "line" },
+      expected: null,
+    },
+    {
+      name: "delimiter-carrying text is still refused at a site with none",
+      text: "// Returns the path.",
+      style: { form: "line" },
+      expected: null,
+    },
+  ])("$name", ({ text, style, expected }) => {
+    expect(conformToStyle(text, style)).toBe(expected);
+  });
+});

--- a/plugins/comments/apply/comment-syntax.ts
+++ b/plugins/comments/apply/comment-syntax.ts
@@ -1,0 +1,140 @@
+import type { EditItem } from "./edits";
+
+/**
+ * The delimiters in use at a comment site. They are absent when the site's
+ * markers are unrecognized, and text cannot be conformed to a style that
+ * carries none.
+ */
+export interface CommentStyle {
+  form: "block" | "line";
+  open?: string | undefined;
+  close?: string | undefined;
+  continuation?: string | undefined;
+  linePrefix?: string | undefined;
+}
+
+interface BlockOpener {
+  open: string;
+  close: string;
+  continuation?: string | undefined;
+}
+
+/** Longest opener first, so `/**` is not read as `/*`. */
+const BLOCK_OPENERS: BlockOpener[] = [
+  { open: "/**", close: "*/", continuation: "*" },
+  { open: "/*", close: "*/" },
+  { open: '"""', close: '"""' },
+  { open: "'''", close: "'''" },
+];
+
+/**
+ * Longest prefix first, so a Rust `///` or `//!` doc comment is not read as a
+ * plain `//` and quietly demoted to one when its delimiters are re-emitted.
+ */
+const LINE_PREFIXES = ["///", "//!", "//", "#", "--"];
+
+/** The comment's own text, with the code before and after its span removed. */
+function spanLines(lines: string[], item: EditItem): string[] {
+  const first = lines[item.startLine - 1] ?? "";
+  if (item.startLine === item.endLine) return [first.slice(item.startColumn, item.endColumn)];
+  const out = [first.slice(item.startColumn)];
+  for (let n = item.startLine + 1; n < item.endLine; n++) out.push(lines[n - 1] ?? "");
+  out.push((lines[item.endLine - 1] ?? "").slice(0, item.endColumn));
+  return out;
+}
+
+function readStyle(commentLines: string[]): CommentStyle | null {
+  const first = (commentLines[0] ?? "").trimStart();
+  for (const opener of BLOCK_OPENERS) {
+    if (!first.startsWith(opener.open)) continue;
+    const interior = commentLines.slice(1, -1);
+    const starred = interior.some((line) => line.trim().startsWith("*"));
+    const continuation = starred ? "*" : opener.continuation;
+    return { form: "block", open: opener.open, close: opener.close, continuation };
+  }
+  for (const prefix of LINE_PREFIXES) {
+    if (first.startsWith(prefix)) return { form: "line", linePrefix: prefix };
+  }
+  return null;
+}
+
+/**
+ * The delimiters actually in use at the comment's source span. Read from the
+ * site rather than inferred from `item.kind`, so a `#` run and a `//` run are
+ * distinguished and a Javadoc block keeps its ` * ` continuation.
+ */
+export function detectStyle(lines: string[], item: EditItem): CommentStyle {
+  const style = readStyle(spanLines(lines, item));
+  if (style) return style;
+  return { form: item.kind === "line" ? "line" : "block" };
+}
+
+/** C-style `/* *​/` and quoted docstrings cannot substitute for each other. */
+function blockFamily(open: string): string {
+  return open.startsWith("/") ? "c" : "quote";
+}
+
+function compatible(text: CommentStyle, site: CommentStyle): boolean {
+  if (text.form !== site.form) return false;
+  if (site.form === "line") return text.linePrefix === site.linePrefix;
+  return (
+    text.open !== undefined &&
+    site.open !== undefined &&
+    blockFamily(text.open) === blockFamily(site.open)
+  );
+}
+
+function stripCommonIndent(text: string): string[] {
+  const lines = text.split("\n");
+  const indents = lines
+    .filter((line) => line.trim().length > 0)
+    .map((line) => line.length - line.trimStart().length);
+  const common = indents.length === 0 ? 0 : Math.min(...indents);
+  return lines.map((line) => line.slice(common));
+}
+
+function wrapBlock(
+  prose: string[],
+  open: string,
+  close: string,
+  continuation: string | undefined,
+): string[] {
+  if (prose.length === 1) return [`${open} ${prose[0]} ${close}`];
+  const body = prose.map((line) => {
+    if (continuation === undefined) return line;
+    return line.length === 0 ? ` ${continuation}` : ` ${continuation} ${line}`;
+  });
+  return [open, ...body, continuation === undefined ? close : ` ${close}`];
+}
+
+function wrapLine(prose: string[], linePrefix: string): string[] {
+  return prose.map((line) => (line.length === 0 ? linePrefix : `${linePrefix} ${line}`));
+}
+
+/** True when the site's markers were recognized, so text can be conformed. */
+export function hasDelimiters(style: CommentStyle): boolean {
+  return style.form === "line" ? style.linePrefix !== undefined : style.open !== undefined;
+}
+
+/**
+ * Make judge-authored text splice-ready for a site in `style`: strip the text's
+ * own common indentation (the applier owns indentation) and give it the site's
+ * delimiters, re-emitting them when the text is bare prose. Returns null when
+ * the text carries a comment form the site cannot host, or when the site's own
+ * markers went unrecognized and there is nothing to re-emit. Both become a
+ * refusal rather than a splice that breaks the file.
+ */
+export function conformToStyle(text: string, style: CommentStyle): string | null {
+  const lines = stripCommonIndent(text);
+  const textStyle = readStyle(lines);
+  if (textStyle) {
+    return hasDelimiters(style) && compatible(textStyle, style) ? lines.join("\n") : null;
+  }
+  if (style.form === "block") {
+    const { open, close } = style;
+    if (open === undefined || close === undefined) return null;
+    return wrapBlock(lines, open, close, style.continuation).join("\n");
+  }
+  const { linePrefix } = style;
+  return linePrefix === undefined ? null : wrapLine(lines, linePrefix).join("\n");
+}

--- a/plugins/comments/apply/edits.test.ts
+++ b/plugins/comments/apply/edits.test.ts
@@ -40,8 +40,6 @@ describe("computeFileEdits", () => {
     skipsEmpty?: boolean;
     skipsLength?: number;
     skipDetail?: RegExp;
-    warningsLength?: number;
-    warningDetail?: RegExp;
   }>([
     {
       name: "case (a): deletes a single full-line comment",
@@ -306,7 +304,26 @@ describe("computeFileEdits", () => {
       skipsEmpty: true,
     },
     {
-      name: "warnings: flags an applier-produced line over maxWidth",
+      name: "width: refuses a splice over an explicit maxWidth",
+      source: "count += 1; // note",
+      items: [
+        item({
+          startLine: 1,
+          endLine: 1,
+          startColumn: 12,
+          endColumn: "count += 1; // note".length,
+          verdict: verdict({
+            trimTo: "// a kept clause long enough to overflow the configured width limit",
+          }),
+        }),
+      ],
+      expected: "count += 1; // note",
+      options: { maxWidth: 40 },
+      skipsLength: 1,
+      skipDetail: /over 40/,
+    },
+    {
+      name: "width: applies the same splice when no maxWidth is passed",
       source: "count += 1; // note",
       items: [
         item({
@@ -320,9 +337,106 @@ describe("computeFileEdits", () => {
         }),
       ],
       expected: "count += 1; // a kept clause long enough to overflow the configured width limit",
-      options: { maxWidth: 40 },
-      warningsLength: 1,
-      warningDetail: /over 40/,
+      skipsEmpty: true,
+    },
+    {
+      name: "syntax: a trimTo of bare prose regains the site's javadoc delimiters",
+      source:
+        "class A {\n    /**\n     * Walks the loop and retries.\n     * The broker rate-limits per key.\n     */\n    void f() {}\n}",
+      items: [
+        item({
+          startLine: 2,
+          endLine: 5,
+          startColumn: 4,
+          endColumn: 7,
+          kind: "docstring",
+          verdict: verdict({ trimTo: "The broker rate-limits per key." }),
+        }),
+      ],
+      expected: "class A {\n    /** The broker rate-limits per key. */\n    void f() {}\n}",
+      skipsEmpty: true,
+    },
+    {
+      name: "syntax: a multi-line trimTo of bare prose regains star continuations",
+      source: "  /**\n   * One.\n   * Two.\n   * Three.\n   */\n  b();",
+      items: [
+        item({
+          startLine: 1,
+          endLine: 5,
+          startColumn: 2,
+          endColumn: 5,
+          kind: "docstring",
+          verdict: verdict({ trimTo: "One.\nThree." }),
+        }),
+      ],
+      expected: "  /**\n   * One.\n   * Three.\n   */\n  b();",
+      skipsEmpty: true,
+    },
+    {
+      name: "syntax: a trailing line comment in a chain keeps its marker",
+      source: "        .retryOn(RATE_LIMIT) // the broker rate-limits per key",
+      items: [
+        item({
+          startLine: 1,
+          endLine: 1,
+          startColumn: 28,
+          endColumn: "        .retryOn(RATE_LIMIT) // the broker rate-limits per key".length,
+          verdict: verdict({ trimTo: "rate-limited per key" }),
+        }),
+      ],
+      expected: "        .retryOn(RATE_LIMIT) // rate-limited per key",
+      skipsEmpty: true,
+    },
+    {
+      name: "syntax: a rust doc comment keeps its doc marker through a trimTo",
+      source: "/// This method walks the loop and retries.\nfn retry() {}",
+      items: [
+        item({
+          startLine: 1,
+          endLine: 1,
+          startColumn: 0,
+          endColumn: "/// This method walks the loop and retries.".length,
+          verdict: verdict({ trimTo: "Retries reuse the first backoff." }),
+        }),
+      ],
+      expected: "/// Retries reuse the first backoff.\nfn retry() {}",
+      skipsEmpty: true,
+    },
+    {
+      name: "syntax: refuses a trimTo at a site whose delimiters go unrecognized",
+      source:
+        "=begin\nThis method walks the loop.\nThe broker rate-limits per key.\n=end\ndef retry; end",
+      items: [
+        item({
+          startLine: 1,
+          endLine: 4,
+          startColumn: 0,
+          endColumn: 4,
+          kind: "block",
+          verdict: verdict({ trimTo: "The broker rate-limits per key." }),
+        }),
+      ],
+      expected:
+        "=begin\nThis method walks the loop.\nThe broker rate-limits per key.\n=end\ndef retry; end",
+      skipsLength: 1,
+      skipDetail: /delimiters the applier does not recognize/,
+    },
+    {
+      name: "syntax: refuses a trimTo carrying a form the site cannot host",
+      source: "  /**\n   * Walks the loop.\n   */\n  b();",
+      items: [
+        item({
+          startLine: 1,
+          endLine: 3,
+          startColumn: 2,
+          endColumn: 5,
+          kind: "docstring",
+          verdict: verdict({ trimTo: "// Walks the loop." }),
+        }),
+      ],
+      expected: "  /**\n   * Walks the loop.\n   */\n  b();",
+      skipsLength: 1,
+      skipDetail: /does not match the \/\*\* \*\//,
     },
     {
       name: "blank collapse: drops the blank left under a block opener by a deleted docstring",
@@ -433,17 +547,7 @@ describe("computeFileEdits", () => {
       expected: "x = 1; /* note */ y = 2;",
       skipDetail: /interleaved/,
     },
-  ])("$name", ({
-    source,
-    items,
-    expected,
-    options,
-    skipsEmpty,
-    skipsLength,
-    skipDetail,
-    warningsLength,
-    warningDetail,
-  }) => {
+  ])("$name", ({ source, items, expected, options, skipsEmpty, skipsLength, skipDetail }) => {
     const result = computeFileEdits(source, items, options);
     expect(result.content).toBe(expected);
     if (skipsEmpty) {
@@ -455,10 +559,40 @@ describe("computeFileEdits", () => {
     if (skipDetail) {
       expect(result.skips[0]?.detail).toMatch(skipDetail);
     }
-    expect(result.warnings).toHaveLength(warningsLength ?? 0);
-    if (warningDetail) {
-      expect(result.warnings[0]?.detail).toMatch(warningDetail);
-    }
+  });
+
+  test("a rewrite carrying its own indentation lands at the site's indentation", () => {
+    const source = [
+      "class Broker {",
+      "    /**",
+      "     * This method walks the loop and retries.",
+      "     */",
+      "    void retry() {}",
+      "}",
+    ].join("\n");
+    const result = computeFileEdits(source, [
+      item({
+        startLine: 2,
+        endLine: 4,
+        startColumn: 4,
+        endColumn: 7,
+        kind: "docstring",
+        verdict: verdict({
+          action: "rewrite",
+          category: "voice",
+          rewrite: "    /**\n     * Retries until the broker's per-key limit clears.\n     */",
+        }),
+      }),
+    ]);
+    expect(result.skips).toEqual([]);
+    expect(result.content).toMatchInlineSnapshot(`
+      "class Broker {
+          /**
+           * Retries until the broker's per-key limit clears.
+           */
+          void retry() {}
+      }"
+    `);
   });
 });
 

--- a/plugins/comments/apply/edits.ts
+++ b/plugins/comments/apply/edits.ts
@@ -1,5 +1,6 @@
 import type { CommentKind } from "../detection/types";
 import type { Verdict } from "../judge/schema";
+import { type CommentStyle, conformToStyle, detectStyle, hasDelimiters } from "./comment-syntax";
 
 /** One comment's range plus the verdict that decides how it is trimmed. */
 export interface EditItem {
@@ -18,21 +19,18 @@ export interface EditSkip {
   detail: string;
 }
 
-/** A line the applier produced that a human should re-check, not a refusal. */
-export interface EditWarning {
-  line: number;
-  detail: string;
-}
-
 export interface FileEditResult {
   content: string;
   skips: EditSkip[];
-  warnings: EditWarning[];
 }
 
 export interface FileEditOptions {
-  /** Applier-produced lines longer than this are flagged in `warnings`. */
-  maxWidth?: number;
+  /**
+   * Refuse a splice that would produce a line longer than this. Opt-in: with no
+   * value, width is not checked, because a limit guessed below the target
+   * repo's own would refuse edits that are in fact fine.
+   */
+  maxWidth?: number | undefined;
 }
 
 /**
@@ -176,13 +174,33 @@ function applyFull(
   });
 }
 
+/** Why judge text could not be conformed to the comment it would replace. */
+function conformRefusal(style: CommentStyle): string {
+  if (!hasDelimiters(style)) {
+    return "comment uses delimiters the applier does not recognize; rewrite by hand";
+  }
+  const markers = style.form === "line" ? style.linePrefix : `${style.open} ${style.close}`;
+  return `replacement text does not match the ${markers} comment it replaces; rewrite by hand`;
+}
+
+/** The refusal detail for a splice that would exceed `maxWidth`, else null. */
+function widthRefusal(produced: string[], maxWidth: number | undefined): string | null {
+  if (maxWidth === undefined) return null;
+  const over = produced.find((line) => line.length > maxWidth);
+  if (!over) return null;
+  return `replacement would produce a ${over.length}-character line (over ${maxWidth}); re-wrap by hand`;
+}
+
 /**
  * Replace a comment's span with judge-authored text (a `rewrite` or a partial
- * trim's `trimTo`). The text carries the delimiters but no leading indentation;
- * the applier owns it. For a full-line comment the span's lines become the
- * indented text lines. For a trailing line comment the text is spliced after
- * the code, one space apart. Anything else (a trailing block, code interleaved
- * on the line) is skipped and flagged, the same conservative bar trims use.
+ * trim's `trimTo`). The text is conformed to the delimiters the site actually
+ * uses and de-indented before the applier adds the site's indentation, so text
+ * that arrives as bare prose or carrying its own indentation still splices as a
+ * valid comment. For a full-line comment the span's lines become the indented
+ * text lines. For a trailing line comment the text is spliced after the code,
+ * one space apart. A form the site cannot host, an over-width result, or code
+ * interleaved on the line is skipped and flagged, the same conservative bar
+ * trims use.
  */
 function replaceSpan(
   item: EditItem,
@@ -191,26 +209,47 @@ function replaceSpan(
   deletions: Set<number>,
   spanInserts: Map<number, string[]>,
   skips: EditSkip[],
+  maxWidth: number | undefined,
 ): void {
   const before = (lines[item.startLine - 1] ?? "").slice(0, item.startColumn);
   const after = (lines[item.endLine - 1] ?? "").slice(item.endColumn);
   const wsBefore = before.trim().length === 0;
   const wsAfter = after.trim().length === 0;
-  const textLines = text.split("\n");
+
+  const style = detectStyle(lines, item);
+  const conformed = conformToStyle(text, style);
+  if (conformed == null) {
+    skips.push({
+      startLine: item.startLine,
+      reason: "manual",
+      detail: conformRefusal(style),
+    });
+    return;
+  }
+  const textLines = conformed.split("\n");
 
   if (wsBefore && wsAfter) {
     const indent = before;
-    spanInserts.set(
-      item.startLine,
-      textLines.map((line) => `${indent}${line}`.replace(/\s+$/, "")),
-    );
+    const produced = textLines.map((line) => `${indent}${line}`.replace(/\s+$/, ""));
+    const tooWide = widthRefusal(produced, maxWidth);
+    if (tooWide) {
+      skips.push({ startLine: item.startLine, reason: "manual", detail: tooWide });
+      return;
+    }
+    spanInserts.set(item.startLine, produced);
     for (let n = item.startLine; n <= item.endLine; n++) deletions.add(n);
     return;
   }
 
   if (!wsBefore && wsAfter && item.kind === "line" && item.startLine === item.endLine) {
     const code = before.replace(/\s+$/, "");
-    spanInserts.set(item.startLine, [`${code} ${textLines.join(" ")}`.replace(/\s+$/, "")]);
+    const produced = [`${code} ${textLines.join(" ")}`.replace(/\s+$/, "")];
+    const tooWide = widthRefusal(produced, maxWidth);
+    if (tooWide) {
+      skips.push({ startLine: item.startLine, reason: "manual", detail: tooWide });
+      return;
+    }
+    spanInserts.set(item.startLine, produced);
     deletions.add(item.startLine);
     return;
   }
@@ -228,6 +267,7 @@ function applyRewrite(
   deletions: Set<number>,
   spanInserts: Map<number, string[]>,
   skips: EditSkip[],
+  maxWidth: number | undefined,
 ): void {
   const rewrite = item.verdict.rewrite;
   if (!rewrite) {
@@ -238,7 +278,7 @@ function applyRewrite(
     });
     return;
   }
-  replaceSpan(item, rewrite, lines, deletions, spanInserts, skips);
+  replaceSpan(item, rewrite, lines, deletions, spanInserts, skips, maxWidth);
 }
 
 /**
@@ -257,20 +297,18 @@ function applyRewrite(
  *
  * Overlapping verdicts on one line resolve with deletion winning over a replace.
  * A span insert at a line takes precedence over its own span's deletions.
- * Applier-produced lines longer than `maxWidth` are flagged in `warnings`.
  */
 export function computeFileEdits(
   source: string,
   items: EditItem[],
   options: FileEditOptions = {},
 ): FileEditResult {
-  const { maxWidth = 100 } = options;
+  const { maxWidth } = options;
   const lines = source.split("\n");
   const deletions = new Set<number>();
   const replacements = new Map<number, string>();
   const spanInserts = new Map<number, string[]>();
   const skips: EditSkip[] = [];
-  const warnings: EditWarning[] = [];
 
   for (const item of items) {
     switch (item.verdict.action) {
@@ -278,7 +316,7 @@ export function computeFileEdits(
         break;
       case "trim": {
         if (item.verdict.trimTo) {
-          replaceSpan(item, item.verdict.trimTo, lines, deletions, spanInserts, skips);
+          replaceSpan(item, item.verdict.trimTo, lines, deletions, spanInserts, skips, maxWidth);
           break;
         }
         const keep = keepLines(item);
@@ -290,19 +328,8 @@ export function computeFileEdits(
         break;
       }
       case "rewrite":
-        applyRewrite(item, lines, deletions, spanInserts, skips);
+        applyRewrite(item, lines, deletions, spanInserts, skips, maxWidth);
         break;
-    }
-  }
-
-  for (const [n, insert] of spanInserts) {
-    for (const line of insert) {
-      if (line.length > maxWidth) {
-        warnings.push({
-          line: n,
-          detail: `applier produced a ${line.length}-character line (over ${maxWidth}); re-wrap by hand`,
-        });
-      }
     }
   }
 
@@ -338,5 +365,5 @@ export function computeFileEdits(
     lastPushed = line;
     lastPushedBlank = isBlank(line);
   }
-  return { content: out.join("\n"), skips, warnings };
+  return { content: out.join("\n"), skips };
 }

--- a/plugins/comments/skills/audit/SKILL.md
+++ b/plugins/comments/skills/audit/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   asked to audit, trim, or clean up code comments, or as the comment pass of a
   branch-finishing flow. Not a general code review: skip it when the change
   added no comments.
-argument-hint: "[--all] [--base <ref>] [--mr <iid>] [--path <glob>] [--sort <key>] [--limit <n>] [--report] [--fix] [--format <template>]"
+argument-hint: "[--all] [--base <ref>] [--mr <iid>] [--path <glob>] [--sort <key>] [--limit <n>] [--report] [--fix] [--format <template>] [--max-width <n>]"
 allowed-tools:
   - Bash
   - Read
@@ -54,6 +54,8 @@ and license headers never reach the judge.
 - `--report`: at apply time, print findings instead of writing a branch.
 - `--format <template>`: at apply time, pipe each edited file through a
   formatter before committing.
+- `--max-width <n>`: at apply time, refuse a splice that would exceed `n`
+  columns. Width goes unchecked when the flag is absent.
 
 ## Preflight
 
@@ -99,7 +101,7 @@ verdicts stay on disk, off the conversation, for `apply` to read.
 ## Apply
 
 ```bash
-bun <plugin-dir>/skills/audit/scripts/audit.ts apply --job <jobDir> [--report] [--fix] [--format <template>]
+bun <plugin-dir>/skills/audit/scripts/audit.ts apply --job <jobDir> [--report] [--fix] [--format <template>] [--max-width <n>]
 ```
 
 Default apply re-extracts the judged files and matches verdicts to comments by
@@ -141,10 +143,27 @@ Pick the formatter from the target repo's own configuration and pass it
 explicitly, or omit the flag. NEVER guess at, auto-discover, or auto-execute a
 formatter the repo does not configure.
 
+Without `--format`, `--max-width` is the only guard on wrapping. Set it to the
+limit the target repo already enforces (its formatter config, `.editorconfig`,
+or linter rule). Never invent one: a limit below the repo's real width refuses
+edits that would have been fine.
+
 ### Manual Handling
 
 Comments the applier cannot change safely are left in place and listed for
-manual handling: a comment interleaved with code, a trim that would break a
-block delimiter, and a line-range trim whose kept line would open mid-sentence.
-Applier-produced lines that exceed the width limit are applied but listed as
-warnings to re-wrap by hand.
+manual handling:
+
+- a comment interleaved with code;
+- a `trimToLines` range that would drop a block's opening or closing delimiter,
+  or whose kept line would open mid-sentence;
+- a `trimTo` or `rewrite` whose text carries a comment form the site cannot
+  host, such as `//` text replacing a `/** */` block;
+- a `trimTo` or `rewrite` at a comment whose own delimiters the applier does
+  not recognize, such as Ruby's `=begin`/`=end`;
+- a `trimTo` or `rewrite` that would produce a line past `--max-width`.
+
+For a `trimTo` or `rewrite`, the applier reads the delimiters the comment
+already uses and re-emits them, so text that arrives as bare prose still
+splices as a valid comment at the right indentation. Doc-comment markers
+(`/**`, `///`, `//!`) survive the round trip rather than decaying to their
+plain form.

--- a/plugins/comments/skills/audit/scripts/audit.ts
+++ b/plugins/comments/skills/audit/scripts/audit.ts
@@ -219,11 +219,15 @@ const applyCmd = command(
         description:
           "Format each edited file through this shell template ({} = path, content on stdin)",
       },
+      maxWidth: {
+        type: Number,
+        description: "Refuse a splice past this line width (unchecked when omitted)",
+      },
     },
   },
   async (parsed) => {
     await chdirToRepoRoot();
-    const { job, report, fix, format } = parsed.flags;
+    const { job, report, fix, format, maxWidth } = parsed.flags;
     if (!job) {
       console.error("--job <dir> is required.");
       process.exit(1);
@@ -257,7 +261,6 @@ const applyCmd = command(
     const matched = new Set<string>();
     const manualSkips: string[] = [];
     const skippedComments = new Set<string>();
-    const editWarnings: { path: string; line: number; detail: string }[] = [];
 
     // Re-extract each judged file and match verdicts by id at the comment's
     // current range. A verdict whose id no longer re-extracts has drifted.
@@ -279,24 +282,20 @@ const applyCmd = command(
           editItems.push(toEditItem(match.comment, match.verdict));
       }
       if (editItems.length > 0) {
-        const result = computeFileEdits(source, editItems);
+        const result = computeFileEdits(source, editItems, { maxWidth });
         for (const skip of result.skips) {
           manualSkips.push(`${path}:${skip.startLine}  ${skip.detail}`);
           skippedComments.add(`${path}:${skip.startLine}`);
         }
-        for (const warning of result.warnings)
-          editWarnings.push({ path, line: warning.line, detail: warning.detail });
         if (result.content !== source) editsByPath.set(path, result.content);
       }
     }
 
-    const formattedPaths = new Set<string>();
     if (format && !report) {
       for (const [path, content] of editsByPath) {
         const formatted = await formatContent(format, path, content);
         if (formatted.formatted) {
           editsByPath.set(path, formatted.content);
-          formattedPaths.add(path);
         } else {
           console.error(
             color.yellow(
@@ -342,14 +341,6 @@ const applyCmd = command(
     if (manualSkips.length > 0) {
       console.error(color.yellow(`Left ${manualSkips.length} comment(s) for manual handling:`));
       for (const skip of manualSkips) console.error(`  ${skip}`);
-    }
-    // A formatter that succeeded owns line wrapping for its file, so its
-    // over-length warnings are stale.
-    const remainingWarnings = editWarnings.filter((warning) => !formattedPaths.has(warning.path));
-    if (remainingWarnings.length > 0) {
-      console.error(color.yellow(`Applied ${remainingWarnings.length} edit(s) worth re-checking:`));
-      for (const warning of remainingWarnings)
-        console.error(`  ${warning.path}:${warning.line}  ${warning.detail}`);
     }
   },
 );


### PR DESCRIPTION
Fixes the applier corrupting comments when it splices judge-authored text.

`replaceSpan` is the shared path for a partial trim's `trimTo` and for a `rewrite`. It split the text on newlines, prefixed each line with the site's indentation, and wrote it in. It never looked at what the target comment was. The delimiter guard SKILL.md promises lived only in `applyTrim`, which serves the legacy `trimToLines` path, so a `trimTo` arriving as bare prose stripped a Javadoc block down to uncommented text, a trailing `//` disappeared from a builder chain, and text carrying its own indentation landed double-indented.

The judge prompt already asks for delimiters. Nothing enforced it, and the judge is the wrong place to fix a determinism problem, so enforcement moves to the applier.

## Conforming to the site

New `comment-syntax.ts` reads the delimiters at the comment's actual source span and reshapes the replacement to match: strip the text's common leading indentation, pass it through when it already carries a compatible form, re-emit the site's delimiters when it is bare prose. Detection reads the span rather than `item.kind`, which cannot tell a `#` run from a `//` run.

Two cases refuse instead of splicing, landing in the existing manual-handling list. Text carrying a form the site cannot host, such as `//` prose replacing a `/** */` block. And a site whose own delimiters go unrecognized, which came out of review: the first draft passed those through untouched, so a Ruby `=begin`/`=end` block with a bare-prose trim got replaced by uncommented source and nothing reported it. Review also caught `//` matching ahead of `///`, which quietly demoted Rust doc comments to ordinary ones.

## Width

Over-width was a post-pass warning against a default of 100, and the edit committed anyway. It is now a refusal gated on a new `--max-width`, off unless passed. Flipping to a refusal at 100 would have turned a cosmetic warning into mass skips in any repo whose real limit is higher, and the repo that surfaced this runs checkstyle at 120. Pick the number from the target repo's own config or leave it off.

Nothing produces warnings anymore, so `EditWarning` and its reporting path in `audit.ts` are gone.

Verified end to end against a scratch Java repo: preflight, a hand-written bare-prose `trimTo` verdict, then apply. The branch diff shows `/** ... */` at the method's indentation, and the same job re-run with `--max-width 60` applies nothing and reports the refusal.

Original Task: [Fix comments:audit applier corrupting Javadoc blocks on partial trims](https://things.bendrucker.me/show?id=Trq93M1Bp6bFpeSSTPRyqZ)
