### PR TITLE
things: resolve the xcall runner when installed

### DIFF
--- a/plugins/things/CLAUDE.md
+++ b/plugins/things/CLAUDE.md
@@ -27,7 +27,11 @@ Biome linting is disabled for `scripts/jxa/` files via the root `biome.json` ove
 
 ## URL Dispatch
 
-`scripts/url.ts` owns the URL handoff. `dispatch(command, params)` builds the Things URL, runs it through the x-callback-url runner when available, and falls back to a Launch Services `open` on any xcall failure, returning the parsed todo id when xcall surfaces one. `inbox.ts`, `reorder.ts`, and `url.ts`'s own CLI call `dispatch` rather than re-implementing the runner-selection and fallback. `buildUrl`, `openUrl`, `xcall`, and `findXcallRunner` are internal to `url.ts`. Inject a `DispatchActions` to test runner selection and fallback without real Launch Services or keychain access, mirroring `plugins/gitlab/scripts/merge.ts`.
+`scripts/url.ts` owns the URL handoff. `dispatch(command, params)` builds the Things URL, runs it through the x-callback-url runner when available, and falls back to a Launch Services `open` on any xcall failure, returning the parsed todo id when xcall surfaces one. `inbox.ts`, `reorder.ts`, and `url.ts`'s own CLI call `dispatch` rather than re-implementing the runner-selection and fallback. `buildUrl`, `openUrl`, and `xcall` are internal to `url.ts`. Inject a `DispatchActions` to test runner selection and fallback without real Launch Services or keychain access, mirroring `plugins/gitlab/scripts/merge.ts`.
+
+`findXcallRunner` resolves the runner from two layouts: a sibling plugin directory in the dev checkout, and `<marketplace>/x-callback-url/<version>/scripts/run.sh` when installed, where `<version>` is the marketplace commit this plugin was installed from. It accepts no other version. `xcallBackstopMs` sizes its timeout from this build's own view of `run.sh`'s bounds, and only the same-commit runner is known to honor them, so a mismatched runner could outlive the backstop and die on a signal instead of naming its own failure.
+
+It takes the plugin root as an argument and is exported so tests can point it at a fixture tree. Injecting it through `DispatchActions` covers what `dispatch` does with a runner, never how one gets found, so the resolver needs its own fixtures across both layouts.
 
 `reorder.ts` and `inbox.ts` are bun TypeScript scripts (not `osascript`). Their Launch Services handoff runs outside the command sandbox via the `claude:dangerouslyDisableSandbox` marker.
 

--- a/plugins/things/scripts/url.test.ts
+++ b/plugins/things/scripts/url.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   buildJsonPayload,
   coerceAttributes,
   type DispatchActions,
   dispatch,
+  findXcallRunner,
   isSandboxBlockedHandoff,
   XcallError,
   xcallBackstopMs,
@@ -283,6 +287,79 @@ describe("dispatch", () => {
 
     await expect(dispatch("add", new Map([["title", "Buy milk"]]), actions)).rejects.toThrow(
       "open blocked",
+    );
+  });
+});
+
+// `dispatch` injects findXcallRunner, so the real resolver ran unexercised and
+// shipped returning null for every installed plugin: it gated its version scan
+// on Bun.file(dir).exists(), which is false for a directory, so the scan never
+// ran and xcall never got invoked.
+describe("findXcallRunner", () => {
+  const version = "69eed9ed34f1";
+  const other = "282d5556b96b";
+
+  async function tree(...paths: string[]): Promise<string> {
+    const root = mkdtempSync(join(tmpdir(), "things-marketplace-"));
+    for (const path of paths) await Bun.write(join(root, path), "");
+    return root;
+  }
+
+  test.each<{
+    name: string;
+    layout: string[];
+    pluginRoot: string[];
+    runner: string[] | null;
+  }>([
+    {
+      name: "resolves the sibling installed from the same marketplace commit",
+      layout: [
+        `things/${version}/scripts/url.ts`,
+        `x-callback-url/${other}/scripts/run.sh`,
+        `x-callback-url/${version}/scripts/run.sh`,
+      ],
+      pluginRoot: ["things", version],
+      runner: ["x-callback-url", version, "scripts", "run.sh"],
+    },
+    {
+      name: "prefers a dev checkout's sibling directory over the installed layout",
+      layout: [
+        "things/scripts/url.ts",
+        "x-callback-url/scripts/run.sh",
+        `x-callback-url/${version}/scripts/run.sh`,
+      ],
+      pluginRoot: ["things"],
+      runner: ["x-callback-url", "scripts", "run.sh"],
+    },
+    {
+      name: "declines a runner from a version this plugin was not installed with",
+      layout: [`things/${version}/scripts/url.ts`, `x-callback-url/${other}/scripts/run.sh`],
+      pluginRoot: ["things", version],
+      runner: null,
+    },
+    {
+      name: "finds nothing when no sibling plugin is installed",
+      layout: [`things/${version}/scripts/url.ts`],
+      pluginRoot: ["things", version],
+      runner: null,
+    },
+    {
+      name: "finds nothing when the matching version carries no runner",
+      layout: [`things/${version}/scripts/url.ts`, `x-callback-url/${version}/scripts/main.swift`],
+      pluginRoot: ["things", version],
+      runner: null,
+    },
+    {
+      name: "finds nothing when a file sits where the sibling plugin should be",
+      layout: [`things/${version}/scripts/url.ts`, "x-callback-url"],
+      pluginRoot: ["things", version],
+      runner: null,
+    },
+  ])("$name", async ({ layout, pluginRoot, runner }) => {
+    const root = await tree(...layout);
+
+    expect(await findXcallRunner(join(root, ...pluginRoot))).toBe(
+      runner ? join(root, ...runner) : null,
     );
   });
 });

--- a/plugins/things/scripts/url.ts
+++ b/plugins/things/scripts/url.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env bun
 // claude:dangerouslyDisableSandbox: hands off to open/xcall for Things URL schemes and osascript via ensure-running, which the command sandbox blocks
 
-import { readdirSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { $ } from "bun";
 import { cli } from "cleye";
 import { ensureThingsRunning } from "./ensure-running";
@@ -103,23 +102,29 @@ async function openUrl(
   }
 }
 
-async function findXcallRunner(): Promise<string | null> {
-  const pluginRoot = join(import.meta.dirname, "..");
-
+export async function findXcallRunner(
+  pluginRoot: string = join(import.meta.dirname, ".."),
+): Promise<string | null> {
   // Dev layout: sibling plugin directory
   const devPath = join(pluginRoot, "..", "x-callback-url", "scripts", "run.sh");
   if (await Bun.file(devPath).exists()) return devPath;
 
-  // Prod layout: up 2 levels to marketplace root, then into x-callback-url/<version>/
-  const marketplaceDir = join(pluginRoot, "..", "..", "x-callback-url");
-  if (await Bun.file(marketplaceDir).exists()) {
-    for (const entry of readdirSync(marketplaceDir)) {
-      const candidate = join(marketplaceDir, entry, "scripts", "run.sh");
-      if (await Bun.file(candidate).exists()) return candidate;
-    }
-  }
-
-  return null;
+  // Installed layout: <marketplace>/<plugin>/<version>, where the version
+  // directory is the marketplace commit. Only the sibling under this plugin's
+  // own version was installed from the same commit, and only its run.sh is
+  // known to honor the bounds xcallBackstopMs sizes its backstop against. A
+  // runner from any other version could outlive the backstop and die on a
+  // signal rather than naming its own failure, so no other version qualifies.
+  const installedPath = join(
+    pluginRoot,
+    "..",
+    "..",
+    "x-callback-url",
+    basename(pluginRoot),
+    "scripts",
+    "run.sh",
+  );
+  return (await Bun.file(installedPath).exists()) ? installedPath : null;
 }
 
 const BOOLEAN_ATTRIBUTES = ["completed", "canceled", "reveal", "duplicate"] as const;


### PR DESCRIPTION
`findXcallRunner` gated its installed-layout scan on `Bun.file(dir).exists()`. That is a file API and returns `false` for a directory, so the scan never ran and the function returned `null` for every installed copy of the plugin. Every write from an installed `things` plugin fell through to a fire-and-forget `open` with no todo id back. Only a dev checkout, which matches on the earlier sibling-directory branch, ever found a runner.

The installed layout is `<marketplace>/<plugin>/<version>`, where the version directory is the marketplace commit the plugin was installed from. The fix resolves the sibling under this plugin's *own* version and accepts no other.

An earlier draft scanned the sibling's other versions and took any runner it found. Adversarial review killed that. `xcallBackstopMs` sizes its `Bun.spawn` timeout from this build's view of `run.sh`'s two env bounds, so a runner built at a different commit could carry different bounds, outlive the backstop, and die on an anonymous `SIGTERM` instead of naming its own failure. Declining the mismatch keeps the diagnostic. A partially-installed marketplace now resolves nothing rather than something unpredictable, which the existing `fallbackReason` path already reports.

The bug survived because `dispatch` takes `findXcallRunner` through `DispatchActions`, so every test injected a stub and the real resolver ran nowhere. It is now exported with the plugin root as a parameter. A `test.each` table walks it over fixture trees covering:

- both layouts, with the dev checkout winning when both are present
- a version mismatch
- a missing sibling plugin
- a matching version carrying no `run.sh`
- a file where the sibling directory should be

Verified against the real cache: 14 of the 15 installed `things` versions now resolve their same-commit runner, and the one with no `x-callback-url` counterpart resolves `null`. Before the fix all 15 resolved `null`.
