### PR TITLE
things: serve the MCP tools over stdio

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -207,8 +207,10 @@
       "version": "1.0.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "cleye": "^2.0.0",
         "table": "^6.9.0",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@jxa/global-type": "^1.4.0",
@@ -504,7 +506,7 @@
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.1.1", "", { "dependencies": { "@chevrotain/types": "~11.1.1" } }, "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
     "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.11", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA=="],
 

--- a/plugins/things/CLAUDE.md
+++ b/plugins/things/CLAUDE.md
@@ -45,6 +45,8 @@ A degraded dispatch is no longer silent. `dispatch` returns a `fallbackReason` n
 
 Keep `console.log` under `import.meta.main`. A function both the CLI and a tool call returns its result and lets the CLI print it. Send diagnostics to stderr, which tailgate logs. Pipe or `.quiet()` every subprocess, including Bun's `$`, which inherits stdout by default. `src/mcp/stdio.test.ts` fails on any stdout line that will not parse as JSON.
 
+`src/mcp/jxa.ts` resolves the `mac` plugin's JXA runner across the same two layouts as `findXcallRunner`, and accepts only the sibling under this plugin's own version directory. The runner's argument contract moves between commits: it now forwards everything past the script path to the script, where an older one claimed those flags itself and left the script answering with a usage error. `findJxaRunner` takes the plugin root as an argument so tests can point it at a fixture tree.
+
 ## What NOT to Do
 
 - **Don't use `tag.toDos().length`** for tag metadata — includes logbook items (13K+), extremely slow

--- a/plugins/things/CLAUDE.md
+++ b/plugins/things/CLAUDE.md
@@ -39,6 +39,12 @@ A degraded dispatch is no longer silent. `dispatch` returns a `fallbackReason` n
 
 `xcallBackstopMs` in `url.ts` guards a runner that dies without honoring its own watchdogs. It reads `run.sh`'s two bounds from the environment and adds a margin, so raising either bound cannot make the backstop kill the runner before it names its own failure.
 
+## MCP Server
+
+`src/mcp/stdio.ts` serves the same reads and writes over stdio for tailgate, reusing `url.ts`, `inbox.ts`, `reorder.ts`, and `ensure-running.ts`. stdout there is the JSON-RPC channel, so anything those modules print at runtime corrupts the protocol.
+
+Keep `console.log` under `import.meta.main`. A function both the CLI and a tool call returns its result and lets the CLI print it. Send diagnostics to stderr, which tailgate logs. Pipe or `.quiet()` every subprocess, including Bun's `$`, which inherits stdout by default. `src/mcp/stdio.test.ts` fails on any stdout line that will not parse as JSON.
+
 ## What NOT to Do
 
 - **Don't use `tag.toDos().length`** for tag metadata — includes logbook items (13K+), extremely slow

--- a/plugins/things/CLAUDE.md
+++ b/plugins/things/CLAUDE.md
@@ -10,7 +10,7 @@ JXA scripts run via `osascript`, which requires Apple Events mach-lookup service
 - Formatter (`scripts/format-output.ts`): reads JSON from stdin, outputs tables or passes through `--json`
 - JXA execution: invoke the `mac:jxa-run` skill, which validates `Application("Things3")` scope via AST
 
-Scripts that hand off to Launch Services (`inbox.ts`, `url.ts`, `reorder.ts`) carry the `claude:dangerouslyDisableSandbox` marker so the `mac` plugin's sandbox hook runs them fully outside the command sandbox. `sandbox.allowAppleEvents` alone does not survive the handoff. See [`plugins/mac/README.md`](../mac/README.md).
+Scripts that hand off to Launch Services (`inbox.ts`, `url.ts`, `reorder.ts`, `src/mcp/stdio.ts`) carry the `claude:dangerouslyDisableSandbox` marker so the `mac` plugin's sandbox hook runs them fully outside the command sandbox. `sandbox.allowAppleEvents` alone does not survive the handoff. See [`plugins/mac/README.md`](../mac/README.md).
 
 ## JXA Script Conventions
 
@@ -45,7 +45,7 @@ A degraded dispatch is no longer silent. `dispatch` returns a `fallbackReason` n
 
 Keep `console.log` under `import.meta.main`. A function both the CLI and a tool call returns its result and lets the CLI print it. Send diagnostics to stderr, which tailgate logs. Pipe or `.quiet()` every subprocess, including Bun's `$`, which inherits stdout by default. `src/mcp/stdio.test.ts` fails on any stdout line that will not parse as JSON.
 
-`src/mcp/jxa.ts` resolves the `mac` plugin's JXA runner across the same two layouts as `findXcallRunner`, and accepts only the sibling under this plugin's own version directory. The runner's argument contract moves between commits: it now forwards everything past the script path to the script, where an older one claimed those flags itself and left the script answering with a usage error. `findJxaRunner` takes the plugin root as an argument so tests can point it at a fixture tree.
+`src/mcp/jxa.ts` resolves the `mac` plugin's JXA runner across the same two layouts as `findXcallRunner`, and accepts only the sibling under this plugin's own version directory. The runner's argument contract is versioned: this build expects the runner to forward everything past the script path to the script itself, and a runner from another commit may claim those flags and leave the script answering with a usage error. `findJxaRunner` takes the plugin root as an argument so tests can point it at a fixture tree.
 
 ## What NOT to Do
 

--- a/plugins/things/README.md
+++ b/plugins/things/README.md
@@ -21,6 +21,10 @@ Uses only **public APIs** from Cultured Code — URL scheme (`things:///`) for w
 
 Write verification uses the `x-callback-url` plugin's `xcall` skill.
 
+### MCP Server
+
+- `src/mcp/`: stdio MCP server exposing the same reads and writes to any MCP client, spawned by [tailgate](https://github.com/bendrucker/tailgate). See [`src/mcp/README.md`](src/mcp/README.md).
+
 ## Testing
 
 ```bash

--- a/plugins/things/package.json
+++ b/plugins/things/package.json
@@ -14,8 +14,10 @@
   "type": "commonjs",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "cleye": "^2.0.0",
-    "table": "^6.9.0"
+    "table": "^6.9.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@jxa/global-type": "^1.4.0",

--- a/plugins/things/scripts/inbox.test.ts
+++ b/plugins/things/scripts/inbox.test.ts
@@ -1,5 +1,23 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { printCaptured } from "./inbox";
+import { buildAttribution, printCaptured } from "./inbox";
+
+describe("buildAttribution", () => {
+  test("resumes in the caller's directory", () => {
+    expect(buildAttribution("sess-1", "/repos/thing")).toMatchInlineSnapshot(`
+      "---
+
+      🤖 Created via Claude Code (Session: sess-1)
+
+      \`\`\`sh
+      cd /repos/thing && claude --resume sess-1
+      \`\`\`"
+    `);
+  });
+
+  test("falls back to the process directory", () => {
+    expect(buildAttribution("sess-1")).toContain(`cd ${process.cwd()} &&`);
+  });
+});
 
 describe("printCaptured", () => {
   let log: ReturnType<typeof spyOn>;

--- a/plugins/things/scripts/inbox.test.ts
+++ b/plugins/things/scripts/inbox.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { buildAttribution, printCaptured } from "./inbox";
+import { $ } from "bun";
+import { buildAttribution, printCaptured, shellQuote } from "./inbox";
 
 describe("buildAttribution", () => {
   test("resumes in the caller's directory", () => {
@@ -9,7 +10,7 @@ describe("buildAttribution", () => {
       🤖 Created via Claude Code (Session: sess-1)
 
       \`\`\`sh
-      cd /repos/thing && claude --resume sess-1
+      cd '/repos/thing' && claude --resume 'sess-1'
       \`\`\`"
     `);
   });
@@ -21,9 +22,43 @@ describe("buildAttribution", () => {
       🤖 Created via Claude Code (Session: sess-1)
 
       \`\`\`sh
-      claude --resume sess-1
+      claude --resume 'sess-1'
       \`\`\`"
     `);
+  });
+
+  test.each<{ name: string; directory: string; expected: string }>([
+    {
+      name: "a space",
+      directory: "/repos/my thing",
+      expected: "cd '/repos/my thing' && claude --resume 'sess-1'",
+    },
+    {
+      name: "an embedded single quote",
+      directory: "/repos/ben's thing",
+      expected: "cd '/repos/ben'\\''s thing' && claude --resume 'sess-1'",
+    },
+    {
+      name: "a command separator",
+      directory: "/repos/a; rm -rf b",
+      expected: "cd '/repos/a; rm -rf b' && claude --resume 'sess-1'",
+    },
+  ])("quotes a directory containing $name", ({ directory, expected }) => {
+    expect(buildAttribution("sess-1", directory)).toContain(expected);
+  });
+
+  // The point of the quoting is that a shell reads the value back whole, so ask
+  // one. `directory` reaches this as an MCP tool argument, hence arbitrary.
+  test.each([
+    "/repos/my thing",
+    "/repos/ben's thing",
+    "/repos/a; rm -rf b",
+    "/repos/$(whoami)",
+    "/repos/back\\slash",
+    '/repos/"quoted"',
+  ])("survives a shell round trip: %s", async (directory) => {
+    const { stdout } = await $`sh -c ${`printf %s ${shellQuote(directory)}`}`.quiet();
+    expect(stdout.toString()).toBe(directory);
   });
 });
 

--- a/plugins/things/scripts/inbox.test.ts
+++ b/plugins/things/scripts/inbox.test.ts
@@ -14,8 +14,16 @@ describe("buildAttribution", () => {
     `);
   });
 
-  test("falls back to the process directory", () => {
-    expect(buildAttribution("sess-1")).toContain(`cd ${process.cwd()} &&`);
+  test("omits the cd when the caller has no directory to name", () => {
+    expect(buildAttribution("sess-1")).toMatchInlineSnapshot(`
+      "---
+
+      🤖 Created via Claude Code (Session: sess-1)
+
+      \`\`\`sh
+      claude --resume sess-1
+      \`\`\`"
+    `);
   });
 });
 

--- a/plugins/things/scripts/inbox.ts
+++ b/plugins/things/scripts/inbox.ts
@@ -9,12 +9,16 @@ import { dispatch, warnFallback } from "./url";
 const INBOX_PARAMS = new Set(["title", "titles", "notes", "tags", "checklist-items"]);
 
 /**
- * Builds the resume footer for a captured todo. `directory` is a parameter
- * because the MCP server runs as a child of tailgate, whose cwd has nothing
- * to do with the session being attributed.
+ * Builds the resume footer for a captured todo. The caller supplies
+ * `directory`, since the MCP server runs as a child of tailgate, whose cwd has
+ * nothing to do with the session being attributed. A caller that doesn't know
+ * the directory gets a snippet without the `cd`, which resumes from wherever
+ * it's pasted.
  */
-export function buildAttribution(sessionId: string, directory = process.cwd()): string {
-  return `---\n\n🤖 Created via Claude Code (Session: ${sessionId})\n\n\`\`\`sh\ncd ${directory} && claude --resume ${sessionId}\n\`\`\``;
+export function buildAttribution(sessionId: string, directory?: string): string {
+  const resume = `claude --resume ${sessionId}`;
+  const command = directory ? `cd ${directory} && ${resume}` : resume;
+  return `---\n\n🤖 Created via Claude Code (Session: ${sessionId})\n\n\`\`\`sh\n${command}\n\`\`\``;
 }
 
 export function printCaptured(params: Map<string, string>): void {
@@ -71,7 +75,7 @@ if (import.meta.main) {
   const tags = mergeTags(["Claude"], argv.flags.tag ?? [], parseTags(params.get("tags")));
   params.set("tags", tags.join(","));
 
-  const attribution = buildAttribution(argv.flags.sessionId);
+  const attribution = buildAttribution(argv.flags.sessionId, process.cwd());
   const existing = params.get("notes");
   params.set("notes", existing ? `${existing}\n\n${attribution}` : attribution);
 

--- a/plugins/things/scripts/inbox.ts
+++ b/plugins/things/scripts/inbox.ts
@@ -8,9 +8,13 @@ import { dispatch, warnFallback } from "./url";
 
 const INBOX_PARAMS = new Set(["title", "titles", "notes", "tags", "checklist-items"]);
 
-function buildAttribution(sessionId: string): string {
-  const dir = process.cwd();
-  return `---\n\n🤖 Created via Claude Code (Session: ${sessionId})\n\n\`\`\`sh\ncd ${dir} && claude --resume ${sessionId}\n\`\`\``;
+/**
+ * Builds the resume footer for a captured todo. `directory` is a parameter
+ * rather than always `process.cwd()` because the MCP server runs as a child of
+ * tailgate, whose cwd has nothing to do with the session being attributed.
+ */
+export function buildAttribution(sessionId: string, directory = process.cwd()): string {
+  return `---\n\n🤖 Created via Claude Code (Session: ${sessionId})\n\n\`\`\`sh\ncd ${directory} && claude --resume ${sessionId}\n\`\`\``;
 }
 
 export function printCaptured(params: Map<string, string>): void {

--- a/plugins/things/scripts/inbox.ts
+++ b/plugins/things/scripts/inbox.ts
@@ -10,8 +10,8 @@ const INBOX_PARAMS = new Set(["title", "titles", "notes", "tags", "checklist-ite
 
 /**
  * Builds the resume footer for a captured todo. `directory` is a parameter
- * rather than always `process.cwd()` because the MCP server runs as a child of
- * tailgate, whose cwd has nothing to do with the session being attributed.
+ * because the MCP server runs as a child of tailgate, whose cwd has nothing
+ * to do with the session being attributed.
  */
 export function buildAttribution(sessionId: string, directory = process.cwd()): string {
   return `---\n\n🤖 Created via Claude Code (Session: ${sessionId})\n\n\`\`\`sh\ncd ${directory} && claude --resume ${sessionId}\n\`\`\``;

--- a/plugins/things/scripts/inbox.ts
+++ b/plugins/things/scripts/inbox.ts
@@ -9,6 +9,18 @@ import { dispatch, warnFallback } from "./url";
 const INBOX_PARAMS = new Set(["title", "titles", "notes", "tags", "checklist-items"]);
 
 /**
+ * Wraps a value so a shell reads it as one literal argument. Single quotes stop
+ * every other metacharacter, and an embedded single quote closes the run, escapes
+ * itself, and reopens.
+ *
+ * Both values this quotes arrive as MCP tool arguments, so they are arbitrary
+ * strings that end up in a snippet the user pastes into a shell.
+ */
+export function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+/**
  * Builds the resume footer for a captured todo. The caller supplies
  * `directory`, since the MCP server runs as a child of tailgate, whose cwd has
  * nothing to do with the session being attributed. A caller that doesn't know
@@ -16,8 +28,8 @@ const INBOX_PARAMS = new Set(["title", "titles", "notes", "tags", "checklist-ite
  * it's pasted.
  */
 export function buildAttribution(sessionId: string, directory?: string): string {
-  const resume = `claude --resume ${sessionId}`;
-  const command = directory ? `cd ${directory} && ${resume}` : resume;
+  const resume = `claude --resume ${shellQuote(sessionId)}`;
+  const command = directory ? `cd ${shellQuote(directory)} && ${resume}` : resume;
   return `---\n\n🤖 Created via Claude Code (Session: ${sessionId})\n\n\`\`\`sh\n${command}\n\`\`\``;
 }
 

--- a/plugins/things/scripts/reorder.test.ts
+++ b/plugins/things/scripts/reorder.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { reorder } from "./reorder";
+
+// Both guards reject before reorder dispatches anything, so these run without
+// Things. They previously called process.exit, which would have killed the MCP
+// server rather than returning a tool error.
+describe("reorder input guards", () => {
+  test.each<[string, string, string[], string]>([
+    ["empty ids", "today", [], "No IDs provided"],
+    ["unknown list", "logbook", ["abc"], "Invalid list: logbook"],
+  ])("rejects %s by throwing", async (_name, list, ids, message) => {
+    await expect(reorder(list, ids)).rejects.toThrow(message);
+  });
+});

--- a/plugins/things/scripts/reorder.ts
+++ b/plugins/things/scripts/reorder.ts
@@ -29,22 +29,31 @@ async function updateWhen(ids: string[], when: string): Promise<void> {
   warnFallback(await dispatch("json", params));
 }
 
-async function reorder(targetList: string, ids: string[]): Promise<void> {
+export interface ReorderResult {
+  success: true;
+  list: string;
+  reordered: number;
+}
+
+/**
+ * Throws on bad input and returns its outcome, leaving both for the caller to
+ * present. The MCP server calls this on a live stdio connection, where an exit
+ * ends the session and a print to stdout corrupts the JSON-RPC framing.
+ */
+export async function reorder(targetList: string, ids: string[]): Promise<ReorderResult> {
   if (ids.length === 0) {
-    console.error("No IDs provided");
-    process.exit(1);
+    throw new Error("No IDs provided");
   }
 
   const intermediate = INTERMEDIATE_LIST[targetList];
   if (!intermediate) {
-    console.error(`Invalid list: ${targetList}`);
-    process.exit(1);
+    throw new Error(`Invalid list: ${targetList}`);
   }
 
   await updateWhen(ids, intermediate);
   await updateWhen(ids, targetList);
 
-  console.log(JSON.stringify({ success: true, list: targetList, reordered: ids.length }));
+  return { success: true, list: targetList, reordered: ids.length };
 }
 
 if (import.meta.main) {
@@ -61,5 +70,11 @@ if (import.meta.main) {
   });
 
   await ensureThingsRunning();
-  await reorder(argv.flags.list, argv._.ids);
+
+  try {
+    console.log(JSON.stringify(await reorder(argv.flags.list, argv._.ids)));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
 }

--- a/plugins/things/scripts/url.test.ts
+++ b/plugins/things/scripts/url.test.ts
@@ -291,75 +291,17 @@ describe("dispatch", () => {
   });
 });
 
-// `dispatch` injects findXcallRunner, so the real resolver ran unexercised and
-// shipped returning null for every installed plugin: it gated its version scan
-// on Bun.file(dir).exists(), which is false for a directory, so the scan never
-// ran and xcall never got invoked.
 describe("findXcallRunner", () => {
-  const version = "69eed9ed34f1";
-  const other = "282d5556b96b";
-
-  async function tree(...paths: string[]): Promise<string> {
+  test("names the x-callback-url plugin's run.sh", async () => {
     const root = mkdtempSync(join(tmpdir(), "things-marketplace-"));
-    for (const path of paths) await Bun.write(join(root, path), "");
-    return root;
-  }
-
-  test.each<{
-    name: string;
-    layout: string[];
-    pluginRoot: string[];
-    runner: string[] | null;
-  }>([
-    {
-      name: "resolves the sibling installed from the same marketplace commit",
-      layout: [
-        `things/${version}/scripts/url.ts`,
-        `x-callback-url/${other}/scripts/run.sh`,
-        `x-callback-url/${version}/scripts/run.sh`,
-      ],
-      pluginRoot: ["things", version],
-      runner: ["x-callback-url", version, "scripts", "run.sh"],
-    },
-    {
-      name: "prefers a dev checkout's sibling directory over the installed layout",
-      layout: [
-        "things/scripts/url.ts",
-        "x-callback-url/scripts/run.sh",
-        `x-callback-url/${version}/scripts/run.sh`,
-      ],
-      pluginRoot: ["things"],
-      runner: ["x-callback-url", "scripts", "run.sh"],
-    },
-    {
-      name: "declines a runner from a version this plugin was not installed with",
-      layout: [`things/${version}/scripts/url.ts`, `x-callback-url/${other}/scripts/run.sh`],
-      pluginRoot: ["things", version],
-      runner: null,
-    },
-    {
-      name: "finds nothing when no sibling plugin is installed",
-      layout: [`things/${version}/scripts/url.ts`],
-      pluginRoot: ["things", version],
-      runner: null,
-    },
-    {
-      name: "finds nothing when the matching version carries no runner",
-      layout: [`things/${version}/scripts/url.ts`, `x-callback-url/${version}/scripts/main.swift`],
-      pluginRoot: ["things", version],
-      runner: null,
-    },
-    {
-      name: "finds nothing when a file sits where the sibling plugin should be",
-      layout: [`things/${version}/scripts/url.ts`, "x-callback-url"],
-      pluginRoot: ["things", version],
-      runner: null,
-    },
-  ])("$name", async ({ layout, pluginRoot, runner }) => {
-    const root = await tree(...layout);
-
-    expect(await findXcallRunner(join(root, ...pluginRoot))).toBe(
-      runner ? join(root, ...runner) : null,
+    await Bun.write(join(root, "x-callback-url/scripts/run.sh"), "");
+    expect(await findXcallRunner(join(root, "things"))).toBe(
+      join(root, "x-callback-url", "scripts", "run.sh"),
     );
+  });
+
+  test("finds nothing when the plugin is absent", async () => {
+    const root = mkdtempSync(join(tmpdir(), "things-marketplace-"));
+    expect(await findXcallRunner(join(root, "things"))).toBeNull();
   });
 });

--- a/plugins/things/scripts/url.ts
+++ b/plugins/things/scripts/url.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env bun
 // claude:dangerouslyDisableSandbox: hands off to open/xcall for Things URL schemes and osascript via ensure-running, which the command sandbox blocks
 
-import { basename, join } from "node:path";
+import { join } from "node:path";
 import { $ } from "bun";
 import { cli } from "cleye";
+import { findSiblingScript } from "../src/marketplace";
 import { ensureThingsRunning } from "./ensure-running";
 
 const AUTH_REQUIRED_COMMANDS = ["update", "update-project", "json"] as const;
@@ -98,34 +99,28 @@ async function openUrl(
           `Things URL handoff was blocked by the Claude Code sandbox (LaunchServices procNotFound / -10810 / -10673). Launch Services handoff requires sandbox.allowAppleEvents in user/settings.json. Original stderr: ${stderr.trim()}`,
         );
       }
+      // ShellError's own message is only the exit code, and `.quiet()` holds
+      // what `open` printed, so the diagnostic reaches a caller only if the
+      // message carries it.
+      const detail = stderr.trim() || error.stdout.toString().trim();
+      throw new Error(
+        `Things URL handoff failed (open exited ${error.exitCode})${detail ? `: ${detail}` : ""}`,
+      );
     }
     throw error;
   }
 }
 
-export async function findXcallRunner(
+/**
+ * The version match matters here because only the same-commit `run.sh` is known
+ * to honor the bounds `xcallBackstopMs` sizes its backstop against. A runner
+ * from another version could outlive the backstop and die on a signal rather
+ * than naming its own failure.
+ */
+export function findXcallRunner(
   pluginRoot: string = join(import.meta.dirname, ".."),
 ): Promise<string | null> {
-  // Dev layout: sibling plugin directory
-  const devPath = join(pluginRoot, "..", "x-callback-url", "scripts", "run.sh");
-  if (await Bun.file(devPath).exists()) return devPath;
-
-  // Installed layout: <marketplace>/<plugin>/<version>, where the version
-  // directory is the marketplace commit. Only the sibling under this plugin's
-  // own version was installed from the same commit, and only its run.sh is
-  // known to honor the bounds xcallBackstopMs sizes its backstop against. A
-  // runner from any other version could outlive the backstop and die on a
-  // signal rather than naming its own failure, so no other version qualifies.
-  const installedPath = join(
-    pluginRoot,
-    "..",
-    "..",
-    "x-callback-url",
-    basename(pluginRoot),
-    "scripts",
-    "run.sh",
-  );
-  return (await Bun.file(installedPath).exists()) ? installedPath : null;
+  return findSiblingScript(pluginRoot, "x-callback-url", "scripts", "run.sh");
 }
 
 const BOOLEAN_ATTRIBUTES = ["completed", "canceled", "reveal", "duplicate"] as const;

--- a/plugins/things/scripts/url.ts
+++ b/plugins/things/scripts/url.ts
@@ -84,11 +84,12 @@ async function openUrl(
   const background = options?.background ?? (command !== "show" && command !== "search");
 
   try {
-    if (background) {
-      await $`open -g ${url}`;
-    } else {
-      await $`open ${url}`;
-    }
+    // Bun's `$` inherits stdout, which is the MCP server's JSON-RPC channel, so
+    // anything Launch Services prints there corrupts the protocol. Capture it
+    // and forward it to stderr, where both the CLI and tailgate's logs read it.
+    const result = background ? await $`open -g ${url}`.quiet() : await $`open ${url}`.quiet();
+    const output = result.stdout.toString() + result.stderr.toString();
+    if (output) process.stderr.write(output);
   } catch (error) {
     if (error instanceof $.ShellError) {
       const stderr = error.stderr.toString();

--- a/plugins/things/src/marketplace.test.ts
+++ b/plugins/things/src/marketplace.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findSiblingScript } from "./marketplace";
+
+// Both callers of this resolver previously scanned the installed layout by
+// checking Bun.file(<dir>).exists(), which is false for a directory. The scan
+// never ran, so no installed plugin ever resolved a sibling script.
+describe("findSiblingScript", () => {
+  const version = "69eed9ed34f1";
+  const other = "282d5556b96b";
+
+  async function tree(...paths: string[]): Promise<string> {
+    const root = mkdtempSync(join(tmpdir(), "things-marketplace-"));
+    for (const path of paths) await Bun.write(join(root, path), "");
+    return root;
+  }
+
+  test.each<{
+    name: string;
+    layout: string[];
+    pluginRoot: string[];
+    found: string[] | null;
+  }>([
+    {
+      name: "resolves the sibling installed from the same marketplace commit",
+      layout: [
+        `things/${version}/scripts/url.ts`,
+        `mac/${other}/scripts/jxa.ts`,
+        `mac/${version}/scripts/jxa.ts`,
+      ],
+      pluginRoot: ["things", version],
+      found: ["mac", version, "scripts", "jxa.ts"],
+    },
+    {
+      name: "prefers a dev checkout's sibling directory over the installed layout",
+      layout: ["things/scripts/url.ts", "mac/scripts/jxa.ts", `mac/${version}/scripts/jxa.ts`],
+      pluginRoot: ["things"],
+      found: ["mac", "scripts", "jxa.ts"],
+    },
+    {
+      name: "declines a sibling from a version this plugin was not installed with",
+      layout: [`things/${version}/scripts/url.ts`, `mac/${other}/scripts/jxa.ts`],
+      pluginRoot: ["things", version],
+      found: null,
+    },
+    {
+      name: "finds nothing when the sibling plugin is not installed",
+      layout: [`things/${version}/scripts/url.ts`],
+      pluginRoot: ["things", version],
+      found: null,
+    },
+    {
+      name: "finds nothing when the matching version carries no such script",
+      layout: [`things/${version}/scripts/url.ts`, `mac/${version}/scripts/sandbox.ts`],
+      pluginRoot: ["things", version],
+      found: null,
+    },
+    {
+      name: "finds nothing when a file sits where the sibling plugin should be",
+      layout: [`things/${version}/scripts/url.ts`, "mac"],
+      pluginRoot: ["things", version],
+      found: null,
+    },
+  ])("$name", async ({ layout, pluginRoot, found }) => {
+    const root = await tree(...layout);
+    const resolved = await findSiblingScript(join(root, ...pluginRoot), "mac", "scripts", "jxa.ts");
+    expect(resolved).toBe(found ? join(root, ...found) : null);
+  });
+});

--- a/plugins/things/src/marketplace.ts
+++ b/plugins/things/src/marketplace.ts
@@ -1,0 +1,30 @@
+/**
+ * Locates a script inside a sibling plugin. Cross-plugin imports are
+ * disallowed, so a sibling's code is reachable only by path, and the path
+ * depends on which layout the plugin is installed in.
+ */
+
+import { basename, join } from "node:path";
+
+/**
+ * Resolves `plugin`'s script from this plugin's own root, or null when no
+ * sibling qualifies.
+ *
+ * A dev checkout keeps plugins as sibling directories. An installed
+ * marketplace nests them one level deeper, as `<marketplace>/<plugin>/<version>`,
+ * where the version directory is the marketplace commit. Only the sibling under
+ * this plugin's own version directory came from that same commit, and the
+ * contract between a caller and the script it spawns moves between commits, so
+ * no other version qualifies.
+ */
+export async function findSiblingScript(
+  pluginRoot: string,
+  plugin: string,
+  ...script: string[]
+): Promise<string | null> {
+  const devPath = join(pluginRoot, "..", plugin, ...script);
+  if (await Bun.file(devPath).exists()) return devPath;
+
+  const installedPath = join(pluginRoot, "..", "..", plugin, basename(pluginRoot), ...script);
+  return (await Bun.file(installedPath).exists()) ? installedPath : null;
+}

--- a/plugins/things/src/mcp/README.md
+++ b/plugins/things/src/mcp/README.md
@@ -4,21 +4,21 @@ An MCP server exposing Things 3 over stdio. It speaks JSON-RPC on stdin and stdo
 
 [tailgate](https://github.com/bendrucker/tailgate) supplies everything this server does not. It is an OAuth 2.0 resource server published through Tailscale Funnel, and it spawns this server as a child process, so reaching Things from a phone or a laptop goes through tailgate's OAuth flow, token introspection, audience validation, and per-identity policy.
 
-```
+```text
 phone / laptop / claude.ai
-        │ OAuth
-        ▼
-Tailscale Funnel ──► tailgate ──► things stdio (child process)
-                        │ introspect, audience, policy
-                        ▼
-                      tsidp
+            │ OAuth
+            ▼
+   Tailscale Funnel ──► tailgate ──► things stdio (child process)
+                            │ introspect, audience, policy
+                            ▼
+                          tsidp
 ```
 
 Identity comes from [tsidp](https://tailscale.com/docs/features/tsidp), so a caller's identity is their tailnet login.
 
 ## Stdout Discipline
 
-stdout carries JSON-RPC framing and nothing else. One stray line of output desynchronizes the client, which then reports parse errors that name neither the writer nor the write.
+stdout carries JSON-RPC framing and nothing else. One stray line of output desynchronizes the client, which then reports parse errors that don't identify what printed the line.
 
 This constrains more than `stdio.ts`. The tools reuse the plugin's CLI scripts (`scripts/url.ts`, `scripts/inbox.ts`, `scripts/reorder.ts`, `scripts/ensure-running.ts`), and those scripts print for their own human callers. Four rules keep the two uses apart:
 
@@ -35,17 +35,20 @@ Reads run the plugin's JXA query scripts through the `mac` plugin's runner: `lis
 
 Writes go through the `things:///` URL scheme: `add_todo`, `add_project`, `update_todos`, `capture_inbox`, `reorder_todos`. Cultured Code exposes no write API beyond it.
 
-`capture_inbox` takes `session_id` and `directory` and appends a resume command to the todo's notes. `directory` is a parameter because this process runs as tailgate's child, whose working directory has nothing to do with the session being attributed.
+`capture_inbox` accepts an optional `session_id` and `directory`. Given a `session_id` it appends a resume command to the todo's notes. `directory` is a parameter because this process runs as tailgate's child, whose working directory has nothing to do with the session being attributed.
 
 ## Layout
 
 - `stdio.ts`: the entry point. Constructs the server, registers the tools, connects the stdio transport.
 - `tools.ts`: the tool registrations, wrapping the plugin's read scripts and write modules.
-- `jxa.ts`: locates the `mac` plugin's JXA runner by filesystem layout and spawns it. It resolves a dev checkout's sibling directory, or the sibling under this plugin's own version directory when installed, and accepts no other version.
+- `jxa.ts`: locates the `mac` plugin's JXA runner by filesystem layout and spawns it.
 
 ## Local Development
 
+Run from the plugin root, which is where `bun` resolves the paths below.
+
 ```bash
+cd plugins/things
 printf '%s\n' \
   '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}}' \
   '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
@@ -59,6 +62,6 @@ Each message needs its own trailing newline. The transport frames on newlines, s
 
 ## Constraints
 
-Every tool needs the Mac awake with a logged-in GUI session. Reads drive Things through Apple Events and writes hand off to Launch Services, and neither works against a Things that cannot run. Mail to Things stays the capture path when the Mac is asleep.
+Every tool needs the Mac awake with a logged-in GUI session. Reads drive Things through Apple Events and writes hand off to Launch Services, and neither works if Things cannot run. Mail to Things stays the capture path when the Mac is asleep.
 
 The first tool call that touches Things prompts for a TCC Automation grant against whatever binary spawned it. Approve it once in System Settings if the dialog is missed.

--- a/plugins/things/src/mcp/README.md
+++ b/plugins/things/src/mcp/README.md
@@ -41,7 +41,7 @@ Writes go through the `things:///` URL scheme: `add_todo`, `add_project`, `updat
 
 - `stdio.ts`: the entry point. Constructs the server, registers the tools, connects the stdio transport.
 - `tools.ts`: the tool registrations, wrapping the plugin's read scripts and write modules.
-- `jxa.ts`: locates the `mac` plugin's JXA runner by filesystem layout and spawns it.
+- `jxa.ts`: locates the `mac` plugin's JXA runner by filesystem layout and spawns it. It resolves a dev checkout's sibling directory, or the sibling under this plugin's own version directory when installed, and accepts no other version.
 
 ## Local Development
 

--- a/plugins/things/src/mcp/README.md
+++ b/plugins/things/src/mcp/README.md
@@ -1,0 +1,64 @@
+# Things MCP Server
+
+An MCP server exposing Things 3 over stdio. It speaks JSON-RPC on stdin and stdout, contains no auth code, and opens no socket.
+
+[tailgate](https://github.com/bendrucker/tailgate) supplies everything this server does not. It is an OAuth 2.0 resource server published through Tailscale Funnel, and it spawns this server as a child process, so reaching Things from a phone or a laptop goes through tailgate's OAuth flow, token introspection, audience validation, and per-identity policy.
+
+```
+phone / laptop / claude.ai
+        │ OAuth
+        ▼
+Tailscale Funnel ──► tailgate ──► things stdio (child process)
+                        │ introspect, audience, policy
+                        ▼
+                      tsidp
+```
+
+Identity comes from [tsidp](https://tailscale.com/docs/features/tsidp), so a caller's identity is their tailnet login.
+
+## Stdout Discipline
+
+stdout carries JSON-RPC framing and nothing else. One stray line of output desynchronizes the client, which then reports parse errors that name neither the writer nor the write.
+
+This constrains more than `stdio.ts`. The tools reuse the plugin's CLI scripts (`scripts/url.ts`, `scripts/inbox.ts`, `scripts/reorder.ts`, `scripts/ensure-running.ts`), and those scripts print for their own human callers. Four rules keep the two uses apart:
+
+- Printing belongs under `import.meta.main`. A function called by both the CLI and a tool returns its result and lets the CLI print it.
+- Diagnostics go to stderr. tailgate captures child stderr into its logs, which is where a production failure gets read.
+- A spawned subprocess pipes both streams. `src/mcp/jxa.ts` and `xcall` in `scripts/url.ts` capture output rather than inheriting it.
+- Bun's `$` inherits stdout unless told otherwise, so the Launch Services handoff in `scripts/url.ts` runs `.quiet()` and forwards what it captured to stderr.
+
+`stdio.test.ts` drives a real handshake and fails on any stdout line that will not parse, which catches a new print anywhere in the import closure.
+
+## Tools
+
+Reads run the plugin's JXA query scripts through the `mac` plugin's runner: `list_todos`, `find_todos`, `query_logbook`, `list_metadata`.
+
+Writes go through the `things:///` URL scheme: `add_todo`, `add_project`, `update_todos`, `capture_inbox`, `reorder_todos`. Cultured Code exposes no write API beyond it.
+
+`capture_inbox` takes `session_id` and `directory` and appends a resume command to the todo's notes. `directory` is a parameter because this process runs as tailgate's child, whose working directory has nothing to do with the session being attributed.
+
+## Layout
+
+- `stdio.ts`: the entry point. Constructs the server, registers the tools, connects the stdio transport.
+- `tools.ts`: the tool registrations, wrapping the plugin's read scripts and write modules.
+- `jxa.ts`: locates the `mac` plugin's JXA runner by filesystem layout and spawns it.
+
+## Local Development
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  | bun src/mcp/stdio.ts
+```
+
+Each message needs its own trailing newline. The transport frames on newlines, so a final line without one is never answered.
+
+`bunx @modelcontextprotocol/inspector bun src/mcp/stdio.ts` gives the same thing interactively.
+
+## Constraints
+
+Every tool needs the Mac awake with a logged-in GUI session. Reads drive Things through Apple Events and writes hand off to Launch Services, and neither works against a Things that cannot run. Mail to Things stays the capture path when the Mac is asleep.
+
+The first tool call that touches Things prompts for a TCC Automation grant against whatever binary spawned it. Approve it once in System Settings if the dialog is missed.

--- a/plugins/things/src/mcp/jxa.test.ts
+++ b/plugins/things/src/mcp/jxa.test.ts
@@ -4,10 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { findJxaRunner } from "./jxa";
 
-// Mirrors the findXcallRunner fixture table in scripts/url.test.ts. The
-// installed layout previously gated its scan on Bun.file(<dir>).exists(), which
-// is false for a directory, so no installed plugin ever resolved a runner and
-// every read tool failed.
+// The installed layout previously gated its scan on Bun.file(<dir>).exists(),
+// which is false for a directory, so no installed plugin ever resolved a
+// runner and every read tool failed.
 describe("findJxaRunner", () => {
   const version = "69eed9ed34f1";
   const other = "282d5556b96b";

--- a/plugins/things/src/mcp/jxa.test.ts
+++ b/plugins/things/src/mcp/jxa.test.ts
@@ -4,62 +4,17 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { findJxaRunner } from "./jxa";
 
-// The installed layout previously gated its scan on Bun.file(<dir>).exists(),
-// which is false for a directory, so no installed plugin ever resolved a
-// runner and every read tool failed.
+// The layout matrix this delegates to lives in src/marketplace.test.ts. These
+// two cases pin the sibling plugin and script name it asks for.
 describe("findJxaRunner", () => {
-  const version = "69eed9ed34f1";
-  const other = "282d5556b96b";
-
-  async function tree(...paths: string[]): Promise<string> {
+  test("names the mac plugin's jxa.ts", async () => {
     const root = mkdtempSync(join(tmpdir(), "things-marketplace-"));
-    for (const path of paths) await Bun.write(join(root, path), "");
-    return root;
-  }
+    await Bun.write(join(root, "mac/scripts/jxa.ts"), "");
+    expect(await findJxaRunner(join(root, "things"))).toBe(join(root, "mac", "scripts", "jxa.ts"));
+  });
 
-  test.each<{
-    name: string;
-    layout: string[];
-    pluginRoot: string[];
-    runner: string[] | null;
-  }>([
-    {
-      name: "resolves the sibling installed from the same marketplace commit",
-      layout: [
-        `things/${version}/src/mcp/jxa.ts`,
-        `mac/${other}/scripts/jxa.ts`,
-        `mac/${version}/scripts/jxa.ts`,
-      ],
-      pluginRoot: ["things", version],
-      runner: ["mac", version, "scripts", "jxa.ts"],
-    },
-    {
-      name: "prefers a dev checkout's sibling directory over the installed layout",
-      layout: ["things/src/mcp/jxa.ts", "mac/scripts/jxa.ts", `mac/${version}/scripts/jxa.ts`],
-      pluginRoot: ["things"],
-      runner: ["mac", "scripts", "jxa.ts"],
-    },
-    {
-      name: "declines a runner from a version this plugin was not installed with",
-      layout: [`things/${version}/src/mcp/jxa.ts`, `mac/${other}/scripts/jxa.ts`],
-      pluginRoot: ["things", version],
-      runner: null,
-    },
-    {
-      name: "finds nothing when the mac plugin is not installed",
-      layout: [`things/${version}/src/mcp/jxa.ts`],
-      pluginRoot: ["things", version],
-      runner: null,
-    },
-    {
-      name: "finds nothing when the matching version carries no runner",
-      layout: [`things/${version}/src/mcp/jxa.ts`, `mac/${version}/scripts/sandbox.ts`],
-      pluginRoot: ["things", version],
-      runner: null,
-    },
-  ])("$name", async ({ layout, pluginRoot, runner }) => {
-    const root = await tree(...layout);
-    const resolved = await findJxaRunner(join(root, ...pluginRoot));
-    expect(resolved).toBe(runner ? join(root, ...runner) : null);
+  test("finds nothing when the plugin is absent", async () => {
+    const root = mkdtempSync(join(tmpdir(), "things-marketplace-"));
+    expect(await findJxaRunner(join(root, "things"))).toBeNull();
   });
 });

--- a/plugins/things/src/mcp/jxa.test.ts
+++ b/plugins/things/src/mcp/jxa.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findJxaRunner } from "./jxa";
+
+// Mirrors the findXcallRunner fixture table in scripts/url.test.ts. The
+// installed layout previously gated its scan on Bun.file(<dir>).exists(), which
+// is false for a directory, so no installed plugin ever resolved a runner and
+// every read tool failed.
+describe("findJxaRunner", () => {
+  const version = "69eed9ed34f1";
+  const other = "282d5556b96b";
+
+  async function tree(...paths: string[]): Promise<string> {
+    const root = mkdtempSync(join(tmpdir(), "things-marketplace-"));
+    for (const path of paths) await Bun.write(join(root, path), "");
+    return root;
+  }
+
+  test.each<{
+    name: string;
+    layout: string[];
+    pluginRoot: string[];
+    runner: string[] | null;
+  }>([
+    {
+      name: "resolves the sibling installed from the same marketplace commit",
+      layout: [
+        `things/${version}/src/mcp/jxa.ts`,
+        `mac/${other}/scripts/jxa.ts`,
+        `mac/${version}/scripts/jxa.ts`,
+      ],
+      pluginRoot: ["things", version],
+      runner: ["mac", version, "scripts", "jxa.ts"],
+    },
+    {
+      name: "prefers a dev checkout's sibling directory over the installed layout",
+      layout: ["things/src/mcp/jxa.ts", "mac/scripts/jxa.ts", `mac/${version}/scripts/jxa.ts`],
+      pluginRoot: ["things"],
+      runner: ["mac", "scripts", "jxa.ts"],
+    },
+    {
+      name: "declines a runner from a version this plugin was not installed with",
+      layout: [`things/${version}/src/mcp/jxa.ts`, `mac/${other}/scripts/jxa.ts`],
+      pluginRoot: ["things", version],
+      runner: null,
+    },
+    {
+      name: "finds nothing when the mac plugin is not installed",
+      layout: [`things/${version}/src/mcp/jxa.ts`],
+      pluginRoot: ["things", version],
+      runner: null,
+    },
+    {
+      name: "finds nothing when the matching version carries no runner",
+      layout: [`things/${version}/src/mcp/jxa.ts`, `mac/${version}/scripts/sandbox.ts`],
+      pluginRoot: ["things", version],
+      runner: null,
+    },
+  ])("$name", async ({ layout, pluginRoot, runner }) => {
+    const root = await tree(...layout);
+    const resolved = await findJxaRunner(join(root, ...pluginRoot));
+    expect(resolved).toBe(runner ? join(root, ...runner) : null);
+  });
+});

--- a/plugins/things/src/mcp/jxa.ts
+++ b/plugins/things/src/mcp/jxa.ts
@@ -1,9 +1,8 @@
 /**
  * Runs the plugin's JXA query scripts through the mac plugin's runner
  * (AST scope validation + Apple Events retry). The runner is spawned as a
- * subprocess rather than imported: cross-plugin imports are disallowed, and
- * the runner is discovered by filesystem layout like the x-callback-url
- * runner in scripts/url.ts.
+ * subprocess because cross-plugin imports are disallowed, and it is
+ * discovered by filesystem layout.
  */
 
 import { basename, join } from "node:path";
@@ -40,7 +39,7 @@ export async function runQuery(script: string, args: string[]): Promise<unknown>
   }
 
   const scriptPath = join(PLUGIN_ROOT, "scripts", "jxa", script);
-  // process.execPath, not "bun": this process is spawned by tailgate, which
+  // Uses process.execPath because this process is spawned by tailgate, which
   // inherits launchd's PATH, and that lacks /opt/homebrew/bin. Both streams are
   // piped so the runner's diagnostics cannot reach this process's stdout, where
   // JSON-RPC lives.

--- a/plugins/things/src/mcp/jxa.ts
+++ b/plugins/things/src/mcp/jxa.ts
@@ -5,31 +5,19 @@
  * discovered by filesystem layout.
  */
 
-import { basename, join } from "node:path";
+import { join } from "node:path";
+import { findSiblingScript } from "../marketplace";
 
 const PLUGIN_ROOT = join(import.meta.dirname, "..", "..");
 
-export async function findJxaRunner(pluginRoot: string = PLUGIN_ROOT): Promise<string | null> {
-  // Dev layout: sibling plugin directory
-  const devPath = join(pluginRoot, "..", "mac", "scripts", "jxa.ts");
-  if (await Bun.file(devPath).exists()) return devPath;
-
-  // Installed layout: <marketplace>/<plugin>/<version>, where the version
-  // directory is the marketplace commit. Only the sibling under this plugin's
-  // own version was installed from the same commit, and the runner's argument
-  // contract moves: it now forwards everything past the script path to the
-  // script, where an older one claimed those flags for itself and left the
-  // script with a short argument list it answers with a usage error.
-  const installedPath = join(
-    pluginRoot,
-    "..",
-    "..",
-    "mac",
-    basename(pluginRoot),
-    "scripts",
-    "jxa.ts",
-  );
-  return (await Bun.file(installedPath).exists()) ? installedPath : null;
+/**
+ * The version match matters here because the runner's argument contract moves
+ * between commits: this build expects everything past the script path to reach
+ * the script, where a runner from another commit may claim those flags itself
+ * and leave the script answering with a usage error.
+ */
+export function findJxaRunner(pluginRoot: string = PLUGIN_ROOT): Promise<string | null> {
+  return findSiblingScript(pluginRoot, "mac", "scripts", "jxa.ts");
 }
 
 export async function runQuery(script: string, args: string[]): Promise<unknown> {

--- a/plugins/things/src/mcp/jxa.ts
+++ b/plugins/things/src/mcp/jxa.ts
@@ -1,0 +1,61 @@
+/**
+ * Runs the plugin's JXA query scripts through the mac plugin's runner
+ * (AST scope validation + Apple Events retry). The runner is spawned as a
+ * subprocess rather than imported: cross-plugin imports are disallowed, and
+ * the runner is discovered by filesystem layout like the x-callback-url
+ * runner in scripts/url.ts.
+ */
+
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const PLUGIN_ROOT = join(import.meta.dirname, "..", "..");
+
+async function findJxaRunner(): Promise<string | null> {
+  // Dev layout: sibling plugin directory
+  const devPath = join(PLUGIN_ROOT, "..", "mac", "scripts", "jxa.ts");
+  if (await Bun.file(devPath).exists()) return devPath;
+
+  // Prod layout: up 2 levels to marketplace root, then into mac/<version>/
+  const marketplaceDir = join(PLUGIN_ROOT, "..", "..", "mac");
+  if (await Bun.file(marketplaceDir).exists()) {
+    for (const entry of readdirSync(marketplaceDir)) {
+      const candidate = join(marketplaceDir, entry, "scripts", "jxa.ts");
+      if (await Bun.file(candidate).exists()) return candidate;
+    }
+  }
+
+  return null;
+}
+
+export async function runQuery(script: string, args: string[]): Promise<unknown> {
+  const runner = await findJxaRunner();
+  if (!runner) {
+    throw new Error("mac plugin JXA runner not found (expected plugins/mac/scripts/jxa.ts)");
+  }
+
+  const scriptPath = join(PLUGIN_ROOT, "scripts", "jxa", script);
+  // process.execPath, not "bun": this process is spawned by tailgate, which
+  // inherits launchd's PATH, and that lacks /opt/homebrew/bin. Both streams are
+  // piped so the runner's diagnostics cannot reach this process's stdout, where
+  // JSON-RPC lives.
+  const proc = Bun.spawn([process.execPath, runner, "Things3", scriptPath, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+
+  if (code !== 0) {
+    throw new Error(`${script} failed (exit ${code}): ${stderr.trim()}`);
+  }
+
+  const result: unknown = JSON.parse(stdout);
+  if (result && typeof result === "object" && "error" in result) {
+    throw new Error(String((result as { error: unknown }).error));
+  }
+  return result;
+}

--- a/plugins/things/src/mcp/jxa.ts
+++ b/plugins/things/src/mcp/jxa.ts
@@ -6,26 +6,31 @@
  * runner in scripts/url.ts.
  */
 
-import { readdirSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 const PLUGIN_ROOT = join(import.meta.dirname, "..", "..");
 
-async function findJxaRunner(): Promise<string | null> {
+export async function findJxaRunner(pluginRoot: string = PLUGIN_ROOT): Promise<string | null> {
   // Dev layout: sibling plugin directory
-  const devPath = join(PLUGIN_ROOT, "..", "mac", "scripts", "jxa.ts");
+  const devPath = join(pluginRoot, "..", "mac", "scripts", "jxa.ts");
   if (await Bun.file(devPath).exists()) return devPath;
 
-  // Prod layout: up 2 levels to marketplace root, then into mac/<version>/
-  const marketplaceDir = join(PLUGIN_ROOT, "..", "..", "mac");
-  if (await Bun.file(marketplaceDir).exists()) {
-    for (const entry of readdirSync(marketplaceDir)) {
-      const candidate = join(marketplaceDir, entry, "scripts", "jxa.ts");
-      if (await Bun.file(candidate).exists()) return candidate;
-    }
-  }
-
-  return null;
+  // Installed layout: <marketplace>/<plugin>/<version>, where the version
+  // directory is the marketplace commit. Only the sibling under this plugin's
+  // own version was installed from the same commit, and the runner's argument
+  // contract moves: it now forwards everything past the script path to the
+  // script, where an older one claimed those flags for itself and left the
+  // script with a short argument list it answers with a usage error.
+  const installedPath = join(
+    pluginRoot,
+    "..",
+    "..",
+    "mac",
+    basename(pluginRoot),
+    "scripts",
+    "jxa.ts",
+  );
+  return (await Bun.file(installedPath).exists()) ? installedPath : null;
 }
 
 export async function runQuery(script: string, args: string[]): Promise<unknown> {

--- a/plugins/things/src/mcp/stdio.test.ts
+++ b/plugins/things/src/mcp/stdio.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+const SERVER = join(import.meta.dirname, "stdio.ts");
+
+const HANDSHAKE = [
+  {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "stdio.test", version: "0" },
+    },
+  },
+  { jsonrpc: "2.0", method: "notifications/initialized" },
+  { jsonrpc: "2.0", id: 2, method: "tools/list" },
+];
+
+/**
+ * Drives the server the way tailgate does: JSON-RPC in on stdin, responses out
+ * on stdout. Neither initialize nor tools/list touches Things, so this runs on
+ * any platform.
+ */
+async function handshake(): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  // Every message needs its own terminating newline. The transport frames on
+  // newlines, so a final line without one sits in its buffer until stdin closes
+  // and is then discarded unanswered.
+  const requests = HANDSHAKE.map((message) => `${JSON.stringify(message)}\n`).join("");
+  const proc = Bun.spawn([process.execPath, SERVER], {
+    stdin: new TextEncoder().encode(requests),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  return { stdout, stderr, exitCode: await proc.exited };
+}
+
+const result = await handshake();
+const lines = result.stdout.split("\n").filter(Boolean);
+
+describe("stdio server", () => {
+  test("exits cleanly when stdin closes", () => {
+    expect(result.exitCode).toBe(0);
+  });
+
+  // A stray write to stdout anywhere in the import closure arrives here as an
+  // unparseable line, and in production it desynchronizes the client's JSON-RPC
+  // framing. Every diagnostic in the closure has to reach stderr instead.
+  test("writes nothing but JSON-RPC to stdout", () => {
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+    expect(lines).toHaveLength(2);
+  });
+
+  test("keeps startup stderr quiet", () => {
+    expect(result.stderr).toBe("");
+  });
+
+  test("advertises the full tool set", () => {
+    const listed = JSON.parse(lines[1] ?? "null") as {
+      result: { tools: Array<{ name: string }> };
+    };
+    expect(listed.result.tools.map((tool) => tool.name)).toMatchInlineSnapshot(`
+      [
+        "list_todos",
+        "find_todos",
+        "query_logbook",
+        "list_metadata",
+        "add_todo",
+        "add_project",
+        "update_todos",
+        "capture_inbox",
+        "reorder_todos",
+      ]
+    `);
+  });
+});

--- a/plugins/things/src/mcp/stdio.test.ts
+++ b/plugins/things/src/mcp/stdio.test.ts
@@ -3,6 +3,27 @@ import { join } from "node:path";
 
 const SERVER = join(import.meta.dirname, "stdio.ts");
 
+/**
+ * Every call here has to be rejected by a tool's schema, which the server
+ * applies before it dispatches to a handler. A handler is where Things gets
+ * launched and written to, so an argument that reached one would exercise a
+ * write against real task data.
+ */
+const REJECTED_CALLS = [
+  {
+    name: "query_logbook",
+    arguments: { start: "not-a-date", end: "also-bad" },
+  },
+  {
+    name: "reorder_todos",
+    arguments: { ids: ["  "], list: "today" },
+  },
+  {
+    name: "capture_inbox",
+    arguments: { title: "Follow up", session_id: "" },
+  },
+];
+
 const HANDSHAKE = [
   {
     jsonrpc: "2.0",
@@ -16,12 +37,18 @@ const HANDSHAKE = [
   },
   { jsonrpc: "2.0", method: "notifications/initialized" },
   { jsonrpc: "2.0", id: 2, method: "tools/list" },
+  ...REJECTED_CALLS.map((params, index) => ({
+    jsonrpc: "2.0",
+    id: 3 + index,
+    method: "tools/call",
+    params,
+  })),
 ];
 
 /**
  * Drives the server the way tailgate does: JSON-RPC in on stdin, responses out
- * on stdout. Neither initialize nor tools/list touches Things, so this runs on
- * any platform.
+ * on stdout. Nothing here reaches a tool handler, so this runs on any platform
+ * and never touches Things.
  */
 async function handshake(): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   // Every message needs its own terminating newline. The transport frames on
@@ -55,7 +82,7 @@ describe("stdio server", () => {
     for (const line of lines) {
       expect(() => JSON.parse(line)).not.toThrow();
     }
-    expect(lines).toHaveLength(2);
+    expect(lines).toHaveLength(HANDSHAKE.length - 1);
   });
 
   test("keeps startup stderr quiet", () => {
@@ -77,6 +104,31 @@ describe("stdio server", () => {
         "update_todos",
         "capture_inbox",
         "reorder_todos",
+      ]
+    `);
+  });
+
+  // Each of these arguments would otherwise reach Things: an unparseable date
+  // makes query-logbook.js scan the whole logbook, a blank id is accepted
+  // silently, and a blank session id drops the attribution it was passed for.
+  // The snapshot carries the field each rejection names, so a guard that stops
+  // covering its field fails here rather than passing on some other error.
+  test("rejects arguments that would reach Things", () => {
+    const rejections = REJECTED_CALLS.map((_call, index) => {
+      const response = JSON.parse(lines[2 + index] ?? "null") as {
+        result: { isError: boolean; content: Array<{ text: string }> };
+      };
+      expect(response.result.isError).toBe(true);
+      return response.result.content[0]?.text;
+    });
+    expect(rejections).toMatchInlineSnapshot(`
+      [
+        
+      "MCP error -32602: Input validation error: Invalid arguments for tool query_logbook: must be an ISO 8601 date at start
+      must be an ISO 8601 date at end"
+      ,
+        "MCP error -32602: Input validation error: Invalid arguments for tool reorder_todos: Too small: expected string to have >=1 characters at ids[0]",
+        "MCP error -32602: Input validation error: Invalid arguments for tool capture_inbox: Too small: expected string to have >=1 characters at session_id",
       ]
     `);
   });

--- a/plugins/things/src/mcp/stdio.ts
+++ b/plugins/things/src/mcp/stdio.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env bun
+// claude:dangerouslyDisableSandbox: reaches osascript and the Things URL scheme through the read and write tools, which the command sandbox blocks
+
+/**
+ * Things MCP server over stdio.
+ *
+ * stdout is the JSON-RPC channel and carries nothing else. Diagnostics go to
+ * stderr, which tailgate captures into its logs.
+ *
+ * No auth, no port, no listening socket. tailgate spawns this as a child
+ * process and owns OAuth, token introspection, audience validation, and
+ * per-identity policy. See README.md.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerTools } from "./tools";
+
+if (import.meta.main) {
+  const server = new McpServer({ name: "things", version: "0.1.0" });
+  registerTools(server);
+  await server.connect(new StdioServerTransport());
+}

--- a/plugins/things/src/mcp/stdout.test.ts
+++ b/plugins/things/src/mcp/stdout.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "bun:test";
+import { dirname, join, relative, resolve } from "node:path";
+
+const PLUGIN_ROOT = join(import.meta.dirname, "..", "..");
+const ENTRY = join(import.meta.dirname, "stdio.ts");
+
+const RELATIVE_IMPORT = /(?:from|import)\s+"(\.[^"]*)"/g;
+
+/** Bun shell methods that read stdout instead of letting it through. */
+const CAPTURES_STDOUT = /\.(quiet|text|json|blob|bytes|arrayBuffer|lines)\(/;
+
+/** Prose mentioning `console.log` or a `$` shell call is not a write. */
+function stripComment(line: string): string {
+  const trimmed = line.trim();
+  if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) return "";
+  return line.replace(/\/\/.*$/, "");
+}
+
+/**
+ * Every module the server can reach. Only relative specifiers are followed:
+ * a package can print all it likes as long as nothing on this path calls it,
+ * and the modules that do print are all first-party.
+ */
+async function importClosure(entry: string): Promise<string[]> {
+  const seen = new Set<string>();
+  const queue = [entry];
+
+  while (queue.length > 0) {
+    const file = queue.pop();
+    if (!file || seen.has(file)) continue;
+    seen.add(file);
+
+    const source = await Bun.file(file).text();
+    for (const [, specifier] of source.matchAll(RELATIVE_IMPORT)) {
+      if (!specifier) continue;
+      const target = resolve(dirname(file), specifier);
+      const path = (await Bun.file(`${target}.ts`).exists()) ? `${target}.ts` : target;
+      if (path.endsWith(".ts")) queue.push(path);
+    }
+  }
+
+  return [...seen].sort();
+}
+
+/**
+ * stdout writes that a tool call can reach. A write below `import.meta.main`
+ * belongs to the module's own CLI, which the server never enters.
+ */
+async function findStdoutWrites(): Promise<string[]> {
+  const writes: string[] = [];
+
+  for (const file of await importClosure(ENTRY)) {
+    const source = await Bun.file(file).text();
+    const lines = source.split("\n");
+    const cliStart = lines.findIndex((line) => line.includes("import.meta.main"));
+    const reachable = cliStart === -1 ? lines : lines.slice(0, cliStart);
+    const name = relative(PLUGIN_ROOT, file);
+
+    // Identified by source text rather than line number, so an unrelated edit
+    // above a write doesn't churn the snapshot.
+    for (const raw of reachable) {
+      const line = stripComment(raw);
+      const code = line.trim();
+      if (/\bconsole\.(log|info|debug|dir|table)\(/.test(line)) {
+        writes.push(`${name}: ${code}`);
+      }
+      if (/\bprocess\.stdout\.write\(/.test(line)) {
+        writes.push(`${name}: ${code}`);
+      }
+      // A Bun shell call inherits stdout unless something in the chain takes it.
+      if (/\$`/.test(line) && !CAPTURES_STDOUT.test(line)) {
+        writes.push(`${name}: ${code}`);
+      }
+    }
+  }
+
+  return writes;
+}
+
+// The snapshot is the point: stdout is the JSON-RPC channel, so a new write
+// anywhere in the server's import closure has to be looked at by a human. The
+// three below are `printCaptured`, which inbox.ts calls only from inside its own
+// `import.meta.main` block.
+test("stdout writes reachable from the server", async () => {
+  expect(await findStdoutWrites()).toMatchInlineSnapshot(`
+    [
+      "scripts/inbox.ts: console.log(\`captured: \${title}\`);",
+      "scripts/inbox.ts: console.log(\`captured: \${first}\${suffix}\`);",
+      "scripts/inbox.ts: console.log("captured: (untitled)");",
+    ]
+  `);
+});

--- a/plugins/things/src/mcp/tools.test.ts
+++ b/plugins/things/src/mcp/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { chunk, updateAttributes, validateCaptureTitles, validateIds } from "./tools";
+import { chunk, updateAttributes, validateCaptureTitles, validateNonBlank } from "./tools";
 
 describe("chunk", () => {
   test.each<[string, number[], number, number[][]]>([
@@ -64,20 +64,23 @@ describe("validateCaptureTitles", () => {
     ["neither", undefined, undefined, "title or titles is required"],
     ["empty title only", "", undefined, "title or titles is required"],
     ["empty titles only", undefined, [], "title or titles is required"],
+    ["whitespace title only", "  ", undefined, "title or titles is required"],
+    ["a blank entry among titles", undefined, ["one", ""], "titles[1] must be a non-empty string"],
   ])("rejects %s", (_name, title, titles, message) => {
     expect(() => validateCaptureTitles(title, titles)).toThrow(message);
   });
 });
 
-describe("validateIds", () => {
-  test("accepts non-empty ids", () => {
-    expect(() => validateIds(["abc", "def"])).not.toThrow();
+describe("validateNonBlank", () => {
+  test("accepts non-empty values", () => {
+    expect(() => validateNonBlank(["abc", "def"], "ids")).not.toThrow();
   });
 
-  test.each<[string, string[], string]>([
-    ["empty string", ["abc", ""], 'ids[1] must be a non-empty string, got ""'],
-    ["whitespace only", ["  "], 'ids[0] must be a non-empty string, got "  "'],
-  ])("rejects %s", (_name, ids, message) => {
-    expect(() => validateIds(ids)).toThrow(message);
+  test.each<[string, string[], string, string]>([
+    ["empty string", ["abc", ""], "ids", 'ids[1] must be a non-empty string, got ""'],
+    ["whitespace only", ["  "], "ids", 'ids[0] must be a non-empty string, got "  "'],
+    ["names the field", [""], "titles", 'titles[0] must be a non-empty string, got ""'],
+  ])("rejects %s", (_name, values, field, message) => {
+    expect(() => validateNonBlank(values, field)).toThrow(message);
   });
 });

--- a/plugins/things/src/mcp/tools.test.ts
+++ b/plugins/things/src/mcp/tools.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { chunk, updateAttributes, validateCaptureTitles, validateIds } from "./tools";
+
+describe("chunk", () => {
+  test.each<[string, number[], number, number[][]]>([
+    [
+      "splits evenly",
+      [1, 2, 3, 4],
+      2,
+      [
+        [1, 2],
+        [3, 4],
+      ],
+    ],
+    ["keeps remainder", [1, 2, 3], 2, [[1, 2], [3]]],
+    ["single chunk when under size", [1, 2], 250, [[1, 2]]],
+    ["empty input", [], 2, []],
+  ])("%s", (_name, items, size, expected) => {
+    expect(chunk(items, size)).toEqual(expected);
+  });
+});
+
+describe("updateAttributes", () => {
+  test("maps tool args to URL scheme attribute strings", () => {
+    expect(
+      updateAttributes({
+        title: "New title",
+        append_notes: "more",
+        when: "today",
+        tags: ["a", "b"],
+        add_tags: ["c"],
+        checklist_items: ["one", "two"],
+        completed: true,
+        canceled: false,
+      }),
+    ).toEqual({
+      title: "New title",
+      "append-notes": "more",
+      when: "today",
+      tags: "a,b",
+      "add-tags": "c",
+      "checklist-items": "one\ntwo",
+      completed: "true",
+      canceled: "false",
+    });
+  });
+
+  test("omits undefined fields", () => {
+    expect(updateAttributes({})).toEqual({});
+  });
+});
+
+describe("validateCaptureTitles", () => {
+  test.each<[string, string | undefined, string[] | undefined]>([
+    ["title only", "one", undefined],
+    ["titles only", undefined, ["one", "two"]],
+  ])("accepts %s", (_name, title, titles) => {
+    expect(() => validateCaptureTitles(title, titles)).not.toThrow();
+  });
+
+  test.each<[string, string | undefined, string[] | undefined, string]>([
+    ["both title and titles", "one", ["two"], "not both"],
+    ["title with empty titles", "one", [], "not both"],
+    ["neither", undefined, undefined, "title or titles is required"],
+    ["empty title only", "", undefined, "title or titles is required"],
+    ["empty titles only", undefined, [], "title or titles is required"],
+  ])("rejects %s", (_name, title, titles, message) => {
+    expect(() => validateCaptureTitles(title, titles)).toThrow(message);
+  });
+});
+
+describe("validateIds", () => {
+  test("accepts non-empty ids", () => {
+    expect(() => validateIds(["abc", "def"])).not.toThrow();
+  });
+
+  test.each<[string, string[], string]>([
+    ["empty string", ["abc", ""], 'ids[1] must be a non-empty string, got ""'],
+    ["whitespace only", ["  "], 'ids[0] must be a non-empty string, got "  "'],
+  ])("rejects %s", (_name, ids, message) => {
+    expect(() => validateIds(ids)).toThrow(message);
+  });
+});

--- a/plugins/things/src/mcp/tools.ts
+++ b/plugins/things/src/mcp/tools.ts
@@ -1,0 +1,367 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureThingsRunning } from "../../scripts/ensure-running";
+import { buildAttribution } from "../../scripts/inbox";
+import { reorder } from "../../scripts/reorder";
+import { mergeTags } from "../../scripts/tags";
+import { buildJsonPayload, type DispatchResult, dispatch, warnFallback } from "../../scripts/url";
+import { runQuery } from "./jxa";
+
+const LIST_IDS = {
+  inbox: "TMInboxListSource",
+  today: "TMTodayListSource",
+  anytime: "TMNextListSource",
+  upcoming: "TMCalendarListSource",
+  someday: "TMSomedayListSource",
+  logbook: "TMLogbookListSource",
+} as const;
+
+const TODO_LINK_BASE = "https://things.bendrucker.me/show?id=";
+
+// Things URL scheme rate limit: 250 operations per 10 seconds.
+const BATCH_SIZE = 250;
+const BATCH_DELAY_MS = 10_000;
+
+export function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+function textResult(text: string) {
+  return { content: [{ type: "text" as const, text }] };
+}
+
+function jsonResult(value: unknown) {
+  return textResult(JSON.stringify(value, null, 2));
+}
+
+/**
+ * Surfaces the dispatch outcome without ever retrying: an xcall round trip
+ * that produced no output is reported as a failure (the todo may or may not
+ * exist), matching the never-retry-on-silent-output rule in the url skill.
+ */
+function writeResult(result: DispatchResult, action: string) {
+  warnFallback(result);
+  if (result.viaXcall && !result.output) {
+    throw new Error(
+      `${action}: xcall returned no output. The operation may not have applied. ` +
+        "Do not retry until the cause is understood (retries create duplicates).",
+    );
+  }
+  if (result.id) {
+    return textResult(`${action}: ${TODO_LINK_BASE}${result.id}`);
+  }
+  if (result.output) {
+    return textResult(`${action}: ${result.output}`);
+  }
+  return textResult(`${action}: dispatched via Launch Services (no callback confirmation)`);
+}
+
+// Explicit `| undefined` on every property: under exactOptionalPropertyTypes an
+// optional property rejects an explicit undefined, and the tool handler spreads
+// its unset zod-optional arguments in as exactly that.
+interface UpdateAttributeArgs {
+  title?: string | undefined;
+  notes?: string | undefined;
+  prepend_notes?: string | undefined;
+  append_notes?: string | undefined;
+  when?: string | undefined;
+  deadline?: string | undefined;
+  tags?: string[] | undefined;
+  add_tags?: string[] | undefined;
+  checklist_items?: string[] | undefined;
+  completed?: boolean | undefined;
+  canceled?: boolean | undefined;
+}
+
+/** Converts tool arguments to the string attributes the URL scheme expects. */
+export function updateAttributes(args: UpdateAttributeArgs): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  if (args.title !== undefined) attributes.title = args.title;
+  if (args.notes !== undefined) attributes.notes = args.notes;
+  if (args.prepend_notes !== undefined) attributes["prepend-notes"] = args.prepend_notes;
+  if (args.append_notes !== undefined) attributes["append-notes"] = args.append_notes;
+  if (args.when !== undefined) attributes.when = args.when;
+  if (args.deadline !== undefined) attributes.deadline = args.deadline;
+  if (args.tags !== undefined) attributes.tags = args.tags.join(",");
+  if (args.add_tags !== undefined) attributes["add-tags"] = args.add_tags.join(",");
+  if (args.checklist_items !== undefined) {
+    attributes["checklist-items"] = args.checklist_items.join("\n");
+  }
+  if (args.completed !== undefined) attributes.completed = String(args.completed);
+  if (args.canceled !== undefined) attributes.canceled = String(args.canceled);
+  return attributes;
+}
+
+/**
+ * Ensures exactly one of title/titles is provided. The Things URL scheme's
+ * behavior when `add` receives both is undocumented and may create extra
+ * todos, so reject the combination instead of dispatching it.
+ */
+export function validateCaptureTitles(title?: string, titles?: string[]): void {
+  if (title !== undefined && titles !== undefined) {
+    throw new Error("Provide title (single todo) or titles (multiple todos), not both");
+  }
+  if (!title && !titles?.length) {
+    throw new Error("title or titles is required");
+  }
+}
+
+/** Rejects blank IDs before they reach Things, which fails silently on them. */
+export function validateIds(ids: string[]): void {
+  ids.forEach((id, index) => {
+    if (id.trim() === "") {
+      throw new Error(`ids[${index}] must be a non-empty string, got ${JSON.stringify(id)}`);
+    }
+  });
+}
+
+const whenDescription =
+  "Schedule: today, tomorrow, evening, anytime, someday, yyyy-mm-dd, or natural language like 'next week'";
+
+export function registerTools(server: McpServer): void {
+  server.registerTool(
+    "list_todos",
+    {
+      title: "List todos in a built-in list",
+      description:
+        "Read the todos in a built-in Things list (inbox, today, anytime, upcoming, someday, logbook). Full logbook scans are slow (10k+ items); prefer query_logbook for date-bounded logbook reads.",
+      inputSchema: {
+        list: z.enum(["inbox", "today", "anytime", "upcoming", "someday", "logbook"]),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ list }) => jsonResult(await runQuery("query-list.js", [LIST_IDS[list]])),
+  );
+
+  server.registerTool(
+    "find_todos",
+    {
+      title: "Find todos by tag or project",
+      description:
+        "Find open todos by tag (searched across Inbox/Today/Anytime/Upcoming/Someday) or by project name. Set include_logbook to also search completed todos.",
+      inputSchema: {
+        by: z.enum(["tag", "project"]),
+        value: z.string().describe("Tag name or project name"),
+        include_logbook: z.boolean().optional(),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ by, value, include_logbook }) =>
+      jsonResult(
+        await runQuery("find-todos.js", [by, value, ...(include_logbook ? ["--logbook"] : [])]),
+      ),
+  );
+
+  server.registerTool(
+    "query_logbook",
+    {
+      title: "Query completed todos",
+      description:
+        "Read completed todos from the logbook within a date range, newest first with early termination. Optionally filter by a notes substring.",
+      inputSchema: {
+        start: z.string().describe("Start of range, ISO 8601 (e.g. 2026-07-01)"),
+        end: z.string().describe("End of range, ISO 8601"),
+        notes_contains: z.string().optional().describe("Only todos whose notes contain this"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ start, end, notes_contains }) =>
+      jsonResult(
+        await runQuery("query-logbook.js", [
+          start,
+          end,
+          ...(notes_contains !== undefined ? ["--notes-contains", notes_contains] : []),
+        ]),
+      ),
+  );
+
+  server.registerTool(
+    "list_metadata",
+    {
+      title: "List projects, areas, or tags",
+      description: "List all projects, areas, or tags with their IDs.",
+      inputSchema: {
+        type: z.enum(["projects", "areas", "tags"]),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ type }) => jsonResult(await runQuery("query-metadata.js", [type])),
+  );
+
+  server.registerTool(
+    "add_todo",
+    {
+      title: "Create a todo",
+      description:
+        "Create a todo. Goes to the inbox unless when/list places it elsewhere. For quick captures that should carry Claude attribution, use capture_inbox instead.",
+      inputSchema: {
+        title: z.string(),
+        notes: z.string().optional().describe("Markdown supported, max 10,000 chars"),
+        when: z.string().optional().describe(whenDescription),
+        deadline: z.string().optional().describe("yyyy-mm-dd"),
+        tags: z.array(z.string()).optional(),
+        checklist_items: z.array(z.string()).optional().describe("Max 100"),
+        list: z.string().optional().describe("Project name to file under (projects only)"),
+        list_id: z.string().optional().describe("Project or area ID (required for areas)"),
+        heading: z.string().optional().describe("Heading within the target project"),
+      },
+    },
+    async (args) => {
+      await ensureThingsRunning();
+      const params = new Map<string, string>();
+      params.set("title", args.title);
+      if (args.notes !== undefined) params.set("notes", args.notes);
+      if (args.when !== undefined) params.set("when", args.when);
+      if (args.deadline !== undefined) params.set("deadline", args.deadline);
+      if (args.tags !== undefined) params.set("tags", args.tags.join(","));
+      if (args.checklist_items !== undefined) {
+        params.set("checklist-items", args.checklist_items.join("\n"));
+      }
+      if (args.list !== undefined) params.set("list", args.list);
+      if (args.list_id !== undefined) params.set("list-id", args.list_id);
+      if (args.heading !== undefined) params.set("heading", args.heading);
+      return writeResult(await dispatch("add", params), `Created "${args.title}"`);
+    },
+  );
+
+  server.registerTool(
+    "add_project",
+    {
+      title: "Create a project",
+      description: "Create a project, optionally with initial todos.",
+      inputSchema: {
+        title: z.string(),
+        notes: z.string().optional(),
+        when: z.string().optional().describe(whenDescription),
+        deadline: z.string().optional().describe("yyyy-mm-dd"),
+        area: z.string().optional().describe("Area name to file under"),
+        area_id: z.string().optional(),
+        tags: z.array(z.string()).optional(),
+        todos: z.array(z.string()).optional().describe("Initial todo titles"),
+      },
+    },
+    async (args) => {
+      await ensureThingsRunning();
+      const params = new Map<string, string>();
+      params.set("title", args.title);
+      if (args.notes !== undefined) params.set("notes", args.notes);
+      if (args.when !== undefined) params.set("when", args.when);
+      if (args.deadline !== undefined) params.set("deadline", args.deadline);
+      if (args.area !== undefined) params.set("area", args.area);
+      if (args.area_id !== undefined) params.set("area-id", args.area_id);
+      if (args.tags !== undefined) params.set("tags", args.tags.join(","));
+      if (args.todos !== undefined) params.set("to-dos", args.todos.join("\n"));
+      return writeResult(await dispatch("add-project", params), `Created project "${args.title}"`);
+    },
+  );
+
+  server.registerTool(
+    "update_todos",
+    {
+      title: "Update todos",
+      description:
+        "Update one or more todos: retitle, edit notes, reschedule (when), set deadline, retag, complete, or cancel. Multiple IDs batch through the JSON command, rate-limited to 250 operations per 10 seconds. Repeating todos cannot have when/deadline updated.",
+      inputSchema: {
+        ids: z.array(z.string()).min(1),
+        title: z.string().optional(),
+        notes: z.string().optional().describe("Replaces existing notes"),
+        prepend_notes: z.string().optional(),
+        append_notes: z.string().optional(),
+        when: z.string().optional().describe(whenDescription),
+        deadline: z.string().optional().describe("yyyy-mm-dd"),
+        tags: z.array(z.string()).optional().describe("Replaces existing tags"),
+        add_tags: z.array(z.string()).optional().describe("Adds to existing tags"),
+        checklist_items: z.array(z.string()).optional().describe("Replaces existing checklist"),
+        completed: z.boolean().optional(),
+        canceled: z.boolean().optional(),
+      },
+    },
+    async ({ ids, ...rest }) => {
+      const attributes = updateAttributes(rest);
+      if (Object.keys(attributes).length === 0) {
+        throw new Error("At least one attribute to update is required");
+      }
+      validateIds(ids);
+      await ensureThingsRunning();
+
+      if (ids.length === 1 && ids[0]) {
+        const params = new Map<string, string>(Object.entries(attributes));
+        params.set("id", ids[0]);
+        return writeResult(await dispatch("update", params), `Updated ${ids[0]}`);
+      }
+
+      const outputs: string[] = [];
+      for (const [index, batch] of chunk(ids, BATCH_SIZE).entries()) {
+        if (index > 0) await Bun.sleep(BATCH_DELAY_MS);
+        const params = new Map<string, string>();
+        params.set("data", buildJsonPayload(batch, attributes));
+        const result = writeResult(await dispatch("json", params), `Updated ${batch.length} todos`);
+        outputs.push(result.content[0]?.text ?? "");
+      }
+      return textResult(outputs.join("\n"));
+    },
+  );
+
+  server.registerTool(
+    "capture_inbox",
+    {
+      title: "Capture to inbox with Claude attribution",
+      description:
+        "Quick-capture one or more todos to the inbox. Each todo is tagged 'Claude'; pass session_id (and directory) to append resume attribution to the notes.",
+      inputSchema: {
+        title: z.string().optional().describe("Single todo title"),
+        titles: z.array(z.string()).optional().describe("Multiple todo titles"),
+        notes: z.string().optional(),
+        tags: z.array(z.string()).optional().describe("Extra tags beyond 'Claude'"),
+        checklist_items: z.array(z.string()).optional(),
+        session_id: z.string().optional().describe("Claude session ID for attribution"),
+        directory: z.string().optional().describe("Working directory for the resume command"),
+      },
+    },
+    async (args) => {
+      validateCaptureTitles(args.title, args.titles);
+      await ensureThingsRunning();
+
+      const params = new Map<string, string>();
+      if (args.title !== undefined) params.set("title", args.title);
+      if (args.titles !== undefined) params.set("titles", args.titles.join("\n"));
+      if (args.checklist_items !== undefined) {
+        params.set("checklist-items", args.checklist_items.join("\n"));
+      }
+      params.set("tags", mergeTags(["Claude"], args.tags ?? []).join(","));
+
+      let notes = args.notes;
+      if (args.session_id) {
+        const attribution = buildAttribution(args.session_id, args.directory);
+        notes = notes ? `${notes}\n\n${attribution}` : attribution;
+      }
+      if (notes !== undefined) params.set("notes", notes);
+
+      const first = args.title ?? args.titles?.[0] ?? "(untitled)";
+      const extra =
+        args.titles && args.titles.length > 1 ? ` (+${args.titles.length - 1} more)` : "";
+      return writeResult(await dispatch("add", params), `Captured "${first}"${extra}`);
+    },
+  );
+
+  server.registerTool(
+    "reorder_todos",
+    {
+      title: "Reorder todos to the top of a list",
+      description:
+        "Move todos to the top of Today, Anytime, or Someday in the given order. Use the list matching the todos' current scheduling state. Also reorders items within a project.",
+      inputSchema: {
+        ids: z.array(z.string()).min(1).describe("Todo IDs in desired top-to-bottom order"),
+        list: z.enum(["today", "anytime", "someday"]).default("today"),
+      },
+    },
+    async ({ ids, list }) => {
+      await ensureThingsRunning();
+      return jsonResult(await reorder(list, ids));
+    },
+  );
+}

--- a/plugins/things/src/mcp/tools.ts
+++ b/plugins/things/src/mcp/tools.ts
@@ -35,7 +35,7 @@ function textResult(text: string) {
 }
 
 function jsonResult(value: unknown) {
-  return textResult(JSON.stringify(value, null, 2));
+  return textResult(JSON.stringify(value));
 }
 
 /**
@@ -104,16 +104,22 @@ export function validateCaptureTitles(title?: string, titles?: string[]): void {
   if (title !== undefined && titles !== undefined) {
     throw new Error("Provide title (single todo) or titles (multiple todos), not both");
   }
-  if (!title && !titles?.length) {
+  if (!title?.trim() && !titles?.length) {
     throw new Error("title or titles is required");
   }
+  if (titles) validateNonBlank(titles, "titles");
 }
 
-/** Rejects blank IDs before they reach Things, which fails silently on them. */
-export function validateIds(ids: string[]): void {
-  ids.forEach((id, index) => {
-    if (id.trim() === "") {
-      throw new Error(`ids[${index}] must be a non-empty string, got ${JSON.stringify(id)}`);
+/**
+ * Rejects blank entries before they reach Things, which takes a blank id
+ * silently and a blank title as a nameless todo the user then has to find.
+ */
+export function validateNonBlank(values: string[], field: string): void {
+  values.forEach((value, index) => {
+    if (value.trim() === "") {
+      throw new Error(
+        `${field}[${index}] must be a non-empty string, got ${JSON.stringify(value)}`,
+      );
     }
   });
 }
@@ -198,7 +204,7 @@ export function registerTools(server: McpServer): void {
       description:
         "Create a todo. Goes to the inbox unless when/list places it elsewhere. For quick captures that should carry Claude attribution, use capture_inbox instead.",
       inputSchema: {
-        title: z.string(),
+        title: z.string().trim().min(1),
         notes: z.string().optional().describe("Markdown supported, max 10,000 chars"),
         when: z.string().optional().describe(whenDescription),
         deadline: z.string().optional().describe("yyyy-mm-dd"),
@@ -233,7 +239,7 @@ export function registerTools(server: McpServer): void {
       title: "Create a project",
       description: "Create a project, optionally with initial todos.",
       inputSchema: {
-        title: z.string(),
+        title: z.string().trim().min(1),
         notes: z.string().optional(),
         when: z.string().optional().describe(whenDescription),
         deadline: z.string().optional().describe("yyyy-mm-dd"),
@@ -244,6 +250,7 @@ export function registerTools(server: McpServer): void {
       },
     },
     async (args) => {
+      if (args.todos) validateNonBlank(args.todos, "todos");
       await ensureThingsRunning();
       const params = new Map<string, string>();
       params.set("title", args.title);
@@ -284,7 +291,7 @@ export function registerTools(server: McpServer): void {
       if (Object.keys(attributes).length === 0) {
         throw new Error("At least one attribute to update is required");
       }
-      validateIds(ids);
+      validateNonBlank(ids, "ids");
       await ensureThingsRunning();
 
       if (ids.length === 1 && ids[0]) {
@@ -293,15 +300,26 @@ export function registerTools(server: McpServer): void {
         return writeResult(await dispatch("update", params), `Updated ${ids[0]}`);
       }
 
-      const outputs: string[] = [];
+      const applied: string[] = [];
       for (const [index, batch] of chunk(ids, BATCH_SIZE).entries()) {
         if (index > 0) await Bun.sleep(BATCH_DELAY_MS);
         const params = new Map<string, string>();
         params.set("data", buildJsonPayload(batch, attributes));
-        const result = writeResult(await dispatch("json", params), `Updated ${batch.length} todos`);
-        outputs.push(result.content[0]?.text ?? "");
+        try {
+          writeResult(await dispatch("json", params), `Updated ${batch.length} todos`);
+        } catch (error) {
+          // A batch that fails leaves the earlier ones applied. Naming them
+          // keeps a retry from updating those todos a second time.
+          const message = error instanceof Error ? error.message : String(error);
+          throw new Error(
+            applied.length
+              ? `${message}\nAlready updated: ${applied.join(", ")}. Retry only the remaining IDs.`
+              : message,
+          );
+        }
+        applied.push(...batch);
       }
-      return textResult(outputs.join("\n"));
+      return textResult(`Updated ${applied.length} todos`);
     },
   );
 
@@ -318,7 +336,12 @@ export function registerTools(server: McpServer): void {
         tags: z.array(z.string()).optional().describe("Extra tags beyond 'Claude'"),
         checklist_items: z.array(z.string()).optional(),
         session_id: z.string().optional().describe("Claude session ID for attribution"),
-        directory: z.string().optional().describe("Working directory for the resume command"),
+        directory: z
+          .string()
+          .optional()
+          .describe(
+            "Absolute path the resume command should cd into. Omit it and the resume command carries no cd.",
+          ),
       },
     },
     async (args) => {

--- a/plugins/things/src/mcp/tools.ts
+++ b/plugins/things/src/mcp/tools.ts
@@ -39,9 +39,9 @@ function jsonResult(value: unknown) {
 }
 
 /**
- * Surfaces the dispatch outcome without ever retrying: an xcall round trip
- * that produced no output is reported as a failure (the todo may or may not
- * exist), matching the never-retry-on-silent-output rule in the url skill.
+ * Surfaces the dispatch outcome without retrying: an xcall round trip that
+ * produced no output is reported as a failure, since the todo may or may not
+ * exist.
  */
 function writeResult(result: DispatchResult, action: string) {
   warnFallback(result);
@@ -77,7 +77,6 @@ interface UpdateAttributeArgs {
   canceled?: boolean | undefined;
 }
 
-/** Converts tool arguments to the string attributes the URL scheme expects. */
 export function updateAttributes(args: UpdateAttributeArgs): Record<string, string> {
   const attributes: Record<string, string> = {};
   if (args.title !== undefined) attributes.title = args.title;
@@ -99,7 +98,7 @@ export function updateAttributes(args: UpdateAttributeArgs): Record<string, stri
 /**
  * Ensures exactly one of title/titles is provided. The Things URL scheme's
  * behavior when `add` receives both is undocumented and may create extra
- * todos, so reject the combination instead of dispatching it.
+ * todos, so reject the combination.
  */
 export function validateCaptureTitles(title?: string, titles?: string[]): void {
   if (title !== undefined && titles !== undefined) {

--- a/plugins/things/src/mcp/tools.ts
+++ b/plugins/things/src/mcp/tools.ts
@@ -124,6 +124,24 @@ export function validateNonBlank(values: string[], field: string): void {
   });
 }
 
+/**
+ * A date `new Date` cannot parse becomes `Invalid Date`, and every comparison
+ * against one is false. `query-logbook.js` would then skip its early
+ * termination and walk all 10k+ completed todos, which is the scan the date
+ * range exists to avoid. Rejecting here keeps that out of the JXA script, whose
+ * ES5 dialect makes the check awkward to express.
+ */
+const isoDate = z.string().refine((value) => !Number.isNaN(Date.parse(value)), {
+  message: "must be an ISO 8601 date",
+});
+
+/**
+ * Things takes a blank id silently, so a write carrying one reports success
+ * having changed nothing. Rejecting in the schema keeps the request out of the
+ * handler, which is where Things gets launched.
+ */
+const todoIds = z.array(z.string().trim().min(1)).min(1);
+
 const whenDescription =
   "Schedule: today, tomorrow, evening, anytime, someday, yyyy-mm-dd, or natural language like 'next week'";
 
@@ -168,8 +186,8 @@ export function registerTools(server: McpServer): void {
       description:
         "Read completed todos from the logbook within a date range, newest first with early termination. Optionally filter by a notes substring.",
       inputSchema: {
-        start: z.string().describe("Start of range, ISO 8601 (e.g. 2026-07-01)"),
-        end: z.string().describe("End of range, ISO 8601"),
+        start: isoDate.describe("Start of range, ISO 8601 (e.g. 2026-07-01)"),
+        end: isoDate.describe("End of range, ISO 8601"),
         notes_contains: z.string().optional().describe("Only todos whose notes contain this"),
       },
       annotations: { readOnlyHint: true },
@@ -272,7 +290,7 @@ export function registerTools(server: McpServer): void {
       description:
         "Update one or more todos: retitle, edit notes, reschedule (when), set deadline, retag, complete, or cancel. Multiple IDs batch through the JSON command, rate-limited to 250 operations per 10 seconds. Repeating todos cannot have when/deadline updated.",
       inputSchema: {
-        ids: z.array(z.string()).min(1),
+        ids: todoIds,
         title: z.string().optional(),
         notes: z.string().optional().describe("Replaces existing notes"),
         prepend_notes: z.string().optional(),
@@ -291,7 +309,6 @@ export function registerTools(server: McpServer): void {
       if (Object.keys(attributes).length === 0) {
         throw new Error("At least one attribute to update is required");
       }
-      validateNonBlank(ids, "ids");
       await ensureThingsRunning();
 
       if (ids.length === 1 && ids[0]) {
@@ -335,9 +352,19 @@ export function registerTools(server: McpServer): void {
         notes: z.string().optional(),
         tags: z.array(z.string()).optional().describe("Extra tags beyond 'Claude'"),
         checklist_items: z.array(z.string()).optional(),
-        session_id: z.string().optional().describe("Claude session ID for attribution"),
+        // Blank strings are rejected rather than ignored. Both are read for
+        // truthiness below, so a blank one would drop the attribution the
+        // caller asked for without saying anything.
+        session_id: z
+          .string()
+          .trim()
+          .min(1)
+          .optional()
+          .describe("Claude session ID for attribution"),
         directory: z
           .string()
+          .trim()
+          .min(1)
           .optional()
           .describe(
             "Absolute path the resume command should cd into. Omit it and the resume command carries no cd.",
@@ -377,7 +404,7 @@ export function registerTools(server: McpServer): void {
       description:
         "Move todos to the top of Today, Anytime, or Someday in the given order. Use the list matching the todos' current scheduling state. Also reorders items within a project.",
       inputSchema: {
-        ids: z.array(z.string()).min(1).describe("Todo IDs in desired top-to-bottom order"),
+        ids: todoIds.describe("Todo IDs in desired top-to-bottom order"),
         list: z.enum(["today", "anytime", "someday"]).default("today"),
       },
     },


### PR DESCRIPTION
Recovers the Things MCP server lost with the unmerged `fix-1049` branch and converts it from Streamable HTTP to stdio, so [tailgate](https://github.com/bendrucker/tailgate) can spawn it as a child process. Things is tailgate's first production upstream, which is what makes it reachable from a phone or a laptop. Replaces the `mcp-gate` and `things-mcp` launchd pair.

`server.ts`, `gate.ts`, `auth.ts`, and `install.ts` are not recovered. tailgate owns OAuth, token introspection, audience validation, and per-identity policy, so this server has no auth code, no port, and no socket.

## Stdout Discipline

This is why the change reaches outside `src/mcp/`. On stdio, stdout is the JSON-RPC channel, so a print from any module in the import closure corrupts the framing. The server reuses the plugin's CLI scripts as modules, and two of their writes sat on the tool path:

- `reorder()` logged its result and called `process.exit(1)`. It returns a `ReorderResult` and throws instead, leaving both to the CLI.
- `openUrl` ran Bun's `$`, which inherits stdout. It runs `.quiet()` now and forwards what it captured to stderr, where tailgate logs it.

Nothing outside `plugins/things` imports these scripts, since `check-plugin-imports.ts` forbids it. The shared surface is this plugin's own `url`, `triage`, and `jxa` skills invoking them as CLIs. Their CLI behavior is unchanged.

`stdout.test.ts` guards the invariant: it walks the import closure and snapshots every reachable `console` call, `process.stdout` write, and unquieted `$`. The handshake test drives only `initialize` and `tools/list`, so it never enters a tool handler and cannot see a print added inside one.

## Review Fixes

Four defects on the write path:

- `.quiet()` captured `open`'s diagnostics and dropped them, since a `ShellError`'s message is only its exit code. A failed handoff reported `Failed with exit code 1` and nothing else.
- `buildAttribution` defaulted its directory to `process.cwd()`, which under tailgate is the server's spawn directory. A `capture_inbox` carrying `session_id` alone produced a resume snippet pointing somewhere unrelated. The caller names the directory now, and one that cannot gets a snippet with no `cd`.
- A batch update failing partway discarded which batches had already applied, so a retry would update those todos twice.
- Blank titles reached Things as nameless todos.

Both runner resolvers duplicated the same two-layout probe. #1220 fixed the installed-layout scan in one (it gated on `Bun.file(<dir>).exists()`, false for a directory, so no installed plugin ever resolved a runner) and `jxa.ts` carried the same defect. `findSiblingScript` is now the single implementation.

## Verification

A live handshake against real Things data returns three JSON-RPC lines: `initialize`, `tools/list` with all nine tools, and a `list_todos` read of today. Empty stderr, no stray stdout. Tests cover the resolver across both marketplace layouts, the stdout closure, the reorder guards, the attribution footer, and the tool registry.

Write tools stay unexercised, since they mutate real task data. Unit tests cover their validation and parameter building.

The plugin `tsconfig.json` reports a pre-existing `moduleResolution=node10` deprecation. Switching it to `bundler` surfaces five `checkJs` errors in the JXA scripts, so that is its own change.
