### PR TITLE
evals: decode external data at the JSON seams

### DIFF
--- a/evals/issue-refine/label/server.ts
+++ b/evals/issue-refine/label/server.ts
@@ -2,6 +2,9 @@
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { cli } from "cleye";
+import { z } from "zod";
+
+const Feedback = z.looseObject({ id: z.string().regex(/^[\w-]+$/), feedback: z.unknown() });
 
 // Local labeling server. Serves the review UI, hands the browser the curated
 // samples, and persists reviewer feedback to feedback/<id>.json so a later
@@ -65,10 +68,10 @@ const server = Bun.serve({
     }
 
     if (url.pathname === "/api/feedback" && req.method === "POST") {
-      const body = (await req.json()) as { id?: string; feedback?: unknown };
-      if (!body.id || !/^[\w-]+$/.test(body.id)) return new Response("bad id", { status: 400 });
-      const path = join(argv.flags.feedback, `${body.id}.json`);
-      await Bun.write(path, JSON.stringify(body.feedback, null, 2));
+      const body = Feedback.safeParse(await req.json());
+      if (!body.success) return new Response(z.prettifyError(body.error), { status: 400 });
+      const path = join(argv.flags.feedback, `${body.data.id}.json`);
+      await Bun.write(path, JSON.stringify(body.data.feedback, null, 2));
       return Response.json({ ok: true });
     }
 

--- a/evals/issue-refine/scripts/ab-prompt.ts
+++ b/evals/issue-refine/scripts/ab-prompt.ts
@@ -2,6 +2,18 @@
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { cli } from "cleye";
+import { z } from "zod";
+import { decodeFile } from "../../../packages/decode/index";
+
+const Brief = z.looseObject({
+  brief: z.string(),
+  context: z
+    .looseObject({
+      files: z.array(z.string()).default([]),
+      related_issues: z.array(z.string()).default([]),
+    })
+    .default({ files: [], related_issues: [] }),
+});
 
 // Assembles the agent prompt for one A/B cell: a skill version (a directory of
 // SKILL.md + guide files) run against one synthetic brief. The agent identifies
@@ -21,7 +33,7 @@ if (!argv.flags.version || !argv.flags.brief) {
   process.exit(1);
 }
 
-const brief = await Bun.file(argv.flags.brief).json();
+const brief = await decodeFile(Brief, argv.flags.brief);
 const files = (await readdir(argv.flags.version)).filter((f) => f.endsWith(".md")).toSorted();
 
 const skillBlocks: string[] = [];
@@ -30,9 +42,8 @@ for (const f of files) {
   skillBlocks.push(`================ ${f} ================\n${body.trim()}`);
 }
 
-const ctx = brief.context ?? {};
-const files_ctx = (ctx.files ?? []).map((x: string) => `- ${x}`).join("\n");
-const issues_ctx = (ctx.related_issues ?? []).map((x: string) => `- ${x}`).join("\n");
+const files_ctx = brief.context.files.map((x) => `- ${x}`).join("\n");
+const issues_ctx = brief.context.related_issues.map((x) => `- ${x}`).join("\n");
 
 const prompt = `You are the issue:refine skill. Refine the brief below into a structured issue by following the skill instructions verbatim.
 

--- a/evals/issue-refine/scripts/ab-report.ts
+++ b/evals/issue-refine/scripts/ab-report.ts
@@ -2,6 +2,13 @@
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { cli } from "cleye";
+import { z } from "zod";
+import { decodeJson } from "../../../packages/decode/index";
+
+const Score = z.looseObject({
+  score: z.number(),
+  byFinding: z.record(z.string(), z.number()),
+});
 
 // Scores the before/after refined issues produced by an A/B run and prints the
 // per-brief delta. Expects ab/out/<brief>.<before|after>.md to exist. The
@@ -24,11 +31,11 @@ const argv = cli({
   },
 });
 
-async function score(file: string): Promise<{ score: number; byFinding: Record<number, number> }> {
+async function score(file: string) {
   const proc = Bun.spawn(["bun", argv.flags.score, "--input", file, "--json"], { stdout: "pipe" });
   const out = await new Response(proc.stdout).text();
   await proc.exited;
-  return JSON.parse(out);
+  return decodeJson(Score, out, `score.ts --input ${file}`);
 }
 
 const files = await readdir(argv.flags.out);

--- a/evals/issue-refine/scripts/build-dataset.ts
+++ b/evals/issue-refine/scripts/build-dataset.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
 import { cli } from "cleye";
+import { z } from "zod";
+import { decodeFile } from "../../../packages/decode/index";
 
 // Builds a curated, type-balanced sample of real issue:refine runs from
 // session history. Inputs are the three JSON exports in raw/ (see README).
@@ -23,19 +25,21 @@ const argv = cli({
   },
 });
 
-type SaveIssue = {
-  session_id: string;
-  project_path: string;
-  title: string | null;
-  issue_id: string | null;
-  description: string;
-};
-type Brief = { session_id: string; project_path: string; brief: string };
-type TypeRow = { session_id: string; type: string };
+const SaveIssue = z.looseObject({
+  session_id: z.string(),
+  project_path: z.string(),
+  title: z.string().nullish(),
+  description: z.string(),
+});
+const Brief = z.looseObject({ session_id: z.string(), brief: z.string() });
+const TypeRow = z.looseObject({ session_id: z.string(), type: z.string() });
 
-const saves: SaveIssue[] = await Bun.file(`${argv.flags.rawDir}/save_issues.json`).json();
-const briefs: Brief[] = await Bun.file(`${argv.flags.rawDir}/briefs.json`).json();
-const types: TypeRow[] = await Bun.file(`${argv.flags.rawDir}/types.json`).json();
+type SaveIssue = z.infer<typeof SaveIssue>;
+type Brief = z.infer<typeof Brief>;
+
+const saves = await decodeFile(z.array(SaveIssue), `${argv.flags.rawDir}/save_issues.json`);
+const briefs = await decodeFile(z.array(Brief), `${argv.flags.rawDir}/briefs.json`);
+const types = await decodeFile(z.array(TypeRow), `${argv.flags.rawDir}/types.json`);
 
 const typeBySession = new Map(types.map((t) => [t.session_id, t.type]));
 
@@ -43,8 +47,7 @@ const typeBySession = new Map(types.map((t) => [t.session_id, t.type]));
 const briefBySession = new Map<string, Brief>();
 for (const b of briefs) {
   const cur = briefBySession.get(b.session_id);
-  if (!cur || (b.brief?.length ?? 0) > (cur.brief?.length ?? 0))
-    briefBySession.set(b.session_id, b);
+  if (!cur || b.brief.length > cur.brief.length) briefBySession.set(b.session_id, b);
 }
 
 // Richest refined body per session (longest description is the fullest draft).

--- a/evals/issue-refine/scripts/build-labelset.ts
+++ b/evals/issue-refine/scripts/build-labelset.ts
@@ -2,7 +2,17 @@
 import { readdir } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { cli } from "cleye";
+import { z } from "zod";
+import { decodeFile } from "../../../packages/decode/index";
 import { parseIssue } from "./frontmatter";
+
+const Brief = z.looseObject({
+  id: z.string().optional(),
+  type: z.string().optional(),
+  size: z.string().optional(),
+  project: z.string().optional(),
+  brief: z.string(),
+});
 
 // Assembles a labeling dataset from generated issues. Pairs each brief in
 // briefs/label/ with the refined artifact an agent wrote to data/label-out/<id>.md,
@@ -36,7 +46,7 @@ const samples: unknown[] = [];
 const missing: string[] = [];
 
 for (const f of files) {
-  const brief = await Bun.file(join(argv.flags.briefs, f)).json();
+  const brief = await decodeFile(Brief, join(argv.flags.briefs, f));
   const id = brief.id ?? basename(f, ".json");
   const outPath = join(argv.flags.out, `${id}.md`);
   const file = Bun.file(outPath);

--- a/evals/issue-refine/scripts/judge.ts
+++ b/evals/issue-refine/scripts/judge.ts
@@ -2,6 +2,20 @@
 import { mkdir, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { cli } from "cleye";
+import { z } from "zod";
+import { decodeFile } from "../../../packages/decode/index";
+
+const Slots = z.object({ "1": z.string(), "2": z.string() });
+const Mapping = z.record(z.string(), Slots);
+
+const Verdict = z.object({
+  brief: z.string(),
+  scores: z.record(z.string(), z.union([z.number(), z.string()])).optional(),
+  better: z.union([z.literal("1"), z.literal("2"), z.literal(1), z.literal(2)]),
+  reason: z.string().optional(),
+});
+
+const Verdicts = z.union([z.object({ verdicts: z.array(Verdict) }), z.array(Verdict)]);
 
 // Prepares a blinded LLM-judge run over an A/B output set. For each brief it
 // assigns before/after to slots "1" and "2" in random order, copies the outputs
@@ -37,13 +51,14 @@ const argv = cli({
 const mappingPath = join(argv.flags.judgeDir, "mapping.json");
 
 if (argv.flags.unblind) {
-  const mapping = await Bun.file(mappingPath).json();
-  const verdict = await Bun.file(argv.flags.unblind).json();
-  for (const v of verdict.verdicts ?? verdict) {
+  const mapping = await decodeFile(Mapping, mappingPath);
+  const decoded = await decodeFile(Verdicts, argv.flags.unblind);
+  for (const v of Array.isArray(decoded) ? decoded : decoded.verdicts) {
     const map = mapping[v.brief];
-    const better = v.better === "1" || v.better === 1 ? map["1"] : map["2"];
-    const s1 = `${map["1"]}=${v.scores?.["1"] ?? v.scores?.[1] ?? "?"}`;
-    const s2 = `${map["2"]}=${v.scores?.["2"] ?? v.scores?.[2] ?? "?"}`;
+    if (!map) throw new Error(`${mappingPath} has no entry for brief ${v.brief}`);
+    const better = String(v.better) === "1" ? map["1"] : map["2"];
+    const s1 = `${map["1"]}=${v.scores?.["1"] ?? "?"}`;
+    const s2 = `${map["2"]}=${v.scores?.["2"] ?? "?"}`;
     console.log(`\n${v.brief}: judge prefers ${better.toUpperCase()}  (${s1}, ${s2})`);
     if (v.reason) console.log(`  ${v.reason}`);
   }

--- a/evals/pr-body/calibrate.ts
+++ b/evals/pr-body/calibrate.ts
@@ -1,17 +1,14 @@
 import { join } from "node:path";
+import { z } from "zod";
+import { decodeFile } from "../../packages/decode/index";
 import { classifyPrHeading } from "./classifier";
 
-interface Label {
-  text: string;
-  words: number;
-  kind: string;
-  url: string;
-  verdict: "good" | "bad" | "skip" | null;
-  notes: string;
-  rewrite: string;
-}
+const Label = z.looseObject({
+  text: z.string(),
+  verdict: z.enum(["good", "bad", "skip"]).nullable(),
+});
 
-const labels: Label[] = await Bun.file(join(import.meta.dirname, "labels.json")).json();
+const labels = await decodeFile(z.array(Label), join(import.meta.dirname, "labels.json"));
 
 const labeled = labels.filter((l) => l.verdict === "good" || l.verdict === "bad");
 

--- a/evals/pr-body/label/server.ts
+++ b/evals/pr-body/label/server.ts
@@ -2,6 +2,9 @@
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { cli } from "cleye";
+import { z } from "zod";
+
+const Feedback = z.looseObject({ id: z.string().regex(/^[\w-]+$/), feedback: z.unknown() });
 
 // Local labeling server. Serves the review UI, hands the browser the mined samples, and persists
 // reviewer feedback to feedback/<id>.json so a later analysis pass can read it back off disk.
@@ -64,10 +67,10 @@ const server = Bun.serve({
     }
 
     if (url.pathname === "/api/feedback" && req.method === "POST") {
-      const body = (await req.json()) as { id?: string; feedback?: unknown };
-      if (!body.id || !/^[\w-]+$/.test(body.id)) return new Response("bad id", { status: 400 });
-      const path = join(argv.flags.feedback, `${body.id}.json`);
-      await Bun.write(path, JSON.stringify(body.feedback, null, 2));
+      const body = Feedback.safeParse(await req.json());
+      if (!body.success) return new Response(z.prettifyError(body.error), { status: 400 });
+      const path = join(argv.flags.feedback, `${body.data.id}.json`);
+      await Bun.write(path, JSON.stringify(body.data.feedback, null, 2));
       return Response.json({ ok: true });
     }
 

--- a/evals/pr-body/scripts/judge.ts
+++ b/evals/pr-body/scripts/judge.ts
@@ -2,8 +2,11 @@
 import { join } from "node:path";
 import Anthropic from "@anthropic-ai/sdk";
 import { cli } from "cleye";
+import { z } from "zod";
+import { decodeJson, decodeJsonLines } from "../../../packages/decode/index";
 import {
-  type Arm,
+  Arm,
+  ARMS,
   addUsage,
   costUsd,
   emptyUsage,
@@ -16,7 +19,7 @@ import {
   type Scenario,
   type TokenRates,
   toUsage,
-  type Usage,
+  Usage,
 } from "./run-eval";
 
 // Blinded pairwise judge over a run written by run-eval.ts. Each pair is one
@@ -39,30 +42,37 @@ export type Axis = (typeof AXES)[number];
 export const SLOTS = ["1", "2"] as const;
 export type Slot = (typeof SLOTS)[number];
 
-export interface AxisVerdict {
-  score: number;
-  justification: string;
-}
+const AxisVerdict = z.looseObject({ score: z.number(), justification: z.string().catch("") });
+export type AxisVerdict = z.infer<typeof AxisVerdict>;
 
-export type CandidateVerdict = Record<Axis, AxisVerdict>;
+// Listed per axis so adding an axis is a type error here.
+const CandidateVerdict = z.looseObject({
+  narrationLeak: AxisVerdict,
+  verbosity: AxisVerdict,
+  selfContained: AxisVerdict,
+  substanceRetention: AxisVerdict,
+});
+export type CandidateVerdict = z.infer<typeof CandidateVerdict>;
 
-export interface Verdict {
-  candidates: Record<Slot, CandidateVerdict>;
-  preference: Slot | "tie";
-  preferenceReason: string;
-}
+const Verdict = z.looseObject({
+  candidates: z.looseObject({ "1": CandidateVerdict, "2": CandidateVerdict }),
+  preference: z.enum([...SLOTS, "tie"]),
+  preferenceReason: z.string().catch(""),
+});
+export type Verdict = z.infer<typeof Verdict>;
 
-export interface JudgmentRow {
-  scenarioId: string;
-  seed: number;
-  model: string;
+const JudgmentRow = z.looseObject({
+  scenarioId: z.string(),
+  seed: z.number(),
+  model: z.string(),
   /** Which arm sat in each blinded slot. */
-  mapping: Record<Slot, Arm>;
-  arms: Record<Arm, CandidateVerdict>;
-  preference: Arm | "tie";
-  preferenceReason: string;
-  usage: Usage;
-}
+  mapping: z.looseObject({ "1": Arm, "2": Arm }),
+  arms: z.looseObject({ a: CandidateVerdict, b: CandidateVerdict }),
+  preference: z.enum([...ARMS, "tie"]),
+  preferenceReason: z.string(),
+  usage: Usage,
+});
+export type JudgmentRow = z.infer<typeof JudgmentRow>;
 
 export interface Pair {
   scenario: Scenario;
@@ -175,56 +185,7 @@ export function verdictSchema(): Record<string, unknown> {
 }
 
 export function parseVerdict(jsonText: string): Verdict {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(jsonText);
-  } catch (error) {
-    throw new Error(`Judge returned invalid JSON: ${(error as Error).message}`, { cause: error });
-  }
-  if (typeof parsed !== "object" || parsed === null) {
-    throw new Error("Judge verdict must be a JSON object");
-  }
-  const record = parsed as Record<string, unknown>;
-  const preference = record.preference;
-  if (preference !== "1" && preference !== "2" && preference !== "tie") {
-    throw new Error(`Judge verdict has an unusable preference: ${String(preference)}`);
-  }
-  const rawCandidates = record.candidates;
-  if (typeof rawCandidates !== "object" || rawCandidates === null) {
-    throw new Error('Judge verdict is missing "candidates"');
-  }
-  const candidates = {} as Record<Slot, CandidateVerdict>;
-  for (const slot of SLOTS) {
-    candidates[slot] = asCandidate((rawCandidates as Record<string, unknown>)[slot], slot);
-  }
-  return {
-    candidates,
-    preference,
-    preferenceReason: typeof record.preferenceReason === "string" ? record.preferenceReason : "",
-  };
-}
-
-function asCandidate(value: unknown, slot: Slot): CandidateVerdict {
-  if (typeof value !== "object" || value === null) {
-    throw new Error(`Judge verdict is missing candidate ${slot}`);
-  }
-  const record = value as Record<string, unknown>;
-  const candidate = {} as CandidateVerdict;
-  for (const axis of AXES) {
-    const raw = record[axis];
-    if (typeof raw !== "object" || raw === null) {
-      throw new Error(`Candidate ${slot} is missing axis ${axis}`);
-    }
-    const entry = raw as Record<string, unknown>;
-    if (typeof entry.score !== "number") {
-      throw new Error(`Candidate ${slot} axis ${axis} has a non-numeric score`);
-    }
-    candidate[axis] = {
-      score: entry.score,
-      justification: typeof entry.justification === "string" ? entry.justification : "",
-    };
-  }
-  return candidate;
+  return decodeJson(Verdict, jsonText, "judge verdict");
 }
 
 export function deblind(
@@ -234,11 +195,9 @@ export function deblind(
   arms: Record<Arm, CandidateVerdict>;
   preference: Arm | "tie";
 } {
+  const [first, second] = [verdict.candidates["1"], verdict.candidates["2"]];
   return {
-    arms: {
-      [mapping["1"]]: verdict.candidates["1"],
-      [mapping["2"]]: verdict.candidates["2"],
-    } as Record<Arm, CandidateVerdict>,
+    arms: mapping["1"] === "a" ? { a: first, b: second } : { a: second, b: first },
     preference: verdict.preference === "tie" ? "tie" : mapping[verdict.preference],
   };
 }
@@ -281,20 +240,20 @@ async function judgePair(
 async function readJudgments(runDir: string): Promise<JudgmentRow[]> {
   const file = Bun.file(judgmentsPath(runDir));
   if (!(await file.exists())) return [];
-  const text = await file.text();
-  return text
-    .split("\n")
-    .filter((line) => line.trim().length > 0)
-    .map((line) => JSON.parse(line) as JudgmentRow);
+  return decodeJsonLines(JudgmentRow, await file.text(), judgmentsPath(runDir));
 }
 
 export function meanScores(rows: JudgmentRow[], arm: Arm): Record<Axis, number> {
-  const means = {} as Record<Axis, number>;
-  for (const axis of AXES) {
+  const mean = (axis: Axis): number => {
     const scores = rows.map((row) => row.arms[arm][axis].score);
-    means[axis] = scores.length === 0 ? 0 : scores.reduce((a, b) => a + b, 0) / scores.length;
-  }
-  return means;
+    return scores.length === 0 ? 0 : scores.reduce((a, b) => a + b, 0) / scores.length;
+  };
+  return {
+    narrationLeak: mean("narrationLeak"),
+    verbosity: mean("verbosity"),
+    selfContained: mean("selfContained"),
+    substanceRetention: mean("substanceRetention"),
+  };
 }
 
 export function formatSummary(rows: JudgmentRow[]): string {

--- a/evals/pr-body/scripts/mine.ts
+++ b/evals/pr-body/scripts/mine.ts
@@ -2,6 +2,8 @@
 import { mkdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { cli } from "cleye";
+import { z } from "zod";
+import { decodeJson } from "../../../packages/decode/index";
 
 // Mine PR bodies authored via Claude Code sessions. The session index's
 // pr_links table maps sessions to the PRs they opened; the bodies themselves
@@ -11,23 +13,23 @@ import { cli } from "cleye";
 // and work PR bodies live on private hosts anyway. The SQL below is hardcoded
 // to host = 'local' and public bendrucker/* repos; keep it that way.
 
-export interface MinedPr {
-  repository: string;
-  pr_number: number;
-  url: string;
-  opened_at: string;
-  session_id: string;
-}
+export const MinedPr = z.looseObject({
+  repository: z.string(),
+  pr_number: z.number(),
+  url: z.string(),
+  session_id: z.string(),
+});
+export type MinedPr = z.infer<typeof MinedPr>;
 
-export interface FetchedPr {
-  number: number;
-  title: string;
-  body: string;
-  url: string;
-  state: string;
-  createdAt: string;
-  author: { login: string };
-}
+export const FetchedPr = z.looseObject({
+  number: z.number(),
+  title: z.string(),
+  body: z.string(),
+  url: z.string(),
+  state: z.string(),
+  createdAt: z.string(),
+});
+export type FetchedPr = z.infer<typeof FetchedPr>;
 
 export interface Item {
   id: string;
@@ -147,7 +149,7 @@ async function queryMined(dbPath: string): Promise<MinedPr[]> {
   if (code !== 0) throw new Error(`duckdb failed (${code}): ${err.trim()}`);
   const trimmed = out.trim();
   if (!trimmed) return [];
-  return JSON.parse(trimmed) as MinedPr[];
+  return decodeJson(z.array(MinedPr), trimmed, `duckdb ${dbPath}`);
 }
 
 async function fetchRepoPrs(repo: string): Promise<Map<number, FetchedPr>> {
@@ -175,7 +177,7 @@ async function fetchRepoPrs(repo: string): Promise<Map<number, FetchedPr>> {
     proc.exited,
   ]);
   if (code !== 0) throw new Error(`gh pr list --repo ${repo} failed (${code}): ${err.trim()}`);
-  const prs = JSON.parse(out) as FetchedPr[];
+  const prs = decodeJson(z.array(FetchedPr), out, `gh pr list --repo ${repo}`);
   return new Map(prs.map((pr) => [pr.number, pr]));
 }
 

--- a/evals/pr-body/scripts/run-eval.ts
+++ b/evals/pr-body/scripts/run-eval.ts
@@ -3,6 +3,8 @@ import { mkdir, readdir } from "node:fs/promises";
 import { basename, join } from "node:path";
 import Anthropic from "@anthropic-ai/sdk";
 import { cli } from "cleye";
+import { z } from "zod";
+import { decodeFile, decodeJson, decodeJsonLines } from "../../../packages/decode/index";
 import { scoreBody } from "./score";
 
 // A/B runner for `pull-request:create` guidance. Each arm is a markdown file
@@ -21,39 +23,43 @@ const GEN_RATES: TokenRates = { input: 5 / 1_000_000, output: 25 / 1_000_000 };
 const MAX_RETRIES = 3;
 
 export const ARMS = ["a", "b"] as const;
-export type Arm = (typeof ARMS)[number];
+export const Arm = z.enum(ARMS);
+export type Arm = z.infer<typeof Arm>;
 
-export interface Scenario {
-  id: string;
-  url: string;
-  title: string;
-  repo: string;
-  tier: "personal";
-  diffSummary: string;
-  substance: string[];
-  originalBody: string;
-}
+export const Scenario = z.looseObject({
+  id: z.string(),
+  url: z.string(),
+  title: z.string(),
+  repo: z.string(),
+  tier: z.literal("personal"),
+  diffSummary: z.string(),
+  substance: z.array(z.string()),
+  originalBody: z.string(),
+});
+export type Scenario = z.infer<typeof Scenario>;
 
 export type ScoreRow = ReturnType<typeof scoreBody>;
 
-export interface GenerationRow {
-  scenarioId: string;
-  /** "original" rows carry the shipped body as a baseline; no model produced them. */
-  arm: Arm | "original";
-  seed: number;
-  model: string | null;
-  title: string;
-  body: string;
-  score: ScoreRow;
-  usage: Usage;
-}
+export const Usage = z.object({
+  input: z.number(),
+  cacheWrite: z.number(),
+  cacheRead: z.number(),
+  output: z.number(),
+});
+export type Usage = z.infer<typeof Usage>;
 
-export interface Usage {
-  input: number;
-  cacheWrite: number;
-  cacheRead: number;
-  output: number;
-}
+/** `score` is written but never read back, so it rides along unmodeled. */
+export const GenerationRow = z.looseObject({
+  scenarioId: z.string(),
+  /** "original" rows carry the shipped body as a baseline; no model produced them. */
+  arm: z.enum([...ARMS, "original"]),
+  seed: z.number(),
+  model: z.string().nullable(),
+  title: z.string(),
+  body: z.string(),
+  usage: Usage,
+});
+export type GenerationRow = z.infer<typeof GenerationRow>;
 
 /** USD per token. Cache writes and reads bill as multiples of the input rate. */
 export interface TokenRates {
@@ -125,36 +131,18 @@ export async function loadScenarios(dir: string): Promise<Scenario[]> {
   const names = (await readdir(dir)).filter((n) => n.endsWith(".json")).toSorted();
   const scenarios: Scenario[] = [];
   for (const name of names) {
-    const parsed: unknown = await Bun.file(join(dir, name)).json();
-    scenarios.push(asScenario(parsed, join(dir, name)));
+    scenarios.push(await decodeFile(Scenario, join(dir, name)));
   }
   if (scenarios.length === 0) throw new Error(`No scenario JSON files in ${dir}`);
   return scenarios;
 }
 
-function asScenario(value: unknown, path: string): Scenario {
-  if (typeof value !== "object" || value === null) {
-    throw new Error(`${path}: scenario must be a JSON object`);
-  }
-  const record = value as Record<string, unknown>;
-  for (const key of ["id", "url", "title", "repo", "tier", "diffSummary", "originalBody"]) {
-    if (typeof record[key] !== "string") {
-      throw new Error(`${path}: missing string field "${key}"`);
-    }
-  }
-  if (!Array.isArray(record.substance) || record.substance.some((s) => typeof s !== "string")) {
-    throw new Error(`${path}: "substance" must be an array of strings`);
-  }
-  return value as Scenario;
+export async function readGenerations(runDir: string): Promise<GenerationRow[]> {
+  const path = generationsPath(runDir);
+  return decodeJsonLines(GenerationRow, await Bun.file(path).text(), path);
 }
 
-export async function readGenerations(runDir: string): Promise<GenerationRow[]> {
-  const text = await Bun.file(generationsPath(runDir)).text();
-  return text
-    .split("\n")
-    .filter((line) => line.trim().length > 0)
-    .map((line) => JSON.parse(line) as GenerationRow);
-}
+const Draft = z.looseObject({ title: z.string(), body: z.string() });
 
 /** JSON schema the generation call is constrained to. */
 export function draftSchema(): Record<string, unknown> {
@@ -229,14 +217,7 @@ async function generate(
   if (block?.type !== "text") {
     throw new Error(`${scenario.id} seed ${seed}: no text block (stop: ${response.stop_reason})`);
   }
-  const parsed: unknown = JSON.parse(block.text);
-  if (typeof parsed !== "object" || parsed === null) {
-    throw new Error(`${scenario.id} seed ${seed}: draft was not a JSON object`);
-  }
-  const draft = parsed as Record<string, unknown>;
-  if (typeof draft.title !== "string" || typeof draft.body !== "string") {
-    throw new Error(`${scenario.id} seed ${seed}: draft is missing title or body`);
-  }
+  const draft = decodeJson(Draft, block.text, `${scenario.id} seed ${seed} draft`);
   return {
     title: draft.title,
     body: draft.body,

--- a/evals/review-voice/label/server.ts
+++ b/evals/review-voice/label/server.ts
@@ -2,6 +2,13 @@
 import { mkdir, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { cli } from "cleye";
+import { z } from "zod";
+
+const Label = z.object({
+  id: z.string().regex(/^[\w-]+$/),
+  label: z.enum(["good", "bad", "skip"]),
+  note: z.string().default(""),
+});
 
 // Local labeling server for review-voice candidates. Serves the UI, hands the
 // browser the mined candidates, and persists each verdict to labels/<id>.json so
@@ -66,14 +73,14 @@ const server = Bun.serve({
     }
 
     if (url.pathname === "/api/label" && req.method === "POST") {
-      const body = (await req.json()) as { id?: string; label?: string; note?: string };
-      if (!body.id || !/^[\w-]+$/.test(body.id)) return new Response("bad id", { status: 400 });
-      if (!body.label || !["good", "bad", "skip"].includes(body.label)) {
-        return new Response("bad label", { status: 400 });
-      }
+      const body = Label.safeParse(await req.json());
+      if (!body.success) return new Response(z.prettifyError(body.error), { status: 400 });
       await mkdir(argv.flags.labels, { recursive: true });
-      const record = { id: body.id, label: body.label, note: body.note ?? "" };
-      await Bun.write(join(argv.flags.labels, `${body.id}.json`), JSON.stringify(record, null, 2));
+      const record = body.data;
+      await Bun.write(
+        join(argv.flags.labels, `${record.id}.json`),
+        JSON.stringify(record, null, 2),
+      );
       return Response.json({ ok: true });
     }
 

--- a/evals/review-voice/scripts/mine.ts
+++ b/evals/review-voice/scripts/mine.ts
@@ -3,6 +3,8 @@ import { createHash } from "node:crypto";
 import { mkdir } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { cli } from "cleye";
+import { z } from "zod";
+import { decodeJson } from "../../../packages/decode/index";
 
 // Mine review-comment bodies out of the Claude Code session index. The bodies
 // posted on GitLab MRs never land inline in the `glab`/`draft-note` commands
@@ -33,13 +35,29 @@ function resolveDbPath(): string {
   return join(dataDir, "session.duckdb");
 }
 
-interface WriteRow {
-  host: string;
-  session_id: string;
-  timestamp: string;
-  file_path: string;
-  content: string;
-}
+const WriteRow = z.looseObject({
+  host: z.string(),
+  session_id: z.string(),
+  timestamp: z.string(),
+  file_path: z.string(),
+  content: z.string(),
+});
+type WriteRow = z.infer<typeof WriteRow>;
+
+const ReviewPayload = z.union([
+  z.array(z.unknown()),
+  z.looseObject({ comments: z.array(z.unknown()) }).transform((value) => value.comments),
+  z.looseObject({ notes: z.array(z.unknown()) }).transform((value) => value.notes),
+]);
+
+const Comment = z.looseObject({
+  body: z.string().optional().catch(undefined),
+  comment: z.string().optional().catch(undefined),
+  text: z.string().optional().catch(undefined),
+  file: z.string().optional().catch(undefined),
+  path: z.string().optional().catch(undefined),
+  line: z.number().optional().catch(undefined),
+});
 
 interface Candidate {
   id: string;
@@ -86,7 +104,7 @@ async function queryRows(dbPath: string): Promise<WriteRow[]> {
   if (code !== 0) throw new Error(`duckdb failed (${code}): ${err.trim()}`);
   const trimmed = out.trim();
   if (!trimmed) return [];
-  return JSON.parse(trimmed) as WriteRow[];
+  return decodeJson(z.array(WriteRow), trimmed, `duckdb ${dbPath}`);
 }
 
 function isText(fp: string): "json" | "md" | null {
@@ -102,9 +120,6 @@ function workdirOf(fp: string): string {
   return basename(dir) || dir;
 }
 
-// A review payload is either a bare array of comment objects or a wrapper with a
-// `comments`/`notes` array. Each element carries the comment body plus its diff
-// anchor. Anything else is treated as a single free-text body (a summary or reply).
 function bodiesFromJson(
   content: string,
 ): Array<{ body: string; file: string | null; line: number | null }> {
@@ -114,29 +129,24 @@ function bodiesFromJson(
   } catch {
     return [];
   }
-  const items = Array.isArray(parsed)
-    ? parsed
-    : Array.isArray((parsed as Record<string, unknown>)?.comments)
-      ? ((parsed as Record<string, unknown>).comments as unknown[])
-      : Array.isArray((parsed as Record<string, unknown>)?.notes)
-        ? ((parsed as Record<string, unknown>).notes as unknown[])
-        : null;
-  if (!items) return [];
+  const items = ReviewPayload.safeParse(parsed);
+  if (!items.success) return [];
+
   const out: Array<{ body: string; file: string | null; line: number | null }> = [];
-  for (const item of items) {
+  for (const item of items.data) {
     if (typeof item === "string") {
       out.push({ body: item, file: null, line: null });
       continue;
     }
-    if (item && typeof item === "object") {
-      const rec = item as Record<string, unknown>;
-      const body = rec.body ?? rec.comment ?? rec.text;
-      if (typeof body !== "string") continue;
-      const file =
-        typeof rec.file === "string" ? rec.file : typeof rec.path === "string" ? rec.path : null;
-      const line = typeof rec.line === "number" ? rec.line : null;
-      out.push({ body, file, line });
-    }
+    const comment = Comment.safeParse(item);
+    if (!comment.success) continue;
+    const body = comment.data.body ?? comment.data.comment ?? comment.data.text;
+    if (body === undefined) continue;
+    out.push({
+      body,
+      file: comment.data.file ?? comment.data.path ?? null,
+      line: comment.data.line ?? null,
+    });
   }
   return out;
 }

--- a/evals/review-voice/scripts/report.ts
+++ b/evals/review-voice/scripts/report.ts
@@ -3,6 +3,8 @@ import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { cli } from "cleye";
 import { table } from "table";
+import { z } from "zod";
+import { decodeFile } from "../../../packages/decode/index";
 
 // Summarize labeled review-voice candidates: verdict counts and the full text of
 // every "bad" case with its note, so the failing phrasings can be lifted into
@@ -33,20 +35,20 @@ const dim = (s: string) => `\x1b[90m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 
-interface Candidate {
-  id: string;
-  host: string;
-  workdir: string;
-  source: string;
-  file: string | null;
-  line: number | null;
-  body: string;
-}
-interface Label {
-  id: string;
-  label: "good" | "bad" | "skip";
-  note: string;
-}
+const Candidate = z.looseObject({
+  id: z.string(),
+  host: z.string(),
+  source: z.string(),
+  line: z.number().nullable(),
+  body: z.string(),
+});
+
+const Label = z.looseObject({
+  id: z.string(),
+  label: z.enum(["good", "bad", "skip"]),
+  note: z.string(),
+});
+type Label = z.infer<typeof Label>;
 
 async function readLabels(dir: string): Promise<Map<string, Label>> {
   const map = new Map<string, Label>();
@@ -58,14 +60,14 @@ async function readLabels(dir: string): Promise<Map<string, Label>> {
   }
   for (const name of names) {
     if (!name.endsWith(".json")) continue;
-    const rec = (await Bun.file(join(dir, name)).json()) as Label;
+    const rec = await decodeFile(Label, join(dir, name));
     map.set(rec.id, rec);
   }
   return map;
 }
 
 async function main() {
-  const candidates = (await Bun.file(argv.flags.data).json()) as Candidate[];
+  const candidates = await decodeFile(z.array(Candidate), argv.flags.data);
   const labels = await readLabels(argv.flags.labels);
   const byId = new Map(candidates.map((c) => [c.id, c]));
 

--- a/evals/writing/label/server.ts
+++ b/evals/writing/label/server.ts
@@ -2,6 +2,9 @@
 import { mkdir, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { cli } from "cleye";
+import { z } from "zod";
+
+const Feedback = z.looseObject({ id: z.string().regex(/^[\w-]+$/), feedback: z.unknown() });
 
 // Local labeling server. Serves the review UI, hands the browser the assembled
 // (input, output) pairs, and persists reviewer feedback to feedback/<id>.json so
@@ -67,10 +70,10 @@ const server = Bun.serve({
     }
 
     if (url.pathname === "/api/feedback" && req.method === "POST") {
-      const body = (await req.json()) as { id?: string; feedback?: unknown };
-      if (!body.id || !/^[\w-]+$/.test(body.id)) return new Response("bad id", { status: 400 });
-      const path = join(argv.flags.feedback, `${body.id}.json`);
-      await Bun.write(path, JSON.stringify(body.feedback, null, 2));
+      const body = Feedback.safeParse(await req.json());
+      if (!body.success) return new Response(z.prettifyError(body.error), { status: 400 });
+      const path = join(argv.flags.feedback, `${body.data.id}.json`);
+      await Bun.write(path, JSON.stringify(body.data.feedback, null, 2));
       return Response.json({ ok: true });
     }
 

--- a/evals/writing/scripts/mine.ts
+++ b/evals/writing/scripts/mine.ts
@@ -2,6 +2,8 @@
 import { mkdir, readdir } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { cli } from "cleye";
+import { z } from "zod";
+import { decodeFile, decodeJson } from "../../../packages/decode/index";
 
 // Assemble a labelable set of writing:rewrite (input, output) pairs.
 //
@@ -20,11 +22,19 @@ import { cli } from "cleye";
 // The probe SQL is hardcoded to host = 'local'; keep it that way. The synthetic
 // drafts are the only content that ships.
 
+const Draft = z.looseObject({
+  category: z.string().optional(),
+  input: z.string(),
+  output: z.string(),
+});
+
 export interface RewriteDraft {
   category: string;
   input: string;
   output: string;
 }
+
+const Probe = z.array(z.looseObject({ invocations: z.number() }));
 
 export interface Item {
   id: string;
@@ -129,7 +139,7 @@ async function probeInvocations(dbPath: string): Promise<number | null> {
     proc.exited,
   ]);
   if (code !== 0) throw new Error(`duckdb failed (${code}): ${err.trim()}`);
-  const rows = JSON.parse(out.trim() || "[]") as Array<{ invocations: number }>;
+  const rows = decodeJson(Probe, out.trim() || "[]", `duckdb ${dbPath}`);
   return rows[0]?.invocations ?? 0;
 }
 
@@ -137,10 +147,7 @@ async function loadDrafts(dir: string): Promise<RewriteDraft[]> {
   const names = (await readdir(dir)).filter((n) => n.endsWith(".json")).toSorted();
   const drafts: RewriteDraft[] = [];
   for (const name of names) {
-    const draft = (await Bun.file(join(dir, name)).json()) as Partial<RewriteDraft>;
-    if (typeof draft.input !== "string" || typeof draft.output !== "string") {
-      throw new Error(`${name}: missing input/output string`);
-    }
+    const draft = await decodeFile(Draft, join(dir, name));
     drafts.push({
       category: draft.category ?? basename(name, ".json"),
       input: draft.input,


### PR DESCRIPTION
Migrates every JSON seam in the four eval harnesses onto `packages/decode`. Second layer of the stack; the boundary and the rule reversal are in #1271.

`evals/*` drops from 60 hits across the five `no-unsafe-*` rules to 3, and from 34 `no-unsafe-type-assertion` hits to 2.

| Seam | Was | Now |
|---|---|---|
| `duckdb -json` stdout (3 miners) | `JSON.parse(out) as Row[]` | `decodeJson(z.array(Row), out, "duckdb <path>")` |
| `gh pr list --json` | `JSON.parse(out) as FetchedPr[]` | `decodeJson(z.array(FetchedPr), out, "gh pr list --repo <r>")` |
| Scenario, brief, draft, label files | `Bun.file().json()` under a return annotation | `decodeFile(Schema, path)` |
| `generations.jsonl`, `judgments.jsonl` | `JSON.parse(line) as Row` per line | `decodeJsonLines(Row, text, path)` |
| Model output (draft, verdict) | hand-walked `Record<string, unknown>` | `decodeJson(Draft \| Verdict, block.text, source)` |
| `POST /api/feedback`, `/api/label` | `(await req.json()) as { id?: string }` | `Schema.safeParse` into a 400 |

## Hand-Rolled Probes

`asScenario`, `parseVerdict`, and `asCandidate` walked a cast `Record<string, unknown>` field by field, and threw on the first miss. Decode reports every issue at once, each with its path. For a judge verdict arriving 40 pairs into a paid run, that is one fix instead of forty.

`bodiesFromJson` in `review-voice/scripts/mine.ts` nested four `as Record<string, unknown>` in a ternary chain to find whichever of `comments` or `notes` a review payload used. It is a union with two transforms.

## Outbound Schemas

`draftSchema()` and `verdictSchema()` stay hand-written. `z.toJSONSchema` could generate them, but their shape reaches the model, and changing it invalidates comparison against runs already on disk. Drift is already ruled out: both sides build their keys from `AXES` and `SLOTS`.

## Schema Scope

`GenerationRow.score` is written by `scoreBody` and read by nothing, so the read schema omits it and `z.looseObject` passes it through. Modeling it means mirroring eleven `ScoreRow` fields to validate a value no consumer touches.

`justification` and `preferenceReason` take `.catch("")`, keeping the tolerance the probes had for a judge that returns a number where prose belongs.

## Label Servers

The `id` regex that kept a POST from writing outside the feedback directory moved into the schema. A rejected body now names the field that failed instead of answering "bad id".

## Verification

The miners ran against the real session index: 516 review-voice candidates through the union and comment schema, and the `pr-body` miner through `gh pr list` across nine repositories. `calibrate.ts` reproduced its confusion matrix over 102 labels, and both server shapes took a valid POST and rejected a traversal id.

Five `evals/` sites are left. None is a boundary. They belong with the rule layers, where the test-file override gets decided.
