### PR TITLE
things: add substring search over todos

### DIFF
--- a/plugins/things/CLAUDE.md
+++ b/plugins/things/CLAUDE.md
@@ -49,6 +49,8 @@ Keep `console.log` under `import.meta.main`. A function both the CLI and a tool 
 
 A list read returns a notes preview per todo, capped at `NOTES_PREVIEW_CHARS`, and `get-todo.js` serves one todo's full notes on request. Notes are most of what a list read weighs, and a client's framing has a hard ceiling, so shipping them everywhere buys a few dozen todos instead of a few hundred. The read scripts also take `--limit`, which breaks the walk rather than slicing the result: each todo visited costs several Apple Events, so the limit is a scan bound.
 
+A `.whose()` predicate only pays off when the collection it scopes is small or the predicate is one Things can answer. Text predicates against the top-level `toDos` answer in well under a second; date predicates and text predicates scoped to the logbook list do not return inside two minutes. Things also keeps working on a predicate whose Apple Event already timed out, so one such call degrades the calls after it.
+
 `src/mcp/jxa.ts` resolves the `mac` plugin's JXA runner across the same two layouts as `findXcallRunner`, and accepts only the sibling under this plugin's own version directory. The runner's argument contract is versioned: this build expects the runner to forward everything past the script path to the script itself, and a runner from another commit may claim those flags and leave the script answering with a usage error. `findJxaRunner` takes the plugin root as an argument so tests can point it at a fixture tree.
 
 ## What NOT to Do

--- a/plugins/things/README.md
+++ b/plugins/things/README.md
@@ -14,7 +14,7 @@ Uses only **public APIs** from Cultured Code — URL scheme (`things:///`) for w
 
 ### Scripts
 
-- `scripts/jxa/` — JXA scripts (`osascript`) returning JSON: `find-todos.js`, `get-todo.js`, `query-list.js`, `query-logbook.js`, `query-metadata.js`, and `create-tags.js`, the one write the URL scheme cannot express
+- `scripts/jxa/` — JXA scripts (`osascript`) returning JSON: `find-todos.js`, `get-todo.js`, `query-list.js`, `search-todos.js`, `query-logbook.js`, `query-metadata.js`, and `create-tags.js`, the one write the URL scheme cannot express
 - `scripts/format-output.ts` — Generic stdin JSON → table formatter with `--json`, `--columns`, `--count-prefix`
 - `scripts/url.ts` — URL scheme wrapper with auth token, encoding, and bulk update via JSON command
 - `scripts/reorder.ts` — List reordering via URL scheme (bun TypeScript, reuses `url.ts` exports)

--- a/plugins/things/scripts/jxa/search-todos.js
+++ b/plugins/things/scripts/jxa/search-todos.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env osascript -l JavaScript
+
+// Notes are the bulk of a list read, so enough to recognize a todo travels here
+// and get-todo.js serves the rest on request.
+var NOTES_PREVIEW_CHARS = 120;
+
+function run(argv) {
+  var text = argv[0];
+  var field = "both";
+  var limit = 0;
+  for (var a = 1; a < argv.length; a++) {
+    if (argv[a] === "--field") {
+      field = argv[a + 1];
+      a++;
+    } else if (argv[a] === "--limit") {
+      limit = parseInt(argv[a + 1], 10);
+      a++;
+    }
+  }
+
+  if (!text) {
+    return JSON.stringify({
+      error: "Usage: search-todos.js <text> [--field name|notes|both] [--limit <n>]",
+    });
+  }
+  if (field !== "name" && field !== "notes" && field !== "both") {
+    return JSON.stringify({ error: "Unknown field: " + field + ". Use name, notes, or both." });
+  }
+
+  var app = Application("Things3");
+
+  // Name and notes are matched by two separate predicates rather than one `_or`,
+  // which Things answers with an empty result instead of a union. Each predicate
+  // runs inside Things, so the pair costs a fraction of a walk over every todo.
+  var batches = [];
+  if (field === "name" || field === "both") {
+    batches.push(app.toDos.whose({ name: { _contains: text } })());
+  }
+  if (field === "notes" || field === "both") {
+    batches.push(app.toDos.whose({ notes: { _contains: text } })());
+  }
+
+  var items = [];
+  var ids = [];
+  var truncated = false;
+  for (var b = 0; b < batches.length && !truncated; b++) {
+    var batch = batches[b];
+    for (var i = 0; i < batch.length; i++) {
+      if (limit > 0 && items.length >= limit) {
+        truncated = true;
+        break;
+      }
+      var todo = batch[i];
+      var id = todo.id();
+      // A todo matching on both fields arrives in both batches.
+      if (ids.indexOf(id) !== -1) continue;
+      ids.push(id);
+      var project = todo.project();
+      var notes = todo.notes() || "";
+      items.push({
+        id: id,
+        name: todo.name(),
+        notesPreview: notes.substring(0, NOTES_PREVIEW_CHARS),
+        hasMoreNotes: notes.length > NOTES_PREVIEW_CHARS,
+        status: todo.status().toString(),
+        tags: todo.tagNames() || "",
+        project: project ? project.name() : null,
+      });
+    }
+  }
+
+  return JSON.stringify({ count: items.length, truncatedByLimit: truncated, items: items });
+}

--- a/plugins/things/src/mcp/README.md
+++ b/plugins/things/src/mcp/README.md
@@ -31,7 +31,7 @@ This constrains more than `stdio.ts`. The tools reuse the plugin's CLI scripts (
 
 ## Tools
 
-Reads run the plugin's JXA scripts through the `mac` plugin's runner: `list_todos`, `get_todo`, `find_todos`, `query_logbook`, `list_metadata`. Tag creation takes the same path, as the one write that the URL scheme cannot express.
+Reads run the plugin's JXA scripts through the `mac` plugin's runner: `list_todos`, `get_todo`, `find_todos`, `search_todos`, `query_logbook`, `list_metadata`. Tag creation takes the same path, as the one write that the URL scheme cannot express.
 
 Writes go through the `things:///` URL scheme: `add_todo`, `add_project`, `update_todos`, `capture_inbox`, `reorder_todos`. Cultured Code exposes no write API beyond it.
 
@@ -58,6 +58,16 @@ A list read returns a preview of each todo's notes rather than the whole thing. 
 Past that, a read that still exceeds 32KB drops items from the end and returns `{truncated, returned, total, note, items}` instead of the bare list. The `note` names an action that tool actually supports: a narrower tag or project for `find_todos`, a smaller `limit` for `list_todos`, and for `query_logbook`, re-querying with `end` set to the `completionDate` of the last item returned. A payload within budget is returned unchanged.
 
 The cap is about framing, not about the client's context: the payload is a JSON string nested in the JSON-RPC envelope, so escaping can roughly double it, and a proxy reading the line with Go's default `bufio.Scanner` drops anything past 64KB without saying why.
+
+## Text Search
+
+`search_todos` matches a substring against a todo's title, its notes, or both. Matching is literal and case-sensitive, because that is what Things' own predicate does.
+
+The predicate runs inside Things rather than as a walk here, which is what makes it affordable: a title match answered in around 570ms and a notes match in around 200ms, against roughly 3s to walk the open todos and compare in JavaScript. Title and notes go as two predicates and merge by id, because Things answers an `_or` of the two with an empty result rather than a union.
+
+The search covers open todos only. Scoping the same predicate to the logbook list did not return in two minutes, the same wall the date predicates hit. `query_logbook` remains the way to reach completed todos.
+
+Note that Things keeps working on a predicate whose Apple Event already timed out. A single logbook `whose` left it churning long enough to time out unrelated searches that answer in under a second on their own.
 
 `list_todos` does not accept the logbook. It holds tens of thousands of items with no attribute to narrow by, and a probe found no predicate that pushes a date filter down to Things: `whose({completionDate: ...})` against the logbook took 49 seconds and against all todos returned nothing. `query_logbook` walks newest-first and stops at the range boundary, which is the only bounded way in. That also rules out a cursor: resuming would re-walk from the top each time.
 

--- a/plugins/things/src/mcp/stdio.test.ts
+++ b/plugins/things/src/mcp/stdio.test.ts
@@ -123,6 +123,7 @@ describe("stdio server", () => {
         "list_todos",
         "get_todo",
         "find_todos",
+        "search_todos",
         "query_logbook",
         "list_metadata",
         "add_todo",

--- a/plugins/things/src/mcp/tools.ts
+++ b/plugins/things/src/mcp/tools.ts
@@ -299,6 +299,35 @@ export function registerTools(server: McpServer): void {
   );
 
   server.registerTool(
+    "search_todos",
+    {
+      title: "Search todos by text",
+      description:
+        "Find todos whose title or notes contain a substring. Matching is case-sensitive and literal, not a word or fuzzy search. Covers open todos only: Things cannot answer a text search over the logbook in bounded time, so use query_logbook to reach completed todos.",
+      inputSchema: {
+        text: z.string().trim().min(1).describe("Substring to look for"),
+        field: z
+          .enum(["name", "notes", "both"])
+          .optional()
+          .describe("Where to look. Defaults to both."),
+        limit: limitParameter,
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ text, field, limit }) =>
+      jsonResult(
+        limitItems(
+          await runScript("search-todos.js", [
+            text,
+            ...(field === undefined ? [] : ["--field", field]),
+            ...limitArgs(limit),
+          ]),
+          "Search a longer or more distinctive substring, or set field to name only.",
+        ),
+      ),
+  );
+
+  server.registerTool(
     "query_logbook",
     {
       title: "Query completed todos",


### PR DESCRIPTION
The MCP had no way to find a todo by its text. An agent that knew roughly what it wanted had to list a whole list and scan, which the response cap then truncated.

Things answers a `_contains` predicate itself, which is what makes this affordable: a title match around 570ms and a notes match around 200ms, against roughly 3s to walk the open todos and compare here. Title and notes go as two predicates merged by id, because Things answers an `_or` of the two with an empty result rather than a union.

Search covers open todos only. The same predicate scoped to the logbook did not return in two minutes, the wall the date predicates already hit, so `query_logbook` stays the way to completed todos. This is a separate tool rather than a mode on `find_todos` because it cannot honor `include_logbook`, and a parameter that silently does nothing is worse than its absence.
