### PR TITLE
mac: forward script flags through the JXA runner

### DIFF
--- a/plugins/mac/scripts/jxa.integration.ts
+++ b/plugins/mac/scripts/jxa.integration.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { beforeAll, describe, expect, it, test } from "bun:test";
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
@@ -59,5 +59,33 @@ describe("jxa cli", () => {
     );
     expect(result.code).toBe(0);
     expect(result.stdout.trim()).toBe("a,b");
+  });
+
+  describe("script file passthrough", () => {
+    const dir = join(import.meta.dirname, "fixtures");
+    const script = join(dir, "echo-argv.js");
+
+    beforeAll(async () => {
+      mkdirSync(dir, { recursive: true });
+      await Bun.write(script, "function run(argv) { return JSON.stringify(argv); }");
+    });
+
+    test.each<{ name: string; args: string[]; expected: string[] }>([
+      { name: "positional arguments", args: ["a", "b"], expected: ["a", "b"] },
+      {
+        name: "flags the script owns",
+        args: ["2026-06-01T00:00:00Z", "--notes-contains", "Discovery:"],
+        expected: ["2026-06-01T00:00:00Z", "--notes-contains", "Discovery:"],
+      },
+      {
+        name: "flags behind an explicit separator",
+        args: ["2026-06-01T00:00:00Z", "--", "--notes-contains", "Discovery:"],
+        expected: ["2026-06-01T00:00:00Z", "--notes-contains", "Discovery:"],
+      },
+    ])("forwards $name", async ({ args, expected }) => {
+      const result = await output(run("Finder", script, ...args));
+      expect(result.code).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual(expected);
+    });
   });
 });

--- a/plugins/mac/scripts/jxa.test.ts
+++ b/plugins/mac/scripts/jxa.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, test } from "bun:test";
 import { join } from "node:path";
 import type { RunResult } from "./jxa";
-import { isRetriableAppleEventsError, runWithRetry, validateAppScope } from "./jxa";
+import { isRetriableAppleEventsError, parseArgv, runWithRetry, validateAppScope } from "./jxa";
 
 type ScopeResult = { valid: boolean; violations: string[] };
 const valid: ScopeResult = { valid: true, violations: [] };
@@ -52,6 +52,112 @@ describe("validateAppScope", () => {
 
   it("throws on syntax errors", () => {
     expect(() => validateAppScope("function {{{", "Things3")).toThrow("Failed to parse JXA source");
+  });
+});
+
+describe("parseArgv", () => {
+  // Regression: cleye consumed unrecognized flags as its own, so a flag meant
+  // for the target script never reached osascript and the script saw a short
+  // argument list.
+  it("forwards every post-script argument to the script", () => {
+    const invocations: Record<string, string[]> = {
+      "documented logbook query": [
+        "Things3",
+        "query-logbook.js",
+        "2026-06-01T00:00:00Z",
+        "2026-08-15T00:00:00Z",
+        "--notes-contains",
+        "Discovery:",
+      ],
+      "explicit -- separator": [
+        "Things3",
+        "query-logbook.js",
+        "2026-06-01T00:00:00Z",
+        "--",
+        "--notes-contains",
+        "Discovery:",
+      ],
+      // No script binds here, so the runner exits with usage rather than
+      // dropping the arguments the parameters do not name.
+      "separator ahead of the script": [
+        "Things3",
+        "--",
+        "query-logbook.js",
+        "2026-06-01T00:00:00Z",
+      ],
+      "script with no arguments": ["Things3", "query-list.js"],
+      "app with no script": ["Things3"],
+      "expression with trailing flags": ["Finder", "-e", "1 + 1", "a", "--flag", "b"],
+      "expression flag before the app": ["--expression=1 + 1", "Finder", "--flag"],
+    };
+
+    const parsed = Object.fromEntries(
+      Object.entries(invocations).map(([name, argv]) => [name, parseArgv(argv)]),
+    );
+    expect(parsed).toMatchInlineSnapshot(`
+      {
+        "app with no script": {
+          "app": "Things3",
+          "args": [],
+          "expression": undefined,
+          "script": undefined,
+        },
+        "documented logbook query": {
+          "app": "Things3",
+          "args": [
+            "2026-06-01T00:00:00Z",
+            "2026-08-15T00:00:00Z",
+            "--notes-contains",
+            "Discovery:",
+          ],
+          "expression": undefined,
+          "script": "query-logbook.js",
+        },
+        "explicit -- separator": {
+          "app": "Things3",
+          "args": [
+            "2026-06-01T00:00:00Z",
+            "--notes-contains",
+            "Discovery:",
+          ],
+          "expression": undefined,
+          "script": "query-logbook.js",
+        },
+        "expression flag before the app": {
+          "app": "Finder",
+          "args": [
+            "--flag",
+          ],
+          "expression": "1 + 1",
+          "script": undefined,
+        },
+        "expression with trailing flags": {
+          "app": "Finder",
+          "args": [
+            "a",
+            "--flag",
+            "b",
+          ],
+          "expression": "1 + 1",
+          "script": undefined,
+        },
+        "script with no arguments": {
+          "app": "Things3",
+          "args": [],
+          "expression": undefined,
+          "script": "query-list.js",
+        },
+        "separator ahead of the script": {
+          "app": "Things3",
+          "args": [
+            "query-logbook.js",
+            "2026-06-01T00:00:00Z",
+          ],
+          "expression": undefined,
+          "script": undefined,
+        },
+      }
+    `);
   });
 });
 

--- a/plugins/mac/scripts/jxa.ts
+++ b/plugins/mac/scripts/jxa.ts
@@ -144,8 +144,8 @@ export function emitResult({ code, stdout, stderr }: RunResult): void {
 
 export interface ParsedArgv {
   app: string;
-  script?: string;
-  expression?: string;
+  script?: string | undefined;
+  expression?: string | undefined;
   args: string[];
 }
 

--- a/plugins/mac/scripts/jxa.ts
+++ b/plugins/mac/scripts/jxa.ts
@@ -2,6 +2,7 @@
 // claude:dangerouslyDisableSandbox: hands off to osascript for JXA Apple Events, which the command sandbox blocks
 
 import * as acorn from "acorn";
+import { cli } from "cleye";
 
 type Node = acorn.Node & Record<string, unknown>;
 
@@ -141,38 +142,84 @@ export function emitResult({ code, stdout, stderr }: RunResult): void {
   process.exitCode = code;
 }
 
-if (import.meta.main) {
-  const { cli } = await import("cleye");
+export interface ParsedArgv {
+  app: string;
+  script?: string;
+  expression?: string;
+  args: string[];
+}
 
-  const argv = cli({
-    name: "jxa",
-    parameters: ["<app>"],
-    flags: {
-      expression: {
-        type: String,
-        alias: "e",
-        description: "Inline JXA expression",
+// The runner's own flags bind ahead of the script path. Everything past it
+// belongs to the target script, flags included, so cleye must not claim it.
+// ignoreArgv leaves ignored elements in the array cleye parses, which makes
+// those leftovers the verbatim argument list for the script.
+export function parseArgv(argv: string[]): ParsedArgv {
+  const args = [...argv];
+  let positionals = 0;
+  let expression = false;
+
+  const parsed = cli(
+    {
+      name: "jxa",
+      parameters: ["<app>", "[script]"],
+      help: {
+        description:
+          "Run a JXA expression or script file scoped to one macOS app. Arguments after the script path pass to the script verbatim.",
+      },
+      flags: {
+        expression: {
+          type: String,
+          alias: "e",
+          description: "Inline JXA expression",
+        },
+      },
+      ignoreArgv: (type: string, flagOrArgv: string) => {
+        if (positionals >= (expression ? 1 : 2)) return true;
+        // Left to cleye, a separator ahead of the script path would sweep the
+        // script and its arguments into `_["--"]` and drop everything the
+        // parameters do not name.
+        if (type === "argument" && flagOrArgv === "--") return true;
+        if (type === "known-flag") {
+          if (flagOrArgv === "expression" || flagOrArgv === "e") expression = true;
+        } else if (type === "argument") {
+          positionals += 1;
+        }
+        return false;
       },
     },
-  });
+    undefined,
+    args,
+  );
 
-  const app = argv._.app;
-  const args = argv._.slice(1);
+  // Callers that wrote an explicit `--` to force passthrough keep working: the
+  // runner absorbs one separator so osascript never receives it as an argument.
+  const separator = args.indexOf("--");
+  if (separator !== -1) args.splice(separator, 1);
+
+  return {
+    app: parsed._.app,
+    script: parsed._.script,
+    expression: parsed.flags.expression,
+    args,
+  };
+}
+
+if (import.meta.main) {
+  const { app, script, expression, args } = parseArgv(process.argv.slice(2));
 
   let source: string;
   let osascriptArgs: string[];
 
-  if (argv.flags.expression) {
-    source = argv.flags.expression;
+  if (expression) {
+    source = expression;
     osascriptArgs = ["-l", "JavaScript", "-e", source, ...args];
   } else {
-    const scriptPath = args[0];
-    if (!scriptPath) {
+    if (!script) {
       console.error("Usage: bun jxa.ts <app> <script> [args...] or bun jxa.ts <app> -e '<expr>'");
       process.exit(1);
     }
-    source = await Bun.file(scriptPath).text();
-    osascriptArgs = ["-l", "JavaScript", scriptPath, ...args.slice(1)];
+    source = await Bun.file(script).text();
+    osascriptArgs = ["-l", "JavaScript", script, ...args];
   }
 
   const result = validateAppScope(source, app);

--- a/plugins/mac/skills/jxa-run/SKILL.md
+++ b/plugins/mac/skills/jxa-run/SKILL.md
@@ -16,7 +16,7 @@ hooks:
 
 # Run JXA
 
-Run the JXA expression or script file from the arguments. `$0` is the app name; remaining arguments pass to the runner.
+Run the JXA expression or script file from the arguments. `$0` is the app name. Runner flags (`-e`) go before the script path. Every argument after the script path reaches the script unchanged, its own flags included.
 
 ```bash
 bun ${CLAUDE_PLUGIN_ROOT}/scripts/jxa.ts $ARGUMENTS


### PR DESCRIPTION
Fixes a silent-wrong-answer path in the JXA runner. `jxa.ts` declared only `<app>` and `-e` to cleye and read the rest off `argv._`, so cleye claimed any `--flag` after the script path as its own and dropped it.

The documented `things:jxa` invocation `query-logbook.js <start> <end> --notes-contains <substring>` reached `osascript` without the flag. `query-logbook.js` then answered with its usage error as JSON. A caller mining the logbook for `Discovery:` markers reads that blob as "no matches" and dedups against nothing.

Runner flags now bind ahead of the script path. cleye's `ignoreArgv` stops parsing once the app and script positionals are bound, and the elements it ignores stay in the array it parses. Those leftovers are the script's argument list, verbatim. `-e` still takes the runner's expression, and `validateAppScope` still gates every source before `osascript` sees it.

A trailing `--` was the workaround for this bug, so the runner absorbs one separator wherever it appears. A `--` written ahead of the script path is the one shape that changes: cleye ends its parse there and no script binds, so the runner exits with usage instead of quietly discarding what follows.

Verified against the real logbook. Both the documented form and the `--` form return the same 44 items for the June-to-August window, where the documented form previously returned the usage error. Added a `parseArgv` unit snapshot over the invocation shapes, including both separator positions and expression mode with trailing flags, plus integration rows asserting what an argument-echoing script receives through `osascript`.

Discovery: 4f2b8e1a0c73
