### PR TITLE
claude-code: add writing doctrine references

### DIFF
--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -103,9 +103,13 @@ Write skill prose as instructions, in the imperative, with conditions before ins
 
 A skill is a folder, not just a markdown file. Keep `SKILL.md` a concise hub and push details into `references/`, `scripts/`, and `assets/`. Tell Claude what files exist and when to read them. Organize references by domain and gate conditional detail behind a pointer, so a question about one domain loads only that file.
 
+The pointer's wording decides whether Claude reaches the file at all, so sharpen the wording before concluding that material has to be inlined. See [references/information-hierarchy.md](references/information-hierarchy.md) for the two budgets a document spends, the ladder each piece sits on, co-location, and when a document earns a split.
+
 #### Don't Railroad Claude
 
 State the goal and constraints, then leave room to adapt. Prefer outcome-oriented instructions over step-by-step scripts.
+
+Goal and constraints still need a done-state: the observable condition that says the work is finished. A vague one lets Claude stop early. A demanding one ("every modified model accounted for") drives thorough work without adding a step, and it binds a body of flat reference the same way it binds a sequence. See [references/levers.md](references/levers.md) for completion criteria, leading words, and pruning.
 
 #### First-Run Setup
 
@@ -183,6 +187,8 @@ A skill-scoped PostToolUse hook runs `skill-lint` automatically when SKILL.md fi
 
 Load detailed guides as needed:
 
+- **[references/information-hierarchy.md](references/information-hierarchy.md)** - Context and cognitive load, context pointers, the step/reference ladder, progressive disclosure, co-location, splitting
+- **[references/levers.md](references/levers.md)** - Completion criteria, leading words, the positive form, pruning
 - **[references/patterns.md](references/patterns.md)** - Dynamic context injection, subagent integration, skill-scoped hooks, anti-patterns
 - **[references/plain-language.md](references/plain-language.md)** - Plain-language rules for skill prose and the conversion procedure
 - **[references/troubleshooting.md](references/troubleshooting.md)** - Activation issues, plugin cache

--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -103,7 +103,7 @@ Write skill prose as instructions, in the imperative, with conditions before ins
 
 A skill is a folder, not just a markdown file. Keep `SKILL.md` a concise hub and push details into `references/`, `scripts/`, and `assets/`. Tell Claude what files exist and when to read them. Organize references by domain and gate conditional detail behind a pointer, so a question about one domain loads only that file.
 
-See [references/information-hierarchy.md](references/information-hierarchy.md) for the two budgets a document spends, the ladder each piece sits on, and when a document earns a split.
+See [references/information-hierarchy.md](references/information-hierarchy.md) for what body, reference, and pointer each cost, how to word a pointer, and when a document earns a split.
 
 #### Don't Railroad Claude
 
@@ -187,8 +187,8 @@ A skill-scoped PostToolUse hook runs `skill-lint` automatically when SKILL.md fi
 
 Load detailed guides as needed:
 
-- **[references/information-hierarchy.md](references/information-hierarchy.md)** - Context and cognitive load, context pointers, the step/reference ladder, progressive disclosure, co-location, splitting
-- **[references/levers.md](references/levers.md)** - Completion criteria, leading words, the positive form, pruning
+- **[references/information-hierarchy.md](references/information-hierarchy.md)** - What body, reference, and pointer cost, pointer wording, splitting
+- **[references/levers.md](references/levers.md)** - Completion criteria, leading words, positive form, pruning
 - **[references/patterns.md](references/patterns.md)** - Dynamic context injection, subagent integration, skill-scoped hooks, anti-patterns
 - **[references/plain-language.md](references/plain-language.md)** - Plain-language rules for skill prose and the conversion procedure
 - **[references/troubleshooting.md](references/troubleshooting.md)** - Activation issues, plugin cache

--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -103,13 +103,13 @@ Write skill prose as instructions, in the imperative, with conditions before ins
 
 A skill is a folder, not just a markdown file. Keep `SKILL.md` a concise hub and push details into `references/`, `scripts/`, and `assets/`. Tell Claude what files exist and when to read them. Organize references by domain and gate conditional detail behind a pointer, so a question about one domain loads only that file.
 
-The pointer's wording decides whether Claude reaches the file at all, so sharpen the wording before concluding that material has to be inlined. See [references/information-hierarchy.md](references/information-hierarchy.md) for the two budgets a document spends, the ladder each piece sits on, co-location, and when a document earns a split.
+See [references/information-hierarchy.md](references/information-hierarchy.md) for the two budgets a document spends, the ladder each piece sits on, and when a document earns a split.
 
 #### Don't Railroad Claude
 
 State the goal and constraints, then leave room to adapt. Prefer outcome-oriented instructions over step-by-step scripts.
 
-Goal and constraints still need a done-state: the observable condition that says the work is finished. A vague one lets Claude stop early. A demanding one ("every modified model accounted for") drives thorough work without adding a step, and it binds a body of flat reference the same way it binds a sequence. See [references/levers.md](references/levers.md) for completion criteria, leading words, and pruning.
+Goal and constraints still need a done-state: the observable condition that says the work is finished. A vague one lets Claude stop early. A demanding one drives thorough work without adding a step. See [references/levers.md](references/levers.md) for completion criteria, leading words, and pruning.
 
 #### First-Run Setup
 

--- a/plugins/claude-code/skills/skill/references/information-hierarchy.md
+++ b/plugins/claude-code/skills/skill/references/information-hierarchy.md
@@ -1,0 +1,83 @@
+# Information Hierarchy
+
+Where each piece of a document sits, and what it costs to put it there. Applies to any document an agent reads: a skill, a `CLAUDE.md`, a rule under `.claude/rules/`, a file reached by a pointer.
+
+## Two Budgets
+
+Every document spends one of two budgets, and which one it spends is decided by how the agent reaches it.
+
+#### Context Load
+
+Material sitting in the window every turn, spending tokens and attention whether or not it fires. A skill description is context load. So is every line of `CLAUDE.md` and every always-on rule.
+
+Three local facts set the price:
+
+- A model-invocable skill spends its description on every session in the catalog. `disable-model-invocation: true` drops it from the catalog entirely, so a user-invoked skill costs zero until it runs.
+- An invoked skill's body is re-injected in full at every compaction, so `SKILL.md` size is a recurring per-compaction cost. Keep bodies under roughly 4k tokens.
+- A `references/` file costs nothing until its pointer fires.
+
+#### Cognitive Load
+
+The cost on the human: knowing which documents exist and when to reach for each. The human is the index.
+
+This one is worth spending. Cognitive load is the price of human agency, so put it where human judgment belongs and take it away where the judgment is mechanical. A user-invoked skill trades context load for cognitive load deliberately: it costs nothing until the user decides it applies.
+
+Material behind a pointer escapes context load for the price of the pointer's own line. Material with no pointer at all rides entirely on cognitive load.
+
+## Context Pointers
+
+A context pointer is a reference held in context that names out-of-context material and encodes the condition for reaching it. A skill's `description` is one. A line in `CLAUDE.md` naming a rule file is the same object. A `See [references/patterns.md]` link inside a `SKILL.md` is one too.
+
+The pointer's wording decides when the agent reaches the material and how reliably. The target has no say. When must-have material sits behind a weakly worded pointer, the result is a variance bug: some runs find it and some do not. Sharpen the wording first. Inline the material only after sharpening has failed.
+
+A pointer does two jobs. It states what the material is, and it lists the branches that should trigger reaching it. A branch is a distinct case the document handles, so different runs take different paths through it.
+
+Every word of an always-loaded pointer costs on every turn, so prune it harder than the body:
+
+- Front-load the trigger word. The pointer is where it does its work.
+- One trigger per branch. Synonyms that rename a single branch are one branch written twice.
+- Cut identity the body already carries.
+
+## The Ladder
+
+A document is built from two content types. Steps are the ordered actions the agent performs. Reference is definitions, rules, and facts consulted on demand. The two mix freely: all steps (a runbook), all reference (a review's angle list), or both.
+
+The decision for each piece is where it sits on a ladder ranked by how immediately the agent needs it:
+
+1. **In-file step**: what the agent does, in order. The primary tier.
+2. **In-file reference**: consulted on demand while the document runs. Often a flat peer set, such as every rule of a review on one rung. That flatness is a legitimate arrangement.
+3. **Disclosed reference**: pushed into a separate file behind a pointer, loaded only when the pointer fires. Spans a sibling in `references/` through a fully external doc any skill can point at.
+
+Push too little down and the top bloats. Push too much down and the agent misses material it needed. That tension is the whole decision.
+
+## Progressive Disclosure
+
+Progressive disclosure is the move down the ladder: out of the main file, behind a pointer, so the top stays legible. Token savings are a side effect. The point is protecting the hierarchy.
+
+Branching is the cleanest test. Inline what every branch needs. Push behind a pointer what only some branches reach.
+
+When a document has steps, in-file reference that belongs one rung lower buries them, and attending to a step becomes a coin flip. Disclosure is a variance lever before it is a legibility one.
+
+## Co-location
+
+The ladder decides how far down a piece sits. Co-location decides what sits beside it once there. Keep a concept's definition, its rules, and its caveats under one heading so reading one part brings its neighbors along.
+
+The test: the document should read like documentation written for the agent. Grouped material reads that way. Scattered material reads like a changelog.
+
+Co-location is a different failure from duplication. Duplication repeats one meaning in two places. Scattering fragments one meaning across many.
+
+## Sprawl
+
+A document can be too long while every line in it is live and unique. Attention thins across the excess, and every extra line is one more to keep relevant.
+
+The cure is the ladder. Disclose reference behind pointers, then split by branch or by sequence so each path carries only what it needs.
+
+## Splitting
+
+Splitting one document into two always spends one of the two budgets, so the cut has to earn it.
+
+Split by sequence when the later steps tempt the agent to rush the one in front of it. Keeping them out of view drives more digging on the current task. The reverse holds as a warning: merging two sequences exposes each step to everything that follows and invites the rush.
+
+Hiding later steps only works across a real context break, meaning a hand-off or a subagent dispatch. An inline call leaves them in context and clears nothing.
+
+Split by invocation when two branches of one skill want different frontmatter: a different model, a different `allowed-tools`, or one branch the model should route to while the other stays user-invoked.

--- a/plugins/claude-code/skills/skill/references/information-hierarchy.md
+++ b/plugins/claude-code/skills/skill/references/information-hierarchy.md
@@ -1,81 +1,43 @@
 # Information Hierarchy
 
-Where each piece of an agent-facing document sits, and what that placement costs. Applies to a skill, a `CLAUDE.md`, a rule under `.claude/rules/`, and any file reached by a pointer.
+Where material goes in a document an agent reads: a skill, a `CLAUDE.md`, a rule under `.claude/rules/`, a file behind a pointer.
 
-## Two Budgets
+## Cost
 
-Every document spends one of two budgets. How the agent reaches the document decides which.
+- Material in an always-loaded file spends tokens and attention every turn, whether or not it fires.
+- Material behind a pointer costs only the pointer's own line.
+- Material nothing points at costs nothing and is reached only when the human remembers it.
 
-#### Context Load
+A model-invocable skill's description costs tokens every session. Keep an invoked skill's body under roughly 4k tokens, since it is re-injected in full at every compaction. A `references/` file costs nothing until its pointer fires.
 
-Tokens and attention spent every turn, whether or not the material fires. A skill description, a `CLAUDE.md` line, and an always-on rule are all context load. Three prices set the cost:
+## Placement
 
-- A model-invocable skill spends its description on every session.
-- An invoked skill's body is re-injected at every compaction. Keep bodies under roughly 4k tokens.
-- A `references/` file costs nothing until its pointer fires.
+Put material in the body when every run needs it. Put it in `references/` when only some runs reach it.
 
-#### Cognitive Load
+Move reference that only some branches need out of a step sequence, even when it is short. Leaving it in place makes the agent attend to the surrounding steps inconsistently across runs, which is a cost beyond the tokens.
 
-What the human must hold: which documents exist, and when each one applies.
+Bodies hold two kinds of material: the ordered actions the agent performs, and the definitions and rules it consults while performing them. Keep a flat list of peer rules flat.
 
-Spend cognitive load where human judgment decides the outcome, and remove it where the judgment is mechanical. Making a skill user-invoked trades context load for cognitive load, since it then costs nothing until the user decides it applies.
+## Pointers
 
-Material behind a pointer costs only the pointer's own line. Material with no pointer costs no tokens and is reached only when the human remembers it.
+A pointer names material outside the context and states when to reach it. A skill's `description`, a `CLAUDE.md` line naming a rule file, and a `See [references/patterns.md]` link are all pointers.
 
-## Context Pointers
+Wording decides whether the agent reaches the material. Sharpen the wording before inlining anything.
 
-A context pointer is a reference held in context that names out-of-context material and states the condition for reaching it. A skill's `description` is a pointer. So is a `CLAUDE.md` line naming a rule file, and a `See [references/patterns.md]` link inside a `SKILL.md`.
-
-The pointer's wording decides when the agent reaches the material and how reliably. The target has no effect on this. When required material sits behind a weak pointer, some runs find it and some do not. Sharpen the wording first, and inline the material only after sharpening fails.
-
-Write a pointer to do two things: state what the material is, and list the branches that should trigger reaching it. A branch is a distinct case the document handles.
-
-Prune a pointer harder than the body, because every word of it costs on every turn:
+Write a pointer to state what the material is and which cases should trigger it. Prune it harder than the body, since it costs every turn:
 
 - Put the trigger word first.
-- Write one trigger per branch. Synonyms renaming a single branch are one branch written twice.
+- One trigger per case. Synonyms for one case are that case written twice.
 - Cut identity the body already carries.
 
-## The Ladder
+## Readability
 
-A document holds two content types. Steps are the ordered actions the agent performs. Reference is definitions, rules, and facts consulted on demand. A document can be all steps, all reference, or both.
+Keep a concept's definition, rules, and caveats under one heading. Test a section by reading it alone: it should answer the question it names without sending the reader elsewhere in the file.
 
-Place each piece on a ladder ranked by how immediately the agent needs it:
-
-1. **In-file step**: what the agent does, in order.
-2. **In-file reference**: consulted on demand while the document runs. A flat set of peer rules on one rung is a correct arrangement, so keep it flat.
-3. **Disclosed reference**: a separate file behind a pointer, loaded when the pointer fires. Ranges from a sibling in `references/` to an external doc any skill can point at.
-
-Pushing too little down bloats the top. Pushing too much down hides material the agent needs.
-
-## Progressive Disclosure
-
-Move material down the ladder, out of the main file and behind a pointer, so the top stays legible.
-
-Use branching as the test. Inline what every branch needs, and disclose what only some branches reach.
-
-In a document with steps, in-file reference that belongs one rung lower buries them, and the agent then attends to a buried step inconsistently across runs. Disclose to reduce that variance, not only to save tokens.
-
-## Co-Location
-
-Once the ladder decides how far down a piece sits, co-location decides what sits beside it. Keep a concept's definition, rules, and caveats under one heading.
-
-Test a section by reading it alone: it should answer the question it names without sending the reader elsewhere in the file.
-
-Co-location and duplication are separate failures. Duplication repeats one meaning in two places. Scattering splits one meaning across many.
-
-## Sprawl
-
-A document can be too long while every line in it is live and unique. Attention thins across the excess, and every added line is another to keep current.
-
-Cure sprawl with the ladder. Disclose reference behind pointers, then split by branch or by sequence so each path carries only what it needs.
+A document can be too long even when every line is live and unique. Attention thins across the excess. Move reference behind pointers, then split by case or by sequence so each path carries only what it needs.
 
 ## Splitting
 
-Splitting one document into two spends one of the two budgets, so split only when the cut pays for itself.
+Split a sequence when later steps tempt the agent to finish the current one early. That works only across a real context break: a hand-off or a subagent dispatch. An inline call leaves the later steps in context.
 
-Split by sequence when later steps tempt the agent to finish the current one early. Hiding them drives more work on the step in front of it. Merging two sequences has the reverse effect, exposing each step to everything that follows.
-
-Hiding later steps requires a real context break, meaning a hand-off or a subagent dispatch. An inline call leaves them in context.
-
-Split by invocation when two branches of one skill need different frontmatter: a different model, different `allowed-tools`, or one branch routed by the model while the other stays user-invoked.
+Split by invocation when two branches need different frontmatter: a different model, different `allowed-tools`, or one branch routed by the model while the other stays user-invoked.

--- a/plugins/claude-code/skills/skill/references/information-hierarchy.md
+++ b/plugins/claude-code/skills/skill/references/information-hierarchy.md
@@ -1,83 +1,81 @@
 # Information Hierarchy
 
-Where each piece of a document sits, and what it costs to put it there. Applies to any document an agent reads: a skill, a `CLAUDE.md`, a rule under `.claude/rules/`, a file reached by a pointer.
+Where each piece of an agent-facing document sits, and what that placement costs. Applies to a skill, a `CLAUDE.md`, a rule under `.claude/rules/`, and any file reached by a pointer.
 
 ## Two Budgets
 
-Every document spends one of two budgets, and which one it spends is decided by how the agent reaches it.
+Every document spends one of two budgets. How the agent reaches the document decides which.
 
 #### Context Load
 
-Material sitting in the window every turn, spending tokens and attention whether or not it fires. A skill description is context load. So is every line of `CLAUDE.md` and every always-on rule.
+Tokens and attention spent every turn, whether or not the material fires. A skill description, a `CLAUDE.md` line, and an always-on rule are all context load. Three prices set the cost:
 
-Three local facts set the price:
-
-- A model-invocable skill spends its description on every session in the catalog. `disable-model-invocation: true` drops it from the catalog entirely, so a user-invoked skill costs zero until it runs.
-- An invoked skill's body is re-injected in full at every compaction, so `SKILL.md` size is a recurring per-compaction cost. Keep bodies under roughly 4k tokens.
+- A model-invocable skill spends its description on every session.
+- An invoked skill's body is re-injected at every compaction. Keep bodies under roughly 4k tokens.
 - A `references/` file costs nothing until its pointer fires.
 
 #### Cognitive Load
 
-The cost on the human: knowing which documents exist and when to reach for each. The human is the index.
+What the human must hold: which documents exist, and when each one applies.
 
-This one is worth spending. Cognitive load is the price of human agency, so put it where human judgment belongs and take it away where the judgment is mechanical. A user-invoked skill trades context load for cognitive load deliberately: it costs nothing until the user decides it applies.
+Spend cognitive load where human judgment decides the outcome, and remove it where the judgment is mechanical. Making a skill user-invoked trades context load for cognitive load, since it then costs nothing until the user decides it applies.
 
-Material behind a pointer escapes context load for the price of the pointer's own line. Material with no pointer at all rides entirely on cognitive load.
+Material behind a pointer costs only the pointer's own line. Material with no pointer costs no tokens and is reached only when the human remembers it.
 
 ## Context Pointers
 
-A context pointer is a reference held in context that names out-of-context material and encodes the condition for reaching it. A skill's `description` is one. A line in `CLAUDE.md` naming a rule file is the same object. A `See [references/patterns.md]` link inside a `SKILL.md` is one too.
+A context pointer is a reference held in context that names out-of-context material and states the condition for reaching it. A skill's `description` is a pointer. So is a `CLAUDE.md` line naming a rule file, and a `See [references/patterns.md]` link inside a `SKILL.md`.
 
-The pointer's wording decides when the agent reaches the material and how reliably. The target has no say. When must-have material sits behind a weakly worded pointer, the result is a variance bug: some runs find it and some do not. Sharpen the wording first. Inline the material only after sharpening has failed.
+The pointer's wording decides when the agent reaches the material and how reliably. The target has no effect on this. When required material sits behind a weak pointer, some runs find it and some do not. Sharpen the wording first, and inline the material only after sharpening fails.
 
-A pointer does two jobs. It states what the material is, and it lists the branches that should trigger reaching it. A branch is a distinct case the document handles, so different runs take different paths through it.
+Write a pointer to do two things: state what the material is, and list the branches that should trigger reaching it. A branch is a distinct case the document handles.
 
-Every word of an always-loaded pointer costs on every turn, so prune it harder than the body:
+Prune a pointer harder than the body, because every word of it costs on every turn:
 
-- Front-load the trigger word. The pointer is where it does its work.
-- One trigger per branch. Synonyms that rename a single branch are one branch written twice.
+- Put the trigger word first.
+- Write one trigger per branch. Synonyms renaming a single branch are one branch written twice.
 - Cut identity the body already carries.
 
 ## The Ladder
 
-A document is built from two content types. Steps are the ordered actions the agent performs. Reference is definitions, rules, and facts consulted on demand. The two mix freely: all steps (a runbook), all reference (a review's angle list), or both.
+A document holds two content types. Steps are the ordered actions the agent performs. Reference is definitions, rules, and facts consulted on demand. A document can be all steps, all reference, or both.
 
-The decision for each piece is where it sits on a ladder ranked by how immediately the agent needs it:
+Place each piece on a ladder ranked by how immediately the agent needs it:
 
-1. **In-file step**: what the agent does, in order. The primary tier.
-2. **In-file reference**: consulted on demand while the document runs. Often a flat peer set, such as every rule of a review on one rung. That flatness is a legitimate arrangement.
-3. **Disclosed reference**: pushed into a separate file behind a pointer, loaded only when the pointer fires. Spans a sibling in `references/` through a fully external doc any skill can point at.
+1. **In-file step**: what the agent does, in order.
+2. **In-file reference**: consulted on demand while the document runs. A flat set of peer rules on one rung is a correct arrangement, so keep it flat.
+3. **Disclosed reference**: a separate file behind a pointer, loaded when the pointer fires. Ranges from a sibling in `references/` to an external doc any skill can point at.
 
-Push too little down and the top bloats. Push too much down and the agent misses material it needed. That tension is the whole decision.
+Pushing too little down bloats the top. Pushing too much down hides material the agent needs.
 
 ## Progressive Disclosure
 
-Progressive disclosure is the move down the ladder: out of the main file, behind a pointer, so the top stays legible. Token savings are a side effect. The point is protecting the hierarchy.
+Move material down the ladder, out of the main file and behind a pointer, so the top stays legible.
 
-Branching is the cleanest test. Inline what every branch needs. Push behind a pointer what only some branches reach.
+Use branching as the test. Inline what every branch needs, and disclose what only some branches reach.
 
-When a document has steps, in-file reference that belongs one rung lower buries them, and attending to a step becomes a coin flip. Disclosure is a variance lever before it is a legibility one.
+In a document with steps, in-file reference that belongs one rung lower buries them, and the agent then attends to a buried step inconsistently across runs. Disclose to reduce that variance, not only to save tokens.
 
-## Co-location
+## Co-Location
 
-The ladder decides how far down a piece sits. Co-location decides what sits beside it once there. Keep a concept's definition, its rules, and its caveats under one heading so reading one part brings its neighbors along.
+Once the ladder decides how far down a piece sits, co-location decides what sits beside it. Keep a concept's definition, rules, and caveats under one heading.
 
-The test: the document should read like documentation written for the agent. Grouped material reads that way. Scattered material reads like a changelog.
+Test a section by reading it alone: it should answer the question it names without sending the reader elsewhere in the file.
 
-Co-location is a different failure from duplication. Duplication repeats one meaning in two places. Scattering fragments one meaning across many.
+Co-location and duplication are separate failures. Duplication repeats one meaning in two places. Scattering splits one meaning across many.
 
 ## Sprawl
 
-A document can be too long while every line in it is live and unique. Attention thins across the excess, and every extra line is one more to keep relevant.
+A document can be too long while every line in it is live and unique. Attention thins across the excess, and every added line is another to keep current.
 
-The cure is the ladder. Disclose reference behind pointers, then split by branch or by sequence so each path carries only what it needs.
+Cure sprawl with the ladder. Disclose reference behind pointers, then split by branch or by sequence so each path carries only what it needs.
 
 ## Splitting
 
-Splitting one document into two always spends one of the two budgets, so the cut has to earn it.
+Splitting one document into two spends one of the two budgets, so split only when the cut pays for itself.
 
-Split by sequence when the later steps tempt the agent to rush the one in front of it. Keeping them out of view drives more digging on the current task. The reverse holds as a warning: merging two sequences exposes each step to everything that follows and invites the rush.
+Split by sequence when later steps tempt the agent to finish the current one early. Hiding them drives more work on the step in front of it. Merging two sequences has the reverse effect, exposing each step to everything that follows.
 
-Hiding later steps only works across a real context break, meaning a hand-off or a subagent dispatch. An inline call leaves them in context and clears nothing.
+Hiding later steps requires a real context break, meaning a hand-off or a subagent dispatch. An inline call leaves them in context.
 
-Split by invocation when two branches of one skill want different frontmatter: a different model, a different `allowed-tools`, or one branch the model should route to while the other stays user-invoked.
+Split by invocation when two branches of one skill need different frontmatter: a different model, different `allowed-tools`, or one branch routed by the model while the other stays user-invoked.

--- a/plugins/claude-code/skills/skill/references/levers.md
+++ b/plugins/claude-code/skills/skill/references/levers.md
@@ -1,0 +1,70 @@
+# Levers
+
+Three things that change what an agent does with a document: how each unit of work ends, which words anchor its behavior, and what gets removed. Companion to [information-hierarchy.md](information-hierarchy.md), which covers where material sits.
+
+## Completion Criteria
+
+Every unit of work ends on a completion criterion, the condition that tells the agent it is done. Two properties make it a lever.
+
+#### Clarity
+
+Can the agent tell done from not-done? A vague bound such as "understanding reached" invites premature completion: ending the work before it is genuinely finished, attention already sliding toward being done. The visible work still ahead supplies the pull. The criterion's clarity supplies the resistance.
+
+Sharpen the bound first. That fix is local and cheap. Only when the bound is irreducibly fuzzy and you have watched the agent rush it should you split the sequence to hide what follows, and that split works only across a real context break (see Splitting in [information-hierarchy.md](information-hierarchy.md)).
+
+#### Demand
+
+How much the criterion requires. "Every modified model accounted for" forces thorough work where "produce a change list" lets the agent stop at three items. Demand drives the digging the agent does inside the work, latent in the wording rather than spelled out as its own instruction.
+
+Demand is not step-bound. "Every rule applied" binds a body of flat reference the same way "every step done" binds a sequence, which is how an all-reference document still carries an exhaustiveness bar. State the observable done-state, and the agent keeps its freedom over how to reach it.
+
+The strongest criteria are both checkable and exhaustive.
+
+## Leading Words
+
+A leading word is a compact concept already living in the model's pretraining that the agent thinks with while running the document. Repeated as a token and never as a sentence, it accumulates a distributed definition across the places it appears and anchors a whole region of behavior in a handful of tokens, because it recruits priors the model already holds.
+
+`LANGUAGE.md` in `improve-codebase-architecture` is this technique at full size: seam, depth, adapter, locality. Each word carries a paragraph of meaning that never has to be restated at the call site.
+
+Coining your own word works when you define it clearly, but an invented word recruits nothing. You pay in definition tokens what a pretrained word gives away. Look for an existing word first.
+
+A leading word anchors twice. In the body it anchors execution: the agent applies the same behavior every time the word appears, and inside flat reference the word focuses attention on a class of thing to look for. In a pointer it anchors invocation: when the same word appears in prompts, in docs, and in the code, the agent links that shared language to the material and reaches it more reliably.
+
+Hunt for passages that collapse into one token. A triad spelled out at three sites. A pointer spending a sentence gesturing at one idea.
+
+- "fast, deterministic, low-overhead" collapses to *tight*, as in a tight loop.
+- "a loop you believe in" collapses to *red*, turning a fuzzy gate into a binary state the agent can observe. The loop goes red on the bug or it does not.
+
+Assume any document you inherit is carrying restatements that a leading word retires. Go find them.
+
+#### The Positive Form
+
+Steering by prohibition drags the forbidden behavior into context and makes it more available. Say *don't think of an elephant* and the elephant is all there is. The negation is a weak modifier that the strongly activated concept runs straight over, so the ban half-reads as an instruction.
+
+State the target behavior instead, so the banned one is never spoken. "Write one-line comments" beats a rule against long ones. A prohibition earns a place only as a hard guardrail with no positive phrasing available, and even then it should carry the positive target beside it so attention lands on what to do.
+
+## Pruning
+
+#### Single Source of Truth
+
+Keep each meaning in one authoritative place, so changing the behavior is a one-place edit. The same meaning in two places costs maintenance and tokens, and it inflates that meaning's apparent rank on the hierarchy past its real one. This is the accidental inverse of a leading word, which repeats a token on purpose and the meaning never.
+
+#### Cache and Environment
+
+The environment is a source of truth too: `package.json` scripts, config files, the directory layout, `--help` output. A document that restates it is a cache, a copy of a lookup, earning its load only when the lookup is expensive.
+
+Cache what the agent cannot find by looking: the unwritten convention, the reason behind a choice, the gotcha no config confesses. Leave one-file and one-command lookups to the environment, where they cannot go stale. `herdr`'s skill states that `--help` enumerates every enum flag, which retires every flag table that would otherwise have to be maintained beside it.
+
+#### No-ops
+
+Hunt sentence by sentence for instructions the model already obeys by default. Each one pays load to say nothing.
+
+The test is model-relative rather than reader-relative: does this line change behavior against the default? Two people disagreeing about a no-op are disagreeing about the default, and they settle it by running the document rather than by arguing. When a sentence fails the test, delete the whole sentence rather than trimming words from it.
+
+The test grades leading words too. A word too weak to beat the default, such as *be thorough* when the agent is already thorough-ish, is a no-op. The fix is a stronger word, not a different technique.
+
+#### Sediment
+
+Check every line for relevance: does it still bear on what the document does? A line loses relevance by never bearing on the task, which covers exposition and branches that should have been disclosed, or by going stale as the world it describes moves.
+
+Without a pruning discipline, the default outcome is sediment: stale layers that settle because adding feels safe and removing feels risky, until finding what is still live means coring down through them. Shorter documents stay relevant more easily. This is the same discipline the repo's curation rule applies to skills, hooks, and wordlist entries, one level down.

--- a/plugins/claude-code/skills/skill/references/levers.md
+++ b/plugins/claude-code/skills/skill/references/levers.md
@@ -1,70 +1,58 @@
 # Levers
 
-What changes an agent's behavior in a document: how each unit of work ends, which words anchor the behavior, and what gets removed. Companion to [information-hierarchy.md](information-hierarchy.md), which covers where material sits.
-
 ## Completion Criteria
 
-End every unit of work on a completion criterion: the condition that tells the agent the work is done. Two properties make it a lever.
+End every unit of work on a completion criterion: the condition that tells the agent the work is done.
 
 #### Clarity
 
-Write a criterion the agent can check. A vague bound such as "understanding reached" lets the agent stop before the work is finished, because visible remaining work pulls toward finishing the current one.
+Write a criterion the agent can check. A vague bound such as "understanding reached" lets the agent stop early.
 
-Sharpen the bound first, since that fix is local and cheap. Split the sequence to hide later work only when the bound cannot be sharpened and you have observed the agent stopping early. That split works only across a real context break (see Splitting in [information-hierarchy.md](information-hierarchy.md)).
+Sharpen the bound first. Split the sequence to hide later work only when the bound cannot be sharpened and you have observed the agent stopping early. That split works only across a real context break (see Splitting in [information-hierarchy.md](information-hierarchy.md)).
 
 #### Demand
 
-Write a criterion that requires the work you want. "Every modified model accounted for" forces a full pass where "produce a change list" lets the agent stop at three items. Demand drives the digging the agent does inside the work, without naming that digging as its own instruction.
+Write a criterion that requires the work you want. "Every modified model accounted for" forces a full pass. "Produce a change list" lets the agent stop at three items.
 
-Demand does not require steps. "Every rule applied" bounds a body of flat reference the same way "every step done" bounds a sequence, so an all-reference document can carry an exhaustiveness bar.
-
-Make criteria both checkable and exhaustive.
+Demand does not require steps. "Every rule applied" bounds a flat reference document the same way "every step done" bounds a sequence.
 
 ## Leading Words
 
-A leading word is a compact concept from the model's pretraining, used as a repeated token rather than restated as a sentence. It accumulates a definition across the places it appears and anchors a region of behavior in few tokens, because the model already holds the priors.
+A leading word is a compact concept from the model's pretraining, reused as the same token instead of restated as a sentence. `LANGUAGE.md` in `improve-codebase-architecture` runs on four of them: seam, depth, adapter, locality.
 
-`LANGUAGE.md` in `improve-codebase-architecture` uses this at full size: seam, depth, adapter, locality. Each word carries a paragraph of meaning that the call site never restates.
+Choose an existing word before coining one. A coined word works only when the document defines it clearly.
 
-Choose an existing word before coining one. A coined word works when the document defines it clearly, but it recruits no priors, so you pay in definition tokens what a pretrained word supplies free.
+In the body, the same word produces the same behavior at each appearance, and inside flat reference it names the class of thing to look for. In a pointer, share the word across prompts, docs, and code so the agent links them to the material.
 
-A leading word anchors in two places. In the body it anchors execution: the same word produces the same behavior at each appearance, and inside flat reference it names the class of thing to look for. In a pointer it anchors invocation: when prompts, docs, and code share the word, the agent links them to the material and reaches it more reliably.
-
-Look for passages that collapse into one token, such as a triad spelled out at three sites or a pointer spending a sentence on one idea:
+Look for passages that collapse into one token:
 
 - "fast, deterministic, low-overhead" collapses to *tight*, as in a tight loop.
 - "a loop you believe in" collapses to *red*: the loop goes red on the bug or it does not.
 
-A leading word is a domain term, so it survives the conversion in [plain-language.md](plain-language.md). A metaphor used once for emphasis does not.
+A leading word is a domain term, so keep it through the plain-language conversion. Convert a metaphor used once for emphasis to its literal fact instead.
 
 #### Positive Form
 
-State the target behavior. A prohibition puts the forbidden behavior in context and makes it more available, and the negation is a weak modifier against the activated concept, so the ban partly reads as an instruction to perform it.
-
-"Write one-line comments" beats a rule against long ones. Use an explicit ban only as a hard guardrail with no positive phrasing available, and pair it with the positive target.
+State the target behavior. "Write one-line comments" beats a rule against long ones. Use an explicit ban only as a hard guardrail with no positive phrasing available, and pair it with the positive target.
 
 ## Pruning
 
-#### Single Source of Truth
+#### Duplication
 
-Keep each meaning in one place, so changing the behavior is a one-place edit. The same meaning in two places costs maintenance and tokens, and it raises that meaning's apparent rank on the ladder above its real one. A leading word is the deliberate inverse, repeating a token and never the meaning.
+Keep each meaning in one place. A leading word is the deliberate exception: it repeats a token, never the meaning.
 
-#### Cache and Environment
+#### Cache
 
-The environment is a source of truth: `package.json` scripts, config files, the directory layout, `--help` output. A document restating it is a cache of a lookup, and it earns its load only when the lookup is expensive.
+The environment is a source of truth: `package.json` scripts, config files, the directory layout, `--help` output. A document restating it is a cache, and earns its place only when the lookup is expensive. The `herdr` skill states that `--help` enumerates every enum flag, which retires the flag tables that would otherwise sit beside it.
 
-Cache what the agent cannot find by looking: the unwritten convention, the reason behind a choice, the gotcha no config records. Leave one-file and one-command lookups to the environment, where they cannot go stale. The `herdr` skill states that `--help` enumerates every enum flag, which retires the flag tables that would otherwise be maintained beside it.
+Cache what the agent cannot find by looking: the unwritten convention, the reason behind a choice, the gotcha no config records. Leave one-file and one-command lookups to the environment.
 
 #### No-ops
 
-Delete instructions the model already follows by default.
+Delete instructions the model already follows by default. Test each sentence against the model's default, not a reader's expectation: does this line change behavior? Settle a disagreement by running the document. When a sentence fails, delete the whole sentence instead of trimming it.
 
-Test each sentence against the model's default rather than a reader's expectation: does this line change behavior? Two people disagreeing about a no-op are disagreeing about the default, and they settle it by running the document. When a sentence fails, delete the whole sentence instead of trimming words from it.
+Replace a leading word too weak to beat the default ("be thorough" when the agent is already thorough) with a stronger word.
 
-The test also grades leading words. A word too weak to beat the default, such as "be thorough" when the agent is already thorough, is a no-op. Replace it with a stronger word.
+#### Relevance
 
-#### Sediment
-
-Check each line for relevance: does it still bear on what the document does? A line loses relevance by never bearing on the task, which covers exposition and branches that should be disclosed, or by going stale as the world it describes changes.
-
-Without a pruning pass, stale layers accumulate, because adding feels safe and removing feels risky. Shorter documents stay current more easily. This is the repo's curation rule applied one level down, to lines instead of to skills.
+Check each line against what the document does. Delete a line that never bore on the task, including exposition and branches that belong behind a pointer. Delete a line that has gone stale as the world it describes changed.

--- a/plugins/claude-code/skills/skill/references/levers.md
+++ b/plugins/claude-code/skills/skill/references/levers.md
@@ -1,70 +1,70 @@
 # Levers
 
-Three things that change what an agent does with a document: how each unit of work ends, which words anchor its behavior, and what gets removed. Companion to [information-hierarchy.md](information-hierarchy.md), which covers where material sits.
+What changes an agent's behavior in a document: how each unit of work ends, which words anchor the behavior, and what gets removed. Companion to [information-hierarchy.md](information-hierarchy.md), which covers where material sits.
 
 ## Completion Criteria
 
-Every unit of work ends on a completion criterion, the condition that tells the agent it is done. Two properties make it a lever.
+End every unit of work on a completion criterion: the condition that tells the agent the work is done. Two properties make it a lever.
 
 #### Clarity
 
-Can the agent tell done from not-done? A vague bound such as "understanding reached" invites premature completion: ending the work before it is genuinely finished, attention already sliding toward being done. The visible work still ahead supplies the pull. The criterion's clarity supplies the resistance.
+Write a criterion the agent can check. A vague bound such as "understanding reached" lets the agent stop before the work is finished, because visible remaining work pulls toward finishing the current one.
 
-Sharpen the bound first. That fix is local and cheap. Only when the bound is irreducibly fuzzy and you have watched the agent rush it should you split the sequence to hide what follows, and that split works only across a real context break (see Splitting in [information-hierarchy.md](information-hierarchy.md)).
+Sharpen the bound first, since that fix is local and cheap. Split the sequence to hide later work only when the bound cannot be sharpened and you have observed the agent stopping early. That split works only across a real context break (see Splitting in [information-hierarchy.md](information-hierarchy.md)).
 
 #### Demand
 
-How much the criterion requires. "Every modified model accounted for" forces thorough work where "produce a change list" lets the agent stop at three items. Demand drives the digging the agent does inside the work, latent in the wording rather than spelled out as its own instruction.
+Write a criterion that requires the work you want. "Every modified model accounted for" forces a full pass where "produce a change list" lets the agent stop at three items. Demand drives the digging the agent does inside the work, without naming that digging as its own instruction.
 
-Demand is not step-bound. "Every rule applied" binds a body of flat reference the same way "every step done" binds a sequence, which is how an all-reference document still carries an exhaustiveness bar. State the observable done-state, and the agent keeps its freedom over how to reach it.
+Demand does not require steps. "Every rule applied" bounds a body of flat reference the same way "every step done" bounds a sequence, so an all-reference document can carry an exhaustiveness bar.
 
-The strongest criteria are both checkable and exhaustive.
+Make criteria both checkable and exhaustive.
 
 ## Leading Words
 
-A leading word is a compact concept already living in the model's pretraining that the agent thinks with while running the document. Repeated as a token and never as a sentence, it accumulates a distributed definition across the places it appears and anchors a whole region of behavior in a handful of tokens, because it recruits priors the model already holds.
+A leading word is a compact concept from the model's pretraining, used as a repeated token rather than restated as a sentence. It accumulates a definition across the places it appears and anchors a region of behavior in few tokens, because the model already holds the priors.
 
-`LANGUAGE.md` in `improve-codebase-architecture` is this technique at full size: seam, depth, adapter, locality. Each word carries a paragraph of meaning that never has to be restated at the call site.
+`LANGUAGE.md` in `improve-codebase-architecture` uses this at full size: seam, depth, adapter, locality. Each word carries a paragraph of meaning that the call site never restates.
 
-Coining your own word works when you define it clearly, but an invented word recruits nothing. You pay in definition tokens what a pretrained word gives away. Look for an existing word first.
+Choose an existing word before coining one. A coined word works when the document defines it clearly, but it recruits no priors, so you pay in definition tokens what a pretrained word supplies free.
 
-A leading word anchors twice. In the body it anchors execution: the agent applies the same behavior every time the word appears, and inside flat reference the word focuses attention on a class of thing to look for. In a pointer it anchors invocation: when the same word appears in prompts, in docs, and in the code, the agent links that shared language to the material and reaches it more reliably.
+A leading word anchors in two places. In the body it anchors execution: the same word produces the same behavior at each appearance, and inside flat reference it names the class of thing to look for. In a pointer it anchors invocation: when prompts, docs, and code share the word, the agent links them to the material and reaches it more reliably.
 
-Hunt for passages that collapse into one token. A triad spelled out at three sites. A pointer spending a sentence gesturing at one idea.
+Look for passages that collapse into one token, such as a triad spelled out at three sites or a pointer spending a sentence on one idea:
 
 - "fast, deterministic, low-overhead" collapses to *tight*, as in a tight loop.
-- "a loop you believe in" collapses to *red*, turning a fuzzy gate into a binary state the agent can observe. The loop goes red on the bug or it does not.
+- "a loop you believe in" collapses to *red*: the loop goes red on the bug or it does not.
 
-Assume any document you inherit is carrying restatements that a leading word retires. Go find them.
+A leading word is a domain term, so it survives the conversion in [plain-language.md](plain-language.md). A metaphor used once for emphasis does not.
 
-#### The Positive Form
+#### Positive Form
 
-Steering by prohibition drags the forbidden behavior into context and makes it more available. Say *don't think of an elephant* and the elephant is all there is. The negation is a weak modifier that the strongly activated concept runs straight over, so the ban half-reads as an instruction.
+State the target behavior. A prohibition puts the forbidden behavior in context and makes it more available, and the negation is a weak modifier against the activated concept, so the ban partly reads as an instruction to perform it.
 
-State the target behavior instead, so the banned one is never spoken. "Write one-line comments" beats a rule against long ones. A prohibition earns a place only as a hard guardrail with no positive phrasing available, and even then it should carry the positive target beside it so attention lands on what to do.
+"Write one-line comments" beats a rule against long ones. Use an explicit ban only as a hard guardrail with no positive phrasing available, and pair it with the positive target.
 
 ## Pruning
 
 #### Single Source of Truth
 
-Keep each meaning in one authoritative place, so changing the behavior is a one-place edit. The same meaning in two places costs maintenance and tokens, and it inflates that meaning's apparent rank on the hierarchy past its real one. This is the accidental inverse of a leading word, which repeats a token on purpose and the meaning never.
+Keep each meaning in one place, so changing the behavior is a one-place edit. The same meaning in two places costs maintenance and tokens, and it raises that meaning's apparent rank on the ladder above its real one. A leading word is the deliberate inverse, repeating a token and never the meaning.
 
 #### Cache and Environment
 
-The environment is a source of truth too: `package.json` scripts, config files, the directory layout, `--help` output. A document that restates it is a cache, a copy of a lookup, earning its load only when the lookup is expensive.
+The environment is a source of truth: `package.json` scripts, config files, the directory layout, `--help` output. A document restating it is a cache of a lookup, and it earns its load only when the lookup is expensive.
 
-Cache what the agent cannot find by looking: the unwritten convention, the reason behind a choice, the gotcha no config confesses. Leave one-file and one-command lookups to the environment, where they cannot go stale. `herdr`'s skill states that `--help` enumerates every enum flag, which retires every flag table that would otherwise have to be maintained beside it.
+Cache what the agent cannot find by looking: the unwritten convention, the reason behind a choice, the gotcha no config records. Leave one-file and one-command lookups to the environment, where they cannot go stale. The `herdr` skill states that `--help` enumerates every enum flag, which retires the flag tables that would otherwise be maintained beside it.
 
 #### No-ops
 
-Hunt sentence by sentence for instructions the model already obeys by default. Each one pays load to say nothing.
+Delete instructions the model already follows by default.
 
-The test is model-relative rather than reader-relative: does this line change behavior against the default? Two people disagreeing about a no-op are disagreeing about the default, and they settle it by running the document rather than by arguing. When a sentence fails the test, delete the whole sentence rather than trimming words from it.
+Test each sentence against the model's default rather than a reader's expectation: does this line change behavior? Two people disagreeing about a no-op are disagreeing about the default, and they settle it by running the document. When a sentence fails, delete the whole sentence instead of trimming words from it.
 
-The test grades leading words too. A word too weak to beat the default, such as *be thorough* when the agent is already thorough-ish, is a no-op. The fix is a stronger word, not a different technique.
+The test also grades leading words. A word too weak to beat the default, such as "be thorough" when the agent is already thorough, is a no-op. Replace it with a stronger word.
 
 #### Sediment
 
-Check every line for relevance: does it still bear on what the document does? A line loses relevance by never bearing on the task, which covers exposition and branches that should have been disclosed, or by going stale as the world it describes moves.
+Check each line for relevance: does it still bear on what the document does? A line loses relevance by never bearing on the task, which covers exposition and branches that should be disclosed, or by going stale as the world it describes changes.
 
-Without a pruning discipline, the default outcome is sediment: stale layers that settle because adding feels safe and removing feels risky, until finding what is still live means coring down through them. Shorter documents stay relevant more easily. This is the same discipline the repo's curation rule applies to skills, hooks, and wordlist entries, one level down.
+Without a pruning pass, stale layers accumulate, because adding feels safe and removing feels risky. Shorter documents stay current more easily. This is the repo's curation rule applied one level down, to lines instead of to skills.


### PR DESCRIPTION
Adds two disclosed references to `claude-code:skill` covering how much a document costs to place and what makes an agent follow it. First of nine lanes adopting from the dmmulroy and mattpocock skill collections. #1246

`information-hierarchy.md` names the two budgets every document spends. Context load sits in the window every turn, priced here against three facts specific to this repo:

- A model-invocable skill spends its description each session.
- An invoked body is re-injected at every compaction.
- A `references/` file costs nothing until its pointer fires.

Cognitive load sits on the human and is worth spending where human judgment decides the outcome, which is what `disable-model-invocation` buys.

The rest of the file covers context pointers, the step-and-reference ladder, progressive disclosure as a variance lever, co-location, sprawl, and when a split pays for itself.

`levers.md` covers completion criteria along two properties, clarity and demand, then leading words, the positive form of a rule, and pruning.

Splitting them this way follows the branching test in the first file. Placement questions and steering questions are reached from different points in authoring, so neither branch pays for the other.

The done-state clause under "Don't Railroad Claude" resolves an apparent conflict. That section argues against step-by-step scripts, and per-step completion criteria read like the thing it rules out. A criterion bounds demand rather than enumerating steps: "every rule applied" bounds a body of flat reference the same way "every step done" bounds a sequence, so it drives thorough work while leaving Claude its own route.

The first pass wrote both files in an essayistic register, which `plain-language.md` rules out and scopes to reference files by name. The second commit converts the metaphor, epigram, and personification to literal statements. The named terms stay, since a leading word is a domain term and the conversion preserves those, and `levers.md` now says so where the two rules would otherwise read as contradicting each other.

Adapted from the `writing-for-agents` skill in `dmmulroy/.dotfiles@a6d5117`. That repo carries no LICENSE, so the prose here is written fresh against the ideas rather than adapted line by line.
