### PR TITLE
x-callback-url: bound the callback wait

### DIFF
--- a/plugins/things/CLAUDE.md
+++ b/plugins/things/CLAUDE.md
@@ -31,7 +31,9 @@ Biome linting is disabled for `scripts/jxa/` files via the root `biome.json` ove
 
 `reorder.ts` and `inbox.ts` are bun TypeScript scripts (not `osascript`). Their Launch Services handoff runs outside the command sandbox via the `claude:dangerouslyDisableSandbox` marker.
 
-The x-callback-url bridge needs `CLAUDE_PLUGIN_DATA` to locate its `.app` bundle, and Claude Code does not export it to Bash tool calls. The `things:url` skill sets it on every documented invocation, where the substitution has already resolved it, and the three scripts inherit it. Keep that prefix on any new documented command, or the callback is lost and `dispatch` silently falls back to `open`.
+The x-callback-url bridge needs `CLAUDE_PLUGIN_DATA` to locate its `.app` bundle, and Claude Code does not export it to Bash tool calls. The `things:url` skill sets it on every documented invocation, where the substitution has already resolved it, and the three scripts inherit it. Keep that prefix on any new documented command, or the callback is lost and `dispatch` falls back to `open`.
+
+A degraded dispatch is no longer silent. `dispatch` returns a `fallbackReason` naming why no id came back (runner missing, bridge build failed, callback timed out, app error) plus the runner's `fallbackDetail` stderr, and `warnFallback` prints both. Every caller of `dispatch` should pass its result through `warnFallback`, because the alternative is a write that lands with no id and no explanation.
 
 ## What NOT to Do
 

--- a/plugins/things/scripts/inbox.ts
+++ b/plugins/things/scripts/inbox.ts
@@ -4,7 +4,7 @@
 import { cli } from "cleye";
 import { ensureThingsRunning } from "./ensure-running";
 import { mergeTags, parseTags } from "./tags";
-import { dispatch } from "./url";
+import { dispatch, warnFallback } from "./url";
 
 const INBOX_PARAMS = new Set(["title", "titles", "notes", "tags", "checklist-items"]);
 
@@ -78,6 +78,7 @@ if (import.meta.main) {
     if (result.id) {
       console.log(`https://things.bendrucker.me/show?id=${result.id}`);
     } else {
+      warnFallback(result);
       printCaptured(params);
     }
   } catch (error) {

--- a/plugins/things/scripts/reorder.ts
+++ b/plugins/things/scripts/reorder.ts
@@ -3,7 +3,7 @@
 
 import { cli } from "cleye";
 import { ensureThingsRunning } from "./ensure-running";
-import { dispatch } from "./url";
+import { dispatch, warnFallback } from "./url";
 
 const INTERMEDIATE_LIST: Record<string, string> = {
   today: "anytime",
@@ -24,7 +24,9 @@ async function updateWhen(ids: string[], when: string): Promise<void> {
       })),
     ),
   );
-  await dispatch("json", params);
+  // Reordering moves the todos out of the list and back, so the second update
+  // must land after the first. A fire-and-forget open guarantees no such order.
+  warnFallback(await dispatch("json", params));
 }
 
 async function reorder(targetList: string, ids: string[]): Promise<void> {

--- a/plugins/things/scripts/url.test.ts
+++ b/plugins/things/scripts/url.test.ts
@@ -5,6 +5,7 @@ import {
   type DispatchActions,
   dispatch,
   isSandboxBlockedHandoff,
+  XcallError,
 } from "./url";
 
 describe("buildJsonPayload", () => {
@@ -173,7 +174,13 @@ describe("dispatch", () => {
 
     const result = await dispatch("add", new Map([["title", "Buy milk"]]), actions);
 
-    expect(result).toEqual({ id: "ABC123", output: expect.any(String), viaXcall: true });
+    expect(result).toEqual({
+      id: "ABC123",
+      output: expect.any(String),
+      viaXcall: true,
+      fallbackReason: null,
+      fallbackDetail: null,
+    });
     expect(calls.open).toEqual([]);
     expect(calls.xcall[0]).toContain("things:///add?");
   });
@@ -192,21 +199,44 @@ describe("dispatch", () => {
 
     const result = await dispatch("add", new Map([["title", "Buy milk"]]), actions);
 
-    expect(result).toEqual({ id: null, output: null, viaXcall: false });
+    expect(result).toEqual({
+      id: null,
+      output: null,
+      viaXcall: false,
+      fallbackReason: "the x-callback-url runner was not found",
+      fallbackDetail: null,
+    });
     expect(calls.xcall).toEqual([]);
     expect(calls.open).toEqual(["add"]);
   });
 
-  test("falls back to openUrl when xcall throws", async () => {
+  test.each<[string, Error, string, string | null]>([
+    [
+      "build failure",
+      new XcallError(3, "swiftc: error: Operation not permitted\n"),
+      "the x-callback-url bridge failed to build",
+      "swiftc: error: Operation not permitted",
+    ],
+    [
+      "callback timeout",
+      new XcallError(4, "xcall gave up after 20s\n"),
+      "the x-callback-url bridge timed out waiting for Things to call back",
+      "xcall gave up after 20s",
+    ],
+    ["app error", new XcallError(1, ""), "xcall exited 1", null],
+    ["non-xcall error", new Error("spawn blew up"), "spawn blew up", null],
+  ])("falls back to openUrl and reports a %s", async (_name, thrown, reason, detail) => {
     const { actions, calls } = trackingActions({
       xcall: async () => {
-        throw new Error("xcall failed (exit 1)");
+        throw thrown;
       },
     });
 
     const result = await dispatch("add", new Map([["title", "Buy milk"]]), actions);
 
     expect(result.viaXcall).toBe(false);
+    expect(result.fallbackReason).toBe(reason);
+    expect(result.fallbackDetail).toBe(detail);
     expect(calls.open).toEqual(["add"]);
   });
 

--- a/plugins/things/scripts/url.ts
+++ b/plugins/things/scripts/url.ts
@@ -173,11 +173,55 @@ export function buildJsonPayload(ids: string[], attributes: Record<string, strin
   return JSON.stringify(data);
 }
 
+/** run.sh statuses that mean the bridge never reached the app. */
+const XCALL_BUILD_FAILED = 3;
+const XCALL_TIMED_OUT = 4;
+
+/**
+ * Backstop for a runner that dies without honoring its own watchdog. It must
+ * exceed a cold Swift build plus run.sh's XCALL_TIMEOUT_SECONDS, or it preempts
+ * the runner's own bounded failure and hides the reason.
+ */
+const XCALL_BACKSTOP_MS = 45_000;
+
+export class XcallError extends Error {
+  constructor(
+    readonly exitCode: number,
+    readonly stderr: string,
+  ) {
+    super(`xcall failed (exit ${exitCode})`);
+    this.name = "XcallError";
+  }
+}
+
+/** Names an xcall failure in one clause, for a "no id because ..." sentence. */
+export function describeXcallFailure(error: unknown): string {
+  if (!(error instanceof XcallError)) {
+    return error instanceof Error ? error.message : String(error);
+  }
+
+  switch (error.exitCode) {
+    case XCALL_BUILD_FAILED:
+      return "the x-callback-url bridge failed to build";
+    case XCALL_TIMED_OUT:
+      return "the x-callback-url bridge timed out waiting for Things to call back";
+    default:
+      return `xcall exited ${error.exitCode}`;
+  }
+}
+
 async function xcall(runner: string, url: string): Promise<string> {
-  const proc = Bun.spawn([runner, url], { stdout: "pipe", timeout: 10_000 });
-  const text = await new Response(proc.stdout).text();
+  const proc = Bun.spawn([runner, url], {
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: XCALL_BACKSTOP_MS,
+  });
+  const [text, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
   const code = await proc.exited;
-  if (code !== 0) throw new Error(`xcall failed (exit ${code})`);
+  if (code !== 0) throw new XcallError(code, stderr);
   return text.trim();
 }
 
@@ -193,6 +237,10 @@ export interface DispatchResult {
   output: string | null;
   /** Whether the call ran via xcall (true) or fell back to Launch Services open (false). */
   viaXcall: boolean;
+  /** Why the call degraded to Launch Services open, or null when it did not. */
+  fallbackReason: string | null;
+  /** Runner stderr behind a degraded call, when it wrote any. */
+  fallbackDetail: string | null;
 }
 
 /**
@@ -210,7 +258,9 @@ const defaultActions: DispatchActions = { findXcallRunner, xcall, openUrl };
 /**
  * Builds the Things URL for an action, runs it through xcall when the
  * x-callback-url runner is available, and falls back to a Launch Services open
- * on any xcall failure. Returns the parsed todo id when xcall surfaced one.
+ * on any xcall failure. Returns the parsed todo id when xcall surfaced one, and
+ * a fallbackReason when it did not, so the caller can say the write landed
+ * without an id instead of degrading silently.
  */
 export async function dispatch(
   command: string,
@@ -218,18 +268,40 @@ export async function dispatch(
   actions: DispatchActions = defaultActions,
 ): Promise<DispatchResult> {
   const runner = await actions.findXcallRunner();
+  let fallbackReason = "the x-callback-url runner was not found";
+  let fallbackDetail: string | null = null;
+
   if (runner) {
     const url = await buildUrl(command, params);
     try {
       const result = await actions.xcall(runner, url);
-      return { id: parseThingsId(result), output: result, viaXcall: true };
-    } catch {
-      // fall through to Launch Services
+      return {
+        id: parseThingsId(result),
+        output: result,
+        viaXcall: true,
+        fallbackReason: null,
+        fallbackDetail: null,
+      };
+    } catch (error) {
+      fallbackReason = describeXcallFailure(error);
+      fallbackDetail = error instanceof XcallError ? error.stderr.trim() || null : null;
     }
   }
 
   await actions.openUrl(command, params);
-  return { id: null, output: null, viaXcall: false };
+  return { id: null, output: null, viaXcall: false, fallbackReason, fallbackDetail };
+}
+
+/**
+ * Reports a degraded dispatch on stderr. The write still landed through Launch
+ * Services, so this is a warning rather than a failure.
+ */
+export function warnFallback(result: DispatchResult): void {
+  if (result.fallbackReason === null) return;
+  console.error(
+    `warning: no todo id available because ${result.fallbackReason}. The change was sent fire-and-forget via open.`,
+  );
+  if (result.fallbackDetail) console.error(result.fallbackDetail);
 }
 
 if (import.meta.main) {
@@ -280,6 +352,7 @@ if (import.meta.main) {
     if (result.output !== null) {
       console.log(result.output);
     }
+    if (argv.flags.callback) warnFallback(result);
   } else {
     const singleId = ids[0];
     if (singleId) {
@@ -289,5 +362,6 @@ if (import.meta.main) {
     if (result.output !== null) {
       console.log(result.output);
     }
+    if (argv.flags.callback) warnFallback(result);
   }
 }

--- a/plugins/x-callback-url/README.md
+++ b/plugins/x-callback-url/README.md
@@ -12,6 +12,8 @@ Call x-callback-url schemes from the CLI and receive responses synchronously.
 
 - `scripts/main.swift` — Swift source for the xcall bridge
 - `scripts/build.sh` — Compiles Swift source into `.app` bundle with URL scheme registration
-- `scripts/run.sh` — Build-if-needed + invoke wrapper
+- `scripts/run.sh` — Build-if-needed + invoke wrapper, with the watchdog that bounds the callback wait
 
 The bundle is installed to `$CLAUDE_PLUGIN_DATA`. Claude Code does not export that variable to Bash tool calls, so a consuming skill sets it on the command it documents.
+
+Both shell scripts carry the `mac` plugin's `claude:dangerouslyDisableSandbox` marker. The command sandbox blocks the compile and the URL-scheme round trip alike, and a sandboxed `xcall` hangs instead of failing, so `run.sh` bounds the wait at `XCALL_TIMEOUT_SECONDS` (default 20) and exits 4.

--- a/plugins/x-callback-url/scripts/build.sh
+++ b/plugins/x-callback-url/scripts/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# claude:dangerouslyDisableSandbox: swiftc writes the bundle under ~/.claude/plugins, which the command sandbox denies
 set -euo pipefail
 
 # Build xcall.app — a macOS .app bundle for x-callback-url bridging.

--- a/plugins/x-callback-url/scripts/run.sh
+++ b/plugins/x-callback-url/scripts/run.sh
@@ -1,16 +1,54 @@
 #!/bin/bash
+# claude:dangerouslyDisableSandbox: compiles the bridge into the plugin data dir and hands off to Launch Services, both of which the command sandbox blocks
 set -euo pipefail
 
 # Exit 3 separates a build failure from xcall's own exit codes (0 success,
-# 1 x-error, 2 x-cancel). Callers treat any non-zero status as "no result", so
-# without it a broken build is indistinguishable from the target app rejecting
-# the request.
+# 1 x-error, 2 x-cancel). Exit 4 separates a wait that ran out of time. Callers
+# treat any non-zero status as "no result", so without them a broken bridge is
+# indistinguishable from the target app rejecting the request.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# xcall's own deadline lives inside applicationDidFinishLaunching, which AppKit
+# never calls when it cannot reach the WindowServer, so the in-process timer is
+# not a guard the bridge can rely on. This watchdog is the one that always runs.
+TIMEOUT_SECONDS="${XCALL_TIMEOUT_SECONDS:-20}"
+KILL_GRACE_SECONDS=2
 
 if ! BINARY="$("$SCRIPT_DIR/build.sh")"; then
   echo "xcall build failed; see errors above" >&2
   exit 3
 fi
 
-exec "$BINARY" "$@"
+"$BINARY" "$@" &
+xcall_pid=$!
+
+(
+  sleep "$TIMEOUT_SECONDS"
+  kill -TERM "$xcall_pid" 2>/dev/null || exit 0
+  sleep "$KILL_GRACE_SECONDS"
+  kill -KILL "$xcall_pid" 2>/dev/null || true
+) &
+watchdog_pid=$!
+
+status=0
+# Redirected so bash's own "Terminated: 15" job notice stays out of the caller's
+# stderr. xcall's own output already reached fd 2 before the wait reaps it.
+wait "$xcall_pid" 2>/dev/null || status=$?
+
+kill "$watchdog_pid" 2>/dev/null || true
+wait "$watchdog_pid" 2>/dev/null || true
+
+# xcall exits 0, 1, or 2 on its own, so any signal status came from the watchdog.
+if [[ $status -gt 128 ]]; then
+  cat >&2 <<EOF
+xcall gave up after ${TIMEOUT_SECONDS}s waiting for a callback on xcall-claude://.
+The command sandbox blocks the URL-scheme round trip, so the callback can never
+arrive from a sandboxed process. Invoke this through a caller carrying the mac
+plugin's claude:dangerouslyDisableSandbox marker, or raise XCALL_TIMEOUT_SECONDS
+if the target app is genuinely slow to answer.
+EOF
+  exit 4
+fi
+
+exit "$status"

--- a/plugins/x-callback-url/skills/xcall/SKILL.md
+++ b/plugins/x-callback-url/skills/xcall/SKILL.md
@@ -17,6 +17,14 @@ Send [x-callback-url](https://x-callback-url.com/) requests from the command lin
 
 Claude Code exports `CLAUDE_PLUGIN_DATA` to hooks and MCP servers but not to Bash tool calls, and `run.sh` is reached both ways. A consuming skill closes that gap by setting the variable on the command it documents, where the substitution has already resolved it. `things:url` does this on every `url.ts`, `inbox.ts`, and `reorder.ts` invocation. `build.sh` never guesses a location of its own, because a second bundle would take the `xcall-claude://` scheme from the first and `lsregister -f` does not take it back.
 
+## Sandbox
+
+Neither half of the bridge survives the command sandbox. `swiftc` cannot write the bundle under `~/.claude/plugins`, and a compiled `xcall` cannot complete the URL-scheme round trip. So `run.sh` and `build.sh` both carry the `mac` plugin's `claude:dangerouslyDisableSandbox` marker, which runs them outside it.
+
+The marker hook reads the script named at the head of a command, past any `VAR=value` prefixes. A wrapper token in front of it (`time`, `env`, `timeout`) hides the script from the hook, the command runs sandboxed, and the callback is lost. Invoke `run.sh` by path with at most environment assignments ahead of it.
+
+A sandboxed `xcall` hangs rather than failing, because its own deadline is scheduled inside `applicationDidFinishLaunching`, which AppKit never calls when it cannot reach the WindowServer. `run.sh` therefore holds the deadline that always runs: it kills the process after `XCALL_TIMEOUT_SECONDS` (default 20) and exits 4.
+
 ## Usage
 
 ```bash
@@ -25,7 +33,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/run.sh "<url>"
 
 **stdout**: `x-success` query string on success
 **stderr**: `x-error` query string or timeout message
-**Exit codes**: 0 = success, 1 = error, 2 = cancel, 3 = build failed
+**Exit codes**: 0 = success, 1 = error, 2 = cancel, 3 = build failed, 4 = timed out waiting for the callback
 
 ## Examples
 
@@ -83,4 +91,4 @@ Apps with their own CLI (e.g., Shortcuts via `shortcuts run`) don't need xcall â
 - `Info.plist`: `CFBundleTypeRole=Editor`, `LSUIElement=true`. `LSBackgroundOnly` is intentionally not set: combining it with `LSUIElement` causes macOS to refuse to route URL scheme callbacks to the app, surfacing as a "no application set" dialog.
 - After building, `build.sh` calls `lsregister -f` and verifies the scheme handler is the freshly built bundle. A bundle left behind at a path an earlier version built into keeps the scheme, and `lsregister -f` does not take it back, so `build.sh` unregisters and deletes that copy before verifying. If verification still fails it exits non-zero.
 - Build is cached â€” recompiles only if `main.swift` is newer than the binary
-- Timeout: 10 seconds
+- Timeouts: `xcall` gives up on the callback after 10 seconds, and `run.sh` kills it after `XCALL_TIMEOUT_SECONDS` (default 20) if it never gets that far


### PR DESCRIPTION
A sandboxed `xcall` never returned. Three independent causes, of which the reported build failure was one.

`xcall` carries a 10s deadline scheduled inside `applicationDidFinishLaunching`. AppKit never calls that method when Seatbelt kills the HIServices XPC connection, so the timer is never armed. An invalid URL proves it: `URL(string:)` fails inside the same delegate method and should exit instantly, and it hung past 20s too. The wait has to be bounded from outside the process. `run.sh` now backgrounds the binary and kills it at `XCALL_TIMEOUT_SECONDS` (default 20, above `xcall`'s own 10 so a normal round trip survives), exiting 4 with a message naming the sandbox, the marker, and the override. Written in bash because `timeout(1)` is not stock macOS.

The build failed sandboxed on two paths. `swiftc` cannot write the bundle under `~/.claude/plugins`, and it cannot write its module cache under `$TMPDIR`. The write profile has no `allowWithinDeny`, so no settings entry reopens either. `run.sh` and `build.sh` take the `mac` plugin's `claude:dangerouslyDisableSandbox` marker instead.

The third cause explains the symptom. The installed binary was months old and no longer completed a round trip even unsandboxed. Every rotated cache dir holds a newer `main.swift`, so `needs_rebuild` stayed permanently true, and every sandboxed call tried to rebuild and died at exit 3. That is the empty stdout on every `things:url` call. A rebuild clears it.

## Error Reporting

`dispatch` treated every failure alike, so a broken bridge and a rejected request both produced empty stdout and no todo id. It now returns `fallbackReason` plus the runner's stderr, printed through `warnFallback` in `url.ts`, `inbox.ts`, and `reorder.ts`. `reorder.ts` needs it most: its two updates must land in order, which `open -g` does not give.

The `Bun.spawn` timeout rises to 45s as a backstop. At 10s it preempts a cold build plus the runner's watchdog and hides the reason.

## Left Undone

`build.sh` still refuses to guess a bundle location, because a second bundle steals `xcall-claude://` and `lsregister -f` will not take it back. A stable directory means `x-callback-url` learning its own `CLAUDE_PLUGIN_DATA`, which Claude Code withholds from a plugin reached as a nested command.

The marker hook reads the script at the head of the command, past `VAR=value` prefixes only. Prefixing with `time`, `env`, or `timeout` hides the marker and the callback is lost silently. Documented in the skill, not enforced.
