### PR TITLE
github: adopt gh --attach for issue and PR media

### DIFF
--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -6,7 +6,7 @@ GitHub workflow, Actions monitoring, and rulesets management for Claude Code.
 
 - **Skills**:
   - `actions-monitor`: Watch a PR's CI and stream state events; invokes the logs agent on failures
-  - `attach`: Upload an image or video to GitHub's user-attachments store and reference it from an issue, PR, or comment
+  - `attach`: Attach an image or video to an issue, PR, comment, or review, through `gh --attach` or the user-attachments endpoint it wraps
   - `copilot`: Cross-model review of the current diff through the Copilot CLI. Slash-invocable only, one call by default and three at most, because the Copilot plan is a fixed budget
   - `notifications`: Inbox management (list, filter, mark read/done, unsubscribe)
   - `pr-comments`: Fetch unresolved review comments from a pull request

--- a/plugins/github/skills/attach/SKILL.md
+++ b/plugins/github/skills/attach/SKILL.md
@@ -10,11 +10,11 @@ allowed-tools:
 
 # Attachments
 
-Images and video in issues and pull requests are served from a user-attachments store. `gh` 2.99.0 added a repeatable `--attach` flag that uploads to it from `gh issue create`, `gh issue edit`, `gh issue comment`, `gh pr create`, `gh pr edit`, and `gh pr comment`. Everything else uploads through the endpoint the flag wraps: review comments and pending reviews, discussions, releases, gists, GitHub Enterprise Server, and any `gh` older than 2.99.0.
+Images and video in issues and pull requests are served from a user-attachments store. `gh` 2.99.0 added a repeatable `--attach` flag that uploads to it from `gh issue create`, `gh issue edit`, `gh issue comment`, `gh pr create`, `gh pr edit`, and `gh pr comment`. Everything else uploads through the endpoint the flag wraps: review comments and pending reviews, discussions, releases, gists, and any `gh` older than 2.99.0. Both paths exist on GitHub.com and Enterprise Cloud only. Enterprise Server has no attachment store.
 
 `--attach` on this build: !`gh issue comment --help 2>/dev/null | grep -q -- '--attach' && echo present || echo absent`
 
-Absent means this `gh` predates 2.99.0. Upgrade it (`brew upgrade gh`) or use the endpoint.
+Absent means this `gh` predates 2.99.0. Upgrade it or use the endpoint.
 
 ## The Flag
 
@@ -28,12 +28,12 @@ gh pr create --title "..." --body-file tmp/pr-body.md --attach ./picker.png --at
 - A file the body never references is appended to the end, in flag order, with the filename as alt text. Alt text follows the path after `#`: `--attach './picker.png#The wide layout'`.
 - `gh pr edit` and `gh issue edit` without a body flag keep the existing body and append.
 - Up to 50 files per command.
-- When some uploads fail, the issue, pull request, or comment still lands with the ones that succeeded, its URL prints, and the exit status is non-zero. Read the output before retrying, or the retry duplicates the assets that did upload.
+- When some uploads fail, the issue, pull request, or comment still lands with the ones that succeeded. Its URL prints, and the exit status is non-zero. Read the output before retrying. A blind retry duplicates the assets that already uploaded.
 - The token needs write access to the repository.
 
 ## The Endpoint
 
-`POST https://uploads.github.com/user-attachments/assets` has no REST route and no documentation, so `gh api` reaches it by full URL. `repository_id` takes the numeric REST id. `gh repo view --json id` returns the GraphQL node id, which fails here.
+`POST https://uploads.github.com/user-attachments/assets` has no REST route and no documentation. `gh api` reaches it by full URL instead. A data-residency Enterprise Cloud tenant has its own upload host in place of `uploads.github.com`. `repository_id` takes the numeric REST id. `gh repo view --json id` returns the GraphQL node id, which fails here.
 
 ```bash
 repo_id=$(gh api repos/{owner}/{repo} --jq .id)
@@ -43,7 +43,7 @@ gh api --method POST \
   --input ./picker.png --jq .url
 ```
 
-The response is `{"url": "https://github.com/user-attachments/assets/<uuid>"}`. The token needs write access to that repository. Read-only access answers 404, which makes a permission problem look like a missing repository.
+The response is `{"url": "https://github.com/user-attachments/assets/<uuid>"}`. The token needs write access to that repository. Read-only access also answers 404. That makes a permission problem look like a missing repository.
 
 An image is ordinary markdown, with `\`, `[`, and `]` escaped in the alt text.
 
@@ -55,7 +55,7 @@ Video has no markdown syntax and no alt text. GitHub renders a player when a bar
 
 ## File Types
 
-Both paths accept the same list, and nothing outside it uploads. Logs, archives, and PDFs have no path here. On the endpoint, the extension in `name` must agree with `content_type`.
+Both paths accept the same list, and nothing outside it uploads. Logs, archives, and PDFs are not supported. On the endpoint, the extension in `name` must agree with `content_type`.
 
 | Extension | `content_type` |
 | --- | --- |
@@ -70,6 +70,6 @@ Both paths accept the same list, and nothing outside it uploads. Logs, archives,
 
 Images cap at 10 MB. Video caps at 100 MB on a paid plan and 10 MB on a free one.
 
-## Ordering
+## Irreversibility
 
-An upload cannot be undone and an asset cannot be deleted. Upload once the body is final and nothing is left that could cancel. An asset nothing references is stranded and permanent, and it answers 404 until something references it, so opening the URL proves nothing about the upload.
+An upload cannot be undone and an asset cannot be deleted. Upload only after the body is final. An unreferenced asset stays stranded permanently. It answers 404 until something references it, unlike the write-access 404 on upload above. A 404 right after uploading does not mean the upload failed.

--- a/plugins/github/skills/attach/SKILL.md
+++ b/plugins/github/skills/attach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github:attach
-description: Upload a local image or video to GitHub and reference it so it renders inline in an issue, pull request, comment, or review. Use when attaching a screenshot, recording, or diagram to GitHub content.
+description: Attach a local image or video to GitHub content so it renders inline in an issue, pull request, comment, or review. Use when attaching a screenshot, recording, or diagram to GitHub content.
 allowed-tools:
   - Bash(gh api:*)
   - Bash(gh issue:*)
@@ -10,11 +10,30 @@ allowed-tools:
 
 # Attachments
 
-Images and video in issues and pull requests are served from a user-attachments store. `POST https://uploads.github.com/user-attachments/assets` puts a file there and answers with the URL to reference. It has no REST route and no documentation, so `gh api` reaches it by full URL.
+Images and video in issues and pull requests are served from a user-attachments store. `gh` 2.99.0 added a repeatable `--attach` flag that uploads to it from `gh issue create`, `gh issue edit`, `gh issue comment`, `gh pr create`, `gh pr edit`, and `gh pr comment`. Everything else uploads through the endpoint the flag wraps: review comments and pending reviews, discussions, releases, gists, GitHub Enterprise Server, and any `gh` older than 2.99.0.
 
-## Upload
+`--attach` on this build: !`gh issue comment --help 2>/dev/null | grep -q -- '--attach' && echo present || echo absent`
 
-`repository_id` takes the numeric REST id. `gh repo view --json id` returns the GraphQL node id, which fails here.
+Absent means this `gh` predates 2.99.0. Upgrade it (`brew upgrade gh`) or use the endpoint.
+
+## The Flag
+
+Write the body with the local path in the markdown, then name each file on the command. `gh` uploads it and rewrites the reference in place. The image lands where the prose put it. The alt text written in the body wins.
+
+```bash
+gh pr create --title "..." --body-file tmp/pr-body.md --attach ./picker.png --attach ./walkthrough.mp4
+```
+
+- A path is absolute or relative to the directory `gh` runs in.
+- A file the body never references is appended to the end, in flag order, with the filename as alt text. Alt text follows the path after `#`: `--attach './picker.png#The wide layout'`.
+- `gh pr edit` and `gh issue edit` without a body flag keep the existing body and append.
+- Up to 50 files per command.
+- When some uploads fail, the issue, pull request, or comment still lands with the ones that succeeded, its URL prints, and the exit status is non-zero. Read the output before retrying, or the retry duplicates the assets that did upload.
+- The token needs write access to the repository.
+
+## The Endpoint
+
+`POST https://uploads.github.com/user-attachments/assets` has no REST route and no documentation, so `gh api` reaches it by full URL. `repository_id` takes the numeric REST id. `gh repo view --json id` returns the GraphQL node id, which fails here.
 
 ```bash
 repo_id=$(gh api repos/{owner}/{repo} --jq .id)
@@ -24,13 +43,19 @@ gh api --method POST \
   --input ./picker.png --jq .url
 ```
 
-The response is `{"url": "https://github.com/user-attachments/assets/<uuid>"}`.
+The response is `{"url": "https://github.com/user-attachments/assets/<uuid>"}`. The token needs write access to that repository. Read-only access answers 404, which makes a permission problem look like a missing repository.
 
-The token needs write access to that repository. Read-only access answers 404, which makes a permission problem look like a missing repository.
+An image is ordinary markdown, with `\`, `[`, and `]` escaped in the alt text.
+
+```markdown
+![Wide window](https://github.com/user-attachments/assets/<uuid>)
+```
+
+Video has no markdown syntax and no alt text. GitHub renders a player when a bare asset URL is the whole of a paragraph.
 
 ## File Types
 
-The extension in `name` must agree with `content_type`, and nothing outside this list uploads. Logs, archives, and PDFs have no path here.
+Both paths accept the same list, and nothing outside it uploads. Logs, archives, and PDFs have no path here. On the endpoint, the extension in `name` must agree with `content_type`.
 
 | Extension | `content_type` |
 | --- | --- |
@@ -43,30 +68,8 @@ The extension in `name` must agree with `content_type`, and nothing outside this
 | `.mov` | `video/quicktime` |
 | `.webm` | `video/webm` |
 
-Images cap at 10 MB. Video caps at 100 MB or lower, depending on the account plan.
-
-## Reference
-
-An image is ordinary markdown, with `\`, `[`, and `]` escaped in the alt text.
-
-```markdown
-![Wide window](https://github.com/user-attachments/assets/<uuid>)
-```
-
-Video has no markdown syntax. GitHub renders a player when a bare asset URL is the whole of a paragraph.
+Images cap at 10 MB. Video caps at 100 MB on a paid plan and 10 MB on a free one.
 
 ## Ordering
 
 An upload cannot be undone and an asset cannot be deleted. Upload once the body is final and nothing is left that could cancel. An asset nothing references is stranded and permanent, and it answers 404 until something references it, so opening the URL proves nothing about the upload.
-
-## The --attach Flag
-
-`--attach` on this build: !`gh issue comment --help 2>/dev/null | grep -q -- '--attach' && echo present || echo absent`
-
-Absent means the upload above is the only way. Present means `--attach` replaces it for `gh issue create`, `gh issue edit`, `gh issue comment`, `gh pr create`, `gh pr edit`, and `gh pr comment`. It repeats, takes a path, and takes alt text after a `#`.
-
-```bash
-gh issue comment 87 --body-file report.md --attach './picker.png#The wide layout'
-```
-
-A body that already links the local path gets that reference rewritten. A body that does not gets the asset appended. Review comments, discussions, releases, and gists are out of the flag's reach and upload through the endpoint either way.

--- a/plugins/github/skills/pr-comments/SKILL.md
+++ b/plugins/github/skills/pr-comments/SKILL.md
@@ -31,7 +31,7 @@ bun ${CLAUDE_PLUGIN_ROOT}/scripts/review-threads.ts reply <thread-id> --resolve 
 bun ${CLAUDE_PLUGIN_ROOT}/scripts/review-threads.ts resolve <thread-id>
 ```
 
-Pass the reply text with `--body`, `--bodyFile <path>`, or stdin. Don't resolve without a reply: a silent resolve hides why the thread closed. Prefer `reply --resolve` so the resolve carries context.
+Pass the reply text with `--body`, `--bodyFile <path>`, or stdin. Don't resolve without a reply: a silent resolve hides why the thread closed. Prefer `reply --resolve` so the resolve carries context. A reply that shows a screenshot uploads it first through the endpoint in `github:attach`. Review threads sit outside the reach of `gh`'s `--attach` flag.
 
 ## Reactions
 

--- a/plugins/gitlab/skills/api/SKILL.md
+++ b/plugins/gitlab/skills/api/SKILL.md
@@ -48,6 +48,16 @@ echo '{"position":{"base_sha":"abc","head_sha":"def","old_path":"file.ts","new_p
 glab api projects/:id/merge_requests/:iid/discussions -X POST -H "Content-Type: application/json" --input /tmp/payload.json
 ```
 
+## Uploads
+
+An image or video for an MR or issue body goes through project uploads, which take multipart form data. `--form` sends the file. `-F` sends the path as a JSON field and the API answers HTTP 400.
+
+```bash
+glab api projects/:id/uploads --form "file=@./shot.png" | jq -r .markdown
+```
+
+The response carries `url` (a project-relative `/uploads/<hash>/shot.png`) and `markdown` (`![shot](/uploads/<hash>/shot.png)`). Paste the markdown into the description or note. The relative URL renders anywhere inside that project. `glab mr` and `glab issue` have no attach flag. The upload runs before the create or update.
+
 ## GraphQL
 
 ```bash

--- a/plugins/gitlab/skills/api/SKILL.md
+++ b/plugins/gitlab/skills/api/SKILL.md
@@ -50,7 +50,7 @@ glab api projects/:id/merge_requests/:iid/discussions -X POST -H "Content-Type: 
 
 ## Uploads
 
-An image or video for an MR or issue body goes through project uploads, which take multipart form data. `--form` sends the file. `-F` sends the path as a JSON field and the API answers HTTP 400.
+An image or video for an MR or issue body goes through project uploads, which take multipart form data. `--form` sends the file. `-F` reads the file and embeds its bytes in a JSON body field, which the endpoint rejects with HTTP 400.
 
 ```bash
 glab api projects/:id/uploads --form "file=@./shot.png" | jq -r .markdown

--- a/plugins/gitlab/skills/merge-request/SKILL.md
+++ b/plugins/gitlab/skills/merge-request/SKILL.md
@@ -74,6 +74,8 @@ git push -u origin feature-branch && glab mr create --fill
 
 **Body from file:** The flag is `--description-file file.md`, not gh's `--body-file`. Prefer it over `--description "$(cat file.md)"`, which passes the body through the shell and keeps it out of some hooks.
 
+**Screenshots:** `glab mr` has no attach flag. Upload each file through project uploads per `gitlab:api` and paste the returned markdown into the description before creating.
+
 **Username resolution:** Flags like `--reviewer` and `--assignee` require exact usernames; invalid names are silently ignored. Look up users first:
 
 ```bash

--- a/plugins/issue/skills/refine/SKILL.md
+++ b/plugins/issue/skills/refine/SKILL.md
@@ -24,7 +24,7 @@ Parse `$ARGUMENTS`:
 
 ## Workflow
 
-Read the type guide, gather context from code and related issues, and draft the refinement following the type's structure. Write it to `tmp/issue-<slug>.md` and output it for approval. After approval, hand the file to the platform skill (for Linear, `linear:linear`), which maps the frontmatter to tracker fields and saves the body. Defer all save mechanics to that skill.
+Read the type guide, gather context from code and related issues, and draft the refinement following the type's structure. Write it to `tmp/issue-<slug>.md` and output it for approval. After approval, hand the file to the platform skill (for Linear, `linear:linear`), which maps the frontmatter to tracker fields and saves the body. Defer all save mechanics to that skill. On GitHub, a screenshot the body references by local path goes on `gh issue create --attach`, per `github:attach`.
 
 ## Output Structure
 

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -11,6 +11,8 @@ allowed-tools:
   - Skill(pull-request:follow-up)
   - Skill(github:stack)
   - Skill(gitlab:merge-request)
+  - Skill(gitlab:api)
+  - Skill(github:attach)
   - "Bash(git add:*)"
   - "Bash(git commit:*)"
   - "Bash(git push:*)"
@@ -81,6 +83,7 @@ Parse `$ARGUMENTS` for these flags. With none, create a PR/MR that is ready for 
 1. Create the PR/MR, appending `--draft` when set, `--base <parent>` when the branch is a stack layer, and `--label <name>` for each label that resolved:
    - **GitHub**: `gh pr create --title "..." --body-file tmp/pr-body-<branch>.md`
    - **GitLab**: `glab mr create --title "..." --description-file tmp/pr-body-<branch>.md`
+   - A screenshot or recording the body references by local path goes up with the command. GitHub: `--attach ./shot.png` per file on `gh pr create`, which rewrites the reference to the uploaded asset. Load `github:attach` first. GitLab: upload each file per the uploads section of `gitlab:api` and paste the returned markdown into the body before creating.
    - Put the branch name in the body filename so concurrent agents don't collide. Writing the file with a quoted heredoc (`cat > tmp/pr-body-<branch>.md <<'EOF'`) in the same call as the create command works: the validation hook reads the heredoc directly.
 1. Chain a GitHub stack layer into its stack once the PR exists. Load `github:stack` for the `gh stack link` forms, the detection query that picks between them, and what an exit code 9 means.
 1. Enable auto-merge after the PR/MR exists, unless `--no-auto` or `--draft` is set. On a repo you own (the Remote URL above names the owner), run `gh pr merge --auto`. On a third-party repo, leave the merge to the maintainer. GitLab, stacked PRs, and a repo that rejects `--auto` take the paths in [`references/merge.md`](references/merge.md).

--- a/plugins/pull-request/skills/create/references/sections.md
+++ b/plugins/pull-request/skills/create/references/sections.md
@@ -60,7 +60,7 @@ A disproved theory, a rejected workaround, or a name the user settled by hand ge
 
 ### By Change Type
 
-- Visual or GUI work: screenshots or a recording. Rejected layouts. Bugs found only by rendering it live.
+- Visual or GUI work: screenshots or a recording, uploaded so they render (`--attach` per `github:attach`, project uploads per `gitlab:api`) rather than linked by a local path. Rejected layouts. Bugs found only by rendering it live.
 - Backend or API work: an example request and response. What breaks without the fix. Performance numbers.
 - Config, tooling, or prose: scope added or dropped, what you chose not to build, the evidence behind the design.
 

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -46,6 +46,7 @@ The PR body documents what will happen when merged, not the journey. Don't echo 
 2. Write the updated body to a temp file (e.g., `tmp/pr-body-<branch>.md`) and apply:
    - **GitHub**: `gh pr edit --body-file tmp/pr-body-<branch>.md`
    - **GitLab**: `glab mr update --description-file tmp/pr-body-<branch>.md`
+   - A screenshot or recording the new body references by local path uploads with it: `--attach ./shot.png` per file on `gh pr edit` (load `github:attach`), or project uploads per `gitlab:api` pasted in before the update. Assets already in the body keep their uploaded URLs.
 
 ## GitLab Notes
 

--- a/plugins/review/skills/follow-up/SKILL.md
+++ b/plugins/review/skills/follow-up/SKILL.md
@@ -135,7 +135,7 @@ After I decide on next steps, use platform-appropriate commands:
 #### GitHub
 
 - Approve: `gh pr review --approve`
-- Comment: `gh pr comment`
+- Comment: `gh pr comment`, with `--attach ./shot.png` for a screenshot the comment references (load `github:attach`)
 - Resolve thread: `gh api graphql` with `resolveReviewThread` mutation
 
 ##### Draft a Pending Review


### PR DESCRIPTION
gh 2.99.0 shipped a repeatable `--attach` flag for issue and PR create, edit, and comment, uploading to the same user-attachments store the `attach` skill already reached by hand. I moved the skill to lead with the flag and kept the raw endpoint documented for what it can't reach: review comments, pending reviews, discussions, releases, gists, and any `gh` build older than 2.99.0. Enterprise Server has no attachment store at all, so both paths scope to GitHub.com and Enterprise Cloud. The PR-body validation hook already accepted `--attach` in the `#alt` form, so it needed no change.

Every skill that could post a body with a screenshot now names `--attach`: PR create and update, issue refine, and review follow-up. `pr-comments` stays on the endpoint, since review-thread replies sit outside the flag's reach.

GitLab has no equivalent flag. The session index turned up five sessions that hit HTTP 400 from `glab api -F file=@...` and fell back to scraping the token out of the glab config for curl. `--form` is the documented multipart path and works. `gitlab:api` now carries the upload call, and the MR and PR skills point at it.

https://claude.ai/code/session_01GgGNNWwi1AS17jWi6WHbK8
