### PR TITLE
worktree: don't match quoted or heredoc text

### DIFF
--- a/user/hooks/worktree/index.test.ts
+++ b/user/hooks/worktree/index.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "bun:test";
-import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { describe, expect, it, test } from "bun:test";
+import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import {
   formatAskOutput,
   formatDenyOutput,
@@ -134,7 +134,69 @@ describe("processInput", () => {
   });
 });
 
+describe("quoted and heredoc content", () => {
+  const brief = [
+    `cat > "$TMPDIR/briefs/task.md" <<'BRIEF'`,
+    "You are working in a git worktree of a fork of the upstream repo.",
+    "BRIEF",
+  ].join("\n");
+
+  test.each<{ name: string; command: string; expected: SyncHookJSONOutput | null }>([
+    {
+      name: "exempts a quoted tmp/ target containing spaces",
+      command: 'git worktree add -q "tmp/wt with space" keepme 2>&1',
+      expected: null,
+    },
+    {
+      name: "exempts a quoted $TMPDIR target containing spaces",
+      command: 'git worktree remove "$TMPDIR/wt with space"',
+      expected: null,
+    },
+    {
+      name: "ignores git worktree prose in a heredoc body",
+      command: brief,
+      expected: null,
+    },
+    {
+      name: "ignores git worktree prose in a single-quoted string",
+      command: "echo 'we run git worktree add ../path through worktrunk'",
+      expected: null,
+    },
+    {
+      name: "ignores git worktree prose in a double-quoted string",
+      command: 'echo "we run git worktree remove ../path through worktrunk"',
+      expected: null,
+    },
+    {
+      name: "denies a genuine add outside the exemptions",
+      command: 'git worktree add ../path -b "my branch"',
+      expected: formatDenyOutput("add"),
+    },
+    {
+      name: "denies a genuine add that follows a heredoc",
+      command: `${brief}\ngit worktree add ../path`,
+      expected: formatDenyOutput("add"),
+    },
+    {
+      name: "denies an add whose only exempt-looking target is in a heredoc body",
+      command: `git worktree add ../path <<'NOTE'\ntmp/decoy\nNOTE`,
+      expected: formatDenyOutput("add"),
+    },
+    {
+      name: "asks for an unknown subcommand with quoted arguments",
+      command: 'git worktree lock "../path with space" --reason "in use"',
+      expected: formatAskOutput(),
+    },
+  ])("$name", ({ command, expected }) => {
+    expect(processInput(bashInput(command))).toEqual(expected);
+  });
+});
+
 describe("isThrowawayAdd", () => {
+  it("matches a quoted tmp/ target containing spaces", () => {
+    expect(isThrowawayAdd('git worktree add -q "tmp/wt with space" keepme 2>&1')).toBe(true);
+  });
+
   it("matches a tmp/ target", () => {
     expect(isThrowawayAdd("git worktree add tmp/x")).toBe(true);
   });

--- a/user/hooks/worktree/index.ts
+++ b/user/hooks/worktree/index.ts
@@ -13,20 +13,47 @@ const TMP_TARGET = /(^|\/)tmp\//;
 const UNEXPANDED_VAR_TARGET = /^\$\{?\w+\}?\//;
 const AGENT_WORKTREE_TARGET = /(^|\/)\.worktrees\//;
 
+// A heredoc body is file content: prose, prompts, and scripts where the literal
+// text `git worktree` is data rather than an invocation. Stripping runs before
+// quotes because the quoted delimiter (`<<'BRIEF'`) anchors the body.
+const HEREDOC_BODY = /<<-?[ \t]*(['"]?)(\w+)\1[\s\S]*?^[ \t]*\2[ \t]*$/gm;
+const QUOTED_SPAN = /'[^']*'|"(?:[^"\\]|\\.)*"/g;
+
+// A token is a run of non-space characters in which a quoted span counts as
+// part of the token, so a target path containing spaces stays whole.
+const TOKEN = /(?:'[^']*'|"(?:[^"\\]|\\.)*"|\S)+/g;
+
+function stripHeredocs(command: string): string {
+  return command.replace(HEREDOC_BODY, " ");
+}
+
+function stripQuoted(command: string): string {
+  return command.replace(QUOTED_SPAN, " ");
+}
+
+// Quote characters delimit the token, they are not part of the path.
+function unquote(token: string): string {
+  return token.replace(/['"]/g, "");
+}
+
+function tokensAfter(command: string, invocation: RegExp): string[] {
+  const after = stripHeredocs(command).split(invocation)[1];
+  if (after === undefined) return [];
+  return (after.match(TOKEN) ?? []).map(unquote);
+}
+
 function isExemptTarget(token: string): boolean {
   return TMP_TARGET.test(token) || UNEXPANDED_VAR_TARGET.test(token);
 }
 
 export function isThrowawayAdd(command: string): boolean {
-  const after = command.split(/\bgit\s+worktree\s+add\b/)[1];
-  if (after === undefined) return false;
-  return after.split(/\s+/).some(isExemptTarget);
+  return tokensAfter(command, /\bgit\s+worktree\s+add\b/).some(isExemptTarget);
 }
 
 export function isThrowawayRemove(command: string): boolean {
-  const after = command.split(/\bgit\s+worktree\s+remove\b/)[1];
-  if (after === undefined) return false;
-  return after.split(/\s+/).some((tok) => isExemptTarget(tok) || AGENT_WORKTREE_TARGET.test(tok));
+  return tokensAfter(command, /\bgit\s+worktree\s+remove\b/).some(
+    (tok) => isExemptTarget(tok) || AGENT_WORKTREE_TARGET.test(tok),
+  );
 }
 
 export function formatDenyOutput(subcommand: string): SyncHookJSONOutput {
@@ -63,7 +90,7 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
     return null;
   }
 
-  const match = command.match(/\bgit\s+worktree\s+(\w+)/);
+  const match = stripQuoted(stripHeredocs(command)).match(/\bgit\s+worktree\s+(\w+)/);
   const subcommand = match?.[1];
   if (!subcommand) {
     return null;


### PR DESCRIPTION
The worktree hook pattern-matched the raw Bash command, so any occurrence of its trigger words counted as an invocation regardless of whether a shell would run them. Two shapes hit this in the last week.

`isThrowawayAdd` split the command on raw whitespace, so a quoted target with spaces (`add -q "tmp/wt with space" keepme`) tokenized to `"tmp/wt`, and the leading quote broke the `(^|\/)tmp\/` anchor. The `tmp/` exemption from 0b8286d0 (#1166) was denied the day after it landed, twice. `processInput`'s subcommand regex scanned the whole command including heredoc bodies, so a `cat > … <<'BRIEF'` block whose prose read "working in a git worktree of a fork" captured `of` as the subcommand and raised a permission prompt through the `ask` fallback. Fired twice yesterday, both times against background agent work where no git command existed.

Both hunks now match against text the shell would execute. Heredoc bodies get blanked first, because stripping quotes would consume the `'DELIM'` that anchors the body, then quoted spans go for the subcommand match. The target scan keeps quoted spans intact and drops only the quote characters, so a path with spaces stays a single token instead of vanishing along with the exemption it carries.

This widens one hole: a real command embedded in a heredoc fed to an interpreter is no longer seen. `plugins/git/scripts/block-default-branch-commit.ts` and `plugins/gitlab/hooks/lint.ts` already accept that tradeoff, and `.claude/rules/hooks.md` documents it as the pattern for Bash-matched hooks. Interpreter-fed heredocs are rare next to prose ones, which were interrupting sessions daily. The helpers stay local rather than shared, since two of the three existing copies live in distributed plugins that cannot depend on a workspace package.

Tests add a `test.each` table over `(command, decision)` covering quoted spaces, single- and double-quoted prose, heredoc prose with no git command, and a heredoc body whose `tmp/` decoy must not exempt a real add. Eight of the new rows fail against the pre-fix hook. Verified against the built script over stdin as well as through the unit tests.

Discovery: b71e4f9a2d68
