### PR TITLE
lead: coordinate a multi-PR project

### DIFF
--- a/user/skills/lead/SKILL.md
+++ b/user/skills/lead/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: lead
+description: >-
+  Lead a multi-PR project: scope issues into pull requests, dispatch with herdr
+argument-hint: "<project url | issue set>"
+disable-model-invocation: true
+---
+
+# Lead
+
+You are the lead agent working on:
+
+$ARGUMENTS
+
+You coordinate work in this herdr space, with a tab per active issue.
+
+## Scope
+
+Read the tracker project and the code it touches. Then decide, in coordination with the user:
+
+- Which issues map to which proposed PRs
+- Boundary/scope per PR
+- Blockers/parallelization
+- Any blocking decisions
+
+Grill me on any ambiguous requirements before dispatching.
+
+## Dispatch
+
+Per PR: one worktree, one agent. Load `herdr` for the mechanics. Open worktrees as tabs in this workspace.
+
+Write the brief to `tmp/BRIEF.md` in the worktree so it survives compaction, then prompt the agent to read it and execute end to end.
+
+Brief should have:
+
+- The (settled) decision that unblocks the work
+- Scope
+- Finish with `/ship`
+- What to report: PR URL, anything that changes the plan for the remaining PRs.
+
+Name branch and agent after the issue.
+
+## Collect
+
+Prompt panes for changes rather than directly executing them.
+
+Focus on blocked agents and coordinating questions the user should answer.
+


### PR DESCRIPTION
Adds a `/lead` skill for a project whose work spans several pull requests. The lead session scopes the issue set into PRs, then dispatches each one to a sibling herdr agent in its own worktree, keeping its own context on sequencing rather than filling it with code.

Extracted from leading the Delete Intelligence project. What worked there was a tab per issue in one workspace and a `tmp/BRIEF.md` written into each worktree, which survives the dispatched agent's compaction where a prompt does not. Each brief asks for the PR URL plus anything the agent found that changes the plan for the remaining PRs, so a report feeds the next dispatch.

Dispatch mechanics stay in `herdr` and finishing stays in `/ship`, so this file carries no command surface that can go stale. `disable-model-invocation` keeps it slash-only and out of the always-on catalog, so it costs nothing until invoked. Retire it if `skill-config-vs-observed` shows it never fires.
