### PR TITLE
session: move the forget sequence into db.ts

### DIFF
--- a/plugins/claude-code/skills/session/scripts/db.test.ts
+++ b/plugins/claude-code/skills/session/scripts/db.test.ts
@@ -8,9 +8,11 @@ import { z } from "zod";
 import {
   compactDatabase,
   type Database,
+  deleteHostRows,
   dirExists,
   ensureIndex,
   ensureSchema,
+  forgetHost,
   getDb,
   invalidateDerived,
   rebuildViews,
@@ -719,10 +721,8 @@ describe("cross-machine history", () => {
     );
     expect(Number(before?.n)).toBeGreaterThan(0);
 
-    await db.run("DELETE FROM raw WHERE host = $host", { host: "gone" });
-    await db.run("DELETE FROM content_items WHERE host = $host", { host: "gone" });
-    await db.run("DELETE FROM indexed_files WHERE host = $host", { host: "gone" });
-    await db.run("DELETE FROM meta WHERE host = $host", { host: "gone" });
+    const removed = await forgetHost(db, "gone");
+    expect(removed).toBe(Number(before?.n));
     await rm(path.join(importsDir, "gone"), { recursive: true, force: true });
 
     const [after] = await db.query(
@@ -746,9 +746,7 @@ describe("cross-machine history", () => {
     await reindex();
 
     await invalidateDerived(db);
-    await db.run("DELETE FROM raw WHERE host = $host", { host: "gone" });
-    await db.run("DELETE FROM indexed_files WHERE host = $host", { host: "gone" });
-    await db.run("DELETE FROM meta WHERE host = $host", { host: "gone" });
+    await deleteHostRows(db, "gone");
     await rm(path.join(importsDir, "gone"), { recursive: true, force: true });
 
     await reindex();

--- a/plugins/claude-code/skills/session/scripts/db.ts
+++ b/plugins/claude-code/skills/session/scripts/db.ts
@@ -389,6 +389,36 @@ export async function rebuildViews(db: Database): Promise<void> {
   await db.run(await readSql(RESOURCES_DIR, "views"));
 }
 
+// One transaction: a partial forget that kept indexed_files rows would make a later
+// re-import of the same label skip every unchanged file while raw stays empty. The views
+// rebuild drops the host from content_items. CHECKPOINT cannot run inside a transaction.
+//
+// Marking the derived tables stale first is what keeps a forget durable. A crash between
+// the commit and the rebuild would otherwise leave the host's rows in content_items with
+// nothing left to ask for their removal: its files are gone, so no later refresh sees a
+// change. Returns the number of raw rows removed.
+export async function forgetHost(db: Database, host: string): Promise<number> {
+  const [row] = await db.query(
+    "SELECT COUNT(*) AS n FROM raw WHERE host = $host",
+    z.object({ n: z.bigint() }),
+    { host },
+  );
+  await invalidateDerived(db);
+  await deleteHostRows(db, host);
+  await rebuildViews(db);
+  await db.run("CHECKPOINT");
+  return Number(row?.n ?? 0n);
+}
+
+// The committed half of a forget, exported so an interrupted one can be reproduced.
+export async function deleteHostRows(db: Database, host: string): Promise<void> {
+  await db.run("BEGIN");
+  await db.run("DELETE FROM raw WHERE host = $host", { host });
+  await db.run("DELETE FROM indexed_files WHERE host = $host", { host });
+  await db.run("DELETE FROM meta WHERE host = $host", { host });
+  await db.run("COMMIT");
+}
+
 async function removeFile(db: Database, host: string, file: string): Promise<void> {
   await db.run("BEGIN");
   await db.run("DELETE FROM raw WHERE host = $host AND source_file = $path", {

--- a/plugins/claude-code/skills/session/scripts/forget.ts
+++ b/plugins/claude-code/skills/session/scripts/forget.ts
@@ -4,16 +4,14 @@
 // when the probe in docs/settings.md succeeds.
 import { rm } from "node:fs/promises";
 import { cli } from "cleye";
-import { z } from "zod";
 import {
   dirExists,
   ensureSchema,
+  forgetHost,
   getDataDir,
   getDb,
   importRoot,
-  invalidateDerived,
   LOCAL_HOST,
-  rebuildViews,
 } from "./db";
 
 const argv = cli({
@@ -43,31 +41,7 @@ const db = await getDb(getDataDir());
 let deleted = 0;
 try {
   await ensureSchema(db);
-  const [row] = await db.query(
-    "SELECT COUNT(*) AS n FROM raw WHERE host = $host",
-    z.object({ n: z.bigint() }),
-    {
-      host: label,
-    },
-  );
-  deleted = Number(row?.n ?? 0n);
-  // One transaction: a partial forget that kept indexed_files rows would make a
-  // later re-import of the same label skip every unchanged file while raw stays
-  // empty. The views rebuild drops the host from content_items. CHECKPOINT cannot
-  // run inside a transaction.
-  //
-  // Marking the derived tables stale first is what keeps a forget durable. A crash
-  // between the commit and the rebuild would otherwise leave the host's rows in
-  // content_items with nothing left to ask for their removal: its files are gone, so no
-  // later refresh sees a change.
-  await invalidateDerived(db);
-  await db.run("BEGIN");
-  await db.run("DELETE FROM raw WHERE host = $host", { host: label });
-  await db.run("DELETE FROM indexed_files WHERE host = $host", { host: label });
-  await db.run("DELETE FROM meta WHERE host = $host", { host: label });
-  await db.run("COMMIT");
-  await rebuildViews(db);
-  await db.run("CHECKPOINT");
+  deleted = await forgetHost(db, label);
 } finally {
   db.close();
 }


### PR DESCRIPTION
The sequence that removes a host from the index lived in `forget.ts`, and `db.test.ts` carried a hand-written copy of the same SQL to assert what it does. The two had no link: editing the script without editing the test left the test asserting the old behavior and still passing.

`forgetHost(db, host)` now owns the whole sequence in `db.ts`, next to the other functions that mutate `raw` and its derived tables, and returns the row count the CLI prints. `forget.ts` keeps only argument parsing, the `local` guard, removal of the synced files, and the summary line, which is how `import.ts` and `hosts.ts` already sit on top of `db.ts`.

The interrupted-forget test needs a forget that stops after the commit and never rebuilds, which rules out calling `forgetHost` directly. `deleteHostRows` splits out the committed half. Both the test and `forgetHost` call it.

Verified by running `forget.ts` against a temp index with an imported host, which removed the rows and the synced directory and still rejected `--host local`.
