### PR TITLE
things: reject tags Things silently drops

### DIFF
--- a/plugins/things/CLAUDE.md
+++ b/plugins/things/CLAUDE.md
@@ -45,6 +45,8 @@ A degraded dispatch is no longer silent. `dispatch` returns a `fallbackReason` n
 
 Keep `console.log` under `import.meta.main`. A function both the CLI and a tool call returns its result and lets the CLI print it. Send diagnostics to stderr, which tailgate logs. Pipe or `.quiet()` every subprocess, including Bun's `$`, which inherits stdout by default. `src/mcp/stdio.test.ts` fails on any stdout line that will not parse as JSON.
 
+`src/mcp/tags.ts` gates every tag-carrying write on the tags Things already holds, because Things drops an unknown tag and still reports success. The matching itself is pure and lives in `scripts/tags.ts`; the module here is the IO shell, with the fetch and the create behind a `TagActions` seam the way `dispatch` puts its runner behind `DispatchActions`. `scripts/inbox.ts` routes its CLI capture through the same requirer, so the CLI and the tool agree on which tags exist.
+
 `src/mcp/jxa.ts` resolves the `mac` plugin's JXA runner across the same two layouts as `findXcallRunner`, and accepts only the sibling under this plugin's own version directory. The runner's argument contract is versioned: this build expects the runner to forward everything past the script path to the script itself, and a runner from another commit may claim those flags and leave the script answering with a usage error. `findJxaRunner` takes the plugin root as an argument so tests can point it at a fixture tree.
 
 ## What NOT to Do

--- a/plugins/things/README.md
+++ b/plugins/things/README.md
@@ -14,7 +14,7 @@ Uses only **public APIs** from Cultured Code — URL scheme (`things:///`) for w
 
 ### Scripts
 
-- `scripts/jxa/` — JXA query scripts (`osascript`) returning JSON: `find-todos.js`, `query-list.js`, `query-logbook.js`, `query-metadata.js`
+- `scripts/jxa/` — JXA scripts (`osascript`) returning JSON: `find-todos.js`, `query-list.js`, `query-logbook.js`, `query-metadata.js`, and `create-tags.js`, the one write the URL scheme cannot express
 - `scripts/format-output.ts` — Generic stdin JSON → table formatter with `--json`, `--columns`, `--count-prefix`
 - `scripts/url.ts` — URL scheme wrapper with auth token, encoding, and bulk update via JSON command
 - `scripts/reorder.ts` — List reordering via URL scheme (bun TypeScript, reuses `url.ts` exports)

--- a/plugins/things/scripts/inbox.ts
+++ b/plugins/things/scripts/inbox.ts
@@ -3,6 +3,7 @@
 
 import { cli } from "cleye";
 import { ensureThingsRunning } from "./ensure-running";
+import { requireTags } from "../src/mcp/tags";
 import { mergeTags, parseTags } from "./tags";
 import { dispatch, warnFallback } from "./url";
 
@@ -84,9 +85,6 @@ if (import.meta.main) {
     }
   }
 
-  const tags = mergeTags(["Claude"], argv.flags.tag ?? [], parseTags(params.get("tags")));
-  params.set("tags", tags.join(","));
-
   const attribution = buildAttribution(argv.flags.sessionId, process.cwd());
   const existing = params.get("notes");
   params.set("notes", existing ? `${existing}\n\n${attribution}` : attribution);
@@ -94,6 +92,11 @@ if (import.meta.main) {
   await ensureThingsRunning();
 
   try {
+    // Things drops a tag it does not already know and still reports success, so
+    // the CLI resolves against the stored tags for the same reason the tool does.
+    const requested = mergeTags(["claude"], argv.flags.tag ?? [], parseTags(params.get("tags")));
+    params.set("tags", (await requireTags(requested, false)).join(","));
+
     const result = await dispatch("add", params);
     if (result.id) {
       console.log(`https://things.bendrucker.me/show?id=${result.id}`);

--- a/plugins/things/scripts/jxa/create-tags.js
+++ b/plugins/things/scripts/jxa/create-tags.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env osascript -l JavaScript
+
+function run(argv) {
+  if (argv.length === 0) {
+    return JSON.stringify({ error: "Usage: create-tags.js <name> [name...]" });
+  }
+
+  var app = Application("Things3");
+  var created = [];
+
+  for (var i = 0; i < argv.length; i++) {
+    var name = argv[i];
+    if (app.tags.whose({ name: name }).length > 0) continue;
+    app.tags.push(app.Tag({ name: name }));
+    created.push(name);
+  }
+
+  return JSON.stringify(created);
+}

--- a/plugins/things/scripts/tags.test.ts
+++ b/plugins/things/scripts/tags.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mergeTags, parseTags } from "./tags";
+import { mergeTags, parseTags, resolveTags, type TagResolution } from "./tags";
 
 describe("parseTags", () => {
   test.each<{ name: string; input: string | undefined; expected: string[] }>([
@@ -39,5 +39,49 @@ describe("mergeTags", () => {
     { name: "handles empty sources", sources: [[], ["Claude"]], expected: ["Claude"] },
   ])("$name", ({ sources, expected }) => {
     expect(mergeTags(...sources)).toEqual(expected);
+  });
+});
+
+describe("resolveTags", () => {
+  const existing = ["claude", "review", "Work"];
+
+  test.each<{ name: string; requested: string[]; expected: TagResolution }>([
+    {
+      name: "passes through a known tag",
+      requested: ["review"],
+      expected: { resolved: ["review"], unknown: [] },
+    },
+    {
+      name: "remaps to the casing Things stores",
+      requested: ["CLAUDE", "work"],
+      expected: { resolved: ["claude", "Work"], unknown: [] },
+    },
+    {
+      name: "collapses spellings that differ only in case",
+      requested: ["claude", "Claude"],
+      expected: { resolved: ["claude"], unknown: [] },
+    },
+    {
+      name: "names a tag Things does not hold",
+      requested: ["review", "bug"],
+      expected: { resolved: ["review"], unknown: ["bug"] },
+    },
+    {
+      name: "reports an unknown tag once",
+      requested: ["bug", "BUG"],
+      expected: { resolved: [], unknown: ["bug"] },
+    },
+    {
+      name: "keeps requested order",
+      requested: ["Work", "claude"],
+      expected: { resolved: ["Work", "claude"], unknown: [] },
+    },
+    { name: "handles no request", requested: [], expected: { resolved: [], unknown: [] } },
+  ])("$name", ({ requested, expected }) => {
+    expect(resolveTags(requested, existing)).toEqual(expected);
+  });
+
+  test("rejects everything when Things holds no tags", () => {
+    expect(resolveTags(["claude"], [])).toEqual({ resolved: [], unknown: ["claude"] });
   });
 });

--- a/plugins/things/scripts/tags.ts
+++ b/plugins/things/scripts/tags.ts
@@ -9,3 +9,44 @@ export function parseTags(value: string | undefined): string[] {
 export function mergeTags(...sources: string[][]): string[] {
   return [...new Set(sources.flat())];
 }
+
+export interface TagResolution {
+  /** Requested tags remapped to the casing Things stores, deduped. */
+  resolved: string[];
+  /** Requested tags with no case-insensitive match in Things. */
+  unknown: string[];
+}
+
+/**
+ * Matches requested tags against the tags Things already holds.
+ *
+ * Things refuses to apply a tag it does not know and reports success anyway, so
+ * a caller only learns a tag was dropped by reading the todo back. Resolving
+ * first turns that silence into either the stored name or a named miss.
+ *
+ * Matching folds case because Things does: asking for `CLAUDE` when `claude`
+ * exists names the same tag, and emitting both would send it twice.
+ */
+export function resolveTags(requested: string[], existing: string[]): TagResolution {
+  const byFolded = new Map<string, string>();
+  for (const tag of existing) {
+    const folded = tag.toLowerCase();
+    if (!byFolded.has(folded)) byFolded.set(folded, tag);
+  }
+
+  const resolved: string[] = [];
+  const unknown: string[] = [];
+  const seen = new Set<string>();
+
+  for (const tag of requested) {
+    const folded = tag.toLowerCase();
+    if (seen.has(folded)) continue;
+    seen.add(folded);
+
+    const match = byFolded.get(folded);
+    if (match === undefined) unknown.push(tag);
+    else resolved.push(match);
+  }
+
+  return { resolved, unknown };
+}

--- a/plugins/things/src/mcp/README.md
+++ b/plugins/things/src/mcp/README.md
@@ -31,16 +31,37 @@ This constrains more than `stdio.ts`. The tools reuse the plugin's CLI scripts (
 
 ## Tools
 
-Reads run the plugin's JXA query scripts through the `mac` plugin's runner: `list_todos`, `find_todos`, `query_logbook`, `list_metadata`.
+Reads run the plugin's JXA scripts through the `mac` plugin's runner: `list_todos`, `find_todos`, `query_logbook`, `list_metadata`. Tag creation takes the same path, as the one write that the URL scheme cannot express.
 
 Writes go through the `things:///` URL scheme: `add_todo`, `add_project`, `update_todos`, `capture_inbox`, `reorder_todos`. Cultured Code exposes no write API beyond it.
 
 `capture_inbox` accepts an optional `session_id` and `directory`. Given a `session_id` it appends a resume command to the todo's notes. `directory` is a parameter because this process runs as tailgate's child, whose working directory has nothing to do with the session being attributed.
 
+## Tags
+
+Things refuses to apply a tag that does not already exist and reports success anyway, so a write naming an unknown tag lands with that tag missing and nothing said about it. Every tag-carrying write (`add_todo`, `add_project`, `update_todos`, `capture_inbox`) therefore resolves its tags against Things before dispatching:
+
+- A tag that exists is sent under the casing Things stores, so `CLAUDE` and `claude` are one tag rather than two spellings of it.
+- A tag that does not exist fails the call, naming it alongside the tags Things holds. Nothing is written.
+- `create_tags: true` creates the missing ones first, which is how a caller opts into growing the tag namespace.
+
+The tag list is fetched once per process (around two seconds) and held. A miss refetches once before it becomes a failure, so a tag created in the Things UI mid-session resolves rather than being rejected from a stale cache.
+
+`update_todos` resolves both `tags` and `add_tags` before its first batch, because a rejection landing partway through would leave the earlier batches written.
+
+## Response Size
+
+Reads that return a list (`list_todos`, `find_todos`, `query_logbook`) cap their payload at 32KB. Past that they drop items from the end and return `{truncated, returned, total, note, items}` instead of the bare list. A payload within budget is returned unchanged.
+
+The cap is about framing, not about the client's context: the payload is a JSON string nested in the JSON-RPC envelope, so escaping can roughly double it, and a proxy reading the line with Go's default `bufio.Scanner` drops anything past 64KB without saying why. An uncapped logbook read runs to megabytes and surfaces as a failure carrying no detail.
+
+`stdio.ts` also defaults `XCALL_TIMEOUT_SECONDS` to 10 so a write cannot spend a client's whole request budget. Both `run.sh` and `xcallBackstopMs` read it, putting the worst case around 47s. An operator's own value wins.
+
 ## Layout
 
 - `stdio.ts`: the entry point. Constructs the server, registers the tools, connects the stdio transport.
 - `tools.ts`: the tool registrations, wrapping the plugin's read scripts and write modules.
+- `tags.ts`: resolves a write's tags against Things and creates missing ones on request.
 - `jxa.ts`: locates the `mac` plugin's JXA runner by filesystem layout and spawns it.
 
 ## Local Development

--- a/plugins/things/src/mcp/jxa.ts
+++ b/plugins/things/src/mcp/jxa.ts
@@ -1,6 +1,6 @@
 /**
- * Runs the plugin's JXA query scripts through the mac plugin's runner
- * (AST scope validation + Apple Events retry). The runner is spawned as a
+ * Runs the plugin's JXA scripts through the mac plugin's runner (AST scope
+ * validation + Apple Events retry). The runner is spawned as a
  * subprocess because cross-plugin imports are disallowed, and it is
  * discovered by filesystem layout.
  */
@@ -20,7 +20,7 @@ export function findJxaRunner(pluginRoot: string = PLUGIN_ROOT): Promise<string 
   return findSiblingScript(pluginRoot, "mac", "scripts", "jxa.ts");
 }
 
-export async function runQuery(script: string, args: string[]): Promise<unknown> {
+export async function runScript(script: string, args: string[]): Promise<unknown> {
   const runner = await findJxaRunner();
   if (!runner) {
     throw new Error("mac plugin JXA runner not found (expected plugins/mac/scripts/jxa.ts)");

--- a/plugins/things/src/mcp/stdio.test.ts
+++ b/plugins/things/src/mcp/stdio.test.ts
@@ -43,7 +43,12 @@ const HANDSHAKE = [
     method: "tools/call",
     params,
   })),
+  // A second listing, after a round of calls, for the stability tests below.
+  { jsonrpc: "2.0", id: 3 + REJECTED_CALLS.length, method: "tools/list" },
 ];
+
+const FIRST_LIST_ID = 2;
+const SECOND_LIST_ID = 3 + REJECTED_CALLS.length;
 
 /**
  * Drives the server the way tailgate does: JSON-RPC in on stdin, responses out
@@ -67,8 +72,30 @@ async function handshake(): Promise<{ stdout: string; stderr: string; exitCode: 
   return { stdout, stderr, exitCode: await proc.exited };
 }
 
+function stdoutLines(stdout: string): string[] {
+  return stdout.split("\n").filter(Boolean);
+}
+
+interface Response {
+  id: number;
+  result: { isError?: boolean; content?: Array<{ text: string }>; tools?: Array<{ name: string }> };
+}
+
+/**
+ * The result the server sent for one request. Keyed by id because responses do
+ * not come back in request order: a `tools/list` is answered synchronously
+ * while a `tools/call` goes through schema validation first.
+ */
+function responseTo(lines: string[], id: number): Response["result"] {
+  const responses = lines.map((line) => JSON.parse(line) as Response);
+  const match = responses.find((response) => response.id === id);
+  if (!match) throw new Error(`no response for request ${id}`);
+  return match.result;
+}
+
 const result = await handshake();
-const lines = result.stdout.split("\n").filter(Boolean);
+const lines = stdoutLines(result.stdout);
+const respawned = stdoutLines((await handshake()).stdout);
 
 describe("stdio server", () => {
   test("exits cleanly when stdin closes", () => {
@@ -90,10 +117,8 @@ describe("stdio server", () => {
   });
 
   test("advertises the full tool set", () => {
-    const listed = JSON.parse(lines[1] ?? "null") as {
-      result: { tools: Array<{ name: string }> };
-    };
-    expect(listed.result.tools.map((tool) => tool.name)).toMatchInlineSnapshot(`
+    const tools = responseTo(lines, FIRST_LIST_ID).tools ?? [];
+    expect(tools.map((tool) => tool.name)).toMatchInlineSnapshot(`
       [
         "list_todos",
         "find_todos",
@@ -115,11 +140,9 @@ describe("stdio server", () => {
   // covering its field fails here rather than passing on some other error.
   test("rejects arguments that would reach Things", () => {
     const rejections = REJECTED_CALLS.map((_call, index) => {
-      const response = JSON.parse(lines[2 + index] ?? "null") as {
-        result: { isError: boolean; content: Array<{ text: string }> };
-      };
-      expect(response.result.isError).toBe(true);
-      return response.result.content[0]?.text;
+      const rejection = responseTo(lines, 3 + index);
+      expect(rejection.isError).toBe(true);
+      return rejection.content?.[0]?.text;
     });
     expect(rejections).toMatchInlineSnapshot(`
       [
@@ -131,5 +154,24 @@ describe("stdio server", () => {
         "MCP error -32602: Input validation error: Invalid arguments for tool capture_inbox: Too small: expected string to have >=1 characters at session_id",
       ]
     `);
+  });
+});
+
+/**
+ * Standing refutation of a report that tool calls started failing mid-session
+ * as "has not been loaded yet". Nothing here registers a tool after `connect`,
+ * so the list a client caches on its first `tools/list` stays correct for the
+ * life of the connection and across restarts. These fail the moment that stops
+ * being true, which is cheaper than re-running the investigation.
+ */
+describe("tool list stability", () => {
+  const first = JSON.stringify(responseTo(lines, FIRST_LIST_ID));
+
+  test("answers a later tools/list with the same tools", () => {
+    expect(JSON.stringify(responseTo(lines, SECOND_LIST_ID))).toBe(first);
+  });
+
+  test("answers a fresh process with the same tools", () => {
+    expect(JSON.stringify(responseTo(respawned, FIRST_LIST_ID))).toBe(first);
   });
 });

--- a/plugins/things/src/mcp/stdio.ts
+++ b/plugins/things/src/mcp/stdio.ts
@@ -17,6 +17,14 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { registerTools } from "./tools";
 
 if (import.meta.main) {
+  // Bounds a write so it cannot spend a client's whole request budget. Both
+  // run.sh and xcallBackstopMs read this, so one assignment moves the worst
+  // case from ~59s to ~47s, inside a typical 60s client timeout. Things answers
+  // an x-callback in well under a second when it answers at all. The 20s
+  // default only ever covered a cold first launch, which the separate build
+  // timeout still covers. An operator's own value wins.
+  process.env.XCALL_TIMEOUT_SECONDS ??= "10";
+
   const server = new McpServer({ name: "things", version: "0.1.0" });
   registerTools(server);
   await server.connect(new StdioServerTransport());

--- a/plugins/things/src/mcp/tags.test.ts
+++ b/plugins/things/src/mcp/tags.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { createTagRequirer, type TagActions } from "./tags";
+
+/**
+ * Serves a mutable tag list and counts what the requirer asked Things for, so a
+ * test can assert the cache is used and the refetch happens exactly once.
+ */
+function stubActions(initial: string[]) {
+  const state = {
+    tags: [...initial],
+    fetches: 0,
+    created: [] as string[][],
+  };
+  const actions: TagActions = {
+    fetchTags: () => {
+      state.fetches += 1;
+      return Promise.resolve([...state.tags]);
+    },
+    createTags: (names) => {
+      state.created.push(names);
+      state.tags.push(...names);
+      return Promise.resolve();
+    },
+  };
+  return { state, actions };
+}
+
+describe("createTagRequirer", () => {
+  test("resolves known tags from one fetch", async () => {
+    const { state, actions } = stubActions(["claude", "review"]);
+    const require = createTagRequirer(actions);
+
+    expect(await require(["CLAUDE"], false)).toEqual(["claude"]);
+    expect(await require(["review"], false)).toEqual(["review"]);
+    expect(state.fetches).toBe(1);
+  });
+
+  // A tag created in the Things UI after the cache warmed would otherwise fail
+  // a write that names it.
+  test("refetches once before calling a tag unknown", async () => {
+    const { state, actions } = stubActions(["claude"]);
+    const require = createTagRequirer(actions);
+    await require(["claude"], false);
+
+    state.tags.push("bug");
+    expect(await require(["bug"], false)).toEqual(["bug"]);
+    expect(state.fetches).toBe(2);
+  });
+
+  test("names the unknown tags and what Things holds", async () => {
+    const { actions } = stubActions(["claude"]);
+    const require = createTagRequirer(actions);
+
+    await expect(require(["bug", "review"], false)).rejects.toThrow(
+      "Tag not found: bug, review. Existing tags: claude. Pass create_tags to create the missing ones.",
+    );
+  });
+
+  test("creates only the missing tags when asked", async () => {
+    const { state, actions } = stubActions(["claude"]);
+    const require = createTagRequirer(actions);
+
+    expect(await require(["claude", "bug"], true)).toEqual(["claude", "bug"]);
+    expect(state.created).toEqual([["bug"]]);
+  });
+
+  test("reports a tag Things accepted the create for but does not hold", async () => {
+    const { actions } = stubActions([]);
+    const require = createTagRequirer({ ...actions, createTags: () => Promise.resolve() });
+
+    await expect(require(["bug"], true)).rejects.toThrow("Things did not create: bug");
+  });
+});

--- a/plugins/things/src/mcp/tags.ts
+++ b/plugins/things/src/mcp/tags.ts
@@ -1,0 +1,70 @@
+/**
+ * Resolves a write's tags against the tags Things already holds, so an unknown
+ * tag fails the call instead of being dropped on the floor.
+ *
+ * The pure matching lives in `scripts/tags.ts`; this is the IO shell around it,
+ * with the Things calls behind an injectable seam the way `dispatch` puts its
+ * runner behind `DispatchActions`.
+ */
+
+import { resolveTags } from "../../scripts/tags";
+import { runScript } from "./jxa";
+
+export interface TagActions {
+  fetchTags(): Promise<string[]>;
+  createTags(names: string[]): Promise<void>;
+}
+
+async function fetchTags(): Promise<string[]> {
+  const tags = (await runScript("query-metadata.js", ["tags"])) as Array<{ name: string }>;
+  return tags.map((tag) => tag.name);
+}
+
+async function createTags(names: string[]): Promise<void> {
+  await runScript("create-tags.js", names);
+}
+
+const defaultActions: TagActions = { fetchTags, createTags };
+
+export type TagRequirer = (requested: string[], createMissing: boolean) => Promise<string[]>;
+
+/**
+ * Builds a requirer over its own cache of Things' tag list. The fetch measures
+ * around two seconds, which is too much to spend on every write, so it is held
+ * for the process lifetime.
+ */
+export function createTagRequirer(actions: TagActions = defaultActions): TagRequirer {
+  let cached: string[] | null = null;
+
+  async function existing(refetch = false): Promise<string[]> {
+    if (refetch || cached === null) cached = await actions.fetchTags();
+    return cached;
+  }
+
+  return async (requested, createMissing) => {
+    let resolution = resolveTags(requested, await existing());
+    if (resolution.unknown.length === 0) return resolution.resolved;
+
+    // A tag created in the Things UI after the cache warmed would otherwise
+    // read as unknown, so a miss buys one refetch before it becomes a failure.
+    resolution = resolveTags(requested, await existing(true));
+    if (resolution.unknown.length === 0) return resolution.resolved;
+
+    if (!createMissing) {
+      throw new Error(
+        `Tag not found: ${resolution.unknown.join(", ")}. ` +
+          `Existing tags: ${(await existing()).join(", ")}. ` +
+          "Pass create_tags to create the missing ones.",
+      );
+    }
+
+    await actions.createTags(resolution.unknown);
+    const created = resolveTags(requested, await existing(true));
+    if (created.unknown.length > 0) {
+      throw new Error(`Things did not create: ${created.unknown.join(", ")}`);
+    }
+    return created.resolved;
+  };
+}
+
+export const requireTags: TagRequirer = createTagRequirer();

--- a/plugins/things/src/mcp/tools.test.ts
+++ b/plugins/things/src/mcp/tools.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { chunk, updateAttributes, validateCaptureTitles, validateNonBlank } from "./tools";
+import {
+  chunk,
+  limitItems,
+  updateAttributes,
+  validateCaptureTitles,
+  validateNonBlank,
+} from "./tools";
 
 describe("chunk", () => {
   test.each<[string, number[], number, number[][]]>([
@@ -82,5 +88,67 @@ describe("validateNonBlank", () => {
     ["names the field", [""], "titles", 'titles[0] must be a non-empty string, got ""'],
   ])("rejects %s", (_name, values, field, message) => {
     expect(() => validateNonBlank(values, field)).toThrow(message);
+  });
+});
+
+describe("limitItems", () => {
+  /** One todo-sized record, padded so a few hundred of them exceed the budget. */
+  function todo(index: number) {
+    return { id: `id-${index}`, name: `Todo ${index}`, notes: "x".repeat(200) };
+  }
+
+  const oversized = Array.from({ length: 400 }, (_, index) => todo(index));
+
+  test("returns a small array untouched", () => {
+    const items = [todo(0), todo(1)];
+    expect(limitItems(items)).toBe(items);
+  });
+
+  test("returns a small object payload untouched", () => {
+    const payload = { count: 1, items: [todo(0)] };
+    expect(limitItems(payload)).toBe(payload);
+  });
+
+  test("passes through a payload with no item list", () => {
+    expect(limitItems({ error: "nope" })).toEqual({ error: "nope" });
+  });
+
+  test("drops items from the end of an oversized array", () => {
+    const limited = limitItems(oversized) as {
+      truncated: boolean;
+      returned: number;
+      total: number;
+      note: string;
+      items: unknown[];
+    };
+
+    expect(limited.truncated).toBe(true);
+    expect(limited.total).toBe(400);
+    expect(limited.returned).toBeLessThan(400);
+    expect(limited.items).toEqual(oversized.slice(0, limited.returned));
+    expect(limited.note).toBe(
+      `Narrow the range or filter; ${400 - limited.returned} of 400 items omitted to fit the response budget.`,
+    );
+  });
+
+  test("keeps the other fields of an oversized object payload", () => {
+    const limited = limitItems({ count: 400, items: oversized }) as {
+      count: number;
+      truncated: boolean;
+      total: number;
+    };
+
+    expect(limited.count).toBe(400);
+    expect(limited.truncated).toBe(true);
+    expect(limited.total).toBe(400);
+  });
+
+  // Serialized size is what decides whether the framed JSON-RPC line fits a
+  // proxy's 64KB read buffer.
+  test.each<[string, unknown]>([
+    ["array", oversized],
+    ["object payload", { count: 400, items: oversized }],
+  ])("holds %s under the budget", (_name, payload) => {
+    expect(JSON.stringify(limitItems(payload)).length).toBeLessThanOrEqual(32_768);
   });
 });

--- a/plugins/things/src/mcp/tools.ts
+++ b/plugins/things/src/mcp/tools.ts
@@ -3,9 +3,9 @@ import { z } from "zod";
 import { ensureThingsRunning } from "../../scripts/ensure-running";
 import { buildAttribution } from "../../scripts/inbox";
 import { reorder } from "../../scripts/reorder";
-import { mergeTags } from "../../scripts/tags";
 import { buildJsonPayload, type DispatchResult, dispatch, warnFallback } from "../../scripts/url";
-import { runQuery } from "./jxa";
+import { runScript } from "./jxa";
+import { requireTags } from "./tags";
 
 const LIST_IDS = {
   inbox: "TMInboxListSource",
@@ -36,6 +36,75 @@ function textResult(text: string) {
 
 function jsonResult(value: unknown) {
   return textResult(JSON.stringify(value));
+}
+
+/**
+ * Ceiling on a read's serialized payload. The payload travels as a JSON string
+ * nested in the JSON-RPC envelope, so escaping can roughly double it, and a
+ * proxy framing the line with Go's default `bufio.Scanner` drops anything past
+ * 64KB without saying why. Half of that leaves room for the escaping and the
+ * envelope. Tunable: raise it once every hop in the path reads longer lines.
+ */
+const MAX_PAYLOAD_BYTES = 32_768;
+
+/** Headroom for the truncation wrapper's own keys, which the fit search omits. */
+const WRAPPER_RESERVE_BYTES = 512;
+
+function payloadBytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value));
+}
+
+/**
+ * The items a read returned: a bare array, or the `items` field of a shape that
+ * carries a count alongside them.
+ */
+function readItems(payload: unknown): unknown[] | null {
+  if (Array.isArray(payload)) return payload;
+  if (payload && typeof payload === "object" && "items" in payload) {
+    const items = (payload as { items: unknown }).items;
+    if (Array.isArray(items)) return items;
+  }
+  return null;
+}
+
+/** Largest prefix of `items` that serializes within the budget. */
+function fittingCount(items: unknown[]): number {
+  const budget = MAX_PAYLOAD_BYTES - WRAPPER_RESERVE_BYTES;
+  let low = 0;
+  let high = items.length;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    if (payloadBytes(items.slice(0, mid)) <= budget) low = mid;
+    else high = mid - 1;
+  }
+  return low;
+}
+
+/**
+ * Caps a read at {@link MAX_PAYLOAD_BYTES}, dropping items from the end and
+ * saying so. An uncapped read of the logbook runs to megabytes, which a client
+ * sees as a failure carrying no detail rather than as too much data.
+ *
+ * A payload within budget is returned untouched, so the common case keeps the
+ * shape callers already parse.
+ */
+export function limitItems(payload: unknown): unknown {
+  const items = readItems(payload);
+  if (items === null || payloadBytes(payload) <= MAX_PAYLOAD_BYTES) return payload;
+
+  const returned = fittingCount(items);
+  const omitted = items.length - returned;
+  // A payload that carries its items in a field keeps that field's siblings,
+  // so a caller reading `count` still finds how many matched.
+  const siblings = Array.isArray(payload) ? {} : (payload as Record<string, unknown>);
+  return {
+    ...siblings,
+    truncated: true,
+    returned,
+    total: items.length,
+    note: `Narrow the range or filter; ${omitted} of ${items.length} items omitted to fit the response budget.`,
+    items: items.slice(0, returned),
+  };
 }
 
 /**
@@ -145,6 +214,11 @@ const todoIds = z.array(z.string().trim().min(1)).min(1);
 const whenDescription =
   "Schedule: today, tomorrow, evening, anytime, someday, yyyy-mm-dd, or natural language like 'next week'";
 
+const tagsDescription = "Tag names; each must already exist in Things unless create_tags is set";
+
+const createTagsDescription =
+  "Create any tag that does not exist yet in Things. Without it, an unknown tag fails the call.";
+
 export function registerTools(server: McpServer): void {
   server.registerTool(
     "list_todos",
@@ -157,7 +231,7 @@ export function registerTools(server: McpServer): void {
       },
       annotations: { readOnlyHint: true },
     },
-    async ({ list }) => jsonResult(await runQuery("query-list.js", [LIST_IDS[list]])),
+    async ({ list }) => jsonResult(limitItems(await runScript("query-list.js", [LIST_IDS[list]]))),
   );
 
   server.registerTool(
@@ -175,7 +249,9 @@ export function registerTools(server: McpServer): void {
     },
     async ({ by, value, include_logbook }) =>
       jsonResult(
-        await runQuery("find-todos.js", [by, value, ...(include_logbook ? ["--logbook"] : [])]),
+        limitItems(
+          await runScript("find-todos.js", [by, value, ...(include_logbook ? ["--logbook"] : [])]),
+        ),
       ),
   );
 
@@ -194,11 +270,13 @@ export function registerTools(server: McpServer): void {
     },
     async ({ start, end, notes_contains }) =>
       jsonResult(
-        await runQuery("query-logbook.js", [
-          start,
-          end,
-          ...(notes_contains !== undefined ? ["--notes-contains", notes_contains] : []),
-        ]),
+        limitItems(
+          await runScript("query-logbook.js", [
+            start,
+            end,
+            ...(notes_contains !== undefined ? ["--notes-contains", notes_contains] : []),
+          ]),
+        ),
       ),
   );
 
@@ -212,7 +290,7 @@ export function registerTools(server: McpServer): void {
       },
       annotations: { readOnlyHint: true },
     },
-    async ({ type }) => jsonResult(await runQuery("query-metadata.js", [type])),
+    async ({ type }) => jsonResult(await runScript("query-metadata.js", [type])),
   );
 
   server.registerTool(
@@ -226,7 +304,8 @@ export function registerTools(server: McpServer): void {
         notes: z.string().optional().describe("Markdown supported, max 10,000 chars"),
         when: z.string().optional().describe(whenDescription),
         deadline: z.string().optional().describe("yyyy-mm-dd"),
-        tags: z.array(z.string()).optional(),
+        tags: z.array(z.string()).optional().describe(tagsDescription),
+        create_tags: z.boolean().optional().describe(createTagsDescription),
         checklist_items: z.array(z.string()).optional().describe("Max 100"),
         list: z.string().optional().describe("Project name to file under (projects only)"),
         list_id: z.string().optional().describe("Project or area ID (required for areas)"),
@@ -240,7 +319,9 @@ export function registerTools(server: McpServer): void {
       if (args.notes !== undefined) params.set("notes", args.notes);
       if (args.when !== undefined) params.set("when", args.when);
       if (args.deadline !== undefined) params.set("deadline", args.deadline);
-      if (args.tags !== undefined) params.set("tags", args.tags.join(","));
+      if (args.tags !== undefined) {
+        params.set("tags", (await requireTags(args.tags, args.create_tags ?? false)).join(","));
+      }
       if (args.checklist_items !== undefined) {
         params.set("checklist-items", args.checklist_items.join("\n"));
       }
@@ -263,7 +344,8 @@ export function registerTools(server: McpServer): void {
         deadline: z.string().optional().describe("yyyy-mm-dd"),
         area: z.string().optional().describe("Area name to file under"),
         area_id: z.string().optional(),
-        tags: z.array(z.string()).optional(),
+        tags: z.array(z.string()).optional().describe(tagsDescription),
+        create_tags: z.boolean().optional().describe(createTagsDescription),
         todos: z.array(z.string()).optional().describe("Initial todo titles"),
       },
     },
@@ -277,7 +359,9 @@ export function registerTools(server: McpServer): void {
       if (args.deadline !== undefined) params.set("deadline", args.deadline);
       if (args.area !== undefined) params.set("area", args.area);
       if (args.area_id !== undefined) params.set("area-id", args.area_id);
-      if (args.tags !== undefined) params.set("tags", args.tags.join(","));
+      if (args.tags !== undefined) {
+        params.set("tags", (await requireTags(args.tags, args.create_tags ?? false)).join(","));
+      }
       if (args.todos !== undefined) params.set("to-dos", args.todos.join("\n"));
       return writeResult(await dispatch("add-project", params), `Created project "${args.title}"`);
     },
@@ -297,19 +381,31 @@ export function registerTools(server: McpServer): void {
         append_notes: z.string().optional(),
         when: z.string().optional().describe(whenDescription),
         deadline: z.string().optional().describe("yyyy-mm-dd"),
-        tags: z.array(z.string()).optional().describe("Replaces existing tags"),
-        add_tags: z.array(z.string()).optional().describe("Adds to existing tags"),
+        tags: z.array(z.string()).optional().describe(`Replaces existing tags. ${tagsDescription}`),
+        add_tags: z
+          .array(z.string())
+          .optional()
+          .describe(`Adds to existing tags. ${tagsDescription}`),
+        create_tags: z.boolean().optional().describe(createTagsDescription),
         checklist_items: z.array(z.string()).optional().describe("Replaces existing checklist"),
         completed: z.boolean().optional(),
         canceled: z.boolean().optional(),
       },
     },
-    async ({ ids, ...rest }) => {
-      const attributes = updateAttributes(rest);
-      if (Object.keys(attributes).length === 0) {
+    async ({ ids, create_tags, ...rest }) => {
+      if (Object.keys(updateAttributes(rest)).length === 0) {
         throw new Error("At least one attribute to update is required");
       }
       await ensureThingsRunning();
+
+      // Both tag fields resolve up front. A rejection landing partway through
+      // the batch loop would leave the earlier chunks already written.
+      const createMissing = create_tags ?? false;
+      const attributes = updateAttributes({
+        ...rest,
+        tags: rest.tags && (await requireTags(rest.tags, createMissing)),
+        add_tags: rest.add_tags && (await requireTags(rest.add_tags, createMissing)),
+      });
 
       if (ids.length === 1 && ids[0]) {
         const params = new Map<string, string>(Object.entries(attributes));
@@ -345,12 +441,16 @@ export function registerTools(server: McpServer): void {
     {
       title: "Capture to inbox with Claude attribution",
       description:
-        "Quick-capture one or more todos to the inbox. Each todo is tagged 'Claude'; pass session_id (and directory) to append resume attribution to the notes.",
+        "Quick-capture one or more todos to the inbox. Each todo is tagged 'claude'; pass session_id (and directory) to append resume attribution to the notes.",
       inputSchema: {
         title: z.string().optional().describe("Single todo title"),
         titles: z.array(z.string()).optional().describe("Multiple todo titles"),
         notes: z.string().optional(),
-        tags: z.array(z.string()).optional().describe("Extra tags beyond 'Claude'"),
+        tags: z
+          .array(z.string())
+          .optional()
+          .describe(`Extra tags beyond 'claude'. ${tagsDescription}`),
+        create_tags: z.boolean().optional().describe(createTagsDescription),
         checklist_items: z.array(z.string()).optional(),
         // Blank strings are rejected rather than ignored. Both are read for
         // truthiness below, so a blank one would drop the attribution the
@@ -381,7 +481,10 @@ export function registerTools(server: McpServer): void {
       if (args.checklist_items !== undefined) {
         params.set("checklist-items", args.checklist_items.join("\n"));
       }
-      params.set("tags", mergeTags(["Claude"], args.tags ?? []).join(","));
+      // Lowercase to match the tag Things stores. resolveTags folds case, so a
+      // caller naming it too gets one tag rather than two spellings of it.
+      const tags = await requireTags(["claude", ...(args.tags ?? [])], args.create_tags ?? false);
+      params.set("tags", tags.join(","));
 
       let notes = args.notes;
       if (args.session_id) {


### PR DESCRIPTION
`capture_inbox` with `tags: ["bug"]` created items tagged only `claude`. Things refuses to apply a tag that does not already exist and reports success anyway, so the missing tag never surfaced. Every tag-carrying write had it: `add_todo`, `add_project`, `update_todos`, `capture_inbox`.

Tags now resolve against Things' stored tags before anything dispatches. An unknown tag fails the call and names itself. `create_tags: true` creates it instead.

Matching folds case. `["Claude","claude"]` resolves to one tag rather than the duplicate the old union produced, and `capture_inbox`'s hardcoded `"Claude"` now matches the stored lowercase tag. `update_todos` resolves both tag fields before its first batch, since a rejection landing mid-batch would leave earlier chunks written. The CLI capture path shares the requirer, so CLI and tool agree on which tags exist.

Verified against Things 3.23: an unknown tag rejects with no todo created, a known tag still applies, `create_tags` creates and applies, and `["CLAUDE"]` yields exactly one `claude`.

## Response Cap

A `query_logbook` over 2.5 months returned a single 71KB JSON-RPC line, and `list_todos` on the logbook returns 14,610 items. A proxy framing that with Go's default `bufio.Scanner` drops any line past 64KB with no detail, which matches a detail-free "MCP tool call failed" report. Reads over 32KB now return a wrapper naming how many items it omitted. Under budget the payload is unchanged.

## Write Latency

`XCALL_TIMEOUT_SECONDS` defaults to 10. `run.sh` and `xcallBackstopMs` both read it, so one assignment moves a write's worst case from ~59s to ~47s, inside a typical 60s client budget. Things answers an x-callback in well under a second when it answers at all, and the 20s default only ever protected a cold first launch that the separate build timeout still covers.

## Tool List Stability

A separate report described tool calls rejected mid-session as unregistered. Every hypothesis was tested against the running server and refuted, and the tests now hold that result: the tool list is byte-identical across two calls on one connection and across separate process spawns, and the server emits no unsolicited message.
