### PR TITLE
bun: repair the 1.4.0 upgrade fallout

### DIFF
--- a/.github/actions/bun-install/action.yml
+++ b/.github/actions/bun-install/action.yml
@@ -6,6 +6,11 @@ runs:
   steps:
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
+      with:
+        # Pinned so a Bun release lands as a reviewable diff. Unpinned, CI
+        # floats to the current release and a runtime behavior change arrives
+        # as an unexplained red build on an untouched branch.
+        bun-version: 1.4.0
 
     - name: Cache dependencies
       uses: actions/cache@v5

--- a/plugins/bun/skills/bun/references/resolution.md
+++ b/plugins/bun/skills/bun/references/resolution.md
@@ -12,7 +12,7 @@ bun --cwd ./packages/app run dev
 
 Never use `.js` extensions in TypeScript imports. Bun resolves `.ts`, `.tsx`, `.jsx`, and `.js` files natively.
 
-```ts
+```ts fragment
 import { handler } from "./routes/auth";  // correct
 import { handler } from "./routes/auth.js";  // wrong
 ```

--- a/user/scripts/statusline.ts
+++ b/user/scripts/statusline.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env bun
 import { mkdirSync } from "node:fs";
 import { basename, dirname } from "node:path";
-import { styleText } from "node:util";
 import { type ContextToken, type DialReport, reportContextDial } from "./context-dial";
 import { effortMarker } from "./effort";
 import { dialGlyph } from "./glyphs";
 import { modelMarker } from "./model";
 import { expandTilde, type RateLimits } from "./rate-limits";
+import { styleText } from "./style";
 
 interface CurrentUsage {
   input_tokens?: number;

--- a/user/scripts/style.ts
+++ b/user/scripts/style.ts
@@ -1,0 +1,9 @@
+import { styleText as styleTextForStream } from "node:util";
+
+// Claude Code always pipes the statusline, so stdout is never a TTY and Bun
+// 1.4.0's styleText drops color on its own. The client renders the escape
+// codes, so opt out of stream detection instead of gating on FORCE_COLOR,
+// which every process the statusline spawns would inherit.
+export function styleText(format: Parameters<typeof styleTextForStream>[0], text: string): string {
+  return styleTextForStream(format, text, { validateStream: false });
+}

--- a/user/scripts/subagent-statusline.test.ts
+++ b/user/scripts/subagent-statusline.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { styleText } from "node:util";
 import { genericGlyph, purposeGlyphs } from "./glyphs";
+import { styleText } from "./style";
 import {
   extractActivity,
   extractModel,

--- a/user/scripts/subagent-statusline.ts
+++ b/user/scripts/subagent-statusline.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env bun
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { styleText } from "node:util";
 import { effortGlyph } from "./effort";
 import { genericGlyph, purposeGlyphs, remoteGlyph } from "./glyphs";
 import { modelMarker } from "./model";
+import { styleText } from "./style";
 
 export interface Task {
   id: string;


### PR DESCRIPTION
CI floated onto Bun 1.4.0 and two unrelated-looking checks went red on an untouched `main`. Both trace to that upgrade, so they're repaired here together.

`Bun.Transpiler.transformSync` got stricter about redeclaration. The import block in `plugins/bun/skills/bun/references/resolution.md` pairs a correct import with the wrong one, so both lines declare `handler` and it can never parse as a single module. `check-md-code` has carried a `fragment` info-string token for exactly this shape since it was written. The fence now uses it.

`styleText` stopped emitting color when stdout is not a TTY. Claude Code always pipes the statusline, so on 1.4.0 both statusline scripts render with no escape codes at all. CI showed this as failing snapshots. What it actually did was turn the statusline monochrome.

`validateStream: false` restores the codes. The new `user/scripts/style.ts` wraps `styleText` with that option so both scripts and the subagent test import one override rather than repeating it across every call site. It sits alongside the `glyphs.ts` and `model.ts` siblings the two scripts already share. `FORCE_COLOR` would also work, but it is process-global and every command the statusline spawns would inherit it.

`oven-sh/setup-bun` was unpinned, which is why a runtime change arrived as a red build with nothing in the log connecting the two. Pinning it means the next Bun release shows up as a diff to review.

## Verification

Swept the tracked markdown for the same never-parses-by-design shape. Three fenced blocks carry `fragment` repo-wide, and each one fails without it. One other correct-versus-wrong pair exists, in `plugins/mac/skills/jxa/SKILL.md`. It keeps its wrong half commented out, so it parses.

The statusline was checked against the piped-stdout path the client actually uses, and it emits the same escape codes it did before the upgrade. The existing snapshots cover the restored output unchanged, so none were rewritten to accommodate this. The remaining failures in the full suite are unrelated and predate this branch.
