### PR TITLE
pull-request: validate heredoc-written PR bodies

### DIFF
--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -320,11 +320,13 @@ export async function findBacktickedCommits(
 // `glab mr create`/`update`, covering compound (`cd <dir> && gh pr create ...`)
 // and env-prefixed (`GH_PAGER=cat gh pr create ...`) forms. This guard repeats
 // the check in-script so the validator is inert under any other dispatch, and
-// runs before the hook reads a body file or shells out to git.
+// runs before the hook reads a body file or shells out to git. It matches the
+// heredoc-stripped text, so a heredoc body that merely mentions a create
+// command stays inert.
 const PR_BODY_COMMAND_PATTERN = /\b(?:gh pr (?:create|edit)|glab mr (?:create|update))\b/;
 
 export function isPrBodyCommand(command: string): boolean {
-  return PR_BODY_COMMAND_PATTERN.test(command);
+  return PR_BODY_COMMAND_PATTERN.test(parseCommand(command).text);
 }
 
 function unquote(value: string): string {
@@ -340,6 +342,117 @@ function expandTmpdir(path: string): string {
   const tmpdir = process.env.TMPDIR?.replace(/\/$/, "");
   if (tmpdir == null || tmpdir === "") return path;
   return path.replace(/\$\{TMPDIR\}|\$TMPDIR/g, tmpdir);
+}
+
+function normalizeBodyPath(raw: string): string {
+  return expandTmpdir(unquote(raw)).replace(/^\.\//, "");
+}
+
+// A heredoc operator with its delimiter word. The lookbehind keeps `<<<`
+// herestrings out. A quoted or escaped delimiter makes the body literal.
+const HEREDOC_OPERATOR = /(?<!<)<<(-?)[ \t]*(?:'([^']+)'|"([^"]+)"|(\\)?([A-Za-z_][A-Za-z0-9_]*))/g;
+
+// Simple-command boundaries within one line. `|` stays inside a segment so a
+// heredoc piped into the CLI remains attached to the command it feeds.
+const SEGMENT_SEPARATOR = /&&|\|\||;/g;
+
+// Where a segment writes its heredoc: a single `>` redirect or a `tee` sink.
+// The redirect lookbehind skips `>>` (an append mixes the heredoc with the
+// file's prior content), fd forms (`2>`), and `&>`. The tee pattern's leading
+// character class skips flags, so `tee -a` also resolves to no target.
+const REDIRECT_TARGET = /(?<![>\d&])>[ \t]*("(?:[^"\\]|\\.)*"|'[^']*'|[^\s;|&<>]+)/;
+const TEE_TARGET = /\btee\s+("(?:[^"\\]|\\.)*"|'[^']*'|[^\s;|&<>-][^\s;|&<>]*)/;
+
+export interface Heredoc {
+  /** Body text as the shell delivers it, with `<<-` tab stripping applied. */
+  content: string;
+  /** The delimiter was quoted or escaped, so the shell expands nothing in the body. */
+  quoted: boolean;
+  /** The simple command the operator sits in. */
+  segment: string;
+  /** Normalized path the segment redirects or tees the body into, or null when it feeds stdin/stdout. */
+  target: string | null;
+}
+
+export interface ParsedCommand {
+  /** Command text with heredoc bodies removed, so verb and flag matching runs on shell syntax alone. */
+  text: string;
+  heredocs: Heredoc[];
+}
+
+interface PendingHeredoc {
+  delimiter: string;
+  quoted: boolean;
+  stripTabs: boolean;
+  segment: string;
+  target: string | null;
+  lines: string[];
+}
+
+function segmentAt(line: string, index: number): string {
+  let start = 0;
+  let end = line.length;
+  for (const sep of line.matchAll(SEGMENT_SEPARATOR)) {
+    if (sep.index < index) {
+      start = sep.index + sep[0].length;
+    } else {
+      end = sep.index;
+      break;
+    }
+  }
+  return line.slice(start, end);
+}
+
+function segmentTarget(segment: string): string | null {
+  const value = segment.match(REDIRECT_TARGET)?.[1] ?? segment.match(TEE_TARGET)?.[1];
+  return value === undefined ? null : normalizeBodyPath(value);
+}
+
+// Line-oriented heredoc scan: a body runs from the line after its operator to
+// the delimiter line, and several operators on one line consume bodies in
+// order. An unterminated heredoc owns the rest of the command, which is also
+// what the shell would feed it.
+export function parseCommand(command: string): ParsedCommand {
+  const kept: string[] = [];
+  const heredocs: Heredoc[] = [];
+  const queue: PendingHeredoc[] = [];
+
+  const close = (pending: PendingHeredoc): void => {
+    heredocs.push({
+      content: pending.lines.length === 0 ? "" : `${pending.lines.join("\n")}\n`,
+      quoted: pending.quoted,
+      segment: pending.segment,
+      target: pending.target,
+    });
+  };
+
+  for (const line of command.split("\n")) {
+    const open = queue[0];
+    if (open !== undefined) {
+      const body = open.stripTabs ? line.replace(/^\t+/, "") : line;
+      if (body === open.delimiter) {
+        queue.shift();
+        close(open);
+      } else {
+        open.lines.push(body);
+      }
+      continue;
+    }
+    kept.push(line);
+    for (const match of line.matchAll(HEREDOC_OPERATOR)) {
+      const segment = segmentAt(line, match.index);
+      queue.push({
+        delimiter: match[2] ?? match[3] ?? match[5] ?? "",
+        quoted: match[2] !== undefined || match[3] !== undefined || match[4] !== undefined,
+        stripTabs: match[1] === "-",
+        segment,
+        target: segmentTarget(segment),
+        lines: [],
+      });
+    }
+  }
+  for (const pending of queue) close(pending);
+  return { text: kept.join("\n"), heredocs };
 }
 
 // One flag value as the shell would word-split it: a quoted string, a command
@@ -470,21 +583,75 @@ function parseInlineValue(raw: string): BodySpec {
   return { kind: "parts", parts };
 }
 
+// Null when the delimiter is unquoted and the body holds an expansion the
+// shell will rewrite before the CLI sees it.
+function heredocLiteral(heredoc: Heredoc): BodyPart | null {
+  if (!heredoc.quoted && SHELL_EXPANSION_PATTERN.test(heredoc.content)) return null;
+  return { kind: "literal", text: heredoc.content };
+}
+
+function heredocExpansion(heredoc: Heredoc): BodySpec {
+  const source = heredoc.content.match(SHELL_EXPANSION_PATTERN)?.[0] ?? "";
+  return {
+    kind: "unreadable",
+    detail: `an unquoted heredoc holding a shell expansion the hook cannot evaluate (\`${source.trim()}\`)`,
+  };
+}
+
+function heredocSpec(heredoc: Heredoc): BodySpec {
+  const part = heredocLiteral(heredoc);
+  if (part === null) return heredocExpansion(heredoc);
+  return { kind: "parts", parts: [part] };
+}
+
+// Swap each file part for the heredoc that writes that path in the same
+// command, so a body created and passed in one call validates without touching
+// a file the command has not written yet. The last write wins, as it would in
+// the shell.
+function resolveHeredocParts(parts: BodyPart[], heredocs: Heredoc[]): BodySpec {
+  const resolved: BodyPart[] = [];
+  for (const part of parts) {
+    if (part.kind === "file") {
+      const heredoc = heredocs.findLast((doc) => doc.target === normalizeBodyPath(part.path));
+      if (heredoc !== undefined) {
+        const replacement = heredocLiteral(heredoc);
+        if (replacement === null) return heredocExpansion(heredoc);
+        resolved.push(replacement);
+        continue;
+      }
+    }
+    resolved.push(part);
+  }
+  return { kind: "parts", parts: resolved };
+}
+
+// Both spellings of stdin. `/dev/stdin` matters because reading it from the
+// hook would consume the hook's own (already-drained) stdin and validate an
+// empty body.
+const STDIN_PATHS = new Set(["-", "/dev/stdin"]);
+
 export function extractBodySpec(command: string): BodySpec {
-  const flags = bodyFlags(command);
-  const fileValue = command.match(flagValuePattern(flags.file))?.[1];
+  const { text, heredocs } = parseCommand(command);
+  const flags = bodyFlags(text);
+  const fileValue = text.match(flagValuePattern(flags.file))?.[1];
   if (fileValue != null && fileValue !== "") {
     const path = unquote(fileValue);
-    if (path === "-") {
-      return { kind: "unreadable", detail: "a body piped in on standard input (`-`)" };
+    if (STDIN_PATHS.has(path)) {
+      const fed = heredocs.find(
+        (doc) => doc.target === null && PR_BODY_COMMAND_PATTERN.test(doc.segment),
+      );
+      if (fed !== undefined) return heredocSpec(fed);
+      return { kind: "unreadable", detail: `a body piped in on standard input (\`${path}\`)` };
     }
     const part = filePart(fileValue);
     if (part === null) return unreadableExpansion(path);
-    return { kind: "parts", parts: [part] };
+    return resolveHeredocParts([part], heredocs);
   }
-  const inlineValue = command.match(flagValuePattern(flags.inline))?.[1];
-  if (inlineValue != null && inlineValue !== "") return parseInlineValue(inlineValue);
-  return { kind: "none" };
+  const inlineValue = text.match(flagValuePattern(flags.inline))?.[1];
+  if (inlineValue == null || inlineValue === "") return { kind: "none" };
+  const inline = parseInlineValue(inlineValue);
+  if (inline.kind !== "parts") return inline;
+  return resolveHeredocParts(inline.parts, heredocs);
 }
 
 /** The body text a command will send, or why the hook cannot see it. */
@@ -501,9 +668,31 @@ async function readBodyFile(path: string, cwd: string): Promise<string | null> {
   }
 }
 
+// A `cd` ahead of the PR command moves where the CLI resolves a relative body
+// path, so the hook follows each one it can evaluate before reading files.
+const CD_PATTERN = /(?:^|&&|\|\||;|\n)\s*cd\s+("(?:[^"\\]|\\.)*"|'[^']*'|[^\s;|&]+)/g;
+
+export function effectiveCwd(command: string, cwd: string): string {
+  const text = parseCommand(command).text;
+  const start = text.search(PR_BODY_COMMAND_PATTERN);
+  const scope = start === -1 ? text : text.slice(0, start);
+  let dir = cwd;
+  for (const match of scope.matchAll(CD_PATTERN)) {
+    const target = expandTmpdir(unquote(match[1] ?? ""));
+    if (target === "" || target === "-" || SHELL_EXPANSION_PATTERN.test(target)) continue;
+    if (target === "~" || target.startsWith("~/")) {
+      dir = join(homedir(), target.slice(1));
+    } else {
+      dir = isAbsolute(target) ? target : join(dir, target);
+    }
+  }
+  return dir;
+}
+
 export async function resolveBody(command: string, cwd: string): Promise<BodyResolution> {
   const spec = extractBodySpec(command);
   if (spec.kind !== "parts") return spec;
+  const base = effectiveCwd(command, cwd);
   const chunks: string[] = [];
   for (const part of spec.parts) {
     if (part.kind === "literal") {
@@ -511,7 +700,7 @@ export async function resolveBody(command: string, cwd: string): Promise<BodyRes
       continue;
     }
     // oxlint-disable-next-line no-await-in-loop -- returns on the first unreadable part, and a command carries at most a few.
-    const text = await readBodyFile(part.path, cwd);
+    const text = await readBodyFile(part.path, base);
     if (text === null) {
       return {
         kind: "unreadable",
@@ -523,14 +712,15 @@ export async function resolveBody(command: string, cwd: string): Promise<BodyRes
   return { kind: "text", text: chunks.join("") };
 }
 
-// Anchored to the `gh pr`/`glab mr` verb with the body values blanked first:
-// an unanchored scan reads a ` -t ` from an earlier command in a compound
-// (`mktemp -t`), and a `--title` mentioned inside an inline body string, as the
-// PR title.
+// Anchored to the `gh pr`/`glab mr` verb with heredoc bodies stripped and the
+// body values blanked first: an unanchored scan reads a ` -t ` from an earlier
+// command in a compound (`mktemp -t`), and a `--title` mentioned inside a body
+// string, as the PR title.
 export function extractTitle(command: string): string | null {
-  const start = command.search(PR_BODY_COMMAND_PATTERN);
-  const flags = bodyFlags(command);
-  const scope = (start === -1 ? command : command.slice(start))
+  const text = parseCommand(command).text;
+  const start = text.search(PR_BODY_COMMAND_PATTERN);
+  const flags = bodyFlags(text);
+  const scope = (start === -1 ? text : text.slice(start))
     .replace(flagValuePattern(flags.file, true), " ")
     .replace(flagValuePattern(flags.inline, true), " ");
   const value = scope.match(/(?:--title|(?<![\w-])-t)[=\s]("(?:[^"\\]|\\.)*"|'[^']*'|[^\s]+)/)?.[1];
@@ -679,7 +869,7 @@ export function validateBody(
 // the command sails through looking validated. The deny names the readable form
 // instead, which is a path either CLI accepts.
 export function unreadableBodyReason(detail: string): string {
-  return `The hook cannot read ${detail}, so none of the body checks ran. Write the body to a file in its own Bash call, then pass that path: \`--body-file <path>\` on \`gh\`, \`--description-file <path>\` on \`glab\`.`;
+  return `The hook cannot read ${detail}, so none of the body checks ran. Write the body to a file with a quoted heredoc (\`cat > <path> <<'EOF'\`), in the same call or its own, then pass that path: \`--body-file <path>\` on \`gh\`, \`--description-file <path>\` on \`glab\`.`;
 }
 
 export async function processInput(input: HookInput): Promise<SyncHookJSONOutput | null> {
@@ -709,10 +899,11 @@ export async function processInput(input: HookInput): Promise<SyncHookJSONOutput
 
   const body = resolved.text;
   const denies = denyReasons(body);
+  const repoCwd = effectiveCwd(command, cwd);
 
   if (!denies.includes(AUTOLINK_REASON)) {
     const candidates = extractBacktickedHexCandidates(body);
-    const commits = await findBacktickedCommits(candidates, gitCommitVerifier(cwd));
+    const commits = await findBacktickedCommits(candidates, gitCommitVerifier(repoCwd));
     if (commits.length > 0) {
       denies.push(AUTOLINK_REASON);
     }
@@ -720,7 +911,7 @@ export async function processInput(input: HookInput): Promise<SyncHookJSONOutput
 
   let personalRepo = false;
   if (isLongBody(body)) {
-    const [remote, hosts] = await Promise.all([readGitRemote(cwd), readGhHosts()]);
+    const [remote, hosts] = await Promise.all([readGitRemote(repoCwd), readGhHosts()]);
     personalRepo = isPersonalRepo(remote, hosts);
   }
 

--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -360,8 +360,8 @@ const SEGMENT_SEPARATOR = /&&|\|\||;/g;
 // The redirect lookbehind skips `>>` (an append mixes the heredoc with the
 // file's prior content), fd forms (`2>`), and `&>`. The tee pattern's leading
 // character class skips flags, so `tee -a` also resolves to no target.
-const REDIRECT_TARGET = /(?<![>\d&])>[ \t]*("(?:[^"\\]|\\.)*"|'[^']*'|[^\s;|&<>]+)/;
-const TEE_TARGET = /\btee\s+("(?:[^"\\]|\\.)*"|'[^']*'|[^\s;|&<>-][^\s;|&<>]*)/;
+const REDIRECT_TARGET = /(?<![>\d&])>[ \t]*("(?:[^"\\]|\\.)*"|'[^']*'|[^\s;|&<>]+)/g;
+const TEE_TARGET = /\btee\s+("(?:[^"\\]|\\.)*"|'[^']*'|[^\s;|&<>-][^\s;|&<>]*)/g;
 
 export interface Heredoc {
   /** Body text as the shell delivers it, with `<<-` tab stripping applied. */
@@ -419,10 +419,38 @@ function quotedSpans(line: string): Array<[number, number]> {
   return spans;
 }
 
-function segmentAt(line: string, index: number): string {
+// Quoted spans across the whole (stripped) text, line by line, so flag
+// matching can skip a flag word sitting inside another flag's quoted value.
+function quotedSpansAll(text: string): Array<[number, number]> {
+  const spans: Array<[number, number]> = [];
+  let offset = 0;
+  for (const line of text.split("\n")) {
+    for (const [start, end] of quotedSpans(line)) spans.push([offset + start, offset + end]);
+    offset += line.length + 1;
+  }
+  return spans;
+}
+
+// First match whose own start sits outside every quoted span. The value a
+// match captures may still be quoted. Only the operator or flag itself must
+// not be.
+function firstUnquotedMatch(
+  text: string,
+  pattern: RegExp,
+  spans: Array<[number, number]>,
+): RegExpExecArray | null {
+  for (const match of text.matchAll(pattern)) {
+    if (!spans.some(([start, end]) => match.index > start && match.index <= end)) return match;
+  }
+  return null;
+}
+
+function segmentAt(line: string, index: number, spans: Array<[number, number]>): string {
   let start = 0;
   let end = line.length;
   for (const sep of line.matchAll(SEGMENT_SEPARATOR)) {
+    if (spans.some(([spanStart, spanEnd]) => sep.index > spanStart && sep.index <= spanEnd))
+      continue;
     if (sep.index < index) {
       start = sep.index + sep[0].length;
     } else {
@@ -434,7 +462,10 @@ function segmentAt(line: string, index: number): string {
 }
 
 function segmentTarget(segment: string): string | null {
-  const value = segment.match(REDIRECT_TARGET)?.[1] ?? segment.match(TEE_TARGET)?.[1];
+  const spans = quotedSpans(segment);
+  const value =
+    firstUnquotedMatch(segment, REDIRECT_TARGET, spans)?.[1] ??
+    firstUnquotedMatch(segment, TEE_TARGET, spans)?.[1];
   return value === undefined ? null : normalizeBodyPath(value);
 }
 
@@ -474,7 +505,7 @@ export function parseCommand(command: string): ParsedCommand {
     const spans = quotedSpans(line);
     for (const match of line.matchAll(HEREDOC_OPERATOR)) {
       if (spans.some(([start, end]) => match.index > start && match.index <= end)) continue;
-      const segment = segmentAt(line, match.index);
+      const segment = segmentAt(line, match.index, spans);
       queue.push({
         delimiter: match[2] ?? match[3] ?? match[5] ?? "",
         quoted: match[2] !== undefined || match[3] !== undefined || match[4] !== undefined,
@@ -670,11 +701,13 @@ const STDIN_PATHS = new Set(["-", "/dev/stdin"]);
 export function extractBodySpec(command: string): BodySpec {
   const { text, heredocs } = parseCommand(command);
   const flags = bodyFlags(text);
-  const fileValue = text.match(flagValuePattern(flags.file))?.[1];
+  const spans = quotedSpansAll(text);
+  const fileValue = firstUnquotedMatch(text, flagValuePattern(flags.file, true), spans)?.[1];
   if (fileValue != null && fileValue !== "") {
     const path = unquote(fileValue);
     if (STDIN_PATHS.has(path)) {
-      const fed = heredocs.find(
+      // The last stdin redirection wins, as it does in the shell.
+      const fed = heredocs.findLast(
         (doc) => doc.target === null && PR_BODY_COMMAND_PATTERN.test(doc.segment),
       );
       if (fed !== undefined) return heredocSpec(fed);
@@ -684,7 +717,7 @@ export function extractBodySpec(command: string): BodySpec {
     if (part === null) return unreadableExpansion(path);
     return resolveHeredocParts([part], precedingHeredocs(text, heredocs));
   }
-  const inlineValue = text.match(flagValuePattern(flags.inline))?.[1];
+  const inlineValue = firstUnquotedMatch(text, flagValuePattern(flags.inline, true), spans)?.[1];
   if (inlineValue == null || inlineValue === "") return { kind: "none" };
   const inline = parseInlineValue(inlineValue);
   if (inline.kind !== "parts") return inline;
@@ -725,11 +758,13 @@ export function effectiveCwd(command: string, cwd: string): string {
   for (const match of scope.matchAll(CD_PATTERN)) {
     const target = expandTmpdir(unquote(match[1] ?? ""));
     if (target === "" || target === "-" || SHELL_EXPANSION_PATTERN.test(target)) continue;
-    if (target === "~" || target.startsWith("~/")) {
+    if (target.startsWith("~")) {
+      // `~user` needs a passwd lookup the hook does not do, so leave dir as-is.
+      if (target !== "~" && !target.startsWith("~/")) continue;
       dir = join(homedir(), target.slice(1));
-    } else {
-      dir = isAbsolute(target) ? target : join(dir, target);
+      continue;
     }
+    dir = isAbsolute(target) ? target : join(dir, target);
   }
   return dir;
 }

--- a/plugins/pull-request/scripts/validate-body.ts
+++ b/plugins/pull-request/scripts/validate-body.ts
@@ -372,6 +372,8 @@ export interface Heredoc {
   segment: string;
   /** Normalized path the segment redirects or tees the body into, or null when it feeds stdin/stdout. */
   target: string | null;
+  /** Offset of the operator in the stripped text, for ordering against the PR command. */
+  offset: number;
 }
 
 export interface ParsedCommand {
@@ -386,7 +388,35 @@ interface PendingHeredoc {
   stripTabs: boolean;
   segment: string;
   target: string | null;
+  offset: number;
   lines: string[];
+}
+
+// Spans of a line covered by a quoted string, so a `<<` inside an argument
+// (`grep "<<EOF" f`) is not read as an operator. Backslash escapes a quote
+// outside single quotes, where the shell treats it literally.
+function quotedSpans(line: string): Array<[number, number]> {
+  const spans: Array<[number, number]> = [];
+  let open: string | null = null;
+  let start = 0;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === "\\" && open !== "'") {
+      i++;
+      continue;
+    }
+    if (open === null) {
+      if (ch === "'" || ch === '"') {
+        open = ch;
+        start = i;
+      }
+    } else if (ch === open) {
+      spans.push([start, i]);
+      open = null;
+    }
+  }
+  if (open !== null) spans.push([start, line.length]);
+  return spans;
 }
 
 function segmentAt(line: string, index: number): string {
@@ -423,9 +453,11 @@ export function parseCommand(command: string): ParsedCommand {
       quoted: pending.quoted,
       segment: pending.segment,
       target: pending.target,
+      offset: pending.offset,
     });
   };
 
+  let textOffset = 0;
   for (const line of command.split("\n")) {
     const open = queue[0];
     if (open !== undefined) {
@@ -439,7 +471,9 @@ export function parseCommand(command: string): ParsedCommand {
       continue;
     }
     kept.push(line);
+    const spans = quotedSpans(line);
     for (const match of line.matchAll(HEREDOC_OPERATOR)) {
+      if (spans.some(([start, end]) => match.index > start && match.index <= end)) continue;
       const segment = segmentAt(line, match.index);
       queue.push({
         delimiter: match[2] ?? match[3] ?? match[5] ?? "",
@@ -447,9 +481,11 @@ export function parseCommand(command: string): ParsedCommand {
         stripTabs: match[1] === "-",
         segment,
         target: segmentTarget(segment),
+        offset: textOffset + match.index,
         lines: [],
       });
     }
+    textOffset += line.length + 1;
   }
   for (const pending of queue) close(pending);
   return { text: kept.join("\n"), heredocs };
@@ -606,8 +642,9 @@ function heredocSpec(heredoc: Heredoc): BodySpec {
 
 // Swap each file part for the heredoc that writes that path in the same
 // command, so a body created and passed in one call validates without touching
-// a file the command has not written yet. The last write wins, as it would in
-// the shell.
+// a file the command has not written yet. Only writes ahead of the PR command
+// count (a later write is not what the CLI reads), and the last of those wins,
+// as it would in the shell.
 function resolveHeredocParts(parts: BodyPart[], heredocs: Heredoc[]): BodySpec {
   const resolved: BodyPart[] = [];
   for (const part of parts) {
@@ -645,13 +682,19 @@ export function extractBodySpec(command: string): BodySpec {
     }
     const part = filePart(fileValue);
     if (part === null) return unreadableExpansion(path);
-    return resolveHeredocParts([part], heredocs);
+    return resolveHeredocParts([part], precedingHeredocs(text, heredocs));
   }
   const inlineValue = text.match(flagValuePattern(flags.inline))?.[1];
   if (inlineValue == null || inlineValue === "") return { kind: "none" };
   const inline = parseInlineValue(inlineValue);
   if (inline.kind !== "parts") return inline;
-  return resolveHeredocParts(inline.parts, heredocs);
+  return resolveHeredocParts(inline.parts, precedingHeredocs(text, heredocs));
+}
+
+function precedingHeredocs(text: string, heredocs: Heredoc[]): Heredoc[] {
+  const prIndex = text.search(PR_BODY_COMMAND_PATTERN);
+  if (prIndex === -1) return [];
+  return heredocs.filter((doc) => doc.offset < prIndex);
 }
 
 /** The body text a command will send, or why the hook cannot see it. */
@@ -670,7 +713,9 @@ async function readBodyFile(path: string, cwd: string): Promise<string | null> {
 
 // A `cd` ahead of the PR command moves where the CLI resolves a relative body
 // path, so the hook follows each one it can evaluate before reading files.
-const CD_PATTERN = /(?:^|&&|\|\||;|\n)\s*cd\s+("(?:[^"\\]|\\.)*"|'[^']*'|[^\s;|&]+)/g;
+// `||` is excluded from the lead-ins: a `cd a || cd b` fallback only runs when
+// the first cd failed, so the hook follows the success path.
+const CD_PATTERN = /(?:^|&&|;|\n)\s*cd\s+("(?:[^"\\]|\\.)*"|'[^']*'|[^\s;|&]+)/g;
 
 export function effectiveCwd(command: string, cwd: string): string {
   const text = parseCommand(command).text;

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -103,6 +103,7 @@ describe("parseCommand", () => {
             quoted: true,
             segment: "cat > body.md <<'EOF'",
             target: "body.md",
+            offset: 14,
           },
         ],
       },
@@ -118,6 +119,7 @@ describe("parseCommand", () => {
             quoted: true,
             segment: "cat <<'EOF' > body.md",
             target: "body.md",
+            offset: 4,
           },
         ],
       },
@@ -133,6 +135,7 @@ describe("parseCommand", () => {
             quoted: true,
             segment: " tee tmp/body.md <<'EOF'",
             target: "tmp/body.md",
+            offset: 32,
           },
         ],
       },
@@ -143,7 +146,13 @@ describe("parseCommand", () => {
       {
         text: "cat >> log.md <<EOF",
         heredocs: [
-          { content: "$VERSION\n", quoted: false, segment: "cat >> log.md <<EOF", target: null },
+          {
+            content: "$VERSION\n",
+            quoted: false,
+            segment: "cat >> log.md <<EOF",
+            target: null,
+            offset: 14,
+          },
         ],
       },
     ],
@@ -158,9 +167,15 @@ describe("parseCommand", () => {
             quoted: true,
             segment: "cat > body.md <<-'EOF'",
             target: "body.md",
+            offset: 14,
           },
         ],
       },
+    ],
+    [
+      "ignores a << inside a quoted argument",
+      'echo "<<EOF"\ngh pr create --body-file body.md',
+      { text: 'echo "<<EOF"\ngh pr create --body-file body.md', heredocs: [] },
     ],
     [
       "gives an unterminated heredoc the rest of the command",
@@ -173,6 +188,7 @@ describe("parseCommand", () => {
             quoted: true,
             segment: "cat > body.md <<'EOF'",
             target: "body.md",
+            offset: 14,
           },
         ],
       },
@@ -238,6 +254,11 @@ describe("extractBodySpec", () => {
     // A heredoc attached to the create command itself feeds its stdin.
     ["gh pr create --title T --body-file - <<'EOF'\nProse.\nEOF", parts(literal("Prose.\n"))],
     ["gh pr create --body-file /dev/stdin <<'EOF'\nProse.\nEOF", parts(literal("Prose.\n"))],
+    // A write sequenced after the create command is not what the CLI reads.
+    [
+      "gh pr create --body-file body.md\ncat > body.md <<'EOF'\nProse.\nEOF",
+      parts(file("body.md")),
+    ],
   ])("extractBodySpec(%p) -> %p", (command, expected) => {
     expect(extractBodySpec(command)).toEqual(expected);
   });
@@ -698,6 +719,8 @@ describe("effectiveCwd", () => {
     ["gh pr create --body-file body.md && cd sub", "/repo"],
     ['cd "$DIR" && gh pr create --body-file body.md', "/repo"],
     ["cd - && gh pr create --body-file body.md", "/repo"],
+    // The || fallback only runs when the first cd failed.
+    ["cd a || cd b && gh pr create --body-file body.md", path.join("/repo", "a")],
   ])("effectiveCwd(%p) -> %p", (command, expected) => {
     expect(effectiveCwd(command, "/repo")).toBe(expected);
   });

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -259,6 +259,23 @@ describe("extractBodySpec", () => {
       "gh pr create --body-file body.md\ncat > body.md <<'EOF'\nProse.\nEOF",
       parts(file("body.md")),
     ],
+    // A flag word inside another flag's quoted value is body text, not a flag.
+    [
+      'gh pr create --body "documents --body-file usage"',
+      parts(literal("documents --body-file usage")),
+    ],
+    // Quoted `;` and `>` in the create command's own arguments do not detach
+    // the stdin heredoc.
+    [
+      "gh pr create --title \"a; b\" --body-file - <<'EOF'\nProse.\nEOF",
+      parts(literal("Prose.\n")),
+    ],
+    [
+      "gh pr create --title \"a > b\" --body-file - <<'EOF'\nProse.\nEOF",
+      parts(literal("Prose.\n")),
+    ],
+    // The shell feeds the last stdin redirection to the CLI.
+    ["gh pr create --body-file - <<'A' <<'B'\nfirst\nA\nsecond\nB", parts(literal("second\n"))],
   ])("extractBodySpec(%p) -> %p", (command, expected) => {
     expect(extractBodySpec(command)).toEqual(expected);
   });
@@ -721,6 +738,8 @@ describe("effectiveCwd", () => {
     ["cd - && gh pr create --body-file body.md", "/repo"],
     // The || fallback only runs when the first cd failed.
     ["cd a || cd b && gh pr create --body-file body.md", path.join("/repo", "a")],
+    // `~user` needs a passwd lookup the hook does not do.
+    ["cd ~nobody && gh pr create --body-file body.md", "/repo"],
   ])("effectiveCwd(%p) -> %p", (command, expected) => {
     expect(effectiveCwd(command, "/repo")).toBe(expected);
   });

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -8,6 +8,7 @@ import {
   type BodyContext,
   type BodyPart,
   type BodySpec,
+  effectiveCwd,
   extractBacktickedHexCandidates,
   extractBodySpec,
   extractTitle,
@@ -22,6 +23,8 @@ import {
   isPersonalRepo,
   isPrBodyCommand,
   type NarrationTell,
+  parseCommand,
+  type ParsedCommand,
   parseGhLogin,
   parseRemote,
   processInput,
@@ -81,8 +84,101 @@ describe("isPrBodyCommand", () => {
     ["{ echo one; echo two; }", false],
     ["for f in *.ts; do wc -l $f; done", false],
     ["cat <<'EOF' > notes.md\nnothing here\nEOF", false],
+    ["cat > notes.md <<'EOF'\nrun gh pr create --body-file x.md later\nEOF", false],
   ])("isPrBodyCommand(%p) -> %p", (command, expected) => {
     expect(isPrBodyCommand(command)).toBe(expected);
+  });
+});
+
+describe("parseCommand", () => {
+  test.each<[string, string, ParsedCommand]>([
+    [
+      "strips the body and captures a > redirect target",
+      "cat > body.md <<'EOF'\nProse.\nEOF\ngh pr create --body-file body.md",
+      {
+        text: "cat > body.md <<'EOF'\ngh pr create --body-file body.md",
+        heredocs: [
+          {
+            content: "Prose.\n",
+            quoted: true,
+            segment: "cat > body.md <<'EOF'",
+            target: "body.md",
+          },
+        ],
+      },
+    ],
+    [
+      "finds a redirect written after the operator",
+      "cat <<'EOF' > body.md\nProse.\nEOF",
+      {
+        text: "cat <<'EOF' > body.md",
+        heredocs: [
+          {
+            content: "Prose.\n",
+            quoted: true,
+            segment: "cat <<'EOF' > body.md",
+            target: "body.md",
+          },
+        ],
+      },
+    ],
+    [
+      "finds a tee sink and scopes the segment to its command",
+      "mkdir -p tmp && tee tmp/body.md <<'EOF'\nProse.\nEOF",
+      {
+        text: "mkdir -p tmp && tee tmp/body.md <<'EOF'",
+        heredocs: [
+          {
+            content: "Prose.\n",
+            quoted: true,
+            segment: " tee tmp/body.md <<'EOF'",
+            target: "tmp/body.md",
+          },
+        ],
+      },
+    ],
+    [
+      "marks an unquoted delimiter and skips an append target",
+      "cat >> log.md <<EOF\n$VERSION\nEOF",
+      {
+        text: "cat >> log.md <<EOF",
+        heredocs: [
+          { content: "$VERSION\n", quoted: false, segment: "cat >> log.md <<EOF", target: null },
+        ],
+      },
+    ],
+    [
+      "strips tabs under <<- and matches a tab-indented terminator",
+      "cat > body.md <<-'EOF'\n\tProse.\n\tEOF",
+      {
+        text: "cat > body.md <<-'EOF'",
+        heredocs: [
+          {
+            content: "Prose.\n",
+            quoted: true,
+            segment: "cat > body.md <<-'EOF'",
+            target: "body.md",
+          },
+        ],
+      },
+    ],
+    [
+      "gives an unterminated heredoc the rest of the command",
+      "cat > body.md <<'EOF'\nProse.\nMore prose.",
+      {
+        text: "cat > body.md <<'EOF'",
+        heredocs: [
+          {
+            content: "Prose.\nMore prose.\n",
+            quoted: true,
+            segment: "cat > body.md <<'EOF'",
+            target: "body.md",
+          },
+        ],
+      },
+    ],
+  ])("%s", (_name, command, expected) => {
+    expect(parseCommand(command)).toEqual(expected);
   });
 });
 
@@ -117,6 +213,31 @@ describe("extractBodySpec", () => {
     // description on glab and the draft switch on gh.
     ["glab mr create -b main --description-file body.md", parts(file("body.md"))],
     ["gh pr create -d --body-file body.md", parts(file("body.md"))],
+    // A heredoc that writes the body file in the same command is the body,
+    // read before the file exists.
+    [
+      "mkdir -p tmp && cat > tmp/body.md <<'EOF'\n## Summary\n\nProse.\nEOF\ngh pr create --title T --body-file tmp/body.md",
+      parts(literal("## Summary\n\nProse.\n")),
+    ],
+    [
+      "cat <<'EOF' > body.md\nProse.\nEOF\ngh pr create --body-file ./body.md",
+      parts(literal("Prose.\n")),
+    ],
+    [
+      "tee body.md <<'EOF'\nProse.\nEOF\nglab mr create --description-file body.md",
+      parts(literal("Prose.\n")),
+    ],
+    [
+      "cat > body.md <<EOF\nPlain prose.\nEOF\ngh pr create --body-file body.md",
+      parts(literal("Plain prose.\n")),
+    ],
+    [
+      "cat > b.md <<'EOF'\nProse.\nEOF\nglab mr create --description \"$(cat b.md)\"",
+      parts(literal("Prose.\n")),
+    ],
+    // A heredoc attached to the create command itself feeds its stdin.
+    ["gh pr create --title T --body-file - <<'EOF'\nProse.\nEOF", parts(literal("Prose.\n"))],
+    ["gh pr create --body-file /dev/stdin <<'EOF'\nProse.\nEOF", parts(literal("Prose.\n"))],
   ])("extractBodySpec(%p) -> %p", (command, expected) => {
     expect(extractBodySpec(command)).toEqual(expected);
   });
@@ -128,7 +249,13 @@ describe("extractBodySpec", () => {
     ['glab mr create --description "$(cat $BODY_FILE)"', "$BODY_FILE"],
     ["glab mr create --description-file -", "standard input"],
     ["gh pr create --body-file -", "standard input"],
+    ["gh pr create --body-file /dev/stdin", "standard input"],
     ["glab mr create --description -", "editor"],
+    [
+      "cat > body.md <<EOF\nRelease $VERSION\nEOF\ngh pr create --body-file body.md",
+      "unquoted heredoc",
+    ],
+    ["gh pr create --body-file - <<EOF\nRelease $VERSION\nEOF", "$VERSION"],
   ])("extractBodySpec(%p) reports it cannot read %p", (command, fragment) => {
     const spec = extractBodySpec(command);
     expect(spec.kind).toBe("unreadable");
@@ -553,8 +680,26 @@ describe("extractTitle", () => {
     ['BODY=$(mktemp -t pr) && gh pr create --title "Real Title" --body-file "$BODY"', "Real Title"],
     ['gh pr create --body "use tar -t archive.tar to list" --title "Real Title"', "Real Title"],
     ['gh pr edit 12 --body "documents the --title flag for the scaffolder"', null],
+    [
+      'cat > b.md <<\'EOF\'\ngh pr create --title "Fake Title"\nEOF\ngh pr create --title "Real Title" --body-file b.md',
+      "Real Title",
+    ],
   ])("extractTitle(%p) -> %p", (command, expected) => {
     expect(extractTitle(command)).toBe(expected);
+  });
+});
+
+describe("effectiveCwd", () => {
+  test.each<[string, string]>([
+    ["gh pr create --body-file body.md", "/repo"],
+    ["cd sub && gh pr create --body-file body.md", path.join("/repo", "sub")],
+    ["cd /abs && gh pr create --body-file body.md", "/abs"],
+    ["cd a && cd b && gh pr create --body-file body.md", path.join("/repo", "a", "b")],
+    ["gh pr create --body-file body.md && cd sub", "/repo"],
+    ['cd "$DIR" && gh pr create --body-file body.md', "/repo"],
+    ["cd - && gh pr create --body-file body.md", "/repo"],
+  ])("effectiveCwd(%p) -> %p", (command, expected) => {
+    expect(effectiveCwd(command, "/repo")).toBe(expected);
   });
 });
 
@@ -711,6 +856,35 @@ describe("processInput", () => {
     const bodyFile = path.join(tempDir, "body.md");
     await Bun.write(bodyFile, "## Two fixes found while testing\n\nReshapes the resolver.");
     const result = await processInput(createInput(build(bodyFile), repoRoot));
+    expect(getPermissionDecision(result)).toBe("deny");
+    expect(getDenyReason(result)).toContain("Two Fixes Found While Testing");
+  });
+
+  // The body file does not exist when the hook runs: the same command writes
+  // it. The heredoc is the body.
+  it("validates a body written by a heredoc in the same command", async () => {
+    const bodyFile = path.join(tempDir, "body.md");
+    const command = `mkdir -p tmp && cat > ${bodyFile} <<'EOF'\n## Two fixes found while testing\n\nReshapes the resolver.\nEOF\ngh pr create --title T --body-file ${bodyFile}`;
+    const result = await processInput(createInput(command, repoRoot));
+    expect(getPermissionDecision(result)).toBe("deny");
+    expect(getDenyReason(result)).toContain("Two Fixes Found While Testing");
+  });
+
+  it("passes a clean body written by a heredoc in the same command", async () => {
+    const bodyFile = path.join(tempDir, "body.md");
+    const command = `cat > ${bodyFile} <<'EOF'\n## Summary\n\nFixes a bug.\nEOF\ngh pr create --title T --body-file ${bodyFile}`;
+    expect(await processInput(createInput(command, repoRoot))).toBeNull();
+  });
+
+  it("resolves a relative body file behind a cd", async () => {
+    const sub = path.join(tempDir, "sub");
+    await Bun.write(
+      path.join(sub, "body.md"),
+      "## Two fixes found while testing\n\nReshapes the resolver.",
+    );
+    const result = await processInput(
+      createInput("cd sub && gh pr create --title T --body-file body.md", tempDir),
+    );
     expect(getPermissionDecision(result)).toBe("deny");
     expect(getDenyReason(result)).toContain("Two Fixes Found While Testing");
   });

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -80,7 +80,7 @@ Parse `$ARGUMENTS` for these flags. With none, create a PR/MR that is ready for 
 1. Create the PR/MR, appending `--draft` when set, `--base <parent>` when the branch is a stack layer, and `--label <name>` for each label that resolved:
    - **GitHub**: `gh pr create --title "..." --body-file tmp/pr-body-<branch>.md`
    - **GitLab**: `glab mr create --title "..." --description-file tmp/pr-body-<branch>.md`
-   - Write the body file in its own Bash call, with the branch name in the filename so concurrent agents don't collide. Start the create command with `gh`/`glab`: the body-validation hook matches that leading word, and a `cd`, chained heredoc, or env assignment in front of it silently skips validation.
+   - Put the branch name in the body filename so concurrent agents don't collide. Writing the file with a quoted heredoc (`cat > tmp/pr-body-<branch>.md <<'EOF'`) in the same call as the create command works: the validation hook reads the heredoc directly.
 1. Chain a GitHub stack layer into its stack once the PR exists. Load `github:stack` for the `gh stack link` forms, the detection query that picks between them, and what an exit code 9 means.
 1. Enable auto-merge after the PR/MR exists, unless `--no-auto` or `--draft` is set. On a repo you own (the Remote URL above names the owner), run `gh pr merge --auto`. On a third-party repo, leave the merge to the maintainer. GitLab, stacked PRs, and a repo that rejects `--auto` take the paths in [`references/merge.md`](references/merge.md).
 1. Suggest reviewers on corporate repos (see [Reviewers](#reviewers)). Skip this step for OSS.


### PR DESCRIPTION
The body-validation hook runs at PreToolUse, before the command executes, so a body file written by a heredoc in the same Bash call did not exist yet and the hook denied the create outright. The hook now parses heredocs out of the command text and substitutes their content for the file the create command names, validating the write-and-create-in-one-call shape without touching disk.

Parsing the command surfaced adjacent matching bugs:

- Heredoc content polluted verb, flag, and title matching. A `gh pr create` or `--body-file` inside a quoted string or heredoc body was matched as the real one. Flags, operators, and segment separators now match only outside quoted spans.
- `--body-file -` and `/dev/stdin` read the hook's own already-drained stdin and validated an empty body, letting any content through. Stdin bodies now resolve to the last untargeted heredoc preceding the create command.
- A `cd` before the create broke relative body-file resolution. Paths now resolve against the effective cwd, following `cd`s while skipping `||` fallbacks.

I parsed heredocs with a line-oriented scanner instead of adding a shell parser dependency. It handles quoted and unquoted delimiters, `<<-` tab stripping, multiple operators per line, and unterminated bodies. An unquoted delimiter whose body carries a shell expansion (`$VERSION`) is denied with guidance to quote the delimiter, since the hook cannot know the expanded value. A heredoc written after the create command never substitutes, and the last stdin redirection wins, matching shell semantics.

Verified by piping hook-style JSON into the real script: the exact command from the failing transcript validates cleanly, an unquoted `$VERSION` body denies naming the expansion, and a deny-worthy body still hits the content checks. The create skill's guidance now allows the same-call heredoc shape.

https://claude.ai/code/session_01Lw6pa8Zj6HimT6vckZhyoy
