### PR TITLE
skills: add a tdd skill

### DIFF
--- a/user/skills/tdd/SKILL.md
+++ b/user/skills/tdd/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: tdd
+description: Test-driven development. Use when building a feature or fixing a bug test-first, when the user asks for red-green-refactor, or when a change needs its tests written before its implementation.
+---
+
+# Test-Driven Development
+
+## Seams
+
+A seam is where a module's interface lives: the place a caller observes behavior without reaching inside. Tests run at seams.
+
+Before writing any test, ask the user what the public interface is and which seams to test. Write no test at an unconfirmed seam.
+
+When the interface shape is itself in question, read [`LANGUAGE.md`](../improve-codebase-architecture/LANGUAGE.md) for the vocabulary: module, interface, implementation, depth, seam, adapter, locality.
+
+## The Loop
+
+One seam, one test, one minimal implementation per cycle.
+
+1. Write one failing test at a confirmed seam. Run it and confirm it fails for the reason you expect.
+2. Write only enough code to pass it. Anticipate no later test and add no speculative feature.
+3. Return to step 1 with what the cycle taught.
+
+Refactoring belongs to review, outside the loop: `review:code` for correctness, `simplify` for reuse and shape.
+
+The work is done when every confirmed seam has a test that failed before its implementation existed.
+
+## What a Good Test Is
+
+Verify behavior through the interface. Name the test as a specification: "user can checkout with valid cart" names a capability. Use the domain language the surrounding code uses.
+
+See [references/tests.md](references/tests.md) for good and bad pairs, and [references/mocking.md](references/mocking.md) for which seams get a substitute adapter.
+
+## Anti-Patterns
+
+#### Implementation-Coupled
+
+The test substitutes an internal collaborator, exercises a private method, or verifies through a side channel such as querying the database instead of reading back through the interface. The tell: a refactor breaks the test while behavior is unchanged.
+
+#### Tautological
+
+The assertion recomputes the expected value the way the code computes it: `expect(add(a, b)).toBe(a + b)`, a snapshot worked out by hand through the same steps, a constant asserted equal to itself. Take expected values from an independent source: a known-good literal, a worked example, the spec.
+
+#### Horizontal Slicing
+
+Writing every test first, then every implementation. Work in vertical slices: one test, one implementation, repeat, each cycle responding to what the last one taught.
+
+---
+
+Adapted from [mattpocock/skills](https://github.com/mattpocock/skills) `skills/engineering/tdd/SKILL.md` at `6654f6b`, MIT.

--- a/user/skills/tdd/references/mocking.md
+++ b/user/skills/tdd/references/mocking.md
@@ -34,6 +34,19 @@ function processPayment(order) {
 }
 ```
 
+```go
+// The caller declares the interface it needs
+type Charger interface {
+	Charge(cents int64) error
+}
+
+func ProcessPayment(order Order, c Charger) error {
+	return c.Charge(order.Total)
+}
+```
+
+Go declares the interface on the consumer side, so `Charger` lives where it is used rather than being exported by the payment package. The seam stays as wide as this one caller needs, and the provider never depends on it.
+
 #### One Function per Operation
 
 Give each external operation its own function rather than one generic caller that branches on its arguments.

--- a/user/skills/tdd/references/mocking.md
+++ b/user/skills/tdd/references/mocking.md
@@ -1,0 +1,59 @@
+# Substitute Adapters
+
+A test double is an adapter: a second concrete thing satisfying an interface at a seam. Add one only where the seam is already real.
+
+## Real Seams
+
+A seam is real when something varies across it. One adapter means a hypothetical seam, two mean a real one. A test double is not the second adapter.
+
+Two things make a seam real:
+
+- **Production varies.** Two payment providers, an in-memory store in development and Postgres in production, a real clock and a simulated one.
+- **The other side sits outside the process.** Network calls, the clock, randomness, the file system. Prefer a real test database and a temp directory where either is practical, and substitute the rest.
+
+Everything the process owns keeps its real implementation: your own modules, internal collaborators, anything you can change.
+
+## Shaping the Interface
+
+#### Pass Adapters In
+
+Take the dependency as a parameter rather than constructing it inside.
+
+```typescript
+// The seam is at the parameter
+function processPayment(order, paymentClient) {
+  return paymentClient.charge(order.total);
+}
+```
+
+```typescript
+// No seam: the implementation is wired in
+function processPayment(order) {
+  const client = new StripeClient(process.env.STRIPE_KEY);
+  return client.charge(order.total);
+}
+```
+
+#### One Function per Operation
+
+Give each external operation its own function rather than one generic caller that branches on its arguments.
+
+```typescript
+// Each operation carries its own interface
+const api = {
+  getUser: (id) => fetch(`/users/${id}`),
+  getOrders: (userId) => fetch(`/users/${userId}/orders`),
+  createOrder: (data) => fetch("/orders", { method: "POST", body: data }),
+};
+```
+
+```typescript
+// One interface for every operation, so every adapter reimplements the routing
+const api = {
+  fetch: (endpoint, options) => fetch(endpoint, options),
+};
+```
+
+---
+
+Adapted from [mattpocock/skills](https://github.com/mattpocock/skills) `skills/engineering/tdd/mocking.md` at `6654f6b`, MIT.

--- a/user/skills/tdd/references/tests.md
+++ b/user/skills/tdd/references/tests.md
@@ -1,0 +1,69 @@
+# Good and Bad Tests
+
+## Good
+
+Test through the real interface, never through a substitute for an internal part.
+
+```typescript
+test("user can checkout with valid cart", async () => {
+  const cart = createCart();
+  cart.add(product);
+  const result = await checkout(cart, paymentMethod);
+  expect(result.status).toBe("confirmed");
+});
+```
+
+Take the test's shape from the project's own testing rules: how many assertions one test carries, whether repeated cases collapse into a table, and whether formatted output gets a snapshot.
+
+## Bad
+
+#### Implementation-Coupled
+
+```typescript
+// BAD: asserts on an internal call
+test("checkout calls paymentService.process", async () => {
+  const mockPayment = jest.mock(paymentService);
+  await checkout(cart, payment);
+  expect(mockPayment.process).toHaveBeenCalledWith(cart.total);
+});
+```
+
+Also a red flag: asserting on call counts or call order, and a test name describing how rather than what.
+
+#### Side-Channel Verification
+
+```typescript
+// BAD: bypasses the interface to verify
+test("createUser saves to database", async () => {
+  await createUser({ name: "Alice" });
+  const row = await db.query("SELECT * FROM users WHERE name = ?", ["Alice"]);
+  expect(row).toBeDefined();
+});
+
+// GOOD: verifies through the interface
+test("createUser makes user retrievable", async () => {
+  const user = await createUser({ name: "Alice" });
+  const retrieved = await getUser(user.id);
+  expect(retrieved.name).toBe("Alice");
+});
+```
+
+#### Tautological
+
+```typescript
+// BAD: the expected value is recomputed the way the code computes it
+test("calculateTotal sums line items", () => {
+  const items = [{ price: 10 }, { price: 5 }];
+  const expected = items.reduce((sum, i) => sum + i.price, 0);
+  expect(calculateTotal(items)).toBe(expected);
+});
+
+// GOOD: the expected value is an independent, known literal
+test("calculateTotal sums line items", () => {
+  expect(calculateTotal([{ price: 10 }, { price: 5 }])).toBe(15);
+});
+```
+
+---
+
+Adapted from [mattpocock/skills](https://github.com/mattpocock/skills) `skills/engineering/tdd/tests.md` at `6654f6b`, MIT.

--- a/user/skills/tdd/references/tests.md
+++ b/user/skills/tdd/references/tests.md
@@ -28,6 +28,16 @@ test("checkout calls paymentService.process", async () => {
 });
 ```
 
+```python
+# BAD: the patch target is an import path, so the test encodes the module layout
+def test_checkout_calls_payment(mocker):
+    mock = mocker.patch("app.services.payment.process")
+    checkout(cart, payment)
+    mock.assert_called_once_with(cart.total)
+```
+
+The target names where `process` is looked up rather than where it is defined. Switching `checkout` between `from app.services.payment import process` and a module-attribute call breaks the test while behavior is unchanged.
+
 Also a red flag: asserting on call counts or call order, and a test name describing how rather than what.
 
 #### Side-Channel Verification


### PR DESCRIPTION
Adds a `tdd` skill: the red-green loop with refactoring outside it, seam confirmation with the user before any test, and three anti-patterns (implementation-coupled, tautological, horizontal slicing). #1246

Test shape defers to the project's own testing rules rather than a fixed assertion count, since a snapshot over formatted output puts several assertions in one test.

`references/mocking.md` treats a seam as real when production varies across it or the other side sits outside the process. A test double is not the second adapter, so a seam introduced to let a test substitute leaves production code with an interface it never varies across.

Stacked on #1260, which adds the testing rules `references/tests.md` defers to.
