### PR TITLE
github, gitlab: decode external data at the seams

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -122,6 +122,7 @@
         "cleye": "^2.0.0",
         "table": "^6.9.0",
         "url-pattern": "^1.0.3",
+        "zod": "^4.4.3",
       },
     },
     "plugins/gitlab": {
@@ -132,6 +133,7 @@
         "cleye": "^2.2.1",
         "table": "^6.9.0",
         "url-pattern": "^1.0.3",
+        "zod": "^4.4.3",
       },
     },
     "plugins/go": {

--- a/plugins/github/package.json
+++ b/plugins/github/package.json
@@ -7,6 +7,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
     "cleye": "^2.0.0",
     "table": "^6.9.0",
-    "url-pattern": "^1.0.3"
+    "url-pattern": "^1.0.3",
+    "zod": "^4.4.3"
   }
 }

--- a/plugins/github/scripts/fetch.test.ts
+++ b/plugins/github/scripts/fetch.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, it, test } from "bun:test";
-import type {
-  PreToolUseHookInput,
-  PreToolUseHookSpecificOutput,
-} from "@anthropic-ai/claude-agent-sdk";
-import { formatOutput, isGitHubUrl, parseGitHubUrl, processInput } from "./fetch";
+import type { PreToolUseHookSpecificOutput } from "@anthropic-ai/claude-agent-sdk";
+import { formatOutput, type HookInput, isGitHubUrl, parseGitHubUrl, processInput } from "./fetch";
 
-function mockInput(url: string): PreToolUseHookInput {
+function mockInput(url: string): HookInput {
   return {
     hook_event_name: "PreToolUse",
     session_id: "test",
@@ -17,10 +14,10 @@ function mockInput(url: string): PreToolUseHookInput {
   };
 }
 
-function getOutput(input: PreToolUseHookInput): PreToolUseHookSpecificOutput | null {
-  const result = processInput(input);
-  if (!result) return null;
-  return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
+function getOutput(input: HookInput): PreToolUseHookSpecificOutput | null {
+  const output = processInput(input)?.hookSpecificOutput;
+  if (output?.hookEventName !== "PreToolUse") return null;
+  return output;
 }
 
 describe("isGitHubUrl", () => {

--- a/plugins/github/scripts/fetch.ts
+++ b/plugins/github/scripts/fetch.ts
@@ -1,9 +1,18 @@
 #!/usr/bin/env bun
 
-import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import UrlPattern from "url-pattern";
+import { z } from "zod";
 
-export type WebFetchInput = { url: string; prompt: string };
+const WebFetchInput = z.looseObject({ url: z.string() });
+export type WebFetchInput = z.infer<typeof WebFetchInput>;
+
+export const HookInput = z.looseObject({ tool_input: z.unknown() });
+export type HookInput = z.infer<typeof HookInput>;
+
+// url-pattern's match() returns `any`.
+const Params = z.record(z.string(), z.string());
+const RepoPath = z.looseObject({ _: z.string().optional().catch(undefined) });
 
 type RouteMatch = {
   type: string;
@@ -66,9 +75,9 @@ export function isGitHubUrl(url: string): boolean {
 
 export function matchRoute(path: string): RouteMatch | null {
   for (const route of routes) {
-    const params = route.pattern.match(path);
-    if (params) {
-      return { type: route.type, params };
+    const params = Params.safeParse(route.pattern.match(path));
+    if (params.success) {
+      return { type: route.type, params: params.data };
     }
   }
   return null;
@@ -77,9 +86,9 @@ export function matchRoute(path: string): RouteMatch | null {
 export function parseGitHubUrl(url: string): { type: string; suggestion: string } | null {
   const path = url.slice("https://github.com/".length);
 
-  const pathMatch = repoPathPattern.match(path);
-  if (pathMatch) {
-    const subpath = pathMatch._ || "";
+  const pathMatch = RepoPath.safeParse(repoPathPattern.match(path));
+  if (pathMatch.success) {
+    const subpath = pathMatch.data._ || "";
 
     // Empty subpath means trailing slash on repo root
     if (subpath === "") {
@@ -102,8 +111,8 @@ export function parseGitHubUrl(url: string): { type: string; suggestion: string 
     return null;
   }
 
-  const baseMatch = repoBasePattern.match(path);
-  if (baseMatch) {
+  const baseMatch = Params.safeParse(repoBasePattern.match(path));
+  if (baseMatch.success) {
     return {
       type: "repo",
       suggestion: `Use: gh repo view [<repository>].`,
@@ -130,8 +139,8 @@ export function isRawGitHubUrl(url: string): boolean {
   return url.startsWith("https://raw.githubusercontent.com/");
 }
 
-export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {
-  const { url } = input.tool_input as WebFetchInput;
+export function processInput(input: HookInput): SyncHookJSONOutput | null {
+  const { url } = WebFetchInput.parse(input.tool_input);
 
   if (isRawGitHubUrl(url)) {
     return formatOutput(
@@ -153,9 +162,9 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
 }
 
 async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
+  let input: HookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
+    input = HookInput.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     console.error(
       `[github/fetch] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/github/scripts/pr-comments.ts
+++ b/plugins/github/scripts/pr-comments.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 
 import { cli } from "cleye";
-import { type Author, isBot, isReviewTarget, loadExtraReviewers } from "./reviewers";
+import { z } from "zod";
+import { Author, isBot, isReviewTarget, loadExtraReviewers } from "./reviewers";
 
 const QUERY = `
 query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
@@ -44,29 +45,33 @@ query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
 }
 `;
 
-export interface Comment {
-  author: Author | null;
-  body: string;
-  createdAt: string;
-}
+export const Comment = z.looseObject({
+  author: Author.nullable(),
+  body: z.string(),
+  createdAt: z.string(),
+});
+export type Comment = z.infer<typeof Comment>;
 
-export interface Thread {
-  id: string;
-  isResolved: boolean;
-  isOutdated: boolean;
-  path: string;
-  line: number | null;
-  startLine: number | null;
-  comments: { nodes: Comment[] };
-}
+export const Thread = z.looseObject({
+  id: z.string(),
+  isResolved: z.boolean(),
+  isOutdated: z.boolean(),
+  path: z.string(),
+  line: z.number().nullable(),
+  startLine: z.number().nullable(),
+  comments: z.looseObject({ nodes: z.array(Comment) }),
+});
+export type Thread = z.infer<typeof Thread>;
 
-export interface Review {
-  author: { login: string; __typename: string } | null;
-  submittedAt: string;
-  state: string;
-}
+export const Review = z.looseObject({
+  author: z.looseObject({ login: z.string(), __typename: z.string() }).nullable(),
+  submittedAt: z.string(),
+  state: z.string(),
+});
+export type Review = z.infer<typeof Review>;
 
-export type Role = "author" | "reviewer";
+export const Role = z.enum(["author", "reviewer"]);
+export type Role = z.infer<typeof Role>;
 
 export function isBotThread(thread: Thread): boolean {
   return isBot(thread.comments.nodes[0]?.author);
@@ -214,28 +219,28 @@ export function formatThreads(
   return lines.join("\n");
 }
 
-interface GraphQLResponse {
-  data: {
-    viewer: { login: string };
-    repository: {
-      pullRequest: {
-        title: string;
-        author: { login: string };
-        reviews: { nodes: Review[] };
-        reviewThreads: {
-          totalCount: number;
-          pageInfo: { hasNextPage: boolean; endCursor: string };
-          nodes: Thread[];
-        };
-      };
-    };
-  };
-}
+const GraphQLResponse = z.looseObject({
+  data: z.looseObject({
+    viewer: z.looseObject({ login: z.string() }),
+    repository: z.looseObject({
+      pullRequest: z.looseObject({
+        title: z.string(),
+        author: Author.nullable(),
+        reviews: z.looseObject({ nodes: z.array(Review) }),
+        reviewThreads: z.looseObject({
+          totalCount: z.number(),
+          pageInfo: z.looseObject({ hasNextPage: z.boolean(), endCursor: z.string().nullable() }),
+          nodes: z.array(Thread),
+        }),
+      }),
+    }),
+  }),
+});
 
 async function fetchGraphQL(
   query: string,
   variables: Record<string, string | number | undefined>,
-): Promise<GraphQLResponse> {
+): Promise<z.infer<typeof GraphQLResponse>> {
   const args = ["gh", "api", "graphql", "-f", `query=${query}`];
   for (const [key, value] of Object.entries(variables)) {
     if (value != null) {
@@ -255,7 +260,7 @@ async function fetchGraphQL(
   }
 
   try {
-    return JSON.parse(stdout);
+    return GraphQLResponse.parse(JSON.parse(stdout));
   } catch {
     throw new Error(`Failed to parse GraphQL response: ${stdout.slice(0, 200)}`);
   }
@@ -307,7 +312,7 @@ async function main(): Promise<void> {
     if (!prTitle) {
       viewer = result.data.viewer.login;
       prTitle = pr.title;
-      prAuthor = pr.author.login;
+      prAuthor = pr.author?.login ?? "ghost";
       reviews = pr.reviews.nodes;
       totalCount = pr.reviewThreads.totalCount;
     }
@@ -315,15 +320,15 @@ async function main(): Promise<void> {
     allThreads.push(...pr.reviewThreads.nodes);
 
     const pageInfo = pr.reviewThreads.pageInfo;
-    cursor = pageInfo.hasNextPage ? pageInfo.endCursor : undefined;
+    cursor = pageInfo.hasNextPage ? (pageInfo.endCursor ?? undefined) : undefined;
   } while (cursor);
 
-  const roleFlag = argv.flags.role;
-  if (roleFlag && roleFlag !== "author" && roleFlag !== "reviewer") {
-    console.error(`Invalid --role: ${roleFlag} (must be "author" or "reviewer")`);
+  const roleFlag = argv.flags.role ? Role.safeParse(argv.flags.role) : null;
+  if (roleFlag && !roleFlag.success) {
+    console.error(`Invalid --role: ${argv.flags.role} (must be "author" or "reviewer")`);
     process.exit(1);
   }
-  const role: Role = (roleFlag as Role) ?? detectRole(viewer, prAuthor);
+  const role: Role = roleFlag?.data ?? detectRole(viewer, prAuthor);
 
   let since: Date | undefined;
   if (argv.flags.since) {
@@ -363,8 +368,8 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.main) {
-  main().catch((error) => {
-    console.error(error.message);
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);
   });
 }

--- a/plugins/github/scripts/review-threads.ts
+++ b/plugins/github/scripts/review-threads.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { cli, command } from "cleye";
+import { z } from "zod";
 
 export const REPLY_MUTATION = `
 mutation($threadId: ID!, $body: String!) {
@@ -36,10 +37,11 @@ mutation($subjectId: ID!, $content: ReactionContent!) {
 }
 `;
 
-async function ghGraphQL<T = unknown>(
+async function ghGraphQL<S extends z.ZodType>(
+  schema: S,
   query: string,
   variables: Record<string, string>,
-): Promise<T> {
+): Promise<z.output<S>> {
   const args = ["gh", "api", "graphql", "-f", `query=${query}`];
   for (const [key, value] of Object.entries(variables)) {
     args.push("-f", `${key}=${value}`);
@@ -55,7 +57,7 @@ async function ghGraphQL<T = unknown>(
   }
 
   try {
-    return JSON.parse(stdout);
+    return schema.parse(JSON.parse(stdout));
   } catch {
     throw new Error(`Failed to parse GraphQL response: ${stdout.slice(0, 200)}`);
   }
@@ -89,9 +91,9 @@ const replyCmd = command(
       process.exit(1);
     }
 
-    await ghGraphQL(REPLY_MUTATION, { threadId, body });
+    await ghGraphQL(z.unknown(), REPLY_MUTATION, { threadId, body });
     if (parsed.flags.resolve) {
-      await ghGraphQL(RESOLVE_MUTATION, { threadId });
+      await ghGraphQL(z.unknown(), RESOLVE_MUTATION, { threadId });
     }
     console.error(`Replied to ${threadId}${parsed.flags.resolve ? " and resolved" : ""}`);
   },
@@ -103,17 +105,23 @@ const resolveCmd = command(
     parameters: ["<thread-id>"],
   },
   async (parsed) => {
-    await ghGraphQL(RESOLVE_MUTATION, { threadId: parsed._.threadId });
+    await ghGraphQL(z.unknown(), RESOLVE_MUTATION, { threadId: parsed._.threadId });
     console.error(`Resolved ${parsed._.threadId}`);
   },
 );
 
-interface ThreadCommentResponse {
-  data: { node: { comments: { nodes: { id: string }[] } } | null };
-}
+const ThreadCommentResponse = z.looseObject({
+  data: z.looseObject({
+    node: z
+      .looseObject({
+        comments: z.looseObject({ nodes: z.array(z.looseObject({ id: z.string() })) }),
+      })
+      .nullable(),
+  }),
+});
 
 async function firstCommentId(threadId: string): Promise<string> {
-  const result = await ghGraphQL<ThreadCommentResponse>(THREAD_COMMENT_QUERY, { threadId });
+  const result = await ghGraphQL(ThreadCommentResponse, THREAD_COMMENT_QUERY, { threadId });
   const id = result.data.node?.comments.nodes[0]?.id;
   if (!id) {
     throw new Error(`No comment found for thread ${threadId}`);
@@ -143,9 +151,9 @@ const reactCmd = command(
     const content = parsed.flags.down ? "THUMBS_DOWN" : "THUMBS_UP";
     const subjectId = await firstCommentId(threadId);
 
-    await ghGraphQL(REACT_MUTATION, { subjectId, content });
+    await ghGraphQL(z.unknown(), REACT_MUTATION, { subjectId, content });
     if (parsed.flags.resolve) {
-      await ghGraphQL(RESOLVE_MUTATION, { threadId });
+      await ghGraphQL(z.unknown(), RESOLVE_MUTATION, { threadId });
     }
     console.error(
       `Reacted ${parsed.flags.down ? "👎" : "👍"} to ${threadId}${parsed.flags.resolve ? " and resolved" : ""}`,

--- a/plugins/github/scripts/reviewers.ts
+++ b/plugins/github/scripts/reviewers.ts
@@ -1,9 +1,11 @@
 import { join } from "node:path";
+import { z } from "zod";
 
-export interface Author {
-  login: string;
-  __typename?: string;
-}
+export const Author = z.looseObject({
+  login: z.string(),
+  __typename: z.string().optional(),
+});
+export type Author = z.infer<typeof Author>;
 
 // GitHub classifies bot accounts natively: GraphQL reports `__typename: "Bot"`
 // for GitHub Apps and bot users (Copilot, CodeRabbit, Greptile, and the rest).

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -3,6 +3,7 @@
 import { type ExecSyncOptions, execSync } from "node:child_process";
 import { cli } from "cleye";
 import UrlPattern from "url-pattern";
+import { z } from "zod";
 
 const DEFAULT_INTERVAL_SECONDS = 180;
 const NO_HISTORY_INTERVAL_SECONDS = 30;
@@ -35,6 +36,51 @@ export type Probe = {
   mergeStateStatus: MergeStateStatus;
   prState: "OPEN" | "CLOSED" | "MERGED";
 };
+
+// url-pattern's match() returns `any`.
+const PrUrlParams = z.object({ owner: z.string(), repo: z.string(), number: z.string() });
+const RepoParams = z.object({ owner: z.string(), repo: z.string() });
+
+// gh reports a status outside the documented set as UNKNOWN, which the caller
+// already treats as undetermined.
+const MergeableField = z
+  .enum(["MERGEABLE", "CONFLICTING", "UNKNOWN"])
+  .catch("UNKNOWN") satisfies z.ZodType<Probe["mergeable"]>;
+const MergeStateStatusField = z
+  .enum(["BEHIND", "BLOCKED", "CLEAN", "DIRTY", "DRAFT", "HAS_HOOKS", "UNKNOWN", "UNSTABLE"])
+  .catch("UNKNOWN") satisfies z.ZodType<MergeStateStatus>;
+
+const PrView = z.looseObject({
+  headRefOid: z.string().catch(""),
+  headRefName: z.string().catch(""),
+  state: z.enum(["OPEN", "CLOSED", "MERGED"]).catch("OPEN"),
+  mergeable: MergeableField,
+  mergeStateStatus: MergeStateStatusField,
+});
+
+const MergeabilityView = z.looseObject({
+  mergeable: MergeableField,
+  mergeStateStatus: MergeStateStatusField,
+});
+
+const Check = z.looseObject({
+  state: z.string().optional().catch(undefined),
+  bucket: z.string().optional().catch(undefined),
+  name: z.string().optional().catch(undefined),
+});
+export type Check = z.infer<typeof Check>;
+const Checks = z.array(Check);
+
+const RunView = z.looseObject({
+  headSha: z.string().catch(""),
+  databaseId: z.union([z.number(), z.string()]).optional().catch(undefined),
+  status: z.string().catch(""),
+  conclusion: z.string().catch(""),
+});
+type RunView = z.infer<typeof RunView>;
+
+const RunList = z.array(RunView);
+const Durations = z.array(z.unknown());
 
 export type Event =
   | { type: "status"; state: StatusState; sha: string; run_id: string | null }
@@ -186,15 +232,15 @@ export function parsePrUrl(url: string): {
   const pattern = new UrlPattern("https\\://github.com/:owner/:repo/pull/:number(/*)", {
     segmentValueCharset: "a-zA-Z0-9-_.~%",
   });
-  const match = pattern.match(url);
-  if (!match) {
+  const match = PrUrlParams.safeParse(pattern.match(url));
+  if (!match.success) {
     throw new Error(`Invalid GitHub PR URL: ${url}`);
   }
-  const number = Number.parseInt(match.number, 10);
+  const number = Number.parseInt(match.data.number, 10);
   if (Number.isNaN(number)) {
     throw new Error(`Invalid PR number in URL: ${url}`);
   }
-  return { owner: match.owner, repo: match.repo, number };
+  return { owner: match.data.owner, repo: match.data.repo, number };
 }
 
 const stripGit = (s: string): string => (s.endsWith(".git") ? s.slice(0, -4) : s);
@@ -204,10 +250,10 @@ export function parseRepo(remoteUrl: string): { owner: string; repo: string } | 
   if (!trimmed) return null;
 
   const tryPattern = (pattern: string): { owner: string; repo: string } | null => {
-    const match = new UrlPattern(pattern, {
-      segmentValueCharset: "a-zA-Z0-9-_.~%",
-    }).match(trimmed);
-    return match ? { owner: match.owner, repo: stripGit(match.repo) } : null;
+    const match = RepoParams.safeParse(
+      new UrlPattern(pattern, { segmentValueCharset: "a-zA-Z0-9-_.~%" }).match(trimmed),
+    );
+    return match.success ? { owner: match.data.owner, repo: stripGit(match.data.repo) } : null;
   };
 
   const urlMatch =
@@ -284,16 +330,7 @@ export type Mergeability = {
 
 function parseMergeability(stdout: string): Mergeability | null {
   try {
-    const parsed = JSON.parse(stdout) as Record<string, unknown>;
-    const mergeable =
-      typeof parsed.mergeable === "string" && parsed.mergeable
-        ? (parsed.mergeable as Probe["mergeable"])
-        : "UNKNOWN";
-    const mergeStateStatus =
-      typeof parsed.mergeStateStatus === "string" && parsed.mergeStateStatus
-        ? (parsed.mergeStateStatus as MergeStateStatus)
-        : "UNKNOWN";
-    return { mergeable, mergeStateStatus };
+    return MergeabilityView.parse(JSON.parse(stdout));
   } catch {
     return null;
   }
@@ -339,9 +376,7 @@ const isQueuedState = (s: string): boolean =>
 // "cancel" | "pending" | "skipping"). It does NOT expose `conclusion`. Use
 // `bucket` for terminal classification and `state` to distinguish running
 // from queued.
-export function deriveChecksState(
-  checks: Array<{ state?: string; bucket?: string; name?: string }>,
-): InternalState {
+export function deriveChecksState(checks: Check[]): InternalState {
   if (checks.length === 0) {
     return "running";
   }
@@ -394,27 +429,19 @@ export function probePr(prNumber: number, repo: string, run: ExecFn = exec): Pro
       stderr: prResult.stderr,
     };
   }
-  let sha = "";
-  let branch = "";
-  let prState: Probe["prState"] = "OPEN";
-  let mergeable: Probe["mergeable"] = "UNKNOWN";
-  let mergeStateStatus: MergeStateStatus = "UNKNOWN";
+  let view: z.infer<typeof PrView>;
   try {
-    const parsed = JSON.parse(prResult.stdout) as Record<string, unknown>;
-    if (typeof parsed.headRefOid === "string") sha = parsed.headRefOid;
-    if (typeof parsed.headRefName === "string") branch = parsed.headRefName;
-    if (typeof parsed.state === "string") prState = parsed.state as Probe["prState"];
-    if (typeof parsed.mergeable === "string" && parsed.mergeable) {
-      mergeable = parsed.mergeable as Probe["mergeable"];
-    }
-    if (typeof parsed.mergeStateStatus === "string" && parsed.mergeStateStatus) {
-      mergeStateStatus = parsed.mergeStateStatus as MergeStateStatus;
-    }
+    view = PrView.parse(JSON.parse(prResult.stdout));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`gh pr view returned unparseable JSON for PR #${prNumber}: ${message}`);
     return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
+  const sha = view.headRefOid;
+  const branch = view.headRefName;
+  const prState = view.state;
+  const mergeable = view.mergeable;
+  const mergeStateStatus = view.mergeStateStatus;
   if (!branch) {
     const message = `gh pr view did not include headRefName for PR #${prNumber}`;
     console.error(`${message}; treating as probe failure`);
@@ -434,16 +461,10 @@ export function probePr(prNumber: number, repo: string, run: ExecFn = exec): Pro
   }
   let state: InternalState;
   try {
-    const parsed = JSON.parse(checksResult.stdout || "[]");
-    if (!Array.isArray(parsed)) {
-      const message = `gh pr checks returned non-array JSON for PR #${prNumber}`;
-      console.error(`${message}; treating as probe failure`);
-      return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
-    }
-    state = deriveChecksState(parsed as Record<string, unknown>[]);
+    state = deriveChecksState(Checks.parse(JSON.parse(checksResult.stdout || "[]")));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error(`gh pr checks returned unparseable JSON for PR #${prNumber}: ${message}`);
+    console.error(`gh pr checks returned unusable JSON for PR #${prNumber}: ${message}`);
     return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
 
@@ -467,8 +488,7 @@ export function probePr(prNumber: number, repo: string, run: ExecFn = exec): Pro
   };
 }
 
-function buildRunProbe(run: Record<string, unknown>, fallbackRunId: string | null): Probe {
-  const headSha = typeof run.headSha === "string" ? run.headSha : "";
+function buildRunProbe(run: RunView, fallbackRunId: string | null): Probe {
   const rawId = run.databaseId;
   const runId =
     typeof rawId === "number"
@@ -476,11 +496,9 @@ function buildRunProbe(run: Record<string, unknown>, fallbackRunId: string | nul
       : typeof rawId === "string" && rawId.length > 0
         ? rawId
         : fallbackRunId;
-  const status = typeof run.status === "string" ? run.status : "";
-  const conclusion = typeof run.conclusion === "string" ? run.conclusion : "";
   return {
-    sha: headSha,
-    state: deriveRunListState({ status, conclusion }),
+    sha: run.headSha,
+    state: deriveRunListState(run),
     runId,
     mergeable: "MERGEABLE",
     mergeStateStatus: "CLEAN",
@@ -503,26 +521,19 @@ export function probeBranch(repo: string, branch: string, run: ExecFn = exec): P
       stderr: result.stderr,
     };
   }
-  let parsed: unknown;
+  let runs: RunView[];
   try {
-    parsed = JSON.parse(result.stdout || "[]");
+    runs = RunList.parse(JSON.parse(result.stdout || "[]"));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error(`gh run list returned unparseable JSON for ${repo}@${branch}: ${message}`);
+    console.error(`gh run list returned unusable JSON for ${repo}@${branch}: ${message}`);
     return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
-  if (!Array.isArray(parsed) || parsed.length === 0) {
+  const latest = runs[0];
+  if (!latest) {
     return { kind: "empty" };
   }
-  const rawRun = parsed[0];
-  if (!rawRun || typeof rawRun !== "object") {
-    return { kind: "empty" };
-  }
-  return {
-    kind: "ok",
-    branch: null,
-    probe: buildRunProbe(rawRun as Record<string, unknown>, null),
-  };
+  return { kind: "ok", branch: null, probe: buildRunProbe(latest, null) };
 }
 
 export function computeInterval(durationsSeconds: number[]): number {
@@ -544,14 +555,8 @@ function fetchInterval(branch: string, repo: string | null): number {
     return DEFAULT_INTERVAL_SECONDS;
   }
   try {
-    const parsed = JSON.parse(result.stdout || "[]");
-    if (Array.isArray(parsed)) {
-      const numbers = parsed.filter((n): n is number => typeof n === "number");
-      return computeInterval(numbers);
-    }
-    console.error(
-      `gh run list returned non-array JSON while computing poll interval for ${branch}; defaulting to ${DEFAULT_INTERVAL_SECONDS}s`,
-    );
+    const parsed = Durations.parse(JSON.parse(result.stdout || "[]"));
+    return computeInterval(parsed.filter((n): n is number => typeof n === "number"));
   } catch (err) {
     console.error(
       `gh run list returned unparseable JSON while computing poll interval for ${branch}; defaulting to ${DEFAULT_INTERVAL_SECONDS}s: ${err instanceof Error ? err.message : String(err)}`,
@@ -578,24 +583,15 @@ export function probeRunId(runId: string, repo: string, run: ExecFn = exec): Pro
       stderr: result.stderr,
     };
   }
-  let parsed: unknown;
+  let view: RunView;
   try {
-    parsed = JSON.parse(result.stdout || "{}");
+    view = RunView.parse(JSON.parse(result.stdout || "{}"));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error(`gh run view returned unparseable JSON for run ${runId}: ${message}`);
+    console.error(`gh run view returned unusable JSON for run ${runId}: ${message}`);
     return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
-  if (!parsed || typeof parsed !== "object") {
-    const message = `gh run view returned non-object JSON for run ${runId}`;
-    console.error(`${message}; treating as probe failure`);
-    return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
-  }
-  return {
-    kind: "ok",
-    branch: null,
-    probe: buildRunProbe(parsed as Record<string, unknown>, runId),
-  };
+  return { kind: "ok", branch: null, probe: buildRunProbe(view, runId) };
 }
 
 type RunOptions = {
@@ -789,7 +785,8 @@ async function main(): Promise<void> {
     return;
   }
 
-  await watch({ mode: "branch", repo: resolveRepo(), branch: branch as string, ...common });
+  if (!branch) return;
+  await watch({ mode: "branch", repo: resolveRepo(), branch, ...common });
 }
 
 if (import.meta.main) {

--- a/plugins/github/skills/copilot/scripts/review.test.ts
+++ b/plugins/github/skills/copilot/scripts/review.test.ts
@@ -11,6 +11,7 @@ import {
   exceedsEntitlement,
   type Meter,
   resolveTier,
+  type Snapshot,
   splitPaths,
   type Tier,
 } from "./review";
@@ -88,7 +89,7 @@ describe("budget", () => {
 
   // Each of these derives the other. Defaulting an absent credits_used to 0 would read an
   // account with 10 credits left as untouched, and the guard would clear every shape.
-  test.each<[string, Record<string, unknown>, number, number]>([
+  test.each<[string, Snapshot, number, number]>([
     ["both reported", { entitlement: 1500, credits_used: 447, remaining: 1052 }, 447, 1052],
     ["only credits_used", { entitlement: 1500, credits_used: 1490 }, 1490, 10],
     ["only remaining", { entitlement: 1500, remaining: 10 }, 1490, 10],

--- a/plugins/github/skills/copilot/scripts/review.ts
+++ b/plugins/github/skills/copilot/scripts/review.ts
@@ -6,6 +6,7 @@ import { dirname, join, sep } from "node:path";
 import { $ } from "bun";
 import { cli } from "cleye";
 import { getBorderCharacters, table } from "table";
+import { z } from "zod";
 
 const DEFAULT_MODEL = "gpt-5.6-terra";
 const CHEAP_MODEL = "gpt-5.6-luna";
@@ -101,22 +102,32 @@ export function daysUntilReset(resetDate: string, now: Date): number {
   return Math.max(1, Math.ceil((reset - now.getTime()) / 86_400_000));
 }
 
+const Snapshot = z.looseObject({
+  entitlement: z.number(),
+  credits_used: z.number().optional().catch(undefined),
+  remaining: z.number().optional().catch(undefined),
+});
+export type Snapshot = z.infer<typeof Snapshot>;
+
+const CopilotUser = z.looseObject({
+  quota_reset_date: z.string().optional().catch(undefined),
+  quota_snapshots: z.looseObject({ premium_interactions: z.unknown() }).optional().catch(undefined),
+});
+
 /**
  * Each figure derives the other, and an absent one must never fall back to a constant.
  * Defaulting a missing credits_used to 0 reads a nearly exhausted account as untouched, and
  * the guard then reserves against nothing and walks the session into billed overage.
  */
 export function deriveUsage(
-  snapshot: Record<string, unknown>,
+  snapshot: Snapshot,
   entitlement: number,
 ): { used: number; remaining: number } {
-  if (typeof snapshot.credits_used === "number") {
+  if (snapshot.credits_used !== undefined) {
     const used = snapshot.credits_used;
-    const remaining =
-      typeof snapshot.remaining === "number" ? snapshot.remaining : entitlement - used;
-    return { used, remaining };
+    return { used, remaining: snapshot.remaining ?? entitlement - used };
   }
-  if (typeof snapshot.remaining === "number") {
+  if (snapshot.remaining !== undefined) {
     return { used: entitlement - snapshot.remaining, remaining: snapshot.remaining };
   }
   throw new Error("premium_interactions quota reports neither credits_used nor remaining.");
@@ -136,23 +147,21 @@ export function readMeter(now: Date): Meter {
     throw new Error(`gh api /copilot_internal/user failed: ${result.stderr.toString().trim()}`);
   }
 
-  let payload: {
-    quota_reset_date?: string;
-    quota_snapshots?: { premium_interactions?: Record<string, unknown> };
-  };
+  let raw: unknown;
   try {
-    payload = JSON.parse(result.stdout.toString());
+    raw = JSON.parse(result.stdout.toString());
   } catch {
     throw new Error("gh api /copilot_internal/user returned output that is not JSON.");
   }
+  const payload = CopilotUser.parse(raw);
 
-  const snapshot = payload.quota_snapshots?.premium_interactions;
-  if (!snapshot || typeof snapshot.entitlement !== "number") {
+  const snapshot = Snapshot.safeParse(payload.quota_snapshots?.premium_interactions);
+  if (!snapshot.success) {
     throw new Error("No premium_interactions quota on this account.");
   }
 
-  const entitlement = snapshot.entitlement;
-  const { used, remaining } = deriveUsage(snapshot, entitlement);
+  const entitlement = snapshot.data.entitlement;
+  const { used, remaining } = deriveUsage(snapshot.data, entitlement);
   const resetDate = payload.quota_reset_date ?? "";
   const days = daysUntilReset(resetDate, now);
   const pace = remaining / days;

--- a/plugins/gitlab/hooks/auth.test.ts
+++ b/plugins/gitlab/hooks/auth.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import type { PostToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { processInput } from "./auth";
+import { type HookInput, processInput } from "./auth";
 
-function mockInput(command: string, toolResponse: unknown = {}): PostToolUseHookInput {
+function mockInput(command: string, toolResponse: unknown = {}): HookInput {
   return {
     session_id: "test",
     hook_event_name: "PostToolUse",
@@ -21,11 +20,11 @@ describe("glab auth hook", () => {
       stdout: "",
       stderr: 'oauth2: "invalid_grant" "The provided authorization grant is invalid"',
     });
-    const result = processInput(input);
-    expect(result).not.toBeNull();
-    expect(
-      (result?.hookSpecificOutput as { additionalContext: string }).additionalContext,
-    ).toContain("glab auth login");
+    const output = processInput(input)?.hookSpecificOutput;
+    if (output?.hookEventName !== "PostToolUse") {
+      throw new Error(`expected PostToolUse output, got ${JSON.stringify(output)}`);
+    }
+    expect(output.additionalContext).toContain("glab auth login");
   });
 
   it("ignores glab commands without auth errors", () => {

--- a/plugins/gitlab/hooks/auth.ts
+++ b/plugins/gitlab/hooks/auth.ts
@@ -1,9 +1,17 @@
 #!/usr/bin/env bun
 
-import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
 
-export function processInput(input: PostToolUseHookInput): SyncHookJSONOutput | null {
-  const command = (input.tool_input as { command?: string }).command;
+export const HookInput = z.looseObject({
+  hook_event_name: z.literal("PostToolUse"),
+  tool_input: z.looseObject({ command: z.string().optional().catch(undefined) }).catch({}),
+  tool_response: z.unknown(),
+});
+export type HookInput = z.infer<typeof HookInput>;
+
+export function processInput(input: HookInput): SyncHookJSONOutput | null {
+  const command = input.tool_input.command;
   if (!command || !command.includes("glab")) return null;
 
   const response = JSON.stringify(input.tool_response ?? "");
@@ -19,16 +27,16 @@ export function processInput(input: PostToolUseHookInput): SyncHookJSONOutput | 
 }
 
 async function main(): Promise<void> {
-  let input: PostToolUseHookInput;
+  let raw: unknown;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PostToolUseHookInput;
+    raw = JSON.parse(await Bun.stdin.text());
   } catch {
     return;
   }
+  const input = HookInput.safeParse(raw);
+  if (!input.success) return;
 
-  if (input.hook_event_name !== "PostToolUse") return;
-
-  const output = processInput(input);
+  const output = processInput(input.data);
   if (output) {
     process.stdout.write(`${JSON.stringify(output)}\n`);
   }

--- a/plugins/gitlab/hooks/lint.test.ts
+++ b/plugins/gitlab/hooks/lint.test.ts
@@ -2,10 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-import { defaultEnv, type LintEnv, MARKER_DIR, processInput } from "./lint";
+import { defaultEnv, type HookInput, type LintEnv, MARKER_DIR, processInput } from "./lint";
 
-function mockInput(command: string, cwd = "/repo"): PreToolUseHookInput {
+function mockInput(command: string, cwd = "/repo"): HookInput {
   return {
     session_id: "test-session",
     hook_event_name: "PreToolUse",
@@ -30,10 +29,8 @@ function fakeEnv(files: Record<string, string> = {}): LintEnv & { touched: strin
 }
 
 function decision(result: Awaited<ReturnType<typeof processInput>>) {
-  const output = result?.hookSpecificOutput as
-    | { permissionDecision?: string; permissionDecisionReason?: string; additionalContext?: string }
-    | undefined;
-  return output;
+  const output = result?.hookSpecificOutput;
+  return output?.hookEventName === "PreToolUse" ? output : undefined;
 }
 
 const GITLAB_REPO = {

--- a/plugins/gitlab/hooks/lint.ts
+++ b/plugins/gitlab/hooks/lint.ts
@@ -1,7 +1,16 @@
 #!/usr/bin/env bun
 
 import { dirname, isAbsolute, join, resolve } from "node:path";
-import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+export const HookInput = z.looseObject({
+  hook_event_name: z.literal("PreToolUse"),
+  session_id: z.string(),
+  cwd: z.string(),
+  tool_input: z.looseObject({ command: z.string().optional().catch(undefined) }).catch({}),
+});
+export type HookInput = z.infer<typeof HookInput>;
 
 // The <session_id> "loaded" marker is written by the bang-execution line in
 // skills/merge-request/SKILL.md. Keep the path in sync with that command.
@@ -187,10 +196,10 @@ export async function nudgeSkill(
 }
 
 export async function processInput(
-  input: PreToolUseHookInput,
+  input: HookInput,
   env: LintEnv = defaultEnv,
 ): Promise<SyncHookJSONOutput | null> {
-  const command = (input.tool_input as { command?: string }).command;
+  const command = input.tool_input.command;
   if (!command) return null;
 
   if (command.includes("glab")) {
@@ -211,16 +220,16 @@ export async function processInput(
 }
 
 async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
+  let raw: unknown;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
+    raw = JSON.parse(await Bun.stdin.text());
   } catch {
     return;
   }
+  const input = HookInput.safeParse(raw);
+  if (!input.success) return;
 
-  if (input.hook_event_name !== "PreToolUse") return;
-
-  const output = await processInput(input);
+  const output = await processInput(input.data);
   if (output) {
     process.stdout.write(`${JSON.stringify(output)}\n`);
   }

--- a/plugins/gitlab/package.json
+++ b/plugins/gitlab/package.json
@@ -7,6 +7,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
     "cleye": "^2.2.1",
     "table": "^6.9.0",
-    "url-pattern": "^1.0.3"
+    "url-pattern": "^1.0.3",
+    "zod": "^4.4.3"
   }
 }

--- a/plugins/gitlab/scripts/fetch.test.ts
+++ b/plugins/gitlab/scripts/fetch.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, it, test } from "bun:test";
-import type {
-  PreToolUseHookInput,
-  PreToolUseHookSpecificOutput,
-} from "@anthropic-ai/claude-agent-sdk";
-import { formatOutput, isGitLabUrl, parseGitLabUrl, processInput } from "./fetch";
+import type { PreToolUseHookSpecificOutput } from "@anthropic-ai/claude-agent-sdk";
+import { formatOutput, type HookInput, isGitLabUrl, parseGitLabUrl, processInput } from "./fetch";
 
-function mockInput(url: string): PreToolUseHookInput {
+function mockInput(url: string): HookInput {
   return {
     hook_event_name: "PreToolUse",
     session_id: "test",
@@ -17,10 +14,10 @@ function mockInput(url: string): PreToolUseHookInput {
   };
 }
 
-function getOutput(input: PreToolUseHookInput): PreToolUseHookSpecificOutput | null {
-  const result = processInput(input);
-  if (!result) return null;
-  return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
+function getOutput(input: HookInput): PreToolUseHookSpecificOutput | null {
+  const output = processInput(input)?.hookSpecificOutput;
+  if (output?.hookEventName !== "PreToolUse") return null;
+  return output;
 }
 
 describe("isGitLabUrl", () => {

--- a/plugins/gitlab/scripts/fetch.ts
+++ b/plugins/gitlab/scripts/fetch.ts
@@ -1,9 +1,16 @@
 #!/usr/bin/env bun
 
-import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import UrlPattern from "url-pattern";
+import { z } from "zod";
 
-export type WebFetchInput = { url: string; prompt: string };
+const WebFetchInput = z.looseObject({ url: z.string() });
+
+export const HookInput = z.looseObject({ tool_input: z.unknown() });
+export type HookInput = z.infer<typeof HookInput>;
+
+// url-pattern's match() returns `any`.
+const Params = z.record(z.string(), z.string());
 
 type RouteMatch = {
   type: string;
@@ -61,9 +68,9 @@ export function isGitLabUrl(url: string): boolean {
 
 export function matchRoute(path: string): RouteMatch | null {
   for (const route of routes) {
-    const params = route.pattern.match(path);
-    if (params) {
-      return { type: route.type, params };
+    const params = Params.safeParse(route.pattern.match(path));
+    if (params.success) {
+      return { type: route.type, params: params.data };
     }
   }
   return null;
@@ -115,8 +122,8 @@ export function formatOutput(
   };
 }
 
-export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {
-  const { url } = input.tool_input as WebFetchInput;
+export function processInput(input: HookInput): SyncHookJSONOutput | null {
+  const { url } = WebFetchInput.parse(input.tool_input);
 
   if (!isGitLabUrl(url)) {
     return null;
@@ -131,9 +138,9 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
 }
 
 async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
+  let input: HookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
+    input = HookInput.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     console.error(
       `[gitlab/fetch] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/gitlab/scripts/merge.ts
+++ b/plugins/gitlab/scripts/merge.ts
@@ -2,6 +2,7 @@
 
 import { $ } from "bun";
 import { cli } from "cleye";
+import { z } from "zod";
 
 // glab has no merge-train command: `glab mr merge --auto-merge` hits the accept
 // endpoint (PUT .../merge). GitLab 19.1+ resolves that to the train server-side,
@@ -22,12 +23,17 @@ export function streamText(stream: unknown): string {
   return "";
 }
 
+const ShellFailure = z.looseObject({
+  stdout: z.unknown().optional(),
+  stderr: z.unknown().optional(),
+});
+
 export function errorText(err: unknown): string {
   // glab spreads a failure across both streams: `glab api` prints the HTTP error body
   // (the JSON message) to stdout and a `glab: <message> (HTTP <code>)` line to stderr.
   // Read both so the already-armed guard matches and callers see the full error text.
-  const record = err as Record<string, unknown>;
-  const streams = [record?.stdout, record?.stderr]
+  const failure = ShellFailure.safeParse(err);
+  const streams = (failure.success ? [failure.data.stdout, failure.data.stderr] : [])
     .map((stream) => streamText(stream).trim())
     .filter((text) => text.length > 0);
   if (streams.length > 0) {
@@ -61,24 +67,20 @@ export async function arm(
   }
 }
 
-interface ProjectConfig {
-  id: number;
-  merge_trains_enabled: boolean;
-}
+const ProjectConfig = z.looseObject({ id: z.number(), merge_trains_enabled: z.boolean() });
+type ProjectConfig = z.infer<typeof ProjectConfig>;
 
 export async function getProjectConfig(): Promise<ProjectConfig> {
-  return $`glab api projects/:id`.json();
+  return ProjectConfig.parse(await $`glab api projects/:id`.json());
 }
 
-interface MergeRequest {
-  iid: number;
-}
+const MergeRequests = z.array(z.looseObject({ iid: z.number() }));
 
 export async function getMrIid(branch: string): Promise<number> {
-  const mrs: MergeRequest[] =
-    await $`glab api projects/:id/merge_requests -X GET --field source_branch=${branch} --field state=opened`.json();
+  const [mr] = MergeRequests.parse(
+    await $`glab api projects/:id/merge_requests -X GET --field source_branch=${branch} --field state=opened`.json(),
+  );
 
-  const [mr] = mrs;
   if (!mr) {
     throw new Error(`No open MR found for branch: ${branch}`);
   }
@@ -86,23 +88,24 @@ export async function getMrIid(branch: string): Promise<number> {
   return mr.iid;
 }
 
-export interface MergeRequestDetail {
-  iid: number;
-  title: string;
-  state: string;
-  draft: boolean;
-  web_url: string;
-  source_branch: string;
-  target_branch: string;
-  detailed_merge_status: string;
-  has_conflicts: boolean;
-  blocking_discussions_resolved: boolean;
-  auto_merge_enabled?: boolean;
-  head_pipeline?: { id: number; status: string } | null;
-}
+export const MergeRequestDetail = z.looseObject({
+  iid: z.number(),
+  title: z.string(),
+  state: z.string(),
+  draft: z.boolean(),
+  web_url: z.string(),
+  source_branch: z.string(),
+  target_branch: z.string(),
+  detailed_merge_status: z.string(),
+  has_conflicts: z.boolean(),
+  blocking_discussions_resolved: z.boolean(),
+  auto_merge_enabled: z.boolean().optional(),
+  head_pipeline: z.looseObject({ id: z.number(), status: z.string() }).nullish(),
+});
+export type MergeRequestDetail = z.infer<typeof MergeRequestDetail>;
 
 export async function getMergeRequest(iid: number): Promise<MergeRequestDetail> {
-  return $`glab api projects/:id/merge_requests/${iid}`.json();
+  return MergeRequestDetail.parse(await $`glab api projects/:id/merge_requests/${iid}`.json());
 }
 
 // The API's has_conflicts/detailed_merge_status stay stale for minutes after a
@@ -172,10 +175,10 @@ const defaultActions: MergeActions = {
   mergeViaGlab,
 };
 
-export interface MergeRequestStatus extends MergeRequestDetail {
+export type MergeRequestStatus = MergeRequestDetail & {
   merge_trains_enabled: boolean;
   rebased_on_target: boolean | null;
-}
+};
 
 export async function status(
   branch: string,

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
@@ -301,8 +301,8 @@ describe("pipelineDurations", () => {
   ])("$name", ({ raw, expected }) => {
     const durations = pipelineDurations(raw);
     expect(durations).toHaveLength(expected.length);
-    durations.forEach((seconds, index) => {
-      expect(seconds).toBeCloseTo(expected[index] as number, 2);
+    expected.forEach((seconds, index) => {
+      expect(durations[index]).toBeCloseTo(seconds, 2);
     });
   });
 

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
@@ -4,6 +4,7 @@ import { type ExecSyncOptions, execSync } from "node:child_process";
 import { streamText } from "../../../scripts/merge";
 import { cli } from "cleye";
 import UrlPattern from "url-pattern";
+import { z } from "zod";
 
 const DEFAULT_INTERVAL_SECONDS = 180;
 const NO_HISTORY_INTERVAL_SECONDS = 30;
@@ -18,6 +19,41 @@ const MERGE_STATUS_RECHECK_SECONDS = 5;
 export type StatusState = "running" | "failing" | "success";
 export type InternalState = StatusState | "queued";
 export type MrState = "opened" | "closed" | "merged" | "locked";
+
+const Entries = z.array(z.unknown());
+
+// url-pattern's match() returns `any`.
+const TailMatch = z.looseObject({ iid: z.string() });
+
+const PipelineEntry = z.looseObject({
+  id: z.union([z.number(), z.string()]).optional().catch(undefined),
+  status: z.string().catch(""),
+  sha: z.string().catch(""),
+  source: z.string().catch(""),
+});
+
+const TimedPipeline = z.looseObject({
+  status: z.string(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+const JobEntry = z.looseObject({
+  name: z.string().catch(""),
+  status: z.string().catch(""),
+  allow_failure: z.boolean().catch(false),
+});
+
+const MrView = z.looseObject({
+  sha: z.string().catch(""),
+  source_branch: z.string().catch(""),
+  has_conflicts: z.boolean().catch(false),
+  merge_status: z.string().catch(""),
+  detailed_merge_status: z.string().catch(""),
+  state: z
+    .enum(["opened", "closed", "merged", "locked"])
+    .catch("opened") satisfies z.ZodType<MrState>,
+});
 
 export type Probe = {
   sha: string;
@@ -203,11 +239,11 @@ export function parseMrUrl(url: string): {
   }
   const tailPattern = new UrlPattern(":iid(/*)");
   const tail = path.slice(markerIndex + marker.length);
-  const tailMatch = tailPattern.match(tail);
-  if (!tailMatch) {
+  const tailMatch = TailMatch.safeParse(tailPattern.match(tail));
+  if (!tailMatch.success) {
     throw new Error(`Invalid GitLab MR URL: ${url}`);
   }
-  const iid = Number.parseInt(tailMatch.iid, 10);
+  const iid = Number.parseInt(tailMatch.data.iid, 10);
   if (Number.isNaN(iid)) {
     throw new Error(`Invalid MR IID in URL: ${url}`);
   }
@@ -274,22 +310,21 @@ export type PipelineRecord = {
 const EXCLUDED_PIPELINE_SOURCES = ["external", "parent_pipeline"];
 
 export function parsePipelineList(raw: unknown): PipelineRecord[] | null {
-  if (!Array.isArray(raw)) return null;
+  const entries = Entries.safeParse(raw);
+  if (!entries.success) return null;
   const records: PipelineRecord[] = [];
-  for (const entry of raw) {
-    if (!entry || typeof entry !== "object") continue;
-    const fields = entry as Record<string, unknown>;
-    const rawId = fields.id;
-    if (typeof rawId !== "number" && typeof rawId !== "string") continue;
-    const id = Number(rawId);
+  for (const entry of entries.data) {
+    const fields = PipelineEntry.safeParse(entry);
+    if (!fields.success) continue;
+    const id = Number(fields.data.id);
     // `Number("")` is 0, so an empty id would otherwise become a `run_id` of
     // "0" and get handed to the logs agent as if it were a real pipeline.
     if (!Number.isFinite(id) || id <= 0) continue;
     records.push({
       id,
-      status: normalizePipelineStatus(typeof fields.status === "string" ? fields.status : ""),
-      sha: typeof fields.sha === "string" ? fields.sha : "",
-      source: typeof fields.source === "string" ? fields.source : "",
+      status: normalizePipelineStatus(fields.data.status),
+      sha: fields.data.sha,
+      source: fields.data.source,
     });
   }
   return records;
@@ -346,15 +381,11 @@ const TIMED_PIPELINE_STATUSES = new Set(["success", "failed", "canceled"]);
 export function pipelineDurations(raw: unknown[]): number[] {
   const durations: number[] = [];
   for (const entry of raw) {
-    if (!entry || typeof entry !== "object") continue;
-    const record = entry as Record<string, unknown>;
-    const status = record.status;
-    const createdAt = record.created_at;
-    const updatedAt = record.updated_at;
-    if (typeof status !== "string" || !TIMED_PIPELINE_STATUSES.has(status)) continue;
-    if (typeof createdAt !== "string" || typeof updatedAt !== "string") continue;
-    const started = Date.parse(createdAt);
-    const ended = Date.parse(updatedAt);
+    const record = TimedPipeline.safeParse(entry);
+    if (!record.success) continue;
+    if (!TIMED_PIPELINE_STATUSES.has(record.data.status)) continue;
+    const started = Date.parse(record.data.created_at);
+    const ended = Date.parse(record.data.updated_at);
     if (Number.isNaN(started) || Number.isNaN(ended)) continue;
     const seconds = (ended - started) / 1000;
     if (seconds > 0) durations.push(seconds);
@@ -428,17 +459,17 @@ function fetchMrMetadata(
     return { ok: false, rateLimited: result.rateLimited, retryAfter: result.retryAfter };
   }
   try {
-    const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
-    const sha = typeof parsed.sha === "string" ? parsed.sha : "";
-    const sourceBranch = typeof parsed.source_branch === "string" ? parsed.source_branch : "";
-    const hasConflicts = parsed.has_conflicts === true;
-    const mergeStatus = typeof parsed.merge_status === "string" ? parsed.merge_status : "";
-    const detailedMergeStatus =
-      typeof parsed.detailed_merge_status === "string" ? parsed.detailed_merge_status : "";
-    const state = (typeof parsed.state === "string" ? parsed.state : "opened") as MrState;
+    const parsed = MrView.parse(JSON.parse(result.stdout));
     return {
       ok: true,
-      metadata: { sha, sourceBranch, hasConflicts, mergeStatus, detailedMergeStatus, state },
+      metadata: {
+        sha: parsed.sha,
+        sourceBranch: parsed.source_branch,
+        hasConflicts: parsed.has_conflicts,
+        mergeStatus: parsed.merge_status,
+        detailedMergeStatus: parsed.detailed_merge_status,
+        state: parsed.state,
+      },
     };
   } catch (err) {
     console.error(
@@ -489,15 +520,12 @@ export async function resolveMergeStatus(
   return current;
 }
 
-function parsePipeline(
-  parsed: Record<string, unknown>,
-): { id: string; status: InternalState; sha: string } | null {
-  const rawId = parsed.id;
-  const id = typeof rawId === "number" || typeof rawId === "string" ? String(rawId) : "";
+function parsePipeline(parsed: unknown): { id: string; status: InternalState; sha: string } | null {
+  const fields = PipelineEntry.safeParse(parsed);
+  if (!fields.success) return null;
+  const id = fields.data.id === undefined ? "" : String(fields.data.id);
   if (!id) return null;
-  const status = typeof parsed.status === "string" ? parsed.status : "";
-  const sha = typeof parsed.sha === "string" ? parsed.sha : "";
-  return { id, status: normalizePipelineStatus(status), sha };
+  return { id, status: normalizePipelineStatus(fields.data.status), sha: fields.data.sha };
 }
 
 export type PipelineTarget = { kind: "mr"; iid: number } | { kind: "branch"; branch: string };
@@ -569,18 +597,19 @@ function fetchJobs(projectEncoded: string, pipelineId: string, run: ExecFn = exe
     );
     return { ok: false };
   }
-  if (!Array.isArray(parsed)) {
+  const entries = Entries.safeParse(parsed);
+  if (!entries.success) {
     console.error(`glab api returned non-array JSON for jobs on pipeline ${pipelineId}`);
     return { ok: false };
   }
   const jobs: JobRecord[] = [];
-  for (const entry of parsed) {
-    if (!entry || typeof entry !== "object") continue;
-    const fields = entry as Record<string, unknown>;
+  for (const entry of entries.data) {
+    const fields = JobEntry.safeParse(entry);
+    if (!fields.success) continue;
     jobs.push({
-      name: typeof fields.name === "string" ? fields.name : "",
-      status: typeof fields.status === "string" ? fields.status : "",
-      allowFailure: fields.allow_failure === true,
+      name: fields.data.name,
+      status: fields.data.status,
+      allowFailure: fields.data.allow_failure,
     });
   }
   return { ok: true, jobs };
@@ -694,8 +723,7 @@ function fetchPipelineById(
     };
   }
   try {
-    const parsed = JSON.parse(result.stdout || "null") as Record<string, unknown> | null;
-    const pipeline = parsed ? parsePipeline(parsed) : null;
+    const pipeline = parsePipeline(JSON.parse(result.stdout || "null"));
     if (!pipeline) {
       // A successful glab call with an empty/null body for a specific pipeline
       // ID is unexpected (404s fail the exec). Surface this as a transient
@@ -783,9 +811,9 @@ function fetchInterval(projectEncoded: string, target: PipelineTarget): number {
     return DEFAULT_INTERVAL_SECONDS;
   }
   try {
-    const parsed = JSON.parse(result.stdout || "[]");
-    if (Array.isArray(parsed)) {
-      return computeInterval(pipelineDurations(parsed));
+    const parsed = Entries.safeParse(JSON.parse(result.stdout || "[]"));
+    if (parsed.success) {
+      return computeInterval(pipelineDurations(parsed.data));
     }
     console.error(
       `glab api returned non-array JSON while computing poll interval for ${label}; defaulting to ${DEFAULT_INTERVAL_SECONDS}s`,

--- a/plugins/gitlab/skills/merge-request/scripts/diff.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/diff.ts
@@ -2,13 +2,22 @@ import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { $ } from "bun";
+import { z } from "zod";
 import { errorText } from "../../../scripts/merge";
 
-export type DiffRefs = { base_sha: string; head_sha: string; start_sha: string };
+const Entries = z.array(z.unknown());
+
+export const DiffRefs = z.looseObject({
+  base_sha: z.string(),
+  head_sha: z.string(),
+  start_sha: z.string(),
+});
+export type DiffRefs = z.infer<typeof DiffRefs>;
 
 export async function getDiffRefs(iid: number | string): Promise<DiffRefs> {
-  const result = await $`glab api projects/:id/merge_requests/${iid} | jq '.diff_refs'`.json();
-  return result as DiffRefs;
+  return DiffRefs.parse(
+    await $`glab api projects/:id/merge_requests/${iid} | jq '.diff_refs'`.json(),
+  );
 }
 
 export type Hunk = {
@@ -41,20 +50,19 @@ export function isLineInDiff(hunks: Hunk[], line: number, side: "new" | "old"): 
   return false;
 }
 
-type MrDiff = {
-  old_path: string;
-  new_path: string;
-  diff: string;
-};
+const MrDiffs = z.array(
+  z.looseObject({ old_path: z.string(), new_path: z.string(), diff: z.string() }),
+);
+type MrDiff = z.infer<typeof MrDiffs>[number];
 
 export function parseGlabPaginated(raw: string): unknown[] {
   const fixed = raw.replace(/\]\s*\[/g, ",");
-  return JSON.parse(fixed);
+  return Entries.parse(JSON.parse(fixed));
 }
 
 export async function fetchMrDiffs(iid: number | string): Promise<MrDiff[]> {
   const raw = await $`glab api projects/:id/merge_requests/${iid}/diffs --paginate`.text();
-  return parseGlabPaginated(raw) as MrDiff[];
+  return MrDiffs.parse(parseGlabPaginated(raw));
 }
 
 export function validateLineInDiff(

--- a/plugins/gitlab/skills/merge-request/scripts/discussions.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/discussions.ts
@@ -3,6 +3,7 @@
 import { $ } from "bun";
 import { cli, command } from "cleye";
 import { table } from "table";
+import { z } from "zod";
 import {
   buildPosition,
   exitOnRejection,
@@ -19,33 +20,40 @@ export { parseGlabPaginated } from "./diff";
 
 exitOnRejection();
 
-type LineRange = {
-  start: { type: "new" | "old"; new_line?: number; old_line?: number };
-  end: { type: "new" | "old"; new_line?: number; old_line?: number };
-};
+const LineEnd = z.looseObject({
+  type: z.enum(["new", "old"]),
+  new_line: z.number().optional(),
+  old_line: z.number().optional(),
+});
 
-type Position = {
-  new_path?: string;
-  old_path?: string;
-  new_line?: number;
-  old_line?: number;
-  position_type?: string;
-  line_range?: LineRange | null;
-};
+const LineRange = z.looseObject({ start: LineEnd, end: LineEnd });
 
-type Note = {
-  author: { username: string };
-  body: string;
-  resolved?: boolean;
-  resolvable?: boolean;
-  position?: Position | null;
-};
+const Position = z.looseObject({
+  new_path: z.string().optional(),
+  old_path: z.string().optional(),
+  new_line: z.number().optional(),
+  old_line: z.number().optional(),
+  position_type: z.string().optional(),
+  line_range: LineRange.nullish(),
+});
+
+const Note = z.looseObject({
+  author: z.looseObject({ username: z.string() }),
+  body: z.string(),
+  resolved: z.boolean().optional(),
+  resolvable: z.boolean().optional(),
+  position: Position.nullish(),
+});
 
 // GitLab omits or nulls `notes` on some system/individual-note discussions.
-export type Discussion = {
-  id: string;
-  notes?: Note[] | null;
-};
+export const Discussion = z.looseObject({
+  id: z.string(),
+  notes: z.array(Note).nullish(),
+});
+export type Discussion = z.infer<typeof Discussion>;
+type Note = z.infer<typeof Note>;
+
+const Discussions = z.array(Discussion);
 
 function firstNote(d: Discussion): Note | null {
   return d.notes?.[0] ?? null;
@@ -252,7 +260,7 @@ const listCmd = command(
   async (parsed) => {
     const iid = parsed._.iid;
     const raw = await $`glab api projects/:id/merge_requests/${iid}/discussions --paginate`.text();
-    let discussions = parseGlabPaginated(raw) as Discussion[];
+    let discussions = Discussions.parse(parseGlabPaginated(raw));
 
     discussions = filterDiscussions(discussions, await buildFilterOptions(parsed.flags));
 
@@ -295,7 +303,7 @@ const summaryCmd = command(
   async (parsed) => {
     const iid = parsed._.iid;
     const raw = await $`glab api projects/:id/merge_requests/${iid}/discussions --paginate`.text();
-    const discussions = parseGlabPaginated(raw) as Discussion[];
+    const discussions = Discussions.parse(parseGlabPaginated(raw));
 
     const resolvable = discussions.filter((d) => firstNote(d)?.resolvable);
     const resolved = resolvable.filter((d) => firstNote(d)?.resolved);

--- a/plugins/gitlab/skills/merge-request/scripts/draft-note.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/draft-note.ts
@@ -2,6 +2,7 @@
 
 import { $ } from "bun";
 import { cli, command } from "cleye";
+import { z } from "zod";
 import {
   buildPosition,
   exitOnRejection,
@@ -11,6 +12,16 @@ import {
   readBody,
   validateLineInDiff,
 } from "./diff";
+
+const RequestChangesResponse = z.looseObject({
+  data: z
+    .looseObject({
+      mergeRequestRequestChanges: z
+        .looseObject({ errors: z.array(z.string()).nullish() })
+        .nullish(),
+    })
+    .nullish(),
+});
 
 exitOnRejection();
 
@@ -144,11 +155,12 @@ const submitCmd = command(
           errors
         }
       }`;
-      const gqlResult =
-        await $`glab api graphql -f query=${query} -f projectPath=${projectPath} -f iid=${String(mr)}`.json();
-      const payload = gqlResult?.data?.mergeRequestRequestChanges;
-      if (payload?.errors?.length) {
-        console.error(`Request changes failed: ${payload.errors.join(", ")}`);
+      const gqlResult = RequestChangesResponse.parse(
+        await $`glab api graphql -f query=${query} -f projectPath=${projectPath} -f iid=${String(mr)}`.json(),
+      );
+      const errors = gqlResult.data?.mergeRequestRequestChanges?.errors ?? [];
+      if (errors.length > 0) {
+        console.error(`Request changes failed: ${errors.join(", ")}`);
         process.exit(1);
       }
       console.error("Requested changes");
@@ -168,12 +180,14 @@ const listCmd = command(
   },
 );
 
-type ReviewEntry = {
-  file?: string;
-  line?: number;
-  oldLine?: number;
-  body: string;
-};
+const ReviewEntries = z.array(
+  z.looseObject({
+    file: z.string().optional(),
+    line: z.number().optional(),
+    oldLine: z.number().optional(),
+    body: z.string(),
+  }),
+);
 
 const reviewCmd = command(
   {
@@ -204,7 +218,7 @@ const reviewCmd = command(
       process.exit(1);
     }
 
-    const entries: ReviewEntry[] = JSON.parse(await Bun.file(parsed.flags.input).text());
+    const entries = ReviewEntries.parse(JSON.parse(await Bun.file(parsed.flags.input).text()));
     const hasPositioned = entries.some((e) => e.file);
 
     const [refs, diffs] = hasPositioned

--- a/plugins/gitlab/skills/merge-request/scripts/review-queue.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/review-queue.ts
@@ -2,25 +2,38 @@
 
 import { $ } from "bun";
 import { cli } from "cleye";
+import { z } from "zod";
 
-export type ReviewState = "UNREVIEWED" | "REVIEW_STARTED" | "REQUESTED_CHANGES" | "APPROVED";
+export const ReviewState = z.enum([
+  "UNREVIEWED",
+  "REVIEW_STARTED",
+  "REQUESTED_CHANGES",
+  "APPROVED",
+]);
+export type ReviewState = z.infer<typeof ReviewState>;
 
-type Reviewer = {
-  username: string;
-  mergeRequestInteraction: { reviewState: ReviewState | null } | null;
-};
+const Reviewer = z.looseObject({
+  username: z.string(),
+  mergeRequestInteraction: z.looseObject({ reviewState: ReviewState.nullable() }).nullish(),
+});
 
-type MergeRequestNode = {
-  reference: string;
-  webUrl: string;
-  title: string;
-  reviewers: { nodes: Reviewer[] } | null;
-};
+const MergeRequestNode = z.looseObject({
+  reference: z.string(),
+  webUrl: z.string(),
+  title: z.string(),
+  reviewers: z.looseObject({ nodes: z.array(Reviewer) }).nullish(),
+});
 
-export type CurrentUser = {
-  username: string;
-  reviewRequestedMergeRequests: { nodes: MergeRequestNode[] };
-};
+export const CurrentUser = z.looseObject({
+  username: z.string(),
+  reviewRequestedMergeRequests: z.looseObject({ nodes: z.array(MergeRequestNode) }),
+});
+export type CurrentUser = z.infer<typeof CurrentUser>;
+
+const ReviewQueueResponse = z.looseObject({
+  data: z.looseObject({ currentUser: CurrentUser.nullish() }).nullish(),
+  errors: z.array(z.looseObject({ message: z.string() })).nullish(),
+});
 
 export type ReviewQueueEntry = { url: string; reference: string; title: string };
 
@@ -68,10 +81,7 @@ if (import.meta.main) {
       flags: {},
     },
     async () => {
-      const result = (await $`glab api graphql -f query=${QUERY}`.json()) as {
-        data?: { currentUser?: CurrentUser | null };
-        errors?: Array<{ message: string }>;
-      };
+      const result = ReviewQueueResponse.parse(await $`glab api graphql -f query=${QUERY}`.json());
       if (result.errors?.length) {
         console.error(`GraphQL errors: ${result.errors.map((e) => e.message).join("; ")}`);
         process.exit(1);


### PR DESCRIPTION
Migrates every `gh` and `glab` seam in both plugins onto zod schemas. Third layer of the stack; the boundary and the rule reversal are in #1271.

The two plugins go from 44 hits across the five `no-unsafe-*` rules and 37 on `no-unsafe-type-assertion` to zero on all six.

| Seam | Was | Now |
|---|---|---|
| `gh pr view --json`, `gh run list --json` | `JSON.parse(out) as PrView` | `PrView.parse(JSON.parse(out))` |
| `gh api graphql` | response shape asserted per call site | `ghGraphQL(schema, query, variables)` |
| `glab api ... \| jq` through Bun `$` | a `Promise<T>` annotation over `any` | `Schema.parse(await $\`...\`.json())` |
| Hook stdin (4 hooks) | `JSON.parse(text) as PreToolUseHookInput` | a local `HookInput` schema |
| `url-pattern.match()` | `any` flowing into route params | `z.record(z.string(), z.string())` |
| `gh api /copilot_internal/user` | `Record<string, unknown>` probing | `CopilotUser`, `Snapshot` |

## Plugin Distribution

Neither plugin imports `packages/decode`. Auto-install skips `workspace:*`. Both declare `zod` in their own `package.json` and call `schema.parse` directly, the way `plugins/things` already does.

## Tolerant Fields

A forge that widens an enum must not fail a poll. So `mergeable`, `mergeStateStatus`, MR `state`, and pipeline and job `status` take `.catch(...)`, which lands an unrecognized value on the arm the caller already treats as undetermined. `gh` documents `UNKNOWN` for this.

## Required Unknowns

`z.unknown()` is a required key inside a zod v4 object. `errorText` reads `stdout` and `stderr` off a rejected Bun `$` promise, and glab populates only one of them, so a schema declaring both plainly rejects every real failure. Both carry `.optional()`. The round-trip test caught the first attempt.

## Signatures

`deriveChecksState`, `deriveUsage`, and `processInput` in all four hooks take the inferred schema type now. Under `exactOptionalPropertyTypes` a schema's `state?: string | undefined` and a hand-written `state?: string` are different types, so the interfaces could not stay.

`getMrIid` destructures the first MR and throws by name where it asserted `mrs[0]!`. `parseGlabPaginated` decodes its concatenated pages as an array, so a body the fix-up did not turn into one fails at the seam instead of downstream.

## Live Runs

`pr-comments.ts` against a real PR rejected its own first schema. `reviewThreads.pageInfo.endCursor` is null on a PR with no threads, and `pullRequest.author` is null for a deleted account. Both are nullable now, and the cursor loop and the author fallback read them that way. The unit fixtures had never held a payload GitHub actually sends.

The rest ran against live data:

- `watch.ts` in PR, run-id, and branch mode.
- `review-threads.ts` resolving a thread's first comment id, and returning nothing for an id that does not exist.
- `copilot/review.ts --status` against the quota endpoint.
- Each of the four hooks on stdin.

GitLab has none. Its OAuth token is expired and re-authenticating needs a browser. That failure exercised one thing anyway: the migrated `hooks/auth.ts` caught the `invalid_grant` and printed its recovery line.
