### PR TITLE
decode: add a zod boundary for external data

### DIFF
--- a/.claude/hooks/ox/index.test.ts
+++ b/.claude/hooks/ox/index.test.ts
@@ -13,6 +13,7 @@ import type {
 } from "@anthropic-ai/claude-agent-sdk";
 import {
   blockCountPath,
+  HookInput,
   invokesGitCommit,
   parseTranscript,
   processInput,
@@ -27,10 +28,14 @@ const execAsync = promisify(exec);
 
 const FIXTURES_DIR = join(import.meta.dirname, "fixtures");
 
-// hookSpecificOutput is a union across every hook event, so narrow it to the
-// PreToolUse arm before reading the permission fields.
 function deniedBy(result: SyncHookJSONOutput | null): PreToolUseHookSpecificOutput | undefined {
-  return result?.hookSpecificOutput as PreToolUseHookSpecificOutput | undefined;
+  const output = result?.hookSpecificOutput;
+  return output?.hookEventName === "PreToolUse" ? output : undefined;
+}
+
+function contextFrom(result: SyncHookJSONOutput | null): string | undefined {
+  const output = result?.hookSpecificOutput;
+  return output?.hookEventName === "PostToolUse" ? output.additionalContext : undefined;
 }
 
 let tempDir: string;
@@ -342,9 +347,7 @@ describe("ox hook", () => {
       expect(result).not.toBeNull();
       expect(result?.hookSpecificOutput).toMatchObject({ hookEventName: "PostToolUse" });
 
-      const additionalContext = (result?.hookSpecificOutput as { additionalContext: string })
-        .additionalContext;
-      expect(additionalContext).toContain("no-dupe-keys");
+      expect(contextFrom(result)).toContain("no-dupe-keys");
       expect(await Bun.file(filePath).text()).toBe(before);
     });
 
@@ -415,14 +418,14 @@ describe("ox hook", () => {
         const session = `limit-${Date.now()}`;
         const transcript = await unfixableSession(session);
 
-        const budget = [];
+        const budget: (SyncHookJSONOutput | null)[] = [];
         for (let stop = 0; stop < STOP_BLOCK_LIMIT; stop++) {
           budget.push(await processStop(mockStopHookInput(transcript, stop > 0, session)));
         }
         const past = await processStop(mockStopHookInput(transcript, true, session));
 
         expect(budget.map((result) => result?.decision)).toEqual(
-          Array(STOP_BLOCK_LIMIT).fill("block"),
+          Array.from({ length: STOP_BLOCK_LIMIT }, () => "block"),
         );
         expect(past?.decision).toBeUndefined();
         expect(past?.systemMessage).toContain("no-dupe-keys");
@@ -686,9 +689,14 @@ describe("ox hook", () => {
       expect(result?.decision).toBe("block");
     });
 
-    it("returns null for unknown event types", async () => {
-      const input = { hook_event_name: "Unknown" } as unknown as PostToolUseHookInput;
-      expect(await processInput(input)).toBeNull();
+    test.each([
+      { title: "an unrecognized event", value: { hook_event_name: "Unknown" } },
+      { title: "a missing event name", value: {} },
+      { title: "PostToolUse without a tool name", value: { hook_event_name: "PostToolUse" } },
+      { title: "Stop without a transcript path", value: { hook_event_name: "Stop" } },
+      { title: "a non-object payload", value: "Stop" },
+    ])("the boundary rejects $title", ({ value }) => {
+      expect(HookInput.safeParse(value).success).toBe(false);
     });
   });
 });

--- a/.claude/hooks/ox/index.ts
+++ b/.claude/hooks/ox/index.ts
@@ -6,20 +6,45 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
-import type {
-  PostToolUseHookInput,
-  PreToolUseHookInput,
-  StopHookInput,
-  SyncHookJSONOutput,
-} from "@anthropic-ai/claude-agent-sdk";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import { decode, decodeJson, decodeStdin } from "../../../packages/decode/index";
 
 const execFileAsync = promisify(execFile);
 
 const OX_EXTENSIONS = new Set(["ts", "tsx", "js", "jsx", "json", "jsonc"]);
 
-type HookInput = PostToolUseHookInput | PreToolUseHookInput | StopHookInput;
+const FilePathInput = z.looseObject({ file_path: z.string().optional() });
+const BashInput = z.looseObject({ command: z.string().optional() });
 
-type BashInput = { command?: string };
+const PreToolUseInput = z.looseObject({
+  hook_event_name: z.literal("PreToolUse"),
+  tool_input: z.unknown(),
+});
+
+const PostToolUseInput = z.looseObject({
+  hook_event_name: z.literal("PostToolUse"),
+  tool_name: z.string(),
+  tool_input: z.unknown(),
+});
+
+const StopInput = z.looseObject({
+  hook_event_name: z.literal("Stop"),
+  session_id: z.string(),
+  transcript_path: z.string(),
+  stop_hook_active: z.boolean().optional(),
+});
+
+export const HookInput = z.discriminatedUnion("hook_event_name", [
+  PreToolUseInput,
+  PostToolUseInput,
+  StopInput,
+]);
+
+type PreToolUseInput = z.infer<typeof PreToolUseInput>;
+type PostToolUseInput = z.infer<typeof PostToolUseInput>;
+type StopInput = z.infer<typeof StopInput>;
+type HookInput = z.infer<typeof HookInput>;
 
 // Flags git accepts between the executable and its subcommand. Enumerated
 // rather than matched as a generic `-\S+` so that a value which happens to be
@@ -43,16 +68,29 @@ export function invokesGitCommit(command: string): boolean {
   return GIT_COMMIT_PATTERN.test(stripQuoted(command));
 }
 
-interface TranscriptEntry {
-  type?: string;
-  message?: {
-    content?: Array<{
-      type: string;
-      name?: string;
-      input?: { file_path?: string };
-    }>;
-  };
-}
+const ContentBlock = z.looseObject({
+  type: z.string(),
+  name: z.string().optional(),
+  input: FilePathInput.optional(),
+});
+
+const TranscriptEntry = z.looseObject({
+  type: z.string().optional(),
+  message: z
+    .looseObject({ content: z.union([z.string(), z.array(ContentBlock)]).optional() })
+    .optional(),
+});
+
+const BinManifest = z.looseObject({
+  bin: z.union([z.string(), z.record(z.string(), z.string())]).optional(),
+});
+
+const BlockState = z.looseObject({ blocks: z.number().optional() });
+
+const CommandFailure = z.looseObject({
+  stdout: z.string().optional(),
+  stderr: z.string().optional(),
+});
 
 function getExtension(filePath: string): string {
   const parts = filePath.split(".");
@@ -109,9 +147,7 @@ async function localBin(pkg: string, binName: string): Promise<string | null> {
     return null;
   }
   try {
-    const manifest = (await Bun.file(manifestPath).json()) as {
-      bin?: string | Record<string, string>;
-    };
+    const manifest = decode(BinManifest, await Bun.file(manifestPath).json(), manifestPath);
     const bin = typeof manifest.bin === "string" ? manifest.bin : manifest.bin?.[binName];
     return bin ? join(dirname(manifestPath), bin) : null;
   } catch {
@@ -212,10 +248,11 @@ export async function parseTranscript(transcriptPath: string): Promise<string[]>
     if (!line.trim()) continue;
 
     try {
-      const entry = JSON.parse(line) as TranscriptEntry;
-      if (entry.type !== "assistant" || !entry.message?.content) continue;
+      const entry = decodeJson(TranscriptEntry, line, transcriptPath);
+      const blocks = entry.message?.content;
+      if (entry.type !== "assistant" || !Array.isArray(blocks)) continue;
 
-      for (const block of entry.message.content) {
+      for (const block of blocks) {
         if (block.type !== "tool_use") continue;
         if (block.name !== "Edit" && block.name !== "Write") continue;
 
@@ -280,8 +317,9 @@ async function groupByWorkingTree(files: string[]): Promise<Map<string | undefin
 }
 
 function commandOutput(error: unknown): string | null {
-  const { stdout, stderr } = error as { stdout?: string; stderr?: string };
-  const output = [stdout, stderr]
+  const failure = CommandFailure.safeParse(error);
+  if (!failure.success) return null;
+  const output = [failure.data.stdout, failure.data.stderr]
     .map((stream) => stream?.trim())
     .filter(Boolean)
     .join("\n");
@@ -477,14 +515,14 @@ async function runOxGate(files: string[]): Promise<string | null> {
 }
 
 export async function processPostToolUse(
-  input: PostToolUseHookInput,
+  input: PostToolUseInput,
 ): Promise<SyncHookJSONOutput | null> {
   const toolName = input.tool_name;
   if (toolName !== "Edit" && toolName !== "Write") {
     return null;
   }
 
-  const filePath = (input.tool_input as { file_path?: string }).file_path;
+  const { file_path: filePath } = decode(FilePathInput, input.tool_input, "PostToolUse tool_input");
   if (!filePath || !isOxFile(filePath)) {
     return null;
   }
@@ -517,8 +555,8 @@ export function blockCountPath(sessionId: string): string {
 
 async function priorBlocks(sessionId: string): Promise<number> {
   try {
-    const state = (await Bun.file(blockCountPath(sessionId)).json()) as { blocks?: number };
-    return typeof state.blocks === "number" ? state.blocks : 0;
+    const path = blockCountPath(sessionId);
+    return decode(BlockState, await Bun.file(path).json(), path).blocks ?? 0;
   } catch {
     return 0;
   }
@@ -539,7 +577,7 @@ async function clearBlocks(sessionId: string): Promise<void> {
   } catch {}
 }
 
-export async function processStop(input: StopHookInput): Promise<SyncHookJSONOutput | null> {
+export async function processStop(input: StopInput): Promise<SyncHookJSONOutput | null> {
   // Every exit that is not a block clears the count, so a stale one can never
   // be read back as progress through a later round's budget.
   if (!(await oxlintCommand())) {
@@ -608,12 +646,12 @@ function lines(stdout: string): string[] {
 }
 
 export async function processPreToolUse(
-  input: PreToolUseHookInput,
+  input: PreToolUseInput,
 ): Promise<SyncHookJSONOutput | null> {
   // The `Bash(git commit:*)` matcher only narrows which calls spawn this hook.
   // It fails open on shell metacharacters, and this path can return a `block`,
   // so the command is re-read here rather than trusted from the matcher.
-  const { command } = input.tool_input as BashInput;
+  const { command } = decode(BashInput, input.tool_input, "PreToolUse tool_input");
   if (!command || !invokesGitCommit(command)) {
     return null;
   }
@@ -673,16 +711,13 @@ export async function processInput(input: HookInput): Promise<SyncHookJSONOutput
   if (input.hook_event_name === "PostToolUse") {
     return processPostToolUse(input);
   }
-  if (input.hook_event_name === "Stop") {
-    return processStop(input);
-  }
-  return null;
+  return processStop(input);
 }
 
 async function main(): Promise<void> {
   let input: HookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as HookInput;
+    input = await decodeStdin(HookInput, "ox hook input");
   } catch (error) {
     console.error(
       `[ox] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/.claude/hooks/plugin-deps/index.ts
+++ b/.claude/hooks/plugin-deps/index.ts
@@ -1,7 +1,17 @@
 #!/usr/bin/env bun
 
 import { join } from "node:path";
-import type { StopHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import { decodeStdin } from "../../../packages/decode/index";
+
+const StopInput = z.looseObject({
+  hook_event_name: z.literal("Stop"),
+  cwd: z.string(),
+  stop_hook_active: z.boolean().optional(),
+});
+
+type StopInput = z.infer<typeof StopInput>;
 
 // Mirrors VIOLATION_EXIT in scripts/check-plugin-deps.ts. Deliberately a
 // literal rather than an import: importing the checker would pull its module
@@ -13,7 +23,7 @@ const VIOLATION_EXIT = 2;
 const CHECKER_PATH = join(import.meta.dirname, "..", "..", "..", "scripts", "check-plugin-deps.ts");
 
 export async function processStop(
-  input: StopHookInput,
+  input: StopInput,
   checkerPath = CHECKER_PATH,
 ): Promise<SyncHookJSONOutput | null> {
   if (input.stop_hook_active) return null;
@@ -44,10 +54,7 @@ export async function processStop(
 }
 
 async function main(): Promise<void> {
-  const input = JSON.parse(await Bun.stdin.text()) as StopHookInput;
-  if (input.hook_event_name !== "Stop") return;
-
-  const output = await processStop(input);
+  const output = await processStop(await decodeStdin(StopInput, "plugin-deps hook input"));
   if (output) process.stdout.write(`${JSON.stringify(output)}\n`);
 }
 

--- a/.claude/hooks/plugin-imports/index.ts
+++ b/.claude/hooks/plugin-imports/index.ts
@@ -1,7 +1,17 @@
 #!/usr/bin/env bun
 
 import { join } from "node:path";
-import type { StopHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import { decodeStdin } from "../../../packages/decode/index";
+
+const StopInput = z.looseObject({
+  hook_event_name: z.literal("Stop"),
+  cwd: z.string(),
+  stop_hook_active: z.boolean().optional(),
+});
+
+type StopInput = z.infer<typeof StopInput>;
 
 // Mirrors VIOLATION_EXIT in scripts/check-plugin-imports.ts. Deliberately a
 // literal rather than an import: importing the checker would pull its module
@@ -20,7 +30,7 @@ const CHECKER_PATH = join(
 );
 
 export async function processStop(
-  input: StopHookInput,
+  input: StopInput,
   checkerPath = CHECKER_PATH,
 ): Promise<SyncHookJSONOutput | null> {
   if (input.stop_hook_active) return null;
@@ -51,10 +61,7 @@ export async function processStop(
 }
 
 async function main(): Promise<void> {
-  const input = JSON.parse(await Bun.stdin.text()) as StopHookInput;
-  if (input.hook_event_name !== "Stop") return;
-
-  const output = await processStop(input);
+  const output = await processStop(await decodeStdin(StopInput, "plugin-imports hook input"));
   if (output) process.stdout.write(`${JSON.stringify(output)}\n`);
 }
 

--- a/.claude/hooks/stop/index.ts
+++ b/.claude/hooks/stop/index.ts
@@ -3,21 +3,42 @@
 import { execFile } from "node:child_process";
 import { isAbsolute, relative, sep } from "node:path";
 import { promisify } from "node:util";
-import type { StopHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import { decodeJson, decodeStdin } from "../../../packages/decode/index";
 
 const execFileAsync = promisify(execFile);
 const PREK_TIMEOUT = 120_000;
 
-interface TranscriptEntry {
-  type?: string;
-  message?: {
-    content?: Array<{
-      type: string;
-      name?: string;
-      input?: { file_path?: string };
-    }>;
-  };
-}
+const ContentBlock = z.looseObject({
+  type: z.string(),
+  name: z.string().optional(),
+  input: z.looseObject({ file_path: z.string().optional() }).optional(),
+});
+
+const TranscriptEntry = z.looseObject({
+  type: z.string().optional(),
+  message: z
+    .looseObject({ content: z.union([z.string(), z.array(ContentBlock)]).optional() })
+    .optional(),
+});
+
+export const StopInput = z.looseObject({
+  hook_event_name: z.literal("Stop"),
+  cwd: z.string(),
+  transcript_path: z.string(),
+  stop_hook_active: z.boolean().optional(),
+});
+
+type StopInput = z.infer<typeof StopInput>;
+
+const PrekFailure = z.looseObject({
+  code: z.string().optional(),
+  killed: z.boolean().optional(),
+  stdout: z.string().optional(),
+  stderr: z.string().optional(),
+  message: z.string().optional(),
+});
 
 async function fileExists(filePath: string): Promise<boolean> {
   return Bun.file(filePath).exists();
@@ -35,10 +56,11 @@ export async function parseTranscript(transcriptPath: string): Promise<string[]>
     if (!line.trim()) continue;
 
     try {
-      const entry = JSON.parse(line) as TranscriptEntry;
-      if (entry.type !== "assistant" || !entry.message?.content) continue;
+      const entry = decodeJson(TranscriptEntry, line, transcriptPath);
+      const blocks = entry.message?.content;
+      if (entry.type !== "assistant" || !Array.isArray(blocks)) continue;
 
-      for (const block of entry.message.content) {
+      for (const block of blocks) {
         if (block.type !== "tool_use") continue;
         if (block.name !== "Edit" && block.name !== "Write") continue;
 
@@ -72,7 +94,7 @@ export function scopePaths(files: string[], cwd: string): string[] {
   return scoped;
 }
 
-export async function processStop(input: StopHookInput): Promise<SyncHookJSONOutput | null> {
+export async function processStop(input: StopInput): Promise<SyncHookJSONOutput | null> {
   if (input.stop_hook_active) {
     return null;
   }
@@ -99,12 +121,8 @@ export async function processStop(input: StopHookInput): Promise<SyncHookJSONOut
     });
     return null;
   } catch (error) {
-    const execError = error as {
-      code?: string;
-      killed?: boolean;
-      stdout?: string;
-      stderr?: string;
-    };
+    const failure = PrekFailure.safeParse(error);
+    const execError = failure.success ? failure.data : {};
     const output = ((execError.stdout || "") + (execError.stderr || "")).trim();
 
     let context: string;
@@ -113,7 +131,7 @@ export async function processStop(input: StopHookInput): Promise<SyncHookJSONOut
     } else if (execError.killed) {
       context = `Checks timed out after ${PREK_TIMEOUT / 1000}s. Partial output:\n\n${output}`;
     } else {
-      context = `Check failures:\n\n${output || (error as Error).message}`;
+      context = `Check failures:\n\n${output || execError.message || String(error)}`;
     }
 
     return {
@@ -124,14 +142,12 @@ export async function processStop(input: StopHookInput): Promise<SyncHookJSONOut
 }
 
 async function main(): Promise<void> {
-  let input: StopHookInput;
+  let input: StopInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as StopHookInput;
+    input = await decodeStdin(StopInput, "stop hook input");
   } catch {
     return;
   }
-
-  if (input.hook_event_name !== "Stop") return;
 
   const output = await processStop(input);
   if (output) {

--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -13,6 +13,14 @@ Auto-install skips `workspace:*` specifiers. A script importing a workspace pack
 
 Repo-internal tooling (`scripts/`, `.claude/hooks/`) must import `packages/` code via relative paths (`../packages/marketplace/index`), so it runs in fresh worktrees without install. Reserve workspace specifiers for distributed plugin code, which cannot use relative imports across the plugin boundary.
 
+# Decoding External Data
+
+`JSON.parse`, subprocess stdout, file reads, and hook input on stdin all produce `unknown`. Validate each against a zod schema at the point it arrives instead of asserting a shape onto it. `user/rules/typescript.md` covers the convention.
+
+`packages/decode` wraps zod with the source label that makes a rejection traceable: `decodeJson(schema, text, "gh pr view output")`, plus `decodeStdin`, `decodeFile`, `decodeFileLines`, and `decodeJsonLines`. Repo-internal tooling imports it relatively (`../packages/decode/index`).
+
+Plugins cannot use it. A distributed plugin resolves its runtime deps through npm auto-install, which skips `workspace:*`, so a plugin declares `zod` in its own `package.json` and calls `schema.parse` directly.
+
 # Script Conventions
 
 - **Argument parsing**: use [cleye](https://github.com/privatenumber/cleye). Load the `cleye` skill for parameters, flags, and subcommands instead of reading existing scripts.

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "table": "^6.9.0",
         "typescript": "^6.0.0",
         "url-pattern": "^1.0.3",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
@@ -38,6 +39,12 @@
       "name": "pr-body-eval",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.116.0",
+      },
+    },
+    "packages/decode": {
+      "name": "@bendrucker/claude-decode",
+      "dependencies": {
+        "zod": "^4.4.3",
       },
     },
     "packages/marketplace": {
@@ -323,6 +330,8 @@
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "@bendrucker/claude-comments": ["@bendrucker/claude-comments@workspace:plugins/comments"],
+
+    "@bendrucker/claude-decode": ["@bendrucker/claude-decode@workspace:packages/decode"],
 
     "@bendrucker/claude-marketplace": ["@bendrucker/claude-marketplace@workspace:packages/marketplace"],
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "plugins/issue",
     "plugins/ui-design",
     "plugins/gitlab",
+    "packages/decode",
     "packages/validate",
     "packages/marketplace",
     "plugins/plan",
@@ -67,7 +68,8 @@
     "cleye": "^2.2.1",
     "table": "^6.9.0",
     "typescript": "^6.0.0",
-    "url-pattern": "^1.0.3"
+    "url-pattern": "^1.0.3",
+    "zod": "^4.4.3"
   },
   "overrides": {
     "@apidevtools/json-schema-ref-parser": "^15.0.0"

--- a/packages/decode/__snapshots__/decode.test.ts.snap
+++ b/packages/decode/__snapshots__/decode.test.ts.snap
@@ -1,0 +1,63 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`failure messages malformed JSON names the source and echoes the input 1`] = `
+"gh pr view output: invalid JSON: JSON Parse error: Unexpected EOF
+  received: {"number":"
+`;
+
+exports[`failure messages empty input 1`] = `
+"gh pr view output: invalid JSON: JSON Parse error: Unexpected EOF
+  received: (empty)"
+`;
+
+exports[`failure messages whitespace-only input 1`] = `
+"gh pr view output: invalid JSON: JSON Parse error: Unexpected EOF
+  received: (empty)"
+`;
+
+exports[`failure messages JSON null against an object schema 1`] = `
+"gh pr view output did not match its schema:
+  ✖ Invalid input: expected object, received null"
+`;
+
+exports[`failure messages wrong type at the root 1`] = `
+"gh pr view output did not match its schema:
+  ✖ Invalid input: expected object, received string"
+`;
+
+exports[`failure messages missing and mistyped fields report every issue 1`] = `
+"gh pr view output did not match its schema:
+  ✖ Invalid input: expected number, received string → at number
+  ✖ Invalid input: expected string, received undefined → at title
+  ✖ Invalid input: expected object, received undefined → at author"
+`;
+
+exports[`failure messages a nested path is spelled out 1`] = `
+"gh pr view output did not match its schema:
+  ✖ Invalid input: expected string, received number → at author.login"
+`;
+
+exports[`failure messages array index appears in the path 1`] = `
+"gh pr view output did not match its schema:
+  ✖ Invalid input: expected string, received number → at [1].name"
+`;
+
+exports[`failure messages an oversized payload is truncated in the echo 1`] = `
+"gh pr view output: invalid JSON: JSON Parse error: Expected '}'
+  received: {"number":99999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999…"
+`;
+
+exports[`decode reports a syntax-free failure without an input echo 1`] = `
+"catalog entry did not match its schema:
+  ✖ Invalid input: expected string, received number → at name"
+`;
+
+exports[`decodeJsonLines a bad record reports its 1-based line number 1`] = `
+"transcript line 2 did not match its schema:
+  ✖ Invalid input: expected string, received number → at name"
+`;
+
+exports[`decodeJsonLines blank lines do not shift the reported line number 1`] = `
+"transcript line 4 did not match its schema:
+  ✖ Invalid input: expected string, received number → at name"
+`;

--- a/packages/decode/decode.test.ts
+++ b/packages/decode/decode.test.ts
@@ -1,0 +1,200 @@
+import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
+import fc from "fast-check";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+import { DecodeError, decode, decodeJson, decodeJsonLines } from "./index";
+import { decodeFile, decodeFileLines, decodeStdin } from "./sources";
+
+const Review = z.object({
+  number: z.number(),
+  title: z.string(),
+  author: z.object({ login: z.string() }),
+});
+
+const Tag = z.object({ name: z.string() });
+
+let tempDir: string;
+
+beforeAll(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "decode-test-"));
+});
+
+afterAll(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+function thrown(run: () => void): DecodeError {
+  try {
+    run();
+  } catch (error) {
+    if (error instanceof DecodeError) return error;
+    throw error;
+  }
+  throw new Error("expected a DecodeError");
+}
+
+function message(run: () => void): string {
+  return thrown(run).message;
+}
+
+describe("failure messages", () => {
+  test.each<{ title: string; text: string; schema?: z.ZodType }>([
+    { title: "malformed JSON names the source and echoes the input", text: '{"number":' },
+    { title: "empty input", text: "" },
+    { title: "whitespace-only input", text: "   \n  " },
+    { title: "JSON null against an object schema", text: "null" },
+    { title: "wrong type at the root", text: '"a string"' },
+    { title: "missing and mistyped fields report every issue", text: '{"number":"12"}' },
+    {
+      title: "a nested path is spelled out",
+      text: '{"number":12,"title":"t","author":{"login":7}}',
+    },
+    {
+      title: "array index appears in the path",
+      text: '[{"name":"ok"},{"name":3}]',
+      schema: z.array(Tag),
+    },
+    {
+      title: "an oversized payload is truncated in the echo",
+      text: `{"number":${"9".repeat(400)}`,
+    },
+  ])("$title", ({ text, schema = Review }) => {
+    expect(message(() => decodeJson(schema, text, "gh pr view output"))).toMatchSnapshot();
+  });
+});
+
+describe("decodeJson", () => {
+  test("returns the parsed value typed by the schema", () => {
+    const pr = decodeJson(Review, '{"number":12,"title":"t","author":{"login":"ben"}}', "gh");
+    expect(pr).toEqual({ number: 12, title: "t", author: { login: "ben" } });
+  });
+
+  test("strips unknown keys under a strict object and keeps them under a loose one", () => {
+    const text = '{"name":"a","extra":1}';
+    expect(decodeJson(Tag, text, "src")).toEqual({ name: "a" });
+    expect(decodeJson(z.looseObject({ name: z.string() }), text, "src")).toEqual({
+      name: "a",
+      extra: 1,
+    });
+  });
+
+  test("applies schema defaults and transforms", () => {
+    const schema = z.object({ retries: z.number().default(3), name: z.string().trim() });
+    expect(decodeJson(schema, '{"name":"  a  "}', "src")).toEqual({ retries: 3, name: "a" });
+  });
+});
+
+describe("decode", () => {
+  test("validates an already-parsed value", () => {
+    expect(decode(Tag, { name: "a" }, "Bun.file().json()")).toEqual({ name: "a" });
+  });
+
+  test("reports a syntax-free failure without an input echo", () => {
+    expect(message(() => decode(Tag, { name: 1 }, "catalog entry"))).toMatchSnapshot();
+  });
+});
+
+describe("decodeJsonLines", () => {
+  test("decodes every record and skips blank lines", () => {
+    const text = '{"name":"a"}\n\n{"name":"b"}\n';
+    expect(decodeJsonLines(Tag, text, "transcript")).toEqual([{ name: "a" }, { name: "b" }]);
+  });
+
+  test("returns an empty array for empty input", () => {
+    expect(decodeJsonLines(Tag, "\n  \n", "transcript")).toEqual([]);
+  });
+
+  test.each([
+    { title: "a bad record reports its 1-based line number", text: '{"name":"a"}\n{"name":3}' },
+    {
+      title: "blank lines do not shift the reported line number",
+      text: '{"name":"a"}\n\n\n{"name":3}',
+    },
+  ])("$title", ({ text }) => {
+    expect(message(() => decodeJsonLines(Tag, text, "transcript"))).toMatchSnapshot();
+  });
+});
+
+describe("DecodeError", () => {
+  test("carries the source and the zod issues", () => {
+    const error = thrown(() => decodeJson(Review, '{"number":"12"}', "gh pr view output"));
+    expect(error.source).toBe("gh pr view output");
+    expect(error.issues.map((issue) => issue.path.join("."))).toEqual([
+      "number",
+      "title",
+      "author",
+    ]);
+  });
+
+  test("a syntax failure carries no issues", () => {
+    expect(thrown(() => decodeJson(Review, "{", "gh pr view output")).issues).toEqual([]);
+  });
+});
+
+describe("roundtrip", () => {
+  test("any value the schema accepts survives stringify then decode", () => {
+    const schema = z.object({
+      name: z.string(),
+      count: z.number().int(),
+      active: z.boolean(),
+      tags: z.array(z.string()),
+      note: z.string().nullable(),
+    });
+
+    fc.assert(
+      fc.property(
+        fc.record({
+          name: fc.string(),
+          count: fc.integer(),
+          active: fc.boolean(),
+          tags: fc.array(fc.string()),
+          note: fc.option(fc.string(), { nil: null }),
+        }),
+        (value) => {
+          expect(decodeJson(schema, JSON.stringify(value), "roundtrip")).toEqual(value);
+        },
+      ),
+    );
+  });
+
+  test("any record list survives stringify then line decode", () => {
+    fc.assert(
+      fc.property(fc.array(fc.record({ name: fc.string() })), (records) => {
+        const text = records.map((record) => JSON.stringify(record)).join("\n");
+        expect(decodeJsonLines(Tag, text, "roundtrip")).toEqual(records);
+      }),
+    );
+  });
+});
+
+describe("sources", () => {
+  test("decodeFile names the path in its failure", async () => {
+    const good = join(tempDir, "good.json");
+    const bad = join(tempDir, "bad.json");
+    await Bun.write(good, '{"name":"a"}');
+    await Bun.write(bad, '{"name":1}');
+
+    expect(await decodeFile(Tag, good)).toEqual({ name: "a" });
+    await expect(decodeFile(Tag, bad)).rejects.toThrow(`${bad} did not match its schema`);
+  });
+
+  test("decodeFileLines reads a JSONL file", async () => {
+    const path = join(tempDir, "lines.jsonl");
+    await Bun.write(path, '{"name":"a"}\n{"name":"b"}\n');
+    expect(await decodeFileLines(Tag, path)).toEqual([{ name: "a" }, { name: "b" }]);
+  });
+
+  test("decodeStdin defaults its source label and accepts an override", async () => {
+    const stdin = spyOn(Bun.stdin, "text").mockResolvedValue('{"name":1}');
+    try {
+      await expect(decodeStdin(Tag)).rejects.toThrow("stdin did not match its schema");
+      await expect(decodeStdin(Tag, "newline/check hook input")).rejects.toThrow(
+        "newline/check hook input did not match its schema",
+      );
+    } finally {
+      stdin.mockRestore();
+    }
+  });
+});

--- a/packages/decode/error.ts
+++ b/packages/decode/error.ts
@@ -1,0 +1,56 @@
+import type { z } from "zod";
+
+const PREVIEW_LIMIT = 120;
+
+function preview(text: string): string {
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  if (collapsed === "") return "(empty)";
+  if (collapsed.length <= PREVIEW_LIMIT) return collapsed;
+  return `${collapsed.slice(0, PREVIEW_LIMIT)}…`;
+}
+
+function formatPath(path: readonly PropertyKey[]): string {
+  return path.reduce<string>((acc, segment) => {
+    if (typeof segment === "number") return `${acc}[${segment}]`;
+    return acc === "" ? String(segment) : `${acc}.${String(segment)}`;
+  }, "");
+}
+
+function prettify(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const path = formatPath(issue.path);
+      return path === "" ? `  ✖ ${issue.message}` : `  ✖ ${issue.message} → at ${path}`;
+    })
+    .join("\n");
+}
+
+/** A rejected boundary payload. `issues` is empty when the text was not JSON. */
+export class DecodeError extends Error {
+  readonly source: string;
+  readonly issues: readonly z.core.$ZodIssue[];
+
+  private constructor(source: string, message: string, issues: readonly z.core.$ZodIssue[]) {
+    super(message);
+    this.name = "DecodeError";
+    this.source = source;
+    this.issues = issues;
+  }
+
+  static syntax(source: string, text: string, cause: unknown): DecodeError {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    return new DecodeError(
+      source,
+      `${source}: invalid JSON: ${detail}\n  received: ${preview(text)}`,
+      [],
+    );
+  }
+
+  static invalid(source: string, error: z.ZodError): DecodeError {
+    return new DecodeError(
+      source,
+      `${source} did not match its schema:\n${prettify(error)}`,
+      error.issues,
+    );
+  }
+}

--- a/packages/decode/index.ts
+++ b/packages/decode/index.ts
@@ -1,0 +1,3 @@
+export { DecodeError } from "./error";
+export { decode, decodeJson, decodeJsonLines } from "./json";
+export { decodeFile, decodeFileLines, decodeStdin } from "./sources";

--- a/packages/decode/json.ts
+++ b/packages/decode/json.ts
@@ -1,0 +1,44 @@
+import type { z } from "zod";
+import { DecodeError } from "./error";
+
+/** Validate an already-parsed value. `source` labels the seam in any failure. */
+export function decode<S extends z.ZodType>(
+  schema: S,
+  value: unknown,
+  source: string,
+): z.output<S> {
+  const result = schema.safeParse(value);
+  if (!result.success) throw DecodeError.invalid(source, result.error);
+  return result.data;
+}
+
+/** Parse JSON text and validate it. `source` labels the seam in any failure. */
+export function decodeJson<S extends z.ZodType>(
+  schema: S,
+  text: string,
+  source: string,
+): z.output<S> {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch (error) {
+    throw DecodeError.syntax(source, text, error);
+  }
+  return decode(schema, value, source);
+}
+
+/** Validate every record of newline-delimited JSON. Blank lines are skipped. */
+export function decodeJsonLines<S extends z.ZodType>(
+  schema: S,
+  text: string,
+  source: string,
+): z.output<S>[] {
+  const records: z.output<S>[] = [];
+
+  for (const [index, line] of text.split("\n").entries()) {
+    if (line.trim() === "") continue;
+    records.push(decodeJson(schema, line, `${source} line ${index + 1}`));
+  }
+
+  return records;
+}

--- a/packages/decode/package.json
+++ b/packages/decode/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@bendrucker/claude-decode",
+  "private": true,
+  "type": "module",
+  "main": "./index.ts",
+  "dependencies": {
+    "zod": "^4.4.3"
+  }
+}

--- a/packages/decode/sources.ts
+++ b/packages/decode/sources.ts
@@ -1,0 +1,26 @@
+import type { z } from "zod";
+import { decodeJson, decodeJsonLines } from "./json";
+
+/** Read and validate a JSON file. Failures name the path. */
+export async function decodeFile<S extends z.ZodType>(
+  schema: S,
+  path: string,
+): Promise<z.output<S>> {
+  return decodeJson(schema, await Bun.file(path).text(), path);
+}
+
+/** Read and validate a newline-delimited JSON file. Failures name the path. */
+export async function decodeFileLines<S extends z.ZodType>(
+  schema: S,
+  path: string,
+): Promise<z.output<S>[]> {
+  return decodeJsonLines(schema, await Bun.file(path).text(), path);
+}
+
+/** Read and validate stdin, the input seam for hook scripts. */
+export async function decodeStdin<S extends z.ZodType>(
+  schema: S,
+  source = "stdin",
+): Promise<z.output<S>> {
+  return decodeJson(schema, await Bun.stdin.text(), source);
+}

--- a/user/rules/typescript.md
+++ b/user/rules/typescript.md
@@ -7,5 +7,19 @@ paths:
 # TypeScript
 
 - Avoid using `any` type. Use specific types or `unknown` if necessary.
-- Never use double type assertions (`as unknown as T`). Cast to `Record<string, unknown>` once, then assert individual values with `as string` etc., or fix the underlying type.
 - Prefer static `import` statements over dynamic `await import()`. There is no reason to defer loading a built-in or first-party module.
+
+## External Data
+
+Everything entering the program is `unknown`: `JSON.parse`, subprocess stdout, file reads, network responses, and hook input on stdin. Validate it against a zod schema where it arrives, and let the schema produce the type.
+
+```ts
+const Pr = z.object({ number: z.number(), title: z.string() });
+const pr = Pr.parse(JSON.parse(stdout));
+```
+
+Describe only the fields the code reads. A schema mirroring an upstream type drifts from it and claims more than the code needs.
+
+An `as` on external data is a promise the compiler cannot check, so a wrong payload runs on undetected and fails somewhere unrelated. Casting to `Record<string, unknown>` and asserting each field with `as string` is the same mistake spread over more lines.
+
+Inside typed code, narrow rather than assert: `typeof`, `instanceof`, `in`, or a `value is T` predicate. Use `satisfies` to check a literal against a type without widening it.


### PR DESCRIPTION
Adds `packages/decode`, a zod wrapper for the seams where external data enters, and reverses the `user/rules/typescript.md` guidance that taught the pattern it replaces. First layer of a stack ending with the five `typescript/no-unsafe-*` rules and `no-unsafe-type-assertion` at error.

Counts on this base: 231 hits across the five, 333 for `no-unsafe-type-assertion`. Of the assertions, 54 are `as Record<string, unknown>` and 21 more are the `as string` that follows one.

## Source Labels

`decodeJson(schema, text, "gh pr view output")` names the seam in its failure. A malformed payload comes back with a truncated echo of what arrived.

```
gh pr view output did not match its schema:
  ✖ Invalid input: expected string, received number → at author.login
```

`decodeStdin`, `decodeFile`, `decodeFileLines`, and `decodeJsonLines` cover the other seams. `decode` takes a value something else already parsed. JSONL failures carry the 1-based line number.

No subprocess helper. Every call site owns its spawn and its non-zero-exit policy already, so `decodeJson(schema, result.stdout, "glab mr view")` is the subprocess path.

## Plugin Distribution

Bun's auto-install resolves registry deps on an installer's machine but skips `workspace:*`, so a distributed plugin importing `@bendrucker/claude-decode` fails with `Cannot find module` outside this monorepo. CI installs the workspace, so it would not catch that.

The plugins hold roughly 400 of the 564 hits. They declare `zod` themselves and call `schema.parse` directly, the way `plugins/things` already does. Publishing the helpers to npm is the alternative, and four small functions do not justify a release commitment. `.claude/rules/scripts.md` records this.

## Schema Scope

`plugins/newline/scripts/check.ts` reads one field out of `tool_input`. Mirroring `PreToolUseHookInput` into zod would drift from the SDK on every release and assert far more than the hook needs, so the rule and the migrated hooks decode only the fields in use, under `z.looseObject`. The exported `process*` signatures in `.claude/hooks` moved from SDK types to `z.infer` of the local schema.

## Migration

`.claude/hooks` goes first and reports zero hits across all six rules. Both `ox` and `stop` parsed transcript JSONL through `JSON.parse(line) as TranscriptEntry`. Both now decode, and `content` is typed as the string-or-array union it actually is rather than cast to the array arm.

The gate that lived in `processInput`, returning null on an unrecognized event, is now the discriminated union at the boundary. A misconfigured registration fails with a named error. Its test became a table over five malformed payloads. Verified by piping input to each of the four hooks:

```
[ox] Failed to parse hook input: ox hook input did not match its schema:
  ✖ Invalid discriminator value. Expected 'PreToolUse' | 'PostToolUse' | 'Stop' → at hook_event_name
```

Two behavior changes. `commandOutput` returned garbage rather than null when handed a non-object. The `prek` failure path in `stop` destructured an error it had asserted a shape onto. Both go through `safeParse` now. Zod reads `Error.message` despite it being non-enumerable, so the fallback text is unchanged.

## Remaining Stack

| Area | Five rules | Assertions |
|---|---|---|
| `evals/*` | 60 | 34 |
| `plugins/comments` | 42 | 38 |
| `plugins/github`, `plugins/gitlab` | 44 | 37 |
| `plugins/writing` | 7 | 66 |
| `plugins/things`, `plugins/plan`, rest | 73 | 84 |
| `scripts/`, `user/`, `packages/` | 13 | 28 |

Two rule layers follow the migrations. The last also revisits what #1268 deferred for want of a boundary: the five `local/no-unknown-returns` suppressions, and `no-runtime-typeof`, rejected at 205 hits because `ajv` lived only in `packages/validate` and `zod` only in `plugins/things`.

## Curation

`user/rules/typescript.md` grows from three bullets to roughly 230 tokens on every `.ts` touch, buying back a rule that was teaching a banned pattern. Without it the lint layers land on a codebase with no sanctioned alternative.

Working: new external-data reads decode instead of asserting. Not working: a growing count of `oxlint-disable` lines for either rule family, or schemas that grow to mirror upstream types.

Removal: delete `packages/decode`, drop the workspace entry and the root `zod` dependency, restore the rule file section.
