### PR TITLE
comments: decode external data at the seams

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -102,6 +102,7 @@
         "parse-diff": "^0.12.0",
         "shiki": "^4.3.0",
         "table": "^6.9.0",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.116.0",

--- a/plugins/comments/apply/comment-syntax.test.ts
+++ b/plugins/comments/apply/comment-syntax.test.ts
@@ -9,8 +9,8 @@ import type { EditItem } from "./edits";
  */
 function span(source: string, kind: CommentKind = "line"): { lines: string[]; item: EditItem } {
   const lines = source.split("\n");
-  const first = lines[0] as string;
-  const last = lines[lines.length - 1] as string;
+  const first = lines[0] ?? "";
+  const last = lines.at(-1) ?? "";
   return {
     lines,
     item: {

--- a/plugins/comments/apply/edits.test.ts
+++ b/plugins/comments/apply/edits.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
+import { z } from "zod";
 import type { CommentKind } from "../detection/types";
 import type { Verdict } from "../judge/schema";
 import { computeFileEdits, type EditItem } from "./edits";
@@ -596,14 +597,29 @@ describe("computeFileEdits", () => {
   });
 });
 
+const FixtureFile = z.looseObject({
+  comment: z.string(),
+  kind: z.enum(["line", "block", "docstring"]) satisfies z.ZodType<CommentKind>,
+  trimTo: z.string(),
+  trimToLines: z.array(z.number()),
+});
+
 describe("migration-data-migration-mixed convention", () => {
   test("trimToLines:[2] keeps the genuine why line and drops the restatement", async () => {
-    const fixture = JSON.parse(
-      await Bun.file(
-        join(import.meta.dirname, "..", "evals", "fixtures", "migration-data-migration-mixed.json"),
-      ).text(),
+    const fixture = FixtureFile.parse(
+      JSON.parse(
+        await Bun.file(
+          join(
+            import.meta.dirname,
+            "..",
+            "evals",
+            "fixtures",
+            "migration-data-migration-mixed.json",
+          ),
+        ).text(),
+      ),
     );
-    const [first, second] = fixture.comment.split("\n") as [string, string];
+    const [first = "", second = ""] = fixture.comment.split("\n");
     expect(fixture.comment.split("\n")).toHaveLength(2);
     expect(fixture.trimToLines).toEqual([2]);
 
@@ -614,7 +630,7 @@ describe("migration-data-migration-mixed convention", () => {
         endLine: 2,
         startColumn: first.length - first.trimStart().length,
         endColumn: second.length,
-        kind: fixture.kind as CommentKind,
+        kind: fixture.kind,
         verdict: verdict(over),
       });
 

--- a/plugins/comments/apply/edits.ts
+++ b/plugins/comments/apply/edits.ts
@@ -341,15 +341,15 @@ export function computeFileEdits(
   for (let n = 1; n <= lines.length; n++) {
     const insert = spanInserts.get(n);
     if (insert) {
-      if (insert.length > 0) {
-        for (const line of insert) out.push(line);
-        lastPushed = insert[insert.length - 1] as string;
-        lastPushedBlank = isBlank(lastPushed);
+      for (const line of insert) {
+        out.push(line);
+        lastPushed = line;
+        lastPushedBlank = isBlank(line);
       }
       continue;
     }
     if (deletions.has(n)) continue;
-    const line = replacements.has(n) ? (replacements.get(n) as string) : (lines[n - 1] as string);
+    const line = replacements.get(n) ?? lines[n - 1] ?? "";
     // A trim can leave a surviving blank line next to a blank we already kept,
     // collapsing `blank / deleted comment / blank` into a double blank. Drop it,
     // but only when a neighbor was deleted, so unrelated blank runs are untouched.

--- a/plugins/comments/apply/join.ts
+++ b/plugins/comments/apply/join.ts
@@ -1,7 +1,18 @@
+import { z } from "zod";
 import { commentId } from "../detection/identity";
 import type { Comment } from "../detection/types";
 import { parseVerdict } from "../judge/judge";
 import type { Verdict } from "../judge/schema";
+
+const ShardEntry = z.looseObject(
+  { id: z.string({ error: "entry id must be a string" }), verdict: z.unknown().optional() },
+  { error: "entry must be an object" },
+);
+
+const Shard = z.looseObject(
+  { verdicts: z.array(ShardEntry, { error: `missing "verdicts" array` }) },
+  { error: "must be a JSON object" },
+);
 
 /**
  * Fold the verdict shards the agents wrote into one id→verdict map, validating
@@ -11,20 +22,13 @@ import type { Verdict } from "../judge/schema";
 export function collectVerdicts(shards: unknown[]): Map<string, Verdict> {
   const map = new Map<string, Verdict>();
   for (const shard of shards) {
-    if (typeof shard !== "object" || shard === null) {
-      throw new Error("Verdict shard must be a JSON object");
+    const parsed = Shard.safeParse(shard);
+    if (!parsed.success) {
+      throw new Error(`Verdict shard ${parsed.error.issues[0]?.message}`);
     }
-    const entries = (shard as Record<string, unknown>).verdicts;
-    if (!Array.isArray(entries)) throw new Error('Verdict shard missing "verdicts" array');
-    for (const entry of entries) {
-      if (typeof entry !== "object" || entry === null) {
-        throw new Error("Verdict entry must be an object");
-      }
-      const record = entry as Record<string, unknown>;
-      const id = record.id;
-      if (typeof id !== "string") throw new Error("Verdict entry id must be a string");
-      if (map.has(id)) throw new Error(`Verdict id ${id} appears more than once`);
-      map.set(id, parseVerdict(record.verdict, id));
+    for (const entry of parsed.data.verdicts) {
+      if (map.has(entry.id)) throw new Error(`Verdict id ${entry.id} appears more than once`);
+      map.set(entry.id, parseVerdict(entry.verdict, entry.id));
     }
   }
   return map;

--- a/plugins/comments/apply/report.ts
+++ b/plugins/comments/apply/report.ts
@@ -21,7 +21,7 @@ export interface ReportItem {
 
 /** The first line of a possibly multi-line comment, for a one-line preview. */
 function firstLine(text: string): string {
-  return text.split("\n")[0] as string;
+  return text.split("\n")[0] ?? "";
 }
 
 /**

--- a/plugins/comments/detection/collect.ts
+++ b/plugins/comments/detection/collect.ts
@@ -1,4 +1,5 @@
 import { $ } from "bun";
+import { z } from "zod";
 import { contextWindow } from "./context";
 import { type DiffOptions, resolveDiff } from "./diff";
 import { isExemptComment } from "./exempt";
@@ -41,15 +42,20 @@ export interface MrSource {
   ref: string;
 }
 
+const MrView = z.looseObject({
+  source_project_id: z.union([z.number(), z.string()]).nullish(),
+  diff_refs: z.looseObject({ head_sha: z.string().nullish() }).nullish(),
+  sha: z.string().nullish(),
+});
+
 export async function resolveMrSource(iid: string): Promise<MrSource | null> {
   const result = await $`glab mr view ${iid} -F json`.quiet().nothrow();
   if (result.exitCode !== 0) return null;
-  const record = JSON.parse(result.text()) as Record<string, unknown>;
-  const projectId = record.source_project_id;
-  const diffRefs = record.diff_refs as Record<string, unknown> | undefined;
-  const ref = diffRefs?.head_sha ?? record.sha;
-  if (typeof ref !== "string") return null;
-  if (typeof projectId !== "number" && typeof projectId !== "string") return null;
+  const view = MrView.safeParse(JSON.parse(result.text()));
+  if (!view.success) return null;
+  const projectId = view.data.source_project_id;
+  const ref = view.data.diff_refs?.head_sha ?? view.data.sha;
+  if (projectId == null || ref == null) return null;
   return { projectId: String(projectId), ref };
 }
 

--- a/plugins/comments/detection/extract.ts
+++ b/plugins/comments/detection/extract.ts
@@ -24,8 +24,12 @@ function getHighlighter(): Promise<Highlighter> {
   return highlighterPromise;
 }
 
+function isBundledLanguage(language: Language): language is BundledLanguage {
+  return language in bundledLanguages;
+}
+
 function bundledLanguage(language: Language): BundledLanguage | null {
-  return language in bundledLanguages ? (language as BundledLanguage) : null;
+  return isBundledLanguage(language) ? language : null;
 }
 
 async function loadLanguage(highlighter: Highlighter, language: BundledLanguage): Promise<void> {

--- a/plugins/comments/evals/eval.ts
+++ b/plugins/comments/evals/eval.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { Glob } from "bun";
 import { cli } from "cleye";
 import { table } from "table";
+import { z } from "zod";
 import type { CommentKind, Language } from "../detection/types";
 import { loadPrompt } from "../judge/judge";
 import {
@@ -51,57 +52,85 @@ export async function loadFixtures(dir: string = FIXTURES_DIR): Promise<Fixture[
   const glob = new Glob("*.json");
   const fixtures: Fixture[] = [];
   for await (const file of glob.scan(dir)) {
-    const parsed = JSON.parse(await Bun.file(join(dir, file)).text());
+    const parsed: unknown = JSON.parse(await Bun.file(join(dir, file)).text());
     fixtures.push(validateFixture(parsed, file));
   }
   fixtures.sort((a, b) => a.id.localeCompare(b.id));
   return fixtures;
 }
 
+const nonEmpty = (name: string) =>
+  z.string({ error: `missing required string "${name}"` }).min(1, {
+    error: `missing required string "${name}"`,
+  });
+
+const FixtureInput = z
+  .looseObject(
+    {
+      id: nonEmpty("id"),
+      path: nonEmpty("path"),
+      language: nonEmpty("language"),
+      kind: z.enum(["line", "block", "docstring"], {
+        error: (issue) => `has an invalid comment kind ${JSON.stringify(issue.input)}`,
+      }) satisfies z.ZodType<CommentKind>,
+      comment: nonEmpty("comment"),
+      context: nonEmpty("context"),
+      action: z.enum(VERDICT_ACTIONS, {
+        error: (issue) => `has an invalid action ${JSON.stringify(issue.input)}`,
+      }),
+      category: z
+        .enum(SLOP_CATEGORIES, {
+          error: (issue) => `has an invalid slop category ${JSON.stringify(issue.input)}`,
+        })
+        .nullish(),
+      rewrite: z.string().nullish(),
+      trimTo: z.string().nullish(),
+      trimToLines: z.array(z.number()).nullish(),
+      source: z.string().nullish(),
+      note: z.string().nullish(),
+    },
+    { error: "is not an object" },
+  )
+  .superRefine((fixture, ctx) => {
+    if (fixture.action === "keep" && fixture.category != null) {
+      ctx.addIssue({ code: "custom", message: `is "keep" but carries a category` });
+    }
+    if (fixture.action !== "keep" && fixture.category == null) {
+      ctx.addIssue({ code: "custom", message: "has an invalid slop category null" });
+    }
+    if (fixture.action === "rewrite" && !fixture.rewrite) {
+      ctx.addIssue({ code: "custom", message: `is "rewrite" but carries no gold rewrite text` });
+    }
+    if (fixture.trimTo != null && (fixture.trimTo.length === 0 || fixture.action !== "trim")) {
+      ctx.addIssue({
+        code: "custom",
+        message: `"trimTo" must be a non-empty string on a "trim" fixture`,
+      });
+    }
+  });
+
 function validateFixture(value: unknown, file: string): Fixture {
-  if (typeof value !== "object" || value === null) {
-    throw new Error(`Fixture ${file} is not an object`);
+  const parsed = FixtureInput.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(`Fixture ${file} ${parsed.error.issues[0]?.message}`);
   }
-  const record = value as Record<string, unknown>;
-  const action = record.action;
-  if (typeof action !== "string" || !VERDICT_ACTIONS.includes(action as VerdictAction)) {
-    throw new Error(`Fixture ${file} has invalid action ${JSON.stringify(action)}`);
-  }
-  const category = record.category ?? null;
-  if (action === "keep" && category !== null) {
-    throw new Error(`Fixture ${file} is "keep" but carries a category`);
-  }
-  if (action !== "keep" && !SLOP_CATEGORIES.includes(category as SlopCategory)) {
-    throw new Error(`Fixture ${file} has invalid slop category ${JSON.stringify(category)}`);
-  }
-  if (action === "rewrite" && (typeof record.rewrite !== "string" || record.rewrite.length === 0)) {
-    throw new Error(`Fixture ${file} is "rewrite" but carries no gold rewrite text`);
-  }
-  for (const key of ["id", "path", "language", "kind", "comment", "context"]) {
-    if (typeof record[key] !== "string" || record[key].length === 0) {
-      throw new Error(`Fixture ${file} missing required string "${key}"`);
-    }
-  }
+  const decoded = parsed.data;
+
   const fixture: Fixture = {
-    id: record.id as string,
-    path: record.path as string,
-    language: record.language as Language,
-    kind: record.kind as CommentKind,
-    comment: record.comment as string,
-    context: record.context as string,
-    action: action as VerdictAction,
-    category: category as SlopCategory | null,
+    id: decoded.id,
+    path: decoded.path,
+    language: decoded.language,
+    kind: decoded.kind,
+    comment: decoded.comment,
+    context: decoded.context,
+    action: decoded.action,
+    category: decoded.category ?? null,
   };
-  if (record.trimTo != null) {
-    if (typeof record.trimTo !== "string" || record.trimTo.length === 0 || action !== "trim") {
-      throw new Error(`Fixture ${file} "trimTo" must be a non-empty string on a "trim" fixture`);
-    }
-    fixture.trimTo = record.trimTo;
-  }
-  if (typeof record.rewrite === "string") fixture.rewrite = record.rewrite;
-  if (Array.isArray(record.trimToLines)) fixture.trimToLines = record.trimToLines as number[];
-  if (typeof record.source === "string") fixture.source = record.source;
-  if (typeof record.note === "string") fixture.note = record.note;
+  if (decoded.trimTo != null) fixture.trimTo = decoded.trimTo;
+  if (decoded.rewrite != null) fixture.rewrite = decoded.rewrite;
+  if (decoded.trimToLines != null) fixture.trimToLines = decoded.trimToLines;
+  if (decoded.source != null) fixture.source = decoded.source;
+  if (decoded.note != null) fixture.note = decoded.note;
   return fixture;
 }
 

--- a/plugins/comments/evals/oracle.ts
+++ b/plugins/comments/evals/oracle.ts
@@ -1,5 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 import Builder from "fast-xml-builder";
+import { z } from "zod";
 import type { CommentKind, Language } from "../detection/types";
 import { BATCH_SIZE, parseVerdict } from "../judge/judge";
 import { batchVerdictSchema, type Verdict } from "../judge/schema";
@@ -54,47 +55,54 @@ export function formatBatch(inputs: CommentJudgeInput[]): string {
   });
 }
 
+const BatchEntry = z.looseObject(
+  { index: z.int({ error: "entry index must be an integer" }), verdict: z.unknown().optional() },
+  { error: "entries must be objects" },
+);
+
+const Batch = z.looseObject(
+  { verdicts: z.array(BatchEntry, { error: `missing "verdicts" array` }) },
+  { error: "must be a JSON object" },
+);
+
 /**
  * Parses the `{ verdicts: [{ index, verdict }] }` batch shape, validating that
  * every index in 0..expected-1 is present exactly once, and returns verdicts
  * ordered by index.
  */
 export function parseBatchVerdicts(json: string, expected: number): Verdict[] {
-  let parsed: unknown;
+  let raw: unknown;
   try {
-    parsed = JSON.parse(json);
+    raw = JSON.parse(json);
   } catch (error) {
-    throw new Error(`Judge returned invalid JSON: ${(error as Error).message}`, { cause: error });
+    throw new Error(
+      `Judge returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
   }
-  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-    throw new Error("Judge batch must be a JSON object");
+  const parsed = Batch.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(`Judge batch ${parsed.error.issues[0]?.message}`);
   }
-  const entries = (parsed as Record<string, unknown>).verdicts;
-  if (!Array.isArray(entries)) throw new Error('Judge batch missing "verdicts" array');
-  const verdicts = Array.from<Verdict | undefined>({ length: expected });
+
+  const verdicts: (Verdict | undefined)[] = Array.from({ length: expected });
   const seen = new Set<number>();
-  for (const entry of entries) {
-    if (typeof entry !== "object" || entry === null) {
-      throw new Error("Judge batch entries must be objects");
+  for (const entry of parsed.data.verdicts) {
+    if (entry.index < 0 || entry.index >= expected) {
+      throw new Error(
+        `Judge batch index ${entry.index} out of range (expected 0..${expected - 1})`,
+      );
     }
-    const record = entry as Record<string, unknown>;
-    const index = record.index;
-    if (typeof index !== "number" || !Number.isInteger(index)) {
-      throw new Error("Judge batch entry index must be an integer");
+    if (seen.has(entry.index)) {
+      throw new Error(`Judge batch index ${entry.index} appears more than once`);
     }
-    if (index < 0 || index >= expected) {
-      throw new Error(`Judge batch index ${index} out of range (expected 0..${expected - 1})`);
-    }
-    if (seen.has(index)) {
-      throw new Error(`Judge batch index ${index} appears more than once`);
-    }
-    verdicts[index] = parseVerdict(record.verdict, `index ${index}`);
-    seen.add(index);
+    verdicts[entry.index] = parseVerdict(entry.verdict, `index ${entry.index}`);
+    seen.add(entry.index);
   }
   if (seen.size !== expected) {
     throw new Error(`Judge batch covered ${seen.size} of ${expected} comments`);
   }
-  return verdicts as Verdict[];
+  return verdicts.filter((verdict) => verdict !== undefined);
 }
 
 export async function judgeComments(

--- a/plugins/comments/judge/job.test.ts
+++ b/plugins/comments/judge/job.test.ts
@@ -2,11 +2,22 @@ import { describe, expect, test } from "bun:test";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { z } from "zod";
 import type { CollectedComment } from "../detection/collect";
 import { commentFeatures } from "../detection/features";
 import { scoreComment } from "../detection/rank";
 import { buildJob, writeJob } from "./job";
 import { loadPrompt } from "./judge";
+
+const ShardFile = z.looseObject({ comments: z.array(z.unknown()) });
+
+const ArgsFile = z.looseObject({
+  shards: z.array(z.object({ id: z.number(), path: z.string() })),
+  promptSha: z.string(),
+  verdictsDir: z.string(),
+  promptText: z.unknown().optional(),
+  promptPath: z.string(),
+});
 
 function collected(i: number): CollectedComment {
   const text = `// comment ${i}`;
@@ -86,10 +97,12 @@ describe("writeJob", () => {
       expect(written.shards).toHaveLength(2);
       expect(written.shards.map((s: { id: number }) => s.id)).toEqual([0, 1]);
 
-      const firstShard = JSON.parse(await Bun.file(written.shards[0]?.path ?? "").text());
+      const firstShard = ShardFile.parse(
+        JSON.parse(await Bun.file(written.shards[0]?.path ?? "").text()),
+      );
       expect(firstShard.comments).toHaveLength(20);
 
-      const args = JSON.parse(await Bun.file(written.argsPath).text());
+      const args = ArgsFile.parse(JSON.parse(await Bun.file(written.argsPath).text()));
       expect(args.shards).toEqual(written.shards);
       expect(args.promptSha).toBe(descriptor.promptSha);
       expect(args.verdictsDir).toBe(written.verdictsDir);

--- a/plugins/comments/judge/judge.test.ts
+++ b/plugins/comments/judge/judge.test.ts
@@ -47,6 +47,27 @@ describe("parseVerdict", () => {
     expect(() => parseVerdict(raw({ action: "delete" }), "x")).toThrow(/"action" must be one of/);
   });
 
+  test.each<{ name: string; value: unknown; error: RegExp }>([
+    {
+      name: "rejects a category outside the taxonomy",
+      value: raw({ category: "vibes" }),
+      error: /"category" must be one of/,
+    },
+    {
+      name: "rejects a confidence outside low/medium/high",
+      value: raw({ confidence: "certain" }),
+      error: /"confidence" must be one of/,
+    },
+    {
+      name: "rejects a non-string rationale",
+      value: raw({ rationale: 7 }),
+      error: /"rationale" must be a string/,
+    },
+    { name: "rejects a non-object verdict", value: "nope", error: /must be an object/ },
+  ])("$name", ({ value, error }) => {
+    expect(() => parseVerdict(value, "x")).toThrow(error);
+  });
+
   test.each<{ name: string; over: Record<string, unknown>; error?: RegExp; trimTo?: string }>([
     {
       name: "accepts trimTo on a trim verdict",

--- a/plugins/comments/judge/judge.ts
+++ b/plugins/comments/judge/judge.ts
@@ -1,12 +1,7 @@
 import { createHash } from "node:crypto";
 import { join } from "node:path";
-import {
-  type Confidence,
-  type SlopCategory,
-  VERDICT_ACTIONS,
-  type Verdict,
-  type VerdictAction,
-} from "./schema";
+import { z } from "zod";
+import { SLOP_CATEGORIES, VERDICT_ACTIONS, type Verdict } from "./schema";
 
 /**
  * Shared judge primitives: the versioned prompt and per-verdict validation, used
@@ -34,6 +29,46 @@ export async function loadPrompt(promptPath: string = PROMPT_PATH): Promise<Vers
 /** Comments per shard in production, and per batch in the oracle. */
 export const BATCH_SIZE = 20;
 
+const TRIM_TO_ERROR = `"trimTo" must be a non-empty string`;
+
+const VerdictInput = z
+  .looseObject(
+    {
+      action: z.enum(VERDICT_ACTIONS, {
+        error: `"action" must be one of ${VERDICT_ACTIONS.join(", ")}`,
+      }),
+      category: z
+        .enum(SLOP_CATEGORIES, {
+          error: `"category" must be one of ${SLOP_CATEGORIES.join(", ")} or null`,
+        })
+        .nullish(),
+      confidence: z.enum(["low", "medium", "high"], {
+        error: `"confidence" must be one of low, medium, high`,
+      }),
+      rationale: z.string({ error: `"rationale" must be a string` }),
+      rewrite: z.string({ error: `"rewrite" must be a string` }).nullish(),
+      suggestedFix: z.string({ error: `"suggestedFix" must be a string` }).nullish(),
+      trimTo: z.string({ error: TRIM_TO_ERROR }).min(1, { error: TRIM_TO_ERROR }).nullish(),
+      trimToLines: z.array(z.unknown(), { error: `"trimToLines" must be an array` }).nullish(),
+    },
+    { error: "must be an object" },
+  )
+  .superRefine((verdict, ctx) => {
+    const rewritten = verdict.action === "rewrite";
+    if (rewritten && !verdict.rewrite) {
+      ctx.addIssue({
+        code: "custom",
+        message: `"rewrite" must be a non-empty string when action is "rewrite"`,
+      });
+    }
+    if (!rewritten && verdict.rewrite) {
+      ctx.addIssue({ code: "custom", message: `"rewrite" is only valid when action is "rewrite"` });
+    }
+    if (verdict.trimTo != null && verdict.action !== "trim") {
+      ctx.addIssue({ code: "custom", message: `"trimTo" is only valid when action is "trim"` });
+    }
+  });
+
 /**
  * Validates one verdict object's shape, returning a typed `Verdict`. `label`
  * identifies the entry in error messages (a comment id on the apply path, or a
@@ -41,56 +76,23 @@ export const BATCH_SIZE = 20;
  * malformed verdicts identically.
  */
 export function parseVerdict(value: unknown, label: string | number): Verdict {
-  if (typeof value !== "object" || value === null) {
-    throw new Error(`Judge verdict ${label} must be an object`);
+  const parsed = VerdictInput.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(`Judge verdict ${label} ${parsed.error.issues[0]?.message}`);
   }
-  const record = value as Record<string, unknown>;
-  if (
-    typeof record.action !== "string" ||
-    !VERDICT_ACTIONS.includes(record.action as VerdictAction)
-  ) {
-    throw new Error(`Judge verdict ${label} "action" must be one of ${VERDICT_ACTIONS.join(", ")}`);
-  }
-  const action = record.action as VerdictAction;
-  if (record.category != null && typeof record.category !== "string") {
-    throw new Error(`Judge verdict ${label} "category" must be a string or null`);
-  }
-  if (typeof record.confidence !== "string") {
-    throw new Error(`Judge verdict ${label} "confidence" must be a string`);
-  }
-  if (typeof record.rationale !== "string") {
-    throw new Error(`Judge verdict ${label} "rationale" must be a string`);
-  }
-  const hasRewrite = typeof record.rewrite === "string" && record.rewrite.length > 0;
-  if (action === "rewrite" && !hasRewrite) {
-    throw new Error(
-      `Judge verdict ${label} "rewrite" must be a non-empty string when action is "rewrite"`,
-    );
-  }
-  if (action !== "rewrite" && hasRewrite) {
-    throw new Error(`Judge verdict ${label} "rewrite" is only valid when action is "rewrite"`);
-  }
-  if (record.trimTo != null) {
-    if (typeof record.trimTo !== "string" || record.trimTo.length === 0) {
-      throw new Error(`Judge verdict ${label} "trimTo" must be a non-empty string`);
-    }
-    if (action !== "trim") {
-      throw new Error(`Judge verdict ${label} "trimTo" is only valid when action is "trim"`);
-    }
-  }
+  const decoded = parsed.data;
+
   const verdict: Verdict = {
-    action,
-    category: (record.category ?? null) as SlopCategory | null,
-    confidence: record.confidence as Confidence,
-    rationale: record.rationale,
-    rewrite: action === "rewrite" ? (record.rewrite as string) : null,
+    action: decoded.action,
+    category: decoded.category ?? null,
+    confidence: decoded.confidence,
+    rationale: decoded.rationale,
+    rewrite: decoded.action === "rewrite" ? (decoded.rewrite ?? null) : null,
   };
-  if (typeof record.suggestedFix === "string") verdict.suggestedFix = record.suggestedFix;
-  if (typeof record.trimTo === "string") verdict.trimTo = record.trimTo;
-  if (Array.isArray(record.trimToLines)) {
-    verdict.trimToLines = record.trimToLines.filter(
-      (line): line is number => typeof line === "number",
-    );
+  if (decoded.suggestedFix != null) verdict.suggestedFix = decoded.suggestedFix;
+  if (decoded.trimTo != null) verdict.trimTo = decoded.trimTo;
+  if (decoded.trimToLines != null) {
+    verdict.trimToLines = decoded.trimToLines.filter((line) => typeof line === "number");
   }
   return verdict;
 }

--- a/plugins/comments/package.json
+++ b/plugins/comments/package.json
@@ -6,7 +6,8 @@
     "cleye": "^2.2.1",
     "parse-diff": "^0.12.0",
     "shiki": "^4.3.0",
-    "table": "^6.9.0"
+    "table": "^6.9.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.116.0",

--- a/plugins/comments/skills/audit/scripts/audit.ts
+++ b/plugins/comments/skills/audit/scripts/audit.ts
@@ -4,6 +4,7 @@ import { readdir } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { $ } from "bun";
 import { cli, command } from "cleye";
+import { z } from "zod";
 import { applyToBranch, isCleanTree } from "../../../apply/branch";
 import { computeFileEdits, type EditItem } from "../../../apply/edits";
 import { formatContent } from "../../../apply/format";
@@ -20,7 +21,7 @@ import type { DiffOptions } from "../../../detection/diff";
 import { extractComments, languageForPath } from "../../../detection/extract";
 import { rankComments, type SortKey } from "../../../detection/rank";
 import type { Comment } from "../../../detection/types";
-import { buildJob, type BuildJobOptions, type JobShard, writeJob } from "../../../judge/job";
+import { buildJob, type BuildJobOptions, writeJob } from "../../../judge/job";
 import type { Verdict } from "../../../judge/schema";
 
 const WORKFLOW_PATH = join(import.meta.dirname, "..", "..", "..", "workflow", "judge.workflow.js");
@@ -34,10 +35,11 @@ const WORKFLOW_PATH = join(import.meta.dirname, "..", "..", "..", "workflow", "j
  */
 const AGENT_OVERHEAD_TOKENS = 25_000;
 
-const SORT_KEYS: SortKey[] = ["lines", "chars", "score"];
+const SORT_KEYS = ["lines", "chars", "score"] as const satisfies readonly SortKey[];
 
 function parseSort(value: string): SortKey {
-  if ((SORT_KEYS as string[]).includes(value)) return value as SortKey;
+  const parsed = z.enum(SORT_KEYS).safeParse(value);
+  if (parsed.success) return parsed.data;
   console.error(
     `Invalid --sort ${JSON.stringify(value)}; expected one of ${SORT_KEYS.join(", ")}.`,
   );
@@ -188,7 +190,7 @@ function toEditItem(comment: Comment, verdict: Verdict): EditItem {
   };
 }
 
-async function readJsonFiles(dir: string, prefix: string): Promise<unknown[]> {
+async function readJsonFiles<T>(dir: string, prefix: string, schema: z.ZodType<T>): Promise<T[]> {
   let names: string[];
   try {
     names = await readdir(dir);
@@ -197,13 +199,17 @@ async function readJsonFiles(dir: string, prefix: string): Promise<unknown[]> {
   }
   const matching = names.filter((name) => name.startsWith(prefix) && name.endsWith(".json"));
   return Promise.all(
-    matching.map(async (name) => JSON.parse(await Bun.file(join(dir, name)).text())),
+    matching.map(async (name) => schema.parse(JSON.parse(await Bun.file(join(dir, name)).text()))),
   );
 }
 
+const Scope = z.looseObject({ mr: z.string().nullish() });
+
+const JobShardFile = z.looseObject({ comments: z.array(z.looseObject({ path: z.string() })) });
+
 /** The files a job judged, recovered from the shards. */
 async function judgedPaths(jobDir: string): Promise<string[]> {
-  const shards = (await readJsonFiles(jobDir, "shard-")) as JobShard[];
+  const shards = await readJsonFiles(jobDir, "shard-", JobShardFile);
   const paths = new Set<string>();
   for (const shard of shards) for (const comment of shard.comments) paths.add(comment.path);
   return [...paths];
@@ -242,7 +248,7 @@ const applyCmd = command(
 
     const scopeFile = Bun.file(join(job, "scope.json"));
     const scope = (await scopeFile.exists())
-      ? (JSON.parse(await scopeFile.text()) as { mr?: string | null })
+      ? Scope.parse(JSON.parse(await scopeFile.text()))
       : { mr: null };
     if (scope.mr && !report) {
       console.error(
@@ -251,7 +257,7 @@ const applyCmd = command(
       process.exit(1);
     }
 
-    const verdictShards = await readJsonFiles(join(job, "verdicts"), "verdict-");
+    const verdictShards = await readJsonFiles(join(job, "verdicts"), "verdict-", z.unknown());
     if (verdictShards.length === 0) {
       console.error(`No verdicts in ${join(job, "verdicts")}. Run the judge workflow first.`);
       process.exit(1);


### PR DESCRIPTION
Migrates the `comments` plugin's file and subprocess seams onto zod schemas. Fourth layer of the stack. The boundary and the rule reversal are in #1271.

The plugin goes from 38 hits on `no-unsafe-type-assertion` and 42 across the five `no-unsafe-*` rules to zero on all six, outside one file covered below.

| Seam | Was | Now |
|---|---|---|
| Agent-written verdicts | `parseVerdict` hand-walked `Record<string, unknown>` | `VerdictInput` plus `superRefine` |
| Verdict shards on disk | `(shard as Record<string, unknown>).verdicts` | `Shard`, `ShardEntry` |
| Oracle batch response | per-entry `typeof` chain | `Batch`, `BatchEntry` |
| Eval fixture corpus | a key loop plus eight `as` casts | `FixtureInput` |
| Job shards and `scope.json` | `as JobShard[]`, `as { mr?: string \| null }` | `readJsonFiles(dir, prefix, schema)` |
| `glab mr view -F json` | `record.diff_refs as Record<string, unknown>` | `MrView` |

## Taxonomy

`Verdict` declared `category: SlopCategory | null` and `confidence: Confidence`. `parseVerdict` accepted any string for either and cast it. A judge that invented a category produced a `Verdict` whose type was a lie, and the scorer then compared it against a fixture label it could never match. Both are enums now, as is the fixture loader's `kind`.

## Error Messages

Each field carries the message its hand-written check used, which is why the schemas set `error` per field rather than taking zod's defaults. Cross-field rules run in `superRefine`. Invariants needing a count the schema does not have (index coverage, duplicate ids) stay in the loop that has it.

## Outbound Schemas

`verdictSchema` and `batchVerdictSchema` stay hand-written JSON Schema. They describe the output the model is asked for, so nothing arriving here needs decoding. `z.toJSONSchema` also emits `type: [...]` unions where the structured-outputs subset requires `anyOf`.

## The Workflow Script

`workflow/judge.workflow.js` holds the remaining 20 hits and keeps them. It is plain JS run by the Workflow runtime against untyped globals, with no imports available. Zod cannot reach it, and its `JSON.parse(args)` cannot be narrowed. The layer that turns these rules on takes an `**/*.workflow.js` override.

## Runs

`preflight --base main --limit 3` wrote a job. A hand-authored `verdict-0.json` then drove `apply --report` through `collectVerdicts`, `parseVerdict`, and the scope read. An unknown action and an unknown category each came back named at the seam.
