### PR TITLE
lint: enforce async correctness rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -24,9 +24,6 @@
     "no-underscore-dangle": ["error", { "allow": ["__typename", "__dirname"] }],
     "no-unsafe-optional-chaining": "off",
     "typescript/no-unsafe-type-assertion": "off",
-    "typescript/await-thenable": "off",
-    "typescript/no-floating-promises": "off",
-    "typescript/unbound-method": "off",
     "typescript/ban-ts-comment": "error",
     "typescript/explicit-module-boundary-types": "error",
     "typescript/no-deprecated": "error",
@@ -35,6 +32,7 @@
     "typescript/no-misused-spread": "error",
     "typescript/only-throw-error": "error",
     "typescript/prefer-promise-reject-errors": "error",
+    "typescript/require-await": "error",
     "no-restricted-imports": [
       "error",
       {

--- a/evals/pr-body/scripts/mine.ts
+++ b/evals/pr-body/scripts/mine.ts
@@ -249,4 +249,4 @@ async function main() {
   for (const [repo, n] of Object.entries(byRepo)) console.log(`  ${repo}: ${n}`);
 }
 
-if (import.meta.main) main();
+if (import.meta.main) await main();

--- a/evals/review-voice/scripts/mine.ts
+++ b/evals/review-voice/scripts/mine.ts
@@ -225,4 +225,4 @@ async function main() {
   for (const [host, n] of Object.entries(byHost)) console.log(`  ${host}: ${n}`);
 }
 
-main();
+await main();

--- a/evals/review-voice/scripts/report.ts
+++ b/evals/review-voice/scripts/report.ts
@@ -100,4 +100,4 @@ async function main() {
   }
 }
 
-main();
+await main();

--- a/evals/writing/scripts/mine.ts
+++ b/evals/writing/scripts/mine.ts
@@ -208,4 +208,4 @@ async function main() {
   for (const [category, n] of Object.entries(byCategory)) console.log(`  ${category}: ${n}`);
 }
 
-if (import.meta.main) main();
+if (import.meta.main) await main();

--- a/packages/decode/decode.test.ts
+++ b/packages/decode/decode.test.ts
@@ -177,7 +177,7 @@ describe("sources", () => {
     await Bun.write(bad, '{"name":1}');
 
     expect(await decodeFile(Tag, good)).toEqual({ name: "a" });
-    await expect(decodeFile(Tag, bad)).rejects.toThrow(`${bad} did not match its schema`);
+    expect(decodeFile(Tag, bad)).rejects.toThrow(`${bad} did not match its schema`);
   });
 
   test("decodeFileLines reads a JSONL file", async () => {
@@ -186,11 +186,11 @@ describe("sources", () => {
     expect(await decodeFileLines(Tag, path)).toEqual([{ name: "a" }, { name: "b" }]);
   });
 
-  test("decodeStdin defaults its source label and accepts an override", async () => {
+  test("decodeStdin defaults its source label and accepts an override", () => {
     const stdin = spyOn(Bun.stdin, "text").mockResolvedValue('{"name":1}');
     try {
-      await expect(decodeStdin(Tag)).rejects.toThrow("stdin did not match its schema");
-      await expect(decodeStdin(Tag, "newline/check hook input")).rejects.toThrow(
+      expect(decodeStdin(Tag)).rejects.toThrow("stdin did not match its schema");
+      expect(decodeStdin(Tag, "newline/check hook input")).rejects.toThrow(
         "newline/check hook input did not match its schema",
       );
     } finally {

--- a/packages/validate/run.test.ts
+++ b/packages/validate/run.test.ts
@@ -91,7 +91,7 @@ describe("runValidation", () => {
     });
 
     try {
-      await expect(runValidation({ files: [file], schema: schemaPath })).rejects.toThrow("exit");
+      expect(runValidation({ files: [file], schema: schemaPath })).rejects.toThrow("exit");
       expect(exitSpy).toHaveBeenCalledWith(1);
     } finally {
       exitSpy.mockRestore();

--- a/plugins/claude-code/skills/session/scripts/db.test.ts
+++ b/plugins/claude-code/skills/session/scripts/db.test.ts
@@ -1535,7 +1535,7 @@ describe("change catalog", () => {
       const subdir = path.join(importsDir, "guarded", "projects", "-Users-test-project");
       await $`chmod 000 ${subdir}`.quiet();
       try {
-        await expect(reindex()).rejects.toThrow();
+        expect(reindex()).rejects.toThrow();
       } finally {
         await $`chmod 755 ${subdir}`.quiet();
       }
@@ -1566,7 +1566,7 @@ describe("view versioning", () => {
     await db.run("DROP VIEW tool_calls");
     await reindex();
 
-    await expect(db.query("SELECT * FROM tool_calls LIMIT 1", z.unknown())).rejects.toThrow();
+    expect(db.query("SELECT * FROM tool_calls LIMIT 1", z.unknown())).rejects.toThrow();
   });
 });
 

--- a/plugins/comments/apply/branch.test.ts
+++ b/plugins/comments/apply/branch.test.ts
@@ -70,7 +70,7 @@ describe("applyToBranch", () => {
     const edits = new Map([["note.ts", "// keep\nconst x = 1;\n"]]);
     await applyToBranch(edits, { branch: "audit" });
 
-    await expect(applyToBranch(edits, { branch: "audit" })).rejects.toThrow(/audit/);
+    expect(applyToBranch(edits, { branch: "audit" })).rejects.toThrow(/audit/);
 
     const status = (await $`git status --porcelain`.quiet()).text().trim();
     expect(status).toBe("");

--- a/plugins/comments/evals/oracle.test.ts
+++ b/plugins/comments/evals/oracle.test.ts
@@ -116,9 +116,9 @@ describe("judgeComments", () => {
     const inputs = Array.from({ length: total }, (_, i) => input({ text: `// comment ${i}` }));
     const callSizes: number[] = [];
     let cursor = 0;
-    const fake: CommentJudge = async (batch) => {
+    const fake: CommentJudge = (batch) => {
       callSizes.push(batch.length);
-      return batch.map(() => verdict({ rationale: `r${cursor++}` }));
+      return Promise.resolve(batch.map(() => verdict({ rationale: `r${cursor++}` })));
     };
 
     const result = await judgeComments(fake, inputs);
@@ -132,9 +132,9 @@ describe("judgeComments", () => {
 
   test("returns an empty array for no inputs without calling the judge", async () => {
     let called = false;
-    const fake: CommentJudge = async () => {
+    const fake: CommentJudge = () => {
       called = true;
-      return [];
+      return Promise.resolve([]);
     };
     expect(await judgeComments(fake, [])).toEqual([]);
     expect(called).toBe(false);

--- a/plugins/comments/skills/audit/scripts/audit.ts
+++ b/plugins/comments/skills/audit/scripts/audit.ts
@@ -353,7 +353,7 @@ const applyCmd = command(
   },
 );
 
-cli(
+await cli(
   {
     name: "audit",
     commands: [preflightCmd, applyCmd],

--- a/plugins/git/scripts/https-fallback.test.ts
+++ b/plugins/git/scripts/https-fallback.test.ts
@@ -188,8 +188,9 @@ describe("formatContext", () => {
   });
 });
 
-const noRemotes = async () => "";
-const githubSshRemote = async () => "remote.origin.url git@github.com:bendrucker/claude.git\n";
+const noRemotes = () => Promise.resolve("");
+const githubSshRemote = () =>
+  Promise.resolve("remote.origin.url git@github.com:bendrucker/claude.git\n");
 
 describe("processInput", () => {
   test("suggests the HTTPS retry for a Secretive refusal on a GitHub SSH clone", async () => {
@@ -231,7 +232,8 @@ describe("processInput", () => {
   });
 
   test("stays silent when a bare pull fails against an unrecognized remote", async () => {
-    const unknownRemote = async () => "remote.origin.url git@git.example.com:owner/repo.git\n";
+    const unknownRemote = () =>
+      Promise.resolve("remote.origin.url git@git.example.com:owner/repo.git\n");
     expect(await processInput(mockInput("git pull", SECRETIVE_FAILURE), unknownRemote)).toBeNull();
   });
 
@@ -243,7 +245,7 @@ describe("processInput", () => {
     },
     {
       name: "gitlab remote routes through glab",
-      remotes: async () => "remote.origin.url git@gitlab.com:owner/repo.git\n",
+      remotes: () => Promise.resolve("remote.origin.url git@gitlab.com:owner/repo.git\n"),
       expected: "url.https://gitlab.com/.insteadOf=git@gitlab.com:",
     },
   ])(

--- a/plugins/github/scripts/review-threads.ts
+++ b/plugins/github/scripts/review-threads.ts
@@ -162,7 +162,7 @@ const reactCmd = command(
 );
 
 if (import.meta.main) {
-  cli(
+  await cli(
     {
       name: "review-threads",
       commands: [replyCmd, resolveCmd, reactCmd],

--- a/plugins/github/skills/copilot/scripts/review.ts
+++ b/plugins/github/skills/copilot/scripts/review.ts
@@ -848,5 +848,5 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.main) {
-  main();
+  await main();
 }

--- a/plugins/gitlab/hooks/lint.test.ts
+++ b/plugins/gitlab/hooks/lint.test.ts
@@ -20,10 +20,11 @@ function fakeEnv(files: Record<string, string> = {}): LintEnv & { touched: strin
   const touched: string[] = [];
   return {
     touched,
-    fileExists: async (path) => path in files || touched.includes(path),
-    readFile: async (path) => files[path] ?? null,
-    touch: async (path) => {
+    fileExists: (path) => Promise.resolve(path in files || touched.includes(path)),
+    readFile: (path) => Promise.resolve(files[path] ?? null),
+    touch: (path) => {
       touched.push(path);
+      return Promise.resolve();
     },
   };
 }

--- a/plugins/gitlab/scripts/merge.test.ts
+++ b/plugins/gitlab/scripts/merge.test.ts
@@ -114,13 +114,13 @@ describe("merge", () => {
     expect(actions.addToMergeTrain).not.toHaveBeenCalled();
   });
 
-  test("throws when no open MR found for branch", async () => {
+  test("throws when no open MR found for branch", () => {
     const actions = createActions({
       getProjectConfig: mock(() => Promise.resolve({ id: 42, merge_trains_enabled: true })),
       getMrIid: mock(() => Promise.reject(new Error("No open MR found for branch: no-mr"))),
     });
 
-    await expect(merge("no-mr", { autoMerge: true }, actions)).rejects.toThrow(
+    expect(merge("no-mr", { autoMerge: true }, actions)).rejects.toThrow(
       "No open MR found for branch: no-mr",
     );
   });
@@ -179,20 +179,20 @@ describe("arm", () => {
     expect(sleep).toHaveBeenCalledTimes(2);
   });
 
-  test("throws after exhausting retries on a persistent transient", async () => {
+  test("throws after exhausting retries on a persistent transient", () => {
     const run = mock(() => Promise.reject(new Error("approvals_syncing")));
     const sleep = mock(() => Promise.resolve());
 
-    await expect(arm(run, sleep)).rejects.toThrow("approvals_syncing");
+    expect(arm(run, sleep)).rejects.toThrow("approvals_syncing");
     expect(run).toHaveBeenCalledTimes(5);
     expect(sleep).toHaveBeenCalledTimes(4);
   });
 
-  test("rethrows a non-transient error immediately", async () => {
+  test("rethrows a non-transient error immediately", () => {
     const run = mock(() => Promise.reject(new Error("404 Not Found")));
     const sleep = mock(() => Promise.resolve());
 
-    await expect(arm(run, sleep)).rejects.toThrow("404 Not Found");
+    expect(arm(run, sleep)).rejects.toThrow("404 Not Found");
     expect(run).toHaveBeenCalledTimes(1);
     expect(sleep).not.toHaveBeenCalled();
   });
@@ -222,7 +222,7 @@ describe("arm", () => {
     expect(sleep).not.toHaveBeenCalled();
   });
 
-  test("falls back to the Error message when both streams are empty", async () => {
+  test("falls back to the Error message when both streams are empty", () => {
     const run = mock(() =>
       Promise.reject(
         Object.assign(new Error("glab exited with code 1"), { stderr: Buffer.from("") }),
@@ -230,7 +230,7 @@ describe("arm", () => {
     );
     const sleep = mock(() => Promise.resolve());
 
-    await expect(arm(run, sleep)).rejects.toThrow("glab exited with code 1");
+    expect(arm(run, sleep)).rejects.toThrow("glab exited with code 1");
     expect(run).toHaveBeenCalledTimes(1);
   });
 });
@@ -287,11 +287,11 @@ describe("status", () => {
     expect((await status("feature", actions)).rebased_on_target).toBeNull();
   });
 
-  test("throws when no open MR found for branch", async () => {
+  test("throws when no open MR found for branch", () => {
     const actions = createActions({
       getMrIid: mock(() => Promise.reject(new Error("No open MR found for branch: no-mr"))),
     });
 
-    await expect(status("no-mr", actions)).rejects.toThrow("No open MR found for branch: no-mr");
+    expect(status("no-mr", actions)).rejects.toThrow("No open MR found for branch: no-mr");
   });
 });

--- a/plugins/gitlab/scripts/merge.ts
+++ b/plugins/gitlab/scripts/merge.ts
@@ -158,12 +158,12 @@ export async function mergeViaGlab(branch: string, autoMerge: boolean): Promise<
 }
 
 export interface MergeActions {
-  getProjectConfig(): Promise<ProjectConfig>;
-  getMrIid(branch: string): Promise<number>;
-  getMergeRequest(iid: number): Promise<MergeRequestDetail>;
-  isRebasedOnTarget(target: string, source: string): Promise<boolean | null>;
-  addToMergeTrain(opts: MergeTrainOptions): Promise<void>;
-  mergeViaGlab(branch: string, autoMerge: boolean): Promise<void>;
+  getProjectConfig: () => Promise<ProjectConfig>;
+  getMrIid: (branch: string) => Promise<number>;
+  getMergeRequest: (iid: number) => Promise<MergeRequestDetail>;
+  isRebasedOnTarget: (target: string, source: string) => Promise<boolean | null>;
+  addToMergeTrain: (opts: MergeTrainOptions) => Promise<void>;
+  mergeViaGlab: (branch: string, autoMerge: boolean) => Promise<void>;
 }
 
 const defaultActions: MergeActions = {

--- a/plugins/gitlab/skills/merge-request/scripts/discussions.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/discussions.ts
@@ -339,7 +339,7 @@ const summaryCmd = command(
   },
 );
 
-cli(
+await cli(
   {
     name: "discussions",
     commands: [createCmd, listCmd, resolveCmd, summaryCmd],

--- a/plugins/gitlab/skills/merge-request/scripts/draft-note.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/draft-note.ts
@@ -268,7 +268,7 @@ const reviewCmd = command(
   },
 );
 
-cli(
+await cli(
   {
     name: "draft-note",
     commands: [createCmd, publishCmd, submitCmd, listCmd, reviewCmd],

--- a/plugins/gitlab/skills/merge-request/scripts/review-queue.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/review-queue.ts
@@ -75,7 +75,7 @@ export function filterReviewQueue(currentUser: CurrentUser): ReviewQueueEntry[] 
 }
 
 if (import.meta.main) {
-  cli(
+  await cli(
     {
       name: "review-queue",
       flags: {},

--- a/plugins/plan/hooks/gate.test.ts
+++ b/plugins/plan/hooks/gate.test.ts
@@ -448,7 +448,7 @@ describe("fail open", () => {
   it("reports rather than swallows an unusable state root", async () => {
     await Bun.write(join(stateRoot, "blocked"), "");
     const blocked = join(stateRoot, "blocked", "nested");
-    await expect(processInput(mockInput("My plan"), blocked)).rejects.toBeInstanceOf(
+    expect(processInput(mockInput("My plan"), blocked)).rejects.toBeInstanceOf(
       StateUnavailableError,
     );
   });

--- a/plugins/pull-request/scripts/detect-bot.test.ts
+++ b/plugins/pull-request/scripts/detect-bot.test.ts
@@ -7,9 +7,9 @@ import { type Cooldown, detect, parseCooldowns } from "./detect-bot";
 const NOW = new Date("2026-08-02T00:00:00Z");
 const REMOTE = "git@github.com:bendrucker/claude.git";
 
-const none = async () => [];
-const origin = async () => REMOTE;
-const noOrigin = async () => null;
+const none = () => Promise.resolve([]);
+const origin = () => Promise.resolve(REMOTE);
+const noOrigin = () => Promise.resolve(null);
 
 async function repo(files: string[]): Promise<string> {
   const root = mkdtempSync(join(tmpdir(), "detect-bot-"));
@@ -134,7 +134,7 @@ test.each<{ name: string; records: unknown; expected: string }>([
     expected: "greptile: repo config (.greptile/config.json), CLI installed",
   },
 ])("cooldown: $name", async ({ records, expected }) => {
-  const cooldowns = async () => parseCooldowns(JSON.stringify(records));
+  const cooldowns = () => Promise.resolve(parseCooldowns(JSON.stringify(records)));
   const root = await repo([".greptile/config.json"]);
   expect(await detect(root, { which: onlyGreptile, cooldowns, remote: origin, now: NOW })).toBe(
     expected,
@@ -154,7 +154,7 @@ test.each<{ name: string; records: Cooldown[]; expected: string }>([
     expected: "greptile: repo config (.greptile/config.json), CLI installed",
   },
 ])("unresolvable remote: $name", async ({ records, expected }) => {
-  const cooldowns = async () => records;
+  const cooldowns = () => Promise.resolve(records);
   const root = await repo([".greptile/config.json"]);
   expect(await detect(root, { which: onlyGreptile, cooldowns, remote: noOrigin, now: NOW })).toBe(
     expected,
@@ -162,7 +162,7 @@ test.each<{ name: string; records: Cooldown[]; expected: string }>([
 });
 
 test("cooldown: unparseable JSON", async () => {
-  const cooldowns = async () => parseCooldowns("not json");
+  const cooldowns = () => Promise.resolve(parseCooldowns("not json"));
   const root = await repo([".greptile/config.json"]);
   expect(await detect(root, { which: onlyGreptile, cooldowns, remote: origin, now: NOW })).toBe(
     "greptile: repo config (.greptile/config.json), CLI installed",

--- a/plugins/review/skills/inbox/scripts/store.test.ts
+++ b/plugins/review/skills/inbox/scripts/store.test.ts
@@ -85,11 +85,11 @@ describe("store", () => {
 
     test("creates directory if it does not exist", async () => {
       const dir = join(tmpDir, "review-inbox");
-      await expect(readdir(dir)).rejects.toThrow();
+      expect(readdir(dir)).rejects.toThrow();
 
       await writeState({ dispatched: [] }, tmpDir);
 
-      await expect(readdir(dir)).resolves.toBeDefined();
+      expect(readdir(dir)).resolves.toBeDefined();
     });
   });
 

--- a/plugins/review/skills/tuicr/scripts/ledger.ts
+++ b/plugins/review/skills/tuicr/scripts/ledger.ts
@@ -290,7 +290,7 @@ const reconcileCmd = command(
 );
 
 if (import.meta.main) {
-  cli({
+  await cli({
     name: "ledger",
     commands: [resolveCmd, upsertCmd, listCmd, reconcileCmd],
   });

--- a/plugins/review/skills/tuicr/scripts/mapping.ts
+++ b/plugins/review/skills/tuicr/scripts/mapping.ts
@@ -71,7 +71,7 @@ const mapCmd = command(
 );
 
 if (import.meta.main) {
-  cli({
+  await cli({
     name: "mapping",
     commands: [mapCmd],
   });

--- a/plugins/things/scripts/reorder.test.ts
+++ b/plugins/things/scripts/reorder.test.ts
@@ -8,7 +8,7 @@ describe("reorder input guards", () => {
   test.each<[string, string, string[], string]>([
     ["empty ids", "today", [], "No IDs provided"],
     ["unknown list", "logbook", ["abc"], "Invalid list: logbook"],
-  ])("rejects %s by throwing", async (_name, list, ids, message) => {
-    await expect(reorder(list, ids)).rejects.toThrow(message);
+  ])("rejects %s by throwing", (_name, list, ids, message) => {
+    expect(reorder(list, ids)).rejects.toThrow(message);
   });
 });

--- a/plugins/things/scripts/url.test.ts
+++ b/plugins/things/scripts/url.test.ts
@@ -195,13 +195,14 @@ describe("dispatch", () => {
   } {
     const calls = { xcall: [] as string[], open: [] as string[] };
     const actions: DispatchActions = {
-      findXcallRunner: async () => "/runner",
-      xcall: async (_runner, url) => {
+      findXcallRunner: () => Promise.resolve("/runner"),
+      xcall: (_runner, url) => {
         calls.xcall.push(url);
-        return "";
+        return Promise.resolve("");
       },
-      openUrl: async (command) => {
+      openUrl: (command) => {
         calls.open.push(command);
+        return Promise.resolve();
       },
       ...overrides,
     };
@@ -210,9 +211,9 @@ describe("dispatch", () => {
 
   test("runs via xcall and parses the returned id", async () => {
     const { actions, calls } = trackingActions({
-      xcall: async (_runner, url) => {
+      xcall: (_runner, url) => {
         calls.xcall.push(url);
-        return "things:///x-callback-url/add?x-things-id=ABC123&x-source=Things";
+        return Promise.resolve("things:///x-callback-url/add?x-things-id=ABC123&x-source=Things");
       },
     });
 
@@ -230,7 +231,7 @@ describe("dispatch", () => {
   });
 
   test("returns a null id when xcall surfaces no id", async () => {
-    const { actions } = trackingActions({ xcall: async () => "" });
+    const { actions } = trackingActions({ xcall: () => Promise.resolve("") });
 
     const result = await dispatch("add", new Map([["title", "Buy milk"]]), actions);
 
@@ -239,7 +240,7 @@ describe("dispatch", () => {
   });
 
   test("falls back to openUrl when no runner is available", async () => {
-    const { actions, calls } = trackingActions({ findXcallRunner: async () => null });
+    const { actions, calls } = trackingActions({ findXcallRunner: () => Promise.resolve(null) });
 
     const result = await dispatch("add", new Map([["title", "Buy milk"]]), actions);
 
@@ -271,9 +272,7 @@ describe("dispatch", () => {
     ["non-xcall error", new Error("spawn blew up"), "spawn blew up", null],
   ])("falls back to openUrl and reports a %s", async (_name, thrown, reason, detail) => {
     const { actions, calls } = trackingActions({
-      xcall: async () => {
-        throw thrown;
-      },
+      xcall: () => Promise.reject(thrown),
     });
 
     const result = await dispatch("add", new Map([["title", "Buy milk"]]), actions);
@@ -284,15 +283,13 @@ describe("dispatch", () => {
     expect(calls.open).toEqual(["add"]);
   });
 
-  test("propagates openUrl errors", async () => {
+  test("propagates openUrl errors", () => {
     const { actions } = trackingActions({
-      findXcallRunner: async () => null,
-      openUrl: async () => {
-        throw new Error("open blocked");
-      },
+      findXcallRunner: () => Promise.resolve(null),
+      openUrl: () => Promise.reject(new Error("open blocked")),
     });
 
-    await expect(dispatch("add", new Map([["title", "Buy milk"]]), actions)).rejects.toThrow(
+    expect(dispatch("add", new Map([["title", "Buy milk"]]), actions)).rejects.toThrow(
       "open blocked",
     );
   });
@@ -358,11 +355,11 @@ describe("resolveTagParams", () => {
 
   // The silent drop this guards: Things takes an unknown tag, reports success,
   // and writes the todo without it.
-  test("rejects an unknown tag instead of dropping it", async () => {
+  test("rejects an unknown tag instead of dropping it", () => {
     const { requirer } = stubRequirer(["claude"]);
     const params = new Map([["tags", "claude,bug"]]);
 
-    await expect(resolveTagParams(params, false, requirer)).rejects.toThrow("Tag not found: bug");
+    expect(resolveTagParams(params, false, requirer)).rejects.toThrow("Tag not found: bug");
   });
 
   test("passes create_tags through so an unknown tag can be created", async () => {

--- a/plugins/things/scripts/url.ts
+++ b/plugins/things/scripts/url.ts
@@ -413,7 +413,7 @@ if (import.meta.main) {
 
   const callbackActions: DispatchActions = argv.flags.callback
     ? defaultActions
-    : { ...defaultActions, findXcallRunner: async () => null };
+    : { ...defaultActions, findXcallRunner: () => Promise.resolve(null) };
 
   if (useBulkJson) {
     const attributes: Record<string, string> = {};

--- a/plugins/things/src/mcp/tags.test.ts
+++ b/plugins/things/src/mcp/tags.test.ts
@@ -47,11 +47,11 @@ describe("createTagRequirer", () => {
     expect(state.fetches).toBe(2);
   });
 
-  test("names the unknown tags and what Things holds", async () => {
+  test("names the unknown tags and what Things holds", () => {
     const { actions } = stubActions(["claude"]);
     const require = createTagRequirer(actions);
 
-    await expect(require(["bug", "review"], false)).rejects.toThrow(
+    expect(require(["bug", "review"], false)).rejects.toThrow(
       "Tag not found: bug, review. Existing tags: claude. Pass create_tags to create the missing ones.",
     );
   });
@@ -64,10 +64,10 @@ describe("createTagRequirer", () => {
     expect(state.created).toEqual([["bug"]]);
   });
 
-  test("reports a tag Things accepted the create for but does not hold", async () => {
+  test("reports a tag Things accepted the create for but does not hold", () => {
     const { actions } = stubActions([]);
     const require = createTagRequirer({ ...actions, createTags: () => Promise.resolve() });
 
-    await expect(require(["bug"], true)).rejects.toThrow("Things did not create: bug");
+    expect(require(["bug"], true)).rejects.toThrow("Things did not create: bug");
   });
 });

--- a/plugins/ui-design/skills/wireframe/scripts/render-html.integration.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/render-html.integration.ts
@@ -49,20 +49,20 @@ describe("render-html", () => {
     expect(pngBuffer.length).toBeGreaterThan(0);
   });
 
-  it("throws when no root div found", async () => {
+  it("throws when no root div found", () => {
     const inputPath = path.join(fixturesDir, "no-root-div.html");
     const outputPath = path.join(tmpDir, "no-root-div.png");
 
-    await expect(renderFile(inputPath, outputPath, { browser })).rejects.toThrow(
+    expect(renderFile(inputPath, outputPath, { browser })).rejects.toThrow(
       "No root div found in HTML",
     );
   });
 
-  it("throws when bounding box is null", async () => {
+  it("throws when bounding box is null", () => {
     const inputPath = path.join(fixturesDir, "hidden-div.html");
     const outputPath = path.join(tmpDir, "hidden-div.png");
 
-    await expect(renderFile(inputPath, outputPath, { browser })).rejects.toThrow(
+    expect(renderFile(inputPath, outputPath, { browser })).rejects.toThrow(
       "Could not get bounding box",
     );
   });

--- a/plugins/ui-design/skills/wireframe/scripts/render.test.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/render.test.ts
@@ -59,10 +59,10 @@ describe("render", () => {
     expect(pngBuffer.length).toBeGreaterThan(0);
   });
 
-  it("throws on invalid SVG content", async () => {
+  it("throws on invalid SVG content", () => {
     const invalidSvg = Buffer.from("not valid svg content");
     const outputPath = path.join(tmpDir, "invalid.png");
 
-    await expect(render(invalidSvg, outputPath)).rejects.toThrow();
+    expect(render(invalidSvg, outputPath)).rejects.toThrow();
   });
 });

--- a/plugins/ui-design/skills/wireframe/scripts/validate.test.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/validate.test.ts
@@ -84,8 +84,8 @@ describe("validateFiles", () => {
     expect(results[2]?.violations.length).toBeGreaterThan(0);
   });
 
-  it("rejects on file not found", async () => {
-    await expect(validateFile("/nonexistent/file.svg")).rejects.toThrow();
+  it("rejects on file not found", () => {
+    expect(validateFile("/nonexistent/file.svg")).rejects.toThrow();
   });
 });
 

--- a/plugins/writing/hooks/pretooluse.test.ts
+++ b/plugins/writing/hooks/pretooluse.test.ts
@@ -261,7 +261,7 @@ describe("heading checker gate", () => {
     "agrees with headings.check on .%s",
     async (ext) => {
       const toolInput = { file_path: `docs/note.${ext}`, content: HEADING_VIOLATION };
-      const direct = await headingCheck(mockInput("Write", toolInput));
+      const direct = headingCheck(mockInput("Write", toolInput));
       const { log } = await dispatch(mockInput("Write", toolInput));
       expect(log.category ?? null).toBe(direct?.category ?? null);
     },

--- a/plugins/writing/skills/analyze/scripts/judge-run.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge-run.test.ts
@@ -13,15 +13,15 @@ function verdictFor(flags: Partial<Record<CriterionKey, boolean>>): JudgeVerdict
 }
 
 describe("runGate", () => {
-  test("rejects a stale prompt hash before any judging", async () => {
-    const judge = async () => verdictFor({});
-    await expect(runGate(judge, "0".repeat(64))).rejects.toThrow("does not match the pinned");
+  test("rejects a stale prompt hash before any judging", () => {
+    const judge = () => Promise.resolve(verdictFor({}));
+    expect(runGate(judge, "0".repeat(64))).rejects.toThrow("does not match the pinned");
   });
 
   test("passes when the judge matches every committed expectation", async () => {
     // A mock judge that flags exactly the criterion each positive fixture
     // targets and stays clean on negatives, keyed off the fixture text.
-    const judge = async (text: string) => {
+    const judge = (text: string) => {
       const flags: Partial<Record<CriterionKey, boolean>> = {};
       if (text.includes("All 12 tests pass")) flags.information_density = true;
       if (text.includes("Renamed the Config struct")) flags.motivation_presence = true;
@@ -29,7 +29,7 @@ describe("runGate", () => {
       if (text.includes("should hopefully")) flags.hedging_density = true;
       if (text.includes("Excellent question")) flags.sycophancy = true;
       if (text.includes("## Key Benefits")) flags.press_release_structure = true;
-      return verdictFor(flags);
+      return Promise.resolve(verdictFor(flags));
     };
     const results = await runGate(judge, JUDGE_PROMPT_SHA256);
     expect(results.length).toBeGreaterThan(0);
@@ -37,7 +37,7 @@ describe("runGate", () => {
   });
 
   test("reports per-criterion mismatches when the judge drifts", async () => {
-    const judge = async () => verdictFor({ marketing_phrasing: true });
+    const judge = () => Promise.resolve(verdictFor({ marketing_phrasing: true }));
     const results = await runGate(judge, JUDGE_PROMPT_SHA256);
     const negative = results.find((r) => r.id === "negative-mechanism-first");
     expect(negative?.pass).toBe(false);

--- a/plugins/writing/skills/analyze/scripts/judge-run.ts
+++ b/plugins/writing/skills/analyze/scripts/judge-run.ts
@@ -310,7 +310,7 @@ if (import.meta.main) {
     },
   );
 
-  cli(
+  await cli(
     {
       name: "judge-run",
       help: {

--- a/plugins/writing/skills/analyze/scripts/judge.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.test.ts
@@ -195,9 +195,9 @@ describe("aggregateVerdicts", () => {
 describe("judgeDocument", () => {
   test("judges each chunk and aggregates", async () => {
     const seen: string[] = [];
-    const judge = async (chunk: string) => {
+    const judge = (chunk: string) => {
       seen.push(chunk);
-      return verdict({ information_density: seen.length === 2 });
+      return Promise.resolve(verdict({ information_density: seen.length === 2 }));
     };
     const long = `${Array.from({ length: 1400 }, () => "alpha").join(" ")}\n\n${Array.from({ length: 1400 }, () => "beta").join(" ")}`;
     const result = await judgeDocument(judge, long);
@@ -222,9 +222,9 @@ describe("estimateCost", () => {
     const counted: string[] = [];
     const estimate = await estimateCost(["doc one", "doc two"], {
       promptText: "prompt words here",
-      countTokens: async (userContent) => {
+      countTokens: (userContent) => {
         counted.push(userContent);
-        return 1000;
+        return Promise.resolve(1000);
       },
     });
     expect(counted).toEqual(["doc one", "doc two"]);
@@ -239,9 +239,9 @@ describe("estimateCost", () => {
     const batches: string[] = [];
     const estimate = await estimateHeadingCost(headings, {
       promptText: "prompt words here",
-      countTokens: async (userContent) => {
+      countTokens: (userContent) => {
         batches.push(userContent);
-        return 500;
+        return Promise.resolve(500);
       },
     });
     expect(estimate.calls).toBe(3);
@@ -273,7 +273,7 @@ describe("modelPricing", () => {
     const estimate = await estimateCost(["doc"], {
       promptText: "prompt",
       model,
-      countTokens: async () => 1000,
+      countTokens: () => Promise.resolve(1000),
     });
     expect(estimate.usd).toBeCloseTo(usd, 6);
   });
@@ -284,7 +284,7 @@ describe("modelPricing", () => {
       const estimate = await estimateCost(["doc"], {
         promptText: "prompt",
         model: "some-other-vendor-model",
-        countTokens: async () => 1000,
+        countTokens: () => Promise.resolve(1000),
       });
       expect(estimate.usd).toBeCloseTo(0.0025, 6);
       expect(warn).toHaveBeenCalledTimes(1);
@@ -300,7 +300,7 @@ describe("modelPricing", () => {
       await estimateCost(["doc"], {
         promptText: "prompt",
         model: JUDGE_MODEL,
-        countTokens: async () => 1000,
+        countTokens: () => Promise.resolve(1000),
       });
       expect(warn).not.toHaveBeenCalled();
     } finally {
@@ -317,7 +317,7 @@ describe("judgeCorpus", () => {
       verdict(),
     ];
     let i = 0;
-    const judge = async () => verdicts[i++] ?? verdict();
+    const judge = () => Promise.resolve(verdicts[i++] ?? verdict());
     const audit = await judgeCorpus(judge, ["a", "b", "c"], {
       promptSha256: "abc123",
       model: "claude-haiku-4-5",
@@ -352,7 +352,7 @@ describe("judgeCorpus", () => {
   });
 
   test("caps sampled spans", async () => {
-    const judge = async () => verdict({ marketing_phrasing: "seamless" });
+    const judge = () => Promise.resolve(verdict({ marketing_phrasing: "seamless" }));
     const audit = await judgeCorpus(
       judge,
       Array.from({ length: 8 }, () => "doc"),
@@ -393,9 +393,9 @@ describe("parseHeadingVerdicts", () => {
 describe("judgeHeadings", () => {
   test("batches headings per call", async () => {
     const batches: number[] = [];
-    const judge = async (headings: string[]) => {
+    const judge = (headings: string[]) => {
       batches.push(headings.length);
-      return headings.map(() => false);
+      return Promise.resolve(headings.map(() => false));
     };
     const verdicts = await judgeHeadings(
       judge,

--- a/plugins/writing/skills/analyze/scripts/judge.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.ts
@@ -365,8 +365,8 @@ export function anthropicTokenCounter(options: AnthropicJudgeOptions): InputToke
 /** Word-count heuristic for contexts without API credentials (tests, dry runs). */
 function heuristicTokenCounter(promptText: string): InputTokenCounter {
   const promptTokens = Math.ceil(countWords(promptText) * TOKENS_PER_WORD);
-  return async (userContent: string) =>
-    promptTokens + Math.ceil(countWords(userContent) * TOKENS_PER_WORD);
+  return (userContent: string) =>
+    Promise.resolve(promptTokens + Math.ceil(countWords(userContent) * TOKENS_PER_WORD));
 }
 
 async function mapPooled<T, R>(items: T[], fn: (item: T) => Promise<R>): Promise<R[]> {

--- a/plugins/writing/skills/scan/scripts/scan.ts
+++ b/plugins/writing/skills/scan/scripts/scan.ts
@@ -225,7 +225,7 @@ const scoreCmd = command(
 );
 
 if (import.meta.main) {
-  cli(
+  await cli(
     {
       name: "scan",
       commands: [auditCmd, scoreCmd],

--- a/scripts/coverage/index.ts
+++ b/scripts/coverage/index.ts
@@ -25,10 +25,10 @@ function changedFiles(base: string): string[] {
     .filter((f) => f && isSourceFile(f));
 }
 
-function persistLcov(reports: Parameters<typeof formatLcov>[0]): void {
+async function persistLcov(reports: Parameters<typeof formatLcov>[0]): Promise<void> {
   const dir = join(repoRoot, "coverage");
   mkdirSync(dir, { recursive: true });
-  Bun.write(join(dir, "lcov.info"), formatLcov(reports));
+  await Bun.write(join(dir, "lcov.info"), formatLcov(reports));
 }
 
 const argv = cli({
@@ -67,7 +67,7 @@ if (files.length === 0 && argv.flags.changed) {
 const reports = await runCoverage(files);
 
 // Persist a merged report so the PostToolUse hook has fresh data to surface.
-persistLcov(reports);
+await persistLcov(reports);
 
 // When specific files were requested, focus the report on them.
 const targets = files.length

--- a/scripts/list-plugins.ts
+++ b/scripts/list-plugins.ts
@@ -67,4 +67,4 @@ async function main(): Promise<void> {
   console.log(JSON.stringify(await Promise.all(plugins.map(toMatrixEntry))));
 }
 
-main();
+await main();

--- a/scripts/schemas/index.ts
+++ b/scripts/schemas/index.ts
@@ -59,7 +59,7 @@ const check = command({ name: "check" }, async () => {
   console.log(green("\nAll schema overlays are current with upstream."));
 });
 
-cli(
+await cli(
   {
     name: "schemas",
     commands: [check],

--- a/user/scripts/hook-metrics.test.ts
+++ b/user/scripts/hook-metrics.test.ts
@@ -121,7 +121,7 @@ test("timeHook records an error outcome and rethrows", async () => {
   const path = metricsPath();
   const boom = new Error("boom");
 
-  await expect(
+  expect(
     timeHook(
       "worktree",
       { session_id: "abc" },

--- a/user/skills/scheduled/scripts/scheduled.ts
+++ b/user/skills/scheduled/scripts/scheduled.ts
@@ -396,7 +396,7 @@ function resolveFullLabel(input: string): string {
   return fullLabel(input.slice(0, dot), input.slice(dot + 1));
 }
 
-async function runCommand(labelArg: string): Promise<void> {
+function runCommand(labelArg: string): void {
   const uid = requireUid();
   const label = resolveFullLabel(labelArg);
   const result = Bun.spawnSync(["launchctl", "kickstart", `gui/${uid}/${label}`], {
@@ -455,12 +455,12 @@ if (import.meta.main) {
           "Kickstart an installed agent immediately (<group>.<label> or full launchd label)",
       },
     },
-    async (parsed) => {
-      await runCommand(parsed._.label);
+    (parsed) => {
+      runCommand(parsed._.label);
     },
   );
 
-  cli(
+  await cli(
     {
       name: "scheduled",
       commands: [syncCmd, listCmd, statusCmd, runCmd],


### PR DESCRIPTION
Re-enables the three type-aware async rules #1222 turned off as noisy, and adds `require-await` beside them. I fixed every hit at the source. The change adds no `oxlint-disable` line and no test override block.

| Rule | Hits | Disposition |
|---|---|---|
| `await-thenable` | 27 | 26 awaits on `expect(...).rejects`/`.resolves`, plus one genuinely stray. All removed. |
| `no-floating-promises` | 18 | 17 top-level `cli()` calls now awaited. One was a real write race. |
| `require-await` | 39 | 36 test stubs re-typed to return `Promise.resolve`, 3 production functions de-asynced. |
| `unbound-method` | 11 | All fixed by reshaping one interface. |

## Coverage Write

`scripts/coverage/index.ts` called `Bun.write` from a synchronous `persistLcov` without awaiting it. The script could exit before the write finished, leaving `lcov.info` half written and the PostToolUse hook that reads it parsing a truncated file. `persistLcov` is now async and awaited.

## Matcher Awaits

26 of the 27 `await-thenable` hits are `await expect(...).rejects.toThrow()`. bun-types declares `rejects: Matchers<unknown>` with matchers returning `void`, which is why the rule fires on them. Dropping the await is safe because Bun's matcher drains the event loop synchronously inside the call: a non-async test with no await anywhere still observes the promise settling during the matcher call, including a rejection delayed 300ms.

The behavior is undocumented. Bun could later make these genuinely async, and `no-floating-promises`, enabled by this change, covers that case: a matcher returning `Promise<void>` as a bare statement is a floating promise. I checked against a stub:

```
error typescript(no-floating-promises): Promises must be awaited, add void operator to ignore.
```

All 26 sites would error at build time.

## Require-Await Split

36 of the 39 are test stubs satisfying a Promise-returning interface. Each returns `Promise.resolve(...)` rather than carrying `async`, which keeps the signature and clears the rule. Two that threw became `Promise.reject(...)`, so the rejection stays asynchronous. The three production functions had no awaited work left:

- `user/skills/scheduled/scripts/scheduled.ts`, whose body is `Bun.spawnSync` and `process.exit`.
- `plugins/writing/skills/analyze/scripts/judge.ts`, returning an `InputTokenCounter`.
- `plugins/things/scripts/url.ts`, a `findXcallRunner` override returning null.

Fixing `await-thenable` first pushes `require-await` from 39 to 55: 16 test callbacks lose their only await. Those are de-asynced too.

## Unbound Method

All 11 come from `merge.test.ts` referencing `MergeActions` members. Changing that interface from method shorthand to function properties fixes every one at the source, and also makes the parameters contravariant under `strictFunctionTypes`. No test override block.

## Enforcement

All four rules are type-aware. #1277 made `--type-aware` the default path, so `bun run lint` and `bun run check` now report them beside the syntactic rules. CI's `build` job adds `--type-check` on top and gates every PR.

