### PR TITLE
skills: drop effort pins from inline skills

### DIFF
--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -28,6 +28,7 @@ Plugins cannot use it. A distributed plugin resolves its runtime deps through np
 - **Output width**: use a fixed default with a flag override (`--truncate <n>`). Do not read `process.stdout.columns` or gate on `process.stdout.isTTY`, both undefined when piped. The `local/no-terminal-width` lint rule enforces this.
 - **Ancestor paths**: use `join(import.meta.dirname, "..")` rather than chained `dirname()` calls.
 - **Terminal colors**: use ANSI colors 0-15, which the terminal theme remaps for light and dark mode. Avoid 256-color and truecolor escapes for foreground text.
+- **Gate output**: redirect on the first run. `bun run check` and `bun test` re-execute everything each time they are called, so run `bun run check 2>&1 | tee tmp/check.log | tail -n 50` and read further into `tmp/check.log` with `sed`.
 
 # Sandbox and Nested Commands
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -20,6 +20,7 @@ After changing a plugin script, run it directly with real arguments as well as i
 - **Assertion chains are allowed in tests only.** `local/no-chained-type-assertions` is off under `**/*.test.ts` so a test can build a deliberately-invalid input for a rejection path. Everywhere else the chain has to go.
 - **Prefer skills over agents** for anything that should be directly invocable. Skills are invocable via the `Skill` tool.
 - **Hook E2E tests drive the real dispatcher.** A unit test proves the script's logic, not that Claude Code dispatches to it. Run headless `claude -p` with `--plugin-dir` against a throwaway repo with the external CLI (`gh`, `glab`) stubbed onto `PATH`, then assert on what the stub recorded. These live at `plugins/<name>/scripts/e2e-*.ts` and run in CI only, from a path-filtered workflow holding the `CLAUDE_CODE_OAUTH_TOKEN` secret, because each run spends API tokens.
+- **Capture check and test output once.** `bun run check` and `bun test` re-execute the whole gate every time. Redirect on the first run (`bun run check 2>&1 | tee tmp/check.log | tail -n 50`) and read further into `tmp/check.log` with `sed`.
 
 ## CI Structure
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -20,7 +20,6 @@ After changing a plugin script, run it directly with real arguments as well as i
 - **Assertion chains are allowed in tests only.** `local/no-chained-type-assertions` is off under `**/*.test.ts` so a test can build a deliberately-invalid input for a rejection path. Everywhere else the chain has to go.
 - **Prefer skills over agents** for anything that should be directly invocable. Skills are invocable via the `Skill` tool.
 - **Hook E2E tests drive the real dispatcher.** A unit test proves the script's logic, not that Claude Code dispatches to it. Run headless `claude -p` with `--plugin-dir` against a throwaway repo with the external CLI (`gh`, `glab`) stubbed onto `PATH`, then assert on what the stub recorded. These live at `plugins/<name>/scripts/e2e-*.ts` and run in CI only, from a path-filtered workflow holding the `CLAUDE_CODE_OAUTH_TOKEN` secret, because each run spends API tokens.
-- **Capture check and test output once.** `bun run check` and `bun test` re-execute the whole gate every time. Redirect on the first run (`bun run check 2>&1 | tee tmp/check.log | tail -n 50`) and read further into `tmp/check.log` with `sed`.
 
 ## CI Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ Path-specific guidance lives in [`.claude/rules/`](.claude/rules/) and auto-inje
 - `bun scripts/check-hook-paths.ts`: verifies every hook command in `user/settings.json` and `.claude/settings.json` names a tracked path, so a hook cannot outlive the script it invokes. Runs in CI.
 - `bun run schemas check`: fetches current upstream and verifies the upstream-backed schema overlays still apply, flagging overlay edits that upstream has absorbed and warning on edits that overwrite an upstream definition. Runs in CI.
 - `bun run skill-lint "plugins/<name>/skills/*"`: validates SKILL.md frontmatter and reference depth. `skill-lint` is a workspace package in `packages/skill-lint`, not an npm registry package.
+- `bun run check`: runs `oxlint --type-aware` then `oxfmt --check`. Runs in CI.
 
 ## Evals
 

--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -69,7 +69,7 @@ hooks:
 - `argument-hint`: Arguments the skill accepts, shown in the slash menu after the skill name. See [Argument Hints](#argument-hints).
 - `allowed-tools`: Tools Claude can use without permission when skill is active
 - `model`: Override the conversation's model. Prefer a tier alias (`haiku`, `sonnet`, `opus`, `fable`) or `inherit` over a dated model ID.
-- `effort`: Reasoning effort while the skill is active. Pin `low` on mechanical skills such as monitoring, execution, and formatting. Defaults to the conversation's effort.
+- `effort`: Reasoning effort while the skill is active. Pin it only under `context: fork`. See [Reasoning Effort](references/patterns.md#reasoning-effort) for why. Defaults to the conversation's effort.
 - `context`: Set to `fork` to run in isolated subagent context
 - `agent`: Agent type when `context: fork` (`Explore`, `Plan`, `general-purpose`, or custom)
 - `background`: Only with `context: fork`. `false` waits for the fork's result in the invoking turn instead of backgrounding it. Default `true`.

--- a/plugins/claude-code/skills/skill/SKILL.md
+++ b/plugins/claude-code/skills/skill/SKILL.md
@@ -189,7 +189,7 @@ Load detailed guides as needed:
 
 - **[references/information-hierarchy.md](references/information-hierarchy.md)** - What body, reference, and pointer cost, pointer wording, splitting
 - **[references/levers.md](references/levers.md)** - Completion criteria, leading words, positive form, pruning
-- **[references/patterns.md](references/patterns.md)** - Dynamic context injection, subagent integration, skill-scoped hooks, anti-patterns
+- **[references/patterns.md](references/patterns.md)** - Dynamic context injection, subagent integration, reasoning effort, skill-scoped hooks, anti-patterns
 - **[references/plain-language.md](references/plain-language.md)** - Plain-language rules for skill prose and the conversion procedure
 - **[references/troubleshooting.md](references/troubleshooting.md)** - Activation issues, plugin cache
 

--- a/plugins/claude-code/skills/skill/references/patterns.md
+++ b/plugins/claude-code/skills/skill/references/patterns.md
@@ -61,6 +61,18 @@ A forked skill is a regular subagent. It never receives `AskUserQuestion`. `back
 
 `context: fork` loses all conversation history. If the skill needs awareness of what the user has been working on, run it inline and use `Agent` subagents to offload verbose work. The inline skill retains full context while keeping the heavy lifting out of the main conversation.
 
+## Reasoning Effort
+
+Pinning `effort` in frontmatter switches reasoning effort for the skill's duration and reverts when it finishes. On a deployment that applies effort as a top-level request parameter, entering the pinned level invalidates the conversation's cached prefix: everything before that turn is rewritten at cache-creation rates instead of read from cache. Reverting is cheap, because the pre-switch cache entry is usually still live.
+
+A separate mid-conversation mechanism changes effort without a cache reset. As of the current beta it covers Claude Opus 5, Claude Fable 5.1, and Claude Mythos 5.1 through the Claude API. Support on Bedrock, Vertex, and Foundry is unspecified. Assume the rewrite cost applies unless the running model and harness are both confirmed to take that path.
+
+A skill running under `context: fork` starts a subagent with no inherited conversation, so its effort switch has no cached prefix to rewrite. Pin `effort` there freely.
+
+An inline skill pays the rewrite on entry, every time it fires. Low effort saves output tokens during the run by consolidating tool calls and cutting preamble. Once a conversation carries more than a few thousand tokens of prefix, one rewrite costs more than a run of the skill saves. A skill that polls in a loop is worse still: each cycle that alternates effort pays the rewrite again.
+
+A skill cannot detect its model or platform at author time, so the rule stays blanket: do not pin `effort` on an inline skill.
+
 ## Skill-Scoped Hooks
 
 Hooks in frontmatter run during the skill's lifecycle and are cleaned up when the skill finishes. `once: true` runs a hook only once per session, then removes it, useful for one-time validation or setup.

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/rules/frontmatter.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/rules/frontmatter.ts
@@ -230,6 +230,40 @@ export const allowedToolsFormat: Rule = {
   },
 };
 
+export const effortRequiresFork: Rule = {
+  name: "effort-requires-fork",
+  severity: "warn",
+  check(content: SkillContent): RuleResult {
+    const effort = content.frontmatter.effort;
+
+    if (effort === undefined) {
+      return {
+        rule: "effort-requires-fork",
+        severity: "warn",
+        passed: true,
+        message: "effort not set",
+      };
+    }
+
+    if (content.frontmatter.context !== "fork") {
+      return {
+        rule: "effort-requires-fork",
+        severity: "warn",
+        passed: false,
+        message:
+          "`effort` on an inline skill rewrites the conversation's cached prefix on every invocation. Pin it only under `context: fork`.",
+      };
+    }
+
+    return {
+      rule: "effort-requires-fork",
+      severity: "warn",
+      passed: true,
+      message: "effort pinned under context: fork",
+    };
+  },
+};
+
 export const frontmatterRules: Rule[] = [
   nameFormat,
   nameLength,
@@ -238,4 +272,5 @@ export const frontmatterRules: Rule[] = [
   descriptionRequired,
   descriptionLength,
   allowedToolsFormat,
+  effortRequiresFork,
 ];

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/rules/references.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/rules/references.ts
@@ -11,7 +11,7 @@ export function findReferences(body: string): string[] {
   const refs = new Set<string>();
 
   for (const match of matches) {
-    const ref = match[1];
+    const ref = match[1]?.split("#")[0];
     if (ref != null && ref !== "") refs.add(ref);
   }
 

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
@@ -7,6 +7,7 @@ import {
   allowedToolsFormat,
   descriptionLength,
   descriptionRequired,
+  effortRequiresFork,
   nameConsecutiveHyphens,
   nameEdgeHyphens,
   nameFormat,
@@ -14,6 +15,7 @@ import {
 } from "../rules/frontmatter";
 import { preferHeaders } from "../rules/headers";
 import { namespaceMismatch, namespaceStutter } from "../rules/namespace";
+import { findReferences } from "../rules/references";
 import type { RuleResult, Severity } from "../types";
 
 const fixturesDir = path.join(import.meta.dirname, "fixtures");
@@ -194,6 +196,40 @@ describe("frontmatter rules", () => {
     const content = parseSkill(frontmatter);
     const result = single(allowedToolsFormat.check(content, ""));
     expect(result.passed).toBe(passed);
+  });
+
+  test.each<{ name: string; frontmatter: string; passed: boolean }>([
+    {
+      name: "passes when effort is not set",
+      frontmatter: "---\nname: test\n---\n",
+      passed: true,
+    },
+    {
+      name: "passes when effort is paired with context: fork",
+      frontmatter: "---\neffort: low\ncontext: fork\n---\n",
+      passed: true,
+    },
+    {
+      name: "fails when effort is set on an inline skill",
+      frontmatter: "---\neffort: low\n---\n",
+      passed: false,
+    },
+    {
+      name: "fails when effort is set with a non-fork context",
+      frontmatter: "---\neffort: low\ncontext: inline\n---\n",
+      passed: false,
+    },
+  ])("effortRequiresFork: $name", ({ frontmatter, passed }) => {
+    const content = parseSkill(frontmatter);
+    const result = single(effortRequiresFork.check(content, ""));
+    expect(result.passed).toBe(passed);
+  });
+});
+
+describe("findReferences", () => {
+  it("strips anchor fragments so link variants resolve to one file", () => {
+    const body = "[a](references/patterns.md) and [b](references/patterns.md#reasoning-effort)";
+    expect(findReferences(body)).toEqual(["references/patterns.md"]);
   });
 });
 

--- a/plugins/github/skills/actions-monitor/SKILL.md
+++ b/plugins/github/skills/actions-monitor/SKILL.md
@@ -2,7 +2,6 @@
 name: github:actions-monitor
 description: Monitor GitHub Actions runs and extract failure diagnostics. Use when watching PR CI, branch builds, or specific workflow runs.
 argument-hint: "[pr-url | branch | run-id] [--max-minutes N] [--interval S]"
-effort: low
 allowed-tools:
   - Monitor
   - TaskStop

--- a/plugins/gitlab/skills/ci-monitor/SKILL.md
+++ b/plugins/gitlab/skills/ci-monitor/SKILL.md
@@ -2,7 +2,6 @@
 name: gitlab:ci-monitor
 description: Watch GitLab CI and investigate pipeline failures. Use when a pipeline or job is failing or red, when watching MR CI, branch builds, or a specific pipeline, when waiting for CI to go green, or when authoring or validating .gitlab-ci.yml.
 argument-hint: "[mr-url | branch | pipeline-id] [--max-minutes N] [--project group/project]"
-effort: low
 allowed-tools:
   - Monitor
   - TaskStop

--- a/plugins/mac/skills/jxa-run/SKILL.md
+++ b/plugins/mac/skills/jxa-run/SKILL.md
@@ -2,7 +2,6 @@
 name: mac:jxa-run
 description: Execute JXA scripts scoped to a macOS application. Use when running JXA expressions or script files against an app via osascript. Validates Application() scope via AST.
 argument-hint: <app> <expression-or-script-file>
-effort: low
 allowed-tools:
   - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/jxa.ts:*)"
 hooks:

--- a/plugins/pull-request/skills/babysit/SKILL.md
+++ b/plugins/pull-request/skills/babysit/SKILL.md
@@ -2,7 +2,6 @@
 name: pull-request:babysit
 description: Monitor a PR's CI, fix trivial failures, and self-cancel when green; --merge drives to merged, --reviews hands off to AI-review triage.
 argument-hint: "[pr-url] [--merge] [--reviews]"
-effort: low
 allowed-tools:
   - Monitor
   - TaskStop

--- a/plugins/things/skills/url/SKILL.md
+++ b/plugins/things/skills/url/SKILL.md
@@ -2,7 +2,6 @@
 name: things:url
 description: Create, update, and manage Things 3 tasks and projects, including quick inbox captures. Not for reads. Use things:jxa to query data.
 argument-hint: "<add | update | show | search | json | capture> [key=value ...]"
-effort: low
 allowed-tools:
   - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/url.ts:*)"
   - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/inbox.ts:*)"

--- a/plugins/tmux/skills/tmux/SKILL.md
+++ b/plugins/tmux/skills/tmux/SKILL.md
@@ -2,7 +2,6 @@
 name: tmux
 description: Tmux session, window, and pane management. Use when capturing output, sending keys, opening processes in panes, or checking notifications.
 argument-hint: "[capture | send | split | notify | list] [target ...]"
-effort: low
 allowed-tools:
   - "Bash(bash ${CLAUDE_SKILL_DIR}/scripts/pane.sh:*)"
   - "Bash(bash ${CLAUDE_SKILL_DIR}/scripts/window.sh:*)"


### PR DESCRIPTION
Removes `effort: low` from six skills and rewrites the guidance that put it there.

Entering a pinned effort level applies effort as a top-level request parameter, which invalidates the conversation's cached prefix. Everything before that turn is rewritten at cache-creation rates instead of read from cache.

Measured over the session index: 621 mid-session switches across 281 sessions, roughly 68.9M excess cache-creation tokens. `pull-request:babysit` alone is 201 switches and 33.3M. Output savings during a pinned run are absent or negative.

PR #1007 committed to a removal check on output tokens, which cannot observe a cache write. Reverting is cheap, so the cost sits entirely on entry, once per invocation, and a polling skill pays it every cycle.

`tmux` is here as dead config. Zero low-effort turns and zero switch events in the whole corpus, because herdr replaced it. It contributes nothing to the numbers above.

`effort-requires-fork` keeps this from returning. A skill under `context: fork` has no inherited prefix to rewrite, so pinning there is free and the rule permits it. Severity is `warn` to match the linter's taxonomy, where `error` means Agent Skills spec conformance.

One gap: CI runs `skill-lint` without `--strict`, so warnings do not fail the build. The `check-lint.ts` PostToolUse hook is what bites, feeding the warning back the moment a `SKILL.md` is written. Enabling `--strict` repo-wide would first fail on four pre-existing `prefer-headers` warnings in `ui-design` and `x-callback-url`, so that is its own change.

`findReferences` now strips anchor fragments. `references/patterns.md#reasoning-effort` is the repo's first anchored reference link, and `reference-exists` called it a missing file.

Relax the rule if the per-message effort beta (`mid-conversation-output-config-2026-07-01`) becomes the path Claude Code takes. Every CLI version in the corpus, 2.1.240 through 2.1.258, does the full rewrite. Re-check when `message_usage` shows high-to-low switches without a six-figure cache-creation write. Retire it if authors start adding `context: fork` purely to satisfy the linter.

Two documentation changes ride along from the same audit. `CLAUDE.md` now lists `bun run check` under Verification, where it was the only CI gate missing. The convention for capturing gate output went into `.claude/rules/scripts.md` rather than `testing.md`, whose `paths` frontmatter would have injected it only while editing a test file.

Cut one proposed change: rewriting `user/skills/lead/SKILL.md` to `@`-mention the brief. That assumes Claude Code resolves an `@` mention delivered through herdr's bracketed paste. The docs describe `@` as triggering interactive autocomplete and store pasted content as `[Pasted text #N]`. Needs a live dispatch test first.

https://claude.ai/code/session_01BXBVzFg3RnmhcxsYq6Lthe
