### PR TITLE
lint: tighten type-assertion rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -8,7 +8,8 @@
   "rules": {
     "prefer-template": "error",
     "no-template-curly-in-string": "warn",
-    "typescript/no-non-null-assertion": "warn",
+    "typescript/no-non-null-assertion": "error",
+    "typescript/no-unnecessary-type-assertion": "error",
     "no-unused-vars": [
       "error",
       {
@@ -23,9 +24,7 @@
     "no-underscore-dangle": ["error", { "allow": ["__typename", "__dirname"] }],
     "no-unsafe-optional-chaining": "off",
     "typescript/no-unsafe-type-assertion": "off",
-    "typescript/restrict-template-expressions": "off",
     "typescript/await-thenable": "off",
-    "typescript/no-base-to-string": "off",
     "typescript/no-floating-promises": "off",
     "typescript/unbound-method": "off",
     "typescript/ban-ts-comment": "error",
@@ -78,7 +77,8 @@
       "files": ["**/*.test.ts"],
       "rules": {
         "local/no-chained-type-assertions": "off",
-        "unicorn/consistent-function-scoping": "off"
+        "unicorn/consistent-function-scoping": "off",
+        "typescript/no-non-null-assertion": "off"
       }
     }
   ],

--- a/plugins/claude-code/skills/session/scripts/refresh.ts
+++ b/plugins/claude-code/skills/session/scripts/refresh.ts
@@ -55,7 +55,9 @@ async function cleanupStrayDatabases(): Promise<void> {
       await rm(dir, { recursive: true, force: true });
       console.error(`refresh: removed stale index at ${dir}`);
     } catch (err) {
-      console.error(`refresh: could not remove stale index at ${dir}: ${err}`);
+      console.error(
+        `refresh: could not remove stale index at ${dir}: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 }

--- a/plugins/comments/detection/collect.ts
+++ b/plugins/comments/detection/collect.ts
@@ -48,7 +48,8 @@ export async function resolveMrSource(iid: string): Promise<MrSource | null> {
   const projectId = record.source_project_id;
   const diffRefs = record.diff_refs as Record<string, unknown> | undefined;
   const ref = diffRefs?.head_sha ?? record.sha;
-  if (projectId == null || typeof ref !== "string") return null;
+  if (typeof ref !== "string") return null;
+  if (typeof projectId !== "number" && typeof projectId !== "string") return null;
   return { projectId: String(projectId), ref };
 }
 

--- a/plugins/github/scripts/pr-comments.ts
+++ b/plugins/github/scripts/pr-comments.ts
@@ -234,7 +234,7 @@ interface GraphQLResponse {
 
 async function fetchGraphQL(
   query: string,
-  variables: Record<string, unknown>,
+  variables: Record<string, string | number | undefined>,
 ): Promise<GraphQLResponse> {
   const args = ["gh", "api", "graphql", "-f", `query=${query}`];
   for (const [key, value] of Object.entries(variables)) {
@@ -298,7 +298,7 @@ async function main(): Promise<void> {
   let reviews: Review[] = [];
 
   do {
-    const variables: Record<string, unknown> = { owner, repo, number };
+    const variables: Record<string, string | number | undefined> = { owner, repo, number };
     if (cursor) variables.cursor = cursor;
 
     const result = await fetchGraphQL(QUERY, variables);

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -246,13 +246,18 @@ export function detectRateLimit(stderr: string): { rateLimited: boolean; retryAf
   return { rateLimited, retryAfter };
 }
 
+function streamText(stream: unknown): string {
+  if (typeof stream === "string") return stream;
+  if (stream instanceof Uint8Array) return new TextDecoder().decode(stream);
+  return "";
+}
+
 function exec(command: string): ExecResult {
   try {
     const stdout = execSync(command, execOptions).toString().trim();
     return { ok: true, stdout };
   } catch (err) {
-    const stderr =
-      err && typeof err === "object" && "stderr" in err ? String(err.stderr ?? "") : "";
+    const stderr = err && typeof err === "object" && "stderr" in err ? streamText(err.stderr) : "";
     const { rateLimited, retryAfter } = detectRateLimit(stderr);
     return { ok: false, stderr, rateLimited, retryAfter };
   }

--- a/plugins/gitlab/scripts/merge.test.ts
+++ b/plugins/gitlab/scripts/merge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { MergeActions, MergeRequestDetail } from "./merge";
-import { arm, merge, mergeArgs, status } from "./merge";
+import { arm, errorText, merge, mergeArgs, status } from "./merge";
 
 function shellError(streams: { stdout?: string; stderr?: string }): Error {
   return Object.assign(new Error("glab exited non-zero"), {
@@ -38,6 +38,34 @@ function createActions(overrides: Partial<MergeActions> = {}): MergeActions {
     ...overrides,
   };
 }
+
+describe("errorText", () => {
+  const encode = (text: string) => new TextEncoder().encode(text);
+
+  test.each<[string, unknown, string]>([
+    [
+      "decodes Buffer streams",
+      { stdout: encode('{"message":"denied"}'), stderr: encode("") },
+      '{"message":"denied"}',
+    ],
+    [
+      "joins both streams",
+      { stdout: encode("body"), stderr: encode("glab: boom (HTTP 500)") },
+      "body\nglab: boom (HTTP 500)",
+    ],
+    ["accepts string streams", { stdout: "body", stderr: "" }, "body"],
+    ["trims surrounding whitespace", { stdout: encode("  body\n"), stderr: "" }, "body"],
+    [
+      "skips streams that are not text",
+      { stdout: { code: 1 }, stderr: encode("glab: boom") },
+      "glab: boom",
+    ],
+    ["falls back to the Error message", new Error("network down"), "network down"],
+    ["falls back to the raw value", "plain failure", "plain failure"],
+  ])("%s", (_name, err, expected) => {
+    expect(errorText(err)).toBe(expected);
+  });
+});
 
 describe("merge", () => {
   test("uses merge train API when merge trains enabled and auto-merge requested", async () => {

--- a/plugins/gitlab/scripts/merge.test.ts
+++ b/plugins/gitlab/scripts/merge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { MergeActions, MergeRequestDetail } from "./merge";
-import { arm, errorText, merge, mergeArgs, status } from "./merge";
+import { arm, errorText, merge, mergeArgs, status, streamText } from "./merge";
 
 function shellError(streams: { stdout?: string; stderr?: string }): Error {
   return Object.assign(new Error("glab exited non-zero"), {
@@ -38,6 +38,16 @@ function createActions(overrides: Partial<MergeActions> = {}): MergeActions {
     ...overrides,
   };
 }
+
+describe("streamText", () => {
+  test.each<[string, unknown, string]>([
+    ["passes a string through untrimmed", "  body\n", "  body\n"],
+    ["decodes a Uint8Array", new TextEncoder().encode("body"), "body"],
+    ["drops a value that is not text", { code: 1 }, ""],
+  ])("%s", (_name, stream, expected) => {
+    expect(streamText(stream)).toBe(expected);
+  });
+});
 
 describe("errorText", () => {
   const encode = (text: string) => new TextEncoder().encode(text);

--- a/plugins/gitlab/scripts/merge.ts
+++ b/plugins/gitlab/scripts/merge.ts
@@ -16,13 +16,19 @@ const TRANSIENT = ["approvals_syncing"];
 const MAX_ATTEMPTS = 5;
 const RETRY_DELAY_MS = 2000;
 
+function streamText(stream: unknown): string {
+  if (typeof stream === "string") return stream.trim();
+  if (stream instanceof Uint8Array) return new TextDecoder().decode(stream).trim();
+  return "";
+}
+
 export function errorText(err: unknown): string {
   // glab spreads a failure across both streams: `glab api` prints the HTTP error body
   // (the JSON message) to stdout and a `glab: <message> (HTTP <code>)` line to stderr.
   // Read both so the already-armed guard matches and callers see the full error text.
   const record = err as Record<string, unknown>;
   const streams = [record?.stdout, record?.stderr]
-    .map((stream) => (stream == null ? "" : String(stream).trim()))
+    .map(streamText)
     .filter((text) => text.length > 0);
   if (streams.length > 0) {
     return streams.join("\n");
@@ -72,11 +78,12 @@ export async function getMrIid(branch: string): Promise<number> {
   const mrs: MergeRequest[] =
     await $`glab api projects/:id/merge_requests -X GET --field source_branch=${branch} --field state=opened`.json();
 
-  if (mrs.length === 0) {
+  const [mr] = mrs;
+  if (!mr) {
     throw new Error(`No open MR found for branch: ${branch}`);
   }
 
-  return mrs[0]!.iid;
+  return mr.iid;
 }
 
 export interface MergeRequestDetail {

--- a/plugins/gitlab/scripts/merge.ts
+++ b/plugins/gitlab/scripts/merge.ts
@@ -16,9 +16,9 @@ const TRANSIENT = ["approvals_syncing"];
 const MAX_ATTEMPTS = 5;
 const RETRY_DELAY_MS = 2000;
 
-function streamText(stream: unknown): string {
-  if (typeof stream === "string") return stream.trim();
-  if (stream instanceof Uint8Array) return new TextDecoder().decode(stream).trim();
+export function streamText(stream: unknown): string {
+  if (typeof stream === "string") return stream;
+  if (stream instanceof Uint8Array) return new TextDecoder().decode(stream);
   return "";
 }
 
@@ -28,7 +28,7 @@ export function errorText(err: unknown): string {
   // Read both so the already-armed guard matches and callers see the full error text.
   const record = err as Record<string, unknown>;
   const streams = [record?.stdout, record?.stderr]
-    .map(streamText)
+    .map((stream) => streamText(stream).trim())
     .filter((text) => text.length > 0);
   if (streams.length > 0) {
     return streams.join("\n");

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { type ExecSyncOptions, execSync } from "node:child_process";
+import { streamText } from "../../../scripts/merge";
 import { cli } from "cleye";
 import UrlPattern from "url-pattern";
 
@@ -378,12 +379,6 @@ export type ExecResult =
   | { ok: false; stderr: string; rateLimited: boolean; retryAfter: string };
 
 export type ExecFn = (command: string) => ExecResult;
-
-function streamText(stream: unknown): string {
-  if (typeof stream === "string") return stream;
-  if (stream instanceof Uint8Array) return new TextDecoder().decode(stream);
-  return "";
-}
 
 function exec(command: string): ExecResult {
   try {

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
@@ -379,13 +379,18 @@ export type ExecResult =
 
 export type ExecFn = (command: string) => ExecResult;
 
+function streamText(stream: unknown): string {
+  if (typeof stream === "string") return stream;
+  if (stream instanceof Uint8Array) return new TextDecoder().decode(stream);
+  return "";
+}
+
 function exec(command: string): ExecResult {
   try {
     const stdout = execSync(command, execOptions).toString().trim();
     return { ok: true, stdout };
   } catch (err) {
-    const stderr =
-      err && typeof err === "object" && "stderr" in err ? String(err.stderr ?? "") : "";
+    const stderr = err && typeof err === "object" && "stderr" in err ? streamText(err.stderr) : "";
     // glab does not surface structured rate-limit metadata. Rather than
     // regexing human text we rely on the api-error counter instead.
     return { ok: false, stderr, rateLimited: false, retryAfter: "" };

--- a/plugins/meme/skills/image/scripts/render.ts
+++ b/plugins/meme/skills/image/scripts/render.ts
@@ -312,7 +312,7 @@ if (import.meta.main) {
     }
     console.log(result.outPath);
   } catch (error) {
-    console.error(`error: ${error instanceof Error ? error.message : error}`);
+    console.error(`error: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
   }
 }

--- a/plugins/things/scripts/format-output.ts
+++ b/plugins/things/scripts/format-output.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { cli } from "cleye";
-import { formatDate, selectColumns, table } from "./format";
+import { formatDate, selectColumns, stringify, table } from "./format";
 
 const argv = cli({
   name: "format-output",
@@ -41,18 +41,18 @@ if (argv.flags.countPrefix) {
   console.log(`${count} ${argv.flags.countPrefix}\n`);
 }
 
-if (items.length === 0) {
+const [first] = items;
+if (!first) {
   process.exit(0);
 }
 
-const first = items[0];
-const keys = Object.keys(first as Record<string, unknown>);
+const keys = Object.keys(first);
 let headers = keys.map(camelToTitle);
 let rows = items.map((item) =>
   keys.map((k) => {
     const v = item[k];
     if (v == null) return "";
-    const s = String(v);
+    const s = stringify(v);
     if (isIsoDate(s)) return formatDate(s);
     return s;
   }),

--- a/plugins/things/scripts/format-output.ts
+++ b/plugins/things/scripts/format-output.ts
@@ -41,9 +41,14 @@ if (argv.flags.countPrefix) {
   console.log(`${count} ${argv.flags.countPrefix}\n`);
 }
 
+if (items.length === 0) {
+  process.exit(0);
+}
+
 const [first] = items;
 if (!first) {
-  process.exit(0);
+  console.error("format-output: first item is not an object");
+  process.exit(1);
 }
 
 const keys = Object.keys(first);

--- a/plugins/things/scripts/format.test.ts
+++ b/plugins/things/scripts/format.test.ts
@@ -7,7 +7,8 @@ describe("stringify", () => {
     [3, "3"],
     [true, "true"],
     [{ name: "Inbox" }, '{"name":"Inbox"}'],
-    [["a", "b"], '["a","b"]'],
+    [["a", "b"], "a, b"],
+    [[], ""],
   ])("%o -> %s", (value, expected) => {
     expect(stringify(value)).toBe(expected);
   });

--- a/plugins/things/scripts/format.test.ts
+++ b/plugins/things/scripts/format.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, mock, test } from "bun:test";
-import { selectColumns } from "./format";
+import { selectColumns, stringify } from "./format";
+
+describe("stringify", () => {
+  test.each<[unknown, string]>([
+    ["Ship it", "Ship it"],
+    [3, "3"],
+    [true, "true"],
+    [{ name: "Inbox" }, '{"name":"Inbox"}'],
+    [["a", "b"], '["a","b"]'],
+  ])("%o -> %s", (value, expected) => {
+    expect(stringify(value)).toBe(expected);
+  });
+});
 
 describe("selectColumns", () => {
   const headers = ["Name", "Status", "Due Date", "Project"];
@@ -7,6 +19,11 @@ describe("selectColumns", () => {
     ["Task 1", "open", "2025-01-01", "Project A"],
     ["Task 2", "completed", "2025-02-01", "Project B"],
   ];
+
+  test("fills a cell a short row does not reach", () => {
+    const [, r] = selectColumns(headers, [["Task 1", "open"]], ["name", "project"]);
+    expect(r).toEqual([["Task 1", ""]]);
+  });
 
   test.each<[string, string[] | undefined, string[], string[][] | undefined]>([
     ["returns input unchanged when columns is undefined", undefined, headers, rows],

--- a/plugins/things/scripts/format.ts
+++ b/plugins/things/scripts/format.ts
@@ -5,6 +5,11 @@ export function formatDate(value: string | null): string {
   return value.slice(0, 10);
 }
 
+export function stringify(value: unknown): string {
+  if (typeof value === "object" && value !== null) return JSON.stringify(value);
+  return String(value);
+}
+
 const normalize = (s: string) => s.toLowerCase().replace(/\s+/g, "-");
 
 export function selectColumns(
@@ -14,17 +19,20 @@ export function selectColumns(
 ): [string[], string[][]] {
   if (!columns || columns.length === 0) return [headers, rows];
 
-  const headerMap = new Map(headers.map((h, i) => [normalize(h), i]));
+  const headerMap = new Map(headers.map((header, index) => [normalize(header), { header, index }]));
 
-  const indices: number[] = [];
+  const selected: { header: string; index: number }[] = [];
   for (const col of columns) {
-    const idx = headerMap.get(normalize(col));
-    if (idx === undefined) {
+    const match = headerMap.get(normalize(col));
+    if (match === undefined) {
       console.error(`Unknown column: ${col}. Available: ${headers.join(", ")}`);
       process.exit(1);
     }
-    indices.push(idx);
+    selected.push(match);
   }
 
-  return [indices.map((i) => headers[i]!), rows.map((row) => indices.map((i) => row[i]!))];
+  return [
+    selected.map((c) => c.header),
+    rows.map((row) => selected.map((c) => row[c.index] ?? "")),
+  ];
 }

--- a/plugins/things/scripts/format.ts
+++ b/plugins/things/scripts/format.ts
@@ -6,6 +6,7 @@ export function formatDate(value: string | null): string {
 }
 
 export function stringify(value: unknown): string {
+  if (Array.isArray(value)) return value.map(stringify).join(", ");
   if (typeof value === "object" && value !== null) return JSON.stringify(value);
   return String(value);
 }

--- a/plugins/things/src/array.ts
+++ b/plugins/things/src/array.ts
@@ -22,7 +22,7 @@ export interface JXAArray<T> {
 export function toArray<T>(jxaArr: JXAArray<T>): T[] {
   const arr: T[] = [];
   for (let i = 0; i < jxaArr.length; i++) {
-    arr.push(jxaArr[i]);
+    arr.push(jxaArr[i] as T);
   }
   return arr;
 }

--- a/plugins/things/src/array.ts
+++ b/plugins/things/src/array.ts
@@ -22,7 +22,7 @@ export interface JXAArray<T> {
 export function toArray<T>(jxaArr: JXAArray<T>): T[] {
   const arr: T[] = [];
   for (let i = 0; i < jxaArr.length; i++) {
-    arr.push(jxaArr[i] as T);
+    arr.push(jxaArr[i]);
   }
   return arr;
 }

--- a/plugins/tmux/hooks/notification.ts
+++ b/plugins/tmux/hooks/notification.ts
@@ -49,20 +49,19 @@ function updateSummary(): void {
 
   const entries: NotificationEntry[] = [];
   for (const line of output.split("\n")) {
-    const match = line.match(/^@claude_notification_\d+ "?(.+?)"?$/);
-    if (match) {
-      const entry = parseEntry(match[1]!);
-      if (entry) entries.push(entry);
-    }
+    const payload = line.match(/^@claude_notification_\d+ "?(.+?)"?$/)?.[1];
+    if (payload === undefined) continue;
+    const entry = parseEntry(payload);
+    if (entry) entries.push(entry);
   }
 
-  if (entries.length === 0) {
+  const [first] = entries;
+  if (!first) {
     tmux("set-option", "-gu", "@claude_notification");
     return;
   }
 
   const toolMax = maxToolLength();
-  const first = entries[0]!;
   let text = `${first.window}:${truncate(first.tool, toolMax)}`;
   if (entries.length > 1) {
     text += ` (+${entries.length - 1})`;

--- a/plugins/ui-design/skills/wireframe/scripts/render-html.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/render-html.ts
@@ -94,7 +94,7 @@ if (import.meta.main) {
       const result = await renderFile(file, outputPath, { scale });
       console.log(`Rendered ${result.input} to ${result.output}`);
     } catch (error) {
-      console.error(`Failed ${file}: ${error instanceof Error ? error.message : error}`);
+      console.error(`Failed ${file}: ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);
     }
   }

--- a/scripts/inventory/report.ts
+++ b/scripts/inventory/report.ts
@@ -156,7 +156,7 @@ function columns(inventory: Inventory, kind: Kind, width: number): Columns {
         rows: inventory.mcpServers.map((m) => [m.name, m.plugin, m.path]),
       };
     default:
-      throw new Error(`Unknown inventory kind: ${kind}`);
+      throw new Error(`Unknown inventory kind: ${String(kind)}`);
   }
 }
 

--- a/user/hooks/permission-denied/index.ts
+++ b/user/hooks/permission-denied/index.ts
@@ -70,6 +70,8 @@ if (import.meta.main) {
     // The exit code is ignored on this event, so a logging failure cannot break
     // the session. It still has to be visible: an empty log is the signal that
     // retires this hook, and a silent failure forges that signal.
-    console.error(`[permission-denied] Failed to log denial: ${error}`);
+    console.error(
+      `[permission-denied] Failed to log denial: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 }

--- a/user/scripts/subagent-statusline.test.ts
+++ b/user/scripts/subagent-statusline.test.ts
@@ -80,6 +80,11 @@ describe("humanizeTool", () => {
     ["TodoWrite", {}, "Updating todos"],
     ["Skill", { skill: "writing:writing" }, "Running /writing:writing"],
     ["MysteryTool", {}, "MysteryTool"],
+    ["Read", { file_path: { path: "/a/b.ts" } }, "Reading "],
+    ["Grep", { pattern: {} }, "Searching"],
+    ["Grep", { query: "needle" }, "Searching needle"],
+    ["SendMessage", { summary: { text: "hi" } }, "→ message"],
+    ["Task", { description: [] }, "Spawning agent"],
   ];
 
   test.each(cases)("%s %o -> %s", (name, input, expected) => {

--- a/user/scripts/subagent-statusline.ts
+++ b/user/scripts/subagent-statusline.ts
@@ -171,14 +171,9 @@ interface TranscriptEntry {
   message?: { role?: string; content?: ContentBlock[]; model?: string };
 }
 
-const basename = (p: unknown): string =>
-  String(p ?? "")
-    .split("/")
-    .pop() ?? "";
-const firstWord = (cmd: unknown): string =>
-  String(cmd ?? "")
-    .trim()
-    .split(/\s+/)[0] ?? "";
+const text = (value: unknown): string => (typeof value === "string" ? value : "");
+const basename = (p: unknown): string => text(p).split("/").pop() ?? "";
+const firstWord = (cmd: unknown): string => text(cmd).trim().split(/\s+/)[0] ?? "";
 const oneLine = (s: string): string => s.replace(/\s+/g, " ").trim();
 
 // A tool call renders as a verb plus its most telling argument: the file for
@@ -199,22 +194,22 @@ export function humanizeTool(name: string, input: Record<string, unknown> = {}):
       return `Running ${firstWord(input.command)}`;
     case "Grep":
     case "WebSearch":
-      return oneLine(`Searching ${String(input.pattern ?? input.query ?? "")}`);
+      return oneLine(`Searching ${text(input.pattern) || text(input.query)}`);
     case "Glob":
-      return oneLine(`Globbing ${String(input.pattern ?? "")}`);
+      return oneLine(`Globbing ${text(input.pattern)}`);
     case "ToolSearch":
       return "Searching tools";
     case "WebFetch":
       return `Fetching ${basename(input.url)}`;
     case "SendMessage":
-      return `→ ${String(input.summary ?? "message")}`;
+      return `→ ${text(input.summary) || "message"}`;
     case "Task":
     case "Agent":
-      return `Spawning ${String(input.description ?? "agent")}`;
+      return `Spawning ${text(input.description) || "agent"}`;
     case "TodoWrite":
       return "Updating todos";
     case "Skill":
-      return oneLine(`Running /${String(input.skill ?? input.command ?? "")}`);
+      return oneLine(`Running /${text(input.skill) || text(input.command)}`);
     default:
       return name || "working";
   }


### PR DESCRIPTION
Turns on the four type-assertion rules the config had suppressed or demoted, fixing every site rather than suppressing it. The `no-unsafe-*` family stays off. It belongs to the decode-boundary work in #1271.

| Rule | Before | After | Hits | Disposition |
|---|---|---|---|---|
| `typescript/no-unnecessary-type-assertion` | absent | `error` | 26 | 23 autofixed, 3 by hand. |
| `typescript/no-base-to-string` | `off` | inherits `correctness` | 13 | Fixed by typing or formatting the value. |
| `typescript/restrict-template-expressions` | `off` | inherits `correctness` | 6 | Five `unknown` catch bindings, one `never`. Defaults kept. |
| `typescript/no-non-null-assertion` | `warn` | `error` | 43 | 38 in tests, exempted by override. 5 narrowed. |

Deleting an `off` entry lands the rule on `categories.correctness`, which this config sets to `error`. `bunx oxlint --print-config` reports `deny` for all four.

## Template Expression Options

`allowNumber: false` costs 503 hits. This repo interpolates counts, indices, and IDs into strings constantly, and `${String(n)}` at every one of those sites is worse than what it replaces. `allowRegExp: false` costs nothing today, but a zero-hit option is config the reader has to account for with no behavior behind it.

## Non-Null Assertions in Tests

38 of 43 hits are in `*.test.ts` (20 in `db.test.ts`, 15 in `pr-comments.test.ts`), reaching into a fixture the test just built. The override matches the one #1268 added for `local/no-chained-type-assertions`: same glob, same reasoning. That leaves `*.integration.ts` outside the exemption, where none of the six files trip the rule today, and both overrides move together when one has to.

The 5 non-test fixes narrow rather than swap in an `as`. `merge.ts` read `mrs[0]!.iid` and now destructures, throwing the "no open MR" error the assertion had been skipping past.

## Config Divergence

The autofixer deleted two assertions in `plugins/things` that `bun run check` needs, because that plugin's `tsconfig.json` omitted `noUncheckedIndexedAccess` while the root set it, and oxlint's type-aware pass resolves the nearest tsconfig. #1273 has since aligned the two configs, so the divergence itself is fixed on main.

Rebasing onto that fix re-broke `toArray` in `plugins/things/src/array.ts`, where the removed `as T` became necessary again. That assertion is restored.

`selectColumns` keeps the rewrite instead. It resolves each requested column to a `{ header, index }` record up front and reads through those records, which type-checks under either config. `stringify` moved into `format.ts` for a test seam, and the ragged-row path the deleted assertion covered has a test.
