### PR TITLE
pull-request: guard the copied heading-case hook

### DIFF
--- a/plugins/pull-request/scripts/sentence-heading.test.ts
+++ b/plugins/pull-request/scripts/sentence-heading.test.ts
@@ -4,21 +4,23 @@ import { classifyPrHeading } from "./sentence-heading";
 
 const root = join(import.meta.dirname, "..", "..", "..");
 
-// The files under `linguistics/` are byte-for-byte copies of the writing
-// plugin's. The duplication is deliberate: plugins are distributed and installed
-// one at a time, so runtime code can only import published npm packages, which
-// rules out both a cross-plugin import and a `workspace:*` package. Read as text
-// rather than imported, so the plugin-boundary checker still passes.
-test.each(["heading.ts", "preprocess.ts", "tags.ts"])(
-  "linguistics/%s stays identical to the writing plugin's copy",
-  async (file) => {
-    const [writing, pullRequest] = await Promise.all([
-      Bun.file(join(root, "plugins", "writing", "linguistics", file)).text(),
-      Bun.file(join(root, "plugins", "pull-request", "scripts", "linguistics", file)).text(),
-    ]);
-    expect(pullRequest).toBe(writing);
-  },
-);
+// These files are byte-for-byte copies of the writing plugin's. The duplication
+// is deliberate: plugins are distributed and installed one at a time, so runtime
+// code can only import published npm packages, which rules out both a
+// cross-plugin import and a `workspace:*` package. Read as text rather than
+// imported, so the plugin-boundary checker still passes.
+test.each([
+  ["linguistics/heading.ts", "scripts/linguistics/heading.ts"],
+  ["linguistics/preprocess.ts", "scripts/linguistics/preprocess.ts"],
+  ["linguistics/tags.ts", "scripts/linguistics/tags.ts"],
+  ["hooks/heading-case.ts", "scripts/heading-case.ts"],
+])("writing/%s and pull-request/%s stay identical", async (source, destination) => {
+  const [writing, pullRequest] = await Promise.all([
+    Bun.file(join(root, "plugins", "writing", source)).text(),
+    Bun.file(join(root, "plugins", "pull-request", destination)).text(),
+  ]);
+  expect(pullRequest).toBe(writing);
+});
 
 test.each<[string, string, boolean]>([
   ["flags an interrogative opener", "Why This Happens", true],


### PR DESCRIPTION
`plugins/pull-request/scripts/heading-case.ts` is a byte-for-byte copy of the writing plugin's `hooks/heading-case.ts`, and nothing caught the two drifting apart. The identity test guarded only the three files under `linguistics/`, which are the copies that happen to share a relative path across both plugins.

The table now carries a source and destination pair per file, so a copy is covered regardless of where each plugin keeps it. The two `heading-case.ts` files are identical today, so the new case passes as written.

https://claude.ai/code/session_013XTw1P7XCWhDQB1KAPKkeX
