### PR TITLE
things: match tool contracts to behavior

### DIFF
--- a/plugins/things/scripts/jxa/find-todos.js
+++ b/plugins/things/scripts/jxa/find-todos.js
@@ -88,13 +88,17 @@ function run(argv) {
         break;
       }
       var pt = projectTodos[pi];
+      // A project holds its finished children alongside its open ones, so the
+      // same flag that widens the tag search to the logbook widens this.
+      var projectStatus = pt.status().toString();
+      if (!includeLogbook && projectStatus !== "open") continue;
       var projectNotes = pt.notes() || "";
       projectItems.push({
         id: pt.id(),
         name: pt.name(),
         notesPreview: projectNotes.substring(0, NOTES_PREVIEW_CHARS),
         hasMoreNotes: projectNotes.length > NOTES_PREVIEW_CHARS,
-        status: pt.status().toString(),
+        status: projectStatus,
         tags: pt.tagNames() || "",
       });
     }

--- a/plugins/things/src/mcp/tools.ts
+++ b/plugins/things/src/mcp/tools.ts
@@ -279,7 +279,10 @@ export function registerTools(server: McpServer): void {
       inputSchema: {
         by: z.enum(["tag", "project"]),
         value: z.string().describe("Tag name or project name"),
-        include_logbook: z.boolean().optional(),
+        include_logbook: z
+          .boolean()
+          .optional()
+          .describe("Also return completed and cancelled todos, which are otherwise excluded"),
         limit: limitParameter,
       },
       annotations: { readOnlyHint: true },
@@ -336,7 +339,12 @@ export function registerTools(server: McpServer): void {
       inputSchema: {
         start: isoDate.describe("Start of range, ISO 8601 (e.g. 2026-07-01)"),
         end: isoDate.describe("End of range, ISO 8601"),
-        notes_contains: z.string().optional().describe("Only todos whose notes contain this"),
+        notes_contains: z
+          .string()
+          .optional()
+          .describe(
+            "Only todos whose notes contain this substring. Matched literally and case-sensitively against the notes alone, never the title.",
+          ),
         limit: limitParameter,
       },
       annotations: { readOnlyHint: true },
@@ -580,7 +588,7 @@ export function registerTools(server: McpServer): void {
     {
       title: "Reorder todos to the top of a list",
       description:
-        "Move todos to the top of Today, Anytime, or Someday in the given order. Use the list matching the todos' current scheduling state. Also reorders items within a project.",
+        "Move todos to the top of Today, Anytime, or Someday in the given order. Use the list matching the todos' current scheduling state. This works by rescheduling each todo out of the list and back, so a todo carrying a specific date has that date replaced by the target list.",
       inputSchema: {
         ids: todoIds.describe("Todo IDs in desired top-to-bottom order"),
         list: z.enum(["today", "anytime", "someday"]).default("today"),


### PR DESCRIPTION
Three tool descriptions promised behavior the tools did not have.

`find_todos` accepted `include_logbook` in project mode and never read it. The flag now excludes completed and cancelled children unless it is set, which is what tag mode already did and what the tool's own description promised.

`reorder_todos` claimed it also reorders within a project. It has no project parameter and cannot have one: it works by rewriting each todo's `when`, which moves it in the scheduled lists and leaves project order alone. The description now names the mechanism, including that a todo carrying a specific date loses that date to the target list.

`query_logbook`'s `notes_contains` said only that it matches notes containing a value. It is literal and case-sensitive and never looks at the title, none of which a caller could tell from the schema.
