### PR TITLE
skills: trim ship and improve-claude-code bodies

### DIFF
--- a/user/skills/improve-claude-code/SKILL.md
+++ b/user/skills/improve-claude-code/SKILL.md
@@ -45,21 +45,13 @@ Ask the user which items to work on (numbers, ranges like `1-3`, or `all`). The 
 
 ## Session Context
 
-Each todo's notes embed the originating session as `Session: <uuid>`. For every selected todo, parse that UUID and use the `claude-code:session` skill to pull the original context: what you were doing, the commands that ran, and the errors that prompted the todo. This is richer than the todo's prose summary and grounds each plan in the real failure.
-
-Refresh the index once (`refresh.ts --refresh`), then look up each todo's session over the shared file with `duckdb -readonly` at the stable DB path (see the session skill's "Parallel Queries" section). Read-only opens coexist, so a batch of lookups runs concurrently without contending; never re-refresh per todo. Query `messages` / `content_items` / `text_content` filtered by `WHERE session_id = '<uuid>'`. Do not filter by `host`: many todos come from the work machine, whose corpus is imported as a separate host, and omitting the filter spans every machine. Distill the result to a few lines per todo and pass it, with the title and notes, to the matching agent in the [Plan](#plan) workflow. Agents receive the stable DB path for any further read-only lookup but never refresh.
-
-If the UUID is absent from the index (not yet imported, or the index needs a refresh), proceed with notes only and say so for that todo.
-
-#### Egress
-
-Session context informs local planning only. Imported hosts may be marked `block_egress`, so never paste session-derived content into PR bodies or any other output that leaves the machine.
+Each todo's notes embed the originating session as `Session: <uuid>`. For every selected todo, use the `claude-code:session` skill to pull the original context (what you were doing, the commands that ran, the errors that prompted the todo) before planning: richer than the todo's prose summary and grounds each plan in the real failure. Session context informs local planning only: never paste session-derived content into PR bodies or any other output that leaves the machine. Index refresh, DuckDB lookup mechanics, host filtering, and the full egress rule: [references/session-context.md](references/session-context.md).
 
 ## Plan
 
 The mechanical fan-out runs as a **Workflow**. Instructing `Workflow` from inside this user-invoked skill is a sanctioned opt-in under the Workflow tool's own rules, so author and run the script rather than refusing mid-run.
 
-Run one Workflow (`parallel`) with one agent per selected todo. Give each agent its todo title, full notes, and the distilled session context, and have it explore the repo and produce an implementation plan. Point agents at the relevant domain skills: `claude-code:skill` for skill changes, `claude-code:hook` for hooks, `bun:bun` for scripts. Preserve the [egress](#egress) rule inside the workflow: session-derived context stays local and never enters agent output that leaves the machine.
+Run one Workflow (`parallel`) with one agent per selected todo. Give each agent its todo title, full notes, and the distilled session context, and have it explore the repo and produce an implementation plan. Point agents at the relevant domain skills: `claude-code:skill` for skill changes, `claude-code:hook` for hooks, `bun:bun` for scripts. Preserve the [egress rule](references/session-context.md) inside the workflow: session-derived context stays local and never enters agent output that leaves the machine.
 
 Each agent returns a structured plan:
 
@@ -71,69 +63,7 @@ The workflow returns the plans to the main loop. Present them there and collect 
 
 ## Implement
 
-Feed the approved plans into a second Workflow shaped as `pipeline(approvedPlans, implement, ciGate)`:
-
-- `implement`: an `agent` with `agentType: 'general-purpose'` and `isolation: "worktree"` implements the plan, runs `bun test`, runs `review:code <effort>` at the approved level, commits, and opens the PR via `pull-request:create` with the [`Original Task`](#pr-body) backlink. Returns `{ thingsId, prUrl, branch }`.
-- `ciGate`: a fast initial CI check with one trivial-failure fix pass. Returns `{ thingsId, prUrl, ciStatus }`.
-
-Do not hold worktree agents open on long CI waits: the gate catches trivial breakage, then Watch handles the rest. Back in the main loop, [Annotate Things](#annotate-things) and [Summary](#summary) consume the pipeline results unchanged.
-
-The Workflow tool delivers `args` as a JSON string, so normalize it before use (the `parallel` plan workflow takes no args). The pipeline shape and each stage's result schema (`meta` must be a pure literal):
-
-```javascript
-export const meta = {
-  name: 'improve-cc-implement',
-  description: 'Implement each approved plan as a PR, then fast-gate CI',
-  phases: [{ title: 'Implement' }, { title: 'CI gate' }],
-}
-
-const { approved } = typeof args === 'string' ? JSON.parse(args) : args
-
-const IMPLEMENTED = {
-  type: 'object',
-  required: ['thingsId', 'prUrl', 'branch'],
-  properties: {
-    thingsId: { type: 'string' },
-    prUrl: { type: 'string' },
-    branch: { type: 'string' },
-  },
-}
-
-const CI_GATE = {
-  type: 'object',
-  required: ['thingsId', 'prUrl', 'ciStatus'],
-  properties: {
-    thingsId: { type: 'string' },
-    prUrl: { type: 'string' },
-    ciStatus: { type: 'string' },
-  },
-}
-
-const results = await pipeline(
-  approved,
-  (plan) =>
-    agent(implementPrompt(plan), {
-      agentType: 'general-purpose',
-      isolation: 'worktree',
-      phase: 'Implement',
-      schema: IMPLEMENTED,
-    }),
-  (built, plan) =>
-    agent(ciGatePrompt(built), {
-      label: `ci:${plan.thingsId}`,
-      phase: 'CI gate',
-      schema: CI_GATE,
-    }),
-)
-```
-
-#### PR body
-
-Include an `Original Task` link so the PR traces back to the Things todo:
-
-```
-Original Task: [<todo-title>](https://things.bendrucker.me/show?id=<todo-id>)
-```
+Feed the approved plans into a pipeline Workflow: `implement` (a worktree `general-purpose` agent implements the plan, runs `bun test` and `review:code <effort>` at the approved level, commits, and opens the PR via `pull-request:create` with an `Original Task` backlink) then `ciGate` (a fast initial CI check with one trivial-failure fix pass). Do not hold worktree agents open on long CI waits: the gate catches trivial breakage, then Watch handles the rest. Back in the main loop, [Annotate Things](#annotate-things) and [Summary](#summary) consume the pipeline results unchanged. Pipeline shape, stage schemas, and the PR body format: [references/implement.md](references/implement.md).
 
 ## Monitor CI and Fix Failures
 

--- a/user/skills/improve-claude-code/references/implement.md
+++ b/user/skills/improve-claude-code/references/implement.md
@@ -1,0 +1,67 @@
+# Implement
+
+The mechanics behind [Implement](../SKILL.md#implement): the pipeline Workflow shape, stage contracts, and PR body format.
+
+Feed the approved plans into a second Workflow shaped as `pipeline(approvedPlans, implement, ciGate)`:
+
+- `implement`: an `agent` with `agentType: 'general-purpose'` and `isolation: "worktree"` implements the plan, runs `bun test`, runs `review:code <effort>` at the approved level, commits, and opens the PR via `pull-request:create` with the [PR body](#pr-body) backlink. Returns `{ thingsId, prUrl, branch }`.
+- `ciGate`: a fast initial CI check with one trivial-failure fix pass. Returns `{ thingsId, prUrl, ciStatus }`.
+
+Do not hold worktree agents open on long CI waits: the gate catches trivial breakage, then Watch handles the rest.
+
+The Workflow tool delivers `args` as a JSON string, so normalize it before use (the `parallel` plan workflow takes no args). The pipeline shape and each stage's result schema (`meta` must be a pure literal):
+
+```javascript
+export const meta = {
+  name: 'improve-cc-implement',
+  description: 'Implement each approved plan as a PR, then fast-gate CI',
+  phases: [{ title: 'Implement' }, { title: 'CI gate' }],
+}
+
+const { approved } = typeof args === 'string' ? JSON.parse(args) : args
+
+const IMPLEMENTED = {
+  type: 'object',
+  required: ['thingsId', 'prUrl', 'branch'],
+  properties: {
+    thingsId: { type: 'string' },
+    prUrl: { type: 'string' },
+    branch: { type: 'string' },
+  },
+}
+
+const CI_GATE = {
+  type: 'object',
+  required: ['thingsId', 'prUrl', 'ciStatus'],
+  properties: {
+    thingsId: { type: 'string' },
+    prUrl: { type: 'string' },
+    ciStatus: { type: 'string' },
+  },
+}
+
+const results = await pipeline(
+  approved,
+  (plan) =>
+    agent(implementPrompt(plan), {
+      agentType: 'general-purpose',
+      isolation: 'worktree',
+      phase: 'Implement',
+      schema: IMPLEMENTED,
+    }),
+  (built, plan) =>
+    agent(ciGatePrompt(built), {
+      label: `ci:${plan.thingsId}`,
+      phase: 'CI gate',
+      schema: CI_GATE,
+    }),
+)
+```
+
+## PR body
+
+Include an `Original Task` link so the PR traces back to the Things todo:
+
+```
+Original Task: [<todo-title>](https://things.bendrucker.me/show?id=<todo-id>)
+```

--- a/user/skills/improve-claude-code/references/session-context.md
+++ b/user/skills/improve-claude-code/references/session-context.md
@@ -1,0 +1,13 @@
+# Session Context
+
+The mechanics behind [Session Context](../SKILL.md#session-context): how to pull each todo's originating session and query it safely.
+
+Each todo's notes embed the originating session as `Session: <uuid>`. For every selected todo, parse that UUID and use the `claude-code:session` skill to pull the original context: what you were doing, the commands that ran, and the errors that prompted the todo. This is richer than the todo's prose summary and grounds each plan in the real failure.
+
+Refresh the index once (`refresh.ts --refresh`), then look up each todo's session over the shared file with `duckdb -readonly` at the stable DB path (see the session skill's "Parallel Queries" section). Read-only opens coexist, so a batch of lookups runs concurrently without contending; never re-refresh per todo. Query `messages` / `content_items` / `text_content` filtered by `WHERE session_id = '<uuid>'`. Do not filter by `host`: many todos come from the work machine, whose corpus is imported as a separate host, and omitting the filter spans every machine. Distill the result to a few lines per todo and pass it, with the title and notes, to the matching agent in the [Plan](../SKILL.md#plan) workflow. Agents receive the stable DB path for any further read-only lookup but never refresh.
+
+If the UUID is absent from the index (not yet imported, or the index needs a refresh), proceed with notes only and say so for that todo.
+
+## Egress
+
+Session context informs local planning only. Imported hosts may be marked `block_egress`, so never paste session-derived content into PR bodies or any other output that leaves the machine.

--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -35,10 +35,10 @@ Default end state **green and ready**: CI green, bot comments triaged, body refr
 
 Resolve the base to a **remote** ref so ship's view matches what the PR merges against. From the base branch (default `main`, or `--base <parent>` on a stack), take its tracking ref via `git rev-parse --abbrev-ref --symbolic-full-name <base>@{u}`, falling back to `origin/<base>`. Fetch it first (`git fetch`) so a stale local `<base>` never inflates the diff with already-merged commits. Diff `git diff <resolved>...HEAD`, plus a plain `git diff` for uncommitted work, and thread the resolved ref as `--base` to every gated pass (including `review:code`). Gate each pass on the file set, its size, and the content behind any judgment call (new comments, refactor or new behavior). Full matrix and heuristics: [`references/passes.md`](references/passes.md).
 
-- **`plan:review`**: a substantial approved plan is in context (`~/.claude/plans/` file) *and* the session ran long or redirected enough that the diff could have drifted from it. No plan, or a small plan in a tight session, skips.
+- **`plan:review`**: a substantial approved plan is in context (`~/.claude/plans/` file) *and* the session ran long or redirected enough that the diff could have drifted from it. Skip otherwise ([full gate](references/passes.md)).
 - **Correctness and quality**: code changed. Exactly one of `review:code <effort> --fix` (default) or `simplify` (pure refactor, no new behavior). Skip on docs/config-only.
 - **`comments:audit`**: diff adds code comments.
-- **`pull-request:follow-up --local`**: a supported review bot is available for the repo *and* the diff clears the Bot Review Gate. Reviews are metered, so availability alone is not enough. Follow-up's `local.md` owns detection (repo config fast path, live cooldowns, hosted signals when no config is committed) and exits early when nothing is available. Runs the hosted reviewer locally before the PR exists.
+- **`pull-request:follow-up --local`**: a supported review bot is available for the repo *and* the diff clears the [Bot Review Gate](references/passes.md). Runs the hosted reviewer locally before the PR exists.
 - **`writing:review`**: diff touches prose (`.md`, `.mdx`, `.rst`, docs).
 - **`run`**: diff has a runtime surface. Drive the change in the real app, not just tests. Skip on docs-only and tests-only.
 
@@ -66,14 +66,12 @@ Dirty tree at the comment pass: ask whether to commit first. `comments:audit` op
 
 #### Comment Trims
 
-`comments:audit` commits trims to a fresh `comments/audit-<hash>` branch off `HEAD`, leaving the tree untouched. Run `comments:audit --base <base> --fix` and capture the branch name. No branch means nothing to trim: skip. Otherwise dispatch a short-lived `general-purpose` Agent with that name to fast-forward and delete it:
+`comments:audit` commits trims to a fresh `comments/audit-<hash>` branch off `HEAD`, leaving the tree untouched. Run `comments:audit --base <base> --fix` and capture the branch name. No branch means nothing to trim: skip. Otherwise dispatch a short-lived `general-purpose` Agent with that name to fast-forward and delete it (rationale and rejected alternatives: [`references/passes.md`](references/passes.md)):
 
 ```
 git merge --ff-only comments/audit-<hash>
 git branch -d comments/audit-<hash>
 ```
-
-The commit sits on `HEAD`, so the fast-forward is clean. It runs in the Agent to keep ship's own commands to `git diff` and `git status`. Rejected alternatives: [`references/passes.md`](references/passes.md).
 
 ## Create
 
@@ -81,16 +79,14 @@ Join the background `plan:review` first if it was gated in. Act on fix-worthy dr
 
 Pass `--base <parent>` through when `/ship --base` named a stack parent. Create needs it to target the PR at the parent and to link the layer into the stack on GitHub. Without it the PR opens against the default branch and carries every lower layer's diff.
 
-Pass the hosted reviewer's label through (`--label review` on my repos) only when the Bot Review Gate routed to the hosted channel, which happens when it said spend and the local CLI could not run. The review then starts with the PR. A local pass already covered the diff, so labeling after it pays a second credit for the same review.
+Pass `--label review` only when the [Bot Review Gate](references/passes.md) routed to the hosted channel (local CLI unavailable); the review then starts with the PR. A local pass already covered the diff, so labeling after it pays a second credit for the same review.
 
 ## Babysit
 
 `pull-request:babysit <url>` watches CI and fixes trivial failures to green.
 
-- `--reviews` (default on): after first green, hand bot comments to `pull-request:follow-up --auto`.
+- `--reviews` (default on): after first green, hand bot comments to `pull-request:follow-up --auto`. Covers a bot review landing after the green push with no CI event to key off ([why](references/passes.md)).
 - `--merge`: only when `/ship --merge` was passed; else stop at green.
-
-A bot review often lands after the green push with no CI event to key off. `--reviews` covers this: follow-up waits for an expected review's first pass, then triages it. Babysit owns the CI waits. Follow-up owns which reviews are expected (the signals in its `reviewers.md`) and the wait for them, so ship never restates them or hand-rolls a reviews-API poll. With none expected, the hand-off returns at once and ship stops at green.
 
 ## Refresh the Body
 

--- a/user/skills/ship/references/passes.md
+++ b/user/skills/ship/references/passes.md
@@ -84,6 +84,10 @@ Infer `review:code` effort from the diff unless `--effort` overrides. `high` is 
 
 Alternatives, not a pair. Pick `simplify` for a pure refactor or cleanup with no new behavior: extraction, renaming, dedup, dead-code removal, moving code. It covers reuse, simplification, efficiency, and altitude, and does not hunt bugs. Pick `review:code` for anything with new behavior, a bug fix, or a feature, which need the correctness coverage `simplify` skips. `--simplify` forces the `simplify` path.
 
+## Babysit and Reviews
+
+A bot review often lands after the green push with no CI event to key off. `--reviews` covers this: follow-up waits for an expected review's first pass, then triages it. Babysit owns the CI waits. Follow-up owns which reviews are expected (the signals in its `reviewers.md`) and the wait for them, so ship never restates them or hand-rolls a reviews-API poll. With none expected, the hand-off returns at once and ship stops at green.
+
 ## Comment Trims
 
 `comments:audit` commits trims to a fresh `comments/audit-<hash>` branch off `HEAD` via git plumbing, and its apply requires a clean tree. Ship needs the trims on the shipping branch, so it runs the audit first (clean tree) and fast-forwards the shipping branch onto the audit commit. A clean audit writes no branch, so skip the fast-forward when none was printed.


### PR DESCRIPTION
Trims the `ship` and `improve-claude-code` SKILL.md bodies. Both re-inject in full on every compaction (`ship` alone saw 19 restores), making body size a recurring cost. Detail moves into `references/` files loaded only on the branch that needs it. Every behavioral rule and `allowed-tools` entry stays, just relocated.

`ship` extends the existing `references/passes.md` pattern. Three spots were restating content `passes.md` already carried in full, so they got compressed to point at it instead:

- the "Decide What Applies" bullets
- the Comment Trims rationale
- the hosted-review-label rule

Added a Babysit and Reviews section to `passes.md` for the one bit of babysit rationale that had nowhere else to live.

`improve-claude-code` extracts the Implement pipeline's Workflow code into `references/implement.md`, and the Session Context DuckDB query mechanics into `references/session-context.md`. Both mirror the `discover`/`watch`/`sweep` mode files already in that skill.

`bun run skill-lint "user/skills/ship" "user/skills/improve-claude-code"` passes clean on both. `SKILL.md` token counts land well under the 4k target: `ship` ~1,713, `improve-claude-code` ~1,649.

Discovery: a4baf6b47018
Discovery: 7561c097a165
