### PR TITLE
gitlab: accept null sides in discussion positions

### DIFF
--- a/plugins/gitlab/skills/merge-request/scripts/discussions.test.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/discussions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, test } from "bun:test";
 import type { Discussion, DiscussionSummary, FilterOptions } from "./discussions";
 import {
   deduplicateDiscussions,
+  Discussion,
   filterDiscussions,
   formatDigest,
   formatLocation,
@@ -217,5 +218,45 @@ describe("null notes tolerance", () => {
 
   it("deduplicateDiscussions skips discussions without notes", () => {
     expect(deduplicateDiscussions(degenerate).map((d) => d.id)).toEqual(["real"]);
+  });
+});
+
+describe("null position fields", () => {
+  // GitLab nulls the side of a position that does not exist: old_line and
+  // old_path on a purely added line, new_line and new_path on a deleted one.
+  // Requiring numbers there rejected every thread on an added line.
+  test.each<{ name: string; position: Record<string, unknown> }>([
+    {
+      name: "added line",
+      position: { old_line: null, new_line: 42, old_path: null, new_path: "src/a.ts" },
+    },
+    {
+      name: "deleted line",
+      position: { old_line: 42, new_line: null, old_path: "src/a.ts", new_path: null },
+    },
+  ])("parses a position on an $name", ({ position }) => {
+    const parsed = Discussion.parse({ id: "1", notes: [makeNote({ position })] });
+    expect(parsed.notes?.[0]?.position).toMatchObject(position);
+  });
+
+  it("parses a line_range whose ends null the absent side", () => {
+    const parsed = Discussion.parse({
+      id: "1",
+      notes: [
+        makeNote({
+          position: {
+            new_path: "src/a.ts",
+            old_path: null,
+            new_line: 10,
+            old_line: null,
+            line_range: {
+              start: { type: "new", new_line: 10, old_line: null },
+              end: { type: "new", new_line: 12, old_line: null },
+            },
+          },
+        }),
+      ],
+    });
+    expect(parsed.notes?.[0]?.position?.line_range?.start.new_line).toBe(10);
   });
 });

--- a/plugins/gitlab/skills/merge-request/scripts/discussions.test.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/discussions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "bun:test";
-import type { Discussion, DiscussionSummary, FilterOptions } from "./discussions";
+import type { DiscussionSummary, FilterOptions } from "./discussions";
 import {
   deduplicateDiscussions,
   Discussion,

--- a/plugins/gitlab/skills/merge-request/scripts/discussions.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/discussions.ts
@@ -22,17 +22,17 @@ exitOnRejection();
 
 const LineEnd = z.looseObject({
   type: z.enum(["new", "old"]),
-  new_line: z.number().optional(),
-  old_line: z.number().optional(),
+  new_line: z.number().nullish(),
+  old_line: z.number().nullish(),
 });
 
 const LineRange = z.looseObject({ start: LineEnd, end: LineEnd });
 
 const Position = z.looseObject({
-  new_path: z.string().optional(),
-  old_path: z.string().optional(),
-  new_line: z.number().optional(),
-  old_line: z.number().optional(),
+  new_path: z.string().nullish(),
+  old_path: z.string().nullish(),
+  new_line: z.number().nullish(),
+  old_line: z.number().nullish(),
   position_type: z.string().optional(),
   line_range: LineRange.nullish(),
 });


### PR DESCRIPTION
Fixes a `ZodError` that made `discussions.ts list` unusable on any MR whose review touched added lines.

GitLab nulls the half of a diff position that has no counterpart: `old_line` and `old_path` on a purely added line, `new_line` and `new_path` on a deleted one. The schema declared all four `.optional()`, which accepts an absent key but rejects an explicit `null`, so four threads on a real MR failed validation and the command exited before printing anything. Making them `.nullish()` accepts both. The line-range ends carry the same nulls and get the same treatment.

Every consumer already coalesced these fields (`new_line ?? old_line`, `new_path ?? old_path`, then a `!= null` check), so the null flows through the existing paths untouched.

https://claude.ai/code/session_01X2nvd2Nd41zZVagbovTaN2
