### PR TITLE
lint: adopt the import plugin and complexity rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "unicorn", "oxc", "promise", "node"],
+  "plugins": ["typescript", "unicorn", "oxc", "promise", "node", "import"],
   "categories": {
     "correctness": "error",
     "suspicious": "error"
@@ -22,6 +22,12 @@
     ],
     "no-unused-expressions": ["error", { "allowTernary": true }],
     "no-underscore-dangle": ["error", { "allow": ["__typename", "__dirname"] }],
+    "eqeqeq": ["error", "always", { "null": "ignore" }],
+    "max-depth": "error",
+    "import/no-named-as-default-member": "error",
+    "oxc/no-map-spread": "error",
+    "unicorn/prefer-array-find": "error",
+    "unicorn/prefer-set-has": "error",
     "no-unsafe-optional-chaining": "off",
     "typescript/no-unsafe-type-assertion": "off",
     "typescript/ban-ts-comment": "error",

--- a/evals/pr-body/scripts/mine.test.ts
+++ b/evals/pr-body/scripts/mine.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import fc from "fast-check";
+import * as fc from "fast-check";
 import { type FetchedPr, type Item, type MinedPr, selectSample, toItem, weave } from "./mine";
 
 function makeItem(overrides: Partial<Item>): Item {

--- a/evals/writing/scripts/mine.test.ts
+++ b/evals/writing/scripts/mine.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import fc from "fast-check";
+import * as fc from "fast-check";
 import { type Item, type RewriteDraft, selectSample, toItem, weave } from "./mine";
 
 function makeItem(overrides: Partial<Item>): Item {

--- a/packages/decode/decode.test.ts
+++ b/packages/decode/decode.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
-import fc from "fast-check";
+import * as fc from "fast-check";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/claude-code/skills/session/scripts/db.test.ts
+++ b/plugins/claude-code/skills/session/scripts/db.test.ts
@@ -438,7 +438,7 @@ describe("discovery", () => {
 
   it("describes messages with the expected pinned columns", async () => {
     const rows = await db.query("DESCRIBE messages", z.object({ column_name: z.string() }));
-    const cols = rows.map((r) => r.column_name);
+    const cols = new Set(rows.map((r) => r.column_name));
     const pinned = [
       "session_id",
       "type",
@@ -456,7 +456,7 @@ describe("discovery", () => {
       "content_text",
       "summary",
     ];
-    expect(pinned.filter((col) => !cols.includes(col))).toEqual([]);
+    expect(pinned.filter((col) => !cols.has(col))).toEqual([]);
   });
 });
 
@@ -1274,9 +1274,9 @@ describe("delegation query", () => {
 
   it("separates the generic path from the pinned-agent path", async () => {
     const rows = await delegationRows();
-    const generic = rows.filter((r) => r.parent_family === "opus" && r.path === "generic");
+    const generic = rows.find((r) => r.parent_family === "opus" && r.path === "generic");
     const pinned = rows.filter((r) => r.parent_family === "opus" && r.path === "pinned");
-    expect(Number(generic[0]?.path_spawns)).toBe(3);
+    expect(Number(generic?.path_spawns)).toBe(3);
     expect(Number(pinned[0]?.path_spawns)).toBe(1);
     expect(pinned.map((r) => r.actual_family)).toEqual(["haiku"]);
   });
@@ -1313,13 +1313,13 @@ describe("delegation query", () => {
 
   it("computes override and cheaper-override rates as a fraction of every spawn in the group", async () => {
     const rows = await delegationRows();
-    const generic = rows.filter((r) => r.parent_family === "opus" && r.path === "generic");
+    const generic = rows.find((r) => r.parent_family === "opus" && r.path === "generic");
     // 2 of 3 generic spawns carried an explicit override (haiku, sonnet), and
     // both were cheaper than the opus main model.
-    expect(generic[0]?.override_rate_pct).toBeCloseTo(66.7, 1);
-    expect(generic[0]?.cheaper_override_rate_pct).toBeCloseTo(66.7, 1);
-    const pinned = rows.filter((r) => r.parent_family === "opus" && r.path === "pinned");
-    expect(pinned[0]?.override_rate_pct).toBe(0);
+    expect(generic?.override_rate_pct).toBeCloseTo(66.7, 1);
+    expect(generic?.cheaper_override_rate_pct).toBeCloseTo(66.7, 1);
+    const pinned = rows.find((r) => r.parent_family === "opus" && r.path === "pinned");
+    expect(pinned?.override_rate_pct).toBe(0);
   });
 
   it("sums expensive-model spend only from spawns whose actual family is opus/fable", async () => {

--- a/plugins/comments/detection/rank.test.ts
+++ b/plugins/comments/detection/rank.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import fc from "fast-check";
+import * as fc from "fast-check";
 import { rankComments, type SortKey, scoreComment } from "./rank";
 import type { Comment } from "./types";
 

--- a/plugins/comments/detection/scope.test.ts
+++ b/plugins/comments/detection/scope.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import fc from "fast-check";
+import * as fc from "fast-check";
 import { overlaps, scopeIntroduced } from "./scope";
 import type { Comment, LineRange } from "./types";
 

--- a/plugins/gitlab/hooks/lint.ts
+++ b/plugins/gitlab/hooks/lint.ts
@@ -120,6 +120,26 @@ function isGitLabHost(host: string): boolean {
   return host.split(".").includes("gitlab");
 }
 
+async function pointerConfigPath(
+  dir: string,
+  pointer: string,
+  env: LintEnv,
+): Promise<string | null> {
+  const gitdir = pointer.match(/^gitdir:\s*(.+)\s*$/m)?.at(1);
+  if (gitdir == null || gitdir === "") return null;
+
+  const gitDir = isAbsolute(gitdir) ? gitdir : resolve(dir, gitdir);
+  for (const candidate of [
+    join(gitDir, "config"),
+    // A linked worktree's gitdir is <main>/.git/worktrees/<name>.
+    // The shared config lives two levels up.
+    resolve(gitDir, "..", "..", "config"),
+  ]) {
+    if (await env.fileExists(candidate)) return candidate;
+  }
+  return null;
+}
+
 async function gitConfigPath(cwd: string, env: LintEnv): Promise<string | null> {
   let dir = cwd;
   for (;;) {
@@ -129,21 +149,7 @@ async function gitConfigPath(cwd: string, env: LintEnv): Promise<string | null> 
 
     // Worktrees and submodules use a `.git` file: `gitdir: <path>`.
     const pointer = await env.readFile(dotGit);
-    if (pointer != null && pointer !== "") {
-      const gitdir = pointer.match(/^gitdir:\s*(.+)\s*$/m)?.at(1);
-      if (gitdir != null && gitdir !== "") {
-        const gitDir = isAbsolute(gitdir) ? gitdir : resolve(dir, gitdir);
-        for (const candidate of [
-          join(gitDir, "config"),
-          // A linked worktree's gitdir is <main>/.git/worktrees/<name>.
-          // The shared config lives two levels up.
-          resolve(gitDir, "..", "..", "config"),
-        ]) {
-          if (await env.fileExists(candidate)) return candidate;
-        }
-      }
-      return null;
-    }
+    if (pointer != null && pointer !== "") return pointerConfigPath(dir, pointer, env);
 
     const parent = dirname(dir);
     if (parent === dir) return null;

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "bun:test";
-import fc from "fast-check";
+import * as fc from "fast-check";
 import {
   clearApiErrors,
   computeInterval,

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
@@ -307,7 +307,7 @@ export type PipelineRecord = {
 // pipelines are children whose status the parent already aggregates, so a green
 // child says nothing about the run as a whole. Either one can outrank the real
 // pipeline by id and produce a false green.
-const EXCLUDED_PIPELINE_SOURCES = ["external", "parent_pipeline"];
+const EXCLUDED_PIPELINE_SOURCES = new Set(["external", "parent_pipeline"]);
 
 export function parsePipelineList(raw: unknown): PipelineRecord[] | null {
   const entries = Entries.safeParse(raw);
@@ -340,7 +340,7 @@ export function selectPipeline(
   records: PipelineRecord[],
   prefer: "merge-request" | "branch",
 ): PipelineRecord | null {
-  const eligible = records.filter((record) => !EXCLUDED_PIPELINE_SOURCES.includes(record.source));
+  const eligible = records.filter((record) => !EXCLUDED_PIPELINE_SOURCES.has(record.source));
   const mergeRequestPipelines = eligible.filter(
     (record) => record.source === "merge_request_event",
   );

--- a/plugins/linear/hooks/save-issue.ts
+++ b/plugins/linear/hooks/save-issue.ts
@@ -22,7 +22,7 @@ export function getDefaultState(assignee: string | undefined): string {
 
 // Wrapper keys the connector tolerates inconsistently. A single one whose value
 // is the real field object is unwrapped to flat top-level keys.
-const WRAPPER_KEYS = ["issue", "input", "parameters"];
+const WRAPPER_KEYS = new Set(["issue", "input", "parameters"]);
 
 function isFieldObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -46,7 +46,7 @@ export function normalizeInput(toolInput: Record<string, unknown>): NormalizeRes
   if (
     wrapperKey != null &&
     wrapperKey !== "" &&
-    WRAPPER_KEYS.includes(wrapperKey) &&
+    WRAPPER_KEYS.has(wrapperKey) &&
     isFieldObject(input[wrapperKey])
   ) {
     input = input[wrapperKey];

--- a/plugins/newline/scripts/newline.test.ts
+++ b/plugins/newline/scripts/newline.test.ts
@@ -4,7 +4,7 @@ import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PostToolUseHookInput, PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import fc from "fast-check";
+import * as fc from "fast-check";
 import { processInput as checkInput, hasTrailingNewline } from "./check";
 import { processInput as ensureInput, ensureTrailingNewline } from "./ensure";
 import { processInput as preserveInput, preserveNewlineState } from "./preserve";

--- a/plugins/review/skills/tuicr/scripts/diff.ts
+++ b/plugins/review/skills/tuicr/scripts/diff.ts
@@ -142,9 +142,7 @@ export function parseDiff(diffText: string): ParsedDiff {
           currentKey !== "" &&
           newPath !== currentKey
         ) {
-          if (current.oldPath === undefined) {
-            current.oldPath = currentKey;
-          }
+          current.oldPath ??= currentKey;
           rename(newPath);
         }
       }

--- a/plugins/shortcuts/hooks/open.ts
+++ b/plugins/shortcuts/hooks/open.ts
@@ -17,6 +17,25 @@ export type HookInput = z.infer<typeof HookInput>;
 // receives.
 const OPERATORS = new Set([";", "&", "|", "<", ">", "(", ")", "{", "}", "`", "$", "#", "\n"]);
 
+function readDoubleQuoted(command: string, start: number): { value: string; end: number } | null {
+  let value = "";
+  let j = start + 1;
+  for (; j < command.length && command[j] !== '"'; j++) {
+    const inner = command.charAt(j);
+    if (inner === "$" || inner === "`") return null;
+    if (inner === "\\") {
+      const escaped = command[j + 1];
+      if (escaped === undefined) return null;
+      value += escaped;
+      j++;
+      continue;
+    }
+    value += inner;
+  }
+  if (j >= command.length) return null;
+  return { value, end: j };
+}
+
 // Split a command into shell words, or return null when it is not a single
 // simple command: an unbalanced quote, an operator, or any substitution
 // (`$(...)`, `${x}`, backticks) whose value is unknowable here.
@@ -45,23 +64,10 @@ function tokenize(command: string): string[] | null {
     }
 
     if (char === '"') {
-      let value = "";
-      let j = i + 1;
-      for (; j < command.length && command[j] !== '"'; j++) {
-        const inner = command.charAt(j);
-        if (inner === "$" || inner === "`") return null;
-        if (inner === "\\") {
-          const escaped = command[j + 1];
-          if (escaped === undefined) return null;
-          value += escaped;
-          j++;
-          continue;
-        }
-        value += inner;
-      }
-      if (j >= command.length) return null;
-      current = (current ?? "") + value;
-      i = j;
+      const quoted = readDoubleQuoted(command, i);
+      if (!quoted) return null;
+      current = (current ?? "") + quoted.value;
+      i = quoted.end;
       continue;
     }
 

--- a/plugins/writing/detection/tropes.test.ts
+++ b/plugins/writing/detection/tropes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "bun:test";
-import fc from "fast-check";
+import * as fc from "fast-check";
 import {
   firstByTier,
   type PatternMatch,

--- a/plugins/writing/linguistics/natural.ts
+++ b/plugins/writing/linguistics/natural.ts
@@ -14,7 +14,7 @@ export const naturalTagger: Tagger = {
     const words = tokenizer.tokenize(text);
     const tokens = brill.tag(words).taggedWords.map((tagged) => {
       const normal = tagged.token.toLowerCase();
-      const mapped =
+      const { tag, finite } =
         normal === CODE_SENTINEL
           ? { tag: "CODE" as const, finite: false }
           : mapPenn(tagged.tag, normal);
@@ -22,7 +22,8 @@ export const naturalTagger: Tagger = {
         text: tagged.token,
         normal,
         fine: [tagged.tag],
-        ...mapped,
+        tag,
+        finite,
       };
     });
     return [{ text, tokens }];

--- a/plugins/writing/linguistics/power.test.ts
+++ b/plugins/writing/linguistics/power.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import fc from "fast-check";
+import * as fc from "fast-check";
 import { powerFromCurrentSample, requiredPositiveCount } from "./power";
 
 describe("requiredPositiveCount", () => {

--- a/plugins/writing/linguistics/tricolon.test.ts
+++ b/plugins/writing/linguistics/tricolon.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import fc from "fast-check";
+import * as fc from "fast-check";
 import type { CoarseTag } from "./tags";
 import { normalizedDistance, tagShape, tricolonHits } from "./tricolon";
 

--- a/plugins/writing/skills/analyze/scripts/analyze.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.ts
@@ -335,13 +335,12 @@ export async function runAnalysis(
       const baseline = voiceProfile
         ? phraseProfileStat(voiceProfile, r.phrase)
         : { count: 0, perMillion: 0 };
-      return {
-        ...r,
+      return Object.assign(r, {
         sessions: sessionCounts.get(r.phrase) ?? 0,
         baselineCount: baseline.count,
         baselinePerM: baseline.perMillion,
         quote: findQuote(r.phrase, deliverableRows),
-      };
+      });
     });
 
   console.error("Auditing deliverable corpus for wordlist rules");
@@ -366,11 +365,12 @@ export async function runAnalysis(
     .filter((r) => r.lift >= config.tagMinLift)
     .filter((r) => (tagAssistant.sessionSpread.get(r.phrase) ?? 0) >= minSessions)
     .slice(0, config.tagTop)
-    .map((r) => ({
-      ...r,
-      sessions: tagAssistant.sessionSpread.get(r.phrase) ?? 0,
-      example: tagExamples.get(r.phrase) ?? null,
-    }));
+    .map((r) =>
+      Object.assign(r, {
+        sessions: tagAssistant.sessionSpread.get(r.phrase) ?? 0,
+        example: tagExamples.get(r.phrase) ?? null,
+      }),
+    );
 
   console.error("Fetching correction candidates");
   const corrections = await db.runQuery("correction-candidates", CorrectionRow, baseParams);

--- a/plugins/writing/skills/analyze/scripts/hook-health.ts
+++ b/plugins/writing/skills/analyze/scripts/hook-health.ts
@@ -92,7 +92,8 @@ export function summarize(entries: RunLogEntry[]): HookHealth {
   const categories = [...perCategory.entries()]
     .map(([category, counts]) => ({
       category,
-      ...counts,
+      fired: counts.fired,
+      suppressed: counts.suppressed,
       share: injections > 0 ? counts.fired / injections : 0,
     }))
     .toSorted((a, b) => (b.fired === a.fired ? b.suppressed - a.suppressed : b.fired - a.fired));

--- a/plugins/writing/skills/analyze/scripts/ngram.test.ts
+++ b/plugins/writing/skills/analyze/scripts/ngram.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import fc from "fast-check";
+import * as fc from "fast-check";
 import {
   addNgrams,
   cleanText,

--- a/plugins/writing/skills/analyze/scripts/ngram.ts
+++ b/plugins/writing/skills/analyze/scripts/ngram.ts
@@ -144,6 +144,39 @@ export interface ProcessRowsOptions {
   examples?: Map<string, string>;
 }
 
+interface NgramSessionInput {
+  tokens: string[];
+  n: number;
+  sessionId: string;
+  sentence: string;
+  phraseSessions: Map<string, Set<string>>;
+  examples: Map<string, string> | undefined;
+}
+
+function recordNgramSessions({
+  tokens,
+  n,
+  sessionId,
+  sentence,
+  phraseSessions,
+  examples,
+}: NgramSessionInput): void {
+  for (let i = 0; i <= tokens.length - n; i++) {
+    const key = tokens.slice(i, i + n).join(" ");
+    let sessions = phraseSessions.get(key);
+    if (sessions === undefined) {
+      sessions = new Set();
+      phraseSessions.set(key, sessions);
+    }
+    sessions.add(sessionId);
+    if (examples !== undefined) {
+      const existing = examples.get(key);
+      if (existing == null || existing === "" || sentence.length < existing.length)
+        examples.set(key, sentence);
+    }
+  }
+}
+
 export function processRows(
   rows: Array<{ session_id: string; text?: string }>,
   sizes: number[] = [2, 3, 4],
@@ -166,20 +199,14 @@ export function processRows(
         const counts = stats.ngrams.get(n);
         if (!counts) continue;
         addNgrams(counts, tokens, n);
-        for (let i = 0; i <= tokens.length - n; i++) {
-          const key = tokens.slice(i, i + n).join(" ");
-          let sessions = phraseSessions.get(key);
-          if (!sessions) {
-            sessions = new Set();
-            phraseSessions.set(key, sessions);
-          }
-          sessions.add(row.session_id);
-          if (examples) {
-            const existing = examples.get(key);
-            if (existing == null || existing === "" || sent.length < existing.length)
-              examples.set(key, sent);
-          }
-        }
+        recordNgramSessions({
+          tokens,
+          n,
+          sessionId: row.session_id,
+          sentence: sent,
+          phraseSessions,
+          examples,
+        });
       }
     }
   }

--- a/plugins/writing/skills/analyze/scripts/voice-corpus.test.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-corpus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import fc from "fast-check";
+import * as fc from "fast-check";
 import { mergeDocuments, parseCorpus, serializeCorpus, type VoiceDocument } from "./voice-corpus";
 
 // A document that survives serialize/parse: the source is a single non-empty

--- a/scripts/check-hook-matchers.ts
+++ b/scripts/check-hook-matchers.ts
@@ -81,11 +81,11 @@ export async function allMatcherEntries(): Promise<MatcherEntryContext[]> {
     Promise.all(
       SOURCES.map(async ({ file }) => {
         const parsed = await decodeFile(SettingsHooks, join(root, file));
-        return [...settingsEntries(file, parsed.hooks ?? {})];
+        return Array.from(settingsEntries(file, parsed.hooks ?? {}));
       }),
     ),
   ]);
-  return [...plugins.flatMap((plugin) => [...matcherEntries(plugin)]), ...settings.flat()];
+  return [...plugins.flatMap((plugin) => Array.from(matcherEntries(plugin))), ...settings.flat()];
 }
 
 if (import.meta.main) {

--- a/scripts/check-mcp-matchers.test.ts
+++ b/scripts/check-mcp-matchers.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test";
+import { missingVariants } from "./check-mcp-matchers";
+
+const FILE = "plugins/example/hooks/hooks.json";
+
+const resolve = (server: string): string | null => (server === "unknown" ? null : server);
+
+test.each<{ name: string; pattern: string; also?: string[]; expected: string[] }>([
+  {
+    name: "non-mcp matcher",
+    pattern: "Bash",
+    expected: [],
+  },
+  {
+    name: "already plugin-scoped",
+    pattern: "mcp__plugin_linear_linear__create_issue",
+    expected: [],
+  },
+  {
+    name: "already Claude AI scoped",
+    pattern: "mcp__claude_ai_Linear__save_issue",
+    expected: [],
+  },
+  {
+    name: "server with no known plugin",
+    pattern: "mcp__unknown__do_thing",
+    expected: [],
+  },
+  {
+    name: "unmapped server wants only the plugin variant",
+    pattern: "mcp__things__add_todo",
+    expected: [
+      `${FILE}: matcher "mcp__things__add_todo" is missing plugin variant "mcp__plugin_things_things__add_todo"`,
+    ],
+  },
+  {
+    name: "unmapped server with the plugin variant present",
+    pattern: "mcp__things__add_todo",
+    also: ["mcp__plugin_things_things__add_todo"],
+    expected: [],
+  },
+  {
+    name: "mapped server wants both variants, with the tool renamed",
+    pattern: "mcp__linear__create_issue",
+    expected: [
+      `${FILE}: matcher "mcp__linear__create_issue" is missing plugin variant "mcp__plugin_linear_linear__create_issue"`,
+      `${FILE}: matcher "mcp__linear__create_issue" is missing Claude AI variant "mcp__claude_ai_Linear__save_issue"`,
+    ],
+  },
+  {
+    name: "mapped server keeps a tool name it has no rename for",
+    pattern: "mcp__linear__list_issues",
+    also: ["mcp__plugin_linear_linear__list_issues"],
+    expected: [
+      `${FILE}: matcher "mcp__linear__list_issues" is missing Claude AI variant "mcp__claude_ai_Linear__list_issues"`,
+    ],
+  },
+  {
+    name: "mapped server fully covered",
+    pattern: "mcp__linear__create_issue",
+    also: ["mcp__plugin_linear_linear__create_issue", "mcp__claude_ai_Linear__save_issue"],
+    expected: [],
+  },
+])("$name", ({ pattern, also = [], expected }) => {
+  expect(missingVariants(FILE, pattern, [pattern, ...also], resolve)).toEqual(expected);
+});

--- a/scripts/check-mcp-matchers.ts
+++ b/scripts/check-mcp-matchers.ts
@@ -14,6 +14,41 @@ const CLAUDE_AI_MAPPINGS: Record<string, { displayName: string; tools: Record<st
   },
 };
 
+export function missingVariants(
+  file: string,
+  pattern: string,
+  patterns: string[],
+  resolvePluginName: (server: string) => string | null,
+): string[] {
+  const match = MCP_PATTERN.exec(pattern);
+  if (!match) return [];
+
+  const server = match[1];
+  const tool = match[2];
+  if (server == null || server === "" || tool == null || tool === "") return [];
+
+  const pluginName = resolvePluginName(server);
+  if (pluginName == null || pluginName === "") return [];
+
+  const errors: string[] = [];
+  const pluginVariant = `mcp__plugin_${pluginName}_${server}__${tool}`;
+  if (!patterns.includes(pluginVariant)) {
+    errors.push(`${file}: matcher "${pattern}" is missing plugin variant "${pluginVariant}"`);
+  }
+
+  const claudeAi = CLAUDE_AI_MAPPINGS[server];
+  if (claudeAi) {
+    const mappedTool = claudeAi.tools[tool] ?? tool;
+    const claudeAiVariant = `mcp__claude_ai_${claudeAi.displayName}__${mappedTool}`;
+    if (!patterns.includes(claudeAiVariant)) {
+      errors.push(
+        `${file}: matcher "${pattern}" is missing Claude AI variant "${claudeAiVariant}"`,
+      );
+    }
+  }
+  return errors;
+}
+
 async function checkMatchers(): Promise<string[]> {
   const [plugins, enabledNames] = await Promise.all([loadPlugins(), enabledPluginNames()]);
 
@@ -25,6 +60,9 @@ async function checkMatchers(): Promise<string[]> {
     }
   }
 
+  const resolvePluginName = (server: string): string | null =>
+    knownServers.get(server) ?? (enabledNames.has(server) ? server : null);
+
   const errors: string[] = [];
 
   for (const plugin of plugins) {
@@ -33,31 +71,7 @@ async function checkMatchers(): Promise<string[]> {
       const patterns = entry.matcher.split("|");
 
       for (const pattern of patterns) {
-        const match = MCP_PATTERN.exec(pattern);
-        if (!match) continue;
-
-        const server = match[1];
-        const tool = match[2];
-        if (server == null || server === "" || tool == null || tool === "") continue;
-
-        const pluginName = knownServers.get(server) ?? (enabledNames.has(server) ? server : null);
-        if (pluginName == null || pluginName === "") continue;
-
-        const pluginVariant = `mcp__plugin_${pluginName}_${server}__${tool}`;
-        if (!patterns.includes(pluginVariant)) {
-          errors.push(`${file}: matcher "${pattern}" is missing plugin variant "${pluginVariant}"`);
-        }
-
-        const claudeAi = CLAUDE_AI_MAPPINGS[server];
-        if (claudeAi) {
-          const mappedTool = claudeAi.tools[tool] ?? tool;
-          const claudeAiVariant = `mcp__claude_ai_${claudeAi.displayName}__${mappedTool}`;
-          if (!patterns.includes(claudeAiVariant)) {
-            errors.push(
-              `${file}: matcher "${pattern}" is missing Claude AI variant "${claudeAiVariant}"`,
-            );
-          }
-        }
+        errors.push(...missingVariants(file, pattern, patterns, resolvePluginName));
       }
     }
   }
@@ -65,10 +79,12 @@ async function checkMatchers(): Promise<string[]> {
   return errors;
 }
 
-await runCheck(
-  async () => ({
-    header: "MCP hook matchers missing plugin variants:",
-    violations: await checkMatchers(),
-  }),
-  { success: "All MCP hook matchers include plugin and Claude AI variants" },
-);
+if (import.meta.main) {
+  await runCheck(
+    async () => ({
+      header: "MCP hook matchers missing plugin variants:",
+      violations: await checkMatchers(),
+    }),
+    { success: "All MCP hook matchers include plugin and Claude AI variants" },
+  );
+}

--- a/scripts/check-skill-hook-vars.ts
+++ b/scripts/check-skill-hook-vars.ts
@@ -30,14 +30,12 @@ async function checkSkillHookVars(): Promise<string[]> {
     const hooks = decode(SkillHooks, data.hooks, `${file} hooks`);
     if (!hooks) continue;
 
-    for (const entries of Object.values(hooks)) {
-      for (const entry of entries) {
-        for (const hook of entry.hooks ?? []) {
-          const command = hook.command ?? "";
-          const args = (hook.args ?? []).join(" ");
-          if (FORBIDDEN.test(command) || FORBIDDEN.test(args)) {
-            violations.push(`${file}: ${command !== "" ? command : args}`);
-          }
+    for (const entry of Object.values(hooks).flat()) {
+      for (const hook of entry.hooks ?? []) {
+        const command = hook.command ?? "";
+        const args = (hook.args ?? []).join(" ");
+        if (FORBIDDEN.test(command) || FORBIDDEN.test(args)) {
+          violations.push(`${file}: ${command !== "" ? command : args}`);
         }
       }
     }

--- a/scripts/coverage/lcov.test.ts
+++ b/scripts/coverage/lcov.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import fc from "fast-check";
+import * as fc from "fast-check";
 import {
   coveredLines,
   type FileCoverage,

--- a/scripts/inventory/report.ts
+++ b/scripts/inventory/report.ts
@@ -69,12 +69,14 @@ function counts(inventory: Inventory): Columns {
         inventory.plugins.length,
         `${inventory.plugins.filter((p) => p.enabled).length} enabled`,
       ),
-      ...scoped.map(({ kind, items }) => [
-        kind,
-        ...SCOPES.map((scope) => String(items.filter((item) => item.scope === scope).length)),
-        String(items.length),
-        "",
-      ]),
+      ...scoped.map(({ kind, items }) => {
+        const row = [kind];
+        for (const scope of SCOPES) {
+          row.push(String(items.filter((item) => item.scope === scope).length));
+        }
+        row.push(String(items.length), "");
+        return row;
+      }),
       pluginOnly("mcp", inventory.mcpServers.length, ""),
     ],
   };

--- a/user/rules/testing-typescript.md
+++ b/user/rules/testing-typescript.md
@@ -47,7 +47,7 @@ Past roughly 20 lines, use `toMatchSnapshot()`, which writes to `__snapshots__/*
 Write one `fast-check` property plus a small example table. `fast-check` needs no runner adapter.
 
 ```ts
-import fc from "fast-check";
+import * as fc from "fast-check";
 
 test("encode/decode roundtrip", () => {
   fc.assert(

--- a/user/scripts/subagent-statusline.test.ts
+++ b/user/scripts/subagent-statusline.test.ts
@@ -288,6 +288,21 @@ describe("renderTask", () => {
     expect(strip(out.content)).toContain("· 1m 5s · 1.5k");
   });
 
+  test.each<{ name: string; task: Task; expected: string }>([
+    {
+      name: "epoch start still renders elapsed",
+      task: { id: "a", name: "x", startTime: 0, tokenCount: 1500 },
+      expected: "x · 1m 5s · 1.5k",
+    },
+    {
+      name: "omitted start drops the elapsed segment",
+      task: { id: "a", name: "x", tokenCount: 1500 },
+      expected: "x · 1.5k",
+    },
+  ])("$name", ({ task, expected }) => {
+    expect(strip(renderTask(task, null, now, null).content)).toEndWith(expected);
+  });
+
   test("type name trails after the meta as dim text", () => {
     const out = renderTask(
       { id: "a", description: "search", startTime: 0, tokenCount: 1500 },


### PR DESCRIPTION
Adds the `import` plugin to `.oxlintrc.json` with complexity, performance, and equality rules. Touches only the keys it adds, so it unions with the other lint config work in flight.

The plugin's whole `correctness` category finds nothing here. It earns its place through one suspicious-level rule.

## Dispositions

| Rule | Hits | Disposition |
|---|---|---|
| `import/no-named-as-default-member` | 111 | One cause across 13 files. One import rewrite clears all of them. |
| `eslint/max-depth` | 8 | Four extracted helpers, one flattened loop, one `??=`. |
| `oxc/no-map-spread` | 7 | Explicit object construction, or a push loop where the accumulator is reused. |
| `unicorn/prefer-array-find` | 3 | `.filter(...)[0]` in `db.test.ts`. |
| `unicorn/prefer-set-has` | 3 | `ci-monitor/scripts/watch.ts`, `linear/hooks/save-issue.ts`, `session/scripts/db.test.ts`. |
| `eslint/eqeqeq` | 0 | Configured `{ "null": "ignore" }`. Ships as a guard. |

## Import Plugin

`fast-check` publishes `fc` as both its default export and its namespace. `import fc from "fast-check"` followed by `fc.assert` therefore reads a named export through a default binding, 111 times across 13 test files. `import * as fc` clears every one.

`user/rules/testing-typescript.md` showed the default form in its `fast-check` example, and that rule auto-injects for every `*.test.ts`. Fixed the example alongside the call sites, which is what keeps the count from growing back.

The rewrite pushes `import/no-namespace` from 29 hits to 42. The two rules disagree about any package with this export shape. I took the one catching a binding error over the one enforcing import style.

## Equality

At full strictness `eqeqeq` finds 476 sites across 148 files on main, and every one is `== null`. Most arrived with #1279, whose `strict-boolean-expressions` fixes take the shape `x == null || x === ""`. Banning `== null` would mean rewriting all of them.

`{ "null": "ignore" }` exempts that idiom. What's left is `==` between two non-null operands, which this repo has none of, so the rule ships as a guard like `no-terminal-width` in #1268.

## Lint Cost

Under the noise floor. Over 40 `hyperfine` runs per config, user CPU was 660 ms without the plugin against 675 ms with it. Nowhere near a doubling.

## Testing

`check-mcp-matchers.ts` had no tests because its body sat inside three nested loops. Extracting `missingVariants` for `max-depth` made it callable, so it now has a table over the plugin variant, the Claude AI tool mapping, its fallback, and the shapes producing nothing.

`subagent-statusline.ts` gained rows pinning `startTime: 0` against an omitted one. The zero case is what matters: a truthiness guard there renders `29797452m 13s`.

## Deferred Work

Setting `oxc/no-map-spread`'s `ignoreArgs` and `ignoreRereads` to false surfaces five more sites:

- `plugins/writing/linguistics/classifiers.ts:114`
- `plugins/writing/linguistics/compromise.ts:70`
- `plugins/writing/skills/analyze/scripts/hook-health.test.ts:19`
- `scripts/inventory/collect.ts:262`
- `user/scripts/statusline.ts:180`

The last is `spans.map((s) => [...s.text])`, a string-to-chars spread rather than the object-property pattern the rule targets. Four real sites and one suppression. Left at defaults.
