### PR TITLE
writing: scope the active-voice rule to PR prose

### DIFF
--- a/plugins/writing/skills/writing/SKILL.md
+++ b/plugins/writing/skills/writing/SKILL.md
@@ -29,7 +29,7 @@ The hook enforces most of these automatically; the rest ship in the scan and rev
 
 #### PR and Review Prose
 
-- Active voice. Not "X is added" but "Adds X."
+- Active voice in PR and review prose. Not "X is added" but "Adds X." Commit subjects take the imperative: "Add X".
 - Not "Tests cover X" but "Added tests covering X."
 - No trailing hedge adverbs ("regardless.", "nonetheless.").
 - No cross-sentence negation ("It isn't X. It is Y."). Combine or drop the negation.


### PR DESCRIPTION
Scopes the active-voice bullet in `writing:writing` to PR and review prose, and names the commit case on the same line.

The skill's frontmatter advertises it for commit messages, but its only mood rule lived under `#### PR and Review Prose` and read `Active voice. Not "X is added" but "Adds X."` A session that loads the skill to write a commit gets pointed at `Adds timeout to request`, which is exactly the form the imperative test rejects. "If applied, this commit will Adds timeout" does not parse. The heading scopes the bullet correctly, but nothing states the commit case, so the scoping is left to inference.

No defect prompted this. Across 1115 subjects on `main` there are 0 third-person or past-tense openers, and across 381 branch commits there is 1, from Renovate. The imperative already holds without an instruction, most likely because the commit flow reads recent log entries and matches them.

So this buys internal consistency in a skill that claims commit messages, and it is priced accordingly: one line reworded, no new heading, no new bullet.

The measurement doubles as the removal trigger. Re-run it in a few months, and if it still reads 0, or if the `Adds X` bullet is ever narrowed or dropped, take the clause out.

```bash
git log --format='%s' | sed -E 's/^[a-z0-9:_/-]+: //' \
  | grep -icE '^(adds|added|adding|fixes|fixed|fixing|updates|updated|updating|removes|removed|removing|changes|changed|changing|makes|made|refactors|refactored|implements|implemented|drops|dropped) '
```

This came out of two commit-message articles sitting in my inbox. Everything else in them was already covered: `sections.md` is a strict superset of their PR-body advice, and the blank-line rule falls out of the repeated `-m` flags. The line-wrapping guidance stays unadopted.
