### PR TITLE
terraform: declare the private eval-corpus bucket

### DIFF
--- a/terraform/eval-corpus.tf
+++ b/terraform/eval-corpus.tf
@@ -1,0 +1,79 @@
+# Mined eval corpora, too personal to commit to this public repo. The
+# `ben-drucker-agents-` prefix is the whole of this workspace's S3 grant.
+resource "aws_s3_bucket" "eval_corpus" {
+  bucket = "ben-drucker-agents-eval-corpus"
+}
+
+resource "aws_s3_bucket_versioning" "eval_corpus" {
+  bucket = aws_s3_bucket.eval_corpus.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "eval_corpus" {
+  bucket = aws_s3_bucket.eval_corpus.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "eval_corpus" {
+  bucket = aws_s3_bucket.eval_corpus.id
+
+  rule {
+    id     = "expire-noncurrent-versions"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+  }
+
+  rule {
+    id     = "abort-incomplete-uploads"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+data "aws_iam_policy_document" "eval_corpus" {
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.eval_corpus.arn,
+      "${aws_s3_bucket.eval_corpus.arn}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "eval_corpus" {
+  bucket = aws_s3_bucket.eval_corpus.id
+  policy = data.aws_iam_policy_document.eval_corpus.json
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1"
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  cloud {
+    organization = "bendrucker"
+
+    workspaces {
+      name = "claude"
+    }
+  }
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+
+  required_version = ">= 1.1"
+}


### PR DESCRIPTION
Adds the Terraform root that declares where mined eval corpora live. The `no-diary` corpus is session excerpts and hand labels, too personal for a public repo, and the four gitignored harnesses under `evals/` carry the same problem. The workaround has been gitignored local files, which lose everything on a machine wipe.

Terraform Cloud runs this root as workspace `claude` against a dedicated `agents` AWS account, using dynamic provider credentials already set on the workspace. The run role's only S3 grant is `s3:*` on `arn:aws:s3:::ben-drucker-agents-*`, which fixes the bucket name to that prefix. The role has no other permissions. Widening this root later means a change in the infrastructure repo.

There is no GitHub Actions OIDC role. A fork PR's subject is `repo:bendrucker/claude:pull_request`, and any trust policy matching `repo:bendrucker/claude:*` would hand credentials to whoever opened the PR. With no CI credential path at all, a fork has nothing to reach.

No per-bucket `aws_s3_bucket_public_access_block` appears here. Public access is blocked account-wide on 419603636763, set from the infrastructure repo. `s3:PutAccountPublicAccessBlock` acts on the account rather than a bucket ARN. This role couldn't set one even if the resource lived here.

Merging applies the config directly. The workspace auto-applies on main, and its speculative plan on this PR shows what that will create.
