### PR TITLE
lint: enforce the no-unsafe-* family

### DIFF
--- a/.claude/hooks/ox/index.test.ts
+++ b/.claude/hooks/ox/index.test.ts
@@ -1,4 +1,14 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
 import { exec } from "node:child_process";
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -23,6 +33,10 @@ import {
   runOxlintAgent,
   STOP_BLOCK_LIMIT,
 } from ".";
+
+// Every check here spawns oxlint and oxfmt over a real fixture, and the
+// type-aware pass alone outruns the 5s default on CI.
+setDefaultTimeout(30_000);
 
 const execAsync = promisify(exec);
 
@@ -385,10 +399,6 @@ describe("ox hook", () => {
   });
 
   describe("processStop", () => {
-    // Each Stop runs a whole-tree type-aware check, so a test driving the gate
-    // three times needs a budget the 5s default does not give it on CI.
-    const MULTI_STOP_TIMEOUT_MS = 30_000;
-
     // A session holding one lint error oxfmt cannot fix, stopped repeatedly.
     // Each block-budget test drives its own so the on-disk count stays its own.
     async function unfixableSession(session: string): Promise<string> {
@@ -412,26 +422,22 @@ describe("ox hook", () => {
     });
 
     // An error the model cannot clear would otherwise block every Stop forever.
-    it(
-      "gives way once the issues survive the block limit",
-      async () => {
-        const session = `limit-${Date.now()}`;
-        const transcript = await unfixableSession(session);
+    it("gives way once the issues survive the block limit", async () => {
+      const session = `limit-${Date.now()}`;
+      const transcript = await unfixableSession(session);
 
-        const budget: (SyncHookJSONOutput | null)[] = [];
-        for (let stop = 0; stop < STOP_BLOCK_LIMIT; stop++) {
-          budget.push(await processStop(mockStopHookInput(transcript, stop > 0, session)));
-        }
-        const past = await processStop(mockStopHookInput(transcript, true, session));
+      const budget: (SyncHookJSONOutput | null)[] = [];
+      for (let stop = 0; stop < STOP_BLOCK_LIMIT; stop++) {
+        budget.push(await processStop(mockStopHookInput(transcript, stop > 0, session)));
+      }
+      const past = await processStop(mockStopHookInput(transcript, true, session));
 
-        expect(budget.map((result) => result?.decision)).toEqual(
-          Array.from({ length: STOP_BLOCK_LIMIT }, () => "block"),
-        );
-        expect(past?.decision).toBeUndefined();
-        expect(past?.systemMessage).toContain("no-dupe-keys");
-      },
-      MULTI_STOP_TIMEOUT_MS,
-    );
+      expect(budget.map((result) => result?.decision)).toEqual(
+        Array.from({ length: STOP_BLOCK_LIMIT }, () => "block"),
+      );
+      expect(past?.decision).toBeUndefined();
+      expect(past?.systemMessage).toContain("no-dupe-keys");
+    });
 
     // Blocking without a recorded count is the runaway itself: every re-entrant
     // Stop would read zero and block again, with nothing to release it.
@@ -449,20 +455,16 @@ describe("ox hook", () => {
 
     // The budget is per round. A Stop the model did not reach through a block
     // ends the previous round, so the next one starts with its full count.
-    it(
-      "restarts the count on a stop that did not follow a block",
-      async () => {
-        const session = `restart-${Date.now()}`;
-        const transcript = await unfixableSession(session);
+    it("restarts the count on a stop that did not follow a block", async () => {
+      const session = `restart-${Date.now()}`;
+      const transcript = await unfixableSession(session);
 
-        await processStop(mockStopHookInput(transcript, false, session));
-        await processStop(mockStopHookInput(transcript, true, session));
-        const fresh = await processStop(mockStopHookInput(transcript, false, session));
+      await processStop(mockStopHookInput(transcript, false, session));
+      await processStop(mockStopHookInput(transcript, true, session));
+      const fresh = await processStop(mockStopHookInput(transcript, false, session));
 
-        expect(fresh?.decision).toBe("block");
-      },
-      MULTI_STOP_TIMEOUT_MS,
-    );
+      expect(fresh?.decision).toBe("block");
+    });
 
     it("returns null when no files were modified", async () => {
       const transcriptPath = join(tempDir, `transcript-empty-${Date.now()}.jsonl`);

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -70,7 +70,12 @@
     "local/no-conditional-empty-object-spread": "error",
     "local/no-module-mocking": "error",
     "local/no-terminal-width": "error",
-    "local/no-unknown-returns": "error"
+    "local/no-unknown-returns": "error",
+    "typescript/no-unsafe-argument": "error",
+    "typescript/no-unsafe-assignment": "error",
+    "typescript/no-unsafe-call": "error",
+    "typescript/no-unsafe-member-access": "error",
+    "typescript/no-unsafe-return": "error"
   },
   "overrides": [
     {
@@ -79,6 +84,16 @@
         "local/no-chained-type-assertions": "off",
         "unicorn/consistent-function-scoping": "off",
         "typescript/no-non-null-assertion": "off"
+      }
+    },
+    {
+      "files": ["**/*.workflow.js"],
+      "rules": {
+        "typescript/no-unsafe-argument": "off",
+        "typescript/no-unsafe-assignment": "off",
+        "typescript/no-unsafe-call": "off",
+        "typescript/no-unsafe-member-access": "off",
+        "typescript/no-unsafe-return": "off"
       }
     }
   ],


### PR DESCRIPTION
Turns on `no-unsafe-argument`, `no-unsafe-assignment`, `no-unsafe-call`, `no-unsafe-member-access`, and `no-unsafe-return` at error. Sixth layer of the stack, on top of #1286.

The five rules catch an `any` crossing into typed code. Nothing in the repo produces one any more: the seams that used to (`JSON.parse`, subprocess stdout, file reads, hook stdin) decode against a zod schema after the five migration layers below this one.

## Workflow Scripts

`plugins/comments/workflow/judge.workflow.js` keeps them off through a `**/*.workflow.js` override. A Workflow script runs inside the tool's sandbox with no module resolution, so it cannot import zod, and it reads a global `args` the runtime types as nothing. Removing the override reinstates 20 errors in that one file.

The pattern generalizes to any workflow script the repo grows later, which is why the override matches by extension rather than by path.
