### PR TITLE
skills: fail CI on skill-lint warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Lint skills
         if: steps.inspect.outputs.has_skills == 'true'
-        run: bun run skill-lint "plugins/${{ matrix.plugin.name }}/skills/*"
+        run: bun run skill-lint --strict "plugins/${{ matrix.plugin.name }}/skills/*"
 
       - name: Validate Swift syntax
         if: steps.inspect.outputs.has_swift == 'true'
@@ -295,7 +295,7 @@ jobs:
       - uses: ./.github/actions/bun-install
 
       - name: Lint skills
-        run: bun run skill-lint "user/skills/*"
+        run: bun run skill-lint --strict "user/skills/*"
 
   coverage:
     runs-on: ubuntu-latest

--- a/plugins/ui-design/skills/wireframe/SKILL.md
+++ b/plugins/ui-design/skills/wireframe/SKILL.md
@@ -34,7 +34,7 @@ Wireframes are skeletal, black-and-white representations of UI layout, focused o
 | **SVG** | Precise positioning, overlapping elements, custom shapes, artistic layouts | `render.ts` |
 | **HTML/Tailwind** | Standard UI patterns (forms, grids, navigation, modals), flexbox layouts | `render-html.ts` |
 
-**Before creating any wireframe**: Read the reference file for your chosen approach. The references contain required patterns, component examples, and the rendering workflow.
+Before creating a wireframe, read the reference file for your chosen approach. The references contain required patterns, component examples, and the rendering workflow.
 
 ## References
 

--- a/plugins/x-callback-url/skills/xcall/SKILL.md
+++ b/plugins/x-callback-url/skills/xcall/SKILL.md
@@ -34,9 +34,11 @@ The marker hook reads the script named at the head of a command, past any `VAR=v
 ${CLAUDE_PLUGIN_ROOT}/scripts/run.sh "<url>"
 ```
 
-**stdout**: `x-success` query string on success
-**stderr**: `x-error` query string or timeout message
-**Exit codes**: 0 = success, 1 = error, 2 = cancel, 3 = build failed, 4 = timed out waiting for the callback
+| Output | Contents |
+| :--- | :--- |
+| stdout | `x-success` query string on success |
+| stderr | `x-error` query string or timeout message |
+| Exit codes | 0 = success, 1 = error, 2 = cancel, 3 = build failed, 4 = timed out waiting for the callback |
 
 ## Examples
 


### PR DESCRIPTION
Every repo-opinion rule in `skill-lint` carries `warn` severity, because `error` is reserved for Agent Skills spec conformance. CI ran the linter without `--strict`, so warnings exited 0 and the opinion layer had no consequence on a pull request. The only thing enforcing it was the `check-lint.ts` PostToolUse hook, which reaches a session already editing a `SKILL.md` and nothing else.

Four `prefer-headers` warnings stood in the way. The `xcall` output contract is three parallel key-value pairs, so it became a table. The `wireframe` label introduced a single emphasized sentence rather than a subsection, so it reads as prose with the condition first.

Checked the gate in both directions against a throwaway skill carrying one bold label, so a warning is known to stop the step and its absence is known not to. The sweep covers every per-plugin glob the matrix runs, in the quoted form the workflow uses, plus `user/skills/*`.

This promotes every `warn` rule to blocking, so a rule nothing trips today still gates the first skill that does. #1342 adds `effort-requires-fork` and defers its enforcement to this change, so that rule starts blocking once both land.

Reconsider if authors begin restructuring prose to satisfy a rule rather than because it reads better, which is the signal that a rule costs more in false positives than it catches. The remedy then is per-rule severity, since dropping `--strict` returns the whole layer to advisory.
