### PR TITLE
git: fall back to HTTPS when SSH signing fails

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -14,13 +14,15 @@ Git workflow and branching best practices for Claude Code.
 
 [Secretive](https://github.com/maxgoedjen/secretive) gates every SSH signature behind Touch ID, so an unattended `git fetch`, `pull`, or `push` gets `agent refused operation` and then `Permission denied (publickey)`, exiting 128. Ordinary fetches and pulls fail the same way.
 
-The `PostToolUseFailure` hook watches failing `git` commands for that signature. When the repository (or the command) names a `github.com` SSH remote, it returns the same command rewritten to go over HTTPS:
+The `PostToolUseFailure` hook watches failing `git` commands for that signature. When the repository (or the command) names an SSH remote on a host whose CLI holds HTTPS credentials (`github.com` via `gh`, `gitlab.com` via `glab`), it returns the same command rewritten to go over HTTPS:
 
 ```
 git -c credential.helper= -c 'credential.helper=!gh auth git-credential' -c 'url.https://github.com/.insteadOf=git@github.com:' -c 'url.https://github.com/.insteadOf=ssh://git@github.com/' fetch origin
 ```
 
-The hook suggests, it does not retry. Rewriting the URL through `insteadOf` rather than substituting the remote with a bare URL keeps the remote name, its refspecs, and its remote-tracking ref updates identical to the SSH attempt. `gh auth git-credential` supplies the token for the duration of that one command, so nothing is written to the repository's config and no credential is stored or echoed. The leading `credential.helper=` resets the helper list so a stale keychain entry cannot win.
+The hook suggests, it does not retry. Rewriting the URL through `insteadOf` rather than substituting the remote with a bare URL keeps the remote name, its refspecs, and its remote-tracking ref updates identical to the SSH attempt. The provider CLI's `auth git-credential` helper supplies the token for the duration of that one command, so nothing is written to the repository's config and no credential is stored or echoed. The leading `credential.helper=` resets the helper list so a stale keychain entry cannot win.
+
+A host outside the provider table (a self-hosted forge, an enterprise domain) gets no suggestion, since no known CLI could authenticate the retry. Extending support is one row in `PROVIDERS` in `scripts/https-fallback.ts`.
 
 Commit and tag signing use a different code path (`ssh-keygen -Y sign`) and are out of scope. Those still need Touch ID.
 

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -8,6 +8,21 @@ Git workflow and branching best practices for Claude Code.
   - `conflicts`: Resolve git merge conflicts during rebase, merge, or cherry-pick. Drives the operation to completion and pushes when asked.
 - **Hooks**:
   - Blocks direct commits to the default branch
+  - Recovers a failed git network operation over HTTPS when the SSH agent refuses to sign
+
+## HTTPS Fallback
+
+[Secretive](https://github.com/maxgoedjen/secretive) gates every SSH signature behind Touch ID, so an unattended `git fetch`, `pull`, or `push` gets `agent refused operation` and then `Permission denied (publickey)`, exiting 128. Ordinary fetches and pulls fail the same way.
+
+The `PostToolUseFailure` hook watches failing `git` commands for that signature. When the repository (or the command) names a `github.com` SSH remote, it returns the same command rewritten to go over HTTPS:
+
+```
+git -c credential.helper= -c 'credential.helper=!gh auth git-credential' -c 'url.https://github.com/.insteadOf=git@github.com:' -c 'url.https://github.com/.insteadOf=ssh://git@github.com/' fetch origin
+```
+
+The hook suggests, it does not retry. Rewriting the URL through `insteadOf` rather than substituting the remote with a bare URL keeps the remote name, its refspecs, and its remote-tracking ref updates identical to the SSH attempt. `gh auth git-credential` supplies the token for the duration of that one command, so nothing is written to the repository's config and no credential is stored or echoed. The leading `credential.helper=` resets the helper list so a stale keychain entry cannot win.
+
+Commit and tag signing use a different code path (`ssh-keygen -Y sign`) and are out of scope. Those still need Touch ID.
 
 ## Testing
 

--- a/plugins/git/hooks/hooks.json
+++ b/plugins/git/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Blocks direct commits to the default branch",
+  "description": "Blocks direct commits to the default branch and recovers SSH-agent auth failures over HTTPS",
   "hooks": {
     "PreToolUse": [
       {
@@ -8,6 +8,18 @@
           {
             "type": "command",
             "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/block-default-branch-commit.ts\""
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/https-fallback.ts\"",
+            "if": "Bash(git *)"
           }
         ]
       }

--- a/plugins/git/scripts/__snapshots__/https-fallback.test.ts.snap
+++ b/plugins/git/scripts/__snapshots__/https-fallback.test.ts.snap
@@ -38,3 +38,21 @@ The url.insteadOf rewrite keeps the remote name and refspecs, so remote-tracking
 `;
 
 exports[`rewriteCommand targets the network op, not an earlier git 1`] = `"git status && git -c credential.helper= -c 'credential.helper=!gh auth git-credential' -c 'url.https://github.com/.insteadOf=git@github.com:' -c 'url.https://github.com/.insteadOf=ssh://git@github.com/' push origin main"`;
+
+exports[`rewriteCommand gitlab push routes through glab 1`] = `"git -c credential.helper= -c 'credential.helper=!glab auth git-credential' -c 'url.https://gitlab.com/.insteadOf=git@gitlab.com:' -c 'url.https://gitlab.com/.insteadOf=ssh://git@gitlab.com/' push -u origin HEAD"`;
+
+exports[`processInput suggests the glab-backed retry for a GitLab SSH push 1`] = `
+{
+  "hookSpecificOutput": {
+    "additionalContext": 
+"The SSH agent refused to sign, so this git operation could not authenticate over SSH.
+Retry the exact same operation over HTTPS, which authenticates through glab's credential helper:
+
+git -c credential.helper= -c 'credential.helper=!glab auth git-credential' -c 'url.https://gitlab.com/.insteadOf=git@gitlab.com:' -c 'url.https://gitlab.com/.insteadOf=ssh://git@gitlab.com/' push -u origin HEAD git@gitlab.com:owner/repo.git
+
+The url.insteadOf rewrite keeps the remote name and refspecs, so remote-tracking refs update as they would have over SSH. Do not change the repository's configured remote URLs."
+,
+    "hookEventName": "PostToolUseFailure",
+  },
+}
+`;

--- a/plugins/git/scripts/__snapshots__/https-fallback.test.ts.snap
+++ b/plugins/git/scripts/__snapshots__/https-fallback.test.ts.snap
@@ -1,0 +1,40 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`rewriteCommand bare pull 1`] = `"git -c credential.helper= -c 'credential.helper=!gh auth git-credential' -c 'url.https://github.com/.insteadOf=git@github.com:' -c 'url.https://github.com/.insteadOf=ssh://git@github.com/' pull"`;
+
+exports[`rewriteCommand fetch with remote 1`] = `"git -c credential.helper= -c 'credential.helper=!gh auth git-credential' -c 'url.https://github.com/.insteadOf=git@github.com:' -c 'url.https://github.com/.insteadOf=ssh://git@github.com/' fetch origin"`;
+
+exports[`rewriteCommand push with upstream 1`] = `"git -c credential.helper= -c 'credential.helper=!gh auth git-credential' -c 'url.https://github.com/.insteadOf=git@github.com:' -c 'url.https://github.com/.insteadOf=ssh://git@github.com/' push -u origin HEAD"`;
+
+exports[`rewriteCommand clone over ssh 1`] = `"git -c credential.helper= -c 'credential.helper=!gh auth git-credential' -c 'url.https://github.com/.insteadOf=git@github.com:' -c 'url.https://github.com/.insteadOf=ssh://git@github.com/' clone git@github.com:owner/repo.git"`;
+
+exports[`rewriteCommand -C prefix preserved 1`] = `"git -c credential.helper= -c 'credential.helper=!gh auth git-credential' -c 'url.https://github.com/.insteadOf=git@github.com:' -c 'url.https://github.com/.insteadOf=ssh://git@github.com/' -C /repo fetch --all"`;
+
+exports[`rewriteCommand chained after cd 1`] = `"cd /repo && git -c credential.helper= -c 'credential.helper=!gh auth git-credential' -c 'url.https://github.com/.insteadOf=git@github.com:' -c 'url.https://github.com/.insteadOf=ssh://git@github.com/' push origin main"`;
+
+exports[`formatContext names the retry command and forbids mutating remotes 1`] = `
+"The SSH agent refused to sign, so this git operation could not authenticate over SSH.
+Retry the exact same operation over HTTPS, which authenticates through gh's credential helper:
+
+git -c foo=bar fetch origin
+
+The url.insteadOf rewrite keeps the remote name and refspecs, so remote-tracking refs update as they would have over SSH. Do not change the repository's configured remote URLs."
+`;
+
+exports[`processInput suggests the HTTPS retry for a Secretive refusal on a GitHub SSH clone 1`] = `
+{
+  "hookSpecificOutput": {
+    "additionalContext": 
+"The SSH agent refused to sign, so this git operation could not authenticate over SSH.
+Retry the exact same operation over HTTPS, which authenticates through gh's credential helper:
+
+git -c credential.helper= -c 'credential.helper=!gh auth git-credential' -c 'url.https://github.com/.insteadOf=git@github.com:' -c 'url.https://github.com/.insteadOf=ssh://git@github.com/' clone git@github.com:owner/repo.git
+
+The url.insteadOf rewrite keeps the remote name and refspecs, so remote-tracking refs update as they would have over SSH. Do not change the repository's configured remote URLs."
+,
+    "hookEventName": "PostToolUseFailure",
+  },
+}
+`;
+
+exports[`rewriteCommand targets the network op, not an earlier git 1`] = `"git status && git -c credential.helper= -c 'credential.helper=!gh auth git-credential' -c 'url.https://github.com/.insteadOf=git@github.com:' -c 'url.https://github.com/.insteadOf=ssh://git@github.com/' push origin main"`;

--- a/plugins/git/scripts/https-fallback.test.ts
+++ b/plugins/git/scripts/https-fallback.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PostToolUseFailureHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { $ } from "bun";
+import {
+  formatContext,
+  gitNetworkSubcommand,
+  hasSshAuthFailure,
+  processInput,
+  readRemoteUrls,
+  rewriteCommand,
+  usesSshGithub,
+} from "./https-fallback";
+
+const SECRETIVE_FAILURE = [
+  'sign_and_send_pubkey: signing failed for RSA "SHA256:abc" from agent: agent refused operation',
+  "git@github.com: Permission denied (publickey).",
+  "fatal: Could not read from remote repository.",
+].join("\n");
+
+function mockInput(
+  command: string,
+  error: string,
+  cwd = "/nonexistent",
+): PostToolUseFailureHookInput {
+  return {
+    session_id: "test",
+    hook_event_name: "PostToolUseFailure",
+    tool_name: "Bash",
+    tool_input: { command },
+    tool_use_id: "test",
+    error,
+    transcript_path: "/tmp/transcript.json",
+    cwd,
+  };
+}
+
+describe("hasSshAuthFailure", () => {
+  test.each<{ name: string; output: string; expected: boolean }>([
+    { name: "secretive agent refusal", output: SECRETIVE_FAILURE, expected: true },
+    {
+      name: "bare publickey denial",
+      output: "git@github.com: Permission denied (publickey).",
+      expected: true,
+    },
+    {
+      name: "signing failure alone",
+      output: "sign_and_send_pubkey: signing failed for ED25519",
+      expected: true,
+    },
+    {
+      name: "network unreachable",
+      output: "ssh: connect to host github.com port 22: Network is unreachable",
+      expected: false,
+    },
+    {
+      name: "merge conflict",
+      output: "CONFLICT (content): Merge conflict in README.md",
+      expected: false,
+    },
+    { name: "empty output", output: "", expected: false },
+  ])("$name", ({ output, expected }) => {
+    expect(hasSshAuthFailure(output)).toBe(expected);
+  });
+});
+
+describe("gitNetworkSubcommand", () => {
+  test.each<{ name: string; command: string; expected: string | null }>([
+    { name: "bare fetch", command: "git fetch", expected: "fetch" },
+    { name: "fetch with remote", command: "git fetch origin", expected: "fetch" },
+    { name: "fetch all", command: "git fetch --all --prune", expected: "fetch" },
+    { name: "pull with rebase", command: "git pull --rebase origin main", expected: "pull" },
+    { name: "push with upstream", command: "git push -u origin HEAD", expected: "push" },
+    { name: "push force", command: "git push --force-with-lease", expected: "push" },
+    { name: "clone", command: "git clone git@github.com:owner/repo.git", expected: "clone" },
+    { name: "ls-remote", command: "git ls-remote origin", expected: "ls-remote" },
+    { name: "submodule update", command: "git submodule update --init", expected: "submodule" },
+    { name: "-C before subcommand", command: "git -C /repo fetch origin", expected: "fetch" },
+    { name: "-c before subcommand", command: "git -c core.pager=cat pull", expected: "pull" },
+    { name: "--no-pager before subcommand", command: "git --no-pager fetch", expected: "fetch" },
+    { name: "chained after cd", command: "cd /repo && git push origin main", expected: "push" },
+    {
+      name: "network op in a later segment",
+      command: "git status && git push origin main",
+      expected: "push",
+    },
+    { name: "every segment local-only", command: "git add -A && git commit -m x", expected: null },
+    { name: "local-only status", command: "git status", expected: null },
+    { name: "local-only commit", command: "git commit -m 'x'", expected: null },
+    { name: "not git at all", command: "gh pr create", expected: null },
+    {
+      name: "value option swallows subcommand-lookalike",
+      command: "git -C push status",
+      expected: null,
+    },
+  ])("$name", ({ command, expected }) => {
+    expect(gitNetworkSubcommand(command)).toBe(expected);
+  });
+});
+
+describe("usesSshGithub", () => {
+  test.each<{ name: string; text: string; expected: boolean }>([
+    { name: "scp-style remote", text: "git@github.com:bendrucker/claude.git", expected: true },
+    { name: "ssh:// remote", text: "ssh://git@github.com/bendrucker/claude.git", expected: true },
+    {
+      name: "ssh:// with port",
+      text: "ssh://git@github.com:22/bendrucker/claude.git",
+      expected: true,
+    },
+    { name: "https remote", text: "https://github.com/bendrucker/claude.git", expected: false },
+    { name: "gitlab ssh remote", text: "git@gitlab.com:bendrucker/claude.git", expected: false },
+    { name: "enterprise host", text: "git@github.example.com:owner/repo.git", expected: false },
+    { name: "no remote", text: "", expected: false },
+  ])("$name", ({ text, expected }) => {
+    expect(usesSshGithub(text)).toBe(expected);
+  });
+});
+
+describe("rewriteCommand", () => {
+  test.each<{ name: string; command: string }>([
+    { name: "bare pull", command: "git pull" },
+    { name: "fetch with remote", command: "git fetch origin" },
+    { name: "push with upstream", command: "git push -u origin HEAD" },
+    { name: "clone over ssh", command: "git clone git@github.com:owner/repo.git" },
+    { name: "-C prefix preserved", command: "git -C /repo fetch --all" },
+    { name: "chained after cd", command: "cd /repo && git push origin main" },
+    {
+      name: "targets the network op, not an earlier git",
+      command: "git status && git push origin main",
+    },
+  ])("$name", ({ command }) => {
+    expect(rewriteCommand(command)).toMatchSnapshot();
+  });
+
+  test("returns null when the line has no git invocation", () => {
+    expect(rewriteCommand("gh pr create")).toBeNull();
+  });
+
+  test("does not match a word merely containing git", () => {
+    expect(rewriteCommand("legit fetch")).toBeNull();
+  });
+
+  test("returns null when no segment runs a network operation", () => {
+    expect(rewriteCommand("git add -A && git commit -m x")).toBeNull();
+  });
+});
+
+describe("formatContext", () => {
+  test("names the retry command and forbids mutating remotes", () => {
+    expect(formatContext("git -c foo=bar fetch origin")).toMatchSnapshot();
+  });
+});
+
+const noRemotes = async () => "";
+const githubSshRemote = async () => "remote.origin.url git@github.com:bendrucker/claude.git\n";
+
+describe("processInput", () => {
+  test("suggests the HTTPS retry for a Secretive refusal on a GitHub SSH clone", async () => {
+    const result = await processInput(
+      mockInput("git clone git@github.com:owner/repo.git", SECRETIVE_FAILURE),
+      noRemotes,
+    );
+    expect(result).toMatchSnapshot();
+  });
+
+  test.each<{ name: string; command: string; error: string }>([
+    { name: "non-network git subcommand", command: "git status", error: SECRETIVE_FAILURE },
+    {
+      name: "unrelated failure",
+      command: "git fetch git@github.com:owner/repo.git",
+      error: "fatal: couldn't find remote ref main",
+    },
+    { name: "non-git command", command: "ssh git@github.com", error: SECRETIVE_FAILURE },
+    {
+      name: "non-github host",
+      command: "git fetch git@gitlab.com:owner/repo.git",
+      error: "git@gitlab.com: Permission denied (publickey).",
+    },
+  ])("stays silent for $name", async ({ command, error }) => {
+    expect(await processInput(mockInput(command, error), noRemotes)).toBeNull();
+  });
+
+  test("stays silent when the command carries no command field", async () => {
+    const input = { ...mockInput("git fetch", SECRETIVE_FAILURE), tool_input: {} };
+    expect(await processInput(input, githubSshRemote)).toBeNull();
+  });
+
+  test("stays silent when a bare pull fails against a non-GitHub remote", async () => {
+    const gitlabRemote = async () => "remote.origin.url git@gitlab.com:owner/repo.git\n";
+    expect(await processInput(mockInput("git pull", SECRETIVE_FAILURE), gitlabRemote)).toBeNull();
+  });
+
+  test("resolves the remote from the repo when the command names none", async () => {
+    const result = await processInput(mockInput("git pull", SECRETIVE_FAILURE), githubSshRemote);
+    expect(result).not.toBeNull();
+    const context = (result?.hookSpecificOutput as { additionalContext: string }).additionalContext;
+    expect(context).toContain("url.https://github.com/.insteadOf=git@github.com:");
+  });
+});
+
+describe("readRemoteUrls", () => {
+  test("returns empty outside a repository", async () => {
+    expect(await readRemoteUrls(tmpdir())).toBe("");
+  });
+
+  test("reads a configured remote", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "https-fallback-"));
+    await $`git init -q ${dir}`.quiet();
+    await $`git -C ${dir} remote add origin git@github.com:owner/repo.git`.quiet();
+    expect(await readRemoteUrls(dir)).toContain("git@github.com:owner/repo.git");
+    await rm(dir, { recursive: true, force: true });
+  });
+});

--- a/plugins/git/scripts/https-fallback.test.ts
+++ b/plugins/git/scripts/https-fallback.test.ts
@@ -11,8 +11,12 @@ import {
   processInput,
   readRemoteUrls,
   rewriteCommand,
-  usesSshGithub,
+  sshProviderOf,
 } from "./https-fallback";
+
+const github = sshProviderOf("git@github.com:owner/repo.git");
+const gitlab = sshProviderOf("git@gitlab.com:owner/repo.git");
+if (!github || !gitlab) throw new Error("provider table missing github.com or gitlab.com");
 
 const SECRETIVE_FAILURE = [
   'sign_and_send_pubkey: signing failed for RSA "SHA256:abc" from agent: agent refused operation',
@@ -100,26 +104,52 @@ describe("gitNetworkSubcommand", () => {
   });
 });
 
-describe("usesSshGithub", () => {
-  test.each<{ name: string; text: string; expected: boolean }>([
-    { name: "scp-style remote", text: "git@github.com:bendrucker/claude.git", expected: true },
-    { name: "ssh:// remote", text: "ssh://git@github.com/bendrucker/claude.git", expected: true },
+describe("sshProviderOf", () => {
+  test.each<{ name: string; text: string; expected: string | null }>([
+    {
+      name: "scp-style github remote",
+      text: "git@github.com:bendrucker/claude.git",
+      expected: "gh",
+    },
+    {
+      name: "ssh:// github remote",
+      text: "ssh://git@github.com/bendrucker/claude.git",
+      expected: "gh",
+    },
     {
       name: "ssh:// with port",
       text: "ssh://git@github.com:22/bendrucker/claude.git",
-      expected: true,
+      expected: "gh",
     },
-    { name: "https remote", text: "https://github.com/bendrucker/claude.git", expected: false },
-    { name: "gitlab ssh remote", text: "git@gitlab.com:bendrucker/claude.git", expected: false },
-    { name: "enterprise host", text: "git@github.example.com:owner/repo.git", expected: false },
-    { name: "no remote", text: "", expected: false },
+    {
+      name: "scp-style gitlab remote",
+      text: "git@gitlab.com:bendrucker/claude.git",
+      expected: "glab",
+    },
+    {
+      name: "ssh:// gitlab remote",
+      text: "ssh://git@gitlab.com/bendrucker/claude.git",
+      expected: "glab",
+    },
+    { name: "https remote", text: "https://github.com/bendrucker/claude.git", expected: null },
+    {
+      name: "unknown enterprise host",
+      text: "git@github.example.com:owner/repo.git",
+      expected: null,
+    },
+    {
+      name: "lookalike subdomain of a known host",
+      text: "git@gitlab.com.evil.example:owner/repo.git",
+      expected: null,
+    },
+    { name: "no remote", text: "", expected: null },
   ])("$name", ({ text, expected }) => {
-    expect(usesSshGithub(text)).toBe(expected);
+    expect(sshProviderOf(text)?.cli ?? null).toBe(expected);
   });
 });
 
 describe("rewriteCommand", () => {
-  test.each<{ name: string; command: string }>([
+  test.each<{ name: string; command: string; target?: typeof gitlab }>([
     { name: "bare pull", command: "git pull" },
     { name: "fetch with remote", command: "git fetch origin" },
     { name: "push with upstream", command: "git push -u origin HEAD" },
@@ -130,26 +160,31 @@ describe("rewriteCommand", () => {
       name: "targets the network op, not an earlier git",
       command: "git status && git push origin main",
     },
-  ])("$name", ({ command }) => {
-    expect(rewriteCommand(command)).toMatchSnapshot();
+    {
+      name: "gitlab push routes through glab",
+      command: "git push -u origin HEAD",
+      target: gitlab,
+    },
+  ])("$name", ({ command, target }) => {
+    expect(rewriteCommand(command, target ?? github)).toMatchSnapshot();
   });
 
   test("returns null when the line has no git invocation", () => {
-    expect(rewriteCommand("gh pr create")).toBeNull();
+    expect(rewriteCommand("gh pr create", github)).toBeNull();
   });
 
   test("does not match a word merely containing git", () => {
-    expect(rewriteCommand("legit fetch")).toBeNull();
+    expect(rewriteCommand("legit fetch", github)).toBeNull();
   });
 
   test("returns null when no segment runs a network operation", () => {
-    expect(rewriteCommand("git add -A && git commit -m x")).toBeNull();
+    expect(rewriteCommand("git add -A && git commit -m x", github)).toBeNull();
   });
 });
 
 describe("formatContext", () => {
   test("names the retry command and forbids mutating remotes", () => {
-    expect(formatContext("git -c foo=bar fetch origin")).toMatchSnapshot();
+    expect(formatContext("git -c foo=bar fetch origin", "gh")).toMatchSnapshot();
   });
 });
 
@@ -165,6 +200,14 @@ describe("processInput", () => {
     expect(result).toMatchSnapshot();
   });
 
+  test("suggests the glab-backed retry for a GitLab SSH push", async () => {
+    const result = await processInput(
+      mockInput("git push -u origin HEAD git@gitlab.com:owner/repo.git", SECRETIVE_FAILURE),
+      noRemotes,
+    );
+    expect(result).toMatchSnapshot();
+  });
+
   test.each<{ name: string; command: string; error: string }>([
     { name: "non-network git subcommand", command: "git status", error: SECRETIVE_FAILURE },
     {
@@ -174,9 +217,9 @@ describe("processInput", () => {
     },
     { name: "non-git command", command: "ssh git@github.com", error: SECRETIVE_FAILURE },
     {
-      name: "non-github host",
-      command: "git fetch git@gitlab.com:owner/repo.git",
-      error: "git@gitlab.com: Permission denied (publickey).",
+      name: "host with no known CLI",
+      command: "git fetch git@git.example.com:owner/repo.git",
+      error: "git@git.example.com: Permission denied (publickey).",
     },
   ])("stays silent for $name", async ({ command, error }) => {
     expect(await processInput(mockInput(command, error), noRemotes)).toBeNull();
@@ -187,16 +230,30 @@ describe("processInput", () => {
     expect(await processInput(input, githubSshRemote)).toBeNull();
   });
 
-  test("stays silent when a bare pull fails against a non-GitHub remote", async () => {
-    const gitlabRemote = async () => "remote.origin.url git@gitlab.com:owner/repo.git\n";
-    expect(await processInput(mockInput("git pull", SECRETIVE_FAILURE), gitlabRemote)).toBeNull();
+  test("stays silent when a bare pull fails against an unrecognized remote", async () => {
+    const unknownRemote = async () => "remote.origin.url git@git.example.com:owner/repo.git\n";
+    expect(await processInput(mockInput("git pull", SECRETIVE_FAILURE), unknownRemote)).toBeNull();
   });
 
-  test("resolves the remote from the repo when the command names none", async () => {
-    const result = await processInput(mockInput("git pull", SECRETIVE_FAILURE), githubSshRemote);
+  test.each<{ name: string; remotes: () => Promise<string>; expected: string }>([
+    {
+      name: "github remote routes through gh",
+      remotes: githubSshRemote,
+      expected: "url.https://github.com/.insteadOf=git@github.com:",
+    },
+    {
+      name: "gitlab remote routes through glab",
+      remotes: async () => "remote.origin.url git@gitlab.com:owner/repo.git\n",
+      expected: "url.https://gitlab.com/.insteadOf=git@gitlab.com:",
+    },
+  ])("resolves the remote from the repo when the command names none: $name", async ({
+    remotes,
+    expected,
+  }) => {
+    const result = await processInput(mockInput("git pull", SECRETIVE_FAILURE), remotes);
     expect(result).not.toBeNull();
     const context = (result?.hookSpecificOutput as { additionalContext: string }).additionalContext;
-    expect(context).toContain("url.https://github.com/.insteadOf=git@github.com:");
+    expect(context).toContain(expected);
   });
 });
 

--- a/plugins/git/scripts/https-fallback.ts
+++ b/plugins/git/scripts/https-fallback.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env bun
+
+import type {
+  PostToolUseFailureHookInput,
+  SyncHookJSONOutput,
+} from "@anthropic-ai/claude-agent-sdk";
+import { $ } from "bun";
+
+/**
+ * Secretive gates every signature behind Touch ID, so an unattended `ssh` gets
+ * `agent refused operation` instead of a signature. A key that never reached the
+ * agent produces the plain publickey denial, which HTTPS also resolves.
+ */
+const SSH_AUTH_SIGNATURES = [
+  "agent refused operation",
+  "Permission denied (publickey)",
+  "sign_and_send_pubkey: signing failed",
+];
+
+const NETWORK_SUBCOMMANDS = new Set([
+  "clone",
+  "fetch",
+  "ls-remote",
+  "pull",
+  "push",
+  "remote",
+  "submodule",
+]);
+
+/** `git` options that consume the following argument, so it is not the subcommand. */
+const VALUE_OPTIONS = new Set([
+  "-C",
+  "-c",
+  "--git-dir",
+  "--work-tree",
+  "--namespace",
+  "--exec-path",
+]);
+
+const SSH_GITHUB_PATTERNS = [/\bgit@github\.com:/, /\bssh:\/\/git@github\.com[:/]/];
+
+const HTTPS_CONFIG = [
+  "-c credential.helper=",
+  "-c 'credential.helper=!gh auth git-credential'",
+  "-c 'url.https://github.com/.insteadOf=git@github.com:'",
+  "-c 'url.https://github.com/.insteadOf=ssh://git@github.com/'",
+].join(" ");
+
+export function hasSshAuthFailure(output: string): boolean {
+  return SSH_AUTH_SIGNATURES.some((signature) => output.includes(signature));
+}
+
+export function usesSshGithub(text: string): boolean {
+  return SSH_GITHUB_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+const GIT_INVOCATION = /(?:^|[;&|]\s*|\s)git(?=\s)/g;
+const SEGMENT_SEPARATOR = /(?:&&|\|\||[;|\n])/;
+
+/** Resolves the subcommand of one `git` invocation, skipping git's own options. */
+function subcommandOf(args: string[]): string | null {
+  let skipValue = false;
+  for (const token of args) {
+    if (skipValue) {
+      skipValue = false;
+      continue;
+    }
+    if (VALUE_OPTIONS.has(token)) {
+      skipValue = true;
+      continue;
+    }
+    if (token.startsWith("-")) continue;
+    return token;
+  }
+  return null;
+}
+
+/**
+ * Locates the `git` invocation in a shell line that performs a network operation,
+ * returning its subcommand and the offset just past the `git` token. Detection and
+ * rewriting share this so a line like `git status && git push` rewrites the push.
+ */
+function findNetworkInvocation(command: string): { subcommand: string; insertAt: number } | null {
+  for (const match of command.matchAll(GIT_INVOCATION)) {
+    const insertAt = match.index + match[0].length;
+    const [segment = ""] = command.slice(insertAt).split(SEGMENT_SEPARATOR);
+    const subcommand = subcommandOf(segment.trim().split(/\s+/).filter(Boolean));
+    if (subcommand && NETWORK_SUBCOMMANDS.has(subcommand)) return { subcommand, insertAt };
+  }
+  return null;
+}
+
+/** Returns the git network subcommand a shell line invokes, or null. */
+export function gitNetworkSubcommand(command: string): string | null {
+  return findNetworkInvocation(command)?.subcommand ?? null;
+}
+
+/**
+ * Inserts the HTTPS config into the failing `git` invocation. Rewriting the URL
+ * through `insteadOf` keeps the remote name, refspecs, and remote-tracking ref
+ * updates identical to the SSH attempt.
+ */
+export function rewriteCommand(command: string): string | null {
+  const invocation = findNetworkInvocation(command);
+  if (!invocation) return null;
+
+  const { insertAt } = invocation;
+  return `${command.slice(0, insertAt)} ${HTTPS_CONFIG}${command.slice(insertAt)}`;
+}
+
+export function formatContext(retryCommand: string): string {
+  return [
+    "The SSH agent refused to sign, so this git operation could not authenticate over SSH.",
+    "Retry the exact same operation over HTTPS, which authenticates through gh's credential helper:",
+    "",
+    retryCommand,
+    "",
+    "The url.insteadOf rewrite keeps the remote name and refspecs, so remote-tracking refs update as they would have over SSH. Do not change the repository's configured remote URLs.",
+  ].join("\n");
+}
+
+/** Reads the repo's remote URLs so a bare `git pull` still resolves to a GitHub SSH remote. */
+export async function readRemoteUrls(cwd: string): Promise<string> {
+  // Interpolated so Bun's shell escapes the pattern instead of glob-expanding it.
+  const pattern = String.raw`^remote\..*\.url$`;
+  const result = await $`git config --get-regexp ${pattern}`.cwd(cwd).quiet().nothrow();
+  return result.exitCode === 0 ? result.text() : "";
+}
+
+export async function processInput(
+  input: PostToolUseFailureHookInput,
+  readRemotes: (cwd: string) => Promise<string> = readRemoteUrls,
+): Promise<SyncHookJSONOutput | null> {
+  const command = (input.tool_input as { command?: string } | null)?.command;
+  if (!command) return null;
+
+  if (!gitNetworkSubcommand(command)) return null;
+  if (!hasSshAuthFailure(input.error ?? "")) return null;
+
+  const cwd = input.cwd ?? process.cwd();
+  if (!usesSshGithub(command) && !usesSshGithub(await readRemotes(cwd))) return null;
+
+  const retryCommand = rewriteCommand(command);
+  if (!retryCommand) return null;
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PostToolUseFailure",
+      additionalContext: formatContext(retryCommand),
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  let input: PostToolUseFailureHookInput;
+  try {
+    input = JSON.parse(await Bun.stdin.text()) as PostToolUseFailureHookInput;
+  } catch {
+    return;
+  }
+
+  if (input.hook_event_name !== "PostToolUseFailure") return;
+
+  const output = await processInput(input);
+  if (output) {
+    process.stdout.write(`${JSON.stringify(output)}\n`);
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/plugins/git/scripts/https-fallback.ts
+++ b/plugins/git/scripts/https-fallback.ts
@@ -37,21 +37,47 @@ const VALUE_OPTIONS = new Set([
   "--exec-path",
 ]);
 
-const SSH_GITHUB_PATTERNS = [/\bgit@github\.com:/, /\bssh:\/\/git@github\.com[:/]/];
+export interface Provider {
+  host: string;
+  cli: string;
+  patterns: RegExp[];
+}
 
-const HTTPS_CONFIG = [
-  "-c credential.helper=",
-  "-c 'credential.helper=!gh auth git-credential'",
-  "-c 'url.https://github.com/.insteadOf=git@github.com:'",
-  "-c 'url.https://github.com/.insteadOf=ssh://git@github.com/'",
-].join(" ");
+function provider(host: string, cli: string): Provider {
+  const escaped = host.replaceAll(".", String.raw`\.`);
+  return {
+    host,
+    cli,
+    patterns: [
+      new RegExp(String.raw`\bgit@${escaped}:`),
+      new RegExp(String.raw`\bssh://git@${escaped}[:/]`),
+    ],
+  };
+}
+
+/**
+ * Hosts whose CLI holds credentials that grant HTTPS push access. A host absent
+ * here (self-hosted forges, enterprise domains) has no known credential helper,
+ * so the hook stays silent rather than suggest a retry that cannot authenticate.
+ */
+const PROVIDERS = [provider("github.com", "gh"), provider("gitlab.com", "glab")];
+
+function httpsConfig({ host, cli }: Provider): string {
+  return [
+    "-c credential.helper=",
+    `-c 'credential.helper=!${cli} auth git-credential'`,
+    `-c 'url.https://${host}/.insteadOf=git@${host}:'`,
+    `-c 'url.https://${host}/.insteadOf=ssh://git@${host}/'`,
+  ].join(" ");
+}
 
 export function hasSshAuthFailure(output: string): boolean {
   return SSH_AUTH_SIGNATURES.some((signature) => output.includes(signature));
 }
 
-export function usesSshGithub(text: string): boolean {
-  return SSH_GITHUB_PATTERNS.some((pattern) => pattern.test(text));
+/** Returns the provider whose SSH remote form appears in the text, or null. */
+export function sshProviderOf(text: string): Provider | null {
+  return PROVIDERS.find((p) => p.patterns.some((pattern) => pattern.test(text))) ?? null;
 }
 
 const GIT_INVOCATION = /(?:^|[;&|]\s*|\s)git(?=\s)/g;
@@ -100,18 +126,18 @@ export function gitNetworkSubcommand(command: string): string | null {
  * through `insteadOf` keeps the remote name, refspecs, and remote-tracking ref
  * updates identical to the SSH attempt.
  */
-export function rewriteCommand(command: string): string | null {
+export function rewriteCommand(command: string, target: Provider): string | null {
   const invocation = findNetworkInvocation(command);
   if (!invocation) return null;
 
   const { insertAt } = invocation;
-  return `${command.slice(0, insertAt)} ${HTTPS_CONFIG}${command.slice(insertAt)}`;
+  return `${command.slice(0, insertAt)} ${httpsConfig(target)}${command.slice(insertAt)}`;
 }
 
-export function formatContext(retryCommand: string): string {
+export function formatContext(retryCommand: string, cli: string): string {
   return [
     "The SSH agent refused to sign, so this git operation could not authenticate over SSH.",
-    "Retry the exact same operation over HTTPS, which authenticates through gh's credential helper:",
+    `Retry the exact same operation over HTTPS, which authenticates through ${cli}'s credential helper:`,
     "",
     retryCommand,
     "",
@@ -119,7 +145,7 @@ export function formatContext(retryCommand: string): string {
   ].join("\n");
 }
 
-/** Reads the repo's remote URLs so a bare `git pull` still resolves to a GitHub SSH remote. */
+/** Reads the repo's remote URLs so a bare `git pull` still resolves to a provider's SSH remote. */
 export async function readRemoteUrls(cwd: string): Promise<string> {
   // Interpolated so Bun's shell escapes the pattern instead of glob-expanding it.
   const pattern = String.raw`^remote\..*\.url$`;
@@ -138,15 +164,16 @@ export async function processInput(
   if (!hasSshAuthFailure(input.error ?? "")) return null;
 
   const cwd = input.cwd ?? process.cwd();
-  if (!usesSshGithub(command) && !usesSshGithub(await readRemotes(cwd))) return null;
+  const target = sshProviderOf(command) ?? sshProviderOf(await readRemotes(cwd));
+  if (!target) return null;
 
-  const retryCommand = rewriteCommand(command);
+  const retryCommand = rewriteCommand(command, target);
   if (!retryCommand) return null;
 
   return {
     hookSpecificOutput: {
       hookEventName: "PostToolUseFailure",
-      additionalContext: formatContext(retryCommand),
+      additionalContext: formatContext(retryCommand, target.cli),
     },
   };
 }


### PR DESCRIPTION
Secretive gates every SSH signature behind Touch ID, so git operations run while nobody is at the machine fail: `agent refused operation`, then `Permission denied (publickey)`, exit 128. That is 15 failures in 10 days across both machines. Fetches and pulls fail the same way pushes do. The old workaround (push over an `https://github.com/...` URL, let gh supply credentials) covered pushes only and lived nowhere in config.

Adds a `PostToolUseFailure` hook that watches failing `git` commands for the agent-refusal signature. When the command or the repository names an SSH remote on a known provider, it returns that command rewritten to run over HTTPS.

## Design Notes

The hook emits `additionalContext` rather than re-running the operation. A hook that runs `git fetch` or `git push` itself would mutate refs outside the permission system, and the transcript would show a failure followed by an unexplained success. Suggesting keeps the retry visible and permissioned.

It prefixes the invocation with `url.<https>.insteadOf` rather than substituting a bare HTTPS URL. `git fetch https://github.com/owner/repo.git` is not `git fetch origin`: it drops the remote's refspecs and leaves `refs/remotes/origin/*` untouched, so the fetch silently updates nothing. Both SSH spellings are covered.

Credentials come from the provider CLI's `auth git-credential` helper for that one command. Nothing lands in the repo config and no token is stored or echoed. The leading empty `credential.helper=` resets the helper list so a stale keychain entry cannot answer first.

Providers are a table mapping SSH host to the CLI whose credentials can authenticate the retry: `github.com` via `gh` and `gitlab.com` via `glab`, with another forge being one row. A host outside the table draws no suggestion, since no known helper could make the retry succeed. Commit and tag signing use `ssh-keygen -Y sign` rather than the SSH auth path, so they still need Touch ID.

## Event Choice

I probed the harness instead of assuming. A non-zero Bash exit fires `PostToolUseFailure` only, never `PostToolUse`, and `error` carries `Exit code 128` plus the full stderr. Registering only the failure event means successful `git status` and `git log` calls spawn nothing.

The same probe suggests `plugins/gitlab/hooks/auth.ts` is dead: it detects expired glab credentials on `PostToolUse`, which never fires for a non-zero `glab` exit. Separate PR.

The push that opened this PR hit the exact failure, and the command the hook emits pushed the branch on the first try.

Discovery: ddcd1fea5c62

