### PR TITLE
writing: decode external data at the seams

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -279,6 +279,7 @@
         "stemmer": "^2.0.1",
         "table": "^6.9.0",
         "unist-util-visit": "^5.1.0",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/mdast": "^4.0.4",

--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -193,7 +193,7 @@ function connectorDensityHits(text: string): Hits {
   const connected = sentences.filter(isConnectorSentence);
   if (connected.length < MIN_CONNECTOR_SENTENCES) return { count: 0, sample: "" };
   if (connected.length / sentences.length < CONNECTOR_DENSITY) return { count: 0, sample: "" };
-  const first = connected[0] as string;
+  const first = connected[0] ?? "";
   const i = CLAUSE_CONNECTOR.exec(first)?.index ?? 0;
   return { count: connected.length, sample: first.slice(Math.max(0, i - 20), i + 24).trim() };
 }
@@ -211,7 +211,7 @@ export function semicolonSpliceHits(text: string, minSplices: number): Hits {
     (s) => !LIST_ITEM.test(s) && SEMICOLON_SPLICE.test(s),
   );
   if (spliced.length < minSplices) return { count: 0, sample: "" };
-  const first = spliced[0] as string;
+  const first = spliced[0] ?? "";
   const i = SEMICOLON_SPLICE.exec(first)?.index ?? 0;
   return { count: spliced.length, sample: first.slice(Math.max(0, i - 20), i + 24).trim() };
 }
@@ -248,8 +248,8 @@ const ADVERSATIVE_OPENER = /^\s*(?:However|But|Yet|Nevertheless|Nonetheless|Stil
 function adversativeNegationFlipHits(text: string): Hits {
   const sentences = splitSentences(text);
   for (let i = 0; i < sentences.length - 1; i++) {
-    const current = sentences[i] as string;
-    const next = sentences[i + 1] as string;
+    const current = sentences[i] ?? "";
+    const next = sentences[i + 1] ?? "";
     if (NEGATION_CUE.test(current) && ADVERSATIVE_OPENER.test(next)) {
       return { count: 1, sample: `${current.slice(0, 60)} / ${next.slice(0, 40)}` };
     }
@@ -276,7 +276,7 @@ function questionAnswerCadenceHits(text: string): Hits {
     }
   }
   if (questionOpeners.length < QA_QUESTION_THRESHOLD) return { count: 0, sample: "" };
-  return { count: questionOpeners.length, sample: questionOpeners[0] as string };
+  return { count: questionOpeners.length, sample: questionOpeners[0] ?? "" };
 }
 
 // A salutation addresses a person before the substance starts: a greeting word,
@@ -471,7 +471,7 @@ function salutationHits(text: string): Hits {
   if (GREETING_OPENER.test(line)) return { count: 1, sample: line.slice(0, 40) };
   const address = ADDRESS_OPENER.exec(line)?.[1];
   if (!address) return { count: 0, sample: "" };
-  const head = address.split(/\s+/)[0] as string;
+  const head = address.split(/\s+/)[0] ?? "";
   if (!isNameShaped(head)) return { count: 0, sample: "" };
   return { count: 1, sample: `${address},` };
 }

--- a/plugins/writing/hooks/check-tropes.test.ts
+++ b/plugins/writing/hooks/check-tropes.test.ts
@@ -10,21 +10,39 @@ async function processInput(input: PreToolUseHookInput): Promise<SyncHookJSONOut
   return (await check(input))?.output ?? null;
 }
 
-function mockWrite(content: string): PreToolUseHookInput {
+function contextOf(output: SyncHookJSONOutput | null): string | undefined {
+  const specific = output?.hookSpecificOutput;
+  return specific?.hookEventName === "PreToolUse" ? specific.additionalContext : undefined;
+}
+
+function denialOf(output: SyncHookJSONOutput | null): {
+  decision: string | undefined;
+  reason: string | undefined;
+} {
+  const specific = output?.hookSpecificOutput;
+  if (specific?.hookEventName !== "PreToolUse") return { decision: undefined, reason: undefined };
+  return { decision: specific.permissionDecision, reason: specific.permissionDecisionReason };
+}
+
+function mockWrite(content: string, filePath = "test.md"): PreToolUseHookInput {
   return {
     hook_event_name: "PreToolUse",
     session_id: "test",
     transcript_path: "/tmp/test",
     cwd: "/tmp",
     tool_name: "Write",
-    tool_input: { file_path: "test.md", content },
+    tool_input: { file_path: filePath, content },
     tool_use_id: "test",
   };
 }
 
-function mockEdit(newString: string, oldString?: string): PreToolUseHookInput {
+function mockEdit(
+  newString: string,
+  oldString?: string,
+  filePath = "test.md",
+): PreToolUseHookInput {
   const toolInput: Record<string, unknown> = {
-    file_path: "test.md",
+    file_path: filePath,
     new_string: newString,
   };
   if (oldString !== undefined) toolInput.old_string = oldString;
@@ -76,15 +94,17 @@ describe("wordlist files", () => {
     ],
     ["skips Edit to wordlist file", "Edit", "delve\nadded entry\n"],
   ])("%s", async (_name, tool, content) => {
-    const input = tool === "Write" ? mockWrite(content) : mockEdit(content);
-    (input.tool_input as Record<string, unknown>).file_path = wordlistPath;
+    const input =
+      tool === "Write"
+        ? mockWrite(content, wordlistPath)
+        : mockEdit(content, undefined, wordlistPath);
     expect(await processInput(input)).toBeNull();
   });
 
   it("does not skip non-wordlist .txt files", async () => {
-    const input = mockWrite("delve into the data is the way forward.");
-    (input.tool_input as Record<string, unknown>).file_path = "/tmp/notes.txt";
-    const result = await processInput(input);
+    const result = await processInput(
+      mockWrite("delve into the data is the way forward.", "/tmp/notes.txt"),
+    );
     expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
   });
 });
@@ -100,15 +120,11 @@ describe("connector density file scoping", () => {
   });
 
   it("skips connector density in shell scripts", async () => {
-    const input = mockWrite(denseText);
-    (input.tool_input as Record<string, unknown>).file_path = "deploy.sh";
-    expect(await processInput(input)).toBeNull();
+    expect(await processInput(mockWrite(denseText, "deploy.sh"))).toBeNull();
   });
 
   it("skips connector density in TypeScript files", async () => {
-    const input = mockWrite(denseText);
-    (input.tool_input as Record<string, unknown>).file_path = "index.ts";
-    expect(await processInput(input)).toBeNull();
+    expect(await processInput(mockWrite(denseText, "index.ts"))).toBeNull();
   });
 });
 
@@ -116,7 +132,7 @@ describe("Write/Edit", () => {
   it("returns reminder for Write with spaced em dash", async () => {
     const result = await processInput(mockWrite("This \u2014 is bad"));
     expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
-    const ctx = (result?.hookSpecificOutput as { additionalContext: string }).additionalContext;
+    const ctx = contextOf(result);
     expect(ctx).toContain("follow-up Edit");
   });
 
@@ -185,9 +201,9 @@ describe("diff-aware filtering", () => {
     const dir = mkdtempSync(join(tmpdir(), "trope-diff-"));
     const file = join(dir, "doc.md");
     await Bun.write(file, "Title \u2014 already here in the existing file.\n");
-    const input = mockWrite("Title \u2014 already here in the existing file.\nAdded line.\n");
-    (input.tool_input as Record<string, unknown>).file_path = file;
-    const result = await processInput(input);
+    const result = await processInput(
+      mockWrite("Title \u2014 already here in the existing file.\nAdded line.\n", file),
+    );
     await rm(dir, { recursive: true, force: true });
     expect(result).toBeNull();
   });
@@ -196,9 +212,9 @@ describe("diff-aware filtering", () => {
     const dir = mkdtempSync(join(tmpdir(), "trope-diff-"));
     const file = join(dir, "doc.md");
     await Bun.write(file, "Title \u2014 already here.\n");
-    const input = mockWrite("Title \u2014 already here.\nNow another \u2014 line.\n");
-    (input.tool_input as Record<string, unknown>).file_path = file;
-    const result = await processInput(input);
+    const result = await processInput(
+      mockWrite("Title \u2014 already here.\nNow another \u2014 line.\n", file),
+    );
     await rm(dir, { recursive: true, force: true });
     expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
   });
@@ -211,9 +227,7 @@ describe("diff-aware filtering", () => {
 
 describe("semicolon splices", () => {
   function codeEdit(newString: string, oldString: string): PreToolUseHookInput {
-    const input = mockEdit(newString, oldString);
-    (input.tool_input as Record<string, unknown>).file_path = "index.ts";
-    return input;
+    return mockEdit(newString, oldString, "index.ts");
   }
 
   it("flags a code-file edit introducing a spliced comment", async () => {
@@ -221,7 +235,7 @@ describe("semicolon splices", () => {
       codeEdit("// keep sorted; callers rely on order\nconst x = 1;", "const x = 1;"),
     );
     expect(result?.hookSpecificOutput).toHaveProperty("additionalContext");
-    const ctx = (result?.hookSpecificOutput as { additionalContext: string }).additionalContext;
+    const ctx = contextOf(result);
     expect(ctx).toContain("semicolon");
   });
 
@@ -439,10 +453,9 @@ describe("Bash processInput", () => {
     const result = await processInput(
       mockBash(`glab mr note 871 --message "Dana, we should delve into the retry budget."`),
     );
-    expect(result?.hookSpecificOutput).toMatchObject({
-      permissionDecision: "deny",
-      permissionDecisionReason: expect.stringContaining("salutation"),
-    });
+    const denial = denialOf(result);
+    expect(denial.decision).toBe("deny");
+    expect(denial.reason).toContain("salutation");
   });
 
   it("returns null for non-text Bash commands", async () => {

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -8,7 +8,7 @@ import {
   scanIntroduced,
   semicolonSpliceHits,
 } from "../detection/tropes";
-import { formatContext, formatDecision, type HookResult } from "./io";
+import { formatContext, formatDecision, type HookResult, type ToolInput, toolInputOf } from "./io";
 
 const FILE_OP_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
 
@@ -68,36 +68,25 @@ function extractInlineArg(command: string, flag: string): string | null {
   return match?.[1] ?? match?.[2] ?? null;
 }
 
-function collectMultiEditPairs(toolInput: Record<string, unknown>): {
-  newText: string;
-  oldText: string;
-} {
-  const edits = toolInput.edits;
-  if (!Array.isArray(edits)) return { newText: "", oldText: "" };
-  const newParts: string[] = [];
-  const oldParts: string[] = [];
-  for (const edit of edits) {
-    if (!edit || typeof edit !== "object") continue;
-    const fields = edit as Record<string, unknown>;
-    if (typeof fields.new_string === "string") newParts.push(fields.new_string);
-    if (typeof fields.old_string === "string") oldParts.push(fields.old_string);
-  }
+function collectMultiEditPairs(toolInput: ToolInput): { newText: string; oldText: string } {
+  const edits = toolInput.edits ?? [];
+  const newParts = edits.map((edit) => edit.new_string).filter((text) => text !== undefined);
+  const oldParts = edits.map((edit) => edit.old_string).filter((text) => text !== undefined);
   return { newText: newParts.join("\n"), oldText: oldParts.join("\n") };
 }
 
 async function collectFileOpPair(
   input: PreToolUseHookInput,
 ): Promise<{ newText: string; oldText: string } | null> {
-  const toolInput = input.tool_input as Record<string, unknown>;
+  const toolInput = toolInputOf(input);
   const toolName = input.tool_name;
 
   if (toolName === "Write") {
     const content = toolInput.content;
-    if (typeof content !== "string" || content.length === 0) return null;
-    const filePath = toolInput.file_path;
+    if (!content) return null;
     let oldText = "";
-    if (typeof filePath === "string") {
-      const file = Bun.file(filePath);
+    if (toolInput.file_path !== undefined) {
+      const file = Bun.file(toolInput.file_path);
       if (await file.exists()) oldText = await file.text();
     }
     return { newText: content, oldText };
@@ -105,9 +94,8 @@ async function collectFileOpPair(
 
   if (toolName === "Edit") {
     const newString = toolInput.new_string;
-    if (typeof newString !== "string" || newString.length === 0) return null;
-    const oldString = toolInput.old_string;
-    return { newText: newString, oldText: typeof oldString === "string" ? oldString : "" };
+    if (!newString) return null;
+    return { newText: newString, oldText: toolInput.old_string ?? "" };
   }
 
   if (toolName === "MultiEdit") {
@@ -120,7 +108,7 @@ async function collectFileOpPair(
 }
 
 export async function collectText(input: PreToolUseHookInput): Promise<string[]> {
-  const toolInput = input.tool_input as Record<string, unknown>;
+  const toolInput = toolInputOf(input);
   const toolName = input.tool_name;
 
   if (FILE_OP_TOOLS.has(toolName)) {
@@ -128,19 +116,20 @@ export async function collectText(input: PreToolUseHookInput): Promise<string[]>
     return pair ? [pair.newText] : [];
   }
 
-  if (toolName === "Bash" && typeof toolInput.command === "string") {
+  if (toolName === "Bash" && toolInput.command !== undefined) {
+    const command = toolInput.command;
     const texts: string[] = [];
-    const bodyFile = extractBodyFilePath(toolInput.command);
+    const bodyFile = extractBodyFilePath(command);
     const files = bodyFile
-      ? [bodyFile, ...extractFieldFilePaths(toolInput.command)]
-      : extractFieldFilePaths(toolInput.command);
+      ? [bodyFile, ...extractFieldFilePaths(command)]
+      : extractFieldFilePaths(command);
     for (const path of files) {
       if (await Bun.file(path).exists()) {
         texts.push(await Bun.file(path).text());
       }
     }
     for (const flag of PROSE_FLAGS) {
-      const value = extractInlineArg(toolInput.command, flag);
+      const value = extractInlineArg(command, flag);
       if (value) texts.push(value);
     }
     return texts;
@@ -152,9 +141,8 @@ export async function collectText(input: PreToolUseHookInput): Promise<string[]>
 const WORDLIST_PATH_PATTERN = /\/wordlists\/[^/]+\.txt$/;
 
 function isWordlistFile(input: PreToolUseHookInput): boolean {
-  const filePath = (input.tool_input as Record<string, unknown>).file_path;
-  if (typeof filePath !== "string") return false;
-  return WORDLIST_PATH_PATTERN.test(filePath);
+  const filePath = toolInputOf(input).file_path;
+  return filePath !== undefined && WORDLIST_PATH_PATTERN.test(filePath);
 }
 
 function buildFileOpReminder(
@@ -185,7 +173,7 @@ function commentSplice(comments: { newText: string; oldText: string }): string |
 async function processFileOp(input: PreToolUseHookInput): Promise<HookResult | null> {
   const pair = await collectFileOpPair(input);
   if (!pair) return null;
-  const filePath = (input.tool_input as Record<string, unknown>).file_path as string | undefined;
+  const filePath = toolInputOf(input).file_path;
 
   // Prose rules target prose. In a code file the model's prose surface is its
   // comments, so scan those; strings and identifiers are program text the

--- a/plugins/writing/hooks/headings.test.ts
+++ b/plugins/writing/hooks/headings.test.ts
@@ -20,7 +20,9 @@ function mockWriteInput(filePath: string, content: string): PreToolUseHookInput 
 function getOutput(input: PreToolUseHookInput): PreToolUseHookSpecificOutput | null {
   const result = check(input);
   if (!result) return null;
-  return result.output.hookSpecificOutput as PreToolUseHookSpecificOutput;
+  const output = result.output.hookSpecificOutput;
+  if (output?.hookEventName !== "PreToolUse") return null;
+  return output;
 }
 
 const titleCaseCases: { description: string; content: string; match: boolean }[] = [

--- a/plugins/writing/hooks/headings.ts
+++ b/plugins/writing/hooks/headings.ts
@@ -5,7 +5,7 @@ import { visit } from "unist-util-visit";
 import { getExtension, isMarkdownFile } from "../detection/paths";
 import { classifyHeadingBaseline } from "../linguistics/heading";
 import { headingCaseViolations } from "./heading-case";
-import { type EditInput, formatContext, type HookResult, type WriteInput } from "./io";
+import { editedContent, formatContext, type HookResult } from "./io";
 
 // Reports the exact re-casing rather than just naming the heading, so the fix
 // needs no second guess about which words AP lowercases.
@@ -65,22 +65,9 @@ export function checkSentenceHeading(content: string): string | null {
 }
 
 export function check(input: PreToolUseHookInput): HookResult | null {
-  const toolName = input.tool_name;
-
-  let content: string;
-  let filePath: string;
-
-  if (toolName === "Write") {
-    const toolInput = input.tool_input as WriteInput;
-    content = toolInput.content;
-    filePath = toolInput.file_path;
-  } else if (toolName === "Edit") {
-    const toolInput = input.tool_input as EditInput;
-    content = toolInput.new_string;
-    filePath = toolInput.file_path;
-  } else {
-    return null;
-  }
+  const edited = editedContent(input);
+  if (!edited) return null;
+  const { content, filePath } = edited;
 
   const ext = getExtension(filePath);
   if (!isMarkdownFile(ext)) return null;

--- a/plugins/writing/hooks/io.ts
+++ b/plugins/writing/hooks/io.ts
@@ -1,9 +1,42 @@
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
 
 export type { SyncHookJSONOutput };
 
-export type WriteInput = { file_path: string; content: string };
-export type EditInput = { file_path: string; new_string: string };
+// Every field any writing hook reads off `tool_input`, across the Write, Edit,
+// MultiEdit, and Bash surfaces.
+const ToolInput = z.looseObject({
+  file_path: z.string().optional().catch(undefined),
+  content: z.string().optional().catch(undefined),
+  new_string: z.string().optional().catch(undefined),
+  old_string: z.string().optional().catch(undefined),
+  command: z.string().optional().catch(undefined),
+  edits: z
+    .array(
+      z.looseObject({
+        new_string: z.string().optional().catch(undefined),
+        old_string: z.string().optional().catch(undefined),
+      }),
+    )
+    .optional()
+    .catch(undefined),
+});
+export type ToolInput = z.infer<typeof ToolInput>;
+
+export function toolInputOf(input: PreToolUseHookInput): ToolInput {
+  return ToolInput.safeParse(input.tool_input).data ?? {};
+}
+
+/** The text a Write or Edit puts on disk, and where. Null for any other tool. */
+export function editedContent(
+  input: PreToolUseHookInput,
+): { content: string; filePath: string } | null {
+  if (input.tool_name !== "Write" && input.tool_name !== "Edit") return null;
+  const toolInput = toolInputOf(input);
+  const content = input.tool_name === "Write" ? toolInput.content : toolInput.new_string;
+  if (content === undefined || toolInput.file_path === undefined) return null;
+  return { content, filePath: toolInput.file_path };
+}
 
 // A checker's finding: the formatted hook output plus the rule category the
 // dispatcher uses for session-scoped repeat suppression and the run log.
@@ -13,10 +46,12 @@ export type HookResult = { output: SyncHookJSONOutput; category: string; suppres
 
 export type PermissionTier = "deny" | "ask" | "context";
 
+const Tier = z.looseObject({
+  permissionDecision: z.enum(["deny", "ask"]).optional().catch(undefined),
+});
+
 export function tierOf(output: SyncHookJSONOutput): PermissionTier {
-  const specific = output.hookSpecificOutput as Record<string, unknown> | undefined;
-  const decision = specific?.permissionDecision;
-  return decision === "deny" || decision === "ask" ? decision : "context";
+  return Tier.safeParse(output.hookSpecificOutput).data?.permissionDecision ?? "context";
 }
 
 export function isPlanMode(input: PreToolUseHookInput): boolean {

--- a/plugins/writing/hooks/numbering.test.ts
+++ b/plugins/writing/hooks/numbering.test.ts
@@ -51,7 +51,9 @@ async function getOutput(
 ): Promise<PreToolUseHookSpecificOutput | null> {
   const result = await check(input, mode);
   if (!result) return null;
-  return result.output.hookSpecificOutput as PreToolUseHookSpecificOutput;
+  const output = result.output.hookSpecificOutput;
+  if (output?.hookEventName !== "PreToolUse") return null;
+  return output;
 }
 
 describe("formatDecision", () => {

--- a/plugins/writing/hooks/numbering.ts
+++ b/plugins/writing/hooks/numbering.ts
@@ -6,14 +6,9 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import type { Heading, Text } from "mdast";
+import { z } from "zod";
 import { getExtension, isMarkdownFile } from "../detection/paths";
-import {
-  type EditInput,
-  formatContext,
-  formatDecision,
-  type HookResult,
-  type WriteInput,
-} from "./io";
+import { editedContent, formatContext, formatDecision, type HookResult } from "./io";
 import { loadMarkdown } from "./mdast";
 
 export type Mode = "write" | "edit";
@@ -33,9 +28,9 @@ type MarkdownMatch = {
   column: number;
 };
 
-type AstGrepMatch = {
-  message: string;
-};
+const AstGrepMatches = z.array(z.looseObject({ message: z.string() }));
+
+const ExecFailure = z.looseObject({ stdout: z.string().optional() });
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -94,15 +89,12 @@ export async function checkCode(content: string, ext: string): Promise<string | 
       }).trim();
     } catch (error) {
       // execSync throws on non-zero exit, but we want stdout
-      const execError = error as { stdout?: string };
-      result = (execError.stdout || "").trim();
+      result = (ExecFailure.safeParse(error).data?.stdout ?? "").trim();
     }
 
     if (result) {
-      const matches: AstGrepMatch[] = JSON.parse(result);
-      if (matches.length > 0) {
-        return matches[0]?.message ?? null;
-      }
+      const matches = AstGrepMatches.parse(JSON.parse(result));
+      return matches[0]?.message ?? null;
     }
   } catch {
     // sg failed or parse error
@@ -130,24 +122,11 @@ async function fileAlreadyNumbered(filePath: string, ext: string): Promise<boole
 }
 
 export async function check(input: PreToolUseHookInput, mode: Mode): Promise<HookResult | null> {
-  const toolName = input.tool_name;
+  const edited = editedContent(input);
+  if (!edited) return null;
+  const { content, filePath } = edited;
 
-  let content: string;
-  let filePath: string;
-
-  if (toolName === "Write") {
-    const toolInput = input.tool_input as WriteInput;
-    content = toolInput.content;
-    filePath = toolInput.file_path;
-  } else if (toolName === "Edit") {
-    const toolInput = input.tool_input as EditInput;
-    content = toolInput.new_string;
-    filePath = toolInput.file_path;
-  } else {
-    return null;
-  }
-
-  if (typeof content !== "string" || !hasNumberingHint(content)) return null;
+  if (!hasNumberingHint(content)) return null;
 
   const ext = getExtension(filePath);
   let match: string | null = null;

--- a/plugins/writing/hooks/pretooluse.test.ts
+++ b/plugins/writing/hooks/pretooluse.test.ts
@@ -48,8 +48,9 @@ function mockInput(
 // (numbering + headings) and a spaced em dash (tropes).
 const MULTI_VIOLATION = "# step 1: introduction\n\nThis — is bad\n";
 
-function contextOf(output: SyncHookJSONOutput | null): string {
-  return (output?.hookSpecificOutput as { additionalContext: string }).additionalContext;
+function contextOf(output: SyncHookJSONOutput | null): string | undefined {
+  const specific = output?.hookSpecificOutput;
+  return specific?.hookEventName === "PreToolUse" ? specific.additionalContext : undefined;
 }
 
 describe("single output per tool call", () => {

--- a/plugins/writing/hooks/pretooluse.ts
+++ b/plugins/writing/hooks/pretooluse.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
 import {
   getExtension,
   isMarkdownFile,
@@ -9,7 +10,7 @@ import {
   isScratchPath,
 } from "../detection/paths";
 import * as tropes from "./check-tropes";
-import { type HookResult, isPlanMode, type SyncHookJSONOutput, tierOf } from "./io";
+import { type HookResult, isPlanMode, type SyncHookJSONOutput, tierOf, toolInputOf } from "./io";
 import * as numbering from "./numbering";
 import { appendRunLog, type RunLogEntry, type RunOutcome } from "./run-log";
 import { recentlyFired, recordFired } from "./session-state";
@@ -25,8 +26,7 @@ export type DispatchResult = {
 
 function filePathOf(input: PreToolUseHookInput): string | undefined {
   if (!FILE_OP_TOOLS.has(input.tool_name)) return undefined;
-  const filePath = (input.tool_input as Record<string, unknown>).file_path;
-  return typeof filePath === "string" ? filePath : undefined;
+  return toolInputOf(input).file_path;
 }
 
 // Every heading check is markdown-only: `headings.check` returns null for any
@@ -118,10 +118,21 @@ export async function dispatch(
   );
 }
 
+const HookInput = z.looseObject({
+  hook_event_name: z.literal("PreToolUse"),
+  session_id: z.string().catch(""),
+  transcript_path: z.string().catch(""),
+  cwd: z.string().catch(""),
+  permission_mode: z.string().catch(""),
+  tool_name: z.string(),
+  tool_input: z.unknown().catch(undefined),
+  tool_use_id: z.string().catch(""),
+}) satisfies z.ZodType<PreToolUseHookInput>;
+
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
+    input = HookInput.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     console.error(
       `[writing/pretooluse] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/writing/hooks/run-log.test.ts
+++ b/plugins/writing/hooks/run-log.test.ts
@@ -46,12 +46,12 @@ describe("appendRunLog", () => {
 
     const lines = (await Bun.file(path).text()).trim().split("\n");
     expect(lines).toHaveLength(2);
-    expect(JSON.parse(lines[0] as string)).toMatchObject({
+    expect(JSON.parse(lines[0] ?? "")).toMatchObject({
       outcome: "context",
       category: "numbering",
       tool: "Write",
     });
-    expect(JSON.parse(lines[1] as string)).toMatchObject({ suppressed: true });
+    expect(JSON.parse(lines[1] ?? "")).toMatchObject({ suppressed: true });
   });
 
   it("does nothing when logging is disabled", () => {
@@ -72,6 +72,6 @@ describe("appendRunLog", () => {
     expect(rotated.size).toBe(filler.length);
     const fresh = (await Bun.file(path).text()).trim().split("\n");
     expect(fresh).toHaveLength(1);
-    expect(JSON.parse(fresh[0] as string)).toMatchObject({ outcome: "deny" });
+    expect(JSON.parse(fresh[0] ?? "")).toMatchObject({ outcome: "deny" });
   });
 });

--- a/plugins/writing/hooks/run-log.ts
+++ b/plugins/writing/hooks/run-log.ts
@@ -3,19 +3,22 @@
 import { appendFileSync, mkdirSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { z } from "zod";
 
-export type RunOutcome = "silent" | "context" | "ask" | "deny" | "skipped-scratch";
+export const RunOutcome = z.enum(["silent", "context", "ask", "deny", "skipped-scratch"]);
+export type RunOutcome = z.infer<typeof RunOutcome>;
 
-export type RunLogEntry = {
-  ts: string;
-  session_id: string;
-  tool: string;
-  ext: string;
-  duration_ms: number;
-  outcome: RunOutcome;
-  category?: string;
-  suppressed?: boolean;
-};
+export const RunLogEntry = z.object({
+  ts: z.string(),
+  session_id: z.string(),
+  tool: z.string(),
+  ext: z.string(),
+  duration_ms: z.number(),
+  outcome: RunOutcome,
+  category: z.string().optional(),
+  suppressed: z.boolean().optional(),
+});
+export type RunLogEntry = z.infer<typeof RunLogEntry>;
 
 const MAX_LOG_BYTES = 5 * 1024 * 1024;
 const OFF_VALUES = new Set(["0", "false", "off"]);

--- a/plugins/writing/hooks/session-state.ts
+++ b/plugins/writing/hooks/session-state.ts
@@ -1,5 +1,6 @@
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { z } from "zod";
 
 // Session-scoped repeat suppression: a context-tier rule that already fired
 // recently in this session gets muted instead of re-injected. The state is one
@@ -7,7 +8,8 @@ import { join } from "node:path";
 // machine's temp cleanup and needs no explicit lifecycle.
 export const SUPPRESS_WINDOW_MS = 5 * 60 * 1000;
 
-export type SessionState = Record<string, number>;
+const SessionState = z.record(z.string(), z.number());
+export type SessionState = z.infer<typeof SessionState>;
 
 function statePath(sessionId: string): string {
   const safe = sessionId.replace(/[^\w-]/g, "");
@@ -18,9 +20,8 @@ async function readState(sessionId: string): Promise<SessionState> {
   try {
     const file = Bun.file(statePath(sessionId));
     if (!(await file.exists())) return {};
-    const parsed: unknown = await file.json();
-    if (!parsed || typeof parsed !== "object") return {};
-    return parsed as SessionState;
+    const parsed = SessionState.safeParse(await file.json());
+    return parsed.success ? parsed.data : {};
   } catch {
     return {};
   }

--- a/plugins/writing/linguistics/compromise.ts
+++ b/plugins/writing/linguistics/compromise.ts
@@ -1,4 +1,5 @@
 import nlp from "compromise";
+import { z } from "zod";
 import type { Tagger } from "./tagger";
 import {
   CODE_SENTINEL,
@@ -9,16 +10,16 @@ import {
   type TaggedToken,
 } from "./tags";
 
-interface CompromiseTerm {
-  text: string;
-  normal?: string;
-  tags?: string[];
-}
+const CompromiseTerm = z.looseObject({
+  text: z.string().catch(""),
+  normal: z.string().optional().catch(undefined),
+  tags: z.array(z.string()).optional().catch(undefined),
+});
+type CompromiseTerm = z.infer<typeof CompromiseTerm>;
 
-interface CompromiseSentence {
-  text: string;
-  terms: CompromiseTerm[];
-}
+const CompromiseSentences = z.array(
+  z.looseObject({ text: z.string().catch(""), terms: z.array(CompromiseTerm).catch([]) }),
+);
 
 function mapTerm(term: CompromiseTerm): Pick<TaggedToken, "tag" | "finite"> {
   const tags = new Set(term.tags ?? []);
@@ -63,7 +64,7 @@ function mapTerm(term: CompromiseTerm): Pick<TaggedToken, "tag" | "finite"> {
 export const compromiseTagger: Tagger = {
   name: "compromise",
   tag(text: string): TaggedSentence[] {
-    const sentences = nlp(text).json() as CompromiseSentence[];
+    const sentences = CompromiseSentences.parse(nlp(text).json());
     return sentences.map((sentence) => ({
       text: sentence.text,
       tokens: sentence.terms.map((term) => ({

--- a/plugins/writing/linguistics/tricolon.ts
+++ b/plugins/writing/linguistics/tricolon.ts
@@ -37,16 +37,12 @@ function editDistance(a: CoarseTag[], b: CoarseTag[]): number {
   for (let i = 1; i <= a.length; i++) {
     const current: number[] = [i];
     for (let j = 1; j <= b.length; j++) {
-      const substitution = (previous[j - 1] as number) + (a[i - 1] === b[j - 1] ? 0 : 1);
-      current[j] = Math.min(
-        (previous[j] as number) + 1,
-        (current[j - 1] as number) + 1,
-        substitution,
-      );
+      const substitution = (previous[j - 1] ?? 0) + (a[i - 1] === b[j - 1] ? 0 : 1);
+      current[j] = Math.min((previous[j] ?? 0) + 1, (current[j - 1] ?? 0) + 1, substitution);
     }
     previous = current;
   }
-  return previous[b.length] as number;
+  return previous[b.length] ?? 0;
 }
 
 /** Edit distance between two tag sequences, normalized to [0, 1] by the longer length. */
@@ -70,9 +66,8 @@ export function tricolonHits(text: string): Hits {
   if (sentences.length < 3) return { count: 0, sample: "" };
   const shapes = sentences.map(tagShape);
   for (let i = 0; i + 2 < sentences.length; i++) {
-    const a = shapes[i] as CoarseTag[];
-    const b = shapes[i + 1] as CoarseTag[];
-    const c = shapes[i + 2] as CoarseTag[];
+    const [a, b, c] = [shapes[i], shapes[i + 1], shapes[i + 2]];
+    if (!a || !b || !c) continue;
     if (Math.min(a.length, b.length, c.length) < TRICOLON_MIN_TOKENS) continue;
     if (!isParallelTriple(a, b, c)) continue;
     const sample = sentences

--- a/plugins/writing/package.json
+++ b/plugins/writing/package.json
@@ -12,7 +12,8 @@
     "mdast-util-from-markdown": "^2.0.2",
     "stemmer": "^2.0.1",
     "table": "^6.9.0",
-    "unist-util-visit": "^5.1.0"
+    "unist-util-visit": "^5.1.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/mdast": "^4.0.4",

--- a/plugins/writing/skills/analyze/scripts/analyze.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.ts
@@ -7,12 +7,12 @@ import { corpusPath, profilePath, resolveDataDir } from "./data-dir";
 import { type Database, openSessionDb } from "./db";
 import { auditDeliverableCorpus } from "./deliverable-audit";
 import {
-  type CorrectionRow,
-  type CorrectiveRow,
-  type DeliverableRow,
-  type ModelSummaryRow,
+  CorrectionRow,
+  CorrectiveRow,
+  DeliverableRow,
+  ModelSummaryRow,
   serializeCorpus,
-  type TextRow,
+  TextRow,
   totalChars,
 } from "./dump";
 import { escapeRegex, frustrationRegex, gatedRegex } from "./frustration";
@@ -21,7 +21,7 @@ import { computeLift, excludePhrases, processCorpus, processRows } from "./ngram
 import { findQuote } from "./quote-context";
 import { aggregateTrends, analyzeDocument } from "./rate-detectors";
 import { type CandidatePhrase, type ReportInput, renderReport } from "./report";
-import { buildRuleHealth, type FtsAuditRow } from "./rule-health";
+import { buildRuleHealth, FtsAuditRow } from "./rule-health";
 import { auditStructuralPatterns } from "./structural";
 import { type TagSignatureRow, tagSequence } from "./tag-ngram";
 import { computeCorpusRates } from "./voice-delta";
@@ -268,14 +268,14 @@ export async function runAnalysis(
 
   console.error("Auditing wordlists via FTS");
   const auditTerms = wordlistEntries.map((e) => e.phrase.toLowerCase()).join(",");
-  const auditRows = await db.runQuery<FtsAuditRow>("fts-phrase-audit", { terms: auditTerms });
+  const auditRows = await db.runQuery("fts-phrase-audit", FtsAuditRow, { terms: auditTerms });
   const auditByTerm = new Map(auditRows.map((r) => [r.term, r]));
 
   console.error("Fetching model summary");
-  const modelSummary = await db.runQuery<ModelSummaryRow>("model-summary", baseParams);
+  const modelSummary = await db.runQuery("model-summary", ModelSummaryRow, baseParams);
 
   console.error("Dumping all assistant text");
-  const assistantRows = await db.runQuery<TextRow>("text-export", {
+  const assistantRows = await db.runQuery("text-export", TextRow, {
     ...baseParams,
     role: "assistant",
     model: config.modelFilter,
@@ -283,13 +283,13 @@ export async function runAnalysis(
   });
 
   console.error("Dumping deliverable-prose corpus (Write/Edit/Bash tool inputs)");
-  const deliverableRows = await db.runQuery<DeliverableRow>("deliverable-prose", {
+  const deliverableRows = await db.runQuery("deliverable-prose", DeliverableRow, {
     ...baseParams,
     model: config.modelFilter,
   });
 
   console.error("Dumping user corpus (human input only)");
-  const userRows = await db.runQuery<TextRow>("text-export", {
+  const userRows = await db.runQuery("text-export", TextRow, {
     ...baseParams,
     role: "user",
     model: null,
@@ -372,13 +372,13 @@ export async function runAnalysis(
     }));
 
   console.error("Fetching correction candidates");
-  const corrections = await db.runQuery<CorrectionRow>("correction-candidates", baseParams);
+  const corrections = await db.runQuery("correction-candidates", CorrectionRow, baseParams);
 
   console.error("Fetching corrective feedback (frustration lexicon)");
   const primaryPattern = frustrationRegex();
   const primaryRe = new RegExp(primaryPattern, "i");
   const combinedLexicon = `(?:${primaryPattern})|(?:${gatedRegex()})`;
-  const rawCorrective = await db.runQuery<CorrectiveRow>("corrective-feedback", {
+  const rawCorrective = await db.runQuery("corrective-feedback", CorrectiveRow, {
     ...baseParams,
     lexicon: combinedLexicon,
     max_user_chars: "400",

--- a/plugins/writing/skills/analyze/scripts/db.ts
+++ b/plugins/writing/skills/analyze/scripts/db.ts
@@ -1,13 +1,18 @@
 import * as path from "node:path";
 import { DuckDBInstance } from "@duckdb/node-api";
+import { z } from "zod";
 
 const QUERIES_DIR = path.join(import.meta.dirname, "..", "resources", "queries");
 
 export interface Database {
   run(sql: string): Promise<void>;
-  query<T>(sql: string): Promise<T[]>;
+  query<T>(sql: string, schema: z.ZodType<T>): Promise<T[]>;
   setParams(params: Record<string, string | null>): Promise<void>;
-  runQuery<T>(queryName: string, params?: Record<string, string | null>): Promise<T[]>;
+  runQuery<T>(
+    queryName: string,
+    schema: z.ZodType<T>,
+    params?: Record<string, string | null>,
+  ): Promise<T[]>;
   execQuery(queryName: string, params?: Record<string, string | null>): Promise<void>;
   close(): void;
 }
@@ -20,10 +25,10 @@ export async function openSessionDb(dbPath: string): Promise<Database> {
     await connection.run(sql);
   }
 
-  async function query<T>(sql: string): Promise<T[]> {
+  async function query<T>(sql: string, schema: z.ZodType<T>): Promise<T[]> {
     const reader = await connection.runAndReadAll(sql);
     const rows = reader.getRowObjectsJS();
-    return rows.map(narrowBigints) as T[];
+    return z.array(schema).parse(rows.map(narrowBigints));
   }
 
   async function setParams(params: Record<string, string | null>): Promise<void> {
@@ -41,10 +46,14 @@ export async function openSessionDb(dbPath: string): Promise<Database> {
     query,
     setParams,
 
-    async runQuery<T>(queryName: string, params: Record<string, string | null> = {}): Promise<T[]> {
+    async runQuery<T>(
+      queryName: string,
+      schema: z.ZodType<T>,
+      params: Record<string, string | null> = {},
+    ): Promise<T[]> {
       await setParams(params);
       const sql = await readSql(queryName);
-      return query<T>(sql);
+      return query(sql, schema);
     },
 
     async execQuery(queryName: string, params: Record<string, string | null> = {}): Promise<void> {

--- a/plugins/writing/skills/analyze/scripts/dump.test.ts
+++ b/plugins/writing/skills/analyze/scripts/dump.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { CorrectionRow, CorrectiveRow, DeliverableRow } from "./dump";
+
+const corrective = {
+  session_id: "s1",
+  project: null,
+  timestamp: new Date("2026-05-20T10:01:00Z"),
+  user_chars: 12,
+  user_text: "too flowery",
+  user_source_file: null,
+  user_source_line: null,
+  matched_term: "fluff",
+  context_chars: null,
+  context_snippet: null,
+};
+
+describe("row decoding", () => {
+  test("renders a Date column as ISO text", () => {
+    expect(CorrectiveRow.parse(corrective).timestamp).toBe("2026-05-20T10:01:00.000Z");
+  });
+
+  test("keeps a timestamp that already arrived as text", () => {
+    const parsed = CorrectionRow.parse({
+      session_id: "s1",
+      project: null,
+      assistant_timestamp: "2026-05-20T10:00:00Z",
+      user_timestamp: new Date("2026-05-20T10:01:00Z"),
+      assistant_chars: 40,
+      user_chars: 12,
+      assistant_snippet: "a",
+      user_snippet: "b",
+      prose_signal: true,
+    });
+    expect(parsed.assistant_timestamp).toBe("2026-05-20T10:00:00Z");
+    expect(parsed.user_timestamp).toBe("2026-05-20T10:01:00.000Z");
+  });
+
+  test("rejects a row missing a nullable column", () => {
+    expect(() =>
+      DeliverableRow.parse({ session_id: "s1", source_file: null, source_line: null, text: "x" }),
+    ).toThrow("file_path");
+  });
+});

--- a/plugins/writing/skills/analyze/scripts/dump.ts
+++ b/plugins/writing/skills/analyze/scripts/dump.ts
@@ -1,48 +1,60 @@
-export interface TextRow {
-  session_id: string;
-  text: string;
-}
+import { z } from "zod";
 
-export interface DeliverableRow {
-  session_id: string;
-  source_file: string | null;
-  source_line: number | null;
-  file_path: string | null;
-  text: string;
-}
+// DuckDB hands TIMESTAMP columns back as Date. Reports render the ISO form.
+const Timestamp = z
+  .union([z.string(), z.date()])
+  .transform((value) => (typeof value === "string" ? value : value.toISOString()));
 
-export interface CorrectiveRow {
-  session_id: string;
-  project: string | null;
-  timestamp: string;
-  user_chars: number;
-  user_text: string;
-  user_source_file: string | null;
-  user_source_line: number | null;
-  matched_term: string;
-  context_chars: number | null;
-  context_snippet: string | null;
-}
+export const TextRow = z.object({
+  session_id: z.string(),
+  text: z.string(),
+});
+export type TextRow = z.infer<typeof TextRow>;
 
-export interface CorrectionRow {
-  session_id: string;
-  project: string | null;
-  assistant_timestamp: string;
-  user_timestamp: string;
-  assistant_chars: number;
-  user_chars: number;
-  assistant_snippet: string;
-  user_snippet: string;
-  prose_signal: boolean;
-}
+export const DeliverableRow = z.object({
+  session_id: z.string(),
+  source_file: z.string().nullable(),
+  source_line: z.number().nullable(),
+  file_path: z.string().nullable(),
+  text: z.string(),
+});
+export type DeliverableRow = z.infer<typeof DeliverableRow>;
 
-export interface ModelSummaryRow {
-  model: string;
-  text_items: number;
-  messages: number;
-  sessions: number;
-  total_chars: number;
-}
+export const CorrectiveRow = z.object({
+  session_id: z.string(),
+  project: z.string().nullable(),
+  timestamp: Timestamp,
+  user_chars: z.number(),
+  user_text: z.string(),
+  user_source_file: z.string().nullable(),
+  user_source_line: z.number().nullable(),
+  matched_term: z.string(),
+  context_chars: z.number().nullable(),
+  context_snippet: z.string().nullable(),
+});
+export type CorrectiveRow = z.infer<typeof CorrectiveRow>;
+
+export const CorrectionRow = z.object({
+  session_id: z.string(),
+  project: z.string().nullable(),
+  assistant_timestamp: Timestamp,
+  user_timestamp: Timestamp,
+  assistant_chars: z.number(),
+  user_chars: z.number(),
+  assistant_snippet: z.string(),
+  user_snippet: z.string(),
+  prose_signal: z.boolean(),
+});
+export type CorrectionRow = z.infer<typeof CorrectionRow>;
+
+export const ModelSummaryRow = z.object({
+  model: z.string(),
+  text_items: z.number(),
+  messages: z.number(),
+  sessions: z.number(),
+  total_chars: z.number(),
+});
+export type ModelSummaryRow = z.infer<typeof ModelSummaryRow>;
 
 export function serializeCorpus(rows: Array<{ text?: string }>): string {
   return rows

--- a/plugins/writing/skills/analyze/scripts/headings-eval.ts
+++ b/plugins/writing/skills/analyze/scripts/headings-eval.ts
@@ -22,12 +22,13 @@ import { cli } from "cleye";
 import type { Heading, Text } from "mdast";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { table } from "table";
+import { z } from "zod";
 import { visit } from "unist-util-visit";
 import { CLASSIFIERS } from "../../../linguistics/classifiers";
 import type { HeadingClassifier, HeadingKind } from "../../../linguistics/heading";
 import { powerFromCurrentSample } from "../../../linguistics/power";
 import { openSessionDb } from "./db";
-import type { DeliverableRow } from "./dump";
+import { DeliverableRow } from "./dump";
 
 export interface HeadingRecord {
   heading: string;
@@ -149,21 +150,23 @@ export function evaluateClassifiers(
 /** Wilson score interval for a binomial proportion (95%). */
 export function wilson(successes: number, n: number): { lo: number; hi: number } {
   if (n === 0) return { lo: 0, hi: 1 };
-  const z = 1.96;
+  const zScore = 1.96;
   const p = successes / n;
-  const denom = 1 + z ** 2 / n;
-  const center = (p + z ** 2 / (2 * n)) / denom;
-  const margin = (z * Math.sqrt((p * (1 - p)) / n + z ** 2 / (4 * n ** 2))) / denom;
+  const denom = 1 + zScore ** 2 / n;
+  const center = (p + zScore ** 2 / (2 * n)) / denom;
+  const margin = (zScore * Math.sqrt((p * (1 - p)) / n + zScore ** 2 / (4 * n ** 2))) / denom;
   return { lo: Math.max(0, center - margin), hi: Math.min(1, center + margin) };
 }
 
-export const LABELS: HeadingKind[] = [
+export const LABELS = [
   "noun-phrase",
   "clause",
   "imperative",
   "interrogative",
   "fragment",
-];
+] as const satisfies readonly HeadingKind[];
+
+const HeadingLabel = z.enum(LABELS);
 
 export const SHOULD_FLAG = new Set<HeadingKind>(["clause", "imperative"]);
 
@@ -219,12 +222,13 @@ export function parseLabelsFile(content: string): LabeledHeading[] {
     if (line.startsWith("#") || line.trim().length === 0) continue;
     const [heading, label, source] = line.split("\t");
     if (!heading || !label) continue;
-    if (!LABELS.includes(label as HeadingKind)) {
+    const parsed = HeadingLabel.safeParse(label);
+    if (!parsed.success) {
       throw new Error(`Unknown label "${label}" for heading "${heading}"`);
     }
     labeled.push({
       heading,
-      label: label as HeadingKind,
+      label: parsed.data,
       source: source === "disagreement" ? "disagreement" : "random",
     });
   }
@@ -315,7 +319,7 @@ async function corpusFromSessionDb(
   const db = await openSessionDb(isolatedPath);
   try {
     console.error("Dumping deliverable-prose corpus");
-    return await db.runQuery<DeliverableRow>("deliverable-prose", params);
+    return await db.runQuery("deliverable-prose", DeliverableRow, params);
   } finally {
     db.close();
   }

--- a/plugins/writing/skills/analyze/scripts/hook-health.ts
+++ b/plugins/writing/skills/analyze/scripts/hook-health.ts
@@ -2,7 +2,7 @@
 
 import { cli } from "cleye";
 import { table } from "table";
-import { type RunLogEntry, type RunOutcome, resolveLogPath } from "../../../hooks/run-log";
+import { RunLogEntry, type RunOutcome, resolveLogPath } from "../../../hooks/run-log";
 
 export type CategoryHealth = {
   category: string;
@@ -27,10 +27,8 @@ export function parseLog(text: string): RunLogEntry[] {
   for (const line of text.split("\n")) {
     if (!line.trim()) continue;
     try {
-      const parsed: unknown = JSON.parse(line);
-      if (parsed && typeof parsed === "object" && "outcome" in parsed) {
-        entries.push(parsed as RunLogEntry);
-      }
+      const parsed = RunLogEntry.safeParse(JSON.parse(line));
+      if (parsed.success) entries.push(parsed.data);
     } catch {
       // A torn write from a concurrent session produces a partial line.
     }

--- a/plugins/writing/skills/analyze/scripts/ingest-voice.ts
+++ b/plugins/writing/skills/analyze/scripts/ingest-voice.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { mkdirSync } from "node:fs";
 import { cli } from "cleye";
+import { z } from "zod";
 import { corpusPath, resolveDataDir, voiceBaselineDir } from "./data-dir";
 import { mergeDocuments, parseCorpus, serializeCorpus, type VoiceDocument } from "./voice-corpus";
 
@@ -67,6 +68,10 @@ async function collectIncoming(): Promise<VoiceDocument[]> {
   throw new Error(`Unknown source: ${argv.flags.source}. Use 'github' or 'file'.`);
 }
 
+const SearchResults = z.array(
+  z.object({ url: z.string(), body: z.string(), createdAt: z.string() }),
+);
+
 async function fetchGithub(): Promise<VoiceDocument[]> {
   const author = argv.flags.author;
   if (!author) {
@@ -97,11 +102,7 @@ async function fetchGithub(): Promise<VoiceDocument[]> {
     throw new Error(`gh search prs failed (exit ${exitCode}): ${stderr.trim()}`);
   }
 
-  const results = JSON.parse(stdout) as Array<{
-    url: string;
-    body: string;
-    createdAt: string;
-  }>;
+  const results = SearchResults.parse(JSON.parse(stdout));
 
   return results
     .filter((pr) => pr.body && pr.body.trim().length >= 30)

--- a/plugins/writing/skills/analyze/scripts/judge-run.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge-run.test.ts
@@ -1,16 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import type { LabeledHeading } from "./headings-eval";
-import { type CriterionKey, JUDGE_CRITERIA, type JudgeVerdict } from "./judge";
+import { byCriterion, type CriterionKey, JUDGE_CRITERIA, type JudgeVerdict } from "./judge";
 import { JUDGE_PROMPT_SHA256 } from "./judge-fixtures";
 import { runGate, scoreHeadingBaseline } from "./judge-run";
 
 function verdictFor(flags: Partial<Record<CriterionKey, boolean>>): JudgeVerdict {
-  const v = {} as JudgeVerdict;
-  for (const c of JUDGE_CRITERIA) {
-    const flagged = flags[c.key] ?? false;
-    v[c.key] = { flagged, span: flagged ? `span for ${c.id}` : null };
-  }
-  return v;
+  return byCriterion((key) => {
+    const flagged = flags[key] ?? false;
+    const id = JUDGE_CRITERIA.find((c) => c.key === key)?.id ?? key;
+    return { flagged, span: flagged ? `span for ${id}` : null };
+  });
 }
 
 describe("runGate", () => {

--- a/plugins/writing/skills/analyze/scripts/judge.test.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import {
+  byCriterion,
   aggregateVerdicts,
   CHUNK_WORD_LIMIT,
   type CriterionKey,
@@ -24,18 +25,12 @@ import {
 } from "./judge";
 
 function verdict(overrides: Partial<Record<CriterionKey, boolean | string>> = {}): JudgeVerdict {
-  const v = {} as JudgeVerdict;
-  for (const c of JUDGE_CRITERIA) {
-    const override = overrides[c.key];
-    if (override === undefined) {
-      v[c.key] = { flagged: false, span: null };
-    } else if (typeof override === "boolean") {
-      v[c.key] = { flagged: override, span: null };
-    } else {
-      v[c.key] = { flagged: true, span: override };
-    }
-  }
-  return v;
+  return byCriterion((key) => {
+    const override = overrides[key];
+    if (override === undefined) return { flagged: false, span: null };
+    if (typeof override === "boolean") return { flagged: override, span: null };
+    return { flagged: true, span: override };
+  });
 }
 
 describe("JUDGE_CRITERIA", () => {
@@ -93,7 +88,7 @@ describe("prompt artifact", () => {
 
 describe("verdictSchema", () => {
   test("requires every criterion and forbids extras", () => {
-    const schema = verdictSchema() as { required: string[]; additionalProperties: boolean };
+    const schema = verdictSchema();
     expect(schema.required).toEqual(JUDGE_CRITERIA.map((c) => c.key));
     expect(schema.additionalProperties).toBe(false);
   });
@@ -115,24 +110,35 @@ describe("parseVerdict", () => {
   });
 
   test("rejects a missing criterion", () => {
-    const partial: Record<string, unknown> = JSON.parse(JSON.stringify(verdict()));
-    delete partial.hedging_density;
+    const { hedging_density: _dropped, ...partial } = verdict();
     expect(() => parseVerdict(JSON.stringify(partial))).toThrow(
       'missing criterion "hedging_density"',
     );
   });
 
-  test("rejects non-boolean flagged and non-string span", () => {
-    const bad = JSON.parse(JSON.stringify(verdict())) as Record<
-      string,
-      { flagged: unknown; span: unknown }
-    >;
-    const sycophancy = bad.sycophancy as { flagged: unknown; span: unknown };
-    sycophancy.flagged = "yes";
-    expect(() => parseVerdict(JSON.stringify(bad))).toThrow("must be a boolean");
-    sycophancy.flagged = true;
-    sycophancy.span = 7;
-    expect(() => parseVerdict(JSON.stringify(bad))).toThrow("must be a string or null");
+  test.each<{ name: string; sycophancy: unknown; error: string }>([
+    {
+      name: "non-boolean flagged",
+      sycophancy: { flagged: "yes", span: null },
+      error: "must be a boolean",
+    },
+    {
+      name: "non-string span",
+      sycophancy: { flagged: true, span: 7 },
+      error: "must be a string or null",
+    },
+    {
+      name: "a non-object criterion",
+      sycophancy: "flagged",
+      error: 'missing criterion "sycophancy"',
+    },
+    { name: "a non-object verdict", sycophancy: undefined, error: "must be a JSON object" },
+  ])("rejects $name", ({ name, sycophancy, error }) => {
+    const json =
+      name === "a non-object verdict"
+        ? JSON.stringify(["not", "an", "object"])
+        : JSON.stringify({ ...verdict(), sycophancy });
+    expect(() => parseVerdict(json)).toThrow(error);
   });
 });
 
@@ -193,7 +199,7 @@ describe("judgeDocument", () => {
       seen.push(chunk);
       return verdict({ information_density: seen.length === 2 });
     };
-    const long = `${Array(1400).fill("alpha").join(" ")}\n\n${Array(1400).fill("beta").join(" ")}`;
+    const long = `${Array.from({ length: 1400 }, () => "alpha").join(" ")}\n\n${Array.from({ length: 1400 }, () => "beta").join(" ")}`;
     const result = await judgeDocument(judge, long);
     expect(seen.length).toBe(2);
     expect(result.information_density.flagged).toBe(true);
@@ -202,7 +208,9 @@ describe("judgeDocument", () => {
 
 describe("estimateCost", () => {
   test("counts one call per chunk and prices by model", async () => {
-    const longDoc = Array(3).fill(Array(1200).fill("word").join(" ")).join("\n\n");
+    const longDoc = Array.from({ length: 3 }, () =>
+      Array.from({ length: 1200 }, () => "word").join(" "),
+    ).join("\n\n");
     const docs = ["short doc one", longDoc];
     const estimate = await estimateCost(docs, { promptText: "prompt words here" });
     expect(estimate.calls).toBe(4);
@@ -224,7 +232,10 @@ describe("estimateCost", () => {
   });
 
   test("heading estimate counts one call per batch, not per heading", async () => {
-    const headings = Array(HEADING_BATCH_SIZE * 2 + 1).fill("Deployment Topology");
+    const headings = Array.from(
+      { length: HEADING_BATCH_SIZE * 2 + 1 },
+      () => "Deployment Topology",
+    );
     const batches: string[] = [];
     const estimate = await estimateHeadingCost(headings, {
       promptText: "prompt words here",
@@ -240,7 +251,9 @@ describe("estimateCost", () => {
 
   test("a 200-document run of 1k-word PR bodies stays under a dollar on haiku", async () => {
     const prompt = await loadPrompt();
-    const docs = Array(200).fill(Array(1000).fill("word").join(" "));
+    const docs = Array.from({ length: 200 }, () =>
+      Array.from({ length: 1000 }, () => "word").join(" "),
+    );
     const estimate = await estimateCost(docs, { promptText: prompt.text });
     expect(estimate.usd).toBeLessThan(1);
   });
@@ -304,7 +317,7 @@ describe("judgeCorpus", () => {
       verdict(),
     ];
     let i = 0;
-    const judge = async () => verdicts[i++] as JudgeVerdict;
+    const judge = async () => verdicts[i++] ?? verdict();
     const audit = await judgeCorpus(judge, ["a", "b", "c"], {
       promptSha256: "abc123",
       model: "claude-haiku-4-5",
@@ -340,12 +353,16 @@ describe("judgeCorpus", () => {
 
   test("caps sampled spans", async () => {
     const judge = async () => verdict({ marketing_phrasing: "seamless" });
-    const audit = await judgeCorpus(judge, Array(8).fill("doc"), {
-      promptSha256: "abc",
-      model: "claude-haiku-4-5",
-      estimatedCostUsd: 0,
-      maxSpans: 2,
-    });
+    const audit = await judgeCorpus(
+      judge,
+      Array.from({ length: 8 }, () => "doc"),
+      {
+        promptSha256: "abc",
+        model: "claude-haiku-4-5",
+        estimatedCostUsd: 0,
+        maxSpans: 2,
+      },
+    );
     const marketing = audit.criteria.find((c) => c.id === "marketing-phrasing");
     expect(marketing?.flagged).toBe(8);
     expect(marketing?.spans?.length).toBe(2);
@@ -380,7 +397,10 @@ describe("judgeHeadings", () => {
       batches.push(headings.length);
       return headings.map(() => false);
     };
-    const verdicts = await judgeHeadings(judge, Array(HEADING_BATCH_SIZE + 3).fill("Heading"));
+    const verdicts = await judgeHeadings(
+      judge,
+      Array.from({ length: HEADING_BATCH_SIZE + 3 }, () => "Heading"),
+    );
     expect(batches).toEqual([HEADING_BATCH_SIZE, 3]);
     expect(verdicts.length).toBe(HEADING_BATCH_SIZE + 3);
   });

--- a/plugins/writing/skills/analyze/scripts/judge.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import * as path from "node:path";
 import Anthropic from "@anthropic-ai/sdk";
+import { z } from "zod";
 import type { DeliverableRow } from "./dump";
 
 /**
@@ -142,8 +143,28 @@ export interface CriterionVerdict {
 
 export type JudgeVerdict = Record<CriterionKey, CriterionVerdict>;
 
+/** Keeps every per-criterion record exhaustive against `CriterionKey`. */
+export function byCriterion<T>(value: (key: CriterionKey) => T): Record<CriterionKey, T> {
+  return {
+    information_density: value("information_density"),
+    motivation_presence: value("motivation_presence"),
+    marketing_phrasing: value("marketing_phrasing"),
+    hedging_density: value("hedging_density"),
+    sycophancy: value("sycophancy"),
+    press_release_structure: value("press_release_structure"),
+  };
+}
+
+/** The structured-output envelope both judges send to the API. */
+export type OutputSchema = {
+  type: "object";
+  properties: Record<string, unknown>;
+  required: string[];
+  additionalProperties: false;
+};
+
 /** JSON schema for the judge's structured output (one object per chunk). */
-export function verdictSchema(): Record<string, unknown> {
+export function verdictSchema(): OutputSchema {
   const criterion = {
     type: "object",
     properties: {
@@ -165,33 +186,36 @@ export function verdictSchema(): Record<string, unknown> {
   };
 }
 
+const criterionInput = (key: CriterionKey) =>
+  z.object(
+    {
+      flagged: z.boolean({ error: `Judge verdict "${key}.flagged" must be a boolean` }),
+      span: z.union([z.string(), z.null()], {
+        error: `Judge verdict "${key}.span" must be a string or null`,
+      }),
+    },
+    { error: `Judge verdict missing criterion "${key}"` },
+  );
+
+const VerdictInput = z.object(byCriterion(criterionInput), {
+  error: "Judge verdict must be a JSON object",
+});
+
 export function parseVerdict(json: string): JudgeVerdict {
   let parsed: unknown;
   try {
     parsed = JSON.parse(json);
   } catch (error) {
-    throw new Error(`Judge returned invalid JSON: ${(error as Error).message}`, { cause: error });
+    throw new Error(
+      `Judge returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
   }
-  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-    throw new Error("Judge verdict must be a JSON object");
+  const result = VerdictInput.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(result.error.issues[0]?.message ?? "Judge verdict must be a JSON object");
   }
-  const record = parsed as Record<string, unknown>;
-  const verdict = {} as JudgeVerdict;
-  for (const criterion of JUDGE_CRITERIA) {
-    const value = record[criterion.key];
-    if (typeof value !== "object" || value === null) {
-      throw new Error(`Judge verdict missing criterion "${criterion.key}"`);
-    }
-    const entry = value as Record<string, unknown>;
-    if (typeof entry.flagged !== "boolean") {
-      throw new Error(`Judge verdict "${criterion.key}.flagged" must be a boolean`);
-    }
-    if (entry.span !== null && typeof entry.span !== "string") {
-      throw new Error(`Judge verdict "${criterion.key}.span" must be a string or null`);
-    }
-    verdict[criterion.key] = { flagged: entry.flagged, span: entry.span };
-  }
-  return verdict;
+  return result.data;
 }
 
 export function countWords(text: string): number {
@@ -231,15 +255,13 @@ export function chunkDocument(text: string, wordLimit: number = CHUNK_WORD_LIMIT
  */
 export function aggregateVerdicts(verdicts: JudgeVerdict[]): JudgeVerdict {
   if (verdicts.length === 0) throw new Error("aggregateVerdicts requires at least one verdict");
-  const aggregate = {} as JudgeVerdict;
-  for (const criterion of JUDGE_CRITERIA) {
-    const flagged = verdicts.filter((v) => v[criterion.key].flagged);
-    aggregate[criterion.key] = {
+  return byCriterion((key) => {
+    const flagged = verdicts.filter((v) => v[key].flagged);
+    return {
       flagged: flagged.length > 0,
-      span: flagged.find((v) => v[criterion.key].span !== null)?.[criterion.key].span ?? null,
+      span: flagged.find((v) => v[key].span !== null)?.[key].span ?? null,
     };
-  }
-  return aggregate;
+  });
 }
 
 /** Judges one chunk of text. The seam tests mock; the SDK call implements. */
@@ -454,18 +476,19 @@ export async function judgeCorpus(
   meta: JudgeCorpusMeta,
 ): Promise<MeaningAudit> {
   const maxSpans = meta.maxSpans ?? MAX_SAMPLE_SPANS;
-  const stats = new Map<CriterionKey, MeaningCriterionStat>(
-    JUDGE_CRITERIA.map((c) => [
-      c.key,
-      { id: c.id, question: c.question, flagged: 0, total: texts.length, spans: [] },
-    ]),
-  );
+  const stats: MeaningCriterionStat[] = JUDGE_CRITERIA.map((c) => ({
+    id: c.id,
+    question: c.question,
+    flagged: 0,
+    total: texts.length,
+    spans: [],
+  }));
   for (const text of texts) {
     const verdict = await judgeDocument(judge, text);
-    for (const criterion of JUDGE_CRITERIA) {
+    for (const [index, criterion] of JUDGE_CRITERIA.entries()) {
+      const stat = stats[index];
       const entry = verdict[criterion.key];
-      if (!entry.flagged) continue;
-      const stat = stats.get(criterion.key) as MeaningCriterionStat;
+      if (!stat || !entry.flagged) continue;
       stat.flagged++;
       if (entry.span && stat.spans.length < maxSpans) stat.spans.push(entry.span);
     }
@@ -475,7 +498,7 @@ export async function judgeCorpus(
     model: meta.model,
     documents: texts.length,
     estimatedCostUsd: meta.estimatedCostUsd,
-    criteria: JUDGE_CRITERIA.map((c) => stats.get(c.key) as MeaningCriterionStat),
+    criteria: stats,
   };
 }
 
@@ -528,7 +551,7 @@ export function meaningDetector(options: MeaningDetectorOptions = {}): MeaningDe
  * Schema for the heading baseline: one boolean per heading, by index, marking
  * whether the heading is sentence-shaped.
  */
-export function headingBatchSchema(): Record<string, unknown> {
+export function headingBatchSchema(): OutputSchema {
   return {
     type: "object",
     properties: {
@@ -550,27 +573,40 @@ export function headingBatchSchema(): Record<string, unknown> {
   };
 }
 
+const HEADING_ENTRY_ERROR = "Heading verdict entries must carry numeric index and boolean verdict";
+const HEADINGS_ERROR = 'Heading verdict missing "headings" array';
+
+const HeadingVerdicts = z.object(
+  {
+    headings: z.array(
+      z.looseObject(
+        {
+          index: z.number({ error: HEADING_ENTRY_ERROR }),
+          sentence_shaped: z.boolean({ error: HEADING_ENTRY_ERROR }),
+        },
+        { error: HEADING_ENTRY_ERROR },
+      ),
+      { error: HEADINGS_ERROR },
+    ),
+  },
+  { error: HEADINGS_ERROR },
+);
+
 export function parseHeadingVerdicts(json: string, expected: number): boolean[] {
   let parsed: unknown;
   try {
     parsed = JSON.parse(json);
   } catch (error) {
-    throw new Error(`Heading judge returned invalid JSON: ${(error as Error).message}`, {
-      cause: error,
-    });
+    throw new Error(
+      `Heading judge returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
   }
-  const record = parsed as Record<string, unknown>;
-  const entries = record.headings;
-  if (!Array.isArray(entries)) throw new Error('Heading verdict missing "headings" array');
+  const result = HeadingVerdicts.safeParse(parsed);
+  if (!result.success) throw new Error(result.error.issues[0]?.message ?? HEADINGS_ERROR);
   const verdicts = Array.from<boolean>({ length: expected }).fill(false);
   const seen = new Set<number>();
-  for (const entry of entries) {
-    const item = entry as Record<string, unknown>;
-    const index = item.index;
-    const flagged = item.sentence_shaped;
-    if (typeof index !== "number" || typeof flagged !== "boolean") {
-      throw new Error("Heading verdict entries must carry numeric index and boolean verdict");
-    }
+  for (const { index, sentence_shaped: flagged } of result.data.headings) {
     if (index < 0 || index >= expected) {
       throw new Error(`Heading verdict index ${index} out of range (expected 0..${expected - 1})`);
     }

--- a/plugins/writing/skills/analyze/scripts/rule-health.ts
+++ b/plugins/writing/skills/analyze/scripts/rule-health.ts
@@ -1,17 +1,19 @@
+import { z } from "zod";
 import { type DeliverableAudit, isDeliverableSurface } from "./deliverable-audit";
 import type { QuoteContext } from "./quote-context";
 import type { VoiceProfile } from "./voice-profile";
 import { phraseProfileStatStemmed } from "./voice-profile";
 import type { WordlistEntry } from "./wordlists";
 
-export interface FtsAuditRow {
-  term: string;
-  assistant_count: number;
-  user_count: number;
-  assistant_per_m: number | null;
-  user_per_m: number | null;
-  lift: number | null;
-}
+export const FtsAuditRow = z.object({
+  term: z.string(),
+  assistant_count: z.number(),
+  user_count: z.number(),
+  assistant_per_m: z.number().nullable(),
+  user_per_m: z.number().nullable(),
+  lift: z.number().nullable(),
+});
+export type FtsAuditRow = z.infer<typeof FtsAuditRow>;
 
 export type RemoveReason = "dead" | "not distinctive";
 export type AuditSurface = "chat" | "deliverable";

--- a/plugins/writing/skills/analyze/scripts/voice-delta.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-delta.ts
@@ -15,6 +15,8 @@
 // per-document flags. They are rates-only in every surface. Only ungoverned
 // features may produce per-document flags.
 
+import { z } from "zod";
+
 export type Provenance = "skill-prescribed" | "skill-encouraged" | "ungoverned";
 
 export interface VoiceDeltaFeature {
@@ -398,9 +400,10 @@ export function computeCorpusRates(texts: string[]): Map<string, FeatureRate> {
 // comparison. Computed during profile build from the baseline corpus.
 // When a loaded profile predates this extension (voiceDelta missing), each
 // feature degrades to a "no baseline" display.
-export interface VoiceDeltaBaseline {
+export const VoiceDeltaBaseline = z.object({
   // Feature id -> mean rate across the baseline corpus.
-  rates: Record<string, number>;
-  documentCount: number;
-  computedAt: string;
-}
+  rates: z.record(z.string(), z.number()),
+  documentCount: z.number(),
+  computedAt: z.string(),
+});
+export type VoiceDeltaBaseline = z.infer<typeof VoiceDeltaBaseline>;

--- a/plugins/writing/skills/analyze/scripts/voice-profile.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-profile.ts
@@ -1,11 +1,12 @@
 #!/usr/bin/env bun
 import { mkdirSync } from "node:fs";
 import { cli } from "cleye";
+import { z } from "zod";
 import { corpusPath, profilePath, resolveDataDir, voiceBaselineDir } from "./data-dir";
 import { stemPhrase, stemTokens } from "./deliverable-audit";
 import { cleanText, splitSentences, tokenizeSentence } from "./ngram";
 import { parseCorpus, type VoiceDocument } from "./voice-corpus";
-import { computeCorpusRates, type VoiceDeltaBaseline } from "./voice-delta";
+import { computeCorpusRates, VoiceDeltaBaseline } from "./voice-delta";
 
 // Word n-gram sizes the profile records. Unigrams cover single-word tells
 // (e.g. "cleanly"); bigrams and trigrams cover phrase tells (e.g. "source of
@@ -13,27 +14,30 @@ import { computeCorpusRates, type VoiceDeltaBaseline } from "./voice-delta";
 // leading trigram (see phraseProfileMatch).
 export const PROFILE_SIZES = [1, 2, 3] as const;
 
-export interface VoiceProfile {
-  documentCount: number;
-  totalTokens: number;
+const NgramCounts = z.record(z.string(), z.record(z.string(), z.number()));
+
+export const VoiceProfile = z.object({
+  documentCount: z.number(),
+  totalTokens: z.number(),
   // n-gram size -> phrase -> count. Stored as plain objects for JSON. Built from
   // unstemmed tokens; the candidate-additions path looks these up directly.
-  ngrams: Record<string, Record<string, number>>;
+  ngrams: NgramCounts,
   // Same shape, but built from Porter-stemmed tokens via the deliverable-audit
   // stemming. The deliverable rule-health path looks these up so an inflected
   // baseline phrase ("fails loudly") matches the rule's stem ("fail loudli"),
   // mirroring how auditDeliverableCorpus stems the model's deliverable corpus.
-  stemmedNgrams: Record<string, Record<string, number>>;
+  stemmedNgrams: NgramCounts,
   // Stemmed token count, the denominator for stemmed per-million rates. Differs
   // from totalTokens because the two tokenizers split prose differently.
-  totalStemmedTokens: number;
-  generatedAt: string;
-  sources: string[];
+  totalStemmedTokens: z.number(),
+  generatedAt: z.string(),
+  sources: z.array(z.string()),
   // Voice-delta aggregate stats from the baseline corpus. Optional: profiles
   // built before this field was added will not have it. Callers should treat
   // its absence as "no baseline for voice-delta features".
-  voiceDelta?: VoiceDeltaBaseline;
-}
+  voiceDelta: VoiceDeltaBaseline.optional(),
+});
+export type VoiceProfile = z.infer<typeof VoiceProfile>;
 
 export type { VoiceDeltaBaseline };
 
@@ -106,7 +110,7 @@ export function buildProfileFromCorpus(corpusText: string, generatedAt: string):
 export async function loadProfile(path: string): Promise<VoiceProfile | null> {
   const file = Bun.file(path);
   if (!(await file.exists())) return null;
-  return (await file.json()) as VoiceProfile;
+  return VoiceProfile.parse(await file.json());
 }
 
 export interface PhraseProfileStat {

--- a/plugins/writing/skills/analyze/scripts/wordlists.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlists.ts
@@ -1,17 +1,20 @@
 import { readdirSync } from "node:fs";
 import * as path from "node:path";
+import { z } from "zod";
 
 export interface WordlistEntry {
   phrase: string;
   source: string;
 }
 
+const FileError = z.looseObject({ code: z.string().optional().catch(undefined) });
+
 export async function loadWordlists(dir: string): Promise<WordlistEntry[]> {
   let files: string[];
   try {
     files = readdirSync(dir).filter((f) => f.endsWith(".txt"));
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    if (FileError.safeParse(err).data?.code === "ENOENT") return [];
     throw err;
   }
   const entries: WordlistEntry[] = [];


### PR DESCRIPTION
Migrates every external-data seam in the writing plugin onto zod schemas. Fifth layer of the stack, over #1271, which holds the boundary and the rule reversal. Auto-install skips `workspace:*`, so the plugin declares `zod` itself and calls `schema.parse` directly.

The plugin goes from 132 hits across the five `no-unsafe-*` rules and 66 on `no-unsafe-type-assertion` to zero on all six.

| Seam | Was | Now |
|---|---|---|
| Hook stdin | `JSON.parse(text) as PreToolUseHookInput` | a local `HookInput` schema |
| `tool_input` on Write, Edit, MultiEdit, Bash | a `WriteInput`/`EditInput` alias asserted per branch | one `ToolInput` schema, read through `toolInputOf` and `editedContent` |
| `hookSpecificOutput` tier read | `output.hookSpecificOutput as { permissionDecision }` | `Tier` schema, `"context"` when absent |
| Session state file | `(await file.json()) as SessionState` | `z.record(z.string(), z.number())` |
| DuckDB result rows | `rows.map(narrowBigints) as T[]` | `query(sql, schema)` and `runQuery(name, schema, params)` |
| Voice profile file | `(await file.json()) as VoiceProfile` | `VoiceProfile.parse` |
| Hook run log | `parsed as RunLogEntry` after an `in` check | `RunLogEntry.safeParse` per line |
| `gh search prs --json` | `JSON.parse(stdout) as Array<{...}>` | `SearchResults.parse` |
| `ast-grep --json` in the numbering hook | `JSON.parse(result)[0].message` | `AstGrepMatches` schema |
| compromise `nlp(text).json()` | `any` walked for terms and tags | `CompromiseSentences` schema |
| Judge verdicts, heading verdicts | a hand-walk with six assertions each | `VerdictInput`, `HeadingVerdicts` |

## Timestamps

`CorrectiveRow.timestamp` and both `CorrectionRow` timestamps were declared `string`. DuckDB hands a TIMESTAMP column back as a `Date`, so the corrective-feedback report heading rendered a `Date` toString on every real run. The fixture and its snapshot use ISO text.

Decoding rejected the live row and exposed that. Those three columns now take either shape and normalize to ISO. `dump.test.ts` covers both directions.

## Exhaustive Records

`JudgeVerdict` is a record keyed by `CriterionKey`. Four places built one by seeding `{} as JudgeVerdict` and filling it in a loop. `byCriterion` takes a per-key function and returns the whole record, so the compiler checks the key set for every one of them.

`verdictSchema()` and `headingBatchSchema()` return a declared `OutputSchema`. Both stay hand-written. They describe what the model is asked to emit, and `z.toJSONSchema` writes `type: [...]` where the structured-outputs subset takes `anyOf`.

## Runs

- `analyze.ts` over the live session DB for a week's window, which is what surfaced the timestamp bug.
- `hook-health.ts` over 15,319 real log lines.
- `voice-profile.ts` loading the 1.6 MB committed profile.
- `headings-eval.ts` in sample and score mode, plus a bad label rejected by name.
- The `gh search prs` payload through its schema.
