### PR TITLE
things: read an area's todos

### DIFF
--- a/plugins/things/scripts/jxa/find-todos.js
+++ b/plugins/things/scripts/jxa/find-todos.js
@@ -21,7 +21,7 @@ function run(argv) {
 
   if (!mode || !value) {
     return JSON.stringify({
-      error: "Usage: find-todos.js <tag|project> <value> [--logbook] [--limit <n>]",
+      error: "Usage: find-todos.js <tag|project|area> <value> [--logbook] [--limit <n>]",
     });
   }
 
@@ -109,5 +109,42 @@ function run(argv) {
     });
   }
 
-  return JSON.stringify({ error: "Unknown mode: " + mode + ". Use 'tag' or 'project'." });
+  if (mode === "area") {
+    var areas = app.areas.whose({ name: value });
+    if (areas.length === 0) {
+      return JSON.stringify({ error: "Area not found: " + value });
+    }
+    // Only todos filed directly in the area. A todo inside one of the area's
+    // projects belongs to that project, and find-todos.js project reaches it.
+    var areaTodos = areas[0].toDos();
+    var areaItems = [];
+    var areaTruncated = false;
+    for (var ai = 0; ai < areaTodos.length; ai++) {
+      if (limit > 0 && areaItems.length >= limit) {
+        areaTruncated = true;
+        break;
+      }
+      var at = areaTodos[ai];
+      var areaStatus = at.status().toString();
+      if (!includeLogbook && areaStatus !== "open") continue;
+      var areaNotes = at.notes() || "";
+      var areaProject = at.project();
+      areaItems.push({
+        id: at.id(),
+        name: at.name(),
+        notesPreview: areaNotes.substring(0, NOTES_PREVIEW_CHARS),
+        hasMoreNotes: areaNotes.length > NOTES_PREVIEW_CHARS,
+        status: areaStatus,
+        tags: at.tagNames() || "",
+        project: areaProject ? areaProject.name() : null,
+      });
+    }
+    return JSON.stringify({
+      count: areaItems.length,
+      truncatedByLimit: areaTruncated,
+      items: areaItems,
+    });
+  }
+
+  return JSON.stringify({ error: "Unknown mode: " + mode + ". Use 'tag', 'project', or 'area'." });
 }

--- a/plugins/things/src/mcp/README.md
+++ b/plugins/things/src/mcp/README.md
@@ -33,7 +33,7 @@ This constrains more than `stdio.ts`. The tools reuse the plugin's CLI scripts (
 
 Reads run the plugin's JXA scripts through the `mac` plugin's runner: `list_todos`, `get_todo`, `find_todos`, `search_todos`, `query_logbook`, `list_metadata`. Tag creation takes the same path, as the one write that the URL scheme cannot express.
 
-Writes go through the `things:///` URL scheme: `add_todo`, `add_project`, `update_todos`, `capture_inbox`, `reorder_todos`. Cultured Code exposes no write API beyond it.
+Writes go through the `things:///` URL scheme: `add_todo`, `add_project`, `update_todos`, `update_project`, `capture_inbox`, `reorder_todos`. Cultured Code exposes no write API beyond it.
 
 `capture_inbox` accepts an optional `session_id` and `directory`. Given a `session_id` it appends a resume command to the todo's notes. `directory` is a parameter because this process runs as tailgate's child, whose working directory has nothing to do with the session being attributed.
 
@@ -96,6 +96,12 @@ printf '%s\n' \
 Each message needs its own trailing newline. The transport frames on newlines, so a final line without one is never answered.
 
 `bunx @modelcontextprotocol/inspector bun src/mcp/stdio.ts` gives the same thing interactively.
+
+## What Cannot Be Read
+
+Checklist items are write-only. The URL scheme sets, prepends, and appends them, and `update_todos` exposes all three, but Things' scripting dictionary has no accessor for them, so no tool can read one back. `get_todo` says so in its description rather than returning a field that is always absent.
+
+Deleting has no URL-scheme command, so no tool exposes it and `update_todos` with `canceled` is as close as a caller gets. Things' scripting dictionary does offer `delete`, which moves an item to the Trash list rather than erasing it. A trashed todo keeps its id and still reports status `open`, so `get_todo` cannot tell one from a live todo.
 
 ## Constraints
 

--- a/plugins/things/src/mcp/tools.ts
+++ b/plugins/things/src/mcp/tools.ts
@@ -304,10 +304,10 @@ export function registerTools(server: McpServer): void {
     {
       title: "Find todos by tag or project",
       description:
-        "Find open todos by tag (searched across Inbox/Today/Anytime/Upcoming/Someday) or by project name. Set include_logbook to also search completed todos. Returns a notes preview per todo, with get_todo serving one todo's full notes.",
+        "Find open todos by tag (searched across Inbox/Today/Anytime/Upcoming/Someday), by project name, or by area name. An area returns only the todos filed directly in it, since a todo inside one of its projects belongs to that project. Set include_logbook to also return completed and cancelled todos. Returns a notes preview per todo, with get_todo serving one todo's full notes.",
       inputSchema: {
-        by: z.enum(["tag", "project"]),
-        value: z.string().describe("Tag name or project name"),
+        by: z.enum(["tag", "project", "area"]),
+        value: z.string().describe("Tag, project, or area name, matched exactly"),
         include_logbook: z
           .boolean()
           .optional()


### PR DESCRIPTION
Areas were listable through `list_metadata` but nothing could read their contents, so an area was a name with no way in. `find_todos` gained an area mode returning the todos filed directly in the area, because a todo inside one of the area's projects belongs to that project and the project mode already reaches it.

Checklist items and deletion are recorded as ceilings rather than left as apparent gaps. `update_todos` can set, prepend, and append checklist items, but Things' scripting dictionary has no accessor for them, so nothing can read one back. `get_todo` says so instead of returning a field that is always absent.

Deletion has no URL-scheme command, so no tool exposes it. The scripting interface does have `delete`, which moves an item to the Trash list rather than erasing it. A trashed todo keeps its id and still reports status `open`, so `get_todo` returns it looking live.
