### PR TITLE
skills: trim two oversized descriptions

### DIFF
--- a/plugins/github/skills/attach/SKILL.md
+++ b/plugins/github/skills/attach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github:attach
-description: Upload a local image or video to GitHub and reference it so it renders inline in an issue, pull request, comment, or review. Use when attaching a screenshot, screen recording, or generated diagram to GitHub content, or when a body would otherwise link a local path the reader cannot open. Load before posting to uploads.github.com.
+description: Upload a local image or video to GitHub and reference it so it renders inline in an issue, pull request, comment, or review. Use when attaching a screenshot, recording, or diagram to GitHub content.
 allowed-tools:
   - Bash(gh api:*)
   - Bash(gh issue:*)

--- a/plugins/review/skills/tuicr/SKILL.md
+++ b/plugins/review/skills/tuicr/SKILL.md
@@ -2,13 +2,10 @@
 name: review:tuicr
 argument-hint: "[-w | -r <range> | pr <N> | mr <N>]"
 description: >
-  Drive tuicr, the terminal code-review TUI, as a live local review surface in tmux: launch a
-  session, seed agent comments, collect inline comments to act on, or watch comments arrive live.
-  The shared core that review:self (inbound) and review:peer (outbound) delegate to, and the
-  model-invocable path to pick up comments already left in a running session and apply them. Use
-  when reviewing through tuicr, or when the user says their review is done and comments need
-  applying: "review in tuicr", "tuicr session", "open the diff in tuicr", "watch my comments", "I
-  left review comments", "I finished my review, apply them", "pick up my tuicr comments".
+  Drive tuicr, the terminal code-review TUI, in tmux: launch a session, seed comments, or collect
+  and apply comments left in a running session. Shared core that review:self and review:peer
+  delegate to. Use when reviewing through tuicr, or when a review is done and its comments need
+  applying: "review in tuicr", "I left review comments", "pick up my tuicr comments".
 allowed-tools:
   - Bash(tuicr:*)
   - Bash(tmux:*)


### PR DESCRIPTION
Trims the two most oversized skill descriptions in the repo, moving them toward the 215-char median.

- `review:tuicr`: 664 -> 365 chars. Kept the trigger phrases ("review in tuicr", "I left review comments", "pick up my tuicr comments") and the relationship to `review:self`/`review:peer`, cut the duplicated example phrases and restated detail already in the body.
- `github:attach`: 331 -> 198 chars. Kept the "upload so it renders inline" trigger, cut the redundant "Load before posting" line the body already states.

`bun run skill-lint "plugins/review/skills/*"` and `bun run skill-lint "plugins/github/skills/*"` both pass with 0 errors/warnings on all skills in each plugin.

Original Task: https://things.bendrucker.me/show?id=Q6f1XVG73W5xLDr8ucu3mh
Original Task: https://things.bendrucker.me/show?id=VPVB1ApRkiQFuSYQLUW7wq
Discovery: 617320f4c0b8
Discovery: ad7b319ca19e

https://claude.ai/code/session_01CvGD2aV31Y5u4ri46J8baj
