### PR TITLE
x-callback-url: tie a callback to its caller

### DIFF
--- a/plugins/things/scripts/url.test.ts
+++ b/plugins/things/scripts/url.test.ts
@@ -162,8 +162,11 @@ describe("xcallBackstopMs", () => {
     { name: "a zero bound", env: { XCALL_TIMEOUT_SECONDS: "0" } },
   ])("outwaits run.sh with $name", ({ env }) => {
     const bound = (name: string) => Number(env[name]) || 20;
+    // run.sh waits out a lock holder's whole turn before starting its own, so
+    // the callback bound counts once for the wait and once for the call.
+    const callback = bound("XCALL_TIMEOUT_SECONDS");
     const runnerCeilingMs =
-      (bound("XCALL_BUILD_TIMEOUT_SECONDS") + bound("XCALL_TIMEOUT_SECONDS") + 2) * 1000;
+      (bound("XCALL_BUILD_TIMEOUT_SECONDS") + (callback + 2 + 1) + callback + 2) * 1000;
 
     expect(xcallBackstopMs(env)).toBeGreaterThan(runnerCeilingMs);
   });
@@ -174,8 +177,8 @@ describe("xcallBackstopMs", () => {
       raised: xcallBackstopMs({ XCALL_BUILD_TIMEOUT_SECONDS: "90", XCALL_TIMEOUT_SECONDS: "60" }),
     }).toMatchInlineSnapshot(`
       {
-        "defaults": 57000,
-        "raised": 167000,
+        "defaults": 80000,
+        "raised": 230000,
       }
     `);
   });

--- a/plugins/things/scripts/url.ts
+++ b/plugins/things/scripts/url.ts
@@ -192,15 +192,22 @@ function boundSeconds(env: Record<string, string | undefined>, name: string): nu
 
 /**
  * Backstop for a runner that dies without honoring its own watchdogs. Derived
- * from run.sh's two bounds rather than fixed, because run.sh invites raising
- * either one in its own timeout message. A backstop below their sum kills the
- * runner before it can name why it failed, and the caller gets an anonymous
- * signal in place of exit 3 or 4.
+ * from run.sh's bounds rather than fixed, because run.sh invites raising them
+ * in its own timeout messages. A backstop below their sum kills the runner
+ * before it can name why it failed, and the caller gets an anonymous signal in
+ * place of exit 3, 4, or 5.
+ *
+ * The callback timeout counts twice. run.sh serializes on a lock first, and a
+ * caller that finds the bridge busy waits out the holder's full turn before
+ * starting its own.
  */
 export function xcallBackstopMs(env: Record<string, string | undefined>): number {
+  const callback = boundSeconds(env, "XCALL_TIMEOUT_SECONDS");
+  const lockWait = callback + XCALL_KILL_GRACE_SECONDS + 1;
   const bounds =
     boundSeconds(env, "XCALL_BUILD_TIMEOUT_SECONDS") +
-    boundSeconds(env, "XCALL_TIMEOUT_SECONDS") +
+    lockWait +
+    callback +
     XCALL_KILL_GRACE_SECONDS;
   return bounds * 1000 + XCALL_BACKSTOP_MARGIN_MS;
 }

--- a/plugins/x-callback-url/README.md
+++ b/plugins/x-callback-url/README.md
@@ -16,7 +16,11 @@ Call x-callback-url schemes from the CLI and receive responses synchronously.
 
 One bundle serves every consumer, at `~/.cache/claude/x-callback-url/xcall.app`, because macOS registers exactly one handler for `xcall-claude://`.
 
-Both shell scripts carry the `mac` plugin's `claude:dangerouslyDisableSandbox` marker. The command sandbox blocks Launch Services registration and the URL-scheme round trip alike, and a sandboxed `xcall` hangs instead of failing, so `run.sh` owns the deadline for both phases: `XCALL_BUILD_TIMEOUT_SECONDS` (exit 3) and `XCALL_TIMEOUT_SECONDS` (exit 4), 20 seconds each by default.
+That one handler is why a callback needs to say who it belongs to. Every waiting instance is a candidate recipient for every callback, and macOS chooses among them. Each invocation therefore mints a token, carries it out on the `x-success`/`x-error`/`x-cancel` URLs, and answers only to a callback that brings the same token back. The token is stripped before the query reaches stdout. Without it an instance reports another instance's result as its own, which reads as a successful call returning the wrong id.
+
+The token makes a stray callback harmless, not deliverable, so `run.sh` also serializes on `~/.cache/claude/x-callback-url/xcall.lock` and one invocation waits at a time (exit 5 if the bridge stays busy). The two together are what make concurrent callers safe: the token rules out a wrong answer, and the lock rules out a lost one.
+
+Both shell scripts carry the `mac` plugin's `claude:dangerouslyDisableSandbox` marker. The command sandbox blocks Launch Services registration and the URL-scheme round trip alike, and a sandboxed `xcall` hangs instead of failing, so `run.sh` owns the deadline for both phases: `XCALL_BUILD_TIMEOUT_SECONDS` (exit 3) and `XCALL_TIMEOUT_SECONDS` (exit 4), 20 seconds each by default. A caller that waits out the lock instead exits 5.
 
 ## Tests
 

--- a/plugins/x-callback-url/scripts/main.swift
+++ b/plugins/x-callback-url/scripts/main.swift
@@ -22,6 +22,15 @@ import Foundation
 
 let callbackScheme = "xcall-claude"
 
+// macOS binds one handler bundle to xcall-claude://, so every concurrently
+// waiting instance is a candidate recipient for every callback, and the three
+// callback URLs are otherwise identical between them. Without something to tell
+// them apart, an instance can accept the answer to another instance's request
+// and report that request's id as its own. The token travels out on the
+// callback URL and comes back on the event, and an instance answers only to its
+// own.
+let callbackToken = UUID().uuidString
+
 guard CommandLine.arguments.count >= 2 else {
     fputs("Usage: xcall <url>\n", stderr)
     exit(1)
@@ -40,9 +49,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             andEventID: AEEventID(kAEGetURL)
         )
 
-        let successCB = "\(callbackScheme)://x-callback-url/success"
-        let errorCB = "\(callbackScheme)://x-callback-url/error"
-        let cancelCB = "\(callbackScheme)://x-callback-url/cancel"
+        let successCB = "\(callbackScheme)://x-callback-url/success?token=\(callbackToken)"
+        let errorCB = "\(callbackScheme)://x-callback-url/error?token=\(callbackToken)"
+        let cancelCB = "\(callbackScheme)://x-callback-url/cancel?token=\(callbackToken)"
 
         var urlString = baseURL
         let sep = urlString.contains("?") ? "&" : "?"
@@ -75,7 +84,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let path = url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        let query = components.query ?? ""
+
+        // Percent-encoded throughout: the target app's values carry whatever a
+        // caller wrote, and decoding here only to re-encode on the way out
+        // would be a chance to change them.
+        let items = components.percentEncodedQueryItems ?? []
+        guard items.first(where: { $0.name == "token" })?.value == callbackToken else {
+            return
+        }
+
+        // The token is this bridge's own bookkeeping, so it does not reach the
+        // caller reading the query off stdout.
+        var answer = URLComponents()
+        let rest = items.filter { $0.name != "token" }
+        answer.percentEncodedQueryItems = rest.isEmpty ? nil : rest
+        let query = answer.percentEncodedQuery ?? ""
 
         switch path {
         case "success":

--- a/plugins/x-callback-url/scripts/run.sh
+++ b/plugins/x-callback-url/scripts/run.sh
@@ -3,9 +3,10 @@
 set -euo pipefail
 
 # Exit 3 separates a build failure from xcall's own exit codes (0 success,
-# 1 x-error, 2 x-cancel). Exit 4 separates a wait that ran out of time. Callers
-# treat any non-zero status as "no result", so without them a broken bridge is
-# indistinguishable from the target app rejecting the request.
+# 1 x-error, 2 x-cancel). Exit 4 separates a wait that ran out of time. Exit 5
+# separates a wait for the bridge itself. Callers treat any non-zero status as
+# "no result", so without them a broken bridge is indistinguishable from the
+# target app rejecting the request.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -76,6 +77,29 @@ if ((build_status != 0)); then
   fi
   exit 3
 fi
+
+# One xcall runs at a time, across every process that calls this script. Two
+# waiting instances share one registered handler for xcall-claude://, and macOS
+# picks which of them a callback reaches. Each instance answers only to its own
+# token, so a stray callback is ignored rather than misread, but the instance it
+# belonged to never sees it and waits out its deadline. Holding the bridge to
+# one waiter is what keeps the callback unambiguous to deliver.
+LOCK_FILE="${XDG_CACHE_HOME:-$HOME/.cache}/claude/x-callback-url/xcall.lock"
+mkdir -p "$(dirname "$LOCK_FILE")"
+
+# A holder cannot outlive its own watchdog, so the wait covers one full turn
+# plus the grace the watchdog allows before SIGKILL. shlock reclaims a lock
+# whose recorded pid is gone, which covers a holder killed outside that path.
+LOCK_WAIT_SECONDS=$((TIMEOUT_SECONDS + KILL_GRACE_SECONDS + 1))
+lock_deadline=$((SECONDS + LOCK_WAIT_SECONDS))
+until shlock -f "$LOCK_FILE" -p $$; do
+  if ((SECONDS >= lock_deadline)); then
+    echo "another xcall held the xcall-claude:// bridge for more than ${LOCK_WAIT_SECONDS}s" >&2
+    exit 5
+  fi
+  sleep 0.1
+done
+trap 'rm -f "$LOCK_FILE"' EXIT
 
 xcall_status=0
 run_bounded "$TIMEOUT_SECONDS" "$BINARY" "$@" || xcall_status=$?


### PR DESCRIPTION
Fixes a bug where two concurrent `xcall` invocations could each report the other's result.

macOS binds one handler bundle to `xcall-claude://`. `build.sh` relies on that. Every waiting instance is therefore a candidate recipient for every callback, and the three callback URLs were byte-identical between instances. An instance took whichever callback arrived and printed its query as the answer to its own request.

## Repro

Park an instance on a command Things never answers, then fire a success callback it never earned:

```bash
XCALL_TIMEOUT_SECONDS=8 run.sh "things:///zzz-not-a-command" &
sleep 3
open "xcall-claude://x-callback-url/success?x-things-id=INJECTED-NOT-MINE"
```

Before this change the parked instance prints `x-things-id=INJECTED-NOT-MINE` and exits 0. After it, the callback is ignored and the instance times out with exit 4.

This surfaced through the Things MCP server, where two writes dispatched close together came back carrying each other's ids. Both writes landed. They were attributed to the wrong requests, so a caller following up on a returned id edits a different todo than the one it created.

## Fix

Each invocation mints a UUID, carries it on the `x-success`/`x-error`/`x-cancel` URLs, and ignores any callback that doesn't bring the same token back. Things echoes the query, verified end to end against Things 3.23. The token is stripped from the query before it reaches stdout, so callers parsing `x-things-id` see no change.

A token makes a stray callback harmless without making it deliverable: the instance it belonged to would still wait out its deadline. So `run.sh` also serializes on a lock file. The lock has to work across processes rather than within one, because the MCP server and the CLI scripts (`inbox.ts`, `reorder.ts`, `url.ts`) each call the bridge from their own process. `shlock` handles the stale-lock case by checking whether the recorded pid is alive.

Waiting for the bridge gets its own exit code (5) so it stays distinguishable from a build failure (3) and a callback timeout (4).

## Backstop Counterpart

`xcallBackstopMs` in `plugins/things/scripts/url.ts` sizes its backstop from `run.sh`'s bounds, and the lock adds a bound that didn't exist. Without the counterpart change the backstop kills the runner mid-wait and the caller gets an anonymous signal instead of exit 5, which is the exact failure that function's comment says it exists to prevent. The callback timeout now counts twice: once for waiting out a lock holder's full turn, once for the caller's own.
