### PR TITLE
skills: write skill prose in plain language

### DIFF
--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -95,6 +95,10 @@ The description field is a trigger, not a summary. It's what Claude scans to dec
 
 The context window is a public good. Don't restate what Claude already knows. Spend tokens on what pushes Claude out of its defaults: gotchas, internal conventions, non-obvious constraints. The highest-signal content in any skill is a `## Gotchas` section documenting failure modes hit in practice; grow it as edge cases surface.
 
+#### Plain Language
+
+Write skill prose as instructions, in the imperative, with conditions before instructions and common verbs. Metaphor, epigram, and personification aim at a human reader and make weaker match targets than literal statements. See [references/plain-language.md](references/plain-language.md) for the sentence forms, the conversions, and the procedure for converting an existing skill.
+
 #### Progressive Disclosure
 
 A skill is a folder, not just a markdown file. Keep `SKILL.md` a concise hub and push details into `references/`, `scripts/`, and `assets/`. Tell Claude what files exist and when to read them. Organize references by domain and gate conditional detail behind a pointer, so a question about one domain loads only that file.
@@ -180,6 +184,7 @@ A skill-scoped PostToolUse hook runs `skill-lint` automatically when SKILL.md fi
 Load detailed guides as needed:
 
 - **[references/patterns.md](references/patterns.md)** - Dynamic context injection, subagent integration, skill-scoped hooks, anti-patterns
+- **[references/plain-language.md](references/plain-language.md)** - Plain-language rules for skill prose and the conversion procedure
 - **[references/troubleshooting.md](references/troubleshooting.md)** - Activation issues, plugin cache
 
 ## Resources

--- a/plugins/claude-code/skills/skill/references/plain-language.md
+++ b/plugins/claude-code/skills/skill/references/plain-language.md
@@ -1,0 +1,51 @@
+# Plain Language
+
+Rules for skill prose: SKILL.md bodies and reference files. Load this when writing skill instructions or converting an existing skill to plain language. Based on the [Google developer documentation style guide](https://developers.google.com/style) and the [federal plain language principles](https://digital.gov/guides/plain-language/principles/).
+
+Skill prose is instructions for a model performing a task. Judge every sentence by whether it changes the model's behavior. Style aimed at a human reader (rhythm, metaphor, epigram) spends tokens without changing behavior, and a figurative phrasing is a weaker match target than a literal one when the model scans for the rule that applies.
+
+## Sentence Form
+
+- Write instructions in the imperative: "Keep the title under 50 characters."
+- Put the condition before the instruction: "When the repo has a PR template, follow its sections."
+- One instruction per sentence. Split a sentence that stacks an instruction, its exception, and its reason.
+- Active voice, with a named actor: the model, the user, or a tool.
+- Present tense and common verbs: "use", not "leverage"; "check", not "interrogate".
+
+## Rule Then Reason
+
+State the rule first, in the imperative. Add the reason after it, in one clause, only when knowing why lets the model handle a case the rule doesn't list. Cut a reason that only argues the rule is right.
+
+## Conversions
+
+Rewrite these constructions wherever they appear:
+
+- Metaphor and idiom become the literal fact. "Backticks kill the link" becomes "backticked refs don't auto-link".
+- Epigrams get deleted. A short punchy sentence closing a rule for emphasis ("Arming the platform was the whole request.") adds no instruction. If it carries a distinct rule, state that rule plainly.
+- Personified artifacts become an actor and an action. "A title that wants a serial comma" becomes "if the title needs a serial comma". "When length earns them" becomes "when the body is long enough to need them".
+- Contrast frames ("X, not Y") become the positive instruction. Keep an explicit ban alongside it only when the wrong behavior is likely without one.
+- Cadence connectives get deleted. Sentence-opening "So" and "And", a trailing "though", and rhetorical questions add no instruction.
+- Writerly verbs become common ones: "mine" becomes "review", "arm" becomes "enable", "surface" becomes "report".
+
+## Cuts
+
+Most of the reduction comes from deleting whole sentences rather than converting them:
+
+- Duplicated rules. State each rule once, in the file and section where the model needs it, and cut the restatements. A SKILL.md that summarizes a reference file repeats it.
+- Second examples. One example per rule. An example repeated in two sections keeps the copy in the section that owns the rule.
+- Rationale-only sentences. A sentence that argues a rule is right, restates it with emphasis, or describes the defect the rule prevents adds no instruction.
+- Framing sentences. Openers that introduce what the section is about to say ("The most common defect is…") duplicate the heading.
+- Cross-references to context the model already has in the same file.
+
+## Preserved Content
+
+Conversion keeps these:
+
+- Every behavioral rule. Plain language changes the style and keeps every rule. A sentence that yields no rule when rewritten is the one to delete.
+- Domain terms. "Rebase", "worktree", and "auto-merge" are precise names, not jargon to simplify.
+- Negative rules and detector lists. A ban on a specific construction is an executable instruction.
+- Short concrete examples and before/after pairs. They pin a rule down more cheaply than added prose.
+
+## Procedure
+
+For each sentence of the source, extract the instruction, its condition, and its reason. Rewrite as condition, then imperative instruction, then the reason if it passes the test above. Delete sentences that yield no instruction. Then make a cut pass over the whole skill: dedupe rules across sections and files, cap examples at one per rule, and delete rationale that repeats its rule. Re-read each section afterward and confirm every remaining sentence is an instruction or attached to one.

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -38,18 +38,18 @@ allowed-tools:
 - Check the log in the context above to determine the repo's commit style:
   - **subject** (default): `${subject}: ${summary}` (e.g., `api: add timeout to request`)
   - **conventional**: `${type}: ${summary}` (e.g., `fix: add timeout to request`)
-- Name the primary change. A title that wants a serial comma is an enumeration. Find the theme the changes share, or name the biggest one and let the body carry the rest.
-- Keep under 50 characters. Past that, cut scope from the title rather than truncating words.
+- Name the primary change. If the title needs a serial comma, it's naming several changes. Name the shared theme or the largest change, and put the rest in the body.
+- Keep under 50 characters. Cut scope rather than truncating words.
 - Use imperative mood, lowercase except proper nouns
 
 ## Body
 
-Lead with intent: why this change, the decisions a reviewer can't reconstruct from the diff, and how you know it works. Don't restate what the diff, git, or the status checks already carry. Mine the session for the substance that never reached the code (rejected alternatives, scope added or dropped, what you observed testing) and state each as a self-contained decision, not as a delta against a plan the reviewer never saw.
+Lead with intent: why the change exists, the decisions a reviewer can't reconstruct from the diff, and how you know it works. Don't restate what the diff, the git log, or the status checks show. Review the session for content that never reached the code (rejected alternatives, scope changes, test observations) and state each as a self-contained decision, never as a delta against a plan the reviewer hasn't seen.
 
 - Open with a bare verb ("Adds", "Fixes", "Removes") when the change is self-evident, or with the problem when it needs justifying. Don't restate the title.
-- Default to prose. A small PR is a tight paragraph with no headers. Add `##` sections only when length earns them. Length tracks substance, not diff size.
+- Default to prose. Write a small PR as one paragraph with no headings. Add `##` sections only when the body is long enough to need them. Base length on substance, not diff size.
 - Reference the motivating issue at the end of the opening (`Closes #N`, `Fixes #N`, or bare `#N` if not closing). Never touch the issue itself: no comments, labels, milestones, or assignees.
-- Wrap code identifiers in backticks, but leave bare anything the platform auto-links: commit SHAs and issue/MR refs (`#N`, `!N`, `owner/repo#N`). Backticks kill the link.
+- Wrap code identifiers in backticks, but leave bare anything the platform auto-links: commit SHAs and issue/MR refs (`#N`, `!N`, `owner/repo#N`). Backticked refs don't auto-link.
 
 Load the `writing` skill for the full set of tropes to avoid.
 
@@ -57,30 +57,30 @@ When the context above shows a detected PR template, follow its structure instea
 
 ## Reviewers
 
-Corporate and internal repos only. On OSS (a public repo you don't own) the maintainer triages, so skip this and add no noise. Suggest reviewers, never assign; the user always chooses. Load [`references/reviewers.md`](references/reviewers.md) for the visibility gate, the ranking script, and username resolution.
+Corporate and internal repos only. On OSS (a public repo you don't own), skip this step and leave triage to the maintainer. Suggest reviewers for the user to choose from. Never assign them yourself. Load [`references/reviewers.md`](references/reviewers.md) for the visibility gate, the ranking script, and username resolution.
 
 ## Arguments
 
-Parse `$ARGUMENTS` for these flags. With none, create a PR/MR that is ready for review and, on a repo you own, armed to auto-merge.
+Parse `$ARGUMENTS` for these flags. With none, create a PR/MR that is ready for review and, on a repo you own, set to auto-merge.
 
 - `--draft`: open the PR/MR as a draft. Default: ready for review.
 - `--no-auto`: skip auto-merge. Default: auto-merge on a repo you own, off on a third-party repo and off under `--draft`. See [`references/merge.md`](references/merge.md).
-- `--base <ref>`: parent branch to target. A branch whose parent is another topic branch is a stack layer, and this flag or the user saying so are the only signals for that, since a branch's upstream ref tracks its own remote copy. Default: the repo's default branch.
-- `--label <name>`: apply a label, repeatable. Where a repo gates its hosted review bot on a label, this is how a review gets requested (see follow-up's `reviewers.md`). Confirm each label exists before creating, per [`references/labels.md`](references/labels.md). Default: none.
+- `--base <ref>`: parent branch to target. A branch whose parent is another topic branch is a stack layer. Only this flag or the user identifies one. The upstream ref tracks the branch's own remote copy, so it can't identify the parent. Default: the repo's default branch.
+- `--label <name>`: apply a label, repeatable. On a repo that gates its hosted review bot on a label, apply the label to request the review (see follow-up's `reviewers.md`). Confirm each label exists first, per [`references/labels.md`](references/labels.md). Default: none.
 
 ## Workflow
 
 1. **Branch validation**: If the context above shows you're on a default branch (main/master), stop and ask the user to switch to a feature branch first.
 1. Stage changes if not already staged: `git add .`
 1. Commit if there are no commits yet on the branch, using the same format as the PR title.
-1. Local bot review, gated: the Review bot line in Context above is the fast-path verdict, covering repo config, CLI presence, and any live cooldown. On a repo config hit with no cooldown, decide whether the diff is worth a metered review (follow-up's SKILL.md defines the gate). When it is, run `pull-request:follow-up --local` before pushing so findings surface while the branch is still local. With no config, a bot may still review the repo: follow-up's `local.md` hosted signals decide. Skip when a local bot pass already ran on this branch in this session (`/ship` runs it as a gated pass), when the gate says skip, when the provider is paused, when detection comes up empty, or when the user declines.
+1. Local bot review, gated: the Review bot line above reports repo config, CLI presence, and any cooldown. On a config hit with no cooldown, apply the gate in follow-up's SKILL.md to decide whether the diff needs a metered review. If it does, run `pull-request:follow-up --local` before pushing. With no config, decide from the hosted signals in follow-up's `local.md`. Skip when a local bot pass already ran on this branch this session (`/ship` runs one), the gate says skip, the provider is paused, detection finds nothing, or the user declines.
 1. Push the branch to remote: `git push -u origin HEAD`
 1. Resolve any `--label` values against the repo before creating (see [`references/labels.md`](references/labels.md)).
-1. Draft the body. Past a single paragraph, read [`references/sections.md`](references/sections.md) first: audience tiers, the substance catalog by change type, density and heading rules, evidence grounding, optional sections, and slop to cut.
+1. Draft the body. Past a single paragraph, read [`references/sections.md`](references/sections.md) first: audience tiers, session content, density and heading rules, evidence, optional sections, slop to cut.
 1. Create the PR/MR, appending `--draft` when set, `--base <parent>` when the branch is a stack layer, and `--label <name>` for each label that resolved:
    - **GitHub**: `gh pr create --title "..." --body-file tmp/pr-body-<branch>.md`
    - **GitLab**: `glab mr create --title "..." --description "$(cat tmp/pr-body-<branch>.md)"`
-   - Write the body to the temp file in its own Bash call, with the branch name in the filename so concurrent agents don't collide. The create call has to *start* with `gh`/`glab`: the body-validation hook matches on that leading verb, so anything in front of it (a `cd`, a chained heredoc that writes the body, an env assignment) skips validation silently. Never `cd` to the directory you are already in.
+   - Write the body file in its own Bash call, with the branch name in the filename so concurrent agents don't collide. Start the create command with `gh`/`glab`: the body-validation hook matches that leading word, and a `cd`, chained heredoc, or env assignment in front of it silently skips validation.
 1. Chain a GitHub stack layer into its stack once the PR exists. Load `github:stack` for the `gh stack link` forms, the detection query that picks between them, and what an exit code 9 means.
-1. Arm auto-merge after the PR/MR exists, unless `--no-auto` or `--draft` is set. On a repo you own (the Remote URL above names the owner), run `gh pr merge --auto`. On a third-party repo, leave the merge to the maintainer. GitLab, stacked PRs, and a repo that rejects `--auto` take the paths in [`references/merge.md`](references/merge.md).
+1. Enable auto-merge after the PR/MR exists, unless `--no-auto` or `--draft` is set. On a repo you own (the Remote URL above names the owner), run `gh pr merge --auto`. On a third-party repo, leave the merge to the maintainer. GitLab, stacked PRs, and a repo that rejects `--auto` take the paths in [`references/merge.md`](references/merge.md).
 1. Suggest reviewers on corporate repos (see [Reviewers](#reviewers)). Skip this step for OSS.

--- a/plugins/pull-request/skills/create/references/labels.md
+++ b/plugins/pull-request/skills/create/references/labels.md
@@ -1,12 +1,12 @@
 # Labels
 
-`--label` belongs on the create call. A hosted review bot decides whether to review when the PR opens, and on a repo that gates review on a label it reads the labels present at that moment. A label added a moment later arrives as a `labeled` event, which a repo running with automatic re-review off may ignore, leaving the requested review to never start.
+Pass `--label` on the create call. A review bot that gates on a label reads the labels present when the PR opens. A label added afterward arrives as a `labeled` event, which a repo with automatic re-review off may ignore.
 
-An undefined label fails the create outright, though, which would throw away the body and every pre-PR pass behind it. So confirm each one first and pass only what resolved:
+An undefined label fails the create outright, discarding the body. Confirm each label first and pass only the ones that resolve:
 
 ```
 gh label list --search <name> --json name --jq '.[].name'   # GitHub
 glab label list                                             # GitLab
 ```
 
-No match means the label does not exist. Say which one, offer `gh label create <name>`, and open the PR without it. When the missing label was gating a review, say that the review waits on someone adding it.
+On no match, say which label doesn't exist, offer `gh label create <name>`, and open the PR without it. If the missing label gated a review, say the review waits until someone adds the label.

--- a/plugins/pull-request/skills/create/references/merge.md
+++ b/plugins/pull-request/skills/create/references/merge.md
@@ -1,11 +1,11 @@
 # Auto-Merge
 
-Auto-merge is passive: it arms the platform and returns. Branch protection still gates the actual merge on checks and required approvals. It does not fix red CI or wait out a review, which is what `pull-request:babysit` is for.
+Enabling auto-merge only sets a flag. Branch protection still gates the merge on checks and approvals. Auto-merge can't fix red CI or wait for a review to finish. Use `pull-request:babysit` for that.
 
-On a repo you own it is the default. You are going to merge that PR yourself once the checks clear, and arming it up front saves the round trip. On a third-party repo it stays off, because the maintainer decides when the PR merges. A draft stays off too: GitHub refuses to arm auto-merge on a draft, so `--draft` and auto-merge never combine. `--no-auto` skips it anywhere.
+Enable it by default on a repo you own. Leave it off on a third-party repo (the maintainer decides) and on a draft (GitHub refuses it there). `--no-auto` disables it everywhere.
 
 - **GitHub**: `gh pr merge --auto`. Add `--squash` or `--rebase` to match the repo's merge method when known (`gh repo view --json squashMergeAllowed,mergeCommitAllowed,rebaseMergeAllowed`).
-- **GitHub, stacked**: auto-merge has no equivalent on a stacked PR. Say so and suggest `pull-request:babysit <url> --merge`, which drives the stack merge at green.
-- **GitLab**: load `gitlab:merge-request` and run its `merge.ts --auto-merge`, which handles merge trains and falls back to `glab mr merge` as needed.
+- **GitHub, stacked**: no auto-merge equivalent exists for a stacked PR. Say so and suggest `pull-request:babysit <url> --merge`.
+- **GitLab**: load `gitlab:merge-request` and run its `merge.ts --auto-merge`, which handles merge trains and falls back to `glab mr merge`.
 
-A repo with auto-merge turned off rejects `gh pr merge --auto`. Report that the PR waits for a manual merge and move on. Leave the landing to whoever decides it. Arming the platform was the whole request.
+A repo with auto-merge disabled rejects `gh pr merge --auto`. Report that the PR needs a manual merge and continue. Don't merge it yourself.

--- a/plugins/pull-request/skills/create/references/sections.md
+++ b/plugins/pull-request/skills/create/references/sections.md
@@ -1,51 +1,43 @@
 # Pull Request Body
 
-What goes in the body, and what to leave out. The create and update skills both use this.
+What goes in a PR body. Used by the create and update skills.
 
-The body conveys what the diff cannot. The reviewer reads the code for what changed. Use the body for why it changed, the decisions you made, and how you know it works.
+The body covers what the diff can't: why the change exists, the decisions behind it, and how you know it works. The reviewer reads the code for what changed.
 
-Write the body to stand on its own. The reviewer has the diff and the linked issue and nothing else: not your plan, not the issue you were handed, not the session that produced the change. Every reference must point to something they can open: a linked issue, a PR, a permalink. A phrase like "the plan", "as originally planned", "per the plan", or "the issue specified" (or a `## Deviations From the Plan` heading) points at an artifact they can't see, so it lands as a dead end. State the decision itself instead of the gap between it and an instruction only you saw.
+Write the body to stand alone. The reviewer sees only the diff and links that open for them: issues, PRs, permalinks. Don't reference your plan, your instructions, or the session ("as planned", "the issue specified", a `## Deviations From the Plan` heading). State each decision itself, not its difference from an instruction the reviewer never saw.
 
-Write in active voice and first person for your own calls. "I chose X over Y because…", "I traced this to…". Don't write passively ("X was added", "the bug was caused by…"). Keep the prose plain. Technical terms are fine. Marketing and model flourishes (`source of truth`, `fail loudly`, `escape hatch`, `cleanly`, `wires up`) are not. Load the `writing` skill for the full set of tropes to avoid.
-
-Never quote this document's own vocabulary in the body. Instruction words describe what to select. They are not phrasing to reuse. A body that says a detail is subtle, or names its own restraint about what it left out, is narrating its instructions instead of the change.
+Use active voice, first person for your own decisions ("I chose X over Y because…"). Keep the prose plain. Technical terms are fine. Marketing flourishes (`source of truth`, `fail loudly`, `cleanly`) are not. Load the `writing` skill for the full trope list. Don't reuse this document's vocabulary in the body. A body that calls a detail subtle or notes what it left out is narrating its instructions.
 
 ## Audience
 
-How much a body earns depends on who reads it. Read the tier from the repo's owner and visibility, the same probe the create skill runs for reviewers.
+Set depth from the repo's owner and visibility, the same probe the create skill runs for reviewers. The rules below apply at every tier.
 
-- **Personal** (a repo you own, public or private): you review it through Claude, and no one else reads the body. Budget one to three paragraphs. State the intent and the decisions a reviewer should re-examine, and skip background you already carry. Go past three paragraphs only when the change carries that much real substance, and spend the extra length on decisions and their evidence.
-- **Corporate** (a private or org-owned repo): coworkers skim it. Lead with intent so the skim lands, and keep supporting detail moderate.
-- **Open source** (a public repo you don't own): external maintainers scrutinize it, and unclear intent has the widest blast radius. Spend the most here on decisions, alternatives ruled out, and evidence.
-
-The tier scales depth and length. It does not license a wall of text: the shape and density rules below hold at every tier.
+- **Personal** (a repo you own, public or private): no one else reads the body. One to three paragraphs: intent and the decisions worth re-examining. Skip background you already have.
+- **Corporate** (a private or org-owned repo): coworkers skim it. Put the intent in the first sentence and keep supporting detail moderate.
+- **Open source** (a public repo you don't own): maintainers scrutinize it. Spend the most here on decisions, rejected alternatives, and evidence.
 
 ## Intent
 
-Restating the diff has a subtle form that passes for substance: narrating the code at a higher altitude. A paragraph that walks the new control flow, names what each function now does, or describes how the pieces fit is still a retelling of the diff. A careful reviewer reconstructs all of it by reading the change.
-
-Intent is what the code cannot state about itself: why the change exists, the requirement it satisfies, the constraint that forced this shape, the alternative it beat. Test each sentence. If a reader could reconstruct it by reading the changed code, it is narration, so cut it or replace it with the reason behind it. Quote or point to the issue requirement the change satisfies rather than paraphrasing what the code now does.
+Intent is what the code can't say: why the change exists, the requirement it satisfies, the constraint that forced the design, the alternative you rejected. Narrating the code at a higher level (walking the new control flow, naming what each function now does) is still restating the diff. Cut any sentence the reviewer could reconstruct from the changed code. Quote or link the issue requirement instead of paraphrasing the code.
 
 ## Density
 
-The most common defect in real bodies is not the wrong content, it is the right content packed too tightly.
-
-- One thread per paragraph. A paragraph that runs past three or four sentences is doing too much. Split it.
-- One idea per sentence. A sentence that stacks clauses behind three or more commas is a list wearing prose clothing. It reads as a wall even when every clause is true.
-- Past four or five paragraphs, unsectioned prose gets hard to scan. Give it headings.
-- Prose carries reasoning that connects one point to the next. A list carries items that merely co-occur: findings, cases a test covers, checks run, files touched for one reason. When the content is a set of parallel items, make it a list. "Default to prose" bans the reflexive `## Changes` plus `## Testing` scaffold, not lists: compressing an enumeration into a run-on sentence is the same mistake from the other direction.
+- One thread per paragraph. Split past three or four sentences.
+- One idea per sentence. A sentence stacking clauses behind three or more commas is a list. Format it as one.
+- Add headings once prose passes four or five paragraphs.
+- Prose for connected reasoning, lists for parallel items (findings, cases covered, checks run). "Default to prose" bans the reflexive `## Changes` plus `## Testing` scaffold, not lists.
 
 ## Headings
 
-A heading names the section's topic. It is not a sentence about the topic. Write a noun phrase in AP title case, usually two or three words, and let the prose below carry the explanation.
+A heading is two or three words in AP title case, usually a noun phrase. Put the explanation in the prose below the heading.
 
-- Cut the clause riding the head noun, whether a qualifying tail (`Structural audit sourced from the hook` → `Structural Audit`), a parenthetical (`Context Tier (Soft Reminder Only)` → `Context Tier`), or a colon-spliced status (`Not Yet Met: The Live Proof` → `Deferred Proof`). The explanation goes in the first sentence under the heading.
-- Let the parent frame the leaf: under `## Tiers`, `Deny Tier` → `Deny`; under `## Decisions`, `Why Not an N-Gram View in DuckDB` → `N-Gram View`. Nest so the child heading stays bare.
-- Name the topic, not the question or the meta-move: `What Changed` → `Changes`; `What I Didn't Do` → `Deferred Work`; `What I Didn't Change` → `Unchanged Behavior`. The "why" is the prose, or the parent section (`## Decisions`, `## Alternatives`), never a `Why`/`What`/`How` heading.
-- Keep imperatives tight: `Hide the Inherited `--format` Flag` → `Hide Inherited `--format` Flag`. Drop the article, lose the trailing clause.
-- Don't open with a `## Summary` heading when you aren't following a template. The first paragraph is the summary already.
+- Cut qualifying tails (`Structural audit sourced from the hook` → `Structural Audit`), parentheticals (`Context Tier (Soft Reminder Only)` → `Context Tier`), and colon-spliced status (`Not Yet Met: The Live Proof` → `Deferred Proof`).
+- Drop context the parent heading already gives, nesting so the child stays bare: under `## Decisions`, `Why Not an N-Gram View in DuckDB` → `N-Gram View`.
+- Name the topic, not the question: `What I Didn't Do` → `Deferred Work`. No `Why`/`What`/`How` headings. Put the why in the prose below or in a parent section (`## Decisions`, `## Alternatives`).
+- Drop articles and trailing clauses from imperatives: `Hide the Inherited --format Flag` → `Hide Inherited --format Flag`.
+- No `## Summary` heading outside a template. The first paragraph is the summary.
 
-A heading has slipped into a sentence when it carries a comma, a colon, a trailing period or question mark, a linking verb (`is`, `are`, `exits`), a relative clause (`that`, `which`), or a subject pronoun (`this`, `it`).
+A heading carrying a comma, a colon, trailing punctuation, a linking verb, a relative clause, or a subject pronoun has become a sentence.
 
 ### AP Title Case
 
@@ -55,57 +47,53 @@ The PR-body hook re-cases every heading through `heading-case.ts` and denies the
 - A hyphenated compound capitalizes each element and applies the same list past the first: `Follow-up Tasks` → `Follow-Up Tasks`, while `Ready-to-Ship Checklist` keeps its lowercase `to`.
 - Inline code spans, unbackticked CLI flags (`--body-file`), identifiers with an internal capital (`gitLab`), and unbackticked filenames or config names carrying a dot (`tmux.conf`) pass through as written.
 
-## Mine the Conversation
+## Session Content
 
-The best content is substance that lived in the session but never reached the code. Review the conversation and pick the two or three items, across every category in this section, that would change how someone reviews the change. State each in one or two sentences, as a self-contained decision: what you did and why, never a delta against a plan or instruction the reader never saw. Write "I added a `Bash(git push:*)` entry because the workflow pushes the branch," not "I added an entry beyond what the plan listed."
+The best material happened in the session but never reached the code. Review the conversation and pick the two or three items that would change how someone reviews the change, one or two sentences each. In rough order of value:
 
-Draw from, in rough order of value:
+- A decision with a rejected alternative: what lost and why.
+- Scope added or dropped.
+- Test observations: the actual result or failure, with real output. Name what you couldn't test and the concrete blocker ("brew install failed locally", not "needs a real machine").
+- A follow-up, named concretely ("follow-up in #N to…").
 
-- A decision with a rejected alternative. Name what you chose against and the reason it lost.
-- Scope you added or dropped along the way.
-- What you observed testing: the actual result, surprise, or failure mode, with the real numbers or output when they exist. Name what you could not test and the concrete blocker ("brew install failed locally", not "needs a real machine").
-- A follow-up, named concretely ("follow-up in #N to…"), not a vague TODO.
-
-A theory you disproved on the way gets one sentence, and only when it changes how someone reviews the change. A workaround you rejected as fragile, or a name the user settled by hand, earns its sentence by the same test. Everything else is padding. An item that would not change the review does not go in, and the body never mentions the items it left out.
-
-When the work ran through sub-agents, the substance is in their returned summaries. Pull it forward before it gets smoothed away.
+A disproved theory, a rejected workaround, or a name the user settled by hand gets one sentence, and only when it changes the review. Don't mention what you left out. When sub-agents did the work, pull the material from their returned summaries before it's lost.
 
 ### By Change Type
 
-- Visual or GUI work: screenshots or a recording of the result. Rejected layouts. Bugs only live rendering surfaced.
-- Backend or API work: an example request and response. The mechanism proof for a fix (what breaks without it). Performance numbers.
-- Config, tooling, or prose: the scope you added or dropped, what you chose not to build, and the evidence that grounds the design.
+- Visual or GUI work: screenshots or a recording. Rejected layouts. Bugs found only by rendering it live.
+- Backend or API work: an example request and response. What breaks without the fix. Performance numbers.
+- Config, tooling, or prose: scope added or dropped, what you chose not to build, the evidence behind the design.
 
-## Ground Claims in Evidence
+## Evidence
 
-Prefer showing to asserting. Link a permalink to the exact lines instead of paraphrasing code. Blockquote the doc or spec you reason from. Paste the real error, stack trace, or test output in a fence rather than describing it. "Reverting the fix makes `TestX` fail with `exit 2`" beats "added a test for the fix".
+Show instead of asserting: permalink the exact lines instead of paraphrasing code, blockquote the spec you reason from, paste the real error or test output in a fence.
 
 ## Optional Sections
 
-Use these only when the body is long enough to earn them. A small PR stays a paragraph.
+Only when the body is long enough to need them. A small PR stays one paragraph.
 
 ### Changes
 
-Organize by concept, not by file. Each bullet is one conceptual shift, even when it spans files. Never write `**path**: description`. Reference an identifier only when it adds something the diff doesn't. Don't pair a count with an enumeration ("all three X (a, b, c)"). Enumerate or summarize, not both. Omit cleanup that follows from the main change (dead imports). The diff shows it.
+Organize by concept, not by file. One bullet per conceptual change, even when it spans files. Never `**path**: description`. Name an identifier only when it adds what the diff doesn't. Don't pair a count with an enumeration (`all three X (a, b, c)`): enumerate or summarize. Skip cleanup that follows from the main change.
 
-For a schema change, name the tables and columns touched, because a file name rarely reveals them. Two limits keep this from becoming a diff transcript. Past roughly ten columns, naming each one is rote, so summarize the change and name only the columns that carry a decision. And when the schema is generated from a model whose name maps to the table, the changed model already tells the reviewer which table moved, so add only what that mapping doesn't. Describe a hand-written, date-prefixed migration. Skip a regenerated schema file.
+For a schema change, name the tables and columns touched, since file names rarely show them. Past roughly ten columns, summarize and name only the columns that involved a decision. When the schema is generated from a model that names the table, add only what that mapping doesn't show. Describe a hand-written, date-prefixed migration. Skip a regenerated schema file.
 
 ### Testing
 
-Include this only when a test or a hand check tells the reviewer something the status checks won't. State what the test proves, not that it exists: the falsification ("reverting the fix makes `TestX` fail"), the edge cases covered, what you verified by hand and what you couldn't.
+Include only when a test or hand check tells the reviewer something the status checks won't. State what the test proves: the falsification ("reverting the fix makes `TestX` fail with `exit 2`"), the edge cases covered, what you verified by hand and what you couldn't.
 
-- Say nothing CI will post. A roll-call of green checks (`lint passes`, `types clean`, `build` green, `193 pass, 0 fail`, `0 errors, 0 warnings`) restates the status checks the reviewer already sees on the PR. Name a check only when its result is not one CI carries: a check CI doesn't run, an intentional exclusion (`ruff over the repo, generated tree excluded`), or a pre-existing warning you're leaving in place.
-- Never test counts ("added 5 tests", "1165 assertions"). They measure nothing.
-- Paste real output over claiming success.
+- Nothing CI already posts: no green-check lists (`lint passes`, `193 pass, 0 fail`). Name a check only when CI doesn't show its result: an intentional exclusion (`ruff over the repo, generated tree excluded`), a pre-existing warning left in place.
+- No test counts.
+- Paste real output instead of claiming success.
 
 ### References
 
-Related links, issues, or reviews that aren't the motivating issue. Use `Closes #N` for what this resolves and `Relates to #N` for context, keeping the two distinct. Every link must resolve for the reviewer. On a corporate or open-source repo, a private task-tracker URL (a Things link, an internal note) is a dead end. Drop it or replace it with the openable artifact it points to. On a personal repo the reviewer is the owner, so an `Original Task:` Things link resolves for exactly the person reading it and stays.
+Links that aren't the motivating issue: `Closes #N` for what this resolves, `Relates to #N` for context. Every link must open for the reviewer. On a corporate or open-source repo, drop a private task-tracker URL or replace it with the artifact it points to. On a personal repo the owner is the reviewer, so an `Original Task:` Things link stays.
 
 ## Slop to Cut
 
-Beyond what the sections above already ban:
+Beyond what the sections above ban:
 
 - The "This PR introduces" opening. Lead with the change or the problem.
-- Count-padding ("six detectors, three and three"). The number is rarely the point.
-- The consequence chain (`, so the…`) used as a filler connective, and the antithesis (`not just X but Y`, `X instead of Y`) used as framing. Both read as tics when habitual.
+- Count-padding ("six detectors, three and three").
+- The consequence chain (`, so the…`) as a filler connective and the antithesis (`not just X but Y`, `X instead of Y`) as framing.


### PR DESCRIPTION
Rewrites `pull-request:create`'s `SKILL.md` and reference files into plain instructional language, and adds `references/plain-language.md` to `claude-code:skill` so later skill conversions follow the same rule set. Skill prose is read by a model executing a task: figurative phrasing like "a title that wants a serial comma" or "backticks kill the link" costs the same tokens as the literal rule but matches worse when a model scans for the rule that applies. The rules come from the Google developer documentation style guide and the federal plain language principles.

Most of the reduction in `sections.md` came from cutting content rather than rewriting sentences:

- Rules duplicated across sections got stated once
- Examples got capped at one per rule
- Sentences that only argued a rule was right got deleted

`sections.md` dropped from 2,027 words to 1,332.

`plain-language.md` also names what a conversion has to keep, so a later pass doesn't cut real instructions along with the prose:

- Domain terms
- Negative rules and detector lists, like the `X instead of Y` construction and the date-prefixed migration signal
- Short examples
- Every behavioral rule, even when its wording changes

Follow-up: convert `pull-request:update`, `follow-up`, and `babysit` with the same procedure.
