### PR TITLE
user,repo: fill gaps in the always-on rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ The [`user/`](user/) directory contains user-level Claude Code configuration tha
 
 Every customization (skill, hook, wordlist entry, agent, rule, permission) costs tokens on every session that touches it. Adding is cheap, accumulation is silent, and removal has no natural trigger. Before adding one, define how it gets removed: what evidence shows it's earning its cost, what evidence shows it isn't, and where that evidence surfaces. Detectors of model behavior need particular care: models drift and rules lose value, so pair detection with a path to evolve or retire.
 
+An invoked skill's body is re-injected in full at every compaction, so `SKILL.md` size is a recurring per-compaction cost rather than a one-time load. Author bodies under roughly 4k tokens and keep the detail in `references/`.
+
 A customization must also stay harmonious with Claude Code's native behavior. When the harness changes a default or an application-level behavior, assume the change encodes aggregate usage data and evaluation knowledge you do not have, and default to accommodating that direction rather than overriding it. So before adding a customization that touches native behavior, apply the harmony test: ask whether it works with the harness's intent or against it, and prefer accommodation. Add a customization that pushes back on a native behavior only as a light-touch experiment, carrying explicit forward evaluation criteria and a removal trigger. When Claude Code v2.1.198 made the built-in `Explore` agent inherit the conversation model (capped at Opus) instead of running on Haiku, hard-pinning it back to Haiku would contravene that intent, so any Explore steering stays a soft default and gets removed if it proves inert after a couple of weeks.
 
 ## Rules

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -11,7 +11,7 @@
 - Prefer meaningful anchor text over raw URLs.
 - Use bullet points for lists, checklists if I ask for tasks.
 - Use code comments ONLY to clarify code that is not self-explanatory to OTHER readers. If you need to explain the code, do so in a separate message before editing.
-- Load the `writing:writing` skill before writing any long-form prose for others (PR comments, review feedback, documents, issue descriptions, Slack messages). The skill enforces tone and style rules that must be followed.
+- Load the `writing:writing` skill before the first long-form prose you write for others in a context (PR comments, review feedback, documents, issue descriptions, Slack messages). Its tone and style rules must be followed, and they stay in effect for the rest of the session, so one load covers every later piece.
 
 ## Organization
 
@@ -30,6 +30,8 @@ Prefer accommodating Claude Code's native defaults over overriding them, since a
 - The user has carefully curated skills for their common workflows. Load skills when possible to adhere to the user's preferences and navigate their projects efficiently.
 - A skill that instructs a subagent fan-out or a background dispatch already carries the user's authorization for `Agent`. Run the dispatch as the skill writes it, and degrade to an inline pass only when `Agent` is absent from the tool set, saying in the output that it ran inline.
 - For questions about Claude Code features or usage, use the `Agent` tool with `subagent_type='claude-code-guide'` to consult official documentation.
+- A scoped read-only lookup dispatched via `Agent` should carry an explicit cheap `model` (`haiku` or `sonnet`). Subagents otherwise inherit this session's model, so a lookup bills at orchestrator rates.
+- A cross-model or GPT review runs through `herdr`, dispatched into the `copilot-gpt` worktree in the claude workspace, which is the path to GPT and Codex reviews. "Consult fable" asks for the same adversarial second opinion from a Fable session.
 - Prefer the `agent-browser` skill over `WebFetch`/`WebSearch` when a task needs a real browser — interacting with a page, screenshots, scraping JS-rendered content, or web-app QA/dogfooding. It loads the CLI's version-matched `skills get` workflows. Plain `WebFetch` stays fine for static page fetches.
 - Finish a branch with `/ship`: it runs the warranted review passes, opens the PR, babysits CI to green, triages bot comments, and refreshes the body. Don't hand-chain `EnterWorktree` + `pull-request:create` for a branch finish.
 - `pull-request:create` remains the skill for opening a PR directly (it is what `/ship` calls). If it's unavailable, create the PR with an empty body.
@@ -67,6 +69,8 @@ claude-cli://open?q=<url-encoded prompt>&cwd=<absolute main repo path>
 - For commit messages, use multiple `-m` flags for a simple subject and body. Each `-m` is a separate paragraph. For complex messages, pass the message through a heredoc.
 
 ## Worktrees
+
+Any change intended to become its own PR starts in a worktree, created with `worktrunk:wt-switch-create`. Stay put only when the session is already on a topic branch inside one.
 
 I use Worktrunk (the `wt` CLI) for git worktrees, exposed through two skills:
 


### PR DESCRIPTION
Five always-on rules that sessions were either being told by hand or getting wrong. Each is one or two lines, since these load on every session.

The worktree section said which skill to use but never when a worktree is warranted, so "use a worktree" got typed as an imperative 14 times in 10 days. The new lead line makes the PR the trigger rather than the ask. A session already on a topic branch inside a worktree stays put.

The `writing:writing` line read as a per-artifact obligation and drove 26 reloads inside single contexts. It now says load before the first long-form prose in a context, and that the rules hold for the rest of the session.

The cross-model consult rule was dictated on 2026-08-02 and never landed anywhere. "Cross-model review" and "GPT review" mean a herdr dispatch into the `copilot-gpt` worktree in the claude workspace. "Consult fable" means the same adversarial second opinion from a Fable session.

The cheap-model line is the light-touch experiment the repo's harmony test calls for. Since v2.1.198 `Explore` inherits the conversation model instead of running free on Haiku. Delegation volume moved to `general-purpose`, which has no cheap default either.

Re-pinning `Explore` to Haiku would contravene the harness's intent, so the rule instead asks for an explicit cheap `model` on scoped read-only `Agent` lookups.

Delete the line if the cheaper-override rate under expensive parents has not risen in a few weeks. The `delegation` query in `claude-code:session` reports that rate.

The repo-level curation note records why skill bodies are budgeted differently. Every invoked skill's body is re-injected in full at each compaction, making body size a recurring cost rather than a one-time load. That is the reason for the sub-4k-token convention and for pushing detail into `references/`.

Discovery: 6be982d4fad4
Discovery: 632daabe6811
Discovery: 8400f3d083cd
