### PR TITLE
herdr: inject signatures for six more commands

### DIFF
--- a/user/skills/herdr/scripts/commands.sh
+++ b/user/skills/herdr/scripts/commands.sh
@@ -12,6 +12,8 @@ groups=$(
     printf '%s\n' plugin server
   } | sort -u
 )
+# A command earns a line by measured demand: how often sessions that had
+# already loaded this skill still ran `<command> --help`.
 hot=(
   "agent prompt"
   "agent wait"
@@ -21,7 +23,13 @@ hot=(
   "pane wait-output"
   "pane split"
   "pane run"
+  "pane move"
+  "workspace create"
+  "workspace close"
+  "tab create"
+  "worktree create"
   "worktree open"
+  "worktree remove"
 )
 
 for g in $groups; do


### PR DESCRIPTION
The hot-signature block from #1148 works. None of the nine commands it covers is looked up any more by a session that loaded the skill, while sessions without the skill still look them up: `pane split` 16 times, `agent start` 11, `pane read` 7, `pane run` 6. Every residual lookup is a command the block never covered.

Ranked over the session index from 2026-08-04, the day #1148 landed, counting only sessions that had already loaded the skill:

| command | lookups | sessions |
|---|---|---|
| `worktree create` | 39 | 35 |
| `workspace create` | 8 | 8 |
| `tab create` | 8 | 8 |
| `worktree remove` | 8 | 6 |
| `pane move` | 7 | 7 |
| `worktree open` (already covered) | 6 | 6 |
| `workspace close` | 4 | 4 |
| `pane report-metadata` | 4 | 3 |

`worktree create` dominates because "Starting an Agent" names it as how a sibling agent gets its own checkout, and it is the only command carrying `--base`. Creating a worktree off `origin/main` cost a `--help` round trip every time, with `worktree open` sitting one line above it fully documented. Exit-2 usage errors point the same way: `worktree create` in 4 sessions, `pane move` in 1.

I added the six that earn a permanent line and skipped `pane report-metadata`. It has the thinnest demand of the set and renders 268 characters of display-only flags, inverting the cost against every other addition. `--help` still reaches it. Every signature comes from `--help` at load time, so the CLI stays authoritative and none of this can go stale.

The command surface goes from ~484 to ~654 tokens. `SKILL.md` is unchanged at ~3,688 because the additions are bang-executed rather than transcribed. The expanded body moves from ~4,172 to ~4,342, already past the 4k guideline before this change.

Removal criterion is the same query. A command whose in-skill lookups have gone to zero is earning its line; one whose lookups continue is not being helped by the signature and should come back out.

```sql
WITH loaded AS (SELECT DISTINCT session_id, host FROM skill_calls WHERE skill_name ILIKE '%herdr%'),
h AS (
  SELECT tc.session_id, regexp_extract(tc.command, '(?:^|[|;&(]\s*)(herdr(?:\s+[a-z][a-z0-9-]*)*)\s+(?:-h|--help)', 1) AS cmd
  FROM tool_calls tc JOIN loaded l ON l.session_id = tc.session_id AND l.host = tc.host
  WHERE tc.tool_name = 'Bash' AND regexp_matches(tc.command, 'herdr[^|;&]*\s(-h|--help)')
    AND tc.timestamp >= DATE '2026-09-02'
)
SELECT cmd, count(*) AS lookups, count(DISTINCT session_id) AS sessions
FROM h WHERE cmd <> '' GROUP BY 1 ORDER BY lookups DESC;
```

https://claude.ai/code/session_01KLQVD7ueMWvZnqCD6NF88s
