### PR TITLE
gitlab: report undecodable hook payloads

### DIFF
--- a/plugins/gitlab/hooks/auth.test.ts
+++ b/plugins/gitlab/hooks/auth.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
+import { join } from "node:path";
 import { type HookInput, processInput } from "./auth";
 
 function mockInput(command: string, toolResponse: unknown = {}): HookInput {
@@ -42,5 +43,31 @@ describe("glab auth hook", () => {
   it("ignores commands with no response", () => {
     const input = mockInput("glab mr view 1");
     expect(processInput(input)).toBeNull();
+  });
+});
+
+async function runHook(payload: string) {
+  const hook = Bun.spawn(["bun", join(import.meta.dir, "auth.ts")], {
+    stdin: new TextEncoder().encode(payload),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(hook.stdout).text(),
+    new Response(hook.stderr).text(),
+    hook.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("undecodable payload", () => {
+  test.each<{ name: string; payload: string }>([
+    { name: "not JSON", payload: "not json" },
+    { name: "wrong event", payload: JSON.stringify({ hook_event_name: "PreToolUse" }) },
+  ])("$name logs and exits 0", async ({ payload }) => {
+    const { stdout, stderr, exitCode } = await runHook(payload);
+    expect(stderr).toContain("[gitlab/auth] Failed to parse hook input:");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
   });
 });

--- a/plugins/gitlab/hooks/auth.ts
+++ b/plugins/gitlab/hooks/auth.ts
@@ -2,7 +2,7 @@
 
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
-import { BashHookInput, parseHookInput } from "./hook-input";
+import { BashHookInput, readHookInput } from "./hook-input";
 
 export const HookInput = BashHookInput.extend({
   hook_event_name: z.literal("PostToolUse"),
@@ -27,7 +27,7 @@ export function processInput(input: HookInput): SyncHookJSONOutput | null {
 }
 
 async function main(): Promise<void> {
-  const input = parseHookInput(HookInput, "auth", await Bun.stdin.text());
+  const input = await readHookInput(HookInput, "auth");
   if (input == null) return;
 
   const output = processInput(input);

--- a/plugins/gitlab/hooks/auth.ts
+++ b/plugins/gitlab/hooks/auth.ts
@@ -2,10 +2,10 @@
 
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
+import { BashHookInput, parseHookInput } from "./hook-input";
 
-export const HookInput = z.looseObject({
+export const HookInput = BashHookInput.extend({
   hook_event_name: z.literal("PostToolUse"),
-  tool_input: z.looseObject({ command: z.string().optional().catch(undefined) }).catch({}),
   tool_response: z.unknown(),
 });
 export type HookInput = z.infer<typeof HookInput>;
@@ -27,16 +27,10 @@ export function processInput(input: HookInput): SyncHookJSONOutput | null {
 }
 
 async function main(): Promise<void> {
-  let raw: unknown;
-  try {
-    raw = JSON.parse(await Bun.stdin.text());
-  } catch {
-    return;
-  }
-  const input = HookInput.safeParse(raw);
-  if (!input.success) return;
+  const input = parseHookInput(HookInput, "auth", await Bun.stdin.text());
+  if (input == null) return;
 
-  const output = processInput(input.data);
+  const output = processInput(input);
   if (output) {
     process.stdout.write(`${JSON.stringify(output)}\n`);
   }

--- a/plugins/gitlab/hooks/hook-input.ts
+++ b/plugins/gitlab/hooks/hook-input.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const BashHookInput = z.looseObject({
+  tool_input: z.looseObject({ command: z.string().optional().catch(undefined) }).catch({}),
+});
+
+// A hook that dies on an undecodable payload takes the tool call down with it,
+// so the failure is reported on stderr and the hook exits without output.
+export function parseHookInput<S extends z.ZodType>(
+  schema: S,
+  hook: string,
+  text: string,
+): z.output<S> | null {
+  try {
+    return schema.parse(JSON.parse(text));
+  } catch (error) {
+    console.error(
+      `[gitlab/${hook}] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
+}

--- a/plugins/gitlab/hooks/hook-input.ts
+++ b/plugins/gitlab/hooks/hook-input.ts
@@ -4,15 +4,15 @@ export const BashHookInput = z.looseObject({
   tool_input: z.looseObject({ command: z.string().optional().catch(undefined) }).catch({}),
 });
 
-// A hook that dies on an undecodable payload takes the tool call down with it,
-// so the failure is reported on stderr and the hook exits without output.
-export function parseHookInput<S extends z.ZodType>(
+// A hook that dies on an unreadable or undecodable payload takes the tool call
+// down with it, so every failure reaching stdin is reported on stderr and the
+// hook exits without output.
+export async function readHookInput<S extends z.ZodType>(
   schema: S,
   hook: string,
-  text: string,
-): z.output<S> | null {
+): Promise<z.output<S> | null> {
   try {
-    return schema.parse(JSON.parse(text));
+    return schema.parse(JSON.parse(await Bun.stdin.text()));
   } catch (error) {
     console.error(
       `[gitlab/${hook}] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/gitlab/hooks/lint.test.ts
+++ b/plugins/gitlab/hooks/lint.test.ts
@@ -234,3 +234,32 @@ describe("pass-through", () => {
     expect(await processInput(input, fakeEnv())).toBeNull();
   });
 });
+
+async function runHook(payload: string) {
+  const hook = Bun.spawn(["bun", join(import.meta.dir, "lint.ts")], {
+    stdin: new TextEncoder().encode(payload),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(hook.stdout).text(),
+    new Response(hook.stderr).text(),
+    hook.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("undecodable payload", () => {
+  test.each<{ name: string; payload: string }>([
+    { name: "not JSON", payload: "not json" },
+    {
+      name: "missing cwd",
+      payload: JSON.stringify({ hook_event_name: "PreToolUse", session_id: "s" }),
+    },
+  ])("$name logs and exits 0", async ({ payload }) => {
+    const { stdout, stderr, exitCode } = await runHook(payload);
+    expect(stderr).toContain("[gitlab/lint] Failed to parse hook input:");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/plugins/gitlab/hooks/lint.ts
+++ b/plugins/gitlab/hooks/lint.ts
@@ -3,12 +3,12 @@
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
+import { BashHookInput, parseHookInput } from "./hook-input";
 
-export const HookInput = z.looseObject({
+export const HookInput = BashHookInput.extend({
   hook_event_name: z.literal("PreToolUse"),
   session_id: z.string(),
   cwd: z.string(),
-  tool_input: z.looseObject({ command: z.string().optional().catch(undefined) }).catch({}),
 });
 export type HookInput = z.infer<typeof HookInput>;
 
@@ -229,16 +229,10 @@ export async function processInput(
 }
 
 async function main(): Promise<void> {
-  let raw: unknown;
-  try {
-    raw = JSON.parse(await Bun.stdin.text());
-  } catch {
-    return;
-  }
-  const input = HookInput.safeParse(raw);
-  if (!input.success) return;
+  const input = parseHookInput(HookInput, "lint", await Bun.stdin.text());
+  if (input == null) return;
 
-  const output = await processInput(input.data);
+  const output = await processInput(input);
   if (output) {
     process.stdout.write(`${JSON.stringify(output)}\n`);
   }

--- a/plugins/gitlab/hooks/lint.ts
+++ b/plugins/gitlab/hooks/lint.ts
@@ -3,7 +3,7 @@
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
-import { BashHookInput, parseHookInput } from "./hook-input";
+import { BashHookInput, readHookInput } from "./hook-input";
 
 export const HookInput = BashHookInput.extend({
   hook_event_name: z.literal("PreToolUse"),
@@ -229,7 +229,7 @@ export async function processInput(
 }
 
 async function main(): Promise<void> {
-  const input = parseHookInput(HookInput, "lint", await Bun.stdin.text());
+  const input = await readHookInput(HookInput, "lint");
   if (input == null) return;
 
   const output = await processInput(input);

--- a/plugins/gitlab/scripts/fetch.test.ts
+++ b/plugins/gitlab/scripts/fetch.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, test } from "bun:test";
+import { join } from "node:path";
 import type { PreToolUseHookSpecificOutput } from "@anthropic-ai/claude-agent-sdk";
 import { formatOutput, type HookInput, isGitLabUrl, parseGitLabUrl, processInput } from "./fetch";
 
@@ -198,5 +199,23 @@ describe("processInput", () => {
     const output = getOutput(mockInput("https://gitlab.com/gitlab-org/gitlab/-/settings"));
     expect(output?.permissionDecision).toBe("ask");
     expect(output?.permissionDecisionReason).toContain("Unknown GitLab URL pattern");
+  });
+});
+
+describe("undecodable payload", () => {
+  it("logs and exits 0", async () => {
+    const hook = Bun.spawn(["bun", join(import.meta.dir, "fetch.ts")], {
+      stdin: new TextEncoder().encode("not json"),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(hook.stdout).text(),
+      new Response(hook.stderr).text(),
+      hook.exited,
+    ]);
+    expect(stderr).toContain("[gitlab/fetch] Failed to parse hook input:");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
   });
 });

--- a/plugins/gitlab/scripts/fetch.ts
+++ b/plugins/gitlab/scripts/fetch.ts
@@ -3,6 +3,7 @@
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import UrlPattern from "url-pattern";
 import { z } from "zod";
+import { readHookInput } from "../hooks/hook-input";
 
 const WebFetchInput = z.looseObject({ url: z.string() });
 
@@ -138,15 +139,8 @@ export function processInput(input: HookInput): SyncHookJSONOutput | null {
 }
 
 async function main(): Promise<void> {
-  let input: HookInput;
-  try {
-    input = HookInput.parse(JSON.parse(await Bun.stdin.text()));
-  } catch (error) {
-    console.error(
-      `[gitlab/fetch] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return;
-  }
+  const input = await readHookInput(HookInput, "fetch");
+  if (input == null) return;
 
   const output = processInput(input);
   if (output) {


### PR DESCRIPTION
A GitLab hook handed a payload it could not decode returned without a word, so a malformed payload looked exactly like a command the hook had nothing to say about. Every hook now reports the failure on stderr and still exits 0, since a hook that dies takes the tool call down with it.

The reader owns the stdin read as well as the decode, so an unreadable payload and an undecodable one produce the same one-line diagnostic. `fetch.ts` already had this shape hand-rolled and now calls the shared reader, which leaves the plugin with one place where the failure policy lives.

The two Bash hooks shared only their `tool_input.command` shape, so only that moved into `BashHookInput`. Each hook extends it with its own event fields rather than widening a common schema to cover both. `.extend()` on a `looseObject` preserves the catchall and the per-field `.catch()` fallbacks, verified against the installed zod rather than assumed.

Each hook's parse-failure test spawns the hook and asserts the stderr line, empty stdout, and the exit code. A direct call on the reader cannot observe a process exit, and exiting 0 is the property that keeps a broken payload from failing the tool call.

https://claude.ai/code/session_0173Bb4hSKiqNJhuZ4SnihLy
