### PR TITLE
things: shrink what a list read returns

### DIFF
--- a/plugins/things/CLAUDE.md
+++ b/plugins/things/CLAUDE.md
@@ -47,6 +47,8 @@ Keep `console.log` under `import.meta.main`. A function both the CLI and a tool 
 
 `src/mcp/tags.ts` gates every tag-carrying write on the tags Things already holds, because Things drops an unknown tag and still reports success. The matching itself is pure and lives in `scripts/tags.ts`; the module here is the IO shell, with the fetch and the create behind a `TagActions` seam the way `dispatch` puts its runner behind `DispatchActions`. `scripts/inbox.ts` routes its CLI capture through the same requirer, so the CLI and the tool agree on which tags exist.
 
+A list read returns a notes preview per todo, capped at `NOTES_PREVIEW_CHARS`, and `get-todo.js` serves one todo's full notes on request. Notes are most of what a list read weighs, and a client's framing has a hard ceiling, so shipping them everywhere buys a few dozen todos instead of a few hundred. The read scripts also take `--limit`, which breaks the walk rather than slicing the result: each todo visited costs several Apple Events, so the limit is a scan bound.
+
 `src/mcp/jxa.ts` resolves the `mac` plugin's JXA runner across the same two layouts as `findXcallRunner`, and accepts only the sibling under this plugin's own version directory. The runner's argument contract is versioned: this build expects the runner to forward everything past the script path to the script itself, and a runner from another commit may claim those flags and leave the script answering with a usage error. `findJxaRunner` takes the plugin root as an argument so tests can point it at a fixture tree.
 
 ## What NOT to Do

--- a/plugins/things/README.md
+++ b/plugins/things/README.md
@@ -14,7 +14,7 @@ Uses only **public APIs** from Cultured Code — URL scheme (`things:///`) for w
 
 ### Scripts
 
-- `scripts/jxa/` — JXA scripts (`osascript`) returning JSON: `find-todos.js`, `query-list.js`, `query-logbook.js`, `query-metadata.js`, and `create-tags.js`, the one write the URL scheme cannot express
+- `scripts/jxa/` — JXA scripts (`osascript`) returning JSON: `find-todos.js`, `get-todo.js`, `query-list.js`, `query-logbook.js`, `query-metadata.js`, and `create-tags.js`, the one write the URL scheme cannot express
 - `scripts/format-output.ts` — Generic stdin JSON → table formatter with `--json`, `--columns`, `--count-prefix`
 - `scripts/url.ts` — URL scheme wrapper with auth token, encoding, and bulk update via JSON command
 - `scripts/reorder.ts` — List reordering via URL scheme (bun TypeScript, reuses `url.ts` exports)

--- a/plugins/things/scripts/jxa/find-todos.js
+++ b/plugins/things/scripts/jxa/find-todos.js
@@ -1,12 +1,28 @@
 #!/usr/bin/env osascript -l JavaScript
 
+// Notes are the bulk of a list read: over the logbook they ran 61% of the
+// payload, median 223 characters and up to 3552. Enough to recognize a todo
+// travels here, and get-todo.js serves the rest on request.
+var NOTES_PREVIEW_CHARS = 120;
+
 function run(argv) {
   var mode = argv[0];
   var value = argv[1];
-  var includeLogbook = argv[2] === "--logbook";
+  var includeLogbook = false;
+  var limit = 0;
+  for (var a = 2; a < argv.length; a++) {
+    if (argv[a] === "--logbook") {
+      includeLogbook = true;
+    } else if (argv[a] === "--limit") {
+      limit = parseInt(argv[a + 1], 10);
+      a++;
+    }
+  }
 
   if (!mode || !value) {
-    return JSON.stringify({ error: "Usage: find-todos.js <tag|project> <value> [--logbook]" });
+    return JSON.stringify({
+      error: "Usage: find-todos.js <tag|project> <value> [--logbook] [--limit <n>]",
+    });
   }
 
   var app = Application("Things3");
@@ -29,24 +45,32 @@ function run(argv) {
     }
 
     var items = [];
-    for (var li = 0; li < lists.length; li++) {
+    var truncated = false;
+    for (var li = 0; li < lists.length && !truncated; li++) {
       var listId = lists[li][0];
       var listName = lists[li][1];
       var todos = app.lists.byId(listId).toDos.whose({ tagNames: { _contains: value } })();
       for (var i = 0; i < todos.length; i++) {
+        if (limit > 0 && items.length >= limit) {
+          truncated = true;
+          break;
+        }
         var t = todos[i];
         var project = t.project();
+        var notes = t.notes() || "";
         items.push({
           id: t.id(),
           name: t.name(),
-          notes: t.notes() || "",
+          notesPreview: notes.substring(0, NOTES_PREVIEW_CHARS),
+          hasMoreNotes: notes.length > NOTES_PREVIEW_CHARS,
           status: t.status().toString(),
+          tags: t.tagNames() || "",
           list: listName,
           project: project ? project.name() : null,
         });
       }
     }
-    return JSON.stringify(items);
+    return JSON.stringify({ count: items.length, truncatedByLimit: truncated, items: items });
   }
 
   if (mode === "project") {
@@ -55,18 +79,30 @@ function run(argv) {
       return JSON.stringify({ error: "Project not found: " + value });
     }
     var proj = projects[0];
-    var todos = proj.toDos();
-    var items = [];
-    for (var i = 0; i < todos.length; i++) {
-      var t = todos[i];
-      items.push({
-        id: t.id(),
-        name: t.name(),
-        status: t.status().toString(),
-        notes: t.notes() || "",
+    var projectTodos = proj.toDos();
+    var projectItems = [];
+    var projectTruncated = false;
+    for (var pi = 0; pi < projectTodos.length; pi++) {
+      if (limit > 0 && projectItems.length >= limit) {
+        projectTruncated = true;
+        break;
+      }
+      var pt = projectTodos[pi];
+      var projectNotes = pt.notes() || "";
+      projectItems.push({
+        id: pt.id(),
+        name: pt.name(),
+        notesPreview: projectNotes.substring(0, NOTES_PREVIEW_CHARS),
+        hasMoreNotes: projectNotes.length > NOTES_PREVIEW_CHARS,
+        status: pt.status().toString(),
+        tags: pt.tagNames() || "",
       });
     }
-    return JSON.stringify(items);
+    return JSON.stringify({
+      count: projectItems.length,
+      truncatedByLimit: projectTruncated,
+      items: projectItems,
+    });
   }
 
   return JSON.stringify({ error: "Unknown mode: " + mode + ". Use 'tag' or 'project'." });

--- a/plugins/things/scripts/jxa/get-todo.js
+++ b/plugins/things/scripts/jxa/get-todo.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env osascript -l JavaScript
+
+// Full detail for one todo, the counterpart to the previews the list reads
+// return. Checklist items are absent because Things' scripting dictionary has
+// no accessor for them. The URL scheme can write a checklist, but nothing can
+// read one back.
+
+function run(argv) {
+  var id = argv[0];
+  if (!id) {
+    return JSON.stringify({ error: "Usage: get-todo.js <id>" });
+  }
+
+  var app = Application("Things3");
+  var todo;
+  try {
+    todo = app.toDos.byId(id);
+    todo.id();
+  } catch (error) {
+    return JSON.stringify({ error: "Todo not found: " + id });
+  }
+
+  var props = todo.properties();
+  var project = todo.project();
+  var area = todo.area();
+
+  return JSON.stringify({
+    id: props.id,
+    name: props.name,
+    notes: props.notes || "",
+    status: props.status,
+    tags: props.tagNames || "",
+    project: project ? project.name() : null,
+    area: area ? area.name() : null,
+    dueDate: props.dueDate ? props.dueDate.toISOString() : null,
+    activationDate: props.activationDate ? props.activationDate.toISOString() : null,
+    completionDate: props.completionDate ? props.completionDate.toISOString() : null,
+    cancellationDate: props.cancellationDate ? props.cancellationDate.toISOString() : null,
+    creationDate: props.creationDate ? props.creationDate.toISOString() : null,
+    modificationDate: props.modificationDate ? props.modificationDate.toISOString() : null,
+  });
+}

--- a/plugins/things/scripts/jxa/query-list.js
+++ b/plugins/things/scripts/jxa/query-list.js
@@ -1,9 +1,21 @@
 #!/usr/bin/env osascript -l JavaScript
 
+// Notes are the bulk of a list read: measured over the logbook they ran 61% of
+// the payload, median 223 characters and up to 3552. A list view needs enough
+// to recognize a todo, so it carries a preview and get-todo.js serves the rest.
+var NOTES_PREVIEW_CHARS = 120;
+
 function run(argv) {
   var listId = argv[0];
+  var limit = 0;
+  for (var a = 1; a < argv.length; a++) {
+    if (argv[a] === "--limit") {
+      limit = parseInt(argv[a + 1], 10);
+      a++;
+    }
+  }
   if (!listId) {
-    return JSON.stringify({ error: "Usage: query-list.js <list-id>" });
+    return JSON.stringify({ error: "Usage: query-list.js <list-id> [--limit <n>]" });
   }
 
   var app = Application("Things3");
@@ -11,15 +23,25 @@ function run(argv) {
   var todos = list.toDos();
   var result = [];
 
+  // The limit stops the loop rather than slicing afterwards. Each iteration
+  // costs three Apple Events, so bounding the walk is what makes a large list
+  // affordable.
+  var truncated = false;
   for (var i = 0; i < todos.length; i++) {
+    if (limit > 0 && result.length >= limit) {
+      truncated = true;
+      break;
+    }
     var t = todos[i];
     var props = t.properties();
     var project = t.project();
     var area = t.area();
+    var notes = props.notes || "";
     result.push({
       id: props.id,
       name: props.name,
-      notes: props.notes || "",
+      notesPreview: notes.substring(0, NOTES_PREVIEW_CHARS),
+      hasMoreNotes: notes.length > NOTES_PREVIEW_CHARS,
       status: props.status,
       dueDate: props.dueDate ? props.dueDate.toISOString() : null,
       activationDate: props.activationDate ? props.activationDate.toISOString() : null,
@@ -30,5 +52,9 @@ function run(argv) {
     });
   }
 
-  return JSON.stringify(result);
+  return JSON.stringify({
+    count: result.length,
+    truncatedByLimit: truncated,
+    items: result,
+  });
 }

--- a/plugins/things/scripts/jxa/query-logbook.js
+++ b/plugins/things/scripts/jxa/query-logbook.js
@@ -4,13 +4,21 @@ function run(argv) {
   var startIso = argv[0];
   var endIso = argv[1];
   var notesContains = null;
-  if (argv[2] === "--notes-contains") {
-    notesContains = argv[3];
+  var limit = 0;
+  for (var a = 2; a < argv.length; a++) {
+    if (argv[a] === "--notes-contains") {
+      notesContains = argv[a + 1];
+      a++;
+    } else if (argv[a] === "--limit") {
+      limit = parseInt(argv[a + 1], 10);
+      a++;
+    }
   }
 
-  if (!startIso || !endIso || (argv.length > 2 && !notesContains)) {
+  if (!startIso || !endIso) {
     return JSON.stringify({
-      error: "Usage: query-logbook.js <start-iso> <end-iso> [--notes-contains <substring>]",
+      error:
+        "Usage: query-logbook.js <start-iso> <end-iso> [--notes-contains <substring>] [--limit <n>]",
     });
   }
 
@@ -21,7 +29,12 @@ function run(argv) {
   var todos = logbook.toDos();
 
   var items = [];
+  var truncated = false;
   for (var i = 0; i < todos.length; i++) {
+    if (limit > 0 && items.length >= limit) {
+      truncated = true;
+      break;
+    }
     var todo = todos[i];
     var p = todo.properties();
     if (!p.completionDate) continue;
@@ -42,5 +55,5 @@ function run(argv) {
     items.push(item);
   }
 
-  return JSON.stringify({ count: items.length, items: items });
+  return JSON.stringify({ count: items.length, truncatedByLimit: truncated, items: items });
 }

--- a/plugins/things/src/mcp/README.md
+++ b/plugins/things/src/mcp/README.md
@@ -31,7 +31,7 @@ This constrains more than `stdio.ts`. The tools reuse the plugin's CLI scripts (
 
 ## Tools
 
-Reads run the plugin's JXA scripts through the `mac` plugin's runner: `list_todos`, `find_todos`, `query_logbook`, `list_metadata`. Tag creation takes the same path, as the one write that the URL scheme cannot express.
+Reads run the plugin's JXA scripts through the `mac` plugin's runner: `list_todos`, `get_todo`, `find_todos`, `query_logbook`, `list_metadata`. Tag creation takes the same path, as the one write that the URL scheme cannot express.
 
 Writes go through the `things:///` URL scheme: `add_todo`, `add_project`, `update_todos`, `capture_inbox`, `reorder_todos`. Cultured Code exposes no write API beyond it.
 
@@ -51,9 +51,15 @@ The tag list is fetched once per process (around two seconds) and held. A miss r
 
 ## Response Size
 
-Reads that return a list (`list_todos`, `find_todos`, `query_logbook`) cap their payload at 32KB. Past that they drop items from the end and return `{truncated, returned, total, note, items}` instead of the bare list. A payload within budget is returned unchanged.
+A list read returns a preview of each todo's notes rather than the whole thing. Notes are the bulk of the payload: over the logbook they measured 61% of it, median 223 characters and up to 3552, so a read that carried them in full fit a few dozen todos where the preview fits a few hundred. `get_todo` serves one todo's full notes and dates, and it reaches completed todos too, so nothing is lost by not shipping notes in every list.
 
-The cap is about framing, not about the client's context: the payload is a JSON string nested in the JSON-RPC envelope, so escaping can roughly double it, and a proxy reading the line with Go's default `bufio.Scanner` drops anything past 64KB without saying why. An uncapped logbook read runs to megabytes and surfaces as a failure carrying no detail.
+`list_todos`, `find_todos`, and `query_logbook` each take a `limit`. It stops the JXA walk rather than trimming the response, which matters because every todo the walk visits costs several Apple Events.
+
+Past that, a read that still exceeds 32KB drops items from the end and returns `{truncated, returned, total, note, items}` instead of the bare list. The `note` names an action that tool actually supports: a narrower tag or project for `find_todos`, a smaller `limit` for `list_todos`, and for `query_logbook`, re-querying with `end` set to the `completionDate` of the last item returned. A payload within budget is returned unchanged.
+
+The cap is about framing, not about the client's context: the payload is a JSON string nested in the JSON-RPC envelope, so escaping can roughly double it, and a proxy reading the line with Go's default `bufio.Scanner` drops anything past 64KB without saying why.
+
+`list_todos` does not accept the logbook. It holds tens of thousands of items with no attribute to narrow by, and a probe found no predicate that pushes a date filter down to Things: `whose({completionDate: ...})` against the logbook took 49 seconds and against all todos returned nothing. `query_logbook` walks newest-first and stops at the range boundary, which is the only bounded way in. That also rules out a cursor: resuming would re-walk from the top each time.
 
 `stdio.ts` also defaults `XCALL_TIMEOUT_SECONDS` to 10 so a write cannot spend a client's whole request budget. Both `run.sh` and `xcallBackstopMs` read it, putting the worst case around 47s. An operator's own value wins.
 

--- a/plugins/things/src/mcp/stdio.test.ts
+++ b/plugins/things/src/mcp/stdio.test.ts
@@ -121,6 +121,7 @@ describe("stdio server", () => {
     expect(tools.map((tool) => tool.name)).toMatchInlineSnapshot(`
       [
         "list_todos",
+        "get_todo",
         "find_todos",
         "query_logbook",
         "list_metadata",

--- a/plugins/things/src/mcp/tools.test.ts
+++ b/plugins/things/src/mcp/tools.test.ts
@@ -99,22 +99,24 @@ describe("limitItems", () => {
 
   const oversized = Array.from({ length: 400 }, (_, index) => todo(index));
 
+  const guidance = "Pass a limit.";
+
   test("returns a small array untouched", () => {
     const items = [todo(0), todo(1)];
-    expect(limitItems(items)).toBe(items);
+    expect(limitItems(items, guidance)).toBe(items);
   });
 
   test("returns a small object payload untouched", () => {
     const payload = { count: 1, items: [todo(0)] };
-    expect(limitItems(payload)).toBe(payload);
+    expect(limitItems(payload, guidance)).toBe(payload);
   });
 
   test("passes through a payload with no item list", () => {
-    expect(limitItems({ error: "nope" })).toEqual({ error: "nope" });
+    expect(limitItems({ error: "nope" }, guidance)).toEqual({ error: "nope" });
   });
 
   test("drops items from the end of an oversized array", () => {
-    const limited = limitItems(oversized) as {
+    const limited = limitItems(oversized, guidance) as {
       truncated: boolean;
       returned: number;
       total: number;
@@ -127,12 +129,12 @@ describe("limitItems", () => {
     expect(limited.returned).toBeLessThan(400);
     expect(limited.items).toEqual(oversized.slice(0, limited.returned));
     expect(limited.note).toBe(
-      `Narrow the range or filter; ${400 - limited.returned} of 400 items omitted to fit the response budget.`,
+      `${400 - limited.returned} of 400 items omitted to fit the response budget. ${guidance}`,
     );
   });
 
   test("keeps the other fields of an oversized object payload", () => {
-    const limited = limitItems({ count: 400, items: oversized }) as {
+    const limited = limitItems({ count: 400, items: oversized }, guidance) as {
       count: number;
       truncated: boolean;
       total: number;
@@ -149,6 +151,6 @@ describe("limitItems", () => {
     ["array", oversized],
     ["object payload", { count: 400, items: oversized }],
   ])("holds %s under the budget", (_name, payload) => {
-    expect(JSON.stringify(limitItems(payload)).length).toBeLessThanOrEqual(32_768);
+    expect(JSON.stringify(limitItems(payload, guidance)).length).toBeLessThanOrEqual(32_768);
   });
 });

--- a/plugins/things/src/mcp/tools.ts
+++ b/plugins/things/src/mcp/tools.ts
@@ -13,7 +13,6 @@ const LIST_IDS = {
   anytime: "TMNextListSource",
   upcoming: "TMCalendarListSource",
   someday: "TMSomedayListSource",
-  logbook: "TMLogbookListSource",
 } as const;
 
 const TODO_LINK_BASE = "https://things.bendrucker.me/show?id=";
@@ -88,7 +87,7 @@ function fittingCount(items: unknown[]): number {
  * A payload within budget is returned untouched, so the common case keeps the
  * shape callers already parse.
  */
-export function limitItems(payload: unknown): unknown {
+export function limitItems(payload: unknown, guidance: string): unknown {
   const items = readItems(payload);
   if (items === null || payloadBytes(payload) <= MAX_PAYLOAD_BYTES) return payload;
 
@@ -102,7 +101,7 @@ export function limitItems(payload: unknown): unknown {
     truncated: true,
     returned,
     total: items.length,
-    note: `Narrow the range or filter; ${omitted} of ${items.length} items omitted to fit the response budget.`,
+    note: `${omitted} of ${items.length} items omitted to fit the response budget. ${guidance}`,
     items: items.slice(0, returned),
   };
 }
@@ -219,19 +218,56 @@ const tagsDescription = "Tag names; each must already exist in Things unless cre
 const createTagsDescription =
   "Create any tag that does not exist yet in Things. Without it, an unknown tag fails the call.";
 
+/**
+ * A limit stops the JXA walk rather than trimming the response, and each todo
+ * the walk visits costs several Apple Events. Passing one is what makes a large
+ * list affordable, so it reads as a scan bound rather than a display bound.
+ */
+const limitParameter = z
+  .number()
+  .int()
+  .positive()
+  .optional()
+  .describe("Stop after this many todos, bounding the scan and not just the response");
+
+function limitArgs(limit: number | undefined): string[] {
+  return limit === undefined ? [] : ["--limit", String(limit)];
+}
+
 export function registerTools(server: McpServer): void {
   server.registerTool(
     "list_todos",
     {
       title: "List todos in a built-in list",
       description:
-        "Read the todos in a built-in Things list (inbox, today, anytime, upcoming, someday, logbook). Full logbook scans are slow (10k+ items); prefer query_logbook for date-bounded logbook reads.",
+        "Read the todos in a built-in Things list. Returns a notes preview per todo, with get_todo serving one todo's full notes. The logbook is absent here because it can hold tens of thousands of items with nothing to narrow by. Use query_logbook, which bounds by date.",
       inputSchema: {
-        list: z.enum(["inbox", "today", "anytime", "upcoming", "someday", "logbook"]),
+        list: z.enum(["inbox", "today", "anytime", "upcoming", "someday"]),
+        limit: limitParameter,
       },
       annotations: { readOnlyHint: true },
     },
-    async ({ list }) => jsonResult(limitItems(await runScript("query-list.js", [LIST_IDS[list]]))),
+    async ({ list, limit }) =>
+      jsonResult(
+        limitItems(
+          await runScript("query-list.js", [LIST_IDS[list], ...limitArgs(limit)]),
+          "Pass a limit, or use find_todos to narrow by tag or project.",
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "get_todo",
+    {
+      title: "Read one todo in full",
+      description:
+        "Read one todo by id, with its full notes and dates. The counterpart to the previews the list reads return. Works for completed todos too. Checklist items are not included: Things' scripting interface cannot read them.",
+      inputSchema: {
+        id: z.string().trim().min(1).describe("Todo id, as returned by any list read"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ id }) => jsonResult(await runScript("get-todo.js", [id])),
   );
 
   server.registerTool(
@@ -239,18 +275,25 @@ export function registerTools(server: McpServer): void {
     {
       title: "Find todos by tag or project",
       description:
-        "Find open todos by tag (searched across Inbox/Today/Anytime/Upcoming/Someday) or by project name. Set include_logbook to also search completed todos.",
+        "Find open todos by tag (searched across Inbox/Today/Anytime/Upcoming/Someday) or by project name. Set include_logbook to also search completed todos. Returns a notes preview per todo, with get_todo serving one todo's full notes.",
       inputSchema: {
         by: z.enum(["tag", "project"]),
         value: z.string().describe("Tag name or project name"),
         include_logbook: z.boolean().optional(),
+        limit: limitParameter,
       },
       annotations: { readOnlyHint: true },
     },
-    async ({ by, value, include_logbook }) =>
+    async ({ by, value, include_logbook, limit }) =>
       jsonResult(
         limitItems(
-          await runScript("find-todos.js", [by, value, ...(include_logbook ? ["--logbook"] : [])]),
+          await runScript("find-todos.js", [
+            by,
+            value,
+            ...(include_logbook ? ["--logbook"] : []),
+            ...limitArgs(limit),
+          ]),
+          "Search a narrower tag or project, or leave include_logbook unset to skip completed todos.",
         ),
       ),
   );
@@ -265,17 +308,20 @@ export function registerTools(server: McpServer): void {
         start: isoDate.describe("Start of range, ISO 8601 (e.g. 2026-07-01)"),
         end: isoDate.describe("End of range, ISO 8601"),
         notes_contains: z.string().optional().describe("Only todos whose notes contain this"),
+        limit: limitParameter,
       },
       annotations: { readOnlyHint: true },
     },
-    async ({ start, end, notes_contains }) =>
+    async ({ start, end, notes_contains, limit }) =>
       jsonResult(
         limitItems(
           await runScript("query-logbook.js", [
             start,
             end,
             ...(notes_contains !== undefined ? ["--notes-contains", notes_contains] : []),
+            ...limitArgs(limit),
           ]),
+          "Results run newest first. To continue backwards, re-query with end set to the completionDate of the last item returned.",
         ),
       ),
   );


### PR DESCRIPTION
A list read carried every todo's full notes. Measured over the logbook, notes were 61% of the payload, median 223 characters and up to 3552, so the 32KB cap fit a few dozen todos where it could fit a few hundred. List reads now carry a 120-character preview plus `hasMoreNotes`, and `get_todo` serves one todo's full notes and dates by id. `byId` reaches completed todos, so the logbook stays addressable by id.

`list_todos`, `find_todos`, and `query_logbook` take a `limit`. It breaks the JXA walk rather than slicing the result, which matters because every todo the walk visits costs several Apple Events.

`list_todos` no longer accepts the logbook. It holds tens of thousands of items with nothing to narrow by, and no predicate pushes a date filter down: `whose({completionDate})` took 49s against the logbook and matched nothing against all todos. `query_logbook`'s newest-first walk with an early stop is the only bounded way in, which also rules out a cursor, since resuming would re-walk from the top. The truncation note there tells a caller to re-query with `end` set to the last item's completion date.

The truncation note now names an action each tool actually supports. It previously told a `list_todos` caller to narrow a range that tool has no parameter for.
