### PR TITLE
gitlab: pass --auto-merge explicitly in merge.ts

### DIFF
--- a/plugins/gitlab/scripts/merge.test.ts
+++ b/plugins/gitlab/scripts/merge.test.ts
@@ -1,11 +1,31 @@
 import { describe, expect, mock, test } from "bun:test";
-import type { MergeActions } from "./merge";
-import { arm, merge } from "./merge";
+import type { MergeActions, MergeRequestDetail } from "./merge";
+import { arm, merge, mergeArgs, status } from "./merge";
+
+function createMergeRequest(overrides: Partial<MergeRequestDetail> = {}): MergeRequestDetail {
+  return {
+    iid: 10,
+    title: "Add tenants config",
+    state: "opened",
+    draft: false,
+    web_url: "https://gitlab.com/acme/tenants-config/-/merge_requests/10",
+    source_branch: "feature",
+    target_branch: "main",
+    detailed_merge_status: "mergeable",
+    has_conflicts: false,
+    blocking_discussions_resolved: true,
+    auto_merge_enabled: false,
+    head_pipeline: { id: 7, status: "success" },
+    ...overrides,
+  };
+}
 
 function createActions(overrides: Partial<MergeActions> = {}): MergeActions {
   return {
     getProjectConfig: mock(() => Promise.resolve({ id: 42, merge_trains_enabled: false })),
     getMrIid: mock(() => Promise.resolve(10)),
+    getMergeRequest: mock(() => Promise.resolve(createMergeRequest())),
+    isRebasedOnTarget: mock(() => Promise.resolve(true)),
     addToMergeTrain: mock(() => Promise.resolve()),
     mergeViaGlab: mock(() => Promise.resolve()),
     ...overrides,
@@ -168,5 +188,66 @@ describe("arm", () => {
 
     await expect(arm(run, sleep)).rejects.toThrow("glab exited with code 1");
     expect(run).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("mergeArgs", () => {
+  // glab enables auto-merge by default when a pipeline is running, so omitting the
+  // flag silently queues the MR. Both branches must send it explicitly.
+  test.each([
+    [true, "--auto-merge=true"],
+    [false, "--auto-merge=false"],
+  ])("passes the auto-merge choice explicitly when autoMerge is %p", (autoMerge, flag) => {
+    expect(mergeArgs("feature", autoMerge)).toEqual(["feature", flag, "-y"]);
+  });
+});
+
+describe("status", () => {
+  test("reports merge readiness without merging", async () => {
+    const actions = createActions({
+      getProjectConfig: mock(() => Promise.resolve({ id: 42, merge_trains_enabled: true })),
+    });
+
+    const result = await status("feature", actions);
+
+    expect(result).toMatchObject({
+      iid: 10,
+      detailed_merge_status: "mergeable",
+      merge_trains_enabled: true,
+      rebased_on_target: true,
+    });
+    expect(actions.isRebasedOnTarget).toHaveBeenCalledWith("main", "feature");
+    expect(actions.mergeViaGlab).not.toHaveBeenCalled();
+    expect(actions.addToMergeTrain).not.toHaveBeenCalled();
+  });
+
+  test("surfaces a child MR still targeting a merged parent branch", async () => {
+    const actions = createActions({
+      getMergeRequest: mock(() =>
+        Promise.resolve(createMergeRequest({ target_branch: "parent-layer" })),
+      ),
+      isRebasedOnTarget: mock(() => Promise.resolve(false)),
+    });
+
+    const result = await status("feature", actions);
+
+    expect(result.target_branch).toBe("parent-layer");
+    expect(result.rebased_on_target).toBe(false);
+  });
+
+  test("reports null when the ancestry check cannot run", async () => {
+    const actions = createActions({
+      isRebasedOnTarget: mock(() => Promise.resolve(null)),
+    });
+
+    expect((await status("feature", actions)).rebased_on_target).toBeNull();
+  });
+
+  test("throws when no open MR found for branch", async () => {
+    const actions = createActions({
+      getMrIid: mock(() => Promise.reject(new Error("No open MR found for branch: no-mr"))),
+    });
+
+    await expect(status("no-mr", actions)).rejects.toThrow("No open MR found for branch: no-mr");
   });
 });

--- a/plugins/gitlab/scripts/merge.ts
+++ b/plugins/gitlab/scripts/merge.ts
@@ -76,6 +76,46 @@ export async function getMrIid(branch: string): Promise<number> {
   return mrs[0]!.iid;
 }
 
+export interface MergeRequestDetail {
+  iid: number;
+  title: string;
+  state: string;
+  draft: boolean;
+  web_url: string;
+  source_branch: string;
+  target_branch: string;
+  detailed_merge_status: string;
+  has_conflicts: boolean;
+  blocking_discussions_resolved: boolean;
+  auto_merge_enabled?: boolean;
+  head_pipeline?: { id: number; status: string } | null;
+}
+
+export async function getMergeRequest(iid: number): Promise<MergeRequestDetail> {
+  return $`glab api projects/:id/merge_requests/${iid}`.json();
+}
+
+// The API's has_conflicts/detailed_merge_status stay stale for minutes after a
+// rebase, so ancestry against the fetched target ref is the reliable "is this
+// rebased" signal. Returns null when either remote ref is missing locally.
+export async function isRebasedOnTarget(target: string, source: string): Promise<boolean | null> {
+  await $`git fetch --quiet origin ${target} ${source}`.nothrow().quiet();
+
+  const refs = await Promise.all(
+    [target, source].map((branch) =>
+      $`git rev-parse --verify --quiet origin/${branch}`.nothrow().quiet(),
+    ),
+  );
+  if (refs.some((ref) => ref.exitCode !== 0)) {
+    return null;
+  }
+
+  const ancestor = await $`git merge-base --is-ancestor origin/${target} origin/${source}`
+    .nothrow()
+    .quiet();
+  return ancestor.exitCode === 0;
+}
+
 interface MergeTrainOptions {
   projectId: number;
   iid: number;
@@ -94,19 +134,53 @@ export async function addToMergeTrain(opts: MergeTrainOptions): Promise<void> {
   );
 }
 
+// `glab mr merge` turns auto-merge on by default whenever a pipeline is running, so
+// omitting the flag arms the MR instead of merging it. Always send the caller's choice.
+export function mergeArgs(branch: string, autoMerge: boolean): string[] {
+  return [branch, `--auto-merge=${autoMerge}`, "-y"];
+}
+
 export async function mergeViaGlab(branch: string, autoMerge: boolean): Promise<void> {
-  const flags = autoMerge ? "--auto-merge" : "";
-  await arm(() => $`glab mr merge ${branch} ${{ raw: flags }} -y`);
+  await arm(() => $`glab mr merge ${mergeArgs(branch, autoMerge)}`);
 }
 
 export interface MergeActions {
   getProjectConfig(): Promise<ProjectConfig>;
   getMrIid(branch: string): Promise<number>;
+  getMergeRequest(iid: number): Promise<MergeRequestDetail>;
+  isRebasedOnTarget(target: string, source: string): Promise<boolean | null>;
   addToMergeTrain(opts: MergeTrainOptions): Promise<void>;
   mergeViaGlab(branch: string, autoMerge: boolean): Promise<void>;
 }
 
-const defaultActions: MergeActions = { getProjectConfig, getMrIid, addToMergeTrain, mergeViaGlab };
+const defaultActions: MergeActions = {
+  getProjectConfig,
+  getMrIid,
+  getMergeRequest,
+  isRebasedOnTarget,
+  addToMergeTrain,
+  mergeViaGlab,
+};
+
+export interface MergeRequestStatus extends MergeRequestDetail {
+  merge_trains_enabled: boolean;
+  rebased_on_target: boolean | null;
+}
+
+export async function status(
+  branch: string,
+  actions: MergeActions = defaultActions,
+): Promise<MergeRequestStatus> {
+  const project = await actions.getProjectConfig();
+  const iid = await actions.getMrIid(branch);
+  const mr = await actions.getMergeRequest(iid);
+
+  return {
+    ...mr,
+    merge_trains_enabled: project.merge_trains_enabled,
+    rebased_on_target: await actions.isRebasedOnTarget(mr.target_branch, mr.source_branch),
+  };
+}
 
 export async function merge(
   branch: string,
@@ -143,13 +217,22 @@ if (import.meta.main) {
         description: "Squash commits when merging",
         default: false,
       },
+      status: {
+        type: Boolean,
+        description: "Print the MR's merge readiness as JSON and exit without merging",
+        default: false,
+      },
     },
   });
 
   const branch = argv._.branch || (await $`git branch --show-current`.text()).trim();
 
-  await merge(branch, {
-    autoMerge: argv.flags.autoMerge,
-    squash: argv.flags.squash,
-  });
+  if (argv.flags.status) {
+    console.log(JSON.stringify(await status(branch), null, 2));
+  } else {
+    await merge(branch, {
+      autoMerge: argv.flags.autoMerge,
+      squash: argv.flags.squash,
+    });
+  }
 }

--- a/plugins/gitlab/skills/merge-request/SKILL.md
+++ b/plugins/gitlab/skills/merge-request/SKILL.md
@@ -36,6 +36,17 @@ bun ${CLAUDE_PLUGIN_ROOT}/scripts/merge.ts --auto-merge
 bun ${CLAUDE_PLUGIN_ROOT}/scripts/merge.ts feature-branch --auto-merge --squash
 ```
 
+Never call `glab mr merge` directly. It turns auto-merge on by default whenever a pipeline is running. A bare invocation then queues the MR to merge itself later instead of merging it now, silently breaking a deliberate merge order. `merge.ts` always sends `--auto-merge=<choice>` so the default cannot apply.
+
+### Inspect Before Merging
+
+`--status` prints the MR's merge readiness as JSON and exits without touching it: target branch, draft state, `detailed_merge_status`, head pipeline, and a `rebased_on_target` ancestry check computed from git rather than the API's stale conflict fields.
+
+```bash
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/merge.ts --status
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/merge.ts feature-branch --status
+```
+
 ### Re-Arm Auto-Merge After a Push
 
 Pushing new commits cancels queued auto-merge and drops the MR from the merge train. GitLab does this deliberately so the new commits get a fresh pipeline and review. To keep auto-merge, re-run `merge.ts --auto-merge` after every push that intends to stay armed. The script is idempotent: it treats an already-armed MR as success and retries through the brief `approvals_syncing` window that follows a push, so re-running it is always safe.
@@ -45,6 +56,10 @@ A push also resets approvals when `reset_approvals_on_push` is on. Re-trigger re
 ### Inspect or Recover a Train
 
 To inspect the active train or clear a stuck entry via the API (`glab` has no merge-train command), see [merge-trains.md](merge-trains.md).
+
+## Stacked MRs
+
+Merging one layer of a stack leaves the layer above it targeting a branch that already merged. GitLab does not retarget it. Retarget, rebase, and verify after every layer, see [stacked-mrs.md](stacked-mrs.md).
 
 ## Patterns
 

--- a/plugins/gitlab/skills/merge-request/stacked-mrs.md
+++ b/plugins/gitlab/skills/merge-request/stacked-mrs.md
@@ -1,0 +1,44 @@
+# Stacked MRs
+
+An MR stack is a chain where each MR targets the branch below it. Merging the bottom layer does not fix the layer above it. GitLab's auto-retarget only fires when the merge deletes the merged MR's source branch, and a stack's parent branch survives its own merge because the child MR still references it. The child then keeps targeting a branch that is already in `main`, its diff shows commits that merged with the parent, and the parent branch lingers.
+
+Enabling `remove_source_branch_after_merge` on the project does not help. GitLab refuses to delete a branch another open MR targets. The setting is a no-op for exactly the case that needs it.
+
+## Per-Layer Retarget
+
+After each layer merges, run this against the next open layer before merging that one.
+
+Retarget the child at `main`. This also resets approvals, which a serial merge wants: the layer gets a fresh review against its real base.
+
+```bash
+glab mr update <child-iid> --target-branch main
+```
+
+Rebase, dropping the parent's commits from the diff.
+
+```bash
+glab mr rebase <child-iid>
+```
+
+Verify against git.
+
+```bash
+git fetch origin main <child-branch>
+git merge-base --is-ancestor origin/main origin/<child-branch>
+```
+
+A zero exit means the rebase landed. Do not check the MR's `conflicts` or `detailed_merge_status` field instead. GitLab recomputes those asynchronously and serves the pre-rebase value for minutes, long enough that a polling loop reports a conflict that no longer exists.
+
+`merge.ts --status` reads the MR without mutating it and reports the same ancestry check as `rebased_on_target`, alongside target branch, pipeline, and merge status:
+
+```bash
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/merge.ts <child-branch> --status
+```
+
+## Parent Branch Cleanup
+
+Once the child targets `main`, nothing references the merged parent branch:
+
+```bash
+glab api projects/:id/repository/branches/<parent-branch> -X DELETE
+```


### PR DESCRIPTION
`glab mr merge` turns auto-merge on by default whenever a pipeline is running. `merge.ts` built its flags as `autoMerge ? "--auto-merge" : ""`. That sent nothing on the false branch, so glab's default won and the script's own `autoMerge: false` never reached the CLI.

A bare `merge.ts` run therefore queued any MR with a live pipeline to merge itself later. It broke a deliberate serial-merge order on `tenants-config!26` on 2026-08-24. `mergeArgs()` now builds the argv, both branches send `--auto-merge=<choice>`, and a table test pins each one.

During that incident the script offered no way to look at an MR without acting on it. `--status` adds one. It reports target branch, draft state, `detailed_merge_status`, head pipeline, and a `rebased_on_target` check computed with `git merge-base --is-ancestor`.

Reading the MR's `conflicts` field instead does not work. GitLab recomputes it asynchronously and serves the pre-rebase value for minutes.

The new `stacked-mrs.md` reference covers the second half of that incident. Merging one layer of a stack leaves the layer above it targeting a branch already in `main`. GitLab's auto-retarget only fires when the merge deletes the source branch, and it refuses to delete a branch an open child MR targets. `remove_source_branch_after_merge` is a no-op for exactly this case.

## Judgment Calls

- `--status` is a flag rather than a subcommand. Subcommands read better. Converting the CLI would break `merge.ts --auto-merge` and `merge.ts <branch> --squash`, which the skill documents and other callers use.
- `isRebasedOnTarget` runs `git fetch` first. It is read-only against GitLab, not against local state: it updates remote-tracking refs for the two branches. Comparing the refs as they already stand would be fully passive, and it would answer a stale question. That is the failure the check exists to catch.
- The status payload spreads GitLab's raw MR fields and adds two computed ones. A curated projection was the alternative. Raw field names stay greppable against GitLab's API docs, at the cost of a wide payload that moves with the API.
- The ancestry check ships in the script as well as the doc. Documenting it alone was the smaller change. Anyone who has loaded the skill can run the `git` command directly.

Exercised `isRebasedOnTarget` against real refs here for all three outcomes: a rebased branch, a branch five commits behind `origin/main`, and a missing remote ref.
