### PR TITLE
worktree: fix throwaway-exemption regexes

### DIFF
--- a/user/hooks/worktree/index.test.ts
+++ b/user/hooks/worktree/index.test.ts
@@ -48,9 +48,36 @@ describe("processInput", () => {
     );
   });
 
-  it("denies git worktree add to a path that merely contains tmp/", () => {
+  it("denies git worktree add to a path with a tmp-lookalike segment", () => {
     expect(processInput(bashInput("git worktree add notmp/foo"))).toEqual(formatDenyOutput("add"));
-    expect(processInput(bashInput("git worktree add a/tmp/foo"))).toEqual(formatDenyOutput("add"));
+    expect(processInput(bashInput("git worktree add tmpfoo/x"))).toEqual(formatDenyOutput("add"));
+  });
+
+  it("allows git worktree add under a nested tmp/ segment", () => {
+    expect(processInput(bashInput("git worktree add a/tmp/foo"))).toBeNull();
+  });
+
+  it("allows git worktree add under an absolute /tmp/ path", () => {
+    expect(
+      processInput(bashInput("git worktree add /tmp/claude-baseline-check")),
+    ).toBeNull();
+  });
+
+  it("allows git worktree add under an absolute /private/tmp/ path", () => {
+    expect(
+      processInput(bashInput("git worktree add /private/tmp/claude-baseline-check")),
+    ).toBeNull();
+  });
+
+  it("allows git worktree add under a repo-absolute tmp/ path", () => {
+    expect(
+      processInput(bashInput("git worktree add /Users/me/repo/tmp/verify")),
+    ).toBeNull();
+  });
+
+  it("allows git worktree add under an unexpanded $TMPDIR", () => {
+    expect(processInput(bashInput("git worktree add $TMPDIR/verify"))).toBeNull();
+    expect(processInput(bashInput("git worktree add ${TMPDIR}/verify"))).toBeNull();
   });
 
   it("denies git worktree add under .worktrees/", () => {
@@ -68,9 +95,9 @@ describe("processInput", () => {
   });
 
   it("allows git worktree remove of agent worktrees", () => {
-    expect(processInput(bashInput("git worktree remove .claude/worktrees/agent-x"))).toBeNull();
+    expect(processInput(bashInput("git worktree remove .worktrees/agent-x"))).toBeNull();
     expect(
-      processInput(bashInput("git worktree remove /Users/me/repo/.claude/worktrees/agent-x")),
+      processInput(bashInput("git worktree remove /Users/me/repo/.worktrees/agent-x")),
     ).toBeNull();
   });
 
@@ -120,12 +147,33 @@ describe("isThrowawayAdd", () => {
     expect(isThrowawayAdd("git worktree add ./tmp/x")).toBe(true);
   });
 
+  it("matches an absolute /tmp/ target", () => {
+    expect(isThrowawayAdd("git worktree add /tmp/claude-baseline-check")).toBe(true);
+  });
+
+  it("matches an absolute /private/tmp/ target", () => {
+    expect(isThrowawayAdd("git worktree add /private/tmp/claude-baseline-check")).toBe(true);
+  });
+
+  it("matches a repo-absolute tmp/ target", () => {
+    expect(isThrowawayAdd("git worktree add /Users/me/repo/tmp/verify")).toBe(true);
+  });
+
+  it("matches a tmp/ target nested below another directory", () => {
+    expect(isThrowawayAdd("git worktree add a/tmp/x")).toBe(true);
+  });
+
+  it("matches an unexpanded $TMPDIR target", () => {
+    expect(isThrowawayAdd("git worktree add $TMPDIR/x")).toBe(true);
+    expect(isThrowawayAdd("git worktree add ${TMPDIR}/x")).toBe(true);
+  });
+
   it("does not match a tmp-prefixed sibling directory", () => {
     expect(isThrowawayAdd("git worktree add tmpfoo/x")).toBe(false);
   });
 
-  it("does not match tmp/ nested below another directory", () => {
-    expect(isThrowawayAdd("git worktree add a/tmp/x")).toBe(false);
+  it("does not match a path that merely contains the substring tmp", () => {
+    expect(isThrowawayAdd("git worktree add notmp/x")).toBe(false);
   });
 });
 
@@ -138,14 +186,20 @@ describe("isThrowawayRemove", () => {
     expect(isThrowawayRemove("git worktree remove ./tmp/x")).toBe(true);
   });
 
-  it("matches a relative .claude/worktrees/ target", () => {
-    expect(isThrowawayRemove("git worktree remove .claude/worktrees/agent-x")).toBe(true);
+  it("matches an absolute /tmp/ target", () => {
+    expect(isThrowawayRemove("git worktree remove /tmp/claude-baseline-check")).toBe(true);
   });
 
-  it("matches an absolute .claude/worktrees/ target", () => {
-    expect(isThrowawayRemove("git worktree remove /Users/me/repo/.claude/worktrees/agent-x")).toBe(
-      true,
-    );
+  it("matches an unexpanded $TMPDIR target", () => {
+    expect(isThrowawayRemove("git worktree remove $TMPDIR/x")).toBe(true);
+  });
+
+  it("matches a relative .worktrees/ target", () => {
+    expect(isThrowawayRemove("git worktree remove .worktrees/agent-x")).toBe(true);
+  });
+
+  it("matches an absolute .worktrees/ target", () => {
+    expect(isThrowawayRemove("git worktree remove /Users/me/repo/.worktrees/agent-x")).toBe(true);
   });
 
   it("skips flags and matches a later tmp/ target", () => {
@@ -156,11 +210,7 @@ describe("isThrowawayRemove", () => {
     expect(isThrowawayRemove("git worktree remove tmpfoo/x")).toBe(false);
   });
 
-  it("does not match tmp/ nested below another directory", () => {
-    expect(isThrowawayRemove("git worktree remove a/tmp/x")).toBe(false);
-  });
-
-  it("does not match a worktrees dir outside .claude/", () => {
+  it("does not match a worktrees dir outside the .worktrees/ segment", () => {
     expect(isThrowawayRemove("git worktree remove worktrees/x")).toBe(false);
   });
 

--- a/user/hooks/worktree/index.test.ts
+++ b/user/hooks/worktree/index.test.ts
@@ -58,9 +58,7 @@ describe("processInput", () => {
   });
 
   it("allows git worktree add under an absolute /tmp/ path", () => {
-    expect(
-      processInput(bashInput("git worktree add /tmp/claude-baseline-check")),
-    ).toBeNull();
+    expect(processInput(bashInput("git worktree add /tmp/claude-baseline-check"))).toBeNull();
   });
 
   it("allows git worktree add under an absolute /private/tmp/ path", () => {
@@ -70,9 +68,7 @@ describe("processInput", () => {
   });
 
   it("allows git worktree add under a repo-absolute tmp/ path", () => {
-    expect(
-      processInput(bashInput("git worktree add /Users/me/repo/tmp/verify")),
-    ).toBeNull();
+    expect(processInput(bashInput("git worktree add /Users/me/repo/tmp/verify"))).toBeNull();
   });
 
   it("allows git worktree add under an unexpanded $TMPDIR", () => {

--- a/user/hooks/worktree/index.ts
+++ b/user/hooks/worktree/index.ts
@@ -9,19 +9,24 @@ export type BashInput = {
 
 const ALLOWED_SUBCOMMANDS = new Set(["list", "prune", "unlock"]);
 const REPLACED_SUBCOMMANDS = new Set(["add", "remove"]);
-const TMP_TARGET = /^(\.\/)?tmp\//;
-const AGENT_WORKTREE_TARGET = /(^|\/)\.claude\/worktrees\//;
+const TMP_TARGET = /(^|\/)tmp\//;
+const UNEXPANDED_VAR_TARGET = /^\$\{?\w+\}?\//;
+const AGENT_WORKTREE_TARGET = /(^|\/)\.worktrees\//;
+
+function isExemptTarget(token: string): boolean {
+  return TMP_TARGET.test(token) || UNEXPANDED_VAR_TARGET.test(token);
+}
 
 export function isThrowawayAdd(command: string): boolean {
   const after = command.split(/\bgit\s+worktree\s+add\b/)[1];
   if (after === undefined) return false;
-  return after.split(/\s+/).some((tok) => TMP_TARGET.test(tok));
+  return after.split(/\s+/).some(isExemptTarget);
 }
 
 export function isThrowawayRemove(command: string): boolean {
   const after = command.split(/\bgit\s+worktree\s+remove\b/)[1];
   if (after === undefined) return false;
-  return after.split(/\s+/).some((tok) => TMP_TARGET.test(tok) || AGENT_WORKTREE_TARGET.test(tok));
+  return after.split(/\s+/).some((tok) => isExemptTarget(tok) || AGENT_WORKTREE_TARGET.test(tok));
 }
 
 export function formatDenyOutput(subcommand: string): SyncHookJSONOutput {
@@ -30,7 +35,7 @@ export function formatDenyOutput(subcommand: string): SyncHookJSONOutput {
     subcommand === "add"
       ? `${base} For a throwaway verification checkout, add it under \`tmp/\`.`
       : subcommand === "remove"
-        ? `${base} Throwaway worktrees under \`tmp/\` or \`.claude/worktrees/\` may be removed directly.`
+        ? `${base} Throwaway worktrees under \`tmp/\` or \`.worktrees/\` may be removed directly.`
         : base;
   return {
     hookSpecificOutput: {


### PR DESCRIPTION
Fixes the worktree guard's exemption regexes so they match the real-world shapes they were written to allow. Session data showed both exemptions denying the exact cases they exist for:

- 7 of 20 local `add` denials targeted intended-exempt temp paths
- 6 of 20 `remove` denials targeted agent worktrees
- 86% of denies never resulted in a `worktrunk` call

`TMP_TARGET` was anchored to token start (`^(\.\/)?tmp\//`), so it only matched relative `tmp/` or `./tmp/`. Absolute temp paths (`/tmp/...`, `/private/tmp/...`), a repo-absolute `tmp/` path, and `$TMPDIR/...` all failed and got denied. It's now `(^|\/)tmp\//`, exempting any target with a `tmp/` path segment anywhere. A new `UNEXPANDED_VAR_TARGET` regex also exempts an unexpandable `$VAR/...` token outright. A shell variable can't be matched pre-expansion, and failing open here costs a spawn while failing closed costs a turn.

`AGENT_WORKTREE_TARGET` matched `.claude/worktrees/`, but agent worktrees actually live at `<repo>/.worktrees/agent-<hash>` per worktrunk's `WORKTRUNK_WORKTREE_PATH` template. Repointed it at `.worktrees/`. The old pattern wasn't referenced anywhere else in the repo, so it's replaced rather than kept alongside.

Extended `index.test.ts` with cases for each previously-denied shape (absolute `/tmp`, `/private/tmp`, repo-absolute `tmp/`, nested `tmp/` segments, `$TMPDIR`/`${TMPDIR}`, and `.worktrees/`).

Open question for a follow-up: does `remove` belong in `REPLACED_SUBCOMMANDS` at all? The auto-mode "Worktree Removal" allow rule in `user/settings.json` already adjudicates removals with better context (session-created vs. foreign worktree, force flags) than this hook's path-matching can. Not implemented here.

Discovery: 4aaed0438d5f