### PR TITLE
review: co-locate the model pin with each spawn

### DIFF
--- a/plugins/review/skills/code/SKILL.md
+++ b/plugins/review/skills/code/SKILL.md
@@ -60,9 +60,7 @@ Otherwise run the selected angles from [angles.md](angles.md). Each surfaces up 
 
 #### Fan-out cells
 
-`medium`, `high`, and `xhigh` on the default and Sonnet families, plus `xhigh` on Fable 5. Run each angle as an independent `Agent` with `subagent_type: review:angle`. Invoking this skill is the request for that fan-out, so run it whenever `Agent` is in the tool set. Give every agent the scope block, its single angle text, its candidate cap, and the cleanup-precedence block if it carries a cleanup lens.
-
-`review:angle` and `review:verifier` pin no model, so every fan-out spawn passes `model: sonnet`, here and in Phase 2 and Phase 3. Breadth costs Sonnet rates whatever model is orchestrating.
+`medium`, `high`, and `xhigh` on the default and Sonnet families, plus `xhigh` on Fable 5. Run each angle as an independent `Agent` with `subagent_type: review:angle, model: sonnet`. Invoking this skill is the request for that fan-out, so run it whenever `Agent` is in the tool set. Give every agent the scope block, its single angle text, its candidate cap, and the cleanup-precedence block if it carries a cleanup lens. The agent pins no model, so the spawn supplies it, and breadth costs Sonnet rates whatever model is orchestrating.
 
 #### Inline cells
 
@@ -82,7 +80,7 @@ Inline cells stop here: dedup only, no verify, no re-judging. Same defect, same 
 
 Degraded cells with no `Agent` tool dedup, then re-check each remaining candidate against the diff in this context.
 
-Fan-out cells verify: for each remaining candidate, run one `Agent` with `subagent_type: review:verifier` on Sonnet. Give it the scope block, the relevant files, the candidate, and the ladder below. Group candidates that share a location into one verifier returning one verdict per candidate, each judged independently on its own claim. A candidate the verifier renders no verdict on is dropped, never reported as an unverified PLAUSIBLE.
+Fan-out cells verify: for each remaining candidate, run one `Agent` with `subagent_type: review:verifier, model: sonnet`. Give it the scope block, the relevant files, the candidate, and the ladder below. Group candidates that share a location into one verifier returning one verdict per candidate, each judged independently on its own claim. A candidate the verifier renders no verdict on is dropped, never reported as an unverified PLAUSIBLE.
 
 Each verdict is exactly one of:
 
@@ -104,7 +102,7 @@ At `xhigh`, a single non-REFUTED vote carries the finding. Do not drop on uncert
 
 Only at `xhigh` and `inline-xhigh`.
 
-Take one more pass as a fresh reviewer holding the verified list. On fan-out cells this is one more `review:angle` `Agent` on Sonnet, carrying the sweep gap focus as its angle. On inline and degraded cells it is one more pass in this context.
+Take one more pass as a fresh reviewer holding the verified list. On fan-out cells this is one more `Agent` with `subagent_type: review:angle, model: sonnet`, carrying the sweep gap focus as its angle. On inline and degraded cells it is one more pass in this context.
 
 Re-read the diff and the enclosing functions looking ONLY for defects not already listed. Do not re-derive or re-confirm anything already there. The job is gaps. Focus on what the first pass tends to miss (see the sweep gap focus in [angles.md](angles.md)).
 

--- a/plugins/review/skills/code/efforts.md
+++ b/plugins/review/skills/code/efforts.md
@@ -17,7 +17,7 @@ A capable orchestrator reviews better working through the angles itself than it 
 
 ## Spawn Model
 
-Every fan-out spawn passes `model: sonnet`. What a fan-out cell buys is breadth, and breadth comes from many independent readers of the same diff. Paying the orchestrator's own rate for each of those readers buys nothing extra. Most diffs fail on lines, and lines are what Sonnet reads well and cheaply.
+Every fan-out spawn passes `model: sonnet` alongside its `subagent_type`. What a fan-out cell buys is breadth, and breadth comes from many independent readers of the same diff. Paying the orchestrator's own rate for each of those readers buys nothing extra. Most diffs fail on lines, and lines are what Sonnet reads well and cheaply.
 
 ## Budgets
 
@@ -77,7 +77,7 @@ On Sonnet 5 at `high` or `xhigh`, scale the fleet to the diff size instead of us
 budget = clamp(ceil(lines / 150), 2, 8)
 ```
 
-Spawn about that many finder subagents. The committed-range count is a floor: uncommitted changes are not in it, so scale up if Phase 0 finds additional working-tree scope.
+Spawn about that many finder subagents, each with `subagent_type: review:angle, model: sonnet`. The committed-range count is a floor: uncommitted changes are not in it, so scale up if Phase 0 finds additional working-tree scope.
 
 No other model family gets this hint.
 


### PR DESCRIPTION
The fan-out instruction in `review:code` named `subagent_type: review:angle` and left `model: sonnet` to a paragraph of its own two lines below. A reader who follows the spawn sentence and stops before the next paragraph loses the pin, and the pin is the only thing keeping a breadth pass off the orchestrator's model.

Between 2026-08-01 and 08-14 on this machine, 138 `Agent` spawns were attributed to `review:code`:

- 67 dropped both halves at once, dispatching `subagent_type: general-purpose` with no `model` param, which inherits whatever the orchestrator is running
- Of the 39 where the model could be resolved, none ran on Sonnet. All were Opus or Fable
- Their prompts confirm genuine angle work ("Angle A line-by-line scan", "Altitude angle", "Conventions angle")
- The documented path was taken 53 times

The fix is co-location rather than a new rule or a louder version of the existing one. Every spawn site now writes the call shape out in full as `subagent_type: review:angle, model: sonnet`. Phase 1's fan-out, Phase 2's verify, Phase 3's sweep, and the Sonnet 5 finder budget hint in `efforts.md` each carry both parameters at the point of the call instead of referring back.

Removing the standalone paragraph leaves SKILL.md slightly smaller, which matters because an invoked skill's body is re-injected at every compaction.

`review:angle` and `review:verifier` still pin no model in their own frontmatter. That stays deliberate. The caller chooses the model, and the caller now says which one at every call.

Discovery: a3d21b7c4e05
