### PR TITLE
plan: add drift stamps and assumption stops

### DIFF
--- a/plugins/plan/references/guidelines.md
+++ b/plugins/plan/references/guidelines.md
@@ -49,9 +49,16 @@ Defer naming to implementation when the deliverable is not the code itself (an i
 The plan is a do-now spec for a session that reads nothing else:
 
 - Open with the non-negotiable conventions and a stop condition (implement, ship, end). Without a stop condition, the implementing session absorbs the next job too.
+- Stamp the plan with the commit it was written against (`**Planned at**: commit <short SHA>, <date>`) and make the executor's first instruction a drift check: `git diff --stat <SHA>..HEAD -- <the plan's in-scope paths>`. A `⏰` check-in fires days later against a repo that has moved, and the file records nothing else about what it was true of. When a listed path has changed, compare the plan's excerpts against the live code before executing, and treat a mismatch as an assumption stop.
 - Deferred design goes to a separate linked file the implementer is told not to open, with one pointer line in the plan. A handoff plan heavy with deferred design forces the implementing session to re-plan work the original session never resolved.
 - Resolved decisions and research synthesis move to a companion `<plan>-decisions.md` that the plan links.
 - Keep plans focused and under roughly 10k characters. Past that, plans get rejected: split the scope or consolidate before presenting.
+
+## Assumption Stops
+
+The stop condition above bounds the job. This section bounds the plan's accuracy. It lists the assumptions whose falsification means the plan no longer describes the repo. An implementer that hits one reports back instead of improvising a change nobody approved.
+
+Each entry names something this plan's own reading could have gotten wrong: an excerpt that no longer matches, a call-site count that has changed, a fix that turns out to need a file the plan never listed, a decision resting on a premise the code could contradict. Each ends in a stop instruction. A condition that would read identically in any other plan ("if tests fail", "if something is unclear") lists nothing. Where a repeated verification failure is the risk here, name the verification and the attempt count that ends it. When nothing in the plan rests on an assumption that could be wrong, omit the section.
 
 ## Verification
 


### PR DESCRIPTION
A plan is written against one commit and executed against another. A `⏰` check-in widens that gap to days: the launch URL fires a fresh session at a plan path, and nothing in the plan records what the repo looked like when it was true. Plans now carry a `**Planned at**` stamp naming that commit, and the executor's first instruction is a `git diff --stat <SHA>..HEAD` over the plan's in-scope paths. When a listed path changed, the implementer compares the plan's excerpts against the live code before acting on them.

Adds an Assumption Stops section for the assumptions whose falsification means the plan no longer describes the repo. Plan Shape already asks for a stop condition, but that one bounds the job (implement, ship, end). This one bounds whether the plan still describes reality. The section opens by drawing that line, since the two sit close enough to read as redundant.

Against the section decaying into a template slot, every entry has to come from this plan's own reading: a named excerpt, a call-site count, a decision's premise. A condition that would read identically in any other plan lists nothing. A plan resting on no falsifiable assumption omits the section entirely.

Removal trigger: grep `~/.claude/plans/` for the stamp in a month. If no plan carries it, the guideline never took. If every stamped plan's drift check comes back empty and no check-in-launched session reports a mismatch, the stamp is ceremony. Either way both come out.

Both mechanisms come from shadcn/improve's plan template.
