### PR TITLE
review: split review-plan and generate its schemas

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -232,9 +232,6 @@
         "table": "^6.9.0",
         "zod": "^4.4.3",
       },
-      "devDependencies": {
-        "ajv": "^8.17.1",
-      },
     },
     "plugins/shortcuts": {
       "name": "shortcuts",

--- a/plugins/review/package.json
+++ b/plugins/review/package.json
@@ -6,8 +6,5 @@
     "cleye": "^2.0.0",
     "table": "^6.9.0",
     "zod": "^4.4.3"
-  },
-  "devDependencies": {
-    "ajv": "^8.17.1"
   }
 }

--- a/plugins/review/skills/code/angles.schema.json
+++ b/plugins/review/skills/code/angles.schema.json
@@ -1,53 +1,58 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/bendrucker/claude/plugins/review/skills/code/angles.schema.json",
-  "title": "Review finder angles",
-  "description": "Finder angles for review:code, with the preamble and precedence blocks every finder receives.",
   "type": "object",
-  "additionalProperties": false,
-  "required": ["preamble", "angles", "cleanupPrecedence", "sweepGapFocus"],
   "properties": {
     "preamble": {
       "type": "string",
-      "minLength": 1,
       "description": "Candidate shape and the no-suppression rule, given to every finder."
     },
     "angles": {
-      "type": "array",
       "minItems": 1,
-      "description": "Angles in the order finders receive them.",
+      "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
-        "required": ["id", "name", "kind", "sets", "text"],
         "properties": {
-          "id": { "type": "string", "pattern": "^[A-Za-z][A-Za-z0-9-]*$" },
+          "id": {
+            "type": "string",
+            "pattern": "^[A-Za-z][A-Za-z0-9-]*$"
+          },
           "name": {
             "type": "string",
-            "minLength": 1,
             "description": "Heading the finder sees above its angle text."
           },
-          "kind": { "enum": ["correctness", "cleanup", "altitude", "conventions"] },
-          "sets": {
-            "type": "array",
-            "minItems": 1,
-            "uniqueItems": true,
-            "items": { "enum": ["core", "full"] },
-            "description": "Angle sets this angle belongs to. Stated rather than derived, so the xhigh-only angles are explicit."
+          "kind": {
+            "type": "string",
+            "enum": ["correctness", "cleanup", "altitude", "conventions"]
           },
-          "text": { "type": "string", "minLength": 1 }
-        }
-      }
+          "sets": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["core", "full"]
+            },
+            "description": "Sets this angle belongs to. Stated rather than derived, so xhigh-only is explicit."
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": ["id", "name", "kind", "sets", "text"],
+        "additionalProperties": false
+      },
+      "description": "Angles in the order finders receive them."
     },
     "cleanupPrecedence": {
       "type": "string",
-      "minLength": 1,
       "description": "Emitted when the selected set carries a cleanup, altitude, or conventions angle."
     },
     "sweepGapFocus": {
       "type": "string",
-      "minLength": 1,
       "description": "Emitted when the cell runs a sweep pass."
     }
-  }
+  },
+  "required": ["preamble", "angles", "cleanupPrecedence", "sweepGapFocus"],
+  "additionalProperties": false,
+  "title": "Review finder angles",
+  "description": "Finder angles for review:code, with the preamble and precedence blocks every finder receives."
 }

--- a/plugins/review/skills/code/efforts.md
+++ b/plugins/review/skills/code/efforts.md
@@ -1,6 +1,6 @@
 # Effort Cells
 
-The cells live in [efforts.yaml](efforts.yaml), and [scripts/review-plan.ts](scripts/review-plan.ts) resolves and prints the one a review runs. No review reads this file. It holds the reasoning behind the cell assignments, for whoever changes them next.
+The cells live in [efforts.yaml](efforts.yaml), and [scripts/review-plan.ts](scripts/review-plan.ts) resolves and prints the one a review runs. No review reads this file. The `.schema.json` files beside the YAML are generated from the zod schemas in `scripts/efforts.ts` and `scripts/angles.ts` by `bun scripts/schemas.ts`, so a shape change starts there. It holds the reasoning behind the cell assignments, for whoever changes them next.
 
 ## Inline Families
 

--- a/plugins/review/skills/code/efforts.schema.json
+++ b/plugins/review/skills/code/efforts.schema.json
@@ -1,10 +1,262 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/bendrucker/claude/plugins/review/skills/code/efforts.schema.json",
-  "title": "Review effort cells",
-  "description": "Cell selection, budgets, and framing for the review:code skill, served by scripts/review-plan.ts.",
   "type": "object",
-  "additionalProperties": false,
+  "properties": {
+    "spawnModel": {
+      "type": "string",
+      "description": "Model every fan-out spawn pins, substituted for {spawnModel}."
+    },
+    "levels": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Canonical effort levels, weakest first. A CLI token resolves by unique prefix."
+    },
+    "aliases": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-]*$"
+      },
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Extra spellings resolving to a canonical level."
+    },
+    "modes": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "enum": ["fanout", "inline", "direct"]
+      },
+      "additionalProperties": {
+        "type": "string"
+      },
+      "required": ["fanout", "inline", "direct"],
+      "description": "One line on how each mode runs its angles."
+    },
+    "families": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]*$"
+          },
+          "match": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["id", "match"],
+        "additionalProperties": false
+      },
+      "description": "Families in match order. The entry with no match strings is the fallback."
+    },
+    "selection": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-]*$"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "propertyNames": {
+          "type": "string"
+        },
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "cell": {
+              "type": "string"
+            },
+            "modifiers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": ["cell", "modifiers"],
+          "additionalProperties": false
+        }
+      },
+      "description": "family id -> level -> the cell that pair runs."
+    },
+    "cells": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": ["fanout", "inline", "direct"]
+          },
+          "angleSet": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["core", "full"]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Null on the direct cells, which run no angles."
+          },
+          "candidatesPerAngle": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "verify": {
+            "type": "string"
+          },
+          "sweep": {
+            "type": "boolean"
+          },
+          "cap": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Maximum findings reported. Null where the cell sets only a floor."
+          },
+          "floor": {
+            "anyOf": [
+              {
+                "anyOf": [
+                  {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Target minimum, either a count or an expression such as min(files_changed, 4)."
+          },
+          "framing": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9-]*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Key into framings. Null on the low cells, whose instructions carry their own."
+          },
+          "reportsVia": {
+            "type": "string",
+            "enum": ["ReportFindings", "text"]
+          }
+        },
+        "required": [
+          "mode",
+          "angleSet",
+          "candidatesPerAngle",
+          "verify",
+          "sweep",
+          "cap",
+          "floor",
+          "framing",
+          "reportsVia"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "framings": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-]*$"
+      },
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Framing paragraphs, emitted before the find phase."
+    },
+    "lowInstructions": {
+      "type": "object",
+      "properties": {
+        "shared": {
+          "type": "string"
+        },
+        "cells": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Where the direct cells differ."
+        }
+      },
+      "required": ["shared", "cells"],
+      "additionalProperties": false
+    },
+    "floorInstruction": {
+      "type": "string",
+      "description": "Emitted on any cell with a floor. {floor} is replaced."
+    },
+    "finderBudget": {
+      "type": "object",
+      "properties": {
+        "linesPerAgent": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "min": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "max": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "text": {
+          "type": "string"
+        }
+      },
+      "required": ["linesPerAgent", "min", "max", "text"],
+      "additionalProperties": false,
+      "description": "clamp(ceil(lines / linesPerAgent), min, max), on finder-budget cells."
+    }
+  },
   "required": [
     "spawnModel",
     "levels",
@@ -18,187 +270,7 @@
     "floorInstruction",
     "finderBudget"
   ],
-  "properties": {
-    "spawnModel": {
-      "type": "string",
-      "description": "Model every fan-out spawn pins, substituted for {spawnModel} in the fanout mode text."
-    },
-    "levels": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "items": { "$ref": "#/$defs/level" },
-      "description": "Canonical effort levels, weakest first. A CLI level token resolves by unique prefix."
-    },
-    "aliases": {
-      "type": "object",
-      "description": "Extra spellings that resolve to a canonical level, matched by prefix alongside the level names.",
-      "propertyNames": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
-      "additionalProperties": { "$ref": "#/$defs/level" }
-    },
-    "modes": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["fanout", "inline", "direct"],
-      "description": "One line describing how each mode runs its angles.",
-      "properties": {
-        "fanout": { "type": "string" },
-        "inline": { "type": "string" },
-        "direct": { "type": "string" }
-      }
-    },
-    "families": {
-      "type": "array",
-      "minItems": 1,
-      "description": "Model families in match order. The entry with no match strings is the fallback and must be last.",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["id", "match"],
-        "properties": {
-          "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
-          "match": {
-            "type": "array",
-            "uniqueItems": true,
-            "items": { "type": "string", "minLength": 1 },
-            "description": "Substrings of the active model id. Empty marks the fallback family."
-          }
-        }
-      }
-    },
-    "selection": {
-      "type": "object",
-      "description": "family id -> level -> the cell that pair runs.",
-      "propertyNames": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
-      "additionalProperties": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["low", "medium", "high", "xhigh"],
-        "properties": {
-          "low": { "$ref": "#/$defs/selected" },
-          "medium": { "$ref": "#/$defs/selected" },
-          "high": { "$ref": "#/$defs/selected" },
-          "xhigh": { "$ref": "#/$defs/selected" }
-        }
-      }
-    },
-    "cells": {
-      "type": "object",
-      "propertyNames": { "$ref": "#/$defs/cellName" },
-      "additionalProperties": { "$ref": "#/$defs/cell" }
-    },
-    "framings": {
-      "type": "object",
-      "description": "Precision/recall framing paragraphs, emitted verbatim before the find phase.",
-      "propertyNames": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
-      "additionalProperties": { "type": "string", "minLength": 1 }
-    },
-    "lowInstructions": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["shared", "cells"],
-      "properties": {
-        "shared": { "type": "string", "minLength": 1 },
-        "cells": {
-          "type": "object",
-          "description": "Where the low cells differ: test-hunk skipping, caps, and floors.",
-          "propertyNames": { "$ref": "#/$defs/cellName" },
-          "additionalProperties": { "type": "string", "minLength": 1 }
-        }
-      }
-    },
-    "floorInstruction": {
-      "type": "string",
-      "minLength": 1,
-      "description": "Emitted on any cell with a floor. {floor} is replaced with the cell's floor."
-    },
-    "finderBudget": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["linesPerAgent", "min", "max", "text"],
-      "description": "clamp(ceil(lines / linesPerAgent), min, max), applied on cells carrying the finder-budget modifier.",
-      "properties": {
-        "linesPerAgent": { "type": "integer", "minimum": 1 },
-        "min": { "type": "integer", "minimum": 1 },
-        "max": { "type": "integer", "minimum": 1 },
-        "text": { "type": "string", "minLength": 1 }
-      }
-    }
-  },
-  "$defs": {
-    "level": { "enum": ["low", "medium", "high", "xhigh"] },
-    "cellName": {
-      "enum": [
-        "low",
-        "low-sonnet5",
-        "inline-low",
-        "medium",
-        "high",
-        "xhigh",
-        "inline-med",
-        "inline-high",
-        "inline-xhigh"
-      ]
-    },
-    "modifier": { "enum": ["finder-budget"] },
-    "selected": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["cell", "modifiers"],
-      "properties": {
-        "cell": { "$ref": "#/$defs/cellName" },
-        "modifiers": {
-          "type": "array",
-          "uniqueItems": true,
-          "items": { "$ref": "#/$defs/modifier" }
-        }
-      }
-    },
-    "cell": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "mode",
-        "angleSet",
-        "candidatesPerAngle",
-        "verify",
-        "sweep",
-        "cap",
-        "floor",
-        "framing",
-        "reportsVia"
-      ],
-      "properties": {
-        "mode": { "enum": ["fanout", "inline", "direct"] },
-        "angleSet": {
-          "oneOf": [{ "enum": ["core", "full"] }, { "type": "null" }],
-          "description": "Null on the direct cells, which run no angles."
-        },
-        "candidatesPerAngle": {
-          "oneOf": [{ "type": "integer", "minimum": 1 }, { "type": "null" }]
-        },
-        "verify": { "type": "string", "minLength": 1 },
-        "sweep": { "type": "boolean" },
-        "cap": {
-          "oneOf": [{ "type": "integer", "minimum": 1 }, { "type": "null" }],
-          "description": "Maximum findings reported. Null where the cell sets only a floor."
-        },
-        "floor": {
-          "oneOf": [
-            { "type": "integer", "minimum": 1 },
-            { "type": "string", "minLength": 1 },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Target minimum, either a count or an expression such as min(files_changed, 4)."
-        },
-        "framing": {
-          "oneOf": [{ "type": "string", "pattern": "^[a-z][a-z0-9-]*$" }, { "type": "null" }],
-          "description": "Key into framings. Null on the low cells, whose instructions carry their own framing."
-        },
-        "reportsVia": { "enum": ["ReportFindings", "text"] }
-      }
-    }
-  }
+  "additionalProperties": false,
+  "title": "Review effort cells",
+  "description": "Cell selection, budgets, and framing for review:code, served by scripts/review-plan.ts."
 }

--- a/plugins/review/skills/code/scripts/angles.ts
+++ b/plugins/review/skills/code/scripts/angles.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import { angleSetSchema, type AngleSet } from "./efforts";
+
+export const angleSchema = z.strictObject({
+  id: z.string().regex(/^[A-Za-z][A-Za-z0-9-]*$/),
+  name: z.string().describe("Heading the finder sees above its angle text."),
+  kind: z.enum(["correctness", "cleanup", "altitude", "conventions"]),
+  sets: z
+    .array(angleSetSchema)
+    .nonempty()
+    .describe("Sets this angle belongs to. Stated rather than derived, so xhigh-only is explicit."),
+  text: z.string(),
+});
+
+export const anglesSchema = z
+  .strictObject({
+    preamble: z
+      .string()
+      .describe("Candidate shape and the no-suppression rule, given to every finder."),
+    angles: z.array(angleSchema).nonempty().describe("Angles in the order finders receive them."),
+    cleanupPrecedence: z
+      .string()
+      .describe("Emitted when the selected set carries a cleanup, altitude, or conventions angle."),
+    sweepGapFocus: z.string().describe("Emitted when the cell runs a sweep pass."),
+  })
+  .meta({
+    title: "Review finder angles",
+    description:
+      "Finder angles for review:code, with the preamble and precedence blocks every finder receives.",
+  });
+
+export type Angle = z.infer<typeof angleSchema>;
+export type Angles = z.infer<typeof anglesSchema>;
+
+export function anglesIn({ angles }: Angles, set: AngleSet | null): Angle[] {
+  return set === null ? [] : angles.filter((angle) => angle.sets.includes(set));
+}

--- a/plugins/review/skills/code/scripts/efforts.ts
+++ b/plugins/review/skills/code/scripts/efforts.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+
+const count = z.number().int().positive();
+const key = z.string().regex(/^[a-z][a-z0-9-]*$/);
+
+export const modeSchema = z.enum(["fanout", "inline", "direct"]);
+export const angleSetSchema = z.enum(["core", "full"]);
+
+export const cellSchema = z.strictObject({
+  mode: modeSchema,
+  angleSet: angleSetSchema.nullable().describe("Null on the direct cells, which run no angles."),
+  candidatesPerAngle: count.nullable(),
+  verify: z.string(),
+  sweep: z.boolean(),
+  cap: count
+    .nullable()
+    .describe("Maximum findings reported. Null where the cell sets only a floor."),
+  floor: z
+    .union([count, z.string()])
+    .nullable()
+    .describe("Target minimum, either a count or an expression such as min(files_changed, 4)."),
+  framing: key
+    .nullable()
+    .describe("Key into framings. Null on the low cells, whose instructions carry their own."),
+  reportsVia: z.enum(["ReportFindings", "text"]),
+});
+
+export const effortsSchema = z
+  .strictObject({
+    spawnModel: z
+      .string()
+      .describe("Model every fan-out spawn pins, substituted for {spawnModel}."),
+    levels: z
+      .array(z.string())
+      .nonempty()
+      .describe("Canonical effort levels, weakest first. A CLI token resolves by unique prefix."),
+    aliases: z.record(key, z.string()).describe("Extra spellings resolving to a canonical level."),
+    modes: z.record(modeSchema, z.string()).describe("One line on how each mode runs its angles."),
+    families: z
+      .array(z.strictObject({ id: key, match: z.array(z.string()) }))
+      .nonempty()
+      .describe("Families in match order. The entry with no match strings is the fallback."),
+    selection: z
+      .record(
+        key,
+        z.record(z.string(), z.strictObject({ cell: z.string(), modifiers: z.array(z.string()) })),
+      )
+      .describe("family id -> level -> the cell that pair runs."),
+    cells: z.record(z.string(), cellSchema),
+    framings: z
+      .record(key, z.string())
+      .describe("Framing paragraphs, emitted before the find phase."),
+    lowInstructions: z.strictObject({
+      shared: z.string(),
+      cells: z.record(z.string(), z.string()).describe("Where the direct cells differ."),
+    }),
+    floorInstruction: z.string().describe("Emitted on any cell with a floor. {floor} is replaced."),
+    finderBudget: z
+      .strictObject({ linesPerAgent: count, min: count, max: count, text: z.string() })
+      .describe("clamp(ceil(lines / linesPerAgent), min, max), on finder-budget cells."),
+  })
+  .meta({
+    title: "Review effort cells",
+    description:
+      "Cell selection, budgets, and framing for review:code, served by scripts/review-plan.ts.",
+  });
+
+export type Mode = z.infer<typeof modeSchema>;
+export type AngleSet = z.infer<typeof angleSetSchema>;
+export type Cell = z.infer<typeof cellSchema>;
+export type Efforts = z.infer<typeof effortsSchema>;
+
+// A level token resolves by unique prefix over the canonical levels plus the
+// aliases, so `hi`, `hig`, and `high` all land on `high` while `mediumish`
+// lands nowhere. Ambiguity is an error rather than a silent pick.
+export function resolveLevel(
+  token: string,
+  { levels, aliases }: Efforts,
+): { ok: true; level: string } | { ok: false; reason: string } {
+  const canonical = (name: string) => aliases[name] ?? name;
+  const names = [...levels, ...Object.keys(aliases)];
+  const valid = `Valid levels: ${levels.join(", ")} (${Object.keys(aliases).join(", ")}).`;
+  const wanted = token.trim().toLowerCase();
+  const unknown = { ok: false, reason: `"${token}" is not an effort level. ${valid}` } as const;
+
+  if (!/^[a-z]+$/.test(wanted)) return unknown;
+  const exact = names.find((name) => name === wanted);
+  if (exact !== undefined) return { ok: true, level: canonical(exact) };
+
+  const matched = [...new Set(names.filter((name) => name.startsWith(wanted)).map(canonical))];
+  const [only] = matched;
+  if (only !== undefined && matched.length === 1) return { ok: true, level: only };
+  if (matched.length === 0) return unknown;
+  return { ok: false, reason: `"${token}" is ambiguous: ${matched.join(", ")}. ${valid}` };
+}
+
+// Families match on a substring of the active model id, in declaration order.
+// The fallback family declares no substrings and so matches anything.
+export function resolveFamily(modelId: string, { families }: Efforts): string {
+  const id = modelId.trim().toLowerCase();
+  const family = families.find(
+    ({ match }) => match.length === 0 || match.some((needle) => id.includes(needle)),
+  );
+  if (family === undefined) throw new Error("efforts.yaml declares no fallback family.");
+  return family.id;
+}
+
+export function finderAgents(
+  diffLines: number,
+  { linesPerAgent, min, max }: Efforts["finderBudget"],
+): number {
+  return Math.min(max, Math.max(min, Math.ceil(diffLines / linesPerAgent)));
+}

--- a/plugins/review/skills/code/scripts/plan.ts
+++ b/plugins/review/skills/code/scripts/plan.ts
@@ -1,0 +1,86 @@
+import { join } from "node:path";
+import { anglesIn, anglesSchema, type Angle, type Angles } from "./angles";
+import { effortsSchema, finderAgents, type Cell, type Efforts } from "./efforts";
+
+export type FinderBudget = { agents: number | null; diffLines: number | null; text: string };
+
+export type Plan = {
+  family: string;
+  level: string;
+  cellName: string;
+  cell: Cell;
+  modifiers: string[];
+  spawnModel: string;
+  modeText: string;
+  framing: string | null;
+  floorInstruction: string | null;
+  lowInstructions: string | null;
+  finderBudget: FinderBudget | null;
+  preamble: string | null;
+  angles: Angle[];
+  cleanupPrecedence: string | null;
+  sweepGapFocus: string | null;
+};
+
+const SKILL_DIR = join(import.meta.dirname, "..");
+
+export async function load(dir = SKILL_DIR): Promise<{ efforts: Efforts; angles: Angles }> {
+  const read = (name: string) => Bun.file(join(dir, `${name}.yaml`)).text();
+  const [efforts, angles] = await Promise.all([read("efforts"), read("angles")]);
+  return {
+    efforts: effortsSchema.parse(Bun.YAML.parse(efforts)),
+    angles: anglesSchema.parse(Bun.YAML.parse(angles)),
+  };
+}
+
+export function resolvePlan(
+  efforts: Efforts,
+  angles: Angles,
+  options: { family: string; level: string; diffLines?: number | undefined },
+): Plan {
+  const { cells, framings, lowInstructions, modes, spawnModel, floorInstruction } = efforts;
+  const { family, level, diffLines } = options;
+
+  const selected = efforts.selection[family]?.[level];
+  if (selected === undefined) throw new Error(`No cell for family ${family} at level ${level}.`);
+  const cell = cells[selected.cell];
+  if (cell === undefined) throw new Error(`efforts.yaml selects unknown cell ${selected.cell}.`);
+
+  const framing = cell.framing === null ? null : framings[cell.framing];
+  if (framing === undefined) {
+    throw new Error(`efforts.yaml cell ${selected.cell} names unknown framing ${cell.framing}.`);
+  }
+
+  const chosen = anglesIn(angles, cell.angleSet);
+  const direct = [lowInstructions.shared, lowInstructions.cells[selected.cell] ?? ""]
+    .map((text) => text.trim())
+    .filter((text) => text.length > 0)
+    .join("\n\n");
+
+  return {
+    family,
+    level,
+    cellName: selected.cell,
+    cell,
+    modifiers: selected.modifiers,
+    spawnModel,
+    modeText: modes[cell.mode].replace("{spawnModel}", spawnModel),
+    framing: framing === null ? null : framing.trim(),
+    floorInstruction:
+      cell.floor === null ? null : floorInstruction.trim().replace("{floor}", String(cell.floor)),
+    lowInstructions: cell.mode === "direct" ? direct : null,
+    finderBudget: selected.modifiers.includes("finder-budget")
+      ? {
+          agents: diffLines === undefined ? null : finderAgents(diffLines, efforts.finderBudget),
+          diffLines: diffLines ?? null,
+          text: efforts.finderBudget.text,
+        }
+      : null,
+    preamble: chosen.length > 0 ? angles.preamble.trim() : null,
+    angles: chosen,
+    cleanupPrecedence: chosen.some((angle) => angle.kind !== "correctness")
+      ? angles.cleanupPrecedence.trim()
+      : null,
+    sweepGapFocus: cell.sweep ? angles.sweepGapFocus.trim() : null,
+  };
+}

--- a/plugins/review/skills/code/scripts/render.ts
+++ b/plugins/review/skills/code/scripts/render.ts
@@ -1,0 +1,80 @@
+import { getBorderCharacters, table } from "table";
+import type { Plan } from "./plan";
+
+// The plan block is prompt text, so the table carries no borders and the
+// padding `table` adds to square each column comes back off.
+function rows(pairs: [string, string | null][]): string {
+  const present = pairs.flatMap(([label, value]): string[][] =>
+    value === null ? [] : [[`  ${label}`, value]],
+  );
+  return table(present, {
+    border: getBorderCharacters("void"),
+    columnDefault: { paddingLeft: 0, paddingRight: 2 },
+    drawHorizontalLine: () => false,
+  }).replaceAll(/ +$/gm, "");
+}
+
+function section(title: string, body: string | null): string[] {
+  return body === null ? [] : ["", title, body];
+}
+
+function quote(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => (line.length > 0 ? `> ${line}` : ">"))
+    .join("\n");
+}
+
+export function render(plan: Plan, options: { angles: boolean }): string {
+  const { cell, finderBudget, angles } = plan;
+  const budget = finderBudget?.agents ?? null;
+
+  const summary = rows([
+    ["mode", plan.modeText],
+    ["angles", cell.angleSet === null ? null : `${cell.angleSet} (${angles.length})`],
+    [
+      "candidates",
+      cell.candidatesPerAngle === null ? null : `${cell.candidatesPerAngle} per angle`,
+    ],
+    [
+      "finders",
+      budget === null ? null : `${budget} agents for ${finderBudget?.diffLines} changed lines`,
+    ],
+    ["verify", cell.verify],
+    ["sweep", cell.sweep ? "yes" : null],
+    ["cap", cell.cap === null ? null : String(cell.cap)],
+    ["floor", cell.floor === null ? null : String(cell.floor)],
+    ["report", cell.reportsVia],
+  ]);
+
+  const audience = cell.mode === "fanout" ? "give to every angle agent" : "applies to every angle";
+  const angleText =
+    angles.length === 0
+      ? []
+      : [
+          "",
+          "ANGLES",
+          ...angles.flatMap((angle) => [`### ${angle.name}`, "", angle.text.trim(), ""]),
+        ];
+
+  return [
+    `CELL ${plan.cellName}   family ${plan.family}   level ${plan.level}`,
+    "",
+    summary.trimEnd(),
+    ...section("FINDER BUDGET", finderBudget === null ? null : finderBudget.text.trim()),
+    ...section(
+      "FRAMING (emit verbatim before Phase 1)",
+      plan.framing === null ? null : quote(plan.framing),
+    ),
+    ...section("FLOOR", plan.floorInstruction),
+    ...section("INSTRUCTIONS", plan.lowInstructions),
+    ...(options.angles
+      ? [
+          ...section(`FINDER PREAMBLE (${audience})`, plan.preamble),
+          ...angleText.slice(0, -1),
+          ...section("CLEANUP PRECEDENCE", plan.cleanupPrecedence),
+          ...section("SWEEP GAP FOCUS", plan.sweepGapFocus),
+        ]
+      : []),
+  ].join("\n");
+}

--- a/plugins/review/skills/code/scripts/review-plan.test.ts
+++ b/plugins/review/skills/code/scripts/review-plan.test.ts
@@ -1,25 +1,24 @@
 import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
-import Ajv2020 from "ajv/dist/2020";
-import anglesSchema from "../angles.schema.json";
-import effortsSchema from "../efforts.schema.json";
-import {
-  finderAgents,
-  load,
-  render,
-  resolveFamily,
-  resolveLevel,
-  resolvePlan,
-} from "./review-plan";
+import { anglesIn } from "./angles";
+import { finderAgents, resolveFamily, resolveLevel } from "./efforts";
+import { load, resolvePlan } from "./plan";
+import { render } from "./render";
+import { documentNames, schemaObject, schemaPath, serialize } from "./schemas";
 
 const SKILL_DIR = join(import.meta.dirname, "..");
 const { efforts, angles } = await load(SKILL_DIR);
 
-const pairs = Object.keys(efforts.selection).flatMap((family) =>
-  efforts.levels.map((level) => [family, level] as const),
+const selections = Object.entries(efforts.selection).flatMap(([family, levels]) =>
+  Object.entries(levels).map(([level, { cell, modifiers }]) => ({
+    family,
+    level,
+    cell,
+    modifiers,
+  })),
 );
 
-test.each(pairs)("renders the %s / %s plan", (family, level) => {
+test.each(selections)("renders the $family / $level plan", ({ family, level }) => {
   expect(
     render(resolvePlan(efforts, angles, { family, level }), { angles: true }),
   ).toMatchSnapshot();
@@ -42,6 +41,11 @@ describe("level tokens", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toContain("low, medium, high, xhigh");
   });
+
+  test("an exact level name beats a longer prefix match", () => {
+    const shadowed = { ...efforts, aliases: { ...efforts.aliases, highest: "xhigh" } };
+    expect(resolveLevel("high", shadowed)).toEqual({ ok: true, level: "high" });
+  });
 });
 
 test.each([
@@ -54,37 +58,18 @@ test.each([
   expect(resolveFamily(model, efforts)).toBe(family);
 });
 
-describe("schemas", () => {
-  const ajv = new Ajv2020({ strict: true, allErrors: true });
-
-  test.each([
-    ["efforts", effortsSchema, efforts],
-    ["angles", anglesSchema, angles],
-  ])("%s.yaml validates against its schema", (_, schema, data) => {
-    const validate = ajv.compile(schema);
-    expect(validate(data) ? [] : validate.errors).toEqual([]);
-  });
+test.each([...documentNames])("%s.schema.json matches the zod schema", async (name) => {
+  const committed = await Bun.file(schemaPath(SKILL_DIR, name)).text();
+  expect(schemaObject(committed)).toEqual(schemaObject(serialize(name)));
 });
 
 describe("cross-file invariants", () => {
-  const selections = Object.entries(efforts.selection).flatMap(([family, levels]) =>
-    Object.entries(levels).map(([level, selected]) => ({
-      family,
-      level,
-      cell: selected.cell,
-      modifiers: selected.modifiers,
-    })),
-  );
-
   test.each(selections)("$family/$level selects a declared cell", ({ cell }) => {
     expect(Object.keys(efforts.cells)).toContain(cell);
   });
 
   test.each(Object.entries(efforts.cells))("cell %s resolves its angles and framing", (_, cell) => {
-    const set = cell.angleSet;
-    if (set !== null) {
-      expect(angles.angles.filter((angle) => angle.sets.includes(set))).not.toBeEmpty();
-    }
+    if (cell.angleSet !== null) expect(anglesIn(angles, cell.angleSet)).not.toBeEmpty();
     if (cell.framing !== null) expect(efforts.framings).toHaveProperty(cell.framing);
   });
 
@@ -114,14 +99,8 @@ describe("cross-file invariants", () => {
     );
   });
 
-  test("an exact level name beats a longer prefix match", () => {
-    const shadowed = { ...efforts, aliases: { ...efforts.aliases, highest: "xhigh" } };
-    expect(resolveLevel("high", shadowed)).toEqual({ ok: true, level: "high" });
-  });
-
   test("core is a subset of full", () => {
-    const core = angles.angles.filter((angle) => angle.sets.includes("core"));
-    expect(core.every((angle) => angle.sets.includes("full"))).toBe(true);
+    expect(anglesIn(angles, "core").every((angle) => angle.sets.includes("full"))).toBe(true);
   });
 });
 

--- a/plugins/review/skills/code/scripts/review-plan.ts
+++ b/plugins/review/skills/code/scripts/review-plan.ts
@@ -1,316 +1,50 @@
 #!/usr/bin/env bun
 
-import { join } from "node:path";
 import { cli } from "cleye";
-import { z } from "zod";
-
-const modeSchema = z.enum(["fanout", "inline", "direct"]);
-const angleSetSchema = z.enum(["core", "full"]);
-const angleKindSchema = z.enum(["correctness", "cleanup", "altitude", "conventions"]);
-const countSchema = z.number().int().positive();
-
-const cellSchema = z.object({
-  mode: modeSchema,
-  angleSet: angleSetSchema.nullable(),
-  candidatesPerAngle: countSchema.nullable(),
-  verify: z.string(),
-  sweep: z.boolean(),
-  cap: countSchema.nullable(),
-  floor: z.union([countSchema, z.string()]).nullable(),
-  framing: z.string().nullable(),
-  reportsVia: z.enum(["ReportFindings", "text"]),
-});
-
-const effortsSchema = z.object({
-  spawnModel: z.string(),
-  levels: z.array(z.string()).nonempty(),
-  aliases: z.record(z.string(), z.string()),
-  modes: z.record(modeSchema, z.string()),
-  families: z.array(z.object({ id: z.string(), match: z.array(z.string()) })).nonempty(),
-  selection: z.record(
-    z.string(),
-    z.record(z.string(), z.object({ cell: z.string(), modifiers: z.array(z.string()) })),
-  ),
-  cells: z.record(z.string(), cellSchema),
-  framings: z.record(z.string(), z.string()),
-  lowInstructions: z.object({ shared: z.string(), cells: z.record(z.string(), z.string()) }),
-  floorInstruction: z.string(),
-  finderBudget: z.object({
-    linesPerAgent: countSchema,
-    min: countSchema,
-    max: countSchema,
-    text: z.string(),
-  }),
-});
-
-const angleSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  kind: angleKindSchema,
-  sets: z.array(angleSetSchema).nonempty(),
-  text: z.string(),
-});
-
-const anglesSchema = z.object({
-  preamble: z.string(),
-  angles: z.array(angleSchema).nonempty(),
-  cleanupPrecedence: z.string(),
-  sweepGapFocus: z.string(),
-});
-
-export type Mode = z.infer<typeof modeSchema>;
-export type AngleSet = z.infer<typeof angleSetSchema>;
-export type AngleKind = z.infer<typeof angleKindSchema>;
-export type Cell = z.infer<typeof cellSchema>;
-export type Efforts = z.infer<typeof effortsSchema>;
-export type Angle = z.infer<typeof angleSchema>;
-export type Angles = z.infer<typeof anglesSchema>;
-
-export type Plan = {
-  family: string;
-  level: string;
-  cellName: string;
-  cell: Cell;
-  modifiers: string[];
-  spawnModel: string;
-  modeText: string;
-  framing: string | null;
-  floorInstruction: string | null;
-  lowInstructions: string | null;
-  finderBudget: { agents: number | null; diffLines: number | null; text: string } | null;
-  preamble: string | null;
-  angles: Angle[];
-  cleanupPrecedence: string | null;
-  sweepGapFocus: string | null;
-};
+import { resolveFamily, resolveLevel } from "./efforts";
+import { load, resolvePlan, type Plan } from "./plan";
+import { render } from "./render";
 
 function fail(message: string): never {
   console.error(message);
   process.exit(1);
 }
 
-const SKILL_DIR = join(import.meta.dirname, "..");
+const argv = cli({
+  name: "review-plan",
+  parameters: ["[level]"],
+  strictFlags: true,
+  help: {
+    description:
+      "Resolve the review:code plan for a model and effort level: cell, caps, framing, and angle text.",
+  },
+  flags: {
+    model: { type: String, description: "Active model id, e.g. claude-opus-5" },
+    diffLines: { type: Number, description: "Changed lines in the range, for the finder budget" },
+    noAngles: { type: Boolean, description: "Print the plan block only, without the angle text" },
+    json: { type: Boolean, description: "Print the resolved plan as JSON" },
+  },
+});
 
-export async function load(dir = SKILL_DIR): Promise<{ efforts: Efforts; angles: Angles }> {
-  const [effortsText, anglesText] = await Promise.all([
-    Bun.file(join(dir, "efforts.yaml")).text(),
-    Bun.file(join(dir, "angles.yaml")).text(),
-  ]);
-  return {
-    efforts: effortsSchema.parse(Bun.YAML.parse(effortsText)),
-    angles: anglesSchema.parse(Bun.YAML.parse(anglesText)),
-  };
-}
+const { model, diffLines, noAngles, json } = argv.flags;
+if (model === undefined) fail("--model is required. Pass the active model id.");
 
-// A level token resolves by unique prefix over the canonical levels plus the
-// aliases, so `hi`, `hig`, and `high` all land on `high` while `mediumish`
-// lands nowhere. Ambiguity is an error rather than a silent pick.
-export function resolveLevel(
-  token: string,
-  efforts: Efforts,
-): { ok: true; level: string } | { ok: false; reason: string } {
-  const names = [...efforts.levels, ...Object.keys(efforts.aliases)];
-  const valid = `Valid levels: ${efforts.levels.join(", ")} (${Object.keys(efforts.aliases).join(", ")}).`;
-  const wanted = token.trim().toLowerCase();
-  if (!/^[a-z]+$/.test(wanted)) {
-    return { ok: false, reason: `"${token}" is not an effort level. ${valid}` };
+const { efforts, angles } = await load();
+const resolved = resolveLevel(argv._.level ?? "medium", efforts);
+if (!resolved.ok) fail(resolved.reason);
+
+const plan = ((): Plan => {
+  try {
+    return resolvePlan(efforts, angles, {
+      family: resolveFamily(model, efforts),
+      level: resolved.level,
+      diffLines,
+    });
+  } catch (error) {
+    return fail(error instanceof Error ? error.message : String(error));
   }
-  const canonical = (name: string) => efforts.aliases[name] ?? name;
-  const exact = names.find((name) => name === wanted);
-  if (exact !== undefined) return { ok: true, level: canonical(exact) };
-  const matches = names.filter((name) => name.startsWith(wanted));
-  const levels = [...new Set(matches.map(canonical))];
-  const [only] = levels;
-  if (only !== undefined && levels.length === 1) return { ok: true, level: only };
-  if (levels.length === 0) {
-    return { ok: false, reason: `"${token}" is not an effort level. ${valid}` };
-  }
-  return { ok: false, reason: `"${token}" is ambiguous: ${levels.join(", ")}. ${valid}` };
-}
+})();
 
-// Families match on a substring of the active model id, in declaration order.
-// The fallback family declares no substrings and so matches anything.
-export function resolveFamily(modelId: string, efforts: Efforts): string {
-  const id = modelId.trim().toLowerCase();
-  const family = efforts.families.find(
-    (candidate) =>
-      candidate.match.length === 0 || candidate.match.some((needle) => id.includes(needle)),
-  );
-  if (family === undefined) throw new Error("efforts.yaml declares no fallback family.");
-  return family.id;
-}
-
-export function finderAgents(diffLines: number, budget: Efforts["finderBudget"]): number {
-  const scaled = Math.ceil(diffLines / budget.linesPerAgent);
-  return Math.min(budget.max, Math.max(budget.min, scaled));
-}
-
-export function resolvePlan(
-  efforts: Efforts,
-  angles: Angles,
-  options: { family: string; level: string; diffLines?: number | undefined },
-): Plan {
-  const selected = efforts.selection[options.family]?.[options.level];
-  if (selected === undefined) {
-    throw new Error(`No cell for family ${options.family} at level ${options.level}.`);
-  }
-  const cell = efforts.cells[selected.cell];
-  if (cell === undefined) throw new Error(`efforts.yaml selects unknown cell ${selected.cell}.`);
-
-  const set = cell.angleSet;
-  const chosen = set === null ? [] : angles.angles.filter((angle) => angle.sets.includes(set));
-  const hasCleanup = chosen.some((angle) => angle.kind !== "correctness");
-
-  const framing = cell.framing === null ? null : efforts.framings[cell.framing];
-  if (framing === undefined) {
-    throw new Error(`efforts.yaml cell ${selected.cell} names unknown framing ${cell.framing}.`);
-  }
-
-  const lowText = efforts.lowInstructions.cells[selected.cell];
-  const budget = selected.modifiers.includes("finder-budget")
-    ? {
-        agents:
-          options.diffLines === undefined
-            ? null
-            : finderAgents(options.diffLines, efforts.finderBudget),
-        diffLines: options.diffLines ?? null,
-        text: efforts.finderBudget.text,
-      }
-    : null;
-
-  return {
-    family: options.family,
-    level: options.level,
-    cellName: selected.cell,
-    cell,
-    modifiers: selected.modifiers,
-    spawnModel: efforts.spawnModel,
-    modeText: efforts.modes[cell.mode].replace("{spawnModel}", efforts.spawnModel),
-    framing: framing === null ? null : framing.trim(),
-    floorInstruction:
-      cell.floor === null
-        ? null
-        : efforts.floorInstruction.trim().replace("{floor}", String(cell.floor)),
-    lowInstructions:
-      cell.mode === "direct"
-        ? [efforts.lowInstructions.shared, lowText ?? ""]
-            .map((text) => text.trim())
-            .filter((text) => text.length > 0)
-            .join("\n\n")
-        : null,
-    finderBudget: budget,
-    preamble: chosen.length > 0 ? angles.preamble.trim() : null,
-    angles: chosen,
-    cleanupPrecedence: hasCleanup ? angles.cleanupPrecedence.trim() : null,
-    sweepGapFocus: cell.sweep ? angles.sweepGapFocus.trim() : null,
-  };
-}
-
-function quote(text: string): string {
-  return text
-    .split("\n")
-    .map((line) => (line.length > 0 ? `> ${line}` : ">"))
-    .join("\n");
-}
-
-export function render(plan: Plan, options: { angles: boolean }): string {
-  const { cell } = plan;
-  const rows: [string, string][] = [["mode", plan.modeText]];
-  if (cell.angleSet !== null) rows.push(["angles", `${cell.angleSet} (${plan.angles.length})`]);
-  if (cell.candidatesPerAngle !== null) {
-    rows.push(["candidates", `${cell.candidatesPerAngle} per angle`]);
-  }
-  if (plan.finderBudget !== null && plan.finderBudget.agents !== null) {
-    rows.push([
-      "finders",
-      `${plan.finderBudget.agents} agents for ${plan.finderBudget.diffLines} changed lines`,
-    ]);
-  }
-  rows.push(["verify", cell.verify]);
-  if (cell.sweep) rows.push(["sweep", "yes"]);
-  if (cell.cap !== null) rows.push(["cap", String(cell.cap)]);
-  if (cell.floor !== null) rows.push(["floor", String(cell.floor)]);
-  rows.push(["report", cell.reportsVia]);
-
-  const width = Math.max(...rows.map(([label]) => label.length));
-  const out: string[] = [
-    `CELL ${plan.cellName}   family ${plan.family}   level ${plan.level}`,
-    "",
-    ...rows.map(([label, value]) => `  ${label.padEnd(width)}  ${value}`),
-  ];
-
-  if (plan.finderBudget !== null) out.push("", "FINDER BUDGET", plan.finderBudget.text.trim());
-
-  if (plan.framing !== null) {
-    out.push("", "FRAMING (emit verbatim before Phase 1)", quote(plan.framing));
-  }
-
-  if (plan.floorInstruction !== null) out.push("", "FLOOR", plan.floorInstruction);
-
-  if (plan.lowInstructions !== null) {
-    out.push("", "INSTRUCTIONS", plan.lowInstructions);
-  }
-
-  if (options.angles) {
-    if (plan.preamble !== null) {
-      const audience =
-        plan.cell.mode === "fanout" ? "give to every angle agent" : "applies to every angle";
-      out.push("", `FINDER PREAMBLE (${audience})`, plan.preamble);
-    }
-
-    if (plan.angles.length > 0) {
-      out.push("", "ANGLES");
-      for (const angle of plan.angles) out.push(`### ${angle.name}`, "", angle.text.trim(), "");
-      out.pop();
-    }
-
-    if (plan.cleanupPrecedence !== null) out.push("", "CLEANUP PRECEDENCE", plan.cleanupPrecedence);
-    if (plan.sweepGapFocus !== null) out.push("", "SWEEP GAP FOCUS", plan.sweepGapFocus);
-  }
-
-  return out.join("\n");
-}
-
-if (import.meta.main) {
-  const argv = cli({
-    name: "review-plan",
-    parameters: ["[level]"],
-    strictFlags: true,
-    help: {
-      description:
-        "Resolve the review:code plan for a model and effort level: cell, caps, framing, and angle text.",
-    },
-    flags: {
-      model: { type: String, description: "Active model id, e.g. claude-opus-5" },
-      diffLines: { type: Number, description: "Changed lines in the range, for the finder budget" },
-      noAngles: { type: Boolean, description: "Print the plan block only, without the angle text" },
-      json: { type: Boolean, description: "Print the resolved plan as JSON" },
-    },
-  });
-
-  const { efforts, angles } = await load();
-
-  const model = argv.flags.model;
-  if (model === undefined) fail("--model is required. Pass the active model id.");
-
-  const resolved = resolveLevel(argv._.level ?? "medium", efforts);
-  if (!resolved.ok) fail(resolved.reason);
-
-  const plan = ((): Plan => {
-    try {
-      return resolvePlan(efforts, angles, {
-        family: resolveFamily(model, efforts),
-        level: resolved.level,
-        diffLines: argv.flags.diffLines,
-      });
-    } catch (error) {
-      return fail(error instanceof Error ? error.message : String(error));
-    }
-  })();
-
-  console.log(
-    argv.flags.json
-      ? JSON.stringify(plan, null, 2)
-      : render(plan, { angles: !argv.flags.noAngles }),
-  );
-}
+console.log(
+  json === true ? JSON.stringify(plan, null, 2) : render(plan, { angles: noAngles !== true }),
+);

--- a/plugins/review/skills/code/scripts/schemas.ts
+++ b/plugins/review/skills/code/scripts/schemas.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env bun
+
+import { join } from "node:path";
+import { z } from "zod";
+import { anglesSchema } from "./angles";
+import { effortsSchema } from "./efforts";
+
+export const documentNames = ["efforts", "angles"] as const;
+
+export type Document = (typeof documentNames)[number];
+
+// The YAML files carry a `yaml-language-server` directive pointing at these,
+// so the editor validates against the same shapes the CLI parses with.
+const documents: Record<Document, z.ZodType> = { efforts: effortsSchema, angles: anglesSchema };
+
+export function schemaPath(dir: string, name: Document): string {
+  return join(dir, `${name}.schema.json`);
+}
+
+// oxfmt owns the formatting of the committed files, so comparisons go through
+// the parsed object rather than the serialized text.
+export function schemaObject(text: string): Record<string, unknown> {
+  return z.record(z.string(), z.unknown()).parse(JSON.parse(text));
+}
+
+export function serialize(name: Document): string {
+  const schema = z.toJSONSchema(documents[name], { target: "draft-2020-12" });
+  return `${JSON.stringify(schema, null, 2)}\n`;
+}
+
+if (import.meta.main) {
+  const dir = join(import.meta.dirname, "..");
+  await Promise.all(documentNames.map((name) => Bun.write(schemaPath(dir, name), serialize(name))));
+}


### PR DESCRIPTION
Follow-up to #1294, all structural.

`review-plan.ts` held five concerns in one file. It now groups the schema with the functions that act on it: `efforts.ts` carries the cell shape plus level, family, and budget resolution; `angles.ts` carries the angle shape plus set filtering; `plan.ts` combines them; `render.ts` formats; `review-plan.ts` is the CLI entry and nothing else.

## Generated Schemas

The hand-written `.schema.json` files were a second definition of shapes zod already described, kept in sync by hand and checked by `ajv`. They are now `z.toJSONSchema` output, written by `scripts/schemas.ts`, so a shape change happens once in the zod schema. The `yaml-language-server` directives still point at the committed files, which is why they stay on disk rather than being generated on demand. A test compares the committed JSON to freshly generated output, so a stale file fails rather than silently misleading the editor.

`z.strictObject` supplies `additionalProperties: false` and `.describe()` supplies the hover text the hand-written schemas carried. `ajv` is gone; the zod parse in `load()` is the runtime validation.

## Rendering

The plan block used a hand-computed column width and `padEnd`. It now goes through the `table` package that the rest of the repo's scripts use, configured borderless with the squaring padding stripped, since this output is prompt text rather than a terminal table. Output is byte-identical, which the unchanged snapshots show.

Elsewhere the repetition came off through destructuring in the resolver signatures and a `section(title, body)` helper replacing a run of null guards that each pushed three lines.
