### PR TITLE
settings: disable the session-URL attribution

### DIFF
--- a/user/settings.json
+++ b/user/settings.json
@@ -40,7 +40,8 @@
   },
   "attribution": {
     "commit": "",
-    "pr": ""
+    "pr": "",
+    "sessionUrl": false
   },
   "permissions": {
     "defaultMode": "auto",


### PR DESCRIPTION
Commits and PR bodies still picked up a `Claude-Session: https://claude.ai/code/session_...` line even though `attribution.commit` and `attribution.pr` were already empty strings. The session link is a third, independent switch. `attribution.sessionUrl` is a boolean defaulting to true, covering both the commit trailer and the PR-body link on web and Remote Control sessions.

Confirmed against the [settings reference](https://code.claude.com/docs/en/settings-reference) and the zod schema compiled into the 2.1.258 CLI. Its own description reads "Set to false to omit the Claude-Session trailer and PR-body link." That schema also marks the older `includeCoAuthoredBy` deprecated in favor of `attribution`, so nothing else needs adding.
