### PR TITLE
herdr: track integration v8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ node_modules/
 # The coverage tooling lives in a directory named `coverage`. Re-include it
 # against a global `coverage` ignore so the source stays tracked.
 !scripts/coverage/
+
+# terminal-browser's installer drops a skill symlink into ~/.claude/skills,
+# which is this repo's user/skills. The skill belongs to that install, not here.
+/user/skills/terminal-browser

--- a/user/hooks/herdr-agent-state.sh
+++ b/user/hooks/herdr-agent-state.sh
@@ -3,7 +3,7 @@
 # managed by herdr; reinstalling or updating the integration overwrites this file.
 # add custom hooks beside this file instead of editing it.
 # HERDR_INTEGRATION_ID=claude
-# HERDR_INTEGRATION_VERSION=7
+# HERDR_INTEGRATION_VERSION=8
 
 set -eu
 


### PR DESCRIPTION
Records the herdr Claude integration at v8. The installer rewrites `user/hooks/herdr-agent-state.sh` in place, so every herdr release leaves the deployed clone at `~/.claude-repo` dirty and `claude-upgrade` refuses to sync until the bump is committed.

Its `settings.json` edit stays discarded, as before. The installer cannot recognize the committed `SessionStart` entry, which spells the hook path with `$HOME` rather than a hardcoded home directory, so a reinstall appends a second entry that fires the same hook twice.

The other thing holding up the sync was `user/skills/terminal-browser`, a symlink that terminal-browser's installer drops into `~/.claude/skills`. It belongs to that install, so it is now ignored.
