### PR TITLE
review: split the fan-out into cheap and expensive modes

### DIFF
--- a/plugins/review/README.md
+++ b/plugins/review/README.md
@@ -13,6 +13,14 @@ Code review workflows for Claude Code.
 - **`follow-up`**: Follow up on a PR/MR you reviewed: check if your comments were addressed, find silent resolves, decide whether to re-approve
 - **`inbox`**: Dispatch inbound PR/MR reviews as background sessions that collect in `claude agents` (GitHub and GitLab)
 
+### Agents
+
+- **`angle`**: Runs one finder angle over a diff and returns candidates. The unit of `code`'s find fan-out and its sweep pass.
+- **`verifier`**: Judges candidates against the code as CONFIRMED, PLAUSIBLE, or REFUTED. The unit of `code`'s verify phase.
+- **`architect`**: Reviews a change as a design rather than a diff. Runs once at `max` effort.
+
+None pins a model. `code` picks one per effort tier: Sonnet below `max`, the session model at `max`.
+
 ## Testing
 
 ```sh

--- a/plugins/review/agents/angle.md
+++ b/plugins/review/agents/angle.md
@@ -1,0 +1,22 @@
+---
+name: angle
+description: >-
+  Runs one code-review finder angle over a diff and returns candidate defects. Spawned by the review:code skill's find fan-out and its sweep pass.
+tools: Read, Grep, Glob, Bash(git diff:*), Bash(git log:*), Bash(git show:*), Bash(git rev-parse:*), Bash(git ls-files:*)
+---
+
+You hunt defects in a diff through one lens. You receive a scope block (the diff range, the changed files, the governing CLAUDE.md paths), the single angle to apply, and a candidate cap.
+
+Apply only the angle you were given. Read the diff and whatever surrounding code that angle calls for. Another agent covers every other lens, so an out-of-angle observation never displaces an in-angle one.
+
+Return up to the cap of candidates, each carrying:
+
+- `file`, `line`
+- `summary`: one line
+- `failure_scenario`: the user-visible consequence (an error, wrong output, data loss), not an intermediate state
+
+Pass through every candidate you can name a failure scenario for. A verifier judges them afterward, so a candidate you drop for being half-believed never reaches that check, and that is the dominant cause of misses.
+
+Return nothing when the angle finds nothing. Do not pad.
+
+You read and judge. You never edit the code under review.

--- a/plugins/review/agents/architect.md
+++ b/plugins/review/agents/architect.md
@@ -1,0 +1,31 @@
+---
+name: architect
+description: >-
+  Reviews a change as a design rather than a diff: interface shape, layering, cross-file coherence, and future change cost. Spawned by the review:code skill's architecture pass at max effort.
+tools: Read, Grep, Glob, Bash(git diff:*), Bash(git log:*), Bash(git show:*), Bash(git rev-parse:*), Bash(git ls-files:*)
+---
+
+You review a change as a design. Every other agent on this review reads hunks. You read the modules the hunks live in, and you judge the shape the change leaves behind.
+
+You receive a scope block (the diff range, the changed files, the governing CLAUDE.md paths). Read each affected module in full, along with enough of its callers and neighbors to see what shape the codebase already had.
+
+Judge the change on:
+
+- **Interface and API shape**: what the change asks callers to know, pass, or remember. Parameters that encode a caller's internals, return shapes that force every caller to branch, options that exist because one call site needed them.
+- **Cross-file coherence**: whether the pieces added across files tell one story. The same concept named or modeled two ways, state split across modules that must now stay in sync, a rule enforced in one path and not its sibling.
+- **Layering and dependency direction**: whether the change points dependencies the way the codebase points them. A lower layer reaching upward, a module gaining a dependency that ties two previously independent areas together, business rules landing in transport or storage code.
+- **Naming as architecture**: names that describe the mechanism instead of the concept, or that make a boundary read as something it is not. A name is the interface most readers actually consume.
+- **With or against the grain**: whether the change follows the structure the codebase already established or fights it. A change that works only by bypassing an existing mechanism, or that adds a parallel mechanism beside one that already exists, is going against the grain even when it is correct.
+- **Future change cost**: what this diff makes harder next time. Which likely next change now has to touch several files, which invariant is now maintained by convention instead of by construction.
+
+Return two separate lists.
+
+**Defects** are line-anchored. A specific line is wrong or will break, and you can point at it. Each carries `file`, `line`, a one-line `summary`, and a `failure_scenario` naming the user-visible consequence. These go through the same verification the other finders' candidates do, so pass through anything you can name a scenario for.
+
+**Judgments** are architectural calls with no single line to blame. Each carries the file or module it concerns, a one-line `summary`, and a `cost`: what this shape makes harder, concretely, and what you would do instead. Do not force a line number onto a judgment to make it look like a defect. Do not soften a defect into a judgment to avoid being checked.
+
+Judge shape. Every judgment names a concrete cost a maintainer will pay. An opinion about how you would have written it, with no cost attached, is not a finding.
+
+Return an empty list for either kind when you have nothing. Do not pad.
+
+You read and judge. You never edit the code under review.

--- a/plugins/review/agents/verifier.md
+++ b/plugins/review/agents/verifier.md
@@ -1,0 +1,22 @@
+---
+name: verifier
+description: >-
+  Judges candidate code-review findings against the code as CONFIRMED, PLAUSIBLE, or REFUTED. Spawned by the review:code skill's verify phase.
+tools: Read, Grep, Glob, Bash(git diff:*), Bash(git log:*), Bash(git show:*), Bash(git rev-parse:*), Bash(git ls-files:*)
+---
+
+You judge candidate review findings against the code. You receive a scope block, the relevant files, one or more candidates, and the verdict ladder for the effort level in play.
+
+Candidates that share a location still get judged independently, each on its own claim.
+
+Return exactly one verdict per candidate:
+
+- **CONFIRMED**: you can name the inputs or state that trigger it and the wrong output or crash it produces. Quote the line.
+- **PLAUSIBLE**: the mechanism is real, the trigger is uncertain (timing, environment, config). State what would confirm it.
+- **REFUTED**: factually wrong (the code does not say that) or guarded elsewhere. Quote the line that proves it.
+
+Apply the ladder the caller gave you rather than your own threshold. A recall-biased ladder means realistic-but-unproven state is PLAUSIBLE, not REFUTED.
+
+Return a verdict for every candidate you were handed. A candidate you leave unjudged gets dropped, so silence costs a real finding.
+
+You read and judge. You never edit the code under review.

--- a/plugins/review/skills/code/SKILL.md
+++ b/plugins/review/skills/code/SKILL.md
@@ -60,11 +60,24 @@ Otherwise run the selected angles from [angles.md](angles.md). Each surfaces up 
 
 #### Fan-out cells
 
-`medium`, `high`, `xhigh`, and `max` on the default and Sonnet families, plus `max` on Opus 4.8. Run each angle as an independent `Agent`. Invoking this skill is the request for that fan-out, so run it whenever `Agent` is in the tool set. Give every agent the scope block, its single angle text, and the cleanup-precedence block if it carries a cleanup lens.
+`medium`, `high`, `xhigh`, and `max` on the default and Sonnet families, `xhigh` and `max` on Fable 5, plus `max` on Opus 4.8. Run each angle as an independent `Agent` with `subagent_type: review:angle`. Invoking this skill is the request for that fan-out, so run it whenever `Agent` is in the tool set. Give every agent the scope block, its single angle text, its candidate cap, and the cleanup-precedence block if it carries a cleanup lens.
+
+The spawn model is a property of the tier, not of the agent. `review:angle` and `review:verifier` pin no model, so they take whatever the spawn passes:
+
+- **Cheap mode** covers every fan-out cell below `max`. Pass `model: sonnet` on every angle, verifier, and sweep spawn. Breadth costs Sonnet rates whatever model is orchestrating.
+- **Expensive mode** is `max`. Pass no model at all, so each agent inherits the session model and reviews at the tier the code was authored at.
+
+That rule governs the spawns in Phase 2 and Phase 3 too.
+
+#### Architecture pass
+
+Only at `max`. Alongside the angle fan-out, run one `Agent` with `subagent_type: review:architect` and no model override. Give it the scope block and the changed-file list. It reads the affected modules whole and judges the change as a design: interface shape, cross-file coherence, layering, naming, whether the change follows the codebase's grain, and what it costs the next change.
+
+It returns two lists. Its line-anchored defects join the candidate pool and go through Phase 2 with everything else. Its judgments have no line to check, so they bypass verify and carry through to the report as judgments.
 
 #### Inline cells
 
-`o48-med`, `o48-high`, and `o48-xhigh`. Work through the angles in sequence yourself, in this context. Do not spawn subagents for them.
+`inline-med`, `inline-high`, and `inline-xhigh`. Work through the angles in sequence yourself, in this context. Do not spawn subagents for them.
 
 #### No `Agent` tool
 
@@ -80,7 +93,9 @@ Inline cells stop here: dedup only, no verify, no re-judging. Same defect, same 
 
 Degraded cells with no `Agent` tool dedup, then re-check each remaining candidate against the diff in this context.
 
-Fan-out cells verify: for each remaining candidate, run one verifier `Agent`. Give it the scope block, the relevant files, and the candidate. Group candidates that share a location into one verifier returning one verdict per candidate, each judged independently on its own claim. A candidate the verifier renders no verdict on is dropped, never reported as an unverified PLAUSIBLE.
+Fan-out cells verify: for each remaining candidate, run one `Agent` with `subagent_type: review:verifier`, under the tier's spawn model. Give it the scope block, the relevant files, the candidate, and the ladder below. Group candidates that share a location into one verifier returning one verdict per candidate, each judged independently on its own claim. A candidate the verifier renders no verdict on is dropped, never reported as an unverified PLAUSIBLE.
+
+Architecture-pass judgments carry no line to check against, so they skip this phase entirely. Only the architecture pass's line-anchored defects go to a verifier.
 
 Each verdict is exactly one of:
 
@@ -100,9 +115,9 @@ At `xhigh` and `max`, a single non-REFUTED vote carries the finding. Do not drop
 
 ## Phase 3 — Sweep
 
-Only at `xhigh`, `max`, and `o48-xhigh`.
+Only at `xhigh`, `max`, and `inline-xhigh`.
 
-Take one more pass as a fresh reviewer holding the verified list. On fan-out cells this is one more finder `Agent`. On inline and degraded cells it is one more pass in this context.
+Take one more pass as a fresh reviewer holding the verified list. On fan-out cells this is one more `review:angle` `Agent` under the tier's spawn model, carrying the sweep gap focus as its angle. On inline and degraded cells it is one more pass in this context.
 
 Re-read the diff and the enclosing functions looking ONLY for defects not already listed. Do not re-derive or re-confirm anything already there. The job is gaps. Focus on what the first pass tends to miss (see the sweep gap focus in [angles.md](angles.md)).
 
@@ -112,7 +127,9 @@ Surface up to 8 additional candidates, each naming a defect not already on the l
 
 Merge findings that share a root cause, keeping the best-described one as the primary and noting the others as `[same root cause also at: <loc>, <loc>]`. When a merged member is CONFIRMED, the primary carries CONFIRMED.
 
-Rank most-severe first. Correctness bugs always outrank cleanup, altitude, and conventions findings. Within a severity group, CONFIRMED outranks PLAUSIBLE.
+Rank most-severe first. Correctness bugs always outrank cleanup, altitude, conventions, and architecture findings. Within a severity group, CONFIRMED outranks PLAUSIBLE.
+
+Architecture judgments rank with altitude. Each states the shape it objects to and the cost it imposes on the next change, so a reader can weigh it without a failure scenario.
 
 Cap at the cell's limit. Beyond the cap, omit the least severe. Nothing gets silently dropped while there is room under the cap.
 
@@ -126,8 +143,10 @@ Each entry carries:
 
 - `file`, `line`, `summary`, `failure_scenario`
 - `short_summary` — the claim compressed to 60 characters or fewer, no rationale or consequence clause
-- `category` — a short kebab-case slug for the angle that produced it: `correctness`, `simplification`, `efficiency`, `reuse`, `altitude`, `conventions`, or something more specific like `test-coverage` when it fits better
+- `category` — a short kebab-case slug for the angle that produced it: `correctness`, `simplification`, `efficiency`, `reuse`, `altitude`, `conventions`, `architecture`, or something more specific like `test-coverage` when it fits better
 - `verdict` — only when a verify pass produced one. Inline cells run no verify, so they omit it.
+
+An architecture judgment reports under `category: architecture` with no `verdict`, and its `failure_scenario` states the maintenance cost instead of a runtime failure. Open that text with `Judgment:` so a reader can tell a design call from a defect at a glance.
 
 If nothing survives, call it with an empty array.
 
@@ -144,6 +163,8 @@ If nothing survives, say so in one line.
 After producing the findings list, apply them to the working tree instead of stopping at the report. Fix each one directly: correctness bugs and reuse/simplification/efficiency cleanups alike.
 
 Skip any finding whose fix would change intended behavior, require changes well outside the reviewed diff, or that you judge to be a false positive. Note the skip rather than arguing with it.
+
+Architecture judgments are always reported and never applied. Reshaping a design is the author's call, so mark each one `skipped`.
 
 With `ReportFindings`, call it again with the same findings, each carrying an `outcome`: `fixed`, `no_change_needed` (the finding was wrong or already handled), or `skipped` (real but not applied). Do not repeat the findings as text. After the call, give one line per skipped finding saying why. Without it, finish with a brief summary of what was fixed and what was skipped.
 

--- a/plugins/review/skills/code/efforts.md
+++ b/plugins/review/skills/code/efforts.md
@@ -8,9 +8,24 @@ The review's shape is chosen by `(model family, effort level)`. Read the active 
 | --- | --- | --- | --- | --- | --- |
 | `default` | `low` | `medium` | `high` | `xhigh` | `max` |
 | `claude-sonnet-5` | `low-sonnet5` | `medium` | `high` + finder budget | `xhigh` + finder budget | `max` + finder budget |
-| `claude-opus-4-8` | `o48-low` | `o48-med` | `o48-high` | `o48-xhigh` | `max` |
+| `claude-opus-4-8` | `inline-low` | `inline-med` | `inline-high` | `inline-xhigh` | `max` |
+| `claude-fable-5` | `inline-low` | `inline-med` | `inline-high` | `xhigh` | `max` |
 
-The `o48-*` cells run every angle **inline in this context** with no subagent fan-out and no verify pass. Only `max` reaches the full multi-agent fan-out on Opus 4.8. That is the upstream calibration, kept as-is.
+The `inline-*` cells run every angle **inline in this context** with no subagent fan-out and no verify pass. They are upstream's `o48-*` cells under a family-neutral name, since two families now select them. [references/upstream-2.1.215.md](references/upstream-2.1.215.md) maps each one back to its upstream identifier.
+
+A capable orchestrator reviews better working through the angles itself than it does splitting them across agents, so both Opus 4.8 and Fable 5 stay inline through the middle of the ladder. The families part at `xhigh`. Opus 4.8 keeps upstream's inline calibration there, unchanged. Fable 5 fans out instead, at Sonnet rates, which buys breadth without paying Fable rates per angle.
+
+## Cheap and Expensive Modes
+
+The fan-out cells come in two modes, and the difference is which model the subagents run on. `review:angle`, `review:verifier`, and `review:architect` pin no model of their own, so each spawn decides.
+
+**Cheap mode** is every fan-out cell below `max`. On Fable 5 and Opus 4.8 that means `xhigh`. Angles, verifiers, and the sweep spawn with `model: sonnet`. What these tiers buy is breadth, and breadth comes from many independent readers of the same diff. Paying the orchestrator's own rate for each of those readers buys nothing extra.
+
+**Expensive mode** is `max`, on every family. Angles, verifiers, and the sweep spawn with no model override and inherit the session model, and the architecture pass runs on top.
+
+Expensive mode exists for the relationship between reviewer and author. A reviewer below the authoring model's tier finds what a careful line-by-line reader finds. It rarely disputes the shape of the change, because seeing the shape takes the same capability that produced it. That makes `max` the level for structurally significant work authored by Opus or Fable, where the shape carries the risk. It puts the reviewer at or above the author's tier and adds a pass that reads the design.
+
+Cheap mode stays the right default. Most diffs fail on lines, and lines are what Sonnet reads well and cheaply.
 
 ## Budgets
 
@@ -18,14 +33,14 @@ The `o48-*` cells run every angle **inline in this context** with no subagent fa
 | --- | --- | --- | --- | --- | --- | --- |
 | `low` | 1 diff pass | — | none | no | <=4 | terse, hunk-only, skips test/fixture hunks |
 | `low-sonnet5` | 1 diff pass | — | none | no | floor `min(files, 4)` | same, plus a second pass if under the floor |
-| `o48-low` | 1 diff pass | — | none | no | <=8, floor `min(files, 4)` | no test-hunk skip |
+| `inline-low` | 1 diff pass | — | none | no | <=8, floor `min(files, 4)` | no test-hunk skip |
 | `medium` | 3 correctness + 3 cleanup + altitude + conventions = 8 | 6 | 1-vote, 3-state | no | <=8 | precision |
 | `high` | 8 | 6 | 1-vote, recall-biased | no | <=10 | recall |
 | `xhigh` | 5 correctness + 5 cleanup/altitude/conventions = 10 | 8 | 1-vote, single non-REFUTED carries | yes | <=15 | recall |
-| `max` | 10 | 8 | same as `xhigh` | yes | <=15 | recall, maximum |
-| `o48-med` | 8, inline | 6 | dedup only | no | <=8, floor 4 | recall |
-| `o48-high` | 8, inline | 6 | dedup only | no | <=10, floor 5 | recall |
-| `o48-xhigh` | 10, inline | 8 | dedup only | yes | <=15, floor 7 | recall |
+| `max` | 10 + architecture pass | 8 | same as `xhigh` | yes | <=15 | recall, maximum |
+| `inline-med` | 8, inline | 6 | dedup only | no | <=8, floor 4 | recall |
+| `inline-high` | 8, inline | 6 | dedup only | no | <=10, floor 5 | recall |
+| `inline-xhigh` | 10, inline | 8 | dedup only | yes | <=15, floor 7 | recall |
 
 "8 angles" means Angles A, B, C plus Reuse, Simplification, Efficiency, Altitude, Conventions. "10 angles" adds Angles D and E.
 
@@ -39,31 +54,31 @@ Emit the framing for the selected cell before Phase 1. It sets the precision/rec
 
 > You are reviewing for **precision** at medium effort: every finding you surface should be one a maintainer would act on.
 
-### `high`, `o48-med`, `o48-high`
+### `high`, `inline-med`, `inline-high`
 
 > You are reviewing for **recall** at high effort: catch every real bug a careful reviewer would catch in one sitting. At this level, catching real bugs matters more than avoiding false positives. Err on the side of surfacing.
 
-`o48-med` deliberately uses recall framing rather than the precision framing the default-family `medium` uses.
+`inline-med` deliberately uses recall framing rather than the precision framing the default-family `medium` uses.
 
-### `xhigh`, `o48-xhigh`
+### `xhigh`, `inline-xhigh`
 
 > You are reviewing for **recall** at extra-high effort: catch every real bug. At this level, catching real bugs matters more than avoiding false positives — a missed bug ships. Err on the side of surfacing.
 
 ### `max`
 
-Same as `xhigh` with "maximum" in place of "extra-high". The fan-out is identical. Only the reasoning effort differs.
+Same as `xhigh` with "maximum" in place of "extra-high". The angle set is identical. What `max` adds is the expensive spawn model, the architecture pass, and the reasoning effort.
 
 ## Low Cells
 
 The `low` cells skip the phase structure entirely: one diff read, then findings.
 
-Read the unified diff in one tool call. `low` and `low-sonnet5` skip test/fixture hunks (`test/`, `spec/`, `__tests__/`, `*_test.*`, `*.test.*`, `fixtures/`, `testdata/`), which are not reviewed at those levels. `o48-low` reviews them. No subagents, no full-file reads.
+Read the unified diff in one tool call. `low` and `low-sonnet5` skip test/fixture hunks (`test/`, `spec/`, `__tests__/`, `*_test.*`, `*.test.*`, `fixtures/`, `testdata/`), which are not reviewed at those levels. `inline-low` reviews them. No subagents, no full-file reads.
 
 Flag runtime-correctness bugs visible from the hunk alone: inverted/wrong condition, off-by-one, null/undefined deref where adjacent lines show the value can be absent, removed guard, falsy-zero check, missing `await`, wrong-variable copy-paste, error swallowed in a catch that should propagate. Also flag — still from the hunk alone — new code that duplicates an existing helper visible in the diff context, and dead code the diff leaves behind.
 
 Do **not** flag style, naming, perf, missing tests, or anything outside the hunk.
 
-Output one line per finding, most-severe first: `path/to/file.ext:123 — what's wrong and the concrete failure`. `low` outputs at most 4 and emits exactly `(none)` when nothing qualifies. `low-sonnet5` targets `min(files_changed, 4)` and does one more pass over the largest changed file and any removed blocks before settling for fewer. `o48-low` outputs at most 8, targeting at least `min(files_changed, 4)` and widening to other hunks before stopping.
+Output one line per finding, most-severe first: `path/to/file.ext:123 — what's wrong and the concrete failure`. `low` outputs at most 4 and emits exactly `(none)` when nothing qualifies. `low-sonnet5` targets `min(files_changed, 4)` and does one more pass over the largest changed file and any removed blocks before settling for fewer. `inline-low` outputs at most 8, targeting at least `min(files_changed, 4)` and widening to other hunks before stopping.
 
 `low` never reports through `ReportFindings`. It prints its findings as text.
 
@@ -79,6 +94,6 @@ Spawn about that many finder subagents. The committed-range count is a floor: un
 
 No other model family gets this hint.
 
-## Floors on the Opus 4.8 Cells
+## Floors on the Inline Cells
 
-The `o48-med`, `o48-high`, and `o48-xhigh` cells carry an output floor of `floor(cap / 2)`: target at least that many findings. If fewer genuine findings exist, emit what you have. Do not invent findings to hit the floor.
+The `inline-med`, `inline-high`, and `inline-xhigh` cells carry an output floor of `floor(cap / 2)`: target at least that many findings. If fewer genuine findings exist, emit what you have. Do not invent findings to hit the floor.

--- a/plugins/review/skills/code/references/upstream-2.1.215.md
+++ b/plugins/review/skills/code/references/upstream-2.1.215.md
@@ -2,6 +2,8 @@
 
 Binary: `/opt/homebrew/Caskroom/claude-code@latest/2.1.215/claude` (247 MB, Bun single-file executable).
 
+Cell names here are upstream's. The `inline-low`, `inline-med`, `inline-high`, and `inline-xhigh` cells in [efforts.md](../efforts.md) are upstream's `o48-low-v1`, `o48-med-v1`, `o48-high-v1`, and `o48-xhigh-v1`, renamed because more than one model family now selects them.
+
 ## Method note (important correction)
 
 There is **no UTF-16LE content** in this binary (`strings -e l -n 6` returns 0 lines). Everything is plain ASCII/UTF-8 minified JavaScript. The reason `grep` on `cc-strings.txt` "missed" parts of the body is that `strings` splits on newlines *and drops runs shorter than the minimum length*, so blank lines and short lines (`hunk.`, `}`, `]`, "```json") vanish. The fix is to read **raw byte windows out of the binary** — which is what everything below is taken from.

--- a/plugins/type-ignore/agents/fixer.md
+++ b/plugins/type-ignore/agents/fixer.md
@@ -2,6 +2,7 @@
 name: fixer
 description: >-
   Fixes type errors in a single file instead of ignoring them. Spawned by the detection hook when Claude adds a type ignore, or by the type-ignore:fix skill for parallel multi-file cleanup.
+model: sonnet
 ---
 
 You are a type error resolution specialist. Your job is to fix the underlying type errors that led to ignore comments, not to simply remove or relocate the ignores.


### PR DESCRIPTION
`review:code` spawned bare `Agent` calls for every finder and verifier, inheriting whatever model was orchestrating. Pinning them all to Sonnet fixes the bill in one direction and caps quality in the other. A Fable session would get a Sonnet review of Fable-authored code, permanently.

So the model becomes a per-tier spawn decision. `review:angle` and `review:verifier` pin no model of their own.

## Cheap Mode

Every fan-out cell below `max` passes `model: sonnet` on angles, verifiers, and the sweep. Breadth costs Sonnet rates whatever is orchestrating.

- Sonnet subagent: 12.1 messages, 690k cache-read tokens per spawn
- Fable subagent: 11.5 messages, 727k cache-read tokens per spawn, at 3.5x the price

Same work, different bill. Most diffs fail on lines, and lines are what Sonnet reads well and cheaply, so this stays the default.

## Expensive Mode

`max` passes no model, so every agent inherits the session model.

A reviewer below the authoring model's tier finds what a careful line-by-line reader finds. It rarely disputes the shape of the change, because seeing the shape takes the capability that produced it. `max` is the level for structurally significant work authored by Opus or Fable.

## Architecture Pass

`max` also runs one `review:architect` on the session model. It reads the affected modules whole rather than hunks, judging interface shape, cross-file coherence, layering, naming, and what the diff costs the next change.

Its line-anchored defects verify with everything else. Its architectural judgments have no line to check, so they skip verify and report under `category: architecture`. `--fix` never applies them.

## Cell Selection

Fable gets its own row instead of falling through to `default`: inline through `high`, fan-out at `xhigh` and `max`. Opus 4.8 keeps upstream's inline calibration through `xhigh`.

Two families now select the `o48-*` cells, so they are renamed `inline-*`. `references/upstream-2.1.215.md` maps them back. `check-review-drift.ts` compares only the verbatim angle fences, so the rename is invisible to it.

## Reverted Pin

`user/agents/review.md` no longer takes the Sonnet pin. That persona reviews peer PRs, and downgrading it quietly trades review quality for a small saving. `type-ignore:fixer` keeps its pin as mechanical work.

Discovery: 9173ff594388
Discovery: 48237a17556a
