### PR TITLE
settings: check hook commands name tracked paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Check hook quoting
         run: bun scripts/check-hook-quoting.ts
 
+      - name: Check hook command paths
+        run: bun scripts/check-hook-paths.ts
+
       - name: Check skill hook path variables
         run: bun scripts/check-skill-hook-vars.ts
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 .claude/settings.local.json
 .claude/hooks/logs/
-# Managed by `herdr integration install claude`; the settings.json hook entry
-# that invokes it is committed, the script itself is herdr's to overwrite.
-user/hooks/herdr-agent-state.sh
 .prek/
 node_modules/
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ Path-specific guidance lives in [`.claude/rules/`](.claude/rules/) and auto-inje
 ## Verification
 
 - `bun scripts/check-marketplace.ts`: verifies all plugin directories are listed in `marketplace.json`. Runs in CI.
+- `bun scripts/check-hook-paths.ts`: verifies every hook command in `user/settings.json` and `.claude/settings.json` names a tracked path, so a hook cannot outlive the script it invokes. Runs in CI.
 - `bun run schemas check`: fetches current upstream and verifies the upstream-backed schema overlays still apply, flagging overlay edits that upstream has absorbed and warning on edits that overwrite an upstream definition. Runs in CI.
 - `bun run skill-lint "plugins/<name>/skills/*"`: validates SKILL.md frontmatter and reference depth. `skill-lint` is a workspace package in `packages/skill-lint`, not an npm registry package.
 

--- a/scripts/check-hook-paths.test.ts
+++ b/scripts/check-hook-paths.test.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "bun:test";
+import {
+  load,
+  PROJECT_SETTINGS,
+  paths,
+  references,
+  shipped,
+  USER_SETTINGS,
+  violations,
+} from "./check-hook-paths";
+
+test.each<{ name: string; command: string; expected: string[] }>([
+  {
+    name: "interpreter argument",
+    command: "bun ~/.claude/hooks/worktree",
+    expected: ["user/hooks/worktree"],
+  },
+  {
+    name: "quoted $HOME with trailing arguments",
+    command: 'bash "$HOME/.claude/hooks/herdr-agent-state.sh" session',
+    expected: ["user/hooks/herdr-agent-state.sh"],
+  },
+  {
+    name: "braced HOME",
+    command: `\${HOME}/.claude/scripts/statusline.ts`,
+    expected: ["user/scripts/statusline.ts"],
+  },
+  {
+    name: "nested in sh -c",
+    command: `/bin/sh -c '[ -x "$HOME/.claude/hooks/thing" ] && "$HOME/.claude/hooks/thing"; exit 0'`,
+    expected: ["user/hooks/thing", "user/hooks/thing"],
+  },
+  {
+    name: "plugin cache is installed elsewhere",
+    command: "bun ~/.claude/plugins/cache/bendrucker/mac/scripts/sandbox.ts",
+    expected: [],
+  },
+  {
+    name: "machine-local binary",
+    command: "'/opt/homebrew/bin/moshi-hook' claude-hook",
+    expected: [],
+  },
+  {
+    name: "guarded path outside the config dir",
+    command: `/bin/sh -c '[ -x "$HOME/.vibe-island/bin/bridge" ] && "$HOME/.vibe-island/bin/bridge"; exit 0'`,
+    expected: [],
+  },
+  { name: "no path at all", command: "bash -c 'jq -er .worktree_path'", expected: [] },
+])("$name", ({ command, expected }) => {
+  expect(paths(command, USER_SETTINGS.prefixes)).toEqual(expected);
+});
+
+test.each<{ name: string; command: string; expected: string[] }>([
+  {
+    name: "project dir resolves to the repo root",
+    command: 'bun "$CLAUDE_PROJECT_DIR/.claude/hooks/biome"',
+    expected: [".claude/hooks/biome"],
+  },
+  {
+    name: "an assigned path is data, not the command",
+    command: 'PREK_HOME="$CLAUDE_PROJECT_DIR/.prek" bun "$CLAUDE_PROJECT_DIR/.claude/hooks/stop"',
+    expected: [".claude/hooks/stop"],
+  },
+])("$name", ({ command, expected }) => {
+  expect(paths(command, PROJECT_SETTINGS.prefixes)).toEqual(expected);
+});
+
+test("project dir does not resolve in user settings", () => {
+  expect(
+    paths('bun "$CLAUDE_PROJECT_DIR/.claude/hooks/biome"', USER_SETTINGS.prefixes),
+  ).toBeEmpty();
+});
+
+const settings = {
+  hooks: {
+    SessionStart: [{ hooks: [{ command: "bun ~/.claude/hooks/present" }] }],
+    Stop: [
+      { hooks: [{ command: "bun ~/.claude/hooks/gone" }, { type: "command" }] },
+      { matcher: "*" },
+    ],
+  },
+};
+
+test("every event contributes its commands", () => {
+  expect(references(settings, USER_SETTINGS)).toMatchInlineSnapshot(`
+    [
+      {
+        "command": "bun ~/.claude/hooks/present",
+        "event": "SessionStart",
+        "file": "user/settings.json",
+        "path": "user/hooks/present",
+      },
+      {
+        "command": "bun ~/.claude/hooks/gone",
+        "event": "Stop",
+        "file": "user/settings.json",
+        "path": "user/hooks/gone",
+      },
+    ]
+  `);
+});
+
+test("an untracked path is a violation", () => {
+  const tracked = new Set([
+    "user/hooks/present/index.ts",
+    "user/hooks/present",
+    "user/hooks",
+    "user",
+  ]);
+  expect(violations(references(settings, USER_SETTINGS), tracked)).toEqual([
+    "user/settings.json Stop: user/hooks/gone",
+  ]);
+});
+
+test("every hook command in this repo resolves", async () => {
+  const [refs, files] = await Promise.all([load(), shipped()]);
+  expect(refs).not.toBeEmpty();
+  expect(violations(refs, files)).toBeEmpty();
+});

--- a/scripts/check-hook-paths.ts
+++ b/scripts/check-hook-paths.ts
@@ -1,0 +1,159 @@
+#!/usr/bin/env bun
+
+import { root } from "./assets";
+import { runCheck, tracked } from "./check";
+
+/**
+ * Path prefixes a hook command can name, mapped to the repo-relative directory
+ * they deploy from. `~/.claude` is a set of symlinks into `user/`, so a hook
+ * command naming a path beneath it is naming a file this repo ships.
+ */
+const HOME_PREFIXES: Record<string, string> = {
+  "~/.claude/": "user/",
+  "$HOME/.claude/": "user/",
+  "${HOME}/.claude/": "user/",
+};
+
+const PROJECT_PREFIXES: Record<string, string> = {
+  "$CLAUDE_PROJECT_DIR/": "",
+  "${CLAUDE_PROJECT_DIR}/": "",
+};
+
+/**
+ * Installed by the plugin system into the cache under `~/.claude/plugins`,
+ * which this repo does not check out.
+ */
+const UNMANAGED = ["user/plugins/"];
+
+export interface Source {
+  /** Repo-relative settings file. */
+  file: string;
+  prefixes: Record<string, string>;
+}
+
+export const USER_SETTINGS: Source = { file: "user/settings.json", prefixes: HOME_PREFIXES };
+
+/**
+ * `$CLAUDE_PROJECT_DIR` expands to whatever repository the session runs in, so
+ * it resolves against this checkout only for the project settings file.
+ */
+export const PROJECT_SETTINGS: Source = {
+  file: ".claude/settings.json",
+  prefixes: { ...HOME_PREFIXES, ...PROJECT_PREFIXES },
+};
+
+export const SOURCES: Source[] = [USER_SETTINGS, PROJECT_SETTINGS];
+
+function quoteRegex(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Shell syntax that cannot appear inside an unquoted or quoted path. */
+const PATH_BODY = `[^\\s"';|&)]+`;
+
+/**
+ * Whether the path starting at `at` is the value of an assignment, as in
+ * `PREK_HOME="$CLAUDE_PROJECT_DIR/.prek" bun ...`. An assigned path is data the
+ * command passes along rather than code it runs, and often names a directory
+ * the tool creates on first use.
+ */
+function assigned(command: string, at: number): boolean {
+  return command.slice(0, at).replace(/["']$/, "").endsWith("=");
+}
+
+/**
+ * Repo-relative paths a hook command runs.
+ *
+ * Matching on the prefix rather than parsing the command covers every shape a
+ * hook command takes: a bare path, a path passed to an interpreter (`bun
+ * <path>`), and a path nested inside a `sh -c` string. Paths carrying no
+ * recognized prefix are machine-local (a Homebrew binary, another tool's
+ * install dir) and unverifiable from a checkout, so they are left alone.
+ */
+export function paths(command: string, prefixes: Record<string, string>): string[] {
+  const alternation = Object.keys(prefixes).map(quoteRegex).join("|");
+  const pattern = new RegExp(`(${alternation})(${PATH_BODY})`, "g");
+
+  return [...command.matchAll(pattern)]
+    .filter((match) => !assigned(command, match.index))
+    .map(([, prefix, rest]) => `${prefixes[prefix as string]}${rest}`)
+    .filter((path) => !UNMANAGED.some((prefix) => path.startsWith(prefix)));
+}
+
+interface Settings {
+  hooks?: Record<string, Array<{ hooks?: Array<{ command?: string }> }>>;
+}
+
+export interface Reference {
+  file: string;
+  event: string;
+  command: string;
+  /** Repo-relative path the command names. */
+  path: string;
+}
+
+/** Every repo path named by a hook command in one settings file, across all events. */
+export function references(settings: Settings, source: Source): Reference[] {
+  const found: Reference[] = [];
+
+  for (const [event, entries] of Object.entries(settings.hooks ?? {})) {
+    for (const entry of entries) {
+      for (const { command } of entry.hooks ?? []) {
+        if (!command) continue;
+        for (const path of paths(command, source.prefixes)) {
+          found.push({ file: source.file, event, command, path });
+        }
+      }
+    }
+  }
+
+  return found;
+}
+
+/**
+ * Repo-relative paths of every tracked file and of every directory holding one.
+ *
+ * Tracked rather than present on disk: an imperative installer that writes into
+ * `~/.claude/hooks` lands in this directory through the symlink, so the file
+ * exists locally while a fresh clone gets nothing.
+ */
+export async function shipped(): Promise<Set<string>> {
+  const found = new Set<string>();
+
+  for (const file of await tracked(".", root)) {
+    found.add(file);
+    for (let at = file.indexOf("/"); at !== -1; at = file.indexOf("/", at + 1)) {
+      found.add(file.slice(0, at));
+    }
+  }
+
+  return found;
+}
+
+export function violations(references: Reference[], shipped: Set<string>): string[] {
+  return references
+    .filter((reference) => !shipped.has(reference.path))
+    .map((reference) => `${reference.file} ${reference.event}: ${reference.path}`);
+}
+
+export async function load(): Promise<Reference[]> {
+  const settings = await Promise.all(
+    SOURCES.map(
+      async (source) => [source, await Bun.file(`${root}/${source.file}`).json()] as const,
+    ),
+  );
+  return settings.flatMap(([source, file]) => references(file as Settings, source));
+}
+
+if (import.meta.main) {
+  await runCheck(
+    async () => {
+      const [refs, files] = await Promise.all([load(), shipped()]);
+      return {
+        header: "Hook commands naming paths this repo does not ship:",
+        violations: violations(refs, files),
+      };
+    },
+    { success: "Every hook command resolves to a tracked path" },
+  );
+}

--- a/user/README.md
+++ b/user/README.md
@@ -13,4 +13,12 @@ Run `scripts/install.sh` to create the symlinks.
   - `webfetch-block/` - Steers WebFetch calls toward better tools
   - `session-limit/` - Warns when a session approaches its limit
   - `permission-denied/` - Logs auto mode classifier denials so the `autoMode` rules stay measurable
-  - `herdr-agent-state.sh` - Written by `herdr integration install claude` and gitignored; only its `settings.json` hook entry is committed (rewritten to `$HOME` form). Reinstall after cloning or a herdr version bump to restore the script, then discard the installer's `settings.json` edits: it re-sorts the file and appends a duplicate absolute-path entry it can't recognize as already present.
+  - `herdr-agent-state.sh` - Reports session state to herdr, vendored from `herdr integration install claude`
+
+## Vendored Hooks
+
+`hooks/herdr-agent-state.sh` originates from herdr's integration installer, which writes it to `~/.claude/hooks/`. Because that path is this directory through the symlink, the installed copy and the committed copy are the same file, and the committed copy is what every machine gets.
+
+Keep it byte-identical to what the installer writes, header comments included. herdr owns the contents and bumps `HERDR_INTEGRATION_VERSION` when it changes them, so a herdr upgrade means rerunning `herdr integration install claude` and committing the resulting diff. Discard the installer's `settings.json` edits when you do: it cannot recognize the committed `$HOME`-form hook entry as its own, so it re-sorts the file and appends a duplicate absolute-path entry.
+
+`bun scripts/check-hook-paths.ts` fails if a hook command in either settings file points at a `~/.claude/` or `$CLAUDE_PROJECT_DIR/` path this repo does not ship, which is what catches a vendored script going missing or a hook path outliving the script it named.

--- a/user/hooks/herdr-agent-state.sh
+++ b/user/hooks/herdr-agent-state.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# installed by herdr
+# managed by herdr; reinstalling or updating the integration overwrites this file.
+# add custom hooks beside this file instead of editing it.
+# HERDR_INTEGRATION_ID=claude
+# HERDR_INTEGRATION_VERSION=7
+
+set -eu
+
+action="${1:-}"
+hook_input_file="$(mktemp "${TMPDIR:-/tmp}/herdr-claude-hook.XXXXXX")" || exit 0
+trap 'rm -f "$hook_input_file"' EXIT HUP INT TERM
+cat >"$hook_input_file" 2>/dev/null || true
+
+case "$action" in
+  session) ;;
+  *) exit 0 ;;
+esac
+
+[ "${HERDR_ENV:-}" = "1" ] || exit 0
+[ -n "${HERDR_SOCKET_PATH:-}" ] || exit 0
+[ -n "${HERDR_PANE_ID:-}" ] || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+HERDR_ACTION="$action" HERDR_HOOK_INPUT_FILE="$hook_input_file" python3 - <<'PY'
+import json
+import os
+import random
+import socket
+import time
+
+source = "herdr:claude"
+action = os.environ.get("HERDR_ACTION", "")
+pane_id = os.environ.get("HERDR_PANE_ID")
+socket_path = os.environ.get("HERDR_SOCKET_PATH")
+hook_input_file = os.environ.get("HERDR_HOOK_INPUT_FILE")
+
+if not pane_id or not socket_path:
+    raise SystemExit(0)
+
+hook_input = {}
+if hook_input_file:
+    try:
+        with open(hook_input_file, encoding="utf-8") as handle:
+            content = handle.read()
+        if content.strip():
+            hook_input = json.loads(content)
+    except Exception:
+        hook_input = {}
+
+hook_event_name = str(hook_input.get("hook_event_name") or "")
+is_subagent = bool(hook_input.get("agent_id"))
+if is_subagent:
+    raise SystemExit(0)
+if hook_event_name == "SubagentStop":
+    # SubagentStop is a completion event. Older Herdr integrations mapped it
+    # to durable working, but Claude recap/away-summary can emit it after the
+    # main turn has already stopped. Never let it revive an idle pane.
+    raise SystemExit(0)
+request_id = f"{source}:{int(time.time() * 1000)}:{random.randrange(1_000_000):06d}"
+report_seq = time.time_ns()
+session_id = hook_input.get("session_id")
+agent_session_id = session_id if isinstance(session_id, str) and session_id else None
+transcript_path = hook_input.get("transcript_path")
+agent_session_path = transcript_path if isinstance(transcript_path, str) and transcript_path else None
+session_start_source = hook_input.get("source") if hook_event_name == "SessionStart" else None
+if not isinstance(session_start_source, str) or not session_start_source:
+    session_start_source = None
+if agent_session_id:
+    params = {
+        "pane_id": pane_id,
+        "source": source,
+        "agent": "claude",
+        "seq": report_seq,
+        "agent_session_id": agent_session_id,
+    }
+    if agent_session_path:
+        params["agent_session_path"] = agent_session_path
+    if session_start_source:
+        params["session_start_source"] = session_start_source
+    request = {
+        "id": request_id,
+        "method": "pane.report_agent_session",
+        "params": params,
+    }
+else:
+    raise SystemExit(0)
+
+try:
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.settimeout(0.5)
+    client.connect(socket_path)
+    client.sendall((json.dumps(request) + "\n").encode())
+    try:
+        client.recv(4096)
+    except Exception:
+        pass
+    client.close()
+except Exception:
+    pass
+PY


### PR DESCRIPTION
A hook command in `user/settings.json` names a script path, and nothing verified the script was there. When a path goes stale the hook dies silently on every matching tool call. Dead tmux hook paths sat in settings that way long after tmux was retired.

`herdr-agent-state.sh` was the live case. `herdr integration install claude` writes it into `~/.claude/hooks`, which is a symlink into `user/`. #1123 committed the `SessionStart` entry that invokes it and gitignored the script, so the hook worked on machines that had run the installer and was dead everywhere else.

Tracking the script fixes that. The installed path and the committed path are the same file, so committing it is what makes a fresh clone whole, and the `settings.json` entry needs no change. `user/README.md` records that herdr owns the contents and that a version bump means rerunning the installer and committing the diff.

`scripts/check-hook-paths.ts` is the guard, wired into the `validate` job. It walks every event in both settings files and resolves the `~/.claude/` and `$CLAUDE_PROJECT_DIR/` paths each command names. Anything git does not track fails.

Prefix matching rather than shell parsing covers a bare path, a path handed to an interpreter, and a path nested inside a `sh -c` string alike. Machine-local paths and the plugin cache under `~/.claude/plugins` stay out of scope, since neither comes from a checkout. Tracked rather than present on disk is the point. A script installed locally but never committed fails the check exactly as a fresh clone would experience it.

Discovery: 7f4b8e7b2009
