### PR TITLE
pull-request: drop dangling sections.md symlink

### DIFF
--- a/plugins/pull-request/skills/update/sections.md
+++ b/plugins/pull-request/skills/update/sections.md
@@ -1,1 +1,0 @@
-../create/sections.md


### PR DESCRIPTION
Removes `skills/update/sections.md`, a symlink to `../create/sections.md` that #1170 moved into `create/references/`. That PR repointed `update/SKILL.md` at the new path but left the symlink behind, so it has resolved to nothing since.

Nothing reads it. `update/SKILL.md` links `../create/references/sections.md` directly, and `skill-lint` passes either way.

It was not inert, though. `claude-plugin-audit` verifies an installed plugin by diffing its payload against the marketplace tree, and `diff` reports an unreadable path as an error rather than a difference. So `pull-request@bendrucker` came back unverifiable on every install instead of current or stale, on a plugin nobody had changed.

No lint guard here. This was the repo's only tracked symlink, so a dangling-symlink check would now have nothing to check. The audit is the detector, and it caught this.
