### PR TITLE
hooks: check the command before denying

### DIFF
--- a/.claude/hooks/biome/index.test.ts
+++ b/.claude/hooks/biome/index.test.ts
@@ -10,6 +10,7 @@ import type {
   StopHookInput,
 } from "@anthropic-ai/claude-agent-sdk";
 import {
+  invokesGitCommit,
   parseTranscript,
   processInput,
   processPostToolUse,
@@ -413,13 +414,35 @@ describe("biome hook", () => {
   });
 
   describe("processPreToolUse", () => {
-    // Note: Command filtering is handled by the hook matcher in settings.json
-    // The hook itself just checks staged files when invoked
-
     it("returns null when no staged files", async () => {
       // In test environment, there are no staged git files
       const input = mockPreToolUseInput("git commit -m 'test'");
       expect(await processPreToolUse(input)).toBeNull();
+    });
+
+    // The `Bash(git commit:*)` matcher fails open on shell metacharacters, so
+    // these reach the hook and must not be able to block.
+    test.each<[string]>([
+      ["echo hi > $TMPDIR/probe.txt"],
+      ["{ echo one; echo two; }"],
+      ["for f in *.ts; do wc -l $f; done"],
+      ["cat <<'EOF' > notes.md\nnothing here\nEOF"],
+    ])("returns null for %p", async (command) => {
+      expect(await processPreToolUse(mockPreToolUseInput(command))).toBeNull();
+    });
+  });
+
+  describe("invokesGitCommit", () => {
+    test.each<[string, boolean]>([
+      ["git commit", true],
+      ["git -C /repo commit -m x", true],
+      ["git -c user.name=x commit", true],
+      ["git add . && git commit -m x", true],
+      ["echo hi > $TMPDIR/probe.txt", false],
+      ["git log --grep commit", false],
+      ["echo 'run git commit next'", false],
+    ])("%p → %p", (command, expected) => {
+      expect(invokesGitCommit(command)).toBe(expected);
     });
   });
 

--- a/.claude/hooks/biome/index.ts
+++ b/.claude/hooks/biome/index.ts
@@ -18,6 +18,30 @@ const BIOME_EXTENSIONS = new Set(["ts", "tsx", "js", "jsx", "json", "jsonc"]);
 
 type HookInput = PostToolUseHookInput | PreToolUseHookInput | StopHookInput;
 
+type BashInput = { command?: string };
+
+// Flags git accepts between the executable and its subcommand. Enumerated
+// rather than matched as a generic `-\S+` so that a value which happens to be
+// the word `commit` (`git log --grep commit`) cannot be read as the subcommand.
+// The git plugin's block-default-branch-commit hook keeps its own copy: it
+// ships to other machines and cannot import repo-internal code.
+const VALUE_FLAG = String.raw`(?:-[cC]|--(?:git-dir|work-tree|namespace|exec-path|config-env))(?:=\S+|\s+\S+)`;
+const BOOLEAN_FLAG =
+  "--(?:no-pager|paginate|bare|literal-pathspecs|no-replace-objects|no-optional-locks)";
+const GIT_COMMIT_PATTERN = new RegExp(
+  String.raw`\bgit\s+(?:(?:${VALUE_FLAG}|${BOOLEAN_FLAG})\s+)*commit(?![\w-])`,
+);
+
+// Quoted spans carry commit messages, grep patterns, and here-doc prose, where
+// the literal text `git commit` is data rather than an invocation.
+function stripQuoted(command: string): string {
+  return command.replace(/'[^']*'|"(?:[^"\\]|\\.)*"/g, " ");
+}
+
+export function invokesGitCommit(command: string): boolean {
+  return GIT_COMMIT_PATTERN.test(stripQuoted(command));
+}
+
 interface TranscriptEntry {
   type?: string;
   message?: {
@@ -293,8 +317,16 @@ function formatPreToolUseBlockOutput(issues: Map<string, string>): SyncHookJSONO
 }
 
 export async function processPreToolUse(
-  _input: PreToolUseHookInput,
+  input: PreToolUseHookInput,
 ): Promise<SyncHookJSONOutput | null> {
+  // The `Bash(git commit:*)` matcher only narrows which calls spawn this hook.
+  // It fails open on shell metacharacters, and this path can return a `block`,
+  // so the command is re-read here rather than trusted from the matcher.
+  const { command } = input.tool_input as BashInput;
+  if (!command || !invokesGitCommit(command)) {
+    return null;
+  }
+
   if (!(await hasBiome())) {
     return null;
   }

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -12,6 +12,12 @@ Raw `git worktree add` is denied in favor of the `worktrunk` skill, except under
 
 Wrap `${CLAUDE_PLUGIN_ROOT}` in double quotes in shell-form hook commands: `bun "${CLAUDE_PLUGIN_ROOT}/scripts/foo.ts"`. Matcher fields are not shell commands and should not be quoted. Run `bun scripts/check-hook-quoting.ts` to validate.
 
+## Bash Matchers
+
+A `Bash(...)` matcher or `if` condition is a spawn-reducing pre-filter, never the authorization decision. It fails open on shell metacharacters: under CLI 2.1.223, `Bash(git commit:*)` matched `echo hi > $TMPDIR/probe.txt` while the same command with a literal path passed, and brace groups, for-loops, here-docs, and long pipelines match the same way.
+
+So every Bash-matched hook script must re-read `input.tool_input.command` and confirm the command really invokes what the hook governs before it denies, blocks, or rewrites. `plugins/git/scripts/block-default-branch-commit.ts` (`invokesGitCommit`), `user/hooks/worktree/index.ts` (`/\bgit\s+worktree\s+(\w+)/`), and `plugins/shortcuts/hooks/open.ts` (a quote-aware `tokenize` that yields no target for a compound) are the working examples. A script that decides purely on ambient state, without reading the command, denies unrelated Bash calls the moment the matcher overfires.
+
 ## Async
 
 The `claude-code:hook` skill covers `async` and `asyncRewake`: what they drop, which events kill or outlive a backgrounded process, and when to use them. Read it before marking a hook async here.

--- a/plugins/git/scripts/block-default-branch-commit.test.ts
+++ b/plugins/git/scripts/block-default-branch-commit.test.ts
@@ -7,7 +7,7 @@ import type {
   PreToolUseHookSpecificOutput,
 } from "@anthropic-ai/claude-agent-sdk";
 import { $ } from "bun";
-import { formatDenyOutput, processInput } from "./block-default-branch-commit";
+import { formatDenyOutput, invokesGitCommit, processInput } from "./block-default-branch-commit";
 
 function mockInput(command: string): PreToolUseHookInput {
   return {
@@ -29,6 +29,30 @@ async function getOutput(
   if (!result) return null;
   return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
 }
+
+describe("invokesGitCommit", () => {
+  test.each<[string, boolean]>([
+    ["git commit", true],
+    ['git commit -m "test"', true],
+    ["git -C /repo commit -m x", true],
+    ["git -c user.name=x commit", true],
+    ["git --no-pager commit --amend", true],
+    ["git -C /repo -c commit.gpgsign=false commit", true],
+    ["git add . && git commit -m x", true],
+    ["git status | tee log && git commit", true],
+    ["echo hi > $TMPDIR/probe.txt", false],
+    ["{ echo one; echo two; }", false],
+    ["for f in *.ts; do wc -l $f; done", false],
+    ["cat <<'EOF' > notes.md\nnothing here\nEOF", false],
+    ["git log --oneline | head -20 | awk '{print $1}' | sort | uniq", false],
+    ["git log --grep commit", false],
+    ["git commit-tree $tree", false],
+    ["echo 'run git commit next'", false],
+    ['gh pr create --body "then git commit"', false],
+  ])("%p → %p", (command, expected) => {
+    expect(invokesGitCommit(command)).toBe(expected);
+  });
+});
 
 describe("formatDenyOutput", () => {
   it("formats deny output with branch name", () => {
@@ -77,6 +101,19 @@ describe("processInput", () => {
   ])("blocks %p on main branch", async (command) => {
     const output = await getOutput(mockInput(command), testRepo);
     expect(output?.permissionDecision).toBe("deny");
+  });
+
+  // The matcher fails open on shell metacharacters, so these reach the hook on
+  // the default branch even though none of them commits.
+  test.each<[string]>([
+    ["echo hi > $TMPDIR/probe.txt"],
+    ["{ echo one; echo two; }"],
+    ["for f in *.ts; do wc -l $f; done"],
+    ["cat <<'EOF' > notes.md\nnothing here\nEOF"],
+    ["git log --oneline | head -20 | awk '{print $1}' | sort | uniq"],
+  ])("allows %p on main branch", async (command) => {
+    const output = await processInput(mockInput(command), testRepo);
+    expect(output).toBeNull();
   });
 
   it("allows commit in detached HEAD state", async () => {

--- a/plugins/git/scripts/block-default-branch-commit.ts
+++ b/plugins/git/scripts/block-default-branch-commit.ts
@@ -4,6 +4,28 @@ import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/clau
 import { $ } from "bun";
 import { getDefaultBranch } from "./default-branch";
 
+type BashInput = { command?: string };
+
+// Flags git accepts between the executable and its subcommand. Enumerated
+// rather than matched as a generic `-\S+` so that a value which happens to be
+// the word `commit` (`git log --grep commit`) cannot be read as the subcommand.
+const VALUE_FLAG = String.raw`(?:-[cC]|--(?:git-dir|work-tree|namespace|exec-path|config-env))(?:=\S+|\s+\S+)`;
+const BOOLEAN_FLAG =
+  "--(?:no-pager|paginate|bare|literal-pathspecs|no-replace-objects|no-optional-locks)";
+const GIT_COMMIT_PATTERN = new RegExp(
+  String.raw`\bgit\s+(?:(?:${VALUE_FLAG}|${BOOLEAN_FLAG})\s+)*commit(?![\w-])`,
+);
+
+// Quoted spans carry commit messages, grep patterns, and here-doc prose, where
+// the literal text `git commit` is data rather than an invocation.
+function stripQuoted(command: string): string {
+  return command.replace(/'[^']*'|"(?:[^"\\]|\\.)*"/g, " ");
+}
+
+export function invokesGitCommit(command: string): boolean {
+  return GIT_COMMIT_PATTERN.test(stripQuoted(command));
+}
+
 export function formatDenyOutput(branch: string): SyncHookJSONOutput {
   return {
     hookSpecificOutput: {
@@ -15,9 +37,17 @@ export function formatDenyOutput(branch: string): SyncHookJSONOutput {
 }
 
 export async function processInput(
-  _input: PreToolUseHookInput,
+  input: PreToolUseHookInput,
   cwd?: string,
 ): Promise<SyncHookJSONOutput | null> {
+  // The `Bash(git commit:*)` condition only narrows which calls spawn this hook.
+  // It fails open on shell metacharacters, so the deny decision rests on the
+  // command this hook reads for itself.
+  const { command } = input.tool_input as BashInput;
+  if (!command || !invokesGitCommit(command)) {
+    return null;
+  }
+
   const dir = cwd ?? process.cwd();
 
   // One rev-parse yields both the repo root (cache key) and current branch.


### PR DESCRIPTION
Fixes a PreToolUse hook that denied Bash commands never touching git. `block-default-branch-commit.ts` named its hook input `_input` and decided purely on the current branch, trusting the `Bash(git commit:*)` filter to have established that a commit was underway. That filter fails open on shell metacharacters under CLI 2.1.223, whether it sits in `matcher` or in `if`.

The minimal pair, both reproduced live today: `echo hi > /tmp/claude/probe-redirect.txt` passes and `echo hi > $TMPDIR/probe3.txt` is denied, differing only in the `$TMPDIR` expansion. Brace groups, for-loops, here-docs, and multi-segment pipelines trigger it the same way. All 10 historical denies in the session index contained no `git commit`, and it fired 5+ more times today against read-only analyst commands. Worth an upstream report.

So the filter is a spawn-reducing pre-filter and the script is the decision. Each Bash-matched hook now re-reads `input.tool_input.command`:

- `block-default-branch-commit.ts` denies only when `invokesGitCommit` matches. The pattern enumerates the flags git takes before its subcommand (`-C`, `-c`, `--no-pager`) instead of skipping a generic `-\S+`, so a value that happens to be `commit` is not read as the subcommand. Quoted spans are stripped first, which leaves `bash -c "git commit -m x"` on `main` unblocked. The hook guards against an accidental commit, and a missed deny is recoverable where a false deny halts unrelated work.
- The biome PreToolUse hook carries the same `Bash(git commit:*)` filter and returns `decision: "block"` on staged lint errors, so its overfire blocks too. It keeps its own copy of the check, since repo tooling and a distributed plugin cannot import each other.

`user/hooks/worktree/index.ts` needed no change: its `/\bgit\s+worktree\s+(\w+)/` re-check is the control this generalizes, and the pattern now written into `.claude/rules/hooks.md`. `plugins/shortcuts/hooks/open.ts` is the other live example the rule cites, via the quote-aware tokenizer that yields no target for a compound.

New coverage: a non-commit command returns null while the branch is the default one. The old tests could not catch that regression, because they fed commands into a parameter the script ignored.

An earlier revision also fixed `plugins/tmux/hooks/target.ts`, which rewrote multi-line commands by dropping everything past line one. #1165 deleted that hook, so the fix is moot and no longer part of this branch.

Discovery: 92e50a2b6a1c
