### PR TITLE
hooks: disable nested oxlint config in type-check

### DIFF
--- a/.claude/hooks/ox/index.test.ts
+++ b/.claude/hooks/ox/index.test.ts
@@ -33,6 +33,7 @@ import {
   processStop,
   runOxlintAgent,
   STOP_BLOCK_LIMIT,
+  TYPE_CHECK_ARGS,
 } from ".";
 
 // Every check here spawns oxlint and oxfmt over a real fixture, and the
@@ -400,6 +401,10 @@ describe("ox hook", () => {
       expect(context).toContain(reports);
       expect(context).not.toContain("tsgolint");
     });
+  });
+
+  it("disables nested config discovery for the type-check pass", () => {
+    expect(TYPE_CHECK_ARGS).toContain("--disable-nested-config");
   });
 
   describe("processStop", () => {

--- a/.claude/hooks/ox/index.ts
+++ b/.claude/hooks/ox/index.ts
@@ -425,11 +425,14 @@ type TypeCheckResult = { output: string | null; needsInstall: boolean };
 // already reports them for the files actually edited. --no-error-on-unmatched-pattern
 // covers a tree whose config ignores everything in it, which otherwise exits
 // non-zero with "No files found to lint" and reads as a type failure.
-const TYPE_CHECK_ARGS = [
+// --disable-nested-config avoids a nested checkout under .worktrees/
+// re-registering the root's `local` JS plugin.
+export const TYPE_CHECK_ARGS = [
   "--type-aware",
   "--type-check",
   "--quiet",
   "--no-error-on-unmatched-pattern",
+  "--disable-nested-config",
   "-f",
   "agent",
 ];

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -6,5 +6,12 @@
     "./lint/typescript.json",
     "./packages/oxlint-rules/config.json"
   ],
-  "ignorePatterns": ["**/fixtures/**", "**/*.d.ts", "**/jxa/**/*.js", ".claude/workflows/**"]
+  "ignorePatterns": [
+    "**/fixtures/**",
+    "**/*.d.ts",
+    "**/jxa/**/*.js",
+    ".claude/workflows/**",
+    ".worktrees/**",
+    "tmp/**"
+  ]
 }


### PR DESCRIPTION
Fixes the Stop-time lint gate's whole-tree type-check pass, which dies when a nested checkout sits under `.worktrees/` (as `Agent` tool worktree isolation puts them).
oxlint's nested-config discovery finds that checkout's `.oxlintrc.json` and re-registers the root's `local` JS plugin, aborting with "Plugin name 'local' is already registered."

- `.claude/hooks/ox/index.ts`: add `--disable-nested-config` to `TYPE_CHECK_ARGS`, export it for testing, and add a test asserting the flag is present. `oxfmt` only ever runs per-file in this hook, so it needs no equivalent change.
- `.oxlintrc.json`: ignore `.worktrees/**` and `tmp/**`. With nested discovery off, the walk would otherwise lint stale files under worktrees and scratch files under `tmp/` that only the user's global gitignore hides from git.

CI doesn't reproduce the nested-worktree condition, so this was hand-verified: `oxlint --disable-nested-config --type-aware --type-check --quiet --no-error-on-unmatched-pattern -f agent` exits 0 from a tree with a nested worktree checkout present.

Discovery: 2b694bfc27a5
https://claude.ai/code/session_01P8wD9wf2Yi6YWLxuqjNdvj
