### PR TITLE
pull-request: fix the GitLab reviewer commands

### DIFF
--- a/plugins/pull-request/skills/create/references/reviewers.md
+++ b/plugins/pull-request/skills/create/references/reviewers.md
@@ -5,7 +5,7 @@ Load this after creating the PR/MR on a corporate or internal repo.
 Gate on repository visibility first:
 
 - **GitHub**: `gh repo view --json visibility -q .visibility`
-- **GitLab**: `glab api projects/:fullpath --jq .visibility`
+- **GitLab**: `glab api projects/:fullpath | jq -r .visibility` (`glab api` has no output filter flag)
 
 A public repository is OSS: skip reviewer suggestion and let the maintainer triage. Any other visibility (private, internal) is corporate: continue.
 
@@ -21,4 +21,4 @@ bun <plugin-root>/scripts/suggest-reviewers.ts
 Resolve names to platform usernames only after the user accepts, then assign them to the existing PR/MR:
 
 - **GitHub**: `gh pr edit --add-reviewer <user>` (resolve emails to logins with `mcp__github` if needed).
-- **GitLab**: load `gitlab:merge-request` for username resolution, then `glab mr update --reviewer <user>`.
+- **GitLab**: load `gitlab:merge-request` for username resolution, then `glab mr update --reviewer +<user>`. The `+` prefix appends. A bare username replaces the whole reviewer list, dropping anyone already assigned.


### PR DESCRIPTION
Both GitLab commands in the reviewer flow follow GitHub habit rather than glab's interface.

`glab api projects/:fullpath --jq .visibility` copied gh's output filter. `glab api` has no equivalent flag: its only output control is `--output json|ndjson`. Following the visibility gate produced an unknown-flag error, so the filter moves to a `jq` pipe, which is the form `plugins/gitlab/hooks/lint.ts` already denies `--jq` in favor of.

`glab mr update --reviewer <user>` reads like an append and is a replace. glab parses an unprefixed username into `ToReplace` and resolves it through `UsersFromReplaces`, which sets `reviewer_ids` to that user alone. GitLab's MR update API accepts only a whole `reviewer_ids` list, so every reviewer already assigned is dropped with no warning. The `+` prefix routes to `UsersFromAddRemove`, which glab calls with the merge request's current `Reviewers`, so it unions client-side and sends the full list.

Read the help output of both subcommands on the installed glab 1.116.0, then confirmed the reviewer semantics in `internal/cmdutils/cmdutils.go` and `internal/commands/mr/update/mr_update.go` upstream. The help text ("Prefix with `+` to add") describes the add path but never says the default path sends a replacement, so the source is what establishes the clobber. None of this ran against a live merge request, so the source is the only evidence for the payload glab actually sends.

Audited the file's other commands for the same defect and found none. `gh repo view --json visibility -q .visibility` and `gh pr edit --add-reviewer` match gh's help, and `--add-reviewer` adds rather than replaces. The ranking script path resolves.
