### PR TITLE
flights: fix paths and partial-render parsing

### DIFF
--- a/user/skills/flights/SKILL.md
+++ b/user/skills/flights/SKILL.md
@@ -11,14 +11,15 @@ allowed-tools:
   - AskUserQuestion
   - Bash(cat ~/.config/claude-flights/*)
   - Bash(agent-browser:*)
-  - Bash(bun:*)
+  - Bash(bun ~/.claude/skills/flights/scripts/:*)
+  - Bash(sleep:*)
+  - Bash(grep:*)
+  - Bash(sed:*)
   - Read
   - Write
 ---
 
 # Flights
-
-Search flights the way I actually decide: fully loaded prices, real departure times, and a shortlist short enough to act on.
 
 Preferences: !`cat ~/.config/claude-flights/config.json 2>/dev/null || echo '{}'`
 
@@ -46,9 +47,11 @@ If that came back `{}`, the config is missing. Run the search on what the reques
 
 `cabin.default` names a search cabin, one of `economy`, `premium`, `business`, or `first`, and passes straight to `--cabin`. Economy Plus is a United seat product rather than a search cabin, so a preference for it belongs in `preferences` and gets read off the results.
 
+The parsers live in `~/.claude/skills/flights/scripts/`. Invoke them by that path. The session's working directory is wherever the request came from.
+
 ## Boundaries
 
-These are absolute. They do not bend because a page makes the next step convenient.
+These do not bend because a page makes the next step convenient.
 
 - Read as far as **fare selection and view-only seat maps**. Stop there.
 - Never enter passenger or payment details. Never click `Purchase`, `Confirm`, `Hold`, or `FareLock`. Never spend miles or money.
@@ -59,18 +62,16 @@ These are absolute. They do not bend because a page makes the next step convenie
 
 ## Intake
 
-Ask before searching only what changes the search, and only what the request and config leave open. One `AskUserQuestion` round, not an interview.
+Ask before searching only what changes the search, and only what the request and config leave open. One `AskUserQuestion` round.
 
 - **Baggage.** A bike changes the airline, the aircraft, and sometimes the airport. Skis and oversized cases do the same. Ask when the trip's purpose suggests gear.
 - **Ground plan at each end.** Whether transit works, or someone is driving, decides how much an inconvenient airport actually costs.
 - **Who is paying**, when the answer changes whether miles are on the table.
 - **Shape**, when the request implies flexibility without pinning it down. Enumerate the shapes to compare rather than guessing one.
 
-Skip the round when the request already answers these.
-
 ## Search
 
-Cheap pass first, expensive pass second.
+Cheap pass first, expensive pass second. Say up front how many queries the plan needs, and if a shape gets dropped for budget, say which and why, so the coverage stated matches the coverage run.
 
 ### Google Flights
 
@@ -78,19 +79,23 @@ Run every shape here. It is fast, needs no login, and gives market context acros
 
 For flexible dates, open the **Date grid** first. It prices a whole window of date pairs in one page load, which answers "is there a better fare a day either side" without a query per date. Use it to pick the shortlist, then price those dates properly.
 
-Where the grid does not reach, a round trip still decomposes: the cheapest round trip equals the cheapest outbound one-way plus the cheapest return one-way, verified to within a dollar. So N departure dates against M return dates costs `N + M` queries, not `N × M`.
+Where the grid does not reach, search the departure dates and the return dates as one-ways, so N departure dates against M return dates costs `N + M` queries rather than `N × M`.
+
+Their sum matched the round trip to within a dollar on the US domestic markets checked, which makes the decomposition a shortlisting tool rather than a quote. Round-trip fares diverge from twice a one-way on many international markets and under some fare rules. Price the pair being recommended as an actual round trip, and report that number.
 
 ### united.com
 
 Run the shortlist only. It is slow and needs a login, but it is the only truth for what United will sell, and the only source for award pricing. Use it on the handful of shapes that survived the Google pass.
 
-See [`references/google-flights.md`](references/google-flights.md) and [`references/united.md`](references/united.md) for the mechanics. Both encode gotchas that cost real debugging time. Read the relevant one before driving that site.
+Award pricing renders only for a signed-in session. `united.ts parse` exits non-zero when a page carries itineraries but no award pricing, which is the signal to check sign-in and re-read the page rather than to report the route as having no space.
 
-Bound the work. Say up front how many queries the plan needs, and if a shape gets dropped for budget, say which and why, so the coverage stated matches the coverage run.
+`united.ts` builds one-way URLs only, so a round-trip cash fare gets confirmed on Google.
+
+See [`references/google-flights.md`](references/google-flights.md) and [`references/united.md`](references/united.md) for the mechanics. Read the relevant one before driving that site.
 
 ## Filters
 
-Hard filters come from `filters.hard`, defaulting to Basic Economy, red-eyes, and two or more stops. The parser marks the first two and drops them on request, so let the tool apply those rather than filtering by eye. The reference gives the flags.
+`filters.hard` lists what to exclude, defaulting to Basic Economy, red-eyes, and itineraries with two or more stops. The parser marks Basic Economy and red-eyes and drops them on request, so let the tool apply those rather than filtering by eye. The reference gives the flags.
 
 Stop count has no flag. Build it into the search instead: omit `--stops` and the URL asks Google for nonstops only. Where connections are wanted, read the stop count off the `Stops` column.
 
@@ -100,7 +105,7 @@ Nearby dates are worth a look. Flag a win within a day of the requested date, bu
 
 ## Pricing
 
-Quote the **fully loaded** price by default: what actually gets paid, seat included, not a headline fare that gets topped up later.
+Quote the **fully loaded** price by default: what actually gets paid, seat included, rather than a headline fare that gets topped up later.
 
 Break the seat out as its own line so the base fare and the upgrade stay separately visible. Some trips split who pays which part.
 
@@ -110,7 +115,7 @@ For cash against miles, compute cents per point:
 cpp = (cash_fare - award_taxes) / miles * 100
 ```
 
-Compare that against `miles.centsPerPointThreshold`, defaulting to 1.5 if unset. Report cash, miles, and cpp for every option regardless of which one wins, and say which the arithmetic favors. A saver award is worth calling out by name, because saver space is scarce and dynamic pricing usually lands well below the threshold.
+Both figures come off the same itinerary, and the cash fare is united.com's, since that is the purchase the miles replace. Compare the result against `miles.centsPerPointThreshold`, defaulting to 1.5 if unset. Report cash, miles, and cpp for every option regardless of which one wins, and say which the arithmetic favors. A saver award is worth calling out by name, because saver space is scarce and dynamic pricing usually lands well below the threshold.
 
 ## Output
 

--- a/user/skills/flights/references/google-flights.md
+++ b/user/skills/flights/references/google-flights.md
@@ -7,8 +7,8 @@ The cheap pass. No login, fast, covers every carrier. Use it to explore shapes a
 Build the URL directly. Never drive the search form. Google Flights encodes an entire search into the `tfs` query parameter, a protobuf message in unpadded base64url. Constructing it directly turns each query into a single page load, where driving the form costs a load plus a settle wait per field.
 
 ```bash
-bun user/skills/flights/scripts/google-flights.ts url LAX ORD 2026-04-15
-bun user/skills/flights/scripts/google-flights.ts url LAX ORD 2026-04-15 2026-04-20 --stops
+bun ~/.claude/skills/flights/scripts/google-flights.ts url LAX ORD 2026-04-15
+bun ~/.claude/skills/flights/scripts/google-flights.ts url LAX ORD 2026-04-15 2026-04-20 --stops
 ```
 
 `tfs()` in `scripts/google-flights.ts` is the encoder. Its field map, recovered by reading the `tfs` Google itself produces and verified byte-for-byte against real search URLs:
@@ -56,8 +56,8 @@ It is an overlay on the results URL, not a page of its own:
 ```bash
 agent-browser --session flights open "<url>" && sleep 9 \
   && agent-browser --session flights find text "Date grid" click && sleep 7 \
-  && agent-browser --session flights snapshot > grid.txt
-bun user/skills/flights/scripts/google-flights.ts grid < grid.txt
+  && agent-browser --session flights snapshot > "$TMPDIR/grid.txt"
+bun ~/.claude/skills/flights/scripts/google-flights.ts grid < "$TMPDIR/grid.txt"
 ```
 
 **Snapshot, not read.** This is the one exception to the read-everywhere rule above. `read` returns the results list underneath and never shows the grid, so the click looks like it silently failed. Take a snapshot instead.
@@ -71,7 +71,9 @@ The two encode dates differently, which `parseGrid()` handles:
 | Round trip | `"$467, cheapest price, Nov 8 to Nov 13"` | the label itself |
 | One-way | `"$234, cheapest price"` | position against the header row |
 
-Google marks two tiers, `cheapest price` and `low price`, and a fourth label `selected` marks the dates currently searched. All four shapes appear in one grid, so a regex that only allows `cheapest price` silently drops a third of the cells.
+Google marks two tiers, `cheapest price` and `low price`, and a third label `selected` marks the dates currently searched. A cell can carry a tier and `selected` together, or neither, so a regex that only allows `cheapest price` silently drops a third of the cells.
+
+Grid labels carry no year. A window opened on a late-December search shows `Jan 3` for a date in the following year, so resolve each cell against the dates the search was built from before turning one back into `YYYY-MM-DD`.
 
 `Scroll left` and `Scroll right` buttons move the window if the useful dates fall outside it.
 
@@ -84,8 +86,8 @@ Use `read`, never `snapshot`. `agent-browser snapshot` flaps between a full tree
 This is the opposite of united.com, where snapshot is required because every interaction needs a ref. The results list needs no clicks once the URL carries the search. The Date grid and the booking page are the two places that do, and both are covered below.
 
 ```bash
-agent-browser --session flights open "<url>" && sleep 8 && agent-browser --session flights read > dump.txt
-bun user/skills/flights/scripts/google-flights.ts parse < dump.txt
+agent-browser --session flights open "<url>" && sleep 8 && agent-browser --session flights read > "$TMPDIR/dump.txt"
+bun ~/.claude/skills/flights/scripts/google-flights.ts parse < "$TMPDIR/dump.txt"
 ```
 
 **Run one query per Bash tool call.** Chaining open, sleep, and read inside a single call is correct and preferred. Splitting them across calls, or looping several queries in one call, is what crashes the daemon. After a crash the session resets to `about:blank`.
@@ -121,8 +123,8 @@ The two clicks are the itinerary row, then the fare that opens under it. Both ne
 agent-browser --session flights snapshot | grep -i "button .*\$"
 agent-browser --session flights click "<itinerary ref>" && sleep 4
 agent-browser --session flights click "<fare ref>" && sleep 6
-agent-browser --session flights read > booking-dump.txt
-bun user/skills/flights/scripts/google-flights.ts booking < booking-dump.txt
+agent-browser --session flights read > "$TMPDIR/booking-dump.txt"
+bun ~/.claude/skills/flights/scripts/google-flights.ts booking < "$TMPDIR/booking-dump.txt"
 ```
 
 `parseBooking()` anchors on the `Travel time: ` line and walks outward for times and airports, forward for flight, cabin, and aircraft. The aircraft line repeats the flight code with no separator, as in `Airbus A320UA 817`, so the code gets trimmed off the end.

--- a/user/skills/flights/references/united.md
+++ b/user/skills/flights/references/united.md
@@ -34,12 +34,12 @@ https://www.united.com/en/us/fsr/choose-flights?f=<ORIG>&t=<DEST>&d=<YYYY-MM-DD>
 
 - `f`, `t`, `d` are origin, destination, and `YYYY-MM-DD`.
 - **`at=1` switches the results from dollars to miles.** `at=0` gives cash. This single parameter is the whole award search.
-- `tt=1` is one-way. One-way queries are the right unit here, matching the decomposition described in the skill.
+- `tt=1` is one-way, which is what `united.ts url` builds. Awards price per direction, so one-way is the correct unit for `at=1`. A cash round trip can price differently from two one-ways, and this path will not show that. Confirm a round-trip cash fare on Google.
 - `px` is passenger count.
 
 ```bash
-bun user/skills/flights/scripts/united.ts url SFO EWR 2026-11-11
-bun user/skills/flights/scripts/united.ts url SFO EWR 2026-11-11 --award
+bun ~/.claude/skills/flights/scripts/united.ts url SFO EWR 2026-11-11
+bun ~/.claude/skills/flights/scripts/united.ts url SFO EWR 2026-11-11 --award
 ```
 
 ## The Basic-versus-Standard Trap
@@ -131,7 +131,8 @@ button "Economy Plus® (Extra legroom) From $470 ... select to view fare options
 Extract the departure time from the name rather than trusting row order:
 
 ```bash
-grep -n 'button "Seats for the flight' snap.txt \
+agent-browser --session flights-united --profile Default --headed --idle-timeout 0 snapshot > "$TMPDIR/snap.txt"
+grep -n 'button "Seats for the flight' "$TMPDIR/snap.txt" \
   | sed -E 's/.*at ([0-9:]+ [AP]M) and arrive.*ref=(e[0-9]+).*/\1 \2/'
 ```
 
@@ -152,8 +153,8 @@ Click `Accept cookies` once per profile before anything else. The error message 
 `at=1`, then parse the page text:
 
 ```bash
-bun user/skills/flights/scripts/united.ts parse < award-dump.txt
-bun user/skills/flights/scripts/united.ts parse --json < award-dump.txt
+bun ~/.claude/skills/flights/scripts/united.ts parse < "$TMPDIR/award-dump.txt"
+bun ~/.claude/skills/flights/scripts/united.ts parse --json < "$TMPDIR/award-dump.txt"
 ```
 
 - Prices show a cardmember discount as `Was` / `Now`. The `Now` figure is what gets charged.

--- a/user/skills/flights/scripts/booking.ts
+++ b/user/skills/flights/scripts/booking.ts
@@ -1,3 +1,5 @@
+import { AMOUNT, amount, present } from "./page-text";
+
 // Google Flights' booking page carries what the results list omits: flight
 // numbers, aircraft, on-time reputation, legroom, and the full fare ladder.
 // Reaching it costs two clicks, so the skill only opens it for shortlisted
@@ -34,22 +36,12 @@ export interface Booking {
 const TRAVEL_TIME = "Travel time: ";
 const IATA_SUFFIX = /\(([A-Z]{3})\)\s*$/;
 const FLIGHT = /^(.+?)\s+([A-Z0-9]{2}\s?\d{1,4})$/;
-// The leading digit is required. A comma-only match survives `replaceAll` as an
-// empty string, and `Number("")` is 0, which renders as a real $0 fare.
-const PRICE = /^\$(\d[\d,]*)$/;
+const PRICE = new RegExp(String.raw`^\$(${AMOUNT})$`);
 const BULLET = /^-\s*(.+)$/;
 const LEGROOM = /legroom/i;
 
-// A field the page did not supply arrives as undefined when the line is missing
-// and as an empty string when the line is there but blank. Both mean absent.
-function present(value: string | null | undefined): value is string {
-  return value != null && value !== "";
-}
-
 function money(value: string | undefined): number | null {
-  if (!present(value)) return null;
-  const digits = PRICE.exec(value.trim())?.[1];
-  return present(digits) ? Number(digits.replaceAll(",", "")) : null;
+  return present(value) ? amount(PRICE.exec(value.trim())?.[1]) : null;
 }
 
 function airport(line: string | undefined): string | null {

--- a/user/skills/flights/scripts/google-flights.ts
+++ b/user/skills/flights/scripts/google-flights.ts
@@ -4,6 +4,7 @@ import { cli, command } from "cleye";
 import { table } from "table";
 
 import { parseBooking } from "./booking";
+import { AMOUNT, amount, present } from "./page-text";
 
 // Google Flights encodes an entire search into the `tfs` query parameter: a
 // protobuf message, base64url-encoded without padding. Building it directly
@@ -167,6 +168,7 @@ const STOPS_VIA = /\d+ stops? in ([A-Z]{3}(?:, [A-Z]{3})*)/;
  * with no separator: "AlaskaOperated by Alaska as Hawaiian Airlines".
  */
 const OPERATED_BY = /Operated by.*$/s;
+const PRICE = new RegExp(String.raw`\$(${AMOUNT})`);
 
 function minutesOfDay(time: string): number {
   const match = /(\d+):(\d+)/.exec(time);
@@ -174,12 +176,6 @@ function minutesOfDay(time: string): number {
   const hour = Number(match[1]) % 12;
   const pm = time.toUpperCase().includes("PM");
   return (hour + (pm ? 12 : 0)) * 60 + Number(match[2]);
-}
-
-// A field the page did not supply arrives as undefined when the capture group
-// went unmatched and as an empty string when it matched nothing. Both mean absent.
-function present(value: string | null | undefined): value is string {
-  return value != null && value !== "";
 }
 
 export function parseResults(text: string): Row[] {
@@ -220,8 +216,7 @@ export function parseResults(text: string): Row[] {
     const end = match.index + whole.length;
     const nextBlock = blocks[position + 1]?.index ?? normalized.length;
     const tail = normalized.slice(end, Math.min(end + TAIL, nextBlock));
-    // Requiring a leading digit keeps a half-rendered "$," from parsing as $0.
-    const price = /\$(\d[\d,]*)/.exec(tail)?.[1];
+    const price = amount(PRICE.exec(tail)?.[1]);
     const stops = STOPS.exec(tail);
     const via = STOPS_VIA.exec(tail);
 
@@ -234,7 +229,7 @@ export function parseResults(text: string): Row[] {
       duration,
       stops: stops?.[1] ?? "?",
       via: via?.[1]?.split(", ") ?? [],
-      price: present(price) ? Number(price.replaceAll(",", "")) : null,
+      price,
       // Google states the restriction, and that phrasing survives layout changes
       // better than a "N carry-on bag" string does.
       basic: tail.includes("overhead bin access"),
@@ -264,7 +259,7 @@ export interface GridCell {
 }
 
 /** Round-trip cells name both of their dates. One-way cells name neither. */
-const GRID_CELL = /button "\$(\d[\d,]*)((?:, [^",]+)*)"/g;
+const GRID_CELL = new RegExp(String.raw`button "\$(${AMOUNT})((?:, [^",]+)*)"`, "g");
 const GRID_DATE = /StaticText "([A-Z][a-z]{2} \d{1,2})"/g;
 
 /**
@@ -285,7 +280,8 @@ export function parseGrid(text: string): GridCell[] {
   const positional: Array<Pick<GridCell, "price" | "tier">> = [];
 
   for (const match of scope.matchAll(GRID_CELL)) {
-    const price = Number((match[1] ?? "").replaceAll(",", ""));
+    const price = amount(match[1]);
+    if (price === null) continue;
     const rest = match[2] ?? "";
     const tier = rest.includes("cheapest price")
       ? "cheapest"

--- a/user/skills/flights/scripts/page-text.test.ts
+++ b/user/skills/flights/scripts/page-text.test.ts
@@ -28,6 +28,8 @@ describe("AMOUNT", () => {
     ["$1,23", null],
     ["$12,34", null],
     ["$5.", null],
+    // A cents field caught one digit in would otherwise read as $249.90.
+    ["$249.9", null],
     ["$", null],
     ["$,", null],
   ];

--- a/user/skills/flights/scripts/page-text.test.ts
+++ b/user/skills/flights/scripts/page-text.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+
+import { AMOUNT, amount } from "./page-text";
+
+// A page read mid-render hands the parsers a half-written number. The risk is
+// not a parse failure but a plausible one: `$1,` losing its separator and
+// arriving downstream as a real $1 fare.
+
+const ANYWHERE = new RegExp(String.raw`\$(${AMOUNT})`);
+
+function price(text: string): number | null {
+  return amount(ANYWHERE.exec(text)?.[1]);
+}
+
+describe("AMOUNT", () => {
+  const CASES: Array<[string, number | null]> = [
+    ["$5", 5],
+    ["$234", 234],
+    ["$1,234", 1234],
+    ["$1,234,567", 1234567],
+    // United writes taxes with cents and miles with a fractional thousand.
+    ["$5.60", 5.6],
+    // Ungrouped four-digit amounts appear where the page omits the separator.
+    ["$22500", 22500],
+    // Truncated mid-format. Each of these parsed as a real fare before.
+    ["$1,", null],
+    ["$1,2", null],
+    ["$1,23", null],
+    ["$12,34", null],
+    ["$5.", null],
+    ["$", null],
+    ["$,", null],
+  ];
+
+  test.each(CASES)("%s parses as %p", (text, expected) => {
+    expect(price(text)).toBe(expected);
+  });
+
+  test("a comma opening a list item ends the amount rather than voiding it", () => {
+    // Grid cells carry their tier and dates in the same accessible name, so the
+    // separator that follows a legitimate price is a comma and a space.
+    expect(price('button "$234, cheapest price, Nov 8 to Nov 13"')).toBe(234);
+    expect(price('button "$1,234, cheapest price"')).toBe(1234);
+  });
+});
+
+describe("amount", () => {
+  test("absent input stays absent rather than becoming zero", () => {
+    // `Number("")` is 0, which is what made an unparsed price read as a real one.
+    expect(amount(undefined)).toBeNull();
+    expect(amount(null)).toBeNull();
+    expect(amount("")).toBeNull();
+  });
+});

--- a/user/skills/flights/scripts/page-text.ts
+++ b/user/skills/flights/scripts/page-text.ts
@@ -7,23 +7,34 @@ export function present(value: string | null | undefined): value is string {
   return value != null && value !== "";
 }
 
+/** Whole part of a formatted number: thousands-grouped, or plain when ungrouped. */
+const DIGITS = String.raw`(?:\d{1,3}(?:,\d{3})+|\d+)`;
+
 /**
- * Source fragment matching a formatted amount: thousands-grouped or plain
- * digits, with an optional decimal tail.
+ * Refuses to end a number on a half-written separator.
  *
- * The trailing lookaheads are the point of it. A capture taken mid-render holds
- * amounts like `$1,` or `$1,2`, which a looser `\d[\d,]*` accepts and
- * `replaceAll(",", "")` then turns into a real $1 or $12. Requiring every group
- * after a separator to be whole makes a half-written amount fail to parse
- * instead of arriving downstream as a plausible price.
+ * This is what keeps a capture taken mid-render from parsing. A looser
+ * `\d[\d,]*` accepts the `$1,` or `$1,2` of a `$1,234` still being written, and
+ * `replaceAll(",", "")` turns either into a real $1 or $12. Requiring every
+ * group after a separator to be whole makes those fail instead.
  *
  * A comma that opens a list item rather than a thousands group is followed by a
  * space, as in an accessible name like `$234, cheapest price`, so that one ends
- * the amount instead of rejecting it. The guard reaches partly written
+ * the number instead of rejecting it. The guard reaches partly written
  * separators only. Nothing distinguishes a page that has rendered `$1` of
  * `$1,234` from a genuine `$1`.
  */
-export const AMOUNT = String.raw`(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?(?![\d.])(?!,(?! ))`;
+const WHOLE = String.raw`(?![\d.])(?!,(?! ))`;
+
+/**
+ * A money amount: whole units, or exactly the two decimal places these pages
+ * use for cents. Allowing a shorter tail would read the `$249.9` of a
+ * half-written `$249.99` as $249.90.
+ */
+export const AMOUNT = `${DIGITS}(?:\\.\\d{2})?${WHOLE}`;
+
+/** United's abbreviated mileage, as in `22.5k`. The `k` itself sits outside this. */
+export const THOUSANDS = `${DIGITS}(?:\\.\\d{1,2})?${WHOLE}`;
 
 /** Converts digits captured by {@link AMOUNT}. */
 export function amount(digits: string | null | undefined): number | null {

--- a/user/skills/flights/scripts/page-text.ts
+++ b/user/skills/flights/scripts/page-text.ts
@@ -1,0 +1,33 @@
+// Primitives shared by the three parsers. Every value they read comes out of a
+// live page capture, so each one has to survive a page caught mid-render.
+
+// A field the page did not supply arrives as undefined when the capture group
+// went unmatched and as an empty string when it matched nothing. Both mean absent.
+export function present(value: string | null | undefined): value is string {
+  return value != null && value !== "";
+}
+
+/**
+ * Source fragment matching a formatted amount: thousands-grouped or plain
+ * digits, with an optional decimal tail.
+ *
+ * The trailing lookaheads are the point of it. A capture taken mid-render holds
+ * amounts like `$1,` or `$1,2`, which a looser `\d[\d,]*` accepts and
+ * `replaceAll(",", "")` then turns into a real $1 or $12. Requiring every group
+ * after a separator to be whole makes a half-written amount fail to parse
+ * instead of arriving downstream as a plausible price.
+ *
+ * A comma that opens a list item rather than a thousands group is followed by a
+ * space, as in an accessible name like `$234, cheapest price`, so that one ends
+ * the amount instead of rejecting it. The guard reaches partly written
+ * separators only. Nothing distinguishes a page that has rendered `$1` of
+ * `$1,234` from a genuine `$1`.
+ */
+export const AMOUNT = String.raw`(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?(?![\d.])(?!,(?! ))`;
+
+/** Converts digits captured by {@link AMOUNT}. */
+export function amount(digits: string | null | undefined): number | null {
+  if (!present(digits)) return null;
+  const value = Number(digits.replaceAll(",", ""));
+  return Number.isFinite(value) ? value : null;
+}

--- a/user/skills/flights/scripts/united.test.ts
+++ b/user/skills/flights/scripts/united.test.ts
@@ -194,6 +194,15 @@ describe("parseAwardResults", () => {
   test("skips a block with no itinerary", () => {
     expect(parseAwardResults("NONSTOP\nsome unrelated text\n")).toEqual([]);
   });
+
+  // The CLI reports a sold-out route and a page that stopped short of its
+  // pricing differently, and this is the difference it reads. A sold-out cabin
+  // still renders its label, so it survives as a fare marked unavailable. An
+  // itinerary whose pricing never rendered carries no fare at all.
+  test("distinguishes a sold-out cabin from pricing that never rendered", () => {
+    expect(parseAwardResults(flight(UNAVAILABLE))[0]?.fares).toMatchObject([{ available: false }]);
+    expect(parseAwardResults(flight(""))[0]?.fares).toEqual([]);
+  });
 });
 
 describe("render", () => {

--- a/user/skills/flights/scripts/united.ts
+++ b/user/skills/flights/scripts/united.ts
@@ -3,7 +3,7 @@
 import { cli, command } from "cleye";
 import { table } from "table";
 
-import { AMOUNT, amount, present } from "./page-text";
+import { AMOUNT, amount, present, THOUSANDS } from "./page-text";
 
 // united.com's award results page is the only source for mileage pricing and
 // fare classes. Its rendered text repeats every value twice, once as the visible
@@ -45,8 +45,8 @@ const ORIGIN = /^([A-Z]{3})Origin /;
 const DESTINATION = /^([A-Z]{3})Destination /;
 const DURATION = /^(.+?)Duration /;
 const FLIGHT = /^([A-Z0-9]{2} \d{1,4})(?: \((.+?)\))?Flight Number /;
-const MILES = new RegExp(String.raw`^(${AMOUNT})k?\s*miles$`, "i");
-const BARE_MILES = new RegExp(String.raw`^(${AMOUNT})k$`, "i");
+const MILES = new RegExp(String.raw`^(${THOUSANDS})k?\s*miles$`, "i");
+const BARE_MILES = new RegExp(String.raw`^(${THOUSANDS})k$`, "i");
 const TAXES = new RegExp(String.raw`^\+?\$(${AMOUNT})$`);
 const AWARD_TYPE = /^((?:Saver|Everyday) Award)$/;
 const FARE_CLASS = /^(United .+ \([A-Z]{1,2}\))$/;
@@ -292,13 +292,22 @@ const parseCmd = command(
       process.exit(1);
     }
     // A sold-out cabin still renders its label and prices itself at zero, so a
-    // genuinely empty award map arrives as fares marked unavailable. Itineraries
-    // carrying no fare block at all mean pricing had not rendered yet, which
-    // must not be reported as "no saver space" on a successful exit.
-    if (flights.every((flight) => flight.fares.length === 0)) {
+    // genuinely empty award map arrives as fares marked unavailable. An
+    // itinerary carrying no fare block at all means its pricing had not
+    // rendered, and reporting that as no award space would be wrong.
+    const unpriced = flights.filter((flight) => flight.fares.length === 0);
+    if (unpriced.length === flights.length) {
       console.error("itineraries parsed, but no award pricing. The page may still be rendering.");
       process.exit(1);
     }
+    // Partial pricing still prints, since the itineraries that did price are
+    // worth reading. What it cannot support is a claim about the whole route.
+    if (unpriced.length > 0) {
+      console.error(
+        `${YELLOW}${unpriced.length} of ${flights.length} itineraries carried no award pricing. Re-read the page before treating this as the whole route.${RESET}`,
+      );
+    }
+
     if (parsed.flags.json) {
       console.log(JSON.stringify(flights, null, 2));
       return;
@@ -308,11 +317,14 @@ const parseCmd = command(
     const saver = flights.filter((flight) =>
       flight.fares.some((fare) => fare.available && fare.awardType?.startsWith("Saver")),
     );
-    console.log(
-      saver.length > 0
-        ? `${GREEN}saver space on ${saver.map((flight) => flight.flight ?? `${flight.departTime} connection`).join(", ")}${RESET}`
-        : `${YELLOW}no saver space. Everything here is dynamically priced.${RESET}`,
-    );
+    if (saver.length > 0) {
+      const named = saver.map((flight) => flight.flight ?? `${flight.departTime} connection`);
+      console.log(`${GREEN}saver space on ${named.join(", ")}${RESET}`);
+    } else if (unpriced.length > 0) {
+      console.log(`${YELLOW}no saver space among the itineraries that priced.${RESET}`);
+    } else {
+      console.log(`${YELLOW}no saver space. Everything here is dynamically priced.${RESET}`);
+    }
   },
 );
 

--- a/user/skills/flights/scripts/united.ts
+++ b/user/skills/flights/scripts/united.ts
@@ -3,6 +3,8 @@
 import { cli, command } from "cleye";
 import { table } from "table";
 
+import { AMOUNT, amount, present } from "./page-text";
+
 // united.com's award results page is the only source for mileage pricing and
 // fare classes. Its rendered text repeats every value twice, once as the visible
 // label and once inside the screen-reader description ("3:00 PMDeparting at
@@ -43,12 +45,9 @@ const ORIGIN = /^([A-Z]{3})Origin /;
 const DESTINATION = /^([A-Z]{3})Destination /;
 const DURATION = /^(.+?)Duration /;
 const FLIGHT = /^([A-Z0-9]{2} \d{1,4})(?: \((.+?)\))?Flight Number /;
-// Each amount has to open on a digit. A punctuation-only match such as "$," or
-// "., " survives `replaceAll` as an empty string, and `Number("")` is 0, which
-// reads downstream as a real price of zero rather than a failed parse.
-const MILES = /^(\d[\d,.]*)k?\s*miles$/i;
-const BARE_MILES = /^(\d[\d,.]*)k$/i;
-const TAXES = /^\+?\$(\d[\d,.]*)$/;
+const MILES = new RegExp(String.raw`^(${AMOUNT})k?\s*miles$`, "i");
+const BARE_MILES = new RegExp(String.raw`^(${AMOUNT})k$`, "i");
+const TAXES = new RegExp(String.raw`^\+?\$(${AMOUNT})$`);
 const AWARD_TYPE = /^((?:Saver|Everyday) Award)$/;
 const FARE_CLASS = /^(United .+ \([A-Z]{1,2}\))$/;
 
@@ -61,17 +60,9 @@ const CABINS = new Set([
   "First",
 ]);
 
-// A field the page did not supply arrives as undefined when the capture group
-// went unmatched and as an empty string when it matched nothing. Both mean absent.
-function present(value: string | null | undefined): value is string {
-  return value != null && value !== "";
-}
-
 function miles(token: string): number | null {
-  const digits = (MILES.exec(token) ?? BARE_MILES.exec(token))?.[1];
-  if (!present(digits)) return null;
-  const value = Number(digits.replaceAll(",", ""));
-  if (Number.isNaN(value)) return null;
+  const value = amount((MILES.exec(token) ?? BARE_MILES.exec(token))?.[1]);
+  if (value === null) return null;
   // "22.5k" is thousands. A bare "22500" is already absolute.
   return /k$/i.test(token.replace(/\s*miles$/i, "")) ? Math.round(value * 1000) : value;
 }
@@ -113,7 +104,7 @@ function parseFares(lines: string[]): AwardFare[] {
       // With a discount the page lists the old price first, then the new one.
       miles: available ? (discounted ? (amounts[1] ?? null) : (amounts[0] ?? null)) : null,
       standardMiles: available && discounted ? (amounts[0] ?? null) : null,
-      taxes: available && present(taxes) ? Number(taxes.replaceAll(",", "")) : null,
+      taxes: available ? amount(taxes) : null,
       awardType: firstMatch(scope, AWARD_TYPE),
       fareClass: firstMatch(scope, FARE_CLASS),
       available,
@@ -298,6 +289,14 @@ const parseCmd = command(
     const flights = parseAwardResults(await Bun.stdin.text());
     if (flights.length === 0) {
       console.error("no flights parsed. The page may not have rendered yet.");
+      process.exit(1);
+    }
+    // A sold-out cabin still renders its label and prices itself at zero, so a
+    // genuinely empty award map arrives as fares marked unavailable. Itineraries
+    // carrying no fare block at all mean pricing had not rendered yet, which
+    // must not be reported as "no saver space" on a successful exit.
+    if (flights.every((flight) => flight.fares.length === 0)) {
+      console.error("itineraries parsed, but no award pricing. The page may still be rendering.");
       process.exit(1);
     }
     if (parsed.flags.json) {


### PR DESCRIPTION
Follows up #1299, addressing its open review threads and taking a second pass over the skill.

The skill could not run outside this repository. Both references invoked the parsers as `bun user/skills/flights/scripts/...`, but the skill installs to `~/.claude/skills/flights` and runs from wherever the request came from. They now name the install path, and page dumps go to `$TMPDIR`.

`allowed-tools` is a pre-approval rather than a restriction, and each subcommand of a chained call is matched independently. The reference commands chain `sleep`, `grep`, and `sed`, which were prompting on every browser read.

## Partial Renders

Both parser threads were one defect: a page caught mid-render producing a plausible number instead of an error. `\d[\d,]*` matches the `1,` of a `$1,234` still being written, and dropping the separator makes it a real $1 fare. `page-text.ts` now holds one pattern requiring every group after a separator to be whole. A comma opening a list item is followed by a space, so `$234, cheapest price` still reads as 234. Nothing distinguishes a rendered `$1` of `$1,234` from a genuine `$1`, so the guard reaches partly written separators only.

A cross-model pass caught two gaps in that. Any decimal tail was allowed, so the `$249.9` of a `$249.99` parsed as $249.90. Money now takes whole units or exactly two decimals, and `22.5k` mileage keeps its own fragment.

The other was the award guard. A sold-out cabin renders its label and prices itself at zero, so an empty award map survives as fares marked unavailable. An itinerary with no fare block never rendered its pricing at all. Failing only when every itinerary lacked pricing left the partial case exiting zero and still claiming "no saver space" for the route.

That case now warns and drops the whole-route claim. It warns rather than exits because no dump proves every real itinerary carries a fare block, and a hard failure on an unknown layout would break the search outright.

## Round-Trip Decomposition

The claim that a round trip decomposes into two one-ways "to within a dollar" holds on the US domestic markets checked. It is not a law. Round-trip fares diverge from twice a one-way on many international markets and under some fare rules.

The technique survives, since it is what makes N dates against M cost `N + M` queries. It is now scoped to shortlisting, and the recommended pair gets priced as an actual round trip before a number is reported. `united.ts` builds one-way URLs only, so that confirmation happens on Google.

## Second Pass

Award pricing renders only for a signed-in session, which the skill never said to check. The new non-zero exit is that signal. Date-grid labels carry no year, so a late-December search shows `Jan 3` for the following year.

`SKILL.md` went from ~1,740 to ~1,919 tokens. The cuts were smaller than the gaps that needed filling.
