### PR TITLE
docs: point the inventory paragraph at the trigger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This repository contains my personal Claude Code configuration and a plugin mark
 
 ## Inventory
 
-`bun run inventory [kind]` lists the repository's Claude Code assets, so "which skills exist", "what registers a `Stop` hook", or "which plugins ship agents" takes one command instead of a glob sweep. Kinds: `summary` (default), `plugins`, `skills`, `agents`, `commands`, `hooks`, `rules`, `mcp`. Rows carry the asset's path and its scope (`plugins/`, `user/`, or `.claude/`), so a listing is the starting point for a `Read` or a narrowed `grep`. `--help` covers the flags.
+Answer any repo-wide "which X exists" question with `bun run inventory [kind]` before globbing or grepping `plugins/`, `skills/`, `hooks/`, or `agents/`. Rows carry each asset's path and scope, so the listing is where a `Read` or a narrowed `grep` starts. `bun run inventory --help` covers the kinds and flags.
 
 ## User
 


### PR DESCRIPTION
Rewrites the `## Inventory` paragraph in `CLAUDE.md` so it names when to run the CLI instead of describing what the CLI is.

The paragraph loads on every session that touches this repo, so the curation rule wants evidence it earns that. The session index over the 10 days since the CLI shipped says it half does. `bun run inventory` ran 18 times, but across only 4 of the 20 repo-touching sessions, and `plugins/` enumeration sweeps fell from 44.8 per session to 36.5 against the preceding 11 days. The tool is running alongside globbing rather than displacing it, which is a wording problem rather than a reason to delete either the paragraph or the script.

So the first sentence is now an instruction with a trigger attached: a repo-wide "which X exists" question starts here, before any `Glob` or `Grep` over `plugins/`, `skills/`, `hooks/`, or `agents/`. The kind catalog moves out to `bun run inventory --help`, which already lists every kind, and the paragraph gets shorter in the process.

Re-check in 3-4 weeks with the same query. If sweeps per session stay flat while invocations rise, the paragraph is inert and it and `scripts/inventory` should be removed together.

Original Task: https://things.bendrucker.me/show?id=EwAQ1VkytGbfE984DNnbSf
