### PR TITLE
lint: triage and enforce no-await-in-loop

### DIFF
--- a/.claude/hooks/ox/index.test.ts
+++ b/.claude/hooks/ox/index.test.ts
@@ -189,9 +189,11 @@ describe("ox hook", () => {
   // wrote by name: the directory holds live sessions' counts too.
   afterAll(async () => {
     await rm(tempDir, { recursive: true, force: true });
-    for (const session of gateSessions) {
-      await rm(blockCountPath(session), { recursive: true, force: true });
-    }
+    await Promise.all(
+      [...gateSessions].map((session) =>
+        rm(blockCountPath(session), { recursive: true, force: true }),
+      ),
+    );
   });
 
   describe("runOxlintAgent", () => {
@@ -430,6 +432,7 @@ describe("ox hook", () => {
 
       const budget: (SyncHookJSONOutput | null)[] = [];
       for (let stop = 0; stop < STOP_BLOCK_LIMIT; stop++) {
+        // oxlint-disable-next-line no-await-in-loop -- each stop increments the persisted block count that the next stop reads.
         budget.push(await processStop(mockStopHookInput(transcript, stop > 0, session)));
       }
       const past = await processStop(mockStopHookInput(transcript, true, session));

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -7,6 +7,7 @@
   },
   "rules": {
     "prefer-template": "error",
+    "no-await-in-loop": "error",
     "no-template-curly-in-string": "warn",
     "typescript/no-non-null-assertion": "error",
     "typescript/no-unnecessary-type-assertion": "error",

--- a/evals/issue-refine/label/server.ts
+++ b/evals/issue-refine/label/server.ts
@@ -37,12 +37,15 @@ async function readAllFeedback(): Promise<Record<string, unknown>> {
   } catch {
     return out;
   }
-  for (const n of names) {
-    if (!n.endsWith(".json")) continue;
-    try {
-      out[n.replace(/\.json$/, "")] = await Bun.file(join(argv.flags.feedback, n)).json();
-    } catch {}
-  }
+  await Promise.all(
+    names
+      .filter((n) => n.endsWith(".json"))
+      .map(async (n) => {
+        try {
+          out[n.replace(/\.json$/, "")] = await Bun.file(join(argv.flags.feedback, n)).json();
+        } catch {}
+      }),
+  );
   return out;
 }
 

--- a/evals/issue-refine/scripts/ab-prompt.ts
+++ b/evals/issue-refine/scripts/ab-prompt.ts
@@ -38,14 +38,16 @@ if (
   process.exit(1);
 }
 
+const versionDir = argv.flags.version;
 const brief = await decodeFile(Brief, argv.flags.brief);
-const files = (await readdir(argv.flags.version)).filter((f) => f.endsWith(".md")).toSorted();
+const files = (await readdir(versionDir)).filter((f) => f.endsWith(".md")).toSorted();
 
-const skillBlocks: string[] = [];
-for (const f of files) {
-  const body = await Bun.file(join(argv.flags.version, f)).text();
-  skillBlocks.push(`================ ${f} ================\n${body.trim()}`);
-}
+const skillBlocks = await Promise.all(
+  files.map(async (f) => {
+    const body = await Bun.file(join(versionDir, f)).text();
+    return `================ ${f} ================\n${body.trim()}`;
+  }),
+);
 
 const files_ctx = brief.context.files.map((x) => `- ${x}`).join("\n");
 const issues_ctx = brief.context.related_issues.map((x) => `- ${x}`).join("\n");

--- a/evals/issue-refine/scripts/ab-report.ts
+++ b/evals/issue-refine/scripts/ab-report.ts
@@ -59,11 +59,14 @@ let totalAfter = 0;
 for (const brief of briefs) {
   const beforeFile = join(argv.flags.out, `${brief}.before.md`);
   const afterFile = join(argv.flags.out, `${brief}.after.md`);
+  // oxlint-disable-next-line no-await-in-loop -- each brief prints its own report block, so scoring follows the printed order.
   if (!(await Bun.file(beforeFile).exists()) || !(await Bun.file(afterFile).exists())) {
     console.log(`${brief}: missing before/after output, skipping`);
     continue;
   }
+  // oxlint-disable-next-line no-await-in-loop -- each brief prints its own report block, so scoring follows the printed order.
   const b = await score(beforeFile);
+  // oxlint-disable-next-line no-await-in-loop -- each brief prints its own report block, so scoring follows the printed order.
   const a = await score(afterFile);
   totalBefore += b.score;
   totalAfter += a.score;

--- a/evals/issue-refine/scripts/build-labelset.ts
+++ b/evals/issue-refine/scripts/build-labelset.ts
@@ -42,34 +42,36 @@ const argv = cli({
 });
 
 const files = (await readdir(argv.flags.briefs)).filter((f) => f.endsWith(".json")).toSorted();
-const samples: unknown[] = [];
-const missing: string[] = [];
 
-for (const f of files) {
-  const brief = await decodeFile(Brief, join(argv.flags.briefs, f));
-  const id = brief.id ?? basename(f, ".json");
-  const outPath = join(argv.flags.out, `${id}.md`);
-  const file = Bun.file(outPath);
-  if (!(await file.exists())) {
-    missing.push(id);
-    continue;
-  }
-  const { title, type, body } = parseIssue(await file.text());
-  samples.push({
-    id,
-    type:
-      typeof brief.type === "string" && brief.type !== ""
-        ? brief.type
-        : type !== ""
-          ? type
-          : "unknown",
-    size: brief.size ?? "full",
-    project: brief.project ?? "synthetic",
-    brief: brief.brief,
-    title,
-    refined: body,
-  });
-}
+const loaded = await Promise.all(
+  files.map(async (f) => {
+    const brief = await decodeFile(Brief, join(argv.flags.briefs, f));
+    const id = brief.id ?? basename(f, ".json");
+    const file = Bun.file(join(argv.flags.out, `${id}.md`));
+    if (!(await file.exists())) return { id, sample: null };
+    const { title, type, body } = parseIssue(await file.text());
+    return {
+      id,
+      sample: {
+        id,
+        type:
+          typeof brief.type === "string" && brief.type !== ""
+            ? brief.type
+            : type !== ""
+              ? type
+              : "unknown",
+        size: brief.size ?? "full",
+        project: brief.project ?? "synthetic",
+        brief: brief.brief,
+        title,
+        refined: body,
+      },
+    };
+  }),
+);
+
+const samples: unknown[] = loaded.flatMap((entry) => (entry.sample ? [entry.sample] : []));
+const missing: string[] = loaded.filter((entry) => !entry.sample).map((entry) => entry.id);
 
 await Bun.write(argv.flags.output, JSON.stringify(samples, null, 2));
 console.log(`wrote ${samples.length} samples to ${argv.flags.output}`);

--- a/evals/issue-refine/scripts/judge.ts
+++ b/evals/issue-refine/scripts/judge.ts
@@ -74,20 +74,23 @@ const briefs = [
 ].toSorted();
 
 const mapping: Record<string, Record<string, string>> = {};
-const blocks: string[] = [];
-for (const brief of briefs) {
-  const flip = Math.random() < 0.5;
-  const slot1 = flip ? "after" : "before";
-  const slot2 = flip ? "before" : "after";
-  mapping[brief] = { "1": slot1, "2": slot2 };
-  const v1 = await Bun.file(join(argv.flags.out, `${brief}.${slot1}.md`)).text();
-  const v2 = await Bun.file(join(argv.flags.out, `${brief}.${slot2}.md`)).text();
-  await Bun.write(join(argv.flags.judgeDir, `${brief}.1.md`), v1);
-  await Bun.write(join(argv.flags.judgeDir, `${brief}.2.md`), v2);
-  blocks.push(
-    `#### Brief: ${brief}\n\n--- Version 1 ---\n${v1.trim()}\n\n--- Version 2 ---\n${v2.trim()}`,
-  );
-}
+const blocks = await Promise.all(
+  briefs.map(async (brief) => {
+    const flip = Math.random() < 0.5;
+    const slot1 = flip ? "after" : "before";
+    const slot2 = flip ? "before" : "after";
+    mapping[brief] = { "1": slot1, "2": slot2 };
+    const [v1, v2] = await Promise.all([
+      Bun.file(join(argv.flags.out, `${brief}.${slot1}.md`)).text(),
+      Bun.file(join(argv.flags.out, `${brief}.${slot2}.md`)).text(),
+    ]);
+    await Promise.all([
+      Bun.write(join(argv.flags.judgeDir, `${brief}.1.md`), v1),
+      Bun.write(join(argv.flags.judgeDir, `${brief}.2.md`), v2),
+    ]);
+    return `#### Brief: ${brief}\n\n--- Version 1 ---\n${v1.trim()}\n\n--- Version 2 ---\n${v2.trim()}`;
+  }),
+);
 await Bun.write(mappingPath, JSON.stringify(mapping, null, 2));
 
 const rubric = await Bun.file(argv.flags.rubric).text();

--- a/evals/pr-body/label/server.ts
+++ b/evals/pr-body/label/server.ts
@@ -36,12 +36,15 @@ async function readAllFeedback(): Promise<Record<string, unknown>> {
   } catch {
     return out;
   }
-  for (const n of names) {
-    if (!n.endsWith(".json")) continue;
-    try {
-      out[n.replace(/\.json$/, "")] = await Bun.file(join(argv.flags.feedback, n)).json();
-    } catch {}
-  }
+  await Promise.all(
+    names
+      .filter((n) => n.endsWith(".json"))
+      .map(async (n) => {
+        try {
+          out[n.replace(/\.json$/, "")] = await Bun.file(join(argv.flags.feedback, n)).json();
+        } catch {}
+      }),
+  );
   return out;
 }
 

--- a/evals/pr-body/scripts/judge.ts
+++ b/evals/pr-body/scripts/judge.ts
@@ -325,6 +325,7 @@ async function main(): Promise<void> {
   };
   for (const row of judged) {
     addUsage(total, row.usage);
+    // oxlint-disable-next-line no-await-in-loop -- emit appends to a single FileSink; carried-over judgments must be written back in order.
     await emit(row);
   }
   let done = 0;

--- a/evals/pr-body/scripts/mine.ts
+++ b/evals/pr-body/scripts/mine.ts
@@ -219,6 +219,7 @@ async function main() {
   const repos = [...new Set(mined.map((m) => m.repository))].toSorted();
   const fetched = new Map<string, Map<number, FetchedPr>>();
   for (const repo of repos) {
+    // oxlint-disable-next-line no-await-in-loop -- each repo is a paginated GitHub API sweep; serializing keeps the run inside the REST rate limit.
     fetched.set(repo, await fetchRepoPrs(repo));
   }
 

--- a/evals/pr-body/scripts/run-eval.ts
+++ b/evals/pr-body/scripts/run-eval.ts
@@ -129,10 +129,9 @@ export function manifestPath(runDir: string): string {
 
 export async function loadScenarios(dir: string): Promise<Scenario[]> {
   const names = (await readdir(dir)).filter((n) => n.endsWith(".json")).toSorted();
-  const scenarios: Scenario[] = [];
-  for (const name of names) {
-    scenarios.push(await decodeFile(Scenario, join(dir, name)));
-  }
+  const scenarios = await Promise.all(
+    names.map(async (name) => decodeFile(Scenario, join(dir, name))),
+  );
   if (scenarios.length === 0) throw new Error(`No scenario JSON files in ${dir}`);
   return scenarios;
 }
@@ -239,6 +238,7 @@ export async function mapPool<T, R>(
         const index = cursor++;
         const item = items[index];
         if (index >= items.length || item === undefined) return;
+        // oxlint-disable-next-line no-await-in-loop -- this is the worker body of the bounded pool above; the pool is the parallelism.
         results[index] = await fn(item);
       }
     }),
@@ -359,6 +359,7 @@ async function main(): Promise<void> {
 
   for (const row of recorded) {
     addUsage(total, row.usage);
+    // oxlint-disable-next-line no-await-in-loop -- emit appends to a single FileSink; resumed rows must be written back in order.
     await emit(row);
   }
   if (recorded.length > 0) {
@@ -368,6 +369,7 @@ async function main(): Promise<void> {
   if (!argv.flags.skipBaseline) {
     for (const scenario of scenarios) {
       if (done.has(rowKey(scenario.id, "original", 0))) continue;
+      // oxlint-disable-next-line no-await-in-loop -- emit appends to a single FileSink; baseline rows must land in scenario order.
       await emit({
         scenarioId: scenario.id,
         arm: "original",

--- a/evals/review-voice/label/server.ts
+++ b/evals/review-voice/label/server.ts
@@ -42,12 +42,15 @@ async function readAllLabels(): Promise<Record<string, unknown>> {
   } catch {
     return out;
   }
-  for (const name of names) {
-    if (!name.endsWith(".json")) continue;
-    try {
-      out[name.replace(/\.json$/, "")] = await Bun.file(join(argv.flags.labels, name)).json();
-    } catch {}
-  }
+  await Promise.all(
+    names
+      .filter((name) => name.endsWith(".json"))
+      .map(async (name) => {
+        try {
+          out[name.replace(/\.json$/, "")] = await Bun.file(join(argv.flags.labels, name)).json();
+        } catch {}
+      }),
+  );
   return out;
 }
 

--- a/evals/review-voice/scripts/report.ts
+++ b/evals/review-voice/scripts/report.ts
@@ -58,11 +58,12 @@ async function readLabels(dir: string): Promise<Map<string, Label>> {
   } catch {
     return map;
   }
-  for (const name of names) {
-    if (!name.endsWith(".json")) continue;
-    const rec = await decodeFile(Label, join(dir, name));
-    map.set(rec.id, rec);
-  }
+  const records = await Promise.all(
+    names
+      .filter((name) => name.endsWith(".json"))
+      .map(async (name) => decodeFile(Label, join(dir, name))),
+  );
+  for (const rec of records) map.set(rec.id, rec);
   return map;
 }
 

--- a/evals/writing/label/server.ts
+++ b/evals/writing/label/server.ts
@@ -39,12 +39,15 @@ async function readAllFeedback(): Promise<Record<string, unknown>> {
   } catch {
     return out;
   }
-  for (const n of names) {
-    if (!n.endsWith(".json")) continue;
-    try {
-      out[n.replace(/\.json$/, "")] = await Bun.file(join(argv.flags.feedback, n)).json();
-    } catch {}
-  }
+  await Promise.all(
+    names
+      .filter((n) => n.endsWith(".json"))
+      .map(async (n) => {
+        try {
+          out[n.replace(/\.json$/, "")] = await Bun.file(join(argv.flags.feedback, n)).json();
+        } catch {}
+      }),
+  );
   return out;
 }
 

--- a/evals/writing/scripts/mine.ts
+++ b/evals/writing/scripts/mine.ts
@@ -150,15 +150,16 @@ async function probeInvocations(dbPath: string): Promise<number | null> {
 
 async function loadDrafts(dir: string): Promise<RewriteDraft[]> {
   const names = (await readdir(dir)).filter((n) => n.endsWith(".json")).toSorted();
-  const drafts: RewriteDraft[] = [];
-  for (const name of names) {
-    const draft = await decodeFile(Draft, join(dir, name));
-    drafts.push({
-      category: draft.category ?? basename(name, ".json"),
-      input: draft.input,
-      output: draft.output,
-    });
-  }
+  const drafts = await Promise.all(
+    names.map(async (name) => {
+      const draft = await decodeFile(Draft, join(dir, name));
+      return {
+        category: draft.category ?? basename(name, ".json"),
+        input: draft.input,
+        output: draft.output,
+      };
+    }),
+  );
   return drafts;
 }
 

--- a/packages/skill-lint/cli.ts
+++ b/packages/skill-lint/cli.ts
@@ -47,26 +47,27 @@ function tryReaddir(dir: string) {
 }
 
 async function resolveSkillDirs(patterns: string[]): Promise<string[]> {
-  const dirs: string[] = [];
-  for (const pattern of patterns) {
-    if (pattern.includes("*")) {
+  const perPattern = await Promise.all(
+    patterns.map(async (pattern) => {
+      if (!pattern.includes("*")) {
+        return (await Bun.file(path.join(pattern, "SKILL.md")).exists()) ? [pattern] : [];
+      }
+
       const base = pattern.split("*")[0] ?? "";
       const suffix = pattern.split("*").slice(1).join("*");
 
       const entries = tryReaddir(base);
-      if (!entries) continue;
-      for (const d of entries) {
-        if (!d.isDirectory()) continue;
-        const p = path.join(base, d.name, suffix.replace(/^\*?\/?/, ""));
-        if (await Bun.file(path.join(p, "SKILL.md")).exists()) {
-          dirs.push(p);
-        }
-      }
-    } else if (await Bun.file(path.join(pattern, "SKILL.md")).exists()) {
-      dirs.push(pattern);
-    }
-  }
-  return dirs;
+      if (!entries) return [];
+      const candidates = entries
+        .filter((d) => d.isDirectory())
+        .map((d) => path.join(base, d.name, suffix.replace(/^\*?\/?/, "")));
+      const present = await Promise.all(
+        candidates.map((p) => Bun.file(path.join(p, "SKILL.md")).exists()),
+      );
+      return candidates.filter((_, index) => present[index]);
+    }),
+  );
+  return perPattern.flat();
 }
 
 const skillDirs = await resolveSkillDirs(positionals);

--- a/packages/validate/run.ts
+++ b/packages/validate/run.ts
@@ -21,8 +21,14 @@ export async function runValidation(target: ValidationTarget): Promise<void> {
   let ajv: Ajv | undefined;
   if (target.extraSchemas != null && target.extraSchemas.length !== 0) {
     ajv = createValidator();
-    for (const extra of target.extraSchemas) {
-      ajv.addSchema(await loadSchema(extra.schema), extra.key);
+    const extras = await Promise.all(
+      target.extraSchemas.map(async (extra) => ({
+        key: extra.key,
+        schema: await loadSchema(extra.schema),
+      })),
+    );
+    for (const extra of extras) {
+      ajv.addSchema(extra.schema, extra.key);
     }
   }
 
@@ -32,11 +38,13 @@ export async function runValidation(target: ValidationTarget): Promise<void> {
 
   const result: ValidationResult = { errors: [], warnings: [] };
   for (const file of target.files) {
+    // oxlint-disable-next-line no-await-in-loop -- each file prints its bullet as it is validated, so the checks follow the printed order.
     if (!(await Bun.file(resolve(file)).exists())) {
       console.log(`• ${file} (not found, skipped)`);
       continue;
     }
     console.log(`• ${file}`);
+    // oxlint-disable-next-line no-await-in-loop -- each file prints its bullet as it is validated, so the checks follow the printed order.
     const r = await validateFile(file, target.schema, options);
     result.errors.push(...r.errors);
     result.warnings.push(...r.warnings);

--- a/plugins/claude-code/skills/session/scripts/db.test.ts
+++ b/plugins/claude-code/skills/session/scripts/db.test.ts
@@ -670,6 +670,7 @@ describe("cross-machine history", () => {
     await reindex();
 
     for (const tbl of ["sessions", "messages", "content_items"]) {
+      // oxlint-disable-next-line no-await-in-loop -- one DuckDB connection serves the suite; concurrent statements on it interleave.
       const rows = await db.query(
         `SELECT DISTINCT host FROM ${tbl} ORDER BY host`,
         z.object({ host: z.string() }),
@@ -720,6 +721,7 @@ describe("cross-machine history", () => {
     // (mtime, size), so an old-mtime file on a new host is still a new path.
     await importFixtureHost("archive");
     for (const rel of ["-Users-test-project/basic.jsonl", "-Users-test-webapp/webapp.jsonl"]) {
+      // oxlint-disable-next-line no-await-in-loop -- two fixture files; concurrency buys nothing.
       await backdate(path.join(importsDir, "archive", "projects", rel));
     }
     await reindex();
@@ -1499,6 +1501,7 @@ describe("change catalog", () => {
 
     for (const table of ["raw", "content_items", "indexed_files"]) {
       const column = table === "indexed_files" ? "path" : "source_file";
+      // oxlint-disable-next-line no-await-in-loop -- one DuckDB connection serves the suite; concurrent statements on it interleave.
       const [after] = await db.query(
         `SELECT COUNT(*) AS n FROM ${table} WHERE host = 'shrinking' AND ${column} = $path`,
         z.object({ n: z.bigint() }),
@@ -1998,6 +2001,7 @@ describe("plan-sections query", () => {
       ["assistant", assistant, "2026-02-01T10:00:00"],
       ["user", result, "2026-02-01T10:01:00"],
     ] as const) {
+      // oxlint-disable-next-line no-await-in-loop -- rows insert in fixture order on one connection so the assertions see a fixed layout.
       await db.run(
         `INSERT INTO raw (host, session_id, type, project_path, timestamp, data)
          VALUES ('local', 'disk-plan-session', $type, '/Users/test/project',
@@ -2395,6 +2399,7 @@ describe("message_usage cost columns and usage queries", () => {
     ];
     let line = 1;
     for (const r of rows) {
+      // oxlint-disable-next-line no-await-in-loop -- rows insert in fixture order on one connection so source_line stays deterministic.
       await db.run(
         `INSERT INTO raw
            (host, session_id, type, project_path, is_sidechain, timestamp,

--- a/plugins/claude-code/skills/session/scripts/db.ts
+++ b/plugins/claude-code/skills/session/scripts/db.ts
@@ -156,23 +156,26 @@ function readDirEntries(dir: string) {
 
 export async function listImportedHosts(importsDir?: string): Promise<ImportedHost[]> {
   const root = getImportsDir(importsDir);
-  const hosts: ImportedHost[] = [];
-  for (const entry of readDirEntries(root)) {
-    if (!entry.isDirectory()) continue;
-    const hostRoot = path.join(root, entry.name);
-    const manifestPath = path.join(hostRoot, "manifest.json");
-    try {
-      hosts.push({
-        label: entry.name,
-        root: hostRoot,
-        manifestPath,
-        manifest: Manifest.parse(await Bun.file(manifestPath).json()),
-      });
-    } catch {
-      // A missing or undecodable manifest means this directory is not a registered host.
-    }
-  }
-  return hosts;
+  const read = await Promise.all(
+    readDirEntries(root)
+      .filter((entry) => entry.isDirectory())
+      .map(async (entry) => {
+        const hostRoot = path.join(root, entry.name);
+        const manifestPath = path.join(hostRoot, "manifest.json");
+        try {
+          return {
+            label: entry.name,
+            root: hostRoot,
+            manifestPath,
+            manifest: Manifest.parse(await Bun.file(manifestPath).json()),
+          };
+        } catch {
+          // A missing or undecodable manifest means this directory is not a registered host.
+          return null;
+        }
+      }),
+  );
+  return read.filter((host) => host !== null);
 }
 
 export async function enumerateHosts(
@@ -221,7 +224,9 @@ async function applySchema(db: Database): Promise<void> {
     .filter((f) => f.endsWith(".sql"))
     .toSorted();
   for (const file of files) {
+    // oxlint-disable-next-line no-await-in-loop -- schema files apply in sorted order; later DDL depends on tables earlier DDL created.
     const sql = await Bun.file(path.join(SCHEMA_DIR, file)).text();
+    // oxlint-disable-next-line no-await-in-loop -- schema files apply in sorted order; later DDL depends on tables earlier DDL created.
     await db.run(sql);
   }
 }
@@ -328,6 +333,7 @@ export async function ensureIndex(
     const scanned = scanJsonlFiles(entry.root);
     corpusBytes += scanned.reduce((sum, f) => sum + f.size, 0);
 
+    // oxlint-disable-next-line no-await-in-loop -- one DuckDB connection serves the refresh; concurrent statements on it interleave.
     const indexed = await db.query(
       "SELECT path, mtime, size FROM indexed_files WHERE host = $host",
       z.object({ path: z.string(), mtime: z.bigint(), size: z.bigint() }),
@@ -342,19 +348,27 @@ export async function ensureIndex(
     });
     const removed = indexed.filter((r) => !scannedPaths.has(r.path));
 
+    // oxlint-disable-next-line no-await-in-loop -- SET VARIABLE is connection-global state the per-file import below reads back.
     await db.run("SET VARIABLE host = $host", { host: entry.host });
     for (const file of changed) {
+      // oxlint-disable-next-line no-await-in-loop -- SET VARIABLE is connection-global state the import statement below reads back.
       await db.run("SET VARIABLE source_path = $path", { path: file.path });
+      // oxlint-disable-next-line no-await-in-loop -- SET VARIABLE is connection-global state the import statement below reads back.
       await db.run("SET VARIABLE source_mtime = $mtime", { mtime: String(file.mtime) });
+      // oxlint-disable-next-line no-await-in-loop -- SET VARIABLE is connection-global state the import statement below reads back.
       await db.run("SET VARIABLE source_size = $size", { size: String(file.size) });
+      // oxlint-disable-next-line no-await-in-loop -- reads the SET VARIABLE state set just above; overlapping imports would cross files.
       await db.run(importSql);
     }
     for (const file of removed) {
+      // oxlint-disable-next-line no-await-in-loop -- one DuckDB connection serves the refresh; concurrent statements on it interleave.
       await removeFile(db, entry.host, file.path);
     }
 
     if (changed.length > 0 || removed.length > 0) {
+      // oxlint-disable-next-line no-await-in-loop -- one DuckDB connection serves the refresh; concurrent statements on it interleave.
       await db.run("DELETE FROM meta WHERE host = $host", { host: entry.host });
+      // oxlint-disable-next-line no-await-in-loop -- the insert must follow the delete above on the same connection.
       await db.run("INSERT INTO meta VALUES ($host, CURRENT_TIMESTAMP)", { host: entry.host });
     }
     changedFiles += changed.length;
@@ -420,8 +434,10 @@ export async function runQuery<T>(
 ): Promise<T[]> {
   for (const [key, value] of Object.entries(params)) {
     if (value === null) {
+      // oxlint-disable-next-line no-await-in-loop -- SET VARIABLE is connection-global state the query below reads back.
       await db.run(`SET VARIABLE "${key}" = NULL`);
     } else {
+      // oxlint-disable-next-line no-await-in-loop -- SET VARIABLE is connection-global state the query below reads back.
       await db.run(`SET VARIABLE "${key}" = $value`, { value });
     }
   }

--- a/plugins/claude-code/skills/session/scripts/refresh.integration.ts
+++ b/plugins/claude-code/skills/session/scripts/refresh.integration.ts
@@ -126,7 +126,9 @@ describe("refresh.ts", () => {
     const initial = Bun.file(dbPath).size;
 
     for (let i = 0; i < 5; i++) {
+      // oxlint-disable-next-line no-await-in-loop -- the test measures growth across repeated reimports, so each cycle must follow the last.
       await touchCorpusFile(path.join("-Users-test-project", "basic.jsonl"));
+      // oxlint-disable-next-line no-await-in-loop -- the test measures growth across repeated reimports, so each cycle must follow the last.
       const { exitCode } = await run("--refresh");
       expect(exitCode).toBe(0);
     }

--- a/plugins/claude-code/skills/session/scripts/refresh.ts
+++ b/plugins/claude-code/skills/session/scripts/refresh.ts
@@ -48,8 +48,10 @@ async function cleanupStrayDatabases(): Promise<void> {
   const strayDirs = new Set([path.join(tmpdir(), "claude-session"), "/tmp/claude-session"]);
   for (const dir of strayDirs) {
     if (path.resolve(dir) === path.resolve(dataDir)) continue;
+    // oxlint-disable-next-line no-await-in-loop -- two known stray directories; concurrency buys nothing.
     if (!(await Bun.file(sessionDbPath(dir)).exists())) continue;
     try {
+      // oxlint-disable-next-line no-await-in-loop -- two known stray directories; concurrency buys nothing.
       await rm(dir, { recursive: true, force: true });
       console.error(`refresh: removed stale index at ${dir}`);
     } catch (err) {
@@ -72,13 +74,16 @@ async function stampIsFresh(): Promise<boolean> {
 async function openWithRetry(): Promise<Database | null> {
   for (let attempt = 0; ; attempt++) {
     try {
+      // oxlint-disable-next-line no-await-in-loop -- retry loop: an attempt runs only because the previous one hit the write lock.
       return await getDb(dataDir);
     } catch (err) {
       if (!/lock/i.test(String(err)) || attempt >= 3) {
+        // oxlint-disable-next-line no-await-in-loop -- retry loop: an attempt runs only because the previous one hit the write lock.
         if ((await Bun.file(dbPath).exists()) && /lock/i.test(String(err))) return null;
         throw err;
       }
     }
+    // oxlint-disable-next-line no-await-in-loop -- backoff between lock retries.
     await Bun.sleep(250);
   }
 }

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/index.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/index.ts
@@ -22,15 +22,14 @@ export async function lintSkill(skillDir: string): Promise<SkillLintResult> {
   const refs = findReferences(content.body);
   const referenceResults = await Promise.all(refs.map((ref) => lintReference(skillDir, ref)));
 
-  let totalTokens = estimateTokens(raw);
-  for (const ref of referenceResults) {
-    const refPath = path.join(skillDir, ref.path);
-    const refFile = Bun.file(refPath);
-    if (await refFile.exists()) {
-      const refContent = await refFile.text();
-      totalTokens += estimateTokens(refContent);
-    }
-  }
+  const refTokens = await Promise.all(
+    referenceResults.map(async (ref) => {
+      const refFile = Bun.file(path.join(skillDir, ref.path));
+      if (!(await refFile.exists())) return 0;
+      return estimateTokens(await refFile.text());
+    }),
+  );
+  const totalTokens = refTokens.reduce((sum, tokens) => sum + tokens, estimateTokens(raw));
 
   for (const ref of referenceResults) {
     results.push(...ref.results);

--- a/plugins/comments/apply/branch.ts
+++ b/plugins/comments/apply/branch.ts
@@ -43,10 +43,13 @@ export async function applyToBranch(
   try {
     await $`git read-tree HEAD`.env(env).quiet();
     for (const [path, content] of editsByPath) {
+      // oxlint-disable-next-line no-await-in-loop -- the edits write into one GIT_INDEX_FILE; git update-index cannot run concurrently against it.
       const mode = await headMode(path);
+      // oxlint-disable-next-line no-await-in-loop -- the edits write into one GIT_INDEX_FILE; git update-index cannot run concurrently against it.
       const blob = (await $`git hash-object -w --stdin < ${Buffer.from(content)}`.quiet())
         .text()
         .trim();
+      // oxlint-disable-next-line no-await-in-loop -- the edits write into one GIT_INDEX_FILE; git update-index cannot run concurrently against it.
       await $`git update-index --cacheinfo ${`${mode},${blob},${path}`}`.env(env).quiet();
     }
     const tree = (await $`git write-tree`.env(env).quiet()).text().trim();

--- a/plugins/comments/no-sdk-leak.test.ts
+++ b/plugins/comments/no-sdk-leak.test.ts
@@ -12,15 +12,18 @@ describe("no SDK leak into the product path", () => {
   const productDirs = ["detection", "judge", "apply", "skills", "workflow"];
 
   test("no @anthropic-ai/sdk import outside evals/", async () => {
-    const offenders: string[] = [];
-    for (const dir of productDirs) {
-      const glob = new Glob("**/*.{ts,js}");
-      for await (const path of glob.scan(join(root, dir))) {
-        if (path.includes("node_modules")) continue;
-        const text = await Bun.file(join(root, dir, path)).text();
-        if (text.includes("@anthropic-ai/sdk")) offenders.push(join(dir, path));
-      }
-    }
-    expect(offenders).toEqual([]);
+    const perDir = await Promise.all(
+      productDirs.map(async (dir) => {
+        const glob = new Glob("**/*.{ts,js}");
+        const found: string[] = [];
+        for await (const path of glob.scan(join(root, dir))) {
+          if (path.includes("node_modules")) continue;
+          const text = await Bun.file(join(root, dir, path)).text();
+          if (text.includes("@anthropic-ai/sdk")) found.push(join(dir, path));
+        }
+        return found;
+      }),
+    );
+    expect(perDir.flat()).toEqual([]);
   });
 });

--- a/plugins/comments/skills/audit/scripts/audit.ts
+++ b/plugins/comments/skills/audit/scripts/audit.ts
@@ -275,9 +275,12 @@ const applyCmd = command(
     for (const path of await judgedPaths(job)) {
       const language = languageForPath(path);
       const file = Bun.file(path);
+      // oxlint-disable-next-line no-await-in-loop -- the report lists findings in judged-path order and the body threads shared accumulators.
       if (language == null || language === "" || !(await file.exists())) continue;
+      // oxlint-disable-next-line no-await-in-loop -- the report lists findings in judged-path order and the body threads shared accumulators.
       const source = await file.text();
       const editItems: EditItem[] = [];
+      // oxlint-disable-next-line no-await-in-loop -- the report lists findings in judged-path order and the body threads shared accumulators.
       for (const match of matchVerdicts(path, await extractComments(source, language), verdicts)) {
         matched.add(match.id);
         reportItems.push({
@@ -301,6 +304,7 @@ const applyCmd = command(
 
     if (format != null && format !== "" && !report) {
       for (const [path, content] of editsByPath) {
+        // oxlint-disable-next-line no-await-in-loop -- bounds formatter subprocess fan-out to one `sh -c` per edited file at a time.
         const formatted = await formatContent(format, path, content);
         if (formatted.formatted) {
           editsByPath.set(path, formatted.content);

--- a/plugins/git/skills/conflicts/scripts/context.ts
+++ b/plugins/git/skills/conflicts/scripts/context.ts
@@ -12,6 +12,7 @@ async function detectOperation(): Promise<{ op: Operation; ref: string | null }>
   ];
 
   for (const { op, ref } of checks) {
+    // oxlint-disable-next-line no-await-in-loop -- first match wins: a later ref must not be probed once an earlier one verified.
     const result = await $`git rev-parse --verify ${ref}`.quiet().nothrow();
     if (result.exitCode === 0) {
       return { op, ref };

--- a/plugins/git/skills/conflicts/scripts/status.ts
+++ b/plugins/git/skills/conflicts/scripts/status.ts
@@ -11,6 +11,7 @@ if (files.trim() === "") {
 
 for (const file of files.trim().split("\n")) {
   try {
+    // oxlint-disable-next-line no-await-in-loop -- each conflicted file prints its own line, so reads follow the printed order.
     const content = await Bun.file(file).text();
     const count = (content.match(/^<{7} /gm) || []).length;
     console.log(`- ${file} (${count} conflict${count !== 1 ? "s" : ""})`);

--- a/plugins/github/scripts/pr-comments.ts
+++ b/plugins/github/scripts/pr-comments.ts
@@ -323,6 +323,7 @@ async function main(): Promise<void> {
     const variables: Record<string, string | number | undefined> = { owner, repo, number };
     if (cursor != null && cursor !== "") variables.cursor = cursor;
 
+    // oxlint-disable-next-line no-await-in-loop -- cursor pagination: each page's cursor comes from the response before it.
     const result = await fetchGraphQL(QUERY, variables);
     const pr = result.data.repository.pullRequest;
 

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -365,6 +365,7 @@ export async function resolveMergeable(
       }
     }
     if (attempt < MERGEABLE_UNKNOWN_RETRIES - 1) {
+      // oxlint-disable-next-line no-await-in-loop -- backoff between mergeability rechecks.
       await sleepFn(MERGEABLE_RECHECK_SECONDS * 1000);
     }
   }
@@ -680,6 +681,7 @@ async function watch(options: RunOptions): Promise<void> {
       // same cycle as a stale `success`, ahead of the terminal return below.
       let probe = result.probe;
       if (options.mode === "pr" && prNumber !== null && probeIsUndetermined(probe)) {
+        // oxlint-disable-next-line no-await-in-loop -- poll loop: each cycle reads state the previous cycle left behind.
         const resolved = await resolveMergeable(prNumber, repo, exec, sleep);
         probe = {
           ...probe,
@@ -705,6 +707,7 @@ async function watch(options: RunOptions): Promise<void> {
       if (terminal) return;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- poll interval between API cycles.
     await sleep((intervalSeconds ?? DEFAULT_INTERVAL_SECONDS) * 1000);
   }
 }

--- a/plugins/github/skills/copilot/scripts/review.ts
+++ b/plugins/github/skills/copilot/scripts/review.ts
@@ -582,6 +582,7 @@ async function collectContents(diff: Diff, cwd: string, maxBytes: number) {
       continue;
     }
     running += file.size;
+    // oxlint-disable-next-line no-await-in-loop -- the running byte budget checked above accumulates across iterations.
     contents.set(path, await file.text());
   }
 
@@ -816,6 +817,7 @@ async function main(): Promise<void> {
     const results: Result[] = [];
     for (const { angle, prompt } of prompts) {
       results.push(
+        // oxlint-disable-next-line no-await-in-loop -- every spawn shares COPILOT_HOME and the session ledger written there.
         await runCopilot(prompt, angle, { model, cap, cwd: workdir, agentic: argv.flags.agentic }),
       );
     }

--- a/plugins/gitlab/hooks/lint.ts
+++ b/plugins/gitlab/hooks/lint.ts
@@ -135,6 +135,7 @@ async function pointerConfigPath(
     // The shared config lives two levels up.
     resolve(gitDir, "..", "..", "config"),
   ]) {
+    // oxlint-disable-next-line no-await-in-loop -- first match wins: the shared config is only probed when the direct one misses.
     if (await env.fileExists(candidate)) return candidate;
   }
   return null;
@@ -145,9 +146,11 @@ async function gitConfigPath(cwd: string, env: LintEnv): Promise<string | null> 
   for (;;) {
     const dotGit = join(dir, ".git");
     const direct = join(dotGit, "config");
+    // oxlint-disable-next-line no-await-in-loop -- walks up to the parent directory only after the current one misses.
     if (await env.fileExists(direct)) return direct;
 
     // Worktrees and submodules use a `.git` file: `gitdir: <path>`.
+    // oxlint-disable-next-line no-await-in-loop -- walks up to the parent directory only after the current one misses.
     const pointer = await env.readFile(dotGit);
     if (pointer != null && pointer !== "") return pointerConfigPath(dir, pointer, env);
 

--- a/plugins/gitlab/scripts/merge.ts
+++ b/plugins/gitlab/scripts/merge.ts
@@ -51,6 +51,7 @@ export async function arm(
 ): Promise<void> {
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     try {
+      // oxlint-disable-next-line no-await-in-loop -- retry loop: an attempt runs only because the previous one failed transiently.
       await run();
       return;
     } catch (err) {
@@ -59,6 +60,7 @@ export async function arm(
         return;
       }
       if (attempt < MAX_ATTEMPTS && TRANSIENT.some((t) => message.includes(t))) {
+        // oxlint-disable-next-line no-await-in-loop -- backoff between retries.
         await sleep(RETRY_DELAY_MS);
         continue;
       }

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
@@ -515,6 +515,7 @@ export async function resolveMergeStatus(
       }
     }
     if (attempt < MERGE_STATUS_UNKNOWN_RETRIES - 1) {
+      // oxlint-disable-next-line no-await-in-loop -- backoff between merge-status rechecks.
       await sleepFn(MERGE_STATUS_RECHECK_SECONDS * 1000);
     }
   }
@@ -942,6 +943,7 @@ async function watch(options: RunOptions): Promise<void> {
       // same cycle as a stale `success`, ahead of the terminal return below.
       let probe = result.probe;
       if (target.mode === "mr" && iid !== null && probeIsUndetermined(probe)) {
+        // oxlint-disable-next-line no-await-in-loop -- poll loop: each cycle reads state the previous cycle left behind.
         const resolved = await resolveMergeStatus(projectEncoded, iid, exec, sleep);
         probe = {
           ...probe,
@@ -960,6 +962,7 @@ async function watch(options: RunOptions): Promise<void> {
         : DEFAULT_INTERVAL_SECONDS;
     }
 
+    // oxlint-disable-next-line no-await-in-loop -- poll interval between API cycles.
     await sleep((intervalSeconds ?? DEFAULT_INTERVAL_SECONDS) * 1000);
   }
 }

--- a/plugins/gitlab/skills/merge-request/scripts/discussions.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/discussions.ts
@@ -293,6 +293,7 @@ const resolveCmd = command(
     const iid = parsed._.iid;
 
     for (const id of parsed._.ids) {
+      // oxlint-disable-next-line no-await-in-loop -- one API mutation per discussion, each confirmed on stderr as it resolves.
       await $`glab api projects/:id/merge_requests/${iid}/discussions/${id} -X PUT -f resolved=true`.text();
       console.error(`Resolved: ${id}`);
     }

--- a/plugins/gitlab/skills/merge-request/scripts/draft-note.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/draft-note.ts
@@ -245,6 +245,7 @@ const reviewCmd = command(
           });
         }
 
+        // oxlint-disable-next-line no-await-in-loop -- one API POST per note; the created/failed tally and its error lines follow entry order.
         await glabApiPost(apiPath(mr), payload);
         created++;
       } catch (err) {

--- a/plugins/mac/hooks/sandbox.ts
+++ b/plugins/mac/hooks/sandbox.ts
@@ -93,6 +93,7 @@ export async function processInput(
   if (toolInput?.command == null || toolInput.command === "") return null;
 
   for (const { scriptArg } of extractCommands(toolInput.command)) {
+    // oxlint-disable-next-line no-await-in-loop -- first match wins: the scan stops at the first command carrying a bypass marker.
     if (scriptArg != null && scriptArg !== "" && (await hasBypassMarker(scriptArg))) {
       return disableSandbox(toolInput);
     }

--- a/plugins/mac/scripts/jxa.ts
+++ b/plugins/mac/scripts/jxa.ts
@@ -127,7 +127,9 @@ export async function runWithRetry(
     if (result.code === 0 || !isRetriableAppleEventsError(result.code, result.stderr)) {
       return result;
     }
+    // oxlint-disable-next-line no-await-in-loop -- backoff before retrying a transient Apple Events failure.
     await sleep(delay);
+    // oxlint-disable-next-line no-await-in-loop -- retry loop: an attempt runs only because the previous one returned a retriable error.
     result = await run(args);
   }
   return result;

--- a/plugins/mermaid/skills/diagram/scripts/validate.ts
+++ b/plugins/mermaid/skills/diagram/scripts/validate.ts
@@ -89,6 +89,7 @@ async function validateBlock(block: MermaidBlock): Promise<ValidationError | nul
 export async function validateBlocks(blocks: MermaidBlock[]): Promise<ValidationError[]> {
   const errors: ValidationError[] = [];
   for (const block of blocks) {
+    // oxlint-disable-next-line no-await-in-loop -- mermaid parses through a shared global parser; concurrent parses interleave its state.
     const error = await validateBlock(block);
     if (error) {
       errors.push(error);
@@ -129,6 +130,7 @@ async function main() {
   let hasErrors = false;
 
   for (const file of files) {
+    // oxlint-disable-next-line no-await-in-loop -- mermaid parses through a shared global parser; concurrent parses interleave its state.
     const result = await validateFile(file);
     results.push(result);
     if (result.errors.length > 0) {

--- a/plugins/plan/hooks/gate.test.ts
+++ b/plugins/plan/hooks/gate.test.ts
@@ -397,6 +397,7 @@ describe("recorded re-presents", () => {
       recorded.sessions.map(async ({ session, date, presents }) => {
         const labels: string[] = [];
         for (const plan of presents) {
+          // oxlint-disable-next-line no-await-in-loop -- the gate decides each presentation against the state the prior presentations left.
           labels.push(label(await runGate(mockInput(plan, session))));
         }
         return [`${date} ${session}`, labels] as const;

--- a/plugins/pull-request/scripts/contributing.ts
+++ b/plugins/pull-request/scripts/contributing.ts
@@ -12,7 +12,9 @@ export async function findContributing(
   for (const candidate of CANDIDATES) {
     const full = join(repoRoot, candidate);
     const file = Bun.file(full);
+    // oxlint-disable-next-line no-await-in-loop -- first match wins: a later candidate must not be read once an earlier one exists.
     if (await file.exists()) {
+      // oxlint-disable-next-line no-await-in-loop -- first match wins: a later candidate must not be read once an earlier one exists.
       return { path: candidate, content: await file.text() };
     }
   }

--- a/plugins/pull-request/scripts/detect-bot.test.ts
+++ b/plugins/pull-request/scripts/detect-bot.test.ts
@@ -13,9 +13,7 @@ const noOrigin = () => Promise.resolve(null);
 
 async function repo(files: string[]): Promise<string> {
   const root = mkdtempSync(join(tmpdir(), "detect-bot-"));
-  for (const file of files) {
-    await Bun.write(join(root, file), "{}");
-  }
+  await Promise.all(files.map((file) => Bun.write(join(root, file), "{}")));
   return root;
 }
 

--- a/plugins/pull-request/scripts/detect-bot.ts
+++ b/plugins/pull-request/scripts/detect-bot.ts
@@ -115,6 +115,7 @@ export async function detect(root: string, options: DetectOptions = {}): Promise
   for (const provider of PROVIDERS) {
     let config: string | null = null;
     for (const path of provider.configs) {
+      // oxlint-disable-next-line no-await-in-loop -- first match wins: the scan stops at the first config a provider ships.
       if (await Bun.file(join(root, path)).exists()) {
         config = path;
         break;

--- a/plugins/pull-request/scripts/e2e-hook-fire.ts
+++ b/plugins/pull-request/scripts/e2e-hook-fire.ts
@@ -98,10 +98,12 @@ async function setupCliStubs(root: string): Promise<{ binDir: string; logPath: s
   await mkdir(binDir, { recursive: true });
   for (const cli of ["gh", "glab"]) {
     const stub = join(binDir, cli);
+    // oxlint-disable-next-line no-await-in-loop -- two known CLIs, so concurrency buys nothing.
     await Bun.write(
       stub,
       `#!/bin/sh\nprintf '%s %s\\n' ${cli} "$*" >> ${JSON.stringify(logPath)}\nexit 0\n`,
     );
+    // oxlint-disable-next-line no-await-in-loop -- two known CLIs, so concurrency buys nothing.
     await run(["chmod", "+x", stub], root);
   }
   await Bun.write(logPath, "");
@@ -207,6 +209,7 @@ async function main(): Promise<void> {
     const { binDir, logPath } = await setupCliStubs(root);
 
     for (const testCase of CASES) {
+      // oxlint-disable-next-line no-await-in-loop -- the cases share one repo, one stub bin directory, and one call log.
       const { failures, output } = await runCase(testCase, root, binDir, logPath);
       if (failures.length === 0) {
         console.log(`PASS ${testCase.name}`);

--- a/plugins/pull-request/scripts/pr-template.test.ts
+++ b/plugins/pull-request/scripts/pr-template.test.ts
@@ -25,11 +25,13 @@ describe("findTemplate", () => {
   });
 
   async function writeFiles(files: TemplateFile[]) {
-    for (const [file, content] of files) {
-      const dest = path.join(tempDir, file);
-      mkdirSync(path.dirname(dest), { recursive: true });
-      await Bun.write(dest, content);
-    }
+    await Promise.all(
+      files.map(([file, content]) => {
+        const dest = path.join(tempDir, file);
+        mkdirSync(path.dirname(dest), { recursive: true });
+        return Bun.write(dest, content);
+      }),
+    );
   }
 
   test.each<[string, TemplateFile[], "github" | "gitlab", string | null]>([

--- a/plugins/pull-request/scripts/pr-template.ts
+++ b/plugins/pull-request/scripts/pr-template.ts
@@ -27,7 +27,9 @@ export async function findTemplate(provider: Provider, repoRoot: string): Promis
   for (const p of paths) {
     const full = join(repoRoot, p);
     const file = Bun.file(full);
+    // oxlint-disable-next-line no-await-in-loop -- first match wins: a later candidate must not be read once an earlier one exists.
     if (await file.exists()) {
+      // oxlint-disable-next-line no-await-in-loop -- first match wins: a later candidate must not be read once an earlier one exists.
       return await file.text();
     }
   }

--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -510,6 +510,7 @@ export async function resolveBody(command: string, cwd: string): Promise<BodyRes
       chunks.push(part.text);
       continue;
     }
+    // oxlint-disable-next-line no-await-in-loop -- returns on the first unreadable part, and a command carries at most a few.
     const text = await readBodyFile(part.path, cwd);
     if (text === null) {
       return {

--- a/plugins/review/skills/inbox/scripts/watch.ts
+++ b/plugins/review/skills/inbox/scripts/watch.ts
@@ -51,6 +51,8 @@ const { dataDir, queue: queues, interval } = argv.flags;
 // Monitor sees a single long-lived process (no shell while/sleep loop, which
 // breaks on macOS due to PATH-stripped eval and nice(5) restrictions).
 while (true) {
+  // oxlint-disable-next-line no-await-in-loop -- poll loop: the next iteration only runs after this one finishes.
   await iteration(queues, dataDir);
+  // oxlint-disable-next-line no-await-in-loop -- poll interval between iterations.
   await sleep(interval * 1000);
 }

--- a/plugins/review/skills/tuicr/scripts/ledger.ts
+++ b/plugins/review/skills/tuicr/scripts/ledger.ts
@@ -242,6 +242,7 @@ const upsertCmd = command(
     const ledger = await resolveLedger(parsed.flags);
     const comments = decodeComments(await Bun.stdin.text());
     for (const comment of comments) {
+      // oxlint-disable-next-line no-await-in-loop -- upsert is a read-modify-write of one ledger file; concurrent upserts drop comments.
       await ledger.upsert(comment);
     }
     console.error(`Upserted ${comments.length} comment(s)`);

--- a/plugins/review/skills/tuicr/scripts/watch.ts
+++ b/plugins/review/skills/tuicr/scripts/watch.ts
@@ -57,6 +57,7 @@ async function watch(slug: string, repo: string, pollSeconds: number): Promise<v
       seen.add(comment.id);
       console.log(describeComment(comment));
     }
+    // oxlint-disable-next-line no-await-in-loop -- poll interval between reads of the tuicr session.
     await Bun.sleep(pollSeconds * 1000);
   }
 }

--- a/plugins/things/scripts/url.ts
+++ b/plugins/things/scripts/url.ts
@@ -155,6 +155,7 @@ export async function resolveTagParams(
   for (const key of TAG_PARAMS) {
     const requested = parseTags(params.get(key));
     if (requested.length === 0) continue;
+    // oxlint-disable-next-line no-await-in-loop -- the requirer caches the tag list across calls and creates the missing ones.
     params.set(key, (await requirer(requested, createMissing)).join(","));
   }
 }

--- a/plugins/things/src/marketplace.test.ts
+++ b/plugins/things/src/marketplace.test.ts
@@ -13,7 +13,7 @@ describe("findSiblingScript", () => {
 
   async function tree(...paths: string[]): Promise<string> {
     const root = mkdtempSync(join(tmpdir(), "things-marketplace-"));
-    for (const path of paths) await Bun.write(join(root, path), "");
+    await Promise.all(paths.map((path) => Bun.write(join(root, path), "")));
     return root;
   }
 

--- a/plugins/things/src/mcp/stdout.test.ts
+++ b/plugins/things/src/mcp/stdout.test.ts
@@ -30,11 +30,13 @@ async function importClosure(entry: string): Promise<string[]> {
     if (file == null || file === "" || seen.has(file)) continue;
     seen.add(file);
 
+    // oxlint-disable-next-line no-await-in-loop -- breadth-first walk: the queue this loop drains is refilled from the file it just read.
     const source = await Bun.file(file).text();
     for (const match of source.matchAll(RELATIVE_IMPORT)) {
       const specifier = match.at(1);
       if (specifier === undefined) continue;
       const target = resolve(dirname(file), specifier);
+      // oxlint-disable-next-line no-await-in-loop -- breadth-first walk: the queue this loop drains is refilled from the file it just read.
       const path = (await Bun.file(`${target}.ts`).exists()) ? `${target}.ts` : target;
       if (path.endsWith(".ts")) queue.push(path);
     }
@@ -48,34 +50,36 @@ async function importClosure(entry: string): Promise<string[]> {
  * belongs to the module's own CLI, which the server never enters.
  */
 async function findStdoutWrites(): Promise<string[]> {
-  const writes: string[] = [];
+  const perFile = await Promise.all(
+    (await importClosure(ENTRY)).map(async (file) => {
+      const source = await Bun.file(file).text();
+      const lines = source.split("\n");
+      const cliStart = lines.findIndex((line) => line.includes("import.meta.main"));
+      const reachable = cliStart === -1 ? lines : lines.slice(0, cliStart);
+      const name = relative(PLUGIN_ROOT, file);
+      const writes: string[] = [];
 
-  for (const file of await importClosure(ENTRY)) {
-    const source = await Bun.file(file).text();
-    const lines = source.split("\n");
-    const cliStart = lines.findIndex((line) => line.includes("import.meta.main"));
-    const reachable = cliStart === -1 ? lines : lines.slice(0, cliStart);
-    const name = relative(PLUGIN_ROOT, file);
+      // Identified by source text rather than line number, so an unrelated edit
+      // above a write doesn't churn the snapshot.
+      for (const raw of reachable) {
+        const line = stripComment(raw);
+        const code = line.trim();
+        if (/\bconsole\.(log|info|debug|dir|table)\(/.test(line)) {
+          writes.push(`${name}: ${code}`);
+        }
+        if (/\bprocess\.stdout\.write\(/.test(line)) {
+          writes.push(`${name}: ${code}`);
+        }
+        // A Bun shell call inherits stdout unless something in the chain takes it.
+        if (/\$`/.test(line) && !CAPTURES_STDOUT.test(line)) {
+          writes.push(`${name}: ${code}`);
+        }
+      }
+      return writes;
+    }),
+  );
 
-    // Identified by source text rather than line number, so an unrelated edit
-    // above a write doesn't churn the snapshot.
-    for (const raw of reachable) {
-      const line = stripComment(raw);
-      const code = line.trim();
-      if (/\bconsole\.(log|info|debug|dir|table)\(/.test(line)) {
-        writes.push(`${name}: ${code}`);
-      }
-      if (/\bprocess\.stdout\.write\(/.test(line)) {
-        writes.push(`${name}: ${code}`);
-      }
-      // A Bun shell call inherits stdout unless something in the chain takes it.
-      if (/\$`/.test(line) && !CAPTURES_STDOUT.test(line)) {
-        writes.push(`${name}: ${code}`);
-      }
-    }
-  }
-
-  return writes;
+  return perFile.flat();
 }
 
 // The snapshot is the point: stdout is the JSON-RPC channel, so a new write

--- a/plugins/things/src/mcp/tools.ts
+++ b/plugins/things/src/mcp/tools.ts
@@ -595,10 +595,12 @@ export function registerTools(server: McpServer): void {
 
       const applied: string[] = [];
       for (const [index, batch] of chunk(ids, BATCH_SIZE).entries()) {
+        // oxlint-disable-next-line no-await-in-loop -- deliberate pacing: the Things URL scheme drops batches sent back to back.
         if (index > 0) await Bun.sleep(BATCH_DELAY_MS);
         const params = new Map<string, string>();
         params.set("data", buildJsonPayload(batch, attributes));
         try {
+          // oxlint-disable-next-line no-await-in-loop -- a failed batch names the batches already applied, which requires knowing their order.
           writeResult(await dispatch("json", params), `Updated ${batch.length} todos`);
         } catch (error) {
           // A batch that fails leaves the earlier ones applied. Naming them

--- a/plugins/tmux/hooks/notification-clear.test.ts
+++ b/plugins/tmux/hooks/notification-clear.test.ts
@@ -22,6 +22,7 @@ describe("PreToolUse --clear guard", () => {
     };
     for (const [name, body] of Object.entries(stubs)) {
       const path = join(binDir, name);
+      // oxlint-disable-next-line no-await-in-loop -- two stub scripts; concurrency buys nothing.
       await Bun.write(path, `#!/bin/sh\necho "${name} $*" >> "$CALL_LOG"\n${body}`);
       Bun.spawnSync(["chmod", "+x", path]);
     }

--- a/plugins/ui-design/skills/wireframe/scripts/render-html.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/render-html.ts
@@ -91,6 +91,7 @@ if (import.meta.main) {
 
   for (const file of files) {
     try {
+      // oxlint-disable-next-line no-await-in-loop -- each render drives a headless browser and prints its result before the next starts.
       const result = await renderFile(file, outputPath, { scale });
       console.log(`Rendered ${result.input} to ${result.output}`);
     } catch (error) {

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -125,11 +125,13 @@ export async function collectText(input: PreToolUseHookInput): Promise<string[]>
       bodyFile != null && bodyFile !== ""
         ? [bodyFile, ...extractFieldFilePaths(command)]
         : extractFieldFilePaths(command);
-    for (const path of files) {
-      if (await Bun.file(path).exists()) {
-        texts.push(await Bun.file(path).text());
-      }
-    }
+    const bodies = await Promise.all(
+      files.map(async (path) => {
+        const file = Bun.file(path);
+        return (await file.exists()) ? await file.text() : null;
+      }),
+    );
+    texts.push(...bodies.filter((body) => body !== null));
     for (const flag of PROSE_FLAGS) {
       const value = extractInlineArg(command, flag);
       if (value != null && value !== "") texts.push(value);

--- a/plugins/writing/hooks/pretooluse.ts
+++ b/plugins/writing/hooks/pretooluse.ts
@@ -85,6 +85,7 @@ export async function dispatch(
   const results: HookResult[] = [];
   for (const checker of checkers) {
     try {
+      // oxlint-disable-next-line no-await-in-loop -- three checkers, each reported individually when it throws; concurrency buys nothing.
       const result = await checker();
       if (result) results.push(result);
     } catch (error) {
@@ -105,10 +106,12 @@ export async function dispatch(
   for (const result of ordered) {
     const tier = tierOf(result.output);
     if (tier === "context" && result.suppressible !== false) {
+      // oxlint-disable-next-line no-await-in-loop -- the loop returns at the first unsuppressed result, and recentlyFired reads state recordFired writes.
       if (await recentlyFired(input.session_id, result.category, now)) {
         suppressed ??= result;
         continue;
       }
+      // oxlint-disable-next-line no-await-in-loop -- the loop returns at the first unsuppressed result, and recentlyFired reads state recordFired writes.
       await recordFired(input.session_id, result.category, now);
     }
     return finish(result.output, tier, { category: result.category });

--- a/plugins/writing/skills/analyze/scripts/db.ts
+++ b/plugins/writing/skills/analyze/scripts/db.ts
@@ -34,8 +34,10 @@ export async function openSessionDb(dbPath: string): Promise<Database> {
   async function setParams(params: Record<string, string | null>): Promise<void> {
     for (const [key, value] of Object.entries(params)) {
       if (value === null) {
+        // oxlint-disable-next-line no-await-in-loop -- SET VARIABLE is connection-global state the query below reads back.
         await connection.run(`SET VARIABLE "${key}" = NULL`);
       } else {
+        // oxlint-disable-next-line no-await-in-loop -- SET VARIABLE is connection-global state the query below reads back.
         await connection.run(`SET VARIABLE "${key}" = $value`, { value });
       }
     }
@@ -60,6 +62,7 @@ export async function openSessionDb(dbPath: string): Promise<Database> {
       await setParams(params);
       const sql = await readSql(queryName);
       for (const stmt of splitStatements(sql)) {
+        // oxlint-disable-next-line no-await-in-loop -- statements from one query file apply in order on a single connection.
         await connection.run(stmt);
       }
     },

--- a/plugins/writing/skills/analyze/scripts/hook-health.ts
+++ b/plugins/writing/skills/analyze/scripts/hook-health.ts
@@ -235,6 +235,7 @@ async function readLog(path: string, since?: string): Promise<RunLogEntry[]> {
   const texts: string[] = [];
   for (const candidate of [`${path}.1`, path]) {
     const file = Bun.file(candidate);
+    // oxlint-disable-next-line no-await-in-loop -- the rotated log and the live log concatenate in that order.
     if (await file.exists()) texts.push(await file.text());
   }
   let entries = parseLog(texts.join("\n"));

--- a/plugins/writing/skills/analyze/scripts/judge-run.ts
+++ b/plugins/writing/skills/analyze/scripts/judge-run.ts
@@ -62,6 +62,7 @@ export async function runGate(judge: ChunkJudge, promptSha256: string): Promise<
   }
   const results: GateResult[] = [];
   for (const fixture of JUDGE_FIXTURES) {
+    // oxlint-disable-next-line no-await-in-loop -- one judge API call per fixture; serializing keeps the gate inside the rate limit.
     const verdict = await judgeDocument(judge, fixture.text);
     const mismatches: GateMismatch[] = [];
     for (const criterion of JUDGE_CRITERIA) {
@@ -162,10 +163,7 @@ function renderAudit(audit: MeaningAudit): string {
 async function filesMain(paths: string[], model: string, limit: number): Promise<void> {
   requireApiKey();
   const prompt = await loadPrompt();
-  const texts: string[] = [];
-  for (const p of paths.slice(0, limit)) {
-    texts.push(await Bun.file(p).text());
-  }
+  const texts = await Promise.all(paths.slice(0, limit).map((p) => Bun.file(p).text()));
   const cost = await estimateCost(texts, {
     promptText: prompt.text,
     model,

--- a/plugins/writing/skills/analyze/scripts/judge.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.test.ts
@@ -410,12 +410,14 @@ describe("hook wall", () => {
   test("no hook or detection module imports the judge", async () => {
     const glob = new Bun.Glob("**/*.ts");
     const root = `${import.meta.dirname}/../../../`;
-    for (const dir of ["hooks", "detection", "linguistics"]) {
-      for await (const file of glob.scan(`${root}${dir}`)) {
-        const source = await Bun.file(`${root}${dir}/${file}`).text();
-        expect(source).not.toMatch(/from\s+["'][^"']*judge["']/);
-        expect(source).not.toContain("@anthropic-ai/sdk");
-      }
-    }
+    await Promise.all(
+      ["hooks", "detection", "linguistics"].map(async (dir) => {
+        for await (const file of glob.scan(`${root}${dir}`)) {
+          const source = await Bun.file(`${root}${dir}/${file}`).text();
+          expect(source).not.toMatch(/from\s+["'][^"']*judge["']/);
+          expect(source).not.toContain("@anthropic-ai/sdk");
+        }
+      }),
+    );
   });
 });

--- a/plugins/writing/skills/analyze/scripts/judge.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.ts
@@ -301,6 +301,7 @@ export async function judgeDocument(judge: ChunkJudge, text: string): Promise<Ju
   const chunks = chunkDocument(text);
   const verdicts: JudgeVerdict[] = [];
   for (const chunk of chunks) {
+    // oxlint-disable-next-line no-await-in-loop -- one judge API call per chunk; serializing keeps a document inside the rate limit.
     verdicts.push(await judge(chunk));
   }
   return aggregateVerdicts(verdicts);
@@ -374,6 +375,7 @@ async function mapPooled<T, R>(items: T[], fn: (item: T) => Promise<R>): Promise
   const queue = items.map((item, index) => ({ item, index }));
   const workers = Array.from({ length: Math.min(COUNT_CONCURRENCY, items.length) }, async () => {
     for (let entry = queue.shift(); entry; entry = queue.shift()) {
+      // oxlint-disable-next-line no-await-in-loop -- this is the worker body of the bounded pool above; the pool is the parallelism.
       results[entry.index] = await fn(entry.item);
     }
   });
@@ -484,6 +486,7 @@ export async function judgeCorpus(
     spans: [],
   }));
   for (const text of texts) {
+    // oxlint-disable-next-line no-await-in-loop -- one judge API call per document; serializing keeps the corpus run inside the rate limit.
     const verdict = await judgeDocument(judge, text);
     for (const [index, criterion] of JUDGE_CRITERIA.entries()) {
       const stat = stats[index];
@@ -656,6 +659,7 @@ export function anthropicHeadingJudge(options: AnthropicJudgeOptions): HeadingJu
 export async function judgeHeadings(judge: HeadingJudge, headings: string[]): Promise<boolean[]> {
   const verdicts: boolean[] = [];
   for (let i = 0; i < headings.length; i += HEADING_BATCH_SIZE) {
+    // oxlint-disable-next-line no-await-in-loop -- one judge API call per heading batch; serializing keeps the run inside the rate limit.
     verdicts.push(...(await judge(headings.slice(i, i + HEADING_BATCH_SIZE))));
   }
   return verdicts;

--- a/plugins/writing/skills/analyze/scripts/wordlists.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlists.ts
@@ -17,15 +17,18 @@ export async function loadWordlists(dir: string): Promise<WordlistEntry[]> {
     if (FileError.safeParse(err).data?.code === "ENOENT") return [];
     throw err;
   }
-  const entries: WordlistEntry[] = [];
-  for (const file of files.toSorted()) {
-    const text = await Bun.file(path.join(dir, file)).text();
-    for (const rawLine of text.split("\n")) {
-      const line = rawLine.replace(/#.*$/, "").trim();
-      if (line.length === 0) continue;
-      const phrase = line.replace(/\s+[\d.]+$/, "");
-      entries.push({ phrase, source: file });
-    }
-  }
-  return entries;
+  const perFile = await Promise.all(
+    files.toSorted().map(async (file) => {
+      const text = await Bun.file(path.join(dir, file)).text();
+      const entries: WordlistEntry[] = [];
+      for (const rawLine of text.split("\n")) {
+        const line = rawLine.replace(/#.*$/, "").trim();
+        if (line.length === 0) continue;
+        const phrase = line.replace(/\s+[\d.]+$/, "");
+        entries.push({ phrase, source: file });
+      }
+      return entries;
+    }),
+  );
+  return perFile.flat();
 }

--- a/plugins/writing/skills/scan/scripts/scan.ts
+++ b/plugins/writing/skills/scan/scripts/scan.ts
@@ -70,6 +70,7 @@ export type FileViolations = { path: string; violations: ScanResult[] };
 export async function scanFiles(files: string[]): Promise<FileViolations[]> {
   const results: FileViolations[] = [];
   for (const path of files) {
+    // oxlint-disable-next-line no-await-in-loop -- audit runs over an arbitrary tree; reading every file at once would hold the whole corpus in memory.
     const text = await Bun.file(path).text();
     const violations = scanAll(text, path);
     if (violations.length > 0) results.push({ path, violations });
@@ -118,8 +119,8 @@ function printSummary(results: FileViolations[]): void {
 
 async function collectAcross(paths: string[]): Promise<string[]> {
   const files = new Set<string>();
-  for (const path of paths) {
-    for (const file of await collectFiles(path)) files.add(file);
+  for (const collected of await Promise.all(paths.map(collectFiles))) {
+    for (const file of collected) files.add(file);
   }
   return [...files].toSorted();
 }

--- a/scripts/assets.ts
+++ b/scripts/assets.ts
@@ -47,6 +47,7 @@ export async function* assetPaths(patterns: string[]): AsyncGenerator<string> {
   for (const pattern of patterns) {
     // `dot` reaches the project scope under `.claude/`. A pattern whose
     // directory is absent yields nothing.
+    // oxlint-disable-next-line no-await-in-loop -- an async generator streaming matches in pattern order; the consumer drives it.
     for await (const path of new Bun.Glob(pattern).scan({ cwd: root, dot: true })) {
       if (!isFixture(path)) yield path;
     }

--- a/scripts/check-permission-rules.ts
+++ b/scripts/check-permission-rules.ts
@@ -42,11 +42,21 @@ const SettingsPermissions = z.union([
   z.array(z.unknown()).transform(() => ({ permissions: undefined })),
 ]);
 
+async function loadTracked(pattern: string): Promise<{ file: string; raw: string | null }[]> {
+  return Promise.all(
+    (await tracked(pattern, root)).map(async (file) => ({
+      file,
+      raw: await readTracked(file, root),
+    })),
+  );
+}
+
 async function checkSettings(): Promise<string[]> {
   const violations: string[] = [];
 
-  for (const file of await tracked("*settings*.json", root)) {
-    const raw = await readTracked(file, root);
+  const settings = await loadTracked("*settings*.json");
+
+  for (const { file, raw } of settings) {
     if (raw === null) continue;
 
     const { permissions } = decodeJson(SettingsPermissions, raw, file);
@@ -71,8 +81,9 @@ function frontmatterRules(value: unknown): string[] {
 async function checkFrontmatter(): Promise<string[]> {
   const violations: string[] = [];
 
-  for (const file of await tracked("*.md", root)) {
-    const raw = await readTracked(file, root);
+  const markdown = await loadTracked("*.md");
+
+  for (const { file, raw } of markdown) {
     if (raw === null || !raw.startsWith("---")) continue;
 
     let data: Frontmatter;

--- a/scripts/check-plugin-deps.ts
+++ b/scripts/check-plugin-deps.ts
@@ -69,20 +69,21 @@ async function getImportedPackages(pluginDir: string): Promise<Set<string>> {
 }
 
 async function checkDeps(): Promise<string[]> {
-  const violations: string[] = [];
+  const perPlugin = await Promise.all(
+    (await loadPlugins()).map(async (plugin) => {
+      if (plugin.dir == null || plugin.dir === "") return [];
 
-  for (const plugin of await loadPlugins()) {
-    if (plugin.dir == null || plugin.dir === "") continue;
+      const [declared, imported] = await Promise.all([
+        getPluginDeps(plugin.dir),
+        getImportedPackages(plugin.dir),
+      ]);
 
-    const declared = await getPluginDeps(plugin.dir);
-    const imported = await getImportedPackages(plugin.dir);
-
-    for (const pkg of imported) {
-      if (!declared.has(pkg) && !declared.has(`@types/${pkg}`)) {
-        violations.push(`${plugin.name}: missing dependency "${pkg}"`);
-      }
-    }
-  }
+      return [...imported]
+        .filter((pkg) => !declared.has(pkg) && !declared.has(`@types/${pkg}`))
+        .map((pkg) => `${plugin.name}: missing dependency "${pkg}"`);
+    }),
+  );
+  const violations = perPlugin.flat();
 
   return violations;
 }

--- a/scripts/schemas/index.ts
+++ b/scripts/schemas/index.ts
@@ -20,6 +20,7 @@ const check = command({ name: "check" }, async () => {
   let failed = false;
   let warned = false;
   for (const source of await loadSources(SCHEMAS_DIR)) {
+    // oxlint-disable-next-line no-await-in-loop -- each source prints its verdict as it is checked, so the fetches follow the printed order.
     const [base, patch] = await Promise.all([
       fetchBase(source.url),
       loadPatch(SCHEMAS_DIR, source),

--- a/user/scripts/subagent-statusline.ts
+++ b/user/scripts/subagent-statusline.ts
@@ -352,18 +352,20 @@ if (import.meta.main) {
       ? extractModel(await readEntries(input.transcript_path))
       : null;
 
-  const lines: string[] = [];
-  for (const task of input.tasks ?? []) {
-    const base = subagentBase(task.id, projectDir);
-    const meta = base != null && base !== "" ? await readMeta(base) : null;
-    const entries = base != null && base !== "" ? await readEntries(`${base}.jsonl`) : [];
-    const activity = extractActivity(entries);
-    // The payload's model is resolved at spawn and covers a subagent that has
-    // yet to write a turn. Task types that carry none fall back to the
-    // transcript this loop already read for the activity.
-    const model = subagentModelLetter(task.model ?? extractModel(entries), sessionModel);
-    lines.push(
-      JSON.stringify(
+  const lines = await Promise.all(
+    (input.tasks ?? []).map(async (task) => {
+      const base = subagentBase(task.id, projectDir);
+      const hasBase = base != null && base !== "";
+      const [meta, entries] = await Promise.all([
+        hasBase ? readMeta(base) : null,
+        hasBase ? readEntries(`${base}.jsonl`) : [],
+      ]);
+      const activity = extractActivity(entries);
+      // The payload's model is resolved at spawn and covers a subagent that has
+      // yet to write a turn. Task types that carry none fall back to the
+      // transcript read alongside the activity.
+      const model = subagentModelLetter(task.model ?? extractModel(entries), sessionModel);
+      return JSON.stringify(
         renderTask(
           task,
           input.columns ?? null,
@@ -373,8 +375,8 @@ if (import.meta.main) {
           meta?.description ?? null,
           model,
         ),
-      ),
-    );
-  }
+      );
+    }),
+  );
   if (lines.length !== 0) process.stdout.write(`${lines.join("\n")}\n`);
 }

--- a/user/skills/scheduled/scripts/scheduled.ts
+++ b/user/skills/scheduled/scripts/scheduled.ts
@@ -261,6 +261,7 @@ async function installDescriptor(descriptor: Descriptor, group: string): Promise
   for (let attempt = 0; attempt < 5; attempt++) {
     const result = Bun.spawnSync(["launchctl", "bootstrap", `gui/${uid}`, dest]);
     if (result.exitCode === 0) break;
+    // oxlint-disable-next-line no-await-in-loop -- backoff between launchctl bootstrap retries.
     await Bun.sleep(500);
   }
 
@@ -288,6 +289,7 @@ async function syncGroups(dirs: string[], dryRun: boolean): Promise<void> {
   const failures: string[] = [];
 
   for (const { group, dir } of groups) {
+    // oxlint-disable-next-line no-await-in-loop -- each group runs launchctl against the shared user domain and appends its rows in order.
     const entries = await listDescriptors(dir);
     const headless = entries.filter((e) => e.descriptor.mode === "headless");
     for (const skipped of entries.filter((e) => e.descriptor.mode !== "headless")) {
@@ -307,6 +309,7 @@ async function syncGroups(dirs: string[], dryRun: boolean): Promise<void> {
     for (const label of desired) {
       if (install.includes(label)) continue;
       const entry = byShortLabel.get(label);
+      // oxlint-disable-next-line no-await-in-loop -- each group runs launchctl against the shared user domain and appends its rows in order.
       if (entry && (await changedContent(entry, group))) update.push(label);
     }
 
@@ -318,11 +321,13 @@ async function syncGroups(dirs: string[], dryRun: boolean): Promise<void> {
     if (!dryRun) {
       for (const label of [...install, ...update]) {
         const entry = byShortLabel.get(label);
+        // oxlint-disable-next-line no-await-in-loop -- installDescriptor boots a launchd agent into the shared user domain.
         if (entry && !(await installDescriptor(entry.descriptor, group))) {
           failures.push(fullLabel(group, entry.descriptor.label));
         }
       }
       for (const label of plan.prune) {
+        // oxlint-disable-next-line no-await-in-loop -- pruneAgent removes a launchd agent from the shared user domain.
         await pruneAgent(group, label.slice(group.length + 1));
       }
     }
@@ -356,6 +361,7 @@ async function listCommand(dirs: string[], withLoadState: boolean): Promise<void
   const rows: string[][] = [header];
 
   for (const { group, dir } of groups) {
+    // oxlint-disable-next-line no-await-in-loop -- each group appends its rows to one table in group order.
     const entries = await listDescriptors(dir);
     const declared = new Map(
       entries.map((e) => [shortLabel(group, e.descriptor.label), e] as const),


### PR DESCRIPTION
`eslint/no-await-in-loop` is now enforced at error. Each of the 147 sites it flags took one of two outcomes: the loop was rewritten to run its iterations concurrently, or it stays sequential and carries an inline `oxlint-disable-next-line` naming the constraint that forces the ordering. No disable is bare.

The reasons are the review surface. A rewrite that reorders results and a disable whose stated reason does not hold are the two ways this can ship wrong, so both tables below name a representative site you can check against the code.

### Kept Sequential (108)

| Reason class | Sites | Representative |
|---|---|---|
| Shared mutable state | 40 | `session/scripts/db.ts:354`: `SET VARIABLE` is connection-global state the import below reads back |
| Iteration depends on the previous | 23 | `github/scripts/pr-comments.ts:326`: each page's cursor comes from the response before it |
| Retry / backoff | 10 | `mac/scripts/jxa.ts:130`: sleeps before retrying a transient Apple Events failure |
| Rate limit / remote pacing | 8 | `things/src/mcp/tools.ts:598`: the Things URL scheme drops batches sent back to back |
| Ordered output | 8 | `packages/validate/run.ts:41`: each file prints its bullet as it is validated |
| Poll loop | 7 | `review/skills/inbox/scripts/watch.ts:56`: poll interval between iterations |
| Bounded tiny N | 8 | `session/scripts/refresh.ts:51`: two known stray directories |
| Worker-pool body | 2 | `evals/pr-body/scripts/run-eval.ts:241`: the pool above is the parallelism |
| Memory bound | 1 | `writing/skills/scan/scripts/scan.ts:73`: the audit runs over an arbitrary tree |
| Bounded subprocess fan-out | 1 | `comments/skills/audit/scripts/audit.ts:307`: one `sh -c` formatter per edited file |

Shared mutable state resolves to six shared resources:

- one DuckDB connection, which `session/scripts/db.ts` alone holds 13 sites against
- one `GIT_INDEX_FILE` in `comments/apply/branch.ts`
- one `FileSink` in the eval writers
- one launchd user domain in `scheduled.ts`
- mermaid's global parser
- `COPILOT_HOME`'s session ledger

### Parallelized (39)

| Group | Loops | Sites | Example |
|---|---|---|---|
| Eval corpus and label readers | 10 | 15 | `evals/pr-body/scripts/run-eval.ts` `loadScenarios` reads every scenario JSON at once |
| Repo and config scanners | 9 | 13 | `scripts/check-plugin-deps.ts` scans each plugin's package.json and imports concurrently |
| Hooks and statusline | 2 | 4 | `user/scripts/subagent-statusline.ts` reads each subagent's meta and transcript concurrently |
| Tests | 7 | 7 | `things/src/mcp/stdout.test.ts` reads the import closure concurrently |

Every rewrite keeps result ordering. `Promise.all` over `map` preserves index order, and the collecting loops end in `flat()` or an ordered reduce. No rewrite touches a loop that spawns a subprocess with side effects, drives an interactive or long-lived loop, or writes shared state.

### Verification

None of the rewritten check scripts has unit coverage that would catch an argument-shape break, so each ran directly against the repo. `check-permission-rules`, `check-plugin-deps`, `validate/hooks.ts`, and `skill-lint "plugins/writing/skills/*"` all produce their expected output.

The failures this repo already carries on `main`, in `buildAttribution`, `upstream.ts`, `readRemoteUrls`, and the session index, sit in paths this branch does not touch.

### Config

This branch rebases onto every sibling oxlint PR, so `.oxlintrc.json` now carries all of their rules. This change adds the one `no-await-in-loop` key on top of them.
