### PR TITLE
tech-spec: make skills model-invocable

### DIFF
--- a/plugins/tech-spec/skills/create/SKILL.md
+++ b/plugins/tech-spec/skills/create/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: tech-spec:create
-disable-model-invocation: true
-description: |
-  Create a technical specification through interactive planning and expert review. Use when starting a new feature or project that needs documented architecture, implementation approach, and design decisions. Invoke with product requirements (PRD, brief, or similar).
+description: Write a technical specification for a feature or project from product requirements.
 ---
 
 # Create Technical Specification

--- a/plugins/tech-spec/skills/review/SKILL.md
+++ b/plugins/tech-spec/skills/review/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: tech-spec:review
-disable-model-invocation: true
-description: |
-  Review a technical specification through expert lenses. Use to identify gaps, risks, and missing considerations in an existing spec. Works on any tech spec, not just those created with tech-spec:create.
+description: Review an existing technical specification for gaps, risks, and missing considerations.
 ---
 
 # Review Technical Specification


### PR DESCRIPTION
Both tech-spec skills carried `disable-model-invocation`, so only a typed `/tech-spec:create` reached them. That blocks natural-language routing and skill-to-skill delegation: a session that decides a feature needs a spec has no way to get there, and no other skill can hand off to the review pass.

A spec is a distinctive enough artifact to be worth routing on. Nothing else in the catalog claims it, so the descriptions don't have to compete for a match.

The flag was buying zero recurring context, since a user-only skill's description never loads. Model-invocable descriptions load every session, so both are cut to one clause naming the artifact and the trigger. If the routing never fires, the flag goes back.
