### PR TITLE
comments: test the audit through a judge seam

### DIFF
--- a/plugins/comments/apply/branch.test.ts
+++ b/plugins/comments/apply/branch.test.ts
@@ -8,15 +8,19 @@ import { applyToBranch } from "./branch";
 /** A fresh git repo with a normal file and an executable shell script committed. */
 async function makeRepo(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "comments-branch-"));
-  const git = $.cwd(dir).env({ ...process.env, GIT_CONFIG_GLOBAL: "/dev/null" });
-  await git`git init -b main`.quiet();
-  await git`git config user.email test@example.com`.quiet();
-  await git`git config user.name Test`.quiet();
+  const git = (...args: string[]) =>
+    $`git ${args}`
+      .cwd(dir)
+      .env({ ...process.env, GIT_CONFIG_GLOBAL: "/dev/null" })
+      .quiet();
+  await git("init", "-b", "main");
+  await git("config", "user.email", "test@example.com");
+  await git("config", "user.name", "Test");
   await Bun.write(join(dir, "note.ts"), "// keep\n// slop\nconst x = 1;\n");
   await Bun.write(join(dir, "run.sh"), "#!/bin/sh\necho hi\n");
-  await $.cwd(dir)`chmod 755 run.sh`.quiet();
-  await git`git add note.ts run.sh`.quiet();
-  await git`git commit -m init`.quiet();
+  await $`chmod 755 run.sh`.cwd(dir).quiet();
+  await git("add", "note.ts", "run.sh");
+  await git("commit", "-m", "init");
   return dir;
 }
 

--- a/plugins/comments/evals/oracle.ts
+++ b/plugins/comments/evals/oracle.ts
@@ -2,6 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import Builder from "fast-xml-builder";
 import { z } from "zod";
 import type { CommentKind, Language } from "../detection/types";
+import { type JudgeAdapter, shardJudge } from "../judge/adapter";
 import { BATCH_SIZE, parseVerdict } from "../judge/judge";
 import { batchVerdictSchema, type Verdict } from "../judge/schema";
 
@@ -146,4 +147,12 @@ export function anthropicCommentJudge(options: AnthropicJudgeOptions): CommentJu
     }
     return parseBatchVerdicts(block.text, inputs.length);
   };
+}
+
+/**
+ * The oracle behind the audit's judge seam: scores each written shard in one
+ * Messages call and writes its verdict file where the agent fan-out would.
+ */
+export function anthropicJudgeAdapter(options: AnthropicJudgeOptions): JudgeAdapter {
+  return shardJudge(anthropicCommentJudge(options));
 }

--- a/plugins/comments/judge/adapter.ts
+++ b/plugins/comments/judge/adapter.ts
@@ -35,6 +35,11 @@ export function workflowJudge(log: (line: string) => void): JudgeAdapter {
   };
 }
 
+/** Where a shard's verdict file lands, the name the workflow prompt spells out to each agent. */
+export function verdictPath(verdictsDir: string, shardId: number): string {
+  return join(verdictsDir, `verdict-${shardId}.json`);
+}
+
 /** Scores one shard's comments, returning verdicts in the same order. */
 export type ShardJudge = (comments: ShardComment[]) => Promise<Verdict[]>;
 
@@ -59,7 +64,7 @@ export function shardJudge(judge: ShardJudge): JudgeAdapter {
           verdict: verdicts[i],
         }));
         await Bun.write(
-          join(job.verdictsDir, `verdict-${ref.id}.json`),
+          verdictPath(job.verdictsDir, ref.id),
           JSON.stringify({ verdicts: entries }, null, 2),
         );
       }),

--- a/plugins/comments/judge/adapter.ts
+++ b/plugins/comments/judge/adapter.ts
@@ -1,0 +1,68 @@
+import { join } from "node:path";
+import { readShard, type ShardComment, type WrittenJob } from "./job";
+import type { Verdict } from "./schema";
+
+/**
+ * The judge seam. Given a written job, get one `verdict-<shard id>.json` per
+ * shard into `job.verdictsDir`, each holding
+ * `{ verdicts: [{ id: <comment id>, verdict: { ... } }] }`. Apply reads that
+ * directory and knows nothing about who filled it.
+ */
+export type JudgeAdapter = (job: WrittenJob) => Promise<void>;
+
+export const WORKFLOW_PATH = join(import.meta.dirname, "..", "workflow", "judge.workflow.js");
+
+/**
+ * The production judge: hand the job to the Workflow tool. The skill reads the
+ * `<preflight>` block, asks the user to confirm, and fans out one agent per
+ * shard. Those agents write the verdict files, so in-process there is nothing
+ * more to do.
+ */
+export function workflowJudge(log: (line: string) => void): JudgeAdapter {
+  return (job) => {
+    log("<preflight>");
+    log(
+      JSON.stringify({
+        scriptPath: WORKFLOW_PATH,
+        argsPath: job.argsPath,
+        jobDir: job.jobDir,
+        count: job.count,
+        shardCount: job.shardCount,
+      }),
+    );
+    log("</preflight>");
+    return Promise.resolve();
+  };
+}
+
+/** Scores one shard's comments, returning verdicts in the same order. */
+export type ShardJudge = (comments: ShardComment[]) => Promise<Verdict[]>;
+
+/**
+ * An in-process judge behind the same seam: read each shard back from disk,
+ * score it, and write its verdict file in the shape the agents write. Shards
+ * score concurrently, matching the agent fan-out.
+ */
+export function shardJudge(judge: ShardJudge): JudgeAdapter {
+  return async (job) => {
+    await Promise.all(
+      job.shards.map(async (ref) => {
+        const shard = await readShard(ref.path);
+        const verdicts = await judge(shard.comments);
+        if (verdicts.length !== shard.comments.length) {
+          throw new Error(
+            `Judge returned ${verdicts.length} verdicts for ${shard.comments.length} comments in shard ${ref.id}`,
+          );
+        }
+        const entries = shard.comments.map((comment, i) => ({
+          id: comment.id,
+          verdict: verdicts[i],
+        }));
+        await Bun.write(
+          join(job.verdictsDir, `verdict-${ref.id}.json`),
+          JSON.stringify({ verdicts: entries }, null, 2),
+        );
+      }),
+    );
+  };
+}

--- a/plugins/comments/judge/job.ts
+++ b/plugins/comments/judge/job.ts
@@ -1,6 +1,7 @@
 import { mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { z } from "zod";
 import type { CollectedComment } from "../detection/collect";
 import type { CommentKind, Language } from "../detection/types";
 import { BATCH_SIZE, loadPrompt, sha256 } from "./judge";
@@ -18,6 +19,25 @@ export interface ShardComment {
 export interface JobShard {
   id: number;
   comments: ShardComment[];
+}
+
+const ShardFile = z.object({
+  id: z.number(),
+  comments: z.array(
+    z.object({
+      id: z.string(),
+      path: z.string(),
+      language: z.string(),
+      kind: z.enum(["line", "block", "docstring"]),
+      text: z.string(),
+      context: z.string(),
+    }),
+  ),
+}) satisfies z.ZodType<JobShard>;
+
+/** A shard read back from the file `writeJob` wrote. */
+export async function readShard(path: string): Promise<JobShard> {
+  return ShardFile.parse(JSON.parse(await Bun.file(path).text()));
 }
 
 export interface JobDescriptor {

--- a/plugins/comments/judge/job.ts
+++ b/plugins/comments/judge/job.ts
@@ -115,10 +115,14 @@ export interface WrittenJob {
 
 export const DEFAULT_JOB_BASE = join(tmpdir(), "comments-audit");
 
-/** Content-hash the descriptor so re-running identical input reuses the same job dir. */
+/**
+ * Content-hash the descriptor so re-running identical input reuses the same job
+ * dir. The full prompt text is hashed, not the rubric's sha alone, so a `--fix`
+ * run lands in its own dir instead of reading the plain run's verdicts.
+ */
 function jobHash(descriptor: JobDescriptor): string {
   return sha256(
-    JSON.stringify({ shards: descriptor.shards, promptSha: descriptor.promptSha }),
+    JSON.stringify({ shards: descriptor.shards, promptText: descriptor.promptText }),
   ).slice(0, 16);
 }
 

--- a/plugins/comments/skills/audit/scripts/apply.ts
+++ b/plugins/comments/skills/audit/scripts/apply.ts
@@ -14,7 +14,7 @@ import { AuditError, type AuditIo } from "./io";
 export interface ApplyOptions {
   /** The job dir preflight printed. */
   job: string;
-  /** Print findings instead of applying. */
+  /** Prints findings only. */
   report: boolean;
   /** Include suggestions in the report. */
   fix: boolean;

--- a/plugins/comments/skills/audit/scripts/apply.ts
+++ b/plugins/comments/skills/audit/scripts/apply.ts
@@ -83,9 +83,9 @@ function judgedPaths(shards: JobShard[]): string[] {
 }
 
 /**
- * Every shard's verdict file, covering every comment the shard carried. A shard
- * whose agent never wrote one, or skipped a comment, fails the run rather than
- * reading as drift or as keep.
+ * Every shard's verdict file, each covering every comment its own shard carried.
+ * A shard whose agent never wrote one, or skipped a comment, fails the run rather
+ * than reading as drift or as keep.
  */
 async function readVerdicts(jobDir: string, shards: JobShard[]): Promise<Map<string, Verdict>> {
   const verdictsDir = join(jobDir, "verdicts");
@@ -97,18 +97,17 @@ async function readVerdicts(jobDir: string, shards: JobShard[]): Promise<Map<str
       `No verdicts for shard(s) ${missing.join(", ")} in ${verdictsDir}. Run the judge workflow first.`,
     );
   }
-  const verdicts = collectVerdicts(
-    await Promise.all(files.map((file) => readJson(file.path, z.unknown()))),
-  );
-  const unjudged = shards.flatMap((shard) =>
-    shard.comments.filter((comment) => !verdicts.has(comment.id)).map((comment) => comment.id),
-  );
+  const contents = await Promise.all(files.map((file) => readJson(file.path, z.unknown())));
+  const unjudged = shards.flatMap((shard, i) => {
+    const own = collectVerdicts([contents[i]]);
+    return shard.comments.filter((comment) => !own.has(comment.id)).map((comment) => comment.id);
+  });
   if (unjudged.length > 0) {
     throw new AuditError(
       `Verdicts in ${verdictsDir} omit ${unjudged.length} judged comment(s): ${unjudged.join(", ")}. Rerun the judge workflow.`,
     );
   }
-  return verdicts;
+  return collectVerdicts(contents);
 }
 
 async function guardScope(options: ApplyOptions): Promise<void> {

--- a/plugins/comments/skills/audit/scripts/apply.ts
+++ b/plugins/comments/skills/audit/scripts/apply.ts
@@ -1,0 +1,200 @@
+import { readdir } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { z } from "zod";
+import { applyToBranch, isCleanTree } from "../../../apply/branch";
+import { computeFileEdits, type EditItem } from "../../../apply/edits";
+import { formatContent } from "../../../apply/format";
+import { collectVerdicts, matchVerdicts } from "../../../apply/join";
+import { color, type ReportItem, renderReport, summarize } from "../../../apply/report";
+import { extractComments, languageForPath } from "../../../detection/extract";
+import type { Comment } from "../../../detection/types";
+import type { Verdict } from "../../../judge/schema";
+import { AuditError, type AuditIo } from "./io";
+
+export interface ApplyOptions {
+  /** The job dir preflight printed. */
+  job: string;
+  /** Print findings instead of applying. */
+  report: boolean;
+  /** Include suggestions in the report. */
+  fix: boolean;
+  /** Shell template to format each edited file through (`{}` = path, content on stdin). */
+  format?: string | undefined;
+  /** Refuse a splice past this line width. Unchecked when omitted. */
+  maxWidth?: number | undefined;
+}
+
+export interface ApplyResult {
+  items: ReportItem[];
+  /** New content per edited path, after formatting. */
+  edits: Map<string, string>;
+  /** The branch the edits landed on, or null in report mode or with nothing to apply. */
+  branch: string | null;
+  /** Verdict ids whose comment no longer re-extracts at its preflight position. */
+  drift: string[];
+  /** `path:line  detail` for each edit the applier refused. */
+  manual: string[];
+}
+
+function toEditItem(comment: Comment, verdict: Verdict): EditItem {
+  return {
+    startLine: comment.startLine,
+    endLine: comment.endLine,
+    startColumn: comment.startColumn,
+    endColumn: comment.endColumn,
+    kind: comment.kind,
+    verdict,
+  };
+}
+
+async function readJsonFiles<T = unknown>(
+  dir: string,
+  prefix: string,
+  schema: z.ZodType<T>,
+): Promise<T[]> {
+  let names: string[];
+  try {
+    names = await readdir(dir);
+  } catch {
+    return [];
+  }
+  const matching = names.filter((name) => name.startsWith(prefix) && name.endsWith(".json"));
+  return Promise.all(
+    matching.map(async (name) => schema.parse(JSON.parse(await Bun.file(join(dir, name)).text()))),
+  );
+}
+
+const Scope = z.looseObject({ mr: z.string().nullish() });
+
+const ShardPaths = z.looseObject({ comments: z.array(z.looseObject({ path: z.string() })) });
+
+/** The files a job judged, recovered from its shards. */
+async function judgedPaths(jobDir: string): Promise<string[]> {
+  const shards = await readJsonFiles(jobDir, "shard-", ShardPaths);
+  const paths = new Set<string>();
+  for (const shard of shards) for (const comment of shard.comments) paths.add(comment.path);
+  return [...paths];
+}
+
+async function readVerdicts(jobDir: string): Promise<Map<string, Verdict>> {
+  const verdictsDir = join(jobDir, "verdicts");
+  const shards = await readJsonFiles(verdictsDir, "verdict-", z.unknown());
+  if (shards.length === 0) {
+    throw new AuditError(`No verdicts in ${verdictsDir}. Run the judge workflow first.`);
+  }
+  return collectVerdicts(shards);
+}
+
+async function guardScope(options: ApplyOptions): Promise<void> {
+  if (!(await Bun.file(join(options.job, "job-args.json")).exists())) {
+    throw new AuditError(`No job at ${options.job}. Pass the job dir printed by preflight.`);
+  }
+  const scopeFile = Bun.file(join(options.job, "scope.json"));
+  const scope = (await scopeFile.exists())
+    ? Scope.parse(JSON.parse(await scopeFile.text()))
+    : { mr: null };
+  if (scope.mr != null && scope.mr !== "" && !options.report) {
+    throw new AuditError(
+      `This job audited merge request !${scope.mr} from its remote source. Apply writes trims to the local tree from HEAD, so every comment would read as drift. Re-run with --report, or check out the MR branch and re-run preflight with --base.`,
+    );
+  }
+}
+
+/**
+ * Re-extract each judged file, match the verdicts to comments by id at their
+ * current range, and either print the findings or land the edits on a fresh
+ * branch off HEAD. Runs from the repo root.
+ */
+export async function apply(options: ApplyOptions, io: AuditIo): Promise<ApplyResult> {
+  await guardScope(options);
+  const verdicts = await readVerdicts(options.job);
+
+  const items: ReportItem[] = [];
+  const edits = new Map<string, string>();
+  const matched = new Set<string>();
+  const manual: string[] = [];
+  const skippedComments = new Set<string>();
+
+  // A verdict whose id no longer re-extracts has drifted.
+  for (const path of await judgedPaths(options.job)) {
+    const language = languageForPath(path);
+    const file = Bun.file(path);
+    // oxlint-disable-next-line no-await-in-loop -- the report lists findings in judged-path order and the body threads shared accumulators.
+    if (language == null || language === "" || !(await file.exists())) continue;
+    // oxlint-disable-next-line no-await-in-loop -- the report lists findings in judged-path order and the body threads shared accumulators.
+    const source = await file.text();
+    const editItems: EditItem[] = [];
+    // oxlint-disable-next-line no-await-in-loop -- the report lists findings in judged-path order and the body threads shared accumulators.
+    for (const match of matchVerdicts(path, await extractComments(source, language), verdicts)) {
+      matched.add(match.id);
+      items.push({
+        path,
+        startLine: match.comment.startLine,
+        verdict: match.verdict,
+        text: match.comment.text,
+      });
+      if (match.verdict.action !== "keep") editItems.push(toEditItem(match.comment, match.verdict));
+    }
+    if (editItems.length > 0) {
+      const result = computeFileEdits(source, editItems, { maxWidth: options.maxWidth });
+      for (const skip of result.skips) {
+        manual.push(`${path}:${skip.startLine}  ${skip.detail}`);
+        skippedComments.add(`${path}:${skip.startLine}`);
+      }
+      if (result.content !== source) edits.set(path, result.content);
+    }
+  }
+
+  if (options.format != null && options.format !== "" && !options.report) {
+    for (const [path, content] of edits) {
+      // oxlint-disable-next-line no-await-in-loop -- bounds formatter subprocess fan-out to one `sh -c` per edited file at a time.
+      const formatted = await formatContent(options.format, path, content);
+      if (formatted.formatted) {
+        edits.set(path, formatted.content);
+      } else {
+        io.warn(
+          color.yellow(
+            `Formatter failed for ${path} (${formatted.error}); keeping unformatted content.`,
+          ),
+        );
+      }
+    }
+  }
+
+  for (const item of items) {
+    if (skippedComments.has(`${item.path}:${item.startLine}`)) item.skipped = true;
+  }
+
+  const drift = [...verdicts.keys()].filter((id) => !matched.has(id));
+
+  let branch: string | null = null;
+  if (options.report) {
+    io.log(renderReport(items, { fix: options.fix }));
+  } else if (edits.size === 0) {
+    io.log(color.dim("Nothing to apply."));
+  } else if (!(await isCleanTree())) {
+    throw new AuditError(
+      "Working tree is not clean. Commit or stash before applying, or use --report.",
+    );
+  } else {
+    branch = `comments/audit-${basename(options.job)}`;
+    await applyToBranch(edits, { branch });
+    io.log(
+      `Applied ${summarize(items)} on branch ${color.bold(branch)}. Review with git diff HEAD..${branch}.`,
+    );
+  }
+
+  if (drift.length > 0) {
+    io.warn(
+      color.yellow(
+        `Skipped ${drift.length} judged comment(s) no longer found at preflight position (file changed since preflight).`,
+      ),
+    );
+  }
+  if (manual.length > 0) {
+    io.warn(color.yellow(`Left ${manual.length} comment(s) for manual handling:`));
+    for (const skip of manual) io.warn(`  ${skip}`);
+  }
+
+  return { items, edits, branch, drift, manual };
+}

--- a/plugins/comments/skills/audit/scripts/apply.ts
+++ b/plugins/comments/skills/audit/scripts/apply.ts
@@ -1,4 +1,3 @@
-import { readdir } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { z } from "zod";
 import { applyToBranch, isCleanTree } from "../../../apply/branch";
@@ -8,6 +7,7 @@ import { collectVerdicts, matchVerdicts } from "../../../apply/join";
 import { color, type ReportItem, renderReport, summarize } from "../../../apply/report";
 import { extractComments, languageForPath } from "../../../detection/extract";
 import type { Comment } from "../../../detection/types";
+import type { ShardRef } from "../../../judge/job";
 import type { Verdict } from "../../../judge/schema";
 import { AuditError, type AuditIo } from "./io";
 
@@ -47,48 +47,54 @@ function toEditItem(comment: Comment, verdict: Verdict): EditItem {
   };
 }
 
-async function readJsonFiles<T = unknown>(
-  dir: string,
-  prefix: string,
-  schema: z.ZodType<T>,
-): Promise<T[]> {
-  let names: string[];
-  try {
-    names = await readdir(dir);
-  } catch {
-    return [];
-  }
-  const matching = names.filter((name) => name.startsWith(prefix) && name.endsWith(".json"));
-  return Promise.all(
-    matching.map(async (name) => schema.parse(JSON.parse(await Bun.file(join(dir, name)).text()))),
-  );
+async function readJson<T = unknown>(path: string, schema: z.ZodType<T>): Promise<T> {
+  return schema.parse(JSON.parse(await Bun.file(path).text()));
 }
+
+const JobArgsFile = z.looseObject({
+  shards: z.array(z.looseObject({ id: z.number(), path: z.string() })),
+});
 
 const Scope = z.looseObject({ mr: z.string().nullish() });
 
 const ShardPaths = z.looseObject({ comments: z.array(z.looseObject({ path: z.string() })) });
 
+/** The shards preflight wrote, from the args it handed the workflow. */
+async function readShardRefs(jobDir: string): Promise<ShardRef[]> {
+  const argsPath = join(jobDir, "job-args.json");
+  if (!(await Bun.file(argsPath).exists())) {
+    throw new AuditError(`No job at ${jobDir}. Pass the job dir printed by preflight.`);
+  }
+  return (await readJson(argsPath, JobArgsFile)).shards;
+}
+
 /** The files a job judged, recovered from its shards. */
-async function judgedPaths(jobDir: string): Promise<string[]> {
-  const shards = await readJsonFiles(jobDir, "shard-", ShardPaths);
+async function judgedPaths(shards: ShardRef[]): Promise<string[]> {
   const paths = new Set<string>();
-  for (const shard of shards) for (const comment of shard.comments) paths.add(comment.path);
+  for (const shard of await Promise.all(shards.map((ref) => readJson(ref.path, ShardPaths)))) {
+    for (const comment of shard.comments) paths.add(comment.path);
+  }
   return [...paths];
 }
 
-async function readVerdicts(jobDir: string): Promise<Map<string, Verdict>> {
+/** Every shard's verdict file. A shard whose agent never wrote one fails the run rather than reading as drift. */
+async function readVerdicts(jobDir: string, shards: ShardRef[]): Promise<Map<string, Verdict>> {
   const verdictsDir = join(jobDir, "verdicts");
-  const shards = await readJsonFiles(verdictsDir, "verdict-", z.unknown());
-  if (shards.length === 0) {
-    throw new AuditError(`No verdicts in ${verdictsDir}. Run the judge workflow first.`);
+  const files = shards.map((ref) => ({
+    id: ref.id,
+    path: join(verdictsDir, `verdict-${ref.id}.json`),
+  }));
+  const present = await Promise.all(files.map((file) => Bun.file(file.path).exists()));
+  const missing = files.filter((_, i) => !present[i]).map((file) => file.id);
+  if (missing.length > 0) {
+    throw new AuditError(
+      `No verdicts for shard(s) ${missing.join(", ")} in ${verdictsDir}. Run the judge workflow first.`,
+    );
   }
-  return collectVerdicts(shards);
+  return collectVerdicts(await Promise.all(files.map((file) => readJson(file.path, z.unknown()))));
 }
 
 async function guardScope(options: ApplyOptions): Promise<void> {
-  if (!(await Bun.file(join(options.job, "job-args.json")).exists())) {
-    throw new AuditError(`No job at ${options.job}. Pass the job dir printed by preflight.`);
-  }
   const scopeFile = Bun.file(join(options.job, "scope.json"));
   const scope = (await scopeFile.exists())
     ? Scope.parse(JSON.parse(await scopeFile.text()))
@@ -106,8 +112,9 @@ async function guardScope(options: ApplyOptions): Promise<void> {
  * branch off HEAD. Runs from the repo root.
  */
 export async function apply(options: ApplyOptions, io: AuditIo): Promise<ApplyResult> {
+  const shards = await readShardRefs(options.job);
   await guardScope(options);
-  const verdicts = await readVerdicts(options.job);
+  const verdicts = await readVerdicts(options.job, shards);
 
   const items: ReportItem[] = [];
   const edits = new Map<string, string>();
@@ -116,7 +123,7 @@ export async function apply(options: ApplyOptions, io: AuditIo): Promise<ApplyRe
   const skippedComments = new Set<string>();
 
   // A verdict whose id no longer re-extracts has drifted.
-  for (const path of await judgedPaths(options.job)) {
+  for (const path of await judgedPaths(shards)) {
     const language = languageForPath(path);
     const file = Bun.file(path);
     // oxlint-disable-next-line no-await-in-loop -- the report lists findings in judged-path order and the body threads shared accumulators.

--- a/plugins/comments/skills/audit/scripts/apply.ts
+++ b/plugins/comments/skills/audit/scripts/apply.ts
@@ -7,7 +7,8 @@ import { collectVerdicts, matchVerdicts } from "../../../apply/join";
 import { color, type ReportItem, renderReport, summarize } from "../../../apply/report";
 import { extractComments, languageForPath } from "../../../detection/extract";
 import type { Comment } from "../../../detection/types";
-import type { ShardRef } from "../../../judge/job";
+import { verdictPath } from "../../../judge/adapter";
+import { readShard, type ShardRef } from "../../../judge/job";
 import type { Verdict } from "../../../judge/schema";
 import { AuditError, type AuditIo } from "./io";
 
@@ -57,8 +58,6 @@ const JobArgsFile = z.looseObject({
 
 const Scope = z.looseObject({ mr: z.string().nullish() });
 
-const ShardPaths = z.looseObject({ comments: z.array(z.looseObject({ path: z.string() })) });
-
 /** The shards preflight wrote, from the args it handed the workflow. */
 async function readShardRefs(jobDir: string): Promise<ShardRef[]> {
   const argsPath = join(jobDir, "job-args.json");
@@ -71,19 +70,19 @@ async function readShardRefs(jobDir: string): Promise<ShardRef[]> {
 /** The files a job judged, recovered from its shards. */
 async function judgedPaths(shards: ShardRef[]): Promise<string[]> {
   const paths = new Set<string>();
-  for (const shard of await Promise.all(shards.map((ref) => readJson(ref.path, ShardPaths)))) {
+  for (const shard of await Promise.all(shards.map((ref) => readShard(ref.path)))) {
     for (const comment of shard.comments) paths.add(comment.path);
   }
   return [...paths];
 }
 
-/** Every shard's verdict file. A shard whose agent never wrote one fails the run rather than reading as drift. */
+/**
+ * Every shard's verdict file. A shard whose agent never wrote one fails the run
+ * rather than reading as drift.
+ */
 async function readVerdicts(jobDir: string, shards: ShardRef[]): Promise<Map<string, Verdict>> {
   const verdictsDir = join(jobDir, "verdicts");
-  const files = shards.map((ref) => ({
-    id: ref.id,
-    path: join(verdictsDir, `verdict-${ref.id}.json`),
-  }));
+  const files = shards.map((ref) => ({ id: ref.id, path: verdictPath(verdictsDir, ref.id) }));
   const present = await Promise.all(files.map((file) => Bun.file(file.path).exists()));
   const missing = files.filter((_, i) => !present[i]).map((file) => file.id);
   if (missing.length > 0) {
@@ -95,9 +94,9 @@ async function readVerdicts(jobDir: string, shards: ShardRef[]): Promise<Map<str
 }
 
 async function guardScope(options: ApplyOptions): Promise<void> {
-  const scopeFile = Bun.file(join(options.job, "scope.json"));
-  const scope = (await scopeFile.exists())
-    ? Scope.parse(JSON.parse(await scopeFile.text()))
+  const scopePath = join(options.job, "scope.json");
+  const scope = (await Bun.file(scopePath).exists())
+    ? await readJson(scopePath, Scope)
     : { mr: null };
   if (scope.mr != null && scope.mr !== "" && !options.report) {
     throw new AuditError(

--- a/plugins/comments/skills/audit/scripts/apply.ts
+++ b/plugins/comments/skills/audit/scripts/apply.ts
@@ -8,7 +8,7 @@ import { color, type ReportItem, renderReport, summarize } from "../../../apply/
 import { extractComments, languageForPath } from "../../../detection/extract";
 import type { Comment } from "../../../detection/types";
 import { verdictPath } from "../../../judge/adapter";
-import { readShard, type ShardRef } from "../../../judge/job";
+import { type JobShard, readShard, type ShardRef } from "../../../judge/job";
 import type { Verdict } from "../../../judge/schema";
 import { AuditError, type AuditIo } from "./io";
 
@@ -67,22 +67,29 @@ async function readShardRefs(jobDir: string): Promise<ShardRef[]> {
   return (await readJson(argsPath, JobArgsFile)).shards;
 }
 
+/** The shard contents preflight wrote, read back through the refs it handed the workflow. */
+async function readShards(jobDir: string): Promise<JobShard[]> {
+  const refs = await readShardRefs(jobDir);
+  return Promise.all(refs.map((ref) => readShard(ref.path)));
+}
+
 /** The files a job judged, recovered from its shards. */
-async function judgedPaths(shards: ShardRef[]): Promise<string[]> {
+function judgedPaths(shards: JobShard[]): string[] {
   const paths = new Set<string>();
-  for (const shard of await Promise.all(shards.map((ref) => readShard(ref.path)))) {
+  for (const shard of shards) {
     for (const comment of shard.comments) paths.add(comment.path);
   }
   return [...paths];
 }
 
 /**
- * Every shard's verdict file. A shard whose agent never wrote one fails the run
- * rather than reading as drift.
+ * Every shard's verdict file, covering every comment the shard carried. A shard
+ * whose agent never wrote one, or skipped a comment, fails the run rather than
+ * reading as drift or as keep.
  */
-async function readVerdicts(jobDir: string, shards: ShardRef[]): Promise<Map<string, Verdict>> {
+async function readVerdicts(jobDir: string, shards: JobShard[]): Promise<Map<string, Verdict>> {
   const verdictsDir = join(jobDir, "verdicts");
-  const files = shards.map((ref) => ({ id: ref.id, path: verdictPath(verdictsDir, ref.id) }));
+  const files = shards.map((shard) => ({ id: shard.id, path: verdictPath(verdictsDir, shard.id) }));
   const present = await Promise.all(files.map((file) => Bun.file(file.path).exists()));
   const missing = files.filter((_, i) => !present[i]).map((file) => file.id);
   if (missing.length > 0) {
@@ -90,7 +97,18 @@ async function readVerdicts(jobDir: string, shards: ShardRef[]): Promise<Map<str
       `No verdicts for shard(s) ${missing.join(", ")} in ${verdictsDir}. Run the judge workflow first.`,
     );
   }
-  return collectVerdicts(await Promise.all(files.map((file) => readJson(file.path, z.unknown()))));
+  const verdicts = collectVerdicts(
+    await Promise.all(files.map((file) => readJson(file.path, z.unknown()))),
+  );
+  const unjudged = shards.flatMap((shard) =>
+    shard.comments.filter((comment) => !verdicts.has(comment.id)).map((comment) => comment.id),
+  );
+  if (unjudged.length > 0) {
+    throw new AuditError(
+      `Verdicts in ${verdictsDir} omit ${unjudged.length} judged comment(s): ${unjudged.join(", ")}. Rerun the judge workflow.`,
+    );
+  }
+  return verdicts;
 }
 
 async function guardScope(options: ApplyOptions): Promise<void> {
@@ -111,7 +129,7 @@ async function guardScope(options: ApplyOptions): Promise<void> {
  * branch off HEAD. Runs from the repo root.
  */
 export async function apply(options: ApplyOptions, io: AuditIo): Promise<ApplyResult> {
-  const shards = await readShardRefs(options.job);
+  const shards = await readShards(options.job);
   await guardScope(options);
   const verdicts = await readVerdicts(options.job, shards);
 
@@ -122,7 +140,7 @@ export async function apply(options: ApplyOptions, io: AuditIo): Promise<ApplyRe
   const skippedComments = new Set<string>();
 
   // A verdict whose id no longer re-extracts has drifted.
-  for (const path of await judgedPaths(shards)) {
+  for (const path of judgedPaths(shards)) {
     const language = languageForPath(path);
     const file = Bun.file(path);
     // oxlint-disable-next-line no-await-in-loop -- the report lists findings in judged-path order and the body threads shared accumulators.

--- a/plugins/comments/skills/audit/scripts/audit.test.ts
+++ b/plugins/comments/skills/audit/scripts/audit.test.ts
@@ -397,6 +397,17 @@ describe("apply", () => {
     );
   });
 
+  test("refuses a verdict file that skips one of its shard's comments", async () => {
+    const job = await judgedJob();
+    const path = join(job.verdictsDir, "verdict-0.json");
+    const file = await readJson(path, VerdictFile);
+    const dropped = file.verdicts.pop();
+    await Bun.write(path, JSON.stringify(file));
+    expect(await rejection(runApply(job, { report: true }))).toMatch(
+      new RegExp(`omit 1 judged comment\\(s\\): ${dropped?.id}`),
+    );
+  });
+
   test("gives a --fix run its own job dir", async () => {
     const plain = await judgedJob();
     const fix = await judgedJob({ fix: true });

--- a/plugins/comments/skills/audit/scripts/audit.test.ts
+++ b/plugins/comments/skills/audit/scripts/audit.test.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { shardJudge, type ShardJudge } from "../../../judge/adapter";
 import type { ShardComment, WrittenJob } from "../../../judge/job";
 import type { Verdict } from "../../../judge/schema";
-import { apply, type ApplyOptions } from "./apply";
+import { apply, type ApplyOptions, type ApplyResult } from "./apply";
 import type { AuditIo } from "./io";
 import { preflight, type PreflightOptions } from "./preflight";
 
@@ -166,7 +166,7 @@ async function judgedJob(options: Partial<PreflightOptions> = {}): Promise<Writt
 async function runApply(
   job: WrittenJob,
   options: Partial<ApplyOptions> = {},
-): Promise<Capture & { result: Awaited<ReturnType<typeof apply>> }> {
+): Promise<Capture & { result: ApplyResult }> {
   const captured = capture();
   const result = await apply(
     { job: job.jobDir, report: false, fix: false, ...options },
@@ -441,6 +441,7 @@ describe("audit.ts", () => {
     const block = /<preflight>\n(.*)\n<\/preflight>/.exec(pre.stdout);
     const handoff = Preflight.parse(JSON.parse(block?.[1] ?? ""));
     expect(handoff.scriptPath).toEndWith("workflow/judge.workflow.js");
+    expect(await Bun.file(handoff.scriptPath).exists()).toBe(true);
     expect(handoff.jobDir.startsWith(jobs)).toBe(true);
     expect(handoff).toMatchObject({ count: 4, shardCount: 2 });
 

--- a/plugins/comments/skills/audit/scripts/audit.test.ts
+++ b/plugins/comments/skills/audit/scripts/audit.test.ts
@@ -1,0 +1,449 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { $ } from "bun";
+import { z } from "zod";
+import { shardJudge, type ShardJudge } from "../../../judge/adapter";
+import type { ShardComment, WrittenJob } from "../../../judge/job";
+import type { Verdict } from "../../../judge/schema";
+import { apply, type ApplyOptions } from "./apply";
+import type { AuditIo } from "./io";
+import { preflight, type PreflightOptions } from "./preflight";
+
+const TS_SOURCE = [
+  "// increment the counter",
+  "let counter = 0;",
+  "counter += 1;",
+  "",
+  "/**",
+  " * Retries are capped at three because the upstream limiter resets every ten",
+  " * seconds and a fourth attempt always lands inside the same window.",
+  " */",
+  "export function retry(): void {}",
+  "",
+  "// This is a robust, production-grade helper that carefully handles the config.",
+  "export const config = { retries: 3 };",
+  "",
+].join("\n");
+
+const PY_SOURCE = [
+  "# Parse the header line, then validate each field against the schema. The",
+  "# validation runs before parsing the body so a bad header fails fast.",
+  "def parse():",
+  "    return 1",
+  "",
+].join("\n");
+
+/** The scripted judge: one verdict per fixture comment, matched on a distinctive substring. */
+const SCRIPT: [needle: string, verdict: Verdict][] = [
+  [
+    "// increment the counter",
+    {
+      action: "trim",
+      category: "restate-the-what",
+      confidence: "high",
+      rationale: "Paraphrases the increment below it.",
+      rewrite: null,
+    },
+  ],
+  [
+    "Retries are capped",
+    {
+      action: "keep",
+      category: null,
+      confidence: "high",
+      rationale: "Explains a limit the code cannot.",
+      rewrite: null,
+    },
+  ],
+  [
+    "// This is a robust",
+    {
+      action: "rewrite",
+      category: "voice",
+      confidence: "medium",
+      rationale: "Names the shared config under praise.",
+      rewrite: "// Retry config shared by every client.",
+    },
+  ],
+  [
+    "# Parse the header line",
+    {
+      action: "trim",
+      category: "restate-the-what",
+      confidence: "medium",
+      rationale: "The ordering fact survives, the narration goes.",
+      rewrite: null,
+      trimTo: "# Validate the header before the body so a bad header fails fast.",
+    },
+  ],
+];
+
+function verdictFor(comment: ShardComment): Verdict {
+  const hit = SCRIPT.find(([needle]) => comment.text.includes(needle));
+  if (!hit) throw new Error(`No scripted verdict for ${comment.path}: ${comment.text}`);
+  return hit[1];
+}
+
+const scripted: ShardJudge = (comments) => Promise.resolve(comments.map(verdictFor));
+
+interface Capture {
+  io: AuditIo;
+  out: string[];
+  err: string[];
+}
+
+function capture(): Capture {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { io: { log: (line) => out.push(line), warn: (line) => err.push(line) }, out, err };
+}
+
+const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+const strip = (text: string) => text.replaceAll(ANSI, "");
+
+/** The message a promise rejects with. Fails the test if it resolves. */
+async function rejection(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error("expected a rejection");
+}
+
+let root: string;
+let repo: string;
+let jobs: string;
+let prevCwd: string;
+
+const git = (...args: string[]) =>
+  $`git ${args}`
+    .cwd(repo)
+    .env({ ...process.env, GIT_CONFIG_GLOBAL: "/dev/null" })
+    .quiet();
+
+async function commitAll(message: string): Promise<void> {
+  await git("add", "-A");
+  await git("commit", "-q", "-m", message);
+}
+
+/** A repo whose second commit introduces the two fixture files, so `--base HEAD~1` scopes to them. */
+beforeEach(async () => {
+  prevCwd = process.cwd();
+  root = await mkdtemp(join(tmpdir(), "comments-audit-"));
+  repo = join(root, "repo");
+  jobs = join(root, "jobs");
+  await mkdir(repo);
+  await git("init", "-q", "-b", "main");
+  await git("config", "user.email", "test@example.com");
+  await git("config", "user.name", "Test");
+  await Bun.write(join(repo, "README.md"), "# fixture\n");
+  await commitAll("init");
+  await Bun.write(join(repo, "src/a.ts"), TS_SOURCE);
+  await Bun.write(join(repo, "src/b.py"), PY_SOURCE);
+  await commitAll("add sources");
+  process.chdir(repo);
+});
+
+afterEach(async () => {
+  process.chdir(prevCwd);
+  await rm(root, { recursive: true, force: true });
+});
+
+const PREFLIGHT: PreflightOptions = { base: "HEAD~1", all: false, sort: "score", fix: false };
+
+async function judgedJob(options: Partial<PreflightOptions> = {}): Promise<WrittenJob> {
+  const job = await preflight(
+    { ...PREFLIGHT, jobBase: jobs, ...options },
+    { io: capture().io, judge: shardJudge(scripted) },
+  );
+  if (!job) throw new Error("preflight found no comments");
+  return job;
+}
+
+async function runApply(
+  job: WrittenJob,
+  options: Partial<ApplyOptions> = {},
+): Promise<Capture & { result: Awaited<ReturnType<typeof apply>> }> {
+  const captured = capture();
+  const result = await apply(
+    { job: job.jobDir, report: false, fix: false, ...options },
+    captured.io,
+  );
+  return { ...captured, result };
+}
+
+const VerdictFile = z.object({
+  verdicts: z.array(z.object({ id: z.string(), verdict: z.unknown() })),
+});
+
+async function readJson<T>(path: string, schema: z.ZodType<T>): Promise<T> {
+  return schema.parse(JSON.parse(await Bun.file(path).text()));
+}
+
+async function show(ref: string, path: string): Promise<string> {
+  return (await git("show", `${ref}:${path}`)).text();
+}
+
+describe("preflight", () => {
+  test("shards the ranked comments and the judge answers each shard on disk", async () => {
+    const captured = capture();
+    const job = await preflight(
+      { ...PREFLIGHT, jobBase: jobs, shardSize: 2 },
+      { io: captured.io, judge: shardJudge(scripted) },
+    );
+
+    expect(job?.count).toBe(4);
+    expect(job?.shardCount).toBe(2);
+    expect(strip(captured.out[0] ?? "")).toMatch(
+      /^4 comments \/ 2 files \/ ~2 agents \/ ~\d+ tokens/,
+    );
+
+    const [shard0, shard1] = await Promise.all(
+      (job?.shards ?? []).map(async (ref) => {
+        const shard = await readJson(
+          ref.path,
+          z.object({ comments: z.array(z.object({ id: z.string() })) }),
+        );
+        const verdicts = await readJson(
+          join(job?.verdictsDir ?? "", `verdict-${ref.id}.json`),
+          VerdictFile,
+        );
+        return {
+          ids: shard.comments.map((c) => c.id),
+          verdictIds: verdicts.verdicts.map((v) => v.id),
+        };
+      }),
+    );
+    expect(shard0?.verdictIds).toEqual(shard0?.ids);
+    expect(shard1?.verdictIds).toEqual(shard1?.ids);
+    expect(new Set([...(shard0?.ids ?? []), ...(shard1?.ids ?? [])]).size).toBe(4);
+  });
+
+  test("hands back null with nothing in scope", async () => {
+    const captured = capture();
+    const job = await preflight(
+      { ...PREFLIGHT, jobBase: jobs, pathGlobs: ["docs/**"] },
+      { io: captured.io, judge: shardJudge(scripted) },
+    );
+    expect(job).toBeNull();
+    expect(strip(captured.out.join("\n"))).toBe("No comments to judge.");
+  });
+
+  test("refuses --all on a dirty tree", async () => {
+    await Bun.write(join(repo, "README.md"), "# edited\n");
+    const message = await rejection(
+      preflight(
+        { ...PREFLIGHT, base: undefined, all: true, jobBase: jobs },
+        { io: capture().io, judge: shardJudge(scripted) },
+      ),
+    );
+    expect(message).toMatch(/Working tree is not clean/);
+  });
+});
+
+describe("apply --report", () => {
+  test("prints the findings grouped by file and writes nothing", async () => {
+    const job = await judgedJob({ shardSize: 2 });
+    const { out, err, result } = await runApply(job, { report: true });
+
+    expect(result.branch).toBeNull();
+    expect(err).toEqual([]);
+    expect(strip(out.join("\n"))).toMatchInlineSnapshot(`
+      "1 delete / 1 trim / 1 rewrite across 2 file(s)
+
+      src/a.ts
+        :1  delete  restate-the-what  high
+            Paraphrases the increment below it.
+        :11  rewrite  voice  medium
+            Names the shared config under praise.
+            old: // This is a robust, production-grade helper that carefully handles the config.
+            new: // Retry config shared by every client.
+
+      src/b.py
+        :1  trim  restate-the-what  medium
+            The ordering fact survives, the narration goes.
+            keep: # Validate the header before the body so a bad header fails fast."
+    `);
+    expect((await git("branch", "--list", "comments/*")).text().trim()).toBe("");
+  });
+
+  test("still reports a merge-request job the branch mode refuses", async () => {
+    const job = await judgedJob();
+    await Bun.write(join(job.jobDir, "scope.json"), JSON.stringify({ mr: "12" }));
+
+    expect(await rejection(runApply(job))).toMatch(/merge request !12 .* Re-run with --report/);
+    const { out } = await runApply(job, { report: true });
+    expect(strip(out.join("\n"))).toMatch(/^1 delete \/ 1 trim \/ 1 rewrite across 2 file\(s\)/);
+  });
+});
+
+describe("apply", () => {
+  test("lands the trim, partial trim, and rewrite on a fresh branch off HEAD", async () => {
+    const job = await judgedJob({ shardSize: 1 });
+    const head = (await git("rev-parse", "HEAD")).text().trim();
+    const { out, err, result } = await runApply(job);
+
+    const branch = `comments/audit-${basename(job.jobDir)}`;
+    expect(result.branch).toBe(branch);
+    expect(err).toEqual([]);
+    expect(strip(out.join("\n"))).toBe(
+      `Applied 1 delete / 1 trim / 1 rewrite across 2 file(s) on branch ${branch}. Review with git diff HEAD..${branch}.`,
+    );
+
+    expect((await git("rev-parse", `${branch}^`)).text().trim()).toBe(head);
+    expect((await git("branch", "--show-current")).text().trim()).toBe("main");
+    expect((await git("status", "--porcelain")).text().trim()).toBe("");
+    expect(await show(branch, "src/a.ts")).toMatchInlineSnapshot(`
+      "let counter = 0;
+      counter += 1;
+
+      /**
+       * Retries are capped at three because the upstream limiter resets every ten
+       * seconds and a fourth attempt always lands inside the same window.
+       */
+      export function retry(): void {}
+
+      // Retry config shared by every client.
+      export const config = { retries: 3 };
+      "
+    `);
+    expect(await show(branch, "src/b.py")).toMatchInlineSnapshot(`
+      "# Validate the header before the body so a bad header fails fast.
+      def parse():
+          return 1
+      "
+    `);
+  });
+
+  test("formats each edited file through the template", async () => {
+    const job = await judgedJob();
+    const { err, result } = await runApply(job, { format: "cat && printf '# formatted %s\\n' {}" });
+
+    expect(err).toEqual([]);
+    expect(await show(result.branch ?? "", "src/a.ts")).toEndWith("# formatted src/a.ts\n");
+    expect(await show(result.branch ?? "", "src/b.py")).toEndWith("# formatted src/b.py\n");
+  });
+
+  test("keeps the unformatted content when the formatter fails", async () => {
+    const job = await judgedJob();
+    const { err, result } = await runApply(job, { format: "exit 3" });
+
+    expect(strip(err.join("\n"))).toBe(
+      [
+        "Formatter failed for src/a.ts (exit 3: ); keeping unformatted content.",
+        "Formatter failed for src/b.py (exit 3: ); keeping unformatted content.",
+      ].join("\n"),
+    );
+    expect(await show(result.branch ?? "", "src/b.py")).toBe(result.edits.get("src/b.py") ?? "");
+  });
+
+  test("skips a comment that changed since preflight and reports the drift", async () => {
+    const job = await judgedJob();
+    await Bun.write(
+      join(repo, "src/b.py"),
+      PY_SOURCE.replace("Parse the header", "Read the header"),
+    );
+    await commitAll("edit b.py");
+    const { err, result } = await runApply(job);
+
+    expect(result.drift).toHaveLength(1);
+    expect([...result.edits.keys()]).toEqual(["src/a.ts"]);
+    expect(strip(err.join("\n"))).toBe(
+      "Skipped 1 judged comment(s) no longer found at preflight position (file changed since preflight).",
+    );
+    expect((await git("diff", "--name-only", `HEAD..${result.branch ?? ""}`)).text().trim()).toBe(
+      "src/a.ts",
+    );
+  });
+
+  test("skips a judged file that no longer exists", async () => {
+    const job = await judgedJob();
+    await git("rm", "-q", "src/a.ts");
+    await commitAll("drop a.ts");
+    const { out, result } = await runApply(job, { report: true });
+
+    expect(result.drift).toHaveLength(3);
+    expect(strip(out.join("\n"))).toMatch(/^0 delete \/ 1 trim \/ 0 rewrite across 1 file\(s\)/);
+    expect(strip(out.join("\n"))).not.toContain("src/a.ts");
+  });
+
+  test("refuses a dirty tree in branch mode", async () => {
+    const job = await judgedJob();
+    await Bun.write(join(repo, "README.md"), "# edited\n");
+    expect(await rejection(runApply(job))).toMatch(/Working tree is not clean/);
+  });
+
+  test("names the missing job or verdicts", async () => {
+    const judged = await judgedJob();
+    expect(await rejection(runApply({ ...judged, jobDir: join(jobs, "nope") }))).toMatch(
+      /No job at/,
+    );
+    const unjudged = await preflight(
+      { ...PREFLIGHT, jobBase: join(root, "unjudged") },
+      { io: capture().io, judge: () => Promise.resolve() },
+    );
+    if (!unjudged) throw new Error("preflight found no comments");
+    expect(await rejection(runApply(unjudged))).toMatch(/No verdicts in/);
+  });
+});
+
+describe("audit.ts", () => {
+  const script = join(import.meta.dirname, "audit.ts");
+
+  async function run(...args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+    const proc = Bun.spawn([process.execPath, script, ...args], {
+      cwd: repo,
+      env: { ...process.env, TMPDIR: jobs, GIT_CONFIG_GLOBAL: "/dev/null" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { stdout: strip(stdout), stderr: strip(stderr), code };
+  }
+
+  const Preflight = z.object({
+    scriptPath: z.string(),
+    argsPath: z.string(),
+    jobDir: z.string(),
+    count: z.number(),
+    shardCount: z.number(),
+  });
+
+  const JobArgs = z.object({
+    shards: z.array(z.object({ id: z.number(), path: z.string() })),
+    verdictsDir: z.string(),
+  });
+
+  test("preflight hands the job to the workflow and apply reads the verdicts back", async () => {
+    const pre = await run("preflight", "--all", "--shard-size", "2");
+    expect(pre.code).toBe(0);
+    const block = /<preflight>\n(.*)\n<\/preflight>/.exec(pre.stdout);
+    const handoff = Preflight.parse(JSON.parse(block?.[1] ?? ""));
+    expect(handoff.scriptPath).toEndWith("workflow/judge.workflow.js");
+    expect(handoff.jobDir.startsWith(jobs)).toBe(true);
+    expect(handoff).toMatchObject({ count: 4, shardCount: 2 });
+
+    const args = await readJson(handoff.argsPath, JobArgs);
+    await shardJudge(scripted)({ ...handoff, ...args });
+
+    const applied = await run("apply", "--job", handoff.jobDir, "--report");
+    expect(applied.code).toBe(0);
+    expect(applied.stderr).toBe("");
+    expect(applied.stdout).toMatch(/^1 delete \/ 1 trim \/ 1 rewrite across 2 file\(s\)\n/);
+  });
+
+  test("exits 1 with the message on a usage error", async () => {
+    const result = await run("apply", "--job", join(jobs, "nope"));
+    expect(result.code).toBe(1);
+    expect(result.stderr.trim()).toBe(
+      `No job at ${join(jobs, "nope")}. Pass the job dir printed by preflight.`,
+    );
+  });
+});

--- a/plugins/comments/skills/audit/scripts/audit.test.ts
+++ b/plugins/comments/skills/audit/scripts/audit.test.ts
@@ -408,6 +408,22 @@ describe("apply", () => {
     );
   });
 
+  test("refuses a verdict filed under another shard", async () => {
+    const job = await judgedJob({ shardSize: 2 });
+    const firstPath = join(job.verdictsDir, "verdict-0.json");
+    const secondPath = join(job.verdictsDir, "verdict-1.json");
+    const first = await readJson(firstPath, VerdictFile);
+    const second = await readJson(secondPath, VerdictFile);
+    const moved = second.verdicts.pop();
+    if (!moved) throw new Error("second shard has no verdicts");
+    first.verdicts.push(moved);
+    await Bun.write(firstPath, JSON.stringify(first));
+    await Bun.write(secondPath, JSON.stringify(second));
+    expect(await rejection(runApply(job, { report: true }))).toMatch(
+      new RegExp(`omit 1 judged comment\\(s\\): ${moved.id}`),
+    );
+  });
+
   test("gives a --fix run its own job dir", async () => {
     const plain = await judgedJob();
     const fix = await judgedJob({ fix: true });

--- a/plugins/comments/skills/audit/scripts/audit.test.ts
+++ b/plugins/comments/skills/audit/scripts/audit.test.ts
@@ -386,7 +386,21 @@ describe("apply", () => {
       { io: capture().io, judge: () => Promise.resolve() },
     );
     if (!unjudged) throw new Error("preflight found no comments");
-    expect(await rejection(runApply(unjudged))).toMatch(/No verdicts in/);
+    expect(await rejection(runApply(unjudged))).toMatch(/No verdicts for shard\(s\) 0 in/);
+  });
+
+  test("refuses a job whose shards were only partly judged", async () => {
+    const job = await judgedJob({ shardSize: 2 });
+    await rm(join(job.verdictsDir, "verdict-1.json"));
+    expect(await rejection(runApply(job, { report: true }))).toMatch(
+      /No verdicts for shard\(s\) 1 in/,
+    );
+  });
+
+  test("gives a --fix run its own job dir", async () => {
+    const plain = await judgedJob();
+    const fix = await judgedJob({ fix: true });
+    expect(fix.jobDir).not.toBe(plain.jobDir);
   });
 });
 

--- a/plugins/comments/skills/audit/scripts/audit.ts
+++ b/plugins/comments/skills/audit/scripts/audit.ts
@@ -1,40 +1,13 @@
 #!/usr/bin/env bun
 
-import { readdir } from "node:fs/promises";
-import { basename, join } from "node:path";
 import { $ } from "bun";
 import { cli, command } from "cleye";
 import { z } from "zod";
-import { applyToBranch, isCleanTree } from "../../../apply/branch";
-import { computeFileEdits, type EditItem } from "../../../apply/edits";
-import { formatContent } from "../../../apply/format";
-import { collectVerdicts, matchVerdicts } from "../../../apply/join";
-import { color, type ReportItem, renderReport, summarize } from "../../../apply/report";
-import {
-  type CollectedComment,
-  collectDiff,
-  collectRepo,
-  type MrSource,
-  resolveMrSource,
-} from "../../../detection/collect";
-import { densityWeights, type ScoredFile } from "../../../detection/density";
-import type { DiffOptions } from "../../../detection/diff";
-import { extractComments, languageForPath } from "../../../detection/extract";
-import { rankCommentsWeighted, type SortKey } from "../../../detection/rank";
-import type { Comment } from "../../../detection/types";
-import { buildJob, type BuildJobOptions, writeJob } from "../../../judge/job";
-import type { Verdict } from "../../../judge/schema";
-
-const WORKFLOW_PATH = join(import.meta.dirname, "..", "..", "..", "workflow", "judge.workflow.js");
-
-/**
- * Fixed token cost of one judging agent beyond its comment payload: the Claude
- * Code system prompt and tool schemas (~15k), the rubric read (~2.5k), and the
- * multi-turn read/write/output cycle. The preflight estimate is the number the
- * user consents to, so it must include this, not just payload; overhead
- * dominates payload at the default shard size.
- */
-const AGENT_OVERHEAD_TOKENS = 25_000;
+import type { SortKey } from "../../../detection/rank";
+import { workflowJudge } from "../../../judge/adapter";
+import { apply } from "./apply";
+import { AuditError, consoleIo } from "./io";
+import { preflight } from "./preflight";
 
 const SORT_KEYS = ["lines", "chars", "score"] as const satisfies readonly SortKey[];
 
@@ -62,9 +35,15 @@ async function chdirToRepoRoot(): Promise<void> {
   process.chdir(root);
 }
 
-function preview(text: string): string {
-  const firstLine = text.split("\n")[0] ?? "";
-  return firstLine.length > 64 ? `${firstLine.slice(0, 61)}...` : firstLine;
+async function run(task: () => Promise<void>): Promise<void> {
+  await chdirToRepoRoot();
+  try {
+    await task();
+  } catch (error) {
+    if (!(error instanceof AuditError)) throw error;
+    console.error(error.message);
+    process.exit(1);
+  }
 }
 
 const preflightCmd = command(
@@ -95,132 +74,15 @@ const preflightCmd = command(
       },
     },
   },
-  async (parsed) => {
-    await chdirToRepoRoot();
-    const { base, mr, all, path, sort, limit, shardSize, fix } = parsed.flags;
-    const pathGlobs = path;
-    const sortKey = parseSort(sort);
-
-    // Per-file added-line density, gathered while collect has each file's
-    // content in hand, weights the ranking so the shard budget lands on the
-    // heaviest files first.
-    const densities: ScoredFile[] = [];
-    const onFileDensity = (file: ScoredFile) => densities.push(file);
-
-    let comments: CollectedComment[];
-    if (all) {
-      if (!(await isCleanTree())) {
-        console.error(
-          "Working tree is not clean. --all reads the working tree but applies from HEAD. Commit or stash first.",
-        );
-        process.exit(1);
-      }
-      comments = await collectRepo({ pathGlobs, onFileDensity });
-    } else {
-      const options: DiffOptions = {};
-      if (base != null && base !== "") options.base = base;
-      if (mr != null && mr !== "") options.mr = mr;
-      let mrSource: MrSource | null = null;
-      if (mr != null && mr !== "") {
-        mrSource = await resolveMrSource(mr);
-        if (!mrSource) {
-          console.error("Could not resolve the merge request's source ref via glab.");
-          process.exit(1);
-        }
-      }
-      comments = await collectDiff(options, mrSource, { pathGlobs, onFileDensity });
-    }
-
-    const ranked = rankCommentsWeighted(comments, densityWeights(densities), sortKey);
-    const limited = typeof limit === "number" ? ranked.slice(0, limit) : ranked;
-    if (limited.length === 0) {
-      console.log(color.dim("No comments to judge."));
-      return;
-    }
-
-    const options: BuildJobOptions = { fix };
-    if (shardSize != null && shardSize !== 0) options.shardSize = shardSize;
-    const descriptor = await buildJob(limited, options);
-    const written = await writeJob(descriptor);
-    // An --mr job records comment text from the remote MR ref, but apply trims
-    // the local tree from HEAD. Persist the scope so apply can refuse to branch
-    // off a local checkout that would read every comment as drift.
-    await Bun.write(join(written.jobDir, "scope.json"), JSON.stringify({ mr: mr ?? null }));
-
-    // Deterministic features per judged comment, keyed by the same id the
-    // verdicts use. Each run leaves a (features, verdict) pair in its job dir,
-    // the training data for routing obvious comments away from the judge later.
-    const features = Object.fromEntries(
-      limited.map((c) => [c.id, { path: c.path, startLine: c.startLine, ...c.features }]),
-    );
-    await Bun.write(join(written.jobDir, "features.json"), JSON.stringify(features, null, 2));
-
-    const fileCount = new Set(limited.map((c) => c.path)).size;
-    const payloadTokens = Math.ceil(
-      limited.reduce((sum, c) => sum + c.text.length + c.context.length, 0) / 4,
-    );
-    const tokens = payloadTokens + written.shardCount * AGENT_OVERHEAD_TOKENS;
-
-    console.log(
-      color.bold(
-        `${limited.length} comments / ${fileCount} files / ~${written.shardCount} agents / ~${tokens} tokens (rough)`,
-      ),
-    );
-    for (const c of limited.slice(0, 10)) {
-      console.log(
-        `  ${color.dim(String(c.score.score).padStart(5))}  ${c.path}:${c.startLine}  ${preview(c.text)}`,
+  (parsed) =>
+    run(async () => {
+      const { base, mr, all, path, sort, limit, shardSize, fix } = parsed.flags;
+      await preflight(
+        { base, mr, all, pathGlobs: path, sort: parseSort(sort), limit, shardSize, fix },
+        { io: consoleIo, judge: workflowJudge((line) => consoleIo.log(line)) },
       );
-    }
-    console.log("");
-    console.log("<preflight>");
-    console.log(
-      JSON.stringify({
-        scriptPath: WORKFLOW_PATH,
-        argsPath: written.argsPath,
-        jobDir: written.jobDir,
-        count: written.count,
-        shardCount: written.shardCount,
-      }),
-    );
-    console.log("</preflight>");
-  },
+    }),
 );
-
-function toEditItem(comment: Comment, verdict: Verdict): EditItem {
-  return {
-    startLine: comment.startLine,
-    endLine: comment.endLine,
-    startColumn: comment.startColumn,
-    endColumn: comment.endColumn,
-    kind: comment.kind,
-    verdict,
-  };
-}
-
-async function readJsonFiles<T>(dir: string, prefix: string, schema: z.ZodType<T>): Promise<T[]> {
-  let names: string[];
-  try {
-    names = await readdir(dir);
-  } catch {
-    return [];
-  }
-  const matching = names.filter((name) => name.startsWith(prefix) && name.endsWith(".json"));
-  return Promise.all(
-    matching.map(async (name) => schema.parse(JSON.parse(await Bun.file(join(dir, name)).text()))),
-  );
-}
-
-const Scope = z.looseObject({ mr: z.string().nullish() });
-
-const JobShardFile = z.looseObject({ comments: z.array(z.looseObject({ path: z.string() })) });
-
-/** The files a job judged, recovered from the shards. */
-async function judgedPaths(jobDir: string): Promise<string[]> {
-  const shards = await readJsonFiles(jobDir, "shard-", JobShardFile);
-  const paths = new Set<string>();
-  for (const shard of shards) for (const comment of shard.comments) paths.add(comment.path);
-  return [...paths];
-}
 
 const applyCmd = command(
   {
@@ -240,128 +102,12 @@ const applyCmd = command(
       },
     },
   },
-  async (parsed) => {
-    await chdirToRepoRoot();
-    const { job, report, fix, format, maxWidth } = parsed.flags;
-    if (job == null || job === "") {
-      console.error("--job <dir> is required.");
-      process.exit(1);
-    }
-
-    if (!(await Bun.file(join(job, "job-args.json")).exists())) {
-      console.error(`No job at ${job}. Pass the job dir printed by preflight.`);
-      process.exit(1);
-    }
-
-    const scopeFile = Bun.file(join(job, "scope.json"));
-    const scope = (await scopeFile.exists())
-      ? Scope.parse(JSON.parse(await scopeFile.text()))
-      : { mr: null };
-    if (scope.mr != null && scope.mr !== "" && !report) {
-      console.error(
-        `This job audited merge request !${scope.mr} from its remote source. Apply writes trims to the local tree from HEAD, so every comment would read as drift. Re-run with --report, or check out the MR branch and re-run preflight with --base.`,
-      );
-      process.exit(1);
-    }
-
-    const verdictShards = await readJsonFiles(join(job, "verdicts"), "verdict-", z.unknown());
-    if (verdictShards.length === 0) {
-      console.error(`No verdicts in ${join(job, "verdicts")}. Run the judge workflow first.`);
-      process.exit(1);
-    }
-    const verdicts = collectVerdicts(verdictShards);
-
-    const reportItems: ReportItem[] = [];
-    const editsByPath = new Map<string, string>();
-    const matched = new Set<string>();
-    const manualSkips: string[] = [];
-    const skippedComments = new Set<string>();
-
-    // Re-extract each judged file and match verdicts by id at the comment's
-    // current range. A verdict whose id no longer re-extracts has drifted.
-    for (const path of await judgedPaths(job)) {
-      const language = languageForPath(path);
-      const file = Bun.file(path);
-      // oxlint-disable-next-line no-await-in-loop -- the report lists findings in judged-path order and the body threads shared accumulators.
-      if (language == null || language === "" || !(await file.exists())) continue;
-      // oxlint-disable-next-line no-await-in-loop -- the report lists findings in judged-path order and the body threads shared accumulators.
-      const source = await file.text();
-      const editItems: EditItem[] = [];
-      // oxlint-disable-next-line no-await-in-loop -- the report lists findings in judged-path order and the body threads shared accumulators.
-      for (const match of matchVerdicts(path, await extractComments(source, language), verdicts)) {
-        matched.add(match.id);
-        reportItems.push({
-          path,
-          startLine: match.comment.startLine,
-          verdict: match.verdict,
-          text: match.comment.text,
-        });
-        if (match.verdict.action !== "keep")
-          editItems.push(toEditItem(match.comment, match.verdict));
-      }
-      if (editItems.length > 0) {
-        const result = computeFileEdits(source, editItems, { maxWidth });
-        for (const skip of result.skips) {
-          manualSkips.push(`${path}:${skip.startLine}  ${skip.detail}`);
-          skippedComments.add(`${path}:${skip.startLine}`);
-        }
-        if (result.content !== source) editsByPath.set(path, result.content);
-      }
-    }
-
-    if (format != null && format !== "" && !report) {
-      for (const [path, content] of editsByPath) {
-        // oxlint-disable-next-line no-await-in-loop -- bounds formatter subprocess fan-out to one `sh -c` per edited file at a time.
-        const formatted = await formatContent(format, path, content);
-        if (formatted.formatted) {
-          editsByPath.set(path, formatted.content);
-        } else {
-          console.error(
-            color.yellow(
-              `Formatter failed for ${path} (${formatted.error}); keeping unformatted content.`,
-            ),
-          );
-        }
-      }
-    }
-
-    for (const item of reportItems) {
-      if (skippedComments.has(`${item.path}:${item.startLine}`)) item.skipped = true;
-    }
-
-    const driftSkips = [...verdicts.keys()].filter((id) => !matched.has(id));
-
-    if (report) {
-      console.log(renderReport(reportItems, { fix }));
-    } else {
-      const branch = `comments/audit-${basename(job)}`;
-      if (editsByPath.size === 0) {
-        console.log(color.dim("Nothing to apply."));
-      } else if (!(await isCleanTree())) {
-        console.error(
-          "Working tree is not clean. Commit or stash before applying, or use --report.",
-        );
-        process.exit(1);
-      } else {
-        await applyToBranch(editsByPath, { branch });
-        console.log(
-          `Applied ${summarize(reportItems)} on branch ${color.bold(branch)}. Review with git diff HEAD..${branch}.`,
-        );
-      }
-    }
-
-    if (driftSkips.length > 0) {
-      console.error(
-        color.yellow(
-          `Skipped ${driftSkips.length} judged comment(s) no longer found at preflight position (file changed since preflight).`,
-        ),
-      );
-    }
-    if (manualSkips.length > 0) {
-      console.error(color.yellow(`Left ${manualSkips.length} comment(s) for manual handling:`));
-      for (const skip of manualSkips) console.error(`  ${skip}`);
-    }
-  },
+  (parsed) =>
+    run(async () => {
+      const { job, report, fix, format, maxWidth } = parsed.flags;
+      if (job == null || job === "") throw new AuditError("--job <dir> is required.");
+      await apply({ job, report, fix, format, maxWidth }, consoleIo);
+    }),
 );
 
 await cli(

--- a/plugins/comments/skills/audit/scripts/io.ts
+++ b/plugins/comments/skills/audit/scripts/io.ts
@@ -1,0 +1,13 @@
+/** Where the pipeline's human-facing lines go: stdout for results, stderr for warnings. */
+export interface AuditIo {
+  log(line: string): void;
+  warn(line: string): void;
+}
+
+export const consoleIo: AuditIo = {
+  log: (line) => console.log(line),
+  warn: (line) => console.error(line),
+};
+
+/** A failure the user can act on. The CLI prints the message alone and exits 1. */
+export class AuditError extends Error {}

--- a/plugins/comments/skills/audit/scripts/preflight.ts
+++ b/plugins/comments/skills/audit/scripts/preflight.ts
@@ -19,8 +19,8 @@ import { AuditError, type AuditIo } from "./io";
  * Fixed token cost of one judging agent beyond its comment payload: the Claude
  * Code system prompt and tool schemas (~15k), the rubric read (~2.5k), and the
  * multi-turn read/write/output cycle. The preflight estimate is the number the
- * user consents to, so it must include this, not just payload; overhead
- * dominates payload at the default shard size.
+ * user consents to, so it must include this cost; overhead dominates payload
+ * at the default shard size.
  */
 const AGENT_OVERHEAD_TOKENS = 25_000;
 

--- a/plugins/comments/skills/audit/scripts/preflight.ts
+++ b/plugins/comments/skills/audit/scripts/preflight.ts
@@ -1,0 +1,141 @@
+import { join } from "node:path";
+import { isCleanTree } from "../../../apply/branch";
+import { color } from "../../../apply/report";
+import {
+  type CollectedComment,
+  collectDiff,
+  collectRepo,
+  type MrSource,
+  resolveMrSource,
+} from "../../../detection/collect";
+import { densityWeights, type ScoredFile } from "../../../detection/density";
+import type { DiffOptions } from "../../../detection/diff";
+import { rankCommentsWeighted, type SortKey } from "../../../detection/rank";
+import type { JudgeAdapter } from "../../../judge/adapter";
+import { buildJob, type BuildJobOptions, writeJob, type WrittenJob } from "../../../judge/job";
+import { AuditError, type AuditIo } from "./io";
+
+/**
+ * Fixed token cost of one judging agent beyond its comment payload: the Claude
+ * Code system prompt and tool schemas (~15k), the rubric read (~2.5k), and the
+ * multi-turn read/write/output cycle. The preflight estimate is the number the
+ * user consents to, so it must include this, not just payload; overhead
+ * dominates payload at the default shard size.
+ */
+const AGENT_OVERHEAD_TOKENS = 25_000;
+
+export interface PreflightOptions {
+  /** Diff scope: comments introduced vs the merge-base with this ref. */
+  base?: string | undefined;
+  /** Diff scope: comments introduced by a GitLab merge request (iid). */
+  mr?: string | undefined;
+  /** Repo scope: every tracked code file's comments. */
+  all: boolean;
+  pathGlobs?: string[] | undefined;
+  sort: SortKey;
+  limit?: number | undefined;
+  shardSize?: number | undefined;
+  fix: boolean;
+  /** Where job dirs land. Defaults to the content-keyed dir under the OS tmpdir. */
+  jobBase?: string | undefined;
+}
+
+export interface PreflightDeps {
+  io: AuditIo;
+  judge: JudgeAdapter;
+}
+
+function preview(text: string): string {
+  const firstLine = text.split("\n")[0] ?? "";
+  return firstLine.length > 64 ? `${firstLine.slice(0, 61)}...` : firstLine;
+}
+
+async function collect(
+  options: PreflightOptions,
+  onFileDensity: (file: ScoredFile) => void,
+): Promise<CollectedComment[]> {
+  const { pathGlobs } = options;
+  if (options.all) {
+    if (!(await isCleanTree())) {
+      throw new AuditError(
+        "Working tree is not clean. --all reads the working tree but applies from HEAD. Commit or stash first.",
+      );
+    }
+    return collectRepo({ pathGlobs, onFileDensity });
+  }
+  const diff: DiffOptions = {};
+  if (options.base != null && options.base !== "") diff.base = options.base;
+  if (options.mr != null && options.mr !== "") diff.mr = options.mr;
+  let mrSource: MrSource | null = null;
+  if (diff.mr != null) {
+    mrSource = await resolveMrSource(diff.mr);
+    if (!mrSource) {
+      throw new AuditError("Could not resolve the merge request's source ref via glab.");
+    }
+  }
+  return collectDiff(diff, mrSource, { pathGlobs, onFileDensity });
+}
+
+/**
+ * Collect and rank the in-scope comments, materialize the judging job on disk,
+ * print the cost summary, and hand the job to the judge. Returns the written job,
+ * or null when nothing was in scope. Runs from the repo root.
+ */
+export async function preflight(
+  options: PreflightOptions,
+  deps: PreflightDeps,
+): Promise<WrittenJob | null> {
+  const { io, judge } = deps;
+
+  // Per-file added-line density, gathered while collect has each file's
+  // content in hand, weights the ranking so the shard budget lands on the
+  // heaviest files first.
+  const densities: ScoredFile[] = [];
+  const comments = await collect(options, (file) => densities.push(file));
+
+  const ranked = rankCommentsWeighted(comments, densityWeights(densities), options.sort);
+  const limited = typeof options.limit === "number" ? ranked.slice(0, options.limit) : ranked;
+  if (limited.length === 0) {
+    io.log(color.dim("No comments to judge."));
+    return null;
+  }
+
+  const jobOptions: BuildJobOptions = { fix: options.fix };
+  if (options.shardSize != null && options.shardSize !== 0)
+    jobOptions.shardSize = options.shardSize;
+  const descriptor = await buildJob(limited, jobOptions);
+  const written = await writeJob(descriptor, options.jobBase);
+  // An --mr job records comment text from the remote MR ref, but apply trims
+  // the local tree from HEAD. Persist the scope so apply can refuse to branch
+  // off a local checkout that would read every comment as drift.
+  await Bun.write(join(written.jobDir, "scope.json"), JSON.stringify({ mr: options.mr ?? null }));
+
+  // Deterministic features per judged comment, keyed by the same id the
+  // verdicts use. Each run leaves a (features, verdict) pair in its job dir,
+  // the training data for routing obvious comments away from the judge later.
+  const features = Object.fromEntries(
+    limited.map((c) => [c.id, { path: c.path, startLine: c.startLine, ...c.features }]),
+  );
+  await Bun.write(join(written.jobDir, "features.json"), JSON.stringify(features, null, 2));
+
+  const fileCount = new Set(limited.map((c) => c.path)).size;
+  const payloadTokens = Math.ceil(
+    limited.reduce((sum, c) => sum + c.text.length + c.context.length, 0) / 4,
+  );
+  const tokens = payloadTokens + written.shardCount * AGENT_OVERHEAD_TOKENS;
+
+  io.log(
+    color.bold(
+      `${limited.length} comments / ${fileCount} files / ~${written.shardCount} agents / ~${tokens} tokens (rough)`,
+    ),
+  );
+  for (const c of limited.slice(0, 10)) {
+    io.log(
+      `  ${color.dim(String(c.score.score).padStart(5))}  ${c.path}:${c.startLine}  ${preview(c.text)}`,
+    );
+  }
+  io.log("");
+
+  await judge(written);
+  return written;
+}

--- a/plugins/comments/skills/audit/scripts/preflight.ts
+++ b/plugins/comments/skills/audit/scripts/preflight.ts
@@ -3,6 +3,7 @@ import { isCleanTree } from "../../../apply/branch";
 import { color } from "../../../apply/report";
 import {
   type CollectedComment,
+  type CollectOptions,
   collectDiff,
   collectRepo,
   type MrSource,
@@ -54,14 +55,15 @@ async function collect(
   options: PreflightOptions,
   onFileDensity: (file: ScoredFile) => void,
 ): Promise<CollectedComment[]> {
-  const { pathGlobs } = options;
+  const scope: CollectOptions = { onFileDensity };
+  if (options.pathGlobs) scope.pathGlobs = options.pathGlobs;
   if (options.all) {
     if (!(await isCleanTree())) {
       throw new AuditError(
         "Working tree is not clean. --all reads the working tree but applies from HEAD. Commit or stash first.",
       );
     }
-    return collectRepo({ pathGlobs, onFileDensity });
+    return collectRepo(scope);
   }
   const diff: DiffOptions = {};
   if (options.base != null && options.base !== "") diff.base = options.base;
@@ -73,7 +75,7 @@ async function collect(
       throw new AuditError("Could not resolve the merge request's source ref via glab.");
     }
   }
-  return collectDiff(diff, mrSource, { pathGlobs, onFileDensity });
+  return collectDiff(diff, mrSource, scope);
 }
 
 /**


### PR DESCRIPTION
The audit CLI sequenced well-tested stages with nothing composing them, and the judge lived only in a workflow prompt. This turns the judge into an adapter over the directory contract the agents already honor, then drives preflight and apply end to end under `bun test` with a scripted judge writing verdict files through that same seam.

`preflight` and `apply` are now functions that take an output sink and throw `AuditError` for user-facing failures, with `audit.ts` left as the cleye layer. A `JudgeAdapter` receives the written job and must leave one `verdict-<shard>.json` per shard in its verdicts dir. The production adapter prints the `<preflight>` handoff block, since handing the job to the Workflow tool is how the agents come to fill that directory. `shardJudge` wraps any in-process scorer and writes files in the agents' shape, which is how the test scripts verdicts and how the eval oracle fits the seam as `anthropicJudgeAdapter`.

I left the eval runner scoring fixtures directly. Fixtures carry no repo to re-extract against, so routing them through collect and apply has nothing to test.

Two bugs predate this change and now have tests. A shard whose agent never wrote its verdict file, or wrote one that skipped some of its comments, left those comments unreported instead of failing the run. Apply now reads the shard list from the job args and refuses unless every comment in every shard has a verdict entry. The job hash also keyed on the rubric's sha rather than the full prompt text, so a `--fix` rerun landed in the plain run's job dir and could apply its stale verdicts.

`branch.test.ts` also called `$.cwd(dir)`, which sets Bun's process-wide shell default. Once anything else in the plugin shelled out without an explicit cwd, later test files ran git inside a deleted temp dir.

The end-to-end test builds a temp repo with TypeScript and Python fixtures and covers:

- delete, partial trim, rewrite, and keep verdicts in report and branch modes
- the `--mr` guard and shard path reconstruction
- `--format` success and a failing formatter
- drift after an edit or a deleted file, dirty-tree refusals, and a partly judged job
- the CLI round trip through a subprocess, with `TMPDIR` redirected so the content-keyed job dir never collides with a prior run

https://claude.ai/code/session_01YHReSQeqE5ho2CKHteNi45
