### PR TITLE
session: run documented scripts through bun

### DIFF
--- a/plugins/claude-code/skills/session/SKILL.md
+++ b/plugins/claude-code/skills/session/SKILL.md
@@ -30,7 +30,7 @@ The session index is a DuckDB database at `${CLAUDE_PLUGIN_DATA}/session.duckdb`
 Run `refresh.ts` before querying. It scans `~/.claude/projects/**/*.jsonl` plus any imported hosts, imports files whose mtime or size changed, drops rows for deleted files, and prints the DB path. When a prior refresh finished within `--max-age` (default 300 seconds), it prints the path and exits without opening the database, so calling it before every query is cheap. Pass `--refresh` to rescan regardless when the user asks for the latest data.
 
 ```bash
-${CLAUDE_SKILL_DIR}/scripts/refresh.ts
+bun ${CLAUDE_SKILL_DIR}/scripts/refresh.ts
 ```
 
 ### Querying

--- a/plugins/claude-code/skills/session/references/cross-machine.md
+++ b/plugins/claude-code/skills/session/references/cross-machine.md
@@ -5,7 +5,7 @@ Procedures for listing, importing, re-syncing, and forgetting another machine's 
 ## Listing Hosts
 
 ```bash
-${CLAUDE_SKILL_DIR}/scripts/hosts.ts
+bun ${CLAUDE_SKILL_DIR}/scripts/hosts.ts
 ```
 
 Shows each host with its import time, egress policy, last index, rsync source, and a ready-to-run re-sync command.
@@ -18,7 +18,7 @@ Copy the source machine's `~/.claude/projects/` into the import root, then regis
 mkdir -p ~/.claude/session-imports/<label>/projects
 rsync -avn --update <user@host>:.claude/projects/ ~/.claude/session-imports/<label>/projects/   # dry run
 rsync -av  --update <user@host>:.claude/projects/ ~/.claude/session-imports/<label>/projects/   # real copy
-${CLAUDE_SKILL_DIR}/scripts/import.ts --host <label> --source '<user@host>:.claude/projects/'
+bun ${CLAUDE_SKILL_DIR}/scripts/import.ts --host <label> --source '<user@host>:.claude/projects/'
 ```
 
 `import.ts` writes a manifest (dirs `0700`, manifest `0600`) recording the label, `--source`, and egress policy, then re-indexes. The whole `projects/` tree is copied even though only `*.jsonl` is indexed, because that tree is also the re-sync unit.
@@ -29,7 +29,7 @@ The source stored in the manifest doubles as the re-sync input, so refreshing is
 
 ```bash
 rsync -av --update <source> ~/.claude/session-imports/<label>/projects/
-${CLAUDE_SKILL_DIR}/scripts/import.ts --host <label>
+bun ${CLAUDE_SKILL_DIR}/scripts/import.ts --host <label>
 ```
 
 Re-running `import.ts` on a registered host leaves its manifest intact and re-indexes only the changed files. Change detection is a per-file catalog keyed on path plus (mtime, size), so `rsync -a` preserving old source mtimes is not a problem: a newly delivered file is a new path, and an updated file differs in mtime or size. `hosts.ts` prints the exact line per host.
@@ -37,7 +37,7 @@ Re-running `import.ts` on a registered host leaves its manifest intact and re-in
 ## Forgetting a Machine
 
 ```bash
-${CLAUDE_SKILL_DIR}/scripts/forget.ts --host <label>
+bun ${CLAUDE_SKILL_DIR}/scripts/forget.ts --host <label>
 ```
 
 Deletes the host's rows from the index and removes its synced files. `local` cannot be forgotten.


### PR DESCRIPTION
Prefixes `bun` on the five bare-path script invocations in the session skill's docs. Bare-path execution of a `.ts` script reliably trips Claude Code's permission classifier. The `bun` form never does.

The session index shows 7 direct-path `refresh.ts` invocations over 60 days, spanning 5 plugin-cache versions, every one requiring `dangerouslyDisableSandbox`. Two of them failed outright with an approval refusal, most recently in the discover run that filed this task. That run was refused twice, the second time with the bypass already set, and then succeeded immediately when the same path was run through `bun`.

The `mac` plugin's bypass marker is not the gap. `plugins/mac/hooks/sandbox.ts` treats a bare `.ts` path and a `bun`-prefixed one identically for marker detection, and `refresh.ts` already carries the marker and the executable bit. The refusal comes from the classifier, upstream of the marker.

The change is additive. Each script runs through its own `#!/usr/bin/env bun` shebang either way, and nothing depends on the bare form. These five were the only bare-path invocations left in any skill doc; the other 49 script blocks across skills already prefix `bun`.

To confirm the diagnosis was right rather than coincidental, `sandbox_bypasses` and `tool_errors` should show no further approval failures against these five scripts.

Original Task: https://things.bendrucker.me/show?id=12zTxRsne5uqFcfPt1VL7m
