### PR TITLE
statusline: report the context dial to herdr

### DIFF
--- a/user/scripts/context-dial.test.ts
+++ b/user/scripts/context-dial.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { CONTEXT_TOKENS, cachePath, findPane, reportArgs, shouldReport } from "./context-dial";
+
+const HOUR_MS = 3_600_000;
+
+const paneList = JSON.stringify({
+  id: "cli:pane:list",
+  result: {
+    type: "pane_list",
+    panes: [
+      { pane_id: "w1:p1", agent_status: "unknown" },
+      {
+        pane_id: "w2:p1",
+        agent_session: { agent: "claude", kind: "id", source: "herdr:claude", value: "session-a" },
+      },
+      {
+        pane_id: "w2:p2",
+        agent_session: { agent: "claude", kind: "id", source: "herdr:claude", value: "session-b" },
+      },
+    ],
+  },
+});
+
+describe("findPane", () => {
+  test.each([
+    ["matching session", "session-b", "w2:p2"],
+    ["unknown session", "session-z", null],
+  ])("%s", (_name, sessionId, expected) => {
+    expect(findPane(paneList, sessionId)).toBe(expected);
+  });
+
+  test.each([
+    ["malformed json", "not json"],
+    ["empty output", ""],
+    ["error envelope", JSON.stringify({ error: { code: "server_unavailable" } })],
+  ])("%s yields no pane", (_name, output) => {
+    expect(findPane(output, "session-a")).toBeNull();
+  });
+});
+
+describe("shouldReport", () => {
+  const now = 1_000 * HOUR_MS;
+
+  test.each([
+    ["no cache", null, true],
+    ["same dial, fresh", { sig: "ctx_mid=x", at: now - 1_000 }, false],
+    ["same dial, stale", { sig: "ctx_mid=x", at: now - HOUR_MS }, true],
+    ["different glyph", { sig: "ctx_mid=y", at: now }, true],
+    ["different token", { sig: "ctx_high=x", at: now }, true],
+  ])("%s", (_name, cached, expected) => {
+    expect(shouldReport(cached, "ctx_mid=x", now)).toBe(expected);
+  });
+});
+
+describe("reportArgs", () => {
+  test("sets the live token and clears the other levels", () => {
+    expect(reportArgs("w2:p2", { token: "ctx_high", value: "\u{f0aa2}" })).toMatchInlineSnapshot(`
+      [
+        "pane",
+        "report-metadata",
+        "w2:p2",
+        "--source",
+        "claude-statusline",
+        "--ttl-ms",
+        "86400000",
+        "--token",
+        "ctx_high=󰪢",
+        "--clear-token",
+        "ctx_low",
+        "--clear-token",
+        "ctx_mid",
+        "--clear-token",
+        "ctx_crit",
+      ]
+    `);
+  });
+
+  const levels = CONTEXT_TOKENS.map((token) => [token] as const);
+
+  test.each(levels)("%s clears every other level", (token) => {
+    const args = reportArgs("w2:p2", { token, value: "\u{f0a9e}" });
+    const cleared = args.filter((_arg, i) => args[i - 1] === "--clear-token");
+    expect(cleared).toEqual(CONTEXT_TOKENS.filter((other) => other !== token));
+  });
+});
+
+describe("cachePath", () => {
+  test("keeps a session-scoped file out of the session's own tree", () => {
+    const path = cachePath("4cba0d0a-8875-48eb-b6cd-90874f2a875b");
+    expect(path).toEndWith("claude-context-dial/4cba0d0a-8875-48eb-b6cd-90874f2a875b.json");
+  });
+
+  test("sanitizes a session id that would escape the directory", () => {
+    expect(cachePath("../../etc/passwd")).toEndWith("claude-context-dial/..-..-etc-passwd.json");
+  });
+});

--- a/user/scripts/context-dial.ts
+++ b/user/scripts/context-dial.ts
@@ -1,0 +1,119 @@
+#!/usr/bin/env bun
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// herdr strips control bytes out of reported token values, so a pre-colored
+// value cannot survive: the escape is dropped and its `[32m` residue renders as
+// text. The dial's color therefore has to be the token's *name*, which herdr's
+// sidebar config styles per name. One name carries the glyph at a time and the
+// rest are cleared, so the four here mirror the four `dialColor` levels.
+export const CONTEXT_TOKENS = ["ctx_low", "ctx_mid", "ctx_high", "ctx_crit"] as const;
+
+export type ContextToken = (typeof CONTEXT_TOKENS)[number];
+
+export interface DialReport {
+  token: ContextToken;
+  value: string;
+}
+
+interface CachedReport {
+  sig: string;
+  at: number;
+}
+
+const SOURCE = "claude-statusline";
+const TTL_MS = 86_400_000;
+const REFRESH_MS = 3_600_000;
+const HERDR_TIMEOUT_MS = 5_000;
+const UNSAFE_NAME = /[^A-Za-z0-9._-]+/g;
+
+export function cachePath(sessionId: string): string {
+  return join(tmpdir(), "claude-context-dial", `${sessionId.replace(UNSAFE_NAME, "-")}.json`);
+}
+
+export function shouldReport(cached: CachedReport | null, sig: string, now: number): boolean {
+  if (!cached || cached.sig !== sig) return true;
+  // A herdr restart drops every reported token, and an unconditional cache hit
+  // would leave the sidebar blank until the dial next moves, which can be hours.
+  return now - cached.at >= REFRESH_MS;
+}
+
+export function reportArgs(paneId: string, report: DialReport): string[] {
+  const args = [
+    "pane",
+    "report-metadata",
+    paneId,
+    "--source",
+    SOURCE,
+    "--ttl-ms",
+    String(TTL_MS),
+    "--token",
+    `${report.token}=${report.value}`,
+  ];
+  for (const name of CONTEXT_TOKENS) {
+    if (name !== report.token) args.push("--clear-token", name);
+  }
+  return args;
+}
+
+// `agent_session.value` is the Claude session UUID herdr's integration hook
+// reports, which makes the pane match exact where cwd or title would guess.
+export function findPane(paneList: string, sessionId: string): string | null {
+  let parsed: {
+    result?: { panes?: Array<{ pane_id?: string; agent_session?: { value?: string } }> };
+  };
+  try {
+    parsed = JSON.parse(paneList);
+  } catch {
+    return null;
+  }
+  const pane = parsed.result?.panes?.find((p) => p.agent_session?.value === sessionId);
+  return pane?.pane_id ?? null;
+}
+
+async function readCache(path: string): Promise<CachedReport | null> {
+  try {
+    const cached = JSON.parse(await Bun.file(path).text()) as CachedReport;
+    return typeof cached.sig === "string" && typeof cached.at === "number" ? cached : null;
+  } catch {
+    return null;
+  }
+}
+
+// Called on every status line render, so the steady state has to be a file read
+// and nothing else. Only a changed dial reaches herdr, and it reaches it through
+// a detached child: the status line must render at the same speed whether herdr
+// is fast, slow, or not running.
+export async function reportContextDial(sessionId: string, report: DialReport): Promise<void> {
+  if (!process.env.HERDR_PANE_ID) return;
+
+  const sig = `${report.token}=${report.value}`;
+  const path = cachePath(sessionId);
+  if (!shouldReport(await readCache(path), sig, Date.now())) return;
+
+  // The cache records the attempt rather than the outcome. A herdr that is down
+  // would otherwise turn every later render back into a spawn.
+  await Bun.write(path, JSON.stringify({ sig, at: Date.now() }));
+
+  Bun.spawn([process.execPath, import.meta.path, sessionId, report.token, report.value], {
+    stdio: ["ignore", "ignore", "ignore"],
+  }).unref();
+}
+
+function parseToken(value: string | undefined): ContextToken | null {
+  return CONTEXT_TOKENS.find((token) => token === value) ?? null;
+}
+
+if (import.meta.main) {
+  const [sessionId, token, value] = process.argv.slice(2);
+  const name = parseToken(token);
+  if (sessionId && name && value) {
+    const list = Bun.spawnSync(["herdr", "pane", "list"], { timeout: HERDR_TIMEOUT_MS });
+    const paneId = list.success ? findPane(list.stdout.toString(), sessionId) : null;
+    if (paneId) {
+      Bun.spawnSync(["herdr", ...reportArgs(paneId, { token: name, value })], {
+        timeout: HERDR_TIMEOUT_MS,
+      });
+    }
+  }
+}

--- a/user/scripts/statusline.test.ts
+++ b/user/scripts/statusline.test.ts
@@ -3,8 +3,10 @@ import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ContextToken } from "./context-dial";
 import {
   buildStatusLine,
+  contextDial,
   dialColor,
   dialIndex,
   dialSegment,
@@ -244,6 +246,35 @@ describe("exceeds200k", () => {
     expect(strip(before ?? "")).not.toBe(strip(after ?? ""));
     // The post-compaction dial uses the un-escalated color for its low percentage.
     expect(after).toBe(dialSegment({ context_window: { used_percentage: 10 } }));
+  });
+});
+
+describe("contextDial", () => {
+  test.each<[number, ContextToken]>([
+    [0, "ctx_low"],
+    [39, "ctx_low"],
+    [40, "ctx_mid"],
+    [64, "ctx_mid"],
+    [65, "ctx_high"],
+    [79, "ctx_high"],
+    [80, "ctx_crit"],
+    [100, "ctx_crit"],
+  ])("%i%% reports %s", (pct, token) => {
+    const input = { context_window: { used_percentage: pct } };
+    // The sidebar shows the same glyph the status line renders, minus the color.
+    expect(contextDial(input)).toEqual({ token, value: strip(dialSegment(input) ?? "") });
+  });
+
+  test("carries the exceeds_200k escalation the rendered dial uses", () => {
+    const input = {
+      context_window: { used_percentage: 30, current_usage: { input_tokens: 250_000 } },
+    };
+    expect(contextDial(input)?.token).toBe("ctx_mid");
+    expect(contextDial({ context_window: { used_percentage: 30 } })?.token).toBe("ctx_low");
+  });
+
+  test("reports nothing without a percentage", () => {
+    expect(contextDial({})).toBeNull();
   });
 });
 

--- a/user/scripts/statusline.ts
+++ b/user/scripts/statusline.ts
@@ -2,6 +2,7 @@
 import { mkdirSync } from "node:fs";
 import { basename, dirname } from "node:path";
 import { styleText } from "node:util";
+import { type ContextToken, type DialReport, reportContextDial } from "./context-dial";
 import { effortMarker } from "./effort";
 import { dialGlyph } from "./glyphs";
 import { modelMarker } from "./model";
@@ -15,6 +16,7 @@ interface CurrentUsage {
 }
 
 interface StatusInput {
+  session_id?: string;
   model?: { id?: string; display_name?: string } | null;
   effort?: { level?: string } | null;
   context_window?: { used_percentage?: number | null; current_usage?: CurrentUsage | null };
@@ -117,13 +119,31 @@ export function effortSegment(input: StatusInput): string | null {
   return marker ? configMarker(marker.glyph, marker.isDefault) : null;
 }
 
-export function dialSegment(input: StatusInput): string | null {
+function dialState(input: StatusInput): { color: DialColor; glyph: string } | null {
   const pct = input.context_window?.used_percentage;
   if (pct == null) return null;
 
   const intPct = Math.round(pct);
-  const color = dialColor(intPct, exceeds200k(input));
-  return styleText(color, dialGlyph(dialIndex(intPct)));
+  return { color: dialColor(intPct, exceeds200k(input)), glyph: dialGlyph(dialIndex(intPct)) };
+}
+
+export function dialSegment(input: StatusInput): string | null {
+  const dial = dialState(input);
+  return dial ? styleText(dial.color, dial.glyph) : null;
+}
+
+const DIAL_TOKENS: Record<DialColor, ContextToken> = {
+  green: "ctx_low",
+  yellow: "ctx_mid",
+  redBright: "ctx_high",
+  red: "ctx_crit",
+};
+
+// The same dial herdr's sidebar shows, named by color rather than styled: see
+// `context-dial.ts` for why the color rides on the token name.
+export function contextDial(input: StatusInput): DialReport | null {
+  const dial = dialState(input);
+  return dial ? { token: DIAL_TOKENS[dial.color], value: dial.glyph } : null;
 }
 
 export function linesSegment(input: StatusInput): string | null {
@@ -333,5 +353,14 @@ if (import.meta.main) {
     const parsed = Number(process.env.COLUMNS);
     const columns = Number.isInteger(parsed) && parsed > 0 ? parsed : 80;
     process.stdout.write(buildStatusLine(input, columns, resolveWorktree()));
+
+    const dial = contextDial(input);
+    if (dial && input.session_id) {
+      try {
+        await reportContextDial(input.session_id, dial);
+      } catch {
+        // The sidebar mirror is best-effort, and the line is already written.
+      }
+    }
   }
 }


### PR DESCRIPTION
The status line already knows how full a session's context is, and that answer only exists inside the pane. Reporting it as herdr pane metadata puts the same dial glyph on the sidebar row. A session about to compact becomes visible without switching to it.

herdr strips control bytes out of reported token values. Probing a live pane with `A\x1b[31mB\x1b[39mC` and reading it back through `herdr api snapshot` returns `A[31mB[39mC`. The escape is gone, and its `[31m` residue would render as text. TAB and BEL go the same way, while the Nerd Font codepoint survives.

So the color rides on the token name, and herdr's config styles each name. `dialColor` has four levels, and the fourth is where the `exceeds_200k` escalation lands, so there are four names: `ctx_low`, `ctx_mid`, `ctx_high`, `ctx_crit`. One carries the glyph and the same call clears the other three. The sidebar row config that assigns their colors lives in dotfiles.

Nothing here can cost per-render work. A render compares the dial against a cached signature in the temp dir and stops there. That is the steady state, since `dialIndex` moves eight times across a whole session. Only a changed level goes further, and it goes to a detached child, so a herdr that is slow, hung, or absent cannot delay the line.

Two smaller decisions fall out of that. The cache records the attempt rather than the outcome, because retrying a failed report on the next render is the spawn storm this exists to avoid. A report older than an hour is re-sent anyway: a herdr restart drops every reported token, and pure change-detection would leave the row blank until the dial next moved.

The pane comes from matching the payload's `session_id` against `agent_session.value` in `herdr pane list`. `HERDR_PANE_ID` only gates whether herdr exists at all. The inherited value goes stale after a `pane move`.

Verified against a live pane. The token lands, and changing level replaces it and clears the old one. An unchanged dial sends nothing, confirmed by clearing the token by hand and watching a re-render leave it cleared.

Timing held at ~310 ms/run before and after. Forcing a spawn on every render did not move it. Neither did a `herdr` stub that hangs for 30 seconds.
