### PR TITLE
settings: show the Claude mark in herdr agent rows

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -291,6 +291,16 @@
         ]
       },
       {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/bin/sh -c '[ \"$HERDR_ENV\" = 1 ] && [ -n \"$HERDR_PANE_ID\" ] && command -v herdr >/dev/null && herdr pane report-metadata \"$HERDR_PANE_ID\" --source claude-brand --display-agent \"\"; exit 0'",
+            "async": true
+          }
+        ]
+      },
+      {
         "matcher": "*",
         "hooks": [
           {


### PR DESCRIPTION
herdr's sidebar rows take built-in tokens and pane-metadata `$name` tokens. Neither is a literal string, so config alone cannot put a glyph in a row. `report-metadata --display-agent` overrides what the existing `agent` token already renders, which leaves `herdr/config.toml` in dotfiles untouched.

Nerd Fonts 3.5.0 ships `U+EC82` (`cod-claude`). The mark resolves on the stock cask now, and bendrucker/dotfiles#656 moves the font over.

The source is `claude-brand`. herdr's own managed integration reports under `herdr:claude`, and its hook file says to add custom hooks beside it rather than edit it, so this goes in `settings.json` instead.

Verified against a live pane. `display_agent` cleared to null, then read back as `U+EC82` after running the configured command verbatim. Outside a herdr pane the guards make it a no-op.
