### PR TITLE
diagnosing-bugs: gate diagnosis on a red command

### DIFF
--- a/user/skills/diagnosing-bugs/SKILL.md
+++ b/user/skills/diagnosing-bugs/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: diagnosing-bugs
+description: Diagnose a known bug or performance regression by building a command that reproduces it before forming any theory. Use when something is broken, throwing, failing, hanging, corrupting data, or slower than it was, when a test fails for reasons nobody understands, or when the user says debug this, diagnose this, or asks why something is happening.
+argument-hint: "[<what is broken>]"
+---
+
+# Diagnosing Bugs
+
+Diagnose the bug in `$ARGUMENTS`, or the failure the user just reported. Work the sections below in the order they appear, by whatever route reaches each done-state. Feedback Loop is not skippable, and skipping a later section means naming the done-state you are claiming without it.
+
+## Redact
+
+Replace every secret with `<REDACTED>` before showing a command, its output, or a captured artifact. Quote only the signal-carrying lines of a captured trace.
+
+When redaction removes what you need to diagnose the bug, say so and ask the user.
+
+## Feedback Loop
+
+Goal: one command that goes **red** on this bug.
+
+A loop is **red** when it drives the real code path and asserts the user's exact symptom. A command that checks only that nothing crashed is not red. A loop is **tight** when it is fast, deterministic, and runnable unattended.
+
+Build the loop before reading code to explain it.
+
+Read [references/loops.md](references/loops.md) to pick a rung from the ladder, or when the loop you built is slow, flaky, or impossible to construct.
+
+Done when you can name one command, have run it at least once, and have shown the invocation and its redacted output going red on this bug.
+
+## Reproduction
+
+Goal: the smallest scenario that still goes red.
+
+Run the loop. Confirm the failure it produces is the one the user described rather than a nearby one, and that the verdict repeats across runs. When it does not, raise and record a reproduction rate before continuing. Capture the exact symptom: error text, wrong value, measured timing.
+
+Then cut the scenario down: inputs, callers, config, data, and steps, one at a time, re-running the loop after each cut. Keep a cut that leaves the loop red. Revert a cut that stops the failure.
+
+Done when every remaining element is required.
+
+## Hypotheses
+
+Goal: a ranked set of falsifiable causes, written before any of them is tested.
+
+Write three to five hypotheses. Each states a prediction the loop can settle: if X is the cause, changing Y stops the loop failing, or changing Z raises the failure rate. Sharpen or drop a hypothesis that states no prediction.
+
+Show the ranked list to the user before testing. Proceed on your own ranking when they do not answer.
+
+## Instrumentation
+
+Goal: every hypothesis settled by a run of the loop.
+
+Change one variable per run. Aim each probe at a specific prediction.
+
+Use a debugger or REPL where the runtime supports one. Otherwise log where the hypotheses predict different values. Tag every debug log with a unique prefix such as `[DEBUG-a4f2]`.
+
+For a performance regression, measure rather than log. Establish a baseline with a timing harness, a profiler run, or a query plan, then bisect against it.
+
+Done when every hypothesis is marked eliminated or surviving, each by a named run of the loop. When none survives, return to Hypotheses with what these runs ruled out.
+
+## Fix and Regression Test
+
+Goal: a fix the loop proves, and a test at a seam that catches the bug returning.
+
+Find the seam first. A correct seam exercises the real pattern the bug takes at the call site. A single-caller test for a bug that needs two callers is too shallow.
+
+Report a missing seam as a finding about the module's shape, and continue. Name the module and the part of its interface that blocks the test.
+
+With a seam: turn the minimized scenario into a test there, watch it fail, apply the fix, watch it pass. Then re-run the loop against the original, pre-minimization scenario.
+
+Done when the regression test fails without the fix and passes with it, and the original scenario no longer reproduces under the loop. A missing seam substitutes for the test only when the report names it.
+
+## Cleanup
+
+Done when all of these hold:
+
+- Re-running the loop after cleanup still fails to reproduce the original scenario.
+- The regression test passes, or the report names the seam that does not exist.
+- A grep for the debug prefix returns nothing.
+- No throwaway harness remains outside a path with `debug` in its name.
+- The commit or PR message states which hypothesis was correct.

--- a/user/skills/diagnosing-bugs/references/loops.md
+++ b/user/skills/diagnosing-bugs/references/loops.md
@@ -1,0 +1,36 @@
+# Feedback Loops
+
+## The Ladder
+
+Pick the cheapest rung that reaches the bug.
+
+1. **Failing test** at the seam the bad value crosses.
+2. **HTTP request** scripted with `curl`, when a running dev server reaches the bug.
+3. **CLI invocation** on a fixture input, diffed against a known-good snapshot.
+4. **Headless browser script** when the symptom appears only through the UI.
+5. **Trace replay** when a real request, payload, or event log can be captured and fed back through the code path.
+6. **Throwaway harness** when the bug needs a subset of the system standing and the rest faked.
+7. **Property or fuzz loop** when the symptom is wrong output on some inputs.
+8. **Bisection harness** when the bug appeared between two known states: commits, dataset versions, dependency versions.
+9. **Differential loop** against a known-good adapter, when a previous version or a second implementation produces the right output.
+10. **Human-in-the-loop script** when a person has to click. Start from [../scripts/hitl-loop.template.sh](../scripts/hitl-loop.template.sh).
+
+## Tightening
+
+- Faster: cache setup, skip initialization the bug does not touch, narrow the test to the failing case.
+- Deterministic: pin the clock, seed the RNG, isolate the filesystem, block the network.
+- Unattended: replace a manual step with a fixture, a stub, or a scripted click.
+
+Stop when the verdict arrives in seconds and two runs on one input never disagree.
+
+## Intermittent Bugs
+
+Raise the reproduction rate until a fix is distinguishable from noise: loop the trigger a hundred times, run copies in parallel, add load, narrow the timing window, or inject sleeps at the point where the ordering matters. Record the rate you reach as the threshold later runs are compared against.
+
+## When No Loop Is Possible
+
+Say so directly and stop. List every rung you tried and what part of the bug it could not reach. Then ask the user for one of these, and wait:
+
+- Access to an environment where the bug reproduces.
+- A redacted artifact captured while it happened: HAR file, log dump, core dump, or screen recording with timestamps.
+- Permission to add temporary instrumentation where it happens.

--- a/user/skills/diagnosing-bugs/scripts/hitl-loop.template.sh
+++ b/user/skills/diagnosing-bugs/scripts/hitl-loop.template.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Human-in-the-loop reproduction loop. Copy this file, replace the block between
+# the edit markers, and have the user run it in their own terminal.
+#
+#   step "<instruction>"        print an instruction, wait for the user
+#   observe NAME "<question>"   ask a question, record one line as NAME
+#
+# Answers print under RESULTS at exit, one NAME=value per line, including on an
+# abort partway through. Use step, never observe, for anything that involves a
+# credential.
+
+set -euo pipefail
+
+if [ ! -t 0 ]; then
+  echo 'hitl-loop needs a terminal: have the user run it, not a tool call' >&2
+  exit 2
+fi
+
+results=()
+
+step() {
+  printf '\n>>> %s\n' "$1"
+  read -r -p '    press enter when done '
+}
+
+observe() {
+  local name=$1 question=$2 answer
+  printf '\n>>> %s\n' "$question"
+  IFS= read -r -p '    > ' answer
+  results+=("$name=$answer")
+}
+
+report() {
+  printf '\n--- RESULTS ---\n'
+  if [ ${#results[@]} -gt 0 ]; then
+    printf '%s\n' "${results[@]}"
+  fi
+}
+
+trap report EXIT
+
+# --- replace below ----------------------------------------------------------
+
+step 'Open http://localhost:3000 and sign in.'
+
+observe FAILED 'Click Export. Did it fail? (y/n)'
+
+observe SYMPTOM 'Type the first line of the error, or none.'
+
+# --- replace above ----------------------------------------------------------


### PR DESCRIPTION
Adds a `diagnosing-bugs` skill covering the path from a bug report to an established cause. Reproduce the failure with a command, settle the cause against that command, hand off to plan mode, and re-run the original reproduction before calling anything fixed.

An earlier draft ran six phases with a ten-rung ladder of reproduction techniques, a ranked-hypotheses step, a minimization step, and redaction and cleanup rules. Checking each against 7,286 organic user turns and 160 bug-report sessions in the session index removed all of it:

- **Ranked hypotheses.** Zero occurrences. 68 hand-reviewed hits for "what could cause", "possible reasons", "theories", and "just diagnose" are all singular asks for the cause, with discussion as the fallback. Find the Cause reports one.
- **The ladder.** It ranked ten rungs against nothing. Across 23,746 Bash calls the real distribution is grep (7,894), duckdb (1,490), git diff/log/show (~2,900), pytest (569), curl (391). Headless browser, `git bisect`, and human-in-the-loop scripts are zero in bug sessions. `scripts/hitl-loop.template.sh` goes along with `references/loops.md`.
- **Minimization.** No episode shows it. Fixes come off the first reproduction.
- **Redaction and cleanup.** Both address failures with zero occurrences. The hostname rule is proactive authoring guidance, never something caught mid-debug. Tolerance for leftover debug logging is unknown rather than benign. The skill takes no position on it.

The hard gate went too. Of 26 episodes with an observable first tool call, 16 ran a command and 7 read code, and in the one session where the repro-first rule gets stated explicitly the first twenty calls are reads to learn the test harness. Reading is how the reproduction gets built. Reproduce says that rather than forbidding it.

What the corpus did support is now the shape. CI and lint failures are the most common and shortest reports ("ci fails", "103 still failing, why"). They reach the description now, and route to `github:actions-monitor` or `gitlab:ci-monitor` instead of being reconstructed locally. Premature done-claiming is the top failure mode by count ("nope ded still broke", "def not fixed"), which is Confirm. The grounding line in Find the Cause answers "are you looking at my actual local database or are you just guessing there?". Hand Off stops at plan mode because that is the stated policy, which is also why fix, regression test, and cleanup are gone.

One file, 501 tokens. The reproduce-before-theorizing idea comes from [`dmmulroy/.dotfiles@a6d5117`](https://github.com/dmmulroy/.dotfiles/tree/a6d5117/home/.agents/skills/diagnosing-bugs), which carries no LICENSE. Everything else is written fresh.

#1246
