### PR TITLE
writing: suppress gen-5 gravity-marker vocabulary

### DIFF
--- a/plugins/writing/detection/tropes.test.ts
+++ b/plugins/writing/detection/tropes.test.ts
@@ -678,7 +678,7 @@ describe("scan", () => {
 
   describe("filler", () => {
     it.each([
-      "It's worth noting that the cache is cold.",
+      "Importantly, the test was skipped.",
       "In terms of latency, it improved.",
     ])("flags: %j", (text) => {
       expect(firstByTier(scan(text), "context")?.category).toBe("filler");
@@ -686,6 +686,23 @@ describe("scan", () => {
 
     it("allows prose without filler markers", () => {
       expect(scan("The cache starts cold.").find((m) => m.category === "filler")).toBeUndefined();
+    });
+  });
+
+  describe("gravity markers", () => {
+    it.each<{ text: string; category: string | undefined }>([
+      { text: "The ordering here is load-bearing.", category: "load-bearing" },
+      { text: "Removing the check breaks the parser.", category: undefined },
+      { text: "The honest answer is the cache never worked.", category: "honest qualifier" },
+      { text: "The prefix keeps the test honest.", category: undefined },
+      { text: "Be honest about the coverage limits.", category: undefined },
+      { text: "Two things worth flagging before this merges.", category: "attention-flag worth" },
+      { text: "It's worth noting that the cache is cold.", category: "attention-flag worth" },
+      { text: "One caveat worth your attention.", category: "attention-flag worth" },
+      { text: "The refactor is worth doing before the freeze.", category: undefined },
+      { text: "The fix is worth confirming against staging.", category: undefined },
+    ])("$text -> $category", ({ text, category }) => {
+      expect(firstByTier(scan(text), "context")?.category).toBe(category);
     });
   });
 

--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -777,6 +777,104 @@ export const PATTERNS: PatternDef[] = [
   },
   {
     tier: "context",
+    layer: "vocabulary",
+    category: "load-bearing",
+    test: /\bload[- ]bearing\b/gi,
+    message: (matched) =>
+      `"${matched}" asserts importance by metaphor. Name the dependency instead: say what breaks or changes without it.`,
+    positives: [
+      "That comment is load-bearing for the retry logic.",
+      "The ordering here is load bearing.",
+    ],
+    negatives: [
+      "Removing the check breaks the parser.",
+      "The retry logic depends on this ordering.",
+    ],
+    evidence:
+      "User-flagged 2026-08 as the flagship gen-5 tell. Corpus audit (gen-5 era, 10.3M assistant chars): 287 hits at 27.8/M versus 3.4/M in typed user text, and several of the user hits are complaints about the word itself. A verify pass judged 43% of sampled uses bare gravity markers with no named load path; even the precise uses read better as a stated dependency.",
+    retire:
+      "Remove when the gen-5+ assistant rate falls under 5/M in a corpus audit window, or when a labeling pass shows most surviving uses name the dependency in-sentence.",
+  },
+  {
+    tier: "context",
+    layer: "vocabulary",
+    category: "honest qualifier",
+    test: /\bhonest\s+(?:(?:caveat|answer|statement|framing|read|assessment|version|number|timeline|headline|option|alternative|take)s?|summar(?:y|ies))\b/gi,
+    message: (matched) =>
+      `"${matched}" claims candor instead of showing it. Drop "honest" and state the fact; if a competing version is wrong, say what it gets wrong.`,
+    positives: [
+      "The honest answer is the cache never worked.",
+      "One honest caveat: the benchmark only ran once.",
+    ],
+    negatives: ["The prefix keeps the test honest.", "Be honest about the coverage limits."],
+    evidence:
+      "Gen-5 corpus audit 2026-08: bare 'honest' runs 16.8/M assistant versus 3.7/M user, and 59 of 174 hits are the self-crediting noun frame (honest caveat/answer/statement/framing). Every sampled instance of the frame survived deletion of the adjective with no loss. The frame regex targets that shape and structurally spares the precise idioms ('keeps X honest', 'be honest about') and the instructed manner adverb ('report that honestly').",
+    retire:
+      "Remove when the noun-frame rate falls under 2/M in a corpus audit window. Extend the noun list only from corpus hits, never speculatively.",
+  },
+  {
+    tier: "context",
+    layer: "vocabulary",
+    category: "attention-flag worth",
+    test: /\bworth\s+(?:noting|knowing|flagging|mentioning|saying|stating|naming|recording|remembering|a\s+look|your\s+(?:attention|awareness|time|call))\b/gi,
+    message: (matched) =>
+      `"${matched}" announces that a point matters instead of making it. Cut the wrapper and state the point.`,
+    positives: [
+      "Two things worth flagging before this merges.",
+      "Also worth noting for the rollout: the flag defaults off.",
+      "One caveat worth your attention.",
+    ],
+    negatives: [
+      "The refactor is worth doing before the freeze.",
+      "That tradeoff is not worth it.",
+      "The fix is worth confirming against staging.",
+    ],
+    evidence:
+      "Gen-5 corpus audit 2026-08: the attention-flag frame (worth noting/knowing/flagging/your attention) runs 52.6/M assistant versus 2.9/M typed user (16.6x) across 166 sessions, and a verify pass found the wrapper deletable in every sampled case. The frame regex targets the flag lead-in and leaves cost-benefit judgments (worth doing/fixing/checking/it) unmatched. Subsumes the retired 'it's worth noting that' filler alternative.",
+    retire:
+      "Remove when the frame rate falls to the typed-user baseline in a corpus audit window, or when a labeling pass shows the frame mostly preceding genuinely optional asides.",
+  },
+  {
+    tier: "context",
+    layer: "vocabulary",
+    category: "full picture",
+    test: /\b(?:(?:full|complete|whole|real|bigger|clearer?)\s+picture|(?:chang(?:es?|ed|ing)|shift(?:s|ed|ing)?|complet(?:es?|ed|ing))\s+the\s+picture)\b/gi,
+    skillOnly: true,
+    message: (matched) =>
+      `"${matched}" is a transition marker that defers the substance. Say what you learned or what changed.`,
+    positives: [
+      "After the third log read I have a complete picture.",
+      "That stack trace changed the picture.",
+    ],
+    negatives: ["The picture shows the login screen.", "A reviewer would picture the whole flow."],
+    evidence:
+      "Gen-5 corpus audit 2026-08: 96 of 159 'picture' hits sit in two fixed frames (full/complete/whole picture, changes the picture), running 15.4/M assistant versus 3.7/M user, almost always as preamble before the actual finding. Zero hits in the deliverable sample, so it ships skillOnly: the hook never sees the chat surface where it lives.",
+    retire:
+      "Remove if a later corpus pass shows the frame rate collapsed, or fold into a chat-voice rewrite pass if one ships. Do not promote to hook while deliverable hits stay near zero.",
+  },
+  {
+    tier: "context",
+    layer: "vocabulary",
+    category: "abstract story",
+    test: /\b(?:rollback|cleanup|migration|error|consumer|state|budget|ingest|deletion|upgrade|onboarding|testing|deploy(?:ment)?|win)\s+stor(?:y|ies)\b/gi,
+    skillOnly: true,
+    message: (matched) =>
+      `"${matched}" dresses up a plain referent. Name the thing: the rollback plan, the cleanup path, the error handling.`,
+    positives: [
+      "The migration story gets messy across major versions.",
+      "This improves the rollback story.",
+    ],
+    negatives: [
+      "The Storybook story renders the grid.",
+      "The user story covers the checkout flow.",
+    ],
+    evidence:
+      "Gen-5 corpus audit 2026-08: raw 'story' hits (415) are dominated by Storybook and agile user-story senses, so the noun list enumerates the abstraction frame's observed heads (rollback/cleanup/budget/ingest/consumer/state story, ~30 hits, chat-dominant). Ships skillOnly: low volume and no deliverable presence.",
+    retire:
+      "Drop head nouns that stop appearing in corpus audits. Remove the pattern when the frame stops recurring in chat output, or if the enumerated list needs constant extension to keep up (allowlist churn signals the wrong detector shape).",
+  },
+  {
+    tier: "context",
     layer: "grammar",
     category: "hedging observation",
     test: /\b(?:looks|appears|seems)\s+(?:like|to)\b/gi,
@@ -793,12 +891,12 @@ export const PATTERNS: PatternDef[] = [
     tier: "context",
     layer: "vocabulary",
     category: "filler",
-    test: /\b(?:it's worth noting that|importantly|interestingly|it should be noted|as mentioned|in terms of)\b/gi,
+    test: /\b(?:importantly|interestingly|it should be noted|as mentioned|in terms of)\b/gi,
     message: (matched) => `"${matched}" is filler. Cut it.`,
-    positives: ["It's worth noting that the cache is cold.", "Importantly, the test was skipped."],
+    positives: ["Interestingly, the cache is cold.", "Importantly, the test was skipped."],
     negatives: ["The cache is cold.", "Note that the test was skipped."],
     evidence:
-      "Pre-dates the curation principle; no corpus evidence recorded. Retained as a vocabulary-level filler gate covering common AI preamble phrases.",
+      "Pre-dates the curation principle; no corpus evidence recorded. Retained as a vocabulary-level filler gate covering common AI preamble phrases. The 'it's worth noting that' alternative moved to the attention-flag worth pattern, whose frame regex covers it with corpus evidence.",
     retire:
       "Remove or migrate individual entries to vocabulary.txt after per-entry corpus audit confirms distinctiveness.",
   },

--- a/plugins/writing/skills/writing/SKILL.md
+++ b/plugins/writing/skills/writing/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 
 ## Patterns to Avoid
 
-The hook enforces these automatically. Specific vocabulary and marketing-verb lists live in [`wordlists/`](../../wordlists/).
+The hook enforces most of these automatically; the rest ship in the scan and review skills. Specific vocabulary and marketing-verb lists live in [`wordlists/`](../../wordlists/).
 
 #### Structure
 
@@ -25,6 +25,7 @@ The hook enforces these automatically. Specific vocabulary and marketing-verb li
 - Don't write "reaching for X." Use "use X" or "prefer X over Y."
 - Don't write "dig into" / "dive into." Name what you're looking at.
 - Hedging verbs ("looks like", "appears to", "seems to") are vague. State directly or name the uncertainty.
+- No gravity markers. "Load-bearing", "the honest answer", "worth noting/flagging", "the full picture", and "the cleanup story" all assert that something matters instead of saying why. Replace each with its substance: name what breaks without the dependency, state the fact plainly, make the point without announcing it.
 
 #### PR and Review Prose
 


### PR DESCRIPTION
Gen-5 models lean on a new family of slippery vocabulary: words that assert importance or candor without adding information, with "load-bearing" as the flagship. This remines the session corpus for that family and adds detectors for the tells the evidence supports.

The mining ran over the gen-5 era (June through August, 10.3M chars of assistant text) in two stages. Sonnet miners read sampled chat and deliverable chunks. Opus verifiers then pulled per-term concordance and rates from the full index against a typed-user baseline that filters out pasted model prose.

Three frames cleared the bar for the hook:

- `load-bearing`: 27.8/M assistant vs 3.4/M user
- the `honest <noun>` qualifier ("honest caveat/answer/statement"): the adjective deleted cleanly in every sampled use
- the `worth noting/knowing/flagging` attention flag: 16.6x the user rate across 166 sessions, subsuming the old `it's worth noting that` filler alternative

Two chat-dominant frames ship `skillOnly` since the hook never sees chat: `full picture` and the `<abstract> story` construction (rollback/cleanup/budget story), whose head nouns are enumerated to spare Storybook and agile senses. A companion bullet in `writing:writing` covers the chat surface the hook cannot reach.

Each detector is frame-scoped rather than bare-token so the precise senses survive: "keeps the test honest", "worth doing", and cost-benefit "worth your money" all stay unmatched. Candidates the verify pass showed to be mostly legitimate or shared vocabulary stayed out: "genuinely"/"genuine" (mostly real contrastive work), "real" (mock-vs-live contrasts), "shape", "framing", and "trap".

One known tradeoff: "error story"/"state story" can collide with literal Storybook story names in UI repos. The pattern is batch-only and its retire clause treats allowlist churn as the removal signal.
