### PR TITLE
hooks: fix matchers that could never fire

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -17,6 +17,7 @@ After making changes to plugin scripts, run them directly to verify they work en
 - **Prefix dotdir paths with `./` in `bun test`**: A positional arg is a *filter* (substring match against discovered test paths), not a path. Discovery skips dotdirs, so `bun test .claude/hooks` matches nothing and silently runs 0 tests. Writing `bun test ./.claude/hooks` makes bun read it as a path and run the tests under it. Always use a `./` prefix for hidden-dir paths in CI and local test commands.
 - **No `.js` imports in TypeScript**: Import from `./module` not `./module.js`. The bundler/runtime handles resolution.
 - **Prefer skills over agents**: Skills are invocable via the `Skill` tool. Agents require the `Agent` tool. If something should be directly invocable, make it a skill.
+- **Hook E2E tests drive the real dispatcher**: A unit test over a hook script proves the script's logic, not that Claude Code ever dispatches to it. To prove dispatch, run headless `claude -p` with `--plugin-dir` against a throwaway repo with the external CLI (`gh`, `glab`) stubbed onto `PATH`, then assert on what the stub recorded. These live at `plugins/<name>/scripts/e2e-*.ts`. Each run spends API tokens, so they stay out of `bun test` and run in CI only from a path-filtered workflow holding the `CLAUDE_CODE_OAUTH_TOKEN` secret.
 
 ## Technique Selection
 

--- a/.github/workflows/hook-e2e.yml
+++ b/.github/workflows/hook-e2e.yml
@@ -1,0 +1,37 @@
+name: hook-e2e
+
+on:
+  pull_request:
+    paths:
+      - plugins/pull-request/hooks/**
+      - plugins/pull-request/scripts/validate*
+      - plugins/pull-request/scripts/e2e-*
+      - plugins/pull-request/scripts/e2e-fixtures/**
+      - .github/workflows/hook-e2e.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install Claude Code CLI
+        id: cli
+        background: true
+        run: curl -fsSL https://claude.ai/install.sh | bash
+
+      - uses: ./.github/actions/bun-install
+
+      - name: Wait for CLI
+        wait: cli
+
+      - name: Fire the PR body hook
+        run: bun plugins/pull-request/scripts/e2e-hook-fire.ts

--- a/.github/workflows/hook-e2e.yml
+++ b/.github/workflows/hook-e2e.yml
@@ -3,10 +3,8 @@ name: hook-e2e
 on:
   pull_request:
     paths:
-      - plugins/pull-request/hooks/**
-      - plugins/pull-request/scripts/validate*
-      - plugins/pull-request/scripts/e2e-*
-      - plugins/pull-request/scripts/e2e-fixtures/**
+      - plugins/*/hooks/**
+      - plugins/*/scripts/**
       - .github/workflows/hook-e2e.yml
 
 concurrency:
@@ -14,9 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pull-request:
+  e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     env:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     steps:
@@ -33,5 +31,16 @@ jobs:
       - name: Wait for CLI
         wait: cli
 
-      - name: Fire the PR body hook
-        run: bun plugins/pull-request/scripts/e2e-hook-fire.ts
+      - name: Run hook E2E tests
+        run: |
+          found=0
+          while IFS= read -r -d '' test; do
+            found=1
+            echo "::group::$test"
+            bun "$test"
+            echo "::endgroup::"
+          done < <(find plugins/*/scripts -maxdepth 1 -name 'e2e-*.ts' -print0 | sort -z)
+          if [[ "$found" == "0" ]]; then
+            echo "No hook E2E tests found"
+            exit 1
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Check MCP hook matchers
         run: bun scripts/check-mcp-matchers.ts
 
+      - name: Check hook matchers
+        run: bun scripts/check-hook-matchers.ts
+
       - name: Check plugin dependencies
         run: bun scripts/check-plugin-deps.ts
 

--- a/packages/marketplace/index.ts
+++ b/packages/marketplace/index.ts
@@ -4,6 +4,8 @@ import { join } from "node:path";
 export interface HookCommand {
   type: string;
   command: string;
+  /** Permission rule scoping the command, e.g. `Bash(gh pr create:*)`. */
+  if?: string;
 }
 
 export interface MatcherEntry {

--- a/plugins/git/hooks/hooks.json
+++ b/plugins/git/hooks/hooks.json
@@ -3,11 +3,12 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash(git commit:*)",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/block-default-branch-commit.ts\""
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/block-default-branch-commit.ts\"",
+            "if": "Bash(git commit:*)"
           }
         ]
       }

--- a/plugins/github/hooks/hooks.json
+++ b/plugins/github/hooks/hooks.json
@@ -8,7 +8,7 @@
           {
             "type": "command",
             "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts\"",
-            "if": "WebFetch(https://github.com/*)"
+            "if": "WebFetch(domain:github.com)"
           }
         ]
       }

--- a/plugins/gitlab/hooks/hooks.json
+++ b/plugins/gitlab/hooks/hooks.json
@@ -8,7 +8,7 @@
           {
             "type": "command",
             "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts\"",
-            "if": "WebFetch(https://gitlab.com/*)"
+            "if": "WebFetch(domain:gitlab.com)"
           }
         ]
       },

--- a/plugins/go/hooks/hooks.json
+++ b/plugins/go/hooks/hooks.json
@@ -8,7 +8,17 @@
           {
             "type": "command",
             "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/check.ts\"",
-            "if": "Edit(**/*.go)|MultiEdit(**/*.go)|Write(**/*.go)"
+            "if": "Edit(**/*.go)"
+          },
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/check.ts\"",
+            "if": "MultiEdit(**/*.go)"
+          },
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/check.ts\"",
+            "if": "Write(**/*.go)"
           }
         ]
       }

--- a/plugins/linear/hooks/hooks.json
+++ b/plugins/linear/hooks/hooks.json
@@ -3,11 +3,12 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "WebFetch(domain:linear.app)",
+        "matcher": "WebFetch",
         "hooks": [
           {
             "type": "command",
             "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/fetch.ts\"",
+            "if": "WebFetch(domain:linear.app)",
             "timeout": 10
           }
         ]

--- a/plugins/pull-request/hooks/hooks.json
+++ b/plugins/pull-request/hooks/hooks.json
@@ -3,11 +3,27 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash(gh pr create:*)|Bash(gh pr edit:*)|Bash(glab mr create:*)|Bash(glab mr update:*)",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/validate.ts\""
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/validate.ts\"",
+            "if": "Bash(gh pr create:*)"
+          },
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/validate.ts\"",
+            "if": "Bash(gh pr edit:*)"
+          },
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/validate.ts\"",
+            "if": "Bash(glab mr create:*)"
+          },
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/validate.ts\"",
+            "if": "Bash(glab mr update:*)"
           }
         ]
       }

--- a/plugins/pull-request/scripts/e2e-fixtures/clean.md
+++ b/plugins/pull-request/scripts/e2e-fixtures/clean.md
@@ -1,0 +1,3 @@
+Scopes the body validation hook to the commands that carry a PR body.
+
+Command scoping moves into a per-command permission rule, so the tool-name matcher only has to name Bash.

--- a/plugins/pull-request/scripts/e2e-fixtures/deny.md
+++ b/plugins/pull-request/scripts/e2e-fixtures/deny.md
@@ -1,0 +1,5 @@
+Scopes the body validation hook to the commands that carry a PR body.
+
+## Testing
+
+Added 12 unit tests covering the parser.

--- a/plugins/pull-request/scripts/e2e-hook-fire.ts
+++ b/plugins/pull-request/scripts/e2e-hook-fire.ts
@@ -2,9 +2,9 @@
 
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 
-const PLUGIN_DIR = resolve(import.meta.dirname, "..");
+const PLUGIN_DIR = join(import.meta.dirname, "..");
 const FIXTURE_DIR = join(import.meta.dirname, "e2e-fixtures");
 const RUN_TIMEOUT_MS = 3 * 60 * 1000;
 const DENY_REASON_FRAGMENT = "test counts";

--- a/plugins/pull-request/scripts/e2e-hook-fire.ts
+++ b/plugins/pull-request/scripts/e2e-hook-fire.ts
@@ -1,0 +1,182 @@
+#!/usr/bin/env bun
+
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const PLUGIN_DIR = resolve(import.meta.dirname, "..");
+const FIXTURE_DIR = join(import.meta.dirname, "e2e-fixtures");
+const RUN_TIMEOUT_MS = 3 * 60 * 1000;
+const DENY_REASON_FRAGMENT = "test counts";
+
+interface Case {
+  name: string;
+  fixture: string;
+  expectCreate: boolean;
+}
+
+const CASES: Case[] = [
+  { name: "deny", fixture: "deny.md", expectCreate: false },
+  { name: "clean", fixture: "clean.md", expectCreate: true },
+];
+
+interface RunResult {
+  output: string;
+  timedOut: boolean;
+  exitCode: number;
+}
+
+async function run(
+  command: string[],
+  cwd: string,
+  env: Record<string, string | undefined> = process.env,
+): Promise<void> {
+  const proc = Bun.spawn(command, { cwd, env, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  if (code !== 0) {
+    throw new Error(`${command.join(" ")} failed (${code}):\n${stdout}${stderr}`);
+  }
+}
+
+async function setupRepo(root: string): Promise<void> {
+  const env = { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" };
+  const git = (args: string[]) => run(["git", ...args], root, env);
+  await git(["init", "-b", "main"]);
+  await git(["config", "user.email", "e2e@example.com"]);
+  await git(["config", "user.name", "E2E"]);
+  await Bun.write(join(root, "README.md"), "# e2e\n");
+  await git(["add", "README.md"]);
+  await git(["commit", "-m", "init"]);
+}
+
+async function setupGhStub(root: string): Promise<{ binDir: string; logPath: string }> {
+  const binDir = join(root, "bin");
+  const logPath = join(root, "gh-invocations.log");
+  await mkdir(binDir, { recursive: true });
+  const stub = join(binDir, "gh");
+  await Bun.write(stub, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(logPath)}\nexit 0\n`);
+  await run(["chmod", "+x", stub], root);
+  await Bun.write(logPath, "");
+  return { binDir, logPath };
+}
+
+function instruction(fixturePath: string): string {
+  return [
+    "Run exactly one command with the Bash tool:",
+    `gh pr create --title "e2e" --body-file ${fixturePath}`,
+    "Run nothing else. Do not read, write, or edit any file.",
+    "If the command is blocked, do not retry it and do not change anything.",
+    "Then stop and reply with the single word done.",
+  ].join(" ");
+}
+
+async function runClaude(cwd: string, binDir: string, prompt: string): Promise<RunResult> {
+  const proc = Bun.spawn(
+    [
+      "claude",
+      "-p",
+      prompt,
+      "--plugin-dir",
+      PLUGIN_DIR,
+      "--setting-sources",
+      "local",
+      "--model",
+      "haiku",
+      "--allowedTools",
+      "Bash",
+      "--output-format",
+      "stream-json",
+      "--verbose",
+    ],
+    {
+      cwd,
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill("SIGKILL");
+  }, RUN_TIMEOUT_MS);
+
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  clearTimeout(timer);
+
+  return { output: `${stdout}${stderr}`, timedOut, exitCode };
+}
+
+async function prCreateCount(logPath: string): Promise<number> {
+  const log = await Bun.file(logPath).text();
+  return log.split("\n").filter((line) => line.includes("pr create")).length;
+}
+
+async function runCase(testCase: Case, root: string, binDir: string, logPath: string) {
+  const fixturePath = join(FIXTURE_DIR, testCase.fixture);
+  await Bun.write(logPath, "");
+
+  const { output, timedOut, exitCode } = await runClaude(root, binDir, instruction(fixturePath));
+  const failures: string[] = [];
+
+  if (timedOut) {
+    failures.push(`claude timed out after ${RUN_TIMEOUT_MS / 1000}s`);
+  } else if (exitCode !== 0) {
+    failures.push(`claude exited ${exitCode}`);
+  }
+
+  const created = await prCreateCount(logPath);
+  if (testCase.expectCreate && created === 0) {
+    failures.push("expected the gh stub to record a `pr create`, it recorded none");
+  }
+  if (!testCase.expectCreate) {
+    if (created > 0) {
+      failures.push(`hook did not block: gh stub recorded ${created} \`pr create\` invocation(s)`);
+    }
+    if (!output.includes(DENY_REASON_FRAGMENT)) {
+      failures.push(`stream output never mentioned "${DENY_REASON_FRAGMENT}"`);
+    }
+  }
+
+  return { failures, output };
+}
+
+async function main(): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), "pr-hook-e2e-"));
+  let failed = false;
+  try {
+    await setupRepo(root);
+    const { binDir, logPath } = await setupGhStub(root);
+
+    for (const testCase of CASES) {
+      const { failures, output } = await runCase(testCase, root, binDir, logPath);
+      if (failures.length === 0) {
+        console.log(`PASS ${testCase.name}`);
+        continue;
+      }
+      failed = true;
+      console.log(`FAIL ${testCase.name}`);
+      for (const failure of failures) {
+        console.log(`  - ${failure}`);
+      }
+      console.log(output.split("\n").slice(-40).join("\n"));
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+
+  if (failed) {
+    process.exit(1);
+  }
+}
+
+await main();

--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -176,10 +176,10 @@ export async function findBacktickedCommits(
   return results.filter((sha): sha is string => sha !== null);
 }
 
-// The hook now matches every Bash call and filters here, because the previous
-// `Bash(gh pr create:*)` matcher is a prefix match: it missed the majority of
-// real invocations, which lead with `cd <dir> &&`, an env assignment
-// (`GH_PAGER=cat`, `GIT_SSH_COMMAND=false`), or a heredoc writing the body.
+// The `if` rules in hooks.json scope dispatch to `gh pr create`/`edit` and
+// `glab mr create`/`update`, covering compound (`cd <dir> && gh pr create ...`)
+// and env-prefixed (`GH_PAGER=cat gh pr create ...`) forms. This guard repeats
+// the check in-script so the validator is inert under any other dispatch.
 const PR_BODY_COMMAND_PATTERN = /\b(?:gh pr (?:create|edit)|glab mr (?:create|update))\b/;
 
 export function isPrBodyCommand(command: string): boolean {
@@ -210,34 +210,64 @@ export function extractInlineBody(command: string): string | null {
   return raw.replace(/\\(["`$\\])/g, "$1");
 }
 
-function warn(reasons: string[]): SyncHookJSONOutput {
+function bullets(reasons: string[]): string {
+  return reasons.map((reason) => `- ${reason}`).join("\n");
+}
+
+// A deny reason carries an exact fix, so the whole set is worth reporting at
+// once: the model would otherwise rewrite the body, retry, and be blocked again
+// by the next one.
+function decide(denyReasons: string[], warnReasons: string[]): SyncHookJSONOutput | null {
+  if (denyReasons.length > 0) {
+    return {
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: `Fix the PR body before retrying:\n${bullets(denyReasons)}`,
+      },
+    };
+  }
+  if (warnReasons.length === 0) {
+    return null;
+  }
   const intro =
-    reasons.length === 1
+    warnReasons.length === 1
       ? "PR body has a structural-slop pattern:"
       : "PR body has structural-slop patterns:";
   return {
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
-      additionalContext: `${intro}\n${reasons.map((reason) => `- ${reason}`).join("\n")}`,
+      additionalContext: `${intro}\n${bullets(warnReasons)}`,
     },
   };
 }
 
-function denyForTestCount(body: string): SyncHookJSONOutput | null {
-  if (!TEST_COUNT_PATTERN.test(body)) {
-    return null;
+// Patterns with a mechanical fix the body can't argue its way out of.
+function denyReasons(body: string): string[] {
+  const reasons: string[] = [];
+  if (TEST_COUNT_PATTERN.test(body)) {
+    reasons.push(
+      "Testing section should not mention test counts. Describe what is covered instead.",
+    );
   }
-  return {
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason:
-        "Testing section should not mention test counts. Describe what is covered instead.",
-    },
-  };
+  const headingViolations = headingCaseViolations(body);
+  if (headingViolations.length > 0) {
+    const suggestions = headingViolations
+      .map((violation) => `"${violation.text}" → "${violation.suggested}"`)
+      .join("; ");
+    reasons.push(
+      `Section headings should use AP title case. Apply: ${suggestions}. A heading that is intentionally cased (proper noun, code identifier) can be reworded so it satisfies AP case.`,
+    );
+  }
+  if (hasBacktickedRef(body)) {
+    reasons.push(AUTOLINK_REASON);
+  }
+  return reasons;
 }
 
-function structuralReasons(body: string): string[] {
+// Patterns whose fix is a judgment call, so the author gets the note and keeps
+// the decision.
+function warnReasons(body: string): string[] {
   const reasons: string[] = [];
   if (hasReflexiveScaffold(body)) {
     reasons.push(
@@ -259,29 +289,11 @@ function structuralReasons(body: string): string[] {
       "A prose paragraph runs long: over four sentences, a sentence past 280 characters, or several clauses stacked behind commas. Split the thread, or move an enumeration into a list.",
     );
   }
-  if (hasBacktickedRef(body)) {
-    reasons.push(AUTOLINK_REASON);
-  }
-  const headingViolations = headingCaseViolations(body);
-  if (headingViolations.length > 0) {
-    const suggestions = headingViolations
-      .map((violation) => `"${violation.text}" → "${violation.suggested}"`)
-      .join("; ");
-    reasons.push(
-      `Section headings should use AP title case. Suggested: ${suggestions}. Adjust unless a heading is intentionally cased (proper noun, code identifier).`,
-    );
-  }
   return reasons;
 }
 
 export function validateBody(body: string): SyncHookJSONOutput | null {
-  const deny = denyForTestCount(body);
-  if (deny) {
-    return deny;
-  }
-
-  const reasons = structuralReasons(body);
-  return reasons.length > 0 ? warn(reasons) : null;
+  return decide(denyReasons(body), warnReasons(body));
 }
 
 async function resolveBody(command: string): Promise<string | null> {
@@ -308,19 +320,16 @@ export async function processInput(input: PreToolUseHookInput): Promise<SyncHook
     return null;
   }
 
-  const deny = denyForTestCount(body);
-  if (deny) {
-    return deny;
+  const denies = denyReasons(body);
+
+  if (!denies.includes(AUTOLINK_REASON)) {
+    const cwd = input.cwd ?? process.cwd();
+    const candidates = extractBacktickedHexCandidates(body);
+    const commits = await findBacktickedCommits(candidates, gitCommitVerifier(cwd));
+    if (commits.length > 0) {
+      denies.push(AUTOLINK_REASON);
+    }
   }
 
-  const reasons = structuralReasons(body);
-
-  const cwd = input.cwd ?? process.cwd();
-  const candidates = extractBacktickedHexCandidates(body);
-  const commits = await findBacktickedCommits(candidates, gitCommitVerifier(cwd));
-  if (commits.length > 0 && !reasons.includes(AUTOLINK_REASON)) {
-    reasons.push(AUTOLINK_REASON);
-  }
-
-  return reasons.length > 0 ? warn(reasons) : null;
+  return decide(denies, warnReasons(body));
 }

--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -216,28 +216,30 @@ function bullets(reasons: string[]): string {
 
 // A deny reason carries an exact fix, so the whole set is worth reporting at
 // once: the model would otherwise rewrite the body, retry, and be blocked again
-// by the next one.
-function decide(denyReasons: string[], warnReasons: string[]): SyncHookJSONOutput | null {
-  if (denyReasons.length > 0) {
+// by the next one. Warnings ride along on a deny for the same reason.
+function decide(denies: string[], warns: string[]): SyncHookJSONOutput | null {
+  if (denies.length > 0) {
+    const alsoWorth =
+      warns.length > 0 ? `\nAlso worth addressing in the same edit:\n${bullets(warns)}` : "";
     return {
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
         permissionDecision: "deny",
-        permissionDecisionReason: `Fix the PR body before retrying:\n${bullets(denyReasons)}`,
+        permissionDecisionReason: `Fix the PR body before retrying:\n${bullets(denies)}${alsoWorth}`,
       },
     };
   }
-  if (warnReasons.length === 0) {
+  if (warns.length === 0) {
     return null;
   }
   const intro =
-    warnReasons.length === 1
+    warns.length === 1
       ? "PR body has a structural-slop pattern:"
       : "PR body has structural-slop patterns:";
   return {
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
-      additionalContext: `${intro}\n${bullets(warnReasons)}`,
+      additionalContext: `${intro}\n${bullets(warns)}`,
     },
   };
 }
@@ -299,8 +301,11 @@ export function validateBody(body: string): SyncHookJSONOutput | null {
 async function resolveBody(command: string): Promise<string | null> {
   const bodyFilePath = extractBodyFilePath(command);
   if (bodyFilePath) {
-    const file = Bun.file(bodyFilePath);
-    return (await file.exists()) ? await file.text() : null;
+    try {
+      return await Bun.file(bodyFilePath).text();
+    } catch {
+      return null;
+    }
   }
   return extractInlineBody(command);
 }

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -142,12 +142,15 @@ describe("validateBody", () => {
     expect(reason).toContain("proper noun, code identifier");
   });
 
-  it("lets a deny short-circuit the structural warnings", () => {
+  it("folds structural warnings into the deny reason", () => {
     const result = validateBody(
       "## Changes to the cache\n\n- **src/cache.ts**: adds a cache\n\n## Testing\n\nManual.",
     );
     expect(getPermissionDecision(result)).toBe("deny");
     expect(getAdditionalContext(result)).toBeUndefined();
+    const reason = getDenyReason(result);
+    expect(reason).toContain("Also worth addressing in the same edit:");
+    expect(reason).toContain("file by file");
   });
 
   it("warns on a CI-status roll-call", () => {
@@ -460,7 +463,7 @@ describe("processInput", () => {
     expect(reason).toContain("- Commit SHAs and issue/MR refs");
   });
 
-  it("suppresses warnings when the body also earns a deny", async () => {
+  it("carries warnings inside the deny instead of a separate warn", async () => {
     const bodyFile = path.join(tempDir, "body.md");
     await Bun.write(bodyFile, "## Changes to the cache\n\n- **src/cache.ts**: adds a cache");
     const result = await processInput(
@@ -468,5 +471,6 @@ describe("processInput", () => {
     );
     expect(getPermissionDecision(result)).toBe("deny");
     expect(getAdditionalContext(result)).toBeUndefined();
+    expect(getDenyReason(result)).toContain("Also worth addressing in the same edit:");
   });
 });

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -36,6 +36,14 @@ function getAdditionalContext(result: Awaited<ReturnType<typeof validateBody>>) 
   return undefined;
 }
 
+function getDenyReason(result: Awaited<ReturnType<typeof validateBody>>) {
+  const output = result?.hookSpecificOutput;
+  if (output && "permissionDecisionReason" in output) {
+    return output.permissionDecisionReason;
+  }
+  return undefined;
+}
+
 // Long enough to clear SMALL_BODY_WORD_LIMIT, but shaped as short paragraphs so
 // it doesn't itself trip the run-on detector when a test needs a large body.
 const LONG_PROSE = Array(6)
@@ -56,8 +64,6 @@ describe("extractBodyFilePath", () => {
   });
 });
 
-// The prefix matcher these replace missed 503 of 843 real `gh pr create` calls,
-// because the command usually leads with something other than `gh`.
 describe("isPrBodyCommand", () => {
   test.each<[string, boolean]>([
     ["gh pr create --body-file body.md", true],
@@ -96,18 +102,52 @@ describe("validateBody", () => {
     ).toBeNull();
   });
 
-  test.each<[string, string]>([
-    ["'Added N tests' pattern", "## Test plan\nAdded 5 tests for the new feature"],
-    ["'Added N unit tests' pattern", "## Test plan\nAdded 3 unit tests"],
-    ["'Added N integration tests' pattern", "## Test plan\nAdded 2 integration tests"],
-    ["'N tests' pattern", "## Test plan\n5 tests verify the behavior"],
-    ["lowercase 'added' pattern", "## Test plan\nadded 10 tests"],
-    ["assertion count", "## Testing\nThe suite runs 1165 assertions."],
-    ["pass/fail count", "## Testing\n`bun test`: 193 pass, 0 fail."],
-  ])("denies body with %s", (_name, body) => {
+  test.each<[string, string, string]>([
+    ["'Added N tests' pattern", "## Testing\nAdded 5 tests for the new feature", "test counts"],
+    ["'Added N unit tests' pattern", "## Testing\nAdded 3 unit tests", "test counts"],
+    ["'Added N integration tests' pattern", "## Testing\nAdded 2 integration tests", "test counts"],
+    ["'N tests' pattern", "## Testing\n5 tests verify the behavior", "test counts"],
+    ["lowercase 'added' pattern", "## Testing\nadded 10 tests", "test counts"],
+    ["assertion count", "## Testing\nThe suite runs 1165 assertions.", "test counts"],
+    ["pass/fail count", "## Testing\n`bun test`: 193 pass, 0 fail.", "test counts"],
+    [
+      "a sentence-case section heading",
+      "## Two fixes found while testing\n\nReshapes the resolver.",
+      '"Two fixes found while testing" → "Two Fixes Found While Testing"',
+    ],
+    [
+      "a heading whose inline code must survive the suggestion",
+      "## changes to `validate.ts`\n\nReshapes the resolver.",
+      '"changes to `validate.ts`" → "Changes to `validate.ts`"',
+    ],
+    ["a backticked issue ref", "Closes `#123`.", "auto-link"],
+    ["a backticked MR ref", "Supersedes `!45`.", "auto-link"],
+  ])("denies body with %s", (_name, body, fragment) => {
     const result = validateBody(body);
-    expect(result).not.toBeNull();
     expect(getPermissionDecision(result)).toBe("deny");
+    expect(getDenyReason(result)).toContain(fragment);
+  });
+
+  it("lists every deny reason as a bullet in one decision", () => {
+    const result = validateBody("## Two fixes found while testing\n\nAdded 5 tests. Closes `#12`.");
+    expect(getPermissionDecision(result)).toBe("deny");
+    const reason = getDenyReason(result);
+    expect(reason).toContain("- Testing section should not mention test counts");
+    expect(reason).toContain("- Section headings should use AP title case");
+    expect(reason).toContain("- Commit SHAs and issue/MR refs");
+  });
+
+  it("keeps the AP-case escape note in the deny reason", () => {
+    const reason = getDenyReason(validateBody("## Two fixes found while testing\n\nReshapes it."));
+    expect(reason).toContain("proper noun, code identifier");
+  });
+
+  it("lets a deny short-circuit the structural warnings", () => {
+    const result = validateBody(
+      "## Changes to the cache\n\n- **src/cache.ts**: adds a cache\n\n## Testing\n\nManual.",
+    );
+    expect(getPermissionDecision(result)).toBe("deny");
+    expect(getAdditionalContext(result)).toBeUndefined();
   });
 
   it("warns on a CI-status roll-call", () => {
@@ -173,21 +213,6 @@ describe("validateBody", () => {
       "## Changes\n\n- **Caching**: stores records in memory\n- **Eviction**: drops the oldest entry",
     );
     expect(result).toBeNull();
-  });
-
-  it("warns on a sentence-case section heading", () => {
-    const result = validateBody("## Two fixes found while testing\n\nReshapes the resolver.");
-    expect(getPermissionDecision(result)).toBeUndefined();
-    expect(getAdditionalContext(result)).toContain("AP title case");
-    expect(getAdditionalContext(result)).toContain("Two Fixes Found While Testing");
-  });
-
-  it("keeps a heading's inline code intact in the suggestion", () => {
-    const result = validateBody("## changes to `validate.ts`\n\nReshapes the resolver.");
-    expect(getPermissionDecision(result)).toBeUndefined();
-    expect(getAdditionalContext(result)).toContain(
-      '"changes to `validate.ts`" → "Changes to `validate.ts`"',
-    );
   });
 
   it("does not warn on AP-cased headings with an acronym", () => {
@@ -384,14 +409,24 @@ describe("processInput", () => {
     expect(getPermissionDecision(result)).toBe("deny");
   });
 
-  it("warns on a backticked real commit SHA", async () => {
+  it("denies a backticked real commit SHA", async () => {
     const bodyFile = path.join(tempDir, "body.md");
     await Bun.write(bodyFile, `Builds on \`${headSha}\`.`);
     const result = await processInput(
       createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
     );
-    expect(getPermissionDecision(result)).toBeUndefined();
-    expect(getAdditionalContext(result)).toContain("auto-link");
+    expect(getPermissionDecision(result)).toBe("deny");
+    expect(getDenyReason(result)).toContain("auto-link");
+  });
+
+  it("reports a verified SHA once when the body also has a backticked ref", async () => {
+    const bodyFile = path.join(tempDir, "body.md");
+    await Bun.write(bodyFile, `Builds on \`${headSha}\`. Closes \`#12\`.`);
+    const result = await processInput(
+      createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
+    );
+    expect(getPermissionDecision(result)).toBe("deny");
+    expect(getDenyReason(result)?.match(/auto-link/g)).toHaveLength(1);
   });
 
   it("does not warn on a bare commit SHA", async () => {
@@ -403,22 +438,35 @@ describe("processInput", () => {
     expect(result).toBeNull();
   });
 
-  it("warns on a sentence-case heading in a body file", async () => {
+  it("denies a sentence-case heading in a body file", async () => {
     const bodyFile = path.join(tempDir, "body.md");
     await Bun.write(bodyFile, "## Two fixes found while testing\n\nReshapes the resolver.");
     const result = await processInput(
       createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
     );
-    expect(getPermissionDecision(result)).toBeUndefined();
-    expect(getAdditionalContext(result)).toContain("Two Fixes Found While Testing");
+    expect(getPermissionDecision(result)).toBe("deny");
+    expect(getDenyReason(result)).toContain("Two Fixes Found While Testing");
   });
 
-  it("lets a test-count deny precede a backticked SHA warning", async () => {
+  it("combines a test-count and a backticked SHA into one deny", async () => {
     const bodyFile = path.join(tempDir, "body.md");
     await Bun.write(bodyFile, `Builds on \`${headSha}\`.\n\nAdded 5 tests`);
     const result = await processInput(
       createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
     );
     expect(getPermissionDecision(result)).toBe("deny");
+    const reason = getDenyReason(result);
+    expect(reason).toContain("- Testing section should not mention test counts");
+    expect(reason).toContain("- Commit SHAs and issue/MR refs");
+  });
+
+  it("suppresses warnings when the body also earns a deny", async () => {
+    const bodyFile = path.join(tempDir, "body.md");
+    await Bun.write(bodyFile, "## Changes to the cache\n\n- **src/cache.ts**: adds a cache");
+    const result = await processInput(
+      createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
+    );
+    expect(getPermissionDecision(result)).toBe("deny");
+    expect(getAdditionalContext(result)).toBeUndefined();
   });
 });

--- a/plugins/shortcuts/hooks/hooks.json
+++ b/plugins/shortcuts/hooks/hooks.json
@@ -3,11 +3,12 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash(open:*)",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/open.ts\""
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/open.ts\"",
+            "if": "Bash(open:*)"
           }
         ]
       }

--- a/plugins/tmux/hooks/hooks.json
+++ b/plugins/tmux/hooks/hooks.json
@@ -30,11 +30,12 @@
         ]
       },
       {
-        "matcher": "Bash(tmux:*)",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/target.ts\""
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/target.ts\"",
+            "if": "Bash(tmux:*)"
           }
         ]
       }

--- a/plugins/type-ignore/hooks/hooks.json
+++ b/plugins/type-ignore/hooks/hooks.json
@@ -8,7 +8,22 @@
           {
             "type": "command",
             "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/detect.ts\"",
-            "if": "Edit(**/*.ts)|Edit(**/*.tsx)|Write(**/*.ts)|Write(**/*.tsx)"
+            "if": "Edit(**/*.ts)"
+          },
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/detect.ts\"",
+            "if": "Edit(**/*.tsx)"
+          },
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/detect.ts\"",
+            "if": "Write(**/*.ts)"
+          },
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/hooks/detect.ts\"",
+            "if": "Write(**/*.tsx)"
           }
         ]
       }

--- a/scripts/check-hook-matchers.test.ts
+++ b/scripts/check-hook-matchers.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+import type { HookCommand, MatcherEntryContext } from "../packages/marketplace/index";
+import { violations } from "./check-hook-matchers";
+
+function entry(matcher: string | undefined, ...ifs: (string | undefined)[]): MatcherEntryContext {
+  const hooks: HookCommand[] = ifs.map((rule) => ({
+    type: "command",
+    command: "bun hook.ts",
+    ...(rule === undefined ? {} : { if: rule }),
+  }));
+  return {
+    file: "plugins/example/hooks/hooks.json",
+    entry: { ...(matcher === undefined ? {} : { matcher }), hooks },
+  };
+}
+
+test.each<{ name: string; entries: MatcherEntryContext[]; expected: number }>([
+  { name: "tool name matcher", entries: [entry("Bash")], expected: 0 },
+  { name: "alternation of tool names", entries: [entry("Bash|Monitor")], expected: 0 },
+  { name: "mcp tool matcher", entries: [entry("mcp__linear__create_issue")], expected: 0 },
+  { name: "no matcher", entries: [entry(undefined)], expected: 0 },
+  {
+    name: "gitlab Bash entry",
+    entries: [entry("Bash", "Bash(glab *)", "Bash(gh *)")],
+    expected: 0,
+  },
+  {
+    name: "gitlab WebFetch entry",
+    entries: [entry("WebFetch", "WebFetch(domain:gitlab.com)")],
+    expected: 0,
+  },
+  {
+    name: "WebFetch if with a URL instead of a domain",
+    entries: [entry("WebFetch", "WebFetch(https://gitlab.com/*)")],
+    expected: 1,
+  },
+  { name: "bare tool if", entries: [entry("Bash", "Bash")], expected: 0 },
+  { name: "permission rule matcher", entries: [entry("Bash(gh pr create:*)")], expected: 1 },
+  {
+    name: "one defect per entry, not per segment",
+    entries: [entry("Bash(gh pr create:*)|Bash(gh pr edit:*)")],
+    expected: 1,
+  },
+  { name: "pipe-joined ifs", entries: [entry("Bash", "Bash(gh *)|Bash(glab *)")], expected: 1 },
+  { name: "prose if", entries: [entry("Bash", "the command creates a PR")], expected: 1 },
+  { name: "empty if", entries: [entry("Bash", "")], expected: 1 },
+  { name: "nested parens in if", entries: [entry("Bash", "Bash(gh (pr) create:*)")], expected: 1 },
+  {
+    name: "every command is checked",
+    entries: [entry("Bash", "Bash(gh *)", "", "gh pr create")],
+    expected: 2,
+  },
+])("$name", ({ entries, expected }) => {
+  expect(violations(entries)).toHaveLength(expected);
+});
+
+test("the pull-request matcher that never fired", () => {
+  const matcher =
+    "Bash(gh pr create:*)|Bash(gh pr edit:*)|Bash(glab mr create:*)|Bash(glab mr update:*)";
+  expect(violations([entry(matcher)])).toMatchInlineSnapshot(`
+    [
+      "plugins/example/hooks/hooks.json: matcher "Bash(gh pr create:*)|Bash(gh pr edit:*)|Bash(glab mr create:*)|Bash(glab mr update:*)" uses permission-rule syntax and can never match a tool name. Move command scoping to a per-hook "if" field.",
+    ]
+  `);
+});

--- a/scripts/check-hook-matchers.ts
+++ b/scripts/check-hook-matchers.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env bun
+
+import {
+  loadPlugins,
+  type MatcherEntryContext,
+  matcherEntries,
+} from "../packages/marketplace/index";
+import { runCheck } from "./check";
+
+/** A `Tool(...)` permission rule: legal in an `if`, never in a matcher. */
+const PERMISSION_RULE = /^[A-Za-z_]\w*\(.*\)$/;
+
+/** A lone `Tool` or `Tool(specifier)` token, the only shape an `if` accepts. */
+const SINGLE_RULE = /^[A-Za-z_][\w-]*(\([^()]*\))?$/;
+
+/** WebFetch rules match hostnames only, via a `domain:` specifier. */
+const WEBFETCH_RULE = /^WebFetch\(domain:[^\s()]+\)$/;
+
+/**
+ * Matcher and `if` defects across a set of hook entries.
+ *
+ * A matcher is a regex over tool names, so `Bash(gh pr create:*)` there is a
+ * pattern that no tool name can satisfy and the hook never fires. Command
+ * scoping belongs in a per-command `if`, which holds exactly one permission
+ * rule and rejects the pipe-joined alternation a matcher allows.
+ */
+export function violations(entries: MatcherEntryContext[]): string[] {
+  const messages: string[] = [];
+
+  for (const { file, entry } of entries) {
+    for (const segment of entry.matcher?.split("|") ?? []) {
+      if (!PERMISSION_RULE.test(segment)) continue;
+      messages.push(
+        `${file}: matcher "${entry.matcher}" uses permission-rule syntax and can never match a tool name. Move command scoping to a per-hook "if" field.`,
+      );
+      break;
+    }
+
+    for (const command of entry.hooks) {
+      if (command.if === undefined) continue;
+      if (!SINGLE_RULE.test(command.if)) {
+        messages.push(`${file}: "if" must be exactly one permission rule, got "${command.if}"`);
+        continue;
+      }
+      if (command.if.startsWith("WebFetch(") && !WEBFETCH_RULE.test(command.if)) {
+        messages.push(
+          `${file}: WebFetch rules match hostnames only. Rewrite "${command.if}" as WebFetch(domain:<host>).`,
+        );
+      }
+    }
+  }
+
+  return messages;
+}
+
+export async function entries(): Promise<MatcherEntryContext[]> {
+  const plugins = await loadPlugins();
+  return plugins.flatMap((plugin) => [...matcherEntries(plugin)]);
+}
+
+if (import.meta.main) {
+  await runCheck(
+    async () => ({
+      header: "Hook matchers that cannot fire:",
+      violations: violations(await entries()),
+    }),
+    { success: 'All hook matchers match tool names and every "if" holds one permission rule' },
+  );
+}


### PR DESCRIPTION
The pull-request plugin's body-validation hook has never fired. Its PreToolUse matcher used permission-rule syntax (`Bash(gh pr create:*)|...`), but a matcher is a regex over tool names, so the pattern could never match `Bash` and the dispatcher never ran `validate.ts`. The session index shows zero live firings, and the body of #1142 went through despite containing a test count the hook denies. Dispatch now uses `matcher: "Bash"` with one permission rule per command form in the `if` field, which evaluates per subcommand with env prefixes stripped, so compound and env-prefixed invocations match too.

The same defect class was live in eight more hooks, all found by a new CI lint (`scripts/check-hook-matchers.ts`) that rejects three shapes the dispatcher parses as never-matching:

- permission-rule syntax in a matcher: git, linear, shortcuts, tmux
- pipe-joined `if` rules, where the docs require exactly one: go, type-ignore
- URL-form WebFetch rules, where only `domain:` matches: github, gitlab

All eight are rewritten to the working shape with behavior otherwise unchanged. Reviving them turns on gates that were silently off, most visibly git's block on committing to the default branch.

Validation strictness now splits by fixability. Findings with an exact mechanical fix deny: test counts, heading case (the reason carries the corrected headings), and backticked refs or SHAs. Judgment calls stay warnings: scaffold, file tours, CI roll-calls, run-on prose. A deny folds the warnings into its reason so one edit clears everything, instead of a second blocked attempt discovering them.

Unit tests could not have caught the dead matcher: they exercise the script, not the dispatcher. The new `e2e-hook-fire.ts` runs headless `claude -p` with `--plugin-dir` against a throwaway repo, with a stub `gh` on PATH recording invocations. A fixture with a test count must be blocked before the stub runs, with the deny reason visible in the stream output, and a clean fixture must reach the stub. Both held in a real local run.

The `hook-e2e` workflow repeats that proof in CI: it discovers every `plugins/*/scripts/e2e-*.ts` and runs them all on PRs touching any plugin's hooks or scripts, so a new plugin's test needs no workflow edit. It authenticates with the existing `CLAUDE_CODE_OAUTH_TOKEN` secret, since each run spends API tokens and the repo has no `ANTHROPIC_API_KEY` secret. I did not extend dispatch proof to the other eight plugins. The lint guards the class statically.
