### PR TITLE
writing: defer the markdown parser to the parse

### DIFF
--- a/plugins/writing/hooks/mdast.ts
+++ b/plugins/writing/hooks/mdast.ts
@@ -1,0 +1,25 @@
+import type { Root } from "mdast";
+
+type Markdown = {
+  fromMarkdown: (value: string) => Root;
+  visit: typeof import("unist-util-visit").visit;
+};
+
+let pending: Promise<Markdown> | undefined;
+
+// The markdown parser and its tree walker cost about 25ms to load, the largest
+// single entry in the PreToolUse dispatcher's module graph. The checkers that
+// use them sit behind a markdown-extension test, so a static import spends that
+// 25ms on every fire against a code file, a data file, or a Bash command, none
+// of which can reach a parse. Resolving inside the parse is the only way to put
+// a runtime-conditional graph behind a runtime condition.
+//
+// The promise is memoized, so several parses in one run share one resolution.
+// Measured against the static import it costs roughly 3ms when a parse does
+// happen, and saves the full 25ms when none does.
+export function loadMarkdown(): Promise<Markdown> {
+  pending ??= Promise.all([import("mdast-util-from-markdown"), import("unist-util-visit")]).then(
+    ([{ fromMarkdown }, { visit }]) => ({ fromMarkdown, visit }),
+  );
+  return pending;
+}

--- a/plugins/writing/hooks/numbering.test.ts
+++ b/plugins/writing/hooks/numbering.test.ts
@@ -114,8 +114,8 @@ describe("checkMarkdown", () => {
       "## 2. AskUserQuestion Misalignment (7 of 8)",
       null,
     ],
-  ])("%s", (_name, content, expected) => {
-    const match = checkMarkdown(content);
+  ])("%s", async (_name, content, expected) => {
+    const match = await checkMarkdown(content);
     expected === null ? expect(match).toBeNull() : expect(match).toContain(expected);
   });
 });

--- a/plugins/writing/hooks/numbering.ts
+++ b/plugins/writing/hooks/numbering.ts
@@ -6,8 +6,6 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import type { Heading, Text } from "mdast";
-import { fromMarkdown } from "mdast-util-from-markdown";
-import { visit } from "unist-util-visit";
 import { getExtension, isMarkdownFile } from "../detection/paths";
 import {
   type EditInput,
@@ -16,6 +14,7 @@ import {
   type HookResult,
   type WriteInput,
 } from "./io";
+import { loadMarkdown } from "./mdast";
 
 export type Mode = "write" | "edit";
 
@@ -44,7 +43,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // so only explicit step labels count.
 const STEP_HEADING = /^(Step|Phase|Part)\s+[0-9]+/i;
 
-export function checkMarkdown(content: string): string | null {
+export async function checkMarkdown(content: string): Promise<string | null> {
+  const { fromMarkdown, visit } = await loadMarkdown();
   const ast = fromMarkdown(content);
   const matches: MarkdownMatch[] = [];
 
@@ -123,7 +123,9 @@ async function fileAlreadyNumbered(filePath: string, ext: string): Promise<boole
     return false;
   }
 
-  const match = isMarkdownFile(ext) ? checkMarkdown(existing) : await checkCode(existing, ext);
+  const match = isMarkdownFile(ext)
+    ? await checkMarkdown(existing)
+    : await checkCode(existing, ext);
   return match !== null;
 }
 
@@ -151,7 +153,7 @@ export async function check(input: PreToolUseHookInput, mode: Mode): Promise<Hoo
   let match: string | null = null;
 
   if (isMarkdownFile(ext)) {
-    match = checkMarkdown(content);
+    match = await checkMarkdown(content);
   } else {
     match = await checkCode(content, ext);
   }

--- a/plugins/writing/hooks/pretooluse.test.ts
+++ b/plugins/writing/hooks/pretooluse.test.ts
@@ -4,6 +4,7 @@ import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { check as headingCheck } from "./headings";
 import { dispatch } from "./pretooluse";
 
 // Session-state files land in $TMPDIR. Redirect it so test runs do not litter
@@ -242,6 +243,36 @@ describe("scratch paths", () => {
     );
     await rm(dir, { recursive: true, force: true });
     expect(contextOf(output)).toContain("delve");
+  });
+});
+
+// The dispatcher loads the heading checker only for markdown, so its own
+// extension test has to agree with the checker's for every extension the hook
+// sees. Where they disagree the hook quietly stops reporting findings it used
+// to report, and nothing else fails.
+describe("heading checker gate", () => {
+  // A lowercase heading over clean prose. Only the heading checker has a rule
+  // for it, so the dispatcher's winning category names that checker exactly
+  // when it ran.
+  const HEADING_VIOLATION = "# the cache layer\n\nStores records in memory.\n";
+
+  test.each([
+    "md",
+    "markdown",
+    "mdx",
+    "txt",
+    "rst",
+    "adoc",
+    "ts",
+    "go",
+    "yml",
+    "json",
+    "vue",
+  ])("agrees with headings.check on .%s", async (ext) => {
+    const toolInput = { file_path: `docs/note.${ext}`, content: HEADING_VIOLATION };
+    const direct = await headingCheck(mockInput("Write", toolInput));
+    const { log } = await dispatch(mockInput("Write", toolInput));
+    expect(log.category ?? null).toBe(direct?.category ?? null);
   });
 });
 

--- a/plugins/writing/hooks/pretooluse.ts
+++ b/plugins/writing/hooks/pretooluse.ts
@@ -1,9 +1,14 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { getExtension, isMemoryPath, isPlanPath, isScratchPath } from "../detection/paths";
+import {
+  getExtension,
+  isMarkdownFile,
+  isMemoryPath,
+  isPlanPath,
+  isScratchPath,
+} from "../detection/paths";
 import * as tropes from "./check-tropes";
-import * as headings from "./headings";
 import { type HookResult, isPlanMode, type SyncHookJSONOutput, tierOf } from "./io";
 import * as numbering from "./numbering";
 import { appendRunLog, type RunLogEntry, type RunOutcome } from "./run-log";
@@ -24,6 +29,18 @@ function filePathOf(input: PreToolUseHookInput): string | undefined {
   return typeof filePath === "string" ? filePath : undefined;
 }
 
+// Every heading check is markdown-only: `headings.check` returns null for any
+// other extension and for the Bash surface, which is most of what this hook
+// sees. Its module graph is not free, though. It reaches an AP title-case
+// library, the heading classifier, and the markdown parser, together the
+// largest block of the ~40ms this dispatcher spent parsing modules before it
+// could read its input. Loading it from the markdown branch is the only way to
+// keep a runtime-conditional graph out of an unconditional import.
+async function headingResult(input: PreToolUseHookInput): Promise<HookResult | null> {
+  const headings = await import("./headings");
+  return headings.check(input);
+}
+
 // One dispatcher run sequences all checkers in-process and emits at most one
 // output. Priority is deny > ask > context, and within a tier the earliest
 // checker in numbering → headings → tropes order wins.
@@ -33,12 +50,13 @@ export async function dispatch(
 ): Promise<DispatchResult> {
   const start = performance.now();
   const filePath = filePathOf(input);
+  const ext = filePath ? getExtension(filePath) : "";
 
   const base = {
     ts: new Date(now).toISOString(),
     session_id: input.session_id,
     tool: input.tool_name,
-    ext: filePath ? getExtension(filePath) : "",
+    ext,
   };
 
   const finish = (
@@ -57,7 +75,7 @@ export async function dispatch(
   const mode: numbering.Mode = input.tool_name === "Edit" ? "edit" : "write";
   const checkers = [
     () => numbering.check(input, mode),
-    () => headings.check(input),
+    () => (isMarkdownFile(ext) ? headingResult(input) : null),
     () => tropes.check(input),
   ];
 


### PR DESCRIPTION
The dispatcher reports 2ms p50 for its own work against 68ms measured from the harness. The gap is bun startup and module parsing, and the markdown parser is the largest single entry at ~25ms. Both checkers that touch it sit behind a markdown-extension test, so the 5,969 of 8,429 logged fires against `.ts`, `.go`, `.vue`, and friends paid for a parse they could never reach.

`numbering` now resolves the mdast packages inside `checkMarkdown`, and the dispatcher loads `headings` from its markdown branch. That defers the AP title-case library and the heading classifier too.

Running the real `hooks.json` command against representative payloads, alternating branch and `origin/main` in one process: non-markdown file ops and scratch paths drop ~21ms, markdown drops 2ms, Bash is unchanged. Weighted by the log's extension mix that is ~114s per 29 days, roughly a fifth of what the hook costs. A new case per extension in `pretooluse.test.ts` pins the dispatcher's markdown gate to `headings.check`'s own extension test, since drift between them would stop reporting findings without failing anything.

`user/rules/typescript.md` prefers a static import over `await import()`, on the grounds that deferring a first-party module buys nothing. That holds until the graph is conditional on a runtime value, which a static import cannot express.

Two ways around it were tried. Pushing the deferral into `heading-case.ts` forces its API async, and that file is a byte-identical twin of the pull-request plugin's copy, so it drags the refactor through `validate-body.ts` and its callers. A synchronous `createRequire` keeps every signature but costs 13ms more, turning the 2ms markdown win into a 12ms regression.

I also built the shell prefilter for the `Edit`/`Write` matchers and then removed it on its own numbers. `in=$(cat)` plus a `grep` costs 11ms per fire against a bare `bun` invocation, and it skips a spawn only on fires that match. At the log's ~17% skip rate that nets a 5ms per-fire loss.

`case` globs get it to break-even. Only a `read -r` builtin makes it clearly positive, and that truncates any payload longer than one line.

One thing worth keeping from the log: `toml`, `yml`, and `jsonc` produced 11 context injections on comment prose over the full window, so config formats are not inert and should not be prefiltered away. `json` is, at 254 fires and nothing found.

`heading-case.test.ts` fails here and on `origin/main` alike. That is #1158 landing a `depth` field without its twin, fixed in #1182.

Discovery: 3de4f8fcccbe
