### PR TITLE
github: name the run that actually failed

### DIFF
--- a/plugins/github/agents/logs.md
+++ b/plugins/github/agents/logs.md
@@ -51,3 +51,4 @@ Keep `lines` short (10 to 50 lines per job). The caller can read `log_file` for 
 
 - Do not analyze root causes or suggest fixes. Extract and summarize.
 - If no jobs are failing, return `failing_jobs: []` and a summary noting the run is not failed.
+- If the run id is missing or null, no Actions run failed. Return `failing_jobs: []` with that summary and run no `gh run view`.

--- a/plugins/github/skills/actions-monitor/SKILL.md
+++ b/plugins/github/skills/actions-monitor/SKILL.md
@@ -66,6 +66,8 @@ The script exits on `status:success`, `pr-closed`, `merged`, and `max-time-reach
 
 On a `status` event with `state == "failing"`, invoke the `github:logs` agent via the `Agent` tool, passing the `run_id` and the PR URL (or branch name) from the event. It returns a structured JSON summary of the failing jobs and persists the raw logs to a known temp path; read that file for more context.
 
+A failing event with `"run_id": null` means no Actions run failed: the red check is an external status (a hosted reviewer, a deployment) with no job logs to fetch. Skip the `github:logs` dispatch and name the failing checks from `gh pr checks` instead.
+
 - `conflicts` / `mergeable-unknown` (PR mode): note the SHA; the caller (e.g. `pull-request:babysit`) decides whether to resolve or run an authoritative local check. `mergeable-unknown` means GitHub could not settle mergeability after bounded re-polling.
 - `queued-timeout` / `api-error`: surface to the user.
 - `rate-limited`: back off and retry once the window passes.

--- a/plugins/github/skills/actions-monitor/scripts/watch.test.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.test.ts
@@ -531,72 +531,46 @@ describe("parseRepo", () => {
 });
 
 describe("selectRunId", () => {
-  // Captured from a PR whose newest branch run is the skipped Claude Code
-  // workflow while the failure came from `lint`. The failing event names the
-  // run `github:logs` will fetch, so naming a skipped run spends a dispatch on
-  // a run with no failing jobs.
-  const runs = [
-    { databaseId: 33220884467, headSha: "sha-head", conclusion: "skipped", workflowDatabaseId: 1 },
-    {
-      databaseId: 33223106137,
-      headSha: "sha-head",
-      conclusion: "cancelled",
-      workflowDatabaseId: 2,
-    },
-    { databaseId: 33220042301, headSha: "sha-head", conclusion: "failure", workflowDatabaseId: 3 },
-    { databaseId: 33219000000, headSha: "sha-old", conclusion: "failure", workflowDatabaseId: 3 },
-  ];
+  // A failing event names the run `github:logs` fetches. Naming a run that did
+  // not fail spends a dispatch on a run with no failing jobs to report.
+  const run = (
+    databaseId: number,
+    conclusion: string,
+    workflowDatabaseId: number,
+    createdAt = "2026-08-28T00:00:00Z",
+    headSha = "sha-head",
+  ) => ({ databaseId, headSha, conclusion, workflowDatabaseId, createdAt });
 
-  it("skips over skipped and cancelled runs to the run that failed", () => {
-    expect(selectRunId(runs, "sha-head", "failing")).toBe("33220042301");
-  });
-
-  test.each(["skipped", "cancelled"])(
-    "returns null when the only %s runs cannot explain a failing check",
-    (conclusion) => {
-      const noFailure = [{ databaseId: 1, headSha: "sha-head", conclusion }];
-      expect(selectRunId(noFailure, "sha-head", "failing")).toBeNull();
-    },
-  );
-
-  it("returns null when the failure is a check with no Actions run", () => {
-    const allGreen = [{ databaseId: 1, headSha: "sha-head", conclusion: "success" }];
-    expect(selectRunId(allGreen, "sha-head", "failing")).toBeNull();
-  });
-
-  it("ignores runs from other SHAs", () => {
-    expect(selectRunId(runs, "sha-other", "failing")).toBeNull();
-    expect(selectRunId(runs, "sha-other", "running")).toBeNull();
-  });
-
-  test.each<InternalState>(["running", "queued", "success"])(
-    "names the newest run for the SHA when state is %s",
-    (state) => {
-      expect(selectRunId(runs, "sha-head", state)).toBe("33220884467");
-    },
-  );
-
-  it("ignores a failure a later run of the same workflow replaced", () => {
-    const rerun = [
-      { databaseId: 200, headSha: "sha-head", conclusion: "success", workflowDatabaseId: 3 },
-      { databaseId: 100, headSha: "sha-head", conclusion: "failure", workflowDatabaseId: 3 },
-    ];
-    expect(selectRunId(rerun, "sha-head", "failing")).toBeNull();
-  });
-
-  it("names a workflow's own failure even when another workflow re-ran green", () => {
-    const mixed = [
-      { databaseId: 200, headSha: "sha-head", conclusion: "success", workflowDatabaseId: 3 },
-      { databaseId: 150, headSha: "sha-head", conclusion: "failure", workflowDatabaseId: 4 },
-      { databaseId: 100, headSha: "sha-head", conclusion: "failure", workflowDatabaseId: 3 },
-    ];
-    expect(selectRunId(mixed, "sha-head", "failing")).toBe("150");
-  });
-
-  it("tolerates entries gh could not shape", () => {
-    expect(
-      selectRunId([null, "x", {}, { databaseId: 7, headSha: "sha-head" }], "sha-head", "running"),
-    ).toBe("7");
+  test.each<[string, unknown[], string | null]>([
+    [
+      "picks the failed run past skipped and cancelled ones",
+      [run(1, "skipped", 10), run(2, "cancelled", 20), run(3, "failure", 30)],
+      "3",
+    ],
+    ["skipped run alone", [run(1, "skipped", 10)], null],
+    ["cancelled run alone", [run(1, "cancelled", 10)], null],
+    ["run still awaiting approval", [run(1, "action_required", 10)], null],
+    ["every run green (the red check is not an Actions run)", [run(1, "success", 10)], null],
+    ["a timed-out run", [run(1, "timed_out", 10)], "1"],
+    [
+      "a failure a later run of the same workflow replaced",
+      [run(2, "success", 10, "2026-08-28T02:00:00Z"), run(1, "failure", 10)],
+      null,
+    ],
+    [
+      "another workflow's live failure past a workflow that re-ran green",
+      [run(3, "success", 10, "2026-08-28T02:00:00Z"), run(2, "failure", 20), run(1, "failure", 10)],
+      "2",
+    ],
+    [
+      "a re-run listed before the older attempt it replaced",
+      [run(1, "failure", 10), run(2, "success", 10, "2026-08-28T02:00:00Z")],
+      null,
+    ],
+    ["runs from another commit", [run(1, "failure", 10, undefined, "sha-other")], null],
+    ["entries gh could not shape", [null, "x", {}, run(1, "failure", 10)], "1"],
+  ])("%s -> %p", (_name, runs, expected) => {
+    expect(selectRunId(runs, "sha-head")).toBe(expected as string);
   });
 });
 
@@ -719,17 +693,15 @@ describe("probePr (gh schema integration)", () => {
     const { exec, remaining } = makeExec([
       { match: "gh pr view 42", result: ok(prJson) },
       { match: "gh pr checks 42", result: ok(checksJson) },
-      {
-        match: "gh run list --repo owner/repo --commit abc123",
-        result: ok(JSON.stringify([{ databaseId: 999, headSha: "abc123", conclusion: "success" }])),
-      },
     ]);
     const result = probePr(42, "owner/repo", exec);
     expect(result.kind).toBe("ok");
     if (result.kind !== "ok") return;
     expect(result.probe.state).toBe("success");
     expect(result.probe.sha).toBe("abc123");
-    expect(result.probe.runId).toBe("999");
+    // A green poll has no run to name and skips the lookup, so no `gh run list`
+    // call is scripted above and the exec queue must come back empty.
+    expect(result.probe.runId).toBeNull();
     expect(result.branch).toBe("feature/x");
     expect(remaining()).toEqual([]);
   });
@@ -880,24 +852,49 @@ describe("probePr (gh schema integration)", () => {
       seen.push(command);
       if (command.startsWith("gh pr view")) return ok(prJson);
       if (command.startsWith("gh pr checks")) {
-        return ok(JSON.stringify([{ state: "SUCCESS", bucket: "pass", name: "x" }]));
+        return ok(JSON.stringify([{ state: "FAILURE", bucket: "fail", name: "x" }]));
       }
       if (command.startsWith("gh run list")) return ok("[]");
       throw new Error(`unexpected: ${command}`);
     };
     probePr(42, "owner/repo", recordingExec);
     const runsCall = seen.find((c) => c.startsWith("gh run list"));
-    expect(runsCall).toContain("--json databaseId,headSha,conclusion,workflowDatabaseId");
+    expect(runsCall).toContain("--json databaseId,headSha,conclusion,workflowDatabaseId,createdAt");
     expect(runsCall).toContain("--commit abc123");
+  });
+
+  it("skips the run lookup entirely while checks are still running", () => {
+    const { exec, remaining } = makeExec([
+      { match: "gh pr view", result: ok(prJson) },
+      {
+        match: "gh pr checks",
+        result: ok(JSON.stringify([{ state: "IN_PROGRESS", bucket: "pending", name: "x" }])),
+      },
+    ]);
+    const result = probePr(42, "owner/repo", exec);
+    expect(result.kind).toBe("ok");
+    expect(remaining()).toEqual([]);
   });
 
   it("returns kind=error when gh run list emits unparseable JSON", () => {
     const { exec } = makeExec([
       { match: "gh pr view", result: ok(prJson) },
-      { match: "gh pr checks", result: ok(JSON.stringify([])) },
+      {
+        match: "gh pr checks",
+        result: ok(JSON.stringify([{ state: "FAILURE", bucket: "fail", name: "x" }])),
+      },
       { match: "gh run list", result: ok("not json") },
     ]);
     expect(probePr(42, "owner/repo", exec).kind).toBe("error");
+  });
+
+  it("returns kind=error when gh pr view omits the head SHA", () => {
+    const noSha = JSON.stringify({ headRefName: "feature/x", state: "OPEN" });
+    const { exec } = makeExec([{ match: "gh pr view", result: ok(noSha) }]);
+    const result = probePr(42, "owner/repo", exec);
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") return;
+    expect(result.stderr).toContain("headRefOid");
   });
 
   it("emits state=queued when all checks pending in QUEUED state", () => {

--- a/plugins/github/skills/actions-monitor/scripts/watch.test.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.test.ts
@@ -18,6 +18,7 @@ import {
   probeRunId,
   registerApiError,
   resolveMergeable,
+  selectRunId,
   type WatcherState,
 } from "./watch";
 
@@ -122,12 +123,59 @@ describe("deriveChecksState", () => {
       "failing",
     ],
     [
-      "any check in cancel bucket",
+      "a cancelled check alongside passing checks",
       [
         { state: "SUCCESS", bucket: "pass", name: "a" },
         { state: "CANCELLED", bucket: "cancel", name: "b" },
       ],
+      "success",
+    ],
+    [
+      "a skipped check alongside passing checks",
+      [
+        { state: "SUCCESS", bucket: "pass", name: "a" },
+        { state: "SKIPPED", bucket: "skipping", name: "b" },
+      ],
+      "success",
+    ],
+    [
+      "skipped and cancelled checks alongside an in-flight check",
+      [
+        { state: "SKIPPED", bucket: "skipping", name: "a" },
+        { state: "CANCELLED", bucket: "cancel", name: "b" },
+        { state: "IN_PROGRESS", bucket: "pending", name: "c" },
+      ],
+      "running",
+    ],
+    [
+      "skipped and cancelled checks alongside a failing check",
+      [
+        { state: "SKIPPED", bucket: "skipping", name: "a" },
+        { state: "CANCELLED", bucket: "cancel", name: "b" },
+        { state: "FAILURE", bucket: "fail", name: "c" },
+      ],
       "failing",
+    ],
+    [
+      "every check skipped or cancelled",
+      [
+        { state: "SKIPPED", bucket: "skipping", name: "a" },
+        { state: "CANCELLED", bucket: "cancel", name: "b" },
+      ],
+      "success",
+    ],
+    // Shape captured from a green PR whose automerge and claude workflows are
+    // skipped on every push. Skipped workflows are routine, so a skip that
+    // counts against the PR turns every such PR permanently failing.
+    [
+      "captured green payload with skipped automerge and claude workflows",
+      [
+        { state: "SUCCESS", bucket: "pass", name: "lint" },
+        { state: "SKIPPED", bucket: "skipping", name: "claude" },
+        { state: "SUCCESS", bucket: "pass", name: "build" },
+        { state: "SKIPPED", bucket: "skipping", name: "automerge" },
+      ],
+      "success",
     ],
     [
       "any check is IN_PROGRESS",
@@ -152,14 +200,6 @@ describe("deriveChecksState", () => {
         { state: "SUCCESS", bucket: "pass", name: "b" },
       ],
       "running",
-    ],
-    [
-      "all checks pass or skip",
-      [
-        { state: "SUCCESS", bucket: "pass", name: "a" },
-        { state: "SKIPPED", bucket: "skipping", name: "b" },
-      ],
-      "success",
     ],
     // Exact shape captured from `gh pr checks <num> --json state,bucket,name`
     // against a fully-green PR. If this assertion ever flips back to "running"
@@ -479,6 +519,54 @@ describe("parseRepo", () => {
   });
 });
 
+describe("selectRunId", () => {
+  // Captured from a PR whose newest branch run is the skipped Claude Code
+  // workflow while the failure came from `lint`. The failing event names the
+  // run `github:logs` will fetch, so naming a skipped run spends a dispatch on
+  // a run with no failing jobs.
+  const runs = [
+    { databaseId: 33220884467, headSha: "sha-head", conclusion: "skipped" },
+    { databaseId: 33223106137, headSha: "sha-head", conclusion: "cancelled" },
+    { databaseId: 33220042301, headSha: "sha-head", conclusion: "failure" },
+    { databaseId: 33219000000, headSha: "sha-old", conclusion: "failure" },
+  ];
+
+  it("skips over skipped and cancelled runs to the run that failed", () => {
+    expect(selectRunId(runs, "sha-head", "failing")).toBe("33220042301");
+  });
+
+  test.each(["skipped", "cancelled"])(
+    "returns null when the only %s runs cannot explain a failing check",
+    (conclusion) => {
+      const noFailure = [{ databaseId: 1, headSha: "sha-head", conclusion }];
+      expect(selectRunId(noFailure, "sha-head", "failing")).toBeNull();
+    },
+  );
+
+  it("returns null when the failure is a check with no Actions run", () => {
+    const allGreen = [{ databaseId: 1, headSha: "sha-head", conclusion: "success" }];
+    expect(selectRunId(allGreen, "sha-head", "failing")).toBeNull();
+  });
+
+  it("ignores runs from other SHAs", () => {
+    expect(selectRunId(runs, "sha-other", "failing")).toBeNull();
+    expect(selectRunId(runs, "sha-other", "running")).toBeNull();
+  });
+
+  test.each<InternalState>(["running", "queued", "success"])(
+    "names the newest run for the SHA when state is %s",
+    (state) => {
+      expect(selectRunId(runs, "sha-head", state)).toBe("33220884467");
+    },
+  );
+
+  it("tolerates entries gh could not shape", () => {
+    expect(
+      selectRunId([null, "x", {}, { databaseId: 7, headSha: "sha-head" }], "sha-head", "running"),
+    ).toBe("7");
+  });
+});
+
 describe("deriveRunListState", () => {
   test.each<[string, string, InternalState]>([
     ["completed", "failure", "failing"],
@@ -598,7 +686,10 @@ describe("probePr (gh schema integration)", () => {
     const { exec, remaining } = makeExec([
       { match: "gh pr view 42", result: ok(prJson) },
       { match: "gh pr checks 42", result: ok(checksJson) },
-      { match: "gh run list --repo owner/repo --branch feature/x", result: ok("999") },
+      {
+        match: "gh run list --repo owner/repo --commit abc123",
+        result: ok(JSON.stringify([{ databaseId: 999, headSha: "abc123", conclusion: "success" }])),
+      },
     ]);
     const result = probePr(42, "owner/repo", exec);
     expect(result.kind).toBe("ok");
@@ -622,7 +713,7 @@ describe("probePr (gh schema integration)", () => {
       if (command.startsWith("gh pr checks")) {
         return ok(JSON.stringify([{ state: "SUCCESS", bucket: "pass", name: "x" }]));
       }
-      if (command.startsWith("gh run list")) return ok("");
+      if (command.startsWith("gh run list")) return ok("[]");
       throw new Error(`unexpected: ${command}`);
     };
     probePr(42, "owner/repo", recordingExec);
@@ -655,7 +746,9 @@ describe("probePr (gh schema integration)", () => {
       if (command.startsWith("gh pr checks")) {
         return ok(JSON.stringify([{ state: "SUCCESS", bucket: "pass", name: "x" }]));
       }
-      if (command.startsWith("gh run list")) return ok("999");
+      if (command.startsWith("gh run list")) {
+        return ok(JSON.stringify([{ databaseId: 999, headSha: "abc123", conclusion: "success" }]));
+      }
       throw new Error(`unexpected: ${command}`);
     };
     probePr(42, "owner/repo", recordingExec);
@@ -673,12 +766,105 @@ describe("probePr (gh schema integration)", () => {
     const { exec } = makeExec([
       { match: "gh pr view", result: ok(prJson) },
       { match: "gh pr checks", result: ok(checksJson) },
-      { match: "gh run list", result: ok("123") },
+      {
+        match: "gh run list",
+        result: ok(JSON.stringify([{ databaseId: 123, headSha: "abc123", conclusion: "failure" }])),
+      },
     ]);
     const result = probePr(42, "owner/repo", exec);
     expect(result.kind).toBe("ok");
     if (result.kind !== "ok") return;
     expect(result.probe.state).toBe("failing");
+  });
+
+  it("names the failed run, not the branch's newest skipped run, on a failing PR", () => {
+    const checksJson = JSON.stringify([
+      { state: "SUCCESS", bucket: "pass", name: "build" },
+      { state: "FAILURE", bucket: "fail", name: "lint" },
+      { state: "SKIPPED", bucket: "skipping", name: "claude" },
+    ]);
+    const runsJson = JSON.stringify([
+      { databaseId: 33220884467, headSha: "abc123", conclusion: "skipped" },
+      { databaseId: 33223106137, headSha: "abc123", conclusion: "cancelled" },
+      { databaseId: 33220042301, headSha: "abc123", conclusion: "failure" },
+    ]);
+    const { exec } = makeExec([
+      { match: "gh pr view", result: ok(prJson) },
+      { match: "gh pr checks", result: ok(checksJson) },
+      { match: "gh run list", result: ok(runsJson) },
+    ]);
+    const result = probePr(42, "owner/repo", exec);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.probe.state).toBe("failing");
+    expect(result.probe.runId).toBe("33220042301");
+  });
+
+  it("emits a null run_id when the failing check is not an Actions run", () => {
+    const checksJson = JSON.stringify([
+      { state: "SUCCESS", bucket: "pass", name: "build" },
+      { state: "FAILURE", bucket: "fail", name: "Greptile Review" },
+    ]);
+    const runsJson = JSON.stringify([
+      { databaseId: 33220884467, headSha: "abc123", conclusion: "skipped" },
+      { databaseId: 33223106137, headSha: "abc123", conclusion: "success" },
+    ]);
+    const { exec } = makeExec([
+      { match: "gh pr view", result: ok(prJson) },
+      { match: "gh pr checks", result: ok(checksJson) },
+      { match: "gh run list", result: ok(runsJson) },
+    ]);
+    const result = probePr(42, "owner/repo", exec);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.probe.state).toBe("failing");
+    expect(result.probe.runId).toBeNull();
+  });
+
+  it("stays green when the only non-passing checks are skipped and cancelled", () => {
+    const checksJson = JSON.stringify([
+      { state: "SUCCESS", bucket: "pass", name: "build" },
+      { state: "SKIPPED", bucket: "skipping", name: "claude" },
+      { state: "CANCELLED", bucket: "cancel", name: "automerge" },
+    ]);
+    const runsJson = JSON.stringify([
+      { databaseId: 33220884467, headSha: "abc123", conclusion: "skipped" },
+    ]);
+    const { exec } = makeExec([
+      { match: "gh pr view", result: ok(prJson) },
+      { match: "gh pr checks", result: ok(checksJson) },
+      { match: "gh run list", result: ok(runsJson) },
+    ]);
+    const result = probePr(42, "owner/repo", exec);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.probe.state).toBe("success");
+  });
+
+  it("requests gh run list with the fields run attribution needs (regression)", () => {
+    const seen: string[] = [];
+    const recordingExec: ExecFn = (command) => {
+      seen.push(command);
+      if (command.startsWith("gh pr view")) return ok(prJson);
+      if (command.startsWith("gh pr checks")) {
+        return ok(JSON.stringify([{ state: "SUCCESS", bucket: "pass", name: "x" }]));
+      }
+      if (command.startsWith("gh run list")) return ok("[]");
+      throw new Error(`unexpected: ${command}`);
+    };
+    probePr(42, "owner/repo", recordingExec);
+    const runsCall = seen.find((c) => c.startsWith("gh run list"));
+    expect(runsCall).toContain("--json databaseId,headSha,conclusion");
+    expect(runsCall).toContain("--commit abc123");
+  });
+
+  it("returns kind=error when gh run list emits unparseable JSON", () => {
+    const { exec } = makeExec([
+      { match: "gh pr view", result: ok(prJson) },
+      { match: "gh pr checks", result: ok(JSON.stringify([])) },
+      { match: "gh run list", result: ok("not json") },
+    ]);
+    expect(probePr(42, "owner/repo", exec).kind).toBe("error");
   });
 
   it("emits state=queued when all checks pending in QUEUED state", () => {
@@ -689,7 +875,10 @@ describe("probePr (gh schema integration)", () => {
     const { exec } = makeExec([
       { match: "gh pr view", result: ok(prJson) },
       { match: "gh pr checks", result: ok(checksJson) },
-      { match: "gh run list", result: ok("123") },
+      {
+        match: "gh run list",
+        result: ok(JSON.stringify([{ databaseId: 123, headSha: "abc123", conclusion: "failure" }])),
+      },
     ]);
     const result = probePr(42, "owner/repo", exec);
     expect(result.kind).toBe("ok");

--- a/plugins/github/skills/actions-monitor/scripts/watch.test.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.test.ts
@@ -122,13 +122,16 @@ describe("deriveChecksState", () => {
       ],
       "failing",
     ],
+    // A cancelled check is not a failure, but GitHub does not count it as
+    // passing either, so calling the PR green here exits the watcher on a PR
+    // branch protection still blocks.
     [
       "a cancelled check alongside passing checks",
       [
         { state: "SUCCESS", bucket: "pass", name: "a" },
         { state: "CANCELLED", bucket: "cancel", name: "b" },
       ],
-      "success",
+      "running",
     ],
     [
       "a skipped check alongside passing checks",
@@ -161,6 +164,14 @@ describe("deriveChecksState", () => {
       [
         { state: "SKIPPED", bucket: "skipping", name: "a" },
         { state: "CANCELLED", bucket: "cancel", name: "b" },
+      ],
+      "running",
+    ],
+    [
+      "every check skipped",
+      [
+        { state: "SKIPPED", bucket: "skipping", name: "a" },
+        { state: "SKIPPED", bucket: "skipping", name: "b" },
       ],
       "success",
     ],
@@ -525,10 +536,15 @@ describe("selectRunId", () => {
   // run `github:logs` will fetch, so naming a skipped run spends a dispatch on
   // a run with no failing jobs.
   const runs = [
-    { databaseId: 33220884467, headSha: "sha-head", conclusion: "skipped" },
-    { databaseId: 33223106137, headSha: "sha-head", conclusion: "cancelled" },
-    { databaseId: 33220042301, headSha: "sha-head", conclusion: "failure" },
-    { databaseId: 33219000000, headSha: "sha-old", conclusion: "failure" },
+    { databaseId: 33220884467, headSha: "sha-head", conclusion: "skipped", workflowDatabaseId: 1 },
+    {
+      databaseId: 33223106137,
+      headSha: "sha-head",
+      conclusion: "cancelled",
+      workflowDatabaseId: 2,
+    },
+    { databaseId: 33220042301, headSha: "sha-head", conclusion: "failure", workflowDatabaseId: 3 },
+    { databaseId: 33219000000, headSha: "sha-old", conclusion: "failure", workflowDatabaseId: 3 },
   ];
 
   it("skips over skipped and cancelled runs to the run that failed", () => {
@@ -559,6 +575,23 @@ describe("selectRunId", () => {
       expect(selectRunId(runs, "sha-head", state)).toBe("33220884467");
     },
   );
+
+  it("ignores a failure a later run of the same workflow replaced", () => {
+    const rerun = [
+      { databaseId: 200, headSha: "sha-head", conclusion: "success", workflowDatabaseId: 3 },
+      { databaseId: 100, headSha: "sha-head", conclusion: "failure", workflowDatabaseId: 3 },
+    ];
+    expect(selectRunId(rerun, "sha-head", "failing")).toBeNull();
+  });
+
+  it("names a workflow's own failure even when another workflow re-ran green", () => {
+    const mixed = [
+      { databaseId: 200, headSha: "sha-head", conclusion: "success", workflowDatabaseId: 3 },
+      { databaseId: 150, headSha: "sha-head", conclusion: "failure", workflowDatabaseId: 4 },
+      { databaseId: 100, headSha: "sha-head", conclusion: "failure", workflowDatabaseId: 3 },
+    ];
+    expect(selectRunId(mixed, "sha-head", "failing")).toBe("150");
+  });
 
   it("tolerates entries gh could not shape", () => {
     expect(
@@ -821,11 +854,11 @@ describe("probePr (gh schema integration)", () => {
     expect(result.probe.runId).toBeNull();
   });
 
-  it("stays green when the only non-passing checks are skipped and cancelled", () => {
+  it("stays green when the only non-passing checks are skipped", () => {
     const checksJson = JSON.stringify([
       { state: "SUCCESS", bucket: "pass", name: "build" },
       { state: "SKIPPED", bucket: "skipping", name: "claude" },
-      { state: "CANCELLED", bucket: "cancel", name: "automerge" },
+      { state: "SKIPPED", bucket: "skipping", name: "automerge" },
     ]);
     const runsJson = JSON.stringify([
       { databaseId: 33220884467, headSha: "abc123", conclusion: "skipped" },
@@ -854,7 +887,7 @@ describe("probePr (gh schema integration)", () => {
     };
     probePr(42, "owner/repo", recordingExec);
     const runsCall = seen.find((c) => c.startsWith("gh run list"));
-    expect(runsCall).toContain("--json databaseId,headSha,conclusion");
+    expect(runsCall).toContain("--json databaseId,headSha,conclusion,workflowDatabaseId");
     expect(runsCall).toContain("--commit abc123");
   });
 

--- a/plugins/github/skills/actions-monitor/scripts/watch.test.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, test } from "bun:test";
 import {
+  AttributionRun,
   clearApiErrors,
   computeInterval,
   deriveChecksState,
@@ -539,9 +540,9 @@ describe("selectRunId", () => {
     workflowDatabaseId: number,
     createdAt = "2026-08-28T00:00:00Z",
     headSha = "sha-head",
-  ) => ({ databaseId, headSha, conclusion, workflowDatabaseId, createdAt });
+  ) => AttributionRun.parse({ databaseId, headSha, conclusion, workflowDatabaseId, createdAt });
 
-  test.each<[string, unknown[], string | null]>([
+  test.each<[string, AttributionRun[], string | null]>([
     [
       "picks the failed run past skipped and cancelled ones",
       [run(1, "skipped", 10), run(2, "cancelled", 20), run(3, "failure", 30)],
@@ -568,9 +569,8 @@ describe("selectRunId", () => {
       null,
     ],
     ["runs from another commit", [run(1, "failure", 10, undefined, "sha-other")], null],
-    ["entries gh could not shape", [null, "x", {}, run(1, "failure", 10)], "1"],
   ])("%s -> %p", (_name, runs, expected) => {
-    expect(selectRunId(runs, "sha-head")).toBe(expected as string);
+    expect(selectRunId(runs, "sha-head")).toBe(expected);
   });
 });
 
@@ -874,6 +874,18 @@ describe("probePr (gh schema integration)", () => {
     const result = probePr(42, "owner/repo", exec);
     expect(result.kind).toBe("ok");
     expect(remaining()).toEqual([]);
+  });
+
+  it("returns kind=error when gh run list emits an entry that is not a run", () => {
+    const { exec } = makeExec([
+      { match: "gh pr view", result: ok(prJson) },
+      {
+        match: "gh pr checks",
+        result: ok(JSON.stringify([{ state: "FAILURE", bucket: "fail", name: "x" }])),
+      },
+      { match: "gh run list", result: ok(JSON.stringify([null, "x"])) },
+    ]);
+    expect(probePr(42, "owner/repo", exec).kind).toBe("error");
   });
 
   it("returns kind=error when gh run list emits unparseable JSON", () => {

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -375,6 +375,10 @@ export async function resolveMergeable(
 const isQueuedState = (s: string): boolean =>
   s === "QUEUED" || s === "PENDING" || s === "WAITING" || s === "REQUESTED" || s === "EXPECTED";
 
+// A skipped or cancelled check reports no verdict on the PR: it neither fails
+// the target nor stands in for a check that passed.
+const NEUTRAL_BUCKETS = new Set(["cancel", "skipping"]);
+
 // `gh pr checks --json` exposes a unified `state` (status when in-flight,
 // conclusion when complete) and a normalized `bucket` ("pass" | "fail" |
 // "cancel" | "pending" | "skipping"). It does NOT expose `conclusion`. Use
@@ -384,18 +388,60 @@ export function deriveChecksState(checks: Check[]): InternalState {
   if (checks.length === 0) {
     return "running";
   }
-  const buckets = checks.map((c) => (c.bucket ?? "").toLowerCase());
-  if (buckets.some((b) => b === "fail" || b === "cancel")) {
+  const decisive = checks.filter((c) => !NEUTRAL_BUCKETS.has((c.bucket ?? "").toLowerCase()));
+  if (decisive.length === 0) {
+    return "success";
+  }
+  const buckets = decisive.map((c) => (c.bucket ?? "").toLowerCase());
+  if (buckets.some((b) => b === "fail")) {
     return "failing";
   }
-  const states = checks.map((c) => (c.state ?? "").toUpperCase());
+  const states = decisive.map((c) => (c.state ?? "").toUpperCase());
   if (states.some((s) => s === "IN_PROGRESS")) return "running";
   const anyQueued = states.some(isQueuedState);
   const allQueued = states.every(isQueuedState);
   if (allQueued && anyQueued) return "queued";
   if (anyQueued) return "running";
-  if (buckets.every((b) => b === "pass" || b === "skipping")) return "success";
+  if (buckets.every((b) => b === "pass")) return "success";
   return "running";
+}
+
+// Headroom over the runs one commit can trigger, counting re-runs.
+const RUN_LOOKUP_LIMIT = 50;
+
+// Conclusions worth pulling logs for. `cancelled` and `skipped` are excluded:
+// neither leaves failing job output behind.
+const FAILED_CONCLUSIONS = new Set(["failure", "timed_out", "startup_failure", "action_required"]);
+
+type RunListEntry = { databaseId: string | null; headSha: string; conclusion: string };
+
+function parseRunListEntry(value: unknown): RunListEntry | null {
+  if (!value || typeof value !== "object") return null;
+  const entry = value as Record<string, unknown>;
+  const id =
+    typeof entry.databaseId === "number"
+      ? String(entry.databaseId)
+      : typeof entry.databaseId === "string" && entry.databaseId.length > 0
+        ? entry.databaseId
+        : null;
+  return {
+    databaseId: id,
+    headSha: typeof entry.headSha === "string" ? entry.headSha : "",
+    conclusion: typeof entry.conclusion === "string" ? entry.conclusion.toLowerCase() : "",
+  };
+}
+
+// `github:logs` fetches whatever run a failing event names, so a failing event
+// must name a run that actually failed. A PR can also fail on a check that is
+// no Actions run at all (an external reviewer, a hosted status), which leaves
+// nothing to fetch and so no run id.
+export function selectRunId(runs: unknown[], sha: string, state: InternalState): string | null {
+  const forSha = runs
+    .map(parseRunListEntry)
+    .filter((r): r is RunListEntry => r !== null && r.headSha === sha);
+  const match =
+    state === "failing" ? forSha.find((r) => FAILED_CONCLUSIONS.has(r.conclusion)) : forSha[0];
+  return match ? match.databaseId : null;
 }
 
 export function deriveRunListState(run: { status?: string; conclusion?: string }): InternalState {
@@ -474,18 +520,31 @@ export function probePr(prNumber: number, repo: string, run: ExecFn = exec): Pro
     return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
 
-  const runIdResult = run(
-    `gh run list --repo ${repo} --branch ${branch} --limit 1 --json databaseId --jq '.[0].databaseId // ""'`,
+  const runsResult = run(
+    `gh run list --repo ${repo} --commit ${sha} --limit ${RUN_LOOKUP_LIMIT} --json databaseId,headSha,conclusion`,
   );
-  if (!runIdResult.ok) {
+  if (!runsResult.ok) {
     return {
       kind: "error",
-      rateLimited: runIdResult.rateLimited,
-      retryAfter: runIdResult.retryAfter,
-      stderr: runIdResult.stderr,
+      rateLimited: runsResult.rateLimited,
+      retryAfter: runsResult.retryAfter,
+      stderr: runsResult.stderr,
     };
   }
-  const runId = runIdResult.stdout !== "" ? runIdResult.stdout : null;
+  let runId: string | null;
+  try {
+    const parsed = JSON.parse(runsResult.stdout || "[]");
+    if (!Array.isArray(parsed)) {
+      const message = `gh run list returned non-array JSON for ${repo}@${sha}`;
+      console.error(`${message}; treating as probe failure`);
+      return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
+    }
+    runId = selectRunId(parsed, sha, state);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`gh run list returned unparseable JSON for ${repo}@${sha}: ${message}`);
+    return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
+  }
 
   return {
     kind: "ok",

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -411,18 +411,20 @@ export function deriveChecksState(checks: Check[]): InternalState {
 // Headroom over the runs one commit can trigger, counting re-runs.
 const RUN_LOOKUP_LIMIT = 50;
 
-// Conclusions worth pulling logs for. `cancelled` and `skipped` are excluded:
-// neither leaves failing job output behind.
-const FAILED_CONCLUSIONS = new Set(["failure", "timed_out", "startup_failure", "action_required"]);
+// Conclusions that leave failing job output behind. A run that was cancelled,
+// skipped, blocked on approval, or that never started has no logs to fetch, so
+// naming it costs a dispatch that finds nothing.
+const FAILED_CONCLUSIONS = new Set(["failure", "timed_out"]);
 
 type RunListEntry = {
   databaseId: string | null;
   headSha: string;
   conclusion: string;
   workflow: string;
+  createdAt: string;
 };
 
-function id(value: unknown): string | null {
+function runIdFrom(value: unknown): string | null {
   if (typeof value === "number") return String(value);
   if (typeof value === "string" && value.length > 0) return value;
   return null;
@@ -432,10 +434,11 @@ function parseRunListEntry(value: unknown): RunListEntry | null {
   if (!value || typeof value !== "object") return null;
   const entry = value as Record<string, unknown>;
   return {
-    databaseId: id(entry.databaseId),
+    databaseId: runIdFrom(entry.databaseId),
     headSha: typeof entry.headSha === "string" ? entry.headSha : "",
     conclusion: typeof entry.conclusion === "string" ? entry.conclusion.toLowerCase() : "",
-    workflow: id(entry.workflowDatabaseId) ?? "",
+    workflow: runIdFrom(entry.workflowDatabaseId) ?? "",
+    createdAt: typeof entry.createdAt === "string" ? entry.createdAt : "",
   };
 }
 
@@ -444,21 +447,21 @@ function parseRunListEntry(value: unknown): RunListEntry | null {
 // no Actions run at all (an external reviewer, a hosted status), which leaves
 // nothing to fetch and so no run id.
 //
-// gh lists runs newest first, so the first run of a workflow is that workflow's
-// current state for the commit. Collapsing to it keeps a failure that a later
-// run of the same workflow has already replaced from being reported again.
-export function selectRunId(runs: unknown[], sha: string, state: InternalState): string | null {
-  const current = new Map<string, RunListEntry>();
+// Collapsing each workflow to its newest run for the commit keeps a failure a
+// later run of the same workflow has already replaced from being named again.
+// The caller scopes the query by commit; the `headSha` filter is
+// belt-and-suspenders over that.
+export function selectRunId(runs: unknown[], sha: string): string | null {
+  const newestPerWorkflow = new Map<string, RunListEntry>();
   for (const value of runs) {
     const entry = parseRunListEntry(value);
     if (!entry || entry.headSha !== sha) continue;
     const key = entry.workflow || `run:${entry.databaseId}`;
-    if (!current.has(key)) current.set(key, entry);
+    const seen = newestPerWorkflow.get(key);
+    if (!seen || entry.createdAt > seen.createdAt) newestPerWorkflow.set(key, entry);
   }
-  const latest = [...current.values()];
-  const match =
-    state === "failing" ? latest.find((r) => FAILED_CONCLUSIONS.has(r.conclusion)) : latest[0];
-  return match ? match.databaseId : null;
+  const failed = [...newestPerWorkflow.values()].find((r) => FAILED_CONCLUSIONS.has(r.conclusion));
+  return failed ? failed.databaseId : null;
 }
 
 export function deriveRunListState(run: { status?: string; conclusion?: string }): InternalState {
@@ -514,6 +517,11 @@ export function probePr(prNumber: number, repo: string, run: ExecFn = exec): Pro
     console.error(`${message}; treating as probe failure`);
     return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
+  if (!sha) {
+    const message = `gh pr view did not include headRefOid for PR #${prNumber}`;
+    console.error(`${message}; treating as probe failure`);
+    return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
+  }
 
   const checksResult = run(
     `gh pr checks ${prNumber} --repo ${repo} --required=false --json state,bucket,name`,
@@ -537,30 +545,34 @@ export function probePr(prNumber: number, repo: string, run: ExecFn = exec): Pro
     return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
 
-  const runsResult = run(
-    `gh run list --repo ${repo} --commit ${sha} --limit ${RUN_LOOKUP_LIMIT} --json databaseId,headSha,conclusion,workflowDatabaseId`,
-  );
-  if (!runsResult.ok) {
-    return {
-      kind: "error",
-      rateLimited: runsResult.rateLimited,
-      retryAfter: runsResult.retryAfter,
-      stderr: runsResult.stderr,
-    };
-  }
-  let runId: string | null;
-  try {
-    const parsed = JSON.parse(runsResult.stdout || "[]");
-    if (!Array.isArray(parsed)) {
-      const message = `gh run list returned non-array JSON for ${repo}@${sha}`;
-      console.error(`${message}; treating as probe failure`);
+  // Only a failing event carries the run id anywhere, so a green or in-flight
+  // poll skips the lookup rather than spending an API call on it every cycle.
+  let runId: string | null = null;
+  if (state === "failing") {
+    const runsResult = run(
+      `gh run list --repo ${repo} --commit ${sha} --limit ${RUN_LOOKUP_LIMIT} --json databaseId,headSha,conclusion,workflowDatabaseId,createdAt`,
+    );
+    if (!runsResult.ok) {
+      return {
+        kind: "error",
+        rateLimited: runsResult.rateLimited,
+        retryAfter: runsResult.retryAfter,
+        stderr: runsResult.stderr,
+      };
+    }
+    try {
+      const parsed = JSON.parse(runsResult.stdout || "[]");
+      if (!Array.isArray(parsed)) {
+        const message = `gh run list returned non-array JSON for ${repo}@${sha}`;
+        console.error(`${message}; treating as probe failure`);
+        return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
+      }
+      runId = selectRunId(parsed, sha);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`gh run list returned unparseable JSON for ${repo}@${sha}: ${message}`);
       return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
     }
-    runId = selectRunId(parsed, sha, state);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error(`gh run list returned unparseable JSON for ${repo}@${sha}: ${message}`);
-    return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
 
   return {

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -375,9 +375,11 @@ export async function resolveMergeable(
 const isQueuedState = (s: string): boolean =>
   s === "QUEUED" || s === "PENDING" || s === "WAITING" || s === "REQUESTED" || s === "EXPECTED";
 
-// A skipped or cancelled check reports no verdict on the PR: it neither fails
-// the target nor stands in for a check that passed.
-const NEUTRAL_BUCKETS = new Set(["cancel", "skipping"]);
+// GitHub counts a skipped required check as passing, so a skip is settled and
+// says nothing about the PR either way. A cancelled check is a verdict the PR
+// never got: it does not fail the target, but it cannot stand in for a check
+// that passed, so it holds the PR at running until something re-runs it.
+const SKIPPED_BUCKET = "skipping";
 
 // `gh pr checks --json` exposes a unified `state` (status when in-flight,
 // conclusion when complete) and a normalized `bucket` ("pass" | "fail" |
@@ -388,7 +390,7 @@ export function deriveChecksState(checks: Check[]): InternalState {
   if (checks.length === 0) {
     return "running";
   }
-  const decisive = checks.filter((c) => !NEUTRAL_BUCKETS.has((c.bucket ?? "").toLowerCase()));
+  const decisive = checks.filter((c) => (c.bucket ?? "").toLowerCase() !== SKIPPED_BUCKET);
   if (decisive.length === 0) {
     return "success";
   }
@@ -413,21 +415,27 @@ const RUN_LOOKUP_LIMIT = 50;
 // neither leaves failing job output behind.
 const FAILED_CONCLUSIONS = new Set(["failure", "timed_out", "startup_failure", "action_required"]);
 
-type RunListEntry = { databaseId: string | null; headSha: string; conclusion: string };
+type RunListEntry = {
+  databaseId: string | null;
+  headSha: string;
+  conclusion: string;
+  workflow: string;
+};
+
+function id(value: unknown): string | null {
+  if (typeof value === "number") return String(value);
+  if (typeof value === "string" && value.length > 0) return value;
+  return null;
+}
 
 function parseRunListEntry(value: unknown): RunListEntry | null {
   if (!value || typeof value !== "object") return null;
   const entry = value as Record<string, unknown>;
-  const id =
-    typeof entry.databaseId === "number"
-      ? String(entry.databaseId)
-      : typeof entry.databaseId === "string" && entry.databaseId.length > 0
-        ? entry.databaseId
-        : null;
   return {
-    databaseId: id,
+    databaseId: id(entry.databaseId),
     headSha: typeof entry.headSha === "string" ? entry.headSha : "",
     conclusion: typeof entry.conclusion === "string" ? entry.conclusion.toLowerCase() : "",
+    workflow: id(entry.workflowDatabaseId) ?? "",
   };
 }
 
@@ -435,12 +443,21 @@ function parseRunListEntry(value: unknown): RunListEntry | null {
 // must name a run that actually failed. A PR can also fail on a check that is
 // no Actions run at all (an external reviewer, a hosted status), which leaves
 // nothing to fetch and so no run id.
+//
+// gh lists runs newest first, so the first run of a workflow is that workflow's
+// current state for the commit. Collapsing to it keeps a failure that a later
+// run of the same workflow has already replaced from being reported again.
 export function selectRunId(runs: unknown[], sha: string, state: InternalState): string | null {
-  const forSha = runs
-    .map(parseRunListEntry)
-    .filter((r): r is RunListEntry => r !== null && r.headSha === sha);
+  const current = new Map<string, RunListEntry>();
+  for (const value of runs) {
+    const entry = parseRunListEntry(value);
+    if (!entry || entry.headSha !== sha) continue;
+    const key = entry.workflow || `run:${entry.databaseId}`;
+    if (!current.has(key)) current.set(key, entry);
+  }
+  const latest = [...current.values()];
   const match =
-    state === "failing" ? forSha.find((r) => FAILED_CONCLUSIONS.has(r.conclusion)) : forSha[0];
+    state === "failing" ? latest.find((r) => FAILED_CONCLUSIONS.has(r.conclusion)) : latest[0];
   return match ? match.databaseId : null;
 }
 
@@ -521,7 +538,7 @@ export function probePr(prNumber: number, repo: string, run: ExecFn = exec): Pro
   }
 
   const runsResult = run(
-    `gh run list --repo ${repo} --commit ${sha} --limit ${RUN_LOOKUP_LIMIT} --json databaseId,headSha,conclusion`,
+    `gh run list --repo ${repo} --commit ${sha} --limit ${RUN_LOOKUP_LIMIT} --json databaseId,headSha,conclusion,workflowDatabaseId`,
   );
   if (!runsResult.ok) {
     return {

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -416,31 +416,22 @@ const RUN_LOOKUP_LIMIT = 50;
 // naming it costs a dispatch that finds nothing.
 const FAILED_CONCLUSIONS = new Set(["failure", "timed_out"]);
 
-type RunListEntry = {
-  databaseId: string | null;
-  headSha: string;
-  conclusion: string;
-  workflow: string;
-  createdAt: string;
-};
+// `gh run list` reports an id as a number, but the event schema carries it as a
+// string.
+const RunId = z
+  .union([z.number(), z.string()])
+  .transform(String)
+  .catch("") satisfies z.ZodType<string>;
 
-function runIdFrom(value: unknown): string | null {
-  if (typeof value === "number") return String(value);
-  if (typeof value === "string" && value.length > 0) return value;
-  return null;
-}
-
-function parseRunListEntry(value: unknown): RunListEntry | null {
-  if (!value || typeof value !== "object") return null;
-  const entry = value as Record<string, unknown>;
-  return {
-    databaseId: runIdFrom(entry.databaseId),
-    headSha: typeof entry.headSha === "string" ? entry.headSha : "",
-    conclusion: typeof entry.conclusion === "string" ? entry.conclusion.toLowerCase() : "",
-    workflow: runIdFrom(entry.workflowDatabaseId) ?? "",
-    createdAt: typeof entry.createdAt === "string" ? entry.createdAt : "",
-  };
-}
+export const AttributionRun = z.looseObject({
+  databaseId: RunId,
+  headSha: z.string().catch(""),
+  conclusion: z.string().catch(""),
+  workflowDatabaseId: RunId,
+  createdAt: z.string().catch(""),
+});
+export type AttributionRun = z.infer<typeof AttributionRun>;
+const AttributionRuns = z.array(AttributionRun);
 
 // `github:logs` fetches whatever run a failing event names, so a failing event
 // must name a run that actually failed. A PR can also fail on a check that is
@@ -451,17 +442,19 @@ function parseRunListEntry(value: unknown): RunListEntry | null {
 // later run of the same workflow has already replaced from being named again.
 // The caller scopes the query by commit; the `headSha` filter is
 // belt-and-suspenders over that.
-export function selectRunId(runs: unknown[], sha: string): string | null {
-  const newestPerWorkflow = new Map<string, RunListEntry>();
-  for (const value of runs) {
-    const entry = parseRunListEntry(value);
-    if (!entry || entry.headSha !== sha) continue;
-    const key = entry.workflow || `run:${entry.databaseId}`;
+export function selectRunId(runs: AttributionRun[], sha: string): string | null {
+  const newestPerWorkflow = new Map<string, AttributionRun>();
+  for (const entry of runs) {
+    if (entry.headSha !== sha) continue;
+    const key =
+      entry.workflowDatabaseId !== "" ? entry.workflowDatabaseId : `run:${entry.databaseId}`;
     const seen = newestPerWorkflow.get(key);
     if (!seen || entry.createdAt > seen.createdAt) newestPerWorkflow.set(key, entry);
   }
-  const failed = [...newestPerWorkflow.values()].find((r) => FAILED_CONCLUSIONS.has(r.conclusion));
-  return failed ? failed.databaseId : null;
+  const failed = [...newestPerWorkflow.values()].find((r) =>
+    FAILED_CONCLUSIONS.has(r.conclusion.toLowerCase()),
+  );
+  return failed && failed.databaseId !== "" ? failed.databaseId : null;
 }
 
 export function deriveRunListState(run: { status?: string; conclusion?: string }): InternalState {
@@ -517,7 +510,7 @@ export function probePr(prNumber: number, repo: string, run: ExecFn = exec): Pro
     console.error(`${message}; treating as probe failure`);
     return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
-  if (!sha) {
+  if (sha === "") {
     const message = `gh pr view did not include headRefOid for PR #${prNumber}`;
     console.error(`${message}; treating as probe failure`);
     return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
@@ -545,8 +538,8 @@ export function probePr(prNumber: number, repo: string, run: ExecFn = exec): Pro
     return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
 
-  // Only a failing event carries the run id anywhere, so a green or in-flight
-  // poll skips the lookup rather than spending an API call on it every cycle.
+  // Only a failing event carries a run id, so a green or in-flight poll skips
+  // the lookup and its API call.
   let runId: string | null = null;
   if (state === "failing") {
     const runsResult = run(
@@ -561,16 +554,13 @@ export function probePr(prNumber: number, repo: string, run: ExecFn = exec): Pro
       };
     }
     try {
-      const parsed = JSON.parse(runsResult.stdout || "[]");
-      if (!Array.isArray(parsed)) {
-        const message = `gh run list returned non-array JSON for ${repo}@${sha}`;
-        console.error(`${message}; treating as probe failure`);
-        return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
-      }
-      runId = selectRunId(parsed, sha);
+      const runs = AttributionRuns.parse(
+        JSON.parse(runsResult.stdout !== "" ? runsResult.stdout : "[]"),
+      );
+      runId = selectRunId(runs, sha);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      console.error(`gh run list returned unparseable JSON for ${repo}@${sha}: ${message}`);
+      console.error(`gh run list returned unusable JSON for ${repo}@${sha}: ${message}`);
       return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
     }
   }

--- a/plugins/pull-request/skills/babysit/SKILL.md
+++ b/plugins/pull-request/skills/babysit/SKILL.md
@@ -59,6 +59,8 @@ Compare `git rev-parse HEAD` against the event's `sha`. If HEAD is newer, a fix 
 
 The monitor skill's flow has already invoked the provider's logs agent (`github:logs` or `gitlab:logs`) and produced a summary plus a log-file path. Read the summary to decide triviality.
 
+A failing event carrying no run id has no logs agent behind it: the red check is an external status rather than a CI run. Read the failing check names from the provider's CLI (`gh pr checks`, `glab ci status`), report them, and call `TaskStop`.
+
 Check whether the start SHA's CI run had the same failure. If so, it's pre-existing, not a regression from this branch. Report it and call `TaskStop`.
 
 For trivial failures (lint, type, format, lockfile), attempt a fix. Reproduce the CI step locally to verify (skip reproduction for lockfile-only changes). Commit, push. The watcher picks up the new SHA on its next poll.


### PR DESCRIPTION
The reported symptom was that the watcher counted skipped and cancelled runs as failures. It didn't. Every failing event on #1298 was a real verdict. The bug was in what the event *pointed at*: `probePr` derived state from `gh pr checks`, then took the run id from `gh run list --branch <name> --limit 1`. That is the branch's newest run, related to the failing check only by coincidence, so `github:logs` kept fetching runs with no failing jobs.

`selectRunId` now reads the runs on the failing commit, keeps only conclusions that leave job output behind (`failure`, `timed_out`), and collapses each workflow to its newest run so a failure a re-run replaced is not named again. Replaying 779adfd9 through it yields 33220042315, the real `lint` failure, where the old path yielded the skipped 33220042301.

Only a skipped check is neutral. GitHub counts a skipped required check as passing; branch protection does not accept a cancelled one. Folding cancel into the same bucket exits the watcher green on a PR that cannot merge, so a cancel holds the target at `running` and waits out the wall clock instead.

A failing event can now carry `"run_id": null`, meaning the red check is an external status with no logs to fetch. The monitor skill, `github:logs`, and `babysit` each document that case.

The attribution query decodes through a zod schema, following the convention that landed on main while this branch was open.

`deriveRunListState` is untouched, so branch and run-id mode still map `cancelled` to failing and `skipped` to success. Those watch runs rather than checks, and the event vocabulary has no way to say terminal but inconclusive.
