### PR TITLE
github: treat all-skipped checks as unsettled

### DIFF
--- a/plugins/github/skills/actions-monitor/scripts/watch.test.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.test.ts
@@ -168,13 +168,16 @@ describe("deriveChecksState", () => {
       ],
       "running",
     ],
+    // Reached both by a PR whose every check really is skipped and by one
+    // polled in the seconds after a push, before its real jobs register. A
+    // single probe cannot separate the two, so neither resolves to success.
     [
       "every check skipped",
       [
         { state: "SKIPPED", bucket: "skipping", name: "a" },
         { state: "SKIPPED", bucket: "skipping", name: "b" },
       ],
-      "success",
+      "queued",
     ],
     // Shape captured from a green PR whose automerge and claude workflows are
     // skipped on every push. Skipped workflows are routine, so a skip that

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -391,8 +391,13 @@ export function deriveChecksState(checks: Check[]): InternalState {
     return "running";
   }
   const decisive = checks.filter((c) => (c.bucket ?? "").toLowerCase() !== SKIPPED_BUCKET);
+  // Skips settle first, so for a few seconds after a push every registered
+  // check can be a skip while the real jobs are still being created. That is
+  // indistinguishable from a PR whose checks are all genuinely skipped, and
+  // calling it success ends a babysit before CI has run. Holding at queued
+  // reports the genuinely-skipped PR through the queued timeout instead.
   if (decisive.length === 0) {
-    return "success";
+    return "queued";
   }
   const buckets = decisive.map((c) => (c.bucket ?? "").toLowerCase());
   if (buckets.some((b) => b === "fail")) {


### PR DESCRIPTION
Skipped workflows settle before real jobs are created, so a PR polled in the seconds after a push can have nothing registered but its skips. `deriveChecksState` treated that as terminal green, emitted `status: success`, and the watcher exited. `pull-request:babysit` calls the watcher immediately after pushing a fix, which is exactly when the window is open, so a babysit could report green on a commit whose CI had not started.

Hit this while babysitting #1342. The watcher armed right after the push emitted success with a null run id, while nine jobs were still pending. Re-arming a minute later gave the correct running-then-success sequence.

An empty check list already held at `running`, on the reasoning that no checks carries no information. All skips carries no more, so it now resolves the same way. `queued` rather than `running` because it routes the genuinely-all-skipped PR into the queued timeout, which says nothing is running, instead of leaving it silent until the wall clock expires.

A skip alongside a passing check still resolves to success. That case is what keeps routine skipped workflows from stalling every PR, and it is unchanged.

Reconsider if a repo appears whose PRs legitimately settle with skips and nothing else. Those would wait out the queued timeout instead of finishing promptly, and the fix would be to distinguish the two by checking whether any workflow is still being created rather than by inspecting buckets alone.
