### PR TITLE
rules: split testing guidance by scope

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -5,95 +5,20 @@ paths:
   - ".github/workflows/**"
 ---
 
-# Testing
+# Test Mechanics
 
-Plugins use `bun test`. Run everything with `bun test`, or filter by plugin with `bun test plugins/<name>`.
+Run everything with `bun test`, or filter by plugin with `bun test plugins/<name>`.
 
 After changing a plugin script, run it directly with real arguments as well as its unit tests. Argument parsing and other integration failures only surface at runtime.
 
 ## Conventions
 
 - **Integration tests are not auto-discovered.** Bun discovers `*.test.ts`. Run `*.integration.ts` by passing paths explicitly.
-- **Prefix dotdir paths with `./`.** A positional arg is a filter, matched against discovered paths, and discovery skips dotdirs. `bun test .claude/hooks` silently runs 0 tests; `bun test ./.claude/hooks` runs them.
+- **Prefix dotdir paths with `./`.** A positional arg is a filter, matched against discovered paths, and discovery skips dotdirs. `bun test .claude/hooks` matches nothing and exits 1 with a "files were searched" note. `bun test ./.claude/hooks` runs them.
 - **No `.js` imports in TypeScript.** Import from `./module`, not `./module.js`.
 - **Prefer skills over agents** for anything that should be directly invocable. Skills are invocable via the `Skill` tool.
 - **Hook E2E tests drive the real dispatcher.** A unit test proves the script's logic, not that Claude Code dispatches to it. Run headless `claude -p` with `--plugin-dir` against a throwaway repo with the external CLI (`gh`, `glab`) stubbed onto `PATH`, then assert on what the stub recorded. These live at `plugins/<name>/scripts/e2e-*.ts` and run in CI only, from a path-filtered workflow holding the `CLAUDE_CODE_OAUTH_TOKEN` secret, because each run spends API tokens.
 
-## Technique Selection
-
-Pick the test shape from the code under test.
-
-#### Repeated Blocks → `test.each`
-
-Collapse two or more `test()` blocks differing only in data into one `test.each` with a typed table. Name each row through the title template so a failure identifies the row without counting.
-
-```ts
-// Tuple rows: positional args, %s/%d/%p placeholders in the title
-test.each<[string, number]>([
-  ["", 0],
-  ["a", 1],
-])("length of %p is %d", (input, expected) => {
-  expect(input.length).toBe(expected);
-});
-
-// Object rows: named fields, $field placeholders in the title
-test.each<{ name: string; input: string; expected: number }>([
-  { name: "empty string", input: "", expected: 0 },
-  { name: "single char", input: "a", expected: 1 },
-])("$name", ({ input, expected }) => {
-  expect(input.length).toBe(expected);
-});
-```
-
-`describe.each` parametrizes an entire suite the same way.
-
-#### Formatted Output → Inline Snapshots
-
-Assert formatted or structured output with `toMatchInlineSnapshot()`. Call it with no argument and the first run writes the received value into the test file. Rerun with `--update-snapshots` when output changes intentionally, and review what it wrote. Never assert structured output field-by-field: one snapshot replaces a run of `expect(x.field).toBe(...)` lines and shows the whole shape in the diff. Exemplar: `plugins/comments/apply/report.test.ts`.
-
-Use a file snapshot (`toMatchSnapshot()`) only when the output exceeds roughly 20 lines or is shared across tests.
-
-#### Statable Invariants → Properties
-
-For pure logic with a statable invariant, write one `fast-check` property plus a small example table for documentation. Invariant shapes: roundtrip (`decode(encode(x))` equals `x`), idempotence, permutation invariance, partition, and agreement with a simpler oracle.
-
-`fast-check` runs under `bun test` with no adapter. On failure it shrinks to a minimal counterexample and prints a seed. Replay with `fc.assert(prop, { seed: <printed seed> })`.
-
-```ts
-import fc from "fast-check";
-
-test("encode/decode roundtrip", () => {
-  fc.assert(
-    fc.property(fc.array(fc.integer()), (values) => {
-      expect(decode(encode(values))).toEqual(values);
-    }),
-  );
-});
-```
-
-Put `expect` calls inside the property. Constrain the arbitrary (`fc.integer({ min: 1 })`) or use `fc.pre(condition)` rather than generating values and filtering them.
-
-#### Fake Domain Instances → Arbitraries and Builders
-
-Give tests that need filler instances of a domain type a typed `fc.record` arbitrary defined next to them. Reuse it in properties, and in example tests via seeded `fc.sample` with per-case fields overridden by spread.
-
-```ts
-const finding = fc.record<Finding>({
-  path: fc.string({ minLength: 1 }),
-  line: fc.integer({ min: 1 }),
-  severity: fc.constantFrom("low", "high"),
-});
-
-const [base] = fc.sample(finding, { seed: 1, numRuns: 1 });
-const item = { ...base, path: "src/a.ts" };
-```
-
-A plain `make<Type>(overrides)` builder is fine when only one or two of many fields matter. No faker-style dependencies: realistic-looking values add flake, not signal.
-
-#### Refactor Bar
-
-A test refactor must not change behavior: same assertions, net LOC down, and `bun test <dir>` green before and after.
-
 ## CI Structure
 
-Tests run per-plugin in the CI matrix, so failures name the plugin and slow integration tests run in parallel. Root-level tests (`hooks/`) run in a dedicated job.
+`.github/workflows/test.yml` runs one matrix job per plugin, a `hooks` job over `./.claude ./user scripts/`, and a `validate` job over `packages/`. New plugin tests join the existing matrix instead of getting their own job.

--- a/.claude/workflows/test-upgrade.ts
+++ b/.claude/workflows/test-upgrade.ts
@@ -79,7 +79,8 @@ const VERIFY_SCHEMA = {
 phase("Ground");
 const ground = await agent(
   [
-    "Return, verbatim, the '## Technique Selection' section of .claude/rules/testing.md in the current repo.",
+    "Return, verbatim, the '## Technique Selection' and '## Refactor Bar' sections of user/rules/testing.md in the current repo,",
+    "followed by the whole body of user/rules/testing-typescript.md.",
     "No commentary.",
   ].join("\n"),
   { label: "ground:rule-text", phase: "Ground", effort: "low" },

--- a/user/rules/testing-typescript.md
+++ b/user/rules/testing-typescript.md
@@ -1,0 +1,85 @@
+---
+paths:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*_test.ts"
+  - "**/*_test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+---
+
+# Testing TypeScript
+
+## Matchers
+
+#### Repeated Cases
+
+Use `test.each` with a typed table. Title each row through the template so a failure names the row.
+
+```ts
+// Tuple rows: positional args, %s/%d/%p placeholders in the title
+test.each<[string, number]>([
+  ["", 0],
+  ["a", 1],
+])("length of %p is %d", (input, expected) => {
+  expect(input.length).toBe(expected);
+});
+
+// Object rows: named fields, $field placeholders in the title
+test.each<{ name: string; input: string; expected: number }>([
+  { name: "empty string", input: "", expected: 0 },
+  { name: "single char", input: "a", expected: 1 },
+])("$name", ({ input, expected }) => {
+  expect(input.length).toBe(expected);
+});
+```
+
+`describe.each` parametrizes an entire suite the same way.
+
+#### Formatted Output
+
+Call `toMatchInlineSnapshot()` with no argument. The first run writes the received value into the test file. When the output changes intentionally, rerun with `-u` and review what it wrote.
+
+Past roughly 20 lines, use `toMatchSnapshot()`, which writes to `__snapshots__/*.snap`.
+
+#### Invariants
+
+Write one `fast-check` property plus a small example table. `fast-check` needs no runner adapter.
+
+```ts
+import fc from "fast-check";
+
+test("encode/decode roundtrip", () => {
+  fc.assert(
+    fc.property(fc.array(fc.integer()), (values) => {
+      expect(decode(encode(values))).toEqual(values);
+    }),
+  );
+});
+```
+
+Put `expect` calls inside the property. An assertion failure or any other throw fails the run, except `fc.pre(condition)`, whose throw skips the case. Constrain the arbitrary (`fc.integer({ min: 1 })`, `fc.string({ minLength: 1 })`) or use `fc.pre` instead of generating values and filtering them.
+
+On failure `fast-check` shrinks toward a smaller counterexample and prints `{ seed, path, endOnFailure }`. Replay by passing that object to `fc.assert(prop, ...)`.
+
+#### Fake Instances
+
+Write a `make<Type>(overrides)` builder in the test file.
+
+```ts
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return { path: "src/a.ts", line: 1, severity: "low", ...overrides };
+}
+```
+
+Where `fast-check` is already a dependency, define a typed `fc.record` arbitrary beside the tests and reuse it in properties.
+
+```ts
+const finding = fc.record<Finding>({
+  path: fc.string({ minLength: 1 }),
+  line: fc.integer({ min: 1 }),
+  severity: fc.constantFrom("low", "high"),
+});
+```
+
+Skip faker-style dependencies.

--- a/user/rules/testing.md
+++ b/user/rules/testing.md
@@ -1,0 +1,33 @@
+---
+paths:
+  - "**/*.test.*"
+  - "**/*_test.*"
+  - "**/*.spec.*"
+  - "**/test_*.py"
+---
+
+# Testing
+
+## Technique Selection
+
+#### Repeated Cases
+
+When two or more tests differ only in their data, collapse them into one table-driven test. Give every row a name so a failure identifies the row without counting.
+
+#### Formatted Output
+
+Assert formatted or structured output with one snapshot over the whole value.
+
+#### Invariants
+
+When a property holds across a range of inputs, state it as a property test over generated input. Shapes to look for: roundtrip (`decode(encode(x))` equals `x`), idempotence, permutation invariance, partition (parts recombine to the whole), and agreement with a simpler oracle.
+
+#### Fake Instances
+
+Build filler instances of a domain type from a builder or generator defined beside the tests, overriding the fields the case cares about.
+
+## Refactor Bar
+
+A test refactor preserves behavior: the same assertions, fewer lines, and the same suite passing before and after.
+
+When a test is hard to write, treat the difficulty as evidence about the interface and reshape it before adding scaffolding to the test.


### PR DESCRIPTION
The testing rule fused TypeScript and Bun spellings into guidance that applies to test files in any language, so a Go or Python test file got nothing. Technique selection moves to `user/rules/testing.md`, the matchers to `user/rules/testing-typescript.md`. `.claude/rules/testing.md` keeps bun discovery, the dotdir prefix, hook E2E, and the CI matrix. #1246

`.claude/workflows/test-upgrade.ts` grounded its audit agents on the `## Technique Selection` section of the repo rule. Its prompt now reads both user rules. That file sits outside this lane's scope, changed because leaving it would break the workflow silently.

Checked against bun 1.4.0 and fast-check 4.8.0 as installed here:

- `bun test .claude/hooks` prints a "files were searched" note and exits non-zero.
- `-u` updates snapshots under bun, vitest, and jest alike.
- `fc.pre` throws to skip a case.
- Both `#### Fake Instances` snippets typecheck under `--strict --noUncheckedIndexedAccess`.
- `CI Structure` matches the jobs in `test.yml`.

`**/*_test.go` is subsumed by `**/*_test.*`. `**/*.spec.*` joins the general rule, and `**/*_test.ts`, `**/*.spec.ts`, `**/*.spec.tsx` the TypeScript one.
