### PR TITLE
statusline: keep the Claude mark on a pane

### DIFF
--- a/user/scripts/glyphs.ts
+++ b/user/scripts/glyphs.ts
@@ -19,3 +19,7 @@ export const genericGlyph = String.fromCodePoint(0xf06a9);
 
 // Cloud marker for remote agents.
 export const remoteGlyph = String.fromCodePoint(0xf0c2);
+
+// The Claude mark herdr's sidebar shows in place of its own agent glyph, which
+// is the same robot as genericGlyph above. Nerd Fonts ships cod-claude in 3.5.0.
+export const brandGlyph = String.fromCodePoint(0xec82);

--- a/user/scripts/pane-metadata.test.ts
+++ b/user/scripts/pane-metadata.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { CONTEXT_TOKENS, cachePath, findPane, reportArgs, shouldReport } from "./context-dial";
+import { brandGlyph } from "./glyphs";
+import {
+  CONTEXT_TOKENS,
+  cachePath,
+  findPane,
+  reportArgs,
+  reportSignature,
+  shouldReport,
+} from "./pane-metadata";
 
 const HOUR_MS = 3_600_000;
 
@@ -54,7 +62,11 @@ describe("shouldReport", () => {
 
 describe("reportArgs", () => {
   test("sets the live token and clears the other levels", () => {
-    expect(reportArgs("w2:p2", { token: "ctx_high", value: "\u{f0aa2}" })).toMatchInlineSnapshot(`
+    const args = reportArgs("w2:p2", { token: "ctx_high", value: "\u{f0aa2}" });
+    // The mark stands in as `<brand>`: a private-use glyph inlined here is one
+    // bad paste away from silently snapshotting some other icon. Its codepoint
+    // is asserted below instead.
+    expect(args.map((arg) => (arg === brandGlyph ? "<brand>" : arg))).toMatchInlineSnapshot(`
       [
         "pane",
         "report-metadata",
@@ -63,6 +75,8 @@ describe("reportArgs", () => {
         "claude-statusline",
         "--ttl-ms",
         "86400000",
+        "--display-agent",
+        "<brand>",
         "--token",
         "ctx_high=󰪢",
         "--clear-token",
@@ -75,6 +89,28 @@ describe("reportArgs", () => {
     `);
   });
 
+  test("carries the brand mark with no dial to report", () => {
+    const args = reportArgs("w2:p2", null);
+    expect(args).toEqual([
+      "pane",
+      "report-metadata",
+      "w2:p2",
+      "--source",
+      "claude-statusline",
+      "--ttl-ms",
+      "86400000",
+      "--display-agent",
+      brandGlyph,
+    ]);
+  });
+
+  test("brands the pane whether or not a dial rides along", () => {
+    for (const report of [null, { token: "ctx_low", value: "x" } as const]) {
+      const args = reportArgs("w2:p2", report);
+      expect(args[args.indexOf("--display-agent") + 1]).toBe(brandGlyph);
+    }
+  });
+
   const levels = CONTEXT_TOKENS.map((token) => [token] as const);
 
   test.each(levels)("%s clears every other level", (token) => {
@@ -84,13 +120,23 @@ describe("reportArgs", () => {
   });
 });
 
+describe("reportSignature", () => {
+  test("separates a dial from no dial, so the first one re-reports", () => {
+    expect(reportSignature({ token: "ctx_low", value: "x" })).not.toBe(reportSignature(null));
+  });
+
+  test("moves when the mark moves, so a changed glyph is not cached away", () => {
+    expect(reportSignature(null)).toStartWith(brandGlyph);
+  });
+});
+
 describe("cachePath", () => {
   test("keeps a session-scoped file out of the session's own tree", () => {
     const path = cachePath("4cba0d0a-8875-48eb-b6cd-90874f2a875b");
-    expect(path).toEndWith("claude-context-dial/4cba0d0a-8875-48eb-b6cd-90874f2a875b.json");
+    expect(path).toEndWith("claude-pane-metadata/4cba0d0a-8875-48eb-b6cd-90874f2a875b.json");
   });
 
   test("sanitizes a session id that would escape the directory", () => {
-    expect(cachePath("../../etc/passwd")).toEndWith("claude-context-dial/..-..-etc-passwd.json");
+    expect(cachePath("../../etc/passwd")).toEndWith("claude-pane-metadata/..-..-etc-passwd.json");
   });
 });

--- a/user/scripts/pane-metadata.ts
+++ b/user/scripts/pane-metadata.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { brandGlyph } from "./glyphs";
 
 // herdr strips control bytes out of reported token values, so a pre-colored
 // value cannot survive: the escape is dropped and its `[32m` residue renders as
@@ -28,7 +29,7 @@ const HERDR_TIMEOUT_MS = 5_000;
 const UNSAFE_NAME = /[^A-Za-z0-9._-]+/g;
 
 export function cachePath(sessionId: string): string {
-  return join(tmpdir(), "claude-context-dial", `${sessionId.replace(UNSAFE_NAME, "-")}.json`);
+  return join(tmpdir(), "claude-pane-metadata", `${sessionId.replace(UNSAFE_NAME, "-")}.json`);
 }
 
 export function shouldReport(cached: CachedReport | null, sig: string, now: number): boolean {
@@ -38,7 +39,21 @@ export function shouldReport(cached: CachedReport | null, sig: string, now: numb
   return now - cached.at >= REFRESH_MS;
 }
 
-export function reportArgs(paneId: string, report: DialReport): string[] {
+export function reportSignature(report: DialReport | null): string {
+  return `${brandGlyph}:${report ? `${report.token}=${report.value}` : ""}`;
+}
+
+// The brand mark rides along on the dial's call rather than getting one of its
+// own, because it needs exactly what the dial already has: a report that repeats.
+// herdr holds pane metadata in the server's memory, so every restart drops it,
+// and the nightly `dotfiles-upgrade` restarts the server to install plugins.
+// Reported once at SessionStart, the mark never comes back, and a session that
+// was already open shows herdr's own robot for the rest of its life.
+//
+// The dial is optional so that riding along costs the mark nothing:
+// `context_window` is absent until a turn has closed, and the pane should be
+// branded before then.
+export function reportArgs(paneId: string, report: DialReport | null): string[] {
   const args = [
     "pane",
     "report-metadata",
@@ -47,9 +62,12 @@ export function reportArgs(paneId: string, report: DialReport): string[] {
     SOURCE,
     "--ttl-ms",
     String(TTL_MS),
-    "--token",
-    `${report.token}=${report.value}`,
+    "--display-agent",
+    brandGlyph,
   ];
+  if (!report) return args;
+
+  args.push("--token", `${report.token}=${report.value}`);
   for (const name of CONTEXT_TOKENS) {
     if (name !== report.token) args.push("--clear-token", name);
   }
@@ -81,13 +99,16 @@ async function readCache(path: string): Promise<CachedReport | null> {
 }
 
 // Called on every status line render, so the steady state has to be a file read
-// and nothing else. Only a changed dial reaches herdr, and it reaches it through
-// a detached child: the status line must render at the same speed whether herdr
-// is fast, slow, or not running.
-export async function reportContextDial(sessionId: string, report: DialReport): Promise<void> {
+// and nothing else. Only a changed report reaches herdr, and it reaches it
+// through a detached child: the status line must render at the same speed
+// whether herdr is fast, slow, or not running.
+export async function reportPaneMetadata(
+  sessionId: string,
+  report: DialReport | null,
+): Promise<void> {
   if (!process.env.HERDR_PANE_ID) return;
 
-  const sig = `${report.token}=${report.value}`;
+  const sig = reportSignature(report);
   const path = cachePath(sessionId);
   if (!shouldReport(await readCache(path), sig, Date.now())) return;
 
@@ -95,9 +116,9 @@ export async function reportContextDial(sessionId: string, report: DialReport): 
   // would otherwise turn every later render back into a spawn.
   await Bun.write(path, JSON.stringify({ sig, at: Date.now() }));
 
-  Bun.spawn([process.execPath, import.meta.path, sessionId, report.token, report.value], {
-    stdio: ["ignore", "ignore", "ignore"],
-  }).unref();
+  const argv = [process.execPath, import.meta.path, sessionId];
+  if (report) argv.push(report.token, report.value);
+  Bun.spawn(argv, { stdio: ["ignore", "ignore", "ignore"] }).unref();
 }
 
 function parseToken(value: string | undefined): ContextToken | null {
@@ -107,13 +128,12 @@ function parseToken(value: string | undefined): ContextToken | null {
 if (import.meta.main) {
   const [sessionId, token, value] = process.argv.slice(2);
   const name = parseToken(token);
-  if (sessionId && name && value) {
+  if (sessionId) {
     const list = Bun.spawnSync(["herdr", "pane", "list"], { timeout: HERDR_TIMEOUT_MS });
     const paneId = list.success ? findPane(list.stdout.toString(), sessionId) : null;
     if (paneId) {
-      Bun.spawnSync(["herdr", ...reportArgs(paneId, { token: name, value })], {
-        timeout: HERDR_TIMEOUT_MS,
-      });
+      const report = name && value ? { token: name, value } : null;
+      Bun.spawnSync(["herdr", ...reportArgs(paneId, report)], { timeout: HERDR_TIMEOUT_MS });
     }
   }
 }

--- a/user/scripts/statusline.test.ts
+++ b/user/scripts/statusline.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ContextToken } from "./context-dial";
+import type { ContextToken } from "./pane-metadata";
 import {
   buildStatusLine,
   contextDial,

--- a/user/scripts/statusline.ts
+++ b/user/scripts/statusline.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env bun
 import { mkdirSync } from "node:fs";
 import { basename, dirname } from "node:path";
-import { type ContextToken, type DialReport, reportContextDial } from "./context-dial";
 import { effortMarker } from "./effort";
 import { dialGlyph } from "./glyphs";
 import { modelMarker } from "./model";
+import { type ContextToken, type DialReport, reportPaneMetadata } from "./pane-metadata";
 import { expandTilde, type RateLimits } from "./rate-limits";
 import { styleText } from "./style";
 
@@ -140,7 +140,7 @@ const DIAL_TOKENS: Record<DialColor, ContextToken> = {
 };
 
 // The same dial herdr's sidebar shows, named by color rather than styled: see
-// `context-dial.ts` for why the color rides on the token name.
+// `pane-metadata.ts` for why the color rides on the token name.
 export function contextDial(input: StatusInput): DialReport | null {
   const dial = dialState(input);
   return dial ? { token: DIAL_TOKENS[dial.color], value: dial.glyph } : null;
@@ -354,10 +354,11 @@ if (import.meta.main) {
     const columns = Number.isInteger(parsed) && parsed > 0 ? parsed : 80;
     process.stdout.write(buildStatusLine(input, columns, resolveWorktree()));
 
-    const dial = contextDial(input);
-    if (dial && input.session_id) {
+    // Not gated on the dial: the same report carries the brand mark, which has
+    // to keep being sent even on the renders before `context_window` shows up.
+    if (input.session_id) {
       try {
-        await reportContextDial(input.session_id, dial);
+        await reportPaneMetadata(input.session_id, contextDial(input));
       } catch {
         // The sidebar mirror is best-effort, and the line is already written.
       }

--- a/user/settings.json
+++ b/user/settings.json
@@ -292,16 +292,6 @@
         ]
       },
       {
-        "matcher": "startup|resume|clear",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "/bin/sh -c '[ \"$HERDR_ENV\" = 1 ] && [ -n \"$HERDR_PANE_ID\" ] && command -v herdr >/dev/null && herdr pane report-metadata \"$HERDR_PANE_ID\" --source claude-brand --display-agent \"\"; exit 0'",
-            "async": true
-          }
-        ]
-      },
-      {
         "matcher": "*",
         "hooks": [
           {


### PR DESCRIPTION
The Claude mark on herdr's agent rows kept reverting to herdr's own robot glyph on sessions that had been open a while.

herdr keeps pane metadata in the server's memory. A restart drops all of it, and the nightly `dotfiles-upgrade` restarts the server to install plugins. The mark was reported once from a `SessionStart` hook, so it had no way back. Every session already open fell to the robot and stayed there for the rest of its life. A session started after the restart looked fine, which is what made this read as intermittent.

The context dial already solved this for its tokens: a 24h TTL, re-reported hourly from the status line, with a comment explaining that a herdr restart drops everything. The mark now rides along on that same call rather than keeping a hook of its own, so the two things the status line mirrors into the sidebar arrive together and repeat together.

The dial becomes optional in that report. `context_window` is absent until a turn has closed, and the pane should carry the mark before then.

`context-dial.ts` is now `pane-metadata.ts`, which is what it reports.

## Snapshot

The inline snapshot renders the mark as `<brand>` instead of the glyph itself. A private-use codepoint pasted into a snapshot is invisible when it lands wrong, and Nerd Fonts Material Design marks sit above U+FFFF where a hand-written surrogate pair decodes to a different real icon. The codepoint is asserted against `brandGlyph` in a separate test.
