### PR TITLE
lint: enable error-handling oxlint rules

### DIFF
--- a/.claude/hooks/ox/index.ts
+++ b/.claude/hooks/ox/index.ts
@@ -266,7 +266,9 @@ export async function parseTranscript(transcriptPath: string): Promise<string[]>
           candidates.add(filePath);
         }
       }
-    } catch {}
+    } catch {
+      // must never break the hook: skip a transcript line that fails to decode
+    }
   }
 
   const checks = [...candidates].map(async (path) => ({
@@ -583,7 +585,9 @@ async function recordBlocks(sessionId: string, blocks: number): Promise<boolean>
 async function clearBlocks(sessionId: string): Promise<void> {
   try {
     await rm(blockCountPath(sessionId), { force: true });
-  } catch {}
+  } catch {
+    // best-effort: a stale block-count file gets overwritten on the next write anyway
+  }
 }
 
 export async function processStop(input: StopInput): Promise<SyncHookJSONOutput | null> {

--- a/.claude/hooks/stop/index.ts
+++ b/.claude/hooks/stop/index.ts
@@ -69,7 +69,9 @@ export async function parseTranscript(transcriptPath: string): Promise<string[]>
           existChecks.push(fileExists(filePath).then((exists) => ({ path: filePath, exists })));
         }
       }
-    } catch {}
+    } catch {
+      // must never break the hook: skip a transcript line that fails to decode
+    }
   }
 
   const results = await Promise.all(existChecks);

--- a/lint/base.json
+++ b/lint/base.json
@@ -78,15 +78,19 @@
     "vitest/no-commented-out-tests": "off",
     // This repo tests with bun:test, not vitest. The vitest plugin matches
     // on the Jest-style API shape rather than the import, so it still
-    // applies correctly here.
-    "vitest/prefer-each": "error"
+    // applies correctly here. Like no-commented-out-tests, it only means
+    // something in test files: repo-wide it flags any loop whose body it
+    // reads as a repeated case, such as render.ts drawing one text line
+    // per iteration. Off here, on under **/*.test.ts below.
+    "vitest/prefer-each": "off"
   },
   "overrides": [
     {
       "files": ["**/*.test.ts"],
       "rules": {
         "unicorn/consistent-function-scoping": "off",
-        "vitest/no-commented-out-tests": "error"
+        "vitest/no-commented-out-tests": "error",
+        "vitest/prefer-each": "error"
       }
     }
   ]

--- a/lint/base.json
+++ b/lint/base.json
@@ -12,6 +12,10 @@
     "eqeqeq": ["error", "always", { "null": "ignore" }],
     "max-depth": "error",
     "no-await-in-loop": "error",
+    // An empty block silently swallows whatever it should have handled, hiding bugs.
+    "no-empty": "error",
+    // Nesting an if inside an else block obscures control flow that else if states directly.
+    "no-lonely-if": "error",
     "no-template-curly-in-string": "warn",
     "no-underscore-dangle": ["error", { "allow": ["__typename", "__dirname"] }],
     "no-unsafe-optional-chaining": "off",
@@ -37,6 +41,10 @@
     // A `new Promise` executor that only wraps an existing async API duplicates
     // logic the platform already exposes, and drops its built-in error handling.
     "promise/avoid-new": "error",
+    // A catch binding named anything but "error" reads as an unrelated value at the call site.
+    "unicorn/catch-error-name": "error",
+    // A custom Error subclass that never sets name prints as "Error", losing which error it is.
+    "unicorn/custom-error-definition": "error",
     // An implicit length check reads as a numeric truthiness test rather
     // than a stated "has items" or "is empty" comparison, and looks the
     // same whether the intent is >0, !==0, or something else entirely.

--- a/packages/validate/run.ts
+++ b/packages/validate/run.ts
@@ -65,8 +65,8 @@ export function pluginDirFile(usage: string, file: string): string {
 }
 
 export function runEntry(run: () => Promise<void>): void {
-  run().catch((err) => {
-    console.error(err);
+  run().catch((error) => {
+    console.error(error);
     process.exit(1);
   });
 }

--- a/plugins/claude-code/skills/session/scripts/db.ts
+++ b/plugins/claude-code/skills/session/scripts/db.ts
@@ -67,13 +67,13 @@ async function createDatabase(dbPath: string): Promise<Database> {
     close() {
       try {
         connection.closeSync();
-      } catch (err) {
-        console.error("Failed to close DuckDB connection:", err);
+      } catch (error) {
+        console.error("Failed to close DuckDB connection:", error);
       }
       try {
         instance.closeSync();
-      } catch (err) {
-        console.error("Failed to close DuckDB instance:", err);
+      } catch (error) {
+        console.error("Failed to close DuckDB instance:", error);
       }
     },
   };

--- a/plugins/claude-code/skills/session/scripts/query-header.ts
+++ b/plugins/claude-code/skills/session/scripts/query-header.ts
@@ -66,9 +66,9 @@ export async function loadQueryHeaders(dir: string = QUERIES_DIR): Promise<Query
         const header = parseQueryHeader(await Bun.file(path.join(dir, file)).text());
         if (header.name !== name) throw new Error(`header names "${header.name}"`);
         return header;
-      } catch (err) {
-        throw new Error(`${file}: ${err instanceof Error ? err.message : String(err)}`, {
-          cause: err,
+      } catch (error) {
+        throw new Error(`${file}: ${error instanceof Error ? error.message : String(error)}`, {
+          cause: error,
         });
       }
     }),

--- a/plugins/claude-code/skills/session/scripts/refresh.ts
+++ b/plugins/claude-code/skills/session/scripts/refresh.ts
@@ -54,9 +54,9 @@ async function cleanupStrayDatabases(): Promise<void> {
       // oxlint-disable-next-line no-await-in-loop -- two known stray directories; concurrency buys nothing.
       await rm(dir, { recursive: true, force: true });
       console.error(`refresh: removed stale index at ${dir}`);
-    } catch (err) {
+    } catch (error) {
       console.error(
-        `refresh: could not remove stale index at ${dir}: ${err instanceof Error ? err.message : String(err)}`,
+        `refresh: could not remove stale index at ${dir}: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }
@@ -76,11 +76,11 @@ async function openWithRetry(): Promise<Database | null> {
     try {
       // oxlint-disable-next-line no-await-in-loop -- retry loop: an attempt runs only because the previous one hit the write lock.
       return await getDb(dataDir);
-    } catch (err) {
-      if (!/lock/i.test(String(err)) || attempt >= 3) {
+    } catch (error) {
+      if (!/lock/i.test(String(error)) || attempt >= 3) {
         // oxlint-disable-next-line no-await-in-loop -- retry loop: an attempt runs only because the previous one hit the write lock.
-        if ((await Bun.file(dbPath).exists()) && /lock/i.test(String(err))) return null;
-        throw err;
+        if ((await Bun.file(dbPath).exists()) && /lock/i.test(String(error))) return null;
+        throw error;
       }
     }
     // oxlint-disable-next-line no-await-in-loop -- backoff between lock retries.

--- a/plugins/comments/skills/audit/scripts/io.ts
+++ b/plugins/comments/skills/audit/scripts/io.ts
@@ -10,4 +10,6 @@ export const consoleIo: AuditIo = {
 };
 
 /** A failure the user can act on. The CLI prints the message alone and exits 1. */
-export class AuditError extends Error {}
+export class AuditError extends Error {
+  override readonly name = "AuditError";
+}

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -194,10 +194,8 @@ export function deriveEvents(
       events.push({ type: "queued-timeout", minutes: queuedTimeoutMinutes });
       next = { ...next, queuedTimeoutEmitted: true };
     }
-  } else {
-    if (next.queuedSince !== null || next.queuedTimeoutEmitted) {
-      next = { ...next, queuedSince: null, queuedTimeoutEmitted: false };
-    }
+  } else if (next.queuedSince !== null || next.queuedTimeoutEmitted) {
+    next = { ...next, queuedSince: null, queuedTimeoutEmitted: false };
   }
 
   return { events, state: next };
@@ -304,9 +302,11 @@ function exec(command: string): ExecResult {
   try {
     const stdout = execSync(command, execOptions).toString().trim();
     return { ok: true, stdout };
-  } catch (err) {
+  } catch (error) {
     const stderr =
-      typeof err === "object" && err !== null && "stderr" in err ? streamText(err.stderr) : "";
+      typeof error === "object" && error !== null && "stderr" in error
+        ? streamText(error.stderr)
+        : "";
     const { rateLimited, retryAfter } = detectRateLimit(stderr);
     return { ok: false, stderr, rateLimited, retryAfter };
   }
@@ -496,8 +496,8 @@ export function probePr(prNumber: number, repo: string, run: ExecFn = exec): Pro
   let view: z.infer<typeof PrView>;
   try {
     view = PrView.parse(JSON.parse(prResult.stdout));
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
     console.error(`gh pr view returned unparseable JSON for PR #${prNumber}: ${message}`);
     return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
@@ -533,8 +533,8 @@ export function probePr(prNumber: number, repo: string, run: ExecFn = exec): Pro
     state = deriveChecksState(
       Checks.parse(JSON.parse(checksResult.stdout !== "" ? checksResult.stdout : "[]")),
     );
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
     console.error(`gh pr checks returned unusable JSON for PR #${prNumber}: ${message}`);
     return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
@@ -559,8 +559,8 @@ export function probePr(prNumber: number, repo: string, run: ExecFn = exec): Pro
         JSON.parse(runsResult.stdout !== "" ? runsResult.stdout : "[]"),
       );
       runId = selectRunId(runs, sha);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       console.error(`gh run list returned unusable JSON for ${repo}@${sha}: ${message}`);
       return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
     }
@@ -609,8 +609,8 @@ export function probeBranch(repo: string, branch: string, run: ExecFn = exec): P
   let runs: RunView[];
   try {
     runs = RunList.parse(JSON.parse(result.stdout !== "" ? result.stdout : "[]"));
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
     console.error(`gh run list returned unusable JSON for ${repo}@${branch}: ${message}`);
     return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
@@ -642,9 +642,9 @@ function fetchInterval(branch: string, repo: string | null): number {
   try {
     const parsed = Durations.parse(JSON.parse(result.stdout !== "" ? result.stdout : "[]"));
     return computeInterval(parsed.filter((n): n is number => typeof n === "number"));
-  } catch (err) {
+  } catch (error) {
     console.error(
-      `gh run list returned unparseable JSON while computing poll interval for ${branch}; defaulting to ${DEFAULT_INTERVAL_SECONDS}s: ${err instanceof Error ? err.message : String(err)}`,
+      `gh run list returned unparseable JSON while computing poll interval for ${branch}; defaulting to ${DEFAULT_INTERVAL_SECONDS}s: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
   return DEFAULT_INTERVAL_SECONDS;
@@ -671,8 +671,8 @@ export function probeRunId(runId: string, repo: string, run: ExecFn = exec): Pro
   let view: RunView;
   try {
     view = RunView.parse(JSON.parse(result.stdout !== "" ? result.stdout : "{}"));
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
     console.error(`gh run view returned unusable JSON for run ${runId}: ${message}`);
     return { kind: "error", rateLimited: false, retryAfter: "", stderr: message };
   }
@@ -872,8 +872,8 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.main) {
-  main().catch((err) => {
-    console.error(err instanceof Error ? err.message : String(err));
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);
   });
 }

--- a/plugins/gitlab/scripts/merge.ts
+++ b/plugins/gitlab/scripts/merge.ts
@@ -54,8 +54,8 @@ export async function arm(
       // oxlint-disable-next-line no-await-in-loop -- retry loop: an attempt runs only because the previous one failed transiently.
       await run();
       return;
-    } catch (err) {
-      const message = errorText(err);
+    } catch (error) {
+      const message = errorText(error);
       if (message.includes(ALREADY_ARMED)) {
         return;
       }
@@ -64,7 +64,7 @@ export async function arm(
         await sleep(RETRY_DELAY_MS);
         continue;
       }
-      throw err;
+      throw error;
     }
   }
 }

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
@@ -188,10 +188,8 @@ export function deriveEvents(
       events.push({ type: "queued-timeout", minutes: queuedTimeoutMinutes });
       next = { ...next, queuedTimeoutEmitted: true };
     }
-  } else {
-    if (next.queuedSince !== null || next.queuedTimeoutEmitted) {
-      next = { ...next, queuedSince: null, queuedTimeoutEmitted: false };
-    }
+  } else if (next.queuedSince !== null || next.queuedTimeoutEmitted) {
+    next = { ...next, queuedSince: null, queuedTimeoutEmitted: false };
   }
 
   return { events, state: next };
@@ -415,9 +413,11 @@ function exec(command: string): ExecResult {
   try {
     const stdout = execSync(command, execOptions).toString().trim();
     return { ok: true, stdout };
-  } catch (err) {
+  } catch (error) {
     const stderr =
-      typeof err === "object" && err !== null && "stderr" in err ? streamText(err.stderr) : "";
+      typeof error === "object" && error !== null && "stderr" in error
+        ? streamText(error.stderr)
+        : "";
     // glab does not surface structured rate-limit metadata. Rather than
     // regexing human text we rely on the api-error counter instead.
     return { ok: false, stderr, rateLimited: false, retryAfter: "" };
@@ -468,9 +468,9 @@ function fetchMrMetadata(
         state: parsed.state,
       },
     };
-  } catch (err) {
+  } catch (error) {
     console.error(
-      `glab api returned unparseable JSON for MR !${iid}: ${err instanceof Error ? err.message : String(err)}`,
+      `glab api returned unparseable JSON for MR !${iid}: ${error instanceof Error ? error.message : String(error)}`,
     );
     return { ok: false, rateLimited: false, retryAfter: "" };
   }
@@ -557,9 +557,9 @@ function fetchPipelineList(
   let parsed: unknown;
   try {
     parsed = JSON.parse(result.stdout !== "" ? result.stdout : "null");
-  } catch (err) {
+  } catch (error) {
     console.error(
-      `glab api returned unparseable JSON for pipelines on ${describeTarget(target)}: ${err instanceof Error ? err.message : String(err)}`,
+      `glab api returned unparseable JSON for pipelines on ${describeTarget(target)}: ${error instanceof Error ? error.message : String(error)}`,
     );
     return { ok: false, rateLimited: false, retryAfter: "" };
   }
@@ -589,9 +589,9 @@ function fetchJobs(projectEncoded: string, pipelineId: string, run: ExecFn = exe
   let parsed: unknown;
   try {
     parsed = JSON.parse(result.stdout !== "" ? result.stdout : "null");
-  } catch (err) {
+  } catch (error) {
     console.error(
-      `glab api returned unparseable JSON for jobs on pipeline ${pipelineId}: ${err instanceof Error ? err.message : String(err)}`,
+      `glab api returned unparseable JSON for jobs on pipeline ${pipelineId}: ${error instanceof Error ? error.message : String(error)}`,
     );
     return { ok: false };
   }
@@ -732,9 +732,9 @@ function fetchPipelineById(
       return { ok: false, rateLimited: false, retryAfter: "", notFound: false };
     }
     return { ok: true, pipeline };
-  } catch (err) {
+  } catch (error) {
     console.error(
-      `glab api returned unparseable JSON for pipeline ${pipelineId}: ${err instanceof Error ? err.message : String(err)}`,
+      `glab api returned unparseable JSON for pipeline ${pipelineId}: ${error instanceof Error ? error.message : String(error)}`,
     );
     return { ok: false, rateLimited: false, retryAfter: "", notFound: false };
   }
@@ -816,9 +816,9 @@ function fetchInterval(projectEncoded: string, target: PipelineTarget): number {
     console.error(
       `glab api returned non-array JSON while computing poll interval for ${label}; defaulting to ${DEFAULT_INTERVAL_SECONDS}s`,
     );
-  } catch (err) {
+  } catch (error) {
     console.error(
-      `glab api returned unparseable JSON while computing poll interval for ${label}; defaulting to ${DEFAULT_INTERVAL_SECONDS}s: ${err instanceof Error ? err.message : String(err)}`,
+      `glab api returned unparseable JSON while computing poll interval for ${label}; defaulting to ${DEFAULT_INTERVAL_SECONDS}s: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
   return DEFAULT_INTERVAL_SECONDS;
@@ -1040,8 +1040,8 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.main) {
-  main().catch((err) => {
-    console.error(err instanceof Error ? err.message : String(err));
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);
   });
 }

--- a/plugins/gitlab/skills/merge-request/scripts/draft-note.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/draft-note.ts
@@ -248,9 +248,9 @@ const reviewCmd = command(
         // oxlint-disable-next-line no-await-in-loop -- one API POST per note; the created/failed tally and its error lines follow entry order.
         await glabApiPost(apiPath(mr), payload);
         created++;
-      } catch (err) {
+      } catch (error) {
         console.error(
-          `Failed: ${entry.file ?? "general"}: ${err instanceof Error ? err.message : String(err)}`,
+          `Failed: ${entry.file ?? "general"}: ${error instanceof Error ? error.message : String(error)}`,
         );
         failed++;
       }

--- a/plugins/issue/evals/issue-refine/label/server.ts
+++ b/plugins/issue/evals/issue-refine/label/server.ts
@@ -43,7 +43,9 @@ async function readAllFeedback(): Promise<Record<string, unknown>> {
       .map(async (n) => {
         try {
           out[n.replace(/\.json$/, "")] = await Bun.file(join(argv.flags.feedback, n)).json();
-        } catch {}
+        } catch {
+          // best-effort: skip a feedback file that fails to parse rather than blocking the rest
+        }
       }),
   );
   return out;

--- a/plugins/meme/skills/image/scripts/spec.ts
+++ b/plugins/meme/skills/image/scripts/spec.ts
@@ -50,7 +50,9 @@ export const Spec = z
   });
 export type Spec = z.infer<typeof Spec>;
 
-class SpecError extends Error {}
+class SpecError extends Error {
+  override readonly name = "SpecError";
+}
 
 function fail(path: string, message: string): never {
   throw new SpecError(`${path}: ${message}`);

--- a/plugins/newline/scripts/newline.test.ts
+++ b/plugins/newline/scripts/newline.test.ts
@@ -54,7 +54,9 @@ beforeEach(async () => {
 afterEach(async () => {
   try {
     await rm(testDir, { recursive: true, force: true });
-  } catch {}
+  } catch {
+    // test cleanup: a failed removal shouldn't fail the test
+  }
   await clearAllState();
 });
 

--- a/plugins/pull-request/evals/pr-body/label/server.ts
+++ b/plugins/pull-request/evals/pr-body/label/server.ts
@@ -42,7 +42,9 @@ async function readAllFeedback(): Promise<Record<string, unknown>> {
       .map(async (n) => {
         try {
           out[n.replace(/\.json$/, "")] = await Bun.file(join(argv.flags.feedback, n)).json();
-        } catch {}
+        } catch {
+          // best-effort: skip a feedback file that fails to parse rather than blocking the rest
+        }
       }),
   );
   return out;

--- a/plugins/review/evals/review-voice/label/server.ts
+++ b/plugins/review/evals/review-voice/label/server.ts
@@ -48,7 +48,9 @@ async function readAllLabels(): Promise<Record<string, unknown>> {
       .map(async (name) => {
         try {
           out[name.replace(/\.json$/, "")] = await Bun.file(join(argv.flags.labels, name)).json();
-        } catch {}
+        } catch {
+          // best-effort: skip a label file that fails to parse rather than blocking the rest
+        }
       }),
   );
   return out;

--- a/plugins/review/skills/inbox/scripts/poll.ts
+++ b/plugins/review/skills/inbox/scripts/poll.ts
@@ -26,8 +26,8 @@ export async function fetchUrls(command: string): Promise<FetchResult> {
   try {
     const entries = Queue.parse(JSON.parse(stdoutText));
     return { ok: true, urls: entries.map((entry) => entry.url) };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
     return { ok: false, reason: `JSON parse failed: ${message}` };
   }
 }

--- a/plugins/review/skills/inbox/scripts/store.test.ts
+++ b/plugins/review/skills/inbox/scripts/store.test.ts
@@ -55,6 +55,20 @@ describe("store", () => {
       expect(readState(tmpDir)).rejects.toThrow("Invalid state file");
     });
 
+    test("keeps the parse failure as the cause when the file is not JSON", async () => {
+      const dir = join(tmpDir, "review-inbox");
+      mkdirSync(dir, { recursive: true });
+      await Bun.write(join(dir, "state.json"), "{ not json");
+
+      const thrown = await readState(tmpDir).catch((error: unknown) => error);
+
+      expect(thrown).toHaveProperty(
+        "message",
+        expect.stringContaining("Failed to parse state file"),
+      );
+      expect(thrown).toHaveProperty("cause", expect.any(SyntaxError));
+    });
+
     test("migrates the pre-background { reviews } schema to an empty dedup set", async () => {
       const dir = join(tmpDir, "review-inbox");
       mkdirSync(dir, { recursive: true });

--- a/plugins/review/skills/inbox/scripts/store.ts
+++ b/plugins/review/skills/inbox/scripts/store.ts
@@ -46,8 +46,8 @@ export async function readState(dataDir?: string): Promise<InboxState> {
   let data: unknown;
   try {
     data = await file.json();
-  } catch (cause) {
-    throw new Error(`Failed to parse state file: ${file.name}`, { cause });
+  } catch (error) {
+    throw new Error(`Failed to parse state file: ${file.name}`, { cause: error });
   }
   const state = InboxState.safeParse(data);
   if (state.success) return state.data;

--- a/plugins/writing/evals/writing/label/server.ts
+++ b/plugins/writing/evals/writing/label/server.ts
@@ -45,7 +45,9 @@ async function readAllFeedback(): Promise<Record<string, unknown>> {
       .map(async (n) => {
         try {
           out[n.replace(/\.json$/, "")] = await Bun.file(join(argv.flags.feedback, n)).json();
-        } catch {}
+        } catch {
+          // best-effort: skip a feedback file that fails to parse rather than blocking the rest
+        }
       }),
   );
   return out;

--- a/plugins/writing/skills/analyze/scripts/db.ts
+++ b/plugins/writing/skills/analyze/scripts/db.ts
@@ -70,8 +70,8 @@ export async function openSessionDb(dbPath: string): Promise<Database> {
     close() {
       try {
         connection.closeSync();
-      } catch (err) {
-        console.error("Failed to close DuckDB connection:", err);
+      } catch (error) {
+        console.error("Failed to close DuckDB connection:", error);
       }
     },
   };

--- a/plugins/writing/skills/analyze/scripts/wordlists.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlists.ts
@@ -13,9 +13,9 @@ export async function loadWordlists(dir: string): Promise<WordlistEntry[]> {
   let files: string[];
   try {
     files = readdirSync(dir).filter((f) => f.endsWith(".txt"));
-  } catch (err) {
-    if (FileError.safeParse(err).data?.code === "ENOENT") return [];
-    throw err;
+  } catch (error) {
+    if (FileError.safeParse(error).data?.code === "ENOENT") return [];
+    throw error;
   }
   const perFile = await Promise.all(
     files.toSorted().map(async (file) => {


### PR DESCRIPTION
Enables `unicorn/catch-error-name`, `no-empty`, `unicorn/custom-error-definition`, and `no-lonely-if` in `lint/base.json`. Each rule carries a comment on the cost of the banned form. Fixes every violation the four rules found.

`oxlint --fix` renamed 27 catch bindings to `error`. In `plugins/review/skills/inbox/scripts/store.ts` it also renamed the shorthand `{ cause }` option key to `{ error }`, silently dropping the thrown error's cause chain. Restored it to `{ cause: error }`.

Two `Error` subclasses (`SpecError`, `AuditError`) never set `.name` and printed as generic `Error`; both now set it. Two `else { if }` blocks in the GitHub and GitLab CI-monitor watchers collapsed to `else if`.

The eight bare `catch {}` blocks each got a one-line reason for why the failure is safe to swallow:

- Four eval label/feedback-file readers skip one bad JSON entry rather than failing the whole scan.
- A test's cleanup ignores a failed `rm` of its temp dir.
- Two transcript-parsing hooks skip a malformed JSONL line rather than breaking the hook.
- Clearing a stale block-count file is best-effort: a later write overwrites it regardless.

## Unrelated Main Repair

Rebasing surfaced a break that predates this branch. `vitest/prefer-each` flags any loop whose body it reads as a repeated case, so repo-wide it fires on ordinary source loops.

`plugins/meme/skills/image/scripts/render.ts` draws one text line per iteration and gets told to use `it.each`. That loop arrived with `unicorn/no-array-for-each` in #1356 and the rule with #1355. Each was green alone and red together once both landed, taking `lint`, `build`, and `hooks` down.

Scoped the rule the way `vitest/no-commented-out-tests` already is: off in the base rules, on under `**/*.test.ts`, where a repeated case is a test.
