### PR TITLE
github: teach attaching images and video to GitHub

### DIFF
--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -6,6 +6,7 @@ GitHub workflow, Actions monitoring, and rulesets management for Claude Code.
 
 - **Skills**:
   - `actions-monitor`: Watch a PR's CI and stream state events; invokes the logs agent on failures
+  - `attach`: Upload an image or video to GitHub's user-attachments store and reference it from an issue, PR, or comment
   - `copilot`: Cross-model review of the current diff through the Copilot CLI. Slash-invocable only, one call by default and three at most, because the Copilot plan is a fixed budget
   - `notifications`: Inbox management (list, filter, mark read/done, unsubscribe)
   - `pr-comments`: Fetch unresolved review comments from a pull request

--- a/plugins/github/skills/attach/SKILL.md
+++ b/plugins/github/skills/attach/SKILL.md
@@ -3,32 +3,34 @@ name: github:attach
 description: Upload a local image or video to GitHub and reference it so it renders inline in an issue, pull request, comment, or review. Use when attaching a screenshot, screen recording, or generated diagram to GitHub content, or when a body would otherwise link a local path the reader cannot open. Load before posting to uploads.github.com.
 allowed-tools:
   - Bash(gh api:*)
-  - Bash(gh repo view:*)
   - Bash(gh issue:*)
   - Bash(gh pr:*)
+  - Bash(grep:*)
 ---
 
 # Attachments
 
-Images and video dropped into an issue or pull request on the web are served from a user-attachments store. `POST https://uploads.github.com/user-attachments/assets` puts a file there and answers with the URL to reference. The endpoint has no REST route and no documentation, so `gh api` reaches it by full URL. It is what the web uploader calls, and what `gh --attach` calls.
+Images and video in issues and pull requests are served from a user-attachments store. `POST https://uploads.github.com/user-attachments/assets` puts a file there and answers with the URL to reference. It has no REST route and no documentation, so `gh api` reaches it by full URL.
 
 ## Upload
 
-`repository_id` takes the numeric REST id, which the REST repository route carries. The `id` field of `gh repo view --json id` is the GraphQL node id and fails here.
+`repository_id` takes the numeric REST id. `gh repo view --json id` returns the GraphQL node id, which fails here.
 
 ```bash
 repo_id=$(gh api repos/{owner}/{repo} --jq .id)
 
 gh api --method POST \
-  "https://uploads.github.com/user-attachments/assets?repository_id=$repo_id&name=picker-wide.png&content_type=image/png" \
-  --input ./picker-wide.png --jq .url
+  "https://uploads.github.com/user-attachments/assets?repository_id=$repo_id&name=picker.png&content_type=image/png" \
+  --input ./picker.png --jq .url
 ```
 
-The response is `{"url": "https://github.com/user-attachments/assets/<uuid>"}`. `--input` sends the file's bytes unmodified, and `gh api` supplies the token, so nothing needs `gh auth token` by hand.
+The response is `{"url": "https://github.com/user-attachments/assets/<uuid>"}`.
+
+The token needs write access to that repository. Read-only access answers 404, which makes a permission problem look like a missing repository.
 
 ## File Types
 
-Nine types upload, and the extension in `name` must agree with `content_type`. A mismatch fails validation naming both fields.
+The extension in `name` must agree with `content_type`, and nothing outside this list uploads. Logs, archives, and PDFs have no path here.
 
 | Extension | `content_type` |
 | --- | --- |
@@ -41,40 +43,30 @@ Nine types upload, and the extension in `name` must agree with `content_type`. A
 | `.mov` | `video/quicktime` |
 | `.webm` | `video/webm` |
 
-Anything else comes back as `content_type is not included in the list of allowed content types`. Logs, archives, and PDFs have no path here. Summarize a log into the body rather than attaching it. Images cap at 10 MB and video at 100 MB. The video ceiling varies by account plan. The server can refuse a file under that bound.
-
-## Token and Access
-
-The token needs write access to the repository named by `repository_id`. Read and triage answer 404. A permission problem arrives looking like a missing repository.
-
-A classic PAT, a fine-grained PAT, and the OAuth token behind `gh auth token` all upload. `gh` refuses every other kind before sending, including a GitHub App installation token. That is what an Actions run gets as the default `GITHUB_TOKEN`. A workflow that attaches needs a PAT in its environment.
-
-GitHub Enterprise Server has no upload host. github.com and ghe.com data-residency tenants have one.
+Images cap at 10 MB. Video caps at 100 MB or lower, depending on the account plan.
 
 ## Reference
 
-An image is ordinary markdown. Escape `\`, `[`, and `]` in alt text and replace newlines with spaces, or alt text carrying `](url)` closes the image early and repoints it.
+An image is ordinary markdown, with `\`, `[`, and `]` escaped in the alt text.
 
 ```markdown
 ![Wide window](https://github.com/user-attachments/assets/<uuid>)
 ```
 
-Video has no markdown syntax. GitHub renders a player when a bare asset URL is the whole of a paragraph. Give it its own line with a blank line on each side.
+Video has no markdown syntax. GitHub renders a player when a bare asset URL is the whole of a paragraph.
 
 ## Ordering
 
-An upload cannot be undone, and an asset cannot be deleted. Upload once nothing is left that could cancel: after the editor closes, after the confirmation, after the body is final. An asset nothing references is stranded, unreachable, and permanent.
-
-An asset takes the visibility of the repository it was uploaded against once something references it. Until then it answers 404 to everyone except an authenticated uploader. Opening the URL tells you nothing about whether the upload worked.
+An upload cannot be undone and an asset cannot be deleted. Upload once the body is final and nothing is left that could cancel. An asset nothing references is stranded and permanent, and it answers 404 until something references it, so opening the URL proves nothing about the upload.
 
 ## The --attach Flag
 
-`gh` is adding a repeatable `--attach` to `gh issue create`, `gh issue edit`, `gh issue comment`, `gh pr create`, `gh pr edit`, and `gh pr comment`. It posts to the same endpoint under the same limits.
+`--attach` on this build: !`gh issue comment --help 2>/dev/null | grep -q -- '--attach' && echo present || echo absent`
+
+Absent means the upload above is the only way. Present means `--attach` replaces it for `gh issue create`, `gh issue edit`, `gh issue comment`, `gh pr create`, `gh pr edit`, and `gh pr comment`. It repeats, takes a path, and takes alt text after a `#`.
 
 ```bash
-gh issue comment 87 --body-file report.md --attach './picker-wide.png#The wide layout'
+gh issue comment 87 --body-file report.md --attach './picker.png#The wide layout'
 ```
 
-Alt text follows a `#`, and a video takes none. A body that already links the local path gets that reference rewritten to the uploaded URL. A body that does not gets the asset appended.
-
-`gh issue comment --help` says whether the running build has it. Prefer it where it exists. The flag reaches those six commands only, so review comments, review bodies, discussions, releases, commit comments, and gists still upload first and write the URL into the body.
+A body that already links the local path gets that reference rewritten. A body that does not gets the asset appended. Review comments, discussions, releases, and gists are out of the flag's reach and upload through the endpoint either way.

--- a/plugins/github/skills/attach/SKILL.md
+++ b/plugins/github/skills/attach/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: github:attach
+description: Upload a local image or video to GitHub and reference it so it renders inline in an issue, pull request, comment, or review. Use when attaching a screenshot, screen recording, or generated diagram to GitHub content, or when a body would otherwise link a local path the reader cannot open. Load before posting to uploads.github.com.
+allowed-tools:
+  - Bash(gh api:*)
+  - Bash(gh repo view:*)
+  - Bash(gh issue:*)
+  - Bash(gh pr:*)
+---
+
+# Attachments
+
+Images and video dropped into an issue or pull request on the web are served from a user-attachments store. `POST https://uploads.github.com/user-attachments/assets` puts a file there and answers with the URL to reference. The endpoint has no REST route and no documentation, so `gh api` reaches it by full URL. It is what the web uploader calls, and what `gh --attach` calls.
+
+## Upload
+
+`repository_id` takes the numeric REST id, which the REST repository route carries. The `id` field of `gh repo view --json id` is the GraphQL node id and fails here.
+
+```bash
+repo_id=$(gh api repos/{owner}/{repo} --jq .id)
+
+gh api --method POST \
+  "https://uploads.github.com/user-attachments/assets?repository_id=$repo_id&name=picker-wide.png&content_type=image/png" \
+  --input ./picker-wide.png --jq .url
+```
+
+The response is `{"url": "https://github.com/user-attachments/assets/<uuid>"}`. `--input` sends the file's bytes unmodified, and `gh api` supplies the token, so nothing needs `gh auth token` by hand.
+
+## File Types
+
+Nine types upload, and the extension in `name` must agree with `content_type`. A mismatch fails validation naming both fields.
+
+| Extension | `content_type` |
+| --- | --- |
+| `.png` | `image/png` |
+| `.jpg`, `.jpeg` | `image/jpeg` |
+| `.gif` | `image/gif` |
+| `.webp` | `image/webp` |
+| `.svg` | `image/svg+xml` |
+| `.mp4` | `video/mp4` |
+| `.mov` | `video/quicktime` |
+| `.webm` | `video/webm` |
+
+Anything else comes back as `content_type is not included in the list of allowed content types`. Logs, archives, and PDFs have no path here. Summarize a log into the body rather than attaching it. Images cap at 10 MB and video at 100 MB. The video ceiling varies by account plan. The server can refuse a file under that bound.
+
+## Token and Access
+
+The token needs write access to the repository named by `repository_id`. Read and triage answer 404. A permission problem arrives looking like a missing repository.
+
+A classic PAT, a fine-grained PAT, and the OAuth token behind `gh auth token` all upload. `gh` refuses every other kind before sending, including a GitHub App installation token. That is what an Actions run gets as the default `GITHUB_TOKEN`. A workflow that attaches needs a PAT in its environment.
+
+GitHub Enterprise Server has no upload host. github.com and ghe.com data-residency tenants have one.
+
+## Reference
+
+An image is ordinary markdown. Escape `\`, `[`, and `]` in alt text and replace newlines with spaces, or alt text carrying `](url)` closes the image early and repoints it.
+
+```markdown
+![Wide window](https://github.com/user-attachments/assets/<uuid>)
+```
+
+Video has no markdown syntax. GitHub renders a player when a bare asset URL is the whole of a paragraph. Give it its own line with a blank line on each side.
+
+## Ordering
+
+An upload cannot be undone, and an asset cannot be deleted. Upload once nothing is left that could cancel: after the editor closes, after the confirmation, after the body is final. An asset nothing references is stranded, unreachable, and permanent.
+
+An asset takes the visibility of the repository it was uploaded against once something references it. Until then it answers 404 to everyone except an authenticated uploader. Opening the URL tells you nothing about whether the upload worked.
+
+## The --attach Flag
+
+`gh` is adding a repeatable `--attach` to `gh issue create`, `gh issue edit`, `gh issue comment`, `gh pr create`, `gh pr edit`, and `gh pr comment`. It posts to the same endpoint under the same limits.
+
+```bash
+gh issue comment 87 --body-file report.md --attach './picker-wide.png#The wide layout'
+```
+
+Alt text follows a `#`, and a video takes none. A body that already links the local path gets that reference rewritten to the uploaded URL. A body that does not gets the asset appended.
+
+`gh issue comment --help` says whether the running build has it. Prefer it where it exists. The flag reaches those six commands only, so review comments, review bodies, discussions, releases, commit comments, and gists still upload first and write the URL into the body.


### PR DESCRIPTION
Claude has no way to put a screenshot into an issue or a pull request. Images pasted through the web UI are served from a user-attachments store, reached by POSTing to `uploads.github.com/user-attachments/assets`. That endpoint has no REST route and no documentation. Nothing in the API surface Claude already knows points at it.

`gh` is adding a `--attach` flag for the six issue and PR commands ([cli/cli#13256](https://github.com/cli/cli/issues/13256), stack at [cli/cli#14186](https://github.com/cli/cli/issues/14186)). None of its eight PRs have merged, and the maintainer is aiming for the end of August.

The flag stops at those six commands. Review comments, discussions, releases, and gists keep the raw endpoint as their only path. A bang-execution line resolves whether the running `gh` has the flag when the skill loads, so knowing which path applies costs no model turn.

Every claim about the endpoint is measured against it rather than taken from the writeups that surfaced it:

- The three query parameters, and the 404 that a token without write access gets
- The rejection of `text/plain`, `application/zip`, and `application/pdf`
- The rule that the extension in `name` must agree with `content_type`
- A byte-identical round trip of a 1 MB PNG through `gh api --input`

The token-type allowlist and the size caps are read off the cli/cli implementation.

Removal: the `--attach` half comes out if the flag never ships. The upload half comes out if GitHub documents a REST route, or if `gh` grows to cover the remaining comment surfaces. Absent either, the file keeps earning its cost.