### PR TITLE
hooks: revalidate the stop after an ox block

### DIFF
--- a/.claude/hooks/ox/README.md
+++ b/.claude/hooks/ox/README.md
@@ -12,6 +12,8 @@ When you `Edit` or `Write` a file oxlint understands, it runs and shows any issu
 
 When the session ends, oxfmt formats all edited files, oxlint checks them, and a type check runs over each working tree those files belong to (`oxlint --type-aware --type-check`). If issues remain, the session is blocked until they're resolved.
 
+The stop that follows a block is checked too. It arrives flagged as re-entrant, and waving it through would end the session on a repair nothing looked at, where the original error can still stand or a new cross-file type error can have appeared that the per-edit lint pass cannot see. Two blocks is the budget: the third stop reports what is left as a warning and lets the session end, so an error the model cannot clear does not wedge it. A stop the model did not reach through a block starts the budget over.
+
 ## Pre-Commit Check
 
 The hook does the same on `git commit`, over staged files, and denies the commit if a lint or type error remains. Nothing is auto-fixed beyond formatting, so a lint error blocks whether or not a fixer exists for it. The formatting it applies is restaged, so the commit records the text the check passed.

--- a/.claude/hooks/ox/README.md
+++ b/.claude/hooks/ox/README.md
@@ -10,9 +10,11 @@ When you `Edit` or `Write` a file oxlint understands, it runs and shows any issu
 
 #### Before Stopping (Stop)
 
-When the session ends, oxfmt formats all edited files, oxlint checks them, and a type check runs over each working tree those files belong to (`oxlint --type-aware --type-check`). If issues remain, the session is blocked until they're resolved.
+When the session ends, oxfmt formats all edited files, oxlint checks them, and a type check runs over each working tree those files belong to (`oxlint --type-aware --type-check`). If issues remain, the session is blocked until they're resolved or the budget below runs out.
 
-The stop that follows a block is checked too. It arrives flagged as re-entrant, and waving it through would end the session on a repair nothing looked at, where the original error can still stand or a new cross-file type error can have appeared that the per-edit lint pass cannot see. Two blocks is the budget: the third stop reports what is left as a warning and lets the session end, so an error the model cannot clear does not wedge it. A stop the model did not reach through a block starts the budget over.
+The stop that follows a block is checked too. It arrives flagged as re-entrant, so the hook can tell a retry from a fresh stop. Waving it through would end the session on a repair nothing looked at. The original error can still stand, or a new cross-file type error can have appeared that the per-edit lint pass cannot see.
+
+Two blocks is the budget, counted per session. The third stop reports what is left as a warning and lets the session end, so an error the model cannot clear does not stall it. A stop that is not preceded by a block starts the budget over, and so does a new session.
 
 ## Pre-Commit Check
 
@@ -24,4 +26,4 @@ A staged file carrying further unstaged edits is refused before any of that runs
 
 Only oxlint is required. When oxfmt cannot be resolved, the gates still lint and type-check and simply skip reformatting, rather than passing silently.
 
-A working tree with no `node_modules` skips the type check and says so in the block reason. tsgolint resolves imports through the dependency tree, so without one it reports every external import as missing, and no edit the session makes can clear that. Lint and formatting still run: the binaries come from Bun's install cache, falling back to the main checkout of the same repository, so a fresh worktree is gated before anyone runs `bun install`.
+A working tree with no `node_modules` skips the type check and says so alongside whatever the gate reports. tsgolint resolves imports through the dependency tree, so without one it reports every external import as missing, and no edit the session makes can clear that. Lint and formatting still run: the binaries come from Bun's install cache, falling back to the main checkout of the same repository, so a fresh worktree is gated before anyone runs `bun install`.

--- a/.claude/hooks/ox/index.test.ts
+++ b/.claude/hooks/ox/index.test.ts
@@ -61,9 +61,13 @@ function mockPreToolUseInput(command: string): PreToolUseHookInput {
   };
 }
 
-function mockStopHookInput(transcriptPath: string, stopHookActive = false): StopHookInput {
+function mockStopHookInput(
+  transcriptPath: string,
+  stopHookActive = false,
+  sessionId = "test-session",
+): StopHookInput {
   return {
-    session_id: "test-session",
+    session_id: sessionId,
     hook_event_name: "Stop",
     transcript_path: transcriptPath,
     cwd: process.cwd(),
@@ -306,13 +310,52 @@ describe("ox hook", () => {
   });
 
   describe("processStop", () => {
-    it("returns null when stop_hook_active is true", async () => {
+    // A blocked Stop wakes the model to repair, and the Stop that follows
+    // carries stop_hook_active. Skipping the gate there ends the session on a
+    // repair nothing checked.
+    it("checks the re-entrant stop rather than skipping it", async () => {
       const filePath = await copyFixture("unfixable.ts", tempDir);
       const transcriptPath = join(tempDir, `transcript-active-${Date.now()}.jsonl`);
       await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Edit" }]));
 
-      const input = mockStopHookInput(transcriptPath, true);
-      expect(await processStop(input)).toBeNull();
+      const input = mockStopHookInput(transcriptPath, true, `reentrant-${Date.now()}`);
+      const result = await processStop(input);
+
+      expect(result?.decision).toBe("block");
+      expect(result?.reason).toContain("no-dupe-keys");
+    });
+
+    // An error the model cannot clear would otherwise block every Stop forever,
+    // the runaway stop_hook_active used to prevent by skipping outright.
+    it("gives way once the issues survive the block limit", async () => {
+      const filePath = await copyFixture("unfixable.ts", tempDir);
+      const transcriptPath = join(tempDir, `transcript-limit-${Date.now()}.jsonl`);
+      await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Edit" }]));
+      const session = `limit-${Date.now()}`;
+
+      const first = await processStop(mockStopHookInput(transcriptPath, false, session));
+      const second = await processStop(mockStopHookInput(transcriptPath, true, session));
+      const third = await processStop(mockStopHookInput(transcriptPath, true, session));
+
+      expect(first?.decision).toBe("block");
+      expect(second?.decision).toBe("block");
+      expect(third?.decision).toBeUndefined();
+      expect(third?.systemMessage).toContain("no-dupe-keys");
+    });
+
+    // The budget is per round. A Stop the model did not reach through a block
+    // ends the previous round, so the next one starts with its full count.
+    it("restarts the count on a stop that did not follow a block", async () => {
+      const filePath = await copyFixture("unfixable.ts", tempDir);
+      const transcriptPath = join(tempDir, `transcript-restart-${Date.now()}.jsonl`);
+      await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Edit" }]));
+      const session = `restart-${Date.now()}`;
+
+      await processStop(mockStopHookInput(transcriptPath, false, session));
+      await processStop(mockStopHookInput(transcriptPath, true, session));
+      const fresh = await processStop(mockStopHookInput(transcriptPath, false, session));
+
+      expect(fresh?.decision).toBe("block");
     });
 
     it("returns null when no files were modified", async () => {

--- a/.claude/hooks/ox/index.test.ts
+++ b/.claude/hooks/ox/index.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
 import { exec } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -12,6 +12,7 @@ import type {
   SyncHookJSONOutput,
 } from "@anthropic-ai/claude-agent-sdk";
 import {
+  blockCountPath,
   invokesGitCommit,
   parseTranscript,
   processInput,
@@ -19,6 +20,7 @@ import {
   processPreToolUse,
   processStop,
   runOxlintAgent,
+  STOP_BLOCK_LIMIT,
 } from ".";
 
 const execAsync = promisify(exec);
@@ -61,11 +63,14 @@ function mockPreToolUseInput(command: string): PreToolUseHookInput {
   };
 }
 
+const gateSessions = new Set<string>();
+
 function mockStopHookInput(
   transcriptPath: string,
   stopHookActive = false,
   sessionId = "test-session",
 ): StopHookInput {
+  gateSessions.add(sessionId);
   return {
     session_id: sessionId,
     hook_event_name: "Stop",
@@ -128,8 +133,13 @@ describe("ox hook", () => {
     tempDir = await mkdtemp(join(tmpdir(), "ox-test-"));
   });
 
+  // A stop left blocking keeps its count file. Remove the ones these tests
+  // wrote by name: the directory holds live sessions' counts too.
   afterAll(async () => {
     await rm(tempDir, { recursive: true, force: true });
+    for (const session of gateSessions) {
+      await rm(blockCountPath(session), { recursive: true, force: true });
+    }
   });
 
   describe("runOxlintAgent", () => {
@@ -310,16 +320,23 @@ describe("ox hook", () => {
   });
 
   describe("processStop", () => {
+    // A session holding one lint error oxfmt cannot fix, stopped repeatedly.
+    // Each block-budget test drives its own so the on-disk count stays its own.
+    async function unfixableSession(session: string): Promise<string> {
+      const filePath = await copyFixture("unfixable.ts", tempDir);
+      const transcriptPath = join(tempDir, `transcript-${session}.jsonl`);
+      await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Edit" }]));
+      return transcriptPath;
+    }
+
     // A blocked Stop wakes the model to repair, and the Stop that follows
     // carries stop_hook_active. Skipping the gate there ends the session on a
     // repair nothing checked.
     it("checks the re-entrant stop rather than skipping it", async () => {
-      const filePath = await copyFixture("unfixable.ts", tempDir);
-      const transcriptPath = join(tempDir, `transcript-active-${Date.now()}.jsonl`);
-      await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Edit" }]));
+      const session = `reentrant-${Date.now()}`;
+      const transcript = await unfixableSession(session);
 
-      const input = mockStopHookInput(transcriptPath, true, `reentrant-${Date.now()}`);
-      const result = await processStop(input);
+      const result = await processStop(mockStopHookInput(transcript, true, session));
 
       expect(result?.decision).toBe("block");
       expect(result?.reason).toContain("no-dupe-keys");
@@ -327,32 +344,45 @@ describe("ox hook", () => {
 
     // An error the model cannot clear would otherwise block every Stop forever.
     it("gives way once the issues survive the block limit", async () => {
-      const filePath = await copyFixture("unfixable.ts", tempDir);
-      const transcriptPath = join(tempDir, `transcript-limit-${Date.now()}.jsonl`);
-      await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Edit" }]));
       const session = `limit-${Date.now()}`;
+      const transcript = await unfixableSession(session);
 
-      const first = await processStop(mockStopHookInput(transcriptPath, false, session));
-      const second = await processStop(mockStopHookInput(transcriptPath, true, session));
-      const third = await processStop(mockStopHookInput(transcriptPath, true, session));
+      const budget = [];
+      for (let stop = 0; stop < STOP_BLOCK_LIMIT; stop++) {
+        budget.push(await processStop(mockStopHookInput(transcript, stop > 0, session)));
+      }
+      const past = await processStop(mockStopHookInput(transcript, true, session));
 
-      expect(first?.decision).toBe("block");
-      expect(second?.decision).toBe("block");
-      expect(third?.decision).toBeUndefined();
-      expect(third?.systemMessage).toContain("no-dupe-keys");
+      expect(budget.map((result) => result?.decision)).toEqual(
+        Array(STOP_BLOCK_LIMIT).fill("block"),
+      );
+      expect(past?.decision).toBeUndefined();
+      expect(past?.systemMessage).toContain("no-dupe-keys");
+    });
+
+    // Blocking without a recorded count is the runaway itself: every re-entrant
+    // Stop would read zero and block again, with nothing to release it.
+    it("declines to block when the count cannot be recorded", async () => {
+      const session = `unwritable-${Date.now()}`;
+      const transcript = await unfixableSession(session);
+      // A directory where the state file goes, so every write to it fails.
+      await mkdir(blockCountPath(session), { recursive: true });
+
+      const result = await processStop(mockStopHookInput(transcript, false, session));
+
+      expect(result?.decision).toBeUndefined();
+      expect(result?.systemMessage).toContain("no-dupe-keys");
     });
 
     // The budget is per round. A Stop the model did not reach through a block
     // ends the previous round, so the next one starts with its full count.
     it("restarts the count on a stop that did not follow a block", async () => {
-      const filePath = await copyFixture("unfixable.ts", tempDir);
-      const transcriptPath = join(tempDir, `transcript-restart-${Date.now()}.jsonl`);
-      await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Edit" }]));
       const session = `restart-${Date.now()}`;
+      const transcript = await unfixableSession(session);
 
-      await processStop(mockStopHookInput(transcriptPath, false, session));
-      await processStop(mockStopHookInput(transcriptPath, true, session));
-      const fresh = await processStop(mockStopHookInput(transcriptPath, false, session));
+      await processStop(mockStopHookInput(transcript, false, session));
+      await processStop(mockStopHookInput(transcript, true, session));
+      const fresh = await processStop(mockStopHookInput(transcript, false, session));
 
       expect(fresh?.decision).toBe("block");
     });

--- a/.claude/hooks/ox/index.test.ts
+++ b/.claude/hooks/ox/index.test.ts
@@ -325,8 +325,7 @@ describe("ox hook", () => {
       expect(result?.reason).toContain("no-dupe-keys");
     });
 
-    // An error the model cannot clear would otherwise block every Stop forever,
-    // the runaway stop_hook_active used to prevent by skipping outright.
+    // An error the model cannot clear would otherwise block every Stop forever.
     it("gives way once the issues survive the block limit", async () => {
       const filePath = await copyFixture("unfixable.ts", tempDir);
       const transcriptPath = join(tempDir, `transcript-limit-${Date.now()}.jsonl`);

--- a/.claude/hooks/ox/index.ts
+++ b/.claude/hooks/ox/index.ts
@@ -487,32 +487,30 @@ export async function processPostToolUse(
 // cross-file type error the per-edit lint pass cannot reach. So the re-entrant
 // Stop checks too, and a count of consecutive blocks bounds it, since an error
 // the model cannot clear would otherwise block every Stop forever.
-const STOP_BLOCK_LIMIT = 2;
+export const STOP_BLOCK_LIMIT = 2;
 
 const UNSAFE_SESSION = /[^A-Za-z0-9._-]+/g;
 
-function blockCountPath(sessionId: string): string {
+export function blockCountPath(sessionId: string): string {
   return join(tmpdir(), "claude-ox-gate", `${sessionId.replace(UNSAFE_SESSION, "-")}.json`);
 }
 
-// A Stop the model did not arrive at through a block starts a fresh round, so a
-// count left over from an earlier one cannot shorten it.
-async function priorBlocks(input: StopHookInput): Promise<number> {
-  if (!input.stop_hook_active) {
-    return 0;
-  }
+async function priorBlocks(sessionId: string): Promise<number> {
   try {
-    const state = (await Bun.file(blockCountPath(input.session_id)).json()) as { blocks?: number };
+    const state = (await Bun.file(blockCountPath(sessionId)).json()) as { blocks?: number };
     return typeof state.blocks === "number" ? state.blocks : 0;
   } catch {
     return 0;
   }
 }
 
-async function recordBlocks(sessionId: string, blocks: number): Promise<void> {
+async function recordBlocks(sessionId: string, blocks: number): Promise<boolean> {
   try {
     await Bun.write(blockCountPath(sessionId), JSON.stringify({ blocks }));
-  } catch {}
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function clearBlocks(sessionId: string): Promise<void> {
@@ -522,7 +520,10 @@ async function clearBlocks(sessionId: string): Promise<void> {
 }
 
 export async function processStop(input: StopHookInput): Promise<SyncHookJSONOutput | null> {
+  // Every exit that is not a block clears the count, so a stale one can never
+  // be read back as progress through a later round's budget.
   if (!(await oxlintCommand())) {
+    await clearBlocks(input.session_id);
     return null;
   }
 
@@ -532,18 +533,22 @@ export async function processStop(input: StopHookInput): Promise<SyncHookJSONOut
     return null;
   }
 
-  const blocked = await priorBlocks(input);
-  if (blocked >= STOP_BLOCK_LIMIT) {
-    await clearBlocks(input.session_id);
+  // A Stop the model did not arrive at through a block starts a fresh round.
+  const blocked = input.stop_hook_active ? await priorBlocks(input.session_id) : 0;
+
+  // Blocking is only safe once the count that will later release it is on disk.
+  // A state file that cannot be written would otherwise leave every re-entrant
+  // Stop reading zero and blocking again, forever.
+  if (blocked < STOP_BLOCK_LIMIT && (await recordBlocks(input.session_id, blocked + 1))) {
     return {
-      systemMessage: `⚠️ Ox issues survived ${blocked} blocked stops, so this one is allowed through with them in place:\n\n${sections}`,
+      decision: "block",
+      reason: `❌ Ox check failed. Formatting was auto-applied but issues remain:\n\n${sections}\n\nFix these issues before stopping.`,
     };
   }
 
-  await recordBlocks(input.session_id, blocked + 1);
+  await clearBlocks(input.session_id);
   return {
-    decision: "block",
-    reason: `❌ Ox check failed. Formatting was auto-applied but issues remain:\n\n${sections}\n\nFix these issues before stopping.`,
+    systemMessage: `⚠️ Ox is no longer blocking on these issues, so this stop goes through with them in place:\n\n${sections}`,
   };
 }
 

--- a/.claude/hooks/ox/index.ts
+++ b/.claude/hooks/ox/index.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 
 import { execFile } from "node:child_process";
-import { readdir } from "node:fs/promises";
+import { readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -420,12 +421,7 @@ function withoutRepeats(typeOutput: string, lintOutput: string | null): string {
     .join("\n");
 }
 
-function formatBlockReason(
-  intro: string,
-  verb: string,
-  lintOutput: string | null,
-  typeCheck: TypeCheckResult,
-): string {
+function formatSections(lintOutput: string | null, typeCheck: TypeCheckResult): string {
   const sections = [];
   if (lintOutput) sections.push(`Lint:\n${lintOutput}`);
   const types = typeCheck.output && withoutRepeats(typeCheck.output, lintOutput);
@@ -433,14 +429,16 @@ function formatBlockReason(
   if (typeCheck.needsInstall) {
     sections.push("Types: skipped, dependencies are not installed here (`bun install`).");
   }
-  return `${intro}\n\n${sections.join("\n\n")}\n\nFix these issues before ${verb}.`;
+  return sections.join("\n\n");
 }
 
 // The gate Stop and the pre-commit check share: reformat first so the lint pass
 // sees final text, then lint and type-check concurrently. Only oxlint is
 // required, so a missing oxfmt degrades to checking without reformatting rather
-// than dropping the gate entirely.
-async function runOxGate(files: string[], intro: string, verb: string): Promise<string | null> {
+// than dropping the gate entirely. The diagnostics come back unframed: the two
+// callers say different things about them, and Stop says two different things
+// itself depending on whether it is still willing to block.
+async function runOxGate(files: string[]): Promise<string | null> {
   if (files.length === 0) {
     return null;
   }
@@ -455,7 +453,7 @@ async function runOxGate(files: string[], intro: string, verb: string): Promise<
     return null;
   }
 
-  return formatBlockReason(intro, verb, lintOutput, typeCheck);
+  return formatSections(lintOutput, typeCheck);
 }
 
 export async function processPostToolUse(
@@ -483,21 +481,71 @@ export async function processPostToolUse(
   return formatPostToolUseOutput(filePath, errors);
 }
 
-export async function processStop(input: StopHookInput): Promise<SyncHookJSONOutput | null> {
-  if (input.stop_hook_active) {
-    return null;
-  }
+// A blocked Stop wakes the model to repair, and the Stop that follows carries
+// stop_hook_active. Returning null there ends the session on text the gate never
+// saw: the repair can leave the original error standing, or introduce a
+// cross-file type error the per-edit lint pass cannot reach. So the re-entrant
+// Stop checks too, and a count of consecutive blocks bounds it, since an error
+// the model cannot clear would otherwise block every Stop forever. That runaway
+// is what the flag exists to prevent, and the count replaces it.
+const STOP_BLOCK_LIMIT = 2;
 
+const UNSAFE_SESSION = /[^A-Za-z0-9._-]+/g;
+
+function blockCountPath(sessionId: string): string {
+  return join(tmpdir(), "claude-ox-gate", `${sessionId.replace(UNSAFE_SESSION, "-")}.json`);
+}
+
+// A Stop the model did not arrive at through a block starts a fresh round, so a
+// count left over from an earlier one cannot shorten it.
+async function priorBlocks(input: StopHookInput): Promise<number> {
+  if (!input.stop_hook_active) {
+    return 0;
+  }
+  try {
+    const state = (await Bun.file(blockCountPath(input.session_id)).json()) as { blocks?: number };
+    return typeof state.blocks === "number" ? state.blocks : 0;
+  } catch {
+    return 0;
+  }
+}
+
+async function recordBlocks(sessionId: string, blocks: number): Promise<void> {
+  try {
+    await Bun.write(blockCountPath(sessionId), JSON.stringify({ blocks }));
+  } catch {}
+}
+
+async function clearBlocks(sessionId: string): Promise<void> {
+  try {
+    await rm(blockCountPath(sessionId), { force: true });
+  } catch {}
+}
+
+export async function processStop(input: StopHookInput): Promise<SyncHookJSONOutput | null> {
   if (!(await oxlintCommand())) {
     return null;
   }
 
-  const reason = await runOxGate(
-    await parseTranscript(input.transcript_path),
-    "❌ Ox check failed. Formatting was auto-applied but issues remain:",
-    "stopping",
-  );
-  return reason ? { decision: "block", reason } : null;
+  const sections = await runOxGate(await parseTranscript(input.transcript_path));
+  if (!sections) {
+    await clearBlocks(input.session_id);
+    return null;
+  }
+
+  const blocked = await priorBlocks(input);
+  if (blocked >= STOP_BLOCK_LIMIT) {
+    await clearBlocks(input.session_id);
+    return {
+      systemMessage: `⚠️ Ox issues survived ${blocked} blocked stops, so this one is allowed through with them in place:\n\n${sections}`,
+    };
+  }
+
+  await recordBlocks(input.session_id, blocked + 1);
+  return {
+    decision: "block",
+    reason: `❌ Ox check failed. Formatting was auto-applied but issues remain:\n\n${sections}\n\nFix these issues before stopping.`,
+  };
 }
 
 type StagedOxFiles = { paths: string[]; diverged: string[] };
@@ -559,13 +607,14 @@ export async function processPreToolUse(
     );
   }
 
-  const reason = await runOxGate(
-    staged.paths,
-    "Ox found issues in staged files after auto-formatting:",
-    "committing",
-  );
+  const sections = await runOxGate(staged.paths);
   await restage(staged.paths);
-  return reason ? deny(reason) : null;
+  if (!sections) {
+    return null;
+  }
+  return deny(
+    `Ox found issues in staged files after auto-formatting:\n\n${sections}\n\nFix these issues before committing.`,
+  );
 }
 
 // The gate reformats on disk, which would otherwise leave the index holding the

--- a/.claude/hooks/ox/index.ts
+++ b/.claude/hooks/ox/index.ts
@@ -434,10 +434,10 @@ function formatSections(lintOutput: string | null, typeCheck: TypeCheckResult): 
 
 // The gate Stop and the pre-commit check share: reformat first so the lint pass
 // sees final text, then lint and type-check concurrently. Only oxlint is
-// required, so a missing oxfmt degrades to checking without reformatting rather
-// than dropping the gate entirely. The diagnostics come back unframed: the two
-// callers say different things about them, and Stop says two different things
-// itself depending on whether it is still willing to block.
+// required, so a missing oxfmt degrades to checking without reformatting. The
+// diagnostics come back unframed: the two callers say different things about
+// them, and Stop says two different things itself depending on whether it is
+// still willing to block.
 async function runOxGate(files: string[]): Promise<string | null> {
   if (files.length === 0) {
     return null;
@@ -486,8 +486,7 @@ export async function processPostToolUse(
 // saw: the repair can leave the original error standing, or introduce a
 // cross-file type error the per-edit lint pass cannot reach. So the re-entrant
 // Stop checks too, and a count of consecutive blocks bounds it, since an error
-// the model cannot clear would otherwise block every Stop forever. That runaway
-// is what the flag exists to prevent, and the count replaces it.
+// the model cannot clear would otherwise block every Stop forever.
 const STOP_BLOCK_LIMIT = 2;
 
 const UNSAFE_SESSION = /[^A-Za-z0-9._-]+/g;


### PR DESCRIPTION
The ox Stop gate returned early on any stop carrying `stop_hook_active`, so the repaired state was never checked. Blocking a stop wakes the model to fix what the gate found, and the stop that follows is flagged as re-entrant. That flag was read as "already handled," so the session ended on a repair nothing looked at. The repair could leave the original error standing, or introduce a cross-file type error the per-edit lint pass cannot reach.

The flag was there for a reason: without it, an error the model cannot clear blocks every stop forever. So the gate now counts consecutive blocks in a per-session temp file instead of trusting the flag. Two blocks is the budget. The third stop reports what is left as a non-blocking `systemMessage` and lets the session end. A stop the model did not reach through a block starts the count over, so the budget applies per repair round rather than per session lifetime.

Blocking waits on a successful write of that count. If the state file cannot be written, every re-entrant stop would read zero and block again with nothing to release it, which is the exact wedge the old early return prevented. That path gives way with the warning instead.

Drove the real hook entrypoint through three stops against a file with an unfixable lint error and watched it block, block, then warn.

This is the P1 from the adversarial review on #1222, which shipped three of its six findings. The two P2s (unbounded PostToolUse diagnostic output, session-wide file scope in `parseTranscript`) are still open, along with the pre-existing case where a clean lint run drops the "dependencies are not installed" notice.
