### PR TITLE
plugins: decode external data at the seams

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -113,6 +113,7 @@
       "name": "git",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+        "zod": "^4.4.3",
       },
     },
     "plugins/github": {
@@ -141,6 +142,7 @@
       "name": "go",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+        "zod": "^4.4.3",
       },
     },
     "plugins/issue": {
@@ -154,6 +156,7 @@
       "name": "linear",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+        "zod": "^4.4.3",
       },
     },
     "plugins/mac": {
@@ -162,6 +165,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
         "acorn": "^8.15.0",
         "cleye": "^2.0.0",
+        "zod": "^4.4.3",
       },
     },
     "plugins/meme": {
@@ -171,6 +175,7 @@
         "@napi-rs/canvas": "^0.1.65",
         "cleye": "^2.2.1",
         "sharp": "^0.35.0",
+        "zod": "^4.4.3",
       },
     },
     "plugins/mermaid/skills/diagram": {
@@ -180,6 +185,7 @@
         "cleye": "^2.2.1",
         "jsdom": "^29.0.0",
         "mermaid": "^11.4.0",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/jsdom": "^28.0.0",
@@ -189,12 +195,14 @@
       "name": "newline",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+        "zod": "^4.4.3",
       },
     },
     "plugins/plan": {
       "name": "@bendrucker/claude-plan",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+        "zod": "^4.4.3",
       },
     },
     "plugins/pull-request": {
@@ -204,6 +212,7 @@
         "ap-style-title-case": "^2.0.0",
         "mdast-util-from-markdown": "^2.0.2",
         "unist-util-visit": "^5.1.0",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/mdast": "^4.0.4",
@@ -214,12 +223,14 @@
       "dependencies": {
         "cleye": "^2.0.0",
         "table": "^6.9.0",
+        "zod": "^4.4.3",
       },
     },
     "plugins/shortcuts": {
       "name": "shortcuts",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+        "zod": "^4.4.3",
       },
     },
     "plugins/things": {
@@ -247,12 +258,14 @@
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
         "cleye": "^2.0.0",
         "table": "^6.9.0",
+        "zod": "^4.4.3",
       },
     },
     "plugins/type-ignore": {
       "name": "@bendrucker/type-ignore",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+        "zod": "^4.4.3",
       },
     },
     "plugins/ui-design": {
@@ -264,6 +277,7 @@
         "cleye": "^2.2.1",
         "playwright": "^1.50.1",
         "sharp": "^0.35.0",
+        "zod": "^4.4.3",
       },
     },
     "plugins/writing": {

--- a/plugins/git/package.json
+++ b/plugins/git/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+    "zod": "^4.4.3"
   }
 }

--- a/plugins/git/scripts/block-default-branch-commit.test.ts
+++ b/plugins/git/scripts/block-default-branch-commit.test.ts
@@ -22,9 +22,8 @@ function mockInput(command: string, cwd: string): PreToolUseHookInput {
 }
 
 async function getOutput(input: PreToolUseHookInput): Promise<PreToolUseHookSpecificOutput | null> {
-  const result = await processInput(input);
-  if (!result) return null;
-  return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
+  const specific = (await processInput(input))?.hookSpecificOutput;
+  return specific?.hookEventName === "PreToolUse" ? specific : null;
 }
 
 describe("invokesGitCommit", () => {

--- a/plugins/git/scripts/block-default-branch-commit.ts
+++ b/plugins/git/scripts/block-default-branch-commit.ts
@@ -3,8 +3,7 @@
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { $ } from "bun";
 import { getDefaultBranch } from "./default-branch";
-
-type BashInput = { command?: string };
+import { BashInput, PreToolUse } from "./hook-input";
 
 // Flags git accepts between the executable and its subcommand. Enumerated
 // rather than matched as a generic `-\S+` so that a value which happens to be
@@ -40,7 +39,7 @@ export async function processInput(input: PreToolUseHookInput): Promise<SyncHook
   // The `Bash(git commit:*)` condition only narrows which calls spawn this hook.
   // It fails open on shell metacharacters, so the deny decision rests on the
   // command this hook reads for itself.
-  const { command } = input.tool_input as BashInput;
+  const command = BashInput.safeParse(input.tool_input).data?.command;
   if (!command || !invokesGitCommit(command)) {
     return null;
   }
@@ -77,7 +76,7 @@ export async function processInput(input: PreToolUseHookInput): Promise<SyncHook
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
+    input = PreToolUse.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     console.error(
       `[git/block-default-branch-commit] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/git/scripts/hook-input.ts
+++ b/plugins/git/scripts/hook-input.ts
@@ -1,0 +1,29 @@
+import type {
+  PostToolUseFailureHookInput,
+  PreToolUseHookInput,
+} from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+const base = {
+  session_id: z.string().catch(""),
+  transcript_path: z.string().catch(""),
+  cwd: z.string().catch(""),
+  tool_name: z.string().catch(""),
+  tool_input: z.unknown().catch(undefined),
+  tool_use_id: z.string().catch(""),
+};
+
+export const PreToolUse = z.looseObject({
+  ...base,
+  hook_event_name: z.literal("PreToolUse"),
+}) satisfies z.ZodType<PreToolUseHookInput>;
+
+export const PostToolUseFailure = z.looseObject({
+  ...base,
+  hook_event_name: z.literal("PostToolUseFailure"),
+  error: z.string().catch(""),
+}) satisfies z.ZodType<PostToolUseFailureHookInput>;
+
+/** Every Bash `tool_input` field the git hooks read. */
+export const BashInput = z.looseObject({ command: z.string().optional().catch(undefined) });
+export type BashInput = z.infer<typeof BashInput>;

--- a/plugins/git/scripts/https-fallback.test.ts
+++ b/plugins/git/scripts/https-fallback.test.ts
@@ -251,9 +251,10 @@ describe("processInput", () => {
     async ({ remotes, expected }) => {
       const result = await processInput(mockInput("git pull", SECRETIVE_FAILURE), remotes);
       expect(result).not.toBeNull();
-      const context = (result?.hookSpecificOutput as { additionalContext: string })
-        .additionalContext;
-      expect(context).toContain(expected);
+      const specific = result?.hookSpecificOutput;
+      expect(
+        specific?.hookEventName === "PostToolUseFailure" && specific.additionalContext,
+      ).toContain(expected);
     },
   );
 });

--- a/plugins/git/scripts/https-fallback.ts
+++ b/plugins/git/scripts/https-fallback.ts
@@ -5,6 +5,7 @@ import type {
   SyncHookJSONOutput,
 } from "@anthropic-ai/claude-agent-sdk";
 import { $ } from "bun";
+import { BashInput, PostToolUseFailure } from "./hook-input";
 
 /**
  * Secretive gates every signature behind Touch ID, so an unattended `ssh` gets
@@ -157,7 +158,7 @@ export async function processInput(
   input: PostToolUseFailureHookInput,
   readRemotes: (cwd: string) => Promise<string> = readRemoteUrls,
 ): Promise<SyncHookJSONOutput | null> {
-  const command = (input.tool_input as { command?: string } | null)?.command;
+  const command = BashInput.safeParse(input.tool_input).data?.command;
   if (!command) return null;
 
   if (!gitNetworkSubcommand(command)) return null;
@@ -181,7 +182,7 @@ export async function processInput(
 async function main(): Promise<void> {
   let input: PostToolUseFailureHookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PostToolUseFailureHookInput;
+    input = PostToolUseFailure.parse(JSON.parse(await Bun.stdin.text()));
   } catch {
     return;
   }

--- a/plugins/git/skills/conflicts/scripts/check-markers.ts
+++ b/plugins/git/skills/conflicts/scripts/check-markers.ts
@@ -2,6 +2,7 @@
 
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { $ } from "bun";
+import { PreToolUse } from "../../../scripts/hook-input";
 
 function formatOutput(reason: string): SyncHookJSONOutput {
   return {
@@ -15,7 +16,7 @@ function formatOutput(reason: string): SyncHookJSONOutput {
 
 async function main(): Promise<void> {
   try {
-    JSON.parse(await Bun.stdin.text());
+    PreToolUse.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     console.error(
       `[git/conflicts/check-markers] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/git/skills/conflicts/tests/scripts.test.ts
+++ b/plugins/git/skills/conflicts/tests/scripts.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { join } from "node:path";
 import { $ } from "bun";
+import { z } from "zod";
 import {
   createConflictFixture,
   createDivergenceFixture,
@@ -40,7 +41,18 @@ describe("conflicts scripts", () => {
   });
 
   describe("check-markers.ts", () => {
-    const hookInput = JSON.stringify({ tool_name: "Bash", tool_input: { command: "git commit" } });
+    const hookInput = JSON.stringify({
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+      tool_input: { command: "git commit" },
+    });
+
+    const Denial = z.object({
+      hookSpecificOutput: z.looseObject({
+        permissionDecision: z.string(),
+        permissionDecisionReason: z.string(),
+      }),
+    });
 
     test("outputs deny JSON when markers in staged files", async () => {
       await $`git add file.txt`.cwd(fixture.path).quiet();
@@ -49,9 +61,9 @@ describe("conflicts scripts", () => {
         .cwd(fixture.path)
         .text();
 
-      const output = JSON.parse(result);
-      expect(output.hookSpecificOutput.permissionDecision).toBe("deny");
-      expect(output.hookSpecificOutput.permissionDecisionReason).toContain("Conflict markers");
+      const { hookSpecificOutput } = Denial.parse(JSON.parse(result));
+      expect(hookSpecificOutput.permissionDecision).toBe("deny");
+      expect(hookSpecificOutput.permissionDecisionReason).toContain("Conflict markers");
     });
 
     test("outputs nothing when no markers", async () => {

--- a/plugins/go/package.json
+++ b/plugins/go/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+    "zod": "^4.4.3"
   }
 }

--- a/plugins/go/scripts/check.ts
+++ b/plugins/go/scripts/check.ts
@@ -1,10 +1,13 @@
 #!/usr/bin/env bun
 
-import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
 
-export type FileInput = {
-  file_path?: string;
-};
+const FileInput = z.looseObject({ file_path: z.string().optional().catch(undefined) });
+export type FileInput = z.infer<typeof FileInput>;
+
+export const HookInput = z.looseObject({ tool_input: z.unknown() });
+export type HookInput = z.infer<typeof HookInput>;
 
 const GENERATED_MARKER = /^\/\/\s*Code\s+generated.*DO\s+NOT\s+EDIT\.$/;
 
@@ -35,8 +38,8 @@ export function isGeneratedFile(content: string): boolean {
   return foundMarker && foundCode;
 }
 
-export async function processInput(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
-  const { file_path: filePath } = input.tool_input as FileInput;
+export async function processInput(input: HookInput): Promise<SyncHookJSONOutput | null> {
+  const filePath = FileInput.safeParse(input.tool_input).data?.file_path;
 
   if (!filePath || !filePath.endsWith(".go")) {
     return null;
@@ -63,9 +66,9 @@ export async function processInput(input: PreToolUseHookInput): Promise<SyncHook
 }
 
 async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
+  let input: HookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
+    input = HookInput.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     console.error(
       `[go/check] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/linear/hooks/cli-create.ts
+++ b/plugins/linear/hooks/cli-create.ts
@@ -1,6 +1,12 @@
 #!/usr/bin/env bun
 
-import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+const BashInput = z.looseObject({ command: z.string().optional().catch(undefined) });
+
+export const HookInput = z.looseObject({ tool_input: z.unknown() });
+export type HookInput = z.infer<typeof HookInput>;
 import { getDefaultState } from "./save-issue";
 
 const SHELL_OPERATORS = /\s*(?:&&|\|\||[|;])\s*/;
@@ -25,8 +31,8 @@ export function isSingleInvocation(command: string): boolean {
   return LEADING_CREATE.test(command.trim().replace(ENV_PREFIX, ""));
 }
 
-export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {
-  const { command } = input.tool_input as { command?: string };
+export function processInput(input: HookInput): SyncHookJSONOutput | null {
+  const command = BashInput.safeParse(input.tool_input).data?.command;
   if (!command || !CREATE.test(command)) return null;
   if (HAS_STATE.test(command) || HAS_START.test(command)) return null;
 
@@ -54,9 +60,9 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
 }
 
 async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
+  let input: HookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
+    input = HookInput.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     console.error(
       `[linear/cli-create] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/linear/hooks/save-issue.ts
+++ b/plugins/linear/hooks/save-issue.ts
@@ -1,6 +1,12 @@
 #!/usr/bin/env bun
 
-import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+const Fields = z.record(z.string(), z.unknown());
+
+export const HookInput = z.looseObject({ tool_input: z.unknown() });
+export type HookInput = z.infer<typeof HookInput>;
 
 export type CreateIssueInput = {
   id?: string;
@@ -51,9 +57,9 @@ export function normalizeInput(toolInput: Record<string, unknown>): NormalizeRes
   return { input, mutated };
 }
 
-export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {
+export function processInput(input: HookInput): SyncHookJSONOutput | null {
   const { input: normalized, mutated } = normalizeInput(
-    input.tool_input as Record<string, unknown>,
+    Fields.safeParse(input.tool_input).data ?? {},
   );
   const { id, title, state, assignee } = normalized;
 
@@ -101,9 +107,9 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
 }
 
 async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
+  let input: HookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
+    input = HookInput.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     console.error(
       `[linear/save-issue] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/linear/package.json
+++ b/plugins/linear/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+    "zod": "^4.4.3"
   }
 }

--- a/plugins/linear/scripts/fetch.test.ts
+++ b/plugins/linear/scripts/fetch.test.ts
@@ -18,9 +18,8 @@ function mockInput(url: string): PreToolUseHookInput {
 }
 
 function getOutput(input: PreToolUseHookInput): PreToolUseHookSpecificOutput | null {
-  const result = processInput(input);
-  if (!result) return null;
-  return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
+  const specific = processInput(input)?.hookSpecificOutput;
+  return specific?.hookEventName === "PreToolUse" ? specific : null;
 }
 
 describe("isPublicUrl", () => {

--- a/plugins/linear/scripts/fetch.ts
+++ b/plugins/linear/scripts/fetch.ts
@@ -1,8 +1,13 @@
 #!/usr/bin/env bun
 
-import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
 
-export type WebFetchInput = { url: string };
+const WebFetchInput = z.looseObject({ url: z.string() });
+export type WebFetchInput = z.infer<typeof WebFetchInput>;
+
+export const HookInput = z.looseObject({ tool_input: z.unknown() });
+export type HookInput = z.infer<typeof HookInput>;
 
 const PUBLIC_PATH_PREFIXES = ["/docs", "/developers", "/changelog"];
 
@@ -21,10 +26,9 @@ export function formatOutput(reason: string): SyncHookJSONOutput {
   };
 }
 
-export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {
-  const { url } = input.tool_input as WebFetchInput;
-
-  if (isPublicUrl(url)) {
+export function processInput(input: HookInput): SyncHookJSONOutput | null {
+  const url = WebFetchInput.safeParse(input.tool_input).data?.url;
+  if (url === undefined || isPublicUrl(url)) {
     return null;
   }
 
@@ -34,9 +38,9 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
 }
 
 async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
+  let input: HookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
+    input = HookInput.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     console.error(
       `[linear/fetch] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/mac/hooks/sandbox.test.ts
+++ b/plugins/mac/hooks/sandbox.test.ts
@@ -27,12 +27,19 @@ afterAll(async () => {
   await rm(fixtureDir, { recursive: true, force: true });
 });
 
-function makeInput(command: string, toolName = "Bash"): PreToolUseHookInput {
+function makeInput(toolInput: unknown, toolName = "Bash"): PreToolUseHookInput {
   return {
+    hook_event_name: "PreToolUse",
+    session_id: "s",
+    transcript_path: "/dev/null",
+    cwd: "/",
     tool_name: toolName,
-    tool_input: { command },
-  } as PreToolUseHookInput;
+    tool_input: toolInput,
+    tool_use_id: "t",
+  };
 }
+
+const bashInput = (command: string) => makeInput({ command });
 
 describe("extractCommands", () => {
   test("captures bun script arg", () => {
@@ -78,7 +85,7 @@ describe("extractCommands", () => {
   });
 
   test.each<[string]>([["git status"], ["/usr/bin/touch x"]])("no script arg for %p", (command) => {
-    expect(extractCommands(command)).toEqual([{ cmd: command.split(" ")[0] as string }]);
+    expect(extractCommands(command)).toEqual([{ cmd: command.split(" ")[0] ?? "" }]);
   });
 });
 
@@ -98,37 +105,35 @@ describe("hasBypassMarker", () => {
 
 describe("processInput", () => {
   test("returns null on non-darwin", async () => {
-    const result = await processInput(makeInput(`bun ${markedScriptPath}`), "linux");
+    const result = await processInput(bashInput(`bun ${markedScriptPath}`), "linux");
     expect(result).toBeNull();
   });
 
   test("returns null when command is undefined", async () => {
-    const input = { tool_name: "Bash", tool_input: {} } as PreToolUseHookInput;
+    const input = makeInput({});
     const result = await processInput(input, "darwin");
     expect(result).toBeNull();
   });
 
   test("disables sandbox for marked bun script", async () => {
-    const input = makeInput(`bun ${markedScriptPath} --pr 42`);
+    const command = `bun ${markedScriptPath} --pr 42`;
+    const input = bashInput(command);
     const result = await processInput(input, "darwin");
     expect(result).toEqual({
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
-        updatedInput: {
-          ...(input.tool_input as Record<string, unknown>),
-          dangerouslyDisableSandbox: true,
-        },
+        updatedInput: { command, dangerouslyDisableSandbox: true },
       },
     });
   });
 
   test("does not disable sandbox for unmarked bun script", async () => {
-    const result = await processInput(makeInput(`bun ${unmarkedScriptPath}`), "darwin");
+    const result = await processInput(bashInput(`bun ${unmarkedScriptPath}`), "darwin");
     expect(result).toBeNull();
   });
 
   test("honors marker on second bun invocation in a chain", async () => {
-    const input = makeInput(`bun ${unmarkedScriptPath} && bun ${markedScriptPath}`);
+    const input = bashInput(`bun ${unmarkedScriptPath} && bun ${markedScriptPath}`);
     const result = await processInput(input, "darwin");
     expect(result?.hookSpecificOutput).toMatchObject({
       hookEventName: "PreToolUse",
@@ -137,7 +142,7 @@ describe("processInput", () => {
   });
 
   test("disables sandbox for a marked script run directly", async () => {
-    const result = await processInput(makeInput(`${markedScriptPath} --refresh`), "darwin");
+    const result = await processInput(bashInput(`${markedScriptPath} --refresh`), "darwin");
     expect(result?.hookSpecificOutput).toMatchObject({
       hookEventName: "PreToolUse",
       updatedInput: { dangerouslyDisableSandbox: true },
@@ -145,12 +150,12 @@ describe("processInput", () => {
   });
 
   test("does not disable sandbox for an unmarked script run directly", async () => {
-    const result = await processInput(makeInput(unmarkedScriptPath), "darwin");
+    const result = await processInput(bashInput(unmarkedScriptPath), "darwin");
     expect(result).toBeNull();
   });
 
   test("honors marker on second directly-run script in a chain", async () => {
-    const input = makeInput(`${unmarkedScriptPath} && ${markedScriptPath}`);
+    const input = bashInput(`${unmarkedScriptPath} && ${markedScriptPath}`);
     const result = await processInput(input, "darwin");
     expect(result?.hookSpecificOutput).toMatchObject({
       hookEventName: "PreToolUse",
@@ -159,7 +164,7 @@ describe("processInput", () => {
   });
 
   test("processes Monitor tool input the same as Bash", async () => {
-    const input = makeInput(`bun ${markedScriptPath}`, "Monitor");
+    const input = makeInput({ command: `bun ${markedScriptPath}` }, "Monitor");
     const result = await processInput(input, "darwin");
     expect(result?.hookSpecificOutput).toMatchObject({
       hookEventName: "PreToolUse",

--- a/plugins/mac/hooks/sandbox.ts
+++ b/plugins/mac/hooks/sandbox.ts
@@ -2,8 +2,19 @@
 
 import { basename, extname } from "node:path";
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
 
-type ToolInput = { command: string };
+const ToolInput = z.looseObject({ command: z.string().optional().catch(undefined) });
+
+const HookInput = z.looseObject({
+  hook_event_name: z.literal("PreToolUse"),
+  session_id: z.string().catch(""),
+  transcript_path: z.string().catch(""),
+  cwd: z.string().catch(""),
+  tool_name: z.string().catch(""),
+  tool_input: z.unknown().catch(undefined),
+  tool_use_id: z.string().catch(""),
+}) satisfies z.ZodType<PreToolUseHookInput>;
 
 const SHELL_OPERATORS = /\s*(?:&&|\|\||[|;])\s*/;
 const SCRIPT_INTERPRETERS = new Set(["bun", "node"]);
@@ -25,7 +36,7 @@ export function extractCommands(command: string): Invocation[] {
     let i = 0;
 
     // skip env var prefixes (FOO=bar)
-    while (i < tokens.length && /^[A-Za-z_]\w*=/.test(tokens[i] as string)) {
+    while (i < tokens.length && /^[A-Za-z_]\w*=/.test(tokens[i] ?? "")) {
       i++;
     }
 
@@ -63,7 +74,7 @@ export async function hasBypassMarker(path: string): Promise<boolean> {
   return head ? head.includes(SCRIPT_MARKER) : false;
 }
 
-function disableSandbox(toolInput: Record<string, unknown>): SyncHookJSONOutput {
+function disableSandbox(toolInput: z.infer<typeof ToolInput>): SyncHookJSONOutput {
   return {
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
@@ -78,11 +89,10 @@ export async function processInput(
 ): Promise<SyncHookJSONOutput | null> {
   if (platform !== "darwin") return null;
 
-  const toolInput = input.tool_input as Record<string, unknown>;
-  const { command } = toolInput as ToolInput;
-  if (!command) return null;
+  const toolInput = ToolInput.safeParse(input.tool_input).data;
+  if (!toolInput?.command) return null;
 
-  for (const { scriptArg } of extractCommands(command)) {
+  for (const { scriptArg } of extractCommands(toolInput.command)) {
     if (scriptArg && (await hasBypassMarker(scriptArg))) {
       return disableSandbox(toolInput);
     }
@@ -94,7 +104,7 @@ export async function processInput(
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
+    input = HookInput.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     console.error(
       `[mac/sandbox] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/mac/package.json
+++ b/plugins/mac/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
     "acorn": "^8.15.0",
-    "cleye": "^2.0.0"
+    "cleye": "^2.0.0",
+    "zod": "^4.4.3"
   }
 }

--- a/plugins/mac/scripts/jxa.ts
+++ b/plugins/mac/scripts/jxa.ts
@@ -3,8 +3,20 @@
 
 import * as acorn from "acorn";
 import { cli } from "cleye";
+import { z } from "zod";
 
-type Node = acorn.Node & Record<string, unknown>;
+const AstNode = z.looseObject({ type: z.string() });
+type AstNode = z.infer<typeof AstNode>;
+const AnyList = z.array(z.unknown());
+
+const Identifier = z.looseObject({ type: z.literal("Identifier"), name: z.string() });
+const MemberExpression = z.looseObject({
+  type: z.literal("MemberExpression"),
+  object: AstNode,
+  property: AstNode,
+});
+const CallExpression = z.looseObject({ type: z.literal("CallExpression"), callee: AstNode });
+const StringLiteral = z.looseObject({ type: z.literal("Literal"), value: z.string() });
 
 interface ValidationResult {
   valid: boolean;
@@ -20,19 +32,16 @@ function stripShebang(source: string): string {
   return source;
 }
 
-function walkNode(node: Node, visitor: (n: Node) => void): void {
+/** The nodes reachable from one property of a node: itself, or the ones in its list. */
+function childNodes(value: unknown): AstNode[] {
+  const items = AnyList.safeParse(value).data ?? [value];
+  return items.flatMap((item) => AstNode.safeParse(item).data ?? []);
+}
+
+function walkNode(node: AstNode, visitor: (n: AstNode) => void): void {
   visitor(node);
-  for (const key of Object.keys(node)) {
-    const value = node[key];
-    if (value && typeof value === "object" && "type" in value) {
-      walkNode(value as Node, visitor);
-    } else if (Array.isArray(value)) {
-      for (const item of value) {
-        if (item && typeof item === "object" && "type" in item) {
-          walkNode(item as Node, visitor);
-        }
-      }
-    }
+  for (const value of Object.values(node)) {
+    for (const child of childNodes(value)) walkNode(child, visitor);
   }
 }
 
@@ -50,32 +59,24 @@ export function validateAppScope(source: string, app: string): ValidationResult 
 
   const violations: string[] = [];
 
-  walkNode(ast as Node, (node) => {
-    if (node.type !== "CallExpression") return;
-
-    const callee = node.callee as Node;
+  walkNode(AstNode.parse(ast), (node) => {
+    const call = CallExpression.safeParse(node);
+    if (!call.success) return;
+    const callee = call.data.callee;
 
     // Application.currentApplication() — always allowed
+    const member = MemberExpression.safeParse(callee).data;
     if (
-      callee.type === "MemberExpression" &&
-      (callee.object as Node).type === "Identifier" &&
-      (callee.object as Node).name === "Application" &&
-      (callee.property as Node).type === "Identifier" &&
-      (callee.property as Node).name === "currentApplication"
+      Identifier.safeParse(member?.object).data?.name === "Application" &&
+      Identifier.safeParse(member?.property).data?.name === "currentApplication"
     ) {
       return;
     }
 
     // Application("SomeApp")
-    if (callee.type === "Identifier" && callee.name === "Application") {
-      const args = node.arguments as Node[];
-      const firstArg = args[0];
-      if (firstArg?.type === "Literal" && typeof firstArg.value === "string") {
-        if (firstArg.value !== app) {
-          violations.push(firstArg.value);
-        }
-      }
-    }
+    if (Identifier.safeParse(callee).data?.name !== "Application") return;
+    const first = StringLiteral.safeParse(AnyList.parse(node.arguments)[0]).data;
+    if (first && first.value !== app) violations.push(first.value);
   });
 
   return { valid: violations.length === 0, violations };

--- a/plugins/meme/package.json
+++ b/plugins/meme/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@napi-rs/canvas": "^0.1.65",
     "cleye": "^2.2.1",
-    "sharp": "^0.35.0"
+    "sharp": "^0.35.0",
+    "zod": "^4.4.3"
   }
 }

--- a/plugins/meme/skills/image/scripts/__snapshots__/spec.test.ts.snap
+++ b/plugins/meme/skills/image/scripts/__snapshots__/spec.test.ts.snap
@@ -1,25 +1,46 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`validateSpec rejects not an object 1`] = `"spec: expected an object with boxes and/or captions"`;
+exports[`validateSpec rejects not an object 1`] = `"✖ Invalid input: expected object, received string"`;
 
-exports[`validateSpec rejects empty object 1`] = `"spec: requires at least one of boxes or captions"`;
+exports[`validateSpec rejects empty object 1`] = `"✖ requires at least one box or caption"`;
 
-exports[`validateSpec rejects empty arrays 1`] = `"spec: requires at least one box or caption"`;
+exports[`validateSpec rejects empty arrays 1`] = `"✖ requires at least one box or caption"`;
 
-exports[`validateSpec rejects box missing text 1`] = `"spec.boxes[0].text: required non-empty string"`;
+exports[`validateSpec rejects box missing text 1`] = `
+"✖ Invalid input: expected string, received undefined
+  → at boxes[0].text"
+`;
 
-exports[`validateSpec rejects bad preset 1`] = `"spec.boxes[0].preset: expected one of classic, label, subtitle"`;
+exports[`validateSpec rejects bad preset 1`] = `
+"✖ Invalid option: expected one of "classic"|"label"|"subtitle"
+  → at boxes[0].preset"
+`;
 
-exports[`validateSpec rejects anchor and region together 1`] = `"spec.boxes[0]: anchor and region are mutually exclusive"`;
+exports[`validateSpec rejects anchor and region together 1`] = `
+"✖ anchor and region are mutually exclusive
+  → at boxes[0]"
+`;
 
-exports[`validateSpec rejects region out of range 1`] = `"spec.boxes[0].region.w: expected a number between 0 and 1, got 2"`;
+exports[`validateSpec rejects region out of range 1`] = `
+"✖ Too big: expected number to be <=1
+  → at boxes[0].region.w"
+`;
 
-exports[`validateSpec rejects bad fontSize override 1`] = `"spec.boxes[0].style.fontSize: expected a number between 0 and 1, got 40"`;
+exports[`validateSpec rejects bad fontSize override 1`] = `
+"✖ Too big: expected number to be <=1
+  → at boxes[0].style.fontSize"
+`;
 
-exports[`validateSpec rejects bad caption position 1`] = `"spec.captions[0].position: expected one of top, bottom"`;
+exports[`validateSpec rejects bad caption position 1`] = `
+"✖ Invalid option: expected one of "top"|"bottom"
+  → at captions[0].position"
+`;
+
+exports[`validateSpec rejects non-boolean linkFontSizes 1`] = `
+"✖ Invalid input: expected boolean, received string
+  → at linkFontSizes"
+`;
 
 exports[`specFromFlags rejects no flags 1`] = `"flags: requires at least one of --top, --bottom, --subtitle, --caption, or --spec"`;
 
 exports[`specFromFlags rejects bad caption position 1`] = `"--caption-position: expected top or bottom"`;
-
-exports[`validateSpec rejects non-boolean linkFontSizes 1`] = `"spec.linkFontSizes: expected a boolean"`;

--- a/plugins/meme/skills/image/scripts/presets.ts
+++ b/plugins/meme/skills/image/scripts/presets.ts
@@ -1,5 +1,9 @@
-export type PresetName = "classic" | "label" | "subtitle";
-export type Anchor = "top" | "bottom" | "center";
+import { z } from "zod";
+
+export const PresetName = z.enum(["classic", "label", "subtitle"]);
+export type PresetName = z.infer<typeof PresetName>;
+export const Anchor = z.enum(["top", "bottom", "center"]);
+export type Anchor = z.infer<typeof Anchor>;
 
 export interface PresetStyle {
   fontFamily: string;

--- a/plugins/meme/skills/image/scripts/spec.test.ts
+++ b/plugins/meme/skills/image/scripts/spec.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { specFromFlags, validateSpec } from "./spec";
+import { type Spec, specFromFlags, validateSpec } from "./spec";
 
 describe("validateSpec", () => {
   test.each([
@@ -21,7 +21,7 @@ describe("validateSpec", () => {
   });
 
   test("accepts a full spec unchanged", () => {
-    const spec = {
+    const spec: Spec = {
       boxes: [
         { text: "top text", preset: "classic", anchor: "top" },
         {
@@ -35,7 +35,7 @@ describe("validateSpec", () => {
       ],
       captions: [{ text: "a caption", position: "bottom" }],
     };
-    expect(validateSpec(spec)).toEqual(spec as ReturnType<typeof validateSpec>);
+    expect(validateSpec(spec)).toEqual(spec);
   });
 });
 

--- a/plugins/meme/skills/image/scripts/spec.ts
+++ b/plugins/meme/skills/image/scripts/spec.ts
@@ -1,45 +1,54 @@
-import { type Anchor, type PresetName, presets } from "./presets";
+import { z } from "zod";
+import { Anchor, PresetName } from "./presets";
 
-export interface Region {
-  x: number;
-  y: number;
-  w: number;
-  h: number;
-}
+const fraction = z.number().min(0).max(1);
+const text = z.string().min(1);
 
-export interface StyleOverrides {
-  fill?: string;
-  stroke?: string;
+export const Region = z.object({ x: fraction, y: fraction, w: fraction, h: fraction });
+export type Region = z.infer<typeof Region>;
+
+export const StyleOverrides = z.object({
+  fill: text.optional(),
+  stroke: text.optional(),
   /** Font size as a fraction of image height. */
-  fontSize?: number;
-  font?: string;
-  uppercase?: boolean;
-}
+  fontSize: fraction.optional(),
+  font: text.optional(),
+  uppercase: z.boolean().optional(),
+});
+export type StyleOverrides = z.infer<typeof StyleOverrides>;
 
-export interface TextBox {
-  text: string;
-  preset?: PresetName;
-  anchor?: Anchor;
-  region?: Region;
-  align?: "left" | "center" | "right";
-  valign?: "top" | "middle" | "bottom";
-  style?: StyleOverrides;
-}
+export const TextBox = z
+  .object({
+    text,
+    preset: PresetName.optional(),
+    anchor: Anchor.optional(),
+    region: Region.optional(),
+    align: z.enum(["left", "center", "right"]).optional(),
+    valign: z.enum(["top", "middle", "bottom"]).optional(),
+    style: StyleOverrides.optional(),
+  })
+  .refine((box) => box.anchor === undefined || box.region === undefined, {
+    error: "anchor and region are mutually exclusive",
+  });
+export type TextBox = z.infer<typeof TextBox>;
 
-export interface Caption {
-  text: string;
-  position?: "top" | "bottom";
-}
+export const Caption = z.object({
+  text,
+  position: z.enum(["top", "bottom"]).optional(),
+});
+export type Caption = z.infer<typeof Caption>;
 
-export interface Spec {
-  boxes?: TextBox[];
-  captions?: Caption[];
-  /** Re-fit all boxes at the smallest fitted font size so panels match. */
-  linkFontSizes?: boolean;
-}
-
-const anchors: Anchor[] = ["top", "bottom", "center"];
-const presetNames = Object.keys(presets) as PresetName[];
+export const Spec = z
+  .object({
+    boxes: z.array(TextBox).optional(),
+    captions: z.array(Caption).optional(),
+    /** Re-fit all boxes at the smallest fitted font size so panels match. */
+    linkFontSizes: z.boolean().optional(),
+  })
+  .refine((spec) => (spec.boxes?.length ?? 0) + (spec.captions?.length ?? 0) > 0, {
+    error: "requires at least one box or caption",
+  });
+export type Spec = z.infer<typeof Spec>;
 
 class SpecError extends Error {}
 
@@ -47,115 +56,10 @@ function fail(path: string, message: string): never {
   throw new SpecError(`${path}: ${message}`);
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function validateFraction(value: unknown, path: string): number {
-  if (typeof value !== "number" || Number.isNaN(value) || value < 0 || value > 1) {
-    fail(path, `expected a number between 0 and 1, got ${JSON.stringify(value)}`);
-  }
-  return value;
-}
-
-function validateString(value: unknown, path: string): string {
-  if (typeof value !== "string" || value.length === 0) {
-    fail(path, "required non-empty string");
-  }
-  return value;
-}
-
-function oneOf<T extends string>(value: unknown, options: readonly T[], path: string): T {
-  if (typeof value !== "string" || !(options as readonly string[]).includes(value)) {
-    fail(path, `expected one of ${options.join(", ")}`);
-  }
-  return value as T;
-}
-
-function validateRegion(value: unknown, path: string): Region {
-  if (!isRecord(value)) fail(path, "expected an object {x, y, w, h}");
-  return {
-    x: validateFraction(value.x, `${path}.x`),
-    y: validateFraction(value.y, `${path}.y`),
-    w: validateFraction(value.w, `${path}.w`),
-    h: validateFraction(value.h, `${path}.h`),
-  };
-}
-
-function validateStyle(value: unknown, path: string): StyleOverrides {
-  if (!isRecord(value)) fail(path, "expected an object");
-  const style: StyleOverrides = {};
-  if (value.fill !== undefined) style.fill = validateString(value.fill, `${path}.fill`);
-  if (value.stroke !== undefined) style.stroke = validateString(value.stroke, `${path}.stroke`);
-  if (value.fontSize !== undefined) {
-    style.fontSize = validateFraction(value.fontSize, `${path}.fontSize`);
-  }
-  if (value.font !== undefined) style.font = validateString(value.font, `${path}.font`);
-  if (value.uppercase !== undefined) {
-    if (typeof value.uppercase !== "boolean") fail(`${path}.uppercase`, "expected a boolean");
-    style.uppercase = value.uppercase;
-  }
-  return style;
-}
-
-function validateBox(value: unknown, path: string): TextBox {
-  if (!isRecord(value)) fail(path, "expected an object");
-  if (value.anchor !== undefined && value.region !== undefined) {
-    fail(path, "anchor and region are mutually exclusive");
-  }
-  const box: TextBox = { text: validateString(value.text, `${path}.text`) };
-  if (value.preset !== undefined) {
-    box.preset = oneOf(value.preset, presetNames, `${path}.preset`);
-  }
-  if (value.anchor !== undefined) box.anchor = oneOf(value.anchor, anchors, `${path}.anchor`);
-  if (value.region !== undefined) box.region = validateRegion(value.region, `${path}.region`);
-  if (value.align !== undefined) {
-    box.align = oneOf(value.align, ["left", "center", "right"], `${path}.align`);
-  }
-  if (value.valign !== undefined) {
-    box.valign = oneOf(value.valign, ["top", "middle", "bottom"], `${path}.valign`);
-  }
-  if (value.style !== undefined) box.style = validateStyle(value.style, `${path}.style`);
-  return box;
-}
-
-function validateCaption(value: unknown, path: string): Caption {
-  if (!isRecord(value)) fail(path, "expected an object");
-  const caption: Caption = { text: validateString(value.text, `${path}.text`) };
-  if (value.position !== undefined) {
-    caption.position = oneOf(value.position, ["top", "bottom"], `${path}.position`);
-  }
-  return caption;
-}
-
 export function validateSpec(value: unknown): Spec {
-  if (!isRecord(value)) fail("spec", "expected an object with boxes and/or captions");
-  const boxes = value.boxes;
-  const captions = value.captions;
-  if (boxes === undefined && captions === undefined) {
-    fail("spec", "requires at least one of boxes or captions");
-  }
-  if (boxes !== undefined && !Array.isArray(boxes)) fail("spec.boxes", "expected an array");
-  if (captions !== undefined && !Array.isArray(captions)) {
-    fail("spec.captions", "expected an array");
-  }
-  const spec: Spec = {};
-  if (value.linkFontSizes !== undefined) {
-    if (typeof value.linkFontSizes !== "boolean") {
-      fail("spec.linkFontSizes", "expected a boolean");
-    }
-    spec.linkFontSizes = value.linkFontSizes;
-  }
-  if (Array.isArray(boxes)) {
-    spec.boxes = boxes.map((box, i) => validateBox(box, `spec.boxes[${i}]`));
-  }
-  if (Array.isArray(captions)) {
-    spec.captions = captions.map((c, i) => validateCaption(c, `spec.captions[${i}]`));
-  }
-  if ((spec.boxes?.length ?? 0) + (spec.captions?.length ?? 0) === 0) {
-    fail("spec", "requires at least one box or caption");
-  }
-  return spec;
+  const result = Spec.safeParse(value);
+  if (!result.success) throw new SpecError(z.prettifyError(result.error));
+  return result.data;
 }
 
 export interface TextFlags {

--- a/plugins/mermaid/skills/diagram/package.json
+++ b/plugins/mermaid/skills/diagram/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "cleye": "^2.2.1",
     "jsdom": "^29.0.0",
-    "mermaid": "^11.4.0"
+    "mermaid": "^11.4.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/jsdom": "^28.0.0"

--- a/plugins/mermaid/skills/diagram/scripts/validate.ts
+++ b/plugins/mermaid/skills/diagram/scripts/validate.ts
@@ -159,8 +159,8 @@ async function main() {
 }
 
 if (import.meta.main) {
-  main().catch((error) => {
-    console.error("Error:", error.message);
+  main().catch((error: unknown) => {
+    console.error("Error:", error instanceof Error ? error.message : String(error));
     process.exit(1);
   });
 }

--- a/plugins/newline/package.json
+++ b/plugins/newline/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+    "zod": "^4.4.3"
   }
 }

--- a/plugins/newline/scripts/check.ts
+++ b/plugins/newline/scripts/check.ts
@@ -1,12 +1,9 @@
 #!/usr/bin/env bun
 
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { filePathOf, PreToolUse } from "./hook-input";
 import { isMemoryPath } from "./memory-path";
 import { setState } from "./state";
-
-type ToolInput = {
-  file_path?: string;
-};
 
 export async function hasTrailingNewline(filePath: string): Promise<boolean | null> {
   const file = Bun.file(filePath);
@@ -23,7 +20,7 @@ export async function hasTrailingNewline(filePath: string): Promise<boolean | nu
 }
 
 export async function processInput(input: PreToolUseHookInput): Promise<void> {
-  const { file_path: filePath } = input.tool_input as ToolInput;
+  const filePath = filePathOf(input.tool_input);
   if (!filePath) return;
   if (isMemoryPath(filePath)) return;
 
@@ -39,7 +36,7 @@ export async function processInput(input: PreToolUseHookInput): Promise<void> {
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
+    input = PreToolUse.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     console.error(
       `[newline/check] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/newline/scripts/ensure.ts
+++ b/plugins/newline/scripts/ensure.ts
@@ -1,11 +1,8 @@
 #!/usr/bin/env bun
 
 import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { filePathOf, PostToolUse } from "./hook-input";
 import { isMemoryPath } from "./memory-path";
-
-type ToolInput = {
-  file_path?: string;
-};
 
 export async function ensureTrailingNewline(filePath: string): Promise<string | null> {
   const file = Bun.file(filePath);
@@ -29,7 +26,7 @@ export async function ensureTrailingNewline(filePath: string): Promise<string | 
 export async function processInput(
   input: PostToolUseHookInput,
 ): Promise<SyncHookJSONOutput | null> {
-  const { file_path: filePath } = input.tool_input as ToolInput;
+  const filePath = filePathOf(input.tool_input);
   if (!filePath) return null;
   if (isMemoryPath(filePath)) return null;
 
@@ -50,7 +47,7 @@ export async function processInput(
 async function main(): Promise<void> {
   let input: PostToolUseHookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PostToolUseHookInput;
+    input = PostToolUse.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     console.error(
       `[newline/ensure] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/newline/scripts/hook-input.ts
+++ b/plugins/newline/scripts/hook-input.ts
@@ -1,0 +1,28 @@
+import type { PostToolUseHookInput, PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+const base = {
+  session_id: z.string().catch(""),
+  transcript_path: z.string().catch(""),
+  cwd: z.string().catch(""),
+  tool_name: z.string().catch(""),
+  tool_input: z.unknown().catch(undefined),
+  tool_use_id: z.string().catch(""),
+};
+
+export const PreToolUse = z.looseObject({
+  ...base,
+  hook_event_name: z.literal("PreToolUse"),
+}) satisfies z.ZodType<PreToolUseHookInput>;
+
+export const PostToolUse = z.looseObject({
+  ...base,
+  hook_event_name: z.literal("PostToolUse"),
+  tool_response: z.unknown().catch(undefined),
+}) satisfies z.ZodType<PostToolUseHookInput>;
+
+export const FileInput = z.looseObject({ file_path: z.string().optional().catch(undefined) });
+
+export function filePathOf(toolInput: unknown): string | undefined {
+  return FileInput.safeParse(toolInput).data?.file_path;
+}

--- a/plugins/newline/scripts/newline.test.ts
+++ b/plugins/newline/scripts/newline.test.ts
@@ -3,11 +3,7 @@ import { mkdirSync, mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type {
-  PostToolUseHookInput,
-  PostToolUseHookSpecificOutput,
-  PreToolUseHookInput,
-} from "@anthropic-ai/claude-agent-sdk";
+import type { PostToolUseHookInput, PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import fc from "fast-check";
 import { processInput as checkInput, hasTrailingNewline } from "./check";
 import { processInput as ensureInput, ensureTrailingNewline } from "./ensure";
@@ -148,8 +144,10 @@ describe("ensure.ts", () => {
       await Bun.write(filePath, content);
       const output = await ensureInput(mockPostToolInput(filePath));
       if (expectAdded) {
-        const hookOutput = output?.hookSpecificOutput as PostToolUseHookSpecificOutput | undefined;
-        expect(hookOutput?.additionalContext).toContain("Added trailing newline");
+        const specific = output?.hookSpecificOutput;
+        expect(specific?.hookEventName === "PostToolUse" && specific.additionalContext).toContain(
+          "Added trailing newline",
+        );
       } else {
         expect(output).toBeNull();
       }
@@ -204,7 +202,7 @@ describe("preserve.ts", () => {
       await Bun.write(filePath, content);
       const result = await preserveNewlineState(filePath, state);
       if (contains) {
-        expect(result).toContain(message as string);
+        expect(result).toContain(message ?? "");
       } else {
         expect(result).toBe(message);
       }

--- a/plugins/newline/scripts/preserve.ts
+++ b/plugins/newline/scripts/preserve.ts
@@ -1,12 +1,9 @@
 #!/usr/bin/env bun
 
 import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { filePathOf, PostToolUse } from "./hook-input";
 import { isMemoryPath } from "./memory-path";
 import { clearState, getState } from "./state";
-
-type ToolInput = {
-  file_path?: string;
-};
 
 export async function preserveNewlineState(
   filePath: string,
@@ -40,7 +37,7 @@ export async function preserveNewlineState(
 export async function processInput(
   input: PostToolUseHookInput,
 ): Promise<SyncHookJSONOutput | null> {
-  const { file_path: filePath } = input.tool_input as ToolInput;
+  const filePath = filePathOf(input.tool_input);
   if (!filePath) return null;
   if (isMemoryPath(filePath)) return null;
 
@@ -64,7 +61,7 @@ export async function processInput(
 async function main(): Promise<void> {
   let input: PostToolUseHookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PostToolUseHookInput;
+    input = PostToolUse.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     console.error(
       `[newline/preserve] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/newline/scripts/state.ts
+++ b/plugins/newline/scripts/state.ts
@@ -1,8 +1,10 @@
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { z } from "zod";
 
-type StateStore = Record<string, string>;
+const StateStore = z.record(z.string(), z.string());
+type StateStore = z.infer<typeof StateStore>;
 
 function getStateFilePath(): string {
   return process.env.CLAUDE_NEWLINE_STATE_FILE ?? join(tmpdir(), "claude-newline-state.json");
@@ -14,7 +16,7 @@ async function readStore(): Promise<StateStore> {
     return {};
   }
   try {
-    return (await file.json()) as StateStore;
+    return StateStore.parse(await file.json());
   } catch {
     return {};
   }

--- a/plugins/plan/hooks/gate.test.ts
+++ b/plugins/plan/hooks/gate.test.ts
@@ -7,8 +7,16 @@ import type {
   PreToolUseHookInput,
   PreToolUseHookSpecificOutput,
 } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
 import recorded from "./fixtures/re-presents.json";
 import { processInput, StateUnavailableError } from "./gate";
+
+const GateOutput = z.object({
+  hookSpecificOutput: z.looseObject({
+    permissionDecision: z.string(),
+    permissionDecisionReason: z.string().optional(),
+  }),
+});
 
 let stateRoot: string;
 
@@ -37,10 +45,15 @@ async function decision(
   sessionId = "session-1",
 ): Promise<PreToolUseHookSpecificOutput | null> {
   const result = await processInput(mockInput(plan, sessionId), stateRoot);
-  if (!result) return null;
-  return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
+  const specific = result?.hookSpecificOutput;
+  return specific?.hookEventName === "PreToolUse" ? specific : null;
 }
 
+/** Asserts the gate denied, and hands back the reason for the caller to match on. */
+function denialReason(result: PreToolUseHookSpecificOutput | null): string {
+  expect(result?.permissionDecision).toBe("deny");
+  return result?.permissionDecisionReason ?? "";
+}
 type GateRun = { stdout: string; stderr: string; exitCode: number };
 
 async function runGate(input: PreToolUseHookInput): Promise<GateRun> {
@@ -80,11 +93,7 @@ describe("unchanged re-present", () => {
 
   it("denies a byte-identical resubmission", async () => {
     await decision(plan);
-    expect(await decision(plan)).toEqual({
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: expect.stringContaining("byte-identical"),
-    });
+    expect(denialReason(await decision(plan))).toContain("byte-identical");
   });
 
   it("denies repeatedly until the text changes", async () => {
@@ -131,11 +140,7 @@ describe("append-only re-present", () => {
   it("denies when the re-present keeps nearly all prior lines and only adds new ones", async () => {
     await decision(basePlan);
     const grown = `${basePlan}\n## Rollout\n- Ship behind a flag\n- Monitor error rates`;
-    expect(await decision(grown)).toEqual({
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: expect.stringContaining("carries nearly every prior line"),
-    });
+    expect(denialReason(await decision(grown))).toContain("carries nearly every prior line");
   });
 
   it("allows a genuine revision that rewrites most of the plan", async () => {
@@ -162,11 +167,7 @@ describe("size advisory", () => {
   const bigPlan = (seed: string) => seed + "x".repeat(12_001);
 
   it("denies a plan over 12k characters", async () => {
-    expect(await decision(bigPlan("a"))).toEqual({
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: expect.stringContaining("exceeds 12k characters"),
-    });
+    expect(denialReason(await decision(bigPlan("a")))).toContain("exceeds 12k characters");
   });
 
   it("stays silent at exactly 12k characters", async () => {
@@ -200,11 +201,7 @@ describe("append-only re-present", () => {
   it("denies when a re-present keeps nearly all prior lines and only adds new ones", async () => {
     await decision(initial);
     const appended = `${initial}\nline 10`;
-    expect(await decision(appended)).toEqual({
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: expect.stringContaining("carries nearly every prior line"),
-    });
+    expect(denialReason(await decision(appended))).toContain("carries nearly every prior line");
   });
 
   it("denies a line swap that carries the document at zero net growth", async () => {
@@ -212,11 +209,7 @@ describe("append-only re-present", () => {
     await decision(base);
     // Trade 3 lines for 3 new ones: carry-over 0.94, no net size change.
     const swapped = [...lines(47), ...lines(3, "swapped")].join("\n");
-    expect(await decision(swapped)).toEqual({
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: expect.stringContaining("carries nearly every prior line"),
-    });
+    expect(denialReason(await decision(swapped))).toContain("carries nearly every prior line");
   });
 
   it("returns null for a genuine revision with low carry-over", async () => {
@@ -267,11 +260,7 @@ describe("append-only re-present", () => {
 
     const grown = [...padded(90, "line"), ...padded(5, "new")].join("\n");
     expect(grown.length).toBeGreaterThan(12_000);
-    expect(await decision(grown)).toEqual({
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: expect.stringContaining("carries nearly every prior line"),
-    });
+    expect(denialReason(await decision(grown))).toContain("carries nearly every prior line");
     // Append-only denies before the size check, so the size branch never runs and
     // records no marker: one prompt for append-only, no second prompt for size.
     expect(readdirSync(join(stateRoot, "session-1"))).not.toContain("exit-plan-size-asked");
@@ -290,13 +279,9 @@ describe("sustained growth", () => {
 
   it("denies a second present above the high-water mark", async () => {
     await decision(skeletal);
-    expect(await decision(grown)).toEqual({
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: expect.stringContaining(
-        `Presentation 2 is larger than any before it (${skeletal.length} -> ${grown.length} chars)`,
-      ),
-    });
+    expect(denialReason(await decision(grown))).toContain(
+      `Presentation 2 is larger than any before it (${skeletal.length} -> ${grown.length} chars)`,
+    );
   });
 
   it("stays silent on a first presentation, which has no high-water mark", async () => {
@@ -361,8 +346,9 @@ describe("sustained growth", () => {
 describe("harness invocation", () => {
   it("emits the oversized decision when run as the harness runs it", async () => {
     const { stdout, stderr, exitCode } = await runGate(mockInput("x".repeat(12_001)));
+    const emitted: unknown = JSON.parse(stdout);
 
-    expect({ exitCode, stderr, decision: JSON.parse(stdout) }).toMatchInlineSnapshot(`
+    expect({ exitCode, stderr, decision: emitted }).toMatchInlineSnapshot(`
       {
         "decision": {
           "hookSpecificOutput": {
@@ -399,9 +385,7 @@ describe("recorded re-presents", () => {
   function label(run: GateRun): string {
     if (run.exitCode !== 0 || run.stderr) return `gate failed (${run.exitCode}): ${run.stderr}`;
     if (!run.stdout.trim()) return "allowed";
-    const { hookSpecificOutput } = JSON.parse(run.stdout) as {
-      hookSpecificOutput: PreToolUseHookSpecificOutput;
-    };
+    const { hookSpecificOutput } = GateOutput.parse(JSON.parse(run.stdout));
     const reason = hookSpecificOutput.permissionDecisionReason ?? "";
     const rule = RULES.find(([needle]) => reason.includes(needle))?.[1] ?? "unrecognized";
     return `${hookSpecificOutput.permissionDecision}:${rule}`;

--- a/plugins/plan/hooks/gate.ts
+++ b/plugins/plan/hooks/gate.ts
@@ -4,6 +4,19 @@ import { createHash } from "node:crypto";
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+
+const ToolInput = z.looseObject({ plan: z.string().optional().catch(undefined) });
+
+const HookInput = z.looseObject({
+  hook_event_name: z.literal("PreToolUse"),
+  session_id: z.string().catch(""),
+  transcript_path: z.string().catch(""),
+  cwd: z.string().catch(""),
+  tool_name: z.string().catch(""),
+  tool_input: z.unknown().catch(undefined),
+  tool_use_id: z.string().catch(""),
+}) satisfies z.ZodType<PreToolUseHookInput>;
 
 const SIZE_THRESHOLD = 12_000;
 
@@ -104,15 +117,12 @@ function parseLineSet(raw: string): Set<string> | null {
   }
 }
 
-type PresentHistory = { count: number; maxLength: number };
+const PresentHistory = z.object({ count: z.number(), maxLength: z.number() });
+type PresentHistory = z.infer<typeof PresentHistory>;
 
 function parsePresentHistory(raw: string): PresentHistory | null {
   try {
-    const parsed: unknown = JSON.parse(raw);
-    if (typeof parsed !== "object" || parsed === null) return null;
-    const { count, maxLength } = parsed as Record<string, unknown>;
-    if (typeof count !== "number" || typeof maxLength !== "number") return null;
-    return { count, maxLength };
+    return PresentHistory.safeParse(JSON.parse(raw)).data ?? null;
   } catch {
     return null;
   }
@@ -140,8 +150,8 @@ export async function processInput(
   input: PreToolUseHookInput,
   stateRoot = process.env.CLAUDE_PLAN_MARKER_ROOT || "/tmp/claude",
 ): Promise<SyncHookJSONOutput | null> {
-  const plan = (input.tool_input as { plan?: unknown }).plan;
-  if (typeof plan !== "string") return null;
+  const plan = ToolInput.safeParse(input.tool_input).data?.plan;
+  if (plan === undefined) return null;
 
   const sessionId = input.session_id;
   if (!sessionId) return null;
@@ -222,7 +232,7 @@ function failOpen(problem: string, error: unknown): void {
 async function main(): Promise<void> {
   let input: PreToolUseHookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
+    input = HookInput.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     failOpen("failed to parse hook input", error);
     return;

--- a/plugins/plan/package.json
+++ b/plugins/plan/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+    "zod": "^4.4.3"
   }
 }

--- a/plugins/plan/scripts/plan-inject.test.ts
+++ b/plugins/plan/scripts/plan-inject.test.ts
@@ -3,6 +3,16 @@ import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { z } from "zod";
+
+const Injection = z.object({
+  hookSpecificOutput: z.looseObject({
+    hookEventName: z.string(),
+    additionalContext: z.string(),
+  }),
+});
+
+const injection = (stdout: string) => Injection.parse(JSON.parse(stdout)).hookSpecificOutput;
 
 const scriptPath = join(import.meta.dirname, "plan-inject.sh");
 
@@ -40,9 +50,9 @@ async function opusTranscript(): Promise<string> {
 
 test("emits additionalContext JSON on first plan-mode tool call", async () => {
   const stdout = await run({ permission_mode: "plan", session_id: "t1" });
-  const parsed = JSON.parse(stdout);
-  expect(parsed.hookSpecificOutput.hookEventName).toBe("PreToolUse");
-  expect(parsed.hookSpecificOutput.additionalContext).toContain("Planning Guidelines");
+  const parsed = injection(stdout);
+  expect(parsed.hookEventName).toBe("PreToolUse");
+  expect(parsed.additionalContext).toContain("Planning Guidelines");
 });
 
 test("touches the marker so a second call short-circuits", async () => {
@@ -76,9 +86,9 @@ test("injects once EnterPlanMode has landed, whatever mode the call carried", as
     permission_mode: "auto",
     session_id: "t1",
   });
-  const parsed = JSON.parse(stdout);
-  expect(parsed.hookSpecificOutput.hookEventName).toBe("PostToolUse");
-  expect(parsed.hookSpecificOutput.additionalContext).toContain("Planning Guidelines");
+  const parsed = injection(stdout);
+  expect(parsed.hookEventName).toBe("PostToolUse");
+  expect(parsed.additionalContext).toContain("Planning Guidelines");
 });
 
 test("leaves the marker unspent when EnterPlanMode never lands", async () => {
@@ -96,6 +106,6 @@ test("re-injects for a different session id", async () => {
 test("includes delegation guidance when the model is expensive", async () => {
   const transcript_path = await opusTranscript();
   const stdout = await run({ permission_mode: "plan", session_id: "t1", transcript_path });
-  const parsed = JSON.parse(stdout);
-  expect(parsed.hookSpecificOutput.additionalContext).toContain("# Delegation");
+  const parsed = injection(stdout);
+  expect(parsed.additionalContext).toContain("# Delegation");
 });

--- a/plugins/pull-request/package.json
+++ b/plugins/pull-request/package.json
@@ -6,7 +6,8 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
     "ap-style-title-case": "^2.0.0",
     "mdast-util-from-markdown": "^2.0.2",
-    "unist-util-visit": "^5.1.0"
+    "unist-util-visit": "^5.1.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/mdast": "^4.0.4"

--- a/plugins/pull-request/scripts/detect-bot.ts
+++ b/plugins/pull-request/scripts/detect-bot.ts
@@ -2,6 +2,7 @@
 
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { z } from "zod";
 
 export interface Provider {
   name: string;
@@ -14,12 +15,20 @@ export const PROVIDERS: Provider[] = [
   { name: "coderabbit", configs: [".coderabbit.yaml", ".coderabbit.yml"], cli: "coderabbit" },
 ];
 
-export interface Cooldown {
-  provider: string;
-  remote?: string;
-  pausedUntil: string;
-  reason: string;
-}
+export const Cooldown = z.object({
+  provider: z.string(),
+  remote: z.string().optional(),
+  pausedUntil: z.string(),
+  reason: z.string(),
+});
+export type Cooldown = z.infer<typeof Cooldown>;
+
+// A file written by an older build can carry `remote: null` where the current
+// shape omits the key, and the timestamp is only required to be parseable.
+const CooldownEntry = Cooldown.extend({
+  remote: z.string().nullish(),
+  pausedUntil: z.string().refine((value) => !Number.isNaN(Date.parse(value))),
+});
 
 export type Which = (cli: string) => string | null;
 export type ReadCooldowns = () => Promise<Cooldown[]>;
@@ -34,19 +43,13 @@ export function parseCooldowns(text: string): Cooldown[] {
   } catch {
     return [];
   }
-  if (!Array.isArray(parsed)) return [];
-  const records: Cooldown[] = [];
-  for (const entry of parsed) {
-    if (typeof entry !== "object" || entry === null) continue;
-    const { provider, pausedUntil, reason, remote } = entry as Record<string, unknown>;
-    if (typeof provider !== "string") continue;
-    if (typeof reason !== "string") continue;
-    if (typeof pausedUntil !== "string" || Number.isNaN(Date.parse(pausedUntil))) continue;
-    if (typeof remote === "string") records.push({ provider, pausedUntil, reason, remote });
-    else if (remote === undefined || remote === null)
-      records.push({ provider, pausedUntil, reason });
-  }
-  return records;
+  const entries = z.array(z.unknown()).safeParse(parsed).data ?? [];
+  return entries.flatMap((entry) => {
+    const record = CooldownEntry.safeParse(entry).data;
+    if (!record) return [];
+    const { remote, ...rest } = record;
+    return [remote ? { ...rest, remote } : rest];
+  });
 }
 
 export const readCooldowns: ReadCooldowns = async () =>

--- a/plugins/pull-request/scripts/pr-template.ts
+++ b/plugins/pull-request/scripts/pr-template.ts
@@ -3,7 +3,10 @@
 import { execSync } from "node:child_process";
 import { join } from "node:path";
 import { markdown } from "bun";
-export type Provider = "github" | "gitlab";
+import { z } from "zod";
+
+export const Provider = z.enum(["github", "gitlab"]);
+export type Provider = z.infer<typeof Provider>;
 
 const TEMPLATE_PATHS: Record<Provider, string[]> = {
   github: [
@@ -40,7 +43,7 @@ function getRepoRoot(): string {
 
 if (import.meta.main) {
   const repoRoot = getRepoRoot();
-  const provider = (process.argv[2] as Provider) || "github";
+  const provider = Provider.safeParse(process.argv[2]).data ?? "github";
   const template = await findTemplate(provider, repoRoot);
   if (template) {
     process.stdout.write(markdown.ansi(template));

--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -1,19 +1,19 @@
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
-import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
 import { headingCaseViolations } from "./heading-case";
 import { LINKING_VERBS } from "./linguistics/heading";
 import { countProseWords, headingTexts, linesOutsideFences, stripEmphasis } from "./markdown";
 import { classifyPrHeading } from "./sentence-heading";
 
-function hasBashCommand(input: unknown): input is { command: string } {
-  return (
-    typeof input === "object" &&
-    input !== null &&
-    "command" in input &&
-    typeof input.command === "string"
-  );
-}
+const BashInput = z.looseObject({ command: z.string() });
+
+export const HookInput = z.looseObject({
+  cwd: z.string().optional(),
+  tool_input: z.unknown(),
+});
+export type HookInput = z.infer<typeof HookInput>;
 
 const TEST_COUNT_PATTERN =
   /[Aa]dded [0-9]+ (unit |integration )?tests|[0-9]+ (unit |integration )?tests|[0-9]+ assertions|[0-9]+ pass(?:ed|es)?,\s*[0-9]+ fail/;
@@ -681,13 +681,10 @@ export function unreadableBodyReason(detail: string): string {
   return `The hook cannot read ${detail}, so none of the body checks ran. Write the body to a file in its own Bash call, then pass that path: \`--body-file <path>\` on \`gh\`, \`--description-file <path>\` on \`glab\`.`;
 }
 
-export async function processInput(input: PreToolUseHookInput): Promise<SyncHookJSONOutput | null> {
-  if (!hasBashCommand(input.tool_input)) {
-    return null;
-  }
-  const { command } = input.tool_input;
+export async function processInput(input: HookInput): Promise<SyncHookJSONOutput | null> {
+  const command = BashInput.safeParse(input.tool_input).data?.command;
 
-  if (!isPrBodyCommand(command)) {
+  if (command === undefined || !isPrBodyCommand(command)) {
     return null;
   }
 

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -4,7 +4,6 @@ import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import {
   type BodyContext,
   type BodyPart,
@@ -19,6 +18,7 @@ import {
   hasFileTourBullets,
   hasReflexiveScaffold,
   hasRunOnProse,
+  type HookInput,
   isPersonalRepo,
   isPrBodyCommand,
   type NarrationTell,
@@ -644,10 +644,8 @@ describe("processInput", () => {
     .stdout.trim()
     .slice(0, 12);
 
-  function createInput(command: string, cwd?: string): PreToolUseHookInput {
-    const input: Record<string, unknown> = { tool_name: "Bash", tool_input: { command } };
-    if (cwd) input.cwd = cwd;
-    return input as PreToolUseHookInput;
+  function createInput(command: string, cwd?: string): HookInput {
+    return { tool_input: { command }, ...(cwd && { cwd }) };
   }
 
   it("returns null when command has no --body-file", async () => {
@@ -665,10 +663,7 @@ describe("processInput", () => {
   );
 
   it("returns null when tool_input has no command", async () => {
-    const result = await processInput({
-      tool_name: "Bash",
-      tool_input: {},
-    } as PreToolUseHookInput);
+    const result = await processInput({ tool_input: {} });
     expect(result).toBeNull();
   });
 

--- a/plugins/pull-request/scripts/validate.ts
+++ b/plugins/pull-request/scripts/validate.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
-import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { processInput } from "./validate-body";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { HookInput, processInput } from "./validate-body";
 
 function denyWithError(reason: string): void {
   const output = {
@@ -15,9 +15,9 @@ function denyWithError(reason: string): void {
 }
 
 async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
+  let input: HookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
+    input = HookInput.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`[pull-request/validate] Failed to parse hook input: ${message}`);

--- a/plugins/review/package.json
+++ b/plugins/review/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "dependencies": {
     "cleye": "^2.0.0",
-    "table": "^6.9.0"
+    "table": "^6.9.0",
+    "zod": "^4.4.3"
   }
 }

--- a/plugins/review/skills/inbox/scripts/poll.ts
+++ b/plugins/review/skills/inbox/scripts/poll.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env bun
 
 import { cli } from "cleye";
+import { z } from "zod";
 import { readState } from "./store";
 
-type QueueEntry = { url: string };
+const Queue = z.array(z.looseObject({ url: z.string() }));
 
 export type FetchResult = { ok: true; urls: string[] } | { ok: false; reason: string };
 
@@ -23,7 +24,7 @@ export async function fetchUrls(command: string): Promise<FetchResult> {
     return { ok: false, reason: detail };
   }
   try {
-    const entries = JSON.parse(stdoutText) as QueueEntry[];
+    const entries = Queue.parse(JSON.parse(stdoutText));
     return { ok: true, urls: entries.map((entry) => entry.url) };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/plugins/review/skills/inbox/scripts/spawn.ts
+++ b/plugins/review/skills/inbox/scripts/spawn.ts
@@ -39,15 +39,17 @@ if (!repoPath) {
   process.exit(1);
 }
 
-if (
-  permissionModeFlag !== undefined &&
-  !(PERMISSION_MODES as readonly string[]).includes(permissionModeFlag)
-) {
-  console.error(`--permission-mode must be one of: ${PERMISSION_MODES.join(", ")}`);
-  process.exit(1);
+function resolvePermissionMode(value: string | undefined): PermissionMode | undefined {
+  if (value === undefined) return undefined;
+  const mode = PERMISSION_MODES.find((m) => m === value);
+  if (!mode) {
+    console.error(`--permission-mode must be one of: ${PERMISSION_MODES.join(", ")}`);
+    process.exit(1);
+  }
+  return mode;
 }
 
-const permissionMode = permissionModeFlag as PermissionMode | undefined;
+const permissionMode = resolvePermissionMode(permissionModeFlag);
 
 const state = await readState(dataDir);
 if (isDispatched(state, url)) {

--- a/plugins/review/skills/inbox/scripts/store.ts
+++ b/plugins/review/skills/inbox/scripts/store.ts
@@ -1,20 +1,26 @@
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
+import { z } from "zod";
 
 // Inbox dedup state: the reviews this inbox has already dispatched a background
 // session for. Dispatch is fire-and-forget (each review lives in `claude
 // agents`, not here), so the inbox tracks its own dispatches to avoid launching
 // a second session for a PR it is already reviewing. State persists in the data
 // dir across sessions.
-export interface Dispatch {
-  url: string;
-  sessionId: string | null;
-  dispatchedAt: string;
-}
+export const Dispatch = z.object({
+  url: z.string(),
+  sessionId: z.string().nullable(),
+  dispatchedAt: z.string(),
+});
+export type Dispatch = z.infer<typeof Dispatch>;
 
-export interface InboxState {
-  dispatched: Dispatch[];
-}
+export const InboxState = z.object({ dispatched: z.array(Dispatch) });
+export type InboxState = z.infer<typeof InboxState>;
+
+// The pre-background inbox stored { reviews: [...] } of tmux-pane records. Those
+// carry no meaning for the dispatch launcher, so an old file migrates to an empty
+// dedup set rather than hard-erroring every caller on it.
+const LegacyState = z.object({ reviews: z.array(z.unknown()) });
 
 function resolveDataDir(dataDir?: string): string {
   const base = dataDir ?? process.env.CLAUDE_PLUGIN_DATA;
@@ -43,19 +49,9 @@ export async function readState(dataDir?: string): Promise<InboxState> {
   } catch (cause) {
     throw new Error(`Failed to parse state file: ${file.name}`, { cause });
   }
-  if (!data || typeof data !== "object") {
-    throw new Error(`Invalid state file: ${file.name}`);
-  }
-  const record = data as Record<string, unknown>;
-  if (Array.isArray(record.dispatched)) {
-    return { dispatched: record.dispatched as Dispatch[] };
-  }
-  // The pre-background inbox stored { reviews: [...] } of tmux-pane records.
-  // Those carry no meaning for the dispatch launcher, so migrate the old file to
-  // an empty dedup set rather than hard-erroring every caller on it.
-  if (Array.isArray(record.reviews)) {
-    return { dispatched: [] };
-  }
+  const state = InboxState.safeParse(data);
+  if (state.success) return state.data;
+  if (LegacyState.safeParse(data).success) return { dispatched: [] };
   throw new Error(`Invalid state file: ${file.name}`);
 }
 

--- a/plugins/review/skills/tuicr/scripts/comment.ts
+++ b/plugins/review/skills/tuicr/scripts/comment.ts
@@ -1,19 +1,30 @@
-export type CommentType = "issue" | "suggestion" | "note" | "praise";
-export type CommentSide = "new" | "old";
-export type LifecycleState = "local_draft" | "pushed_draft" | "submitted";
+import { z } from "zod";
 
-export interface TuicrComment {
-  id: string;
-  location: string;
-  path: string | null;
-  start_line: number | null;
-  end_line: number | null;
-  side: CommentSide | null;
-  comment_type: CommentType;
-  lifecycle_state: LifecycleState;
-  created_at?: string;
-  content: string;
-}
+export const CommentType = z.enum(["issue", "suggestion", "note", "praise"]);
+export type CommentType = z.infer<typeof CommentType>;
+export const CommentSide = z.enum(["new", "old"]);
+export type CommentSide = z.infer<typeof CommentSide>;
+export const LifecycleState = z.enum(["local_draft", "pushed_draft", "submitted"]);
+export type LifecycleState = z.infer<typeof LifecycleState>;
+
+export const TuicrComment = z.looseObject({
+  id: z.string(),
+  location: z.string(),
+  path: z.string().nullable(),
+  start_line: z.number().nullable(),
+  end_line: z.number().nullable(),
+  side: CommentSide.nullable(),
+  comment_type: CommentType,
+  lifecycle_state: LifecycleState,
+  created_at: z.string().optional(),
+  content: z.string(),
+});
+export type TuicrComment = z.infer<typeof TuicrComment>;
+
+const CommentPayload = z.union([
+  z.looseObject({ comments: z.array(TuicrComment) }),
+  z.array(TuicrComment),
+]);
 
 export interface Anchor {
   side: CommentSide;
@@ -39,6 +50,6 @@ export function deriveAnchor(comment: TuicrComment): Anchor {
 
 /** Decode a comments JSON payload, accepting either `{ comments: [...] }` or a bare array. */
 export function decodeComments(raw: string): TuicrComment[] {
-  const data = JSON.parse(raw) as { comments: TuicrComment[] } | TuicrComment[];
+  const data = CommentPayload.parse(JSON.parse(raw));
   return Array.isArray(data) ? data : data.comments;
 }

--- a/plugins/review/skills/tuicr/scripts/ledger.ts
+++ b/plugins/review/skills/tuicr/scripts/ledger.ts
@@ -3,20 +3,22 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { cli, command } from "cleye";
 import { table } from "table";
-import { type CommentSide, decodeComments, deriveAnchor, type TuicrComment } from "./comment";
+import { z } from "zod";
+import { CommentSide, decodeComments, deriveAnchor, type TuicrComment } from "./comment";
 
 export type { CommentSide, TuicrComment } from "./comment";
 
-export interface LedgerRecord {
-  id: string;
-  path: string;
-  anchor: { side: CommentSide; line: number };
-  content: string;
-  resolved: boolean;
-  action?: string;
-  ref?: string;
-  updatedAt: string;
-}
+export const LedgerRecord = z.object({
+  id: z.string(),
+  path: z.string(),
+  anchor: z.object({ side: CommentSide, line: z.number() }),
+  content: z.string(),
+  resolved: z.boolean(),
+  action: z.string().optional(),
+  ref: z.string().optional(),
+  updatedAt: z.string(),
+});
+export type LedgerRecord = z.infer<typeof LedgerRecord>;
 
 export interface LedgerOptions {
   dir: string;
@@ -37,11 +39,12 @@ function sanitize(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
-interface LedgerFile {
-  repo: string;
-  branch: string;
-  records: LedgerRecord[];
-}
+const LedgerFile = z.object({
+  repo: z.string(),
+  branch: z.string(),
+  records: z.array(LedgerRecord),
+});
+type LedgerFile = z.infer<typeof LedgerFile>;
 
 export class Ledger {
   private readonly dir: string;
@@ -75,7 +78,7 @@ export class Ledger {
     if (!(await file.exists())) {
       return new Map();
     }
-    const data = JSON.parse(await file.text()) as LedgerFile;
+    const data = LedgerFile.parse(JSON.parse(await file.text()));
     return new Map(data.records.map((record) => [record.id, record]));
   }
 

--- a/plugins/review/skills/tuicr/scripts/mapping.ts
+++ b/plugins/review/skills/tuicr/scripts/mapping.ts
@@ -37,7 +37,7 @@ const mapCmd = command(
       commentList = decodeComments(await Bun.file(comments).text());
       diffText = await Bun.file(diff).text();
     } catch (error) {
-      console.error((error as Error).message);
+      console.error(error instanceof Error ? error.message : String(error));
       process.exit(1);
     }
 

--- a/plugins/shortcuts/hooks/open.test.ts
+++ b/plugins/shortcuts/hooks/open.test.ts
@@ -18,9 +18,8 @@ function mockInput(command: string): PreToolUseHookInput {
 }
 
 function getOutput(input: PreToolUseHookInput): PreToolUseHookSpecificOutput | null {
-  const result = processInput(input);
-  if (!result) return null;
-  return result.hookSpecificOutput as PreToolUseHookSpecificOutput;
+  const specific = processInput(input)?.hookSpecificOutput;
+  return specific?.hookEventName === "PreToolUse" ? specific : null;
 }
 
 describe("processInput", () => {

--- a/plugins/shortcuts/hooks/open.ts
+++ b/plugins/shortcuts/hooks/open.ts
@@ -1,9 +1,13 @@
 #!/usr/bin/env bun
 
 import { extname } from "node:path";
-import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
 
-type BashInput = { command: string };
+const BashInput = z.looseObject({ command: z.string() });
+
+export const HookInput = z.looseObject({ tool_input: z.unknown() });
+export type HookInput = z.infer<typeof HookInput>;
 
 // Characters that end a simple command, splice another one into it, or hide a
 // word from it. A command carrying any of them outside quotes is not a lone
@@ -91,9 +95,9 @@ function extractTarget(command: string): string | null {
   return tokens.at(-1) ?? null;
 }
 
-export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | null {
-  const { command } = input.tool_input as BashInput;
-  const target = extractTarget(command);
+export function processInput(input: HookInput): SyncHookJSONOutput | null {
+  const command = BashInput.safeParse(input.tool_input).data?.command;
+  const target = command === undefined ? null : extractTarget(command);
 
   if (!target) {
     return null;
@@ -121,9 +125,9 @@ export function processInput(input: PreToolUseHookInput): SyncHookJSONOutput | n
 }
 
 async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
+  let input: HookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
+    input = HookInput.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     console.error(
       `[shortcuts/open] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/shortcuts/package.json
+++ b/plugins/shortcuts/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+    "zod": "^4.4.3"
   }
 }

--- a/plugins/shortcuts/tests/discover.integration.ts
+++ b/plugins/shortcuts/tests/discover.integration.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { type ExecFileSyncOptions, execFileSync } from "node:child_process";
 import { join } from "node:path";
+import { z } from "zod";
 
 const script = join(import.meta.dirname, "../skills/shortcut/scripts/discover.swift");
 
@@ -11,8 +12,10 @@ const script = join(import.meta.dirname, "../skills/shortcut/scripts/discover.sw
 const timeoutMs = 60000;
 const opts: ExecFileSyncOptions = { encoding: "utf-8", timeout: timeoutMs };
 
-function run(command: string): string {
-  return execFileSync("swift", [script, command], opts) as string;
+const Entries = z.array(z.record(z.string(), z.unknown()));
+
+function run(command: string): Record<string, unknown>[] {
+  return Entries.parse(JSON.parse(execFileSync("swift", [script, command], opts).toString()));
 }
 
 const ci = !!process.env.CI;
@@ -21,7 +24,7 @@ describe.skipIf(ci)("discover.swift actions", () => {
   let actions: Record<string, unknown>[];
 
   beforeAll(() => {
-    actions = JSON.parse(run("actions")) as Record<string, unknown>[];
+    actions = run("actions");
   }, timeoutMs);
 
   it("returns a large array of built-in actions", () => {
@@ -60,7 +63,7 @@ describe.skipIf(ci)("discover.swift apps", () => {
   let apps: Record<string, unknown>[];
 
   beforeAll(() => {
-    apps = JSON.parse(run("apps")) as Record<string, unknown>[];
+    apps = run("apps");
   }, timeoutMs);
 
   it("returns an array of apps", () => {

--- a/plugins/things/scripts/format-output.ts
+++ b/plugins/things/scripts/format-output.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { cli } from "cleye";
+import { z } from "zod";
 import { formatDate, selectColumns, stringify, table } from "./format";
 
 const argv = cli({
@@ -21,16 +22,23 @@ const argv = cli({
   },
 });
 
-const raw = await Bun.stdin.text();
-const data = JSON.parse(raw);
+const Row = z.record(z.string(), z.unknown());
+const Failure = z.looseObject({ error: z.unknown() });
+const Rows = z.array(Row);
+const Wrapped = z.looseObject({ items: Rows.optional(), count: z.number().optional() });
 
-if (data && typeof data === "object" && "error" in data) {
-  console.error(data.error);
+const data: unknown = JSON.parse(await Bun.stdin.text());
+
+const failure = Failure.safeParse(data);
+if (failure.success) {
+  console.error(failure.data.error);
   process.exit(1);
 }
 
-const items: Record<string, unknown>[] = Array.isArray(data) ? data : (data.items ?? []);
-const count = Array.isArray(data) ? items.length : (data.count ?? items.length);
+const bare = Rows.safeParse(data);
+const wrapped = Wrapped.safeParse(data);
+const items = bare.success ? bare.data : (wrapped.data?.items ?? []);
+const count = bare.success ? items.length : (wrapped.data?.count ?? items.length);
 
 if (argv.flags.json) {
   console.log(JSON.stringify(data, null, 2));

--- a/plugins/things/scripts/format.test.ts
+++ b/plugins/things/scripts/format.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { selectColumns, stringify } from "./format";
 
 describe("stringify", () => {
@@ -55,15 +55,10 @@ describe("selectColumns", () => {
   });
 
   test("exits with error for unknown column", () => {
-    const mockExit = mock(() => {
+    const mockExit = spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
-    const originalExit = process.exit;
-    process.exit = mockExit;
-
-    const mockError = mock();
-    const originalError = console.error;
-    console.error = mockError;
+    const mockError = spyOn(console, "error").mockImplementation(() => {});
 
     try {
       selectColumns(headers, rows, ["unknown"]);
@@ -76,7 +71,7 @@ describe("selectColumns", () => {
       "Unknown column: unknown. Available: Name, Status, Due Date, Project",
     );
 
-    process.exit = originalExit;
-    console.error = originalError;
+    mockExit.mockRestore();
+    mockError.mockRestore();
   });
 });

--- a/plugins/things/scripts/inbox.test.ts
+++ b/plugins/things/scripts/inbox.test.ts
@@ -63,10 +63,11 @@ describe("buildAttribution", () => {
 });
 
 describe("printCaptured", () => {
-  let log: ReturnType<typeof spyOn>;
+  const silenceLog = () => spyOn(console, "log").mockImplementation(() => {});
+  let log: ReturnType<typeof silenceLog>;
 
   beforeEach(() => {
-    log = spyOn(console, "log").mockImplementation(() => {});
+    log = silenceLog();
   });
 
   afterEach(() => {

--- a/plugins/things/scripts/url.test.ts
+++ b/plugins/things/scripts/url.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { z } from "zod";
 import { join } from "node:path";
 import {
   buildJsonPayload,
@@ -14,9 +15,11 @@ import {
   xcallBackstopMs,
 } from "./url";
 
+const Payload = z.array(z.looseObject({ attributes: z.record(z.string(), z.unknown()) }));
+
 describe("buildJsonPayload", () => {
   test("single ID produces correct structure", () => {
-    const result = JSON.parse(buildJsonPayload(["ABC"], { when: "tomorrow" }));
+    const result: unknown = JSON.parse(buildJsonPayload(["ABC"], { when: "tomorrow" }));
     expect(result).toEqual([
       {
         type: "to-do",
@@ -28,7 +31,7 @@ describe("buildJsonPayload", () => {
   });
 
   test("multiple IDs produce one object per ID with same attributes", () => {
-    const result = JSON.parse(
+    const result: unknown = JSON.parse(
       buildJsonPayload(["A", "B", "C"], { when: "today", "add-tags": "Urgent" }),
     );
     const expected = {
@@ -74,8 +77,8 @@ describe("buildJsonPayload", () => {
       },
     ],
   ])("%s", (_name, attrs, expected) => {
-    const result = JSON.parse(buildJsonPayload(["ABC"], attrs));
-    expect(result[0].attributes).toEqual(expected);
+    const result = Payload.parse(JSON.parse(buildJsonPayload(["ABC"], attrs)));
+    expect(result[0]?.attributes).toEqual(expected);
   });
 });
 
@@ -213,11 +216,11 @@ describe("dispatch", () => {
       },
     });
 
-    const result = await dispatch("add", new Map([["title", "Buy milk"]]), actions);
+    const { output, ...result } = await dispatch("add", new Map([["title", "Buy milk"]]), actions);
 
+    expect(typeof output).toBe("string");
     expect(result).toEqual({
       id: "ABC123",
-      output: expect.any(String),
       viaXcall: true,
       fallbackReason: null,
       fallbackDetail: null,

--- a/plugins/things/src/example.ts
+++ b/plugins/things/src/example.ts
@@ -10,9 +10,14 @@ const list = app.lists.byId("TMTodayListSource");
 
 const todos = toArray<Things3.ToDo>(list.toDos());
 
+// The generated Things3 types give every date accessor `any`.
+function asDate(value: unknown): Date | null {
+  return value instanceof Date ? value : null;
+}
+
 // Filter for non-repeating todos (creation date not at midnight)
 const nonRepeating = todos.filter((t) => {
-  const cd = t.creationDate();
+  const cd = asDate(t.creationDate());
   if (!cd) return true;
   return cd.getHours() !== 0 || cd.getMinutes() !== 0 || cd.getSeconds() !== 0;
 });

--- a/plugins/things/src/jxa-globals.d.ts
+++ b/plugins/things/src/jxa-globals.d.ts
@@ -2,14 +2,23 @@
  * JXA global functions available in osascript
  */
 
-declare function Application(name: string): any;
+/** The Things3 sdef surface these scripts reach through, as JXA exposes it. */
+type JXAThings3 = {
+  lists: {
+    byId(id: string): {
+      toDos(): import("./array").JXAArray<import("./Things3").Things3.ToDo>;
+    };
+  };
+};
+
+declare function Application(name: string): JXAThings3;
 
 declare namespace Application {
-  function currentApplication(): any;
+  function currentApplication(): unknown;
 }
 
 declare const console: {
-  log(...args: any[]): void;
+  log(...args: unknown[]): void;
 };
 
 declare function encodeURIComponent(str: string): string;

--- a/plugins/things/src/mcp/jxa.ts
+++ b/plugins/things/src/mcp/jxa.ts
@@ -6,6 +6,7 @@
  */
 
 import { join } from "node:path";
+import { z } from "zod";
 import { findSiblingScript } from "../marketplace";
 
 const PLUGIN_ROOT = join(import.meta.dirname, "..", "..");
@@ -20,7 +21,12 @@ export function findJxaRunner(pluginRoot: string = PLUGIN_ROOT): Promise<string 
   return findSiblingScript(pluginRoot, "mac", "scripts", "jxa.ts");
 }
 
-export async function runScript<T = unknown>(script: string, args: string[]): Promise<T> {
+const JxaFailure = z.looseObject({ error: z.unknown().transform(String) });
+
+// A JXA script prints whatever Things answered, and the tool that asked decides
+// what shape that is, so this seam has no domain type of its own.
+// oxlint-disable-next-line local/no-unknown-returns
+export async function runScript(script: string, args: string[]): Promise<unknown> {
   const runner = await findJxaRunner();
   if (!runner) {
     throw new Error("mac plugin JXA runner not found (expected plugins/mac/scripts/jxa.ts)");
@@ -46,8 +52,7 @@ export async function runScript<T = unknown>(script: string, args: string[]): Pr
   }
 
   const result: unknown = JSON.parse(stdout);
-  if (result && typeof result === "object" && "error" in result) {
-    throw new Error(String(result.error));
-  }
-  return result as T;
+  const failure = JxaFailure.safeParse(result);
+  if (failure.success) throw new Error(failure.data.error);
+  return result;
 }

--- a/plugins/things/src/mcp/stdio.test.ts
+++ b/plugins/things/src/mcp/stdio.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
+import { z } from "zod";
 
 const SERVER = join(import.meta.dirname, "stdio.ts");
 
@@ -76,18 +77,23 @@ function stdoutLines(stdout: string): string[] {
   return stdout.split("\n").filter(Boolean);
 }
 
-interface Response {
-  id: number;
-  result: { isError?: boolean; content?: Array<{ text: string }>; tools?: Array<{ name: string }> };
-}
+const RpcResponse = z.looseObject({
+  id: z.number(),
+  result: z.looseObject({
+    isError: z.boolean().optional(),
+    content: z.array(z.looseObject({ text: z.string() })).optional(),
+    tools: z.array(z.looseObject({ name: z.string() })).optional(),
+  }),
+});
+type RpcResponse = z.infer<typeof RpcResponse>;
 
 /**
  * The result the server sent for one request. Keyed by id because responses do
  * not come back in request order: a `tools/list` is answered synchronously
  * while a `tools/call` goes through schema validation first.
  */
-function responseTo(lines: string[], id: number): Response["result"] {
-  const responses = lines.map((line) => JSON.parse(line) as Response);
+function responseTo(lines: string[], id: number): RpcResponse["result"] {
+  const responses = lines.map((line) => RpcResponse.parse(JSON.parse(line)));
   const match = responses.find((response) => response.id === id);
   if (!match) throw new Error(`no response for request ${id}`);
   return match.result;
@@ -107,7 +113,9 @@ describe("stdio server", () => {
   // framing. Every diagnostic in the closure has to reach stderr instead.
   test("writes nothing but JSON-RPC to stdout", () => {
     for (const line of lines) {
-      expect(() => JSON.parse(line)).not.toThrow();
+      expect(() => {
+        JSON.parse(line);
+      }).not.toThrow();
     }
     expect(lines).toHaveLength(HANDSHAKE.length - 1);
   });

--- a/plugins/things/src/mcp/tags.ts
+++ b/plugins/things/src/mcp/tags.ts
@@ -7,6 +7,7 @@
  * runner behind `DispatchActions`.
  */
 
+import { z } from "zod";
 import { resolveTags } from "../../scripts/tags";
 import { runScript } from "./jxa";
 
@@ -15,8 +16,10 @@ export interface TagActions {
   createTags(names: string[]): Promise<void>;
 }
 
+const TagList = z.array(z.object({ name: z.string() }));
+
 async function fetchTags(): Promise<string[]> {
-  const tags = await runScript<Array<{ name: string }>>("query-metadata.js", ["tags"]);
+  const tags = TagList.parse(await runScript("query-metadata.js", ["tags"]));
   return tags.map((tag) => tag.name);
 }
 

--- a/plugins/things/src/mcp/tools.test.ts
+++ b/plugins/things/src/mcp/tools.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { z } from "zod";
 import {
   chunk,
   limitItems,
-  type TruncatedPayload,
+  TruncatedPayload,
   updateAttributes,
   validateCaptureTitles,
   validateNonBlank,
@@ -117,7 +118,7 @@ describe("limitItems", () => {
   });
 
   test("drops items from the end of an oversized array", () => {
-    const limited = limitItems(oversized, guidance) as TruncatedPayload;
+    const limited = TruncatedPayload.parse(limitItems(oversized, guidance));
 
     expect(limited.truncated).toBe(true);
     expect(limited.total).toBe(400);
@@ -129,11 +130,9 @@ describe("limitItems", () => {
   });
 
   test("keeps the other fields of an oversized object payload", () => {
-    const limited = limitItems({ count: 400, items: oversized }, guidance) as {
-      count: number;
-      truncated: boolean;
-      total: number;
-    };
+    const limited = TruncatedPayload.extend({ count: z.number() }).parse(
+      limitItems({ count: 400, items: oversized }, guidance),
+    );
 
     expect(limited.count).toBe(400);
     expect(limited.truncated).toBe(true);

--- a/plugins/things/src/mcp/tools.ts
+++ b/plugins/things/src/mcp/tools.ts
@@ -57,13 +57,14 @@ function payloadBytes(value: unknown): number {
  * The items a read returned: a bare array, or the `items` field of a shape that
  * carries a count alongside them.
  */
+const ItemList = z.array(z.unknown());
+const ItemsField = z.looseObject({ items: ItemList });
+const Siblings = z.record(z.string(), z.unknown());
+
 function readItems(payload: unknown): unknown[] | null {
-  if (Array.isArray(payload)) return payload;
-  if (payload && typeof payload === "object" && "items" in payload) {
-    const items = payload.items;
-    if (Array.isArray(items)) return items;
-  }
-  return null;
+  const bare = ItemList.safeParse(payload);
+  if (bare.success) return bare.data;
+  return ItemsField.safeParse(payload).data?.items ?? null;
 }
 
 /** Largest prefix of `items` that serializes within the budget. */
@@ -80,13 +81,14 @@ function fittingCount(items: unknown[]): number {
 }
 
 /** What a capped read returns in place of the payload that overran the budget. */
-export interface TruncatedPayload {
-  truncated: true;
-  returned: number;
-  total: number;
-  note: string;
-  items: unknown[];
-}
+export const TruncatedPayload = z.looseObject({
+  truncated: z.literal(true),
+  returned: z.number(),
+  total: z.number(),
+  note: z.string(),
+  items: ItemList,
+});
+export type TruncatedPayload = z.infer<typeof TruncatedPayload>;
 
 /**
  * Caps a read at {@link MAX_PAYLOAD_BYTES}, dropping items from the end and
@@ -107,7 +109,7 @@ export function limitItems(payload: unknown, guidance: string): unknown {
   const omitted = items.length - returned;
   // A payload that carries its items in a field keeps that field's siblings,
   // so a caller reading `count` still finds how many matched.
-  const siblings = Array.isArray(payload) ? {} : (payload as Record<string, unknown>);
+  const siblings = Siblings.safeParse(payload).data ?? {};
   return {
     ...siblings,
     truncated: true,

--- a/plugins/tmux/hooks/notification.ts
+++ b/plugins/tmux/hooks/notification.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { cli } from "cleye";
+import { z } from "zod";
 import { tmux, tmuxQuery } from "./tmux";
 
 const argv = cli({
@@ -85,16 +86,17 @@ function updateSummary(): void {
   tmux("set-option", "-g", "@claude_notification", styled);
 }
 
-interface HookInput {
-  notification_type?: string;
-  message?: string;
-}
+const HookInput = z.looseObject({
+  notification_type: z.string().optional().catch(undefined),
+  message: z.string().optional().catch(undefined),
+});
+type HookInput = z.infer<typeof HookInput>;
 
 async function readHookInput(): Promise<HookInput | null> {
   const text = await Bun.stdin.text();
   if (!text) return null;
   try {
-    return JSON.parse(text);
+    return HookInput.parse(JSON.parse(text));
   } catch (error) {
     console.error(
       `[tmux/notification] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/tmux/package.json
+++ b/plugins/tmux/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
     "cleye": "^2.0.0",
-    "table": "^6.9.0"
+    "table": "^6.9.0",
+    "zod": "^4.4.3"
   }
 }

--- a/plugins/tmux/skills/tmux/scripts/safe-command.test.ts
+++ b/plugins/tmux/skills/tmux/scripts/safe-command.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
+import { z } from "zod";
 
 const script = join(import.meta.dir, "safe-command.sh");
 
@@ -14,12 +15,13 @@ async function run(command: string): Promise<string> {
   return output.trim();
 }
 
+const Decision = z.looseObject({
+  hookSpecificOutput: z.looseObject({ permissionDecision: z.string().optional() }).optional(),
+});
+
 function isAllow(output: string): boolean {
   if (!output) return false;
-  const parsed = JSON.parse(output) as {
-    hookSpecificOutput?: { permissionDecision?: string };
-  };
-  return parsed.hookSpecificOutput?.permissionDecision === "allow";
+  return Decision.parse(JSON.parse(output)).hookSpecificOutput?.permissionDecision === "allow";
 }
 
 describe("safe-command", () => {

--- a/plugins/type-ignore/hooks/detect.ts
+++ b/plugins/type-ignore/hooks/detect.ts
@@ -3,10 +3,28 @@
 import { mkdirSync } from "node:fs";
 import * as path from "node:path";
 import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
 import { EXTENSION_MAP, LANGUAGES, TARGET_EXTENSIONS } from "./languages";
 
-export type WriteInput = { file_path: string; content: string };
-export type EditInput = { file_path: string; old_string: string; new_string: string };
+const HookInput = z.looseObject({
+  hook_event_name: z.literal("PostToolUse"),
+  session_id: z.string().catch(""),
+  transcript_path: z.string().catch(""),
+  cwd: z.string().catch(""),
+  tool_name: z.string().catch(""),
+  tool_input: z.unknown().catch(undefined),
+  tool_response: z.unknown().catch(undefined),
+  tool_use_id: z.string().catch(""),
+}) satisfies z.ZodType<PostToolUseHookInput>;
+
+export const WriteInput = z.looseObject({ file_path: z.string(), content: z.string() });
+export type WriteInput = z.infer<typeof WriteInput>;
+export const EditInput = z.looseObject({
+  file_path: z.string(),
+  old_string: z.string(),
+  new_string: z.string(),
+});
+export type EditInput = z.infer<typeof EditInput>;
 
 export interface PatternMatch {
   label: string;
@@ -113,11 +131,13 @@ export async function processInput(
   let oldContent = "";
 
   if (toolName === "Write") {
-    const writeInput = input.tool_input as WriteInput;
+    const writeInput = WriteInput.safeParse(input.tool_input).data;
+    if (!writeInput) return null;
     filePath = writeInput.file_path;
     newContent = writeInput.content;
   } else if (toolName === "Edit") {
-    const editInput = input.tool_input as EditInput;
+    const editInput = EditInput.safeParse(input.tool_input).data;
+    if (!editInput) return null;
     filePath = editInput.file_path;
     oldContent = editInput.old_string;
     newContent = editInput.new_string;
@@ -153,7 +173,7 @@ export async function processInput(
 async function main(): Promise<void> {
   let input: PostToolUseHookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PostToolUseHookInput;
+    input = HookInput.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     console.error(
       `[type-ignore] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/type-ignore/package.json
+++ b/plugins/type-ignore/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+    "zod": "^4.4.3"
   }
 }

--- a/plugins/type-ignore/tests/detect.integration.ts
+++ b/plugins/type-ignore/tests/detect.integration.ts
@@ -68,8 +68,9 @@ describe("type-ignore detection hook", () => {
 
       const result = await processInput(input);
       expect(result).not.toBeNull();
-      const additionalContext = (result?.hookSpecificOutput as { additionalContext: string })
-        .additionalContext;
+      const specific = result?.hookSpecificOutput;
+      const additionalContext =
+        specific?.hookEventName === "PostToolUse" ? (specific.additionalContext ?? "") : "";
       expect(additionalContext).toContain("@ts-ignore");
       expect(additionalContext).toContain("type-ignore:fixer");
     });
@@ -82,8 +83,9 @@ describe("type-ignore detection hook", () => {
 
       const result = await processInput(input);
       expect(result).not.toBeNull();
-      const additionalContext = (result?.hookSpecificOutput as { additionalContext: string })
-        .additionalContext;
+      const specific = result?.hookSpecificOutput;
+      const additionalContext =
+        specific?.hookEventName === "PostToolUse" ? (specific.additionalContext ?? "") : "";
       expect(additionalContext).toContain("@ts-expect-error");
     });
 
@@ -96,8 +98,9 @@ describe("type-ignore detection hook", () => {
 
       const result = await processInput(input);
       expect(result).not.toBeNull();
-      const additionalContext = (result?.hookSpecificOutput as { additionalContext: string })
-        .additionalContext;
+      const specific = result?.hookSpecificOutput;
+      const additionalContext =
+        specific?.hookEventName === "PostToolUse" ? (specific.additionalContext ?? "") : "";
       expect(additionalContext).toContain("type: ignore");
     });
 
@@ -167,9 +170,10 @@ describe("type-ignore detection hook", () => {
     it("formats output with file, line, and pattern", () => {
       const result = formatOutput("/path/to/file.ts", 42, "@ts-ignore");
 
-      expect(result.hookSpecificOutput?.hookEventName).toBe("PostToolUse");
-      const additionalContext = (result.hookSpecificOutput as { additionalContext: string })
-        .additionalContext;
+      const specific = result.hookSpecificOutput;
+      expect(specific?.hookEventName).toBe("PostToolUse");
+      const additionalContext =
+        specific?.hookEventName === "PostToolUse" ? (specific.additionalContext ?? "") : "";
       expect(additionalContext).toContain("file.ts:42");
       expect(additionalContext).toContain("@ts-ignore");
       expect(additionalContext).toContain("type-ignore:fixer");

--- a/plugins/ui-design/package.json
+++ b/plugins/ui-design/package.json
@@ -7,6 +7,7 @@
     "@xmldom/xmldom": "^0.9.8",
     "cleye": "^2.2.1",
     "playwright": "^1.50.1",
-    "sharp": "^0.35.0"
+    "sharp": "^0.35.0",
+    "zod": "^4.4.3"
   }
 }

--- a/plugins/ui-design/skills/wireframe/scripts/render.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/render.ts
@@ -76,12 +76,15 @@ async function main() {
 
   const files: Array<{ input: string; output?: string }> = [];
 
-  if (svgFiles.length === 1 && nonSvgArgs.length === 1) {
-    files.push({ input: svgFiles[0] as string, ...(nonSvgArgs[0] && { output: nonSvgArgs[0] }) });
+  const [svg] = svgFiles;
+  const [firstArg, secondArg] = args;
+
+  if (svg && nonSvgArgs.length === 1) {
+    files.push({ input: svg, ...(nonSvgArgs[0] && { output: nonSvgArgs[0] }) });
   } else if (svgFiles.length > 0) {
     files.push(...svgFiles.map((input) => ({ input })));
-  } else if (args.length >= 1) {
-    files.push({ input: args[0] as string, ...(args[1] && { output: args[1] }) });
+  } else if (firstArg) {
+    files.push({ input: firstArg, ...(secondArg && { output: secondArg }) });
   }
 
   try {
@@ -97,8 +100,8 @@ async function main() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith("/bun")) {
-  main().catch((error) => {
-    console.error("Error:", error.message);
+  main().catch((error: unknown) => {
+    console.error("Error:", error instanceof Error ? error.message : String(error));
     process.exit(1);
   });
 }

--- a/plugins/ui-design/skills/wireframe/scripts/validate-hook.test.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/validate-hook.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import path from "node:path";
-import type {
-  PostToolUseHookInput,
-  PostToolUseHookSpecificOutput,
-} from "@anthropic-ai/claude-agent-sdk";
+import type { PostToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 
 import { isSvgFile, processInput } from "./validate-hook";
 
@@ -12,9 +9,15 @@ const assetsDir = path.join(import.meta.dirname, "..", "assets");
 
 function makeInput(toolName: string, filePath: string): PostToolUseHookInput {
   return {
+    hook_event_name: "PostToolUse",
+    session_id: "test",
+    transcript_path: "/tmp/test",
+    cwd: "/tmp",
     tool_name: toolName,
     tool_input: { file_path: filePath },
-  } as PostToolUseHookInput;
+    tool_response: {},
+    tool_use_id: "test",
+  };
 }
 
 describe("isSvgFile", () => {
@@ -61,8 +64,10 @@ describe("processInput", () => {
       expect(result).toBeNull();
     } else {
       expect(result).not.toBeNull();
-      const output = result?.hookSpecificOutput as PostToolUseHookSpecificOutput | undefined;
-      expect(output?.additionalContext).toContain(expected);
+      const specific = result?.hookSpecificOutput;
+      expect(specific?.hookEventName === "PostToolUse" && specific.additionalContext).toContain(
+        expected,
+      );
     }
   });
 });

--- a/plugins/ui-design/skills/wireframe/scripts/validate-hook.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/validate-hook.ts
@@ -2,8 +2,22 @@
 
 import { extname } from "node:path";
 import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
 
 import { validate } from "./validate";
+
+const FileInput = z.looseObject({ file_path: z.string().optional().catch(undefined) });
+
+const HookInput = z.looseObject({
+  hook_event_name: z.literal("PostToolUse"),
+  session_id: z.string().catch(""),
+  transcript_path: z.string().catch(""),
+  cwd: z.string().catch(""),
+  tool_name: z.string().catch(""),
+  tool_input: z.unknown().catch(undefined),
+  tool_response: z.unknown().catch(undefined),
+  tool_use_id: z.string().catch(""),
+}) satisfies z.ZodType<PostToolUseHookInput>;
 
 export function isSvgFile(filePath: string): boolean {
   return extname(filePath) === ".svg";
@@ -25,7 +39,7 @@ export async function processInput(
     return null;
   }
 
-  const filePath = (input.tool_input as { file_path?: string }).file_path;
+  const filePath = FileInput.safeParse(input.tool_input).data?.file_path;
   if (!filePath || !isSvgFile(filePath)) {
     return null;
   }
@@ -49,7 +63,7 @@ Fix these layout issues before rendering.`);
 async function main(): Promise<void> {
   let input: PostToolUseHookInput;
   try {
-    input = JSON.parse(await Bun.stdin.text()) as PostToolUseHookInput;
+    input = HookInput.parse(JSON.parse(await Bun.stdin.text()));
   } catch {
     return;
   }

--- a/plugins/ui-design/skills/wireframe/scripts/validate.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/validate.ts
@@ -287,8 +287,8 @@ async function main() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith("/bun")) {
-  main().catch((error) => {
-    console.error("Error:", error.message);
+  main().catch((error: unknown) => {
+    console.error("Error:", error instanceof Error ? error.message : String(error));
     process.exit(1);
   });
 }


### PR DESCRIPTION
Migrates the plugin seams that take in external data onto zod schemas, across fifteen plugins. Sixth layer of the stack. The boundary and the rule reversal are in #1271.

These plugins go from 53 hits across the five `no-unsafe-*` rules and 88 on `no-unsafe-type-assertion` to zero on all six.

| Seam | Was | Now |
|---|---|---|
| Hook stdin | `JSON.parse(text) as PreToolUseHookInput` | a schema per hook |
| `tuicr` comment files | `JSON.parse(raw) as TuicrComment[]` | `decodeComments` over both payload shapes |
| Review inbox state | `as InboxState` over a file the launcher no longer writes | `InboxState` plus a legacy arm |
| Bot-review cooldowns | the parsed array asserted to `Cooldown[]` | per-entry decode that drops what does not fit |
| Meme spec files | hand-rolled `validateFraction`, `oneOf`, `isRecord` | `Spec.safeParse` and `z.prettifyError` |
| JXA stdout | `result as T` from a caller-chosen generic | `unknown` at the seam |

## Hook Input

Two shapes, picked by what the hook reads.

A hook that reads the envelope declares the whole event and pins it with `satisfies z.ZodType<PreToolUseHookInput>`, leaving the SDK type the authority on the field set. Every field takes `.catch(...)`. A hook that cannot parse its own stdin stops firing, which is worse than reading a default.

A hook that reads only the payload declares `z.looseObject({ tool_input: z.unknown() })` and decodes `tool_input` separately. Its `processInput` takes the inferred type, so a test builds a two-field object instead of a whole event. `plugins/git` and `plugins/newline` run several hooks each off one shared `hook-input.ts`.

## Plugin Distribution

No plugin imports `packages/decode`. Auto-install skips `workspace:*`, so each declares `zod` in its own `package.json` and calls `schema.parse` directly, the way `plugins/things` already did.

## Meme Specs

The image skill accepted a spec written by the model, and validated it through about ninety lines of hand-rolled checks that reported one error at a time. `Spec` replaces them, including the two cross-field constraints (`anchor` and `region` are mutually exclusive, and a spec needs at least one box or caption) as `.refine` calls. The snapshots now hold zod's prettified output, which names the failing path.

## Tolerant Reads

A file on disk outlives the code that wrote it. The bot-review cooldown store decodes entry by entry and drops what no longer fits, rather than failing the whole read on one stale record, and it accepts `remote: null` where the current shape omits the key. The review inbox migrates a pre-background state file to an empty dedup set, since its tmux-pane records carry nothing the dispatch launcher can use.

## Untyped by Design

`runScript` in `plugins/things` returns `unknown` and takes the sixth `local/no-unknown-returns` suppression. It prints whatever Things answered and the calling tool decides the shape, so the seam has no domain type to name. The last layer of this stack revisits all six.
