### PR TITLE
writing: deny salutations on published comments

### DIFF
--- a/plugins/writing/detection/tropes.test.ts
+++ b/plugins/writing/detection/tropes.test.ts
@@ -720,6 +720,66 @@ describe("scan", () => {
     });
   });
 
+  describe("salutation", () => {
+    function salutation(text: string): PatternMatch | undefined {
+      return scan(text, undefined, "sideEffect").find((m) => m.category === "salutation");
+    }
+
+    const addressed = [
+      "Dana, this fires for the entire run rather than the changed files.",
+      "Dana Reyes, the retry loop swallows the error.",
+      "Hi Dana,\n\nThe retry loop swallows the error.",
+      "Hey there,\n\nA few notes below.",
+      "Hello team, a few notes below.",
+      "Dear reviewer,\n\nA few notes below.",
+      "## Review\n\nDana, the retry loop swallows the error.",
+      "Dana,\nThe retry loop swallows the error.",
+    ];
+
+    for (const text of addressed) {
+      it(`denies: ${JSON.stringify(text.slice(0, 40))}`, () => {
+        const match = salutation(text);
+        expect(match?.tier).toBe("deny");
+        expect(match?.structural).toBe(true);
+      });
+    }
+
+    const substantive = [
+      "Otherwise, this looks right.",
+      "Given the constraint, the second pass is redundant.",
+      "Nit, but the constant belongs next to its only caller.",
+      "Overall, the shape is right.",
+      "First, the constant is unused.",
+      "Ideally, the retry budget comes from config.",
+      "Naming, formatting, and tests all read fine.",
+      "Agreed, the second pass is redundant.",
+      "The retry loop swallows the error.",
+      "Question, does the sweep cover deleted files?",
+      "`Dana`, the identifier, is a fixture name.",
+      "Today, the sweep still walks every file.",
+      "Upstream, the API dropped the field.",
+      "Tests, then the docs.",
+    ];
+
+    for (const text of substantive) {
+      it(`allows: ${JSON.stringify(text.slice(0, 40))}`, () => {
+        expect(salutation(text)).toBeUndefined();
+      });
+    }
+
+    it("ignores an address that is not on the opening line", () => {
+      expect(salutation("The sweep is too broad.\n\nDana, it fires on every run.")).toBeUndefined();
+    });
+
+    it("skips file context", () => {
+      expect(
+        scan("Dana, this fires for the entire run.", undefined, "file").find(
+          (m) => m.category === "salutation",
+        ),
+      ).toBeUndefined();
+    });
+  });
+
   describe("sideEffectOnly scoping", () => {
     const conversational = [
       { text: "You're right about that.", category: "sycophantic acknowledgment" },

--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -367,7 +367,228 @@ function discourseMarkerDensityHits(text: string): Hits {
   return { count: marked.length, sample: (marked[0] as string).slice(0, 60) };
 }
 
+// A salutation addresses a person before the substance starts: a greeting word,
+// or a name followed by a comma ("Dana, this fires for the entire run"). Only
+// the opening line of a comment can carry one, so the test anchors there.
+// Further down the same shape is ordinary third-person prose.
+const GREETING_OPENER = /^(?:hi|hey|hello|dear|greetings|good\s+(?:morning|afternoon|evening))\b/i;
+const ADDRESS_OPENER = /^([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?),(?:\s|$)/;
+
+// Words that legitimately open a sentence ahead of a comma. Adverbs (-ly) and
+// gerunds (-ing) are covered by shape, so what remains is the closed set of
+// connectives, agreement words, and review idioms. A name that takes one of
+// those forms (Holly, Sterling) is invisible to the check, which is the price
+// of never denying "Otherwise, this looks right".
+const SENTENCE_OPENERS = new Set([
+  "above",
+  "after",
+  "afterward",
+  "again",
+  "agreed",
+  "ah",
+  "ahead",
+  "also",
+  "although",
+  "altogether",
+  "always",
+  "and",
+  "anyhow",
+  "anyway",
+  "anywhere",
+  "aside",
+  "assuming",
+  "because",
+  "before",
+  "below",
+  "besides",
+  "best",
+  "better",
+  "beyond",
+  "both",
+  "but",
+  "caveat",
+  "context",
+  "correct",
+  "ditto",
+  "docs",
+  "done",
+  "downstream",
+  "earlier",
+  "eh",
+  "either",
+  "elsewhere",
+  "everywhere",
+  "exactly",
+  "fair",
+  "false",
+  "fine",
+  "first",
+  "five",
+  "four",
+  "fwiw",
+  "given",
+  "good",
+  "granted",
+  "great",
+  "hence",
+  "here",
+  "hmm",
+  "however",
+  "huh",
+  "if",
+  "imho",
+  "imo",
+  "indeed",
+  "inside",
+  "instead",
+  "last",
+  "later",
+  "likewise",
+  "major",
+  "majors",
+  "maybe",
+  "meantime",
+  "meanwhile",
+  "minor",
+  "minors",
+  "moreover",
+  "neither",
+  "net",
+  "never",
+  "nevertheless",
+  "next",
+  "nit",
+  "nits",
+  "no",
+  "nonetheless",
+  "nope",
+  "not",
+  "note",
+  "notes",
+  "now",
+  "nowhere",
+  "offline",
+  "often",
+  "oh",
+  "ok",
+  "okay",
+  "once",
+  "one",
+  "online",
+  "optional",
+  "or",
+  "otherwise",
+  "outside",
+  "overall",
+  "per",
+  "perhaps",
+  "plus",
+  "question",
+  "questions",
+  "rather",
+  "regardless",
+  "right",
+  "same",
+  "scope",
+  "second",
+  "since",
+  "so",
+  "sometimes",
+  "somewhere",
+  "soon",
+  "sorry",
+  "still",
+  "style",
+  "suggestion",
+  "sure",
+  "tangent",
+  "tbh",
+  "tests",
+  "then",
+  "there",
+  "third",
+  "though",
+  "three",
+  "thus",
+  "tldr",
+  "today",
+  "together",
+  "tomorrow",
+  "tonight",
+  "true",
+  "two",
+  "types",
+  "understood",
+  "unless",
+  "unrelated",
+  "until",
+  "upstream",
+  "well",
+  "when",
+  "where",
+  "whereas",
+  "while",
+  "worse",
+  "wrong",
+  "yep",
+  "yes",
+  "yesterday",
+  "yet",
+  "ymmv",
+]);
+
+function isNameShaped(word: string): boolean {
+  const lower = word.toLowerCase();
+  if (SENTENCE_OPENERS.has(lower)) return false;
+  return !lower.endsWith("ly") && !lower.endsWith("ing");
+}
+
+// Headings are skipped so a body that opens "## Review" is judged on the line
+// that follows. stripCode has already blanked leading fenced code.
+function openingLine(text: string): string {
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length > 0 && !trimmed.startsWith("#")) return trimmed;
+  }
+  return "";
+}
+
+function salutationHits(text: string): Hits {
+  const line = openingLine(text);
+  if (line === "") return { count: 0, sample: "" };
+  if (GREETING_OPENER.test(line)) return { count: 1, sample: line.slice(0, 40) };
+  const address = ADDRESS_OPENER.exec(line)?.[1];
+  if (!address) return { count: 0, sample: "" };
+  const head = address.split(/\s+/)[0] as string;
+  if (!isNameShaped(head)) return { count: 0, sample: "" };
+  return { count: 1, sample: `${address},` };
+}
+
 export const PATTERNS: PatternDef[] = [
+  {
+    tier: "deny",
+    layer: "grammar",
+    category: "salutation",
+    sideEffectOnly: true,
+    structural: true,
+    test: salutationHits,
+    message: (matched) =>
+      `"${matched}" opens the comment with a salutation. Nothing published addresses a person, by name or greeting: no vocative, no invented name for a username. Delete the address and open on the substance.`,
+    positives: [
+      "Dana, this fires for the entire run rather than the changed files.",
+      "Hi Dana,\n\nThe retry loop swallows the error.",
+    ],
+    negatives: [
+      "Otherwise, this looks right.",
+      "Given the constraint, the second pass is redundant.",
+      "Nit, but the constant belongs next to its only caller.",
+      "The retry loop swallows the error Dana, who wrote it, described.",
+    ],
+    evidence:
+      "Recurring corrective feedback on published comments: five vocative openers across MR, PR, and Linear drafts between 2026-05-01 and 2026-08-20. The prose rule alone did not stop the fifth.",
+    retire:
+      "Remove when vocative openers stop appearing in corrective-feedback moments. Rebuild the name-shape test instead of extending it if SENTENCE_OPENERS starts accumulating entries that are not discourse connectives, which would mean the shape is matching ordinary nouns.",
+  },
   {
     tier: "deny",
     layer: "grammar",

--- a/plugins/writing/hooks/check-tropes.test.ts
+++ b/plugins/writing/hooks/check-tropes.test.ts
@@ -407,6 +407,44 @@ describe("Bash processInput", () => {
     }
   });
 
+  it("denies a review comment that opens with a vocative", async () => {
+    const result = await processInput(
+      mockBash(
+        `glab mr note 871 --message "Dana, this fires for the entire run rather than the changed files."`,
+      ),
+    );
+    expect(result?.hookSpecificOutput).toHaveProperty("permissionDecision", "deny");
+  });
+
+  it("denies a body-file comment that opens with a greeting", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "trope-test-"));
+    const file = join(dir, "body.md");
+    await Bun.write(file, "Hi Dana,\n\nThe retry loop swallows the error.\n");
+    const result = await processInput(mockBash(`gh pr review --body-file ${file}`));
+    await rm(dir, { recursive: true, force: true });
+    expect(result?.hookSpecificOutput).toHaveProperty("permissionDecision", "deny");
+  });
+
+  it("allows a comment that opens with a connective", async () => {
+    const result = await processInput(
+      mockBash(`glab mr note 871 --message "Otherwise, this looks right."`),
+    );
+    expect(result).toBeNull();
+  });
+
+  // A soft vocabulary deny is declared earlier in the catalog than the
+  // salutation. Selection by catalog order would report it and let the comment
+  // through with a reminder.
+  it("blocks on the salutation when a softer deny also matches", async () => {
+    const result = await processInput(
+      mockBash(`glab mr note 871 --message "Dana, we should delve into the retry budget."`),
+    );
+    expect(result?.hookSpecificOutput).toMatchObject({
+      permissionDecision: "deny",
+      permissionDecisionReason: expect.stringContaining("salutation"),
+    });
+  });
+
   it("returns null for non-text Bash commands", async () => {
     expect(await processInput(mockBash("git push origin main"))).toBeNull();
   });

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -221,12 +221,17 @@ async function processSideEffect(input: PreToolUseHookInput): Promise<HookResult
   if (texts.length === 0) return null;
 
   const matches = scan(texts.join("\n"), undefined, "sideEffect");
-  const deny = firstByTier(matches, "deny");
-  if (deny?.structural) {
-    return { output: formatDecision("deny", deny.message), category: deny.category };
+
+  // A structural deny blocks the call, so it outranks every other finding
+  // regardless of where its pattern sits in the catalog. Selecting the first
+  // deny of any kind would let a soft vocabulary hit that happens to be
+  // declared earlier downgrade the block to a reminder.
+  const structural = matches.find((match) => match.tier === "deny" && match.structural);
+  if (structural) {
+    return { output: formatDecision("deny", structural.message), category: structural.category };
   }
 
-  const match = deny ?? firstByTier(matches, "context");
+  const match = firstByTier(matches, "deny") ?? firstByTier(matches, "context");
   if (match) return { output: formatContext(match.message), category: match.category };
 
   return null;

--- a/plugins/writing/skills/writing/SKILL.md
+++ b/plugins/writing/skills/writing/SKILL.md
@@ -29,6 +29,7 @@ The hook enforces most of these automatically; the rest ship in the scan and rev
 
 #### PR and Review Prose
 
+- No salutations. A published comment opens on the substance, never on a name or a greeting. Referring to someone in third person is fine, and never invent a name for a username.
 - Active voice in PR and review prose. Not "X is added" but "Adds X." Commit subjects take the imperative: "Add X".
 - Not "Tests cover X" but "Added tests covering X."
 - No trailing hedge adverbs ("regardless.", "nonetheless.").


### PR DESCRIPTION
A drafted review comment opened with the author's first name for the fifth time. The rule against it lives only in a memory file, so it depends on recall at drafting time. Recall failed on 2026-05-01, 2026-07-09, 2026-08-05, 2026-08-10, and 2026-08-20. Every other hard style rule here has a hook behind it.

The `salutation` pattern joins the PreToolUse trope catalog as `sideEffectOnly` and `structural`, so it denies the call. `sideEffectOnly` inherits the Bash prose scoping already in `check-tropes.ts`: `--body`, `--message`, `--description`, `--title`, `--body-file`, and the `gh`/`glab` field-file forms. Those are the publication surfaces, so an MR note, a PR review body, and a Linear comment pass through it. A draft sitting in a file does not.

It reads the opening line only and denies a greeting word or a name-shaped token before a comma. Name-shaped means no `-ly`, no `-ing`, and not in a curated set of connectives, agreement words, and review idioms.

One unrelated fix fell out. The side-effect path picked the first deny in catalog order and blocked only if that one was structural, so a soft vocabulary hit declared earlier could downgrade a salutation to a reminder. Selection now prefers a structural deny over catalog position.

## Judgment Calls

A hook rather than always-on `CLAUDE.md` context. Recall-based enforcement is what already failed five times, and always-on text costs tokens in sessions that never write a comment. The skill still gained a one-line rule, but the block carries the guarantee.

A closed opener list rather than a name list, since names are open-ended and the rule covers invented ones. Inverting it makes the false-positive surface enumerable. The cost is a deny on an unlisted proper noun (`Postgres, unlike MySQL, ...`) and a miss on a name shaped like a listed word (Holly, Sterling). I took the miss over denying `Otherwise, this looks right`.

The list sits in `tropes.ts` because the analyze skill audits everything in `wordlists/` as detection entries and would recommend pruning an allowlist. `retire` names the signal to watch. Ordinary nouns accumulating in the list mean the shape test itself needs rebuilding.

https://claude.ai/code/session_012oAtCvx8GBbwuM9ADFGLoU
