### PR TITLE
review: add four local finder angles

### DIFF
--- a/plugins/review/skills/code/SKILL.md
+++ b/plugins/review/skills/code/SKILL.md
@@ -22,15 +22,13 @@ allowed-tools:
 
 Review the diff for correctness bugs and cleanups: $ARGUMENTS
 
-This is a port of Claude Code's built-in `/code-review`, which is user-invocable only and cannot be reached through the Skill tool. This one is model-invocable, so `ship`, `review:peer`, and any other skill can delegate to it. The upstream text it was ported from is in [references/upstream-2.1.215.md](references/upstream-2.1.215.md).
-
 ## Arguments
 
 - **Effort level**: the first token, if it matches `^(low|med|hig|xhi|max)[a-z]*$` case-insensitively. Prefixes count: `med`, `hi`, `xh` all resolve. `xhigh` is the top of the ladder, and `max` resolves to it. `--effort <level>` is an alias, valid anywhere in the arguments, and its value goes through the same match. Ignore an unrecognized level-shaped token with a brief note naming the valid levels. Do not treat it as a target.
 - **`--fix`**: apply findings to the working tree after reporting. May appear anywhere.
 - **`--base <ref>`**: review against this base instead of the resolved default.
 - **`<target>`**: everything else, free-form. A PR number, branch, ref range, path, or a plain-English scope restriction ("only `src/parser.ts`", "focus on error handling", "skip the test churn").
-- **`ultra`**: not supported here. Stop and tell the user to type `/code-review ultra` themselves. It launches a billed cloud review and only a user-typed invocation can start it.
+- **`ultra`**: not supported here. Stop and tell the user to type `/code-review ultra` themselves.
 
 With no effort level, use the session's effort. Default to `medium`.
 
@@ -56,7 +54,7 @@ Pick the effort cell from [efforts.md](efforts.md). It fixes the fan-out shape, 
 
 At `low`, follow the low-cell instructions in `efforts.md` and skip the remaining phases.
 
-Otherwise run the selected angles from [angles.md](angles.md). Each surfaces up to its cap of candidates with `file`, `line`, a one-line `summary`, and a concrete `failure_scenario`.
+Otherwise run the selected angles from [angles.md](angles.md) and [local-angles.md](local-angles.md). Each surfaces up to its cap of candidates with `file`, `line`, a one-line `summary`, and a concrete `failure_scenario`.
 
 #### Fan-out cells
 

--- a/plugins/review/skills/code/efforts.md
+++ b/plugins/review/skills/code/efforts.md
@@ -26,16 +26,18 @@ Every fan-out spawn passes `model: sonnet` alongside its `subagent_type`. What a
 | `low` | 1 diff pass | — | none | no | <=4 | terse, hunk-only, skips test/fixture hunks |
 | `low-sonnet5` | 1 diff pass | — | none | no | floor `min(files, 4)` | same, plus a second pass if under the floor |
 | `inline-low` | 1 diff pass | — | none | no | <=8, floor `min(files, 4)` | no test-hunk skip |
-| `medium` | 3 correctness + 3 cleanup + altitude + conventions = 8 | 6 | 1-vote, 3-state | no | <=8 | precision |
-| `high` | 8 | 6 | 1-vote, recall-biased | no | <=10 | recall |
-| `xhigh` | 5 correctness + 5 cleanup/altitude/conventions = 10 | 8 | 1-vote, single non-REFUTED carries | yes | <=15 | recall |
-| `inline-med` | 8, inline | 6 | dedup only | no | <=8, floor 4 | recall |
-| `inline-high` | 8, inline | 6 | dedup only | no | <=10, floor 5 | recall |
-| `inline-xhigh` | 10, inline | 8 | dedup only | yes | <=15, floor 7 | recall |
-
-"8 angles" means Angles A, B, C plus Reuse, Simplification, Efficiency, Altitude, Conventions. "10 angles" adds Angles D and E.
+| `medium` | `core` | 6 | 1-vote, 3-state | no | <=8 | precision |
+| `high` | `core` | 6 | 1-vote, recall-biased | no | <=10 | recall |
+| `xhigh` | `full` | 8 | 1-vote, single non-REFUTED carries | yes | <=15 | recall |
+| `inline-med` | `core`, inline | 6 | dedup only | no | <=8, floor 4 | recall |
+| `inline-high` | `core`, inline | 6 | dedup only | no | <=10, floor 5 | recall |
+| `inline-xhigh` | `full`, inline | 8 | dedup only | yes | <=15, floor 7 | recall |
 
 When the `Agent` tool is unavailable, every fan-out cell degrades to a single inline pass. See [SKILL.md](SKILL.md) for that path.
+
+## Angle Sets
+
+Angles D and E in [angles.md](angles.md) are xhigh-only. `core` is that file's other angles. `full` is all of them plus every angle in [local-angles.md](local-angles.md).
 
 ## Framing Paragraphs
 
@@ -77,7 +79,7 @@ On Sonnet 5 at `high` or `xhigh`, scale the fleet to the diff size instead of us
 budget = clamp(ceil(lines / 150), 2, 8)
 ```
 
-Spawn about that many finder subagents, each with `subagent_type: review:angle, model: sonnet`. The committed-range count is a floor: uncommitted changes are not in it, so scale up if Phase 0 finds additional working-tree scope.
+Spawn about that many finder subagents, each with `subagent_type: review:angle, model: sonnet`. Deal the cell's angle set across them in whole angles. A fleet smaller than the set gives some agents more than one angle. The committed-range count is a floor: uncommitted changes are not in it, so scale up if Phase 0 finds additional working-tree scope.
 
 No other model family gets this hint.
 

--- a/plugins/review/skills/code/local-angles.md
+++ b/plugins/review/skills/code/local-angles.md
@@ -1,0 +1,23 @@
+# Local Finder Angles
+
+Selection, caps, and the candidate shape match [angles.md](angles.md). Every angle here belongs to the `full` set in [efforts.md](efforts.md).
+
+## Correctness Angles
+
+### Angle F — typed-failure auditor
+
+Flag an expected failure that leaves its module as a thrown exception, a rejected promise, or a panic while the signature promises a value: a lookup miss, a rejected payload, an unavailable dependency, a write that lost a race. A catch that flattens several of those into one error the caller cannot branch on counts too. Also flag input that reaches typed code in the shape it arrived in, with no parse between: a request body, a database row, a cache hit, an RPC response, an environment variable.
+
+## Cleanup Angles
+
+### Type Discipline
+
+Flag a raw primitive where the surrounding code already declares a domain type for the same thing: a bare string id beside a declared id type, a duration or byte count as a plain number where a unit type exists, a path kept as text past the point something parses it. Name the existing type. Also flag booleans on one record or signature that encode a lifecycle rather than independent facts (`isLoading` beside `isDone`), and name the combination that has no meaning.
+
+### Discoverability
+
+Flag an exported name whose plain-text search returns the wrong window: a one-word name (`diff`, `queue`, `run`), an unqualified verb (`validate`, `format`), a bare-role filename (`utils`, `types`), two spellings of one concept (`orgId` beside `organizationId`), or a name whose behavior changed underneath it. A symbol copied to a second definition site instead of moved counts too.
+
+### Coupling
+
+Flag Feature Envy (a function reading or writing another module's data more than its own), Data Clumps (the same few parameters travelling together through several signatures), Shotgun Surgery (one logical change forcing scattered edits across this diff), Divergent Change (one file edited for several unrelated reasons), and Message Chains (`a.b().c().d()` binding the caller to every hop's shape). Name the smell and the move that removes it. Skip a shape a repo convention endorses or a linter enforces.


### PR DESCRIPTION
Adds four finder angles to `review:code`: `Angle F` (typed-failure auditor, correctness) plus `Type Discipline`, `Discoverability`, and `Coupling` as cleanup lenses. Part of #1246.

They go in a new `local-angles.md` so a later port from the built-in reviewer can move `angles.md` freely.

`efforts.md` names two angle sets, `core` and `full`, instead of counting angles in the budgets table. The four join `full`, so `xhigh` and `inline-xhigh` run them and the cheaper cells keep their current fan-out cost.

That collided with the Sonnet 5 finder budget hint. It clamps the fleet to eight agents, while `SKILL.md` forbids skipping angles. The hint now says to deal the set across the agents in whole angles.
