### PR TITLE
pull-request: exempt dotted filenames in headings

### DIFF
--- a/plugins/pull-request/scripts/heading-case.test.ts
+++ b/plugins/pull-request/scripts/heading-case.test.ts
@@ -69,6 +69,11 @@ describe("headingCaseViolations", () => {
       [{ text: "Rebase Vs. Merge", suggested: "Rebase vs. Merge" }],
     ],
     [
+      "leaves a hyphenated filename whole rather than casing each segment",
+      "## Fix the ci-config.json path",
+      [{ text: "Fix the ci-config.json path", suggested: "Fix the ci-config.json Path" }],
+    ],
+    [
       "does not capitalize into a leading numeral",
       "## 3rd-party tooling",
       [{ text: "3rd-party tooling", suggested: "3rd-Party Tooling" }],

--- a/plugins/pull-request/scripts/heading-case.test.ts
+++ b/plugins/pull-request/scripts/heading-case.test.ts
@@ -35,6 +35,39 @@ describe("headingCaseViolations", () => {
       "## Hide the --format flag",
       [{ text: "Hide the --format flag", suggested: "Hide the --format Flag" }],
     ],
+    ["leaves an unbackticked filename alone", "## Page Column Rule in global.css", []],
+    ["leaves unbackticked config names alone", "## Notes on package.json and bun.lock", []],
+    ["leaves a dotted name in a deeper heading alone", "### Rows From views.sql", []],
+    [
+      "re-cases around an unbackticked filename",
+      "## What sourcing tmux.conf actually does",
+      [
+        {
+          text: "What sourcing tmux.conf actually does",
+          suggested: "What Sourcing tmux.conf Actually Does",
+        },
+      ],
+    ],
+    [
+      "re-cases around several unbackticked filenames",
+      "## sections.md and tsconfig.json both moved",
+      [
+        {
+          text: "sections.md and tsconfig.json both moved",
+          suggested: "sections.md and tsconfig.json Both Moved",
+        },
+      ],
+    ],
+    [
+      "still flags a sentence-case heading that ends in a period",
+      "## Two fixes found while testing.",
+      [{ text: "Two fixes found while testing.", suggested: "Two Fixes Found While Testing." }],
+    ],
+    [
+      "still lowercases the `vs.` stopword",
+      "## Rebase Vs. Merge",
+      [{ text: "Rebase Vs. Merge", suggested: "Rebase vs. Merge" }],
+    ],
     [
       "does not capitalize into a leading numeral",
       "## 3rd-party tooling",

--- a/plugins/pull-request/scripts/heading-case.ts
+++ b/plugins/pull-request/scripts/heading-case.ts
@@ -75,22 +75,10 @@ function restore(text: string, codeSpans: string[]): string {
   return text.replaceAll(PLACEHOLDER, () => `\`${codeSpans[i++]}\``);
 }
 
-// A dot joining two segments marks a filename or config name, which is a code
-// token even unbackticked and carries no internal capital to mark it:
-// `global.css` became `Global.css` and `tmux.conf` became `Tmux.conf`.
-//
-// The dot must sit between two segments, with a lowercase alphanumeric one
-// after it, so a trailing dot never marks a word: a heading ending in a period
-// stays prose, and the AP stopword `vs.` keeps lowercasing. `e.g.` matches and
-// is left as written, which is already its AP form. `U.S.` needs no dot rule
-// because its internal capital marks it.
-const DOTTED_IDENTIFIER = /[A-Za-z0-9]\.[a-z0-9]/;
-
 // AP casing preserves all-caps acronyms on its own, but it title-cases
 // identifiers with a lowercase first letter (`gitLab` -> `GitLab`, `iOS` ->
 // `IOS`). An internal capital marks those so they aren't re-cased.
 function isIdentifier(segment: string): boolean {
-  if (DOTTED_IDENTIFIER.test(segment)) return true;
   const letters = segment.replace(/[^A-Za-z]/g, "");
   if (letters.length < 2) return false;
   return /[A-Z]/.test(letters.slice(1));
@@ -122,6 +110,17 @@ function caseHyphenated(original: string): string {
     .join("-");
 }
 
+// A dot joining two segments marks a filename or config name, which is a code
+// token even unbackticked and carries no internal capital to mark it:
+// `global.css` became `Global.css` and `tmux.conf` became `Tmux.conf`.
+//
+// The dot must sit between two segments, with a lowercase alphanumeric one
+// after it, so a trailing dot never marks a word: a heading ending in a period
+// stays prose, and the AP stopword `vs.` keeps lowercasing. `e.g.` matches and
+// is left as written, which is already its AP form. `U.S.` needs no dot rule
+// because its internal capital marks it.
+const DOTTED_IDENTIFIER = /[A-Za-z0-9]\.[a-z0-9]/;
+
 // One word's AP casing: code spans and identifiers pass through untouched,
 // hyphenated compounds get per-segment casing, everything else takes the
 // library's position-aware result.
@@ -130,6 +129,9 @@ function caseWord(original: string, cased: string): string {
   // A leading dash marks a CLI flag, which is a code token even unbackticked.
   // Casing it produces `--Format` and `-N`.
   if (original.startsWith("-")) return original;
+  // Tested ahead of the hyphen split, which cases each segment on its own and
+  // turned `ci-config.json` into `Ci-config.json`.
+  if (DOTTED_IDENTIFIER.test(original)) return original;
   if (original.includes("-")) return caseHyphenated(original);
   if (isIdentifier(original)) return original;
   return cased;

--- a/plugins/pull-request/scripts/heading-case.ts
+++ b/plugins/pull-request/scripts/heading-case.ts
@@ -75,10 +75,22 @@ function restore(text: string, codeSpans: string[]): string {
   return text.replaceAll(PLACEHOLDER, () => `\`${codeSpans[i++]}\``);
 }
 
+// A dot joining two segments marks a filename or config name, which is a code
+// token even unbackticked and carries no internal capital to mark it:
+// `global.css` became `Global.css` and `tmux.conf` became `Tmux.conf`.
+//
+// The dot must sit between two segments, with a lowercase alphanumeric one
+// after it, so a trailing dot never marks a word: a heading ending in a period
+// stays prose, and the AP stopword `vs.` keeps lowercasing. `e.g.` matches and
+// is left as written, which is already its AP form. `U.S.` needs no dot rule
+// because its internal capital marks it.
+const DOTTED_IDENTIFIER = /[A-Za-z0-9]\.[a-z0-9]/;
+
 // AP casing preserves all-caps acronyms on its own, but it title-cases
 // identifiers with a lowercase first letter (`gitLab` -> `GitLab`, `iOS` ->
 // `IOS`). An internal capital marks those so they aren't re-cased.
 function isIdentifier(segment: string): boolean {
+  if (DOTTED_IDENTIFIER.test(segment)) return true;
   const letters = segment.replace(/[^A-Za-z]/g, "");
   if (letters.length < 2) return false;
   return /[A-Z]/.test(letters.slice(1));

--- a/plugins/writing/hooks/heading-case.test.ts
+++ b/plugins/writing/hooks/heading-case.test.ts
@@ -84,6 +84,11 @@ describe("headingCaseViolations", () => {
       [{ text: "Rebase Vs. Merge", suggested: "Rebase vs. Merge" }],
     ],
     [
+      "leaves a hyphenated filename whole rather than casing each segment",
+      "## Fix the ci-config.json path",
+      [{ text: "Fix the ci-config.json path", suggested: "Fix the ci-config.json Path" }],
+    ],
+    [
       "does not capitalize into a leading numeral",
       "## 3rd-party tooling",
       [{ text: "3rd-party tooling", suggested: "3rd-Party Tooling" }],

--- a/plugins/writing/hooks/heading-case.test.ts
+++ b/plugins/writing/hooks/heading-case.test.ts
@@ -50,6 +50,39 @@ describe("headingCaseViolations", () => {
       "## Hide the --format flag",
       [{ text: "Hide the --format flag", suggested: "Hide the --format Flag" }],
     ],
+    ["leaves an unbackticked filename alone", "## Page Column Rule in global.css", []],
+    ["leaves unbackticked config names alone", "## Notes on package.json and bun.lock", []],
+    ["leaves a dotted name in a deeper heading alone", "### Rows From views.sql", []],
+    [
+      "re-cases around an unbackticked filename",
+      "## What sourcing tmux.conf actually does",
+      [
+        {
+          text: "What sourcing tmux.conf actually does",
+          suggested: "What Sourcing tmux.conf Actually Does",
+        },
+      ],
+    ],
+    [
+      "re-cases around several unbackticked filenames",
+      "## sections.md and tsconfig.json both moved",
+      [
+        {
+          text: "sections.md and tsconfig.json both moved",
+          suggested: "sections.md and tsconfig.json Both Moved",
+        },
+      ],
+    ],
+    [
+      "still flags a sentence-case heading that ends in a period",
+      "## Two fixes found while testing.",
+      [{ text: "Two fixes found while testing.", suggested: "Two Fixes Found While Testing." }],
+    ],
+    [
+      "still lowercases the `vs.` stopword",
+      "## Rebase Vs. Merge",
+      [{ text: "Rebase Vs. Merge", suggested: "Rebase vs. Merge" }],
+    ],
     [
       "does not capitalize into a leading numeral",
       "## 3rd-party tooling",

--- a/plugins/writing/hooks/heading-case.ts
+++ b/plugins/writing/hooks/heading-case.ts
@@ -75,22 +75,10 @@ function restore(text: string, codeSpans: string[]): string {
   return text.replaceAll(PLACEHOLDER, () => `\`${codeSpans[i++]}\``);
 }
 
-// A dot joining two segments marks a filename or config name, which is a code
-// token even unbackticked and carries no internal capital to mark it:
-// `global.css` became `Global.css` and `tmux.conf` became `Tmux.conf`.
-//
-// The dot must sit between two segments, with a lowercase alphanumeric one
-// after it, so a trailing dot never marks a word: a heading ending in a period
-// stays prose, and the AP stopword `vs.` keeps lowercasing. `e.g.` matches and
-// is left as written, which is already its AP form. `U.S.` needs no dot rule
-// because its internal capital marks it.
-const DOTTED_IDENTIFIER = /[A-Za-z0-9]\.[a-z0-9]/;
-
 // AP casing preserves all-caps acronyms on its own, but it title-cases
 // identifiers with a lowercase first letter (`gitLab` -> `GitLab`, `iOS` ->
 // `IOS`). An internal capital marks those so they aren't re-cased.
 function isIdentifier(segment: string): boolean {
-  if (DOTTED_IDENTIFIER.test(segment)) return true;
   const letters = segment.replace(/[^A-Za-z]/g, "");
   if (letters.length < 2) return false;
   return /[A-Z]/.test(letters.slice(1));
@@ -122,6 +110,17 @@ function caseHyphenated(original: string): string {
     .join("-");
 }
 
+// A dot joining two segments marks a filename or config name, which is a code
+// token even unbackticked and carries no internal capital to mark it:
+// `global.css` became `Global.css` and `tmux.conf` became `Tmux.conf`.
+//
+// The dot must sit between two segments, with a lowercase alphanumeric one
+// after it, so a trailing dot never marks a word: a heading ending in a period
+// stays prose, and the AP stopword `vs.` keeps lowercasing. `e.g.` matches and
+// is left as written, which is already its AP form. `U.S.` needs no dot rule
+// because its internal capital marks it.
+const DOTTED_IDENTIFIER = /[A-Za-z0-9]\.[a-z0-9]/;
+
 // One word's AP casing: code spans and identifiers pass through untouched,
 // hyphenated compounds get per-segment casing, everything else takes the
 // library's position-aware result.
@@ -130,6 +129,9 @@ function caseWord(original: string, cased: string): string {
   // A leading dash marks a CLI flag, which is a code token even unbackticked.
   // Casing it produces `--Format` and `-N`.
   if (original.startsWith("-")) return original;
+  // Tested ahead of the hyphen split, which cases each segment on its own and
+  // turned `ci-config.json` into `Ci-config.json`.
+  if (DOTTED_IDENTIFIER.test(original)) return original;
   if (original.includes("-")) return caseHyphenated(original);
   if (isIdentifier(original)) return original;
   return cased;

--- a/plugins/writing/hooks/heading-case.ts
+++ b/plugins/writing/hooks/heading-case.ts
@@ -75,10 +75,22 @@ function restore(text: string, codeSpans: string[]): string {
   return text.replaceAll(PLACEHOLDER, () => `\`${codeSpans[i++]}\``);
 }
 
+// A dot joining two segments marks a filename or config name, which is a code
+// token even unbackticked and carries no internal capital to mark it:
+// `global.css` became `Global.css` and `tmux.conf` became `Tmux.conf`.
+//
+// The dot must sit between two segments, with a lowercase alphanumeric one
+// after it, so a trailing dot never marks a word: a heading ending in a period
+// stays prose, and the AP stopword `vs.` keeps lowercasing. `e.g.` matches and
+// is left as written, which is already its AP form. `U.S.` needs no dot rule
+// because its internal capital marks it.
+const DOTTED_IDENTIFIER = /[A-Za-z0-9]\.[a-z0-9]/;
+
 // AP casing preserves all-caps acronyms on its own, but it title-cases
 // identifiers with a lowercase first letter (`gitLab` -> `GitLab`, `iOS` ->
 // `IOS`). An internal capital marks those so they aren't re-cased.
 function isIdentifier(segment: string): boolean {
+  if (DOTTED_IDENTIFIER.test(segment)) return true;
   const letters = segment.replace(/[^A-Za-z]/g, "");
   if (letters.length < 2) return false;
   return /[A-Z]/.test(letters.slice(1));


### PR DESCRIPTION
Fixes a false deny in the PR-body heading hook. The AP title-case checker exempts inline code spans, CLI flags, and identifiers carrying an internal capital. An unbackticked filename matches none of those, so it gets cased as an ordinary word:

- `Page Column Rule in global.css` denied for `Global.css`
- `What sourcing tmux.conf actually does` denied for `Tmux.conf`
- a heading naming `sections.md` denied for `Sections.md`

The only way past it was to backtick the filename.

A dot between two segments now marks the word as a code token. The dot has to be followed by a lowercase alphanumeric segment, which keeps the rule off ordinary prose. A heading ending in a period has a trailing dot with nothing after it, and the AP stopword `vs.` has that same shape, so both case as before. `e.g.` does match and is left as written, which is already the form AP wants, and `U.S.` was covered all along by the internal-capital rule.

The check sits in `caseWord` ahead of the hyphen branch rather than inside `isIdentifier`. `caseWord` routes any hyphenated word to per-segment casing before the identifier check runs, which turned `ci-config.json` into `Ci-config.json`. Testing the dot first keeps the compound whole and leaves `isIdentifier` at its original contract, so `CI-outage` still gets its per-segment fix.

The writing plugin carries a byte-for-byte copy of the checker for its own hook, since a plugin can only import published packages. A test asserts the two files are identical, so the fix lands in both.
