### PR TITLE
review: narrow the altitude angle to two detectors

### DIFF
--- a/plugins/review/skills/code/angles.md
+++ b/plugins/review/skills/code/angles.md
@@ -42,7 +42,13 @@ Flag wasted work the diff introduces: redundant computation or repeated I/O, ind
 
 ## Altitude
 
-Check that each change is implemented at the right depth, not as a fragile bandaid. Special cases layered on shared infrastructure are a sign the fix isn't deep enough — prefer generalizing the underlying mechanism over adding special cases.
+Two shapes, both anchored in what the diff set out to do.
+
+The change does not reach its own goal. Name what the diff prevents, from its commit message, a comment it adds, or the bug it cites, then trace whether the changed line prevents it: a guard added inside a scope the failure escapes, a fix applied at one call site when every caller shares the defective path, a hardcoded list inside a mechanism whose stated purpose is staying current. Cite the path that still reaches the bad state.
+
+The diff creates an invariant nothing enforces where it breaks. An import another module now depends on, a parameter callers must now pass, a required call order, a referenced path that must exist. The type, guard, or anchoring comment sits a level above the code that depends on it. Name the edit or call that violates it and what fails.
+
+Both need a fix inside the code this change introduced. Skip structure the diff did not create, defects whose real fix lives in another repository or another vendor's product, and code that only differs from how its neighbors are organized: a builder to match sibling modules, a lookup table where a branch is, a shared schema over a local guard. Drop a candidate whose own reasoning concedes the current form is a deliberate tradeoff.
 
 ## Conventions (CLAUDE.md)
 


### PR DESCRIPTION
Altitude confirms at 60% and is applied 39% of the time, the weakest angle in the set. The aggregate does not say why, so this reads the individual findings behind it.

Every declined finding falls into one of three shapes:

- Reorganize working code to match a pattern its neighbors follow. A named builder like the sibling modules, a lookup table where a branch is, a shared schema over a local guard. Six of eleven.
- The real fix lives outside the diff. Another repository's shared component, a third-party application, wiring the change never touched. Three of eleven.
- The candidate's own `failure_scenario` concludes the current form is a deliberate tradeoff. Two of eleven.

Every applied finding names one of two things. A change that does not reach its own stated goal, or an invariant the diff created with nothing enforcing it where it breaks. All of them are fixable inside the code the change introduced.

The angle's old text was describing neither. The one detector it named, generalize rather than special-case, produced only declined findings. This replaces it with the two shapes that got acted on and the exclusions the declined ones share, giving Altitude a firing bar like the one Conventions already carries directly below it.

The sample is 21 findings, 18 of them resolved. The shapes are cleaner than the counts are stable.

Removal trigger: re-run `review-precision` in a month. If altitude's `confirmed_pct` and `acted_pct` have not moved toward the other cleanup angles, the narrowing did not work and the angle should be cut rather than tuned again.
