### PR TITLE
user: scope the island compact hooks to manual and auto

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -152,6 +152,7 @@
     ],
     "PostCompact": [
       {
+        "matcher": "manual|auto",
         "hooks": [
           {
             "type": "command",
@@ -195,6 +196,7 @@
     ],
     "PreCompact": [
       {
+        "matcher": "manual|auto",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
The local capture rewrote the whole file. Everything but the two `PreCompact`/`PostCompact` matchers was key reordering and a downgrade of the `linear-cli` and `worktrunk` marketplace refs, so only the matchers are kept.

`async: true` stays on both entries, matching every other bridge hook.