### PR TITLE
lint: enable the oxlint suspicious category

### DIFF
--- a/.claude/hooks/ox/index.ts
+++ b/.claude/hooks/ox/index.ts
@@ -648,13 +648,13 @@ function deny(reason: string): SyncHookJSONOutput {
 
 export async function processInput(input: HookInput): Promise<SyncHookJSONOutput | null> {
   if (input.hook_event_name === "PreToolUse") {
-    return processPreToolUse(input as PreToolUseHookInput);
+    return processPreToolUse(input);
   }
   if (input.hook_event_name === "PostToolUse") {
-    return processPostToolUse(input as PostToolUseHookInput);
+    return processPostToolUse(input);
   }
   if (input.hook_event_name === "Stop") {
-    return processStop(input as StopHookInput);
+    return processStop(input);
   }
   return null;
 }

--- a/.claude/skills/agent-ideas/scripts/fetch.ts
+++ b/.claude/skills/agent-ideas/scripts/fetch.ts
@@ -43,8 +43,8 @@ function text(value: unknown): string {
   return "";
 }
 
-function decodeEntities(text: string): string {
-  return text
+function decodeEntities(input: string): string {
+  return input
     .replace(/&nbsp;/g, " ")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -2,7 +2,8 @@
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["typescript", "unicorn", "oxc"],
   "categories": {
-    "correctness": "error"
+    "correctness": "error",
+    "suspicious": "error"
   },
   "rules": {
     "prefer-template": "error",
@@ -19,7 +20,9 @@
       }
     ],
     "no-unused-expressions": ["error", { "allowTernary": true }],
+    "no-underscore-dangle": ["error", { "allow": ["__typename", "__dirname"] }],
     "no-unsafe-optional-chaining": "off",
+    "typescript/no-unsafe-type-assertion": "off",
     "typescript/restrict-template-expressions": "off",
     "typescript/await-thenable": "off",
     "typescript/no-base-to-string": "off",
@@ -67,7 +70,8 @@
     {
       "files": ["**/*.test.ts"],
       "rules": {
-        "local/no-chained-type-assertions": "off"
+        "local/no-chained-type-assertions": "off",
+        "unicorn/consistent-function-scoping": "off"
       }
     }
   ],

--- a/evals/issue-refine/scripts/ab-prompt.ts
+++ b/evals/issue-refine/scripts/ab-prompt.ts
@@ -22,7 +22,7 @@ if (!argv.flags.version || !argv.flags.brief) {
 }
 
 const brief = await Bun.file(argv.flags.brief).json();
-const files = (await readdir(argv.flags.version)).filter((f) => f.endsWith(".md")).sort();
+const files = (await readdir(argv.flags.version)).filter((f) => f.endsWith(".md")).toSorted();
 
 const skillBlocks: string[] = [];
 for (const f of files) {

--- a/evals/issue-refine/scripts/ab-report.ts
+++ b/evals/issue-refine/scripts/ab-report.ts
@@ -36,7 +36,7 @@ const briefs = [
   ...new Set(
     files.filter((f) => f.endsWith(".md")).map((f) => f.replace(/\.(before|after)\.md$/, "")),
   ),
-].sort();
+].toSorted();
 
 const FINDING_NAME: Record<number, string> = {
   1: "headings",
@@ -68,7 +68,7 @@ for (const brief of briefs) {
   );
   const findings = [...new Set([...Object.keys(b.byFinding), ...Object.keys(a.byFinding)])]
     .map(Number)
-    .sort((x, y) => x - y);
+    .toSorted((x, y) => x - y);
   for (const f of findings) {
     const bn = b.byFinding[f] ?? 0;
     const an = a.byFinding[f] ?? 0;

--- a/evals/issue-refine/scripts/build-labelset.ts
+++ b/evals/issue-refine/scripts/build-labelset.ts
@@ -31,7 +31,7 @@ const argv = cli({
   },
 });
 
-const files = (await readdir(argv.flags.briefs)).filter((f) => f.endsWith(".json")).sort();
+const files = (await readdir(argv.flags.briefs)).filter((f) => f.endsWith(".json")).toSorted();
 const samples: unknown[] = [];
 const missing: string[] = [];
 

--- a/evals/issue-refine/scripts/judge.ts
+++ b/evals/issue-refine/scripts/judge.ts
@@ -56,7 +56,7 @@ const briefs = [
   ...new Set(
     files.filter((f) => f.endsWith(".md")).map((f) => f.replace(/\.(before|after)\.md$/, "")),
   ),
-].sort();
+].toSorted();
 
 const mapping: Record<string, Record<string, string>> = {};
 const blocks: string[] = [];

--- a/evals/issue-refine/scripts/score.ts
+++ b/evals/issue-refine/scripts/score.ts
@@ -277,7 +277,7 @@ if (argv.flags.json) {
   console.log(`Title: ${title || "(none)"}`);
   console.log(`Type:  ${type || "(none)"}`);
   console.log(`Score: ${score} (lower is better) · ${violations.length} violations\n`);
-  for (const v of violations.sort(
+  for (const v of violations.toSorted(
     (a, b) => SEVERITY_WEIGHT[b.severity] - SEVERITY_WEIGHT[a.severity] || a.finding - b.finding,
   )) {
     console.log(

--- a/evals/pr-body/scripts/judge.ts
+++ b/evals/pr-body/scripts/judge.ts
@@ -106,7 +106,7 @@ export function buildPairs(scenarios: Scenario[], rows: GenerationRow[]): Pair[]
     }
     pairs.push({ scenario, seed: Number(rawSeed), rows: { a: entry.a, b: entry.b } });
   }
-  return pairs.sort((x, y) => x.scenario.id.localeCompare(y.scenario.id) || x.seed - y.seed);
+  return pairs.toSorted((x, y) => x.scenario.id.localeCompare(y.scenario.id) || x.seed - y.seed);
 }
 
 /** Randomizes which arm occupies which slot, so the judge cannot infer the arm from position. */
@@ -179,7 +179,7 @@ export function parseVerdict(jsonText: string): Verdict {
   try {
     parsed = JSON.parse(jsonText);
   } catch (error) {
-    throw new Error(`Judge returned invalid JSON: ${(error as Error).message}`);
+    throw new Error(`Judge returned invalid JSON: ${(error as Error).message}`, { cause: error });
   }
   if (typeof parsed !== "object" || parsed === null) {
     throw new Error("Judge verdict must be a JSON object");

--- a/evals/pr-body/scripts/mine.test.ts
+++ b/evals/pr-body/scripts/mine.test.ts
@@ -28,7 +28,7 @@ test("weave preserves the multiset", () => {
   fc.assert(
     fc.property(fc.array(fc.integer({ min: 0, max: 100 })), (lengths) => {
       const woven = weave(lengths, (n) => n);
-      expect([...woven].sort((a, b) => a - b)).toEqual([...lengths].sort((a, b) => a - b));
+      expect(woven.toSorted((a, b) => a - b)).toEqual(lengths.toSorted((a, b) => a - b));
     }),
   );
 });

--- a/evals/pr-body/scripts/mine.ts
+++ b/evals/pr-body/scripts/mine.ts
@@ -77,7 +77,7 @@ export function toItem(mined: MinedPr, fetched: FetchedPr): Item {
 // Interleave longest and shortest so a truncated labeling session still spans
 // both the sectioned long-form bodies and the tight one-paragraph ones.
 export function weave<T>(items: T[], length: (item: T) => number): T[] {
-  const sorted = [...items].sort((a, b) => length(b) - length(a));
+  const sorted = items.toSorted((a, b) => length(b) - length(a));
   const woven: T[] = [];
   let lo = 0;
   let hi = sorted.length - 1;
@@ -107,7 +107,7 @@ export function selectSample(candidates: Item[], limit: number): Item[] {
       weave(arr, (i) => i.body.length),
     );
   }
-  const order = [...buckets.keys()].sort();
+  const order = [...buckets.keys()].toSorted();
   const selected: Item[] = [];
   let added = true;
   while (added && selected.length < limit) {
@@ -210,7 +210,7 @@ async function main() {
   const mined = await queryMined(dbPath);
   console.log(`Session index: ${mined.length} distinct local bendrucker/* PRs`);
 
-  const repos = [...new Set(mined.map((m) => m.repository))].sort();
+  const repos = [...new Set(mined.map((m) => m.repository))].toSorted();
   const fetched = new Map<string, Map<number, FetchedPr>>();
   for (const repo of repos) {
     fetched.set(repo, await fetchRepoPrs(repo));

--- a/evals/pr-body/scripts/run-eval.ts
+++ b/evals/pr-body/scripts/run-eval.ts
@@ -122,7 +122,7 @@ export function manifestPath(runDir: string): string {
 }
 
 export async function loadScenarios(dir: string): Promise<Scenario[]> {
-  const names = (await readdir(dir)).filter((n) => n.endsWith(".json")).sort();
+  const names = (await readdir(dir)).filter((n) => n.endsWith(".json")).toSorted();
   const scenarios: Scenario[] = [];
   for (const name of names) {
     const parsed: unknown = await Bun.file(join(dir, name)).json();

--- a/evals/writing/scripts/mine.test.ts
+++ b/evals/writing/scripts/mine.test.ts
@@ -24,7 +24,7 @@ test("weave preserves the multiset", () => {
   fc.assert(
     fc.property(fc.array(fc.integer({ min: 0, max: 100 })), (lengths) => {
       const woven = weave(lengths, (n) => n);
-      expect([...woven].sort((a, b) => a - b)).toEqual([...lengths].sort((a, b) => a - b));
+      expect(woven.toSorted((a, b) => a - b)).toEqual(lengths.toSorted((a, b) => a - b));
     }),
   );
 });

--- a/evals/writing/scripts/mine.ts
+++ b/evals/writing/scripts/mine.ts
@@ -60,7 +60,7 @@ export function toItem(draft: RewriteDraft): Item {
 // Interleave longest and shortest so a truncated labeling session still spans
 // both the multi-paragraph rewrites and the tight one-liners.
 export function weave<T>(items: T[], length: (item: T) => number): T[] {
-  const sorted = [...items].sort((a, b) => length(b) - length(a));
+  const sorted = items.toSorted((a, b) => length(b) - length(a));
   const woven: T[] = [];
   let lo = 0;
   let hi = sorted.length - 1;
@@ -90,7 +90,7 @@ export function selectSample(candidates: Item[], limit: number): Item[] {
       weave(arr, (i) => i.output.length),
     );
   }
-  const order = [...buckets.keys()].sort();
+  const order = [...buckets.keys()].toSorted();
   const selected: Item[] = [];
   let added = true;
   while (added && selected.length < limit) {
@@ -134,7 +134,7 @@ async function probeInvocations(dbPath: string): Promise<number | null> {
 }
 
 async function loadDrafts(dir: string): Promise<RewriteDraft[]> {
-  const names = (await readdir(dir)).filter((n) => n.endsWith(".json")).sort();
+  const names = (await readdir(dir)).filter((n) => n.endsWith(".json")).toSorted();
   const drafts: RewriteDraft[] = [];
   for (const name of names) {
     const draft = (await Bun.file(join(dir, name)).json()) as Partial<RewriteDraft>;

--- a/packages/marketplace/index.ts
+++ b/packages/marketplace/index.ts
@@ -165,7 +165,7 @@ export async function loadPlugins(opts?: LoadOptions): Promise<Plugin[]> {
     plugin.listing = listing;
   }
 
-  return [...plugins.values()].sort((a, b) => a.name.localeCompare(b.name));
+  return [...plugins.values()].toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
 /** The settings file read for enabled state, or an empty object when absent. */

--- a/packages/validate/run.test.ts
+++ b/packages/validate/run.test.ts
@@ -84,9 +84,9 @@ describe("runValidation", () => {
 
   it("exits non-zero on validation errors", async () => {
     const file = await writeFixture("invalid", { name: 123 });
-    const exitSpy = spyOn(process, "exit").mockImplementation((() => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
       throw new Error("exit");
-    }) as never);
+    });
 
     try {
       await expect(runValidation({ files: [file], schema: schemaPath })).rejects.toThrow("exit");

--- a/packages/validate/validate.ts
+++ b/packages/validate/validate.ts
@@ -91,10 +91,10 @@ export async function validateFile(
 
   const warnings: string[] = [];
   if (options?.warnAdditional && entry.schema.properties) {
-    const known = new Set(Object.keys(entry.schema.properties as Record<string, unknown>));
-    for (const key of Object.keys(data as Record<string, unknown>)) {
-      if (key !== "$schema" && !known.has(key)) {
-        warnings.push(formatWarning(file, key));
+    const known = new Set(Object.keys(entry.schema.properties));
+    for (const property of Object.keys(data as Record<string, unknown>)) {
+      if (property !== "$schema" && !known.has(property)) {
+        warnings.push(formatWarning(file, property));
       }
     }
   }

--- a/plugins/claude-code/skills/session/scripts/db.test.ts
+++ b/plugins/claude-code/skills/session/scripts/db.test.ts
@@ -1686,7 +1686,7 @@ describe("plan-iterations query", () => {
     });
     return rows
       .filter((r) => r.sid === "plan-ite")
-      .sort((a, b) => Number(a.plan_seq) - Number(b.plan_seq));
+      .toSorted((a, b) => Number(a.plan_seq) - Number(b.plan_seq));
   }
 
   it("leaves growth/removal/carry-over and secs_since_prev null on the first present", async () => {
@@ -1970,7 +1970,7 @@ describe("skill-config-vs-observed query", () => {
 
   it("filters configured names by skill glob", async () => {
     const rows = await skillRows({ skill: "review:*" });
-    expect(rows.map((r) => r.skill_name).sort()).toEqual(["review:inbox", "review:peer"]);
+    expect(rows.map((r) => r.skill_name).toSorted()).toEqual(["review:inbox", "review:peer"]);
   });
 });
 

--- a/plugins/claude-code/skills/session/scripts/db.ts
+++ b/plugins/claude-code/skills/session/scripts/db.ts
@@ -214,7 +214,7 @@ export function scanJsonlFiles(root: string): ScannedFile[] {
 async function applySchema(db: Database): Promise<void> {
   const files = readdirSync(SCHEMA_DIR)
     .filter((f) => f.endsWith(".sql"))
-    .sort();
+    .toSorted();
   for (const file of files) {
     const sql = await Bun.file(path.join(SCHEMA_DIR, file)).text();
     await db.run(sql);
@@ -247,13 +247,11 @@ async function migrateIfNeeded(db: Database): Promise<void> {
   `);
   // Querying index_meta is only safe once the table exists.
   const version = row?.has_version
-    ? Number(
-        (
-          await db.query<{ version: number }>(
-            "SELECT COALESCE(MAX(version), 0) AS version FROM index_meta",
-          )
-        )[0]?.version ?? 0,
-      )
+    ? ((
+        await db.query<{ version: number }>(
+          "SELECT COALESCE(MAX(version), 0) AS version FROM index_meta",
+        )
+      )[0]?.version ?? 0)
     : 0;
   // A pre-host schema (missing data/host) or an older ingestion version both mean
   // the cache predates the current import logic; drop it so the next run rebuilds.

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/rules/bang-execution.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/rules/bang-execution.ts
@@ -23,11 +23,11 @@ function bashMatchers(allowedTools: unknown): string[] {
   return matchers;
 }
 
-function matchesBang(matcherCommand: string, bangCommands: string[]): boolean {
+function matchesBang(matcherCommand: string, commands: string[]): boolean {
   const star = matcherCommand.indexOf("*");
   if (star === -1) return false;
   const prefix = matcherCommand.slice(0, star);
-  return bangCommands.some((command) => command.startsWith(prefix));
+  return commands.some((command) => command.startsWith(prefix));
 }
 
 export const bangExecutionMatcher: Rule = {

--- a/plugins/claude-code/skills/skill/scripts/test-support.ts
+++ b/plugins/claude-code/skills/skill/scripts/test-support.ts
@@ -14,5 +14,5 @@ export function makePostToolUseInput(
     tool_input: { file_path: "/tmp/file", content: "" },
     tool_response: { type: "create", filePath: "/tmp/file", content: "" },
     ...overrides,
-  } as PostToolUseHookInput;
+  };
 }

--- a/plugins/comments/apply/edits.ts
+++ b/plugins/comments/apply/edits.ts
@@ -66,6 +66,8 @@ export const SENTENCE_CONNECTIVES = new Set([
   "where",
 ]);
 
+const isBlank = (line: string): boolean => line.trim().length === 0;
+
 /** A line's prose: leading/trailing comment markers and whitespace stripped. */
 function stripCommentMarkers(line: string): string {
   return line
@@ -333,7 +335,6 @@ export function computeFileEdits(
     }
   }
 
-  const isBlank = (line: string): boolean => line.trim().length === 0;
   const out: string[] = [];
   let lastPushed = "";
   let lastPushedBlank = false;

--- a/plugins/comments/detection/collect.ts
+++ b/plugins/comments/detection/collect.ts
@@ -106,7 +106,7 @@ async function collectDiffFile(
   const lines = source.split("\n");
   const comments = await extractComments(source, language);
   return scopeIntroduced(comments, file.added)
-    .filter((comment) => isExemptComment(comment) === false)
+    .filter((comment) => !isExemptComment(comment))
     .map((comment) => toCollected(file.path, language, comment, lines));
 }
 
@@ -127,7 +127,7 @@ export async function collectDiff(
   const matches = matchesPathGlobs(collect.pathGlobs);
   const [resolved, vendoredRoots] = await Promise.all([resolveDiff(options), listVendoredRoots()]);
   const diffs = resolved.filter(
-    (file) => matches(file.path) && isVendoredPath(file.path, vendoredRoots) === false,
+    (file) => matches(file.path) && !isVendoredPath(file.path, vendoredRoots),
   );
   const perFile = await Promise.all(diffs.map((file) => collectDiffFile(file, options, mrSource)));
   return perFile.flat();
@@ -143,7 +143,7 @@ async function collectRepoFile(path: string): Promise<CollectedComment[]> {
   const lines = source.split("\n");
   const comments = await extractComments(source, language);
   return comments
-    .filter((comment) => isExemptComment(comment) === false)
+    .filter((comment) => !isExemptComment(comment))
     .map((comment) => toCollected(path, language, comment, lines));
 }
 

--- a/plugins/comments/detection/features.ts
+++ b/plugins/comments/detection/features.ts
@@ -76,7 +76,7 @@ function stem(word: string): string {
 /** Lowercased, stemmed content words of the comment, delimiters and stopwords dropped. */
 function contentWords(text: string): string[] {
   const words = text.toLowerCase().match(/[a-z]+/g) ?? [];
-  return words.filter((word) => word.length >= 3 && STOPWORDS.has(word) === false).map(stem);
+  return words.filter((word) => word.length >= 3 && !STOPWORDS.has(word)).map(stem);
 }
 
 /** Stemmed word set of the code's identifiers, camelCase and snake_case split apart. */

--- a/plugins/comments/detection/rank.test.ts
+++ b/plugins/comments/detection/rank.test.ts
@@ -33,8 +33,8 @@ const commentArb: fc.Arbitrary<Comment> = fc
 /** Independent stable sort: descending metric, original index breaks ties. */
 function rankOracle<T extends Comment>(comments: T[], sort: SortKey): T[] {
   return comments
-    .map((comment, index) => ({ comment, index }))
-    .sort((a, b) => {
+    .map((entry, index) => ({ comment: entry, index }))
+    .toSorted((a, b) => {
       const diff = scoreComment(b.comment)[sort] - scoreComment(a.comment)[sort];
       return diff !== 0 ? diff : a.index - b.index;
     })

--- a/plugins/comments/detection/rank.ts
+++ b/plugins/comments/detection/rank.ts
@@ -32,6 +32,6 @@ export function scoreComment(comment: Comment): CommentScore {
 export function rankComments<T extends Comment>(comments: T[], sort: SortKey = "score"): T[] {
   return comments
     .map((comment) => ({ comment, score: scoreComment(comment) }))
-    .sort((a, b) => b.score[sort] - a.score[sort])
+    .toSorted((a, b) => b.score[sort] - a.score[sort])
     .map((entry) => entry.comment);
 }

--- a/plugins/comments/detection/scope.test.ts
+++ b/plugins/comments/detection/scope.test.ts
@@ -38,9 +38,9 @@ const rangeArb: fc.Arbitrary<LineRange> = fc
   .map(({ start, span }) => ({ start, end: start + span }));
 
 /** Independent oracle: enumerate the comment's lines and test membership in the range. */
-function sharesLine(comment: Comment, range: LineRange): boolean {
-  for (let line = comment.startLine; line <= comment.endLine; line++) {
-    if (line >= range.start && line <= range.end) return true;
+function sharesLine(target: Comment, bounds: LineRange): boolean {
+  for (let line = target.startLine; line <= target.endLine; line++) {
+    if (line >= bounds.start && line <= bounds.end) return true;
   }
   return false;
 }

--- a/plugins/comments/detection/walk.ts
+++ b/plugins/comments/detection/walk.ts
@@ -35,7 +35,7 @@ export function isVendoredPath(path: string, vendoredRoots: string[]): boolean {
 /** Drop files under a vendored root. Pure over its inputs. */
 export function excludeVendored(files: string[], vendoredRoots: string[]): string[] {
   if (vendoredRoots.length === 0) return files;
-  return files.filter((path) => isVendoredPath(path, vendoredRoots) === false);
+  return files.filter((path) => !isVendoredPath(path, vendoredRoots));
 }
 
 /**

--- a/plugins/comments/evals/eval.ts
+++ b/plugins/comments/evals/eval.ts
@@ -78,7 +78,7 @@ function validateFixture(value: unknown, file: string): Fixture {
     throw new Error(`Fixture ${file} is "rewrite" but carries no gold rewrite text`);
   }
   for (const key of ["id", "path", "language", "kind", "comment", "context"]) {
-    if (typeof record[key] !== "string" || (record[key] as string).length === 0) {
+    if (typeof record[key] !== "string" || record[key].length === 0) {
       throw new Error(`Fixture ${file} missing required string "${key}"`);
     }
   }

--- a/plugins/comments/evals/oracle.ts
+++ b/plugins/comments/evals/oracle.ts
@@ -64,7 +64,7 @@ export function parseBatchVerdicts(json: string, expected: number): Verdict[] {
   try {
     parsed = JSON.parse(json);
   } catch (error) {
-    throw new Error(`Judge returned invalid JSON: ${(error as Error).message}`);
+    throw new Error(`Judge returned invalid JSON: ${(error as Error).message}`, { cause: error });
   }
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
     throw new Error("Judge batch must be a JSON object");

--- a/plugins/comments/judge/job.test.ts
+++ b/plugins/comments/judge/job.test.ts
@@ -42,7 +42,7 @@ describe("buildJob partitioning", () => {
     [41, [20, 20, 1]],
   ])("partitions %i comments into shards of default size", async (n, sizes) => {
     const job = await buildJob(many(n), { fix: false });
-    expect(job.shards.map((s) => s.comments.length)).toEqual(sizes as number[]);
+    expect(job.shards.map((s) => s.comments.length)).toEqual(sizes);
     expect(job.shards.map((s) => s.id)).toEqual(sizes.map((_, i) => i));
   });
 

--- a/plugins/comments/skills/audit/scripts/audit.ts
+++ b/plugins/comments/skills/audit/scripts/audit.ts
@@ -41,7 +41,7 @@ function parseSort(value: string): SortKey {
   console.error(
     `Invalid --sort ${JSON.stringify(value)}; expected one of ${SORT_KEYS.join(", ")}.`,
   );
-  process.exit(1);
+  return process.exit(1);
 }
 
 /**

--- a/plugins/git/skills/conflicts/scripts/check-markers.ts
+++ b/plugins/git/skills/conflicts/scripts/check-markers.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { $ } from "bun";
 
 function formatOutput(reason: string): SyncHookJSONOutput {
@@ -14,9 +14,8 @@ function formatOutput(reason: string): SyncHookJSONOutput {
 }
 
 async function main(): Promise<void> {
-  let _input: PreToolUseHookInput;
   try {
-    _input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
+    JSON.parse(await Bun.stdin.text());
   } catch (error) {
     console.error(
       `[git/conflicts/check-markers] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/github/scripts/pr-comments.ts
+++ b/plugins/github/scripts/pr-comments.ts
@@ -130,7 +130,7 @@ export function findLastReviewDate(reviews: Review[], viewer: string, role: Role
       ? reviews.filter((r) => r.author?.__typename === "User" && r.author.login !== viewer)
       : reviews.filter((r) => r.author?.login === viewer);
 
-  const sorted = relevant.sort(
+  const sorted = relevant.toSorted(
     (a, b) => new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime(),
   );
 

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -197,11 +197,11 @@ export function parsePrUrl(url: string): {
   return { owner: match.owner, repo: match.repo, number };
 }
 
+const stripGit = (s: string): string => (s.endsWith(".git") ? s.slice(0, -4) : s);
+
 export function parseRepo(remoteUrl: string): { owner: string; repo: string } | null {
   const trimmed = remoteUrl.trim();
   if (!trimmed) return null;
-
-  const stripGit = (s: string): string => (s.endsWith(".git") ? s.slice(0, -4) : s);
 
   const tryPattern = (pattern: string): { owner: string; repo: string } | null => {
     const match = new UrlPattern(pattern, {
@@ -252,9 +252,7 @@ function exec(command: string): ExecResult {
     return { ok: true, stdout };
   } catch (err) {
     const stderr =
-      err && typeof err === "object" && "stderr" in err
-        ? String((err as { stderr: unknown }).stderr ?? "")
-        : "";
+      err && typeof err === "object" && "stderr" in err ? String(err.stderr ?? "") : "";
     const { rateLimited, retryAfter } = detectRateLimit(stderr);
     return { ok: false, stderr, rateLimited, retryAfter };
   }
@@ -328,6 +326,9 @@ export async function resolveMergeable(
   return current;
 }
 
+const isQueuedState = (s: string): boolean =>
+  s === "QUEUED" || s === "PENDING" || s === "WAITING" || s === "REQUESTED" || s === "EXPECTED";
+
 // `gh pr checks --json` exposes a unified `state` (status when in-flight,
 // conclusion when complete) and a normalized `bucket` ("pass" | "fail" |
 // "cancel" | "pending" | "skipping"). It does NOT expose `conclusion`. Use
@@ -345,8 +346,6 @@ export function deriveChecksState(
   }
   const states = checks.map((c) => (c.state ?? "").toUpperCase());
   if (states.some((s) => s === "IN_PROGRESS")) return "running";
-  const isQueuedState = (s: string): boolean =>
-    s === "QUEUED" || s === "PENDING" || s === "WAITING" || s === "REQUESTED" || s === "EXPECTED";
   const anyQueued = states.some(isQueuedState);
   const allQueued = states.every(isQueuedState);
   if (allQueued && anyQueued) return "queued";
@@ -605,7 +604,7 @@ type RunOptions = {
   | { mode: "run-id"; repo: string; runId: string }
 );
 
-async function run(options: RunOptions): Promise<void> {
+async function watch(options: RunOptions): Promise<void> {
   let prNumber: number | null = null;
   let branch: string | null = null;
   let repo: string | null = null;
@@ -766,7 +765,7 @@ async function main(): Promise<void> {
       console.error("--repo only applies in branch or run-id mode");
       process.exit(1);
     }
-    await run({ mode: "pr", prUrl, ...common });
+    await watch({ mode: "pr", prUrl, ...common });
     return;
   }
 
@@ -781,11 +780,11 @@ async function main(): Promise<void> {
   };
 
   if (runId) {
-    await run({ mode: "run-id", repo: resolveRepo(), runId, ...common });
+    await watch({ mode: "run-id", repo: resolveRepo(), runId, ...common });
     return;
   }
 
-  await run({ mode: "branch", repo: resolveRepo(), branch: branch as string, ...common });
+  await watch({ mode: "branch", repo: resolveRepo(), branch: branch as string, ...common });
 }
 
 if (import.meta.main) {

--- a/plugins/github/skills/copilot/scripts/review.ts
+++ b/plugins/github/skills/copilot/scripts/review.ts
@@ -307,7 +307,7 @@ function collectDiff(base: string, cwd: string): Diff {
     names.add(path);
   }
 
-  return { base, patch, files: [...names].sort() };
+  return { base, patch, files: [...names].toSorted() };
 }
 
 const PREAMBLE = `You are reviewing a code change as a second opinion. The author already reviewed it with a different model, so repeating what that model would notice is worthless. Your value is the defect it missed.

--- a/plugins/gitlab/hooks/lint.test.ts
+++ b/plugins/gitlab/hooks/lint.test.ts
@@ -172,7 +172,7 @@ describe("gh on a GitLab remote", () => {
   test("resolves the shared config through a worktree .git file", async () => {
     const env = fakeEnv({
       "/repo/wt/.git": "gitdir: /repo/.git/worktrees/wt\n",
-      "/repo/.git/config": GITLAB_REPO["/repo/.git/config"] as string,
+      "/repo/.git/config": GITLAB_REPO["/repo/.git/config"],
     });
     const output = decision(await processInput(mockInput("gh pr view", "/repo/wt"), env));
     expect(output?.permissionDecision).toBe("deny");
@@ -217,9 +217,9 @@ describe("merge-request skill nudge", () => {
 
   test("defaultEnv.touch writes the marker before the marker directory exists", async () => {
     const base = mkdtempSync(join(tmpdir(), "gitlab-lint-"));
-    const marker = join(base, "gitlab-skill", "session.nudged");
-    await defaultEnv.touch(marker);
-    expect(await defaultEnv.fileExists(marker)).toBe(true);
+    const markerPath = join(base, "gitlab-skill", "session.nudged");
+    await defaultEnv.touch(markerPath);
+    expect(await defaultEnv.fileExists(markerPath)).toBe(true);
   });
 });
 

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
@@ -385,9 +385,7 @@ function exec(command: string): ExecResult {
     return { ok: true, stdout };
   } catch (err) {
     const stderr =
-      err && typeof err === "object" && "stderr" in err
-        ? String((err as { stderr: unknown }).stderr ?? "")
-        : "";
+      err && typeof err === "object" && "stderr" in err ? String(err.stderr ?? "") : "";
     // glab does not surface structured rate-limit metadata. Rather than
     // regexing human text we rely on the api-error counter instead.
     return { ok: false, stderr, rateLimited: false, retryAfter: "" };
@@ -837,7 +835,7 @@ function isTerminal(events: Event[], mode: RunTarget["mode"]): boolean {
   );
 }
 
-async function run(options: RunOptions): Promise<void> {
+async function watch(options: RunOptions): Promise<void> {
   const target = options.target;
   let projectEncoded: string;
   let iid: number | null = null;
@@ -1004,7 +1002,7 @@ async function main(): Promise<void> {
     throw new Error("No target specified");
   }
 
-  await run({
+  await watch({
     target,
     intervalSeconds: argv.flags.interval ?? null,
     maxMinutes: argv.flags.maxMinutes,

--- a/plugins/linear/hooks/save-issue.ts
+++ b/plugins/linear/hooks/save-issue.ts
@@ -38,7 +38,7 @@ export function normalizeInput(toolInput: Record<string, unknown>): NormalizeRes
   const keys = Object.keys(input);
   const wrapperKey = keys.length === 1 ? keys[0] : undefined;
   if (wrapperKey && WRAPPER_KEYS.includes(wrapperKey) && isFieldObject(input[wrapperKey])) {
-    input = input[wrapperKey] as Record<string, unknown>;
+    input = input[wrapperKey];
     mutated = true;
   }
 
@@ -48,7 +48,7 @@ export function normalizeInput(toolInput: Record<string, unknown>): NormalizeRes
     mutated = true;
   }
 
-  return { input: input as CreateIssueInput & Record<string, unknown>, mutated };
+  return { input, mutated };
 }
 
 export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {

--- a/plugins/mac/scripts/jxa.ts
+++ b/plugins/mac/scripts/jxa.ts
@@ -24,7 +24,7 @@ function walkNode(node: Node, visitor: (n: Node) => void): void {
   visitor(node);
   for (const key of Object.keys(node)) {
     const value = node[key];
-    if (value && typeof value === "object" && "type" in (value as object)) {
+    if (value && typeof value === "object" && "type" in value) {
       walkNode(value as Node, visitor);
     } else if (Array.isArray(value)) {
       for (const item of value) {
@@ -44,6 +44,7 @@ export function validateAppScope(source: string, app: string): ValidationResult 
   } catch (error) {
     throw new Error(
       `Failed to parse JXA source: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
     );
   }
 

--- a/plugins/meme/skills/image/scripts/render.ts
+++ b/plugins/meme/skills/image/scripts/render.ts
@@ -35,19 +35,19 @@ const MIN_WIDTH = 400;
 
 const IMPACT_PATH = "/System/Library/Fonts/Supplemental/Impact.ttf";
 
-let classicFamily: string | undefined;
+let cachedFamily: string | undefined;
 
 async function classicFontFamily(): Promise<string> {
-  if (classicFamily) return classicFamily;
+  if (cachedFamily) return cachedFamily;
   if (await Bun.file(IMPACT_PATH).exists()) {
     GlobalFonts.registerFromPath(IMPACT_PATH, "Impact");
-    classicFamily = "Impact";
+    cachedFamily = "Impact";
   } else if (GlobalFonts.has("Arial Black")) {
-    classicFamily = "Arial Black";
+    cachedFamily = "Arial Black";
   } else {
-    classicFamily = "sans-serif";
+    cachedFamily = "sans-serif";
   }
-  return classicFamily;
+  return cachedFamily;
 }
 
 interface ResolvedFont {

--- a/plugins/meme/skills/image/scripts/spec.ts
+++ b/plugins/meme/skills/image/scripts/spec.ts
@@ -48,7 +48,7 @@ function fail(path: string, message: string): never {
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && Array.isArray(value) === false;
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function validateFraction(value: unknown, path: string): number {

--- a/plugins/plan/hooks/gate.test.ts
+++ b/plugins/plan/hooks/gate.test.ts
@@ -229,7 +229,7 @@ describe("append-only re-present", () => {
   it("stays silent when the re-present adds no new lines", async () => {
     await decision(initial);
     // Same lines, reordered: full carry-over, nothing introduced.
-    const reordered = [...lines(10)].reverse().join("\n");
+    const reordered = lines(10).toReversed().join("\n");
     expect(await decision(reordered)).toBeNull();
   });
 

--- a/plugins/pull-request/scripts/suggest-reviewers.ts
+++ b/plugins/pull-request/scripts/suggest-reviewers.ts
@@ -80,7 +80,7 @@ export function blameOwners(files: string[], self: Set<string>, cwd?: string): O
       }
     }
   }
-  return [...byEmail.values()].sort((a, b) => b.lines - a.lines);
+  return [...byEmail.values()].toSorted((a, b) => b.lines - a.lines);
 }
 
 /** PR/MR refs parsed from recent commits touching the changed files on the base branch. */

--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -11,7 +11,7 @@ function hasBashCommand(input: unknown): input is { command: string } {
     typeof input === "object" &&
     input !== null &&
     "command" in input &&
-    typeof (input as { command: unknown }).command === "string"
+    typeof input.command === "string"
   );
 }
 

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -87,7 +87,7 @@ describe("isPrBodyCommand", () => {
 });
 
 const literal = (text: string): BodyPart => ({ kind: "literal", text });
-const file = (path: string): BodyPart => ({ kind: "file", path });
+const file = (filePath: string): BodyPart => ({ kind: "file", path: filePath });
 const parts = (...items: BodyPart[]): BodySpec => ({ kind: "parts", parts: items });
 
 describe("extractBodySpec", () => {

--- a/plugins/review/skills/tuicr/scripts/mapping.ts
+++ b/plugins/review/skills/tuicr/scripts/mapping.ts
@@ -20,15 +20,15 @@ const mapCmd = command(
 
     if (platform !== "github" && platform !== "gitlab") {
       console.error("--platform must be github or gitlab");
-      return process.exit(1);
+      process.exit(1);
     }
     if (comments === undefined || diff === undefined || commit === undefined) {
       console.error("--comments, --diff, and --commit are required");
-      return process.exit(1);
+      process.exit(1);
     }
     if (platform === "gitlab" && (base === undefined || start === undefined)) {
       console.error("gitlab requires --base and --start");
-      return process.exit(1);
+      process.exit(1);
     }
 
     let commentList: TuicrComment[];
@@ -38,7 +38,7 @@ const mapCmd = command(
       diffText = await Bun.file(diff).text();
     } catch (error) {
       console.error((error as Error).message);
-      return process.exit(1);
+      process.exit(1);
     }
 
     const parsedDiff = parseDiff(diffText);

--- a/plugins/things/scripts/ensure-running.ts
+++ b/plugins/things/scripts/ensure-running.ts
@@ -14,6 +14,7 @@ export async function ensureThingsRunning(): Promise<void> {
     } catch (error) {
       throw new Error(
         `Things 3 is not available. Ensure it is installed and can be launched. (${error instanceof Error ? error.message : String(error)})`,
+        { cause: error },
       );
     }
   }

--- a/plugins/things/scripts/format.test.ts
+++ b/plugins/things/scripts/format.test.ts
@@ -41,7 +41,7 @@ describe("selectColumns", () => {
       throw new Error("process.exit");
     });
     const originalExit = process.exit;
-    process.exit = mockExit as never;
+    process.exit = mockExit;
 
     const mockError = mock();
     const originalError = console.error;

--- a/plugins/things/scripts/format.ts
+++ b/plugins/things/scripts/format.ts
@@ -5,6 +5,8 @@ export function formatDate(value: string | null): string {
   return value.slice(0, 10);
 }
 
+const normalize = (s: string) => s.toLowerCase().replace(/\s+/g, "-");
+
 export function selectColumns(
   headers: string[],
   rows: string[][],
@@ -12,7 +14,6 @@ export function selectColumns(
 ): [string[], string[][]] {
   if (!columns || columns.length === 0) return [headers, rows];
 
-  const normalize = (s: string) => s.toLowerCase().replace(/\s+/g, "-");
   const headerMap = new Map(headers.map((h, i) => [normalize(h), i]));
 
   const indices: number[] = [];

--- a/plugins/things/scripts/url.ts
+++ b/plugins/things/scripts/url.ts
@@ -99,6 +99,7 @@ async function openUrl(
       if (isSandboxBlockedHandoff(stderr)) {
         throw new Error(
           `Things URL handoff was blocked by the Claude Code sandbox (LaunchServices procNotFound / -10810 / -10673). Launch Services handoff requires sandbox.allowAppleEvents in user/settings.json. Original stderr: ${stderr.trim()}`,
+          { cause: error },
         );
       }
       // ShellError's own message is only the exit code, and `.quiet()` holds
@@ -107,6 +108,7 @@ async function openUrl(
       const detail = stderr.trim() || error.stdout.toString().trim();
       throw new Error(
         `Things URL handoff failed (open exited ${error.exitCode})${detail ? `: ${detail}` : ""}`,
+        { cause: error },
       );
     }
     throw error;

--- a/plugins/things/src/mcp/jxa.ts
+++ b/plugins/things/src/mcp/jxa.ts
@@ -47,7 +47,7 @@ export async function runScript<T = unknown>(script: string, args: string[]): Pr
 
   const result: unknown = JSON.parse(stdout);
   if (result && typeof result === "object" && "error" in result) {
-    throw new Error(String((result as { error: unknown }).error));
+    throw new Error(String(result.error));
   }
   return result as T;
 }

--- a/plugins/things/src/mcp/stdout.test.ts
+++ b/plugins/things/src/mcp/stdout.test.ts
@@ -39,7 +39,7 @@ async function importClosure(entry: string): Promise<string[]> {
     }
   }
 
-  return [...seen].sort();
+  return [...seen].toSorted();
 }
 
 /**

--- a/plugins/things/src/mcp/tools.ts
+++ b/plugins/things/src/mcp/tools.ts
@@ -60,7 +60,7 @@ function payloadBytes(value: unknown): number {
 function readItems(payload: unknown): unknown[] | null {
   if (Array.isArray(payload)) return payload;
   if (payload && typeof payload === "object" && "items" in payload) {
-    const items = (payload as { items: unknown }).items;
+    const items = payload.items;
     if (Array.isArray(items)) return items;
   }
   return null;
@@ -606,6 +606,7 @@ export function registerTools(server: McpServer): void {
             applied.length
               ? `${message}\nAlready updated: ${applied.join(", ")}. Retry only the remaining IDs.`
               : message,
+            { cause: error },
           );
         }
         applied.push(...batch);

--- a/plugins/things/tsconfig.json
+++ b/plugins/things/tsconfig.json
@@ -7,6 +7,7 @@
     "checkJs": true,
     "noEmit": true,
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "skipLibCheck": true
   },
   "include": ["src/**/*", "scripts/**/*"]

--- a/plugins/writing/hooks/headings.ts
+++ b/plugins/writing/hooks/headings.ts
@@ -1,5 +1,5 @@
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import type { Heading, Paragraph, Strong, Text } from "mdast";
+import type { Heading, Paragraph, Text } from "mdast";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { visit } from "unist-util-visit";
 import { getExtension, isMarkdownFile } from "../detection/paths";
@@ -26,8 +26,7 @@ export function checkBoldAsHeading(content: string): string | null {
     const first = node.children[0];
     if (first?.type !== "strong") return;
 
-    const strong = first as Strong;
-    const text = strong.children
+    const text = first.children
       .filter((child): child is Text => child.type === "text")
       .map((child) => child.value)
       .join("");

--- a/plugins/writing/hooks/pretooluse.test.ts
+++ b/plugins/writing/hooks/pretooluse.test.ts
@@ -41,7 +41,7 @@ function mockInput(
     tool_input: toolInput,
     tool_use_id: "test",
     ...overrides,
-  } as PreToolUseHookInput;
+  };
 }
 
 // Trips all three checkers at context tier: a lowercase step heading

--- a/plugins/writing/hooks/pretooluse.ts
+++ b/plugins/writing/hooks/pretooluse.ts
@@ -96,7 +96,7 @@ export async function dispatch(
   // Stable sort: within a tier the earliest checker keeps priority. A
   // suppressed winner falls through to the next result rather than muting
   // findings whose categories never fired.
-  const ordered = [...results].sort(
+  const ordered = results.toSorted(
     (a, b) => TIER_RANK[tierOf(a.output)] - TIER_RANK[tierOf(b.output)],
   );
   let suppressed: HookResult | undefined;

--- a/plugins/writing/skills/analyze/scripts/analyze.test.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.test.ts
@@ -114,7 +114,7 @@ describe("runAnalysis", () => {
       model: result.modelSummary[0]?.model,
       voiceProfile: result.voiceProfile,
       ruleHealthLength: result.ruleHealth.length,
-      surfaces: [...new Set(result.ruleHealth.map((r) => r.surface))].sort(),
+      surfaces: [...new Set(result.ruleHealth.map((r) => r.surface))].toSorted(),
     }).toMatchInlineSnapshot(`
       {
         "generatedAt": "2026-05-24",

--- a/plugins/writing/skills/analyze/scripts/analyze.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.ts
@@ -396,7 +396,7 @@ export async function runAnalysis(
   );
   const rateDocumentRows = deliverableRows
     .filter((r) => r.text)
-    .map((r) => analyzeDocument(r.session_id, r.text as string));
+    .map((r) => analyzeDocument(r.session_id, r.text));
   const rateTrends = aggregateTrends(rateDocumentRows);
 
   let meaningAudit: ReportInput["meaningAudit"] = null;

--- a/plugins/writing/skills/analyze/scripts/headings-eval.test.ts
+++ b/plugins/writing/skills/analyze/scripts/headings-eval.test.ts
@@ -137,7 +137,7 @@ describe("sampleForLabeling", () => {
     const byHeading = new Map(sample.map((row) => [row.heading, row.source]));
 
     const disagreementRows = sample.filter((row) => row.source === "disagreement");
-    expect(disagreementRows.map((row) => row.heading).sort()).toEqual(["H0", "H1"]);
+    expect(disagreementRows.map((row) => row.heading).toSorted()).toEqual(["H0", "H1"]);
 
     const randomRows = sample.filter((row) => row.source === "random");
     for (const row of randomRows) {

--- a/plugins/writing/skills/analyze/scripts/headings-eval.ts
+++ b/plugins/writing/skills/analyze/scripts/headings-eval.ts
@@ -82,7 +82,7 @@ export function dedupeHeadings(
     heading,
     occurrences,
     sessions: sessions.size,
-  })).sort((a, b) => b.occurrences - a.occurrences);
+  })).toSorted((a, b) => b.occurrences - a.occurrences);
 }
 
 export interface ClassifierStats {
@@ -294,7 +294,7 @@ export function formatPowerReport(
 async function corpusFromDocs(dir: string): Promise<Array<{ session_id: string; text: string }>> {
   const files = readdirSync(dir)
     .filter((name) => name.endsWith(".md"))
-    .sort();
+    .toSorted();
   return Promise.all(
     files.map(async (name) => ({
       session_id: name,

--- a/plugins/writing/skills/analyze/scripts/hook-health.ts
+++ b/plugins/writing/skills/analyze/scripts/hook-health.ts
@@ -97,7 +97,7 @@ export function summarize(entries: RunLogEntry[]): HookHealth {
       ...counts,
       share: injections > 0 ? counts.fired / injections : 0,
     }))
-    .sort((a, b) => b.fired - a.fired || b.suppressed - a.suppressed);
+    .toSorted((a, b) => b.fired - a.fired || b.suppressed - a.suppressed);
 
   return {
     total: entries.length,

--- a/plugins/writing/skills/analyze/scripts/judge-fixtures.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge-fixtures.test.ts
@@ -44,9 +44,9 @@ describe("fixture tuples", () => {
       const expectations = Object.entries(fixture.expect);
       if (fixture.kind === "synthetic-negative") {
         expect(expectations.length).toBe(JUDGE_CRITERIA.length);
-        expect(expectations.every(([, flagged]) => flagged === false)).toBe(true);
+        expect(expectations.every(([, flagged]) => !flagged)).toBe(true);
       } else {
-        expect(expectations.some(([, flagged]) => flagged === true)).toBe(true);
+        expect(expectations.some(([, flagged]) => flagged)).toBe(true);
       }
     }
   });

--- a/plugins/writing/skills/analyze/scripts/judge.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.test.ts
@@ -74,7 +74,7 @@ describe("prompt artifact", () => {
   test("criteria appear in the prompt in rubric order", async () => {
     const prompt = await loadPrompt();
     const positions = JUDGE_CRITERIA.map((c) => prompt.text.indexOf(`### \`${c.key}\``));
-    expect([...positions].sort((a, b) => a - b)).toEqual(positions);
+    expect(positions.toSorted((a, b) => a - b)).toEqual(positions);
   });
 
   test("hash is the sha256 of the file contents", async () => {

--- a/plugins/writing/skills/analyze/scripts/judge.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.ts
@@ -170,7 +170,7 @@ export function parseVerdict(json: string): JudgeVerdict {
   try {
     parsed = JSON.parse(json);
   } catch (error) {
-    throw new Error(`Judge returned invalid JSON: ${(error as Error).message}`);
+    throw new Error(`Judge returned invalid JSON: ${(error as Error).message}`, { cause: error });
   }
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
     throw new Error("Judge verdict must be a JSON object");
@@ -189,7 +189,7 @@ export function parseVerdict(json: string): JudgeVerdict {
     if (entry.span !== null && typeof entry.span !== "string") {
       throw new Error(`Judge verdict "${criterion.key}.span" must be a string or null`);
     }
-    verdict[criterion.key] = { flagged: entry.flagged, span: entry.span as string | null };
+    verdict[criterion.key] = { flagged: entry.flagged, span: entry.span };
   }
   return verdict;
 }
@@ -554,7 +554,9 @@ export function parseHeadingVerdicts(json: string, expected: number): boolean[] 
   try {
     parsed = JSON.parse(json);
   } catch (error) {
-    throw new Error(`Heading judge returned invalid JSON: ${(error as Error).message}`);
+    throw new Error(`Heading judge returned invalid JSON: ${(error as Error).message}`, {
+      cause: error,
+    });
   }
   const record = parsed as Record<string, unknown>;
   const entries = record.headings;

--- a/plugins/writing/skills/analyze/scripts/report.ts
+++ b/plugins/writing/skills/analyze/scripts/report.ts
@@ -172,7 +172,7 @@ function renderProposedRemovals(input: ReportInput): string {
   ];
   const removable = input.ruleHealth
     .filter((r) => r.status === "remove")
-    .sort(
+    .toSorted(
       (a, b) =>
         reasonRank(a.removeReason) - reasonRank(b.removeReason) ||
         (a.modelPerM ?? 0) - (b.modelPerM ?? 0),
@@ -298,7 +298,7 @@ function renderStructuralAudit(input: ReportInput): string {
     lines.push("");
     lines.push("| pattern | scope | assistant hits | user hits | rows | sessions | retire when |");
     lines.push("| --- | --- | --- | --- | --- | --- | --- |");
-    const sorted = [...rows].sort((a, b) => b.assistantHits - a.assistantHits);
+    const sorted = rows.toSorted((a, b) => b.assistantHits - a.assistantHits);
     for (const r of sorted) {
       const scope = r.sideEffectOnly ? "side-effect" : r.fileOnly ? "file-only" : "all";
       lines.push(
@@ -472,7 +472,7 @@ function fmtPct(value: number): string {
 
 function fmtNum(value: number | null): string {
   if (value === null) return "-";
-  return Number(value).toLocaleString();
+  return value.toLocaleString();
 }
 
 function fmtPerM(value: number | null): string {
@@ -512,7 +512,7 @@ function voiceBaselineSummary(profile: VoiceProfile | null): string {
 function formatQuote(quote: QuoteContext | null): string {
   if (!quote) return "(no deliverable occurrence found)";
   const pointer = quote.filePath
-    ? `${quote.filePath}`
+    ? quote.filePath
     : quote.sourceFile
       ? `${quote.sourceFile}:${quote.sourceLine ?? "?"}`
       : "(no source pointer)";

--- a/plugins/writing/skills/analyze/scripts/voice-delta.test.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-delta.test.ts
@@ -30,7 +30,7 @@ describe("VOICE_DELTA_FEATURES", () => {
     const byProvenance = (p: string) =>
       VOICE_DELTA_FEATURES.filter((f) => f.provenance === p)
         .map((f) => f.id)
-        .sort();
+        .toSorted();
     expect(byProvenance("skill-encouraged")).toEqual([
       "body_length",
       "causal_language_rate",

--- a/plugins/writing/skills/analyze/scripts/voice-delta.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-delta.ts
@@ -162,7 +162,7 @@ export const VOICE_DELTA_FEATURES: VoiceDeltaFeature[] = [
       const stripped = stripCode(text);
       const sentences = sentenceSplit(stripped);
       if (sentences.length === 0) return 0;
-      const lengths = sentences.map((s) => wordCount(s)).sort((a, b) => a - b);
+      const lengths = sentences.map((s) => wordCount(s)).toSorted((a, b) => a - b);
       const mid = Math.floor(lengths.length / 2);
       return lengths.length % 2 === 0
         ? ((lengths[mid - 1] ?? 0) + (lengths[mid] ?? 0)) / 2
@@ -179,7 +179,7 @@ export const VOICE_DELTA_FEATURES: VoiceDeltaFeature[] = [
       const stripped = stripCode(text);
       const sentences = sentenceSplit(stripped);
       if (sentences.length === 0) return 0;
-      const lengths = sentences.map((s) => wordCount(s)).sort((a, b) => a - b);
+      const lengths = sentences.map((s) => wordCount(s)).toSorted((a, b) => a - b);
       const idx = Math.floor(lengths.length * 0.9);
       return lengths[Math.min(idx, lengths.length - 1)] ?? 0;
     },

--- a/plugins/writing/skills/analyze/scripts/voice-profile.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-profile.ts
@@ -73,7 +73,7 @@ export function buildProfile(docs: VoiceDocument[], generatedAt: string): VoiceP
     stemmedNgrams: serializeNgrams(stemmedNgrams),
     totalStemmedTokens,
     generatedAt,
-    sources: Array.from(sources).sort(),
+    sources: Array.from(sources).toSorted(),
     voiceDelta,
   };
 }

--- a/plugins/writing/skills/analyze/scripts/wordlists.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlists.ts
@@ -15,7 +15,7 @@ export async function loadWordlists(dir: string): Promise<WordlistEntry[]> {
     throw err;
   }
   const entries: WordlistEntry[] = [];
-  for (const file of files.sort()) {
+  for (const file of files.toSorted()) {
     const text = await Bun.file(path.join(dir, file)).text();
     for (const rawLine of text.split("\n")) {
       const line = rawLine.replace(/#.*$/, "").trim();

--- a/plugins/writing/skills/scan/scripts/scan.ts
+++ b/plugins/writing/skills/scan/scripts/scan.ts
@@ -48,7 +48,7 @@ export async function collectFiles(input: string): Promise<string[]> {
     if (!isProseFile(path)) continue;
     files.push(path);
   }
-  return files.sort();
+  return files.toSorted();
 }
 
 function scanInput(text: string, filePath: string | undefined): number {
@@ -103,12 +103,12 @@ function printSummary(results: FileViolations[]): void {
   }
 
   const categoryRows = [...byCategory.entries()]
-    .sort((a, b) => b[1] - a[1])
+    .toSorted((a, b) => b[1] - a[1])
     .map(([category, count]) => [category, String(count)]);
   console.error(table([["Category", "Count"], ...categoryRows]));
 
   const noisiest = [...byFile.entries()]
-    .sort((a, b) => b[1] - a[1])
+    .toSorted((a, b) => b[1] - a[1])
     .slice(0, 10)
     .map(([path, count]) => [relativeLabel(path), String(count)]);
   console.error(table([["File", "Violations"], ...noisiest]));
@@ -121,7 +121,7 @@ async function collectAcross(paths: string[]): Promise<string[]> {
   for (const path of paths) {
     for (const file of await collectFiles(path)) files.add(file);
   }
-  return [...files].sort();
+  return [...files].toSorted();
 }
 
 const auditCmd = command(

--- a/plugins/writing/skills/scan/scripts/score.ts
+++ b/plugins/writing/skills/scan/scripts/score.ts
@@ -117,8 +117,7 @@ export function renderTable(report: ScoreReport): string {
   for (const group of report.groups) {
     const header = `${group.group} (${group.wordCount} words)`;
     const rows = group.categories
-      .slice()
-      .sort((a, b) => b.density - a.density || a.category.localeCompare(b.category))
+      .toSorted((a, b) => b.density - a.density || a.category.localeCompare(b.category))
       .map((c) => [c.category, String(c.hits), formatDensity(c.density)]);
     if (rows.length === 0) {
       sections.push(`${header}\nNo patterns detected.`);

--- a/scripts/check-hook-matchers.test.ts
+++ b/scripts/check-hook-matchers.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import type { HookCommand, MatcherEntryContext } from "../packages/marketplace/index";
-import { entries, violations } from "./check-hook-matchers";
+import { allMatcherEntries, violations } from "./check-hook-matchers";
 
 function entry(matcher: string | undefined, ...ifs: (string | undefined)[]): MatcherEntryContext {
   const hooks: HookCommand[] = ifs.map((rule) => {
@@ -8,9 +8,9 @@ function entry(matcher: string | undefined, ...ifs: (string | undefined)[]): Mat
     if (rule !== undefined) hook.if = rule;
     return hook;
   });
-  const entry: MatcherEntryContext["entry"] = { hooks };
-  if (matcher !== undefined) entry.matcher = matcher;
-  return { file: "plugins/example/hooks/hooks.json", entry };
+  const hookEntry: MatcherEntryContext["entry"] = { hooks };
+  if (matcher !== undefined) hookEntry.matcher = matcher;
+  return { file: "plugins/example/hooks/hooks.json", entry: hookEntry };
 }
 
 test.each<{ name: string; entries: MatcherEntryContext[]; expected: number }>([
@@ -66,7 +66,7 @@ test("the pull-request matcher that never fired", () => {
 // The ox commit gate sat behind a `Bash(git commit:*)` matcher in project
 // settings and never fired, because this check only ever read plugin hooks.
 test("scans both settings files alongside the plugins", async () => {
-  const files = new Set((await entries()).map((context) => context.file));
+  const files = new Set((await allMatcherEntries()).map((context) => context.file));
   expect(files).toContain("user/settings.json");
   expect(files).toContain(".claude/settings.json");
 });

--- a/scripts/check-hook-matchers.ts
+++ b/scripts/check-hook-matchers.ts
@@ -68,7 +68,7 @@ function* settingsEntries(file: string, hooks: HooksFile["hooks"]): Generator<Ma
  * repo's hook entries live in settings rather than a plugin, and a matcher
  * defect is equally silent in either.
  */
-export async function entries(): Promise<MatcherEntryContext[]> {
+export async function allMatcherEntries(): Promise<MatcherEntryContext[]> {
   const [plugins, settings] = await Promise.all([
     loadPlugins(),
     Promise.all(
@@ -85,7 +85,7 @@ if (import.meta.main) {
   await runCheck(
     async () => ({
       header: "Hook matchers that cannot fire:",
-      violations: violations(await entries()),
+      violations: violations(await allMatcherEntries()),
     }),
     { success: 'All hook matchers match tool names and every "if" holds one permission rule' },
   );

--- a/scripts/check-hook-paths.ts
+++ b/scripts/check-hook-paths.ts
@@ -130,9 +130,9 @@ export async function shipped(): Promise<Set<string>> {
   return found;
 }
 
-export function violations(references: Reference[], shipped: Set<string>): string[] {
-  return references
-    .filter((reference) => !shipped.has(reference.path))
+export function violations(refs: Reference[], shippedPaths: Set<string>): string[] {
+  return refs
+    .filter((reference) => !shippedPaths.has(reference.path))
     .map((reference) => `${reference.file} ${reference.event}: ${reference.path}`);
 }
 

--- a/scripts/check-hook-quoting.ts
+++ b/scripts/check-hook-quoting.ts
@@ -15,9 +15,8 @@ async function checkQuoting(): Promise<string[]> {
     for (const { file, command: hook } of hookCommands(plugin)) {
       if (!hook.command?.includes("${CLAUDE_PLUGIN_ROOT}")) continue;
 
-      for (const _match of hook.command.matchAll(UNQUOTED_PATH)) {
+      if (hook.command.search(UNQUOTED_PATH) !== -1) {
         violations.push(`${file}: ${hook.command}`);
-        break;
       }
     }
   }

--- a/scripts/check-review-drift.ts
+++ b/scripts/check-review-drift.ts
@@ -58,7 +58,7 @@ async function findBinary(): Promise<string> {
 
   const versions = join(homedir(), ".local", "share", "claude", "versions");
   const entries = await readdir(versions).catch(() => []);
-  for (const entry of entries.sort(bySemverDesc)) {
+  for (const entry of entries.toSorted(bySemverDesc)) {
     const candidate = join(versions, entry, "claude");
     if (Bun.file(candidate).size > BUNDLE_MIN_BYTES) return candidate;
   }
@@ -173,7 +173,7 @@ await runCheck(
 
     const snapshot = snapshots.includes(version)
       ? version
-      : (snapshots.sort(bySemverDesc)[0] as string);
+      : (snapshots.toSorted(bySemverDesc)[0] as string);
     if (snapshot !== version) {
       violations.push(
         `Installed Claude Code is ${version}; the newest snapshot is ${snapshot}. Re-extract and land references/upstream-${version}.md, then port any changes into SKILL.md, angles.md, and efforts.md.`,

--- a/scripts/coverage/lcov.test.ts
+++ b/scripts/coverage/lcov.test.ts
@@ -129,7 +129,7 @@ DA:3,1
 end_of_record
 `),
     );
-    expect(merged.map((r) => r.file).sort()).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(merged.map((r) => r.file).toSorted()).toEqual(["src/a.ts", "src/b.ts"]);
     const a = defined(merged.find((r) => r.file === "src/a.ts"));
     expect(a.functionsHit).toBe(2);
     expect(uncoveredLines(a)).toEqual([]);

--- a/scripts/coverage/lcov.ts
+++ b/scripts/coverage/lcov.ts
@@ -19,14 +19,14 @@ export function coveredLines(fc: FileCoverage): number[] {
   return [...fc.lineHits.entries()]
     .filter(([, hits]) => hits > 0)
     .map(([line]) => line)
-    .sort((a, b) => a - b);
+    .toSorted((a, b) => a - b);
 }
 
 export function uncoveredLines(fc: FileCoverage): number[] {
   return [...fc.lineHits.entries()]
     .filter(([, hits]) => hits === 0)
     .map(([line]) => line)
-    .sort((a, b) => a - b);
+    .toSorted((a, b) => a - b);
 }
 
 export interface LineCoverage {
@@ -116,7 +116,7 @@ export function formatLcov(reports: FileCoverage[]): string {
   const blocks: string[] = [];
   for (const fc of reports) {
     const lines = ["TN:", `SF:${fc.file}`, `FNF:${fc.functionsFound}`, `FNH:${fc.functionsHit}`];
-    for (const line of [...fc.lineHits.keys()].sort((a, b) => a - b)) {
+    for (const line of [...fc.lineHits.keys()].toSorted((a, b) => a - b)) {
       lines.push(`DA:${line},${fc.lineHits.get(line)}`);
     }
     const covered = coveredLines(fc).length;
@@ -128,7 +128,7 @@ export function formatLcov(reports: FileCoverage[]): string {
 
 // Collapse sorted line numbers into human-readable ranges: [1,2,3,5,8,9] -> "1-3, 5, 8-9".
 export function formatRanges(lines: number[]): string {
-  const [first, ...rest] = [...lines].sort((a, b) => a - b);
+  const [first, ...rest] = lines.toSorted((a, b) => a - b);
   if (first === undefined) return "";
 
   const ranges: string[] = [];

--- a/scripts/coverage/report.ts
+++ b/scripts/coverage/report.ts
@@ -13,7 +13,7 @@ function pctColor(pct: number): (text: string) => string {
 }
 
 function sortByCoverage(reports: FileCoverage[]): FileCoverage[] {
-  return [...reports].sort((a, b) => lineCoverage(a).pct - lineCoverage(b).pct);
+  return reports.toSorted((a, b) => lineCoverage(a).pct - lineCoverage(b).pct);
 }
 
 export function terminalReport(reports: FileCoverage[]): string {

--- a/scripts/inventory/collect.ts
+++ b/scripts/inventory/collect.ts
@@ -221,8 +221,12 @@ export function filter(inventory: Inventory, { plugin, scope }: Filters): Invent
   };
 }
 
+function owned(items: Origin[], name: string): number {
+  return items.filter((item) => item.plugin === name).length;
+}
+
 function byName<T extends { name: string }>(items: T[]): T[] {
-  return [...items].sort((a, b) => a.name.localeCompare(b.name));
+  return items.toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
 export async function collect(): Promise<Inventory> {
@@ -242,12 +246,9 @@ export async function collect(): Promise<Inventory> {
         ? [...hookEntries(`plugins/${plugin.name}/hooks/hooks.json`, plugin.hooks.hooks)]
         : [],
     ),
-    ...fromSkills.flatMap(({ hooks }) => hooks),
+    ...fromSkills.flatMap(({ hooks: skillHooks }) => skillHooks),
     ...settings.flat(),
   ];
-
-  const owned = (items: Origin[], name: string): number =>
-    items.filter((item) => item.plugin === name).length;
 
   return {
     plugins: plugins.map((plugin) => ({

--- a/scripts/inventory/inventory.test.ts
+++ b/scripts/inventory/inventory.test.ts
@@ -210,7 +210,7 @@ test("plugin agents keep the namespace they are dispatched by", async () => {
   const { agents } = await collect();
   const logs = agents.filter((agent) => agent.path.endsWith("/agents/logs.md"));
 
-  expect(logs.map((agent) => agent.name).sort()).toEqual(["github:logs", "gitlab:logs"]);
+  expect(logs.map((agent) => agent.name).toSorted()).toEqual(["github:logs", "gitlab:logs"]);
 });
 
 test("filter narrows every kind to one plugin", () => {

--- a/scripts/inventory/report.ts
+++ b/scripts/inventory/report.ts
@@ -45,6 +45,12 @@ function invocation(skill: { modelInvocable: boolean; userInvocable: boolean }):
   return modes.join("+") || "none";
 }
 
+// Plugins and MCP servers exist only in the plugin scope, so their row skips
+// the per-scope split the others break down by.
+function pluginOnly(kind: string, total: number, note: string): string[] {
+  return [kind, String(total), "-", "-", String(total), note];
+}
+
 function counts(inventory: Inventory): Columns {
   const scoped = [
     { kind: "skills", items: inventory.skills },
@@ -52,17 +58,6 @@ function counts(inventory: Inventory): Columns {
     { kind: "commands", items: inventory.commands },
     { kind: "rules", items: inventory.rules },
     { kind: "hooks", items: inventory.hooks },
-  ];
-
-  // Plugins and MCP servers exist only in the plugin scope, so their row skips
-  // the per-scope split the others break down by.
-  const pluginOnly = (kind: string, total: number, note: string): string[] => [
-    kind,
-    String(total),
-    "-",
-    "-",
-    String(total),
-    note,
   ];
 
   return {
@@ -160,6 +155,8 @@ function columns(inventory: Inventory, kind: Kind, width: number): Columns {
         head: ["server", "plugin", "path"],
         rows: inventory.mcpServers.map((m) => [m.name, m.plugin, m.path]),
       };
+    default:
+      throw new Error(`Unknown inventory kind: ${kind}`);
   }
 }
 

--- a/user/skills/scheduled/scripts/scheduled.ts
+++ b/user/skills/scheduled/scripts/scheduled.ts
@@ -115,7 +115,7 @@ export function renderPlist(descriptor: Descriptor, group: string): string {
   const label = fullLabel(group, descriptor.label);
   const workdir = expandHome(descriptor.workdir);
   const permissionMode = descriptor.permission_mode ?? "acceptEdits";
-  const command = `claude -p ${JSON.stringify(descriptor.command)} --permission-mode ${permissionMode}`;
+  const invocation = `claude -p ${JSON.stringify(descriptor.command)} --permission-mode ${permissionMode}`;
   const home = homedir();
   const stdout = join(home, "Library/Logs", `claude-${group}-${descriptor.label}.log`);
   const stderr = join(home, "Library/Logs", `claude-${group}-${descriptor.label}.err.log`);
@@ -155,7 +155,7 @@ export function renderPlist(descriptor: Descriptor, group: string): string {
 \t<array>
 \t\t<string>/bin/zsh</string>
 \t\t<string>-lc</string>
-\t\t${plistString(command)}
+\t\t${plistString(invocation)}
 \t</array>
 \t<key>WorkingDirectory</key>
 \t${plistString(workdir)}
@@ -198,8 +198,10 @@ export function parseDescriptor(text: string, source: string): Descriptor {
     throw new Error(`${source}: unknown "mode" ${JSON.stringify(mode)}`);
   }
 
-  const command = data.command;
-  if (typeof command !== "string" || !command) throw new Error(`${source}: missing "command"`);
+  const commandText = data.command;
+  if (typeof commandText !== "string" || !commandText) {
+    throw new Error(`${source}: missing "command"`);
+  }
 
   const workdir = data.workdir;
   if (workdir !== undefined && typeof workdir !== "string") {
@@ -215,7 +217,7 @@ export function parseDescriptor(text: string, source: string): Descriptor {
     label,
     schedule: { at: schedule.at, weekday, day },
     mode,
-    command,
+    command: commandText,
     workdir,
     permission_mode: permissionMode,
   };
@@ -227,7 +229,7 @@ export async function listDescriptors(dir: string): Promise<DescriptorFile[]> {
   for await (const file of glob.scan({ cwd: dir, absolute: true })) {
     results.push({ descriptor: parseDescriptor(await Bun.file(file).text(), file), file });
   }
-  return results.sort((a, b) => a.descriptor.label.localeCompare(b.descriptor.label));
+  return results.toSorted((a, b) => a.descriptor.label.localeCompare(b.descriptor.label));
 }
 
 /** Short-form (`<group>.<label>`) identifiers for every `me.bendrucker.claude.*` agent installed on this machine. */
@@ -386,7 +388,7 @@ async function listCommand(dirs: string[], withLoadState: boolean): Promise<void
     const installedForGroup = new Set(installedAll.filter((l) => l.startsWith(`${group}.`)));
     const all = new Set([...declared.keys(), ...installedForGroup]);
 
-    for (const label of [...all].sort()) {
+    for (const label of [...all].toSorted()) {
       const entry = declared.get(label);
       const installed = installedForGroup.has(label);
       const row = [


### PR DESCRIPTION
#1222 skipped the `suspicious` category at the Biome migration for noise. It is tractable now: 543 findings across twelve rules, 148 of them mechanical. What needs review is the three rules configured rather than fixed.

## Fixed

| Rule | Hits |
| --- | --- |
| `unicorn/no-array-sort` | 59 |
| `eslint/no-shadow` | 35 |
| `typescript/no-unnecessary-type-assertion` | 22 |
| `eslint/preserve-caught-error` | 9 |
| `typescript/no-unnecessary-boolean-literal-compare` | 8 |
| `unicorn/consistent-function-scoping` | 6 |
| `typescript/consistent-return` | 3 |
| `typescript/no-unnecessary-type-conversion` | 2 |
| `unicorn/no-array-reverse` | 1 |
| `typescript/no-unnecessary-template-expression` | 1 |

Every `sort` site consumes its return value, so `toSorted` drops the in-place mutation safely, and sites that guarded with `[...x]` lost the copy. Sixteen shadow hits came from one outer `run(options)` in the two CI watchers, whose inner `run` bindings are injected exec functions and run objects. Renaming the outer to `watch` cleared them together.

## Configured

| Rule | Hits | Entry |
| --- | --- | --- |
| `typescript/no-unsafe-type-assertion` | 351 | `"off"` |
| `unicorn/consistent-function-scoping` | 41 | `"off"` under `**/*.test.ts` |
| `eslint/no-underscore-dangle` | 3 | `allow: ["__typename", "__dirname"]` |

`no-unsafe-type-assertion` flags the decode boundary this repo runs on. Of 351 hits, 106 assert away from `any`, and 89 of those sit within two lines of a `JSON.parse` or `Bun.file().json()` call where the assertion is the only thing giving the parsed value a shape. Another 48 narrow to `Record<string, unknown>`, which [`user/rules/typescript.md`](user/rules/typescript.md) prescribes over a double assertion. #1268 turned down two rules covering the same sites.

The test-file hits are suite-local fixtures: `describe`-scoped stubs, frozen clocks, per-test injections. Several sit beside sibling helpers that do capture, so hoisting would split one fixture set across two scopes. The override joins #1268's existing `**/*.test.ts` entry.

`no-underscore-dangle` fires on identifiers this repo does not own. `__typename` arrives in GitHub GraphQL responses and `__dirname` is the ESM reconstruction.

## Tsconfig Divergence

`plugins/things/tsconfig.json` gains `noUncheckedIndexedAccess` to match the root config. oxlint resolves the nearest tsconfig per file, so `no-unnecessary-type-assertion` judged three assertions under `plugins/things/` against a weaker config than the repo actually checks with, and removing them broke root `tsc`. Aligning the two restores the assertions. It exposes two pre-existing errors in a JXA `.js` file that `ignorePatterns` already excludes, in a project that did not check clean before.
