### PR TITLE
settings: add plannotator plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ node_modules/
 # terminal-browser's installer drops a skill symlink into ~/.claude/skills,
 # which is this repo's user/skills. The skill belongs to that install, not here.
 /user/skills/terminal-browser
+
+# plannotator's installer drops its /plannotator-* skills into ~/.claude/skills,
+# which is this repo's user/skills. They belong to that install, not here, and
+# `install.sh` replaces them on every upgrade.
+/user/skills/plannotator*

--- a/user/settings.json
+++ b/user/settings.json
@@ -436,7 +436,8 @@
     "typescript-lsp@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
     "atuin@bendrucker": true,
-    "comments@bendrucker": true
+    "comments@bendrucker": true,
+    "plannotator@plannotator": true
   },
   "extraKnownMarketplaces": {
     "bendrucker": {
@@ -484,6 +485,13 @@
         "source": "github",
         "repo": "vercel-labs/agent-browser",
         "ref": "v0.33.2"
+      }
+    },
+    "plannotator": {
+      "source": {
+        "source": "github",
+        "repo": "backnotprop/plannotator",
+        "ref": "v0.27.9"
       }
     }
   },


### PR DESCRIPTION
Adds [plannotator](https://plannotator.ai/), a UI for reviewing and annotating plans before they run. The plugin only supplies hooks: a `PermissionRequest` hook on `ExitPlanMode` that hands the plan to the review UI, and an `EnterPlanMode` hook for context. The `plannotator` binary installs separately via `plannotator.ai/install.sh`.

Pinned to `v0.27.9`, matching how the other third-party marketplaces are pinned.

The installer also writes four skills into `~/.claude/skills`, which symlinks into this repo. They're gitignored rather than tracked, following `terminal-browser`. The install owns them and rewrites them on every upgrade, so a tracked copy would go stale and conflict. Ignoring them keeps `/plannotator-review` and friends working on this machine while the repo stays free of vendored third-party skills. They install user-invocable only, so they cost nothing in always-on context.
