### PR TITLE
settings: disable the tmux plugin

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -431,7 +431,6 @@
     "worktrunk@worktrunk": true,
     "plan@bendrucker": true,
     "linear-cli@linear-cli": true,
-    "tmux@bendrucker": true,
     "bun@bendrucker": true,
     "mermaid@bendrucker": true,
     "typescript-lsp@claude-plugins-official": true,


### PR DESCRIPTION
Drops `tmux@bendrucker` from `enabledPlugins`. The migration to herdr is done, so the plugin's `SessionStart` context hook, its two notification hooks, and its skill description stop costing anything per session.

The session index had been holding this back on a technicality. The rule was a quiet week on both machines, and the work host's corpus ended 2026-08-07 on a day it ran an operational `tmux list-panes -a`, so it never produced one. Everything else pointed the same direction: 353 herdr commands against 1 tmux locally last week, and that single hit was a `which herdr zoxide zellij tmux` probe. `tmux:tmux` has not been invoked on either machine since 2026-07-27. The stale-data caveat is moot now that the migration is settled.

Disabled rather than deleted. The plugin stays in the repo and in `marketplace.json`, so anyone installing `tmux@bendrucker` still gets it, and flipping this back is one line. A follow-up decides whether to remove it outright.

The four `Bash(tmux ...)` permissions and the `~/.tmux` socket entries stay as they are. `review:tuicr` drives tmux directly and does not go through this plugin, so stripping them would break it.

Original Task: https://things.bendrucker.me/show?id=EDqTGKULCyQg4XMWdG6xtg
