### PR TITLE
pull-request: deny hard-wrapped bodies

### DIFF
--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -240,7 +240,7 @@ export function wrapReason(wrapped: WrappedParagraph[]): string {
     remaining > 0
       ? `\n\n${remaining} more wrapped paragraph${remaining === 1 ? "" : "s"} to fix the same way.`
       : "";
-  return `Prose in the body is hard-wrapped at a fixed column. A PR body renders in a web UI that soft-wraps, so a hard wrap gains nothing and displays as a narrow column. Write one line per paragraph and one line per list item. This applies to the body only, and markdown files in the repo keep their own wrapping convention.\n\n${examples}${more}`;
+  return `Prose in the body is hard-wrapped at a fixed column. A PR body renders in a web UI that soft-wraps, so a hard wrap gains nothing and displays as a narrow column. Write one line per paragraph and one line per list item. This applies to the body only. A markdown file in the repo keeps its own wrapping convention, so a body sourced from one gets copied to a scratch file and unwrapped there.\n\n${examples}${more}`;
 }
 
 // Vocabulary that leaks the instructions into the output: the body claims a

--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import type { Nodes } from "mdast";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { visit } from "unist-util-visit";
 import { z } from "zod";
@@ -154,10 +155,19 @@ function isTableParagraph(lines: string[]): boolean {
   );
 }
 
-// A paragraph's position starts after the `> ` that opens the blockquote but
-// spans the markers on every later line, so `raw` carries them. Quoted text also
-// reproduces someone else's line breaks, and reflowing it edits the quotation.
-const BLOCKQUOTE_LINE = /^\s*>/;
+/**
+ * Every paragraph under a blockquote, at any depth. Quoted text reproduces
+ * someone else's line breaks, so reflowing it edits the quotation. Under lazy
+ * continuation only the opening line carries a `>`, which puts the answer in the
+ * tree rather than in the text a line test could read.
+ */
+function quotedParagraphs(tree: Nodes): Set<Nodes> {
+  const quoted = new Set<Nodes>();
+  visit(tree, "blockquote", (blockquote) => {
+    visit(blockquote, "paragraph", (paragraph) => quoted.add(paragraph));
+  });
+  return quoted;
+}
 
 export interface WrappedParagraph {
   /** The paragraph exactly as it appears in the body. */
@@ -177,7 +187,10 @@ export interface WrappedParagraph {
  */
 export function hardWrappedParagraphs(body: string): WrappedParagraph[] {
   const found: WrappedParagraph[] = [];
-  visit(fromMarkdown(body), "paragraph", (node) => {
+  const tree = fromMarkdown(body);
+  const quoted = quotedParagraphs(tree);
+  visit(tree, "paragraph", (node) => {
+    if (quoted.has(node)) return;
     const { start, end } = node.position ?? {};
     if (start?.offset === undefined || end?.offset === undefined) return;
     if (start.line === end.line) return;
@@ -185,12 +198,13 @@ export function hardWrappedParagraphs(body: string): WrappedParagraph[] {
     const raw = body.slice(start.offset, end.offset);
     const lines = raw.split("\n");
     if (isTableParagraph(lines)) return;
-    if (lines.some((line) => BLOCKQUOTE_LINE.test(line))) return;
     const heads = lines.slice(0, -1).map((line) => line.trim().length);
     if (!heads.every((length) => length >= WRAP_MIN_LINE && length <= WRAP_MAX_LINE)) return;
     found.push({
       raw,
-      unwrapped: raw.replace(/\n[ \t]*/g, " "),
+      // Consuming the whitespace on both sides of the break keeps a line that
+      // ended in a space from joining as two, and drops the CR of a CRLF body.
+      unwrapped: raw.replace(/[ \t]*\r?\n[ \t]*/g, " "),
       start: start.offset,
       end: end.offset,
     });
@@ -637,8 +651,11 @@ export function extractTitle(command: string): string | null {
   return unescapeDoubleQuoted(unquote(value));
 }
 
+// A reason carrying a correction spans several lines. Indenting its
+// continuations under the marker keeps each reason one visually bounded item, so
+// the next `- ` still reads as the next thing to fix.
 function bullets(reasons: string[]): string {
-  return reasons.map((reason) => `- ${reason}`).join("\n");
+  return reasons.map((reason) => `- ${reason.replaceAll("\n", "\n  ")}`).join("\n");
 }
 
 // A deny reason carries an exact fix, so the whole set is worth reporting at

--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -1,6 +1,8 @@
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { fromMarkdown } from "mdast-util-from-markdown";
+import { visit } from "unist-util-visit";
 import { z } from "zod";
 import { headingCaseViolations } from "./heading-case";
 import { LINKING_VERBS } from "./linguistics/heading";
@@ -126,6 +128,86 @@ export function hasRunOnProse(body: string): boolean {
     }
   }
   return false;
+}
+
+// A PR body renders in a web UI that soft-wraps, so hard-wrapping prose at a
+// column only narrows it. The floor excludes deliberate one-entry-per-line
+// blocks (a list of SHAs, a signature), which sit well under any fill column.
+// The ceiling keeps a genuinely long line from reading as a wrap.
+export const WRAP_MIN_LINE = 50;
+export const WRAP_MAX_LINE = 100;
+
+// `fromMarkdown` runs without the GFM extension, matching `heading-case.ts`, so
+// a table parses as one multi-line paragraph. Skipping a paragraph whose every
+// line opens a table row costs a line, where the extension costs a dependency
+// tree on a hook that runs on every `gh pr create`.
+const TABLE_ROW = /^\s*\|/;
+
+export interface WrappedParagraph {
+  /** The paragraph exactly as it appears in the body. */
+  raw: string;
+  /** The same paragraph on one line. */
+  unwrapped: string;
+  /** Byte offsets of `raw` within the body. */
+  start: number;
+  end: number;
+}
+
+/**
+ * Paragraphs hard-wrapped at a fill column. mdast supplies the block structure,
+ * so fenced code, list continuations, nested lists, indented code, blockquotes,
+ * and HTML need no handling here. A `break` child is a two-space markdown hard
+ * break, which is an explicit line break rather than a wrap.
+ */
+export function hardWrappedParagraphs(body: string): WrappedParagraph[] {
+  const found: WrappedParagraph[] = [];
+  visit(fromMarkdown(body), "paragraph", (node) => {
+    const { start, end } = node.position ?? {};
+    if (start?.offset === undefined || end?.offset === undefined) return;
+    if (start.line === end.line) return;
+    if (node.children.some((child) => child.type === "break")) return;
+    const raw = body.slice(start.offset, end.offset);
+    const lines = raw.split("\n");
+    if (lines.every((line) => TABLE_ROW.test(line))) return;
+    const heads = lines.slice(0, -1).map((line) => line.trim().length);
+    if (!heads.every((length) => length >= WRAP_MIN_LINE && length <= WRAP_MAX_LINE)) return;
+    found.push({
+      raw,
+      unwrapped: raw.replace(/\n[ \t]*/g, " "),
+      start: start.offset,
+      end: end.offset,
+    });
+  });
+  return found;
+}
+
+/**
+ * Rewrite every hard-wrapped paragraph onto one line, leaving the rest of the
+ * body byte-identical. Splicing runs back to front so each offset stays valid.
+ */
+export function unwrapBody(body: string): string {
+  let out = body;
+  for (const { unwrapped, start, end } of hardWrappedParagraphs(body).reverse()) {
+    out = out.slice(0, start) + unwrapped + out.slice(end);
+  }
+  return out;
+}
+
+// Two paragraphs is enough for the model to see the shape of the fix. Quoting
+// every one of them would make the deny reason longer than the body.
+const WRAP_EXAMPLE_LIMIT = 2;
+
+export function wrapReason(wrapped: WrappedParagraph[]): string {
+  const shown = wrapped.slice(0, WRAP_EXAMPLE_LIMIT);
+  const remaining = wrapped.length - shown.length;
+  const examples = shown
+    .map(({ raw, unwrapped }) => `Replace:\n${raw}\nwith:\n${unwrapped}`)
+    .join("\n\n");
+  const more =
+    remaining > 0
+      ? `\n\n${remaining} more wrapped paragraph${remaining === 1 ? "" : "s"} to fix the same way.`
+      : "";
+  return `Prose in the body is hard-wrapped at a fixed column. A PR body renders in a web UI that soft-wraps, so a hard wrap gains nothing and displays as a narrow column. Write one line per paragraph and one line per list item. This applies to the body only, and markdown files in the repo keep their own wrapping convention.\n\n${examples}${more}`;
 }
 
 // Vocabulary that leaks the instructions into the output: the body claims a
@@ -591,6 +673,10 @@ function denyReasons(body: string): string[] {
   }
   if (hasBacktickedRef(body)) {
     reasons.push(AUTOLINK_REASON);
+  }
+  const wrapped = hardWrappedParagraphs(body);
+  if (wrapped.length > 0) {
+    reasons.push(wrapReason(wrapped));
   }
   return reasons;
 }

--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -220,7 +220,7 @@ export function hardWrappedParagraphs(body: string): WrappedParagraph[] {
  */
 export function unwrapBody(body: string): string {
   let out = body;
-  for (const { unwrapped, start, end } of hardWrappedParagraphs(body).reverse()) {
+  for (const { unwrapped, start, end } of hardWrappedParagraphs(body).toReversed()) {
     out = out.slice(0, start) + unwrapped + out.slice(end);
   }
   return out;

--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -138,10 +138,26 @@ export const WRAP_MIN_LINE = 50;
 export const WRAP_MAX_LINE = 100;
 
 // `fromMarkdown` runs without the GFM extension, matching `heading-case.ts`, so
-// a table parses as one multi-line paragraph. Skipping a paragraph whose every
-// line opens a table row costs a line, where the extension costs a dependency
-// tree on a hook that runs on every `gh pr create`.
+// a table parses as one multi-line paragraph. Skipping one costs two shapes,
+// where the extension costs a dependency tree on a hook that runs on every
+// `gh pr create`. Leading pipes are optional in GFM, so a row check alone misses
+// a pipe-less table whose delimiter row is padded out to the column width.
 const TABLE_ROW = /^\s*\|/;
+const TABLE_DELIMITER = /^[\s:|-]+$/;
+
+function isTableParagraph(lines: string[]): boolean {
+  if (lines.every((line) => TABLE_ROW.test(line))) return true;
+  // A delimiter row separates columns with a pipe and pads with dashes. Prose
+  // never produces a line built from nothing else.
+  return lines.some(
+    (line) => TABLE_DELIMITER.test(line) && line.includes("|") && line.includes("-"),
+  );
+}
+
+// A paragraph's position starts after the `> ` that opens the blockquote but
+// spans the markers on every later line, so `raw` carries them. Quoted text also
+// reproduces someone else's line breaks, and reflowing it edits the quotation.
+const BLOCKQUOTE_LINE = /^\s*>/;
 
 export interface WrappedParagraph {
   /** The paragraph exactly as it appears in the body. */
@@ -155,9 +171,9 @@ export interface WrappedParagraph {
 
 /**
  * Paragraphs hard-wrapped at a fill column. mdast supplies the block structure,
- * so fenced code, list continuations, nested lists, indented code, blockquotes,
- * and HTML need no handling here. A `break` child is a two-space markdown hard
- * break, which is an explicit line break rather than a wrap.
+ * so fenced code, list continuations, nested lists, indented code, and HTML need
+ * no handling here. A `break` child is a two-space markdown hard break, which is
+ * an explicit line break rather than a wrap.
  */
 export function hardWrappedParagraphs(body: string): WrappedParagraph[] {
   const found: WrappedParagraph[] = [];
@@ -168,7 +184,8 @@ export function hardWrappedParagraphs(body: string): WrappedParagraph[] {
     if (node.children.some((child) => child.type === "break")) return;
     const raw = body.slice(start.offset, end.offset);
     const lines = raw.split("\n");
-    if (lines.every((line) => TABLE_ROW.test(line))) return;
+    if (isTableParagraph(lines)) return;
+    if (lines.some((line) => BLOCKQUOTE_LINE.test(line))) return;
     const heads = lines.slice(0, -1).map((line) => line.trim().length);
     if (!heads.every((length) => length >= WRAP_MIN_LINE && length <= WRAP_MAX_LINE)) return;
     found.push({

--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -137,11 +137,11 @@ export function hasRunOnProse(body: string): boolean {
 export const WRAP_MIN_LINE = 50;
 export const WRAP_MAX_LINE = 100;
 
-// `fromMarkdown` runs without the GFM extension, matching `heading-case.ts`, so
-// a table parses as one multi-line paragraph. Skipping one costs two shapes,
-// where the extension costs a dependency tree on a hook that runs on every
-// `gh pr create`. Leading pipes are optional in GFM, so a row check alone misses
-// a pipe-less table whose delimiter row is padded out to the column width.
+// `fromMarkdown` runs without the GFM extension, so a table parses as one
+// multi-line paragraph. Skipping one costs two shapes, where the extension
+// costs a dependency tree on a hook that runs on every `gh pr create`. Leading
+// pipes are optional in GFM, so a row check alone misses a pipe-less table
+// whose delimiter row is padded out to the column width.
 const TABLE_ROW = /^\s*\|/;
 const TABLE_DELIMITER = /^[\s:|-]+$/;
 

--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -164,7 +164,9 @@ function isTableParagraph(lines: string[]): boolean {
 function quotedParagraphs(tree: Nodes): Set<Nodes> {
   const quoted = new Set<Nodes>();
   visit(tree, "blockquote", (blockquote) => {
-    visit(blockquote, "paragraph", (paragraph) => quoted.add(paragraph));
+    visit(blockquote, "paragraph", (paragraph) => {
+      quoted.add(paragraph);
+    });
   });
   return quoted;
 }

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -852,13 +852,11 @@ const LIST_INDENT = 2;
 const MIN_COLUMN = WRAP_MIN_LINE + MAX_WORD + 1 + LIST_INDENT;
 const MAX_COLUMN = WRAP_MAX_LINE;
 
-const word = fc
-  .string({
-    minLength: 3,
-    maxLength: MAX_WORD,
-    unit: fc.constantFrom(..."abcdefghijklmnopqrstuvwxyz"),
-  })
-  .filter((w) => w.length >= 3);
+const word = fc.string({
+  minLength: 3,
+  maxLength: MAX_WORD,
+  unit: fc.constantFrom(..."abcdefghijklmnopqrstuvwxyz"),
+});
 
 /** A block long enough to wrap at any column in range: at least 25 words. */
 const block = fc.array(word, { minLength: 25, maxLength: 60 }).map((words) => words.join(" "));
@@ -912,15 +910,10 @@ describe("hardWrappedParagraphs", () => {
   it("recovers the original document when unwrapping a wrapped one", () => {
     fc.assert(
       fc.property(proseDocument, wrapColumn, (doc, column) => {
-        expect(unwrapBody(wrapDocument(doc, column))).toBe(doc);
-      }),
-    );
-  });
-
-  it("converges in one pass, so a single retry always clears the deny", () => {
-    fc.assert(
-      fc.property(proseDocument, wrapColumn, (doc, column) => {
-        expect(hardWrappedParagraphs(unwrapBody(wrapDocument(doc, column)))).toEqual([]);
+        const unwrapped = unwrapBody(wrapDocument(doc, column));
+        expect(unwrapped).toBe(doc);
+        // Converging in one pass is what makes a single retry clear the deny.
+        expect(hardWrappedParagraphs(unwrapped)).toEqual([]);
       }),
     );
   });
@@ -935,6 +928,14 @@ describe("hardWrappedParagraphs", () => {
   });
 
   const LONG = "The resolver caches every lookup it performs and evicts on a timer";
+
+  // Leading pipes are optional in GFM, so the delimiter row is what marks this
+  // as a table. Lazy continuation drops the marker from every quoted line but
+  // the first, which puts the answer in the tree rather than in the text.
+  const PIPELESS_TABLE =
+    "Column heading one here padded out | Column heading two here padded\n---------------------------------- | ---------------------------------\na value in the first column here   | a value in the second column here";
+  const QUOTED = `> ${LONG} that\n> ${LONG} runs every thirty seconds here.`;
+  const LAZY_QUOTED = `> ${LONG} that\n${LONG} runs every thirty seconds here.`;
 
   test.each<[string, string, boolean]>([
     ["wrapped paragraph", `${LONG} that\n${LONG} runs every thirty seconds here.`, true],
@@ -959,26 +960,34 @@ describe("hardWrappedParagraphs", () => {
       false,
     ],
     ["nested list", `- ${LONG} once.\n  - ${LONG} twice.`, false],
-    [
-      "pipe-less table with a padded delimiter row",
-      "Column heading one here padded out | Column heading two here padded\n---------------------------------- | ---------------------------------\na value in the first column here   | a value in the second column here",
-      false,
-    ],
-    ["wrapped blockquote", `> ${LONG} that\n> ${LONG} runs every thirty seconds here.`, false],
+    ["pipe-less table with a padded delimiter row", PIPELESS_TABLE, false],
+    ["wrapped blockquote", QUOTED, false],
+    ["lazily continued blockquote", LAZY_QUOTED, false],
+    ["blockquote nested in a list", `- Context:\n  > ${LONG} that\n  > ${LONG} here.`, false],
   ])("%s", (_name, body, expected) => {
     expect(hardWrappedParagraphs(body).length > 0).toBe(expected);
   });
 
-  // Both shapes carry markers or column padding that a naive unwrap would splice
-  // into the prose, so silence is what keeps the suggested fix trustworthy.
+  // Each shape carries markers or column padding that a naive unwrap would
+  // splice into the prose, so silence is what keeps the suggested fix
+  // trustworthy.
   test.each<[string, string]>([
-    [
-      "pipe-less table",
-      "Column heading one here padded out | Column heading two here padded\n---------------------------------- | ---------------------------------\na value in the first column here   | a value in the second column here",
-    ],
-    ["blockquote", `> ${LONG} that\n> ${LONG} runs every thirty seconds here.`],
+    ["pipe-less table", PIPELESS_TABLE],
+    ["blockquote", QUOTED],
+    ["lazily continued blockquote", LAZY_QUOTED],
   ])("leaves a %s byte-identical", (_name, body) => {
     expect(unwrapBody(body)).toBe(body);
+  });
+
+  // The join has to absorb the whitespace on both sides of the break, or the
+  // correction the hook quotes carries a stray character into the body.
+  test.each<[string, string]>([
+    ["a CRLF body", `${LONG} that\r\n${LONG} runs every thirty seconds here.`],
+    ["a line ending in one space", `${LONG} that \n${LONG} runs every thirty seconds here.`],
+  ])("joins %s on a single space", (_name, body) => {
+    expect(hardWrappedParagraphs(body)[0]?.unwrapped).toBe(
+      `${LONG} that ${LONG} runs every thirty seconds here.`,
+    );
   });
 });
 

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import fc from "fast-check";
+import * as fc from "fast-check";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import {
   type BodyContext,
@@ -852,10 +852,11 @@ const LIST_INDENT = 2;
 const MIN_COLUMN = WRAP_MIN_LINE + MAX_WORD + 1 + LIST_INDENT;
 const MAX_COLUMN = WRAP_MAX_LINE;
 
+const LOWERCASE = "abcdefghijklmnopqrstuvwxyz".split("");
 const word = fc.string({
   minLength: 3,
   maxLength: MAX_WORD,
-  unit: fc.constantFrom(..."abcdefghijklmnopqrstuvwxyz"),
+  unit: fc.constantFrom(...LOWERCASE),
 });
 
 /** A block long enough to wrap at any column in range: at least 25 words. */
@@ -883,7 +884,7 @@ function wrapDocument(doc: string, column: number): string {
  * away. What survives is the structure a reader sees.
  */
 function renderedShape(body: string): string {
-  return JSON.stringify(fromMarkdown(body), (key, value) => {
+  return JSON.stringify(fromMarkdown(body), (key: string, value: unknown) => {
     if (key === "position") return undefined;
     if (key === "value" && typeof value === "string") return value.replace(/\s+/g, " ");
     return value;

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -4,6 +4,8 @@ import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import fc from "fast-check";
+import { fromMarkdown } from "mdast-util-from-markdown";
 import {
   type BodyContext,
   type BodyPart,
@@ -16,6 +18,7 @@ import {
   hasBacktickedRef,
   hasCiStatusRollCall,
   hasFileTourBullets,
+  hardWrappedParagraphs,
   hasReflexiveScaffold,
   hasRunOnProse,
   type HookInput,
@@ -27,7 +30,10 @@ import {
   processInput,
   resolveBody,
   sentenceShapedHeadings,
+  unwrapBody,
   validateBody,
+  WRAP_MAX_LINE,
+  WRAP_MIN_LINE,
 } from "./validate-body";
 
 function getPermissionDecision(result: Awaited<ReturnType<typeof validateBody>>) {
@@ -814,5 +820,153 @@ describe("processInput", () => {
     expect(getPermissionDecision(result)).toBe("deny");
     expect(getAdditionalContext(result)).toBeUndefined();
     expect(getDenyReason(result)).toContain("Also worth addressing in the same edit:");
+  });
+});
+
+// Greedy fill at a column: the thing the detector exists to catch. `indent`
+// prefixes continuation lines so a wrapped list item keeps its hanging indent.
+function wrapAt(text: string, column: number, indent = ""): string {
+  const lines: string[] = [];
+  let current = "";
+  for (const word of text.split(" ")) {
+    const candidate = current === "" ? word : `${current} ${word}`;
+    if (candidate.length > column && current !== "") {
+      lines.push(current);
+      current = indent + word;
+      continue;
+    }
+    current = candidate;
+  }
+  lines.push(current);
+  return lines.join("\n");
+}
+
+// Greedy fill leaves a line longer than column - (MAX_WORD + 1) and never
+// longer than column. Deriving the column floor from that keeps every generated
+// non-final line inside [WRAP_MIN_LINE, WRAP_MAX_LINE], so the generator only
+// emits documents the detector actually claims to catch.
+const MAX_WORD = 9;
+const MIN_COLUMN = WRAP_MIN_LINE + MAX_WORD + 1;
+const MAX_COLUMN = WRAP_MAX_LINE;
+
+const word = fc
+  .string({
+    minLength: 3,
+    maxLength: MAX_WORD,
+    unit: fc.constantFrom(..."abcdefghijklmnopqrstuvwxyz"),
+  })
+  .filter((w) => w.length >= 3);
+
+/** A block long enough to wrap at any column in range: at least 25 words. */
+const block = fc.array(word, { minLength: 25, maxLength: 60 }).map((words) => words.join(" "));
+
+const wrapColumn = fc.integer({ min: MIN_COLUMN, max: MAX_COLUMN });
+
+/** A document of one-line paragraphs and one-line list items. */
+const proseDocument = fc
+  .array(fc.record({ text: block, bullet: fc.boolean() }), { minLength: 1, maxLength: 4 })
+  .map((blocks) => blocks.map(({ text, bullet }) => (bullet ? `- ${text}` : text)).join("\n\n"));
+
+function wrapDocument(doc: string, column: number): string {
+  return doc
+    .split("\n\n")
+    .map((b) => (b.startsWith("- ") ? wrapAt(b, column, "  ") : wrapAt(b, column)))
+    .join("\n\n");
+}
+
+/**
+ * What the body renders to. Positions differ after an unwrap by construction,
+ * and mdast keeps the newline inside a text node's value, so both are normalized
+ * away. What survives is the structure a reader sees.
+ */
+function renderedShape(body: string): string {
+  return JSON.stringify(fromMarkdown(body), (key, value) => {
+    if (key === "position") return undefined;
+    if (key === "value" && typeof value === "string") return value.replace(/\s+/g, " ");
+    return value;
+  });
+}
+
+describe("hardWrappedParagraphs", () => {
+  it("flags a document wrapped at any column in range", () => {
+    fc.assert(
+      fc.property(proseDocument, wrapColumn, (doc, column) => {
+        expect(hardWrappedParagraphs(wrapDocument(doc, column)).length).toBeGreaterThan(0);
+      }),
+    );
+  });
+
+  it("leaves a document alone when every block is on one line", () => {
+    fc.assert(
+      fc.property(proseDocument, (doc) => {
+        expect(hardWrappedParagraphs(doc)).toEqual([]);
+      }),
+    );
+  });
+
+  it("recovers the original document when unwrapping a wrapped one", () => {
+    fc.assert(
+      fc.property(proseDocument, wrapColumn, (doc, column) => {
+        expect(unwrapBody(wrapDocument(doc, column))).toBe(doc);
+      }),
+    );
+  });
+
+  it("converges in one pass, so a single retry always clears the deny", () => {
+    fc.assert(
+      fc.property(proseDocument, wrapColumn, (doc, column) => {
+        expect(hardWrappedParagraphs(unwrapBody(wrapDocument(doc, column)))).toEqual([]);
+      }),
+    );
+  });
+
+  it("never changes what the body renders to", () => {
+    fc.assert(
+      fc.property(proseDocument, wrapColumn, (doc, column) => {
+        const wrapped = wrapDocument(doc, column);
+        expect(renderedShape(unwrapBody(wrapped))).toBe(renderedShape(wrapped));
+      }),
+    );
+  });
+
+  const LONG = "The resolver caches every lookup it performs and evicts on a timer";
+
+  test.each<[string, string, boolean]>([
+    ["wrapped paragraph", `${LONG} that\n${LONG} runs every thirty seconds here.`, true],
+    ["one-line paragraph", `${LONG} that runs every thirty seconds.`, false],
+    ["wrapped list item", `- ${LONG} that\n  ${LONG} runs every thirty seconds here.`, true],
+    ["one-line list items", `- ${LONG} once.\n- ${LONG} twice.`, false],
+    [
+      "table",
+      "| Month | Rate | Notes about the month that make the row long |\n|---|---|---|\n| June | 0.5% | The rate was low and stayed low all month |",
+      false,
+    ],
+    ["fenced code", `\`\`\`ts\nconst first = "${LONG}";\nconst second = "${LONG}";\n\`\`\``, false],
+    ["two-space hard break", `${LONG} that  \n${LONG} runs every thirty seconds here.`, false],
+    [
+      "short deliberate lines",
+      "Discovery: 8a4c11372239\nDiscovery: 7b7e5d6ca37e\nDiscovery: db1ce0b102e0",
+      false,
+    ],
+    [
+      "line past the ceiling",
+      `${LONG} and it also does a great many other things besides that one.\n${LONG} here.`,
+      false,
+    ],
+    ["nested list", `- ${LONG} once.\n  - ${LONG} twice.`, false],
+  ])("%s", (_name, body, expected) => {
+    expect(hardWrappedParagraphs(body).length > 0).toBe(expected);
+  });
+});
+
+describe("validateBody wrapping", () => {
+  it("denies a wrapped body and hands back the corrected paragraph", () => {
+    const body =
+      "The resolver caches every lookup it performs and evicts\non a timer that runs every thirty seconds in the background.";
+    const result = validateBody(body);
+    expect(getPermissionDecision(result)).toBe("deny");
+    expect(getDenyReason(result)).toContain(
+      "The resolver caches every lookup it performs and evicts on a timer that runs every thirty seconds in the background.",
+    );
   });
 });

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -842,11 +842,14 @@ function wrapAt(text: string, column: number, indent = ""): string {
 }
 
 // Greedy fill leaves a line longer than column - (MAX_WORD + 1) and never
-// longer than column. Deriving the column floor from that keeps every generated
-// non-final line inside [WRAP_MIN_LINE, WRAP_MAX_LINE], so the generator only
-// emits documents the detector actually claims to catch.
+// longer than column. A list item spends LIST_INDENT of that budget on its
+// hanging indent, which the detector measures trimmed and so does not count.
+// Deriving the column floor from all three keeps every generated non-final line
+// inside [WRAP_MIN_LINE, WRAP_MAX_LINE], so the generator only emits documents
+// the detector actually claims to catch.
 const MAX_WORD = 9;
-const MIN_COLUMN = WRAP_MIN_LINE + MAX_WORD + 1;
+const LIST_INDENT = 2;
+const MIN_COLUMN = WRAP_MIN_LINE + MAX_WORD + 1 + LIST_INDENT;
 const MAX_COLUMN = WRAP_MAX_LINE;
 
 const word = fc
@@ -870,7 +873,9 @@ const proseDocument = fc
 function wrapDocument(doc: string, column: number): string {
   return doc
     .split("\n\n")
-    .map((b) => (b.startsWith("- ") ? wrapAt(b, column, "  ") : wrapAt(b, column)))
+    .map((b) =>
+      b.startsWith("- ") ? wrapAt(b, column, " ".repeat(LIST_INDENT)) : wrapAt(b, column),
+    )
     .join("\n\n");
 }
 

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -959,8 +959,26 @@ describe("hardWrappedParagraphs", () => {
       false,
     ],
     ["nested list", `- ${LONG} once.\n  - ${LONG} twice.`, false],
+    [
+      "pipe-less table with a padded delimiter row",
+      "Column heading one here padded out | Column heading two here padded\n---------------------------------- | ---------------------------------\na value in the first column here   | a value in the second column here",
+      false,
+    ],
+    ["wrapped blockquote", `> ${LONG} that\n> ${LONG} runs every thirty seconds here.`, false],
   ])("%s", (_name, body, expected) => {
     expect(hardWrappedParagraphs(body).length > 0).toBe(expected);
+  });
+
+  // Both shapes carry markers or column padding that a naive unwrap would splice
+  // into the prose, so silence is what keeps the suggested fix trustworthy.
+  test.each<[string, string]>([
+    [
+      "pipe-less table",
+      "Column heading one here padded out | Column heading two here padded\n---------------------------------- | ---------------------------------\na value in the first column here   | a value in the second column here",
+    ],
+    ["blockquote", `> ${LONG} that\n> ${LONG} runs every thirty seconds here.`],
+  ])("leaves a %s byte-identical", (_name, body) => {
+    expect(unwrapBody(body)).toBe(body);
   });
 });
 

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -823,8 +823,8 @@ describe("processInput", () => {
   });
 });
 
-// Greedy fill at a column: the thing the detector exists to catch. `indent`
-// prefixes continuation lines so a wrapped list item keeps its hanging indent.
+// Greedy fill at a column: the thing the detector exists to catch. The indent
+// keeps a wrapped list item's hanging indent.
 function wrapAt(text: string, column: number, indent = ""): string {
   const lines: string[] = [];
   let current = "";

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -50,6 +50,7 @@ Lead with intent: why the change exists, the decisions a reviewer can't reconstr
 - Default to prose. Write a small PR as one paragraph with no headings. Add `##` sections only when the body is long enough to need them. Base length on substance, not diff size.
 - Reference the motivating issue at the end of the opening (`Closes #N`, `Fixes #N`, or bare `#N` if not closing). Never touch the issue itself: no comments, labels, milestones, or assignees.
 - Wrap code identifiers in backticks, but leave bare anything the platform auto-links: commit SHAs and issue/MR refs (`#N`, `!N`, `owner/repo#N`). Backticked refs don't auto-link.
+- Write one line per paragraph and one line per list item. The body soft-wraps when it renders, so hard-wrapping at a column just narrows it.
 
 Load the `writing` skill for the full set of tropes to avoid.
 

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -50,7 +50,7 @@ Lead with intent: why the change exists, the decisions a reviewer can't reconstr
 - Default to prose. Write a small PR as one paragraph with no headings. Add `##` sections only when the body is long enough to need them. Base length on substance, not diff size.
 - Reference the motivating issue at the end of the opening (`Closes #N`, `Fixes #N`, or bare `#N` if not closing). Never touch the issue itself: no comments, labels, milestones, or assignees.
 - Wrap code identifiers in backticks, but leave bare anything the platform auto-links: commit SHAs and issue/MR refs (`#N`, `!N`, `owner/repo#N`). Backticked refs don't auto-link.
-- Write one line per paragraph and one line per list item. The body soft-wraps when it renders, so hard-wrapping at a column just narrows it.
+- Write one line per paragraph and one line per list item. The body soft-wraps when it renders. Hard-wrapping at a column only narrows it.
 
 Load the `writing` skill for the full set of tropes to avoid.
 

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -6,7 +6,7 @@
 - Minimize unnecessary explanations unless requested.
 - Don't join independent clauses with semicolons or em dashes. End the clause with a period. Swapping one connector for another is not a fix. Semicolons only at rare, normal-English cadence.
 - Wrap filenames and code identifiers with `backticks` in any markdown context.
-- Don't hard-wrap prose you author: one line per paragraph, one line per list item. In an existing file, follow the wrapping it already uses. Git commit bodies keep the conventional ~72 columns.
+- Don't hard-wrap markdown prose you author: one line per paragraph, one line per list item. In an existing file, follow the wrapping it already uses.
 - Include a trailing newline in all new files.
 - Prefer meaningful anchor text over raw URLs.
 - Use bullet points for lists, checklists if I ask for tasks.
@@ -68,6 +68,7 @@ claude-cli://open?q=<url-encoded prompt>&cwd=<absolute main repo path>
 - Never `git push` to the default branch (usually `main` or `master`) unless I explicitly instruct you.
 - Always work on a topic branch with a short hyphenated name.
 - For commit messages, use multiple `-m` flags for a simple subject and body. Each `-m` is a separate paragraph. For complex messages, pass the message through a heredoc.
+- Wrap commit message bodies at the conventional ~72 columns.
 
 ## Worktrees
 

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -6,7 +6,7 @@
 - Minimize unnecessary explanations unless requested.
 - Don't join independent clauses with semicolons or em dashes. End the clause with a period. Swapping one connector for another is not a fix. Semicolons only at rare, normal-English cadence.
 - Wrap filenames and code identifiers with `backticks` in any markdown context.
-- Use natural line breaks unless the surrounding code is wrapped at a specific column.
+- Never hard-wrap markdown prose. One line per paragraph, one line per list item. In a file, match the wrapping the surrounding file already uses. Git commit bodies keep the conventional ~72 columns.
 - Include a trailing newline in all new files.
 - Prefer meaningful anchor text over raw URLs.
 - Use bullet points for lists, checklists if I ask for tasks.

--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -6,7 +6,7 @@
 - Minimize unnecessary explanations unless requested.
 - Don't join independent clauses with semicolons or em dashes. End the clause with a period. Swapping one connector for another is not a fix. Semicolons only at rare, normal-English cadence.
 - Wrap filenames and code identifiers with `backticks` in any markdown context.
-- Never hard-wrap markdown prose. One line per paragraph, one line per list item. In a file, match the wrapping the surrounding file already uses. Git commit bodies keep the conventional ~72 columns.
+- Don't hard-wrap prose you author: one line per paragraph, one line per list item. In an existing file, follow the wrapping it already uses. Git commit bodies keep the conventional ~72 columns.
 - Include a trailing newline in all new files.
 - Prefer meaningful anchor text over raw URLs.
 - Use bullet points for lists, checklists if I ask for tasks.


### PR DESCRIPTION
Claude sometimes hard-wraps PR body prose at a fill column. GitHub soft-wraps the body when it renders, so a hard wrap only narrows it in a wide viewport. 54 of 1,527 bodies in the local session corpus were wrapped this way, at 6.2% in August against 0.4% before. Once one wrapped body lands in a session's context, every later body in that session wraps 28.4% of the time versus 0.7% cold, so the hook denies rather than silently rewriting: the corrected text has to re-enter context to break the imitation loop.

The check keys on where the command writes. A markdown file in the repo has its own wrapping convention, but a PR body is an API payload rendered by a web UI that no file's convention reaches. The hook fires only on the `Bash` calls behind `gh pr create/edit` and `glab mr create/update`, so a repo whose markdown is conventionally wrapped stays untouched. A `--body-file` pointing at a tracked, wrapped file still denies, since the rendered body is still narrow. The message tells you to copy it to a scratch file and unwrap the copy.

Detection parses the body with `mdast-util-from-markdown`, so fenced code, list continuations, nested lists, and indented code need no special handling. A hard-wrapped paragraph spans several lines, carries no `break` child, and has every line but its last between 50 and 100 columns. Blockquotes and pipe-less GFM tables are both skipped, since reflowing a quotation edits someone else's line breaks and a padded delimiter row can otherwise land inside that column band.

`user/CLAUDE.md`'s line-break rule now names markdown specifically, with commit message bodies keeping their own line for the conventional 72-column wrap. Retire the detector itself when a quarter passes with no deny, checked by querying `hook_denies` for the reason text.
