### PR TITLE
statusline: keep color when stdout is piped

### DIFF
--- a/.github/actions/bun-install/action.yml
+++ b/.github/actions/bun-install/action.yml
@@ -6,6 +6,11 @@ runs:
   steps:
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
+      with:
+        # Pinned so a Bun release lands as a reviewable diff. Unpinned, CI
+        # floats to the current release and a runtime behavior change arrives
+        # as an unexplained red build on an untouched branch.
+        bun-version: 1.4.0
 
     - name: Cache dependencies
       uses: actions/cache@v5

--- a/user/scripts/statusline.ts
+++ b/user/scripts/statusline.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env bun
 import { mkdirSync } from "node:fs";
 import { basename, dirname } from "node:path";
-import { styleText } from "node:util";
 import { type ContextToken, type DialReport, reportContextDial } from "./context-dial";
 import { effortMarker } from "./effort";
 import { dialGlyph } from "./glyphs";
 import { modelMarker } from "./model";
 import { expandTilde, type RateLimits } from "./rate-limits";
+import { styleText } from "./style";
 
 interface CurrentUsage {
   input_tokens?: number;

--- a/user/scripts/style.ts
+++ b/user/scripts/style.ts
@@ -1,0 +1,9 @@
+import { styleText as styleTextForStream } from "node:util";
+
+// Claude Code always pipes the statusline, so stdout is never a TTY and Bun
+// 1.4.0's styleText drops color on its own. The client renders the escape
+// codes, so opt out of stream detection instead of gating on FORCE_COLOR,
+// which every process the statusline spawns would inherit.
+export function styleText(format: Parameters<typeof styleTextForStream>[0], text: string): string {
+  return styleTextForStream(format, text, { validateStream: false });
+}

--- a/user/scripts/subagent-statusline.test.ts
+++ b/user/scripts/subagent-statusline.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { styleText } from "node:util";
 import { genericGlyph, purposeGlyphs } from "./glyphs";
+import { styleText } from "./style";
 import {
   extractActivity,
   extractModel,

--- a/user/scripts/subagent-statusline.ts
+++ b/user/scripts/subagent-statusline.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env bun
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { styleText } from "node:util";
 import { effortGlyph } from "./effort";
 import { genericGlyph, purposeGlyphs, remoteGlyph } from "./glyphs";
 import { modelMarker } from "./model";
+import { styleText } from "./style";
 
 export interface Task {
   id: string;


### PR DESCRIPTION
Bun 1.4.0 changed `styleText` to suppress color when stdout is not a TTY. Claude Code always pipes the statusline, so both statusline scripts render entirely without escape codes on that runtime. Failing snapshots were the symptom, and the visible break is a monochrome statusline.

`validateStream: false` restores the codes at the call site. The new `user/scripts/style.ts` wraps `styleText` with that option so both scripts and the subagent test import one override rather than repeating it across every call site. `FORCE_COLOR` would work too, but it is process-global and every command the statusline spawns would inherit it.

`oven-sh/setup-bun` was unpinned, so CI floated onto 1.4.0 and turned red on an untouched `main` with nothing in the log connecting the failure to a runtime upgrade. Pinning it means the next Bun release shows up as a diff to review.

Verified against the piped-stdout path the client actually uses, which emits the same escape codes as it did before the upgrade. The existing snapshots cover the restored output unchanged, so none were rewritten to accommodate this.
