### PR TITLE
plan: deny instead of ask on the ExitPlanMode gate

### DIFF
--- a/plugins/plan/README.md
+++ b/plugins/plan/README.md
@@ -6,7 +6,7 @@ Planning mode guidelines and context injection for Claude Code.
 
 - **Skill** `plan:review`: reviews how an implementation diverged from its approved plan, forking a clean-context agent over the plan and the diff to surface drift and follow-ups
 - **Hook**: Injects planning guidelines the first time a session reaches plan mode, whether that first signal is the `EnterPlanMode` call, a prompt, or a tool call, and appends delegation guidance when the orchestrator runs on an expensive model
-- **Hook**: Gates `ExitPlanMode`, denying byte-identical plan re-presents, asking on a re-present that carries the prior plan nearly intact, asking once per session when a re-present exceeds every present before it, and asking once per session before presenting a plan over 12k characters
+- **Hook**: Gates `ExitPlanMode`, denying byte-identical plan re-presents, a re-present that carries the prior plan nearly intact, once per session a re-present that exceeds every present before it, and once per session a plan over 12k characters
 
 ## How It Works
 
@@ -16,7 +16,11 @@ A third entry registers the same script on `PostToolUse` with matcher `EnterPlan
 
 Both paths call `scripts/injection-content.sh` to assemble the content. It emits `references/guidelines.md` always, and reads the latest assistant `model` from the transcript. When that model is an expensive orchestrator (opus, fable, mythos), it appends `references/delegation.md`, which requires the plan to carry a Delegation section laying out the agent/model/effort DAG. `UserPromptSubmit` returns the content on stdout; `PreToolUse` returns it as `hookSpecificOutput.additionalContext`. Any read or parse problem falls back to the guidelines alone.
 
-The `PreToolUse` gate hook keeps per-session state under `/tmp/claude/<session_id>/` and runs four checks in order. It denies a resubmission whose text is byte-identical to the last presentation. It asks when a re-present carries nearly every prior line and introduces at least one new one, which catches a line swap that nets zero growth as well as a plain append. It asks once per session when a re-present is longer than every present before it, the shape of a plan that accumulates residue instead of shedding it, measured against that high-water mark rather than the present just before. It asks once per session for plans over 12k characters. Infrastructure weirdness (missing session id, unreadable state) fails open.
+The `PreToolUse` gate hook keeps per-session state under `/tmp/claude/<session_id>/` and runs four checks in order. It denies a resubmission whose text is byte-identical to the last presentation. It denies a re-present that carries nearly every prior line and introduces at least one new one, which catches a line swap that nets zero growth as well as a plain append. It denies, once per session, a re-present longer than every present before it, the shape of a plan that accumulates residue instead of shedding it, measured against that high-water mark rather than the present just before. It denies, once per session, a plan over 12k characters.
+
+Every check denies, including the three that read as advice. A `PreToolUse` hook's `permissionDecision: "ask"` is inert on `ExitPlanMode`: the tool runs its own plan-approval prompt, and the harness drops the hook's `permissionDecisionReason` and `systemMessage` alike, so neither the user nor the transcript sees them. `deny` is the only decision that carries a reason back. Each denial is recoverable in one step, since the model reworks the plan and presents again, and the growth and size checks spend their marker on first use.
+
+A missing session id or a plan that is not a string fails open silently, since neither is a fault. Anything else, an unusable state directory or a crash mid-decision, prints to stderr and exits 1: the presentation still goes through, and the failure is visible rather than reading as a plan that passed every check.
 
 The gate reads a plan that will be handed whole to a fresh session, since a rejection usually ends the session and the plan travels by injection into the next one. Its reasons say so: a re-present close to the rejected plan needs reworking rather than re-presenting, because nothing about the rejection travels with the file.
 

--- a/plugins/plan/hooks/gate.test.ts
+++ b/plugins/plan/hooks/gate.test.ts
@@ -7,7 +7,7 @@ import type {
   PreToolUseHookInput,
   PreToolUseHookSpecificOutput,
 } from "@anthropic-ai/claude-agent-sdk";
-import { processInput } from "./gate";
+import { processInput, StateUnavailableError } from "./gate";
 
 let stateRoot: string;
 
@@ -109,12 +109,12 @@ describe("append-only re-present", () => {
     "- Add a test for the backoff schedule",
   ].join("\n");
 
-  it("asks when the re-present keeps nearly all prior lines and only adds new ones", async () => {
+  it("denies when the re-present keeps nearly all prior lines and only adds new ones", async () => {
     await decision(basePlan);
     const grown = `${basePlan}\n## Rollout\n- Ship behind a flag\n- Monitor error rates`;
     expect(await decision(grown)).toEqual({
       hookEventName: "PreToolUse",
-      permissionDecision: "ask",
+      permissionDecision: "deny",
       permissionDecisionReason: expect.stringContaining("carries nearly every prior line"),
     });
   });
@@ -134,7 +134,7 @@ describe("append-only re-present", () => {
     expect(await decision(rewritten)).toBeNull();
   });
 
-  it("does not ask on the first presentation of a plan that would otherwise qualify", async () => {
+  it("stays silent on the first presentation of a plan that would otherwise qualify", async () => {
     expect(await decision(basePlan)).toBeNull();
   });
 });
@@ -142,31 +142,33 @@ describe("append-only re-present", () => {
 describe("size advisory", () => {
   const bigPlan = (seed: string) => seed + "x".repeat(12_001);
 
-  it("asks on a plan over 12k characters", async () => {
+  it("denies a plan over 12k characters", async () => {
     expect(await decision(bigPlan("a"))).toEqual({
       hookEventName: "PreToolUse",
-      permissionDecision: "ask",
+      permissionDecision: "deny",
       permissionDecisionReason: expect.stringContaining("exceeds 12k characters"),
     });
   });
 
-  it("does not ask at exactly 12k characters", async () => {
+  it("stays silent at exactly 12k characters", async () => {
     expect(await decision("x".repeat(12_000))).toBeNull();
   });
 
-  it("asks at most once per session", async () => {
-    expect((await decision(bigPlan("a")))?.permissionDecision).toBe("ask");
+  it("denies at most once per session", async () => {
+    expect((await decision(bigPlan("a")))?.permissionDecision).toBe("deny");
     expect(await decision(bigPlan("b"))).toBeNull();
   });
 
-  it("asks again in a different session", async () => {
+  it("denies again in a different session", async () => {
     await decision(bigPlan("a"), "session-1");
-    expect((await decision(bigPlan("a"), "session-2"))?.permissionDecision).toBe("ask");
+    expect((await decision(bigPlan("a"), "session-2"))?.permissionDecision).toBe("deny");
   });
 
-  it("prefers deny when the oversized plan is also unchanged", async () => {
-    expect((await decision(bigPlan("a")))?.permissionDecision).toBe("ask");
-    expect((await decision(bigPlan("a")))?.permissionDecision).toBe("deny");
+  it("gives the byte-identical reason when the oversized plan is also unchanged", async () => {
+    expect((await decision(bigPlan("a")))?.permissionDecisionReason).toContain(
+      "exceeds 12k characters",
+    );
+    expect((await decision(bigPlan("a")))?.permissionDecisionReason).toContain("byte-identical");
   });
 });
 
@@ -176,24 +178,24 @@ describe("append-only re-present", () => {
 
   const initial = lines(10).join("\n");
 
-  it("asks when a re-present keeps nearly all prior lines and only adds new ones", async () => {
+  it("denies when a re-present keeps nearly all prior lines and only adds new ones", async () => {
     await decision(initial);
     const appended = `${initial}\nline 10`;
     expect(await decision(appended)).toEqual({
       hookEventName: "PreToolUse",
-      permissionDecision: "ask",
+      permissionDecision: "deny",
       permissionDecisionReason: expect.stringContaining("carries nearly every prior line"),
     });
   });
 
-  it("asks on a line swap that carries the document at zero net growth", async () => {
+  it("denies a line swap that carries the document at zero net growth", async () => {
     const base = lines(50).join("\n");
     await decision(base);
     // Trade 3 lines for 3 new ones: carry-over 0.94, no net size change.
     const swapped = [...lines(47), ...lines(3, "swapped")].join("\n");
     expect(await decision(swapped)).toEqual({
       hookEventName: "PreToolUse",
-      permissionDecision: "ask",
+      permissionDecision: "deny",
       permissionDecisionReason: expect.stringContaining("carries nearly every prior line"),
     });
   });
@@ -205,14 +207,14 @@ describe("append-only re-present", () => {
     expect(await decision(revised)).toBeNull();
   });
 
-  it("does not ask when the re-present adds no new lines", async () => {
+  it("stays silent when the re-present adds no new lines", async () => {
     await decision(initial);
     // Same lines, reordered: full carry-over, nothing introduced.
     const reordered = [...lines(10)].reverse().join("\n");
     expect(await decision(reordered)).toBeNull();
   });
 
-  it("does not ask when more than the incidental-drop allowance is removed", async () => {
+  it("stays silent when more than the incidental-drop allowance is removed", async () => {
     const big = lines(100).join("\n");
     await decision(big);
     // Drop 4 prior lines and add 5 new ones: carry-over is still >= 0.9, but
@@ -224,17 +226,19 @@ describe("append-only re-present", () => {
   it("allows and skips state when the stored line set is corrupt", async () => {
     await decision(initial);
     await Bun.write(join(stateRoot, "session-1", "exit-plan-lines"), "not json");
-    // A one-line swap the append-only check would ask on, at unchanged length.
+    // A one-line swap the append-only check would deny, at unchanged length.
     expect(await decision(initial.replace("line 9", "line X"))).toBeNull();
   });
 
-  it("prefers deny when the append-only re-present is byte-identical", async () => {
+  it("gives the byte-identical reason when the append-only re-present repeats", async () => {
     await decision(initial);
     await decision(`${initial}\nline 10`);
-    expect((await decision(`${initial}\nline 10`))?.permissionDecision).toBe("deny");
+    expect((await decision(`${initial}\nline 10`))?.permissionDecisionReason).toContain(
+      "byte-identical",
+    );
   });
 
-  it("asks once for append-only, not size, when the re-present is also oversized", async () => {
+  it("denies once for append-only, not size, when the re-present is also oversized", async () => {
     const pad = "x".repeat(120);
     const padded = (count: number, prefix: string) =>
       Array.from({ length: count }, (_, i) => `${prefix} ${i} ${pad}`);
@@ -246,10 +250,10 @@ describe("append-only re-present", () => {
     expect(grown.length).toBeGreaterThan(12_000);
     expect(await decision(grown)).toEqual({
       hookEventName: "PreToolUse",
-      permissionDecision: "ask",
+      permissionDecision: "deny",
       permissionDecisionReason: expect.stringContaining("carries nearly every prior line"),
     });
-    // Append-only asks before the size check, so the size branch never runs and
+    // Append-only denies before the size check, so the size branch never runs and
     // records no marker: one prompt for append-only, no second prompt for size.
     expect(readdirSync(join(stateRoot, "session-1"))).not.toContain("exit-plan-size-asked");
   });
@@ -265,18 +269,18 @@ describe("sustained growth", () => {
   const grown = rewrite("bravo", 12);
   const grownAgain = rewrite("charlie", 30);
 
-  it("asks on a second present above the high-water mark", async () => {
+  it("denies a second present above the high-water mark", async () => {
     await decision(skeletal);
     expect(await decision(grown)).toEqual({
       hookEventName: "PreToolUse",
-      permissionDecision: "ask",
+      permissionDecision: "deny",
       permissionDecisionReason: expect.stringContaining(
         `Presentation 2 is larger than any before it (${skeletal.length} -> ${grown.length} chars)`,
       ),
     });
   });
 
-  it("does not ask on a first presentation, which has no high-water mark", async () => {
+  it("stays silent on a first presentation, which has no high-water mark", async () => {
     expect(await decision(grownAgain)).toBeNull();
   });
 
@@ -292,18 +296,18 @@ describe("sustained growth", () => {
     expect(await decision(rewrite("echo", 10))).toBeNull();
   });
 
-  it("asks at most once per session", async () => {
+  it("denies at most once per session", async () => {
     await decision(skeletal);
-    expect((await decision(grown))?.permissionDecision).toBe("ask");
+    expect((await decision(grown))?.permissionDecision).toBe("deny");
     expect(await decision(rewrite("delta", 60))).toBeNull();
   });
 
-  it("counts a present the append-only check asked on, and reports its ordinal", async () => {
+  it("counts a present the append-only check denied, and reports its ordinal", async () => {
     await decision(grownAgain);
     await decision(grown);
     // An append-only third present returns before the growth branch, so the
-    // growth ask is still available when a genuine rewrite lands fourth.
-    expect((await decision(`${grown}\nbravo tail`))?.permissionDecision).toBe("ask");
+    // growth denial is still available when a genuine rewrite lands fourth.
+    expect((await decision(`${grown}\nbravo tail`))?.permissionDecision).toBe("deny");
     expect((await decision(rewrite("delta", 60)))?.permissionDecisionReason).toContain(
       "Presentation 4",
     );
@@ -315,19 +319,55 @@ describe("sustained growth", () => {
     expect(await decision(grown)).toBeNull();
   });
 
-  it("still denies a byte-identical re-present after the growth ask has fired", async () => {
+  it("still catches a byte-identical re-present after the growth denial has fired", async () => {
     await decision(skeletal);
-    expect((await decision(grown))?.permissionDecision).toBe("ask");
-    expect((await decision(grown))?.permissionDecision).toBe("deny");
+    expect((await decision(grown))?.permissionDecisionReason).toContain("larger than any before");
+    expect((await decision(grown))?.permissionDecisionReason).toContain("byte-identical");
   });
 
-  it("does not spend the ask on a plan that barely clears the high-water mark", async () => {
+  it("does not spend the denial on a plan that barely clears the high-water mark", async () => {
     await decision(grownAgain);
     // One character over the high-water mark falls inside the noise margin.
     const barelyOver = rewrite("delta", 4).padEnd(grownAgain.length + 1, "x");
     expect(await decision(barelyOver)).toBeNull();
-    // The ask is still available for growth that reads as accumulation.
-    expect((await decision(rewrite("echo", 60)))?.permissionDecision).toBe("ask");
+    // The denial is still available for growth that reads as accumulation.
+    expect((await decision(rewrite("echo", 60)))?.permissionDecision).toBe("deny");
+  });
+});
+
+// Every test above calls processInput directly, which proves the rules and not
+// that a decision survives the trip out. A gate can decide correctly and still
+// reach nobody, so drive the path the harness drives: spawn, parse, decide, print.
+// The oversized rule needs no prior state, so one piped payload covers it.
+describe("harness invocation", () => {
+  it("emits the oversized decision when run as the harness runs it", async () => {
+    const payload = JSON.stringify(mockInput("x".repeat(12_001)));
+    const gate = Bun.spawn(["bun", join(import.meta.dir, "gate.ts")], {
+      stdin: new TextEncoder().encode(payload),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, CLAUDE_PLAN_MARKER_ROOT: stateRoot },
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(gate.stdout).text(),
+      new Response(gate.stderr).text(),
+      gate.exited,
+    ]);
+
+    expect({ exitCode, stderr, decision: JSON.parse(stdout) }).toMatchInlineSnapshot(`
+      {
+        "decision": {
+          "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": "This plan exceeds 12k characters. The session that implements it reads it cold and reads nothing else. Consolidate superseded content into <plan>-decisions.md or split the scope.",
+          },
+        },
+        "exitCode": 0,
+        "stderr": "",
+      }
+    `);
   });
 });
 
@@ -352,10 +392,11 @@ describe("fail open", () => {
     expect(await decision("My plan")).toBeNull();
   });
 
-  it("allows when the state root is unusable", async () => {
+  it("reports rather than swallows an unusable state root", async () => {
     await Bun.write(join(stateRoot, "blocked"), "");
     const blocked = join(stateRoot, "blocked", "nested");
-    expect(await processInput(mockInput("My plan"), blocked)).toBeNull();
-    expect(await processInput(mockInput("My plan"), blocked)).toBeNull();
+    await expect(processInput(mockInput("My plan"), blocked)).rejects.toBeInstanceOf(
+      StateUnavailableError,
+    );
   });
 });

--- a/plugins/plan/hooks/gate.ts
+++ b/plugins/plan/hooks/gate.ts
@@ -18,23 +18,27 @@ const APPEND_ONLY_MIN_ADDED = 1;
 // only on plans over 30 unique lines, since below that the 0.9 floor is stricter.
 const APPEND_ONLY_MAX_REMOVED = 3;
 
-// Only one growth ask fires per session, so a plan that lands a hair over the
+// Only one growth denial fires per session, so a plan that lands a hair over the
 // high-water mark must not spend it. Require a margin that reads as accumulation.
 const GROWTH_MIN_EXCESS_RATIO = 0.05;
 
+// Every rule below denies. On ExitPlanMode a PreToolUse "ask" is inert: the tool
+// runs its own plan-approval prompt, and the harness drops the hook's
+// permissionDecisionReason and systemMessage alike, so neither the user nor the
+// transcript ever sees them. Deny is the only decision that carries a reason back.
 const DENY_REASON =
   "Plan text is byte-identical to the presentation that was just rejected. The plan " +
   "is the whole brief a fresh session implements from, so resubmitting it unchanged " +
   "cannot land. Rework it against the feedback since that presentation, deleting what " +
   "the feedback superseded. If the rejection carried none, ask with AskUserQuestion.";
 
-const APPEND_ONLY_ASK_REASON =
+const APPEND_ONLY_REASON =
   "This re-present carries nearly every prior line. A plan this close to the rejected " +
   "one needs reworking, not re-presenting. It will not be revised interactively. It " +
   "goes whole to a fresh session, so delete what the feedback superseded instead of " +
   "writing around it.";
 
-function growthAskReason(ordinal: number, previousMax: number, length: number): string {
+function growthReason(ordinal: number, previousMax: number, length: number): string {
   return (
     `Presentation ${ordinal} is larger than any before it (${previousMax} -> ${length} chars). ` +
     "If redirects added scope, that growth is right. Otherwise it is residue the fresh " +
@@ -43,16 +47,23 @@ function growthAskReason(ordinal: number, previousMax: number, length: number): 
   );
 }
 
-const ASK_REASON =
+const SIZE_REASON =
   "This plan exceeds 12k characters. The session that implements it reads it cold and " +
   "reads nothing else. Consolidate superseded content into <plan>-decisions.md or " +
   "split the scope.";
 
-function formatDecision(decision: "deny" | "ask", reason: string): SyncHookJSONOutput {
+export class StateUnavailableError extends Error {
+  constructor(directory: string, cause: unknown) {
+    super(`cannot create the per-session state directory ${directory}`, { cause });
+    this.name = "StateUnavailableError";
+  }
+}
+
+function formatDecision(reason: string): SyncHookJSONOutput {
   return {
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
-      permissionDecision: decision,
+      permissionDecision: "deny",
       permissionDecisionReason: reason,
     },
   };
@@ -138,8 +149,10 @@ export async function processInput(
   const dir = join(stateRoot, sessionId);
   try {
     mkdirSync(dir, { recursive: true });
-  } catch {
-    return null;
+  } catch (error) {
+    // Without state the gate is blind to every re-present rule, and a blind gate
+    // is indistinguishable from a plan that passed. Say so rather than passing.
+    throw new StateUnavailableError(dir, error);
   }
 
   const hashPath = join(dir, "exit-plan-hash");
@@ -157,12 +170,12 @@ export async function processInput(
   await writeState(linesPath, JSON.stringify(Array.from(currentLines)));
 
   if (previous !== null && previous === hash) {
-    return formatDecision("deny", DENY_REASON);
+    return formatDecision(DENY_REASON);
   }
 
-  // Past the deny, so a byte-identical resubmission neither advances the count
-  // nor raises the high-water mark. An ask still does: the hook cannot observe
-  // whether the user approved it.
+  // Past the byte-identical check, so an unchanged resubmission neither advances
+  // the count nor raises the high-water mark. Every other presentation does,
+  // denied or not: the hook cannot observe what happened after it answered.
   const presentsRaw = await readState(presentsPath);
   const history = presentsRaw === null ? null : parsePresentHistory(presentsRaw);
   const ordinal = (history?.count ?? 0) + 1;
@@ -173,7 +186,7 @@ export async function processInput(
 
   const previousLines = previousLinesRaw === null ? null : parseLineSet(previousLinesRaw);
   if (previousLines !== null && isAppendOnlyRevision(previousLines, currentLines)) {
-    return formatDecision("ask", APPEND_ONLY_ASK_REASON);
+    return formatDecision(APPEND_ONLY_REASON);
   }
 
   // A non-null history means this is at least the second present, which is the
@@ -185,15 +198,25 @@ export async function processInput(
     (await readState(growthAskedPath)) === null
   ) {
     await writeState(growthAskedPath, "asked");
-    return formatDecision("ask", growthAskReason(ordinal, history.maxLength, plan.length));
+    return formatDecision(growthReason(ordinal, history.maxLength, plan.length));
   }
 
   if (plan.length > SIZE_THRESHOLD && (await readState(askedPath)) === null) {
     await writeState(askedPath, "asked");
-    return formatDecision("ask", ASK_REASON);
+    return formatDecision(SIZE_REASON);
   }
 
   return null;
+}
+
+// Fail open, but never silently: exit 1 lets the ExitPlanMode call through while
+// the harness shows the stderr line, so a gate that has stopped deciding says so
+// instead of reading as a plan that passed every rule.
+function failOpen(problem: string, error: unknown): void {
+  console.error(
+    `[plan/gate] ${problem}: ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exitCode = 1;
 }
 
 async function main(): Promise<void> {
@@ -201,9 +224,7 @@ async function main(): Promise<void> {
   try {
     input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
   } catch (error) {
-    console.error(
-      `[plan/gate] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    failOpen("failed to parse hook input", error);
     return;
   }
 
@@ -214,5 +235,5 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.main) {
-  main().catch(console.error);
+  main().catch((error: unknown) => failOpen("failed to decide on this presentation", error));
 }


### PR DESCRIPTION
Three of the gate's four rules have never reached a user. They returned `permissionDecision: "ask"`, which is inert on `ExitPlanMode`. The tool runs its own plan-approval prompt, and the harness discards the hook's `permissionDecisionReason` and `systemMessage` both. Only `deny` carries a reason back. The byte-identical rule already denied, which is why it worked. The other three have been dark since the gate landed on 2026-07-02 in #943, about six weeks.

Every rule now denies. Thresholds are untouched.

Discovery: 29f7b0c6d81a

## Behavior Change

The three converted rules block instead of prompting. Each denial is recoverable in one step, and the growth and size rules still spend their once-per-session marker on first use. Replaying 166 historical presentations across 110 sessions through the decision function produces 34 denials, so the gate goes from silent to roughly one fire every three sessions.

## Proof

- A live session presenting a 27,391-char plan wrote `exit-plan-size-asked`, which only the size branch writes. The hook reached its decision.
- That session's transcript contains zero occurrences of the reason text.
- A probe hook returning a marked `systemMessage` and a marked ask reason produced neither in the UI nor the transcript.
- One real gate fire exists in the whole corpus: a `deny` on 2026-07-29, delivered as the `ExitPlanMode` tool result.

Both starting theories were wrong. `/tmp/claude` is writable from hooks and its state persists, and the hook never crashed.

## Failure Visibility

`main().catch(console.error)` swallowed any crash into a silent pass, so a broken gate and a passing plan looked identical. An unusable state directory now throws, and any mid-decision failure prints to stderr and exits 1.

## Testing

Reverting the state-directory throw to `return null` fails `reports rather than swallows an unusable state root`. That assertion was missing its `await` at first, so it passed against the reverted code too.

A new test spawns `gate.ts` and pipes it a payload the way the harness does, snapshotting stdout, stderr, and exit code. End to end, a live session with an oversized plan shows the size reason in the terminal and in the transcript.
