### PR TITLE
x-callback-url: bound every wait

### DIFF
--- a/plugins/things/CLAUDE.md
+++ b/plugins/things/CLAUDE.md
@@ -31,9 +31,9 @@ Biome linting is disabled for `scripts/jxa/` files via the root `biome.json` ove
 
 `reorder.ts` and `inbox.ts` are bun TypeScript scripts (not `osascript`). Their Launch Services handoff runs outside the command sandbox via the `claude:dangerouslyDisableSandbox` marker.
 
-The x-callback-url bridge needs `CLAUDE_PLUGIN_DATA` to locate its `.app` bundle, and Claude Code does not export it to Bash tool calls. The `things:url` skill sets it on every documented invocation, where the substitution has already resolved it, and the three scripts inherit it. Keep that prefix on any new documented command, or the callback is lost and `dispatch` falls back to `open`.
-
 A degraded dispatch is no longer silent. `dispatch` returns a `fallbackReason` naming why no id came back (runner missing, bridge build failed, callback timed out, app error) plus the runner's `fallbackDetail` stderr, and `warnFallback` prints both. Every caller of `dispatch` should pass its result through `warnFallback`, because the alternative is a write that lands with no id and no explanation.
+
+`xcallBackstopMs` in `url.ts` guards a runner that dies without honoring its own watchdogs. It reads `run.sh`'s two bounds from the environment and adds a margin, so raising either bound cannot make the backstop kill the runner before it names its own failure.
 
 ## What NOT to Do
 

--- a/plugins/things/scripts/url.test.ts
+++ b/plugins/things/scripts/url.test.ts
@@ -6,6 +6,7 @@ import {
   dispatch,
   isSandboxBlockedHandoff,
   XcallError,
+  xcallBackstopMs,
 } from "./url";
 
 describe("buildJsonPayload", () => {
@@ -141,6 +142,38 @@ describe("isSandboxBlockedHandoff", () => {
     ],
   ])("%s", (_name, stderr, expected) => {
     expect(isSandboxBlockedHandoff(stderr)).toBe(expected);
+  });
+});
+
+describe("xcallBackstopMs", () => {
+  test.each<{ name: string; env: Record<string, string | undefined> }>([
+    { name: "defaults when neither bound is set", env: {} },
+    { name: "a raised build bound", env: { XCALL_BUILD_TIMEOUT_SECONDS: "90" } },
+    { name: "a raised callback bound", env: { XCALL_TIMEOUT_SECONDS: "60" } },
+    {
+      name: "both bounds raised",
+      env: { XCALL_BUILD_TIMEOUT_SECONDS: "90", XCALL_TIMEOUT_SECONDS: "60" },
+    },
+    { name: "a non-numeric bound", env: { XCALL_TIMEOUT_SECONDS: "soon" } },
+    { name: "a zero bound", env: { XCALL_TIMEOUT_SECONDS: "0" } },
+  ])("outwaits run.sh with $name", ({ env }) => {
+    const bound = (name: string) => Number(env[name]) || 20;
+    const runnerCeilingMs =
+      (bound("XCALL_BUILD_TIMEOUT_SECONDS") + bound("XCALL_TIMEOUT_SECONDS") + 2) * 1000;
+
+    expect(xcallBackstopMs(env)).toBeGreaterThan(runnerCeilingMs);
+  });
+
+  test("reports the derived values", () => {
+    expect({
+      defaults: xcallBackstopMs({}),
+      raised: xcallBackstopMs({ XCALL_BUILD_TIMEOUT_SECONDS: "90", XCALL_TIMEOUT_SECONDS: "60" }),
+    }).toMatchInlineSnapshot(`
+      {
+        "defaults": 57000,
+        "raised": 167000,
+      }
+    `);
   });
 });
 

--- a/plugins/things/scripts/url.ts
+++ b/plugins/things/scripts/url.ts
@@ -177,12 +177,32 @@ export function buildJsonPayload(ids: string[], attributes: Record<string, strin
 const XCALL_BUILD_FAILED = 3;
 const XCALL_TIMED_OUT = 4;
 
+/** run.sh's default for each of its two bounds, and its SIGTERM-to-SIGKILL grace. */
+const XCALL_BOUND_DEFAULT_SECONDS = 20;
+const XCALL_KILL_GRACE_SECONDS = 2;
+
+/** Slack over run.sh's own bounds, covering process startup and the Swift build. */
+const XCALL_BACKSTOP_MARGIN_MS = 15_000;
+
+function boundSeconds(env: Record<string, string | undefined>, name: string): number {
+  const seconds = Number(env[name]);
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : XCALL_BOUND_DEFAULT_SECONDS;
+}
+
 /**
- * Backstop for a runner that dies without honoring its own watchdog. It must
- * exceed a cold Swift build plus run.sh's XCALL_TIMEOUT_SECONDS, or it preempts
- * the runner's own bounded failure and hides the reason.
+ * Backstop for a runner that dies without honoring its own watchdogs. Derived
+ * from run.sh's two bounds rather than fixed, because run.sh invites raising
+ * either one in its own timeout message. A backstop below their sum kills the
+ * runner before it can name why it failed, and the caller gets an anonymous
+ * signal in place of exit 3 or 4.
  */
-const XCALL_BACKSTOP_MS = 45_000;
+export function xcallBackstopMs(env: Record<string, string | undefined>): number {
+  const bounds =
+    boundSeconds(env, "XCALL_BUILD_TIMEOUT_SECONDS") +
+    boundSeconds(env, "XCALL_TIMEOUT_SECONDS") +
+    XCALL_KILL_GRACE_SECONDS;
+  return bounds * 1000 + XCALL_BACKSTOP_MARGIN_MS;
+}
 
 export class XcallError extends Error {
   constructor(
@@ -214,7 +234,7 @@ async function xcall(runner: string, url: string): Promise<string> {
   const proc = Bun.spawn([runner, url], {
     stdout: "pipe",
     stderr: "pipe",
-    timeout: XCALL_BACKSTOP_MS,
+    timeout: xcallBackstopMs(process.env),
   });
   const [text, stderr] = await Promise.all([
     new Response(proc.stdout).text(),

--- a/plugins/things/skills/url/SKILL.md
+++ b/plugins/things/skills/url/SKILL.md
@@ -4,9 +4,9 @@ description: Create, update, and manage Things 3 tasks and projects, including q
 argument-hint: "<add | update | show | search | json | capture> [key=value ...]"
 effort: low
 allowed-tools:
-  - "Bash(CLAUDE_PLUGIN_DATA=${CLAUDE_PLUGIN_DATA} bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts:*)"
-  - "Bash(CLAUDE_PLUGIN_DATA=${CLAUDE_PLUGIN_DATA} bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts:*)"
-  - "Bash(CLAUDE_PLUGIN_DATA=${CLAUDE_PLUGIN_DATA} bun ${CLAUDE_PLUGIN_ROOT}/scripts/reorder.ts:*)"
+  - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts:*)"
+  - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts:*)"
+  - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/reorder.ts:*)"
   - Read
 ---
 
@@ -22,13 +22,11 @@ Write operations for Things 3 via the `things:///` URL scheme.
 
 Use `url.ts` for most operations. It handles auth tokens and URL encoding.
 
-Keep the `CLAUDE_PLUGIN_DATA=` prefix on every invocation. Claude Code exports that variable to hooks and MCP servers but not to Bash tool calls, and the x-callback-url bridge needs it to locate its `.app` bundle. Dropping it costs the callback (stderr shows `CLAUDE_PLUGIN_DATA is not set`), so `url.ts` falls back to a fire-and-forget `open` and returns no todo id.
-
 ```bash
-CLAUDE_PLUGIN_DATA=${CLAUDE_PLUGIN_DATA} bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts <command> [key=value ...]
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts <command> [key=value ...]
 
 # Bulk update: pass multiple id= params to batch via JSON command
-CLAUDE_PLUGIN_DATA=${CLAUDE_PLUGIN_DATA} bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts update id=X id=Y id=Z when=tomorrow
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts update id=X id=Y id=Z when=tomorrow
 ```
 
 For raw URL scheme access: `open -g "things:///add?title=Buy%20milk&when=today"`. Use `-g` for data commands to run in background. Omit it for `show`/`search` to foreground Things.
@@ -52,7 +50,7 @@ Full parameters, JSON payload schema, and limits: [url-scheme.md](url-scheme.md)
 ## Reorder Items
 
 ```bash
-CLAUDE_PLUGIN_DATA=${CLAUDE_PLUGIN_DATA} bun ${CLAUDE_PLUGIN_ROOT}/scripts/reorder.ts [--list today|anytime|someday] <id1> <id2> <id3> ...
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/reorder.ts [--list today|anytime|someday] <id1> <id2> <id3> ...
 ```
 
 Items appear at the top of the list in the order specified. Default list is `today`. Also works for items within a project. Use the `--list` value matching the items' current scheduling state.
@@ -62,7 +60,7 @@ Items appear at the top of the list in the order specified. Default list is `tod
 For quick captures to the inbox, use `inbox.ts`. It tags each todo `Claude` and appends session attribution, so prefer it over `url.ts add` when delegating a task mid-session.
 
 ```bash
-CLAUDE_PLUGIN_DATA=${CLAUDE_PLUGIN_DATA} bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts --session-id ${CLAUDE_SESSION_ID} title="Buy milk"
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts --session-id ${CLAUDE_SESSION_ID} title="Buy milk"
 ```
 
 `title` captures one todo. `titles` (newline-separated) captures several at once. Add tags with `--tag` (repeatable). Other params: `notes` (max 10,000 chars), `tags` (comma-separated), `checklist-items` (newline-separated, max 100).

--- a/plugins/x-callback-url/README.md
+++ b/plugins/x-callback-url/README.md
@@ -12,8 +12,12 @@ Call x-callback-url schemes from the CLI and receive responses synchronously.
 
 - `scripts/main.swift` — Swift source for the xcall bridge
 - `scripts/build.sh` — Compiles Swift source into `.app` bundle with URL scheme registration
-- `scripts/run.sh` — Build-if-needed + invoke wrapper, with the watchdog that bounds the callback wait
+- `scripts/run.sh` — Build-if-needed + invoke wrapper, with the watchdogs that bound both waits
 
-The bundle is installed to `$CLAUDE_PLUGIN_DATA`. Claude Code does not export that variable to Bash tool calls, so a consuming skill sets it on the command it documents.
+One bundle serves every consumer, at `~/.cache/claude/x-callback-url/xcall.app`, because macOS registers exactly one handler for `xcall-claude://`.
 
-Both shell scripts carry the `mac` plugin's `claude:dangerouslyDisableSandbox` marker. The command sandbox blocks the compile and the URL-scheme round trip alike, and a sandboxed `xcall` hangs instead of failing, so `run.sh` bounds the wait at `XCALL_TIMEOUT_SECONDS` (default 20) and exits 4.
+Both shell scripts carry the `mac` plugin's `claude:dangerouslyDisableSandbox` marker. The command sandbox blocks Launch Services registration and the URL-scheme round trip alike, and a sandboxed `xcall` hangs instead of failing, so `run.sh` owns the deadline for both phases: `XCALL_BUILD_TIMEOUT_SECONDS` (exit 3) and `XCALL_TIMEOUT_SECONDS` (exit 4), 20 seconds each by default.
+
+## Tests
+
+`bun test plugins/x-callback-url` drives `run.sh` against stub builds and stub binaries, including ones that never finish.

--- a/plugins/x-callback-url/scripts/build.sh
+++ b/plugins/x-callback-url/scripts/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# claude:dangerouslyDisableSandbox: swiftc writes the bundle under ~/.claude/plugins, which the command sandbox denies
+# claude:dangerouslyDisableSandbox: registers the bundle with Launch Services, which the command sandbox blocks
 set -euo pipefail
 
 # Build xcall.app — a macOS .app bundle for x-callback-url bridging.
@@ -7,26 +7,20 @@ set -euo pipefail
 # The .app bundle is required because macOS only delivers URL scheme
 # callbacks to registered applications with CFBundleURLTypes in Info.plist.
 #
-# Installs into ${CLAUDE_PLUGIN_DATA}. Marketplace installs put plugin sources
-# in a content-addressed cache directory whose hash rotates per plugin version,
-# so a bundle built beside the source would leave Launch Services pointing at a
-# deleted path after any plugin update.
-#
 # Output (stdout): path to the compiled binary inside the .app bundle.
-# Cached: only recompiles if main.swift is newer than the existing binary.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SOURCE="$SCRIPT_DIR/main.swift"
 
-# Claude Code exports CLAUDE_PLUGIN_DATA to hooks and MCP servers but not to
-# Bash tool calls. A caller reached from a Bash invocation passes it explicitly,
-# taking the value from its own skill, where the variable is substituted.
-if [[ -z "${CLAUDE_PLUGIN_DATA:-}" ]]; then
-  echo "CLAUDE_PLUGIN_DATA is not set; pass it explicitly, as the things:url skill does" >&2
-  exit 1
-fi
-
-APP_DIR="$CLAUDE_PLUGIN_DATA/xcall.app"
+# macOS registers exactly one handler for xcall-claude://, so one bundle serves
+# every consumer, at a path belonging to none of them. A second bundle takes the
+# scheme, and lsregister -f does not hand it back, so each consumer with its own
+# copy would retire the others in turn. The path also sits outside the plugin
+# tree, whose marketplace cache is content-addressed and rotates its hash per
+# version, leaving Launch Services on a deleted path after an update.
+STATE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/claude/x-callback-url"
+APP_DIR="$STATE_DIR/xcall.app"
+STAMP="$STATE_DIR/installed"
 CONTENTS_DIR="$APP_DIR/Contents"
 MACOS_DIR="$CONTENTS_DIR/MacOS"
 BINARY="$MACOS_DIR/xcall"
@@ -62,18 +56,31 @@ unregister_legacy_bundle() {
   fi
 }
 
-needs_rebuild() {
-  [[ ! -x "$BINARY" ]] || [[ "$SOURCE" -nt "$BINARY" ]]
+# The stamp records that the scheme is bound to this bundle. A run that compiles
+# and then fails to register leaves none, so the next call retries the
+# registration rather than treating the binary's presence as an install and
+# waiting out a callback Launch Services routes elsewhere. Re-reading the
+# binding costs an lsregister dump, seconds of work, so it happens on install.
+needs_install() {
+  [[ ! -x "$BINARY" ]] || [[ ! -f "$STAMP" ]] || [[ "$SOURCE" -nt "$STAMP" ]]
 }
 
+# Both files land through a private path and one rename, so nothing ever reads a
+# half-written bundle. One bundle now serves every consumer, so two sessions
+# reaching a cold cache together both install into the same paths. Each gets its
+# own $$-suffixed scratch file, and rename within a directory is atomic, so the
+# loser of that race is discarded whole instead of interleaved into the winner.
 build_bundle() {
   mkdir -p "$MACOS_DIR"
-  swiftc "$SOURCE" -o "$BINARY"
+  trap 'rm -f "$BINARY.$$" "$CONTENTS_DIR/Info.plist.$$"' EXIT
+
+  swiftc "$SOURCE" -o "$BINARY.$$"
+  mv -f "$BINARY.$$" "$BINARY"
 
   # CFBundleTypeRole=Editor ensures macOS delivers GetURL Apple Events to this app.
   # LSUIElement hides from Dock and Cmd-Tab without disabling URL scheme handling.
   # LSBackgroundOnly would disable it.
-  cat > "$CONTENTS_DIR/Info.plist" << 'PLIST'
+  cat > "$CONTENTS_DIR/Info.plist.$$" << 'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -106,6 +113,8 @@ build_bundle() {
 </dict>
 </plist>
 PLIST
+
+  mv -f "$CONTENTS_DIR/Info.plist.$$" "$CONTENTS_DIR/Info.plist"
 }
 
 # A bundle can survive at a path an earlier version of this script built into.
@@ -143,9 +152,10 @@ register_bundle() {
 
 unregister_legacy_bundle
 
-if needs_rebuild; then
+if needs_install; then
   build_bundle
   register_bundle
+  : >"$STAMP"
 fi
 
 echo "$BINARY"

--- a/plugins/x-callback-url/scripts/main.swift
+++ b/plugins/x-callback-url/scripts/main.swift
@@ -11,8 +11,14 @@ import Foundation
 // Example: xcall "things:///add?title=Buy%20milk"
 //
 // stdout: x-success query string (e.g. x-things-id=ABC123)
-// stderr: x-error query string or timeout message
+// stderr: x-error query string
 // Exit codes: 0 = success, 1 = error, 2 = cancel
+//
+// run.sh holds the deadline for this process, from outside it, and passes the
+// interval through XCALL_TIMEOUT_SECONDS. In-process scheduling could only
+// happen from applicationDidFinishLaunching below, which AppKit skips entirely
+// when it cannot reach the WindowServer, the sandboxed case where the callback
+// can never arrive.
 
 let callbackScheme = "xcall-claude"
 
@@ -58,11 +64,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 fputs("Failed to open URL: \(error.localizedDescription) (domain=\(nsError.domain) code=\(nsError.code)) url=\(urlString)\n", stderr)
                 exit(1)
             }
-        }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-            fputs("Timeout waiting for callback\n", stderr)
-            NSApp.terminate(nil)
         }
     }
 

--- a/plugins/x-callback-url/scripts/run.sh
+++ b/plugins/x-callback-url/scripts/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# claude:dangerouslyDisableSandbox: compiles the bridge into the plugin data dir and hands off to Launch Services, both of which the command sandbox blocks
+# claude:dangerouslyDisableSandbox: registers with Launch Services and hands off a URL scheme to it, both of which the command sandbox blocks
 set -euo pipefail
 
 # Exit 3 separates a build failure from xcall's own exit codes (0 success,
@@ -9,38 +9,79 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# xcall's own deadline lives inside applicationDidFinishLaunching, which AppKit
-# never calls when it cannot reach the WindowServer, so the in-process timer is
-# not a guard the bridge can rely on. This watchdog is the one that always runs.
+# Every wait in this script is bounded from the outside. xcall cannot bound its
+# own: its deadline would live in applicationDidFinishLaunching, which AppKit
+# never calls when it cannot reach the WindowServer, so a sandboxed xcall would
+# sit on a callback that can never arrive. The build has no deadline of its own
+# either, and swiftc and lsregister both talk to system daemons.
 TIMEOUT_SECONDS="${XCALL_TIMEOUT_SECONDS:-20}"
+BUILD_TIMEOUT_SECONDS="${XCALL_BUILD_TIMEOUT_SECONDS:-20}"
 KILL_GRACE_SECONDS=2
 
-if ! BINARY="$("$SCRIPT_DIR/build.sh")"; then
-  echo "xcall build failed; see errors above" >&2
+# Runs a command under a watchdog, returning its status, or a signal status
+# (>128) when the watchdog had to stop it. The watchdog's own descriptors go to
+# /dev/null so it cannot hold a caller's command substitution open past the
+# command it guards.
+run_bounded() {
+  local limit="$1"
+  shift
+
+  # Job control gives the command its own process group, so the watchdog can
+  # signal the whole tree by negating the pid. Signalling only the immediate
+  # child leaves what it forked alive: build.sh runs swiftc and lsregister as
+  # ordinary foreground children, and either one keeps holding the stdout this
+  # function's caller reads through. The watchdog would fire, the child would
+  # die, and the read would go on waiting on a grandchild nobody bounded.
+  set -m
+  "$@" &
+  local pid=$!
+  set +m
+
+  (
+    # The timer runs as a child so the trap can end it. A foreground sleep here
+    # outlives the subshell blocked on it, because the cleanup kill below
+    # reaches the subshell alone. Every call that finishes early would then
+    # leave a sleep reparented and running out the rest of its limit.
+    timer=""
+    trap 'kill "${timer:-}" 2>/dev/null || true; exit 0' TERM
+    sleep "$limit" &
+    timer=$!
+    wait "$timer"
+
+    kill -TERM "-$pid" 2>/dev/null || exit 0
+    sleep "$KILL_GRACE_SECONDS"
+    kill -KILL "-$pid" 2>/dev/null || true
+  ) >/dev/null 2>&1 &
+  local watchdog=$!
+
+  local st=0
+  # Redirected so bash's own "Terminated: 15" job notice stays out of the
+  # caller's stderr. The command's own output already reached fd 2.
+  wait "$pid" 2>/dev/null || st=$?
+
+  kill "$watchdog" 2>/dev/null || true
+  wait "$watchdog" 2>/dev/null || true
+
+  return "$st"
+}
+
+build_status=0
+BINARY="$(run_bounded "$BUILD_TIMEOUT_SECONDS" "$SCRIPT_DIR/build.sh")" || build_status=$?
+
+if ((build_status != 0)); then
+  if ((build_status > 128)); then
+    echo "xcall build did not finish within ${BUILD_TIMEOUT_SECONDS}s; raise XCALL_BUILD_TIMEOUT_SECONDS if swiftc is genuinely this slow" >&2
+  else
+    echo "xcall build failed; see errors above" >&2
+  fi
   exit 3
 fi
 
-"$BINARY" "$@" &
-xcall_pid=$!
-
-(
-  sleep "$TIMEOUT_SECONDS"
-  kill -TERM "$xcall_pid" 2>/dev/null || exit 0
-  sleep "$KILL_GRACE_SECONDS"
-  kill -KILL "$xcall_pid" 2>/dev/null || true
-) &
-watchdog_pid=$!
-
-status=0
-# Redirected so bash's own "Terminated: 15" job notice stays out of the caller's
-# stderr. xcall's own output already reached fd 2 before the wait reaps it.
-wait "$xcall_pid" 2>/dev/null || status=$?
-
-kill "$watchdog_pid" 2>/dev/null || true
-wait "$watchdog_pid" 2>/dev/null || true
+xcall_status=0
+run_bounded "$TIMEOUT_SECONDS" "$BINARY" "$@" || xcall_status=$?
 
 # xcall exits 0, 1, or 2 on its own, so any signal status came from the watchdog.
-if [[ $status -gt 128 ]]; then
+if ((xcall_status > 128)); then
   cat >&2 <<EOF
 xcall gave up after ${TIMEOUT_SECONDS}s waiting for a callback on xcall-claude://.
 The command sandbox blocks the URL-scheme round trip, so the callback can never
@@ -51,4 +92,4 @@ EOF
   exit 4
 fi
 
-exit "$status"
+exit "$xcall_status"

--- a/plugins/x-callback-url/scripts/run.test.ts
+++ b/plugins/x-callback-url/scripts/run.test.ts
@@ -1,0 +1,178 @@
+import { afterAll, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const RUN_SH = join(import.meta.dirname, "run.sh");
+
+/** Watchdog bound handed to run.sh, in seconds. */
+const BOUND = 1;
+
+/**
+ * How long the stubs that refuse to finish sleep for. Long enough that only the
+ * watchdog can end them inside the bound, short enough that a run.sh which
+ * stopped bounding its waits still terminates and fails an assertion. A test
+ * for a hang must not be able to hang.
+ */
+const STUCK_SECONDS = 10;
+
+/** Ceiling for a bounded run: the bound, its kill grace, and process startup. */
+const BOUNDED_MS = 5_000;
+
+// Subprocess calls here go through Bun.spawnSync. Bun's $ shell keeps its
+// working directory in process-global state that sibling test files set to
+// temp dirs they then delete.
+const dirs: string[] = [];
+afterAll(() => {
+  for (const dir of dirs) Bun.spawnSync(["rm", "-rf", dir]);
+});
+
+interface Scenario {
+  name: string;
+  /** Body of the stub build.sh, which prints the binary path run.sh invokes. */
+  build: string;
+  /** Body of the stub binary, when the build reaches one. */
+  binary?: string;
+}
+
+const scenarios: Scenario[] = [
+  {
+    name: "callback never arrives",
+    build: 'echo "$SCRIPT_DIR/xcall-stub"',
+    binary: `exec sleep ${STUCK_SECONDS}`,
+  },
+  {
+    name: "build never finishes",
+    build: `exec sleep ${STUCK_SECONDS}`,
+  },
+  {
+    // build.sh forks swiftc and lsregister, which inherit the stdout run.sh
+    // reads the binary path from. Killing the script alone leaves them holding
+    // that pipe open, and the read waits past the bound the watchdog enforced.
+    name: "build forks a child that outlives it",
+    build: `sleep ${STUCK_SECONDS} &\nexec sleep ${STUCK_SECONDS}`,
+  },
+  {
+    name: "build fails",
+    build: 'echo "swiftc: Operation not permitted" >&2; exit 1',
+  },
+  {
+    name: "callback succeeds",
+    build: 'echo "$SCRIPT_DIR/xcall-stub"',
+    binary: 'echo "x-things-id=ABC123 url=$1"',
+  },
+  {
+    name: "app reports an x-error",
+    build: 'echo "$SCRIPT_DIR/xcall-stub"',
+    binary: 'echo "errorMessage=nope" >&2; exit 1',
+  },
+  {
+    name: "user cancels",
+    build: 'echo "$SCRIPT_DIR/xcall-stub"',
+    binary: 'echo "canceled" >&2; exit 2',
+  },
+];
+
+async function writeExecutable(path: string, contents: string): Promise<string> {
+  await Bun.write(path, contents);
+  Bun.spawnSync(["chmod", "+x", path]);
+  return path;
+}
+
+function stub(body: string): string {
+  return `#!/bin/bash\nset -euo pipefail\nSCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"\n${body}\n`;
+}
+
+interface Outcome {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  elapsedMs: number;
+}
+
+async function runScenario(scenario: Scenario): Promise<Outcome> {
+  const dir = mkdtempSync(join(tmpdir(), "xcall-run-"));
+  dirs.push(dir);
+
+  const runner = await writeExecutable(join(dir, "run.sh"), await Bun.file(RUN_SH).text());
+  await writeExecutable(join(dir, "build.sh"), stub(scenario.build));
+  if (scenario.binary) await writeExecutable(join(dir, "xcall-stub"), stub(scenario.binary));
+
+  const started = Bun.nanoseconds();
+  const proc = Bun.spawn([runner, "things:///version"], {
+    env: {
+      ...process.env,
+      XCALL_TIMEOUT_SECONDS: String(BOUND),
+      XCALL_BUILD_TIMEOUT_SECONDS: String(BOUND),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: (STUCK_SECONDS + 2) * 1000,
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+
+  return {
+    exitCode,
+    stdout: stdout.trim(),
+    stderr: stderr.trim(),
+    elapsedMs: (Bun.nanoseconds() - started) / 1e6,
+  };
+}
+
+function report(scenario: Scenario, outcome: Outcome): string {
+  return [
+    scenario.name,
+    `  exit:   ${outcome.exitCode}`,
+    `  stdout: ${outcome.stdout || "(none)"}`,
+    `  stderr: ${outcome.stderr.split("\n")[0] || "(none)"}`,
+  ].join("\n");
+}
+
+test("run.sh bounds every wait and maps each outcome to its own exit code", async () => {
+  const pairs = await Promise.all(
+    scenarios.map(async (scenario) => ({ scenario, outcome: await runScenario(scenario) })),
+  );
+
+  expect(
+    pairs
+      .filter(({ outcome }) => outcome.elapsedMs >= BOUNDED_MS)
+      .map(({ scenario }) => scenario.name),
+  ).toEqual([]);
+
+  expect(
+    pairs.map(({ scenario, outcome }) => report(scenario, outcome)).join("\n"),
+  ).toMatchInlineSnapshot(`
+    "callback never arrives
+      exit:   4
+      stdout: (none)
+      stderr: xcall gave up after 1s waiting for a callback on xcall-claude://.
+    build never finishes
+      exit:   3
+      stdout: (none)
+      stderr: xcall build did not finish within 1s; raise XCALL_BUILD_TIMEOUT_SECONDS if swiftc is genuinely this slow
+    build forks a child that outlives it
+      exit:   3
+      stdout: (none)
+      stderr: xcall build did not finish within 1s; raise XCALL_BUILD_TIMEOUT_SECONDS if swiftc is genuinely this slow
+    build fails
+      exit:   3
+      stdout: (none)
+      stderr: swiftc: Operation not permitted
+    callback succeeds
+      exit:   0
+      stdout: x-things-id=ABC123 url=things:///version
+      stderr: (none)
+    app reports an x-error
+      exit:   1
+      stdout: (none)
+      stderr: errorMessage=nope
+    user cancels
+      exit:   2
+      stdout: (none)
+      stderr: canceled"
+  `);
+}, 15_000);

--- a/plugins/x-callback-url/skills/xcall/SKILL.md
+++ b/plugins/x-callback-url/skills/xcall/SKILL.md
@@ -13,17 +13,20 @@ Send [x-callback-url](https://x-callback-url.com/) requests from the command lin
 
 ## How It Works
 
-`xcall` is a Swift CLI that builds into a macOS `.app` bundle. The `.app` is required because macOS only delivers URL scheme callbacks to registered applications. On first use, `run.sh` compiles the source into `${CLAUDE_PLUGIN_DATA}/xcall.app` and registers the callback scheme (`xcall-claude://`) with Launch Services. Installing into the plugin's data directory (not the plugin source/cache tree) keeps the registered path stable across plugin updates: the marketplace cache is content-addressed, so building xcall.app inside it would orphan the Launch Services registration on the next update.
+`xcall` is a Swift CLI that builds into a macOS `.app` bundle. The `.app` is required because macOS only delivers URL scheme callbacks to registered applications. On first use, `run.sh` compiles the source into `~/.cache/claude/x-callback-url/xcall.app` and registers the callback scheme (`xcall-claude://`) with Launch Services.
 
-Claude Code exports `CLAUDE_PLUGIN_DATA` to hooks and MCP servers but not to Bash tool calls, and `run.sh` is reached both ways. A consuming skill closes that gap by setting the variable on the command it documents, where the substitution has already resolved it. `things:url` does this on every `url.ts`, `inbox.ts`, and `reorder.ts` invocation. `build.sh` never guesses a location of its own, because a second bundle would take the `xcall-claude://` scheme from the first and `lsregister -f` does not take it back.
+There is one bundle, shared by every consuming plugin, at a path outside the plugin tree. macOS registers exactly one handler for `xcall-claude://`, and `lsregister -f` on a second bundle does not take the scheme back from the first, so a per-consumer bundle makes consumers retire each other's copies in turn. The marketplace cache is content-addressed, so a bundle built beside the source loses its registration to a deleted path on the next plugin update.
 
 ## Sandbox
 
-Neither half of the bridge survives the command sandbox. `swiftc` cannot write the bundle under `~/.claude/plugins`, and a compiled `xcall` cannot complete the URL-scheme round trip. So `run.sh` and `build.sh` both carry the `mac` plugin's `claude:dangerouslyDisableSandbox` marker, which runs them outside it.
+Neither half of the bridge survives the command sandbox. `lsregister` cannot reach Launch Services to register the bundle, and a compiled `xcall` cannot complete the URL-scheme round trip. So `run.sh` and `build.sh` both carry the `mac` plugin's `claude:dangerouslyDisableSandbox` marker, which runs them outside it.
 
 The marker hook reads the script named at the head of a command, past any `VAR=value` prefixes. A wrapper token in front of it (`time`, `env`, `timeout`) hides the script from the hook, the command runs sandboxed, and the callback is lost. Invoke `run.sh` by path with at most environment assignments ahead of it.
 
-A sandboxed `xcall` hangs rather than failing, because its own deadline is scheduled inside `applicationDidFinishLaunching`, which AppKit never calls when it cannot reach the WindowServer. `run.sh` therefore holds the deadline that always runs: it kills the process after `XCALL_TIMEOUT_SECONDS` (default 20) and exits 4.
+`xcall` cannot bound its own wait. Any deadline it scheduled would live in `applicationDidFinishLaunching`, which AppKit never calls when it cannot reach the WindowServer, so the sandboxed case that most needs a deadline is the one where it is never armed. `run.sh` holds both deadlines instead, from outside the process, and neither phase can wait forever:
+
+- `XCALL_BUILD_TIMEOUT_SECONDS` (default 20) bounds the build, and exits 3
+- `XCALL_TIMEOUT_SECONDS` (default 20) bounds the callback, and exits 4
 
 ## Usage
 
@@ -85,10 +88,10 @@ Apps with their own CLI (e.g., Shortcuts via `shortcuts run`) don't need xcall â
 ## Build Details
 
 - Source: `scripts/main.swift` (~100 lines)
-- Build: `scripts/build.sh` compiles to `${CLAUDE_PLUGIN_DATA}/xcall.app/`. It exits non-zero when the variable is unset
+- Build: `scripts/build.sh` compiles to `${XDG_CACHE_HOME:-~/.cache}/claude/x-callback-url/xcall.app/`
 - Bundle ID: `com.bendrucker.xcall-claude`
 - Callback scheme: `xcall-claude://`
 - `Info.plist`: `CFBundleTypeRole=Editor`, `LSUIElement=true`. `LSBackgroundOnly` is intentionally not set: combining it with `LSUIElement` causes macOS to refuse to route URL scheme callbacks to the app, surfacing as a "no application set" dialog.
 - After building, `build.sh` calls `lsregister -f` and verifies the scheme handler is the freshly built bundle. A bundle left behind at a path an earlier version built into keeps the scheme, and `lsregister -f` does not take it back, so `build.sh` unregisters and deletes that copy before verifying. If verification still fails it exits non-zero.
-- Build is cached â€” recompiles only if `main.swift` is newer than the binary
-- Timeouts: `xcall` gives up on the callback after 10 seconds, and `run.sh` kills it after `XCALL_TIMEOUT_SECONDS` (default 20) if it never gets that far
+- Build is cached against an `installed` stamp written next to the bundle once `lsregister` verification passes. A run that compiled but failed to register leaves no stamp, so the next call retries both
+- Timeouts: see [Sandbox](#sandbox). `run.sh` owns both, and `xcall` schedules none of its own


### PR DESCRIPTION
A sandboxed `xcall` hung indefinitely. #1202 gave the callback wait a watchdog. This covers the build phase, which had no bound, and fixes the watchdog that could not stop what it guarded.

`run_bounded` killed the pid it forked. `build.sh` runs `swiftc` and `lsregister` as foreground children, and those inherit the stdout that `BINARY="$(run_bounded ...)"` reads through. Killing the script left them holding the pipe, so the read blocked on a grandchild nobody bounded. Job control now puts each command in its own process group and the watchdog signals the group.

`run.test.ts` covers that case with a stub build forking a child that outlives it. The stubs sleep 10s against a 1s watchdog, so a `run.sh` that stopped bounding fails the elapsed assertion instead of hanging the suite.

The bundle was keyed on the *consuming* plugin's `CLAUDE_PLUGIN_DATA`, under `~/.claude/plugins`, which the sandbox denies. macOS binds one handler per URL scheme and `lsregister -f` does not hand a scheme back, so per-consumer copies retired each other in turn. One bundle now lives in `~/.cache/claude/x-callback-url`: sandbox-writable, and outside the marketplace cache whose hash rotates on every plugin update. It installs through a `$$`-suffixed scratch path and a rename so concurrent installs cannot interleave.

`register_bundle` ran only when the binary was missing, so a run that compiled and then failed to register left a binary Launch Services routed around, and every later call waited out the full timeout. An install stamp written after registration succeeds drives the retry. Re-reading the binding costs a 5.6s `lsregister -dump`, so it happens on install rather than per call.

`main.swift` carried a 10s timer that silently capped whatever `XCALL_TIMEOUT_SECONDS` the caller set, and it could only be armed from `applicationDidFinishLaunching`, which AppKit skips when it cannot reach the WindowServer. That is the sandboxed case where the callback never arrives, so the deadline belongs outside the process. `xcallBackstopMs` now derives from `run.sh`'s two bounds instead of a fixed 45s, because a backstop below their sum kills the runner before it can name its own failure.

Skipped building at install time. There is no plugin post-install hook, and a `SessionStart` hook would put `swiftc` and `lsregister` on every session whether or not anything uses xcall. Skipped a file lock too: the atomic install closes the corruption path, leaving a race that only wastes CPU.

Original Task: https://things.bendrucker.me/show?id=Xyfr9DaRSRrcgVaFKDnKFs
