### PR TITLE
oxlint: enforce boolean-expression strictness

### DIFF
--- a/.claude/hooks/ox/index.ts
+++ b/.claude/hooks/ox/index.ts
@@ -143,13 +143,13 @@ type OxCommand = { bin: string; prefix: string[] };
 // its directory with the `bin` path the manifest itself declares.
 async function localBin(pkg: string, binName: string): Promise<string | null> {
   const manifestPath = await binManifest(pkg);
-  if (!manifestPath) {
+  if (manifestPath == null) {
     return null;
   }
   try {
     const manifest = decode(BinManifest, await Bun.file(manifestPath).json(), manifestPath);
     const bin = typeof manifest.bin === "string" ? manifest.bin : manifest.bin?.[binName];
-    return bin ? join(dirname(manifestPath), bin) : null;
+    return bin != null && bin !== "" ? join(dirname(manifestPath), bin) : null;
   } catch {
     return null;
   }
@@ -165,7 +165,7 @@ async function binManifest(pkg: string): Promise<string | null> {
     return fileURLToPath(import.meta.resolve(`${pkg}/package.json`));
   } catch {
     const checkout = await mainCheckout();
-    if (!checkout) {
+    if (checkout == null) {
       return null;
     }
     const fallback = join(checkout, "node_modules", pkg, "package.json");
@@ -187,7 +187,7 @@ function mainCheckout(): Promise<string | null> {
         { cwd: import.meta.dirname },
       );
       const gitDir = stdout.trim();
-      return gitDir ? dirname(gitDir) : null;
+      return gitDir !== "" ? dirname(gitDir) : null;
     } catch {
       return null;
     }
@@ -205,12 +205,13 @@ async function resolveCommand(pkg: string, binName: string): Promise<OxCommand |
     return cached;
   }
   const local = await localBin(pkg, binName);
-  const global = local ? null : Bun.which(binName);
-  const resolved = local
-    ? { bin: "bun", prefix: [local] }
-    : global
-      ? { bin: global, prefix: [] }
-      : null;
+  const global = local == null ? Bun.which(binName) : null;
+  const resolved =
+    local != null
+      ? { bin: "bun", prefix: [local] }
+      : global != null
+        ? { bin: global, prefix: [] }
+        : null;
   commandCache.set(pkg, resolved);
   return resolved;
 }
@@ -229,7 +230,11 @@ async function runOx(
   cwd: string | undefined,
 ): Promise<string | null> {
   try {
-    await execFileAsync(command.bin, [...command.prefix, ...args], cwd ? { cwd } : undefined);
+    await execFileAsync(
+      command.bin,
+      [...command.prefix, ...args],
+      cwd != null && cwd !== "" ? { cwd } : undefined,
+    );
     return null;
   } catch (error) {
     return commandOutput(error);
@@ -245,7 +250,7 @@ export async function parseTranscript(transcriptPath: string): Promise<string[]>
   const candidates = new Set<string>();
 
   for (const line of content.split("\n")) {
-    if (!line.trim()) continue;
+    if (line.trim() === "") continue;
 
     try {
       const entry = decodeJson(TranscriptEntry, line, transcriptPath);
@@ -257,7 +262,7 @@ export async function parseTranscript(transcriptPath: string): Promise<string[]>
         if (block.name !== "Edit" && block.name !== "Write") continue;
 
         const filePath = block.input?.file_path;
-        if (filePath && isOxFile(filePath)) {
+        if (filePath != null && filePath !== "" && isOxFile(filePath)) {
           candidates.add(filePath);
         }
       }
@@ -289,7 +294,8 @@ async function oxWorkingTree(filePath: string): Promise<string | undefined> {
   let toplevel: string | undefined;
   try {
     const { stdout } = await execFileAsync("git", ["rev-parse", "--show-toplevel"], { cwd: dir });
-    toplevel = stdout.trim() || undefined;
+    const root = stdout.trim();
+    toplevel = root !== "" ? root : undefined;
   } catch {
     toplevel = undefined;
   }
@@ -323,7 +329,7 @@ function commandOutput(error: unknown): string | null {
     .map((stream) => stream?.trim())
     .filter(Boolean)
     .join("\n");
-  return output || null;
+  return output !== "" ? output : null;
 }
 
 // --no-error-on-unmatched-pattern keeps oxlint/oxfmt from exiting non-zero on
@@ -349,7 +355,7 @@ async function runOxlintPass(
     return runOx(command, args, cwd);
   }
   const output = await runOx(command, ["--type-aware", ...args], cwd);
-  return output && MISSING_CHECKER.test(output) ? runOx(command, args, cwd) : output;
+  return output != null && MISSING_CHECKER.test(output) ? runOx(command, args, cwd) : output;
 }
 
 export async function runOxlintAgent(filePath: string): Promise<string | null> {
@@ -372,8 +378,8 @@ async function runOxlintAgentBatch(files: string[]): Promise<string | null> {
       runOx(command, [...LINT_ARGS, ...groupFiles], cwd),
     ),
   );
-  const combined = outputs.filter((output): output is string => Boolean(output)).join("\n");
-  return combined || null;
+  const combined = outputs.filter((output): output is string => output != null).join("\n");
+  return combined !== "" ? combined : null;
 }
 
 // oxfmt --write exits non-zero when a file has a syntax error it cannot
@@ -440,7 +446,7 @@ async function runTypeCheck(files: string[]): Promise<TypeCheckResult> {
         return { output: null, needsInstall: true };
       }
       const output = await runOx(command, TYPE_CHECK_ARGS, cwd);
-      return output && MISSING_CHECKER.test(output)
+      return output != null && MISSING_CHECKER.test(output)
         ? { output: null, needsInstall: true }
         : { output, needsInstall: false };
     }),
@@ -448,10 +454,10 @@ async function runTypeCheck(files: string[]): Promise<TypeCheckResult> {
 
   const combined = results
     .map((result) => result.output)
-    .filter((output): output is string => Boolean(output))
+    .filter((output): output is string => output != null)
     .join("\n");
   return {
-    output: combined || null,
+    output: combined !== "" ? combined : null,
     needsInstall: results.some((result) => result.needsInstall),
   };
 }
@@ -469,7 +475,7 @@ function formatPostToolUseOutput(filePath: string, errors: string): SyncHookJSON
 // there is no flag to narrow it, so drop the lines the scoped lint pass already
 // reported rather than showing each one twice.
 function withoutRepeats(typeOutput: string, lintOutput: string | null): string {
-  if (!lintOutput) {
+  if (lintOutput == null) {
     return typeOutput;
   }
   const reported = new Set(lintOutput.split("\n"));
@@ -481,9 +487,9 @@ function withoutRepeats(typeOutput: string, lintOutput: string | null): string {
 
 function formatSections(lintOutput: string | null, typeCheck: TypeCheckResult): string {
   const sections = [];
-  if (lintOutput) sections.push(`Lint:\n${lintOutput}`);
-  const types = typeCheck.output && withoutRepeats(typeCheck.output, lintOutput);
-  if (types) sections.push(`Types:\n${types}`);
+  if (lintOutput != null) sections.push(`Lint:\n${lintOutput}`);
+  const types = typeCheck.output != null ? withoutRepeats(typeCheck.output, lintOutput) : "";
+  if (types !== "") sections.push(`Types:\n${types}`);
   if (typeCheck.needsInstall) {
     sections.push("Types: skipped, dependencies are not installed here (`bun install`).");
   }
@@ -507,7 +513,7 @@ async function runOxGate(files: string[]): Promise<string | null> {
     runOxlintAgentBatch(files),
     runTypeCheck(files),
   ]);
-  if (!lintOutput && !typeCheck.output) {
+  if (lintOutput == null && typeCheck.output == null) {
     return null;
   }
 
@@ -523,7 +529,7 @@ export async function processPostToolUse(
   }
 
   const { file_path: filePath } = decode(FilePathInput, input.tool_input, "PostToolUse tool_input");
-  if (!filePath || !isOxFile(filePath)) {
+  if (filePath == null || filePath === "" || !isOxFile(filePath)) {
     return null;
   }
 
@@ -532,7 +538,7 @@ export async function processPostToolUse(
   }
 
   const errors = await runOxlintAgent(filePath);
-  if (!errors) {
+  if (errors == null) {
     return null;
   }
 
@@ -586,7 +592,7 @@ export async function processStop(input: StopInput): Promise<SyncHookJSONOutput 
   }
 
   const sections = await runOxGate(await parseTranscript(input.transcript_path));
-  if (!sections) {
+  if (sections == null || sections === "") {
     await clearBlocks(input.session_id);
     return null;
   }
@@ -652,7 +658,7 @@ export async function processPreToolUse(
   // It fails open on shell metacharacters, and this path can return a `block`,
   // so the command is re-read here rather than trusted from the matcher.
   const { command } = decode(BashInput, input.tool_input, "PreToolUse tool_input");
-  if (!command || !invokesGitCommit(command)) {
+  if (command == null || command === "" || !invokesGitCommit(command)) {
     return null;
   }
 
@@ -671,7 +677,7 @@ export async function processPreToolUse(
 
   const sections = await runOxGate(staged.paths);
   await restage(staged.paths);
-  if (!sections) {
+  if (sections == null || sections === "") {
     return null;
   }
   return deny(

--- a/.claude/hooks/stop/index.ts
+++ b/.claude/hooks/stop/index.ts
@@ -53,7 +53,7 @@ export async function parseTranscript(transcriptPath: string): Promise<string[]>
   const existChecks: Array<Promise<{ path: string; exists: boolean }>> = [];
 
   for (const line of content.split("\n")) {
-    if (!line.trim()) continue;
+    if (line.trim() === "") continue;
 
     try {
       const entry = decodeJson(TranscriptEntry, line, transcriptPath);
@@ -65,7 +65,7 @@ export async function parseTranscript(transcriptPath: string): Promise<string[]>
         if (block.name !== "Edit" && block.name !== "Write") continue;
 
         const filePath = block.input?.file_path;
-        if (filePath) {
+        if (filePath != null && filePath !== "") {
           existChecks.push(fileExists(filePath).then((exists) => ({ path: filePath, exists })));
         }
       }
@@ -99,7 +99,7 @@ export async function processStop(input: StopInput): Promise<SyncHookJSONOutput 
     return null;
   }
 
-  if (process.env.CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE) {
+  if ((process.env.CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE ?? "") !== "") {
     return null;
   }
 
@@ -123,7 +123,7 @@ export async function processStop(input: StopInput): Promise<SyncHookJSONOutput 
   } catch (error) {
     const failure = PrekFailure.safeParse(error);
     const execError = failure.success ? failure.data : {};
-    const output = ((execError.stdout || "") + (execError.stderr || "")).trim();
+    const output = `${execError.stdout ?? ""}${execError.stderr ?? ""}`.trim();
 
     let context: string;
     if (execError.code === "ENOENT") {
@@ -131,7 +131,8 @@ export async function processStop(input: StopInput): Promise<SyncHookJSONOutput 
     } else if (execError.killed) {
       context = `Checks timed out after ${PREK_TIMEOUT / 1000}s. Partial output:\n\n${output}`;
     } else {
-      context = `Check failures:\n\n${output || execError.message || String(error)}`;
+      const detail = output !== "" ? output : (execError.message ?? "");
+      context = `Check failures:\n\n${detail !== "" ? detail : String(error)}`;
     }
 
     return {

--- a/.claude/skills/agent-ideas/scripts/fetch.ts
+++ b/.claude/skills/agent-ideas/scripts/fetch.ts
@@ -59,6 +59,15 @@ function text(value: unknown): string {
   return "";
 }
 
+/** The first of several parser values that normalizes to a non-empty string. */
+function firstText(...values: unknown[]): string {
+  for (const value of values) {
+    const normalized = text(value);
+    if (normalized !== "") return normalized;
+  }
+  return "";
+}
+
 function decodeEntities(input: string): string {
   return input
     .replace(/&nbsp;/g, " ")
@@ -105,8 +114,8 @@ function parseAtom(feed: Element): Post[] {
   return Elements.parse(feed.entry).map((entry) => ({
     title: stripHtml(text(entry.title)),
     url: atomLink(entry.link),
-    date: normalizeDate(text(entry.published) || text(entry.updated)),
-    excerpt: excerpt(text(entry.summary) || text(entry.content)),
+    date: normalizeDate(firstText(entry.published, entry.updated)),
+    excerpt: excerpt(firstText(entry.summary, entry.content)),
   }));
 }
 
@@ -114,13 +123,13 @@ function parseRss(channel: Element): Post[] {
   return Elements.parse(channel.item).map((item) => ({
     title: stripHtml(text(item.title)),
     url: text(item.link),
-    date: normalizeDate(text(item.pubDate) || text(item["dc:date"])),
-    excerpt: excerpt(text(item.description) || text(item["content:encoded"])),
+    date: normalizeDate(firstText(item.pubDate, item["dc:date"])),
+    excerpt: excerpt(firstText(item.description, item["content:encoded"])),
   }));
 }
 
 function normalizeDate(raw: string): string | null {
-  if (!raw) return null;
+  if (raw === "") return null;
   const parsed = new Date(raw);
   return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
 }
@@ -153,7 +162,7 @@ function matchesTopic(post: Post, topicHint: string): boolean {
 }
 
 function withinDays(post: Post, days: number, now: number): boolean {
-  if (!post.date) return false;
+  if (post.date == null) return false;
   const age = now - new Date(post.date).getTime();
   return age >= 0 && age <= days * 24 * 60 * 60 * 1000;
 }
@@ -166,7 +175,7 @@ export async function fetchSource(source: Source, days: number, now: number): Pr
     posts: [],
   };
 
-  if (!source.feedUrl) return base;
+  if (source.feedUrl == null || source.feedUrl === "") return base;
 
   try {
     const response = await fetch(source.feedUrl, {
@@ -179,7 +188,10 @@ export async function fetchSource(source: Source, days: number, now: number): Pr
     const xml = await response.text();
     const posts = parseFeed(xml)
       .filter((post) => withinDays(post, days, now))
-      .filter((post) => (source.topicHint ? matchesTopic(post, source.topicHint) : true));
+      .filter((post) => {
+        const hint = source.topicHint;
+        return hint == null || hint === "" || matchesTopic(post, hint);
+      });
     return { ...base, posts };
   } catch (error) {
     return { ...base, error: error instanceof Error ? error.message : String(error) };

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -74,7 +74,19 @@
     "typescript/no-unsafe-call": "error",
     "typescript/no-unsafe-member-access": "error",
     "typescript/no-unsafe-return": "error",
-    "typescript/no-unsafe-type-assertion": "error"
+    "typescript/no-unsafe-type-assertion": "error",
+    "typescript/strict-boolean-expressions": [
+      "error",
+      {
+        "allowString": false,
+        "allowNumber": false,
+        "allowNullableString": false,
+        "allowNullableNumber": false,
+        "allowNullableObject": true,
+        "allowNullableBoolean": true
+      }
+    ],
+    "typescript/no-unnecessary-condition": ["error", { "allowConstantLoopConditions": "always" }]
   },
   "overrides": [
     {

--- a/evals/issue-refine/scripts/ab-prompt.ts
+++ b/evals/issue-refine/scripts/ab-prompt.ts
@@ -28,7 +28,12 @@ const argv = cli({
   },
 });
 
-if (!argv.flags.version || !argv.flags.brief) {
+if (
+  argv.flags.version == null ||
+  argv.flags.version === "" ||
+  argv.flags.brief == null ||
+  argv.flags.brief === ""
+) {
   console.error("usage: ab-prompt --version <dir> --brief <file.json>");
   process.exit(1);
 }
@@ -60,10 +65,10 @@ ${brief.brief}
 
 ================ SYNTHETIC CONTEXT ================
 Files:
-${files_ctx || "(none)"}
+${files_ctx !== "" ? files_ctx : "(none)"}
 
 Related issues:
-${issues_ctx || "(none)"}
+${issues_ctx !== "" ? issues_ctx : "(none)"}
 `;
 
 console.log(prompt);

--- a/evals/issue-refine/scripts/build-dataset.ts
+++ b/evals/issue-refine/scripts/build-dataset.ts
@@ -60,7 +60,8 @@ for (const s of saves) {
 // A save_issue update carries no title; recover it from any titled save in the session.
 const titleBySession = new Map<string, string>();
 for (const s of saves)
-  if (s.title && !titleBySession.has(s.session_id)) titleBySession.set(s.session_id, s.title);
+  if (s.title != null && s.title !== "" && !titleBySession.has(s.session_id))
+    titleBySession.set(s.session_id, s.title);
 
 const project = (p: string) =>
   p

--- a/evals/issue-refine/scripts/build-labelset.ts
+++ b/evals/issue-refine/scripts/build-labelset.ts
@@ -57,7 +57,12 @@ for (const f of files) {
   const { title, type, body } = parseIssue(await file.text());
   samples.push({
     id,
-    type: brief.type || type || "unknown",
+    type:
+      typeof brief.type === "string" && brief.type !== ""
+        ? brief.type
+        : type !== ""
+          ? type
+          : "unknown",
     size: brief.size ?? "full",
     project: brief.project ?? "synthetic",
     brief: brief.brief,
@@ -68,4 +73,4 @@ for (const f of files) {
 
 await Bun.write(argv.flags.output, JSON.stringify(samples, null, 2));
 console.log(`wrote ${samples.length} samples to ${argv.flags.output}`);
-if (missing.length) console.log(`missing output for: ${missing.join(", ")}`);
+if (missing.length !== 0) console.log(`missing output for: ${missing.join(", ")}`);

--- a/evals/issue-refine/scripts/judge.ts
+++ b/evals/issue-refine/scripts/judge.ts
@@ -50,7 +50,7 @@ const argv = cli({
 
 const mappingPath = join(argv.flags.judgeDir, "mapping.json");
 
-if (argv.flags.unblind) {
+if (argv.flags.unblind != null && argv.flags.unblind !== "") {
   const mapping = await decodeFile(Mapping, mappingPath);
   const decoded = await decodeFile(Verdicts, argv.flags.unblind);
   for (const v of Array.isArray(decoded) ? decoded : decoded.verdicts) {
@@ -60,7 +60,7 @@ if (argv.flags.unblind) {
     const s1 = `${map["1"]}=${v.scores?.["1"] ?? "?"}`;
     const s2 = `${map["2"]}=${v.scores?.["2"] ?? "?"}`;
     console.log(`\n${v.brief}: judge prefers ${better.toUpperCase()}  (${s1}, ${s2})`);
-    if (v.reason) console.log(`  ${v.reason}`);
+    if (v.reason != null && v.reason !== "") console.log(`  ${v.reason}`);
   }
   process.exit(0);
 }

--- a/evals/issue-refine/scripts/score.ts
+++ b/evals/issue-refine/scripts/score.ts
@@ -82,7 +82,10 @@ const SMALL_WORDS = new Set([
   "under",
 ]);
 
-const raw = argv.flags.input ? await Bun.file(argv.flags.input).text() : await Bun.stdin.text();
+const raw =
+  argv.flags.input != null && argv.flags.input !== ""
+    ? await Bun.file(argv.flags.input).text()
+    : await Bun.stdin.text();
 const { title: fmTitle, type, body } = parseIssue(raw);
 const title = argv.flags.title ?? fmTitle;
 
@@ -134,7 +137,7 @@ for (const h of headings) {
   const lowerMajor = major
     .filter((w, i) => !SMALL_WORDS.has(w.toLowerCase()) || i === 0)
     .filter((w) => /^[a-z]/.test(w));
-  if (lowerMajor.length)
+  if (lowerMajor.length !== 0)
     add(
       1,
       "minor",
@@ -235,7 +238,7 @@ if (summaryHeading)
   );
 
 // Finding 6: concise, sentence-case title from the frontmatter.
-if (title) {
+if (title !== "") {
   if (title.length > 80)
     add(6, "minor", TITLE_LINE, title, `Title is ${title.length} chars. Keep it short.`);
   if (/\(.*\)/.test(title))
@@ -272,16 +275,17 @@ const byFinding = violations.reduce<Record<number, number>>((m, v) => {
 if (argv.flags.json) {
   console.log(JSON.stringify({ title, type, score, byFinding, violations }, null, 2));
 } else {
-  console.log(`Title: ${title || "(none)"}`);
-  console.log(`Type:  ${type || "(none)"}`);
+  console.log(`Title: ${title !== "" ? title : "(none)"}`);
+  console.log(`Type:  ${type !== "" ? type : "(none)"}`);
   console.log(`Score: ${score} (lower is better) · ${violations.length} violations\n`);
-  for (const v of violations.toSorted(
-    (a, b) => SEVERITY_WEIGHT[b.severity] - SEVERITY_WEIGHT[a.severity] || a.finding - b.finding,
-  )) {
+  for (const v of violations.toSorted((a, b) => {
+    const bySeverity = SEVERITY_WEIGHT[b.severity] - SEVERITY_WEIGHT[a.severity];
+    return bySeverity !== 0 ? bySeverity : a.finding - b.finding;
+  })) {
     console.log(
       `  [${v.severity}] finding ${v.finding} · L${v.line} · "${v.excerpt.slice(0, 60)}"`,
     );
     console.log(`      ${v.message}`);
   }
-  if (!violations.length) console.log("  clean");
+  if (violations.length === 0) console.log("  clean");
 }

--- a/evals/pr-body/calibrate.ts
+++ b/evals/pr-body/calibrate.ts
@@ -33,9 +33,9 @@ for (const item of labeled) {
   } else tn++;
 }
 
-const precision = tp / (tp + fp) || 0;
-const recall = tp / (tp + fn) || 0;
-const f1 = (2 * precision * recall) / (precision + recall) || 0;
+const precision = tp + fp === 0 ? 0 : tp / (tp + fp);
+const recall = tp + fn === 0 ? 0 : tp / (tp + fn);
+const f1 = precision + recall === 0 ? 0 : (2 * precision * recall) / (precision + recall);
 const accuracy = (tp + tn) / labeled.length;
 
 console.log(`Labeled items: ${labeled.length}`);
@@ -66,6 +66,6 @@ console.log(`FALSE NEGATIVES (bad items missed, no lexical tell) — ${falseNega
 for (const fnItem of falseNegatives) {
   console.log(`  "${fnItem.text}"`);
   console.log(
-    `      signals fired: ${fnItem.signals.length ? fnItem.signals.join(", ") : "(none)"}`,
+    `      signals fired: ${fnItem.signals.length !== 0 ? fnItem.signals.join(", ") : "(none)"}`,
   );
 }

--- a/evals/pr-body/scripts/judge.test.ts
+++ b/evals/pr-body/scripts/judge.test.ts
@@ -10,7 +10,7 @@ function rubricAxes(markdown: string): string[] {
   const axes: string[] = [];
   for (const line of markdown.split("\n")) {
     const match = line.match(/^###\s+(.+)$/);
-    if (match?.[1]) axes.push(match[1].trim().replace(/^`|`$/g, ""));
+    if (match?.[1] != null && match[1] !== "") axes.push(match[1].trim().replace(/^`|`$/g, ""));
   }
   return axes;
 }

--- a/evals/pr-body/scripts/judge.ts
+++ b/evals/pr-body/scripts/judge.ts
@@ -116,7 +116,10 @@ export function buildPairs(scenarios: Scenario[], rows: GenerationRow[]): Pair[]
     }
     pairs.push({ scenario, seed: Number(rawSeed), rows: { a: entry.a, b: entry.b } });
   }
-  return pairs.toSorted((x, y) => x.scenario.id.localeCompare(y.scenario.id) || x.seed - y.seed);
+  return pairs.toSorted((x, y) => {
+    const byScenario = x.scenario.id.localeCompare(y.scenario.id);
+    return byScenario !== 0 ? byScenario : x.seed - y.seed;
+  });
 }
 
 /** Randomizes which arm occupies which slot, so the judge cannot infer the arm from position. */

--- a/evals/pr-body/scripts/mine.ts
+++ b/evals/pr-body/scripts/mine.ts
@@ -66,7 +66,7 @@ export function toItem(mined: MinedPr, fetched: FetchedPr): Item {
     id: "",
     repo: mined.repository,
     pr_number: mined.pr_number,
-    url: fetched.url || mined.url,
+    url: fetched.url !== "" ? fetched.url : mined.url,
     title: fetched.title,
     state: fetched.state,
     created_at: fetched.createdAt,
@@ -129,9 +129,13 @@ export function selectSample(candidates: Item[], limit: number): Item[] {
 }
 
 function resolveDbPath(db: string | undefined): string {
-  if (db) return db;
+  if (db != null && db !== "") return db;
+  const pluginData = process.env.CLAUDE_PLUGIN_DATA;
+  const tmp = process.env.TMPDIR;
   const dataDir =
-    process.env.CLAUDE_PLUGIN_DATA || join(process.env.TMPDIR || "/tmp", "claude-session");
+    pluginData != null && pluginData !== ""
+      ? pluginData
+      : join(tmp != null && tmp !== "" ? tmp : "/tmp", "claude-session");
   return join(dataDir, "session.duckdb");
 }
 
@@ -148,7 +152,7 @@ async function queryMined(dbPath: string): Promise<MinedPr[]> {
   ]);
   if (code !== 0) throw new Error(`duckdb failed (${code}): ${err.trim()}`);
   const trimmed = out.trim();
-  if (!trimmed) return [];
+  if (trimmed === "") return [];
   return decodeJson(z.array(MinedPr), trimmed, `duckdb ${dbPath}`);
 }
 

--- a/evals/pr-body/scripts/run-eval.ts
+++ b/evals/pr-body/scripts/run-eval.ts
@@ -247,7 +247,7 @@ export async function mapPool<T, R>(
 }
 
 export function requireApiKey(): void {
-  if (!process.env.ANTHROPIC_API_KEY) {
+  if (process.env.ANTHROPIC_API_KEY == null || process.env.ANTHROPIC_API_KEY === "") {
     throw new Error("ANTHROPIC_API_KEY is not set. The runner only works with live credentials.");
   }
 }
@@ -317,7 +317,7 @@ async function main(): Promise<void> {
   });
 
   const { armA, armB } = argv.flags;
-  if (!armA || !armB) {
+  if (armA == null || armA === "" || armB == null || armB === "") {
     console.error("Both --arm-a and --arm-b are required.\n");
     argv.showHelp();
     process.exit(1);

--- a/evals/pr-body/scripts/score.ts
+++ b/evals/pr-body/scripts/score.ts
@@ -128,7 +128,9 @@ function report(row: ScoreRow): string {
     const flags = [row.title.over50 ? "over 50" : null, row.title.clauseStacking ? "stacked" : null]
       .filter(Boolean)
       .join(", ");
-    lines.push(`title: ${row.title.length} chars${flags ? ` (${flags})` : ""} · ${row.title.text}`);
+    lines.push(
+      `title: ${row.title.length} chars${flags !== "" ? ` (${flags})` : ""} · ${row.title.text}`,
+    );
   }
 
   lines.push(`heading case violations: ${row.headingCaseViolations}`);

--- a/evals/review-voice/scripts/mine.ts
+++ b/evals/review-voice/scripts/mine.ts
@@ -29,9 +29,13 @@ const argv = cli({
 });
 
 function resolveDbPath(): string {
-  if (argv.flags.db) return argv.flags.db;
+  if (argv.flags.db != null && argv.flags.db !== "") return argv.flags.db;
+  const pluginData = process.env.CLAUDE_PLUGIN_DATA;
+  const tmp = process.env.TMPDIR;
   const dataDir =
-    process.env.CLAUDE_PLUGIN_DATA || join(process.env.TMPDIR || "/tmp", "claude-session");
+    pluginData != null && pluginData !== ""
+      ? pluginData
+      : join(tmp != null && tmp !== "" ? tmp : "/tmp", "claude-session");
   return join(dataDir, "session.duckdb");
 }
 
@@ -103,7 +107,7 @@ async function queryRows(dbPath: string): Promise<WriteRow[]> {
   ]);
   if (code !== 0) throw new Error(`duckdb failed (${code}): ${err.trim()}`);
   const trimmed = out.trim();
-  if (!trimmed) return [];
+  if (trimmed === "") return [];
   return decodeJson(z.array(WriteRow), trimmed, `duckdb ${dbPath}`);
 }
 
@@ -117,7 +121,8 @@ function isText(fp: string): "json" | "md" | null {
 function workdirOf(fp: string): string {
   const idx = fp.indexOf("/tmp");
   const dir = idx > 0 ? fp.slice(0, idx) : dirname(fp);
-  return basename(dir) || dir;
+  const base = basename(dir);
+  return base !== "" ? base : dir;
 }
 
 function bodiesFromJson(
@@ -178,9 +183,9 @@ async function main() {
   const seen = new Set<string>();
 
   for (const row of rows) {
-    if (hostFilter && row.host !== hostFilter) continue;
+    if (hostFilter != null && hostFilter !== "" && row.host !== hostFilter) continue;
     const kind = isText(row.file_path);
-    if (!kind) continue;
+    if (kind == null) continue;
 
     const extracted =
       kind === "json"

--- a/evals/review-voice/scripts/report.ts
+++ b/evals/review-voice/scripts/report.ts
@@ -92,9 +92,9 @@ async function main() {
     if (!wanted.includes(label.label)) continue;
     const c = byId.get(id);
     if (!c) continue;
-    const head = `${label.label.toUpperCase()} ${dim(`[${c.host}] ${c.source}${c.line ? `:${c.line}` : ""}`)}`;
+    const head = `${label.label.toUpperCase()} ${dim(`[${c.host}] ${c.source}${c.line != null && c.line !== 0 ? `:${c.line}` : ""}`)}`;
     console.log(label.label === "bad" ? red(head) : green(head));
-    if (label.note) console.log(dim(`note: ${label.note}`));
+    if (label.note !== "") console.log(dim(`note: ${label.note}`));
     console.log(c.body);
     console.log(dim("─".repeat(72)));
   }

--- a/evals/writing/scripts/mine.ts
+++ b/evals/writing/scripts/mine.ts
@@ -120,9 +120,13 @@ export function selectSample(candidates: Item[], limit: number): Item[] {
 }
 
 function resolveDbPath(db: string | undefined): string {
-  if (db) return db;
+  if (db != null && db !== "") return db;
+  const pluginData = process.env.CLAUDE_PLUGIN_DATA;
+  const tmp = process.env.TMPDIR;
   const dataDir =
-    process.env.CLAUDE_PLUGIN_DATA || join(process.env.TMPDIR || "/tmp", "claude-session");
+    pluginData != null && pluginData !== ""
+      ? pluginData
+      : join(tmp != null && tmp !== "" ? tmp : "/tmp", "claude-session");
   return join(dataDir, "session.duckdb");
 }
 
@@ -139,7 +143,8 @@ async function probeInvocations(dbPath: string): Promise<number | null> {
     proc.exited,
   ]);
   if (code !== 0) throw new Error(`duckdb failed (${code}): ${err.trim()}`);
-  const rows = decodeJson(Probe, out.trim() || "[]", `duckdb ${dbPath}`);
+  const json = out.trim();
+  const rows = decodeJson(Probe, json !== "" ? json : "[]", `duckdb ${dbPath}`);
   return rows[0]?.invocations ?? 0;
 }
 

--- a/packages/marketplace/index.ts
+++ b/packages/marketplace/index.ts
@@ -199,7 +199,7 @@ export async function enabledPluginNames(opts?: LoadOptions): Promise<Set<string
   for (const [key, value] of Object.entries(settings?.enabledPlugins ?? {})) {
     if (!value) continue;
     const name = key.split("@")[0];
-    if (name) names.add(name);
+    if (name != null && name !== "") names.add(name);
   }
   return names;
 }

--- a/packages/marketplace/marketplace.test.ts
+++ b/packages/marketplace/marketplace.test.ts
@@ -105,9 +105,9 @@ describe("loadPlugins", () => {
   test("set differences the check scripts depend on", async () => {
     const plugins = await loadPlugins({ root });
     // check-marketplace: on disk but no local listing
-    expect(plugins.filter((p) => p.dir && !p.listing?.local).map((p) => p.name)).toEqual([
-      "orphan",
-    ]);
+    expect(
+      plugins.filter((p) => p.dir !== undefined && p.listing?.local !== true).map((p) => p.name),
+    ).toEqual(["orphan"]);
     // check-enabled-plugins: listed but not enabled
     expect(plugins.filter((p) => p.listing && !p.enabled).map((p) => p.name)).toEqual([
       "beta",

--- a/packages/oxlint-rules/lexical-type-parameters.ts
+++ b/packages/oxlint-rules/lexical-type-parameters.ts
@@ -44,8 +44,8 @@ export function lexicalTypeParameterNames(
 ): ReadonlySet<string> {
   const names = new Set<string>();
   let descendant: ESTree.Node = node;
-  let current: ESTree.Node | null = node;
-  while (current !== null && current.type !== "Program") {
+  let current: ESTree.Node = node;
+  while (current.type !== "Program") {
     if ("typeParameters" in current) {
       for (const parameter of current.typeParameters?.params ?? []) {
         names.add(parameter.name.name);

--- a/packages/oxlint-rules/no-unknown-returns.ts
+++ b/packages/oxlint-rules/no-unknown-returns.ts
@@ -22,9 +22,7 @@ type FunctionWithReturnType =
 function referencedAliasName(type: ESTree.TSType): string | null {
   if (type.type === "TSParenthesizedType") return referencedAliasName(type.typeAnnotation);
   if (type.type !== "TSTypeReference" || type.typeName.type !== "Identifier") return null;
-  return type.typeArguments === null ||
-    type.typeArguments === undefined ||
-    type.typeArguments.params.length === 0
+  return type.typeArguments === null || type.typeArguments.params.length === 0
     ? type.typeName.name
     : null;
 }
@@ -68,10 +66,7 @@ export const noUnknownReturnsRule = defineRule({
       const name = referencedAliasName(type);
       if (name === null || visited.has(name) || shadowedAliases.has(name)) return false;
       const alias = aliases.get(name);
-      if (
-        alias === undefined ||
-        (alias.typeParameters !== null && alias.typeParameters !== undefined)
-      ) {
+      if (alias === undefined || alias.typeParameters !== null) {
         return false;
       }
       const nextVisited = new Set(visited);

--- a/packages/validate/run.ts
+++ b/packages/validate/run.ts
@@ -19,7 +19,7 @@ export interface ValidationTarget {
 
 export async function runValidation(target: ValidationTarget): Promise<void> {
   let ajv: Ajv | undefined;
-  if (target.extraSchemas?.length) {
+  if (target.extraSchemas != null && target.extraSchemas.length !== 0) {
     ajv = createValidator();
     for (const extra of target.extraSchemas) {
       ajv.addSchema(await loadSchema(extra.schema), extra.key);
@@ -49,7 +49,7 @@ export async function runValidation(target: ValidationTarget): Promise<void> {
 
 export function pluginDirFile(usage: string, file: string): string {
   const dir = process.argv[2];
-  if (!dir) {
+  if (dir == null || dir === "") {
     console.error(usage);
     process.exit(1);
   }

--- a/packages/validate/validate.ts
+++ b/packages/validate/validate.ts
@@ -44,7 +44,7 @@ export function formatError(
   file: string,
   error: Pick<ErrorObject, "instancePath" | "message">,
 ): string {
-  const path = error.instancePath || "/";
+  const path = error.instancePath !== "" ? error.instancePath : "/";
   const message = `${path}: ${error.message}`;
 
   if (isCI()) {
@@ -97,7 +97,7 @@ export async function validateFile(
     : (entry.validate.errors?.map((err: ErrorObject) => formatError(file, err)) ?? []);
 
   const warnings: string[] = [];
-  if (options?.warnAdditional && entry.schema.properties) {
+  if (options?.warnAdditional && entry.schema.properties !== "") {
     const known = new Set(Object.keys(Properties.parse(entry.schema.properties)));
     for (const property of Object.keys(data)) {
       if (property !== "$schema" && !known.has(property)) {

--- a/plugins/claude-code/skills/session/scripts/db.test.ts
+++ b/plugins/claude-code/skills/session/scripts/db.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { $ } from "bun";
 import { z } from "zod";
@@ -43,7 +44,7 @@ let importsDir: string;
 // the network, which can exceed the default per-test timeout on a cold CI runner.
 // Warm the shared extension cache once so the per-test LOAD reads from disk.
 beforeAll(async () => {
-  const warmDir = mkdtempSync(path.join(process.env.TMPDIR || "/tmp", "session-warm-"));
+  const warmDir = mkdtempSync(path.join(tmpdir(), "session-warm-"));
   const warm = await getDb(warmDir);
   try {
     await loadExtensions(warm);
@@ -73,7 +74,7 @@ async function reindex() {
 }
 
 beforeEach(async () => {
-  tmpDir = mkdtempSync(path.join(process.env.TMPDIR || "/tmp", "session-test-"));
+  tmpDir = mkdtempSync(path.join(tmpdir(), "session-test-"));
   importsDir = path.join(tmpDir, "imports");
   mkdirSync(importsDir, { recursive: true });
   db = await getDb(tmpDir);

--- a/plugins/claude-code/skills/session/scripts/db.ts
+++ b/plugins/claude-code/skills/session/scripts/db.ts
@@ -80,20 +80,20 @@ async function readSql(dir: string, name: string): Promise<string> {
 }
 
 function getLocalRoot(projectsDir?: string): string {
-  const dir = projectsDir || process.env.CLAUDE_PROJECTS_DIR;
-  if (dir) return dir;
+  const dir = projectsDir ?? process.env.CLAUDE_PROJECTS_DIR;
+  if (dir != null && dir !== "") return dir;
 
-  if (!process.env.HOME) {
+  if (process.env.HOME == null || process.env.HOME === "") {
     throw new Error("Cannot locate projects directory: set CLAUDE_PROJECTS_DIR or HOME");
   }
   return path.join(process.env.HOME, ".claude", "projects");
 }
 
 export function getImportsDir(importsDir?: string): string {
-  const dir = importsDir || process.env.CLAUDE_SESSION_IMPORTS_DIR;
-  if (dir) return dir;
+  const dir = importsDir ?? process.env.CLAUDE_SESSION_IMPORTS_DIR;
+  if (dir != null && dir !== "") return dir;
 
-  if (!process.env.HOME) {
+  if (process.env.HOME == null || process.env.HOME === "") {
     throw new Error("Cannot locate imports directory: set CLAUDE_SESSION_IMPORTS_DIR or HOME");
   }
   return path.join(process.env.HOME, ".claude", "session-imports");
@@ -109,7 +109,8 @@ export function importRoot(label: string, importsDir?: string): string {
 // data/<plugin>-<marketplace>/. The env var remains as an override (tests,
 // hooks, dev checkouts).
 export function getDataDir(): string {
-  if (process.env.CLAUDE_PLUGIN_DATA) return process.env.CLAUDE_PLUGIN_DATA;
+  if (process.env.CLAUDE_PLUGIN_DATA != null && process.env.CLAUDE_PLUGIN_DATA !== "")
+    return process.env.CLAUDE_PLUGIN_DATA;
 
   const segments = import.meta.dirname.split(path.sep);
   const cacheIdx = segments.lastIndexOf("cache");
@@ -187,7 +188,7 @@ export async function enumerateHosts(
     hosts.push({
       host: imported.label,
       root: path.join(imported.root, "projects"),
-      policy: imported.manifest.policy ?? {},
+      policy: imported.manifest.policy,
     });
   }
 
@@ -263,7 +264,7 @@ async function migrateIfNeeded(db: Database): Promise<void> {
     : 0;
   // A pre-host schema (missing data/host) or an older ingestion version both mean
   // the cache predates the current import logic; drop it so the next run rebuilds.
-  if (row?.has_data && row?.has_host && version >= INDEX_VERSION) return;
+  if (row?.has_data && row.has_host && version >= INDEX_VERSION) return;
   await dropCache(db);
 }
 

--- a/plugins/claude-code/skills/session/scripts/forget.ts
+++ b/plugins/claude-code/skills/session/scripts/forget.ts
@@ -28,7 +28,7 @@ const argv = cli({
 
 const label = argv.flags.host;
 
-if (!label) {
+if (label == null || label === "") {
   console.error("--host is required.");
   process.exit(1);
 }

--- a/plugins/claude-code/skills/session/scripts/hosts.ts
+++ b/plugins/claude-code/skills/session/scripts/hosts.ts
@@ -37,7 +37,7 @@ for (const { label, manifest } of imported) {
   rows.push([
     label,
     manifest.imported_at,
-    (manifest.policy?.block_egress ?? true) ? "blocked" : "allowed",
+    (manifest.policy.block_egress ?? true) ? "blocked" : "allowed",
     watermarks[label] ?? "-",
     manifest.source !== "" ? manifest.source : "-",
   ]);

--- a/plugins/claude-code/skills/session/scripts/hosts.ts
+++ b/plugins/claude-code/skills/session/scripts/hosts.ts
@@ -39,7 +39,7 @@ for (const { label, manifest } of imported) {
     manifest.imported_at,
     (manifest.policy?.block_egress ?? true) ? "blocked" : "allowed",
     watermarks[label] ?? "-",
-    manifest.source || "-",
+    manifest.source !== "" ? manifest.source : "-",
   ]);
 }
 
@@ -48,7 +48,7 @@ console.log(table(rows));
 if (imported.length > 0) {
   console.log("Re-sync (copy, paste, run, then re-run import.ts):\n");
   for (const { label, root, manifest } of imported) {
-    const source = manifest.source || "<source>";
+    const source = manifest.source !== "" ? manifest.source : "<source>";
     console.log(`  ${label}:`);
     console.log(`    rsync -av --update ${source} ${path.join(root, "projects")}/`);
   }

--- a/plugins/claude-code/skills/session/scripts/import.ts
+++ b/plugins/claude-code/skills/session/scripts/import.ts
@@ -42,7 +42,7 @@ const argv = cli({
 
 const label = argv.flags.host;
 
-if (!label) {
+if (label == null || label === "") {
   console.error("--host is required.");
   process.exit(1);
 }
@@ -62,7 +62,9 @@ const projectsDir = path.join(root, "projects");
 if (!dirExists(projectsDir)) {
   console.error(`No corpus at ${projectsDir}.`);
   console.error("Sync the source machine's ~/.claude/projects/ there first, then re-run:");
-  console.error(`  rsync -av --update ${argv.flags.source || "<source>"} ${projectsDir}/`);
+  const source = argv.flags.source;
+  const shown = source !== "" ? source : "<source>";
+  console.error(`  rsync -av --update ${shown} ${projectsDir}/`);
   process.exit(1);
 }
 

--- a/plugins/claude-code/skills/session/scripts/import.ts
+++ b/plugins/claude-code/skills/session/scripts/import.ts
@@ -96,6 +96,6 @@ try {
   db.close();
 }
 
-const blockEgress = existing ? (existing.policy?.block_egress ?? true) : !argv.flags.egress;
+const blockEgress = existing ? (existing.policy.block_egress ?? true) : !argv.flags.egress;
 console.log(`${existing ? "Re-indexed" : "Imported"} host "${label}" from ${projectsDir}`);
 console.log(`  egress: ${blockEgress ? "blocked" : "allowed"}`);

--- a/plugins/claude-code/skills/session/scripts/refresh.integration.ts
+++ b/plugins/claude-code/skills/session/scripts/refresh.integration.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { $ } from "bun";
 import { z } from "zod";
@@ -14,7 +15,7 @@ let dataDir: string;
 let corpusDir: string;
 
 beforeEach(async () => {
-  tmpDir = mkdtempSync(path.join(process.env.TMPDIR || "/tmp", "refresh-integration-"));
+  tmpDir = mkdtempSync(path.join(tmpdir(), "refresh-integration-"));
   dataDir = path.join(tmpDir, "data");
   corpusDir = path.join(tmpDir, "projects");
   mkdirSync(corpusDir, { recursive: true });

--- a/plugins/claude-code/skills/session/scripts/refresh.ts
+++ b/plugins/claude-code/skills/session/scripts/refresh.ts
@@ -4,6 +4,7 @@
 // when the probe in docs/settings.md succeeds.
 import { mkdirSync } from "node:fs";
 import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { cli } from "cleye";
 import {
@@ -43,11 +44,8 @@ const stampPath = path.join(dataDir, "last-refresh");
 // against the real (derived) data dir: a CLAUDE_PLUGIN_DATA override means a
 // test or dev run, which must not delete machine-wide state.
 async function cleanupStrayDatabases(): Promise<void> {
-  if (process.env.CLAUDE_PLUGIN_DATA) return;
-  const strayDirs = new Set([
-    path.join(process.env.TMPDIR || "/tmp", "claude-session"),
-    "/tmp/claude-session",
-  ]);
+  if (process.env.CLAUDE_PLUGIN_DATA != null && process.env.CLAUDE_PLUGIN_DATA !== "") return;
+  const strayDirs = new Set([path.join(tmpdir(), "claude-session"), "/tmp/claude-session"]);
   for (const dir of strayDirs) {
     if (path.resolve(dir) === path.resolve(dataDir)) continue;
     if (!(await Bun.file(sessionDbPath(dir)).exists())) continue;

--- a/plugins/claude-code/skills/session/scripts/usage.ts
+++ b/plugins/claude-code/skills/session/scripts/usage.ts
@@ -29,8 +29,10 @@ async function query<T>(dbPath: string, sql: string, schema: z.ZodType<T>): Prom
     new Response(proc.stderr).text(),
     proc.exited,
   ]);
-  if (code !== 0) throw new Error(err.trim() || `duckdb exited ${code}`);
-  return z.array(schema).parse(JSON.parse(out.trim() || "[]"));
+  const detail = err.trim();
+  if (code !== 0) throw new Error(detail !== "" ? detail : `duckdb exited ${code}`);
+  const rows = out.trim();
+  return z.array(schema).parse(JSON.parse(rows !== "" ? rows : "[]"));
 }
 
 function setVariables(vars: Record<string, string | number | undefined>): string {
@@ -40,7 +42,7 @@ function setVariables(vars: Record<string, string | number | undefined>): string
     const literal = typeof value === "number" ? String(value) : sqlString(value);
     lines.push(`SET VARIABLE "${key}" = ${literal};`);
   }
-  return lines.length ? `${lines.join("\n")}\n` : "";
+  return lines.length !== 0 ? `${lines.join("\n")}\n` : "";
 }
 
 const localTime = (ts: string): string =>
@@ -173,7 +175,7 @@ if (!(await Bun.file(dbPath).exists())) {
   process.exit(1);
 }
 
-if (argv.flags.session) {
+if (argv.flags.session != null && argv.flags.session !== "") {
   await renderTimeline(dbPath, argv.flags.session, argv.flags.host, argv.flags.bucket);
 } else {
   await renderTopSessions(dbPath, argv.flags.host, argv.flags.days);

--- a/plugins/claude-code/skills/skill/scripts/check-lint.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-lint.ts
@@ -25,7 +25,7 @@ export async function processPostToolUse(
   lintSkill: LintSkillFn = defaultLintSkill,
 ): Promise<SyncHookJSONOutput | null> {
   const filePath = filePathOf(input.tool_input);
-  if (!filePath || basename(filePath) !== "SKILL.md") return null;
+  if (filePath == null || filePath === "" || basename(filePath) !== "SKILL.md") return null;
 
   const messages = await lintMessages(dirname(filePath), lintSkill);
   if (messages.length === 0) return null;

--- a/plugins/claude-code/skills/skill/scripts/check-namespace.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-namespace.ts
@@ -56,7 +56,7 @@ export function checkSkillNamespace(name: string, pluginName: string): string[] 
   if (localName === pluginName) return warnings;
 
   const stutterWarning = checkStuttering(localName, pluginName);
-  if (stutterWarning) {
+  if (stutterWarning != null && stutterWarning !== "") {
     warnings.push(`Warning: skill name after prefix ${stutterWarning}`);
     warnings.push(
       `  Consider renaming to avoid repetition (e.g., ${prefix}${pluginName}-foo -> ${prefix}foo)`,
@@ -71,21 +71,21 @@ export async function processHookInput(input: HookInput): Promise<string[]> {
 
   if (input.tool_name !== "Write" && input.tool_name !== "Edit") return warnings;
   const filePath = filePathOf(input.tool_input);
-  if (!filePath) return warnings;
+  if (filePath == null || filePath === "") return warnings;
 
   const pluginName = extractPluginName(filePath);
-  if (!pluginName) return warnings;
+  if (pluginName == null || pluginName === "") return warnings;
 
   const type = getResourceType(filePath);
   const name = await getResourceName(filePath, type);
-  if (!name) return warnings;
+  if (name == null || name === "") return warnings;
 
   if (type === "skill") {
     return checkSkillNamespace(name, pluginName);
   }
 
   const stutterWarning = checkStuttering(name, pluginName);
-  if (stutterWarning) {
+  if (stutterWarning != null && stutterWarning !== "") {
     warnings.push(`Warning: ${type} name ${stutterWarning}`);
     warnings.push(`  Qualified name would be: ${pluginName}:${name}`);
     warnings.push(

--- a/plugins/claude-code/skills/skill/scripts/check-structure.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-structure.ts
@@ -36,13 +36,13 @@ export function processHookInput(input: HookInput): string[] {
   if (input.tool_name !== "Write" && input.tool_name !== "Edit") return [];
 
   const filePath = filePathOf(input.tool_input);
-  if (!filePath) return [];
+  if (filePath == null || filePath === "") return [];
 
   const skillRoot = extractSkillRoot(filePath);
-  if (!skillRoot) return [];
+  if (skillRoot == null || skillRoot === "") return [];
 
   const warning = validateSkillPath(filePath, skillRoot);
-  return warning ? [warning] : [];
+  return warning != null && warning !== "" ? [warning] : [];
 }
 
 async function main(): Promise<void> {

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/parse.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/parse.ts
@@ -33,7 +33,7 @@ function parseFrontmatter(yamlContent: string): z.infer<typeof Frontmatter> {
 }
 
 export function countLines(text: string): number {
-  if (!text) return 0;
+  if (text === "") return 0;
   return text.split("\n").length;
 }
 

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/rules/bang-execution.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/rules/bang-execution.ts
@@ -7,7 +7,7 @@ function bangCommands(body: string): string[] {
   const commands: string[] = [];
   for (const match of body.matchAll(BANG_COMMAND)) {
     const command = match[1]?.trim();
-    if (command) commands.push(command);
+    if (command != null && command !== "") commands.push(command);
   }
   return commands;
 }
@@ -18,7 +18,7 @@ function bashMatchers(allowedTools: unknown): string[] {
   for (const tool of allowedTools) {
     if (typeof tool !== "string") continue;
     const match = tool.match(BASH_ENTRY);
-    if (match?.[1]) matchers.push(match[1]);
+    if (match?.[1] != null && match[1] !== "") matchers.push(match[1]);
   }
   return matchers;
 }

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/rules/headers.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/rules/headers.ts
@@ -17,7 +17,7 @@ function frontmatterOffset(content: SkillContent): number {
 
 function closes(line: string, fence: Fence): boolean {
   const match = line.match(FENCE_CLOSE);
-  if (!match?.[1]) return false;
+  if (match?.[1] == null || match[1] === "") return false;
   const marker = match[1];
   return marker[0] === fence.marker && marker.length >= fence.length;
 }
@@ -37,7 +37,7 @@ export const preferHeaders: Rule = {
       }
 
       const open = line.match(FENCE_OPEN);
-      if (open?.[1]) {
+      if (open?.[1] != null && open[1] !== "") {
         fence = { marker: open[1][0] ?? "", length: open[1].length };
         return;
       }

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/rules/namespace.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/rules/namespace.ts
@@ -12,7 +12,7 @@ export const namespaceMismatch: Rule = {
     const name = content.frontmatter.name;
     const plugin = pluginName(path);
 
-    if (typeof name !== "string" || !plugin) {
+    if (typeof name !== "string" || plugin == null || plugin === "") {
       return {
         rule: "namespace-mismatch",
         severity: "error",
@@ -57,7 +57,7 @@ export const namespaceStutter: Rule = {
     const name = content.frontmatter.name;
     const plugin = pluginName(path);
 
-    if (typeof name !== "string" || !plugin) {
+    if (typeof name !== "string" || plugin == null || plugin === "") {
       return {
         rule: "namespace-stutter",
         severity: "warn",

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/rules/references.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/rules/references.ts
@@ -12,7 +12,7 @@ export function findReferences(body: string): string[] {
 
   for (const match of matches) {
     const ref = match[1];
-    if (ref) refs.add(ref);
+    if (ref != null && ref !== "") refs.add(ref);
   }
 
   return Array.from(refs);

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
@@ -246,10 +246,10 @@ describe("bangExecutionMatcher", () => {
     const content = skill(allowedTools, body);
     const result = single(bangExecutionMatcher.check(content, ""));
     expect(result.passed).toBe(passed);
-    if (severity) {
+    if (severity != null) {
       expect(result.severity).toBe(severity);
     }
-    if (message) {
+    if (message != null && message !== "") {
       expect(result.message).toContain(message);
     }
   });

--- a/plugins/comments/apply/branch.ts
+++ b/plugins/comments/apply/branch.ts
@@ -15,7 +15,7 @@ export async function isCleanTree(): Promise<boolean> {
 async function headMode(path: string): Promise<string> {
   const entry = (await $`git ls-files -s -- ${path}`.quiet()).text().trim();
   const mode = entry.split(/\s+/)[0];
-  if (!mode) throw new Error(`Path is not tracked at HEAD: ${path}`);
+  if (mode == null || mode === "") throw new Error(`Path is not tracked at HEAD: ${path}`);
   return mode;
 }
 

--- a/plugins/comments/apply/edits.ts
+++ b/plugins/comments/apply/edits.ts
@@ -109,7 +109,7 @@ function strandsFragment(item: EditItem, kept: Set<number>, lines: string[]): bo
     const firstWord = stripCommentMarkers(lines[n - 1] ?? "")
       .match(/^[A-Za-z']+/)?.[0]
       ?.toLowerCase();
-    if (firstWord && SENTENCE_CONNECTIVES.has(firstWord)) return true;
+    if (firstWord != null && firstWord !== "" && SENTENCE_CONNECTIVES.has(firstWord)) return true;
   }
   return false;
 }
@@ -189,7 +189,7 @@ function conformRefusal(style: CommentStyle): string {
 function widthRefusal(produced: string[], maxWidth: number | undefined): string | null {
   if (maxWidth === undefined) return null;
   const over = produced.find((line) => line.length > maxWidth);
-  if (!over) return null;
+  if (over == null || over === "") return null;
   return `replacement would produce a ${over.length}-character line (over ${maxWidth}); re-wrap by hand`;
 }
 
@@ -234,7 +234,7 @@ function replaceSpan(
     const indent = before;
     const produced = textLines.map((line) => `${indent}${line}`.replace(/\s+$/, ""));
     const tooWide = widthRefusal(produced, maxWidth);
-    if (tooWide) {
+    if (tooWide != null && tooWide !== "") {
       skips.push({ startLine: item.startLine, reason: "manual", detail: tooWide });
       return;
     }
@@ -247,7 +247,7 @@ function replaceSpan(
     const code = before.replace(/\s+$/, "");
     const produced = [`${code} ${textLines.join(" ")}`.replace(/\s+$/, "")];
     const tooWide = widthRefusal(produced, maxWidth);
-    if (tooWide) {
+    if (tooWide != null && tooWide !== "") {
       skips.push({ startLine: item.startLine, reason: "manual", detail: tooWide });
       return;
     }
@@ -272,7 +272,7 @@ function applyRewrite(
   maxWidth: number | undefined,
 ): void {
   const rewrite = item.verdict.rewrite;
-  if (!rewrite) {
+  if (rewrite == null || rewrite === "") {
     skips.push({
       startLine: item.startLine,
       reason: "manual",
@@ -317,7 +317,7 @@ export function computeFileEdits(
       case "keep":
         break;
       case "trim": {
-        if (item.verdict.trimTo) {
+        if (item.verdict.trimTo != null && item.verdict.trimTo !== "") {
           replaceSpan(item, item.verdict.trimTo, lines, deletions, spanInserts, skips, maxWidth);
           break;
         }

--- a/plugins/comments/apply/report.ts
+++ b/plugins/comments/apply/report.ts
@@ -30,7 +30,10 @@ function firstLine(text: string): string {
  */
 function actionLabel(verdict: Verdict): string {
   if (verdict.action !== "trim") return verdict.action;
-  return verdict.trimTo || verdict.trimToLines?.length ? "trim" : "delete";
+  return (verdict.trimTo != null && verdict.trimTo !== "") ||
+    (verdict.trimToLines != null && verdict.trimToLines.length !== 0)
+    ? "trim"
+    : "delete";
 }
 
 /**
@@ -77,16 +80,16 @@ export function renderReport(items: ReportItem[], options: { fix: boolean }): st
         `  ${color.dim(`:${startLine}`)}  ${actionLabel(verdict)}  ${verdict.category}  ${conf}`,
       );
       lines.push(`      ${verdict.rationale}`);
-      if (verdict.action === "rewrite" && verdict.rewrite) {
-        if (text) lines.push(color.dim(`      old: ${firstLine(text)}`));
+      if (verdict.action === "rewrite" && verdict.rewrite != null && verdict.rewrite !== "") {
+        if (text != null && text !== "") lines.push(color.dim(`      old: ${firstLine(text)}`));
         lines.push(color.dim(`      new: ${firstLine(verdict.rewrite)}`));
       }
-      if (options.fix && verdict.suggestedFix) {
+      if (options.fix && verdict.suggestedFix != null && verdict.suggestedFix !== "") {
         lines.push(color.dim(`      fix: ${verdict.suggestedFix}`));
       }
-      if (verdict.trimTo) {
+      if (verdict.trimTo != null && verdict.trimTo !== "") {
         lines.push(color.dim(`      keep: ${firstLine(verdict.trimTo)}`));
-      } else if (verdict.trimToLines?.length) {
+      } else if (verdict.trimToLines != null && verdict.trimToLines.length !== 0) {
         lines.push(color.dim(`      keep lines: ${verdict.trimToLines.join(", ")}`));
       }
     }

--- a/plugins/comments/detection/collect.ts
+++ b/plugins/comments/detection/collect.ts
@@ -68,7 +68,7 @@ async function newFileContent(
   options: DiffOptions,
   mrSource: MrSource | null,
 ): Promise<string | null> {
-  if (options.mr && mrSource) {
+  if (options.mr != null && options.mr !== "" && mrSource) {
     const encoded = encodeURIComponent(path);
     const raw =
       await $`glab api projects/${mrSource.projectId}/repository/files/${encoded}/raw?ref=${mrSource.ref}`
@@ -103,7 +103,7 @@ async function collectDiffFile(
   mrSource: MrSource | null,
 ): Promise<CollectedComment[]> {
   const language = languageForPath(file.path);
-  if (!language || file.added.length === 0) return [];
+  if (language == null || language === "" || file.added.length === 0) return [];
   const source = await newFileContent(file.path, options, mrSource);
   if (source == null) {
     console.error(`skipped ${file.path}: could not read new file content`);
@@ -142,7 +142,7 @@ export async function collectDiff(
 
 async function collectRepoFile(path: string): Promise<CollectedComment[]> {
   const language = languageForPath(path);
-  if (!language) return [];
+  if (language == null || language === "") return [];
   const file = Bun.file(path);
   if (!(await file.exists())) return [];
   const source = await file.text();

--- a/plugins/comments/detection/diff.ts
+++ b/plugins/comments/detection/diff.ts
@@ -47,18 +47,18 @@ export interface DiffOptions {
 }
 
 async function captureDiff(options: DiffOptions): Promise<string> {
-  if (options.mr) {
+  if (options.mr != null && options.mr !== "") {
     return (await $`glab mr diff ${options.mr}`.quiet().nothrow()).text();
   }
-  if (options.base) {
+  if (options.base != null && options.base !== "") {
     const mergeBase = (await $`git merge-base HEAD ${options.base}`.quiet().nothrow())
       .text()
       .trim();
-    const ref = mergeBase || options.base;
+    const ref = mergeBase !== "" ? mergeBase : options.base;
     return (await $`git diff ${ref}..HEAD`.quiet().nothrow()).text();
   }
   const head = (await $`git diff HEAD`.quiet().nothrow()).text();
-  if (head.trim()) return head;
+  if (head.trim() !== "") return head;
   return (await $`git diff --cached`.quiet().nothrow()).text();
 }
 

--- a/plugins/comments/detection/extract.ts
+++ b/plugins/comments/detection/extract.ts
@@ -126,7 +126,7 @@ function extract(highlighter: Highlighter, source: string, language: BundledLang
       theme,
       ...(state != null && { grammarState: state }),
     });
-    const scopes = next?.getScopes() ?? [];
+    const scopes = next.getScopes() ?? [];
     openAfter.push(scopes.some(isCommentScope));
     state = next;
   }
@@ -135,7 +135,7 @@ function extract(highlighter: Highlighter, source: string, language: BundledLang
 
   const comments: Comment[] = [];
   let current: Comment | null = null;
-  tokens.forEach((lineTokens, index) => {
+  for (const [index, lineTokens] of tokens.entries()) {
     const lineNo = index + 1;
     for (const token of lineTokens) {
       if (token.content.length === 0) continue;
@@ -172,7 +172,7 @@ function extract(highlighter: Highlighter, source: string, language: BundledLang
         };
       }
     }
-  });
+  }
   if (current != null) comments.push(current);
 
   const merged = coalesceLineRuns(comments);

--- a/plugins/comments/evals/eval.ts
+++ b/plugins/comments/evals/eval.ts
@@ -98,7 +98,7 @@ const FixtureInput = z
     if (fixture.action !== "keep" && fixture.category == null) {
       ctx.addIssue({ code: "custom", message: "has an invalid slop category null" });
     }
-    if (fixture.action === "rewrite" && !fixture.rewrite) {
+    if (fixture.action === "rewrite" && (fixture.rewrite == null || fixture.rewrite === "")) {
       ctx.addIssue({ code: "custom", message: `is "rewrite" but carries no gold rewrite text` });
     }
     if (fixture.trimTo != null && (fixture.trimTo.length === 0 || fixture.action !== "trim")) {

--- a/plugins/comments/judge/judge.test.ts
+++ b/plugins/comments/judge/judge.test.ts
@@ -104,7 +104,7 @@ describe("parseVerdict", () => {
       return;
     }
     const v = parseVerdict(raw(over), "x");
-    if (trimTo) {
+    if (trimTo != null && trimTo !== "") {
       expect(v.trimTo).toBe(trimTo);
     } else {
       expect(v.trimTo).toBeUndefined();

--- a/plugins/comments/judge/judge.ts
+++ b/plugins/comments/judge/judge.ts
@@ -55,13 +55,13 @@ const VerdictInput = z
   )
   .superRefine((verdict, ctx) => {
     const rewritten = verdict.action === "rewrite";
-    if (rewritten && !verdict.rewrite) {
+    if (rewritten && (verdict.rewrite == null || verdict.rewrite === "")) {
       ctx.addIssue({
         code: "custom",
         message: `"rewrite" must be a non-empty string when action is "rewrite"`,
       });
     }
-    if (!rewritten && verdict.rewrite) {
+    if (!rewritten && verdict.rewrite != null && verdict.rewrite !== "") {
       ctx.addIssue({ code: "custom", message: `"rewrite" is only valid when action is "rewrite"` });
     }
     if (verdict.trimTo != null && verdict.action !== "trim") {

--- a/plugins/comments/skills/audit/scripts/audit.ts
+++ b/plugins/comments/skills/audit/scripts/audit.ts
@@ -54,7 +54,7 @@ function parseSort(value: string): SortKey {
 async function chdirToRepoRoot(): Promise<void> {
   const result = await $`git rev-parse --show-toplevel`.quiet().nothrow();
   const root = result.text().trim();
-  if (result.exitCode !== 0 || !root) {
+  if (result.exitCode !== 0 || root === "") {
     console.error("Not inside a git repository.");
     process.exit(1);
   }
@@ -97,7 +97,7 @@ const preflightCmd = command(
   async (parsed) => {
     await chdirToRepoRoot();
     const { base, mr, all, path, sort, limit, shardSize, fix } = parsed.flags;
-    const pathGlobs = path ?? [];
+    const pathGlobs = path;
     const sortKey = parseSort(sort);
 
     let comments: CollectedComment[];
@@ -111,10 +111,10 @@ const preflightCmd = command(
       comments = await collectRepo({ pathGlobs });
     } else {
       const options: DiffOptions = {};
-      if (base) options.base = base;
-      if (mr) options.mr = mr;
+      if (base != null && base !== "") options.base = base;
+      if (mr != null && mr !== "") options.mr = mr;
       let mrSource: MrSource | null = null;
-      if (mr) {
+      if (mr != null && mr !== "") {
         mrSource = await resolveMrSource(mr);
         if (!mrSource) {
           console.error("Could not resolve the merge request's source ref via glab.");
@@ -132,7 +132,7 @@ const preflightCmd = command(
     }
 
     const options: BuildJobOptions = { fix };
-    if (shardSize) options.shardSize = shardSize;
+    if (shardSize != null && shardSize !== 0) options.shardSize = shardSize;
     const descriptor = await buildJob(limited, options);
     const written = await writeJob(descriptor);
     // An --mr job records comment text from the remote MR ref, but apply trims
@@ -236,7 +236,7 @@ const applyCmd = command(
   async (parsed) => {
     await chdirToRepoRoot();
     const { job, report, fix, format, maxWidth } = parsed.flags;
-    if (!job) {
+    if (job == null || job === "") {
       console.error("--job <dir> is required.");
       process.exit(1);
     }
@@ -250,7 +250,7 @@ const applyCmd = command(
     const scope = (await scopeFile.exists())
       ? Scope.parse(JSON.parse(await scopeFile.text()))
       : { mr: null };
-    if (scope.mr && !report) {
+    if (scope.mr != null && scope.mr !== "" && !report) {
       console.error(
         `This job audited merge request !${scope.mr} from its remote source. Apply writes trims to the local tree from HEAD, so every comment would read as drift. Re-run with --report, or check out the MR branch and re-run preflight with --base.`,
       );
@@ -275,7 +275,7 @@ const applyCmd = command(
     for (const path of await judgedPaths(job)) {
       const language = languageForPath(path);
       const file = Bun.file(path);
-      if (!language || !(await file.exists())) continue;
+      if (language == null || language === "" || !(await file.exists())) continue;
       const source = await file.text();
       const editItems: EditItem[] = [];
       for (const match of matchVerdicts(path, await extractComments(source, language), verdicts)) {
@@ -299,7 +299,7 @@ const applyCmd = command(
       }
     }
 
-    if (format && !report) {
+    if (format != null && format !== "" && !report) {
       for (const [path, content] of editsByPath) {
         const formatted = await formatContent(format, path, content);
         if (formatted.formatted) {

--- a/plugins/comments/workflow/judge.workflow.js
+++ b/plugins/comments/workflow/judge.workflow.js
@@ -55,7 +55,7 @@ const results = await parallel(job.shards.map((shard) => () => judgeShard(shard)
 
 let flagged = 0;
 for (const result of results) {
-  if (result && typeof result.flagged === "number") flagged += result.flagged;
+  if (typeof result?.flagged === "number") flagged += result.flagged;
 }
 
 log(`Judged ${job.shards.length} shard(s); ${flagged} flagged. Verdicts in ${job.verdictsDir}`);

--- a/plugins/git/scripts/block-default-branch-commit.ts
+++ b/plugins/git/scripts/block-default-branch-commit.ts
@@ -40,7 +40,7 @@ export async function processInput(input: PreToolUseHookInput): Promise<SyncHook
   // It fails open on shell metacharacters, so the deny decision rests on the
   // command this hook reads for itself.
   const command = BashInput.safeParse(input.tool_input).data?.command;
-  if (!command || !invokesGitCommit(command)) {
+  if (command == null || command === "" || !invokesGitCommit(command)) {
     return null;
   }
 
@@ -48,7 +48,7 @@ export async function processInput(input: PreToolUseHookInput): Promise<SyncHook
   // the Bash command runs: a subagent working in a worktree reports that
   // worktree as `input.cwd`, and resolving the branch anywhere else reads the
   // wrong repo.
-  const dir = input.cwd ?? process.cwd();
+  const dir = input.cwd;
 
   // One rev-parse yields both the repo root (cache key) and current branch.
   // A non-zero exit means we're outside a repo; "HEAD" means detached.
@@ -57,12 +57,18 @@ export async function processInput(input: PreToolUseHookInput): Promise<SyncHook
     return null;
   }
   const [repoRoot, currentBranch] = rev.text().trim().split("\n");
-  if (!repoRoot || !currentBranch || currentBranch === "HEAD") {
+  if (
+    repoRoot == null ||
+    repoRoot === "" ||
+    currentBranch == null ||
+    currentBranch === "" ||
+    currentBranch === "HEAD"
+  ) {
     return null;
   }
 
   const defaultBranch = await getDefaultBranch(dir, repoRoot);
-  if (!defaultBranch) {
+  if (defaultBranch == null || defaultBranch === "") {
     return null;
   }
 

--- a/plugins/git/scripts/default-branch.ts
+++ b/plugins/git/scripts/default-branch.ts
@@ -9,8 +9,7 @@ export async function getDefaultBranch(cwd?: string, repoRoot?: string): Promise
     const root =
       repoRoot ?? (await $`git rev-parse --show-toplevel`.cwd(dir).quiet()).text().trim();
     const safePath = root.replace(/\//g, "_");
-    const tmpDir = process.env.TMPDIR || tmpdir();
-    const cacheFile = join(tmpDir, `claude-default-branch${safePath}`);
+    const cacheFile = join(tmpdir(), `claude-default-branch${safePath}`);
 
     if (await Bun.file(cacheFile).exists()) {
       return (await Bun.file(cacheFile).text()).trim();
@@ -34,11 +33,10 @@ export async function getDefaultBranch(cwd?: string, repoRoot?: string): Promise
       }
     }
 
-    if (defaultBranch) {
-      await Bun.write(cacheFile, defaultBranch);
-    }
+    if (defaultBranch == null || defaultBranch === "") return null;
 
-    return defaultBranch || null;
+    await Bun.write(cacheFile, defaultBranch);
+    return defaultBranch;
   } catch {
     return null;
   }

--- a/plugins/git/scripts/hook-input.ts
+++ b/plugins/git/scripts/hook-input.ts
@@ -7,7 +7,9 @@ import { z } from "zod";
 const base = {
   session_id: z.string().catch(""),
   transcript_path: z.string().catch(""),
-  cwd: z.string().catch(""),
+  // The SDK types `cwd` as required, so a malformed input falls back to the
+  // hook process's own directory rather than an unusable empty path.
+  cwd: z.string().catch(() => process.cwd()),
   tool_name: z.string().catch(""),
   tool_input: z.unknown().catch(undefined),
   tool_use_id: z.string().catch(""),

--- a/plugins/git/scripts/https-fallback.ts
+++ b/plugins/git/scripts/https-fallback.ts
@@ -112,7 +112,8 @@ function findNetworkInvocation(command: string): { subcommand: string; insertAt:
     const insertAt = match.index + match[0].length;
     const [segment = ""] = command.slice(insertAt).split(SEGMENT_SEPARATOR);
     const subcommand = subcommandOf(segment.trim().split(/\s+/).filter(Boolean));
-    if (subcommand && NETWORK_SUBCOMMANDS.has(subcommand)) return { subcommand, insertAt };
+    if (subcommand != null && subcommand !== "" && NETWORK_SUBCOMMANDS.has(subcommand))
+      return { subcommand, insertAt };
   }
   return null;
 }
@@ -159,17 +160,17 @@ export async function processInput(
   readRemotes: (cwd: string) => Promise<string> = readRemoteUrls,
 ): Promise<SyncHookJSONOutput | null> {
   const command = BashInput.safeParse(input.tool_input).data?.command;
-  if (!command) return null;
+  if (command == null || command === "") return null;
 
-  if (!gitNetworkSubcommand(command)) return null;
-  if (!hasSshAuthFailure(input.error ?? "")) return null;
+  if (gitNetworkSubcommand(command) == null || gitNetworkSubcommand(command) === "") return null;
+  if (!hasSshAuthFailure(input.error)) return null;
 
-  const cwd = input.cwd ?? process.cwd();
+  const cwd = input.cwd;
   const target = sshProviderOf(command) ?? sshProviderOf(await readRemotes(cwd));
   if (!target) return null;
 
   const retryCommand = rewriteCommand(command, target);
-  if (!retryCommand) return null;
+  if (retryCommand == null || retryCommand === "") return null;
 
   return {
     hookSpecificOutput: {
@@ -186,8 +187,6 @@ async function main(): Promise<void> {
   } catch {
     return;
   }
-
-  if (input.hook_event_name !== "PostToolUseFailure") return;
 
   const output = await processInput(input);
   if (output) {

--- a/plugins/git/skills/conflicts/scripts/check-markers.ts
+++ b/plugins/git/skills/conflicts/scripts/check-markers.ts
@@ -27,7 +27,8 @@ async function main(): Promise<void> {
   const result = await $`git diff --cached --check`.quiet().nothrow();
 
   if (result.exitCode !== 0) {
-    const output = result.stderr.toString() || result.stdout.toString();
+    const stderr = result.stderr.toString();
+    const output = stderr !== "" ? stderr : result.stdout.toString();
     const markers = output
       .split("\n")
       .filter((line) => line.includes("conflict marker"))
@@ -35,7 +36,7 @@ async function main(): Promise<void> {
       .join(", ");
 
     const denial = formatOutput(
-      `Conflict markers in staged files: ${markers || "run 'git diff --cached --check' for details"}`,
+      `Conflict markers in staged files: ${markers !== "" ? markers : "run 'git diff --cached --check' for details"}`,
     );
     process.stdout.write(`${JSON.stringify(denial)}\n`);
   }

--- a/plugins/git/skills/conflicts/scripts/context.ts
+++ b/plugins/git/skills/conflicts/scripts/context.ts
@@ -23,7 +23,7 @@ async function detectOperation(): Promise<{ op: Operation; ref: string | null }>
 
 const { op, ref } = await detectOperation();
 
-if (!op || !ref) {
+if (op == null || ref == null || ref === "") {
   console.log("No conflict operation in progress");
   process.exit(0);
 }
@@ -32,7 +32,7 @@ console.log(`Operation: ${op}`);
 console.log("");
 
 const conflictedFiles = await $`git diff --name-only --diff-filter=U`.text();
-if (!conflictedFiles.trim()) {
+if (conflictedFiles.trim() === "") {
   console.log("No conflicted files");
   process.exit(0);
 }
@@ -40,4 +40,5 @@ if (!conflictedFiles.trim()) {
 console.log("Incoming commits:");
 const files = conflictedFiles.trim().split("\n");
 const logs = await $`git log --oneline ${ref} -10 -- ${files}`.text();
-console.log(logs.trim() || "(none found)");
+const trimmedLogs = logs.trim();
+console.log(trimmedLogs !== "" ? trimmedLogs : "(none found)");

--- a/plugins/git/skills/conflicts/scripts/status.ts
+++ b/plugins/git/skills/conflicts/scripts/status.ts
@@ -4,7 +4,7 @@ import { $ } from "bun";
 
 const files = await $`git diff --name-only --diff-filter=U`.text();
 
-if (!files.trim()) {
+if (files.trim() === "") {
   console.log("No conflicted files");
   process.exit(0);
 }

--- a/plugins/git/skills/conflicts/scripts/upstream.ts
+++ b/plugins/git/skills/conflicts/scripts/upstream.ts
@@ -4,7 +4,7 @@ import { $ } from "bun";
 import { getDefaultBranch } from "../../../scripts/default-branch";
 
 const defaultBranch = await getDefaultBranch();
-if (!defaultBranch) {
+if (defaultBranch == null || defaultBranch === "") {
   console.log("Could not determine default branch");
   process.exit(0);
 }
@@ -16,7 +16,7 @@ await $`git fetch origin ${defaultBranch}`.quiet().nothrow();
 const mergeBase = (await $`git merge-base HEAD ${remote}`.quiet().nothrow()).text().trim();
 const upstreamTip = (await $`git rev-parse ${remote}`.quiet().nothrow()).text().trim();
 
-if (!mergeBase || !upstreamTip) {
+if (mergeBase === "" || upstreamTip === "") {
   console.log("Could not determine divergence");
   process.exit(0);
 }

--- a/plugins/github/scripts/fetch.ts
+++ b/plugins/github/scripts/fetch.ts
@@ -88,7 +88,7 @@ export function parseGitHubUrl(url: string): { type: string; suggestion: string 
 
   const pathMatch = RepoPath.safeParse(repoPathPattern.match(path));
   if (pathMatch.success) {
-    const subpath = pathMatch.data._ || "";
+    const subpath = pathMatch.data._ ?? "";
 
     // Empty subpath means trailing slash on repo root
     if (subpath === "") {

--- a/plugins/github/scripts/pr-comments.test.ts
+++ b/plugins/github/scripts/pr-comments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, test } from "bun:test";
 import {
   type Comment,
   detectRole,
+  resolveRole,
   filterThreads,
   findLastReviewDate,
   formatThreads,
@@ -70,6 +71,18 @@ describe("detectRole", () => {
     ["DouweM", "bendrucker", "reviewer"],
   ])("detectRole(viewer=%p, author=%p) -> %p", (viewer, author, expected) => {
     expect(detectRole(viewer, author)).toBe(expected);
+  });
+});
+
+describe("resolveRole", () => {
+  test.each<[string | undefined, Role | null]>([
+    ["author", "author"],
+    ["reviewer", "reviewer"],
+    [undefined, "reviewer"],
+    ["", "reviewer"],
+    ["bogus", null],
+  ])("resolveRole(flag=%p) -> %p", (flag, expected) => {
+    expect(resolveRole(flag, "DouweM", "bendrucker")).toBe(expected);
   });
 });
 

--- a/plugins/github/scripts/pr-comments.ts
+++ b/plugins/github/scripts/pr-comments.ts
@@ -88,7 +88,14 @@ export function parseUrl(url: string): {
   const repo = parts[1];
   const number = Number.parseInt(parts[3] ?? "", 10);
 
-  if (!owner || !repo || parts[2] !== "pull" || Number.isNaN(number)) {
+  if (
+    owner == null ||
+    owner === "" ||
+    repo == null ||
+    repo === "" ||
+    parts[2] !== "pull" ||
+    Number.isNaN(number)
+  ) {
     throw new Error(`Invalid PR URL: ${url}`);
   }
 
@@ -192,9 +199,9 @@ export function formatThreads(
 
     for (const thread of fileThreads) {
       let lineInfo: string;
-      if (thread.startLine) {
+      if (thread.startLine != null) {
         lineInfo = `Lines ${thread.startLine}–${thread.line}`;
-      } else if (thread.line) {
+      } else if (thread.line != null) {
         lineInfo = `Line ${thread.line}`;
       } else {
         lineInfo = "File-level";
@@ -314,12 +321,12 @@ async function main(): Promise<void> {
 
   do {
     const variables: Record<string, string | number | undefined> = { owner, repo, number };
-    if (cursor) variables.cursor = cursor;
+    if (cursor != null && cursor !== "") variables.cursor = cursor;
 
     const result = await fetchGraphQL(QUERY, variables);
     const pr = result.data.repository.pullRequest;
 
-    if (!prTitle) {
+    if (prTitle === "") {
       viewer = result.data.viewer.login;
       prTitle = pr.title;
       prAuthor = pr.author?.login ?? "ghost";
@@ -331,7 +338,7 @@ async function main(): Promise<void> {
 
     const pageInfo = pr.reviewThreads.pageInfo;
     cursor = pageInfo.hasNextPage ? (pageInfo.endCursor ?? undefined) : undefined;
-  } while (cursor);
+  } while (cursor != null && cursor !== "");
 
   const role = resolveRole(argv.flags.role, viewer, prAuthor);
   if (role == null) {
@@ -340,7 +347,7 @@ async function main(): Promise<void> {
   }
 
   let since: Date | undefined;
-  if (argv.flags.since) {
+  if (argv.flags.since != null && argv.flags.since !== "") {
     if (argv.flags.since === "last-review") {
       const date = findLastReviewDate(reviews, viewer, role);
       if (!date) {

--- a/plugins/github/scripts/pr-comments.ts
+++ b/plugins/github/scripts/pr-comments.ts
@@ -99,6 +99,16 @@ export function detectRole(viewer: string, prAuthor: string): Role {
   return viewer === prAuthor ? "author" : "reviewer";
 }
 
+/** An absent or empty --role falls back to detection. A non-empty invalid value returns null. */
+export function resolveRole(
+  roleFlag: string | undefined,
+  viewer: string,
+  prAuthor: string,
+): Role | null {
+  if (roleFlag == null || roleFlag === "") return detectRole(viewer, prAuthor);
+  return Role.safeParse(roleFlag).data ?? null;
+}
+
 export function filterThreads(
   threads: Thread[],
   options: {
@@ -323,12 +333,11 @@ async function main(): Promise<void> {
     cursor = pageInfo.hasNextPage ? (pageInfo.endCursor ?? undefined) : undefined;
   } while (cursor);
 
-  const roleFlag = argv.flags.role ? Role.safeParse(argv.flags.role) : null;
-  if (roleFlag && !roleFlag.success) {
+  const role = resolveRole(argv.flags.role, viewer, prAuthor);
+  if (role == null) {
     console.error(`Invalid --role: ${argv.flags.role} (must be "author" or "reviewer")`);
     process.exit(1);
   }
-  const role: Role = roleFlag?.data ?? detectRole(viewer, prAuthor);
 
   let since: Date | undefined;
   if (argv.flags.since) {

--- a/plugins/github/scripts/review-threads.ts
+++ b/plugins/github/scripts/review-threads.ts
@@ -64,8 +64,8 @@ async function ghGraphQL<S extends z.ZodType>(
 }
 
 async function readBody(body?: string, file?: string): Promise<string> {
-  if (body) return body;
-  if (file) return (await Bun.file(file).text()).trim();
+  if (body != null && body !== "") return body;
+  if (file != null && file !== "") return (await Bun.file(file).text()).trim();
   return (await Bun.stdin.text()).trim();
 }
 
@@ -86,7 +86,7 @@ const replyCmd = command(
   async (parsed) => {
     const threadId = parsed._.threadId;
     const body = await readBody(parsed.flags.body, parsed.flags.bodyFile);
-    if (!body) {
+    if (body === "") {
       console.error("Reply body is empty");
       process.exit(1);
     }
@@ -123,7 +123,7 @@ const ThreadCommentResponse = z.looseObject({
 async function firstCommentId(threadId: string): Promise<string> {
   const result = await ghGraphQL(ThreadCommentResponse, THREAD_COMMENT_QUERY, { threadId });
   const id = result.data.node?.comments.nodes[0]?.id;
-  if (!id) {
+  if (id == null || id === "") {
     throw new Error(`No comment found for thread ${threadId}`);
   }
   return id;

--- a/plugins/github/scripts/reviewers.ts
+++ b/plugins/github/scripts/reviewers.ts
@@ -20,7 +20,7 @@ export function isBot(author: Author | null | undefined): boolean {
 // comments are ignored. Absent file or unset env yields an empty set.
 export async function loadExtraReviewers(): Promise<Set<string>> {
   const dataDir = process.env.CLAUDE_PLUGIN_DATA;
-  if (!dataDir) return new Set();
+  if (dataDir == null || dataDir === "") return new Set();
   const file = Bun.file(join(dataDir, "reviewers.txt"));
   if (!(await file.exists())) return new Set();
   return parseReviewers(await file.text());

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -247,7 +247,7 @@ const stripGit = (s: string): string => (s.endsWith(".git") ? s.slice(0, -4) : s
 
 export function parseRepo(remoteUrl: string): { owner: string; repo: string } | null {
   const trimmed = remoteUrl.trim();
-  if (!trimmed) return null;
+  if (trimmed === "") return null;
 
   const tryPattern = (pattern: string): { owner: string; repo: string } | null => {
     const match = RepoParams.safeParse(
@@ -263,8 +263,10 @@ export function parseRepo(remoteUrl: string): { owner: string; repo: string } | 
 
   // scp-like: git@github.com:owner/repo(.git)
   const scpMatch = trimmed.match(/^git@github\.com:([^/]+)\/(.+)$/);
-  if (scpMatch?.[1] && scpMatch[2]) {
-    return { owner: scpMatch[1], repo: stripGit(scpMatch[2]) };
+  const scpOwner = scpMatch?.at(1);
+  const scpRepo = scpMatch?.at(2);
+  if (scpOwner != null && scpOwner !== "" && scpRepo != null && scpRepo !== "") {
+    return { owner: scpOwner, repo: stripGit(scpRepo) };
   }
 
   return null;
@@ -303,7 +305,8 @@ function exec(command: string): ExecResult {
     const stdout = execSync(command, execOptions).toString().trim();
     return { ok: true, stdout };
   } catch (err) {
-    const stderr = err && typeof err === "object" && "stderr" in err ? streamText(err.stderr) : "";
+    const stderr =
+      typeof err === "object" && err !== null && "stderr" in err ? streamText(err.stderr) : "";
     const { rateLimited, retryAfter } = detectRateLimit(stderr);
     return { ok: false, stderr, rateLimited, retryAfter };
   }
@@ -442,7 +445,7 @@ export function probePr(prNumber: number, repo: string, run: ExecFn = exec): Pro
   const prState = view.state;
   const mergeable = view.mergeable;
   const mergeStateStatus = view.mergeStateStatus;
-  if (!branch) {
+  if (branch === "") {
     const message = `gh pr view did not include headRefName for PR #${prNumber}`;
     console.error(`${message}; treating as probe failure`);
     return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
@@ -461,7 +464,9 @@ export function probePr(prNumber: number, repo: string, run: ExecFn = exec): Pro
   }
   let state: InternalState;
   try {
-    state = deriveChecksState(Checks.parse(JSON.parse(checksResult.stdout || "[]")));
+    state = deriveChecksState(
+      Checks.parse(JSON.parse(checksResult.stdout !== "" ? checksResult.stdout : "[]")),
+    );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`gh pr checks returned unusable JSON for PR #${prNumber}: ${message}`);
@@ -479,7 +484,7 @@ export function probePr(prNumber: number, repo: string, run: ExecFn = exec): Pro
       stderr: runIdResult.stderr,
     };
   }
-  const runId = runIdResult.stdout ? runIdResult.stdout : null;
+  const runId = runIdResult.stdout !== "" ? runIdResult.stdout : null;
 
   return {
     kind: "ok",
@@ -523,7 +528,7 @@ export function probeBranch(repo: string, branch: string, run: ExecFn = exec): P
   }
   let runs: RunView[];
   try {
-    runs = RunList.parse(JSON.parse(result.stdout || "[]"));
+    runs = RunList.parse(JSON.parse(result.stdout !== "" ? result.stdout : "[]"));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`gh run list returned unusable JSON for ${repo}@${branch}: ${message}`);
@@ -544,7 +549,7 @@ export function computeInterval(durationsSeconds: number[]): number {
 }
 
 function fetchInterval(branch: string, repo: string | null): number {
-  const repoFlag = repo ? `--repo ${repo} ` : "";
+  const repoFlag = repo != null && repo !== "" ? `--repo ${repo} ` : "";
   const result = exec(
     `gh run list ${repoFlag}--branch ${branch} --limit 5 --json createdAt,updatedAt,conclusion --jq '[.[] | select(.conclusion == "success") | ((.updatedAt | fromdateiso8601) - (.createdAt | fromdateiso8601))]'`,
   );
@@ -555,7 +560,7 @@ function fetchInterval(branch: string, repo: string | null): number {
     return DEFAULT_INTERVAL_SECONDS;
   }
   try {
-    const parsed = Durations.parse(JSON.parse(result.stdout || "[]"));
+    const parsed = Durations.parse(JSON.parse(result.stdout !== "" ? result.stdout : "[]"));
     return computeInterval(parsed.filter((n): n is number => typeof n === "number"));
   } catch (err) {
     console.error(
@@ -585,7 +590,7 @@ export function probeRunId(runId: string, repo: string, run: ExecFn = exec): Pro
   }
   let view: RunView;
   try {
-    view = RunView.parse(JSON.parse(result.stdout || "{}"));
+    view = RunView.parse(JSON.parse(result.stdout !== "" ? result.stdout : "{}"));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`gh run view returned unusable JSON for run ${runId}: ${message}`);
@@ -640,11 +645,11 @@ async function watch(options: RunOptions): Promise<void> {
     }
 
     let result: Probed;
-    if (options.mode === "pr" && prNumber !== null && repo !== null) {
+    if (options.mode === "pr" && prNumber !== null) {
       result = probePr(prNumber, repo);
-    } else if (options.mode === "branch" && repo !== null && branch !== null) {
+    } else if (options.mode === "branch" && branch !== null) {
       result = probeBranch(repo, branch);
-    } else if (options.mode === "run-id" && repo !== null) {
+    } else if (options.mode === "run-id") {
       result = probeRunId(options.runId, repo);
     } else {
       throw new Error("Invalid run configuration");
@@ -658,7 +663,7 @@ async function watch(options: RunOptions): Promise<void> {
     } else if (result.kind === "error") {
       if (result.rateLimited) {
         emit({ type: "rate-limited", retry_after: result.retryAfter });
-      } else if (result.stderr) {
+      } else if (result.stderr !== "") {
         // Surface the probe failure so callers see *something* before the
         // api-error threshold is reached. Without this, a misshapen gh
         // command (e.g., schema drift in --json fields) silently retries
@@ -670,16 +675,11 @@ async function watch(options: RunOptions): Promise<void> {
       for (const event of outcome.events) emit(event);
     } else {
       state = clearApiErrors(state);
-      if (result.branch) branch = result.branch;
+      if (result.branch != null && result.branch !== "") branch = result.branch;
       // Settle mergeability before deriving events so `conflicts` lands in the
       // same cycle as a stale `success`, ahead of the terminal return below.
       let probe = result.probe;
-      if (
-        options.mode === "pr" &&
-        prNumber !== null &&
-        repo !== null &&
-        probeIsUndetermined(probe)
-      ) {
+      if (options.mode === "pr" && prNumber !== null && probeIsUndetermined(probe)) {
         const resolved = await resolveMergeable(prNumber, repo, exec, sleep);
         probe = {
           ...probe,
@@ -761,8 +761,8 @@ async function main(): Promise<void> {
     apiErrorThreshold: argv.flags.apiErrorThreshold,
   };
 
-  if (prUrl) {
-    if (argv.flags.repo) {
+  if (prUrl != null && prUrl !== "") {
+    if (argv.flags.repo != null && argv.flags.repo !== "") {
       console.error("--repo only applies in branch or run-id mode");
       process.exit(1);
     }
@@ -771,7 +771,7 @@ async function main(): Promise<void> {
   }
 
   const resolveRepo = (): string => {
-    if (argv.flags.repo) return argv.flags.repo;
+    if (argv.flags.repo != null && argv.flags.repo !== "") return argv.flags.repo;
     const detected = detectRepoFromGit();
     if (!detected) {
       console.error("Could not infer repo from git remote. Pass --repo <owner/repo>.");
@@ -780,12 +780,12 @@ async function main(): Promise<void> {
     return `${detected.owner}/${detected.repo}`;
   };
 
-  if (runId) {
+  if (runId != null && runId !== "") {
     await watch({ mode: "run-id", repo: resolveRepo(), runId, ...common });
     return;
   }
 
-  if (!branch) return;
+  if (branch == null || branch === "") return;
   await watch({ mode: "branch", repo: resolveRepo(), branch, ...common });
 }
 

--- a/plugins/github/skills/copilot/scripts/review.ts
+++ b/plugins/github/skills/copilot/scripts/review.ts
@@ -303,7 +303,7 @@ export function splitPaths(output: string): string[] {
 function collectDiff(base: string, cwd: string): Diff {
   const committed = git(["diff", `${base}...HEAD`], cwd);
   const working = git(["diff", "HEAD"], cwd);
-  const patch = [committed, working].filter((part) => part.trim()).join("\n");
+  const patch = [committed, working].filter((part) => part.trim() !== "").join("\n");
 
   const names = new Set<string>();
   for (const range of [`${base}...HEAD`, "HEAD"]) {
@@ -512,7 +512,7 @@ async function runCopilot(prompt: string, angle: Angle, options: RunOptions): Pr
     child.exited,
   ]);
 
-  const output = [stdout, stderr].filter((part) => part.trim()).join("\n");
+  const output = [stdout, stderr].filter((part) => part.trim() !== "").join("\n");
   const credits = output.match(/AI Credits\s+([\d.]+)/);
 
   return { angle, exitCode, output, credits: credits ? Number(credits[1]) : null };
@@ -669,7 +669,7 @@ async function main(): Promise<void> {
   }
   const diff = collectDiff(base, cwd);
 
-  if (!diff.patch.trim() && diff.files.length === 0) {
+  if (diff.patch.trim() === "" && diff.files.length === 0) {
     console.error(`Nothing to review against ${base}.`);
     process.exit(1);
   }
@@ -677,7 +677,7 @@ async function main(): Promise<void> {
   // The agentic worktree is checked out at HEAD, so uncommitted work would put the reviewer
   // in front of code that does not match the diff it was handed, and every finding it read
   // out of a file would be suspect.
-  if (argv.flags.agentic && git(["status", "--porcelain"], cwd).trim()) {
+  if (argv.flags.agentic && git(["status", "--porcelain"], cwd).trim() !== "") {
     console.error(`${RED}--agentic needs a clean tree: it reviews a checkout of HEAD.${RESET}`);
     console.error(`${YELLOW}Commit the working changes, or run the one-shot shape.${RESET}`);
     process.exit(1);
@@ -759,7 +759,7 @@ async function main(): Promise<void> {
   console.error(`  shape      ${argv.flags.agentic ? "agentic, capped session" : "one-shot"}`);
   console.error(`  base       ${base}`);
   console.error(
-    `  files      ${diff.files.length}${skipped.length ? ` (${skipped.length} body omitted)` : ""}`,
+    `  files      ${diff.files.length}${skipped.length !== 0 ? ` (${skipped.length} body omitted)` : ""}`,
   );
   console.error(`  angles     ${angles.length} (${angles.map((angle) => angle.id).join(", ")})`);
   console.error(

--- a/plugins/gitlab/hooks/auth.ts
+++ b/plugins/gitlab/hooks/auth.ts
@@ -12,7 +12,7 @@ export type HookInput = z.infer<typeof HookInput>;
 
 export function processInput(input: HookInput): SyncHookJSONOutput | null {
   const command = input.tool_input.command;
-  if (!command || !command.includes("glab")) return null;
+  if (command == null || command === "" || !command.includes("glab")) return null;
 
   const response = JSON.stringify(input.tool_response ?? "");
   if (!response.includes("invalid_grant")) return null;

--- a/plugins/gitlab/hooks/lint.ts
+++ b/plugins/gitlab/hooks/lint.ts
@@ -129,10 +129,10 @@ async function gitConfigPath(cwd: string, env: LintEnv): Promise<string | null> 
 
     // Worktrees and submodules use a `.git` file: `gitdir: <path>`.
     const pointer = await env.readFile(dotGit);
-    if (pointer) {
-      const match = pointer.match(/^gitdir:\s*(.+)\s*$/m);
-      if (match?.[1]) {
-        const gitDir = isAbsolute(match[1]) ? match[1] : resolve(dir, match[1]);
+    if (pointer != null && pointer !== "") {
+      const gitdir = pointer.match(/^gitdir:\s*(.+)\s*$/m)?.at(1);
+      if (gitdir != null && gitdir !== "") {
+        const gitDir = isAbsolute(gitdir) ? gitdir : resolve(dir, gitdir);
         for (const candidate of [
           join(gitDir, "config"),
           // A linked worktree's gitdir is <main>/.git/worktrees/<name>.
@@ -153,14 +153,14 @@ async function gitConfigPath(cwd: string, env: LintEnv): Promise<string | null> 
 
 export async function originHost(cwd: string, env: LintEnv): Promise<string | null> {
   const configPath = await gitConfigPath(cwd, env);
-  if (!configPath) return null;
+  if (configPath == null || configPath === "") return null;
   const config = await env.readFile(configPath);
-  if (!config) return null;
-  const section = config.match(/\[remote "origin"\]([^[]*)/);
-  if (!section?.[1]) return null;
-  const url = section[1].match(/^\s*url\s*=\s*(.+)\s*$/m);
-  if (!url?.[1]) return null;
-  return remoteHost(url[1].trim());
+  if (config == null || config === "") return null;
+  const section = config.match(/\[remote "origin"\]([^[]*)/)?.at(1);
+  if (section == null || section === "") return null;
+  const url = section.match(/^\s*url\s*=\s*(.+)\s*$/m)?.at(1);
+  if (url == null || url === "") return null;
+  return remoteHost(url.trim());
 }
 
 export async function lintGh(command: string, cwd: string, env: LintEnv): Promise<string | null> {
@@ -170,7 +170,7 @@ export async function lintGh(command: string, cwd: string, env: LintEnv): Promis
   if (!targetsOrigin) return null;
 
   const host = await originHost(cwd, env);
-  if (host && isGitLabHost(host)) {
+  if (host != null && host !== "" && isGitLabHost(host)) {
     return `This repository's origin remote is GitLab (${host}). gh cannot resolve it; use glab instead, and load gitlab:merge-request for MR workflows (or pass -R <owner>/<repo> if you really meant a GitHub repo).`;
   }
   return null;
@@ -200,16 +200,16 @@ export async function processInput(
   env: LintEnv = defaultEnv,
 ): Promise<SyncHookJSONOutput | null> {
   const command = input.tool_input.command;
-  if (!command) return null;
+  if (command == null || command === "") return null;
 
   if (command.includes("glab")) {
     const violation = lintGlab(command);
-    if (violation) return deny(violation);
+    if (violation != null && violation !== "") return deny(violation);
   }
 
   if (/(^|\s)gh\s/.test(command)) {
     const violation = await lintGh(command, input.cwd, env);
-    if (violation) return deny(violation);
+    if (violation != null && violation !== "") return deny(violation);
   }
 
   if (command.includes("glab")) {

--- a/plugins/gitlab/scripts/merge.ts
+++ b/plugins/gitlab/scripts/merge.ts
@@ -238,7 +238,10 @@ if (import.meta.main) {
     },
   });
 
-  const branch = argv._.branch || (await $`git branch --show-current`.text()).trim();
+  const branch =
+    argv._.branch != null && argv._.branch !== ""
+      ? argv._.branch
+      : (await $`git branch --show-current`.text()).trim();
 
   if (argv.flags.status) {
     console.log(JSON.stringify(await status(branch), null, 2));

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
@@ -234,7 +234,7 @@ export function parseMrUrl(url: string): {
     throw new Error(`Invalid GitLab MR URL: ${url}`);
   }
   const project = path.slice(0, markerIndex);
-  if (!project || !project.includes("/")) {
+  if (project === "" || !project.includes("/")) {
     throw new Error(`Invalid GitLab MR URL: ${url}`);
   }
   const tailPattern = new UrlPattern(":iid(/*)");
@@ -256,16 +256,16 @@ export function parseMrUrl(url: string): {
 
 export function parseProject(remoteUrl: string): string {
   const trimmed = remoteUrl.trim();
-  if (!trimmed) {
+  if (trimmed === "") {
     throw new Error("Empty remote URL");
   }
 
-  const match = trimmed.match(/^(?:ssh:\/\/[^/]+\/|[^@\s]+@[^:]+:|https?:\/\/[^/]+\/)(.+)$/);
-  if (!match?.[1]) {
+  const path = trimmed.match(/^(?:ssh:\/\/[^/]+\/|[^@\s]+@[^:]+:|https?:\/\/[^/]+\/)(.+)$/)?.at(1);
+  if (path == null || path === "") {
     throw new Error(`Could not parse remote URL: ${remoteUrl}`);
   }
 
-  const cleaned = match[1].replace(/\/$/, "").replace(/\.git$/, "");
+  const cleaned = path.replace(/\/$/, "").replace(/\.git$/, "");
   if (!cleaned.includes("/")) {
     throw new Error(`Remote URL missing group/project path: ${remoteUrl}`);
   }
@@ -416,7 +416,8 @@ function exec(command: string): ExecResult {
     const stdout = execSync(command, execOptions).toString().trim();
     return { ok: true, stdout };
   } catch (err) {
-    const stderr = err && typeof err === "object" && "stderr" in err ? streamText(err.stderr) : "";
+    const stderr =
+      typeof err === "object" && err !== null && "stderr" in err ? streamText(err.stderr) : "";
     // glab does not surface structured rate-limit metadata. Rather than
     // regexing human text we rely on the api-error counter instead.
     return { ok: false, stderr, rateLimited: false, retryAfter: "" };
@@ -524,7 +525,7 @@ function parsePipeline(parsed: unknown): { id: string; status: InternalState; sh
   const fields = PipelineEntry.safeParse(parsed);
   if (!fields.success) return null;
   const id = fields.data.id === undefined ? "" : String(fields.data.id);
-  if (!id) return null;
+  if (id === "") return null;
   return { id, status: normalizePipelineStatus(fields.data.status), sha: fields.data.sha };
 }
 
@@ -558,7 +559,7 @@ function fetchPipelineList(
   }
   let parsed: unknown;
   try {
-    parsed = JSON.parse(result.stdout || "null");
+    parsed = JSON.parse(result.stdout !== "" ? result.stdout : "null");
   } catch (err) {
     console.error(
       `glab api returned unparseable JSON for pipelines on ${describeTarget(target)}: ${err instanceof Error ? err.message : String(err)}`,
@@ -590,7 +591,7 @@ function fetchJobs(projectEncoded: string, pipelineId: string, run: ExecFn = exe
   }
   let parsed: unknown;
   try {
-    parsed = JSON.parse(result.stdout || "null");
+    parsed = JSON.parse(result.stdout !== "" ? result.stdout : "null");
   } catch (err) {
     console.error(
       `glab api returned unparseable JSON for jobs on pipeline ${pipelineId}: ${err instanceof Error ? err.message : String(err)}`,
@@ -723,7 +724,7 @@ function fetchPipelineById(
     };
   }
   try {
-    const pipeline = parsePipeline(JSON.parse(result.stdout || "null"));
+    const pipeline = parsePipeline(JSON.parse(result.stdout !== "" ? result.stdout : "null"));
     if (!pipeline) {
       // A successful glab call with an empty/null body for a specific pipeline
       // ID is unexpected (404s fail the exec). Surface this as a transient
@@ -811,7 +812,7 @@ function fetchInterval(projectEncoded: string, target: PipelineTarget): number {
     return DEFAULT_INTERVAL_SECONDS;
   }
   try {
-    const parsed = Entries.safeParse(JSON.parse(result.stdout || "[]"));
+    const parsed = Entries.safeParse(JSON.parse(result.stdout !== "" ? result.stdout : "[]"));
     if (parsed.success) {
       return computeInterval(pipelineDurations(parsed.data));
     }
@@ -828,7 +829,7 @@ function fetchInterval(projectEncoded: string, target: PipelineTarget): number {
 
 function detectProjectFromRemote(): string | null {
   const result = exec("git remote get-url origin");
-  if (!result.ok || !result.stdout) return null;
+  if (!result.ok || result.stdout === "") return null;
   try {
     return parseProject(result.stdout);
   } catch {
@@ -1009,18 +1010,18 @@ async function main(): Promise<void> {
   }
 
   let target: RunTarget;
-  if (mrUrl) {
+  if (mrUrl != null && mrUrl !== "") {
     target = { mode: "mr", mrUrl };
-  } else if (branch) {
+  } else if (branch != null && branch !== "") {
     const project = argv.flags.project ?? detectProjectFromRemote();
-    if (!project) {
+    if (project == null || project === "") {
       console.error("Could not infer project from git remote. Pass --project <group/project>.");
       process.exit(1);
     }
     target = { mode: "branch", project, branch };
-  } else if (pipelineId) {
+  } else if (pipelineId != null && pipelineId !== "") {
     const project = argv.flags.project ?? detectProjectFromRemote();
-    if (!project) {
+    if (project == null || project === "") {
       console.error("Could not infer project from git remote. Pass --project <group/project>.");
       process.exit(1);
     }

--- a/plugins/gitlab/skills/merge-request/scripts/diff.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/diff.ts
@@ -137,7 +137,7 @@ export function exitOnRejection(): void {
 }
 
 export async function readBody(file: string | undefined): Promise<string> {
-  if (file === "-" || !file) {
+  if (file === "-" || file == null || file === "") {
     return await Bun.stdin.text();
   }
   return await Bun.file(file).text();

--- a/plugins/gitlab/skills/merge-request/scripts/discussions.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/discussions.ts
@@ -90,9 +90,9 @@ function summarize(d: Discussion): DiscussionSummary | null {
       : null,
   };
   const file = note.position?.new_path ?? note.position?.old_path;
-  if (file) result.file = file;
+  if (file != null && file !== "") result.file = file;
   const line = note.position?.new_line ?? note.position?.old_line;
-  if (line) result.line = line;
+  if (line != null && line !== 0) result.line = line;
   return result;
 }
 
@@ -103,20 +103,23 @@ export function truncateBody(body: string, max: number): string {
 }
 
 export function formatLocation(s: DiscussionSummary): string {
-  if (!s.file) return "";
+  if (s.file == null || s.file === "") return "";
   const loc = s.lineRange ? `${s.lineRange.start}-${s.lineRange.end}` : String(s.line ?? "");
-  return loc ? `${s.file}:${loc}` : s.file;
+  return loc !== "" ? `${s.file}:${loc}` : s.file;
 }
 
 const LOCATION_MAX_WIDTH = 40;
 
 export function formatDigest(summaries: DiscussionSummary[], truncate: number): string {
-  const rows = summaries.map((s) => ({
-    id: s.id.slice(0, 12),
-    location: formatLocation(s) || "-",
-    state: s.resolved ? "[resolved]" : "[open]",
-    body: truncateBody(s.body, truncate),
-  }));
+  const rows = summaries.map((s) => {
+    const location = formatLocation(s);
+    return {
+      id: s.id.slice(0, 12),
+      location: location !== "" ? location : "-",
+      state: s.resolved ? "[resolved]" : "[open]",
+      body: truncateBody(s.body, truncate),
+    };
+  });
   const locWidth = Math.min(Math.max(0, ...rows.map((r) => r.location.length)), LOCATION_MAX_WIDTH);
   const stateWidth = Math.max(0, ...rows.map((r) => r.state.length));
   return rows
@@ -147,7 +150,8 @@ export function filterDiscussions(discussions: Discussion[], opts: FilterOptions
   return discussions.filter((d) => {
     const note = firstNote(d);
     if (!note) return false;
-    if (opts.author && note.author.username !== opts.author) return false;
+    if (opts.author != null && opts.author !== "" && note.author.username !== opts.author)
+      return false;
     if (opts.bots && !isReviewTarget(note.author.username, opts.extra)) return false;
     if (opts.resolvable && !note.resolvable) return false;
     if (opts.unresolved && note.resolved) return false;
@@ -177,7 +181,7 @@ async function buildFilterOptions(flags: {
   bots: boolean;
 }): Promise<FilterOptions> {
   const opts: FilterOptions = {};
-  if (flags.author) opts.author = flags.author;
+  if (flags.author != null && flags.author !== "") opts.author = flags.author;
   if (flags.bots) {
     opts.bots = true;
     opts.extra = await loadExtraReviewers();
@@ -210,7 +214,7 @@ const createCmd = command(
 
     const payload: Record<string, unknown> = { body };
 
-    if (parsed.flags.file) {
+    if (parsed.flags.file != null && parsed.flags.file !== "") {
       const [refs, diffs] = await Promise.all([getDiffRefs(iid), fetchMrDiffs(iid)]);
       validateLineInDiff(diffs, parsed.flags.file, {
         line: parsed.flags.line,
@@ -288,7 +292,7 @@ const resolveCmd = command(
   async (parsed) => {
     const iid = parsed._.iid;
 
-    for (const id of parsed._.ids ?? []) {
+    for (const id of parsed._.ids) {
       await $`glab api projects/:id/merge_requests/${iid}/discussions/${id} -X PUT -f resolved=true`.text();
       console.error(`Resolved: ${id}`);
     }

--- a/plugins/gitlab/skills/merge-request/scripts/draft-note.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/draft-note.ts
@@ -61,12 +61,12 @@ const createCmd = command(
 
     const payload: Record<string, unknown> = { note: body };
 
-    if (parsed.flags.replyTo) {
+    if (parsed.flags.replyTo != null && parsed.flags.replyTo !== "") {
       payload.in_reply_to_discussion_id = parsed.flags.replyTo;
       if (parsed.flags.resolve) {
         payload.resolve_discussion = true;
       }
-    } else if (parsed.flags.file) {
+    } else if (parsed.flags.file != null && parsed.flags.file !== "") {
       const [refs, diffs] = await Promise.all([getDiffRefs(mr), fetchMrDiffs(mr)]);
       validateLineInDiff(diffs, parsed.flags.file, {
         line: parsed.flags.line,
@@ -127,15 +127,16 @@ const submitCmd = command(
       process.exit(1);
     }
 
-    const summaryText = parsed.flags.summaryFile
-      ? await Bun.file(parsed.flags.summaryFile).text()
-      : parsed.flags.summary;
+    const summaryText =
+      parsed.flags.summaryFile != null && parsed.flags.summaryFile !== ""
+        ? await Bun.file(parsed.flags.summaryFile).text()
+        : parsed.flags.summary;
 
     const result = await $`glab api ${apiPath(mr)}/bulk_publish -X POST`.text();
     console.log(result);
     console.error("Published draft notes");
 
-    if (summaryText) {
+    if (summaryText != null && summaryText !== "") {
       const notePath = `projects/:id/merge_requests/${mr}/notes`;
       await glabApiPost(notePath, { body: summaryText });
       console.error("Posted summary comment");
@@ -213,17 +214,17 @@ const reviewCmd = command(
   async (parsed) => {
     const mr = Number(parsed._.mr);
 
-    if (!parsed.flags.input) {
+    if (parsed.flags.input == null || parsed.flags.input === "") {
       console.error("--input is required");
       process.exit(1);
     }
 
     const entries = ReviewEntries.parse(JSON.parse(await Bun.file(parsed.flags.input).text()));
-    const hasPositioned = entries.some((e) => e.file);
+    const hasPositioned = entries.some((e) => e.file != null && e.file !== "");
 
-    const [refs, diffs] = hasPositioned
+    const positioned = hasPositioned
       ? await Promise.all([getDiffRefs(mr), fetchMrDiffs(mr)])
-      : [null, null];
+      : null;
 
     let created = 0;
     let failed = 0;
@@ -232,7 +233,8 @@ const reviewCmd = command(
       try {
         const payload: Record<string, unknown> = { note: entry.body };
 
-        if (entry.file && refs && diffs) {
+        if (entry.file != null && entry.file !== "" && positioned != null) {
+          const [refs, diffs] = positioned;
           validateLineInDiff(diffs, entry.file, {
             line: entry.line,
             oldLine: entry.oldLine,
@@ -260,7 +262,7 @@ const reviewCmd = command(
       console.error("Published draft notes");
 
       if (parsed.flags.approve) {
-        const approveRefs = refs ?? (await getDiffRefs(mr));
+        const approveRefs = positioned?.[0] ?? (await getDiffRefs(mr));
         await $`glab api projects/:id/merge_requests/${mr}/approve -X POST -f sha=${approveRefs.head_sha}`.text();
         console.error("Approved MR");
       }

--- a/plugins/gitlab/skills/merge-request/scripts/review-queue.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/review-queue.ts
@@ -82,8 +82,9 @@ if (import.meta.main) {
     },
     async () => {
       const result = ReviewQueueResponse.parse(await $`glab api graphql -f query=${QUERY}`.json());
-      if (result.errors?.length) {
-        console.error(`GraphQL errors: ${result.errors.map((e) => e.message).join("; ")}`);
+      const errors = result.errors ?? [];
+      if (errors.length > 0) {
+        console.error(`GraphQL errors: ${errors.map((e) => e.message).join("; ")}`);
         process.exit(1);
       }
       const currentUser = result.data?.currentUser;

--- a/plugins/gitlab/skills/merge-request/scripts/reviewers.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/reviewers.ts
@@ -18,7 +18,7 @@ export function isBotUsername(username: string): boolean {
 // `#` comments are ignored. Absent file or unset env yields an empty set.
 export async function loadExtraReviewers(): Promise<Set<string>> {
   const dataDir = process.env.CLAUDE_PLUGIN_DATA;
-  if (!dataDir) return new Set();
+  if (dataDir == null || dataDir === "") return new Set();
   const file = Bun.file(join(dataDir, "reviewers.txt"));
   if (!(await file.exists())) return new Set();
   return parseReviewers(await file.text());

--- a/plugins/go/scripts/check.ts
+++ b/plugins/go/scripts/check.ts
@@ -41,7 +41,7 @@ export function isGeneratedFile(content: string): boolean {
 export async function processInput(input: HookInput): Promise<SyncHookJSONOutput | null> {
   const filePath = FileInput.safeParse(input.tool_input).data?.file_path;
 
-  if (!filePath || !filePath.endsWith(".go")) {
+  if (filePath == null || filePath === "" || !filePath.endsWith(".go")) {
     return null;
   }
 

--- a/plugins/linear/hooks/cli-create.ts
+++ b/plugins/linear/hooks/cli-create.ts
@@ -33,7 +33,7 @@ export function isSingleInvocation(command: string): boolean {
 
 export function processInput(input: HookInput): SyncHookJSONOutput | null {
   const command = BashInput.safeParse(input.tool_input).data?.command;
-  if (!command || !CREATE.test(command)) return null;
+  if (command == null || command === "" || !CREATE.test(command)) return null;
   if (HAS_STATE.test(command) || HAS_START.test(command)) return null;
 
   const state = getDefaultState(command.match(ASSIGNEE)?.[1]);

--- a/plugins/linear/hooks/save-issue.ts
+++ b/plugins/linear/hooks/save-issue.ts
@@ -17,7 +17,7 @@ export type CreateIssueInput = {
 };
 
 export function getDefaultState(assignee: string | undefined): string {
-  return assignee ? "Todo" : "Backlog";
+  return assignee != null && assignee !== "" ? "Todo" : "Backlog";
 }
 
 // Wrapper keys the connector tolerates inconsistently. A single one whose value
@@ -43,7 +43,12 @@ export function normalizeInput(toolInput: Record<string, unknown>): NormalizeRes
 
   const keys = Object.keys(input);
   const wrapperKey = keys.length === 1 ? keys[0] : undefined;
-  if (wrapperKey && WRAPPER_KEYS.includes(wrapperKey) && isFieldObject(input[wrapperKey])) {
+  if (
+    wrapperKey != null &&
+    wrapperKey !== "" &&
+    WRAPPER_KEYS.includes(wrapperKey) &&
+    isFieldObject(input[wrapperKey])
+  ) {
     input = input[wrapperKey];
     mutated = true;
   }
@@ -65,12 +70,12 @@ export function processInput(input: HookInput): SyncHookJSONOutput | null {
 
   // An absent id means create (the connector's save_issue and the local
   // create_issue tool); present id means update.
-  const isCreate = !id;
+  const isCreate = id == null || id === "";
 
   // Unrecoverable: a create with no title cannot proceed. Deny with a message
   // that names neither tool, since this hook fires for both save_issue and
   // create_issue, so the model can recover by supplying title or id.
-  if (isCreate && !title) {
+  if (isCreate && (title == null || title === "")) {
     return {
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
@@ -83,7 +88,7 @@ export function processInput(input: HookInput): SyncHookJSONOutput | null {
 
   // Preserve the original default-state behavior: inject a default only when
   // creating and state is absent. Never override an explicitly set state.
-  const needsDefaultState = isCreate && !state;
+  const needsDefaultState = isCreate && (state == null || state === "");
 
   if (!mutated && !needsDefaultState) {
     return null;

--- a/plugins/mac/hooks/sandbox.ts
+++ b/plugins/mac/hooks/sandbox.ts
@@ -30,7 +30,7 @@ export function extractCommands(command: string): Invocation[] {
 
   for (const segment of segments) {
     const trimmed = segment.trim().replace(/^[()]+|[()]+$/g, "");
-    if (!trimmed) continue;
+    if (trimmed === "") continue;
 
     const tokens = trimmed.split(/\s+/);
     let i = 0;
@@ -41,13 +41,13 @@ export function extractCommands(command: string): Invocation[] {
     }
 
     const cmd = tokens[i];
-    if (!cmd) continue;
+    if (cmd == null || cmd === "") continue;
 
     const name = basename(cmd);
     const invocation: Invocation = { cmd };
     if (SCRIPT_INTERPRETERS.has(name)) {
       const next = tokens[i + 1];
-      if (next && !next.startsWith("-")) {
+      if (next != null && next !== "" && !next.startsWith("-")) {
         invocation.scriptArg = next;
       }
     } else if (SCRIPT_EXTENSIONS.has(extname(name))) {
@@ -90,10 +90,10 @@ export async function processInput(
   if (platform !== "darwin") return null;
 
   const toolInput = ToolInput.safeParse(input.tool_input).data;
-  if (!toolInput?.command) return null;
+  if (toolInput?.command == null || toolInput.command === "") return null;
 
   for (const { scriptArg } of extractCommands(toolInput.command)) {
-    if (scriptArg && (await hasBypassMarker(scriptArg))) {
+    if (scriptArg != null && scriptArg !== "" && (await hasBypassMarker(scriptArg))) {
       return disableSandbox(toolInput);
     }
   }

--- a/plugins/mac/scripts/jxa.ts
+++ b/plugins/mac/scripts/jxa.ts
@@ -212,11 +212,11 @@ if (import.meta.main) {
   let source: string;
   let osascriptArgs: string[];
 
-  if (expression) {
+  if (expression != null && expression !== "") {
     source = expression;
     osascriptArgs = ["-l", "JavaScript", "-e", source, ...args];
   } else {
-    if (!script) {
+    if (script == null || script === "") {
       console.error("Usage: bun jxa.ts <app> <script> [args...] or bun jxa.ts <app> -e '<expr>'");
       process.exit(1);
     }

--- a/plugins/meme/skills/image/scripts/layout.ts
+++ b/plugins/meme/skills/image/scripts/layout.ts
@@ -32,7 +32,7 @@ export function resolveRegion(
 }
 
 export function defaultValign(box: TextBox, anchor: Anchor): "top" | "middle" | "bottom" {
-  if (box.valign) return box.valign;
+  if (box.valign != null) return box.valign;
   if (box.region) return "middle";
   if (anchor === "center") return "middle";
   return anchor;

--- a/plugins/meme/skills/image/scripts/render.ts
+++ b/plugins/meme/skills/image/scripts/render.ts
@@ -38,7 +38,7 @@ const IMPACT_PATH = "/System/Library/Fonts/Supplemental/Impact.ttf";
 let cachedFamily: string | undefined;
 
 async function classicFontFamily(): Promise<string> {
-  if (cachedFamily) return cachedFamily;
+  if (cachedFamily != null && cachedFamily !== "") return cachedFamily;
   if (await Bun.file(IMPACT_PATH).exists()) {
     GlobalFonts.registerFromPath(IMPACT_PATH, "Impact");
     cachedFamily = "Impact";
@@ -293,19 +293,28 @@ if (import.meta.main) {
   });
 
   const { top, bottom, subtitle, caption, captionPosition, spec: specPath, out } = argv.flags;
-  if (!out) {
+  if (out == null || out === "") {
     console.error("error: --out is required");
     process.exit(1);
   }
-  if (specPath && (top || bottom || subtitle || caption || captionPosition)) {
+  if (
+    specPath != null &&
+    specPath !== "" &&
+    ((top != null && top !== "") ||
+      (bottom != null && bottom !== "") ||
+      (subtitle != null && subtitle !== "") ||
+      (caption != null && caption !== "") ||
+      (captionPosition != null && captionPosition !== ""))
+  ) {
     console.error("error: --spec is mutually exclusive with --top/--bottom/--subtitle/--caption");
     process.exit(1);
   }
 
   try {
-    const spec = specPath
-      ? validateSpec(await Bun.file(specPath).json())
-      : specFromFlags({ top, bottom, subtitle, caption, captionPosition });
+    const spec =
+      specPath != null && specPath !== ""
+        ? validateSpec(await Bun.file(specPath).json())
+        : specFromFlags({ top, bottom, subtitle, caption, captionPosition });
     const result = await render(spec, argv._.image, out);
     for (const warning of result.warnings) {
       console.error(`warning: ${warning}`);

--- a/plugins/meme/skills/image/scripts/spec.ts
+++ b/plugins/meme/skills/image/scripts/spec.ts
@@ -73,11 +73,14 @@ export interface TextFlags {
 export function specFromFlags(flags: TextFlags): Spec {
   const spec: Spec = {};
   const boxes: TextBox[] = [];
-  if (flags.top) boxes.push({ text: flags.top, preset: "classic", anchor: "top" });
-  if (flags.bottom) boxes.push({ text: flags.bottom, preset: "classic", anchor: "bottom" });
-  if (flags.subtitle) boxes.push({ text: flags.subtitle, preset: "subtitle" });
+  if (flags.top != null && flags.top !== "")
+    boxes.push({ text: flags.top, preset: "classic", anchor: "top" });
+  if (flags.bottom != null && flags.bottom !== "")
+    boxes.push({ text: flags.bottom, preset: "classic", anchor: "bottom" });
+  if (flags.subtitle != null && flags.subtitle !== "")
+    boxes.push({ text: flags.subtitle, preset: "subtitle" });
   if (boxes.length > 0) spec.boxes = boxes;
-  if (flags.caption) {
+  if (flags.caption != null && flags.caption !== "") {
     const position = flags.captionPosition ?? "top";
     if (position !== "top" && position !== "bottom") {
       fail("--caption-position", "expected top or bottom");

--- a/plugins/mermaid/skills/diagram/scripts/validate.ts
+++ b/plugins/mermaid/skills/diagram/scripts/validate.ts
@@ -73,7 +73,7 @@ export function extractMermaidBlocks(content: string): MermaidBlock[] {
 
 async function validateBlock(block: MermaidBlock): Promise<ValidationError | null> {
   const trimmed = block.content.trim();
-  if (!trimmed) {
+  if (trimmed === "") {
     return { line: block.line, message: "Empty mermaid block" };
   }
 

--- a/plugins/newline/scripts/check.ts
+++ b/plugins/newline/scripts/check.ts
@@ -21,7 +21,7 @@ export async function hasTrailingNewline(filePath: string): Promise<boolean | nu
 
 export async function processInput(input: PreToolUseHookInput): Promise<void> {
   const filePath = filePathOf(input.tool_input);
-  if (!filePath) return;
+  if (filePath == null || filePath === "") return;
   if (isMemoryPath(filePath)) return;
 
   const hasNewline = await hasTrailingNewline(filePath);

--- a/plugins/newline/scripts/ensure.ts
+++ b/plugins/newline/scripts/ensure.ts
@@ -27,12 +27,12 @@ export async function processInput(
   input: PostToolUseHookInput,
 ): Promise<SyncHookJSONOutput | null> {
   const filePath = filePathOf(input.tool_input);
-  if (!filePath) return null;
+  if (filePath == null || filePath === "") return null;
   if (isMemoryPath(filePath)) return null;
 
   const message = await ensureTrailingNewline(filePath);
 
-  if (message) {
+  if (message != null && message !== "") {
     return {
       hookSpecificOutput: {
         hookEventName: "PostToolUse",

--- a/plugins/newline/scripts/preserve.ts
+++ b/plugins/newline/scripts/preserve.ts
@@ -38,7 +38,7 @@ export async function processInput(
   input: PostToolUseHookInput,
 ): Promise<SyncHookJSONOutput | null> {
   const filePath = filePathOf(input.tool_input);
-  if (!filePath) return null;
+  if (filePath == null || filePath === "") return null;
   if (isMemoryPath(filePath)) return null;
 
   const hadNewline = await getState("newline", filePath);
@@ -46,7 +46,7 @@ export async function processInput(
 
   await clearState("newline", filePath);
 
-  if (message) {
+  if (message != null && message !== "") {
     return {
       hookSpecificOutput: {
         hookEventName: "PostToolUse",

--- a/plugins/plan/hooks/gate.test.ts
+++ b/plugins/plan/hooks/gate.test.ts
@@ -383,8 +383,9 @@ describe("recorded re-presents", () => {
   ];
 
   function label(run: GateRun): string {
-    if (run.exitCode !== 0 || run.stderr) return `gate failed (${run.exitCode}): ${run.stderr}`;
-    if (!run.stdout.trim()) return "allowed";
+    if (run.exitCode !== 0 || run.stderr !== "")
+      return `gate failed (${run.exitCode}): ${run.stderr}`;
+    if (run.stdout.trim() === "") return "allowed";
     const { hookSpecificOutput } = GateOutput.parse(JSON.parse(run.stdout));
     const reason = hookSpecificOutput.permissionDecisionReason ?? "";
     const rule = RULES.find(([needle]) => reason.includes(needle))?.[1] ?? "unrecognized";

--- a/plugins/plan/hooks/gate.ts
+++ b/plugins/plan/hooks/gate.ts
@@ -102,7 +102,7 @@ function normalizeLines(plan: string): Set<string> {
   const lines = new Set<string>();
   for (const rawLine of plan.split("\n")) {
     const line = rawLine.trim();
-    if (line) lines.add(line);
+    if (line !== "") lines.add(line);
   }
   return lines;
 }
@@ -146,15 +146,20 @@ function isAppendOnlyRevision(previous: Set<string>, current: Set<string>): bool
   );
 }
 
+function defaultStateRoot(): string {
+  const override = process.env.CLAUDE_PLAN_MARKER_ROOT;
+  return override !== undefined && override !== "" ? override : "/tmp/claude";
+}
+
 export async function processInput(
   input: PreToolUseHookInput,
-  stateRoot = process.env.CLAUDE_PLAN_MARKER_ROOT || "/tmp/claude",
+  stateRoot = defaultStateRoot(),
 ): Promise<SyncHookJSONOutput | null> {
   const plan = ToolInput.safeParse(input.tool_input).data?.plan;
   if (plan === undefined) return null;
 
   const sessionId = input.session_id;
-  if (!sessionId) return null;
+  if (sessionId === "") return null;
 
   const dir = join(stateRoot, sessionId);
   try {

--- a/plugins/pull-request/scripts/detect-bot.ts
+++ b/plugins/pull-request/scripts/detect-bot.ts
@@ -122,12 +122,15 @@ export async function detect(root: string, options: DetectOptions = {}): Promise
     }
     const cli = which(provider.cli) !== null;
     let presence: string;
-    if (config && cli) presence = `repo config (${config}), CLI installed`;
-    else if (config) presence = `repo config (${config}), CLI not installed`;
+    if (config != null && config !== "" && cli) presence = `repo config (${config}), CLI installed`;
+    else if (config != null && config !== "")
+      presence = `repo config (${config}), CLI not installed`;
     else if (cli) presence = "CLI installed, no repo config";
     else continue;
     const paused = pause(records, provider.name, origin, now);
-    lines.push(`${provider.name}: ${presence}${paused ? `, ${paused}` : ""}`);
+    lines.push(
+      `${provider.name}: ${presence}${paused != null && paused !== "" ? `, ${paused}` : ""}`,
+    );
   }
   return lines.length > 0 ? lines.join("\n") : "none: no bot config or CLI found locally";
 }

--- a/plugins/pull-request/scripts/detect-bot.ts
+++ b/plugins/pull-request/scripts/detect-bot.ts
@@ -48,7 +48,7 @@ export function parseCooldowns(text: string): Cooldown[] {
     const record = CooldownEntry.safeParse(entry).data;
     if (!record) return [];
     const { remote, ...rest } = record;
-    return [remote ? { ...rest, remote } : rest];
+    return [remote != null && remote !== "" ? { ...rest, remote } : rest];
   });
 }
 

--- a/plugins/pull-request/scripts/git-context.ts
+++ b/plugins/pull-request/scripts/git-context.ts
@@ -27,16 +27,16 @@ export function gitContext(): string {
 
   const sections = [`Branch: ${branch}`];
 
-  if (status) {
+  if (status !== "") {
     sections.push(`Status:\n${status}`);
   }
 
-  if (log) {
+  if (log !== "") {
     sections.push(`Log:\n${log}`);
   }
 
   const d = diff();
-  if (d) {
+  if (d !== "") {
     sections.push(`Diff:\n${d}`);
   }
 

--- a/plugins/pull-request/scripts/heading-case.ts
+++ b/plugins/pull-request/scripts/heading-case.ts
@@ -172,9 +172,15 @@ export function headingCaseViolations(body: string): { text: string; suggested: 
     const cased = apStyleTitleCase(trimmed, { stopwords: AP_STOPWORDS }).trim().split(/\s+/);
     if (original.length !== cased.length) continue;
 
-    const suggested = original.map((word, i) => caseWord(word, cased[i] ?? word));
+    const suggested: string[] = [];
+    let differs = false;
+    for (const [i, word] of original.entries()) {
+      const next = caseWord(word, cased[i] ?? word);
+      suggested.push(next);
+      if (next !== word) differs = true;
+    }
 
-    if (suggested.some((word, i) => word !== original[i])) {
+    if (differs) {
       violations.push({
         text: restore(original.join(" "), codeSpans),
         suggested: restore(suggested.join(" "), codeSpans),

--- a/plugins/pull-request/scripts/heading-case.ts
+++ b/plugins/pull-request/scripts/heading-case.ts
@@ -172,14 +172,9 @@ export function headingCaseViolations(body: string): { text: string; suggested: 
     const cased = apStyleTitleCase(trimmed, { stopwords: AP_STOPWORDS }).trim().split(/\s+/);
     if (original.length !== cased.length) continue;
 
-    let differs = false;
-    const suggested = original.map((word, i) => {
-      const result = caseWord(word, cased[i] ?? word);
-      if (result !== word) differs = true;
-      return result;
-    });
+    const suggested = original.map((word, i) => caseWord(word, cased[i] ?? word));
 
-    if (differs) {
+    if (suggested.some((word, i) => word !== original[i])) {
       violations.push({
         text: restore(original.join(" "), codeSpans),
         suggested: restore(suggested.join(" "), codeSpans),

--- a/plugins/pull-request/scripts/linguistics/heading.ts
+++ b/plugins/pull-request/scripts/linguistics/heading.ts
@@ -79,7 +79,7 @@ export function classifyHeadingBaseline(heading: string): HeadingVerdict {
 
   // Interrogative-led headings ("Why X is Y", "What was wrong") are a
   // conventional rationale-section label, not the sentence-heading trope.
-  if (lower[0] && INTERROGATIVE_OPENERS.has(lower[0])) {
+  if (lower[0] != null && lower[0] !== "" && INTERROGATIVE_OPENERS.has(lower[0])) {
     return { kind: "interrogative", flagged: false, evidence: ["interrogative opener"] };
   }
 
@@ -97,14 +97,15 @@ export function classifyHeadingBaseline(heading: string): HeadingVerdict {
       .map((word) => word.toLowerCase().replace(/[^a-z']/g, ""))
       .filter((word) => word.length > 0);
     const afterPredicate = after.some((word) => LINKING_VERBS.has(word) || word === "not");
-    const preEnumerator = before[0] ? ENUMERATOR_STOPLIST.test(before[0]) : false;
+    const preEnumerator =
+      before[0] != null && before[0] !== "" ? ENUMERATOR_STOPLIST.test(before[0]) : false;
     if (before.length <= 4 && after.length >= 3 && afterPredicate && !preEnumerator) {
       return { kind: "clause", flagged: true, evidence: ["colon-gated predicate"] };
     }
   }
 
   const linkingVerb = lower.find((word) => LINKING_VERBS.has(word));
-  if (linkingVerb) {
+  if (linkingVerb != null && linkingVerb !== "") {
     return { kind: "clause", flagged: true, evidence: [`linking verb "${linkingVerb}"`] };
   }
 
@@ -115,7 +116,12 @@ export function classifyHeadingBaseline(heading: string): HeadingVerdict {
     return { kind: "clause", flagged: true, evidence: ["relative clause"] };
   }
 
-  if (words.length >= 3 && lower[0] && IMPERATIVE_OPENERS.has(lower[0])) {
+  if (
+    words.length >= 3 &&
+    lower[0] != null &&
+    lower[0] !== "" &&
+    IMPERATIVE_OPENERS.has(lower[0])
+  ) {
     return { kind: "imperative", flagged: true, evidence: [`imperative opener "${lower[0]}"`] };
   }
 

--- a/plugins/pull-request/scripts/pr-template.ts
+++ b/plugins/pull-request/scripts/pr-template.ts
@@ -23,7 +23,7 @@ const TEMPLATE_PATHS: Record<Provider, string[]> = {
 };
 
 export async function findTemplate(provider: Provider, repoRoot: string): Promise<string | null> {
-  const paths = TEMPLATE_PATHS[provider] ?? [];
+  const paths = TEMPLATE_PATHS[provider];
   for (const p of paths) {
     const full = join(repoRoot, p);
     const file = Bun.file(full);
@@ -45,7 +45,7 @@ if (import.meta.main) {
   const repoRoot = getRepoRoot();
   const provider = Provider.safeParse(process.argv[2]).data ?? "github";
   const template = await findTemplate(provider, repoRoot);
-  if (template) {
+  if (template != null && template !== "") {
     process.stdout.write(markdown.ansi(template));
   }
 }

--- a/plugins/pull-request/scripts/sentence-heading.ts
+++ b/plugins/pull-request/scripts/sentence-heading.ts
@@ -180,12 +180,17 @@ export function classifyPrHeading(heading: string): PrHeadingResult {
   // the overwhelming majority bad. Flag them, but require a real verb/object tail so a bare "How It
   // Works" idiom still gets caught (it is also bad here) while not over-firing on noun labels.
   const firstStem = lower[0]?.replace(/'s$/, "");
-  if (firstStem && INTERROGATIVE_OPENERS.has(firstStem) && lower.length >= 2) {
+  if (
+    firstStem != null &&
+    firstStem !== "" &&
+    INTERROGATIVE_OPENERS.has(firstStem) &&
+    lower.length >= 2
+  ) {
     signals.push(`interrogative opener "${firstStem}"`);
   }
 
   const predicate = lower.find((w) => PREDICATE_VERBS.has(w));
-  if (predicate) signals.push(`predicate verb "${predicate}"`);
+  if (predicate != null && predicate !== "") signals.push(`predicate verb "${predicate}"`);
 
   if (toks.length >= 3 && lower.some((w) => RELATIVE_PRONOUNS.has(w))) {
     signals.push("relative clause");
@@ -200,7 +205,10 @@ export function classifyPrHeading(heading: string): PrHeadingResult {
   // reviewer"); the first word is weighted separately because some good labels open lowercase by
   // accident.
   const lowercaseContent = toks.slice(1).filter((t) => isContentWord(t) && /^[a-z]/.test(t));
-  const firstLower = toks[0] && isContentWord(toks[0]) && /^[a-z]/.test(toks[0]) ? [toks[0]] : [];
+  const firstLower =
+    toks[0] != null && toks[0] !== "" && isContentWord(toks[0]) && /^[a-z]/.test(toks[0])
+      ? [toks[0]]
+      : [];
   const lowered = [...firstLower, ...lowercaseContent];
   if (lowercaseContent.length >= 1 || lowered.length >= 2) {
     signals.push(`sentence case (${lowered.length} lowercase content words)`);

--- a/plugins/pull-request/scripts/suggest-reviewers.ts
+++ b/plugins/pull-request/scripts/suggest-reviewers.ts
@@ -41,12 +41,12 @@ export function selfIdentities(cwd?: string): Set<string> {
 
 /** The base ref to diff against (the default branch). */
 function baseRef(cwd?: string, override?: string): string | null {
-  if (override) return override;
+  if (override != null && override !== "") return override;
   const head = git("symbolic-ref --quiet refs/remotes/origin/HEAD", cwd);
-  if (head) return head.replace(/^refs\/remotes\//, "");
+  if (head !== "") return head.replace(/^refs\/remotes\//, "");
   return (
-    ["origin/main", "origin/master", "main", "master"].find((ref) =>
-      git(`rev-parse --verify --quiet ${ref}`, cwd),
+    ["origin/main", "origin/master", "main", "master"].find(
+      (ref) => git(`rev-parse --verify --quiet ${ref}`, cwd) !== "",
     ) ?? null
   );
 }
@@ -55,10 +55,12 @@ function baseRef(cwd?: string, override?: string): string | null {
 export function changedFiles(cwd?: string, base?: string): string[] {
   const ref = baseRef(cwd, base);
   const commands = [
-    ref && `diff --name-only --diff-filter=d ${ref}...HEAD`,
+    ref != null ? `diff --name-only --diff-filter=d ${ref}...HEAD` : null,
     "diff --name-only --diff-filter=d HEAD",
   ];
-  const files = commands.flatMap((c) => (c ? git(c, cwd).split("\n") : [])).filter(Boolean);
+  const files = commands
+    .flatMap((c) => (c != null && c !== "" ? git(c, cwd).split("\n") : []))
+    .filter(Boolean);
   return [...new Set(files)];
 }
 

--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -70,7 +70,7 @@ export function hasReflexiveScaffold(body: string): boolean {
 export function hasFileTourBullets(body: string): boolean {
   for (const match of body.matchAll(BOLD_LABEL_BULLET_PATTERN)) {
     const label = match[1];
-    if (label && looksLikeFilePath(label)) return true;
+    if (label != null && label !== "" && looksLikeFilePath(label)) return true;
   }
   return false;
 }
@@ -224,8 +224,8 @@ export function parseGhLogin(hostsYaml: string): string | null {
       continue;
     }
     if (!inGitHub) continue;
-    const match = line.match(/^\s+user:\s*(.+?)\s*$/);
-    if (match?.[1]) return match[1].replace(/^["']|["']$/g, "");
+    const user = line.match(/^\s+user:\s*(.+?)\s*$/)?.[1];
+    if (user != null && user !== "") return user.replace(/^["']|["']$/g, "");
   }
   return null;
 }
@@ -338,7 +338,7 @@ function unescapeDoubleQuoted(text: string): string {
 
 function expandTmpdir(path: string): string {
   const tmpdir = process.env.TMPDIR?.replace(/\/$/, "");
-  if (!tmpdir) return path;
+  if (tmpdir == null || tmpdir === "") return path;
   return path.replace(/\$\{TMPDIR\}|\$TMPDIR/g, tmpdir);
 }
 
@@ -454,7 +454,7 @@ function parseInlineValue(raw: string): BodySpec {
 
   for (const match of inner.matchAll(SUBSTITUTION_PATTERN)) {
     const source = match[0];
-    const index = match.index ?? 0;
+    const index = match.index;
     const literal = pushLiteral(inner.slice(cursor, index));
     if (literal) return literal;
     const substituted = source.startsWith("`") ? source.slice(1, -1) : source.slice(2, -1);
@@ -472,18 +472,18 @@ function parseInlineValue(raw: string): BodySpec {
 
 export function extractBodySpec(command: string): BodySpec {
   const flags = bodyFlags(command);
-  const fileMatch = command.match(flagValuePattern(flags.file));
-  if (fileMatch?.[1]) {
-    const path = unquote(fileMatch[1]);
+  const fileValue = command.match(flagValuePattern(flags.file))?.[1];
+  if (fileValue != null && fileValue !== "") {
+    const path = unquote(fileValue);
     if (path === "-") {
       return { kind: "unreadable", detail: "a body piped in on standard input (`-`)" };
     }
-    const part = filePart(fileMatch[1]);
+    const part = filePart(fileValue);
     if (part === null) return unreadableExpansion(path);
     return { kind: "parts", parts: [part] };
   }
-  const inlineMatch = command.match(flagValuePattern(flags.inline));
-  if (inlineMatch?.[1]) return parseInlineValue(inlineMatch[1]);
+  const inlineValue = command.match(flagValuePattern(flags.inline))?.[1];
+  if (inlineValue != null && inlineValue !== "") return parseInlineValue(inlineValue);
   return { kind: "none" };
 }
 
@@ -532,9 +532,9 @@ export function extractTitle(command: string): string | null {
   const scope = (start === -1 ? command : command.slice(start))
     .replace(flagValuePattern(flags.file, true), " ")
     .replace(flagValuePattern(flags.inline, true), " ");
-  const match = scope.match(/(?:--title|(?<![\w-])-t)[=\s]("(?:[^"\\]|\\.)*"|'[^']*'|[^\s]+)/);
-  if (!match?.[1]) return null;
-  return unescapeDoubleQuoted(unquote(match[1]));
+  const value = scope.match(/(?:--title|(?<![\w-])-t)[=\s]("(?:[^"\\]|\\.)*"|'[^']*'|[^\s]+)/)?.[1];
+  if (value == null || value === "") return null;
+  return unescapeDoubleQuoted(unquote(value));
 }
 
 function bullets(reasons: string[]): string {

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -645,7 +645,7 @@ describe("processInput", () => {
     .slice(0, 12);
 
   function createInput(command: string, cwd?: string): HookInput {
-    return { tool_input: { command }, ...(cwd && { cwd }) };
+    return { tool_input: { command }, ...(cwd != null && cwd !== "" && { cwd }) };
   }
 
   it("returns null when command has no --body-file", async () => {

--- a/plugins/review/skills/inbox/scripts/args.ts
+++ b/plugins/review/skills/inbox/scripts/args.ts
@@ -4,7 +4,7 @@ export type PermissionMode = (typeof PERMISSION_MODES)[number];
 
 export function parsePermissionMode(value: string): PermissionMode {
   const mode = PERMISSION_MODES.find((m) => m === value);
-  if (!mode) {
+  if (mode == null) {
     throw new Error(
       `Invalid permission mode: ${value} (expected one of ${PERMISSION_MODES.join(", ")})`,
     );
@@ -31,7 +31,7 @@ export function buildDispatchArgs({
     "--bg",
     "--agent",
     "review",
-    ...(permissionMode ? ["--permission-mode", permissionMode] : []),
+    ...(permissionMode != null ? ["--permission-mode", permissionMode] : []),
     url,
   ];
 }

--- a/plugins/review/skills/inbox/scripts/dispatched.ts
+++ b/plugins/review/skills/inbox/scripts/dispatched.ts
@@ -53,7 +53,7 @@ switch (command) {
 
   case "remove": {
     const { url } = argv.flags;
-    if (!url) {
+    if (url == null || url === "") {
       console.error("--url is required for remove");
       process.exit(1);
     }

--- a/plugins/review/skills/inbox/scripts/poll.ts
+++ b/plugins/review/skills/inbox/scripts/poll.ts
@@ -20,8 +20,8 @@ export async function fetchUrls(command: string): Promise<FetchResult> {
     new Response(proc.stderr).text(),
   ]);
   if (exit !== 0) {
-    const detail = stderrText.trim() || `exited with code ${exit}`;
-    return { ok: false, reason: detail };
+    const detail = stderrText.trim();
+    return { ok: false, reason: detail !== "" ? detail : `exited with code ${exit}` };
   }
   try {
     const entries = Queue.parse(JSON.parse(stdoutText));

--- a/plugins/review/skills/inbox/scripts/spawn.ts
+++ b/plugins/review/skills/inbox/scripts/spawn.ts
@@ -34,7 +34,7 @@ const url = argv._.url;
 const { repoPath, dataDir } = argv.flags;
 const permissionModeFlag = argv.flags.permissionMode;
 
-if (!repoPath) {
+if (repoPath == null || repoPath === "") {
   console.error("--repo-path (-C) is required: local clone the review session runs in");
   process.exit(1);
 }
@@ -74,7 +74,7 @@ if (result.exitCode !== 0) {
 }
 
 const sessionId = parseBackgroundedId(result.stdout.toString());
-if (!sessionId) {
+if (sessionId == null || sessionId === "") {
   console.error("Warning: launched but could not read the session id from claude output");
 }
 
@@ -85,7 +85,7 @@ try {
   // The session is already running but never got recorded. Stop it so the dedup
   // set and the live sessions stay consistent. Otherwise the next dispatch sees
   // an unrecorded URL and launches a duplicate review.
-  if (sessionId) {
+  if (sessionId != null && sessionId !== "") {
     Bun.spawnSync(["claude", "stop", sessionId], { stdout: "pipe", stderr: "pipe" });
   }
   throw error;

--- a/plugins/review/skills/inbox/scripts/spawn.ts
+++ b/plugins/review/skills/inbox/scripts/spawn.ts
@@ -42,7 +42,7 @@ if (repoPath == null || repoPath === "") {
 function resolvePermissionMode(value: string | undefined): PermissionMode | undefined {
   if (value === undefined) return undefined;
   const mode = PERMISSION_MODES.find((m) => m === value);
-  if (!mode) {
+  if (mode === undefined) {
     console.error(`--permission-mode must be one of: ${PERMISSION_MODES.join(", ")}`);
     process.exit(1);
   }

--- a/plugins/review/skills/inbox/scripts/store.ts
+++ b/plugins/review/skills/inbox/scripts/store.ts
@@ -24,7 +24,7 @@ const LegacyState = z.object({ reviews: z.array(z.unknown()) });
 
 function resolveDataDir(dataDir?: string): string {
   const base = dataDir ?? process.env.CLAUDE_PLUGIN_DATA;
-  if (!base) {
+  if (base == null || base === "") {
     throw new Error("dataDir is required (or set CLAUDE_PLUGIN_DATA)");
   }
   return base;

--- a/plugins/review/skills/tuicr/scripts/diff.ts
+++ b/plugins/review/skills/tuicr/scripts/diff.ts
@@ -45,7 +45,7 @@ export function parseDiff(diffText: string): ParsedDiff {
 
   function rename(toPath: string): void {
     if (!current) return;
-    if (currentKey && currentKey !== toPath) {
+    if (currentKey != null && currentKey !== "" && currentKey !== toPath) {
       files.delete(currentKey);
       files.set(toPath, current);
       currentKey = toPath;
@@ -119,7 +119,14 @@ export function parseDiff(diffText: string): ParsedDiff {
       const oldMatch = OLD_PATH.exec(line);
       if (oldMatch && oldMatch[1] !== undefined && current) {
         const oldPath = stripDevNull(oldMatch[1]);
-        if (oldPath && currentKey && oldPath !== currentKey) current.oldPath = oldPath;
+        if (
+          oldPath != null &&
+          oldPath !== "" &&
+          currentKey != null &&
+          currentKey !== "" &&
+          oldPath !== currentKey
+        )
+          current.oldPath = oldPath;
       }
       continue;
     }
@@ -128,7 +135,13 @@ export function parseDiff(diffText: string): ParsedDiff {
       const newMatch = NEW_PATH.exec(line);
       if (newMatch && newMatch[1] !== undefined && current) {
         const newPath = stripDevNull(newMatch[1]);
-        if (newPath && currentKey && newPath !== currentKey) {
+        if (
+          newPath != null &&
+          newPath !== "" &&
+          currentKey != null &&
+          currentKey !== "" &&
+          newPath !== currentKey
+        ) {
           if (current.oldPath === undefined) {
             current.oldPath = currentKey;
           }

--- a/plugins/review/skills/tuicr/scripts/ledger.ts
+++ b/plugins/review/skills/tuicr/scripts/ledger.ts
@@ -173,11 +173,11 @@ function resolveLedger(flags: {
   const repo = flags.repo ?? git(["rev-parse", "--show-toplevel"]);
   const branch = flags.branch ?? git(["branch", "--show-current"]);
   const dir = flags.dir ?? defaultLedgerDir();
-  if (!repo) {
+  if (repo == null || repo === "") {
     console.error("Could not determine repo; pass --repo");
     return process.exit(1);
   }
-  if (!branch) {
+  if (branch == null || branch === "") {
     console.error("Could not determine branch; pass --branch");
     return process.exit(1);
   }

--- a/plugins/review/skills/tuicr/scripts/watch.ts
+++ b/plugins/review/skills/tuicr/scripts/watch.ts
@@ -21,7 +21,7 @@ export function describeComment(comment: Pick<TuicrComment, "location" | "conten
 
 /** Comments whose IDs are not yet in `seen` (skipping any without an ID, as tuicr never emits one). */
 export function newComments(seen: Set<string>, comments: TuicrComment[]): TuicrComment[] {
-  return comments.filter((comment) => comment.id && !seen.has(comment.id));
+  return comments.filter((comment) => comment.id !== "" && !seen.has(comment.id));
 }
 
 /**
@@ -43,7 +43,7 @@ async function watch(slug: string, repo: string, pollSeconds: number): Promise<v
 
   // Arm: mark existing comments seen without announcing them.
   for (const comment of readComments(repo, slug) ?? []) {
-    if (comment.id) seen.add(comment.id);
+    if (comment.id !== "") seen.add(comment.id);
   }
   console.log(`WATCHING ${slug}`);
 
@@ -69,6 +69,7 @@ if (import.meta.main) {
       repo: { type: String, default: ".", description: "Checkout path or owner/repo" },
     },
   });
-  const pollSeconds = argv._.pollSeconds ? Number(argv._.pollSeconds) : 30;
+  const pollSeconds =
+    argv._.pollSeconds != null && argv._.pollSeconds !== "" ? Number(argv._.pollSeconds) : 30;
   await watch(argv._.slug, argv.flags.repo, pollSeconds);
 }

--- a/plugins/shortcuts/hooks/open.ts
+++ b/plugins/shortcuts/hooks/open.ts
@@ -99,7 +99,7 @@ export function processInput(input: HookInput): SyncHookJSONOutput | null {
   const command = BashInput.safeParse(input.tool_input).data?.command;
   const target = command === undefined ? null : extractTarget(command);
 
-  if (!target) {
+  if (target == null || target === "") {
     return null;
   }
 

--- a/plugins/shortcuts/tests/discover.integration.ts
+++ b/plugins/shortcuts/tests/discover.integration.ts
@@ -18,7 +18,7 @@ function run(command: string): Record<string, unknown>[] {
   return Entries.parse(JSON.parse(execFileSync("swift", [script, command], opts).toString()));
 }
 
-const ci = !!process.env.CI;
+const ci = !(process.env.CI == null || process.env.CI === "");
 
 describe.skipIf(ci)("discover.swift actions", () => {
   let actions: Record<string, unknown>[];

--- a/plugins/things/scripts/format-output.ts
+++ b/plugins/things/scripts/format-output.ts
@@ -45,7 +45,7 @@ if (argv.flags.json) {
   process.exit(0);
 }
 
-if (argv.flags.countPrefix) {
+if (argv.flags.countPrefix != null && argv.flags.countPrefix !== "") {
   console.log(`${count} ${argv.flags.countPrefix}\n`);
 }
 

--- a/plugins/things/scripts/format.ts
+++ b/plugins/things/scripts/format.ts
@@ -1,7 +1,7 @@
 export { table } from "table";
 
 export function formatDate(value: string | null): string {
-  if (!value) return "";
+  if (value == null || value === "") return "";
   return value.slice(0, 10);
 }
 

--- a/plugins/things/scripts/inbox.ts
+++ b/plugins/things/scripts/inbox.ts
@@ -30,19 +30,20 @@ export function shellQuote(value: string): string {
  */
 export function buildAttribution(sessionId: string, directory?: string): string {
   const resume = `claude --resume ${shellQuote(sessionId)}`;
-  const command = directory ? `cd ${shellQuote(directory)} && ${resume}` : resume;
+  const command =
+    directory != null && directory !== "" ? `cd ${shellQuote(directory)} && ${resume}` : resume;
   return `---\n\n🤖 Created via Claude Code (Session: ${sessionId})\n\n\`\`\`sh\n${command}\n\`\`\``;
 }
 
 export function printCaptured(params: Map<string, string>): void {
   const title = params.get("title");
-  if (title) {
+  if (title != null && title !== "") {
     console.log(`captured: ${title}`);
     return;
   }
   const titles = params.get("titles");
-  if (titles) {
-    const lines = titles.split("\n").filter((line) => line.trim());
+  if (titles != null && titles !== "") {
+    const lines = titles.split("\n").filter((line) => line.trim() !== "");
     const first = lines[0] ?? "(untitled)";
     const suffix = lines.length > 1 ? ` (+${lines.length - 1} more)` : "";
     console.log(`captured: ${first}${suffix}`);
@@ -68,7 +69,7 @@ if (import.meta.main) {
     },
   });
 
-  if (!argv.flags.sessionId) {
+  if (argv.flags.sessionId == null || argv.flags.sessionId === "") {
     console.error("--session-id is required for session attribution");
     process.exit(1);
   }
@@ -87,18 +88,21 @@ if (import.meta.main) {
 
   const attribution = buildAttribution(argv.flags.sessionId, process.cwd());
   const existing = params.get("notes");
-  params.set("notes", existing ? `${existing}\n\n${attribution}` : attribution);
+  params.set(
+    "notes",
+    existing != null && existing !== "" ? `${existing}\n\n${attribution}` : attribution,
+  );
 
   await ensureThingsRunning();
 
   try {
     // Things drops a tag it does not already know and still reports success, so
     // the CLI resolves against the stored tags for the same reason the tool does.
-    const requested = mergeTags(["claude"], argv.flags.tag ?? [], parseTags(params.get("tags")));
+    const requested = mergeTags(["claude"], argv.flags.tag, parseTags(params.get("tags")));
     params.set("tags", (await requireTags(requested, false)).join(","));
 
     const result = await dispatch("add", params);
-    if (result.id) {
+    if (result.id != null && result.id !== "") {
       console.log(`https://things.bendrucker.me/show?id=${result.id}`);
     } else {
       warnFallback(result);

--- a/plugins/things/scripts/reorder.ts
+++ b/plugins/things/scripts/reorder.ts
@@ -5,7 +5,7 @@ import { cli } from "cleye";
 import { ensureThingsRunning } from "./ensure-running";
 import { dispatch, warnFallback } from "./url";
 
-const INTERMEDIATE_LIST: Record<string, string> = {
+const INTERMEDIATE_LIST: Record<string, string | undefined> = {
   today: "anytime",
   anytime: "someday",
   someday: "anytime",
@@ -46,7 +46,7 @@ export async function reorder(targetList: string, ids: string[]): Promise<Reorde
   }
 
   const intermediate = INTERMEDIATE_LIST[targetList];
-  if (!intermediate) {
+  if (intermediate === undefined) {
     throw new Error(`Invalid list: ${targetList}`);
   }
 

--- a/plugins/things/scripts/tags.ts
+++ b/plugins/things/scripts/tags.ts
@@ -1,5 +1,5 @@
 export function parseTags(value: string | undefined): string[] {
-  if (!value) return [];
+  if (value == null || value === "") return [];
   return value
     .split(",")
     .map((t) => t.trim())

--- a/plugins/things/scripts/url.test.ts
+++ b/plugins/things/scripts/url.test.ts
@@ -165,7 +165,10 @@ describe("xcallBackstopMs", () => {
     { name: "a non-numeric bound", env: { XCALL_TIMEOUT_SECONDS: "soon" } },
     { name: "a zero bound", env: { XCALL_TIMEOUT_SECONDS: "0" } },
   ])("outwaits run.sh with $name", ({ env }) => {
-    const bound = (name: string) => Number(env[name]) || 20;
+    const bound = (name: string) => {
+      const parsed = Number(env[name]);
+      return Number.isNaN(parsed) || parsed === 0 ? 20 : parsed;
+    };
     // run.sh waits out a lock holder's whole turn before starting its own, so
     // the callback bound counts once for the wait and once for the call.
     const callback = bound("XCALL_TIMEOUT_SECONDS");

--- a/plugins/things/scripts/url.ts
+++ b/plugins/things/scripts/url.ts
@@ -92,7 +92,7 @@ async function openUrl(
     // and forward it to stderr, where both the CLI and tailgate's logs read it.
     const result = background ? await $`open -g ${url}`.quiet() : await $`open ${url}`.quiet();
     const output = result.stdout.toString() + result.stderr.toString();
-    if (output) process.stderr.write(output);
+    if (output !== "") process.stderr.write(output);
   } catch (error) {
     if (error instanceof $.ShellError) {
       const stderr = error.stderr.toString();
@@ -105,9 +105,10 @@ async function openUrl(
       // ShellError's own message is only the exit code, and `.quiet()` holds
       // what `open` printed, so the diagnostic reaches a caller only if the
       // message carries it.
-      const detail = stderr.trim() || error.stdout.toString().trim();
+      const stderrDetail = stderr.trim();
+      const detail = stderrDetail !== "" ? stderrDetail : error.stdout.toString().trim();
       throw new Error(
-        `Things URL handoff failed (open exited ${error.exitCode})${detail ? `: ${detail}` : ""}`,
+        `Things URL handoff failed (open exited ${error.exitCode})${detail !== "" ? `: ${detail}` : ""}`,
         { cause: error },
       );
     }
@@ -178,7 +179,7 @@ export function coerceAttributes(attributes: Record<string, string>): Record<str
     } else if (key === "checklist-items") {
       result[key] = value
         .split("\n")
-        .filter((line) => line.trim())
+        .filter((line) => line.trim() !== "")
         .map((line) => ({ type: "checklist-item" as const, attributes: { title: line.trim() } }));
     } else {
       result[key] = value;
@@ -331,7 +332,7 @@ export async function dispatch(
   let fallbackReason = "the x-callback-url runner was not found";
   let fallbackDetail: string | null = null;
 
-  if (runner) {
+  if (runner != null && runner !== "") {
     const url = await buildUrl(command, params);
     try {
       const result = await actions.xcall(runner, url);
@@ -344,7 +345,8 @@ export async function dispatch(
       };
     } catch (error) {
       fallbackReason = describeXcallFailure(error);
-      fallbackDetail = error instanceof XcallError ? error.stderr.trim() || null : null;
+      const detail = error instanceof XcallError ? error.stderr.trim() : "";
+      fallbackDetail = detail !== "" ? detail : null;
     }
   }
 
@@ -361,7 +363,8 @@ export function warnFallback(result: DispatchResult): void {
   console.error(
     `warning: no todo id available because ${result.fallbackReason}. The change was sent fire-and-forget via open.`,
   );
-  if (result.fallbackDetail) console.error(result.fallbackDetail);
+  if (result.fallbackDetail != null && result.fallbackDetail !== "")
+    console.error(result.fallbackDetail);
 }
 
 if (import.meta.main) {
@@ -429,8 +432,8 @@ if (import.meta.main) {
     }
     if (argv.flags.callback) warnFallback(result);
   } else {
-    const singleId = ids[0];
-    if (singleId) {
+    const singleId = ids.at(0);
+    if (singleId !== undefined) {
       params.set("id", singleId);
     }
     const result = await dispatch(command, params, callbackActions);

--- a/plugins/things/src/example.ts
+++ b/plugins/things/src/example.ts
@@ -22,7 +22,7 @@ const nonRepeating = todos.filter((t) => {
   return cd.getHours() !== 0 || cd.getMinutes() !== 0 || cd.getSeconds() !== 0;
 });
 
-const withNotes = nonRepeating.filter((t) => t.notes() && t.notes().length > 0);
+const withNotes = nonRepeating.filter((t) => t.notes().length > 0);
 
 const result = withNotes.map((t) => ({
   id: t.id(),

--- a/plugins/things/src/mcp/jxa.ts
+++ b/plugins/things/src/mcp/jxa.ts
@@ -28,7 +28,7 @@ const JxaFailure = z.looseObject({ error: z.unknown().transform(String) });
 // oxlint-disable-next-line local/no-unknown-returns
 export async function runScript(script: string, args: string[]): Promise<unknown> {
   const runner = await findJxaRunner();
-  if (!runner) {
+  if (runner == null || runner === "") {
     throw new Error("mac plugin JXA runner not found (expected plugins/mac/scripts/jxa.ts)");
   }
 

--- a/plugins/things/src/mcp/stdout.test.ts
+++ b/plugins/things/src/mcp/stdout.test.ts
@@ -27,12 +27,13 @@ async function importClosure(entry: string): Promise<string[]> {
 
   while (queue.length > 0) {
     const file = queue.pop();
-    if (!file || seen.has(file)) continue;
+    if (file == null || file === "" || seen.has(file)) continue;
     seen.add(file);
 
     const source = await Bun.file(file).text();
-    for (const [, specifier] of source.matchAll(RELATIVE_IMPORT)) {
-      if (!specifier) continue;
+    for (const match of source.matchAll(RELATIVE_IMPORT)) {
+      const specifier = match.at(1);
+      if (specifier === undefined) continue;
       const target = resolve(dirname(file), specifier);
       const path = (await Bun.file(`${target}.ts`).exists()) ? `${target}.ts` : target;
       if (path.endsWith(".ts")) queue.push(path);

--- a/plugins/things/src/mcp/tools.ts
+++ b/plugins/things/src/mcp/tools.ts
@@ -127,16 +127,16 @@ export function limitItems(payload: unknown, guidance: string): unknown {
  */
 function writeResult(result: DispatchResult, action: string) {
   warnFallback(result);
-  if (result.viaXcall && !result.output) {
+  if (result.viaXcall && (result.output == null || result.output === "")) {
     throw new Error(
       `${action}: xcall returned no output. The operation may not have applied. ` +
         "Do not retry until the cause is understood (retries create duplicates).",
     );
   }
-  if (result.id) {
+  if (result.id != null && result.id !== "") {
     return textResult(`${action}: ${TODO_LINK_BASE}${result.id}`);
   }
-  if (result.output) {
+  if (result.output != null && result.output !== "") {
     return textResult(`${action}: ${result.output}`);
   }
   return textResult(`${action}: dispatched via Launch Services (no callback confirmation)`);
@@ -202,7 +202,7 @@ export function validateCaptureTitles(title?: string, titles?: string[]): void {
   if (title !== undefined && titles !== undefined) {
     throw new Error("Provide title (single todo) or titles (multiple todos), not both");
   }
-  if (!title?.trim() && !titles?.length) {
+  if ((title?.trim() ?? "") === "" && (titles?.length ?? 0) === 0) {
     throw new Error("title or titles is required");
   }
   if (titles) validateNonBlank(titles, "titles");
@@ -587,7 +587,7 @@ export function registerTools(server: McpServer): void {
         add_tags: rest.add_tags && (await requireTags(rest.add_tags, createMissing)),
       });
 
-      if (ids.length === 1 && ids[0]) {
+      if (ids.length === 1 && ids[0] != null && ids[0] !== "") {
         const params = new Map<string, string>(Object.entries(attributes));
         params.set("id", ids[0]);
         return writeResult(await dispatch("update", params), `Updated ${ids[0]}`);
@@ -605,7 +605,7 @@ export function registerTools(server: McpServer): void {
           // keeps a retry from updating those todos a second time.
           const message = error instanceof Error ? error.message : String(error);
           throw new Error(
-            applied.length
+            applied.length !== 0
               ? `${message}\nAlready updated: ${applied.join(", ")}. Retry only the remaining IDs.`
               : message,
             { cause: error },
@@ -668,9 +668,9 @@ export function registerTools(server: McpServer): void {
       params.set("tags", tags.join(","));
 
       let notes = args.notes;
-      if (args.session_id) {
+      if (args.session_id != null && args.session_id !== "") {
         const attribution = buildAttribution(args.session_id, args.directory);
-        notes = notes ? `${notes}\n\n${attribution}` : attribution;
+        notes = notes != null && notes !== "" ? `${notes}\n\n${attribution}` : attribution;
       }
       if (notes !== undefined) params.set("notes", notes);
 

--- a/plugins/tmux/hooks/context.ts
+++ b/plugins/tmux/hooks/context.ts
@@ -14,13 +14,13 @@ const ENV_FORMAT = [
 
 function hookAsset(name: string): string {
   const root = process.env.CLAUDE_PLUGIN_ROOT;
-  if (root) return join(root, "hooks", name);
+  if (root != null && root !== "") return join(root, "hooks", name);
   return join(import.meta.dirname, name);
 }
 
 function scriptPath(name: string): string {
   const root = process.env.CLAUDE_PLUGIN_ROOT;
-  if (root) return join(root, "skills/tmux/scripts", name);
+  if (root != null && root !== "") return join(root, "skills/tmux/scripts", name);
   return join(import.meta.dirname, "..", "skills/tmux/scripts", name);
 }
 
@@ -53,7 +53,7 @@ function isSessionAttached(pane: string): boolean {
 async function writeEnvFile(envFile: string, pane: string): Promise<void> {
   try {
     const output = tmuxQuery("display-message", "-t", pane, "-p", ENV_FORMAT);
-    if (!output) return;
+    if (output == null || output === "") return;
 
     const file = Bun.file(envFile);
     const existing = (await file.exists()) ? await file.text() : "";
@@ -74,19 +74,27 @@ function buildContext(
   const sections = [PREAMBLE];
 
   const children: string[] = [];
-  if (pane) children.push(xml("pane", pane));
-  if (window) children.push(xml("window", window));
+  if (pane != null && pane !== "") children.push(xml("pane", pane));
+  if (window != null && window !== "") children.push(xml("window", window));
   if (children.length > 0) {
     sections.push(xml("tmux", { attached }, children.join("\n\n")));
   }
 
-  if (directive) sections.push(directive);
+  if (directive != null && directive !== "") sections.push(directive);
   return sections.join("\n\n");
 }
 
 async function main(): Promise<void> {
   const pane = process.env.TMUX_PANE;
-  if (!process.env.TMUX || !pane || !process.env.CLAUDE_ENV_FILE) return;
+  if (
+    process.env.TMUX == null ||
+    process.env.TMUX === "" ||
+    pane == null ||
+    pane === "" ||
+    process.env.CLAUDE_ENV_FILE == null ||
+    process.env.CLAUDE_ENV_FILE === ""
+  )
+    return;
 
   const attached = isSessionAttached(pane);
 

--- a/plugins/tmux/hooks/notification-clear.test.ts
+++ b/plugins/tmux/hooks/notification-clear.test.ts
@@ -7,7 +7,8 @@ import hooks from "./hooks.json";
 const found = hooks.hooks.PreToolUse.flatMap((matcher) => matcher.hooks)
   .map((hook) => hook.command)
   .find((command) => command.includes("--clear"));
-if (!found) throw new Error("hooks.json is missing the PreToolUse --clear command");
+if (found == null || found === "")
+  throw new Error("hooks.json is missing the PreToolUse --clear command");
 const clearCommand = found;
 
 describe("PreToolUse --clear guard", () => {

--- a/plugins/tmux/hooks/notification.ts
+++ b/plugins/tmux/hooks/notification.ts
@@ -31,7 +31,7 @@ interface NotificationEntry {
 
 function parseEntry(raw: string): NotificationEntry | null {
   const [window, tool] = raw.split(":");
-  if (!window || !tool) return null;
+  if (window == null || window === "" || tool == null || tool === "") return null;
   return { window, tool };
 }
 
@@ -46,7 +46,7 @@ function truncate(str: string, max: number): string {
 
 function updateSummary(): void {
   const output = tmuxQuery("show-options", "-g");
-  if (!output) return;
+  if (output == null || output === "") return;
 
   const entries: NotificationEntry[] = [];
   for (const line of output.split("\n")) {
@@ -94,7 +94,7 @@ type HookInput = z.infer<typeof HookInput>;
 
 async function readHookInput(): Promise<HookInput | null> {
   const text = await Bun.stdin.text();
-  if (!text) return null;
+  if (text === "") return null;
   try {
     return HookInput.parse(JSON.parse(text));
   } catch (error) {
@@ -106,9 +106,9 @@ async function readHookInput(): Promise<HookInput | null> {
 }
 
 async function main(): Promise<void> {
-  if (!process.env.TMUX) return;
+  if (process.env.TMUX == null || process.env.TMUX === "") return;
   const pane = process.env.TMUX_PANE ?? tmuxQuery("display-message", "-p", "#{pane_id}");
-  if (!pane) return;
+  if (pane == null || pane === "") return;
 
   // hooks.json wraps the --clear invocation in an inline shell guard that
   // skips the bun startup entirely when this pane has no notification marker,
@@ -126,10 +126,18 @@ async function main(): Promise<void> {
     pane,
     "#{pane_tty}\n#{window_index}\n#{window_active}",
   );
-  if (!paneInfo) return;
+  if (paneInfo == null || paneInfo === "") return;
 
   const [tty, window, active] = paneInfo.split("\n");
-  if (!tty || !window || !active) return;
+  if (
+    tty == null ||
+    tty === "" ||
+    window == null ||
+    window === "" ||
+    active == null ||
+    active === ""
+  )
+    return;
 
   if (argv.flags.backgroundOnly && active === "1") return;
 

--- a/plugins/tmux/skills/tmux/scripts/safe-command.test.ts
+++ b/plugins/tmux/skills/tmux/scripts/safe-command.test.ts
@@ -20,7 +20,7 @@ const Decision = z.looseObject({
 });
 
 function isAllow(output: string): boolean {
-  if (!output) return false;
+  if (output === "") return false;
   return Decision.parse(JSON.parse(output)).hookSpecificOutput?.permissionDecision === "allow";
 }
 

--- a/plugins/type-ignore/hooks/detect.ts
+++ b/plugins/type-ignore/hooks/detect.ts
@@ -88,7 +88,7 @@ export function findLineNumber(content: string, pattern: string): number {
 }
 
 function getMarkerPath(sessionId: string): string {
-  return path.join(MARKER_DIR, sessionId || "unknown");
+  return path.join(MARKER_DIR, sessionId !== "" ? sessionId : "unknown");
 }
 
 export async function isCleanupAgentActive(sessionId: string): Promise<boolean> {
@@ -150,7 +150,7 @@ export async function processInput(
   }
 
   const language = getLanguage(filePath);
-  if (!language) {
+  if (language == null || language === "") {
     return null;
   }
 

--- a/plugins/ui-design/skills/wireframe/scripts/render-html.integration.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/render-html.integration.ts
@@ -18,7 +18,7 @@ describe("render-html", () => {
   });
 
   afterAll(async () => {
-    await browser?.close();
+    await browser.close();
     await rm(tmpDir, { recursive: true, force: true });
   });
 

--- a/plugins/ui-design/skills/wireframe/scripts/render-html.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/render-html.ts
@@ -75,7 +75,7 @@ if (import.meta.main) {
   const scale = argv.flags.scale;
 
   const lastArg = args[args.length - 1];
-  const hasOutputPath = lastArg && extname(lastArg) === ".png";
+  const hasOutputPath = lastArg !== undefined && extname(lastArg) === ".png";
   const outputPath = hasOutputPath ? lastArg : undefined;
   const files = hasOutputPath ? args.slice(0, -1) : args;
 

--- a/plugins/ui-design/skills/wireframe/scripts/render.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/render.ts
@@ -20,12 +20,9 @@ export async function render(
   let pipeline = sharp(svgContent);
 
   if (scale !== 1) {
-    const metadata = await sharp(svgContent).metadata();
-    if (metadata.width && metadata.height) {
-      pipeline = pipeline.resize(
-        Math.round(metadata.width * scale),
-        Math.round(metadata.height * scale),
-      );
+    const { width, height } = await sharp(svgContent).metadata();
+    if (width > 0 && height > 0) {
+      pipeline = pipeline.resize(Math.round(width * scale), Math.round(height * scale));
     }
   }
 
@@ -40,7 +37,10 @@ export async function renderFile(
 ): Promise<RenderResult> {
   const scale = options.scale ?? 1;
   const suffix = scale !== 1 ? `@${scale}x` : "";
-  const output = outputPath || inputPath.replace(/\.svg$/, `${suffix}.png`);
+  const output =
+    outputPath != null && outputPath !== ""
+      ? outputPath
+      : inputPath.replace(/\.svg$/, `${suffix}.png`);
   const content = Buffer.from(await Bun.file(inputPath).arrayBuffer());
   await render(content, output, options);
   return { input: inputPath, output, scale };
@@ -59,7 +59,8 @@ async function main() {
   let scale = 1;
   const scaleIndex = args.findIndex((a) => a === "--scale" || a === "-s");
   if (scaleIndex !== -1) {
-    scale = Number.parseFloat(args[scaleIndex + 1] ?? "1") || 1;
+    const parsed = Number.parseFloat(args[scaleIndex + 1] ?? "1");
+    scale = Number.isNaN(parsed) || parsed === 0 ? 1 : parsed;
     args.splice(scaleIndex, 2);
   }
 
@@ -79,12 +80,18 @@ async function main() {
   const [svg] = svgFiles;
   const [firstArg, secondArg] = args;
 
-  if (svg && nonSvgArgs.length === 1) {
-    files.push({ input: svg, ...(nonSvgArgs[0] && { output: nonSvgArgs[0] }) });
+  if (svg != null && svg !== "" && nonSvgArgs.length === 1) {
+    files.push({
+      input: svg,
+      ...(nonSvgArgs[0] != null && nonSvgArgs[0] !== "" && { output: nonSvgArgs[0] }),
+    });
   } else if (svgFiles.length > 0) {
     files.push(...svgFiles.map((input) => ({ input })));
-  } else if (firstArg) {
-    files.push({ input: firstArg, ...(secondArg && { output: secondArg }) });
+  } else if (firstArg != null && firstArg !== "") {
+    files.push({
+      input: firstArg,
+      ...(secondArg != null && secondArg !== "" && { output: secondArg }),
+    });
   }
 
   try {

--- a/plugins/ui-design/skills/wireframe/scripts/validate-hook.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/validate-hook.ts
@@ -40,7 +40,7 @@ export async function processInput(
   }
 
   const filePath = FileInput.safeParse(input.tool_input).data?.file_path;
-  if (!filePath || !isSvgFile(filePath)) {
+  if (filePath == null || filePath === "" || !isSvgFile(filePath)) {
     return null;
   }
 

--- a/plugins/ui-design/skills/wireframe/scripts/validate.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/validate.ts
@@ -21,7 +21,8 @@ export interface ValidationResult {
 type Transform = { x: number; y: number };
 
 function attr(el: XmlElement, name: string, fallback = 0): number {
-  return Number.parseFloat(el.getAttribute(name) || String(fallback));
+  const raw = el.getAttribute(name);
+  return Number.parseFloat(raw != null && raw !== "" ? raw : String(fallback));
 }
 
 function getBounds(el: XmlElement, t: Transform = { x: 0, y: 0 }): Bounds | null {
@@ -38,8 +39,9 @@ function getBounds(el: XmlElement, t: Transform = { x: 0, y: 0 }): Bounds | null
       const x = t.x + attr(el, "x");
       const y = t.y + attr(el, "y");
       const fontSize = attr(el, "font-size", 16);
-      const estimatedWidth = (el.textContent || "").length * fontSize * 0.6;
-      const anchor = el.getAttribute("text-anchor") || "start";
+      const estimatedWidth = (el.textContent ?? "").length * fontSize * 0.6;
+      const anchorAttr = el.getAttribute("text-anchor");
+      const anchor = anchorAttr != null && anchorAttr !== "" ? anchorAttr : "start";
 
       let adjustedX = x;
       if (anchor === "middle") {
@@ -77,9 +79,10 @@ function getBounds(el: XmlElement, t: Transform = { x: 0, y: 0 }): Bounds | null
 }
 
 function parseTransform(transform: string | null): Transform {
-  if (!transform) return { x: 0, y: 0 };
+  if (transform == null || transform === "") return { x: 0, y: 0 };
   const match = transform.match(/translate\(\s*([\d.-]+)\s*,\s*([\d.-]+)\s*\)/);
-  if (!match?.[1] || !match[2]) return { x: 0, y: 0 };
+  if (match?.[1] == null || match[1] === "" || match[2] == null || match[2] === "")
+    return { x: 0, y: 0 };
   return { x: Number.parseFloat(match[1]), y: Number.parseFloat(match[2]) };
 }
 
@@ -93,9 +96,9 @@ function getElementChildren(el: XmlElement): XmlElement[] {
 
 function getElementId(el: XmlElement, index: number): string {
   const id = el.getAttribute("id");
-  if (id) return `#${id}`;
+  if (id != null && id !== "") return `#${id}`;
   const tag = el.tagName;
-  if (tag === "text" && el.textContent) {
+  if (tag === "text" && el.textContent != null && el.textContent !== "") {
     return `<text>"${el.textContent.slice(0, 20)}"`;
   }
   return `<${tag}>[${index}]`;
@@ -126,7 +129,7 @@ function boundsEqual(a: Bounds, b: Bounds): boolean {
 function isContainer(el: XmlElement): boolean {
   if (el.tagName !== "rect") return false;
   const fill = el.getAttribute("fill");
-  return !fill || fill === "none";
+  return fill == null || fill === "" || fill === "none";
 }
 
 interface ChildInfo {
@@ -166,7 +169,7 @@ function validateGroup(
     }
 
     if (child.tagName === "g") {
-      validateGroup(child, bounds || parentBounds, currentTransform, violations);
+      validateGroup(child, bounds, currentTransform, violations);
     }
 
     const isBackground = parentBounds ? boundsEqual(bounds, parentBounds) : false;
@@ -233,10 +236,10 @@ export function validate(svgContent: string): Violation[] {
     return violations;
   }
 
-  const width = Number.parseFloat(svg.getAttribute("width") || "0");
-  const height = Number.parseFloat(svg.getAttribute("height") || "0");
+  const width = attr(svg, "width");
+  const height = attr(svg, "height");
 
-  if (!width || !height) {
+  if (width === 0 || height === 0) {
     violations.push({
       element: "<svg>",
       issue: "missing-dimensions",

--- a/plugins/writing/detection/paths.test.ts
+++ b/plugins/writing/detection/paths.test.ts
@@ -42,7 +42,7 @@ describe("isScratchPath", () => {
 
   test("TMPDIR contents are scratch", () => {
     const tmpDir = process.env.TMPDIR;
-    if (!tmpDir) return;
+    if (tmpDir == null || tmpDir === "") return;
     expect(isScratchPath(`${resolve(tmpDir)}/handoff.md`)).toBe(true);
   });
 });

--- a/plugins/writing/detection/paths.ts
+++ b/plugins/writing/detection/paths.ts
@@ -27,7 +27,7 @@ const JOBS_PATH_PATTERN = /\/\.claude\/jobs\//;
 export function isScratchPath(filePath: string, cwd: string = process.cwd()): boolean {
   const resolved = resolve(cwd, filePath);
   const tmpDir = process.env.TMPDIR;
-  if (tmpDir && resolved.startsWith(`${resolve(tmpDir)}/`)) return true;
+  if (tmpDir != null && tmpDir !== "" && resolved.startsWith(`${resolve(tmpDir)}/`)) return true;
   if (JOBS_PATH_PATTERN.test(resolved)) return true;
   if (resolved.startsWith("/tmp/") || resolved.startsWith("/private/tmp/")) return true;
   const root = resolve(cwd);

--- a/plugins/writing/detection/scan.ts
+++ b/plugins/writing/detection/scan.ts
@@ -116,6 +116,9 @@ export function scanAll(text: string, filePath?: string): ScanResult[] {
     results.push(...weightedResults(stripped, group));
   }
 
-  results.sort((a, b) => a.line - b.line || a.col - b.col);
+  results.sort((a, b) => {
+    const byLine = a.line - b.line;
+    return byLine !== 0 ? byLine : a.col - b.col;
+  });
   return results;
 }

--- a/plugins/writing/detection/tropes.test.ts
+++ b/plugins/writing/detection/tropes.test.ts
@@ -50,7 +50,10 @@ describe("stripCode", () => {
   const inlineCodeLine = fc
     .tuple(
       plainSegment,
-      fc.string().map((s) => s.replace(/[`\n]/g, "") || "x"),
+      fc.string().map((s) => {
+        const stripped = s.replace(/[`\n]/g, "");
+        return stripped !== "" ? stripped : "x";
+      }),
       plainSegment,
     )
     .map(([pre, code, post]) => `${pre}\`${code}\`${post}`);

--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -470,7 +470,7 @@ function salutationHits(text: string): Hits {
   if (line === "") return { count: 0, sample: "" };
   if (GREETING_OPENER.test(line)) return { count: 1, sample: line.slice(0, 40) };
   const address = ADDRESS_OPENER.exec(line)?.[1];
-  if (!address) return { count: 0, sample: "" };
+  if (address == null || address === "") return { count: 0, sample: "" };
   const head = address.split(/\s+/)[0] ?? "";
   if (!isNameShaped(head)) return { count: 0, sample: "" };
   return { count: 1, sample: `${address},` };

--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -271,7 +271,7 @@ function questionAnswerCadenceHits(text: string): Hits {
   const questionOpeners: string[] = [];
   for (const sentences of paragraphs) {
     const first = sentences[0];
-    if (first && QUESTION_OPENER.test(first)) {
+    if (first != null && first !== "" && QUESTION_OPENER.test(first)) {
       questionOpeners.push(first.slice(0, 60));
     }
   }
@@ -1285,7 +1285,7 @@ export function scanIntroduced(
 
   for (const def of PATTERNS) {
     if (def.skillOnly) continue;
-    if (def.fileOnly && filePath && !isProseFile(filePath)) continue;
+    if (def.fileOnly && filePath != null && filePath !== "" && !isProseFile(filePath)) continue;
     if (def.sideEffectOnly && context === "file") continue;
 
     const newHits = patternHits(newStripped, def);
@@ -1303,7 +1303,7 @@ export function scanIntroduced(
   }
 
   for (const group of WEIGHTED_PATTERNS) {
-    if (group.fileOnly && filePath && !isProseFile(filePath)) continue;
+    if (group.fileOnly && filePath != null && filePath !== "" && !isProseFile(filePath)) continue;
 
     const newWeighted = weightedStemHits(newStripped, group.entries);
     if (newWeighted.totalWeight < group.threshold) continue;

--- a/plugins/writing/detection/wordlists.ts
+++ b/plugins/writing/detection/wordlists.ts
@@ -60,7 +60,7 @@ export function compileStemmedWordlist(content: string): (text: string) => Hits 
     for (const word of words) {
       if (stems.has(stemmer(word.toLowerCase()))) {
         count++;
-        if (!sample) sample = word;
+        if (sample === "") sample = word;
       }
     }
     return { count, sample };
@@ -131,7 +131,7 @@ export function stemmedPhraseHits(text: string, phrases: StemmedPhrase[]): Hits 
     const occurrences = countSubsequence(tokens, phrase.stems);
     if (occurrences === 0) continue;
     count += occurrences;
-    if (!sample) sample = phrase.original;
+    if (sample === "") sample = phrase.original;
   }
   return { count, sample };
 }

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -41,18 +41,19 @@ function stripQuotes(token: string): string {
 
 function extractBodyFilePath(command: string): string | null {
   const match = command.match(BODY_FILE_PATTERN);
-  return match?.[1] ? stripQuotes(match[1]) : null;
+  const captured = match?.at(1);
+  return captured != null && captured !== "" ? stripQuotes(captured) : null;
 }
 
 function extractFieldFilePaths(command: string): string[] {
   const paths: string[] = [];
   for (const match of command.matchAll(FIELD_FILE_PATTERN)) {
     const path = stripQuotes(match[2] ?? "");
-    if (path && path !== "-") paths.push(path);
+    if (path !== "" && path !== "-") paths.push(path);
   }
   for (const match of command.matchAll(GIT_MESSAGE_FILE_PATTERN)) {
     const path = stripQuotes(match[1] ?? "");
-    if (path && path !== "-") paths.push(path);
+    if (path !== "" && path !== "-") paths.push(path);
   }
   return paths;
 }
@@ -83,7 +84,7 @@ async function collectFileOpPair(
 
   if (toolName === "Write") {
     const content = toolInput.content;
-    if (!content) return null;
+    if (content == null || content === "") return null;
     let oldText = "";
     if (toolInput.file_path !== undefined) {
       const file = Bun.file(toolInput.file_path);
@@ -94,7 +95,7 @@ async function collectFileOpPair(
 
   if (toolName === "Edit") {
     const newString = toolInput.new_string;
-    if (!newString) return null;
+    if (newString == null || newString === "") return null;
     return { newText: newString, oldText: toolInput.old_string ?? "" };
   }
 
@@ -120,9 +121,10 @@ export async function collectText(input: PreToolUseHookInput): Promise<string[]>
     const command = toolInput.command;
     const texts: string[] = [];
     const bodyFile = extractBodyFilePath(command);
-    const files = bodyFile
-      ? [bodyFile, ...extractFieldFilePaths(command)]
-      : extractFieldFilePaths(command);
+    const files =
+      bodyFile != null && bodyFile !== ""
+        ? [bodyFile, ...extractFieldFilePaths(command)]
+        : extractFieldFilePaths(command);
     for (const path of files) {
       if (await Bun.file(path).exists()) {
         texts.push(await Bun.file(path).text());
@@ -130,7 +132,7 @@ export async function collectText(input: PreToolUseHookInput): Promise<string[]>
     }
     for (const flag of PROSE_FLAGS) {
       const value = extractInlineArg(command, flag);
-      if (value) texts.push(value);
+      if (value != null && value !== "") texts.push(value);
     }
     return texts;
   }
@@ -150,7 +152,7 @@ function buildFileOpReminder(
   filePath: string | undefined,
   deny: PatternMatch,
 ): string {
-  const target = filePath ? `\`${filePath}\`` : "the file";
+  const target = filePath != null && filePath !== "" ? `\`${filePath}\`` : "the file";
   if (toolName === "Write") {
     return `${deny.message} You wrote ${target} introducing this. Issue a follow-up Edit that fixes only the trope you just introduced. Do not modify unrelated parts of the file.`;
   }
@@ -178,7 +180,7 @@ async function processFileOp(input: PreToolUseHookInput): Promise<HookResult | n
   // Prose rules target prose. In a code file the model's prose surface is its
   // comments, so scan those; strings and identifiers are program text the
   // model did not write as prose.
-  const prose = !filePath || isProseFile(filePath);
+  const prose = filePath == null || filePath === "" || isProseFile(filePath);
   const scanPair = prose
     ? pair
     : { newText: extractComments(pair.newText), oldText: extractComments(pair.oldText) };
@@ -200,7 +202,8 @@ async function processFileOp(input: PreToolUseHookInput): Promise<HookResult | n
 
   if (!prose) {
     const splice = commentSplice(scanPair);
-    if (splice) return { output: formatContext(splice), category: "comment splice" };
+    if (splice != null && splice !== "")
+      return { output: formatContext(splice), category: "comment splice" };
   }
 
   return null;

--- a/plugins/writing/hooks/heading-case.ts
+++ b/plugins/writing/hooks/heading-case.ts
@@ -172,9 +172,15 @@ export function headingCaseViolations(body: string): { text: string; suggested: 
     const cased = apStyleTitleCase(trimmed, { stopwords: AP_STOPWORDS }).trim().split(/\s+/);
     if (original.length !== cased.length) continue;
 
-    const suggested = original.map((word, i) => caseWord(word, cased[i] ?? word));
+    const suggested: string[] = [];
+    let differs = false;
+    for (const [i, word] of original.entries()) {
+      const next = caseWord(word, cased[i] ?? word);
+      suggested.push(next);
+      if (next !== word) differs = true;
+    }
 
-    if (suggested.some((word, i) => word !== original[i])) {
+    if (differs) {
       violations.push({
         text: restore(original.join(" "), codeSpans),
         suggested: restore(suggested.join(" "), codeSpans),

--- a/plugins/writing/hooks/heading-case.ts
+++ b/plugins/writing/hooks/heading-case.ts
@@ -172,14 +172,9 @@ export function headingCaseViolations(body: string): { text: string; suggested: 
     const cased = apStyleTitleCase(trimmed, { stopwords: AP_STOPWORDS }).trim().split(/\s+/);
     if (original.length !== cased.length) continue;
 
-    let differs = false;
-    const suggested = original.map((word, i) => {
-      const result = caseWord(word, cased[i] ?? word);
-      if (result !== word) differs = true;
-      return result;
-    });
+    const suggested = original.map((word, i) => caseWord(word, cased[i] ?? word));
 
-    if (differs) {
+    if (suggested.some((word, i) => word !== original[i])) {
       violations.push({
         text: restore(original.join(" "), codeSpans),
         suggested: restore(suggested.join(" "), codeSpans),

--- a/plugins/writing/hooks/headings.ts
+++ b/plugins/writing/hooks/headings.ts
@@ -21,7 +21,7 @@ export function checkBoldAsHeading(content: string): string | null {
   let result: string | null = null;
 
   visit(ast, "paragraph", (node: Paragraph) => {
-    if (result) return;
+    if (result != null && result !== "") return;
 
     const first = node.children[0];
     if (first?.type !== "strong") return;
@@ -44,7 +44,7 @@ export function checkSentenceHeading(content: string): string | null {
   let result: string | null = null;
 
   visit(ast, "heading", (node: Heading) => {
-    if (result) return;
+    if (result != null && result !== "") return;
 
     const allCode = node.children.every((child) => child.type === "inlineCode");
     if (allCode) return;
@@ -73,7 +73,7 @@ export function check(input: PreToolUseHookInput): HookResult | null {
   if (!isMarkdownFile(ext)) return null;
 
   const titleCase = checkTitleCase(content);
-  if (titleCase) {
+  if (titleCase != null && titleCase !== "") {
     return {
       output: formatContext(
         `${titleCase}. Apply AP-style title case: capitalize major words, lowercase articles/prepositions (a, an, the, in, of, etc.) unless they start the heading.`,
@@ -83,7 +83,7 @@ export function check(input: PreToolUseHookInput): HookResult | null {
   }
 
   const boldHeading = checkBoldAsHeading(content);
-  if (boldHeading) {
+  if (boldHeading != null && boldHeading !== "") {
     return {
       output: formatContext(
         `${boldHeading}. Replace the bold-colon pattern with a markdown heading (## ) at the appropriate level.`,
@@ -93,7 +93,7 @@ export function check(input: PreToolUseHookInput): HookResult | null {
   }
 
   const sentenceHeading = checkSentenceHeading(content);
-  if (sentenceHeading) {
+  if (sentenceHeading != null && sentenceHeading !== "") {
     return { output: formatContext(sentenceHeading), category: "sentence heading" };
   }
 

--- a/plugins/writing/hooks/numbering.test.ts
+++ b/plugins/writing/hooks/numbering.test.ts
@@ -309,7 +309,7 @@ describe("processInput with markdown", () => {
       return;
     }
     expect(output).not.toHaveProperty("permissionDecision");
-    if (reasonContains) {
+    if (reasonContains != null && reasonContains !== "") {
       expect(output?.additionalContext).toContain(reasonContains);
     }
   });

--- a/plugins/writing/hooks/numbering.ts
+++ b/plugins/writing/hooks/numbering.ts
@@ -52,8 +52,8 @@ export async function checkMarkdown(content: string): Promise<string | null> {
     if (STEP_HEADING.test(text)) {
       matches.push({
         text: text.trim(),
-        line: node.position?.start?.line || 0,
-        column: node.position?.start?.column || 0,
+        line: node.position?.start.line ?? 0,
+        column: node.position?.start.column ?? 0,
       });
     }
   });
@@ -92,7 +92,7 @@ export async function checkCode(content: string, ext: string): Promise<string | 
       result = (ExecFailure.safeParse(error).data?.stdout ?? "").trim();
     }
 
-    if (result) {
+    if (result !== "") {
       const matches = AstGrepMatches.parse(JSON.parse(result));
       return matches[0]?.message ?? null;
     }
@@ -137,7 +137,7 @@ export async function check(input: PreToolUseHookInput, mode: Mode): Promise<Hoo
     match = await checkCode(content, ext);
   }
 
-  if (!match) {
+  if (match == null || match === "") {
     return null;
   }
 

--- a/plugins/writing/hooks/pretooluse.ts
+++ b/plugins/writing/hooks/pretooluse.ts
@@ -50,7 +50,7 @@ export async function dispatch(
 ): Promise<DispatchResult> {
   const start = performance.now();
   const filePath = filePathOf(input);
-  const ext = filePath ? getExtension(filePath) : "";
+  const ext = filePath != null && filePath !== "" ? getExtension(filePath) : "";
 
   const base = {
     ts: new Date(now).toISOString(),
@@ -69,8 +69,10 @@ export async function dispatch(
   });
 
   if (isPlanMode(input)) return finish(null, "silent");
-  if (filePath && isScratchPath(filePath, input.cwd)) return finish(null, "skipped-scratch");
-  if (filePath && (isPlanPath(filePath) || isMemoryPath(filePath))) return finish(null, "silent");
+  if (filePath != null && filePath !== "" && isScratchPath(filePath, input.cwd))
+    return finish(null, "skipped-scratch");
+  if (filePath != null && filePath !== "" && (isPlanPath(filePath) || isMemoryPath(filePath)))
+    return finish(null, "silent");
 
   const mode: numbering.Mode = input.tool_name === "Edit" ? "edit" : "write";
   const checkers = [

--- a/plugins/writing/hooks/run-log.ts
+++ b/plugins/writing/hooks/run-log.ts
@@ -32,12 +32,12 @@ export function resolveLogPath(
   env: string | undefined = process.env.WRITING_HOOKS_LOG,
 ): string | null {
   if (env !== undefined && OFF_VALUES.has(env.toLowerCase())) return null;
-  if (env && !ON_VALUES.has(env.toLowerCase())) return env;
+  if (env != null && env !== "" && !ON_VALUES.has(env.toLowerCase())) return env;
   return join(homedir(), ".claude", "writing-hooks", "log.jsonl");
 }
 
 export function appendRunLog(entry: RunLogEntry, path: string | null = resolveLogPath()): void {
-  if (!path) return;
+  if (path == null || path === "") return;
   try {
     mkdirSync(dirname(path), { recursive: true });
     const file = Bun.file(path);

--- a/plugins/writing/linguistics/classifiers.ts
+++ b/plugins/writing/linguistics/classifiers.ts
@@ -165,7 +165,8 @@ export function hybridClassifier(tagger: Tagger): HeadingClassifier {
         const predicate = afterTokens.some(
           (token) => (token.finite && token.tag !== "AUX") || token.normal === "not",
         );
-        const preEnumerator = before[0] ? ENUMERATOR_STOPLIST.test(before[0]) : false;
+        const preEnumerator =
+          before[0] != null && before[0] !== "" ? ENUMERATOR_STOPLIST.test(before[0]) : false;
         if (before.length <= 4 && after.length >= 3 && predicate && !preEnumerator) {
           return { kind: "clause", flagged: true, evidence: ["colon-gated predicate"] };
         }

--- a/plugins/writing/linguistics/fixtures.test.ts
+++ b/plugins/writing/linguistics/fixtures.test.ts
@@ -62,7 +62,7 @@ describe("sentence-heading positives", () => {
     it(description, () => {
       const verdict = classifyHeadingBaseline(heading);
       expect(verdict.flagged).toBe(baselineFlagged);
-      if (kind) {
+      if (kind != null) {
         expect(verdict.kind).toBe(kind);
       }
     });

--- a/plugins/writing/linguistics/heading.test.ts
+++ b/plugins/writing/linguistics/heading.test.ts
@@ -130,7 +130,7 @@ describe("classifyHeadingBaseline", () => {
     it(description, () => {
       const verdict = classifyHeadingBaseline(heading);
       expect(verdict.flagged).toBe(flagged);
-      if (kind) {
+      if (kind != null) {
         expect(verdict.kind).toBe(kind);
       }
     });

--- a/plugins/writing/linguistics/heading.ts
+++ b/plugins/writing/linguistics/heading.ts
@@ -79,7 +79,7 @@ export function classifyHeadingBaseline(heading: string): HeadingVerdict {
 
   // Interrogative-led headings ("Why X is Y", "What was wrong") are a
   // conventional rationale-section label, not the sentence-heading trope.
-  if (lower[0] && INTERROGATIVE_OPENERS.has(lower[0])) {
+  if (lower[0] != null && lower[0] !== "" && INTERROGATIVE_OPENERS.has(lower[0])) {
     return { kind: "interrogative", flagged: false, evidence: ["interrogative opener"] };
   }
 
@@ -97,14 +97,15 @@ export function classifyHeadingBaseline(heading: string): HeadingVerdict {
       .map((word) => word.toLowerCase().replace(/[^a-z']/g, ""))
       .filter((word) => word.length > 0);
     const afterPredicate = after.some((word) => LINKING_VERBS.has(word) || word === "not");
-    const preEnumerator = before[0] ? ENUMERATOR_STOPLIST.test(before[0]) : false;
+    const preEnumerator =
+      before[0] != null && before[0] !== "" ? ENUMERATOR_STOPLIST.test(before[0]) : false;
     if (before.length <= 4 && after.length >= 3 && afterPredicate && !preEnumerator) {
       return { kind: "clause", flagged: true, evidence: ["colon-gated predicate"] };
     }
   }
 
   const linkingVerb = lower.find((word) => LINKING_VERBS.has(word));
-  if (linkingVerb) {
+  if (linkingVerb != null && linkingVerb !== "") {
     return { kind: "clause", flagged: true, evidence: [`linking verb "${linkingVerb}"`] };
   }
 
@@ -115,7 +116,12 @@ export function classifyHeadingBaseline(heading: string): HeadingVerdict {
     return { kind: "clause", flagged: true, evidence: ["relative clause"] };
   }
 
-  if (words.length >= 3 && lower[0] && IMPERATIVE_OPENERS.has(lower[0])) {
+  if (
+    words.length >= 3 &&
+    lower[0] != null &&
+    lower[0] !== "" &&
+    IMPERATIVE_OPENERS.has(lower[0])
+  ) {
     return { kind: "imperative", flagged: true, evidence: [`imperative opener "${lower[0]}"`] };
   }
 

--- a/plugins/writing/linguistics/natural.ts
+++ b/plugins/writing/linguistics/natural.ts
@@ -11,7 +11,7 @@ const tokenizer = new natural.WordTokenizer();
 export const naturalTagger: Tagger = {
   name: "natural",
   tag(text: string): TaggedSentence[] {
-    const words = tokenizer.tokenize(text) ?? [];
+    const words = tokenizer.tokenize(text);
     const tokens = brill.tag(words).taggedWords.map((tagged) => {
       const normal = tagged.token.toLowerCase();
       const mapped =

--- a/plugins/writing/scripts/io.ts
+++ b/plugins/writing/scripts/io.ts
@@ -7,10 +7,10 @@
 export async function readInput(
   arg: string | undefined,
 ): Promise<{ text: string; filePath?: string }> {
-  if (arg && (await Bun.file(arg).exists())) {
+  if (arg != null && arg !== "" && (await Bun.file(arg).exists())) {
     return { text: await Bun.file(arg).text(), filePath: arg };
   }
-  if (arg) {
+  if (arg != null && arg !== "") {
     return { text: arg };
   }
   return { text: await new Response(Bun.stdin.stream()).text() };

--- a/plugins/writing/skills/analyze/scripts/analyze.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { mkdirSync } from "node:fs";
 import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { cli } from "cleye";
 import { corpusPath, profilePath, resolveDataDir } from "./data-dir";
@@ -192,7 +193,10 @@ async function main(): Promise<void> {
 
   const detectors: BatchDetectors = {};
   if (argv.flags.judge) {
-    if (!process.env.ANTHROPIC_API_KEY && !process.env.ANTHROPIC_AUTH_TOKEN) {
+    if (
+      (process.env.ANTHROPIC_API_KEY == null || process.env.ANTHROPIC_API_KEY === "") &&
+      (process.env.ANTHROPIC_AUTH_TOKEN == null || process.env.ANTHROPIC_AUTH_TOKEN === "")
+    ) {
       console.error(
         "--judge requires API credentials (ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN). Run without --judge or set one.",
       );
@@ -205,10 +209,7 @@ async function main(): Promise<void> {
   }
 
   const sessionId = process.env.CLAUDE_SESSION_ID ?? "anonymous";
-  const isolatedPath = path.join(
-    process.env.TMPDIR || "/tmp",
-    `session-analyze-${sessionId}.duckdb`,
-  );
+  const isolatedPath = path.join(tmpdir(), `session-analyze-${sessionId}.duckdb`);
   console.error(`Copying session DB to ${isolatedPath}`);
   await Bun.write(isolatedPath, Bun.file(dbPath));
 
@@ -395,7 +396,7 @@ export async function runAnalysis(
     "Computing corpus-level rate trends (action-verb opener, backtick density, template rates)",
   );
   const rateDocumentRows = deliverableRows
-    .filter((r) => r.text)
+    .filter((r) => r.text !== "")
     .map((r) => analyzeDocument(r.session_id, r.text));
   const rateTrends = aggregateTrends(rateDocumentRows);
 

--- a/plugins/writing/skills/analyze/scripts/data-dir.ts
+++ b/plugins/writing/skills/analyze/scripts/data-dir.ts
@@ -5,8 +5,9 @@ import { join } from "node:path";
 // repository at the plugin data dir so it can later grow to include private
 // writing. Resolve CLAUDE_PLUGIN_DATA if set, else the conventional default.
 export function resolveDataDir(override?: string): string {
-  if (override) return override;
-  if (process.env.CLAUDE_PLUGIN_DATA) return process.env.CLAUDE_PLUGIN_DATA;
+  if (override != null && override !== "") return override;
+  if (process.env.CLAUDE_PLUGIN_DATA != null && process.env.CLAUDE_PLUGIN_DATA !== "")
+    return process.env.CLAUDE_PLUGIN_DATA;
   return join(homedir(), ".claude", "plugins", "data", "writing-bendrucker");
 }
 

--- a/plugins/writing/skills/analyze/scripts/deliverable-audit.ts
+++ b/plugins/writing/skills/analyze/scripts/deliverable-audit.ts
@@ -61,7 +61,7 @@ export function auditDeliverableCorpus(
 
   let totalTokens = 0;
   for (const row of rows) {
-    if (!row.text) continue;
+    if (row.text == null || row.text === "") continue;
     const tokens = stemTokens(row.text);
     totalTokens += tokens.length;
     for (const n of needles) {

--- a/plugins/writing/skills/analyze/scripts/headings-eval.ts
+++ b/plugins/writing/skills/analyze/scripts/headings-eval.ts
@@ -68,7 +68,7 @@ export function dedupeHeadings(
 ): HeadingRecord[] {
   const byHeading = new Map<string, { occurrences: number; sessions: Set<string> }>();
   for (const row of rows) {
-    if (!row.text) continue;
+    if (row.text == null || row.text === "") continue;
     for (const heading of extractHeadings(row.text)) {
       let record = byHeading.get(heading);
       if (!record) {
@@ -221,7 +221,7 @@ export function parseLabelsFile(content: string): LabeledHeading[] {
   for (const line of content.split("\n")) {
     if (line.startsWith("#") || line.trim().length === 0) continue;
     const [heading, label, source] = line.split("\t");
-    if (!heading || !label) continue;
+    if (heading == null || heading === "" || label == null || label === "") continue;
     const parsed = HeadingLabel.safeParse(label);
     if (!parsed.success) {
       throw new Error(`Unknown label "${label}" for heading "${heading}"`);
@@ -312,7 +312,11 @@ async function corpusFromSessionDb(
   params: { after_date: string; before_date: string; project: string | null },
 ): Promise<DeliverableRow[]> {
   const sessionId = process.env.CLAUDE_SESSION_ID ?? "anonymous";
-  const isolatedPath = path.join(process.env.TMPDIR || "/tmp", `headings-eval-${sessionId}.duckdb`);
+  const tmp = process.env.TMPDIR;
+  const isolatedPath = path.join(
+    tmp != null && tmp !== "" ? tmp : "/tmp",
+    `headings-eval-${sessionId}.duckdb`,
+  );
   console.error(`Copying session DB to ${isolatedPath}`);
   await Bun.write(isolatedPath, Bun.file(dbPath));
 
@@ -381,11 +385,11 @@ async function main(): Promise<void> {
 
   let rows: Array<{ session_id: string; text?: string }>;
   let source: string;
-  if (argv.flags.docs) {
+  if (argv.flags.docs != null && argv.flags.docs !== "") {
     const dir = path.resolve(argv.flags.docs);
     rows = await corpusFromDocs(dir);
     source = dir;
-  } else if (argv.flags.sessionDb) {
+  } else if (argv.flags.sessionDb != null && argv.flags.sessionDb !== "") {
     rows = await corpusFromSessionDb(path.resolve(argv.flags.sessionDb), {
       after_date: since,
       before_date: until,
@@ -448,7 +452,7 @@ async function main(): Promise<void> {
   }
 
   let labeled: LabeledHeading[] | undefined;
-  if (argv.flags.labels) {
+  if (argv.flags.labels != null && argv.flags.labels !== "") {
     labeled = parseLabelsFile(await Bun.file(argv.flags.labels).text());
     const randomOnly = labeled.filter((row) => row.source === "random");
     console.log(`Labeled: ${labeled.length} rows (${randomOnly.length} random)`);

--- a/plugins/writing/skills/analyze/scripts/hook-health.ts
+++ b/plugins/writing/skills/analyze/scripts/hook-health.ts
@@ -25,7 +25,7 @@ export type HookHealth = {
 export function parseLog(text: string): RunLogEntry[] {
   const entries: RunLogEntry[] = [];
   for (const line of text.split("\n")) {
-    if (!line.trim()) continue;
+    if (line.trim() === "") continue;
     try {
       const parsed = RunLogEntry.safeParse(JSON.parse(line));
       if (parsed.success) entries.push(parsed.data);
@@ -60,12 +60,12 @@ export function summarize(entries: RunLogEntry[]): HookHealth {
   let lastTs = Number.NEGATIVE_INFINITY;
 
   for (const entry of entries) {
-    byOutcome[entry.outcome] = (byOutcome[entry.outcome] ?? 0) + 1;
+    byOutcome[entry.outcome] += 1;
     byTool[entry.tool] = (byTool[entry.tool] ?? 0) + 1;
     durations.push(entry.duration_ms);
     if (entry.outcome === "silent" && !entry.suppressed) silentDurations.push(entry.duration_ms);
 
-    if (entry.category) {
+    if (entry.category != null && entry.category !== "") {
       const bucket = perCategory.get(entry.category) ?? { fired: 0, suppressed: 0 };
       if (entry.suppressed) {
         bucket.suppressed += 1;
@@ -95,7 +95,7 @@ export function summarize(entries: RunLogEntry[]): HookHealth {
       ...counts,
       share: injections > 0 ? counts.fired / injections : 0,
     }))
-    .toSorted((a, b) => b.fired - a.fired || b.suppressed - a.suppressed);
+    .toSorted((a, b) => (b.fired === a.fired ? b.suppressed - a.suppressed : b.fired - a.fired));
 
   return {
     total: entries.length,
@@ -237,7 +237,7 @@ async function readLog(path: string, since?: string): Promise<RunLogEntry[]> {
     if (await file.exists()) texts.push(await file.text());
   }
   let entries = parseLog(texts.join("\n"));
-  if (since) {
+  if (since != null && since !== "") {
     const cutoff = Date.parse(since);
     if (!Number.isNaN(cutoff)) {
       entries = entries.filter((entry) => Date.parse(entry.ts) >= cutoff);
@@ -270,7 +270,7 @@ if (import.meta.main) {
   });
 
   const path = argv.flags.log ?? resolveLogPath();
-  if (!path) {
+  if (path == null || path === "") {
     console.error("Logging is disabled (WRITING_HOOKS_LOG). Pass --log <path>.");
     process.exit(1);
   }

--- a/plugins/writing/skills/analyze/scripts/ingest-voice.ts
+++ b/plugins/writing/skills/analyze/scripts/ingest-voice.ts
@@ -74,7 +74,7 @@ const SearchResults = z.array(
 
 async function fetchGithub(): Promise<VoiceDocument[]> {
   const author = argv.flags.author;
-  if (!author) {
+  if (author == null || author === "") {
     throw new Error("--author is required for the github source");
   }
   // gh search prs does not expose diff sizes, so the meta line carries the
@@ -89,7 +89,8 @@ async function fetchGithub(): Promise<VoiceDocument[]> {
     "--json",
     "url,body,createdAt",
   ];
-  if (argv.flags.created) args.push(`--created=${argv.flags.created}`);
+  if (argv.flags.created != null && argv.flags.created !== "")
+    args.push(`--created=${argv.flags.created}`);
 
   console.error(`Running: gh ${args.join(" ")}`);
   const proc = Bun.spawn(["gh", ...args], { stdout: "pipe", stderr: "pipe" });
@@ -105,7 +106,7 @@ async function fetchGithub(): Promise<VoiceDocument[]> {
   const results = SearchResults.parse(JSON.parse(stdout));
 
   return results
-    .filter((pr) => pr.body && pr.body.trim().length >= 30)
+    .filter((pr) => pr.body.trim().length >= 30)
     .map((pr) => ({
       source: pr.url,
       meta: pr.createdAt,
@@ -115,7 +116,7 @@ async function fetchGithub(): Promise<VoiceDocument[]> {
 
 async function readFileSource(): Promise<VoiceDocument[]> {
   const file = argv.flags.file;
-  if (!file) {
+  if (file == null || file === "") {
     throw new Error("--file is required for the file source");
   }
   const text = await Bun.file(file).text();

--- a/plugins/writing/skills/analyze/scripts/judge-run.ts
+++ b/plugins/writing/skills/analyze/scripts/judge-run.ts
@@ -127,7 +127,10 @@ export function scoreHeadingBaseline(
 }
 
 function requireApiKey(): void {
-  if (!process.env.ANTHROPIC_API_KEY && !process.env.ANTHROPIC_AUTH_TOKEN) {
+  if (
+    (process.env.ANTHROPIC_API_KEY == null || process.env.ANTHROPIC_API_KEY === "") &&
+    (process.env.ANTHROPIC_AUTH_TOKEN == null || process.env.ANTHROPIC_AUTH_TOKEN === "")
+  ) {
     console.error(
       "Neither ANTHROPIC_API_KEY nor ANTHROPIC_AUTH_TOKEN is set. The judge runs only with live API credentials.",
     );
@@ -204,7 +207,7 @@ async function gateMain(model: string): Promise<void> {
     console.log(`FAIL ${result.id}`);
     for (const mismatch of result.mismatches) {
       console.log(
-        `  ${mismatch.criterion}: expected ${mismatch.expected}, got ${mismatch.actual}${mismatch.span ? ` (span: "${mismatch.span}")` : ""}`,
+        `  ${mismatch.criterion}: expected ${mismatch.expected}, got ${mismatch.actual}${mismatch.span != null && mismatch.span !== "" ? ` (span: "${mismatch.span}")` : ""}`,
       );
     }
   }

--- a/plugins/writing/skills/analyze/scripts/judge.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.test.ts
@@ -365,7 +365,7 @@ describe("judgeCorpus", () => {
     );
     const marketing = audit.criteria.find((c) => c.id === "marketing-phrasing");
     expect(marketing?.flagged).toBe(8);
-    expect(marketing?.spans?.length).toBe(2);
+    expect(marketing?.spans.length).toBe(2);
   });
 });
 

--- a/plugins/writing/skills/analyze/scripts/judge.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.ts
@@ -490,7 +490,8 @@ export async function judgeCorpus(
       const entry = verdict[criterion.key];
       if (!stat || !entry.flagged) continue;
       stat.flagged++;
-      if (entry.span && stat.spans.length < maxSpans) stat.spans.push(entry.span);
+      if (entry.span != null && entry.span !== "" && stat.spans.length < maxSpans)
+        stat.spans.push(entry.span);
     }
   }
   return {

--- a/plugins/writing/skills/analyze/scripts/ngram.ts
+++ b/plugins/writing/skills/analyze/scripts/ngram.ts
@@ -157,7 +157,7 @@ export function processRows(
   };
   const phraseSessions = new Map<string, Set<string>>();
   for (const row of rows) {
-    if (!row.text) continue;
+    if (row.text == null || row.text === "") continue;
     for (const sent of splitSentences(cleanText(row.text))) {
       const tokens = tokenize(sent);
       if (tokens.length === 0) continue;
@@ -176,7 +176,8 @@ export function processRows(
           sessions.add(row.session_id);
           if (examples) {
             const existing = examples.get(key);
-            if (!existing || sent.length < existing.length) examples.set(key, sent);
+            if (existing == null || existing === "" || sent.length < existing.length)
+              examples.set(key, sent);
           }
         }
       }

--- a/plugins/writing/skills/analyze/scripts/quote-context.ts
+++ b/plugins/writing/skills/analyze/scripts/quote-context.ts
@@ -24,7 +24,7 @@ const WORD_TOKEN = /[a-zA-Z]+/g;
 export function findQuote(phrase: string, rows: SourceRow[], radius = 60): QuoteContext | null {
   const lowered = phrase.toLowerCase();
   for (const row of rows) {
-    if (!row.text) continue;
+    if (row.text == null || row.text === "") continue;
     const idx = row.text.toLowerCase().indexOf(lowered);
     if (idx >= 0) return makeContext(row, idx, idx + phrase.length, radius);
   }
@@ -32,7 +32,7 @@ export function findQuote(phrase: string, rows: SourceRow[], radius = 60): Quote
   const needle = (lowered.match(WORD_TOKEN) ?? []).map((w) => stemmer(w));
   if (needle.length === 0) return null;
   for (const row of rows) {
-    if (!row.text) continue;
+    if (row.text == null || row.text === "") continue;
     const span = findStemmedSpan(row.text, needle);
     if (span) return makeContext(row, span.start, span.end, radius);
   }

--- a/plugins/writing/skills/analyze/scripts/report.ts
+++ b/plugins/writing/skills/analyze/scripts/report.ts
@@ -62,7 +62,10 @@ export function renderReport(input: ReportInput): string {
 }
 
 function renderHeader(input: ReportInput): string {
-  const project = input.projectFilter ? `\`${input.projectFilter}\`` : "(none)";
+  const project =
+    input.projectFilter != null && input.projectFilter !== ""
+      ? `\`${input.projectFilter}\``
+      : "(none)";
   return [
     `# Writing trope analysis (${input.generatedAt})`,
     "",
@@ -172,11 +175,10 @@ function renderProposedRemovals(input: ReportInput): string {
   ];
   const removable = input.ruleHealth
     .filter((r) => r.status === "remove")
-    .toSorted(
-      (a, b) =>
-        reasonRank(a.removeReason) - reasonRank(b.removeReason) ||
-        (a.modelPerM ?? 0) - (b.modelPerM ?? 0),
-    );
+    .toSorted((a, b) => {
+      const byReason = reasonRank(a.removeReason) - reasonRank(b.removeReason);
+      return byReason !== 0 ? byReason : (a.modelPerM ?? 0) - (b.modelPerM ?? 0);
+    });
   if (removable.length === 0) {
     lines.push("_No removals proposed._");
     return lines.join("\n");
@@ -325,7 +327,7 @@ function renderStructuralSignatures(input: ReportInput): string {
   lines.push("| --- | --- | --- | --- | --- | --- | --- |");
   for (const r of input.structuralSignatures) {
     lines.push(
-      `| \`${r.phrase}\` | ${r.n} | ${fmtPerM(r.assistantPerM)} | ${fmtPerM(r.userPerM)} | ${r.sessions ?? "-"} | ${fmtLiftAgainstRate(r.lift, r.userPerM)} | ${r.example ? esc(truncate(r.example, 100)) : "-"} |`,
+      `| \`${r.phrase}\` | ${r.n} | ${fmtPerM(r.assistantPerM)} | ${fmtPerM(r.userPerM)} | ${r.sessions ?? "-"} | ${fmtLiftAgainstRate(r.lift, r.userPerM)} | ${r.example != null && r.example !== "" ? esc(truncate(r.example, 100)) : "-"} |`,
     );
   }
   return lines.join("\n");
@@ -450,7 +452,7 @@ function renderCorrectiveFeedback(input: ReportInput): string {
   for (const c of input.corrective) {
     lines.push(`### ${c.timestamp} (${c.project ?? "unknown"}): matched \`${c.matched_term}\``);
     lines.push("");
-    if (c.context_snippet) {
+    if (c.context_snippet != null && c.context_snippet !== "") {
       lines.push(`Preceding model output (${fmtNum(c.context_chars)} chars):`);
       lines.push("", "```", c.context_snippet, "```", "");
     }
@@ -506,16 +508,18 @@ function esc(s: string): string {
 
 function voiceBaselineSummary(profile: VoiceProfile | null): string {
   if (!profile) return "not loaded (run ingest-voice.ts + voice-profile.ts)";
-  return `${fmtNum(profile.documentCount)} documents, ${fmtNum(profile.totalTokens)} tokens (sources: ${profile.sources.join("+") || "none"})`;
+  const sources = profile.sources.join("+");
+  return `${fmtNum(profile.documentCount)} documents, ${fmtNum(profile.totalTokens)} tokens (sources: ${sources !== "" ? sources : "none"})`;
 }
 
 function formatQuote(quote: QuoteContext | null): string {
   if (!quote) return "(no deliverable occurrence found)";
-  const pointer = quote.filePath
-    ? quote.filePath
-    : quote.sourceFile
-      ? `${quote.sourceFile}:${quote.sourceLine ?? "?"}`
-      : "(no source pointer)";
+  const pointer =
+    quote.filePath != null && quote.filePath !== ""
+      ? quote.filePath
+      : quote.sourceFile != null && quote.sourceFile !== ""
+        ? `${quote.sourceFile}:${quote.sourceLine ?? "?"}`
+        : "(no source pointer)";
   return `"${quote.window}" (${pointer})`;
 }
 

--- a/plugins/writing/skills/analyze/scripts/rule-health.ts
+++ b/plugins/writing/skills/analyze/scripts/rule-health.ts
@@ -61,7 +61,7 @@ export function buildRuleHealth(input: RuleHealthInput): CurrentRuleHealth[] {
     const surface: AuditSurface = onDeliverable ? "deliverable" : "chat";
     const quote = findQuote ? findQuote(entry, surface) : null;
 
-    if (onDeliverable && deliverableAudit) {
+    if (onDeliverable) {
       return buildDeliverableHealth(entry, deliverableAudit, voiceProfile, minCount, quote);
     }
     return buildChatHealth(entry, chatAudit, minCount, quote);
@@ -79,7 +79,7 @@ function buildChatHealth(
   const baselinePerM = row?.user_per_m ?? null;
   const modelPerM = row?.assistant_per_m ?? null;
   const lift = row?.lift ?? null;
-  const noData = !row || (modelCount === 0 && (row?.user_count ?? 0) === 0);
+  const noData = !row || (modelCount === 0 && row.user_count === 0);
 
   const { status, removeReason } = verdict(modelCount, modelPerM, baselinePerM, minCount);
   return {

--- a/plugins/writing/skills/analyze/scripts/structural.ts
+++ b/plugins/writing/skills/analyze/scripts/structural.ts
@@ -44,7 +44,7 @@ export function auditStructuralPatterns(
     const sessions = new Set<string>();
 
     for (const row of assistantRows) {
-      if (!row.text) continue;
+      if (row.text == null || row.text === "") continue;
       const stripped = stripCode(row.text);
       const hits = countHits(stripped, sp.pattern);
       if (hits > 0) {
@@ -57,7 +57,7 @@ export function auditStructuralPatterns(
     let userHits = 0;
     let userRowCount = 0;
     for (const row of userRows) {
-      if (!row.text) continue;
+      if (row.text == null || row.text === "") continue;
       const stripped = stripCode(row.text);
       const hits = countHits(stripped, sp.pattern);
       if (hits > 0) {

--- a/plugins/writing/skills/analyze/scripts/voice-corpus.test.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-corpus.test.ts
@@ -7,7 +7,10 @@ import { mergeDocuments, parseCorpus, serializeCorpus, type VoiceDocument } from
 // inside the (...) group on the single-line delimiter), and body lines never
 // open with "=" so none masquerade as a delimiter after trimming.
 const voiceDocument = fc.record<VoiceDocument>({
-  source: fc.string({ minLength: 1 }).map((s) => s.replace(/\s/g, "") || "x"),
+  source: fc.string({ minLength: 1 }).map((s) => {
+    const stripped = s.replace(/\s/g, "");
+    return stripped !== "" ? stripped : "x";
+  }),
   meta: fc.string().map((s) => s.replace(/[)\r\n]/g, "")),
   body: fc
     .array(fc.string().map((s) => s.replace(/[\r\n]/g, " ").replace(/^[\s=]+/, "")))

--- a/plugins/writing/skills/scan/scripts/score.ts
+++ b/plugins/writing/skills/scan/scripts/score.ts
@@ -117,7 +117,10 @@ export function renderTable(report: ScoreReport): string {
   for (const group of report.groups) {
     const header = `${group.group} (${group.wordCount} words)`;
     const rows = group.categories
-      .toSorted((a, b) => b.density - a.density || a.category.localeCompare(b.category))
+      .toSorted((a, b) => {
+        const byDensity = b.density - a.density;
+        return byDensity !== 0 ? byDensity : a.category.localeCompare(b.category);
+      })
       .map((c) => [c.category, String(c.hits), formatDensity(c.density)]);
     if (rows.length === 0) {
       sections.push(`${header}\nNo patterns detected.`);
@@ -131,7 +134,7 @@ export function renderTable(report: ScoreReport): string {
 export async function loadCustomMatch(
   path: string | undefined,
 ): Promise<((text: string) => { count: number }) | undefined> {
-  if (!path) return undefined;
+  if (path == null || path === "") return undefined;
   const content = await Bun.file(path).text();
   return compileStemmedWordlist(content);
 }

--- a/plugins/x-callback-url/scripts/run.test.ts
+++ b/plugins/x-callback-url/scripts/run.test.ts
@@ -96,7 +96,8 @@ async function runScenario(scenario: Scenario): Promise<Outcome> {
 
   const runner = await writeExecutable(join(dir, "run.sh"), await Bun.file(RUN_SH).text());
   await writeExecutable(join(dir, "build.sh"), stub(scenario.build));
-  if (scenario.binary) await writeExecutable(join(dir, "xcall-stub"), stub(scenario.binary));
+  if (scenario.binary != null && scenario.binary !== "")
+    await writeExecutable(join(dir, "xcall-stub"), stub(scenario.binary));
 
   const started = Bun.nanoseconds();
   const proc = Bun.spawn([runner, "things:///version"], {
@@ -124,11 +125,12 @@ async function runScenario(scenario: Scenario): Promise<Outcome> {
 }
 
 function report(scenario: Scenario, outcome: Outcome): string {
+  const stderrLine = outcome.stderr.split("\n")[0];
   return [
     scenario.name,
     `  exit:   ${outcome.exitCode}`,
-    `  stdout: ${outcome.stdout || "(none)"}`,
-    `  stderr: ${outcome.stderr.split("\n")[0] || "(none)"}`,
+    `  stdout: ${outcome.stdout !== "" ? outcome.stdout : "(none)"}`,
+    `  stderr: ${stderrLine !== undefined && stderrLine !== "" ? stderrLine : "(none)"}`,
   ].join("\n");
 }
 

--- a/scripts/assets.ts
+++ b/scripts/assets.ts
@@ -78,7 +78,7 @@ export interface Origin {
 export function origin(path: string): Origin {
   const plugin = path.startsWith("plugins/") ? path.split("/")[1] : undefined;
   const result: Origin = { scope: scopeOf(path), path };
-  if (plugin) result.plugin = plugin;
+  if (plugin != null && plugin !== "") result.plugin = plugin;
   return result;
 }
 
@@ -89,7 +89,7 @@ export function origin(path: string): Origin {
  */
 export function namespaced(path: string, name: string): string {
   const plugin = path.startsWith("plugins/") ? path.split("/")[1] : undefined;
-  return plugin && !name.includes(":") ? `${plugin}:${name}` : name;
+  return plugin != null && plugin !== "" && !name.includes(":") ? `${plugin}:${name}` : name;
 }
 
 /**
@@ -100,7 +100,7 @@ export function namespaced(path: string, name: string): string {
  * where the two match. User and project skills carry no namespace.
  */
 export function skillName(path: string, frontmatterName?: string): string {
-  if (frontmatterName) return frontmatterName;
+  if (frontmatterName != null && frontmatterName !== "") return frontmatterName;
 
   const segments = path.split("/");
   const skill = segments.at(-2) ?? "";

--- a/scripts/check-hook-paths.ts
+++ b/scripts/check-hook-paths.ts
@@ -114,7 +114,7 @@ export function references(settings: Settings, source: Source): Reference[] {
   for (const [event, entries] of Object.entries(settings.hooks ?? {})) {
     for (const entry of entries) {
       for (const { command } of entry.hooks ?? []) {
-        if (!command) continue;
+        if (command == null || command === "") continue;
         for (const path of paths(command, source.prefixes)) {
           found.push({ file: source.file, event, command, path });
         }

--- a/scripts/check-hook-quoting.ts
+++ b/scripts/check-hook-quoting.ts
@@ -13,7 +13,7 @@ async function checkQuoting(): Promise<string[]> {
 
   for (const plugin of plugins) {
     for (const { file, command: hook } of hookCommands(plugin)) {
-      if (!hook.command?.includes("${CLAUDE_PLUGIN_ROOT}")) continue;
+      if (!hook.command.includes("${CLAUDE_PLUGIN_ROOT}")) continue;
 
       if (hook.command.search(UNQUOTED_PATH) !== -1) {
         violations.push(`${file}: ${hook.command}`);

--- a/scripts/check-marketplace.ts
+++ b/scripts/check-marketplace.ts
@@ -8,7 +8,9 @@ await runCheck(
     const plugins = await loadPlugins();
     return {
       header: "Plugins missing from marketplace.json:",
-      violations: plugins.filter((p) => p.dir && !p.listing?.local).map((p) => p.name),
+      violations: plugins
+        .filter((p) => p.dir !== undefined && p.listing?.local !== true)
+        .map((p) => p.name),
     };
   },
   { success: "All plugin directories are listed in marketplace.json" },

--- a/scripts/check-mcp-matchers.ts
+++ b/scripts/check-mcp-matchers.ts
@@ -38,10 +38,10 @@ async function checkMatchers(): Promise<string[]> {
 
         const server = match[1];
         const tool = match[2];
-        if (!server || !tool) continue;
+        if (server == null || server === "" || tool == null || tool === "") continue;
 
         const pluginName = knownServers.get(server) ?? (enabledNames.has(server) ? server : null);
-        if (!pluginName) continue;
+        if (pluginName == null || pluginName === "") continue;
 
         const pluginVariant = `mcp__plugin_${pluginName}_${server}__${tool}`;
         if (!patterns.includes(pluginVariant)) {

--- a/scripts/check-md-code.ts
+++ b/scripts/check-md-code.ts
@@ -40,7 +40,7 @@ function firstLine(error: unknown): string {
 
 function checkBlock(node: Code): string | null {
   const lang = node.lang?.toLowerCase();
-  if (!lang) return null;
+  if (lang == null || lang === "") return null;
 
   // A `fragment` token in the info string opts a deliberately-partial or
   // multi-example block out of single-module parsing.
@@ -56,7 +56,7 @@ function checkBlock(node: Code): string | null {
   }
 
   const loader = LOADERS[lang];
-  if (!loader) return null;
+  if (loader == null) return null;
 
   try {
     transpilerFor(loader).transformSync(node.value);

--- a/scripts/check-plugin-deps.ts
+++ b/scripts/check-plugin-deps.ts
@@ -72,7 +72,7 @@ async function checkDeps(): Promise<string[]> {
   const violations: string[] = [];
 
   for (const plugin of await loadPlugins()) {
-    if (!plugin.dir) continue;
+    if (plugin.dir == null || plugin.dir === "") continue;
 
     const declared = await getPluginDeps(plugin.dir);
     const imported = await getImportedPackages(plugin.dir);

--- a/scripts/check-plugin-imports.ts
+++ b/scripts/check-plugin-imports.ts
@@ -22,7 +22,7 @@ async function getPluginDirs(): Promise<string[]> {
   }
 
   const plugins = await loadPlugins();
-  return plugins.flatMap((p) => (p.dir ? [p.dir] : []));
+  return plugins.flatMap((p) => (p.dir != null && p.dir !== "" ? [p.dir] : []));
 }
 
 async function checkPlugin(pluginDir: string): Promise<string[]> {

--- a/scripts/check-review-drift.ts
+++ b/scripts/check-review-drift.ts
@@ -51,10 +51,10 @@ function bySemverDesc(a: string, b: string): number {
  * bundle, so a small file there sends us to the installer's version store.
  */
 async function findBinary(): Promise<string> {
-  if (argv.flags.binary) return argv.flags.binary;
+  if (argv.flags.binary != null && argv.flags.binary !== "") return argv.flags.binary;
 
   const onPath = Bun.which("claude");
-  if (onPath && Bun.file(onPath).size > BUNDLE_MIN_BYTES) return onPath;
+  if (onPath != null && onPath !== "" && Bun.file(onPath).size > BUNDLE_MIN_BYTES) return onPath;
 
   const versions = join(homedir(), ".local", "share", "claude", "versions");
   const entries = await readdir(versions).catch(() => []);
@@ -70,7 +70,8 @@ async function binaryVersion(binary: string): Promise<string> {
   const proc = Bun.spawn([binary, "--version"], { stdout: "pipe", stderr: "ignore" });
   const out = await new Response(proc.stdout).text();
   const version = out.match(/\d+\.\d+\.\d+/)?.[0];
-  if (!version) throw new Error(`Could not read a version from \`${binary} --version\`.`);
+  if (version == null || version === "")
+    throw new Error(`Could not read a version from \`${binary} --version\`.`);
   return version;
 }
 
@@ -99,7 +100,7 @@ async function snapshotFragments(version: string): Promise<Map<string, string>> 
   for (const line of section.split("\n")) {
     if (line.startsWith("```")) {
       if (fence) {
-        if (label && !fragments.has(label)) fragments.set(label, fence.join("\n").trim());
+        if (label !== "" && !fragments.has(label)) fragments.set(label, fence.join("\n").trim());
         fence = undefined;
       } else {
         fence = [];

--- a/scripts/check-skill-hook-vars.ts
+++ b/scripts/check-skill-hook-vars.ts
@@ -36,7 +36,7 @@ async function checkSkillHookVars(): Promise<string[]> {
           const command = hook.command ?? "";
           const args = (hook.args ?? []).join(" ");
           if (FORBIDDEN.test(command) || FORBIDDEN.test(args)) {
-            violations.push(`${file}: ${command || args}`);
+            violations.push(`${file}: ${command !== "" ? command : args}`);
           }
         }
       }

--- a/scripts/check-skill-invocability.ts
+++ b/scripts/check-skill-invocability.ts
@@ -25,7 +25,7 @@ export function skillGrants(allowedTools: string[]): string[] {
     if (!match) return [];
 
     const [target] = (match[1] ?? "").trim().split(/\s+/);
-    return target ? [target] : [];
+    return target != null && target !== "" ? [target] : [];
   });
 }
 
@@ -45,7 +45,7 @@ export function violations(files: SkillFile[]): string[] {
   return files.flatMap((file) =>
     file.grants.flatMap((target) => {
       const reason = unreachable(target, byName);
-      return reason ? [`${file.path}: Skill(${target}) (${reason})`] : [];
+      return reason != null && reason !== "" ? [`${file.path}: Skill(${target}) (${reason})`] : [];
     }),
   );
 }

--- a/scripts/coverage/index.ts
+++ b/scripts/coverage/index.ts
@@ -22,7 +22,7 @@ function changedFiles(base: string): string[] {
   return git(["diff", "--name-only", `${base}...HEAD`])
     .split("\n")
     .map((f) => f.trim())
-    .filter((f) => f && isSourceFile(f));
+    .filter((f) => f !== "" && isSourceFile(f));
 }
 
 async function persistLcov(reports: Parameters<typeof formatLcov>[0]): Promise<void> {
@@ -70,15 +70,14 @@ const reports = await runCoverage(files);
 await persistLcov(reports);
 
 // When specific files were requested, focus the report on them.
-const targets = files.length
-  ? new Set(files.map((f) => relative(repoRoot, join(process.cwd(), f))))
-  : null;
+const targets =
+  files.length !== 0 ? new Set(files.map((f) => relative(repoRoot, join(process.cwd(), f)))) : null;
 const scoped = targets ? reports.filter((fc) => targets.has(fc.file)) : reports;
 
 if (argv.flags.report === "github") {
   const summary = githubReport(scoped);
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
-  if (summaryPath) {
+  if (summaryPath != null && summaryPath !== "") {
     await Bun.write(
       summaryPath,
       `${await Bun.file(summaryPath)

--- a/scripts/coverage/lcov.ts
+++ b/scripts/coverage/lcov.ts
@@ -49,7 +49,7 @@ export function parseLcov(text: string): FileCoverage[] {
 
   for (const raw of text.split("\n")) {
     const line = raw.trim();
-    if (!line) continue;
+    if (line === "") continue;
 
     if (line.startsWith("SF:")) {
       current = {
@@ -70,9 +70,11 @@ export function parseLcov(text: string): FileCoverage[] {
         current.lineHits.set(n, c);
       }
     } else if (line.startsWith("FNF:")) {
-      current.functionsFound = Number(line.slice(4)) || 0;
+      const found = Number(line.slice(4));
+      current.functionsFound = Number.isNaN(found) ? 0 : found;
     } else if (line.startsWith("FNH:")) {
-      current.functionsHit = Number(line.slice(4)) || 0;
+      const hit = Number(line.slice(4));
+      current.functionsHit = Number.isNaN(hit) ? 0 : hit;
     } else if (line === "end_of_record") {
       records.push(current);
       current = null;
@@ -123,7 +125,7 @@ export function formatLcov(reports: FileCoverage[]): string {
     lines.push(`LF:${fc.lineHits.size}`, `LH:${covered}`, "end_of_record");
     blocks.push(lines.join("\n"));
   }
-  return blocks.length ? `${blocks.join("\n")}\n` : "";
+  return blocks.length !== 0 ? `${blocks.join("\n")}\n` : "";
 }
 
 // Collapse sorted line numbers into human-readable ranges: [1,2,3,5,8,9] -> "1-3, 5, 8-9".

--- a/scripts/coverage/report.ts
+++ b/scripts/coverage/report.ts
@@ -23,7 +23,8 @@ export function terminalReport(reports: FileCoverage[]): string {
   const rows = sorted.map((fc) => {
     const { pct } = lineCoverage(fc);
     const paint = pctColor(pct);
-    return [fc.file, paint(`${pct.toFixed(1)}%`), formatRanges(uncoveredLines(fc)) || "—"];
+    const ranges = formatRanges(uncoveredLines(fc));
+    return [fc.file, paint(`${pct.toFixed(1)}%`), ranges !== "" ? ranges : "—"];
   });
 
   const summary = table([["File", "% Lines", "Uncovered"], ...rows]);
@@ -35,14 +36,17 @@ export function terminalReport(reports: FileCoverage[]): string {
     details.push(`${color(31, fc.file)}: ${uncovered.join(", ")}`);
   }
 
-  return details.length ? `${summary}\nUncovered lines:\n${details.join("\n")}` : summary.trimEnd();
+  return details.length !== 0
+    ? `${summary}\nUncovered lines:\n${details.join("\n")}`
+    : summary.trimEnd();
 }
 
 function markdownTable(reports: FileCoverage[]): string {
   const header = "| File | % Lines | Uncovered |\n| --- | --- | --- |";
   const rows = sortByCoverage(reports).map((fc) => {
     const { pct } = lineCoverage(fc);
-    return `| \`${fc.file}\` | ${pct.toFixed(1)}% | ${formatRanges(uncoveredLines(fc)) || "—"} |`;
+    const ranges = formatRanges(uncoveredLines(fc));
+    return `| \`${fc.file}\` | ${pct.toFixed(1)}% | ${ranges !== "" ? ranges : "—"} |`;
   });
   return [header, ...rows].join("\n");
 }
@@ -51,7 +55,7 @@ function markdownTable(reports: FileCoverage[]): string {
 // per-line annotations, which read as defect-grade warnings and hit GitHub's
 // ~10-per-level render cap. Per-line detail lives in the local hook and skill.
 export function githubReport(reports: FileCoverage[]): string {
-  return reports.length
+  return reports.length !== 0
     ? `## Coverage\n\n${markdownTable(reports)}`
     : "## Coverage\n\nNo coverage data.";
 }

--- a/scripts/coverage/run.ts
+++ b/scripts/coverage/run.ts
@@ -23,7 +23,7 @@ function hasTests(dir: string): boolean {
 
 function nearestTestDir(relFile: string): string {
   let dir = dirname(relFile);
-  while (dir && dir !== "." && dir !== "..") {
+  while (dir !== "" && dir !== "." && dir !== "..") {
     if (hasTests(join(repoRoot, dir))) return `./${dir}`;
     dir = dirname(dir);
   }
@@ -76,7 +76,7 @@ function runScope(scope: string): Promise<FileCoverage[]> {
 // Run Bun coverage for every scope the target files belong to, then merge.
 // With no files, measure the default scope set (the repo's test roots).
 export async function runCoverage(files: string[]): Promise<FileCoverage[]> {
-  const scopes = files.length ? resolveScopes(files) : DEFAULT_SCOPES;
+  const scopes = files.length !== 0 ? resolveScopes(files) : DEFAULT_SCOPES;
   const reports = await Promise.all(scopes.map(runScope));
   return merge(...reports);
 }

--- a/scripts/inventory/collect.ts
+++ b/scripts/inventory/collect.ts
@@ -125,12 +125,13 @@ export function* hookEntries(source: string, events: unknown): Generator<Hook> {
   for (const [event, entries] of Object.entries(HookEvents.parse(events))) {
     for (const entry of entries) {
       for (const hook of entry.hooks ?? []) {
+        const command = text(hook.command);
         yield {
           ...from,
           event,
           matcher: entry.matcher ?? "*",
           condition: text(hook.if),
-          command: text(hook.command) || hook.type,
+          command: command !== "" ? command : hook.type,
         };
       }
     }
@@ -157,13 +158,14 @@ async function readAgent(path: string): Promise<Agent> {
   const data = await frontmatterOf(path);
   const allowed = toolList(data.tools);
   const denied = toolList(data.disallowedTools);
+  const name = text(data.name);
 
   return {
     ...origin(path),
-    name: namespaced(path, text(data.name) || basename(path, ".md")),
+    name: namespaced(path, name !== "" ? name : basename(path, ".md")),
     description: text(data.description),
     model: text(data.model),
-    tools: allowed || (denied ? `all except ${denied}` : ""),
+    tools: allowed !== "" ? allowed : denied !== "" ? `all except ${denied}` : "",
   };
 }
 
@@ -178,9 +180,10 @@ function commandName(path: string): string {
 
 async function readCommand(path: string): Promise<Command> {
   const data = await frontmatterOf(path);
+  const name = text(data.name);
   return {
     ...origin(path),
-    name: namespaced(path, text(data.name) || commandName(path)),
+    name: namespaced(path, name !== "" ? name : commandName(path)),
     description: text(data.description),
   };
 }
@@ -219,11 +222,11 @@ export interface Filters {
 
 export function filter(inventory: Inventory, { plugin, scope }: Filters): Inventory {
   const keep = (item: Origin): boolean =>
-    (!plugin || item.plugin === plugin) && (!scope || item.scope === scope);
+    (plugin == null || item.plugin === plugin) && (scope == null || item.scope === scope);
 
   // Plugins and their MCP servers have no scope of their own. They are the plugin scope.
   const named = (name: string): boolean =>
-    (!plugin || name === plugin) && (!scope || scope === "plugin");
+    (plugin == null || name === plugin) && (scope == null || scope === "plugin");
 
   return {
     plugins: inventory.plugins.filter((item) => named(item.name)),

--- a/scripts/inventory/index.ts
+++ b/scripts/inventory/index.ts
@@ -52,8 +52,8 @@ if (!Number.isFinite(truncate)) {
 }
 
 const criteria: Filters = {};
-if (plugin) criteria.plugin = plugin;
-if (scope) criteria.scope = scope;
+if (plugin != null && plugin !== "") criteria.plugin = plugin;
+if (scope != null) criteria.scope = scope;
 const inventory = filter(await collect(), criteria);
 
 if (json) {

--- a/scripts/inventory/report.ts
+++ b/scripts/inventory/report.ts
@@ -42,7 +42,8 @@ function skillDir(path: string): string {
 
 function invocation(skill: { modelInvocable: boolean; userInvocable: boolean }): string {
   const modes = [skill.modelInvocable && "model", skill.userInvocable && "user"].filter(Boolean);
-  return modes.join("+") || "none";
+  const joined = modes.join("+");
+  return joined !== "" ? joined : "none";
 }
 
 // Plugins and MCP servers exist only in the plugin scope, so their row skips
@@ -121,13 +122,16 @@ function columns(inventory: Inventory, kind: Kind, width: number): Columns {
     case "agents":
       return {
         head: ["agent", "model", "tools", "path", "description"],
-        rows: inventory.agents.map((a) => [
-          a.name,
-          a.model || "-",
-          cut(a.tools) || "all",
-          a.path,
-          cut(a.description),
-        ]),
+        rows: inventory.agents.map((a) => {
+          const tools = cut(a.tools);
+          return [
+            a.name,
+            a.model !== "" ? a.model : "-",
+            tools !== "" ? tools : "all",
+            a.path,
+            cut(a.description),
+          ];
+        }),
       };
     case "commands":
       return {
@@ -137,18 +141,24 @@ function columns(inventory: Inventory, kind: Kind, width: number): Columns {
     case "hooks":
       return {
         head: ["event", "matcher", "when", "source", "command"],
-        rows: inventory.hooks.map((h) => [
-          h.event,
-          cut(h.matcher),
-          cut(h.condition) || "-",
-          h.path,
-          cut(h.command),
-        ]),
+        rows: inventory.hooks.map((h) => {
+          const condition = cut(h.condition);
+          return [
+            h.event,
+            cut(h.matcher),
+            condition !== "" ? condition : "-",
+            h.path,
+            cut(h.command),
+          ];
+        }),
       };
     case "rules":
       return {
         head: ["rule", "path", "applies to"],
-        rows: inventory.rules.map((r) => [r.name, r.path, cut(r.paths.join(", ") || "always")]),
+        rows: inventory.rules.map((r) => {
+          const paths = r.paths.join(", ");
+          return [r.name, r.path, cut(paths !== "" ? paths : "always")];
+        }),
       };
     case "mcp":
       return {

--- a/scripts/list-plugins.ts
+++ b/scripts/list-plugins.ts
@@ -31,7 +31,7 @@ function extractPluginNames(files: string[]): string[] {
   const plugins = new Set<string>();
   for (const file of files) {
     const match = file.match(/^plugins\/([^/]+)\//);
-    if (match?.[1]) plugins.add(match[1]);
+    if (match?.[1] != null && match[1] !== "") plugins.add(match[1]);
   }
   return [...plugins];
 }
@@ -48,7 +48,7 @@ async function main(): Promise<void> {
     allowPositionals: true,
   });
 
-  const alwaysPaths = values.always ?? [];
+  const alwaysPaths = values.always;
   const changedFiles = positionals;
   const allPlugins = await getLocalPlugins();
 

--- a/user/hooks/permission-denied/index.ts
+++ b/user/hooks/permission-denied/index.ts
@@ -50,7 +50,7 @@ export function target(toolInput: unknown): string {
     fields.notebook_path,
     fields.prompt,
   ]) {
-    if (value) return value;
+    if (value != null && value !== "") return value;
   }
   return JSON.stringify(toolInput);
 }
@@ -73,12 +73,12 @@ export function resolveLogPath(
   env: string | undefined = process.env.CLAUDE_AUTO_MODE_DENIAL_LOG,
 ): string | null {
   if (env !== undefined && OFF_VALUES.has(env.toLowerCase())) return null;
-  if (env && !ON_VALUES.has(env.toLowerCase())) return env;
+  if (env != null && env !== "" && !ON_VALUES.has(env.toLowerCase())) return env;
   return join(homedir(), ".claude", "auto-mode-denials.jsonl");
 }
 
 export function append(entry: DenialRecord, path: string | null = resolveLogPath()): void {
-  if (!path) return;
+  if (path == null || path === "") return;
   mkdirSync(dirname(path), { recursive: true });
   if (Bun.file(path).size > MAX_LOG_BYTES) {
     renameSync(path, `${path}.1`);

--- a/user/hooks/session-limit/index.ts
+++ b/user/hooks/session-limit/index.ts
@@ -135,7 +135,7 @@ export function evaluate(
 // data. Unset means nothing is being written, so there is nothing to read.
 function rateLimitsPath(): string | null {
   const path = process.env.CLAUDE_STATUSLINE_RATE_LIMITS_PATH;
-  return path ? expandTilde(path) : null;
+  return path != null && path !== "" ? expandTilde(path) : null;
 }
 
 function markerPath(sessionId: string): string {
@@ -166,10 +166,10 @@ export async function processInput(
   nowMs: number,
 ): Promise<SyncHookJSONOutput | null> {
   const sessionId = input.session_id;
-  if (!sessionId) return null;
+  if (sessionId === "") return null;
 
   const source = rateLimitsPath();
-  if (!source) return null;
+  if (source == null || source === "") return null;
 
   const rl = await readJson(RateLimits, source);
   if (!rl) return null;

--- a/user/hooks/worktree/index.ts
+++ b/user/hooks/worktree/index.ts
@@ -86,13 +86,13 @@ export function formatAskOutput(): SyncHookJSONOutput {
 
 export function processInput(input: HookInput): SyncHookJSONOutput | null {
   const command = BashInput.safeParse(input.tool_input).data?.command;
-  if (!command) {
+  if (command == null || command === "") {
     return null;
   }
 
   const match = stripQuoted(stripHeredocs(command)).match(/\bgit\s+worktree\s+(\w+)/);
   const subcommand = match?.[1];
-  if (!subcommand) {
+  if (subcommand == null || subcommand === "") {
     return null;
   }
   if (ALLOWED_SUBCOMMANDS.has(subcommand)) {

--- a/user/scripts/effort.ts
+++ b/user/scripts/effort.ts
@@ -21,9 +21,9 @@ export interface EffortMarker {
 // Null when the level is unknown or the model reports no effort, so the segment
 // simply drops rather than rendering a placeholder.
 export function effortMarker(level?: string | null): EffortMarker | null {
-  if (!level) return null;
+  if (level == null || level === "") return null;
   const glyph = EFFORT_GLYPHS[level];
-  if (!glyph) return null;
+  if (glyph == null || glyph === "") return null;
   return { glyph, isDefault: level === DEFAULT_EFFORT };
 }
 

--- a/user/scripts/hook-metrics.ts
+++ b/user/scripts/hook-metrics.ts
@@ -57,18 +57,21 @@ export function resolveMetricsPath(
 ): string | null {
   if (env !== undefined && OFF_VALUES.has(env.toLowerCase())) return null;
   const dir =
-    env && !ON_VALUES.has(env.toLowerCase()) ? env : join(homedir(), ".claude", "hook-metrics");
+    env != null && env !== "" && !ON_VALUES.has(env.toLowerCase())
+      ? env
+      : join(homedir(), ".claude", "hook-metrics");
   return join(dir, `${hook.replace(UNSAFE_NAME, "-")}.jsonl`);
 }
 
 export function classifyOutcome(output: SyncHookJSONOutput | null | undefined): HookOutcome {
   if (!output) return "silent";
   const specific = output.hookSpecificOutput;
-  if (specific && "permissionDecision" in specific && specific.permissionDecision) {
+  if (specific && "permissionDecision" in specific) {
     return specific.permissionDecision;
   }
   if (output.decision === "block") return "block";
-  if (specific && "additionalContext" in specific && specific.additionalContext) return "context";
+  if (specific && "additionalContext" in specific && specific.additionalContext !== "")
+    return "context";
   return "output";
 }
 
@@ -77,7 +80,7 @@ export function appendHookMetric(
   metric: HookMetric,
   path: string | null = resolveMetricsPath(hook),
 ): void {
-  if (!path) return;
+  if (path == null || path === "") return;
   try {
     mkdirSync(dirname(path), { recursive: true });
     if (Bun.file(path).size > MAX_LOG_BYTES) {

--- a/user/scripts/pane-metadata.ts
+++ b/user/scripts/pane-metadata.ts
@@ -152,8 +152,7 @@ if (import.meta.main) {
     const list = Bun.spawnSync(["herdr", "pane", "list"], { timeout: HERDR_TIMEOUT_MS });
     const paneId = list.success ? findPane(list.stdout.toString(), sessionId) : null;
     if (paneId != null && paneId !== "") {
-      const report =
-        name != null && name !== "" && value != null && value !== "" ? { token: name, value } : null;
+      const report = name != null && value != null && value !== "" ? { token: name, value } : null;
       Bun.spawnSync(["herdr", ...reportArgs(paneId, report)], { timeout: HERDR_TIMEOUT_MS });
     }
   }

--- a/user/scripts/pane-metadata.ts
+++ b/user/scripts/pane-metadata.ts
@@ -125,7 +125,8 @@ export async function reportPaneMetadata(
   sessionId: string,
   report: DialReport | null,
 ): Promise<void> {
-  if (!process.env.HERDR_PANE_ID) return;
+  const paneId = process.env.HERDR_PANE_ID;
+  if (paneId == null || paneId === "") return;
 
   const sig = reportSignature(report);
   const path = cachePath(sessionId);
@@ -147,11 +148,12 @@ function parseToken(value: string | undefined): ContextToken | null {
 if (import.meta.main) {
   const [sessionId, token, value] = process.argv.slice(2);
   const name = parseToken(token);
-  if (sessionId) {
+  if (sessionId != null && sessionId !== "") {
     const list = Bun.spawnSync(["herdr", "pane", "list"], { timeout: HERDR_TIMEOUT_MS });
     const paneId = list.success ? findPane(list.stdout.toString(), sessionId) : null;
-    if (paneId) {
-      const report = name && value ? { token: name, value } : null;
+    if (paneId != null && paneId !== "") {
+      const report =
+        name != null && name !== "" && value != null && value !== "" ? { token: name, value } : null;
       Bun.spawnSync(["herdr", ...reportArgs(paneId, report)], { timeout: HERDR_TIMEOUT_MS });
     }
   }

--- a/user/scripts/statusline.ts
+++ b/user/scripts/statusline.ts
@@ -192,7 +192,7 @@ export function elideSpans(spans: Span[], budget: number): string {
   let pos = 0;
   let out = "";
   let ellipsisDone = false;
-  spans.forEach((span, i) => {
+  for (const [i, span] of spans.entries()) {
     const c = chars[i] ?? [];
     const spanStart = pos;
     const spanEnd = pos + c.length;
@@ -212,9 +212,9 @@ export function elideSpans(spans: Span[], budget: number): string {
       piece += c.slice(tBegin - spanStart, spanEnd - spanStart).join("");
     }
 
-    if (piece) out += `${span.pre}${piece}${span.suf}`;
+    if (piece !== "") out += `${span.pre}${piece}${span.suf}`;
     pos = spanEnd;
-  });
+  }
 
   if (!ellipsisDone) out += "…";
   return out;
@@ -224,7 +224,7 @@ export function elideSpans(spans: Span[], budget: number): string {
 // of the sanitized branch, the branch already carries the repo. Worktrunk names
 // branches worktree-<id> against a <id> worktree, so the repo is a suffix.
 function showRepo(repo: string, sanitizedBranch: string): boolean {
-  if (!repo) return true;
+  if (repo === "") return true;
   return !(sanitizedBranch.startsWith(repo) || sanitizedBranch.endsWith(repo));
 }
 
@@ -234,8 +234,8 @@ export function formatWorktree(data: WorktreeData, budget: number): string[] {
   const repoSuffix = `.${sanitizedBranch}`;
   if (repo.endsWith(repoSuffix)) repo = repo.slice(0, -repoSuffix.length);
 
-  const repoPre = data.repoUrl ? osc8Open(data.repoUrl) : "";
-  const repoSuf = data.repoUrl ? OSC8_CLOSE : "";
+  const repoPre = data.repoUrl != null && data.repoUrl !== "" ? osc8Open(data.repoUrl) : "";
+  const repoSuf = data.repoUrl != null && data.repoUrl !== "" ? OSC8_CLOSE : "";
 
   const spans: Span[] = [];
   if (data.isMain) {
@@ -245,24 +245,26 @@ export function formatWorktree(data: WorktreeData, budget: number): string[] {
       spans.push({ text: repo, pre: repoPre, suf: repoSuf });
       spans.push({ text: "/", pre: DIM.open, suf: DIM.close });
     }
-    const branchPre = data.ciUrl ? CYAN.open + osc8Open(data.ciUrl) : CYAN.open;
-    const branchSuf = data.ciUrl ? OSC8_CLOSE + CYAN.close : CYAN.close;
+    const branchPre =
+      data.ciUrl != null && data.ciUrl !== "" ? CYAN.open + osc8Open(data.ciUrl) : CYAN.open;
+    const branchSuf =
+      data.ciUrl != null && data.ciUrl !== "" ? OSC8_CLOSE + CYAN.close : CYAN.close;
     spans.push({ text: data.branch, pre: branchPre, suf: branchSuf });
   }
 
   const aheadSeg = data.ahead > 0 ? styleText(["dim"], `↑${data.ahead}`) : "";
 
   // Reserve room for the ahead segment (and its separator) before eliding.
-  const labelBudget = aheadSeg ? budget - Bun.stringWidth(aheadSeg) - SEP.length : budget;
+  const labelBudget = aheadSeg !== "" ? budget - Bun.stringWidth(aheadSeg) - SEP.length : budget;
 
   const segments: string[] = [];
   if (labelBudget < 3) {
-    if (aheadSeg) segments.push(aheadSeg);
+    if (aheadSeg !== "") segments.push(aheadSeg);
     return segments;
   }
 
   segments.push(elideSpans(spans, labelBudget));
-  if (aheadSeg) segments.push(aheadSeg);
+  if (aheadSeg !== "") segments.push(aheadSeg);
   return segments;
 }
 
@@ -286,13 +288,13 @@ export function buildStatusLine(
   const segments: string[] = [];
 
   const model = modelSegment(input);
-  if (model) segments.push(model);
+  if (model != null && model !== "") segments.push(model);
   const effort = effortSegment(input);
-  if (effort) segments.push(effort);
+  if (effort != null && effort !== "") segments.push(effort);
   const dial = dialSegment(input);
-  if (dial) segments.push(dial);
+  if (dial != null && dial !== "") segments.push(dial);
   const lines = linesSegment(input);
-  if (lines) segments.push(lines);
+  if (lines != null && lines !== "") segments.push(lines);
 
   // Fixed segments (dials) are measured first and never elided; the worktree
   // label takes whatever width remains so the dial stays visible at any width.
@@ -331,10 +333,10 @@ function resolveWorktree(): WorktreeData | null {
 
     const ciUrl = cur.ci?.url ?? null;
     let repoUrl: string | null = null;
-    if (ciUrl) {
+    if (ciUrl != null && ciUrl !== "") {
       const git = Bun.spawnSync(["git", "remote", "get-url", cur.remote?.name ?? "origin"]);
       const raw = git.success ? git.stdout.toString().trim() : "";
-      if (raw) repoUrl = raw.replace(/^git@([^:]*):/, "https://$1/").replace(/\.git$/, "");
+      if (raw !== "") repoUrl = raw.replace(/^git@([^:]*):/, "https://$1/").replace(/\.git$/, "");
     }
 
     return {
@@ -356,13 +358,13 @@ if (import.meta.main) {
   const raw = await Bun.stdin.text();
   let input: StatusInput | undefined;
   try {
-    if (raw.trim()) input = StatusInput.parse(JSON.parse(raw));
+    if (raw.trim() !== "") input = StatusInput.parse(JSON.parse(raw));
   } catch {
     input = undefined;
   }
   if (input) {
     const rateLimitsPath = process.env.CLAUDE_STATUSLINE_RATE_LIMITS_PATH;
-    if (rateLimitsPath) {
+    if (rateLimitsPath != null && rateLimitsPath !== "") {
       try {
         await emitRateLimits(input, rateLimitsPath);
       } catch {
@@ -376,7 +378,7 @@ if (import.meta.main) {
 
     // Not gated on the dial: the same report carries the brand mark, which has
     // to keep being sent even on the renders before `context_window` shows up.
-    if (input.session_id) {
+    if (input.session_id != null && input.session_id !== "") {
       try {
         await reportPaneMetadata(input.session_id, contextDial(input));
       } catch {

--- a/user/scripts/subagent-statusline.test.ts
+++ b/user/scripts/subagent-statusline.test.ts
@@ -139,7 +139,7 @@ describe("extractModel", () => {
       role: "assistant",
       content: [],
     };
-    if (model) message.model = model;
+    if (model != null && model !== "") message.model = model;
     return { message };
   };
 

--- a/user/scripts/subagent-statusline.ts
+++ b/user/scripts/subagent-statusline.ts
@@ -70,7 +70,9 @@ function statusColor(status: string): "gray" | "green" | "red" {
 // gray dims to recede behind the title; finished green/red stay vivid so a
 // terminal state reads at a glance.
 function typeIcon(agentType: string | null, status: string): string {
-  const glyph = (agentType ? purposeGlyphs.get(agentType) : undefined) ?? genericGlyph;
+  const glyph =
+    (agentType != null && agentType !== "" ? purposeGlyphs.get(agentType) : undefined) ??
+    genericGlyph;
   const color = statusColor(status);
   return styleText(color === "gray" ? [color, "dim"] : color, glyph);
 }
@@ -86,7 +88,7 @@ function remoteMarker(type: string | undefined): string {
 // prefix and sentence-case what remains so the title reads cleanly.
 export function formatDescription(description: string, agentType: string | null): string {
   let text = description;
-  if (agentType) {
+  if (agentType != null && agentType !== "") {
     const prefix = `${agentType}: `;
     if (text.toLowerCase().startsWith(prefix.toLowerCase())) text = text.slice(prefix.length);
   }
@@ -110,22 +112,22 @@ export function renderTask(
   const metaParts: string[] = [];
   if (task.startTime != null) metaParts.push(formatElapsed(task.startTime, now));
   if ((task.tokenCount ?? 0) > 0) metaParts.push(formatTokens(task.tokenCount ?? 0));
-  if (model) metaParts.push(model);
+  if (model != null && model !== "") metaParts.push(model);
   // Every declared level renders. The payload carries no session effort to
   // compare a task's against, and a task's effort is its agent config's
   // declaration rather than a resolved level, so there is no baseline to hide.
   const effort = effortGlyph(task.effort);
-  if (effort) metaParts.push(effort);
+  if (effort != null && effort !== "") metaParts.push(effort);
 
   // The type name trails as dim text after the meta. The icon already conveys
   // the kind, so a narrow terminal can drop the name without losing it.
   const build = (text: string, withType: boolean): string => {
     let body = icon;
-    if (marker) body += ` ${marker}`;
+    if (marker !== "") body += ` ${marker}`;
     body += ` ${text}`;
     const trailing = [...metaParts];
-    if (withType && agentType) trailing.push(agentType);
-    if (trailing.length) {
+    if (withType && agentType != null && agentType !== "") trailing.push(agentType);
+    if (trailing.length !== 0) {
       body += ` ${styleText(["dim"], trailing.map((part) => `· ${part}`).join(" "))}`;
     }
     return body;
@@ -136,16 +138,19 @@ export function renderTask(
   // every teammate. The clean meta description (or stdin description) covers the
   // gap before the teammate's first action; the name is the last resort.
   const fallback = description ?? task.description ?? null;
-  let text = activity
-    ? activity
-    : fallback
-      ? formatDescription(fallback, agentType)
-      : task.name || "agent";
+  let text =
+    activity != null && activity !== ""
+      ? activity
+      : fallback != null && fallback !== ""
+        ? formatDescription(fallback, agentType)
+        : task.name != null && task.name !== ""
+          ? task.name
+          : "agent";
   let content = build(text, true);
 
   if (columns != null && Bun.stringWidth(content) > columns) {
     // Shed the optional type name first; the icon keeps the kind visible.
-    if (agentType) content = build(text, false);
+    if (agentType != null && agentType !== "") content = build(text, false);
     const visible = Bun.stringWidth(content);
     if (visible > columns) {
       const overflow = visible - columns;
@@ -187,6 +192,7 @@ const text = (value: unknown): string => (typeof value === "string" ? value : ""
 const basename = (p: unknown): string => text(p).split("/").pop() ?? "";
 const firstWord = (cmd: unknown): string => text(cmd).trim().split(/\s+/)[0] ?? "";
 const oneLine = (s: string): string => s.replace(/\s+/g, " ").trim();
+const firstText = (...values: unknown[]): string => values.map(text).find((s) => s !== "") ?? "";
 
 // A tool call renders as a verb plus its most telling argument: the file for
 // file tools, the leading command word for Bash (ssh, grep, sed), the message
@@ -206,7 +212,7 @@ export function humanizeTool(name: string, input: Record<string, unknown> = {}):
       return `Running ${firstWord(input.command)}`;
     case "Grep":
     case "WebSearch":
-      return oneLine(`Searching ${text(input.pattern) || text(input.query)}`);
+      return oneLine(`Searching ${firstText(input.pattern, input.query)}`);
     case "Glob":
       return oneLine(`Globbing ${text(input.pattern)}`);
     case "ToolSearch":
@@ -214,16 +220,16 @@ export function humanizeTool(name: string, input: Record<string, unknown> = {}):
     case "WebFetch":
       return `Fetching ${basename(input.url)}`;
     case "SendMessage":
-      return `→ ${text(input.summary) || "message"}`;
+      return `→ ${firstText(input.summary, "message")}`;
     case "Task":
     case "Agent":
-      return `Spawning ${text(input.description) || "agent"}`;
+      return `Spawning ${firstText(input.description, "agent")}`;
     case "TodoWrite":
       return "Updating todos";
     case "Skill":
-      return oneLine(`Running /${text(input.skill) || text(input.command)}`);
+      return oneLine(`Running /${firstText(input.skill, input.command)}`);
     default:
-      return name || "working";
+      return name !== "" ? name : "working";
   }
 }
 
@@ -241,7 +247,7 @@ export function extractActivity(entries: TranscriptEntry[]): string | null {
       if (block?.type === "tool_use" && typeof block.name === "string") {
         return humanizeTool(block.name, block.input ?? {});
       }
-      if (block?.type === "text" && typeof block.text === "string" && block.text.trim()) {
+      if (block?.type === "text" && typeof block.text === "string" && block.text.trim() !== "") {
         return oneLine(block.text);
       }
     }
@@ -253,7 +259,7 @@ export function extractActivity(entries: TranscriptEntry[]): string | null {
 export function extractModel(entries: TranscriptEntry[]): string | null {
   for (let i = entries.length - 1; i >= 0; i--) {
     const model = entries[i]?.message?.model;
-    if (typeof model === "string" && model) return model;
+    if (typeof model === "string" && model !== "") return model;
   }
   return null;
 }
@@ -265,9 +271,10 @@ export function subagentModelLetter(
   subModel: string | null,
   sessionModel: string | null,
 ): string | null {
-  if (!subModel || !sessionModel) return null;
+  if (subModel == null || subModel === "" || sessionModel == null || sessionModel === "")
+    return null;
   const sub = modelMarker(subModel)?.letter ?? null;
-  if (!sub || sub === (modelMarker(sessionModel)?.letter ?? null)) return null;
+  if (sub == null || sub === "" || sub === (modelMarker(sessionModel)?.letter ?? null)) return null;
   return sub;
 }
 
@@ -303,13 +310,13 @@ async function readEntries(path: string): Promise<TranscriptEntry[]> {
   try {
     const file = Bun.file(path);
     const size = file.size;
-    if (!size) return [];
+    if (size === 0) return [];
     const start = Math.max(0, size - TAIL_BYTES);
     const lines = (await file.slice(start).text()).split("\n");
     if (start > 0) lines.shift();
     const entries: TranscriptEntry[] = [];
     for (const line of lines) {
-      if (!line.trim()) continue;
+      if (line.trim() === "") continue;
       try {
         entries.push(TranscriptEntry.parse(JSON.parse(line)));
       } catch {
@@ -328,7 +335,7 @@ if (import.meta.main) {
   const raw = await Bun.stdin.text();
   let input: z.infer<typeof SubagentInput> | null = null;
   try {
-    if (raw.trim()) input = SubagentInput.parse(JSON.parse(raw));
+    if (raw.trim() !== "") input = SubagentInput.parse(JSON.parse(raw));
   } catch {
     input = null;
   }
@@ -340,15 +347,16 @@ if (import.meta.main) {
 
   // All tasks share the parent session named by stdin, so the model every
   // subagent letter is compared against is read once.
-  const sessionModel = input.transcript_path
-    ? extractModel(await readEntries(input.transcript_path))
-    : null;
+  const sessionModel =
+    input.transcript_path != null && input.transcript_path !== ""
+      ? extractModel(await readEntries(input.transcript_path))
+      : null;
 
   const lines: string[] = [];
   for (const task of input.tasks ?? []) {
     const base = subagentBase(task.id, projectDir);
-    const meta = base ? await readMeta(base) : null;
-    const entries = base ? await readEntries(`${base}.jsonl`) : [];
+    const meta = base != null && base !== "" ? await readMeta(base) : null;
+    const entries = base != null && base !== "" ? await readEntries(`${base}.jsonl`) : [];
     const activity = extractActivity(entries);
     // The payload's model is resolved at spawn and covers a subagent that has
     // yet to write a turn. Task types that carry none fall back to the
@@ -368,5 +376,5 @@ if (import.meta.main) {
       ),
     );
   }
-  if (lines.length) process.stdout.write(`${lines.join("\n")}\n`);
+  if (lines.length !== 0) process.stdout.write(`${lines.join("\n")}\n`);
 }

--- a/user/skills/scheduled/scripts/scheduled.ts
+++ b/user/skills/scheduled/scripts/scheduled.ts
@@ -125,7 +125,7 @@ export function renderPlist(descriptor: Descriptor, group: string): string {
   if (descriptor.mode !== "headless") {
     throw new Error(`renderPlist only supports mode "headless", got "${descriptor.mode}"`);
   }
-  if (!descriptor.workdir) {
+  if (descriptor.workdir == null || descriptor.workdir === "") {
     throw new Error(`descriptor "${descriptor.label}" is missing "workdir"`);
   }
 
@@ -147,7 +147,7 @@ export function renderPlist(descriptor: Descriptor, group: string): string {
   }
 
   const intervalKeys: string[] = [];
-  if (descriptor.schedule.weekday) {
+  if (descriptor.schedule.weekday != null && descriptor.schedule.weekday !== "") {
     const weekday = WEEKDAYS[descriptor.schedule.weekday];
     if (weekday === undefined) {
       throw new Error(
@@ -211,7 +211,10 @@ async function listInstalledLabels(): Promise<string[]> {
   const labels: string[] = [];
   for await (const file of glob.scan({ cwd: LAUNCH_AGENTS_DIR })) {
     const match = file.match(pattern);
-    if (match?.[1] && match[2]) labels.push(shortLabel(match[1], match[2]));
+    const unit = match?.at(1);
+    const value = match?.at(2);
+    if (unit != null && unit !== "" && value != null && value !== "")
+      labels.push(shortLabel(unit, value));
   }
   return labels;
 }
@@ -403,7 +406,7 @@ function runCommand(labelArg: string): void {
     stdout: "inherit",
     stderr: "inherit",
   });
-  process.exit(result.exitCode ?? 1);
+  process.exit(result.exitCode);
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
Turns on two type-aware oxlint rules that reject implicit truthiness, and fixes every site they flag.

```json
"typescript/strict-boolean-expressions": ["error", {
  "allowString": false,
  "allowNumber": false,
  "allowNullableString": false,
  "allowNullableNumber": false,
  "allowNullableObject": true,
  "allowNullableBoolean": true
}],
"typescript/no-unnecessary-condition": ["error", { "allowConstantLoopConditions": "always" }]
```

Strings and numbers lose their exemption because their falsy values are the ones that bite: `""` and `0` are legitimate data almost everywhere they appear. Objects and booleans keep theirs, since a nullable object has exactly one falsy value and `if (flag)` on a nullable boolean behaves identically to `flag === true` for every input that matters.

Measured against this base, that tuning takes `strict-boolean-expressions` from 535 hits to 659 and `no-unnecessary-condition` from 45 to 40. The five it removes are all `while (true)` polling loops, each of which would otherwise want a disable comment.

## Dead Condition Triage

`no-unnecessary-condition` claims a check can never fail, which is a claim about the types. Of its 40 hits, 32 were genuinely dead: a `?? []` on an array the schema already defaults, a second `row?.` after the first one narrowed, a `?? 0` on an exhaustive `Record`.

Four were TypeScript failing to model a closure. `let done = false` mutated inside a `forEach` stays narrowed to `false` afterward, so a later `if (!done)` reads as dead when it can still be false at runtime. Those callbacks became `for...of` so the analysis is correct rather than suppressed.

Four needed the type corrected. `lexical-type-parameters.ts` declared a walker cursor `ESTree.Node | null` that is never null. `draft-note.ts` destructured a `[refs, diffs] | [null, null]` tuple whose nullability the checker lost through the ternary, so it became one nullable binding. The git hooks decoded `cwd` as `z.string().catch("")`, making a downstream `?? process.cwd()` unreachable while substituting an unusable empty path. That fallback moved into the schema's `catch`.

Nothing was suppressed, and the branch adds no disable comments.

## Empty Role Flag

`pr-comments.ts` accepted `--role=` and ran as neither author nor reviewer:

```ts
if (roleFlag && roleFlag !== "author" && roleFlag !== "reviewer") { /* reject */ }
const role: Role = (roleFlag as Role) ?? detectRole(viewer, prAuthor);
```

The leading truthiness skips validation for `""`, and `??` will not fall back for a value that is empty rather than nullish, so `role` becomes `""` typed as `Role` and every comparison against it is false. Making the guard explicit is what exposed it. The decode migration in #1281 fixed the same defect on the way past, so what lands here is `resolveRole` extracted as a pure function with a table over the absent, empty, valid, and invalid flags.

## Elsewhere

`pr-comments.ts` compared `thread.startLine` and `thread.line` against `""`, which are numbers. `wireframe/render.ts` guarded sharp's metadata dimensions against `null` when sharp declares them as `number`, so the guard is now `> 0`.

`no-unnecessary-condition` does not model `noUncheckedIndexedAccess`, so it reads `match?.[1]` on a regex capture as an unnecessary chain when the index genuinely can be undefined. Those sites use `.at(1)`, which it handles correctly.
