### PR TITLE
pull-request: gate --auto on the reviewer's score

### DIFF
--- a/plugins/pull-request/skills/follow-up/SKILL.md
+++ b/plugins/pull-request/skills/follow-up/SKILL.md
@@ -1,17 +1,10 @@
 ---
 name: pull-request:follow-up
 description: >
-  Follow up as the author on review feedback left on your own PR/MR: check which reviewer
-  comments still need a response, investigate how threads were resolved (including silent
-  resolves), and draft replies. With --auto, autonomously triage AI-reviewer (bot) threads and
-  loop until the reviewer is satisfied, clearing a bot review hands-off. With --local, run the
-  same bot loop pre-push through the reviewer's CLI (Greptile, CodeRabbit) against unmerged
-  commits, before any PR exists. Use when reviewers commented on your PR and you need to respond
-  or satisfy them. Use --local without being asked when you are about to push or open a PR in a
-  repo with an available bot and the diff warrants a metered review. Triggers:
-  "respond to review comments on my PR", "address reviewer feedback", "make the bot reviewer
-  pass", "greptile review", "coderabbit review", "run the review bot locally", "bot review
-  before pushing".
+  Follow up as the author on review feedback on your PR/MR: triage and draft replies, catch
+  silent resolves, and drive bot reviewers to a passing score. Triggers: "address reviewer
+  feedback", "make the bot reviewer pass", "greptile/coderabbit review", "bot review before
+  pushing".
 argument-hint: "[pr-url] [--auto] [--include-human-nits] [--local [base]]"
 allowed-tools:
   - Bash(git:*)
@@ -32,9 +25,13 @@ Follow up on review feedback for: $ARGUMENTS
 
 Parse the URL and flags from `$ARGUMENTS`. GitHub is primary: work through `gh`, `mcp__github`, and `github:*` skills directly. Delegate all GitLab behavior to `gitlab:merge-request` (no `glab` calls).
 
-- `--auto`: autonomously triage **bot** threads, looping until the reviewer is satisfied (see [The Autonomous Loop](#the-autonomous-loop)).
+## Arguments
+
+- `--auto`: autonomously triage **bot** threads, looping until the acceptance bar is met (see [The Autonomous Loop](#the-autonomous-loop)). Human threads stay gated.
 - `--include-human-nits`: under `--auto`, also act on **human** threads, but only trivial high-confidence changes (typos, renames, one-liners). Off by default.
 - `--local [base]`: run the bot loop pre-push through the reviewer's CLI instead of PR threads, against the branch's unmerged commits (see [Local Mode](#local-mode-pre-push)). The optional base overrides what the review runs against. No PR is involved, so `pr-url` and the other flags don't apply.
+
+With no flags, run the gated default.
 
 ## Default Workflow (Gated)
 
@@ -59,42 +56,31 @@ Triage each bot thread:
 - **Noise / false positive** → reply with a one-line reason and resolve, or thumbs down a clearly wrong bot comment
 - **Unsure** → collect to escalate; don't guess
 
-Then run each round:
+Each round: apply the batched fixes and push once, reply-and-resolve the noise, escalate the unsure threads and pause that subset only, then get CI green and the bot onto the green SHA. [auto.md](auto.md) has the round mechanics: the babysit handoff, the wake cadence while a re-review lands, and repos that review only on request.
 
-1. Apply batched fixes, commit, push **once** (one new SHA to re-review).
-2. Reply-and-resolve the noise threads (`github:pr-comments` or `gitlab:merge-request` do both in one call).
-3. Escalate the unsure threads and pause **that subset only**; actionable pushes proceed.
-4. Hand CI back to `pull-request:babysit` (it owns CI, stops at green). babysit's Monitor watcher re-invokes you on CI events, so don't wrap that wait in `ScheduleWakeup`; the harness wakes you.
-5. Get the bot onto the green SHA. Where the repo re-reviews pushes automatically, wait for it. No Monitor watcher tracks this, so self-pace with `ScheduleWakeup`: arm a tick (`prompt` set to this same `/pull-request:follow-up` invocation so the wake re-enters the loop) at ~270s for an idle wait before re-triggering, or 180-240s when a fast re-review is expected. Never 300s (the cache-expiry boundary). On wake, re-fetch bot threads and evaluate the loop-exit conditions below: if the reviewer is satisfied or another exit fires, stop; otherwise, if no re-review landed, post one top-level `@<bot>` re-trigger, then re-arm the next tick.
+### Acceptance Bar
 
-   On a repo that reviews only on request (Greptile with `triggerOnUpdates: false`, for one), that wait is dead time. No re-review is coming until you ask, so post the `@<bot>` re-trigger right after the green push and arm the tick only to collect the result. `greptile config --json` reports the live setting.
+The loop ends when the reviewer's own score on the current HEAD is at its maximum (Greptile `5/5`, CodeRabbit `Actionable comments posted: 0`), or when every comment still standing below that maximum carries a written reply giving the reason it was declined. Read the score off the summary comment on HEAD ([reviewers.md](reviewers.md)): a score from an earlier SHA is stale, and an absent summary where a review is expected means the review is still running, so keep waiting for it.
 
-Loop until: the reviewer's satisfaction signal hits on HEAD ([reviewers.md](reviewers.md)); no new bot threads for two rounds after a green push; max 4 rounds (oscillation guard); the idle timeout outlasts the re-trigger; or the PR closes/merges.
+A score short of the maximum with a silently skipped comment behind it does not clear the bar. Fix the comment or write the reason.
 
-When a bot review is **expected** ([reviewers.md](reviewers.md) defines the signals) but no summary has landed on HEAD, an empty thread list means pending, not satisfied: wait through the same wake and re-trigger for the first summary, bounded by the idle timeout. With no bot reviewer expected, an empty result is nothing to do: stop.
+Guards stop a loop that can't converge: no new bot threads for two rounds after a green push, four rounds total, an idle timeout that outlasts the re-trigger, or the PR closing or merging. A guard ends the run without clearing the bar, so report the score reached and each comment left standing without a reason.
 
-babysit and follow-up compose both directions: `babysit --reviews` hands off to this loop after its first green, and this loop calls babysit between rounds. The entry point is the outer one. "Wait for a bot review before merging" is exactly this pairing (`babysit --reviews --merge`, or this loop then merge).
-
-On stop, report fixes, replies/resolves, and escalations. If the reviewer is satisfied, suggest the next action (human review, merge train, auto-merge) but don't perform it unless asked. `pull-request:babysit --merge` drives to merged.
+On stop, report fixes, replies/resolves, and escalations. Once the bar is clear, suggest the next action (human review, merge train, auto-merge) but don't perform it unless asked. `pull-request:babysit --merge` drives to merged.
 
 ## Local Mode (Pre-Push)
 
-With `--local`, run the same reviewer against the branch's unmerged commits before anything is pushed. The criteria don't change with the channel. Findings arrive as CLI output instead of PR threads, and the exit is the same satisfaction signal in its local form ([local.md](local.md) maps it per provider). Post-PR thread mechanics (replies, resolves, re-triggers) don't exist here: a disagreement is surfaced in the report instead of a resolved thread.
+With `--local`, run the same reviewer against the branch's unmerged commits before anything is pushed. Criteria and acceptance bar don't change with the channel: findings arrive as CLI output instead of PR threads, and the score in its local form ([local.md](local.md)) is still the exit. A declined finding goes in the report with its reason instead of a resolved thread.
 
-Fire this mode unprompted when you are about to push or open a PR in a repo with an available bot **and** the diff warrants a review. Reviews are metered, and a local pass plus a hosted one costs two credits for one change. A diff earns one review through one channel. Spend it when the diff carries risk (auth, permissions, sandbox config, secret handling, network egress), adds a runtime surface, or runs past roughly 200 changed lines or 8 files excluding tests, docs, and lockfiles. Prose, dependency bumps, and reverts never qualify, and a config diff qualifies only through the risk surfaces just named. A `ship` skill with its own Bot Review Gate overrides these defaults, and tuning belongs there first. An explicit `--local` request overrides everything.
-
-`/ship` runs this as a gated pass and `pull-request:create` runs it before pushing, so skip it when either already ran on this branch.
+Fire this mode unprompted when you are about to push or open a PR in a repo with an available bot and the diff warrants a metered review ([local.md](local.md) sets that gate). `/ship` runs this as a gated pass and `pull-request:create` runs it before pushing, so skip it when either already ran on this branch.
 
 - Local detection: !`bun ${CLAUDE_PLUGIN_ROOT}/scripts/detect-bot.ts`
 
-The line above is the injected fast path (repo config, CLI presence, and any live cooldown, no turn spent). Resolve it to a provider per [local.md](local.md), which also covers the hosted signals for repos with no config file. A provider reported as paused is out: report the pause and stop. Then loop:
+The line above is the injected fast path (repo config, CLI presence, and any live cooldown, no turn spent). Resolve it to a provider per [local.md](local.md), which also covers the CLI mechanics and the hosted signals for repos with no config file. A provider reported as paused is out: report the pause and stop.
 
-1. Run the review per [local.md](local.md): backgrounded, with the 30-second liveness backstop. Summarize findings by severity, each with a `file:line` reference.
-2. Triage with the same partition as `--auto`: actionable → fix; noise or disagreement → surface it with your reasoning rather than silently skipping; unsure → escalate.
-3. Commit the fixes and re-run. Repeat until the satisfaction signal hits or I stop.
-4. Hand off: offer next steps (push, PR, `/ship`) without taking them.
+Then loop: run the review per [local.md](local.md), summarize findings by severity with a `file:line` reference each, triage with the same partition as `--auto`, commit the fixes, and re-run until the bar is clear or I stop. Surface a disagreement with your reasoning rather than skipping it silently. Finish by offering next steps (push, PR, `/ship`) without taking them.
 
-Once a PR exists, triage the hosted bot's comments through the normal flow above.
+Once a PR exists, triage the hosted bot's comments through the flow above.
 
 ## Guardrails
 

--- a/plugins/pull-request/skills/follow-up/auto.md
+++ b/plugins/pull-request/skills/follow-up/auto.md
@@ -1,0 +1,27 @@
+# Autonomous Round Mechanics
+
+How a `--auto` round runs once triage is done. The triage partition and the acceptance bar live in [SKILL.md](SKILL.md#the-autonomous-loop). Per-reviewer scores, expectation signals, and re-trigger phrases live in [reviewers.md](reviewers.md).
+
+## A Round
+
+1. Apply batched fixes, commit, push **once** (one new SHA to re-review).
+2. Reply-and-resolve the noise threads (`github:pr-comments` or `gitlab:merge-request` do both in one call).
+3. Escalate the unsure threads and pause **that subset only**; actionable pushes proceed.
+4. Hand CI back to `pull-request:babysit` (it owns CI, stops at green). babysit's Monitor watcher re-invokes you on CI events, so don't wrap that wait in `ScheduleWakeup`; the harness wakes you.
+5. Get the bot onto the green SHA, then re-read the score.
+
+## Waiting for the Re-Review
+
+Where the repo re-reviews pushes automatically, wait for it. No Monitor watcher tracks this, so self-pace with `ScheduleWakeup`: arm a tick (`prompt` set to this same `/pull-request:follow-up` invocation so the wake re-enters the loop) at ~270s for an idle wait before re-triggering, or 180-240s when a fast re-review is expected. Never 300s (the cache-expiry boundary).
+
+On wake, re-fetch bot threads and read the score on HEAD. Stop if the bar is clear or a guard fires. Otherwise, when no re-review landed, post one top-level `@<bot>` re-trigger ([reviewers.md](reviewers.md)) and re-arm the next tick.
+
+On a repo that reviews only on request (Greptile with `triggerOnUpdates: false`, for one), that wait is dead time. No re-review is coming until you ask, so post the re-trigger right after the green push and arm the tick only to collect the result. `greptile config --json` reports the live setting.
+
+## An Empty Thread List
+
+When a bot review is **expected** ([reviewers.md](reviewers.md) defines the signals) but no summary has landed on HEAD, the review is still running: wait through the same wake and re-trigger for the first summary, bounded by the idle timeout. A thread list that is empty because no bot reviewer is expected is nothing to do, so stop.
+
+## Composing with babysit
+
+babysit and follow-up compose both directions: `babysit --reviews` hands off to this loop after its first green, and this loop calls babysit between rounds. The entry point is the outer one. "Wait for a bot review before merging" is exactly this pairing (`babysit --reviews --merge`, or this loop then merge).

--- a/plugins/pull-request/skills/follow-up/local.md
+++ b/plugins/pull-request/skills/follow-up/local.md
@@ -1,6 +1,12 @@
 # Local Review CLI
 
-Mechanics for running a hosted reviewer's CLI locally in [Local Mode](SKILL.md#local-mode-pre-push). Triage criteria and the loop live in SKILL.md; satisfaction signals live in [reviewers.md](reviewers.md). This file is only the channel: how to detect the provider and drive its CLI.
+Mechanics for running a hosted reviewer's CLI locally in [Local Mode](SKILL.md#local-mode-pre-push). Triage criteria and the [acceptance bar](SKILL.md#acceptance-bar) live in SKILL.md; per-reviewer scores live in [reviewers.md](reviewers.md). This file is the channel: when a local review is worth its credit, how to detect the provider, and how to drive its CLI.
+
+## When the Diff Warrants a Review
+
+Reviews are metered, and a local pass plus a hosted one costs two credits for one change. A diff earns one review through one channel. Spend it when the diff carries risk (auth, permissions, sandbox config, secret handling, network egress), adds a runtime surface, or runs past roughly 200 changed lines or 8 files excluding tests, docs, and lockfiles. Prose, dependency bumps, and reverts never qualify, and a config diff qualifies only through the risk surfaces just named.
+
+A `ship` skill with its own Bot Review Gate overrides these defaults, and tuning belongs there first. An explicit `--local` request overrides everything.
 
 ## Provider Detection
 
@@ -45,7 +51,7 @@ Preflight: confirm you are in a git repo. If the CLI is missing, offer to instal
 
 Run `greptile review --json` backgrounded, adding `-b <base>` only when a base was given. The base flag is `-b`/`--branch`. Absent a base, the CLI reviews against the repository's default branch. Fall back to `--agent` (plain-text output for agents) if `--json` fails. For an interrupted run, `greptile review --resume` continues it and `greptile review status` reports the most recent review. For other flags, check `greptile review --help`.
 
-The `--json` output carries `comments` (each with file, line, severity) plus `confidence` and `summary`. The satisfaction signal is the local form of the hosted one in reviewers.md: zero comments at top confidence.
+The `--json` output carries `comments` (each with file, line, severity) plus `confidence` and `summary`. The acceptance bar is the local form of the hosted one in [reviewers.md](reviewers.md): `confidence` at its maximum with no comments left, or a written reason in the report for each comment you declined.
 
 ## CodeRabbit
 
@@ -53,4 +59,4 @@ Preflight: confirm you are in a git repo. If the CLI is missing, offer to instal
 
 Run `coderabbit review --agent --light` backgrounded, adding `--base <base>` only when a base was given. `--light` trades depth for turnaround, which is the point of the local pass. Absent a base, the CLI reviews against a resolved default base and errors asking for `--base` when it can't find one. Fall back to `--plain` (human-readable output) if the `--agent` output can't be parsed; `coderabbit review findings` re-prints the last local review without re-running. For other flags, check `coderabbit review --help`.
 
-`--agent` emits newline-delimited JSON events. Parse the `finding` events (`severity` = `critical`|`warning`|`info`, `fileName`, `codegenInstructions`) and the terminal `complete` event (`findings` count, `reviewedFiles`). The satisfaction signal is the local form of the hosted one in reviewers.md: a terminal `complete` event with no critical or warning `finding` events. Info-level findings are noise, the local form of the hosted nitpick/LGTM notes, so they don't block satisfaction (a `complete` with `findings: 0` is the clean case, but info-only findings still count as satisfied).
+`--agent` emits newline-delimited JSON events. Parse the `finding` events (`severity` = `critical`|`warning`|`info`, `fileName`, `codegenInstructions`) and the terminal `complete` event (`findings` count, `reviewedFiles`). The acceptance bar is the local form of the hosted one in [reviewers.md](reviewers.md): a terminal `complete` event with no critical or warning `finding` events, or a written reason in the report for each one you declined. Info-level findings are noise, the local form of the hosted nitpick/LGTM notes, so they don't hold the bar (a `complete` with `findings: 0` is the clean case, and info-only findings clear it too).

--- a/plugins/pull-request/skills/follow-up/reviewers.md
+++ b/plugins/pull-request/skills/follow-up/reviewers.md
@@ -1,6 +1,6 @@
 # AI Reviewers
 
-Per-reviewer "satisfied" signals for the `--auto` loop, plus how to add a reviewer and re-trigger an idle one.
+Per-reviewer scores for the `--auto` loop's [acceptance bar](SKILL.md#acceptance-bar), plus how to add a reviewer and re-trigger an idle one.
 
 ## Satisfaction Signals
 
@@ -9,12 +9,14 @@ Third-party reviewers converge on one shape: each leaves a single summary commen
 - Select the summary comment by `updated_at`, not `created_at`. The current signal is an edit to a comment created rounds ago, so newest-created points at the wrong one.
 - Treat the summary body as a thread source. A thread-count check alone reads an unfinished review, with actionable items parked in the summary, as satisfied.
 
-A reviewer is done when its latest summary on the current HEAD reports nothing actionable and no unresolved bot threads remain. A stale signal from an earlier SHA does not count. An **absent** summary on HEAD means the review is still pending, so when a review is expected, wait for the summary to land before reading it. Each vendor phrases "none left" differently; use the string as a fast path, fall back to the thread count:
+A reviewer is done when its latest summary on the current HEAD carries the reviewer's maximum score and no unresolved bot threads remain. A stale score from an earlier SHA does not count. An **absent** summary on HEAD means the review is still running, so when a review is expected, wait for the summary to land before reading it. Each vendor states its maximum differently; use the string as a fast path, fall back to the thread count:
 
 - **CodeRabbit** (GitHub `coderabbitai`, GitLab `group_<id>_bot_<hash>`): `Actionable comments posted: 0`. Nitpick and LGTM notes are noise unless obviously correct.
-- **Greptile** (GitHub `greptile-apps[bot]` / `greptileai`): top confidence score (e.g. `5/5`); actionable items live in its "fix all with AI" section.
+- **Greptile** (GitHub `greptile-apps[bot]` / `greptileai`): confidence score at its maximum, `5/5`; actionable items live in its "fix all with AI" section.
 
-> Verify these strings against recent PR history when a reviewer's wording drifts. The reliable cross-cutting signal is **zero new actionable bot threads on the current HEAD after a re-review**.
+Below the maximum, the [acceptance bar](SKILL.md#acceptance-bar) holds the loop open until each comment still standing carries a written reason for declining it.
+
+> Verify these strings against recent PR history when a reviewer's wording drifts. Where a vendor's wording can't be matched at all, fall back to **zero new actionable bot threads on the current HEAD after a re-review** and report the score you couldn't read.
 
 #### Copilot
 


### PR DESCRIPTION
The `--auto` loop had no concept of the reviewer's score. It exited on a satisfaction signal a thread count could satisfy, so a Greptile review sitting at 3/5 with its remaining comments quietly skipped read as done. You restated the real bar by hand on 8+ PRs in the last 10 days ("greptile 5/5 or address"), which is the tell that the skill wasn't carrying it.

It carries it now, as an Acceptance Bar section: the loop ends at the reviewer's maximum score on HEAD, or when every comment still standing below that maximum carries a written reason for declining it. The old exit conditions demote to guards on a loop that can't converge. A guard stop reports the score reached and each comment left without a reason, rather than passing as satisfied. `local.md` and `reviewers.md` restate the same bar in their local-CLI and per-vendor forms.

The other half is what the skill costs to keep loaded. The frontmatter description was 915 chars, the largest of 59 plugin skills, with the next at 648 and the median near 200. Every char rides in each catalog injection.

It's 279 now. The routing triggers stay, and the `--auto`/`--local` flag documentation moves into an `## Arguments` section in the body where it was already needed. SKILL.md drops from ~2,262 to ~1,658 tokens: per-round mechanics to a new `auto.md`, the metered-review gate to `local.md`, both loaded on demand.

`skills/create/SKILL.md` still says "follow-up's SKILL.md defines the gate" and that gate now lives in `local.md`. Another agent owns that file this session, so the pointer costs one extra hop until it gets fixed there.

Discovery: f1bef3455ee4
Discovery: 9c02ddfb1a99
