### PR TITLE
job: fix the agent join and bound gather

### DIFF
--- a/user/skills/job/SKILL.md
+++ b/user/skills/job/SKILL.md
@@ -54,15 +54,15 @@ Read-only first. The sources are independent (review queue, own PRs, tracker, me
 
 #### Reporting
 
-A dispatched agent's report is the only thing gather consumes, so make the report the contract. End every gather prompt by naming it: the final action is sending the structured report to the orchestrator, before going idle. An agent that goes idle carrying no report gets one nudge asking for it, never a second.
+End every gather prompt by naming the report as the agent's final action: send it to the orchestrator before going idle. An agent that goes idle carrying no report gets one nudge, never a second. When the nudge produces nothing, treat that source as timed out.
 
-Gather runs against a five-minute deadline from dispatch. Past it, stop the outstanding agent and run its source inline. Sub-agent inference is where the time goes, and the orchestrator's own CLI and MCP calls answer these sources in under a second, so waiting longer buys nothing that running it directly does not.
+Gather runs against a five-minute deadline from dispatch. Past it, stop the outstanding agent (`TaskStop` for an `Agent` dispatch) and run its source inline.
 
-Report each source as it lands rather than holding for the set. A stalled source then costs one source instead of the whole brief, and time-sensitive work found early can dispatch before gather finishes.
+Surface each source's findings as it lands, so a stalled source delays one entry instead of the brief. Hold the merge and the brief entries themselves until every source has reported or been run inline.
 
 #### Agents
 
-Background Claude sessions may already be working items in the brief. Run `claude agents --json --all` inline in the orchestrator rather than in a sub-agent: it is one command, and the join needs the raw records that a sub-agent summary would flatten. Each record carries `id`, `sessionId`, `name`, `cwd`, `kind`, `startedAt`, `status`, `state`, and, when blocked, `waitingFor`. `state` is `working`, `blocked`, `done`, or `failed`, and is null for interactive sessions.
+Background Claude sessions may already be working items in the brief. Run `claude agents --json --all` inline in the orchestrator rather than in a sub-agent: it is one command, and the join needs the raw records that a sub-agent summary would flatten. Every record carries `sessionId`, `name`, `cwd`, `kind`, and `startedAt`. The rest is keyed to `kind`: a `background` record adds `id` and `state` (`working`, `blocked`, `done`, or `failed`, plus `waitingFor` when blocked), and an `interactive` record adds `pid` and `status` instead. Join on `sessionId`, the one field both kinds share.
 
 When `HERDR_PANE_ID` is set, a second inline call, `herdr agent list`, maps live sessions to the terminal panes running them. Join its agents to the `claude agents` records on `sessionId == agent_session.value` and record the matched `pane_id` on the brief item. That join is exact, so never fall back to a title or `cwd` comparison. When `HERDR_PANE_ID` is unset there is no herdr server to ask, so skip the call and the resume command below carries the handoff. Load the `herdr` skill for the mechanics and for which commands answer with JSON.
 
@@ -101,19 +101,19 @@ Close with the mode's cross-project synthesis: the day's sequence, or the night'
 Split recommended actions into two groups:
 
 - Safe: reversible or expected. Assign a reviewer, retry CI, add a reaction or brief acknowledgement, post a reply the user has seen drafted, correct a tracker status, archive a handled notification or email.
-- Ask-first: approve, close, merge, anything hard to walk back. Each needs its own confirmation.
+- Ask-first: approve, merge, close without the evidence below, anything hard to walk back. Each needs its own confirmation.
 
-Closing a tracker issue is safe only on evidence the orchestrator checked itself: that issue's own MR merged, or its acceptance criteria met in the code. A sub-agent reporting a merged MR is evidence about the MR. Confirm the MR belongs to the issue before it becomes evidence about the issue, since a linked MR often belongs to a sibling. Without that check, closing is ask-first.
+Closing a tracker issue is safe only on evidence the orchestrator checked itself: that issue's own MR merged, or its acceptance criteria met in the code. A sub-agent reporting a merged MR is evidence about the MR. Confirm the MR belongs to the issue before it becomes evidence about the issue, since a linked MR may belong to a sibling.
 
 Drive inbound to zero. Every review request, message, notification, and email leaves the run with a terminal disposition: handled, reacted to or briefly acknowledged, deferred to the work tracker as a team-backlog item or to the personal inbox for your own next-steps and reminders when one is configured, or archived. Never stand up a tracker issue in place of a personal capture: when the user says "my inbox" that means the personal inbox, and when the destination is unclear, ask. Nothing stays in an ambiguous unread state. Where a reaction or brief acknowledgement closes a thread, prefer that over a filler reply. Draft a reply only when it carries real content, and keep it terse.
 
 #### Questions
 
-A question that blocks a dispatch goes into a running list the moment it arises, ranked by how many dispatches its answer releases. Write the list to a file. It then survives an interrupted turn, and the user can read it before sitting down. Everything the list does not block keeps moving meanwhile.
+A question that blocks a dispatch goes into a running list the moment it arises, ranked by how many dispatches its answer releases. Write the list to a file and name its path in the brief. It survives an interrupted turn, and the user can read it before returning. Everything the list does not block keeps moving meanwhile.
 
-Ask in one pass, top blockers first, when the user is available. Their answering window is often two minutes between meetings, and a serial question per item spends all of it on round trips.
+Ask in one pass, top blockers first, when the user is available.
 
-A background agent's idle notification arrives as a user turn and cancels an open question. So before opening AskUserQuestion, hold every live agent's report in hand or stop the ones still out.
+A background agent's idle notification arrives as a user turn and cancels an open question, so prefer to ask while nothing is mid-flight. When a notification does cancel a question, re-ask it. The interrupt is not an answer.
 
 #### Execution
 
@@ -127,4 +127,4 @@ A prior session that is `done` or `failed` does not block a fresh dispatch, but 
 
 Every session this skill dispatches is named `job-<identifier>`, reusing the identifier from the brief. That is what lets tomorrow's run join by name alone.
 
-Names accept letters, digits, underscores, and hyphens, so sanitize the identifier to that set before dispatching. `ENG-2408` survives as written and `!789` becomes `789`. Prefix a bare number with what scopes it, since `job-789` says nothing about which repo it belongs to. The sanitized name is what `claude agents --json` reports back, so it is also what the join above matches. One form serves both the `Agent` tool's `name` and `claude --bg --name`.
+The `Agent` tool sets the constraint: its `name` accepts letters, digits, underscores, and hyphens, must start with a letter or digit, and caps at 64 characters. `claude --bg --name` is looser, so sanitizing to the `Agent` set yields one form that serves both. Sanitize the identifier and truncate it to fit. `ENG-2408` survives as written, and MR 789 in `acme/api` becomes `job-api-mr-789`, since a bare `job-789` says nothing about which repo it belongs to. The sanitized name is what `claude agents --json` reports back, so it is also what the join above matches.

--- a/user/skills/job/SKILL.md
+++ b/user/skills/job/SKILL.md
@@ -52,6 +52,14 @@ Both modes follow this contract.
 
 Read-only first. The sources are independent (review queue, own PRs, tracker, messaging inbox, email inbox), so dispatch parallel read-only sub-agents and merge their results. Merge on shared identifiers: when items from different sources name the same issue or MR, they are one piece of work and become one brief entry carrying every source's state. The join is the orchestrator's job, keyed on the cross-references each sub-agent returns.
 
+#### Reporting
+
+A dispatched agent's report is the only thing gather consumes, so make the report the contract. End every gather prompt by naming it: the final action is sending the structured report to the orchestrator, before going idle. An agent that goes idle carrying no report gets one nudge asking for it, never a second.
+
+Gather runs against a five-minute deadline from dispatch. Past it, stop the outstanding agent and run its source inline. Sub-agent inference is where the time goes, and the orchestrator's own CLI and MCP calls answer these sources in under a second, so waiting longer buys nothing that running it directly does not.
+
+Report each source as it lands rather than holding for the set. A stalled source then costs one source instead of the whole brief, and time-sensitive work found early can dispatch before gather finishes.
+
 #### Agents
 
 Background Claude sessions may already be working items in the brief. Run `claude agents --json --all` inline in the orchestrator rather than in a sub-agent: it is one command, and the join needs the raw records that a sub-agent summary would flatten. Each record carries `id`, `sessionId`, `name`, `cwd`, `kind`, `startedAt`, `status`, `state`, and, when blocked, `waitingFor`. `state` is `working`, `blocked`, `done`, or `failed`, and is null for interactive sessions.
@@ -60,7 +68,7 @@ When `HERDR_PANE_ID` is set, a second inline call, `herdr agent list`, maps live
 
 Join each record to a brief item in this order:
 
-1. A `name` matching the `job:<identifier>` convention below. Exact and structural, so it is the only join that never guesses.
+1. A `name` matching the `job-<identifier>` convention below, with the identifier in its sanitized form. Exact and structural, so it is the only join that never guesses.
 2. A full PR URL in `name`, or an issue key or `#`-prefixed PR number bounded by non-alphanumeric characters and confirmed against the repo `cwd` resolves to. This covers sessions launched by hand. Do not match a bare substring: `#42` occurs inside `#142`, and every repo has a PR numbered 42.
 3. `cwd` resolved to a repo, narrowing the candidate items, plus a semantic match of the name text against item titles.
 
@@ -92,10 +100,22 @@ Close with the mode's cross-project synthesis: the day's sequence, or the night'
 
 Split recommended actions into two groups:
 
-- Safe: reversible or expected. Assign a reviewer, retry CI, add a reaction or brief acknowledgement, post a reply the user has seen drafted, update tracker status, archive a handled notification or email.
+- Safe: reversible or expected. Assign a reviewer, retry CI, add a reaction or brief acknowledgement, post a reply the user has seen drafted, correct a tracker status, archive a handled notification or email.
 - Ask-first: approve, close, merge, anything hard to walk back. Each needs its own confirmation.
 
+Closing a tracker issue is safe only on evidence the orchestrator checked itself: that issue's own MR merged, or its acceptance criteria met in the code. A sub-agent reporting a merged MR is evidence about the MR. Confirm the MR belongs to the issue before it becomes evidence about the issue, since a linked MR often belongs to a sibling. Without that check, closing is ask-first.
+
 Drive inbound to zero. Every review request, message, notification, and email leaves the run with a terminal disposition: handled, reacted to or briefly acknowledged, deferred to the work tracker as a team-backlog item or to the personal inbox for your own next-steps and reminders when one is configured, or archived. Never stand up a tracker issue in place of a personal capture: when the user says "my inbox" that means the personal inbox, and when the destination is unclear, ask. Nothing stays in an ambiguous unread state. Where a reaction or brief acknowledgement closes a thread, prefer that over a filler reply. Draft a reply only when it carries real content, and keep it terse.
+
+#### Questions
+
+A question that blocks a dispatch goes into a running list the moment it arises, ranked by how many dispatches its answer releases. Write the list to a file. It then survives an interrupted turn, and the user can read it before sitting down. Everything the list does not block keeps moving meanwhile.
+
+Ask in one pass, top blockers first, when the user is available. Their answering window is often two minutes between meetings, and a serial question per item spends all of it on round trips.
+
+A background agent's idle notification arrives as a user turn and cancels an open question. So before opening AskUserQuestion, hold every live agent's report in hand or stop the ones still out.
+
+#### Execution
 
 Present safe actions via AskUserQuestion (execute all, pick a subset, or none). Execute through the delegated skills, then give a short summary of what changed.
 
@@ -105,4 +125,6 @@ Never dispatch over an item with a live session. When the item's session resolve
 
 A prior session that is `done` or `failed` does not block a fresh dispatch, but when the work needs another pass, name that `sessionId` in the new prompt so the new session can look up what already happened.
 
-Every session this skill dispatches gets `--name "job:<identifier>"`, reusing the identifier from the brief. That is what lets tomorrow's run join by name alone.
+Every session this skill dispatches is named `job-<identifier>`, reusing the identifier from the brief. That is what lets tomorrow's run join by name alone.
+
+Names accept letters, digits, underscores, and hyphens, so sanitize the identifier to that set before dispatching. `ENG-2408` survives as written and `!789` becomes `789`. Prefix a bare number with what scopes it, since `job-789` says nothing about which repo it belongs to. The sanitized name is what `claude agents --json` reports back, so it is also what the join above matches. One form serves both the `Agent` tool's `name` and `claude --bg --name`.

--- a/user/skills/job/references/end.md
+++ b/user/skills/job/references/end.md
@@ -4,7 +4,7 @@ The day ends with decisions. Nothing leaves it unsent, unanswered, unfiled, unpu
 
 ## Gather
 
-Dispatch parallel read-only sub-agents:
+Dispatch parallel read-only sub-agents, under the reporting contract and deadline in `SKILL.md`:
 
 - Outbox: your own PRs/MRs created or pushed today, with reviewer assignment, CI state, draft state, and whether the body still matches the diff.
 - Inbound: review requests still open against you, and threads on others' PRs/MRs awaiting your reply.

--- a/user/skills/job/references/start.md
+++ b/user/skills/job/references/start.md
@@ -4,7 +4,7 @@ Start-of-work triage: what needs review, what is stuck in your outbox, what came
 
 ## Gather
 
-Dispatch parallel read-only sub-agents:
+Dispatch parallel read-only sub-agents, under the reporting contract and deadline in `SKILL.md`:
 
 - Inbound: PRs/MRs where the configured username is a requested reviewer or approver, with age, author, and whether you reviewed before.
 - Outbox: your own open PRs/MRs, with CI status, unresolved threads, reviewer assignment, and draft state.


### PR DESCRIPTION
Five defects in the `/job` skill, found by mining its own run history.

The agent join has been broken since it shipped in #1088. `SKILL.md` mandated `--name "job:<identifier>"`, but the `Agent` tool's `name` param rejects the colon. A run that follows the instruction hits an `InputValidationError` and improvises a hyphenated name instead.

Rule 1 of the join order has therefore never fired, and it is the only one of the three that never guesses. The convention is now `job-<identifier>`, sanitized and truncated to what the `name` pattern accepts.

Gather had no deadline. When a source never returns, the orchestrator waits indefinitely, and past a few minutes the sub-agent inference costs more than answering the source inline would. It now caps at five minutes, then stops the straggler and runs that source directly.

An agent that finishes its work and goes idle without sending a report reads identically to one still working. The report is now stated as the agent's final action, with one nudge and no second.

A background agent's idle notification arrives as a user turn and cancels an open `AskUserQuestion`, which is costly when the answering window is short. Blocking questions now accumulate into one ranked pass. A cancelled question gets re-asked rather than treated as answered.

Closing a tracker issue on a sub-agent's "the linked MR merged" inference closes the wrong issue whenever that MR belongs to a sibling. Closing now needs evidence about the issue itself, and is otherwise ask-first.

The second commit corrects the skill's description of `claude agents --json`. `id` and `state` appear only on background records, `pid` and `status` only on interactive ones, and only `sessionId` spans both, where the skill had listed every field as universal. Background session names also accept spaces, so the name charset is the `Agent` tool's constraint rather than a property of dispatched sessions.

`end.md` has never run in any invocation of this skill. It wants a curation decision rather than a pre-run patch.
