### PR TITLE
lint: enforce no-unsafe-type-assertion

### DIFF
--- a/.claude/hooks/ox/index.test.ts
+++ b/.claude/hooks/ox/index.test.ts
@@ -21,6 +21,7 @@ import type {
   StopHookInput,
   SyncHookJSONOutput,
 } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
 import {
   blockCountPath,
   HookInput,
@@ -37,6 +38,8 @@ import {
 // Every check here spawns oxlint and oxfmt over a real fixture, and the
 // type-aware pass alone outruns the 5s default on CI.
 setDefaultTimeout(30_000);
+
+const Reported = z.looseObject({ additionalContext: z.string().optional() });
 
 const execAsync = promisify(exec);
 
@@ -370,8 +373,7 @@ describe("ox hook", () => {
       const result = await processPostToolUse(
         mockPostToolUseInput("Edit", { file_path: filePath }),
       );
-      return (result?.hookSpecificOutput as { additionalContext: string } | undefined)
-        ?.additionalContext;
+      return Reported.safeParse(result?.hookSpecificOutput).data?.additionalContext;
     }
 
     it.each<{ name: string; nodeModules: NodeModules; reports: string }>([

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -75,7 +75,8 @@
     "typescript/no-unsafe-assignment": "error",
     "typescript/no-unsafe-call": "error",
     "typescript/no-unsafe-member-access": "error",
-    "typescript/no-unsafe-return": "error"
+    "typescript/no-unsafe-return": "error",
+    "typescript/no-unsafe-type-assertion": "error"
   },
   "overrides": [
     {

--- a/plugins/comments/apply/join.test.ts
+++ b/plugins/comments/apply/join.test.ts
@@ -27,10 +27,7 @@ function comment(over: Partial<Comment> = {}): Comment {
   };
 }
 
-// Mirrors collectVerdicts's `unknown[]` parameter so well-formed and malformed
-// fixtures share one type.
-// oxlint-disable-next-line local/no-unknown-returns
-function shard(entries: Array<{ id: string; verdict: Verdict }>): unknown {
+function shard(entries: Array<{ id: string; verdict: Verdict }>) {
   return { verdicts: entries };
 }
 

--- a/plugins/things/src/array.ts
+++ b/plugins/things/src/array.ts
@@ -22,6 +22,7 @@ export interface JXAArray<T> {
 export function toArray<T>(jxaArr: JXAArray<T>): T[] {
   const arr: T[] = [];
   for (let i = 0; i < jxaArr.length; i++) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a JXA bridge array is dense over 0..length-1, which noUncheckedIndexedAccess cannot express.
     arr.push(jxaArr[i] as T);
   }
   return arr;

--- a/scripts/inventory/report.ts
+++ b/scripts/inventory/report.ts
@@ -161,10 +161,7 @@ function columns(inventory: Inventory, kind: Kind, width: number): Columns {
 }
 
 /** The records behind a kind, for `--json`. */
-// The shape varies by `kind`, and the only caller passes the result straight
-// to JSON.stringify for --json.
-// oxlint-disable-next-line local/no-unknown-returns
-export function records(inventory: Inventory, kind: Kind): unknown {
+export function records(inventory: Inventory, kind: Kind): Inventory | Inventory[keyof Inventory] {
   if (kind === "summary") return inventory;
   if (kind === "mcp") return inventory.mcpServers;
   return inventory[kind];


### PR DESCRIPTION
Turns on `no-unsafe-type-assertion` at error, the last layer of the stack, on top of #1287.

The rule started at 350 hits, roughly 75 of them the `as Record<string, unknown>` probe that `user/rules/typescript.md` used to teach. It reaches zero here.

## Tests

Tests run under the rule too. The five migration layers took fixtures through the same schemas as the code under test, so a `**/*.test.ts` override would only hide assertions in the place least likely to be believed.

Two test-side patterns resisted decoding. `expect.any(String)` and `expect.stringContaining()` return `any`, so tests using them as inline-snapshot property matchers assert the varying field directly and snapshot the rest. Indexing a fixture with `[0]` under `noUncheckedIndexedAccess` becomes destructuring or `?? fallback`.

## Unknown Returns

#1268 left five `local/no-unknown-returns` suppressions pending a boundary, and #1284 added a sixth. Two are gone: `records()` and the join test's `shard()` had `: unknown` written by hand, and each infers a real type once the annotation goes.

The remaining four are the shape the rule cannot express.

| Site | Why it returns `unknown` |
|---|---|
| `plugins/things/src/mcp/jxa.ts` | `runScript` prints whatever Things answered; the tool that asked owns the schema |
| `plugins/things/src/mcp/tools.ts` | `limitItems` returns a within-budget payload untouched |
| `packages/validate/overlay.ts` | the value at a JSON Pointer depends on a runtime path string |
| `plugins/gitlab/scripts/merge.ts` | `arm` takes a thunk and discards what it resolves to |

Three of the four are the boundary working as designed: the seam hands back `unknown` and each caller parses what it expects. #1268 set a dozen suppressions as the removal trigger, and four after a repo-wide migration stays under it.

## Runtime Typeof Checks

`no-runtime-typeof` stays rejected. #1268 rejected it at 205 hits for having nowhere to route them. The boundary cut it to 71.

Ten sit in `skill-lint`'s frontmatter rules, where `typeof name !== "string"` is the report itself. Eleven are test assertions on a runtime shape, and two are in a Workflow script that cannot import a schema library.

The other 48 narrow a union the code already owns: `string | Date` in a zod transform, `PropertyKey` in the decode error formatter, an overload dispatching on its first argument. Parsing does not remove a `typeof` when the parsed type is a union. It produces one.
