### PR TITLE
shortcuts: don't trust the Bash matcher

### DIFF
--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -319,7 +319,8 @@ export async function findBacktickedCommits(
 // The `if` rules in hooks.json scope dispatch to `gh pr create`/`edit` and
 // `glab mr create`/`update`, covering compound (`cd <dir> && gh pr create ...`)
 // and env-prefixed (`GH_PAGER=cat gh pr create ...`) forms. This guard repeats
-// the check in-script so the validator is inert under any other dispatch.
+// the check in-script so the validator is inert under any other dispatch, and
+// runs before the hook reads a body file or shells out to git.
 const PR_BODY_COMMAND_PATTERN = /\b(?:gh pr (?:create|edit)|glab mr (?:create|update))\b/;
 
 export function isPrBodyCommand(command: string): boolean {

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -87,6 +87,10 @@ describe("isPrBodyCommand", () => {
     ["git status", false],
     ["gh pr list", false],
     ["gh pr view 12", false],
+    ["ls -la", false],
+    ["{ echo one; echo two; }", false],
+    ["for f in *.ts; do wc -l $f; done", false],
+    ["cat <<'EOF' > notes.md\nnothing here\nEOF", false],
   ])("isPrBodyCommand(%p) -> %p", (command, expected) => {
     expect(isPrBodyCommand(command)).toBe(expected);
   });
@@ -564,6 +568,16 @@ describe("processInput", () => {
   it("returns null when command has no --body-file", async () => {
     const result = await processInput(createInput("gh pr create --title 'Test'"));
     expect(result).toBeNull();
+  });
+
+  // A dispatch that escapes the `if` rules must stay inert, including one that
+  // names a body file the hook must not read.
+  test.each<[string]>([
+    ["ls -la"],
+    ["cat /tmp/body.md"],
+    ["{ echo one; echo two; }"],
+  ])("returns null for unrelated command %p", async (command) => {
+    expect(await processInput(createInput(command))).toBeNull();
   });
 
   it("returns null when tool_input has no command", async () => {

--- a/plugins/shortcuts/hooks/open.test.ts
+++ b/plugins/shortcuts/hooks/open.test.ts
@@ -48,11 +48,58 @@ describe("processInput", () => {
       command: 'open -W "out/My Shortcut.shortcut"',
       expected: "allow",
     },
+    {
+      name: "path with an escaped space",
+      command: "open out/My\\ Shortcut.shortcut",
+      expected: "allow",
+    },
     { name: "non-shortcut file", command: 'open "document.pdf"', expected: "deny" },
     { name: "a URL", command: "open https://example.com", expected: "deny" },
     { name: "an application", command: "open /Applications/Safari.app", expected: "deny" },
-    { name: "chained with semicolons", command: "open foo.shortcut; echo pwned", expected: "deny" },
-    { name: "chained with &&", command: "open foo.shortcut && rm -rf /", expected: "deny" },
+    // The `Bash(open:*)` rule fails open on shell metacharacters, so these
+    // reach the hook. None of them is a lone `open`, so none may draw an allow
+    // (which carries a sandbox bypass) off the extension of its last word.
+    { name: "chained with semicolons", command: "open foo.shortcut; echo pwned", expected: null },
+    { name: "chained with &&", command: "open foo.shortcut && rm -rf /", expected: null },
+    {
+      name: "compound ending in a .shortcut word",
+      command: "open notes.txt && echo done.shortcut",
+      expected: null,
+    },
+    {
+      name: "piped into another command",
+      command: "open notes.txt | tee log.shortcut",
+      expected: null,
+    },
+    {
+      name: "redirected output",
+      command: "open notes.txt > out.shortcut",
+      expected: null,
+    },
+    {
+      name: "second line of a multi-line command",
+      command: "open notes.txt\nrm -rf ./scratch.shortcut",
+      expected: null,
+    },
+    {
+      name: "command substitution in the target",
+      command: "open $(cat payload).shortcut",
+      expected: null,
+    },
+    { name: "backtick substitution", command: "open `cat payload`.shortcut", expected: null },
+    {
+      name: "variable expansion in the target",
+      command: 'open "$HOME/x.shortcut"',
+      expected: null,
+    },
+    { name: "brace expansion", command: "open {a,b}.shortcut", expected: null },
+    {
+      name: "target hidden behind a comment",
+      command: "open secret.pdf #x.shortcut",
+      expected: null,
+    },
+    { name: "unterminated quote", command: "open 'unclosed.shortcut", expected: null },
+    { name: "env-prefixed invocation", command: "FOO=bar open x.shortcut", expected: null },
   ])("$name", ({ command, expected }) => {
     const output = getOutput(mockInput(command));
     if (expected === null) {
@@ -65,5 +112,9 @@ describe("processInput", () => {
   it("disables the sandbox when allowing a .shortcut file", () => {
     const output = getOutput(mockInput('open "out/My Shortcut.shortcut"'));
     expect(output?.updatedInput).toEqual({ dangerouslyDisableSandbox: true });
+  });
+
+  it("does not extend the sandbox bypass to a compound command", () => {
+    expect(getOutput(mockInput("open notes.txt && echo done.shortcut"))).toBeNull();
   });
 });

--- a/plugins/shortcuts/hooks/open.ts
+++ b/plugins/shortcuts/hooks/open.ts
@@ -5,27 +5,90 @@ import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/clau
 
 type BashInput = { command: string };
 
-function unquote(arg: string): string {
-  const match = arg.match(/^(["'])(.+)\1$/);
-  return match ? match[2]! : arg;
+// Characters that end a simple command, splice another one into it, or hide a
+// word from it. A command carrying any of them outside quotes is not a lone
+// `open`, so the target this hook reads from it does not describe what the shell
+// would actually run. `#` earns its place with the rest: the shell discards the
+// comment it opens, so a trailing `#x.shortcut` would name a target `open` never
+// receives.
+const OPERATORS = new Set([";", "&", "|", "<", ">", "(", ")", "{", "}", "`", "$", "#", "\n"]);
+
+// Split a command into shell words, or return null when it is not a single
+// simple command: an unbalanced quote, an operator, or any substitution
+// (`$(...)`, `${x}`, backticks) whose value is unknowable here.
+function tokenize(command: string): string[] | null {
+  const tokens: string[] = [];
+  let current: string | null = null;
+
+  for (let i = 0; i < command.length; i++) {
+    const char = command.charAt(i);
+
+    if (/\s/.test(char)) {
+      if (char === "\n") return null;
+      if (current !== null) {
+        tokens.push(current);
+        current = null;
+      }
+      continue;
+    }
+
+    if (char === "'") {
+      const end = command.indexOf("'", i + 1);
+      if (end === -1) return null;
+      current = (current ?? "") + command.slice(i + 1, end);
+      i = end;
+      continue;
+    }
+
+    if (char === '"') {
+      let value = "";
+      let j = i + 1;
+      for (; j < command.length && command[j] !== '"'; j++) {
+        const inner = command.charAt(j);
+        if (inner === "$" || inner === "`") return null;
+        if (inner === "\\") {
+          const escaped = command[j + 1];
+          if (escaped === undefined) return null;
+          value += escaped;
+          j++;
+          continue;
+        }
+        value += inner;
+      }
+      if (j >= command.length) return null;
+      current = (current ?? "") + value;
+      i = j;
+      continue;
+    }
+
+    if (char === "\\") {
+      const escaped = command[i + 1];
+      if (escaped === undefined || escaped === "\n") return null;
+      current = (current ?? "") + escaped;
+      i++;
+      continue;
+    }
+
+    if (OPERATORS.has(char)) return null;
+    current = (current ?? "") + char;
+  }
+
+  if (current !== null) tokens.push(current);
+  return tokens;
 }
 
+// The `Bash(open:*)` rule only narrows which calls spawn this hook. It fails
+// open on shell metacharacters, so `open notes.txt && echo done.shortcut`
+// reaches here, and the extension of the last word would describe the `echo`
+// rather than what `open` receives. Since this hook can hand back a sandbox
+// bypass, it decides on its own parse: a compound yields no target, and the call
+// falls through to normal permissions.
 function extractTarget(command: string): string | null {
-  const trimmed = command.trim();
-  if (!trimmed.startsWith("open ")) {
+  const tokens = tokenize(command) ?? [];
+  if (tokens.length < 2 || tokens[0] !== "open") {
     return null;
   }
-
-  const args = trimmed.slice("open ".length).trim();
-
-  // Match the last quoted or unquoted argument, skipping flags
-  const tokens = args.match(/"[^"]+"|'[^']+'|\S+/g);
-  if (!tokens) {
-    return null;
-  }
-
-  const lastToken = tokens[tokens.length - 1]!;
-  return unquote(lastToken);
+  return tokens.at(-1) ?? null;
 }
 
 export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {


### PR DESCRIPTION
A `Bash(cmd:*)` matcher is a spawn filter, not an authorization decision. It falls back to a permissive match on compound commands and shell metacharacters, so a hook that trusts it decides on a command it never read. PR #1161 fixed that for `plugins/git`, the biome PreToolUse, and tmux. This PR closes the worst remaining exposure, the shortcuts sandbox bypass.

`shortcuts/open.ts` checked that the command started with `open `, then took the last word of the entire string as the target. `open notes.txt && echo done.shortcut` passed both, so the whole compound drew `permissionDecision: allow` plus `dangerouslyDisableSandbox`. It now splits the command into shell words and declines anything that is not a lone simple `open`. A compound yields no decision and falls through to normal permissions, where it used to draw a deny.

Reviewing that parser turned up one more escape: an unquoted `#` opens a comment the shell discards, so `open secret.pdf #x.shortcut` would have named a target `open` never receives. `#` is rejected alongside the other operators.

The second exposure, `pull-request`'s stale `gh pr create:*` matchers, was fixed on main by #1155 while this PR was open. The rebase reduced that half to test coverage: four new `isPrBodyCommand` negative rows (`ls -la`, a brace group, a `for` loop, a heredoc) and a `processInput` null-return table pinning the dispatch semantics #1155 relies on.

Checked by feeding hook JSON on stdin. The compound emits nothing and `open out/My Shortcut.shortcut` still allows with the bypass.

One follow-up for whichever lands second: #1161's new Bash Matchers rule cites `open.ts`'s `trimmed.startsWith("open ")` as a working example, and that guard is gone here.

Discovery: c70cfd40d290
Discovery: 373da44d0dec

