### PR TITLE
Warn on Agent spawns with no model override

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -9,7 +9,7 @@ paths:
 
 Read [`hooks.md`](hooks.md) before adding or changing a hook entry in either file.
 
-Why each sandbox entry exists, and what would retire it, is in [`docs/settings.md`](../../docs/settings.md). Read it before adding, removing, or narrowing a host, write path, socket, or escaped command.
+Why each sandbox grant and hook exists, and what would retire it, is in [`docs/settings.md`](../../docs/settings.md). Read it before adding, removing, or narrowing a host, write path, socket, escaped command, or hook entry.
 
 ## Permission Paths
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,6 +1,6 @@
 # settings.json Entries
 
-Why each sandbox entry in `settings.json` exists and what would retire it. Nothing here auto-injects. [`.claude/rules/settings.md`](../.claude/rules/settings.md) carries the rules that govern an edit and links here.
+Why each sandbox grant and hook in `settings.json` exists and what would retire it. Nothing here auto-injects. [`.claude/rules/settings.md`](../.claude/rules/settings.md) carries the rules that govern an edit and links here.
 
 ## Hosts
 
@@ -67,6 +67,14 @@ The rest are tool caches and state directories holding no credential material:
 A new host needs its secret kept outside the sandbox, and never add an upload-capable one casually. A new escaped command must fit a group above. If it reaches the network without its own auth, keep it sandboxed.
 
 Go CLIs need no entry. `sandbox.network.allowMachLookup` lets Go's `crypto/x509` reach the system `trustd` daemon for TLS verification profile-wide.
+
+## Hooks
+
+Why each hook entry in `user/settings.json` earns its place, and what would retire it. The hook scripts themselves live in [`user/hooks/`](../user/hooks).
+
+[`agent-model`](../user/hooks/agent-model) warns, on a `PreToolUse` matching `Agent`, when a spawn names neither a `model` nor a `subagent_type` that pins one and the parent is running opus or fable. It enforces the delegation rule already written in `user/CLAUDE.md`, which spawns were ignoring: over the 30 days to 2026-09-01, 34 `general-purpose` and 30 bare spawns under opus-family parents carried no `model` and resolved to opus, and their task descriptions were lookup and fan-out shaped. It emits `additionalContext` and no `permissionDecision`, so the spawn still proceeds. `PreToolUse` carries no model field, so the parent's family comes from the last assistant record in the tail of `transcript_path`, and an unresolvable model stays silent.
+
+**Delete it** if the gap it targets has not closed. Around 2026-10-15, run the `claude-code:session` skill's [`delegation`](../plugins/claude-code/skills/session/resources/queries/delegation.sql) query with `host` set to `local` and `after_date` to the day this shipped, and read the `generic` path under an opus or fable `parent_family`. If `cheaper_override_rate_pct` has not risen and the count of spawns carrying no override has not fallen, the warning is not changing behavior and the hook goes.
 
 ## Sandbox Findings
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -70,7 +70,7 @@ Go CLIs need no entry. `sandbox.network.allowMachLookup` lets Go's `crypto/x509`
 
 ## Hooks
 
-Why each hook entry in `user/settings.json` earns its place, and what would retire it. The hook scripts themselves live in [`user/hooks/`](../user/hooks).
+Why a hook entry in `user/settings.json` earns its place, and what would retire it, for the entries that ship no `README.md` of their own. The hook scripts live in [`user/hooks/`](../user/hooks).
 
 [`agent-model`](../user/hooks/agent-model) warns, on a `PreToolUse` matching `Agent`, when a spawn names neither a `model` nor a `subagent_type` that pins one and the parent is running opus or fable. It enforces the delegation rule already written in `user/CLAUDE.md`, which spawns were ignoring: over the 30 days to 2026-09-01, 34 `general-purpose` and 30 bare spawns under opus-family parents carried no `model` and resolved to opus, and their task descriptions were lookup and fan-out shaped. It emits `additionalContext` and no `permissionDecision`, so the spawn still proceeds. `PreToolUse` carries no model field, so the parent's family comes from the last assistant record in the tail of `transcript_path`, and an unresolvable model stays silent.
 

--- a/user/hooks/agent-model/__snapshots__/index.test.ts.snap
+++ b/user/hooks/agent-model/__snapshots__/index.test.ts.snap
@@ -1,0 +1,9 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`warning text 1`] = `
+"This Agent spawn sets no \`model\` and no \`subagent_type\` that pins one, so it inherits the parent's opus and bills the whole subagent at orchestrator rates.
+
+CLAUDE.md: pick a spawn's \`subagent_type\` before its \`model\`, and pass an explicit cheap \`model\` when the type names none.
+
+Either set \`subagent_type\` to \`analyst\` (read-only research, search, judging) or another type whose \`bun run inventory agents\` row names a model, or pass \`model: "haiku"\` or \`model: "sonnet"\`."
+`;

--- a/user/hooks/agent-model/index.test.ts
+++ b/user/hooks/agent-model/index.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
 import type { ModelFamily } from "../../scripts/model";
-import { parentFamily, parseParentFamily, processInput, warning } from "./index";
+import { decide, latestFamily, parentFamily, spawnNeedsModel, warning } from "./index";
+
+const TMP_DIR = process.env.TMPDIR ?? "/tmp";
 
 function mockInput(toolInput: unknown) {
   return {
@@ -12,16 +14,22 @@ function mockInput(toolInput: unknown) {
   };
 }
 
-function assistant(model: string): string {
-  return JSON.stringify({ type: "assistant", message: { role: "assistant", model } });
+interface AssistantRecord {
+  type: string;
+  message: { role: string; model: string };
 }
 
-describe("processInput", () => {
+function assistant(model: string): AssistantRecord {
+  return { type: "assistant", message: { role: "assistant", model } };
+}
+
+describe("decide", () => {
   test.each<[string, unknown, ModelFamily | null, boolean]>([
     ["bare spawn under opus", { description: "look up a symbol" }, "opus", true],
     ["general-purpose under opus", { subagent_type: "general-purpose" }, "opus", true],
     ["bare spawn under fable", { description: "look up a symbol" }, "fable", true],
     ["general-purpose under fable", { subagent_type: "general-purpose" }, "fable", true],
+    ["empty model string under opus", { model: "" }, "opus", true],
     ["pinned type under opus", { subagent_type: "analyst" }, "opus", false],
     ["fork under opus", { subagent_type: "fork" }, "opus", false],
     [
@@ -34,8 +42,9 @@ describe("processInput", () => {
     ["general-purpose under sonnet", { subagent_type: "general-purpose" }, "sonnet", false],
     ["bare spawn under haiku", { description: "look up a symbol" }, "haiku", false],
     ["bare spawn under an unknown parent", { description: "look up a symbol" }, null, false],
-  ])("%s", (_name, toolInput, family, warns) => {
-    const output = processInput(mockInput(toolInput), family);
+    ["tool input that is not an object", "general-purpose", "opus", false],
+  ])("%s", async (_name, toolInput, family, warns) => {
+    const output = await decide(mockInput(toolInput), () => Promise.resolve(family));
     if (!warns) {
       expect(output).toBeNull();
       return;
@@ -48,8 +57,14 @@ describe("processInput", () => {
     );
   });
 
-  test("ignores a tool input that is not an object", () => {
-    expect(processInput(mockInput("general-purpose"), "opus")).toBeNull();
+  test("skips the transcript read when the spawn already names a model", async () => {
+    let resolved = 0;
+    const output = await decide(mockInput({ model: "haiku" }), () => {
+      resolved++;
+      return Promise.resolve("opus" as ModelFamily);
+    });
+    expect(output).toBeNull();
+    expect(resolved).toBe(0);
   });
 });
 
@@ -57,40 +72,44 @@ test("warning text", () => {
   expect(warning("opus")).toMatchSnapshot();
 });
 
-describe("parseParentFamily", () => {
-  test("reads the last assistant record", () => {
-    const tail = [
-      assistant("claude-sonnet-5"),
-      assistant("claude-opus-5"),
-      JSON.stringify({ type: "user", message: { role: "user" } }),
-    ].join("\n");
-    expect(parseParentFamily(tail)).toBe("opus");
+describe("spawnNeedsModel", () => {
+  test.each<[string, unknown, boolean]>([
+    ["bare spawn", { description: "look up a symbol" }, true],
+    ["general-purpose", { subagent_type: "general-purpose" }, true],
+    ["empty model string", { subagent_type: "general-purpose", model: "" }, true],
+    ["pinned type", { subagent_type: "analyst" }, false],
+    ["explicit model", { model: "sonnet" }, false],
+    ["non-object input", 7, false],
+  ])("%s", (_name, toolInput, expected) => {
+    expect(spawnNeedsModel(toolInput)).toBe(expected);
+  });
+});
+
+describe("latestFamily", () => {
+  test("reads the newest record carrying a model", () => {
+    expect(
+      latestFamily([assistant("claude-sonnet-5"), assistant("claude-opus-5"), { type: "user" }]),
+    ).toBe("opus");
   });
 
-  test("skips a truncated leading line", () => {
-    expect(parseParentFamily(`{"type":"assist\n${assistant("claude-haiku-4-5-20251001")}`)).toBe(
-      "haiku",
-    );
+  test("reports an unrecognized newest model as unresolvable", () => {
+    expect(latestFamily([assistant("claude-opus-5"), assistant("claude-unknown-1")])).toBeNull();
   });
 
-  test("returns null without an assistant record", () => {
-    expect(parseParentFamily(JSON.stringify({ type: "user" }))).toBeNull();
-  });
-
-  test("returns null for an unrecognized model", () => {
-    expect(parseParentFamily(assistant("claude-unknown-1"))).toBeNull();
+  test("returns null without a record carrying a model", () => {
+    expect(latestFamily([{ type: "user" }, "not an object"])).toBeNull();
   });
 });
 
 describe("parentFamily", () => {
   test("reads a transcript file", async () => {
-    const path = join(process.env.TMPDIR ?? "/tmp", `agent-model-${crypto.randomUUID()}.jsonl`);
-    await Bun.write(path, `${assistant("claude-opus-5")}\n`);
+    const path = join(TMP_DIR, `agent-model-${crypto.randomUUID()}.jsonl`);
+    await Bun.write(path, `${JSON.stringify(assistant("claude-opus-5"))}\n`);
     expect(await parentFamily(path)).toBe("opus");
   });
 
   test("returns null for a missing transcript", async () => {
-    expect(await parentFamily(join(process.env.TMPDIR ?? "/tmp", "absent.jsonl"))).toBeNull();
+    expect(await parentFamily(join(TMP_DIR, "absent.jsonl"))).toBeNull();
   });
 
   test("returns null without a transcript path", async () => {

--- a/user/hooks/agent-model/index.test.ts
+++ b/user/hooks/agent-model/index.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import type { ModelFamily } from "../../scripts/model";
+import { parentFamily, parseParentFamily, processInput, warning } from "./index";
+
+function mockInput(toolInput: unknown) {
+  return {
+    hook_event_name: "PreToolUse",
+    session_id: "test",
+    tool_name: "Agent",
+    tool_input: toolInput,
+  };
+}
+
+function assistant(model: string): string {
+  return JSON.stringify({ type: "assistant", message: { role: "assistant", model } });
+}
+
+describe("processInput", () => {
+  test.each<[string, unknown, ModelFamily | null, boolean]>([
+    ["bare spawn under opus", { description: "look up a symbol" }, "opus", true],
+    ["general-purpose under opus", { subagent_type: "general-purpose" }, "opus", true],
+    ["bare spawn under fable", { description: "look up a symbol" }, "fable", true],
+    ["general-purpose under fable", { subagent_type: "general-purpose" }, "fable", true],
+    ["pinned type under opus", { subagent_type: "analyst" }, "opus", false],
+    ["fork under opus", { subagent_type: "fork" }, "opus", false],
+    [
+      "explicit model under opus",
+      { subagent_type: "general-purpose", model: "haiku" },
+      "opus",
+      false,
+    ],
+    ["bare spawn with explicit model", { model: "sonnet" }, "opus", false],
+    ["general-purpose under sonnet", { subagent_type: "general-purpose" }, "sonnet", false],
+    ["bare spawn under haiku", { description: "look up a symbol" }, "haiku", false],
+    ["bare spawn under an unknown parent", { description: "look up a symbol" }, null, false],
+  ])("%s", (_name, toolInput, family, warns) => {
+    const output = processInput(mockInput(toolInput), family);
+    if (!warns) {
+      expect(output).toBeNull();
+      return;
+    }
+    const specific = output?.hookSpecificOutput;
+    expect(specific?.hookEventName).toBe("PreToolUse");
+    expect(specific).not.toHaveProperty("permissionDecision");
+    expect(specific && "additionalContext" in specific ? specific.additionalContext : null).toBe(
+      family === null ? null : warning(family),
+    );
+  });
+
+  test("ignores a tool input that is not an object", () => {
+    expect(processInput(mockInput("general-purpose"), "opus")).toBeNull();
+  });
+});
+
+test("warning text", () => {
+  expect(warning("opus")).toMatchSnapshot();
+});
+
+describe("parseParentFamily", () => {
+  test("reads the last assistant record", () => {
+    const tail = [
+      assistant("claude-sonnet-5"),
+      assistant("claude-opus-5"),
+      JSON.stringify({ type: "user", message: { role: "user" } }),
+    ].join("\n");
+    expect(parseParentFamily(tail)).toBe("opus");
+  });
+
+  test("skips a truncated leading line", () => {
+    expect(parseParentFamily(`{"type":"assist\n${assistant("claude-haiku-4-5-20251001")}`)).toBe(
+      "haiku",
+    );
+  });
+
+  test("returns null without an assistant record", () => {
+    expect(parseParentFamily(JSON.stringify({ type: "user" }))).toBeNull();
+  });
+
+  test("returns null for an unrecognized model", () => {
+    expect(parseParentFamily(assistant("claude-unknown-1"))).toBeNull();
+  });
+});
+
+describe("parentFamily", () => {
+  test("reads a transcript file", async () => {
+    const path = join(process.env.TMPDIR ?? "/tmp", `agent-model-${crypto.randomUUID()}.jsonl`);
+    await Bun.write(path, `${assistant("claude-opus-5")}\n`);
+    expect(await parentFamily(path)).toBe("opus");
+  });
+
+  test("returns null for a missing transcript", async () => {
+    expect(await parentFamily(join(process.env.TMPDIR ?? "/tmp", "absent.jsonl"))).toBeNull();
+  });
+
+  test("returns null without a transcript path", async () => {
+    expect(await parentFamily(undefined)).toBeNull();
+  });
+});

--- a/user/hooks/agent-model/index.ts
+++ b/user/hooks/agent-model/index.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { type HookInput, readHookInput } from "../../scripts/hook-input";
 import { timeHook } from "../../scripts/hook-metrics";
 import { type ModelFamily, modelFamily } from "../../scripts/model";
+import { readTranscriptTail } from "../../scripts/transcript";
 
 const AgentInput = z.looseObject({
   subagent_type: z.string().optional(),
@@ -18,36 +19,26 @@ const UNPINNED_TYPES = new Set(["general-purpose"]);
 
 const EXPENSIVE_FAMILIES = new Set<ModelFamily>(["opus", "fable"]);
 
-// PreToolUse carries no model field, so the parent's model comes from the last
-// assistant record in the session transcript. Sidechain turns live in their own
-// `agent-*.jsonl`, so the tail of this file is the parent's own turn: the one
-// that just emitted this spawn.
-const TAIL_BYTES = 128 * 1024;
+// PreToolUse carries no model field, so the parent's model comes from the
+// newest transcript record carrying one, which is its last assistant turn.
+// Sidechain turns live in their own `agent-*.jsonl`, so that turn is the
+// parent's own: the one that just emitted this spawn. The window has to clear a
+// single large turn, because a record starting before it leaves nothing
+// parsable behind it.
+const TAIL_BYTES = 512 * 1024;
 
 const TranscriptRecord = z.looseObject({
-  type: z.string().optional(),
   message: z.looseObject({ model: z.string().optional() }).optional(),
 });
 
-export function parseParentFamily(tail: string): ModelFamily | null {
-  const lines = tail.split("\n");
-  for (let at = lines.length - 1; at >= 0; at--) {
-    const line = lines[at];
-    if (line === undefined || line === "") continue;
-
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(line);
-    } catch {
-      continue;
-    }
-
-    const record = TranscriptRecord.safeParse(parsed).data;
-    if (record?.type !== "assistant") continue;
-    const family = modelFamily(record.message?.model);
-    if (family !== null) return family;
+// The newest record carrying a model decides, whether or not its family is one
+// we know. Falling through to an older turn would report the family the session
+// was on before a `/model` switch.
+export function latestFamily(entries: unknown[]): ModelFamily | null {
+  for (let at = entries.length - 1; at >= 0; at--) {
+    const model = TranscriptRecord.safeParse(entries[at]).data?.message?.model;
+    if (model !== undefined && model !== "") return modelFamily(model);
   }
-
   return null;
 }
 
@@ -55,12 +46,14 @@ export async function parentFamily(
   transcriptPath: string | undefined,
 ): Promise<ModelFamily | null> {
   if (transcriptPath === undefined || transcriptPath === "") return null;
-  try {
-    const file = Bun.file(transcriptPath);
-    return parseParentFamily(await file.slice(Math.max(0, file.size - TAIL_BYTES)).text());
-  } catch {
-    return null;
-  }
+  return latestFamily(await readTranscriptTail(transcriptPath, TAIL_BYTES));
+}
+
+export function spawnNeedsModel(toolInput: unknown): boolean {
+  const agent = AgentInput.safeParse(toolInput).data;
+  if (agent === undefined) return false;
+  if (agent.model !== undefined && agent.model !== "") return false;
+  return agent.subagent_type === undefined || UNPINNED_TYPES.has(agent.subagent_type);
 }
 
 export function warning(family: ModelFamily): string {
@@ -71,16 +64,16 @@ export function warning(family: ModelFamily): string {
   ].join("\n\n");
 }
 
-export function processInput(
+// The tool input decides first so a spawn that already names a model or a
+// pinned type costs no transcript read. That is most of them.
+export async function decide(
   input: HookInput,
-  family: ModelFamily | null,
-): SyncHookJSONOutput | null {
-  if (family === null || !EXPENSIVE_FAMILIES.has(family)) return null;
+  resolveFamily: () => Promise<ModelFamily | null>,
+): Promise<SyncHookJSONOutput | null> {
+  if (!spawnNeedsModel(input.tool_input)) return null;
 
-  const agent = AgentInput.safeParse(input.tool_input).data;
-  if (agent === undefined) return null;
-  if (agent.model !== undefined) return null;
-  if (agent.subagent_type !== undefined && !UNPINNED_TYPES.has(agent.subagent_type)) return null;
+  const family = await resolveFamily();
+  if (family === null || !EXPENSIVE_FAMILIES.has(family)) return null;
 
   return {
     hookSpecificOutput: {
@@ -101,8 +94,8 @@ async function main(): Promise<void> {
     return;
   }
 
-  const output = await timeHook("agent-model", input, async () =>
-    processInput(input, await parentFamily(input.transcript_path)),
+  const output = await timeHook("agent-model", input, () =>
+    decide(input, () => parentFamily(input.transcript_path)),
   );
   if (output) {
     process.stdout.write(`${JSON.stringify(output)}\n`);

--- a/user/hooks/agent-model/index.ts
+++ b/user/hooks/agent-model/index.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env bun
+
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import { type HookInput, readHookInput } from "../../scripts/hook-input";
+import { timeHook } from "../../scripts/hook-metrics";
+import { type ModelFamily, modelFamily } from "../../scripts/model";
+
+const AgentInput = z.looseObject({
+  subagent_type: z.string().optional(),
+  model: z.string().optional(),
+});
+
+// Types that name no model of their own, so the spawn site has to supply one.
+// Every other type either pins a model in its definition or is a deliberate
+// choice the parent already made.
+const UNPINNED_TYPES = new Set(["general-purpose"]);
+
+const EXPENSIVE_FAMILIES = new Set<ModelFamily>(["opus", "fable"]);
+
+// PreToolUse carries no model field, so the parent's model comes from the last
+// assistant record in the session transcript. Sidechain turns live in their own
+// `agent-*.jsonl`, so the tail of this file is the parent's own turn: the one
+// that just emitted this spawn.
+const TAIL_BYTES = 128 * 1024;
+
+const TranscriptRecord = z.looseObject({
+  type: z.string().optional(),
+  message: z.looseObject({ model: z.string().optional() }).optional(),
+});
+
+export function parseParentFamily(tail: string): ModelFamily | null {
+  const lines = tail.split("\n");
+  for (let at = lines.length - 1; at >= 0; at--) {
+    const line = lines[at];
+    if (line === undefined || line === "") continue;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    const record = TranscriptRecord.safeParse(parsed).data;
+    if (record?.type !== "assistant") continue;
+    const family = modelFamily(record.message?.model);
+    if (family !== null) return family;
+  }
+
+  return null;
+}
+
+export async function parentFamily(
+  transcriptPath: string | undefined,
+): Promise<ModelFamily | null> {
+  if (transcriptPath === undefined || transcriptPath === "") return null;
+  try {
+    const file = Bun.file(transcriptPath);
+    return parseParentFamily(await file.slice(Math.max(0, file.size - TAIL_BYTES)).text());
+  } catch {
+    return null;
+  }
+}
+
+export function warning(family: ModelFamily): string {
+  return [
+    `This Agent spawn sets no \`model\` and no \`subagent_type\` that pins one, so it inherits the parent's ${family} and bills the whole subagent at orchestrator rates.`,
+    "CLAUDE.md: pick a spawn's `subagent_type` before its `model`, and pass an explicit cheap `model` when the type names none.",
+    'Either set `subagent_type` to `analyst` (read-only research, search, judging) or another type whose `bun run inventory agents` row names a model, or pass `model: "haiku"` or `model: "sonnet"`.',
+  ].join("\n\n");
+}
+
+export function processInput(
+  input: HookInput,
+  family: ModelFamily | null,
+): SyncHookJSONOutput | null {
+  if (family === null || !EXPENSIVE_FAMILIES.has(family)) return null;
+
+  const agent = AgentInput.safeParse(input.tool_input).data;
+  if (agent === undefined) return null;
+  if (agent.model !== undefined) return null;
+  if (agent.subagent_type !== undefined && !UNPINNED_TYPES.has(agent.subagent_type)) return null;
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      additionalContext: warning(family),
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  let input: HookInput;
+  try {
+    input = await readHookInput("agent-model");
+  } catch (error) {
+    console.error(
+      `[agent-model] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  const output = await timeHook("agent-model", input, async () =>
+    processInput(input, await parentFamily(input.transcript_path)),
+  );
+  if (output) {
+    process.stdout.write(`${JSON.stringify(output)}\n`);
+  }
+}
+
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/user/scripts/hook-input.ts
+++ b/user/scripts/hook-input.ts
@@ -8,6 +8,7 @@ import { decodeStdin } from "../../packages/decode/index";
 export const HookInput = z.looseObject({
   session_id: z.string().catch(""),
   hook_event_name: z.string().catch(""),
+  transcript_path: z.string().optional().catch(undefined),
   tool_name: z.string().optional().catch(undefined),
   tool_input: z.unknown().optional(),
 });

--- a/user/scripts/model.ts
+++ b/user/scripts/model.ts
@@ -1,8 +1,12 @@
-// Single-letter model indicator for the status lines. The family token in the
-// model id is authoritative. display_name is the fallback for ids whose family
-// we don't recognize, so a future model still gets a letter.
+// Model family resolution shared by the status lines and the agent-model hook.
+// The family token in the model id is authoritative. display_name is the
+// fallback for ids whose family we don't recognize, so a future model still
+// gets a letter.
 
-const FAMILY_LETTERS: Record<string, string> = {
+export const MODEL_FAMILIES = ["opus", "sonnet", "haiku", "fable"] as const;
+export type ModelFamily = (typeof MODEL_FAMILIES)[number];
+
+const FAMILY_LETTERS: Record<ModelFamily, string> = {
   opus: "o",
   sonnet: "s",
   haiku: "h",
@@ -11,18 +15,23 @@ const FAMILY_LETTERS: Record<string, string> = {
 
 // The un-highlighted family. Any other model renders in the accent color so a
 // non-default model stands out.
-const DEFAULT_FAMILY = "opus";
+const DEFAULT_FAMILY: ModelFamily = "opus";
 
 export interface ModelMarker {
   letter: string;
   isDefault: boolean;
 }
 
-export function modelMarker(id?: string | null, displayName?: string | null): ModelMarker | null {
+export function modelFamily(id?: string | null): ModelFamily | null {
   const hay = (id ?? "").toLowerCase();
-  for (const [family, letter] of Object.entries(FAMILY_LETTERS)) {
-    if (hay.includes(family)) return { letter, isDefault: family === DEFAULT_FAMILY };
-  }
+  return MODEL_FAMILIES.find((family) => hay.includes(family)) ?? null;
+}
+
+export function modelMarker(id?: string | null, displayName?: string | null): ModelMarker | null {
+  const family = modelFamily(id);
+  if (family !== null)
+    return { letter: FAMILY_LETTERS[family], isDefault: family === DEFAULT_FAMILY };
+
   const fallback = (displayName ?? "").match(/[a-z]/i);
   return fallback ? { letter: fallback[0].toLowerCase(), isDefault: false } : null;
 }

--- a/user/scripts/subagent-statusline.ts
+++ b/user/scripts/subagent-statusline.ts
@@ -6,6 +6,7 @@ import { effortGlyph } from "./effort";
 import { genericGlyph, purposeGlyphs, remoteGlyph } from "./glyphs";
 import { modelMarker } from "./model";
 import { styleText } from "./style";
+import { readTranscriptTail } from "./transcript";
 
 const str = z.string().optional().catch(undefined);
 const num = z.number().optional().catch(undefined);
@@ -303,30 +304,15 @@ async function readMeta(base: string): Promise<AgentMeta | null> {
   }
 }
 
-// Transcripts grow to megabytes. Only the tail holds the latest events, so read
-// a bounded suffix and drop the first line, which a mid-file slice splits.
+// The status line reads the latest events, which sit in the last few records.
 const TAIL_BYTES = 65_536;
 async function readEntries(path: string): Promise<TranscriptEntry[]> {
-  try {
-    const file = Bun.file(path);
-    const size = file.size;
-    if (size === 0) return [];
-    const start = Math.max(0, size - TAIL_BYTES);
-    const lines = (await file.slice(start).text()).split("\n");
-    if (start > 0) lines.shift();
-    const entries: TranscriptEntry[] = [];
-    for (const line of lines) {
-      if (line.trim() === "") continue;
-      try {
-        entries.push(TranscriptEntry.parse(JSON.parse(line)));
-      } catch {
-        // Skip malformed lines.
-      }
-    }
-    return entries;
-  } catch {
-    return [];
+  const entries: TranscriptEntry[] = [];
+  for (const raw of await readTranscriptTail(path, TAIL_BYTES)) {
+    const entry = TranscriptEntry.safeParse(raw).data;
+    if (entry !== undefined) entries.push(entry);
   }
+  return entries;
 }
 
 if (import.meta.main) {

--- a/user/scripts/transcript.test.ts
+++ b/user/scripts/transcript.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test";
+import { join } from "node:path";
+import { readTranscriptTail } from "./transcript";
+
+const TMP_DIR = process.env.TMPDIR ?? "/tmp";
+
+async function write(lines: string[]): Promise<string> {
+  const path = join(TMP_DIR, `transcript-${crypto.randomUUID()}.jsonl`);
+  await Bun.write(path, lines.map((line) => `${line}\n`).join(""));
+  return path;
+}
+
+test("parses every well-formed line", async () => {
+  const path = await write(['{"n":1}', '{"n":2}']);
+  expect(await readTranscriptTail(path, 1024)).toEqual([{ n: 1 }, { n: 2 }]);
+});
+
+test("skips malformed lines", async () => {
+  const path = await write(['{"n":1}', "not json", '{"n":2}']);
+  expect(await readTranscriptTail(path, 1024)).toEqual([{ n: 1 }, { n: 2 }]);
+});
+
+test("drops the partial line a mid-file slice splits", async () => {
+  const path = await write([`{"pad":"${"x".repeat(200)}"}`, '{"n":2}']);
+  expect(await readTranscriptTail(path, 64)).toEqual([{ n: 2 }]);
+});
+
+test("returns nothing for an empty file", async () => {
+  expect(await readTranscriptTail(await write([]), 1024)).toEqual([]);
+});
+
+test("returns nothing for a missing file", async () => {
+  expect(await readTranscriptTail(join(TMP_DIR, "absent.jsonl"), 1024)).toEqual([]);
+});

--- a/user/scripts/transcript.ts
+++ b/user/scripts/transcript.ts
@@ -1,0 +1,29 @@
+// Transcripts grow to megabytes and only the tail holds the latest turns, so
+// read a bounded suffix rather than the file. A mid-file slice splits the first
+// line, which is dropped along with any other line that does not parse: a
+// reader scanning backwards for the newest record of some shape must tolerate
+// malformed lines rather than abort on the first one.
+export async function readTranscriptTail(path: string, tailBytes: number): Promise<unknown[]> {
+  try {
+    const file = Bun.file(path);
+    const size = file.size;
+    if (size === 0) return [];
+
+    const start = Math.max(0, size - tailBytes);
+    const lines = (await file.slice(start).text()).split("\n");
+    if (start > 0) lines.shift();
+
+    const entries: unknown[] = [];
+    for (const line of lines) {
+      if (line.trim() === "") continue;
+      try {
+        entries.push(JSON.parse(line));
+      } catch {
+        // Skip malformed lines.
+      }
+    }
+    return entries;
+  } catch {
+    return [];
+  }
+}

--- a/user/settings.json
+++ b/user/settings.json
@@ -230,6 +230,15 @@
         ]
       },
       {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun ~/.claude/hooks/agent-model"
+          }
+        ]
+      },
+      {
         "matcher": "*",
         "hooks": [
           {


### PR DESCRIPTION
Add a `PreToolUse` hook on `Agent` that warns when a spawn names neither a `model` nor a `subagent_type` that pins one and the parent is running opus or fable. `user/CLAUDE.md` already tells the model to pick `subagent_type` before `model` and to pass a cheap `model` when the type names none, but spawns were ignoring it: over the 30 days to 2026-09-01, 34 `general-purpose` and 30 bare spawns under opus-family parents carried no `model` and inherited opus, roughly 2.5M output and 11.7M cache-creation tokens at orchestrator rates, on tasks that read as lookup and fan-out shaped.

The hook emits `additionalContext` with no `permissionDecision`, so the spawn still runs. A deny would block work on a judgment the hook can't make, since some delegations do want the parent's model.

`PreToolUse` input carries no model field and there's no `CLAUDE_MODEL` variable. `user/hooks/agent-model/index.ts` sources the parent's family from `transcript_path` instead, reading a bounded tail of the session JSONL (`user/scripts/transcript.ts`) and taking the newest record carrying `message.model`. Subagent turns live in their own `agent-*.jsonl`, so that record is always the parent's own turn. Only the newest one decides, so a `/model` switch mid-session isn't missed, and an unresolvable model stays silent.

The tool input is checked before touching the transcript, so a spawn that already names a model or a pinned type reads no file. That covers most spawns, at 0.24ms against about 2ms for the warning path. The 512KB tail window clears a single large assistant record, since a window opening inside one leaves nothing parsable behind it.

`user/scripts/model.ts` now exports `ModelFamily`/`modelFamily` so the hook and the status lines share one list of family tokens. The tail reader in `user/scripts/transcript.ts` also replaces the bespoke scan in `user/scripts/subagent-statusline.ts`, since `decodeJsonLines` throws on the first malformed line and a mid-file slice always produces one.

Only a bare `subagent_type` or `general-purpose` warns. `Explore` and `review:angle` pin no model either and inherit the conversation model since CLI v2.1.198, so they're the same miss and go unwarned for now; widening the set is a follow-up.

`docs/settings.md` carries the removal criterion: around 2026-10-15, re-run the session skill's `delegation` query on this host and read the `generic` path under an opus or fable parent. If the no-override count hasn't fallen, the hook goes.

Original Task: https://things.bendrucker.me/show?id=WFGPnQwpyT1VxdKu7tujPb

Discovery: 8b2badc80832

https://claude.ai/code/session_01VVkqZ85H5zwhXWUcDuPe11
