### PR TITLE
oxlint: restrict string methods

### DIFF
--- a/.claude/hooks/ox/index.ts
+++ b/.claude/hooks/ox/index.ts
@@ -61,7 +61,7 @@ const GIT_COMMIT_PATTERN = new RegExp(
 // Quoted spans carry commit messages, grep patterns, and here-doc prose, where
 // the literal text `git commit` is data rather than an invocation.
 function stripQuoted(command: string): string {
-  return command.replace(/'[^']*'|"(?:[^"\\]|\\.)*"/g, " ");
+  return command.replaceAll(/'[^']*'|"(?:[^"\\]|\\.)*"/g, " ");
 }
 
 export function invokesGitCommit(command: string): boolean {

--- a/.claude/skills/agent-ideas/scripts/fetch.ts
+++ b/.claude/skills/agent-ideas/scripts/fetch.ts
@@ -70,26 +70,26 @@ function firstText(...values: unknown[]): string {
 
 function decodeEntities(input: string): string {
   return input
-    .replace(/&nbsp;/g, " ")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&#0*39;|&apos;/g, "'")
-    .replace(/&quot;/g, '"')
-    .replace(/&#x([0-9a-fA-F]+);/g, (_: string, hex: string) =>
+    .replaceAll("&nbsp;", " ")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll(/&#0*39;|&apos;/g, "'")
+    .replaceAll("&quot;", '"')
+    .replaceAll(/&#x([0-9a-fA-F]+);/g, (_: string, hex: string) =>
       String.fromCodePoint(Number.parseInt(hex, 16)),
     )
-    .replace(/&#(\d+);/g, (_: string, dec: string) =>
+    .replaceAll(/&#(\d+);/g, (_: string, dec: string) =>
       String.fromCodePoint(Number.parseInt(dec, 10)),
     )
-    .replace(/&amp;/g, "&");
+    .replaceAll("&amp;", "&");
 }
 
 function stripHtml(html: string): string {
   // Decode entities before stripping tags so escaped markup (e.g. &lt;b&gt;)
   // becomes real tags and gets removed rather than leaking into the excerpt.
   return decodeEntities(html)
-    .replace(/<[^>]+>/g, " ")
-    .replace(/\s+/g, " ")
+    .replaceAll(/<[^>]+>/g, " ")
+    .replaceAll(/\s+/g, " ")
     .trim();
 }
 

--- a/evals/scripts/results.ts
+++ b/evals/scripts/results.ts
@@ -56,8 +56,8 @@ export function runDate(payload: ExportPayload, override?: string): string {
 export function slug(value: string): string {
   return value
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replaceAll(/^-+|-+$/g, "");
 }
 
 export function suiteName(payload: ExportPayload, override?: string): string {
@@ -72,7 +72,7 @@ export function suiteName(payload: ExportPayload, override?: string): string {
 // promptfoo ids embed an ISO timestamp, whose colons are hostile to filenames and
 // to the S3 sync that mirrors them.
 export function safeId(evalId: string): string {
-  const id = evalId.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  const id = evalId.replaceAll(/[^A-Za-z0-9._-]+/g, "-").replaceAll(/^-+|-+$/g, "");
   if (id === "") throw new Error(`Eval id "${evalId}" has no characters usable in a filename`);
   return id;
 }

--- a/lint/base.json
+++ b/lint/base.json
@@ -30,7 +30,13 @@
     "import/no-named-as-default-member": "error",
     "oxc/no-map-spread": "error",
     "unicorn/prefer-array-find": "error",
-    "unicorn/prefer-set-has": "error"
+    "unicorn/prefer-set-has": "error",
+    // `String.raw` keeps a backslash-heavy literal (a path, a regex) readable as written, instead of forcing a manual escape count that's easy to get wrong.
+    "unicorn/prefer-string-raw": "error",
+    // `replace()` needs a global regex to hit every match, and a dropped `g` flag silently replaces only the first one. `replaceAll()` makes the intent explicit and takes a plain string when there's no pattern to match.
+    "unicorn/prefer-string-replace-all": "error",
+    // `substring()` swaps out-of-order arguments and clamps negatives instead of indexing from the end. `substr()` is deprecated and its second argument is a length. `slice()` is the one method with consistent, current semantics.
+    "unicorn/prefer-string-slice": "error"
   },
   "overrides": [
     {

--- a/packages/decode/error.ts
+++ b/packages/decode/error.ts
@@ -3,7 +3,7 @@ import type { z } from "zod";
 const PREVIEW_LIMIT = 120;
 
 function preview(text: string): string {
-  const collapsed = text.replace(/\s+/g, " ").trim();
+  const collapsed = text.replaceAll(/\s+/g, " ").trim();
   if (collapsed === "") return "(empty)";
   if (collapsed.length <= PREVIEW_LIMIT) return collapsed;
   return `${collapsed.slice(0, PREVIEW_LIMIT)}…`;

--- a/packages/validate/overlay.ts
+++ b/packages/validate/overlay.ts
@@ -60,7 +60,7 @@ export function getPointer(value: unknown, pointer: string): unknown {
   const tokens = pointer
     .slice(1)
     .split("/")
-    .map((token) => token.replace(/~1/g, "/").replace(/~0/g, "~"));
+    .map((token) => token.replaceAll("~1", "/").replaceAll("~0", "~"));
   let current: unknown = value;
   for (const token of tokens) {
     const container = Indexable.safeParse(current).data;

--- a/packages/validate/validate.test.ts
+++ b/packages/validate/validate.test.ts
@@ -84,7 +84,7 @@ describe("validateFile", () => {
 
   for (const fixture of fixtures) {
     it(fixture.name, async () => {
-      const file = join(tempDir, `${fixture.name.replace(/\s+/g, "-")}.json`);
+      const file = join(tempDir, `${fixture.name.replaceAll(/\s+/g, "-")}.json`);
       await Bun.write(file, JSON.stringify(fixture.data));
 
       const result = await validateFile(

--- a/plugins/claude-code/skills/session/scripts/catalog.test.ts
+++ b/plugins/claude-code/skills/session/scripts/catalog.test.ts
@@ -138,8 +138,8 @@ describe("query header", () => {
   it("documents every default its SQL falls back to", async () => {
     const queries = await loadQueries();
     const used = queries.map(([header, sql]) => {
-      const pairs = [...sql.replace(/\s+/g, " ").matchAll(DEFAULT_FALLBACK)].map(
-        ([, name, value]) => `${name}=${(value ?? "").replace(/^'|'$/g, "")}`,
+      const pairs = [...sql.replaceAll(/\s+/g, " ").matchAll(DEFAULT_FALLBACK)].map(
+        ([, name, value]) => `${name}=${(value ?? "").replaceAll(/^'|'$/g, "")}`,
       );
       return [header.name, alphabetical([...new Set(pairs)])] as const;
     });

--- a/plugins/claude-code/skills/session/scripts/catalog.ts
+++ b/plugins/claude-code/skills/session/scripts/catalog.ts
@@ -58,7 +58,7 @@ function renderParam(param: QueryHeader["params"][number]): string {
 }
 
 // Every line of a continuation block indents, so a fenced example stays inside the bullet.
-const indent = (block: string) => block.replace(/^(?=.)/gm, "  ");
+const indent = (block: string) => block.replaceAll(/^(?=.)/gm, "  ");
 
 function renderEntry(header: QueryHeader): string {
   const tail = [

--- a/plugins/claude-code/skills/skill/scripts/check-namespace.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-namespace.ts
@@ -29,7 +29,7 @@ export async function getResourceName(filePath: string, type: string): Promise<s
 }
 
 export function checkStuttering(name: string, pluginName: string): string | null {
-  const pluginPattern = pluginName.replace(/-/g, "[-_]");
+  const pluginPattern = pluginName.replaceAll("-", "[-_]");
   const regex = new RegExp(`^${pluginPattern}[-_]|[-_]${pluginPattern}$|^${pluginPattern}$`, "i");
 
   if (regex.test(name)) {

--- a/plugins/comments/apply/branch.ts
+++ b/plugins/comments/apply/branch.ts
@@ -37,7 +37,10 @@ export async function applyToBranch(
   }
 
   const gitDir = (await $`git rev-parse --git-dir`.quiet()).text().trim();
-  const indexFile = join(gitDir, `comments-apply-index-${options.branch.replace(/[^\w.-]/g, "_")}`);
+  const indexFile = join(
+    gitDir,
+    `comments-apply-index-${options.branch.replaceAll(/[^\w.-]/g, "_")}`,
+  );
   const env = { GIT_INDEX_FILE: indexFile };
 
   try {

--- a/plugins/comments/apply/format.test.ts
+++ b/plugins/comments/apply/format.test.ts
@@ -6,7 +6,7 @@ describe("renderTemplate", () => {
     ["cat", "src/a.ts", "cat"],
     ["prettier --stdin-filepath {}", "src/a.ts", "prettier --stdin-filepath 'src/a.ts'"],
     ["fmt {} {}", "a b.py", "fmt 'a b.py' 'a b.py'"],
-    ["fmt {}", "it's.py", "fmt 'it'\\''s.py'"],
+    ["fmt {}", "it's.py", String.raw`fmt 'it'\''s.py'`],
   ])("%p with %p renders %p", (template, path, expected) => {
     expect(renderTemplate(template, path)).toBe(expected);
   });

--- a/plugins/comments/detection/density.ts
+++ b/plugins/comments/detection/density.ts
@@ -47,7 +47,7 @@ export function addInto(into: AddedLineStats, stats: AddedLineStats): void {
  * re-indented, and realigned lines don't count and each extra duplicate counts
  * once. Returns 1-based indices into the fragment's lines.
  */
-const lineKey = (line: string) => line.replace(/\s+/g, "");
+const lineKey = (line: string) => line.replaceAll(/\s+/g, "");
 
 export function addedLines(
   oldText: string,
@@ -73,7 +73,7 @@ export function addedLines(
 }
 
 function nonWsLen(s: string): number {
-  return s.replace(/\s/g, "").length;
+  return s.replaceAll(/\s/g, "").length;
 }
 
 const DELIMITER = /^\s*(?:\/\/+|\/\*+|\*+\/?|--|#+|;+|"""|''')?\s*/;

--- a/plugins/comments/detection/provenance.ts
+++ b/plugins/comments/detection/provenance.ts
@@ -53,7 +53,7 @@ export function parseLinePorcelain(text: string): Map<number, BlamedLine> {
     const key = space === -1 ? raw : raw.slice(0, space);
     const value = space === -1 ? "" : raw.slice(space + 1);
     if (key === "author") current.author = value;
-    else if (key === "author-mail") current.mail = value.replace(/^<|>$/g, "");
+    else if (key === "author-mail") current.mail = value.replaceAll(/^<|>$/g, "");
     else if (key === "author-time") current.time = Number(value);
   }
   return lines;

--- a/plugins/git/scripts/block-default-branch-commit.ts
+++ b/plugins/git/scripts/block-default-branch-commit.ts
@@ -49,7 +49,7 @@ const HEREDOC_LEAD = /(?<![<\\])<<(?!<)/g;
 const HEREDOC_DELIMITER = /^(-?)[ \t]*((?:'[^']*'|"[^"]*"|\\.|[^\s'"\\<>|&;()])+)/;
 
 function unquoteWord(word: string): string {
-  return word.replace(/'([^']*)'|"([^"]*)"|\\(.)/g, (_, single, double, escaped) =>
+  return word.replaceAll(/'([^']*)'|"([^"]*)"|\\(.)/g, (_, single, double, escaped) =>
     String(single ?? double ?? escaped),
   );
 }

--- a/plugins/git/scripts/default-branch.ts
+++ b/plugins/git/scripts/default-branch.ts
@@ -8,7 +8,7 @@ export async function getDefaultBranch(cwd?: string, repoRoot?: string): Promise
 
     const root =
       repoRoot ?? (await $`git rev-parse --show-toplevel`.cwd(dir).quiet()).text().trim();
-    const safePath = root.replace(/\//g, "_");
+    const safePath = root.replaceAll("/", "_");
     const cacheFile = join(tmpdir(), `claude-default-branch${safePath}`);
 
     if (await Bun.file(cacheFile).exists()) {

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -229,7 +229,7 @@ export function parsePrUrl(url: string): {
   repo: string;
   number: number;
 } {
-  const pattern = new UrlPattern("https\\://github.com/:owner/:repo/pull/:number(/*)", {
+  const pattern = new UrlPattern(String.raw`https\://github.com/:owner/:repo/pull/:number(/*)`, {
     segmentValueCharset: "a-zA-Z0-9-_.~%",
   });
   const match = PrUrlParams.safeParse(pattern.match(url));
@@ -257,8 +257,8 @@ export function parseRepo(remoteUrl: string): { owner: string; repo: string } | 
   };
 
   const urlMatch =
-    tryPattern("https\\://github.com/:owner/:repo(/*)") ??
-    tryPattern("ssh\\://git@github.com/:owner/:repo(/*)");
+    tryPattern(String.raw`https\://github.com/:owner/:repo(/*)`) ??
+    tryPattern(String.raw`ssh\://git@github.com/:owner/:repo(/*)`);
   if (urlMatch) return urlMatch;
 
   // scp-like: git@github.com:owner/repo(.git)

--- a/plugins/gitlab/hooks/lint.ts
+++ b/plugins/gitlab/hooks/lint.ts
@@ -62,7 +62,7 @@ function context(text: string): SyncHookJSONOutput {
 // Blank out quoted spans so flag checks never match text inside argument
 // values (note bodies, field values), only real flags.
 export function stripQuoted(command: string): string {
-  return command.replace(/'[^']*'/g, " ").replace(/"[^"]*"/g, " ");
+  return command.replaceAll(/'[^']*'/g, " ").replaceAll(/"[^"]*"/g, " ");
 }
 
 // Segments approximate one process invocation each, so a `grep -q` elsewhere
@@ -90,7 +90,7 @@ export function lintGlab(command: string): string | null {
     if (!/\bglab\s+api\s+graphql\b/.test(segment)) continue;
     if (/query=["']?[^;&|]*\\\$/.test(segment)) {
       return [
-        "Escaped dollars (\\$) corrupt GraphQL variable declarations. Pass the query via a quoted heredoc so $ needs no escaping:",
+        String.raw`Escaped dollars (\$) corrupt GraphQL variable declarations. Pass the query via a quoted heredoc so $ needs no escaping:`,
         `glab api graphql -f query="$(cat <<'GQL'`,
         "mutation($projectPath: ID!, $iid: String!) { ... }",
         "GQL",

--- a/plugins/gitlab/skills/merge-request/scripts/diff.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/diff.ts
@@ -56,7 +56,7 @@ const MrDiffs = z.array(
 type MrDiff = z.infer<typeof MrDiffs>[number];
 
 export function parseGlabPaginated(raw: string): unknown[] {
-  const fixed = raw.replace(/\]\s*\[/g, ",");
+  const fixed = raw.replaceAll(/\]\s*\[/g, ",");
   return Entries.parse(JSON.parse(fixed));
 }
 

--- a/plugins/gitlab/skills/merge-request/scripts/discussions.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/discussions.ts
@@ -97,7 +97,7 @@ function summarize(d: Discussion): DiscussionSummary | null {
 }
 
 export function truncateBody(body: string, max: number): string {
-  const collapsed = body.replace(/\s+/g, " ").trim();
+  const collapsed = body.replaceAll(/\s+/g, " ").trim();
   if (max <= 0 || collapsed.length <= max) return collapsed;
   return `${collapsed.slice(0, max - 1)}…`;
 }

--- a/plugins/issue/evals/issue-refine/scripts/build-dataset.ts
+++ b/plugins/issue/evals/issue-refine/scripts/build-dataset.ts
@@ -101,7 +101,7 @@ for (const [session_id, refined] of refinedBySession) {
 const norm = (t: string) =>
   t
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ")
+    .replaceAll(/[^a-z0-9]+/g, " ")
     .trim();
 const seen = new Set<string>();
 const unique = candidates.filter((c) => {

--- a/plugins/issue/evals/issue-refine/scripts/score.ts
+++ b/plugins/issue/evals/issue-refine/scripts/score.ts
@@ -105,7 +105,8 @@ const add = (finding: number, severity: Severity, line: number, excerpt: string,
 
 // Finding 1: title-case noun-phrase headings. A body H1 is a defect on its own:
 // the title lives in the frontmatter, so the body should never open one.
-const stripCode = (s: string) => s.replace(/`[^`]*`/g, "").replace(/\[[^\]]*\]\([^)]*\)/g, "$&");
+const stripCode = (s: string) =>
+  s.replaceAll(/`[^`]*`/g, "").replaceAll(/\[[^\]]*\]\([^)]*\)/g, "$&");
 for (const h of headings) {
   if (h.level === 1) {
     add(
@@ -150,7 +151,7 @@ for (const h of headings) {
 // Finding 2: native links for issue/PR references; no bare numbers or raw URLs.
 const linkTargets = new Set([...body.matchAll(/\]\(([^)]+)\)/g)].map((m) => m[1]));
 lines.forEach((l, i) => {
-  const noLinks = l.replace(/\[[^\]]*\]\([^)]*\)/g, "").replace(/`[^`]*`/g, "");
+  const noLinks = l.replaceAll(/\[[^\]]*\]\([^)]*\)/g, "").replaceAll(/`[^`]*`/g, "");
   for (const m of noLinks.matchAll(/\b[A-Z]{2,}-\d+\b/g))
     add(2, "critical", i + 1, m[0], "Bare tracker reference. Use a link that expands inline.");
   for (const m of noLinks.matchAll(/(?:^|\s)(#\d+|MR\s*!\d+|!\d+)\b/g))

--- a/plugins/mac/hooks/sandbox.ts
+++ b/plugins/mac/hooks/sandbox.ts
@@ -29,7 +29,7 @@ export function extractCommands(command: string): Invocation[] {
   const result: Invocation[] = [];
 
   for (const segment of segments) {
-    const trimmed = segment.trim().replace(/^[()]+|[()]+$/g, "");
+    const trimmed = segment.trim().replaceAll(/^[()]+|[()]+$/g, "");
     if (trimmed === "") continue;
 
     const tokens = trimmed.split(/\s+/);

--- a/plugins/mermaid/skills/diagram/scripts/validate.ts
+++ b/plugins/mermaid/skills/diagram/scripts/validate.ts
@@ -82,7 +82,7 @@ async function validateBlock(block: MermaidBlock): Promise<ValidationError | nul
     return null;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    return { line: block.line, message: message.replace(/\n/g, " ").trim() };
+    return { line: block.line, message: message.replaceAll("\n", " ").trim() };
   }
 }
 

--- a/plugins/pull-request/evals/pr-body/scripts/judge.test.ts
+++ b/plugins/pull-request/evals/pr-body/scripts/judge.test.ts
@@ -10,7 +10,7 @@ function rubricAxes(markdown: string): string[] {
   const axes: string[] = [];
   for (const line of markdown.split("\n")) {
     const match = line.match(/^###\s+(.+)$/);
-    if (match?.[1] != null && match[1] !== "") axes.push(match[1].trim().replace(/^`|`$/g, ""));
+    if (match?.[1] != null && match[1] !== "") axes.push(match[1].trim().replaceAll(/^`|`$/g, ""));
   }
   return axes;
 }

--- a/plugins/pull-request/evals/pr-body/scripts/run-eval.ts
+++ b/plugins/pull-request/evals/pr-body/scripts/run-eval.ts
@@ -280,7 +280,7 @@ async function readRecorded(runDir: string): Promise<GenerationRow[]> {
 }
 
 function defaultRunId(): string {
-  return new Date().toISOString().replace(/[:.]/g, "-").replace("Z", "");
+  return new Date().toISOString().replaceAll(/[:.]/g, "-").replace("Z", "");
 }
 
 async function main(): Promise<void> {

--- a/plugins/pull-request/scripts/body-rules.ts
+++ b/plugins/pull-request/scripts/body-rules.ts
@@ -125,7 +125,7 @@ const FILE_EXTENSION_PATTERN =
 function looksLikeFilePath(label: string): boolean {
   const trimmed = label
     .trim()
-    .replace(/^`+|`+$/g, "")
+    .replaceAll(/^`+|`+$/g, "")
     .trim();
   if (trimmed.length === 0) return false;
   if (trimmed.includes("/")) return true;

--- a/plugins/pull-request/scripts/heading-case.ts
+++ b/plugins/pull-request/scripts/heading-case.ts
@@ -79,7 +79,7 @@ function restore(text: string, codeSpans: string[]): string {
 // identifiers with a lowercase first letter (`gitLab` -> `GitLab`, `iOS` ->
 // `IOS`). An internal capital marks those so they aren't re-cased.
 function isIdentifier(segment: string): boolean {
-  const letters = segment.replace(/[^A-Za-z]/g, "");
+  const letters = segment.replaceAll(/[^A-Za-z]/g, "");
   if (letters.length < 2) return false;
   return /[A-Z]/.test(letters.slice(1));
 }

--- a/plugins/pull-request/scripts/linguistics/heading.ts
+++ b/plugins/pull-request/scripts/linguistics/heading.ts
@@ -75,7 +75,7 @@ export function classifyHeadingBaseline(heading: string): HeadingVerdict {
     .trim();
 
   const words = analysis.split(/\s+/).filter((word) => word.length > 0);
-  const lower = words.map((word) => word.toLowerCase().replace(/[^a-z']/g, ""));
+  const lower = words.map((word) => word.toLowerCase().replaceAll(/[^a-z']/g, ""));
 
   // Interrogative-led headings ("Why X is Y", "What was wrong") are a
   // conventional rationale-section label, not the sentence-heading trope.
@@ -94,7 +94,7 @@ export function classifyHeadingBaseline(heading: string): HeadingVerdict {
       .slice(colonIndex + 1)
       .trim()
       .split(/\s+/)
-      .map((word) => word.toLowerCase().replace(/[^a-z']/g, ""))
+      .map((word) => word.toLowerCase().replaceAll(/[^a-z']/g, ""))
       .filter((word) => word.length > 0);
     const afterPredicate = after.some((word) => LINKING_VERBS.has(word) || word === "not");
     const preEnumerator =

--- a/plugins/pull-request/scripts/markdown.ts
+++ b/plugins/pull-request/scripts/markdown.ts
@@ -34,11 +34,11 @@ export function linesOutsideFences(body: string): string[] {
 
 export function stripEmphasis(text: string): string {
   return text
-    .replace(/\*\*\*(.+?)\*\*\*/g, "$1")
-    .replace(/\*\*(.+?)\*\*/g, "$1")
-    .replace(/\*(.+?)\*/g, "$1")
-    .replace(/(?<![\w`])__(.+?)__(?![\w`])/g, "$1")
-    .replace(/(?<![\w`])_(.+?)_(?![\w`])/g, "$1");
+    .replaceAll(/\*\*\*(.+?)\*\*\*/g, "$1")
+    .replaceAll(/\*\*(.+?)\*\*/g, "$1")
+    .replaceAll(/\*(.+?)\*/g, "$1")
+    .replaceAll(/(?<![\w`])__(.+?)__(?![\w`])/g, "$1")
+    .replaceAll(/(?<![\w`])_(.+?)_(?![\w`])/g, "$1");
 }
 
 /**

--- a/plugins/pull-request/scripts/prose.test.ts
+++ b/plugins/pull-request/scripts/prose.test.ts
@@ -66,7 +66,7 @@ function wrapDocument(doc: string, column: number): string {
 function renderedShape(body: string): string {
   return JSON.stringify(fromMarkdown(body), (key: string, value: unknown) => {
     if (key === "position") return undefined;
-    if (key === "value" && typeof value === "string") return value.replace(/\s+/g, " ");
+    if (key === "value" && typeof value === "string") return value.replaceAll(/\s+/g, " ");
     return value;
   });
 }

--- a/plugins/pull-request/scripts/prose.ts
+++ b/plugins/pull-request/scripts/prose.ts
@@ -116,7 +116,7 @@ export function hardWrappedParagraphs(body: string): WrappedParagraph[] {
       raw,
       // Consuming the whitespace on both sides of the break keeps a line that
       // ended in a space from joining as two, and drops the CR of a CRLF body.
-      unwrapped: raw.replace(/[ \t]*\r?\n[ \t]*/g, " "),
+      unwrapped: raw.replaceAll(/[ \t]*\r?\n[ \t]*/g, " "),
       start: start.offset,
       end: end.offset,
     });
@@ -153,7 +153,7 @@ export type NarrationTell = (typeof NARRATION_TELLS)[number];
 
 /** Regex source for one tell, shared with the eval scorer so both match identically. */
 export function narrationTellSource(tell: string): string {
-  return `\\b${tell.replace(/ /g, "\\s+")}\\b`;
+  return `\\b${tell.replaceAll(" ", String.raw`\s+`)}\\b`;
 }
 
 export const TITLE_LENGTH_LIMIT = 50;

--- a/plugins/pull-request/scripts/repo.ts
+++ b/plugins/pull-request/scripts/repo.ts
@@ -35,7 +35,7 @@ export function parseGhLogin(hostsYaml: string): string | null {
     }
     if (!inGitHub) continue;
     const user = line.match(/^\s+user:\s*(.+?)\s*$/)?.[1];
-    if (user != null && user !== "") return user.replace(/^["']|["']$/g, "");
+    if (user != null && user !== "") return user.replaceAll(/^["']|["']$/g, "");
   }
   return null;
 }

--- a/plugins/pull-request/scripts/resolve-body.test.ts
+++ b/plugins/pull-request/scripts/resolve-body.test.ts
@@ -157,7 +157,7 @@ describe("extractBodySpec", () => {
     ["gh pr create --body '## Open Item'", parts(literal("## Open Item"))],
     ["gh pr create -b '## Open Item'", parts(literal("## Open Item"))],
     ['gh pr create --body="## Open Item"', parts(literal("## Open Item"))],
-    ['gh pr create --body "a \\"quoted\\" word"', parts(literal('a "quoted" word'))],
+    [String.raw`gh pr create --body "a \"quoted\" word"`, parts(literal('a "quoted" word'))],
     ["gh pr create --body-file body.md", parts(file("body.md"))],
     ['gh pr create --body "Use \\`code\\` here"', parts(literal("Use `code` here"))],
     ["gh pr create --title 'x'", { kind: "none" }],
@@ -303,7 +303,7 @@ describe("command forms the skills document", () => {
     const body = "## Summary\n\nResolved through the form the skill documents.\n";
     await Bun.write(bodyPath, body);
     // Doc paths are placeholders (`tmp/pr-body-<branch>.md`, `file.md`).
-    const command = snippet.replace(/\S*\.md/g, bodyPath);
+    const command = snippet.replaceAll(/\S*\.md/g, bodyPath);
     expect(await resolveBody(command, REPO_ROOT)).toEqual({ kind: "text", text: body });
   });
 });
@@ -315,7 +315,7 @@ describe("extractTitle", () => {
     ['gh pr create --title="Add an LRU Cache"', "Add an LRU Cache"],
     ["gh pr create -t 'Add an LRU Cache'", "Add an LRU Cache"],
     ["gh pr create --title cache", "cache"],
-    ['gh pr create --title "a \\"quoted\\" word"', 'a "quoted" word'],
+    [String.raw`gh pr create --title "a \"quoted\" word"`, 'a "quoted" word'],
     ['glab mr create --title "Add an LRU Cache" --description x', "Add an LRU Cache"],
     ["gh pr edit 12 --body-file body.md", null],
     ['BODY=$(mktemp -t pr) && gh pr create --title "Real Title" --body-file "$BODY"', "Real Title"],

--- a/plugins/pull-request/scripts/resolve-body.ts
+++ b/plugins/pull-request/scripts/resolve-body.ts
@@ -23,13 +23,13 @@ function unquote(value: string): string {
 }
 
 function unescapeDoubleQuoted(text: string): string {
-  return text.replace(/\\(["`$\\])/g, "$1");
+  return text.replaceAll(/\\(["`$\\])/g, "$1");
 }
 
 function expandTmpdir(path: string): string {
   const tmpdir = process.env.TMPDIR?.replace(/\/$/, "");
   if (tmpdir == null || tmpdir === "") return path;
-  return path.replace(/\$\{TMPDIR\}|\$TMPDIR/g, tmpdir);
+  return path.replaceAll(/\$\{TMPDIR\}|\$TMPDIR/g, tmpdir);
 }
 
 function normalizeBodyPath(raw: string): string {

--- a/plugins/pull-request/scripts/sentence-heading.ts
+++ b/plugins/pull-request/scripts/sentence-heading.ts
@@ -100,7 +100,7 @@ function tokens(text: string): string[] {
 }
 
 function normalize(word: string): string {
-  return word.toLowerCase().replace(/[^a-z']/g, "");
+  return word.toLowerCase().replaceAll(/[^a-z']/g, "");
 }
 
 /**
@@ -135,7 +135,7 @@ const FUNCTION_WORDS = new Set([
 ]);
 
 function isContentWord(word: string): boolean {
-  const bare = word.replace(/[.,:?!"'()]/g, "");
+  const bare = word.replaceAll(/[.,:?!"'()]/g, "");
   if (bare === CODE_SENTINEL) return false;
   if (bare.length === 0) return false;
   // Tokens with internal code shape (digits, slashes, backticks) are not prose.
@@ -154,8 +154,8 @@ export function classifyPrHeading(heading: string): PrHeadingResult {
   // A comma outside code/quotes signals list/clause structure. The contrast idiom ", not Y" is a
   // tight label device the user keeps ("`-F`, not `-f`"), so it is exempt.
   const maskedForComma = maskCode(raw)
-    .replace(/"[^"]*"/g, CODE_SENTINEL)
-    .replace(/,\s*not\b/gi, "");
+    .replaceAll(/"[^"]*"/g, CODE_SENTINEL)
+    .replaceAll(/,\s*not\b/gi, "");
   if (/,/.test(maskedForComma)) signals.push("comma (clause/list)");
 
   // A short label parenthetical is fine ("(Historical)", "(Working Notes)"). Flag parentheticals
@@ -165,7 +165,7 @@ export function classifyPrHeading(heading: string): PrHeadingResult {
     const inner = parenMatch[1] ?? "";
     const innerMasked = maskCode(inner);
     const innerWords = tokens(innerMasked).map(normalize);
-    const hasComma = /,/.test(innerMasked.replace(/"[^"]*"/g, CODE_SENTINEL));
+    const hasComma = /,/.test(innerMasked.replaceAll(/"[^"]*"/g, CODE_SENTINEL));
     const hasPredicate = innerWords.some((w) => PREDICATE_VERBS.has(w));
     if (hasComma) signals.push("parenthetical clause (comma)");
     else if (hasPredicate) signals.push("parenthetical clause (verb)");

--- a/plugins/pull-request/scripts/suggest-reviewers.ts
+++ b/plugins/pull-request/scripts/suggest-reviewers.ts
@@ -73,7 +73,7 @@ export function blameOwners(files: string[], self: Set<string>, cwd?: string): O
       if (line.startsWith("author ")) {
         name = line.slice("author ".length).trim();
       } else if (line.startsWith("author-mail ")) {
-        const email = line.slice("author-mail ".length).trim().replace(/^<|>$/g, "");
+        const email = line.slice("author-mail ".length).trim().replaceAll(/^<|>$/g, "");
         const key = email.toLowerCase();
         if (self.has(key) || self.has(name.toLowerCase())) continue;
         const owner = byEmail.get(key) ?? { name, email, lines: 0 };

--- a/plugins/review/evals/review-voice/scripts/mine.ts
+++ b/plugins/review/evals/review-voice/scripts/mine.ts
@@ -165,7 +165,7 @@ function idFor(host: string, session: string, fp: string, index: number): string
 }
 
 function normalize(body: string): string {
-  return body.replace(/\s+/g, " ").trim().toLowerCase();
+  return body.replaceAll(/\s+/g, " ").trim().toLowerCase();
 }
 
 async function main() {

--- a/plugins/review/skills/inbox/scripts/args.ts
+++ b/plugins/review/skills/inbox/scripts/args.ts
@@ -42,7 +42,7 @@ export function buildDispatchArgs({
 // match skips. Returns null when the line is absent (an older claude, or a
 // launch failure that still exited zero).
 export function parseBackgroundedId(stdout: string): string | null {
-  const clean = stdout.replace(/\[[0-9;]*m/g, "");
+  const clean = stdout.replaceAll(/\[[0-9;]*m/g, "");
   const match = clean.match(/backgrounded[^0-9a-f]*([0-9a-f]{6,})/i);
   return match?.[1] ?? null;
 }

--- a/plugins/review/skills/tuicr/scripts/ledger.ts
+++ b/plugins/review/skills/tuicr/scripts/ledger.ts
@@ -36,7 +36,7 @@ export function defaultLedgerDir(): string {
 }
 
 function sanitize(value: string): string {
-  return value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return value.replaceAll(/[^a-zA-Z0-9._-]+/g, "-").replaceAll(/^-+|-+$/g, "");
 }
 
 const LedgerFile = z.object({

--- a/plugins/review/skills/tuicr/scripts/watch.ts
+++ b/plugins/review/skills/tuicr/scripts/watch.ts
@@ -11,7 +11,7 @@ import { decodeComments, type TuicrComment } from "./comment";
 
 /** Collapse whitespace runs so each comment prints on a single line. */
 export function oneLine(content: string): string {
-  return content.replace(/\s+/g, " ").trim();
+  return content.replaceAll(/\s+/g, " ").trim();
 }
 
 /** The Monitor event line for a freshly seen comment. */

--- a/plugins/things/scripts/format-output.ts
+++ b/plugins/things/scripts/format-output.ts
@@ -76,7 +76,7 @@ const columns = argv.flags.columns?.split(",");
 process.stdout.write(table([headers, ...rows]));
 
 function camelToTitle(s: string): string {
-  return s.replace(/([a-z])([A-Z])/g, "$1 $2").replace(/^./, (c) => c.toUpperCase());
+  return s.replaceAll(/([a-z])([A-Z])/g, "$1 $2").replace(/^./, (c) => c.toUpperCase());
 }
 
 function isIsoDate(s: string): boolean {

--- a/plugins/things/scripts/format.ts
+++ b/plugins/things/scripts/format.ts
@@ -11,7 +11,7 @@ export function stringify(value: unknown): string {
   return String(value);
 }
 
-const normalize = (s: string) => s.toLowerCase().replace(/\s+/g, "-");
+const normalize = (s: string) => s.toLowerCase().replaceAll(/\s+/g, "-");
 
 export function selectColumns(
   headers: string[],

--- a/plugins/things/scripts/inbox.test.ts
+++ b/plugins/things/scripts/inbox.test.ts
@@ -54,7 +54,7 @@ describe("buildAttribution", () => {
     "/repos/ben's thing",
     "/repos/a; rm -rf b",
     "/repos/$(whoami)",
-    "/repos/back\\slash",
+    String.raw`/repos/back\slash`,
     '/repos/"quoted"',
   ])("survives a shell round trip: %s", async (directory) => {
     const { stdout } = await $`sh -c ${`printf %s ${shellQuote(directory)}`}`.quiet();

--- a/plugins/things/scripts/inbox.ts
+++ b/plugins/things/scripts/inbox.ts
@@ -18,7 +18,7 @@ const INBOX_PARAMS = new Set(["title", "titles", "notes", "tags", "checklist-ite
  * strings that end up in a snippet the user pastes into a shell.
  */
 export function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", "'\\''")}'`;
+  return `'${value.replaceAll("'", String.raw`'\''`)}'`;
 }
 
 /**
@@ -79,8 +79,8 @@ if (import.meta.main) {
   for (const arg of argv._.params) {
     const eqIndex = arg.indexOf("=");
     if (eqIndex === -1) continue;
-    const key = arg.substring(0, eqIndex);
-    const value = arg.substring(eqIndex + 1);
+    const key = arg.slice(0, eqIndex);
+    const value = arg.slice(eqIndex + 1);
     if (INBOX_PARAMS.has(key)) {
       params.set(key, value);
     }

--- a/plugins/things/scripts/url.ts
+++ b/plugins/things/scripts/url.ts
@@ -394,8 +394,8 @@ if (import.meta.main) {
   for (const arg of argv._.params) {
     const eqIndex = arg.indexOf("=");
     if (eqIndex === -1) continue;
-    const key = arg.substring(0, eqIndex);
-    const value = arg.substring(eqIndex + 1);
+    const key = arg.slice(0, eqIndex);
+    const value = arg.slice(eqIndex + 1);
     if (key === "id") {
       ids.push(value);
     } else {

--- a/plugins/writing/detection/tropes.test.ts
+++ b/plugins/writing/detection/tropes.test.ts
@@ -46,12 +46,12 @@ describe("stripCode", () => {
   // fenced blocks. That is stripCode's intended domain: inline code that spans
   // a newline is replaced by equal-width spaces, which drops the newline and
   // collapses the line count.
-  const plainSegment = fc.string().map((s) => s.replace(/[`\n]/g, ""));
+  const plainSegment = fc.string().map((s) => s.replaceAll(/[`\n]/g, ""));
   const inlineCodeLine = fc
     .tuple(
       plainSegment,
       fc.string().map((s) => {
-        const stripped = s.replace(/[`\n]/g, "");
+        const stripped = s.replaceAll(/[`\n]/g, "");
         return stripped !== "" ? stripped : "x";
       }),
       plainSegment,

--- a/plugins/writing/detection/wordlists.test.ts
+++ b/plugins/writing/detection/wordlists.test.ts
@@ -27,7 +27,7 @@ describe("compilePlainWordlist", () => {
 
   it("dedupes entries", () => {
     const re = compilePlainWordlist("foo\nfoo\n");
-    expect(re?.source).toBe("\\b(?:foo)\\b");
+    expect(re?.source).toBe(String.raw`\b(?:foo)\b`);
   });
 
   it("honors prefix/suffix/flags overrides", () => {

--- a/plugins/writing/detection/wordlists.ts
+++ b/plugins/writing/detection/wordlists.ts
@@ -30,7 +30,7 @@ function parseLines(content: string): string[] {
 }
 
 function escapeRegex(literal: string): string {
-  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return literal.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
 
 export function compilePlainWordlist(
@@ -40,8 +40,8 @@ export function compilePlainWordlist(
   const entries = parseLines(content);
   if (entries.length === 0) return null;
   const fragments = Array.from(new Set(entries.map(escapeRegex)));
-  const prefix = options.prefix ?? "\\b";
-  const suffix = options.suffix ?? "\\b";
+  const prefix = options.prefix ?? String.raw`\b`;
+  const suffix = options.suffix ?? String.raw`\b`;
   const flags = options.flags ?? "gi";
   return new RegExp(`${prefix}(?:${fragments.join("|")})${suffix}`, flags);
 }

--- a/plugins/writing/hooks/check-tropes.ts
+++ b/plugins/writing/hooks/check-tropes.ts
@@ -36,7 +36,7 @@ const GIT_MESSAGE_FILE_PATTERN = /\bgit\s+(?:commit|tag)\b[^|;&]*?\s(?:-F|--file
 // Shell quoting survives into the raw command string, so a path captured from
 // `-F 'body=@tmp/x.md'` carries the closing quote.
 function stripQuotes(token: string): string {
-  return token.replace(/^['"]+|['"]+$/g, "");
+  return token.replaceAll(/^['"]+|['"]+$/g, "");
 }
 
 function extractBodyFilePath(command: string): string | null {

--- a/plugins/writing/hooks/heading-case.ts
+++ b/plugins/writing/hooks/heading-case.ts
@@ -79,7 +79,7 @@ function restore(text: string, codeSpans: string[]): string {
 // identifiers with a lowercase first letter (`gitLab` -> `GitLab`, `iOS` ->
 // `IOS`). An internal capital marks those so they aren't re-cased.
 function isIdentifier(segment: string): boolean {
-  const letters = segment.replace(/[^A-Za-z]/g, "");
+  const letters = segment.replaceAll(/[^A-Za-z]/g, "");
   if (letters.length < 2) return false;
   return /[A-Z]/.test(letters.slice(1));
 }

--- a/plugins/writing/hooks/session-state.ts
+++ b/plugins/writing/hooks/session-state.ts
@@ -12,7 +12,7 @@ const SessionState = z.record(z.string(), z.number());
 export type SessionState = z.infer<typeof SessionState>;
 
 function statePath(sessionId: string): string {
-  const safe = sessionId.replace(/[^\w-]/g, "");
+  const safe = sessionId.replaceAll(/[^\w-]/g, "");
   return join(process.env.TMPDIR ?? tmpdir(), `writing-hooks-${safe}.json`);
 }
 

--- a/plugins/writing/linguistics/heading.ts
+++ b/plugins/writing/linguistics/heading.ts
@@ -75,7 +75,7 @@ export function classifyHeadingBaseline(heading: string): HeadingVerdict {
     .trim();
 
   const words = analysis.split(/\s+/).filter((word) => word.length > 0);
-  const lower = words.map((word) => word.toLowerCase().replace(/[^a-z']/g, ""));
+  const lower = words.map((word) => word.toLowerCase().replaceAll(/[^a-z']/g, ""));
 
   // Interrogative-led headings ("Why X is Y", "What was wrong") are a
   // conventional rationale-section label, not the sentence-heading trope.
@@ -94,7 +94,7 @@ export function classifyHeadingBaseline(heading: string): HeadingVerdict {
       .slice(colonIndex + 1)
       .trim()
       .split(/\s+/)
-      .map((word) => word.toLowerCase().replace(/[^a-z']/g, ""))
+      .map((word) => word.toLowerCase().replaceAll(/[^a-z']/g, ""))
       .filter((word) => word.length > 0);
     const afterPredicate = after.some((word) => LINKING_VERBS.has(word) || word === "not");
     const preEnumerator =

--- a/plugins/writing/scripts/similarity.ts
+++ b/plugins/writing/scripts/similarity.ts
@@ -204,7 +204,7 @@ const mineContrastCommand = command(
         // One file is written and edited many times across a session, so the
         // path alone is not a unique pointer. Whitespace would break the
         // corpus delimiter line, which drops the document on the way back in.
-        source: `${(row.file_path ?? row.session_id).replace(/\s+/g, "_")}#${index}`,
+        source: `${(row.file_path ?? row.session_id).replaceAll(/\s+/g, "_")}#${index}`,
         meta: row.session_id,
         body: row.text,
       }));

--- a/plugins/writing/similarity/char-ngrams.ts
+++ b/plugins/writing/similarity/char-ngrams.ts
@@ -13,7 +13,7 @@ export const DEFAULT_VOCABULARY_SIZE = 300;
 const GRAM_SIZE = 3;
 
 export function normalizeForGrams(prose: string): string {
-  return prose.toLowerCase().replace(/\s+/g, " ").trim();
+  return prose.toLowerCase().replaceAll(/\s+/g, " ").trim();
 }
 
 export function countGrams(prose: string, into = new Map<string, number>()): Map<string, number> {

--- a/plugins/writing/similarity/report.ts
+++ b/plugins/writing/similarity/report.ts
@@ -19,7 +19,7 @@ export interface Report {
 }
 
 export function truncate(text: string, width: number): string {
-  const flat = text.replace(/\s+/g, " ").trim();
+  const flat = text.replaceAll(/\s+/g, " ").trim();
   // A negative end index counts from the end of the string, which would print
   // the tail of the passage rather than a prefix.
   const room = Math.max(1, Math.trunc(width));

--- a/plugins/writing/skills/analyze/scripts/frustration.ts
+++ b/plugins/writing/skills/analyze/scripts/frustration.ts
@@ -27,7 +27,7 @@ export const FRUSTRATION_TERMS = [
 export const GATED_TERMS = ["sounds like"];
 
 export function escapeRegex(literal: string): string {
-  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return literal.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
 
 // A DuckDB-compatible regex alternation with word boundaries. DuckDB's regexp

--- a/plugins/writing/skills/analyze/scripts/quote-context.ts
+++ b/plugins/writing/skills/analyze/scripts/quote-context.ts
@@ -76,7 +76,7 @@ function makeContext(row: SourceRow, start: number, end: number, radius: number)
   const to = Math.min(row.text?.length ?? 0, end + radius);
   const prefix = from > 0 ? "..." : "";
   const suffix = to < (row.text?.length ?? 0) ? "..." : "";
-  const window = `${prefix}${(row.text ?? "").slice(from, to).replace(/\s+/g, " ").trim()}${suffix}`;
+  const window = `${prefix}${(row.text ?? "").slice(from, to).replaceAll(/\s+/g, " ").trim()}${suffix}`;
   return {
     window,
     sourceFile: row.source_file ?? null,

--- a/plugins/writing/skills/analyze/scripts/report.ts
+++ b/plugins/writing/skills/analyze/scripts/report.ts
@@ -402,7 +402,7 @@ function renderMeaningAudit(input: ReportInput): string {
       for (const span of stat.spans) {
         // Spans are verbatim quotes and may contain newlines, which would
         // break the list item; collapse all whitespace runs to single spaces.
-        const flat = span.replace(/\s+/g, " ").trim();
+        const flat = span.replaceAll(/\s+/g, " ").trim();
         lines.push(`- ${stat.id}: "${esc(truncate(flat, 160))}"`);
       }
     }
@@ -503,7 +503,7 @@ function ruleTypeLabel(source: string): string {
 }
 
 function esc(s: string): string {
-  return s.replace(/\|/g, "\\|");
+  return s.replaceAll("|", String.raw`\|`);
 }
 
 function voiceBaselineSummary(profile: VoiceProfile | null): string {

--- a/plugins/writing/skills/analyze/scripts/voice-corpus.test.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-corpus.test.ts
@@ -8,12 +8,12 @@ import { mergeDocuments, parseCorpus, serializeCorpus, type VoiceDocument } from
 // open with "=" so none masquerade as a delimiter after trimming.
 const voiceDocument = fc.record<VoiceDocument>({
   source: fc.string({ minLength: 1 }).map((s) => {
-    const stripped = s.replace(/\s/g, "");
+    const stripped = s.replaceAll(/\s/g, "");
     return stripped !== "" ? stripped : "x";
   }),
-  meta: fc.string().map((s) => s.replace(/[)\r\n]/g, "")),
+  meta: fc.string().map((s) => s.replaceAll(/[)\r\n]/g, "")),
   body: fc
-    .array(fc.string().map((s) => s.replace(/[\r\n]/g, " ").replace(/^[\s=]+/, "")))
+    .array(fc.string().map((s) => s.replaceAll(/[\r\n]/g, " ").replace(/^[\s=]+/, "")))
     .map((lines) => lines.join("\n").trim()),
 });
 

--- a/plugins/writing/skills/analyze/scripts/voice-delta.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-delta.ts
@@ -56,15 +56,15 @@ function nonEmptyLines(text: string): string[] {
 // denominators. stripCode flattens whitespace, which would destroy line-based
 // rates.
 function stripFencedBlocks(text: string): string {
-  return text.replace(/```[\s\S]*?```/g, "");
+  return text.replaceAll(/```[\s\S]*?```/g, "");
 }
 
 // Strip fenced and inline code blocks before rate counting.
 function stripCode(text: string): string {
   return text
-    .replace(/```[\s\S]*?```/g, " ")
-    .replace(/`[^`]+`/g, " ")
-    .replace(/https?:\/\/\S+/g, " URL ");
+    .replaceAll(/```[\s\S]*?```/g, " ")
+    .replaceAll(/`[^`]+`/g, " ")
+    .replaceAll(/https?:\/\/\S+/g, " URL ");
 }
 
 // Count total words in stripped text. Avoids counting code tokens.
@@ -74,7 +74,7 @@ function strippedWordCount(text: string): number {
 
 function countBackticks(text: string): number {
   // Remove fenced blocks first to avoid double-counting their delimiters.
-  const nofence = text.replace(/```[\s\S]*?```/g, "");
+  const nofence = text.replaceAll(/```[\s\S]*?```/g, "");
   return (nofence.match(/`/g) ?? []).length;
 }
 

--- a/scripts/check-hook-paths.ts
+++ b/scripts/check-hook-paths.ts
@@ -47,7 +47,7 @@ export const PROJECT_SETTINGS: Source = {
 export const SOURCES: Source[] = [USER_SETTINGS, PROJECT_SETTINGS];
 
 function quoteRegex(literal: string): string {
-  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return literal.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
 
 /** Shell syntax that cannot appear inside an unquoted or quoted path. */

--- a/scripts/check-review-drift.ts
+++ b/scripts/check-review-drift.ts
@@ -134,12 +134,12 @@ function fragmentPattern(fragment: string): RegExp {
       if (code > 0x7f) {
         const utf8 = Buffer.from(char, "utf8")
           .toString("latin1")
-          .replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+          .replaceAll(/[\\^$.*+?()[\]{}|]/g, String.raw`\$&`);
         return `(?:${utf8}|\\\\u${code.toString(16).padStart(4, "0")})`;
       }
-      if (char === "\n") return "(?:\\n|\\\\n)";
+      if (char === "\n") return String.raw`(?:\n|\\n)`;
       if (char === "`" || char === "$") return `\\\\?\\${char}`;
-      return char.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+      return char.replaceAll(/[\\^$.*+?()[\]{}|]/g, String.raw`\$&`);
     })
     .join("");
   return new RegExp(escaped);

--- a/scripts/inventory/collect.ts
+++ b/scripts/inventory/collect.ts
@@ -85,7 +85,7 @@ async function frontmatterOf(path: string): Promise<Frontmatter> {
 }
 
 function text(value: unknown): string {
-  return typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";
+  return typeof value === "string" ? value.trim().replaceAll(/\s+/g, " ") : "";
 }
 
 /** Tool lists appear as a comma-joined string or a YAML sequence. */

--- a/user/hooks/worktree/index.ts
+++ b/user/hooks/worktree/index.ts
@@ -33,7 +33,7 @@ function stripQuoted(command: string): string {
 
 // Quote characters delimit the token, they are not part of the path.
 function unquote(token: string): string {
-  return token.replace(/['"]/g, "");
+  return token.replaceAll(/['"]/g, "");
 }
 
 function tokensAfter(command: string, invocation: RegExp): string[] {

--- a/user/scripts/statusline.test.ts
+++ b/user/scripts/statusline.test.ts
@@ -24,7 +24,7 @@ import {
 // glyphs rather than the escape wrappers.
 function strip(s: string): string {
   // oxlint-disable-next-line no-control-regex
-  return s.replace(/\x1b\[[0-9;]*m/g, "").replace(/\x1b\]8;;[^\x1b]*\x1b\\/g, "");
+  return s.replaceAll(/\x1b\[[0-9;]*m/g, "").replaceAll(/\x1b\]8;;[^\x1b]*\x1b\\/g, "");
 }
 
 interface RenderCase {

--- a/user/scripts/statusline.ts
+++ b/user/scripts/statusline.ts
@@ -229,7 +229,7 @@ function showRepo(repo: string, sanitizedBranch: string): boolean {
 }
 
 export function formatWorktree(data: WorktreeData, budget: number): string[] {
-  const sanitizedBranch = data.branch.replace(/[/\\]/g, "-");
+  const sanitizedBranch = data.branch.replaceAll(/[/\\]/g, "-");
   let repo = basename(data.path);
   const repoSuffix = `.${sanitizedBranch}`;
   if (repo.endsWith(repoSuffix)) repo = repo.slice(0, -repoSuffix.length);

--- a/user/scripts/subagent-statusline.test.ts
+++ b/user/scripts/subagent-statusline.test.ts
@@ -17,7 +17,7 @@ import {
 function strip(s: string): string {
   // stripping terminal escapes
   // oxlint-disable-next-line no-control-regex
-  return s.replace(/\x1b\[[0-9;]*m/g, "").replace(/\x1b\]8;;[^\x1b]*\x1b\\/g, "");
+  return s.replaceAll(/\x1b\[[0-9;]*m/g, "").replaceAll(/\x1b\]8;;[^\x1b]*\x1b\\/g, "");
 }
 
 describe("formatElapsed", () => {

--- a/user/scripts/subagent-statusline.ts
+++ b/user/scripts/subagent-statusline.ts
@@ -192,7 +192,7 @@ type TranscriptEntry = z.infer<typeof TranscriptEntry>;
 const text = (value: unknown): string => (typeof value === "string" ? value : "");
 const basename = (p: unknown): string => text(p).split("/").pop() ?? "";
 const firstWord = (cmd: unknown): string => text(cmd).trim().split(/\s+/)[0] ?? "";
-const oneLine = (s: string): string => s.replace(/\s+/g, " ").trim();
+const oneLine = (s: string): string => s.replaceAll(/\s+/g, " ").trim();
 const firstText = (...values: unknown[]): string => values.map(text).find((s) => s !== "") ?? "";
 
 // A tool call renders as a verb plus its most telling argument: the file for
@@ -327,7 +327,7 @@ if (import.meta.main) {
   }
   if (!input) process.exit(0);
 
-  const slug = process.cwd().replace(/[/.]/g, "-");
+  const slug = process.cwd().replaceAll(/[/.]/g, "-");
   const projectDir = join(homedir(), ".claude", "projects", slug);
   const now = Date.now();
 

--- a/user/skills/flights/scripts/google-flights.ts
+++ b/user/skills/flights/scripts/google-flights.ts
@@ -447,7 +447,7 @@ function renderGrid(cells: GridCell[]): string {
 
   const backs = [...new Set(cells.map((cell) => cell.back))];
   return table([
-    ["out \\ back", ...backs.map((back) => back ?? "?")],
+    [String.raw`out \ back`, ...backs.map((back) => back ?? "?")],
     ...outs.map((out) =>
       [out].concat(
         backs.map((back) => money(cells.find((cell) => cell.out === out && cell.back === back))),

--- a/user/skills/scheduled/scripts/scheduled.ts
+++ b/user/skills/scheduled/scripts/scheduled.ts
@@ -97,7 +97,9 @@ export function planReconcile(
   installed: string[],
   prefix: string,
 ): ReconcilePlan {
-  const match = prefix.match(new RegExp(`^${LABEL_ROOT.replace(/\./g, "\\.")}\\.([^.]+)\\.$`));
+  const match = prefix.match(
+    new RegExp(`^${LABEL_ROOT.replaceAll(".", String.raw`\.`)}\\.([^.]+)\\.$`),
+  );
   if (!match) throw new Error(`prefix must look like "${LABEL_ROOT}.<group>.", got "${prefix}"`);
   const group = match[1];
 
@@ -113,7 +115,7 @@ export function planReconcile(
 }
 
 function xmlEscape(value: string): string {
-  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 }
 
 function plistString(value: string): string {
@@ -206,7 +208,9 @@ export async function listDescriptors(dir: string): Promise<DescriptorFile[]> {
 
 /** Short-form (`<group>.<label>`) identifiers for every `me.bendrucker.claude.*` agent installed on this machine. */
 async function listInstalledLabels(): Promise<string[]> {
-  const pattern = new RegExp(`^${LABEL_ROOT.replace(/\./g, "\\.")}\\.([^.]+)\\.(.+)\\.plist$`);
+  const pattern = new RegExp(
+    `^${LABEL_ROOT.replaceAll(".", String.raw`\.`)}\\.([^.]+)\\.(.+)\\.plist$`,
+  );
   const glob = new Bun.Glob(`${LABEL_ROOT}.*.*.plist`);
   const labels: string[] = [];
   for await (const file of glob.scan({ cwd: LAUNCH_AGENTS_DIR })) {


### PR DESCRIPTION
Enables `unicorn/prefer-string-replace-all`, `unicorn/prefer-string-raw`, and `unicorn/prefer-string-slice` in `lint/base.json`, each with a comment on what the banned form costs.

Auto-fix and fix-suggestions cleared most of the resulting violations. The 17 `replace-all` sites the fixer skipped were `replaceAll(regex, ...)` calls whose regex had no special characters, so each became a plain string argument. The 4 `prefer-string-slice` violations were `substring()` calls with in-range, positive arguments, so each became the equivalent `slice()` call.
