### PR TITLE
user: route config changes to bendrucker/claude

### DIFF
--- a/user/CLAUDE.md
+++ b/user/CLAUDE.md
@@ -80,6 +80,19 @@ I use Worktrunk (the `wt` CLI) for git worktrees, exposed through two skills:
 - For everything else (pruning, listing, removing, running hooks, editing config, and general `wt` questions), use the generic `worktrunk:worktrunk` skill.
 - Disposable verification worktrees may be created with `git worktree add tmp/<name>`; everything persistent goes through the worktrunk skills.
 
+## Claude Configuration
+
+My Claude Code setup lives in [`bendrucker/claude`](https://github.com/bendrucker/claude). Two checkouts of it matter, and they are not the same tree:
+
+- `~/.claude-repo` is the deployed one. Each entry under its `user/` directory is symlinked into `~/.claude`, so the instructions, settings, rules, skills, agents, and hooks loaded this session are its files. `claude-upgrade` syncs it from `main`.
+- `~/src/bendrucker/claude` is the dev clone that worktrees are cut from. Work happens there.
+
+A merged change is not live until that sync runs, so never treat an edit as already in effect. Never write to the `~/.claude` symlink targets either, which would edit the deployed checkout behind git's back.
+
+Everything that steers Claude across projects belongs in that repo: these instructions, `settings.json` and its permissions and sandbox entries, rules, skills, agents, hooks, plugins under `plugins/`, and the schemas and evals supporting them. A repo's own `.claude/` directory is the exception, since project-scoped config belongs with the project.
+
+When a request starts in another repo and the real fix turns out to be one of those, hand it to a sibling agent through the `herdr` skill, with its own worktree of `bendrucker/claude`, and report the PR back to me. herdr gives a sibling its checkout without re-rooting this session, which is why it applies here in place of `worktrunk:wt-switch-create`. Where herdr is unavailable, tell me what the change is and let me route it rather than editing in place.
+
 ## Stacked PRs
 
 I work in stacks routinely, in one of two layouts, chosen per stack. Load `github:stack` before any `gh stack` command. `gitlab:merge-request` is the GitLab equivalent.


### PR DESCRIPTION
Work that starts in another repo regularly turns out to need a skill, hook, rule, or settings edit. Nothing said where that goes, so it lands either as an in-place edit of a `~/.claude` symlink target or as a detour that derails the session that found it.

The section names both checkouts, because they are not the same tree and conflating them is the trap worth closing. `~/.claude` symlinks resolve into `~/.claude-repo`, which `claude-upgrade` syncs from `main`. A merged change is not live until that sync runs, and an edit made through the symlinks writes into the deployed clone behind git's back.

Routing goes through `herdr` rather than `worktrunk:wt-switch-create` because the calling session should keep its original task. herdr hands a sibling agent its own checkout, while `wt-switch-create` re-roots the caller. That distinction lives only in the herdr skill body today, so the section states it inline for sessions that have not loaded it, and sits after Worktrees so it can lean on what that section establishes.

Costs about 250 words on every session. Working: config changes start arriving as their own PRs from dispatched sibling agents. Not working: sessions keep editing `~/.claude` in place, or the dispatch fires for project-scoped `.claude/` edits that should have stayed local.
