### PR TITLE
rules: require AST parsing over regex

### DIFF
--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -21,6 +21,24 @@ Repo-internal tooling (`scripts/`, `.claude/hooks/`) must import `packages/` cod
 
 Plugins cannot use it. A distributed plugin resolves its runtime deps through npm auto-install, which skips `workspace:*`, so a plugin declares `zod` in its own `package.json` and calls `schema.parse` directly.
 
+# Parsing Structured Text
+
+Parse structured text with a real parser and match against the tree it returns. This holds for any language a script reads: source code, markup, config, or data.
+
+A regex over lines carries no grammar state, so it drifts at every edge: a delimiter inside a string or a comment, an escape, a construct spanning lines, nesting of any depth. Each drift becomes a false positive or a silent gap in whatever the script enforces.
+
+Pick the parser by what is being read:
+
+- **Source code**: [`ast-grep`](https://ast-grep.github.io), which matches structurally with code-shaped patterns across every language its tree-sitter grammars cover. The `ast-grep` skill wraps it, and `ast-grep:outline` summarizes a file's structure.
+- **Markdown**: `mdast-util-from-markdown` to parse and `unist-util-visit` to walk, typed by `@types/mdast`. [`plugins/pull-request/scripts/prose.ts`](../../plugins/pull-request/scripts/prose.ts) is the reference use.
+- **Data formats**: the format's own loader, such as `JSON.parse` or the `yaml` package, which returns a tree directly.
+
+Nodes carry position data, so a finding still reports an exact line and column.
+
+Bun auto-installs registry dependencies at runtime, so a distributed plugin declares its parser in its own `package.json` like any other npm dependency. The cross-plugin restriction in [`plugins.md`](plugins.md) covers `workspace:*` specifiers, not registry packages.
+
+A regex is fine inside a single node's text, where the grammar is already resolved: matching a word within one paragraph, a flag within one command string.
+
 # Script Conventions
 
 - **Argument parsing**: use [cleye](https://github.com/privatenumber/cleye). Load the `cleye` skill for parameters, flags, and subcommands instead of reading existing scripts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ A customization must also stay harmonious with Claude Code's native behavior. Wh
 Path-specific guidance lives in [`.claude/rules/`](.claude/rules/) and auto-injects when you touch matching files (via `paths` frontmatter), so it stays out of this always-on file:
 
 - [`plugins.md`](.claude/rules/plugins.md) (`plugins/**`): plugin architecture, naming, MCP tool naming, READMEs, metadata, dependencies
-- [`scripts.md`](.claude/rules/scripts.md) (`**/*.ts`): Bun runtime, script conventions, terminal colors, sandbox/nested-command pattern
+- [`scripts.md`](.claude/rules/scripts.md) (`**/*.ts`): Bun runtime, AST-based parsing, script conventions, terminal colors, sandbox/nested-command pattern
 - [`hooks.md`](.claude/rules/hooks.md) (`**/hooks.json`, `**/hooks/**`): hook guidance, quoting, MCP matcher validation
 - [`settings.md`](.claude/rules/settings.md) (`**/settings*.json`): permission paths, `autoMode` scoping, sandbox and `excludedCommands`. Per-entry rationale and removal criteria live in [`docs/settings.md`](docs/settings.md), which does not auto-inject
 - [`testing.md`](.claude/rules/testing.md) (test and workflow files): testing conventions, CI structure


### PR DESCRIPTION
Several plugins here parse markdown or source in order to enforce something, and each has so far used line-oriented regex. A regex carries no grammar state, so it drifts at every edge: a delimiter inside a string or a comment, an escape, a construct spanning lines, nesting of any depth. Every drift lands as a false positive or as a silent gap.

The rule routes the choice by what is being read, rather than by naming a fixed set of languages:

- `ast-grep` for source code. Its tree-sitter grammars already cover far more languages than a list would.
- `mdast-util-from-markdown` for markdown.
- The format's own loader for data.

It also records that a distributed plugin can declare a parser in its own `package.json`. Bun auto-installs registry dependencies, and the cross-plugin restriction in `plugins.md` applies to `workspace:*` specifiers alone. Misreading that restriction is what justified a hand-rolled fence scanner in skill-lint, so the correction belongs where the next author will look.

The rule is bounded. A regex inside a single already-parsed node stays fine, which covers most of the matching these scripts actually do.

It lives in `.claude/rules/scripts.md` rather than `CLAUDE.md`, so it injects on `**/*.ts` and the always-on budget stays flat. Retire it if plugin parsing code stops accumulating, or if a lint rule can enforce the same thing mechanically.
