### PR TITLE
rules: document plugin manifest updates

### DIFF
--- a/.claude/rules/plugins.md
+++ b/.claude/rules/plugins.md
@@ -7,6 +7,8 @@ paths:
 
 Each plugin has `.claude-plugin/plugin.json` plus optional `skills/`, `hooks/`, `commands/`, `agents/`.
 
+Creating or renaming a plugin directory requires adding or updating its entry in `.claude-plugin/marketplace.json`. `bun scripts/check-marketplace.ts` verifies this.
+
 When creating or modifying skills, load the `claude-code:skill` skill.
 
 ## Naming
@@ -33,7 +35,7 @@ Each plugin's `README.md` needs a title with one-line description, a contents li
 
 ## Plugin Metadata
 
-Plugin `settings.json` only supports `agent` and `subagentStatusLine` keys. Don't create schema-only placeholder files. `plugin.json` supports an optional `"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json"` for editor autocomplete, and `displayName` for human-readable names in the UI.
+Plugin `settings.json` only supports `agent` and `subagentStatusLine` keys. Don't create schema-only placeholder files. `plugin.json` supports an optional `"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json"` for editor autocomplete, and `displayName` for human-readable names in the UI. Deleting a plugin's `commands/`, `agents/`, or `hooks/` directory requires removing the matching path key from `plugin.json` in the same change, or `claude plugin validate` fails CI on the dangling path.
 
 ## Dependencies
 


### PR DESCRIPTION
The Stop hook's marketplace completeness check (`bun scripts/check-marketplace.ts`) kept failing because nothing told the plugin-authoring rule to update `.claude-plugin/marketplace.json` when you create a plugin directory. Adds that guidance to `.claude/rules/plugins.md`, which is already scoped to `plugins/**` and loads exactly when it's needed.

A second manifest trap was missing from `plugins.md`: deleting a plugin's `commands/`, `agents/`, or `hooks/` directory without removing the matching `plugin.json` path key fails `claude plugin validate` in CI. This PR adds it.

## Evidence

`bun scripts/check-marketplace.ts` failed 24 times across 13 distinct sessions between 2026-07-10 and 2026-08-21, per this machine's local session index.

Discovery: 242915829915
