### PR TITLE
ci: pipe DuckDB installer to bash instead of sh

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -227,7 +227,7 @@ jobs:
             bun "$plugin/node_modules/.bin/playwright" install chromium --with-deps
           fi
           if echo "$deps" | grep -q '^@duckdb/node-api$'; then
-            curl -fsSL https://install.duckdb.org | sh
+            curl -fsSL https://install.duckdb.org | bash
             echo "$HOME/.duckdb/cli/latest" >> "$GITHUB_PATH"
           fi
 


### PR DESCRIPTION
The DuckDB install script declares `#!/bin/bash -e` and picks between its v1 and v2 extraction paths with `[[` at line 128. Piping it to `sh` runs it under dash on Ubuntu runners, where `[[` isn't a builtin. The version check fails, and `-e` never takes effect since the shebang is bypassed. Execution falls through to the v2 branch for a 1.x version, which requests an artifact layout that doesn't exist.

The download 404s and `tar` exits non-zero, failing the "Install system dependencies" step. This breaks any plugin whose package tree declares `@duckdb/node-api`, currently `plugins/claude-code`. Observed on run 32795598631.
