### PR TITLE
user: defer comment density to the harness

### DIFF
--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -10,7 +10,7 @@
 - Include a trailing newline in all new files.
 - Prefer meaningful anchor text over raw URLs.
 - Use bullet points for lists, checklists if I ask for tasks.
-- Use code comments ONLY to clarify code that is not self-explanatory to OTHER readers. If you need to explain the code, do so in a separate message before editing.
+- When you want to explain code you're writing, put the explanation in a message before the edit.
 - Load the `writing:writing` skill before the first long-form prose you write for others in a context (PR comments, review feedback, documents, issue descriptions, Slack messages). Its tone and style rules must be followed, and they stay in effect for the rest of the session, so one load covers every later piece.
 
 ## Organization


### PR DESCRIPTION
Claude Code's system prompt now ships "Write code that reads like the surrounding code: match its comment density, naming, and idiom." The always-on rule in `user/CLAUDE.md` told Claude to cut comments on those same files. Both sat in every context window, and on a densely commented file they gave opposite answers.

The harmony test in `CLAUDE.md` settles it: a changed harness default encodes usage and eval data we lack, so accommodate it. The density standard moves to `user/rules/code-comments.md`, which is path-injected on code files and states the what-on-dense and why-on-simple carve-outs far more precisely than one always-on line could. `comments:audit` still judges what lands. The deleted clause was the weakest statement of the rule and the only one billing every session in every repo.

What stays in the always-on file is the half nothing else covers: an explanation of code goes in a message before the edit, where you can read it.

Removal trigger: run `comments:audit --base <sha-one-month-back> --report` and count `restate-the-what` verdicts against the comment count preflight reports. If that rate rises over the pre-change baseline, restore the density clause.

`code-comments.md` scopes its `paths` to Python, TypeScript, JavaScript, Go, Rust, SQL, and shell. Terraform, Ruby, Java, and C files now take their comment guidance from the harness line alone, which applies to every language.
