### PR TITLE
writing: portability test and rewrite check

### DIFF
--- a/plugins/writing/skills/rewrite/SKILL.md
+++ b/plugins/writing/skills/rewrite/SKILL.md
@@ -18,6 +18,8 @@ allowed-tools:
 
 Load the `writing:writing` skill for the style rules, then rewrite the input to match them. Preserve all functional information. Change only voice, word choice, and sentence structure, conveying the same information in fewer, clearer words.
 
+When the input is the user's own writing rather than model output, name its core point and a few voice signals before editing: vocabulary, cadence, bluntness, humor, admitted uncertainty, digressions. Keep that note to yourself and make the smallest edit that clears the tells. Stripping the voice is the goal only when the voice is a model's.
+
 These rules apply on top of that skill:
 
 - Specific verbs over vague ones. "Generates a report" not "handles report generation."
@@ -41,6 +43,10 @@ bun ${CLAUDE_SKILL_DIR}/../scan/scripts/scan.ts --input path/to/file.md
 Fix every hard tell (em dash, copula avoidance, hedging, filler, vocabulary, and the other fixed-phrase categories), then re-run until those are clean.
 
 Treat `marketing verb` findings as advisory. The script flags each one, but the live hook only objects when their weighted sum is high enough, so a lone marketing verb may be fine. Consider each in context and replace the ones that read as promotional rather than driving the count to zero.
+
+## Check
+
+Once the tells are clean, answer the questions in [`references/check.md`](references/check.md) against the rewrite beside the original. They cover the failures a detector cannot see: invented or dropped claims, cutting out of proportion to the slop, and a distinctive sentence flattened for consistency. Fix what fails and re-check.
 
 ## Output
 

--- a/plugins/writing/skills/rewrite/references/check.md
+++ b/plugins/writing/skills/rewrite/references/check.md
@@ -1,0 +1,12 @@
+# Output Check
+
+Questions to answer about the rewritten draft before returning it. `scan.ts` already covers the fixed-phrase categories, so these cover only what a regex cannot see. Read the rewrite beside the original, answer each, fix what fails, then check again.
+
+- Does every claim in the rewrite appear in the original? A rewrite that introduces a fact, a number, a cause, or a hedge has invented it.
+- Does every claim in the original survive? Compression that quietly drops a condition or a caveat changed the meaning, however much better it reads.
+- Is the amount cut proportional to the slop that was there? A paragraph with no tells in it should come back nearly untouched, and heavy edits to one are a sign the rewrite is chasing uniformity rather than fixing anything.
+- Did a sentence get rewritten only to match the ones around it? Distinctiveness is a reason to leave a sentence alone.
+- Does every sentence still carry something the reader did not already have?
+- Would the author recognize this as their own writing?
+
+Failing the last two together is the signature of over-compression: the draft reads well and sounds like no one.

--- a/plugins/writing/skills/writing/SKILL.md
+++ b/plugins/writing/skills/writing/SKILL.md
@@ -42,7 +42,7 @@ The hook enforces most of these automatically; the rest ship in the scan and rev
 
 ## Voice
 
-Direct, conversational. Every sentence should teach something new. Cut words that restate the obvious.
+Direct, conversational. Every sentence should teach something new. Cut words that restate the obvious. A sentence that could move unchanged to another person, company, or product is filler: cut it, or replace it with something true only of this subject.
 
 - Substance over filenames or implementation details
 - Shorter sentences over compound constructions


### PR DESCRIPTION
Takes three mechanisms from [petergyang/no-ai-slop](https://github.com/petergyang/no-ai-slop) after measuring its pattern list and finding the patterns themselves worthless.

Sixteen of its patterns went against the session index, 46.8M assistant characters against 1.3M typed-user characters with a paste filter on the user baseline. Twelve are dead, some with single-digit hit counts across the whole corpus. Two run higher in my own typed text than in the model's, including metadiscourse at eight times the rate. Two clear the rate and lift of the weakest detector already shipped, but both are ordinary adverbs that the source itself only handles by attaching a keep-condition, which a regex hook cannot express.

The participial gloss (", highlighting X") was the leading candidate going in, and it is a well-known model tell. It appears at 0.7 per million in assistant text and 0.8 in mine. A detector for it would fire on my own writing as often as on the model's.

## The Portability Test

`writing:writing` said every sentence should teach something new. That is a standard to judge against. The portability test is a check that can actually be run on a sentence: if it could move unchanged to another person, company, or product, it is filler.

This aims at vacuous specificity, which is the complaint that tops my feedback list. One line, in the always-loaded skill.

## Voice Preservation on My Own Drafts

`writing:rewrite` licensed changing voice, word choice, and sentence structure on any input. That is right for model output, where stripping the voice is the entire point, and wrong for my own draft, where it is the thing being destroyed.

It now names the core point and a few voice signals first, then makes the smallest edit that clears the tells. Scoped to the case where the input is mine.

## Output Check

The rewrite loop ran `scan.ts` before and after, closing over the regex categories and nothing else. Nothing asked whether the rewrite kept the meaning.

`references/check.md` covers what a detector cannot see: claims invented or dropped, cutting out of proportion to the slop that was there, a distinctive sentence flattened to match the ones around it. It sits between Lint and Output, parallel to how the judge in `writing:analyze` reaches the meaning layer that `tropes.ts` cannot.

## Removal Trigger

Drop the portability line if a `pr-body` A/B shows no movement on the vacuous-specificity axis. That harness already scores the dimension, so the check is cheap.

`evals/writing/` has `mine.ts` and the label server but no scorer or judge, so it cannot score the two rewrite changes today. The labeling pass is what would measure them.

Original Task: https://things.bendrucker.me/show?id=CZaLy3UkCyJ959DJ7GoBgn
