### PR TITLE
settings: bump ast-grep marketplace pin

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -454,7 +454,7 @@
       "source": {
         "source": "github",
         "repo": "ast-grep/agent-skill",
-        "ref": "c2a9bc154f4ffe08b25d28d5e852dfac8c0d0d8a"
+        "ref": "6b668aa526afdc623c1a9ed1d6ae920e04a717ad"
       }
     },
     "worktrunk": {


### PR DESCRIPTION
Bumps the pin to upstream's current main. The content delta is a README clone-URL fix and a stray backtick removed from `outline/SKILL.md`, so the skill itself barely moves.

A ref bump also has a side effect on the local install. Claude Code validates every `known_marketplaces.json` entry against its `extraKnownMarketplaces` declaration and refuses any whose ref differs, treating it as an undeclared source. A refused marketplace leaves the registry entirely. It stops appearing in `claude plugin marketplace list`, `claude plugin marketplace update <name>` reports it as not found, and every plugin it serves becomes unresolvable.

Nothing recovers from that on its own. `claude-upgrade` refreshes marketplaces by iterating the ones it can see, and swallows the failure with a warning, so a frozen marketplace stays skipped behind a passing nightly run. `astral-sh` has been in that state since #906 bumped its digest on 2026-06-28. Its registry entry was last touched on 2026-08-28 while every other marketplace refreshed last night.

Repairing it meant syncing the registry ref to the declared value and checking the marketplace clone out at that commit. `astral-sh` returned to the registry and both failing commands succeeded. The same repair covers this bump once it deploys.

Renovate reproduces this on every digest-pinned marketplace it bumps, so `claude-upgrade` in dotfiles needs to detect the drift and re-add instead of skipping. That's a separate change.

https://claude.ai/code/session_018c2GX2uwqcW9qFEaEaD4WJ
