### PR TITLE
grilling: vendor upstream onto AskUserQuestion

### DIFF
--- a/user/skills/grilling/README.md
+++ b/user/skills/grilling/README.md
@@ -1,0 +1,23 @@
+# Grilling
+
+Vendored from [mattpocock/skills](https://github.com/mattpocock/skills/blob/1495d01/skills/productivity/grilling/SKILL.md) at [`1495d01`](https://github.com/mattpocock/skills/commit/1495d01). The design tree, the frontier, the round discipline, and "finding facts is your job" are upstream's. The interview runs through `AskUserQuestion` instead of upstream's `❓ **Q1**` / `➡️` markdown convention, which is why the option and answer-reading rules below exist at all.
+
+Question shape comes from [`../ask/SKILL.md`](../ask/SKILL.md), bang-injected at load time so there is one copy. The `grep` takes the rule bullets and leaves `ask`'s framing sentence behind, since grilling has no preceding prose to convert. Reformatting `ask` away from bullets, or moving it, drops the injection to a one-line fallback rather than silently emitting nothing. Nothing in `SKILL.md` restates an injected rule, so the sections there cover only what rounds add: ordering questions across rounds, option counts, and how to read an answer that rejects its own framing.
+
+## Calibration
+
+The option and answer-reading rules were fit to 1,315 `AskUserQuestion` calls (2,398 individual questions) across 757 sessions in the local session index:
+
+- Custom answers rise with option count: 18.3% at two options, 22.3% at three, 43.3% at four. Three calls errored outright on five or more.
+- A `(Recommended)` label lifts the pick rate from 59.9% (the first-option baseline) to 75.6%.
+- Half of calls (50.7%) batch two to four questions, and individual questions get overridden inside a batch rather than the batch getting rejected whole.
+- 4.2% of calls were rejected outright, which is the whole batch declined. Separately, 4.3% of answers came back `(no option selected) notes: ...`, which is one question overridden inside a batch that was otherwise answered normally.
+- Multi-select answers come back restructured (`"Do #1 + #2 in the MR, file #3-#6 as Linear issues"`) far more than ticked.
+
+The close section's escalation contract copies a shape from plan documents written by hand outside this repo: pre-authorize execution that matches what was agreed, stop on irreversible steps and on unknowns the approach rests on. No template for it lives here.
+
+Two things deliberately left out. There is no section on preventing "you should have asked" complaints, because the corpus contains no instance of one. There is no rule against confirmation-seeking in general, because the pushback sample ("just do it", "you rebase and figure it out!!!") is small and fires only on mechanical or already-stated work.
+
+## Removal
+
+Model-invocable as an experiment, against the usual preference for `disable-model-invocation` on personal skills. The evidence is the split between slash entry and Skill-tool entry for `grilling` in the session index, which `plugins/claude-code/skills/session/resources/queries/skill-auto-vs-explicit.sql` already computes per skill. No Skill-tool entries after roughly four weeks means the natural-language triggers are inert and the recurring catalog cost buys nothing, so the skill goes to `disable-model-invocation: true`.

--- a/user/skills/grilling/SKILL.md
+++ b/user/skills/grilling/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: grilling
+description: Interrogate a plan, decision, or idea round by round until every open decision is settled and nothing is silently assumed. Use when the user says grill me, grill this, stress-test this, poke holes in this, or wants their thinking interrogated before committing to it.
+argument-hint: "[<what to grill>]"
+allowed-tools:
+  - AskUserQuestion
+  - Agent
+---
+
+# Grilling
+
+Interview me about $ARGUMENTS until we reach a shared understanding. Do not act on it until I confirm we have.
+
+Map the subject as a design tree: every decision branches into the decisions that hang off it. The frontier is every decision whose prerequisites are already settled, so its questions can be asked now without guessing at answers you have not heard. Work the frontier in rounds.
+
+The decisions are mine. The facts are yours.
+
+## Question Shape
+
+Every round's questions follow my standing `AskUserQuestion` rules:
+
+!`grep '^- ' ~/.claude/skills/ask/SKILL.md 2>/dev/null || echo '- **Fallback: no rule bullets found in ~/.claude/skills/ask/SKILL.md.** One question per open decision, a recommended option on every question, and split the batch when a follow-up depends on an earlier answer.'`
+
+## Rounds
+
+Ask the whole frontier in one round. `AskUserQuestion` caps a call at four questions, so when the frontier is wider, ask the four whose answers settle the most branches below them and name the deferred ones in prose. A question whose answer depends on another question open in this round belongs to a later round.
+
+Say what the round is deciding before you call the tool. The widget renders the question and its options and nothing else, so the reasoning that led to this round has nowhere else to go.
+
+Never ask whether to proceed. Permission to continue is not a decision.
+
+Each round reshapes the tree. Settled decisions push the frontier outward and unblock what depended on them. Recompute it before asking again.
+
+## Finding Facts
+
+Finding facts is your job. Never ask me for anything the repo, the filesystem, or a CLI can answer. Dispatch an `analyst` subagent on `haiku` or `sonnet` for each lookup and name what you sent it after.
+
+Do not block on it. A running lookup is an unsettled prerequisite, so only the questions downstream of it wait. Ask the rest of the frontier now.
+
+## Options
+
+Three options per question is the target and four is the ceiling. Across 2,398 questions asked this way, four-option questions came back overridden 43% of the time against 18% at two options, and a fifth option errors the call before I ever see it. A decision that needs five positions is two decisions.
+
+Reserve `multiSelect` for coarse picks off a flat list. Where the items interact, I answer by restructuring the set rather than ticking boxes, which means the decision was never a checklist.
+
+## Reading Answers
+
+- A note with no option selected rejects the framing, not the difficulty. Rebuild that branch of the tree. Do not re-ask the same question with the same options.
+- An answer that ignores what you asked and supplies new facts or a scope change is still an answer. Fold it in and keep going.
+- "Just do it", "figure it out", or a bare "yes" ends the round. Either it was already settled in something I said, or it is mechanical. Stop asking and act.
+- I override questions individually inside a batch. A note on one is not a rejection of the others.
+
+## Close
+
+The session ends when the frontier is empty, with every branch visited and nothing left silently assumed. Close it with an escalation contract covering the work we just settled:
+
+```
+Proceed without asking on: <the execution that matches what we agreed>
+Stop and consult on:
+- <each irreversible or outward-facing step>
+- <each unknown the whole approach rests on>
+```
+
+Reversibility and blast radius draw that line, not subject matter. Then wait for me to confirm before acting on any of it.


### PR DESCRIPTION
Adopts [mattpocock's grilling skill](https://github.com/mattpocock/skills/blob/1495d01/skills/productivity/grilling/SKILL.md) at 1495d01, reworked to interview through `AskUserQuestion` instead of upstream's `❓ **Q1**` / `➡️` markdown convention. The design tree, the frontier, and the round discipline carry over unchanged.

Lands in `user/skills/` rather than a marketplace plugin, following `improve-codebase-architecture`, the other vendored skill from that repo. Its README already records dropping upstream's `/grilling` dependency to keep the copy standalone. This fills the gap that left.

The option and answer-reading rules are fit to 1,315 `AskUserQuestion` calls across 757 sessions in the local session index:

- Custom answers run 18.3% at two options and 22.3% at three, then jump to 43.3% at four. Three per question is the target. A fourth reads as a mis-scoped option set rather than a picky user.
- A `(Recommended)` label moves the pick rate from 59.9% to 75.6%. Every question carries one, though the skill does not treat it as settled.
- Multi-select answers come back restructured far more often than ticked, so `multiSelect` is reserved for coarse picks off a flat list.

Two plausible sections are absent for cause. Nothing guards against "you should have asked" complaints, because the corpus holds no instance of one. Nothing discourages confirmation-seeking in general either, since that pushback fires only on mechanical or already-stated work.

Question shape is not restated. It bang-injects the rule bullets from `user/skills/ask/SKILL.md` at load time, so the two skills cannot drift. If `ask` moves or stops using bullets, the injection degrades to a one-line summary.

Model-invocable, against the usual `disable-model-invocation` preference for personal skills. That buys natural-language triggers and skill-to-skill delegation, and costs a description in every session's catalog. The README carries the removal trigger: no Skill-tool entries in the session index after roughly four weeks means the triggers are inert and it gets demoted.
