### PR TITLE
Enable agent-browser at user level

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -427,6 +427,7 @@
     "gopls-lsp@claude-plugins-official": true,
     "atuin@bendrucker": true,
     "comments@bendrucker": true,
+    "agent-browser@agent-browser": true,
     "plannotator@plannotator": true
   },
   "extraKnownMarketplaces": {


### PR DESCRIPTION
`agent-browser` was installed at user scope but enabled only in `myra`, so browser automation was unavailable in every other project. Its skill used to carry a fat body. It now delegates to the CLI, so the recurring cost is a description rather than the instructions themselves. Scraping and page interaction come up well outside frontend work.

Enabling a plugin through the in-app toggle writes through the `~/.claude/settings.json` symlink into the tracked file. The nightly `claude-upgrade` then finds a dirty tree and skips the sync, and the enable is discarded on the next manual cleanup. That is what happened to `tech-spec@bendrucker` on 2026-08-27. Committing the entry avoids that path.

The redundant project-level entry in `myra` can come out separately.
