### PR TITLE
claude-code: decode hook stdin with zod

### DIFF
--- a/plugins/claude-code/skills/hook/SKILL.md
+++ b/plugins/claude-code/skills/hook/SKILL.md
@@ -104,9 +104,9 @@ try {
 }
 ```
 
-`looseObject` keeps fields the harness adds later, and `.catch` supplies a per-field default so one unexpected value costs that field rather than the whole payload.
+`looseObject` keeps fields the harness adds later. A per-field `.catch` means one unexpected value costs that field rather than the whole payload.
 
-On an undecodable payload, log one line to stderr and exit 0 so the tool call proceeds. A gate exits 1 instead, letting the call through while the harness surfaces the stderr line, so a gate that has stopped deciding says so rather than reading as a call that passed every rule ([plugins/plan/hooks/gate.ts](../../../plan/hooks/gate.ts)). Reserve exit 2 for the block itself.
+On an undecodable payload, log the failure to stderr and exit 0 so the tool call proceeds. A gate can exit 1 instead. The call still goes through, and the harness surfaces the stderr line, so a gate that has stopped deciding does not read as a call that passed every rule ([plugins/plan/hooks/gate.ts](../../../plan/hooks/gate.ts)).
 
 ## Hook Output
 
@@ -119,7 +119,7 @@ On an undecodable payload, log one line to stderr and exit 0 so the tool call pr
 {"hookSpecificOutput": {"hookEventName": "PreToolUse", "updatedInput": {"state": "Todo"}}}
 ```
 
-On `ExitPlanMode`, `ask` is inert: the tool runs its own plan-approval prompt, and the harness drops the hook's `permissionDecisionReason` and `systemMessage` both. Use `deny` there to carry a reason back.
+On `ExitPlanMode`, `ask` is inert: the tool runs its own plan-approval prompt, and the harness drops both `permissionDecisionReason` and `systemMessage`. Use `deny` there to carry a reason back.
 
 **PostToolUse** - Provide feedback:
 ```json

--- a/plugins/claude-code/skills/hook/SKILL.md
+++ b/plugins/claude-code/skills/hook/SKILL.md
@@ -85,11 +85,28 @@ Commands receive JSON on stdin:
 }
 ```
 
-Parse in TypeScript:
+Stdin is external data, so decode it with a zod schema covering the fields the hook reads. A plugin hook keeps that schema local, since it cannot import a workspace package:
+
 ```typescript
-import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
-const input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
+import { z } from "zod";
+
+const HookInput = z.looseObject({
+  cwd: z.string().catch(""),
+  tool_input: z.looseObject({ file_path: z.string().optional().catch(undefined) }).catch({}),
+});
+
+let input: z.infer<typeof HookInput>;
+try {
+  input = HookInput.parse(JSON.parse(await Bun.stdin.text()));
+} catch (error) {
+  console.error(`[my-hook] undecodable stdin: ${error}`);
+  process.exit(0);
+}
 ```
+
+`looseObject` keeps fields the harness adds later, and `.catch` supplies a per-field default so one unexpected value costs that field rather than the whole payload.
+
+On an undecodable payload, log one line to stderr and exit 0 so the tool call proceeds. A gate exits 1 instead, letting the call through while the harness surfaces the stderr line, so a gate that has stopped deciding says so rather than reading as a call that passed every rule ([plugins/plan/hooks/gate.ts](../../../plan/hooks/gate.ts)). Reserve exit 2 for the block itself.
 
 ## Hook Output
 
@@ -101,6 +118,8 @@ const input = JSON.parse(await Bun.stdin.text()) as PreToolUseHookInput;
 ```json
 {"hookSpecificOutput": {"hookEventName": "PreToolUse", "updatedInput": {"state": "Todo"}}}
 ```
+
+On `ExitPlanMode`, `ask` is inert: the tool runs its own plan-approval prompt, and the harness drops the hook's `permissionDecisionReason` and `systemMessage` both. Use `deny` there to carry a reason back.
 
 **PostToolUse** - Provide feedback:
 ```json


### PR DESCRIPTION
The hook skill's stdin example cast `JSON.parse` output straight to the SDK's `PreToolUseHookInput`, an unchecked promise about external data that `user/rules/typescript.md` forbids. The example now decodes with a local `z.looseObject` covering only the fields the hook reads, parsed inside a `try` that catches both the JSON and schema failure together. A plugin hook can't import a workspace package, so the schema stays inline rather than using `packages/decode`.

States the failure policy the example implies. An undecodable payload logs to stderr and exits 0, letting the tool call proceed. A gate can exit 1 instead: the call still goes through, but the stderr line stays visible, so a gate that has stopped deciding doesn't read as a call that passed every rule.

Also documents that `ask` is inert on `ExitPlanMode` ([#1216](https://github.com/bendrucker/claude/pull/1216)): the tool runs its own approval prompt and the harness drops the hook's reason, so only `deny` carries one back.

https://claude.ai/code/session_01Sqvc6HfAGTxKPH2ASF33rz
