### PR TITLE
pull-request: read GitLab MR bodies

### DIFF
--- a/plugins/gitlab/skills/merge-request/SKILL.md
+++ b/plugins/gitlab/skills/merge-request/SKILL.md
@@ -57,7 +57,7 @@ git push -u origin feature-branch && glab mr create --fill
 
 **Auto-fill vs custom:** `--fill` auto-populates from commits but cannot combine with `--title`/`--description`. Choose one approach.
 
-**Body from file:** No `--body-file` flag; use `--description "$(cat file.md)"`.
+**Body from file:** The flag is `--description-file file.md`, not gh's `--body-file`. Prefer it over `--description "$(cat file.md)"`, which passes the body through the shell and keeps it out of some hooks.
 
 **Username resolution:** Flags like `--reviewer` and `--assignee` require exact usernames; invalid names are silently ignored. Look up users first:
 

--- a/plugins/pull-request/scripts/e2e-hook-fire.ts
+++ b/plugins/pull-request/scripts/e2e-hook-fire.ts
@@ -11,13 +11,52 @@ const DENY_REASON_FRAGMENT = "test counts";
 
 interface Case {
   name: string;
+  /** External CLI the case drives, stubbed onto PATH. */
+  cli: "gh" | "glab";
+  /** How the body reaches the CLI, as the create/update skills write it. */
+  command: (fixturePath: string) => string;
+  /** Substring of a stub log line that means the CLI was reached. */
+  marker: string;
   fixture: string;
   expectCreate: boolean;
 }
 
+// GitLab is covered through both forms it accepts: the `--description-file`
+// path the skills now document, and the `--description "$(cat ...)"` command
+// substitution they used to.
 const CASES: Case[] = [
-  { name: "deny", fixture: "deny.md", expectCreate: false },
-  { name: "clean", fixture: "clean.md", expectCreate: true },
+  {
+    name: "gh deny",
+    cli: "gh",
+    command: (fixture) => `gh pr create --title "e2e" --body-file ${fixture}`,
+    marker: "pr create",
+    fixture: "deny.md",
+    expectCreate: false,
+  },
+  {
+    name: "gh clean",
+    cli: "gh",
+    command: (fixture) => `gh pr create --title "e2e" --body-file ${fixture}`,
+    marker: "pr create",
+    fixture: "clean.md",
+    expectCreate: true,
+  },
+  {
+    name: "glab deny",
+    cli: "glab",
+    command: (fixture) => `glab mr create --title "e2e" --description "$(cat ${fixture})"`,
+    marker: "mr create",
+    fixture: "deny.md",
+    expectCreate: false,
+  },
+  {
+    name: "glab clean",
+    cli: "glab",
+    command: (fixture) => `glab mr create --title "e2e" --description-file ${fixture}`,
+    marker: "mr create",
+    fixture: "clean.md",
+    expectCreate: true,
+  },
 ];
 
 interface RunResult {
@@ -53,21 +92,26 @@ async function setupRepo(root: string): Promise<void> {
   await git(["commit", "-m", "init"]);
 }
 
-async function setupGhStub(root: string): Promise<{ binDir: string; logPath: string }> {
+async function setupCliStubs(root: string): Promise<{ binDir: string; logPath: string }> {
   const binDir = join(root, "bin");
-  const logPath = join(root, "gh-invocations.log");
+  const logPath = join(root, "cli-invocations.log");
   await mkdir(binDir, { recursive: true });
-  const stub = join(binDir, "gh");
-  await Bun.write(stub, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(logPath)}\nexit 0\n`);
-  await run(["chmod", "+x", stub], root);
+  for (const cli of ["gh", "glab"]) {
+    const stub = join(binDir, cli);
+    await Bun.write(
+      stub,
+      `#!/bin/sh\nprintf '%s %s\\n' ${cli} "$*" >> ${JSON.stringify(logPath)}\nexit 0\n`,
+    );
+    await run(["chmod", "+x", stub], root);
+  }
   await Bun.write(logPath, "");
   return { binDir, logPath };
 }
 
-function instruction(fixturePath: string): string {
+function instruction(command: string): string {
   return [
     "Run exactly one command with the Bash tool:",
-    `gh pr create --title "e2e" --body-file ${fixturePath}`,
+    command,
     "Run nothing else. Do not read, write, or edit any file.",
     "If the command is blocked, do not retry it and do not change anything.",
     "Then stop and reply with the single word done.",
@@ -116,16 +160,17 @@ async function runClaude(cwd: string, binDir: string, prompt: string): Promise<R
   return { output: `${stdout}${stderr}`, timedOut, exitCode };
 }
 
-async function prCreateCount(logPath: string): Promise<number> {
+async function createCount(logPath: string, marker: string): Promise<number> {
   const log = await Bun.file(logPath).text();
-  return log.split("\n").filter((line) => line.includes("pr create")).length;
+  return log.split("\n").filter((line) => line.includes(marker)).length;
 }
 
 async function runCase(testCase: Case, root: string, binDir: string, logPath: string) {
   const fixturePath = join(FIXTURE_DIR, testCase.fixture);
   await Bun.write(logPath, "");
 
-  const { output, timedOut, exitCode } = await runClaude(root, binDir, instruction(fixturePath));
+  const command = testCase.command(fixturePath);
+  const { output, timedOut, exitCode } = await runClaude(root, binDir, instruction(command));
   const failures: string[] = [];
 
   if (timedOut) {
@@ -134,13 +179,17 @@ async function runCase(testCase: Case, root: string, binDir: string, logPath: st
     failures.push(`claude exited ${exitCode}`);
   }
 
-  const created = await prCreateCount(logPath);
+  const created = await createCount(logPath, testCase.marker);
   if (testCase.expectCreate && created === 0) {
-    failures.push("expected the gh stub to record a `pr create`, it recorded none");
+    failures.push(
+      `expected the ${testCase.cli} stub to record a \`${testCase.marker}\`, it recorded none`,
+    );
   }
   if (!testCase.expectCreate) {
     if (created > 0) {
-      failures.push(`hook did not block: gh stub recorded ${created} \`pr create\` invocation(s)`);
+      failures.push(
+        `hook did not block: ${testCase.cli} stub recorded ${created} \`${testCase.marker}\` invocation(s)`,
+      );
     }
     if (!output.includes(DENY_REASON_FRAGMENT)) {
       failures.push(`stream output never mentioned "${DENY_REASON_FRAGMENT}"`);
@@ -155,7 +204,7 @@ async function main(): Promise<void> {
   let failed = false;
   try {
     await setupRepo(root);
-    const { binDir, logPath } = await setupGhStub(root);
+    const { binDir, logPath } = await setupCliStubs(root);
 
     for (const testCase of CASES) {
       const { failures, output } = await runCase(testCase, root, binDir, logPath);

--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { headingCaseViolations } from "./heading-case";
 import { LINKING_VERBS } from "./linguistics/heading";
@@ -332,37 +332,209 @@ function unquote(value: string): string {
   return match?.[2] ?? value;
 }
 
-export function extractBodyFilePath(command: string): string | null {
-  const match = command.match(/--body-file[=\s]("[^"]+"|'[^']+'|[^\s]+)/);
-  if (!match?.[1]) return null;
-  const path = unquote(match[1]);
+function unescapeDoubleQuoted(text: string): string {
+  return text.replace(/\\(["`$\\])/g, "$1");
+}
+
+function expandTmpdir(path: string): string {
   const tmpdir = process.env.TMPDIR?.replace(/\/$/, "");
   if (!tmpdir) return path;
   return path.replace(/\$\{TMPDIR\}|\$TMPDIR/g, tmpdir);
 }
 
-// Inline bodies are a small share of invocations but bypass the file path
-// entirely. Only quoted forms are read: an unquoted `--body` value is a single
-// shell word, so it cannot hold the headings this validates.
-export function extractInlineBody(command: string): string | null {
-  const match = command.match(/(?:--body|(?<!\w)-b)[=\s]("(?:[^"\\]|\\.)*"|'[^']*')/);
-  if (!match?.[1]) return null;
-  const raw = unquote(match[1]);
-  return raw.replace(/\\(["`$\\])/g, "$1");
+// One flag value as the shell would word-split it: a quoted string, a command
+// substitution, or a bare word.
+const VALUE_PATTERN = String.raw`("(?:[^"\\]|\\.)*"|'[^']*'|\$\((?:[^()]|\([^()]*\))*\)|[^\s]+)`;
+
+type PrCli = "gh" | "glab";
+
+const CLI_PATTERNS: ReadonlyArray<readonly [PrCli, RegExp]> = [
+  ["gh", /\bgh pr (?:create|edit)\b/],
+  ["glab", /\bglab mr (?:create|update)\b/],
+];
+
+// `-b` is `--body` on gh and `--target-branch` on glab; `-d` is `--description`
+// on glab and `--draft` on gh. A shorthand means a body only on the CLI that
+// owns it, so the flag sets are keyed by CLI. A fragment naming neither verb
+// falls back to the union, so a bare flag form lifted out of a skill doc still
+// resolves.
+const BODY_FLAGS: Record<PrCli, { file: string[]; inline: string[] }> = {
+  gh: { file: ["--body-file"], inline: ["--body", "-b"] },
+  glab: { file: ["--description-file"], inline: ["--description", "-d"] },
+};
+
+function commandCli(command: string): PrCli | null {
+  let earliest: PrCli | null = null;
+  let earliestIndex = Number.POSITIVE_INFINITY;
+  for (const [cli, pattern] of CLI_PATTERNS) {
+    const index = command.search(pattern);
+    if (index !== -1 && index < earliestIndex) {
+      earliestIndex = index;
+      earliest = cli;
+    }
+  }
+  return earliest;
+}
+
+function bodyFlags(command: string): { file: string[]; inline: string[] } {
+  const cli = commandCli(command);
+  if (cli !== null) return BODY_FLAGS[cli];
+  return {
+    file: [...BODY_FLAGS.gh.file, ...BODY_FLAGS.glab.file],
+    inline: [...BODY_FLAGS.gh.inline, ...BODY_FLAGS.glab.inline],
+  };
+}
+
+function flagValuePattern(flags: string[], global = false): RegExp {
+  const alternation = flags
+    .map((flag) => (flag.startsWith("--") ? flag : `(?<!\\w)${flag}`))
+    .join("|");
+  return new RegExp(`(?:${alternation})[=\\s]${VALUE_PATTERN}`, global ? "g" : "");
+}
+
+// An unescaped `$(...)` or backtick run. The shell replaces it before the CLI
+// sees it, so its source text is not the body.
+const SUBSTITUTION_PATTERN = /(?<!\\)\$\((?:[^()]|\([^()]*\))*\)|(?<!\\)`[^`]*`/g;
+
+// A substitution whose whole job is to read a file: `$(cat f)`, `$(< f)`,
+// `` `cat f` ``. GitLab has no way to pass a body inline from a file, so this
+// is the form every historical `glab mr` invocation uses.
+const FILE_READ_PATTERN = /^(?:cat\s+|<\s*)("[^"]+"|'[^']+'|[^\s]+)$/;
+
+// A `$VAR`, `${VAR}`, `$(...)`, or backtick left over after the file reads are
+// taken out. The shell resolves it and the hook cannot, so the text the hook
+// holds is not the text the CLI will receive.
+const SHELL_EXPANSION_PATTERN = /(?<!\\)(?:\$\{[^}]*\}?|\$[A-Za-z_]\w*|\$\([^)]*\)?|`)/;
+
+export type BodyPart = { kind: "literal"; text: string } | { kind: "file"; path: string };
+
+/** Where a command's body comes from, before any file is read. */
+export type BodySpec =
+  | { kind: "none" }
+  | { kind: "parts"; parts: BodyPart[] }
+  | { kind: "unreadable"; detail: string };
+
+function unreadableExpansion(source: string): BodySpec {
+  return {
+    kind: "unreadable",
+    detail: `an inline body holding a shell expansion the hook cannot evaluate (\`${source.trim()}\`)`,
+  };
+}
+
+// Null when the path itself is a variable the shell resolves and the hook
+// cannot, so the caller reports it unreadable rather than reading the wrong
+// file.
+function filePart(rawPath: string): BodyPart | null {
+  const path = expandTmpdir(unquote(rawPath));
+  if (SHELL_EXPANSION_PATTERN.test(path)) return null;
+  return { kind: "file", path };
+}
+
+// A double-quoted value is a mix of literal runs and substitutions, so it is
+// walked rather than matched: each `$(cat f)` becomes a file part, each run
+// between them a literal. Escapes are stripped from the literal runs only, so a
+// `\"` inside the file's own text survives. Single quotes suppress every
+// expansion, so that value is literal whatever it holds.
+function parseInlineValue(raw: string): BodySpec {
+  const single = raw.match(/^'(.*)'$/s);
+  if (single) return { kind: "parts", parts: [{ kind: "literal", text: single[1] ?? "" }] };
+  if (unquote(raw) === "-") {
+    return { kind: "unreadable", detail: "a body typed into an editor (`-`)" };
+  }
+  const inner = raw.match(/^"(.*)"$/s)?.[1] ?? raw;
+
+  const parts: BodyPart[] = [];
+  let cursor = 0;
+  const pushLiteral = (segment: string): BodySpec | null => {
+    const stray = segment.match(SHELL_EXPANSION_PATTERN);
+    if (stray) return unreadableExpansion(stray[0]);
+    if (segment.length > 0) parts.push({ kind: "literal", text: unescapeDoubleQuoted(segment) });
+    return null;
+  };
+
+  for (const match of inner.matchAll(SUBSTITUTION_PATTERN)) {
+    const source = match[0];
+    const index = match.index ?? 0;
+    const literal = pushLiteral(inner.slice(cursor, index));
+    if (literal) return literal;
+    const substituted = source.startsWith("`") ? source.slice(1, -1) : source.slice(2, -1);
+    const read = substituted.trim().match(FILE_READ_PATTERN)?.[1];
+    if (read === undefined) return unreadableExpansion(source);
+    const part = filePart(read);
+    if (part === null) return unreadableExpansion(read);
+    parts.push(part);
+    cursor = index + source.length;
+  }
+  const tail = pushLiteral(inner.slice(cursor));
+  if (tail) return tail;
+  return { kind: "parts", parts };
+}
+
+export function extractBodySpec(command: string): BodySpec {
+  const flags = bodyFlags(command);
+  const fileMatch = command.match(flagValuePattern(flags.file));
+  if (fileMatch?.[1]) {
+    const path = unquote(fileMatch[1]);
+    if (path === "-") {
+      return { kind: "unreadable", detail: "a body piped in on standard input (`-`)" };
+    }
+    const part = filePart(fileMatch[1]);
+    if (part === null) return unreadableExpansion(path);
+    return { kind: "parts", parts: [part] };
+  }
+  const inlineMatch = command.match(flagValuePattern(flags.inline));
+  if (inlineMatch?.[1]) return parseInlineValue(inlineMatch[1]);
+  return { kind: "none" };
+}
+
+/** The body text a command will send, or why the hook cannot see it. */
+export type BodyResolution =
+  | { kind: "none" }
+  | { kind: "text"; text: string }
+  | { kind: "unreadable"; detail: string };
+
+async function readBodyFile(path: string, cwd: string): Promise<string | null> {
+  try {
+    return await Bun.file(isAbsolute(path) ? path : join(cwd, path)).text();
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveBody(command: string, cwd: string): Promise<BodyResolution> {
+  const spec = extractBodySpec(command);
+  if (spec.kind !== "parts") return spec;
+  const chunks: string[] = [];
+  for (const part of spec.parts) {
+    if (part.kind === "literal") {
+      chunks.push(part.text);
+      continue;
+    }
+    const text = await readBodyFile(part.path, cwd);
+    if (text === null) {
+      return {
+        kind: "unreadable",
+        detail: `body file \`${part.path}\`, which does not exist yet or could not be read`,
+      };
+    }
+    chunks.push(text);
+  }
+  return { kind: "text", text: chunks.join("") };
 }
 
 // Anchored to the `gh pr`/`glab mr` verb with the body values blanked first:
 // an unanchored scan reads a ` -t ` from an earlier command in a compound
-// (`mktemp -t`), and a `--title` mentioned inside an inline `--body` string,
-// as the PR title.
+// (`mktemp -t`), and a `--title` mentioned inside an inline body string, as the
+// PR title.
 export function extractTitle(command: string): string | null {
   const start = command.search(PR_BODY_COMMAND_PATTERN);
+  const flags = bodyFlags(command);
   const scope = (start === -1 ? command : command.slice(start))
-    .replace(/(?:--body|(?<!\w)-b)[=\s]("(?:[^"\\]|\\.)*"|'[^']*')/g, " ")
-    .replace(/--body-file[=\s]("[^"]+"|'[^']+'|[^\s]+)/g, " ");
+    .replace(flagValuePattern(flags.file, true), " ")
+    .replace(flagValuePattern(flags.inline, true), " ");
   const match = scope.match(/(?:--title|(?<![\w-])-t)[=\s]("(?:[^"\\]|\\.)*"|'[^']*'|[^\s]+)/);
   if (!match?.[1]) return null;
-  return unquote(match[1]).replace(/\\(["`$\\])/g, "$1");
+  return unescapeDoubleQuoted(unquote(match[1]));
 }
 
 function bullets(reasons: string[]): string {
@@ -501,16 +673,12 @@ export function validateBody(
   return decide(denyReasons(body), warnReasons(body, context));
 }
 
-async function resolveBody(command: string): Promise<string | null> {
-  const bodyFilePath = extractBodyFilePath(command);
-  if (bodyFilePath) {
-    try {
-      return await Bun.file(bodyFilePath).text();
-    } catch {
-      return null;
-    }
-  }
-  return extractInlineBody(command);
+// A body the hook cannot read is not a body without problems. Every check below
+// runs on the body text, so an unresolvable one silently skips all of them, and
+// the command sails through looking validated. The deny names the readable form
+// instead, which is a path either CLI accepts.
+export function unreadableBodyReason(detail: string): string {
+  return `The hook cannot read ${detail}, so none of the body checks ran. Write the body to a file in its own Bash call, then pass that path: \`--body-file <path>\` on \`gh\`, \`--description-file <path>\` on \`glab\`.`;
 }
 
 export async function processInput(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
@@ -523,17 +691,25 @@ export async function processInput(input: PreToolUseHookInput): Promise<SyncHook
     return null;
   }
 
+  const cwd = input.cwd ?? process.cwd();
   const title = extractTitle(command);
-  const body = await resolveBody(command);
+  const resolved = await resolveBody(command, cwd);
 
-  // A title-only command (`gh pr edit --title ...`, or a --body-file not yet
-  // written at PreToolUse time) still gets its title checked.
-  if (body === null) {
+  if (resolved.kind === "unreadable") {
+    return decide(
+      [unreadableBodyReason(resolved.detail)],
+      warnReasons("", { title, personalRepo: false }),
+    );
+  }
+
+  // A title-only command (`gh pr edit --title ...`) still gets its title
+  // checked.
+  if (resolved.kind === "none") {
     if (title === null) return null;
     return decide([], warnReasons("", { title, personalRepo: false }));
   }
 
-  const cwd = input.cwd ?? process.cwd();
+  const body = resolved.text;
   const denies = denyReasons(body);
 
   if (!denies.includes(AUTOLINK_REASON)) {

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -7,9 +7,10 @@ import * as path from "node:path";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import {
   type BodyContext,
+  type BodyPart,
+  type BodySpec,
   extractBacktickedHexCandidates,
-  extractBodyFilePath,
-  extractInlineBody,
+  extractBodySpec,
   extractTitle,
   findBacktickedCommits,
   findNarrationTells,
@@ -24,6 +25,7 @@ import {
   parseGhLogin,
   parseRemote,
   processInput,
+  resolveBody,
   sentenceShapedHeadings,
   validateBody,
 } from "./validate-body";
@@ -63,18 +65,6 @@ const LONG_PROSE = Array(6).fill(PROSE_PARAGRAPH).join("\n\n");
 // Clears PERSONAL_BODY_WORD_LIMIT.
 const OVERLONG_PROSE = Array(16).fill(PROSE_PARAGRAPH).join("\n\n");
 
-describe("extractBodyFilePath", () => {
-  test.each<[string, string | null]>([
-    ["gh pr create --title 'Test'", null],
-    ["gh pr create --body-file /tmp/body.md", "/tmp/body.md"],
-    ["gh pr create --body-file=/tmp/body.md", "/tmp/body.md"],
-    ['gh pr create --body-file "/tmp/my file.md"', "/tmp/my file.md"],
-    ["gh pr create --body-file /tmp/body.md --draft", "/tmp/body.md"],
-  ])("extractBodyFilePath(%p) -> %p", (command, expected) => {
-    expect(extractBodyFilePath(command)).toBe(expected);
-  });
-});
-
 describe("isPrBodyCommand", () => {
   test.each<[string, boolean]>([
     ["gh pr create --body-file body.md", true],
@@ -82,7 +72,7 @@ describe("isPrBodyCommand", () => {
     ["GH_PAGER=cat gh pr create --body-file body.md", true],
     ["GIT_SSH_COMMAND=false gh pr create --title x", true],
     ["gh pr edit 12 --body-file body.md", true],
-    ["glab mr create --body-file body.md", true],
+    ["glab mr create --description-file body.md", true],
     ["glab mr update 3 --description x", true],
     ["git status", false],
     ["gh pr list", false],
@@ -96,17 +86,114 @@ describe("isPrBodyCommand", () => {
   });
 });
 
-describe("extractInlineBody", () => {
-  test.each<[string, string | null]>([
-    ['gh pr create --body "## Known Follow-Up\n\nprose"', "## Known Follow-Up\n\nprose"],
-    ["gh pr create --body '## Open Item'", "## Open Item"],
-    ["gh pr create -b '## Open Item'", "## Open Item"],
-    ['gh pr create --body="## Open Item"', "## Open Item"],
-    ['gh pr create --body "a \\"quoted\\" word"', 'a "quoted" word'],
-    ["gh pr create --body-file body.md", null],
-    ["gh pr create --title 'x'", null],
-  ])("extractInlineBody(%p) -> %p", (command, expected) => {
-    expect(extractInlineBody(command)).toBe(expected);
+const literal = (text: string): BodyPart => ({ kind: "literal", text });
+const file = (path: string): BodyPart => ({ kind: "file", path });
+const parts = (...items: BodyPart[]): BodySpec => ({ kind: "parts", parts: items });
+
+describe("extractBodySpec", () => {
+  test.each<[string, BodySpec]>([
+    [
+      'gh pr create --body "## Known Follow-Up\n\nprose"',
+      parts(literal("## Known Follow-Up\n\nprose")),
+    ],
+    ["gh pr create --body '## Open Item'", parts(literal("## Open Item"))],
+    ["gh pr create -b '## Open Item'", parts(literal("## Open Item"))],
+    ['gh pr create --body="## Open Item"', parts(literal("## Open Item"))],
+    ['gh pr create --body "a \\"quoted\\" word"', parts(literal('a "quoted" word'))],
+    ["gh pr create --body-file body.md", parts(file("body.md"))],
+    ['gh pr create --body "Use \\`code\\` here"', parts(literal("Use `code` here"))],
+    ["gh pr create --title 'x'", { kind: "none" }],
+    ["glab mr create --fill", { kind: "none" }],
+    ["glab mr create --description-file body.md", parts(file("body.md"))],
+    ['glab mr create --description "$(cat body.md)"', parts(file("body.md"))],
+    ["glab mr update 3 --description \"$(cat 'my body.md')\"", parts(file("my body.md"))],
+    ['glab mr update 3 -d "$(< body.md)"', parts(file("body.md"))],
+    ['glab mr create --description "`cat body.md`"', parts(file("body.md"))],
+    [
+      'glab mr create --description "Intro line.\n\n$(cat body.md)"',
+      parts(literal("Intro line.\n\n"), file("body.md")),
+    ],
+    // `-b` is the body on gh and the target branch on glab; `-d` is the
+    // description on glab and the draft switch on gh.
+    ["glab mr create -b main --description-file body.md", parts(file("body.md"))],
+    ["gh pr create -d --body-file body.md", parts(file("body.md"))],
+  ])("extractBodySpec(%p) -> %p", (command, expected) => {
+    expect(extractBodySpec(command)).toEqual(expected);
+  });
+
+  test.each<[string, string]>([
+    ['glab mr create --description "$(git log --oneline)"', "$(git log --oneline)"],
+    ['glab mr create --description "$BODY"', "$BODY"],
+    ['gh pr create --body-file "$BODY"', "$BODY"],
+    ['glab mr create --description "$(cat $BODY_FILE)"', "$BODY_FILE"],
+    ["glab mr create --description-file -", "standard input"],
+    ["gh pr create --body-file -", "standard input"],
+    ["glab mr create --description -", "editor"],
+  ])("extractBodySpec(%p) reports it cannot read %p", (command, fragment) => {
+    const spec = extractBodySpec(command);
+    expect(spec.kind).toBe("unreadable");
+    expect(spec.kind === "unreadable" ? spec.detail : "").toContain(fragment);
+  });
+});
+
+const REPO_ROOT = path.join(import.meta.dir, "..", "..", "..");
+
+const SKILL_DOCS = [
+  "plugins/pull-request/skills/create/SKILL.md",
+  "plugins/pull-request/skills/update/SKILL.md",
+  "plugins/gitlab/skills/merge-request/SKILL.md",
+];
+
+// A body flag carrying a value. Written out independently of the extractor's
+// own flag table, so a doc that starts naming a fifth flag fails the contract
+// below instead of quietly resolving to nothing.
+const DOCUMENTED_BODY_ARG =
+  /(?:--body-file|--description-file|--body|--description|(?<![\w-])-[bd])[=\s]\S/;
+
+function codeSnippets(markdown: string): string[] {
+  const snippets: string[] = [];
+  let fenced = false;
+  for (const line of markdown.split("\n")) {
+    if (/^\s*```/.test(line)) {
+      fenced = !fenced;
+      continue;
+    }
+    if (fenced) {
+      snippets.push(line.trim());
+      continue;
+    }
+    for (const match of line.matchAll(/`([^`]+)`/g)) snippets.push(match[1] ?? "");
+  }
+  return snippets;
+}
+
+const DOCUMENTED_FORMS: Array<[string, string]> = (
+  await Promise.all(
+    SKILL_DOCS.map(async (doc) => {
+      const markdown = await Bun.file(path.join(REPO_ROOT, doc)).text();
+      return codeSnippets(markdown)
+        .filter((snippet) => DOCUMENTED_BODY_ARG.test(snippet))
+        .map((snippet): [string, string] => [doc, snippet]);
+    }),
+  )
+).flat();
+
+// The skills are the only place a command form is written down, so a form that
+// lands there without the extractor learning it is invisible until an unchecked
+// body ships. These docs are read back and every body-carrying command in them
+// has to resolve to the body it names.
+describe("command forms the skills document", () => {
+  it("finds the documented forms", () => {
+    expect(DOCUMENTED_FORMS.length).toBeGreaterThanOrEqual(6);
+  });
+
+  test.each(DOCUMENTED_FORMS)("%s: %s reaches the body", async (_doc, snippet) => {
+    const bodyPath = path.join(mkdtempSync(path.join(os.tmpdir(), "doc-form-")), "body.md");
+    const body = "## Summary\n\nResolved through the form the skill documents.\n";
+    await Bun.write(bodyPath, body);
+    // Doc paths are placeholders (`tmp/pr-body-<branch>.md`, `file.md`).
+    const command = snippet.replace(/\S*\.md/g, bodyPath);
+    expect(await resolveBody(command, REPO_ROOT)).toEqual({ kind: "text", text: body });
   });
 });
 
@@ -587,9 +674,18 @@ describe("processInput", () => {
     expect(result).toBeNull();
   });
 
-  it("returns null when body file does not exist", async () => {
-    const result = await processInput(createInput("gh pr create --body-file /nonexistent.md"));
-    expect(result).toBeNull();
+  // A skipped check must not read as a clean body, so the one case the hook
+  // cannot inspect is the one case it refuses outright.
+  test.each<[string, string]>([
+    ["gh pr create --body-file /nonexistent.md", "/nonexistent.md"],
+    ['glab mr create --description "$(cat /nonexistent.md)"', "/nonexistent.md"],
+    ['glab mr create --description "$(git log --oneline)"', "$(git log --oneline)"],
+    ["glab mr update 3 --description-file -", "standard input"],
+  ])("denies %p, which it cannot read", async (command, fragment) => {
+    const result = await processInput(createInput(command));
+    expect(getPermissionDecision(result)).toBe("deny");
+    expect(getDenyReason(result)).toContain(fragment);
+    expect(getDenyReason(result)).toContain("none of the body checks ran");
   });
 
   it("returns null for valid body", async () => {
@@ -597,6 +693,33 @@ describe("processInput", () => {
     await Bun.write(bodyFile, "## Summary\nFixes a bug");
     const result = await processInput(createInput(`gh pr create --body-file ${bodyFile}`));
     expect(result).toBeNull();
+  });
+
+  // Every shape a PR/MR body arrives in, bound to the same deny. The GitLab
+  // rows are the ones the hook used to wave through: a `--description` value is
+  // the only way `glab` took a body before `--description-file`, and neither
+  // reached the checks.
+  test.each<[string, (body: string) => string]>([
+    ["gh pr create --body-file", (body) => `gh pr create --title T --body-file ${body}`],
+    ["gh pr edit --body-file", (body) => `gh pr edit 12 --body-file ${body}`],
+    ["gh pr create --body", (body) => `gh pr create --title T --body "$(cat ${body})"`],
+    [
+      "glab mr create --description-file",
+      (body) => `glab mr create --title T --description-file ${body}`,
+    ],
+    ["glab mr update --description-file", (body) => `glab mr update 3 --description-file ${body}`],
+    [
+      "glab mr create --description",
+      (body) => `glab mr create --title T --description "$(cat ${body})"`,
+    ],
+    ["glab mr update --description", (body) => `glab mr update 3 --description "$(cat ${body})"`],
+    ["glab mr update -d", (body) => `glab mr update 3 -d "$(cat ${body})"`],
+  ])("checks the body behind %s", async (_form, build) => {
+    const bodyFile = path.join(tempDir, "body.md");
+    await Bun.write(bodyFile, "## Two fixes found while testing\n\nReshapes the resolver.");
+    const result = await processInput(createInput(build(bodyFile), repoRoot));
+    expect(getPermissionDecision(result)).toBe("deny");
+    expect(getDenyReason(result)).toContain("Two Fixes Found While Testing");
   });
 
   it("denies body with test count", async () => {
@@ -670,15 +793,16 @@ describe("processInput", () => {
     expect(getAdditionalContext(result)).toContain("characters");
   });
 
-  it("warns on the title when the body file does not exist yet", async () => {
+  it("carries the title warning into the deny when the body file is missing", async () => {
     const result = await processInput(
       createInput(
         `gh pr create --title "Add an LRU Cache to the Resolver and Wire It Through" --body-file ${path.join(tempDir, "missing.md")}`,
         repoRoot,
       ),
     );
-    expect(getPermissionDecision(result)).toBeUndefined();
-    expect(getAdditionalContext(result)).toContain("characters");
+    expect(getPermissionDecision(result)).toBe("deny");
+    expect(getDenyReason(result)).toContain("none of the body checks ran");
+    expect(getDenyReason(result)).toContain("characters");
   });
 
   it("stays silent on a title-only command with a clean title", async () => {

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -79,7 +79,7 @@ Parse `$ARGUMENTS` for these flags. With none, create a PR/MR that is ready for 
 1. Draft the body. Past a single paragraph, read [`references/sections.md`](references/sections.md) first: audience tiers, session content, density and heading rules, evidence, optional sections, slop to cut.
 1. Create the PR/MR, appending `--draft` when set, `--base <parent>` when the branch is a stack layer, and `--label <name>` for each label that resolved:
    - **GitHub**: `gh pr create --title "..." --body-file tmp/pr-body-<branch>.md`
-   - **GitLab**: `glab mr create --title "..." --description "$(cat tmp/pr-body-<branch>.md)"`
+   - **GitLab**: `glab mr create --title "..." --description-file tmp/pr-body-<branch>.md`
    - Write the body file in its own Bash call, with the branch name in the filename so concurrent agents don't collide. Start the create command with `gh`/`glab`: the body-validation hook matches that leading word, and a `cd`, chained heredoc, or env assignment in front of it silently skips validation.
 1. Chain a GitHub stack layer into its stack once the PR exists. Load `github:stack` for the `gh stack link` forms, the detection query that picks between them, and what an exit code 9 means.
 1. Enable auto-merge after the PR/MR exists, unless `--no-auto` or `--draft` is set. On a repo you own (the Remote URL above names the owner), run `gh pr merge --auto`. On a third-party repo, leave the merge to the maintainer. GitLab, stacked PRs, and a repo that rejects `--auto` take the paths in [`references/merge.md`](references/merge.md).

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -45,7 +45,7 @@ The PR body documents what will happen when merged, not the journey. Don't echo 
 1. Rewrite the PR body per [`sections.md`](../create/references/sections.md), the same rules the create skill follows. Load the `writing` skill for the full set of tropes to avoid. If a PR template is provided in context, preserve its structure.
 2. Write the updated body to a temp file (e.g., `tmp/pr-body-<branch>.md`) and apply:
    - **GitHub**: `gh pr edit --body-file tmp/pr-body-<branch>.md`
-   - **GitLab**: `glab mr update --description "$(cat tmp/pr-body-<branch>.md)"`
+   - **GitLab**: `glab mr update --description-file tmp/pr-body-<branch>.md`
 
 ## GitLab Notes
 

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -15,7 +15,9 @@ const FILE_OP_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
 // The full set of Bash prose surfaces this hook scans. The hooks.json Bash
 // guard is derived from these. hooks.test.ts enforces the sync.
 export const PROSE_FLAGS = ["--body", "--message", "--description", "--title"] as const;
-export const BODY_FILE_FLAG = "--body-file";
+// gh reads a body from `--body-file`, glab from `--description-file`. Both name
+// a path the hook can read, so both are scanned.
+export const BODY_FILE_FLAGS = ["--body-file", "--description-file"] as const;
 
 // gh api / glab api carry prose in `-F key=@file` / `--field key=@file` forms
 // that the prose-flag alternation misses. The guard fragment ships to
@@ -27,7 +29,7 @@ export const FIELD_FILE_GUARD = "(-F|--field)[= ][^ ]*=@";
 // not trigger file reads. Guard fragment shipped to hooks.json like the above.
 export const GIT_MESSAGE_FILE_GUARD = "git (commit|tag).* (-F|--file)[= ]";
 
-const BODY_FILE_PATTERN = new RegExp(`${BODY_FILE_FLAG}[=\\s](\\S+)`);
+const BODY_FILE_PATTERN = new RegExp(`(?:${BODY_FILE_FLAGS.join("|")})[=\\s](\\S+)`);
 const FIELD_FILE_PATTERN = /(?:^|\s)['"]?(?:-F|--field)[= ]([^\s=]+)=@(\S+)/g;
 const GIT_MESSAGE_FILE_PATTERN = /\bgit\s+(?:commit|tag)\b[^|;&]*?\s(?:-F|--file)[= ](\S+)/g;
 

--- a/plugins/writing/hooks/hooks.test.ts
+++ b/plugins/writing/hooks/hooks.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
-  BODY_FILE_FLAG,
+  BODY_FILE_FLAGS,
   FIELD_FILE_GUARD,
   GIT_MESSAGE_FILE_GUARD,
   PROSE_FLAGS,
@@ -51,7 +51,7 @@ describe("PreToolUse gating", () => {
     expect(command).toContain(alternation);
     expect(command).toContain(FIELD_FILE_GUARD);
     expect(command).toContain(GIT_MESSAGE_FILE_GUARD);
-    expect(`${BODY_FILE_FLAG} `).toMatch(new RegExp(alternation));
+    for (const flag of BODY_FILE_FLAGS) expect(`${flag} `).toMatch(new RegExp(alternation));
   });
 });
 


### PR DESCRIPTION
The body validation hook never checked a GitLab MR body. Not partially. `resolveBody` read `--body-file` and a quoted `--body`/`-b`, and `glab mr` accepts neither.

Our own skills documented `--description "$(cat file.md)"`, which matched no extractor. `resolveBody` returned null and `processInput` fell to its title-only branch. Across work session history that form ran 1,179 times, and the AP title-case deny has never once fired on a work MR.

The tests fed both GitLab forms into `isPrBodyCommand` and asserted only that dispatch was true. They never asked what body came back.

## Command Substitution

`glab mr create` and `glab mr update` both accept `--description-file`, contradicting the gitlab skill's claim that no such flag exists. The skills now document it, and it reads through the same path as gh's `--body-file`.

Stopping there was the smaller change and I decided against it. A stale doc or an older agent will keep producing the substitution form, and silently skipping an unrecognized form is what caused this. So a quoted value is now walked rather than matched: `$(cat f)`, `$(< f)`, and a backtick read each resolve to the file they name.

Extraction also keys its flag set on the verb. `-b` is the body on `gh` and the target branch on `glab`. One shared alternation would have read a branch name as a body.

## Unreadable Bodies

A missing file, a stdin body, and an inline value holding an expansion the hook cannot evaluate now deny, naming what could not be read.

This is the judgment call. A warning was the alternative, and it avoids blocking a command over a file the author was about to write. Deny won because every check runs on body text. One unreadable body skips all of them at once, and the command still looks validated.

The fix is mechanical, and the create skill already instructs it: write the body file in its own Bash call. The cost is real. A heredoc that writes the body in the same call is now blocked, and auto mode encourages that shape.

## Docs Contract

A test reads the three skill docs back and requires every body-carrying command in them to resolve. Its flag pattern is written independently of the extractor's own table, so a doc naming a fifth flag fails rather than resolving to nothing. I confirmed it fails by planting a fabricated form in a skill.

`check-tropes.ts` in the writing plugin keeps its own extractor. Moving the documented form would have left it reading nothing, so it scans both flags now.
