### PR TITLE
lint: enable vitest/prefer-each and convert loops

### DIFF
--- a/lint/base.json
+++ b/lint/base.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../node_modules/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "unicorn", "oxc", "promise", "node", "import"],
+  "plugins": ["typescript", "unicorn", "oxc", "promise", "node", "import", "vitest"],
   "categories": {
     "correctness": "error",
     "suspicious": "error"
@@ -39,13 +39,25 @@
     // `replace()` needs a global regex to hit every match, and a dropped `g` flag silently replaces only the first one. `replaceAll()` makes the intent explicit and takes a plain string when there's no pattern to match.
     "unicorn/prefer-string-replace-all": "error",
     // `substring()` swaps out-of-order arguments and clamps negatives instead of indexing from the end. `substr()` is deprecated and its second argument is a length. `slice()` is the one method with consistent, current semantics.
-    "unicorn/prefer-string-slice": "error"
+    "unicorn/prefer-string-slice": "error",
+    // vitest/no-commented-out-tests only means something in test files.
+    // Enabled repo-wide via the plugin's categories, it runs over source
+    // prose too and produces false positives like db.ts's
+    // "... it (00_pinned.sql), so ...", which reads like a commented-out
+    // `it(...)` call but isn't one. Off here. Enabled only under
+    // **/*.test.ts below, where a commented-out test can actually occur.
+    "vitest/no-commented-out-tests": "off",
+    // This repo tests with bun:test, not vitest. The vitest plugin matches
+    // on the Jest-style API shape rather than the import, so it still
+    // applies correctly here.
+    "vitest/prefer-each": "error"
   },
   "overrides": [
     {
       "files": ["**/*.test.ts"],
       "rules": {
-        "unicorn/consistent-function-scoping": "off"
+        "unicorn/consistent-function-scoping": "off",
+        "vitest/no-commented-out-tests": "error"
       }
     }
   ]

--- a/packages/validate/validate.test.ts
+++ b/packages/validate/validate.test.ts
@@ -82,28 +82,26 @@ describe("validateFile", () => {
     },
   ];
 
-  for (const fixture of fixtures) {
-    it(fixture.name, async () => {
-      const file = join(tempDir, `${fixture.name.replaceAll(/\s+/g, "-")}.json`);
-      await Bun.write(file, JSON.stringify(fixture.data));
+  it.each(fixtures)("$name", async (fixture) => {
+    const file = join(tempDir, `${fixture.name.replaceAll(/\s+/g, "-")}.json`);
+    await Bun.write(file, JSON.stringify(fixture.data));
 
-      const result = await validateFile(
-        file,
-        schemaPath,
-        fixture.warnAdditional ? { warnAdditional: true } : undefined,
-      );
+    const result = await validateFile(
+      file,
+      schemaPath,
+      fixture.warnAdditional ? { warnAdditional: true } : undefined,
+    );
 
-      expect(result.errors).toHaveLength(fixture.errors.length);
-      for (const [i, pattern] of fixture.errors.entries()) {
-        expect(result.errors[i]).toContain(pattern);
-      }
+    expect(result.errors).toHaveLength(fixture.errors.length);
+    for (const [i, pattern] of fixture.errors.entries()) {
+      expect(result.errors[i]).toContain(pattern);
+    }
 
-      expect(result.warnings).toHaveLength(fixture.warnings.length);
-      for (const [i, pattern] of fixture.warnings.entries()) {
-        expect(result.warnings[i]).toContain(pattern);
-      }
-    });
-  }
+    expect(result.warnings).toHaveLength(fixture.warnings.length);
+    for (const [i, pattern] of fixture.warnings.entries()) {
+      expect(result.warnings[i]).toContain(pattern);
+    }
+  });
 });
 
 describe("formatError", () => {
@@ -137,24 +135,22 @@ describe("formatError", () => {
     },
   ];
 
-  for (const fixture of fixtures) {
-    it(fixture.name, () => {
-      // isCI() reads both CI and GITHUB_ACTIONS; control both so the ambient
-      // CI environment (GITHUB_ACTIONS=true on Actions) cannot leak in.
-      const original = { CI: process.env.CI, GITHUB_ACTIONS: process.env.GITHUB_ACTIONS };
-      process.env.CI = fixture.ci ? "true" : "";
-      process.env.GITHUB_ACTIONS = fixture.ci ? "true" : "";
+  it.each(fixtures)("$name", (fixture) => {
+    // isCI() reads both CI and GITHUB_ACTIONS; control both so the ambient
+    // CI environment (GITHUB_ACTIONS=true on Actions) cannot leak in.
+    const original = { CI: process.env.CI, GITHUB_ACTIONS: process.env.GITHUB_ACTIONS };
+    process.env.CI = fixture.ci ? "true" : "";
+    process.env.GITHUB_ACTIONS = fixture.ci ? "true" : "";
 
-      try {
-        const result = formatError(fixture.file, fixture.error);
-        expect(result).toBe(fixture.expected);
-      } finally {
-        for (const key of ["CI", "GITHUB_ACTIONS"] as const) {
-          const value = original[key];
-          if (value === undefined) delete process.env[key];
-          else process.env[key] = value;
-        }
+    try {
+      const result = formatError(fixture.file, fixture.error);
+      expect(result).toBe(fixture.expected);
+    } finally {
+      for (const key of ["CI", "GITHUB_ACTIONS"] as const) {
+        const value = original[key];
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
       }
-    });
-  }
+    }
+  });
 });

--- a/plugins/writing/detection/examples.test.ts
+++ b/plugins/writing/detection/examples.test.ts
@@ -10,6 +10,13 @@ import { PATTERNS, type PatternDef } from "./tropes";
 
 const ALL_PATTERNS: PatternDef[] = [...PATTERNS, ...BATCH_PATTERNS];
 
+// An unabridged example runs past 2000 characters and carries newlines, which
+// leaves reporter output unscannable. Bound and escape it for the title the way
+// the hand-built titles did before these cases became parameterized.
+function labeled(texts: readonly string[]): { label: string; text: string }[] {
+  return texts.map((text) => ({ label: JSON.stringify(text.slice(0, 60)), text }));
+}
+
 function hits(def: PatternDef, text: string): number {
   if (typeof def.test === "function") {
     return def.test(text).count;
@@ -25,12 +32,12 @@ describe("pattern examples", () => {
       expect(def.negatives.length).toBeGreaterThanOrEqual(2);
     });
 
-    it.each(def.positives)("matches: %s", (positive) => {
-      expect(hits(def, positive)).toBeGreaterThan(0);
+    it.each(labeled(def.positives))("matches: $label", ({ text }) => {
+      expect(hits(def, text)).toBeGreaterThan(0);
     });
 
-    it.each(def.negatives)("does not match: %s", (negative) => {
-      expect(hits(def, negative)).toBe(0);
+    it.each(labeled(def.negatives))("does not match: $label", ({ text }) => {
+      expect(hits(def, text)).toBe(0);
     });
   });
 

--- a/plugins/writing/detection/examples.test.ts
+++ b/plugins/writing/detection/examples.test.ts
@@ -19,26 +19,20 @@ function hits(def: PatternDef, text: string): number {
 }
 
 describe("pattern examples", () => {
-  for (const def of ALL_PATTERNS) {
-    describe(def.category, () => {
-      it("has at least 2 positives and 2 negatives", () => {
-        expect(def.positives.length).toBeGreaterThanOrEqual(2);
-        expect(def.negatives.length).toBeGreaterThanOrEqual(2);
-      });
-
-      for (const positive of def.positives) {
-        it(`matches: ${JSON.stringify(positive.slice(0, 60))}`, () => {
-          expect(hits(def, positive)).toBeGreaterThan(0);
-        });
-      }
-
-      for (const negative of def.negatives) {
-        it(`does not match: ${JSON.stringify(negative.slice(0, 60))}`, () => {
-          expect(hits(def, negative)).toBe(0);
-        });
-      }
+  describe.each(ALL_PATTERNS)("$category", (def) => {
+    it("has at least 2 positives and 2 negatives", () => {
+      expect(def.positives.length).toBeGreaterThanOrEqual(2);
+      expect(def.negatives.length).toBeGreaterThanOrEqual(2);
     });
-  }
+
+    it.each(def.positives)("matches: %s", (positive) => {
+      expect(hits(def, positive)).toBeGreaterThan(0);
+    });
+
+    it.each(def.negatives)("does not match: %s", (negative) => {
+      expect(hits(def, negative)).toBe(0);
+    });
+  });
 
   it("labels every pattern with a layer", () => {
     for (const def of ALL_PATTERNS) {

--- a/plugins/writing/detection/tropes.test.ts
+++ b/plugins/writing/detection/tropes.test.ts
@@ -84,11 +84,9 @@ describe("scan", () => {
       expect(match[0]?.message).toContain("two sentences");
     });
 
-    for (const allowed of ["This is\u2014fine", "2024 \u2013 2025"]) {
-      it(`allows: "${allowed}"`, () => {
-        expect(firstByTier(scan(allowed), "deny")).toBeUndefined();
-      });
-    }
+    it.each(["This is\u2014fine", "2024 \u2013 2025"])('allows: "%s"', (allowed) => {
+      expect(firstByTier(scan(allowed), "deny")).toBeUndefined();
+    });
   });
 
   describe("AI vocabulary", () => {
@@ -104,35 +102,30 @@ describe("scan", () => {
       "nuanced",
     ];
 
-    for (const word of words) {
-      it(`detects "${word}"`, () => {
-        const deny = firstByTier(scan(`The ${word} of the project`), "deny");
-        expect(deny?.category).toBe("AI vocabulary");
-      });
-    }
+    it.each(words)('detects "%s"', (word) => {
+      const deny = firstByTier(scan(`The ${word} of the project`), "deny");
+      expect(deny?.category).toBe("AI vocabulary");
+    });
 
-    for (const safe of ["```\ndelve into code\n```", "The `delve` function"]) {
-      it(`ignores in code: "${safe.slice(0, 30)}..."`, () => {
+    it.each(["```\ndelve into code\n```", "The `delve` function"])(
+      'ignores in code: "%s..."',
+      (safe) => {
         expect(firstByTier(scan(safe), "deny")).toBeUndefined();
-      });
-    }
+      },
+    );
   });
 
   describe("copula avoidance", () => {
     const deny = ["The module serves as the entry point", "This stands as a reminder"];
     const allow = ["The restaurant serves food"];
 
-    for (const text of deny) {
-      it(`flags: "${text}"`, () => {
-        expect(firstByTier(scan(text), "deny")?.category).toBe("copula avoidance");
-      });
-    }
+    it.each(deny)('flags: "%s"', (text) => {
+      expect(firstByTier(scan(text), "deny")?.category).toBe("copula avoidance");
+    });
 
-    for (const text of allow) {
-      it(`allows: "${text}"`, () => {
-        expect(firstByTier(scan(text), "deny")).toBeUndefined();
-      });
-    }
+    it.each(allow)('allows: "%s"', (text) => {
+      expect(firstByTier(scan(text), "deny")).toBeUndefined();
+    });
   });
 
   describe("test result reporting", () => {
@@ -189,27 +182,21 @@ describe("scan", () => {
       "Write a test for this function.",
     ];
 
-    for (const text of shouldFlag) {
-      it(`flags: "${text.slice(0, 60)}..."`, () => {
-        expect(firstByTier(scan(text), "context")?.category).toBe("test result reporting");
-      });
-    }
+    it.each(shouldFlag)('flags: "%s"', (text) => {
+      expect(firstByTier(scan(text), "context")?.category).toBe("test result reporting");
+    });
 
-    for (const text of shouldNotFlag) {
-      it(`allows: "${text.slice(0, 60)}..."`, () => {
-        expect(scan(text).find((m) => m.category === "test result reporting")).toBeUndefined();
-      });
-    }
+    it.each(shouldNotFlag)('allows: "%s"', (text) => {
+      expect(scan(text).find((m) => m.category === "test result reporting")).toBeUndefined();
+    });
   });
 
   describe("promotional language", () => {
     const flag = ["The library boasts excellent performance", "A groundbreaking approach"];
 
-    for (const text of flag) {
-      it(`flags: "${text}"`, () => {
-        expect(firstByTier(scan(text), "context")?.category).toBe("promotional language");
-      });
-    }
+    it.each(flag)('flags: "%s"', (text) => {
+      expect(firstByTier(scan(text), "context")?.category).toBe("promotional language");
+    });
   });
 
   describe("no X needed brag", () => {
@@ -231,17 +218,13 @@ describe("scan", () => {
       "There is no way the runtime needed that much memory.",
     ];
 
-    for (const text of flag) {
-      it(`flags: "${text}"`, () => {
-        expect(firstByTier(scan(text), "context")?.category).toBe("no X needed brag");
-      });
-    }
+    it.each(flag)('flags: "%s"', (text) => {
+      expect(firstByTier(scan(text), "context")?.category).toBe("no X needed brag");
+    });
 
-    for (const text of allow) {
-      it(`allows: ${JSON.stringify(text)}`, () => {
-        expect(scan(text).find((m) => m.category === "no X needed brag")).toBeUndefined();
-      });
-    }
+    it.each(allow)("allows: %j", (text) => {
+      expect(scan(text).find((m) => m.category === "no X needed brag")).toBeUndefined();
+    });
   });
 
   describe("parallelism", () => {
@@ -251,17 +234,13 @@ describe("scan", () => {
     ];
     const allow = ["Not just yet"];
 
-    for (const text of flag) {
-      it(`flags: "${text}"`, () => {
-        expect(firstByTier(scan(text), "context")?.category).toBe("parallelism");
-      });
-    }
+    it.each(flag)('flags: "%s"', (text) => {
+      expect(firstByTier(scan(text), "context")?.category).toBe("parallelism");
+    });
 
-    for (const text of allow) {
-      it(`allows: "${text}"`, () => {
-        expect(firstByTier(scan(text), "context")).toBeUndefined();
-      });
-    }
+    it.each(allow)('allows: "%s"', (text) => {
+      expect(firstByTier(scan(text), "context")).toBeUndefined();
+    });
   });
 
   describe("connector density", () => {
@@ -274,16 +253,14 @@ describe("scan", () => {
     const hyphen =
       "The cache starts cold - the first request fills it. The retry logic backs off - later attempts succeed. The parser rejects malformed input - it returns an error. The server validates each field. The client sends a token. The job runs nightly.";
 
-    for (const [name, text] of [
+    it.each([
       ["semicolons", semicolons],
       ["unspaced em dashes", emDashes],
       ["mixed connectors", mixed],
       ["letter-flanked hyphens", hyphen],
-    ] as const) {
-      it(`flags ${name}`, () => {
-        expect(firstByTier(scan(text), "context")?.category).toBe("connector density");
-      });
-    }
+    ] as const)("flags %s", (_name, text) => {
+      expect(firstByTier(scan(text), "context")?.category).toBe("connector density");
+    });
 
     it("fires at exactly 30% density (3 of 10)", () => {
       const text =
@@ -402,13 +379,11 @@ describe("scan", () => {
       );
     });
 
-    for (const path of ["script.sh", "index.ts", "style.css"]) {
-      it(`skips in ${path}`, () => {
-        expect(
-          scan(semicolons, path).find((m) => m.category === "connector density"),
-        ).toBeUndefined();
-      });
-    }
+    it.each(["script.sh", "index.ts", "style.css"])("skips in %s", (path) => {
+      expect(
+        scan(semicolons, path).find((m) => m.category === "connector density"),
+      ).toBeUndefined();
+    });
   });
 
   describe("semicolon splice", () => {
@@ -463,13 +438,9 @@ describe("scan", () => {
       ).toBeDefined();
     });
 
-    for (const path of ["script.sh", "index.ts"]) {
-      it(`skips in ${path}`, () => {
-        expect(
-          scan(twoSplices, path).find((m) => m.category === "semicolon splice"),
-        ).toBeUndefined();
-      });
-    }
+    it.each(["script.sh", "index.ts"])("skips in %s", (path) => {
+      expect(scan(twoSplices, path).find((m) => m.category === "semicolon splice")).toBeUndefined();
+    });
   });
 
   it("returns all matches per tier", () => {
@@ -537,11 +508,9 @@ describe("scan", () => {
       "Open a sibling pane rather than reaching for Bash.",
       "Reach for the linter before the formatter.",
     ];
-    for (const text of flag) {
-      it(`flags: "${text}"`, () => {
-        expect(firstByTier(scan(text), "deny")?.category).toBe("reaching for");
-      });
-    }
+    it.each(flag)('flags: "%s"', (text) => {
+      expect(firstByTier(scan(text), "deny")?.category).toBe("reaching for");
+    });
   });
 
   describe("contrast not", () => {
@@ -563,17 +532,13 @@ describe("scan", () => {
       "```\nif err != nil, not ok\n```",
     ];
 
-    for (const text of flag) {
-      it(`flags: "${text}"`, () => {
-        expect(firstByTier(scan(text), "context")?.category).toBe("contrast not");
-      });
-    }
+    it.each(flag)('flags: "%s"', (text) => {
+      expect(firstByTier(scan(text), "context")?.category).toBe("contrast not");
+    });
 
-    for (const text of allow) {
-      it(`allows: ${JSON.stringify(text)}`, () => {
-        expect(scan(text).find((m) => m.category === "contrast not")).toBeUndefined();
-      });
-    }
+    it.each(allow)("allows: %j", (text) => {
+      expect(scan(text).find((m) => m.category === "contrast not")).toBeUndefined();
+    });
   });
 
   describe("passive PR summary", () => {
@@ -739,13 +704,11 @@ describe("scan", () => {
       "Dana,\nThe retry loop swallows the error.",
     ];
 
-    for (const text of addressed) {
-      it(`denies: ${JSON.stringify(text.slice(0, 40))}`, () => {
-        const match = salutation(text);
-        expect(match?.tier).toBe("deny");
-        expect(match?.structural).toBe(true);
-      });
-    }
+    it.each(addressed)("denies: %j", (text) => {
+      const match = salutation(text);
+      expect(match?.tier).toBe("deny");
+      expect(match?.structural).toBe(true);
+    });
 
     const substantive = [
       "Otherwise, this looks right.",
@@ -764,11 +727,9 @@ describe("scan", () => {
       "Tests, then the docs.",
     ];
 
-    for (const text of substantive) {
-      it(`allows: ${JSON.stringify(text.slice(0, 40))}`, () => {
-        expect(salutation(text)).toBeUndefined();
-      });
-    }
+    it.each(substantive)("allows: %j", (text) => {
+      expect(salutation(text)).toBeUndefined();
+    });
 
     it("ignores an address that is not on the opening line", () => {
       expect(salutation("The sweep is too broad.\n\nDana, it fires on every run.")).toBeUndefined();
@@ -791,21 +752,19 @@ describe("scan", () => {
       { text: "I understand the issue.", category: "I understand" },
     ];
 
-    for (const { text, category } of conversational) {
-      it(`fires without context: "${text.slice(0, 40)}"`, () => {
-        expect(scan(text).find((m) => m.category === category)).toBeDefined();
-      });
+    it.each(conversational)('fires without context: "$text"', ({ text, category }) => {
+      expect(scan(text).find((m) => m.category === category)).toBeDefined();
+    });
 
-      it(`fires in sideEffect context: "${text.slice(0, 40)}"`, () => {
-        expect(
-          scan(text, undefined, "sideEffect").find((m) => m.category === category),
-        ).toBeDefined();
-      });
+    it.each(conversational)('fires in sideEffect context: "$text"', ({ text, category }) => {
+      expect(
+        scan(text, undefined, "sideEffect").find((m) => m.category === category),
+      ).toBeDefined();
+    });
 
-      it(`skips in file context: "${text.slice(0, 40)}"`, () => {
-        expect(scan(text, undefined, "file").find((m) => m.category === category)).toBeUndefined();
-      });
-    }
+    it.each(conversational)('skips in file context: "$text"', ({ text, category }) => {
+      expect(scan(text, undefined, "file").find((m) => m.category === category)).toBeUndefined();
+    });
 
     it("non-conversational patterns still fire in file context", () => {
       expect(
@@ -847,16 +806,12 @@ describe("scan", () => {
       "a hatch you can escape through",
       "loudly proclaimed the failure",
     ];
-    for (const text of flag) {
-      it(`flags ${JSON.stringify(text)}`, () => {
-        expect(firstByTier(scan(text), "context")?.category).toBe("flowery phrasing");
-      });
-    }
-    for (const text of allow) {
-      it(`allows ${JSON.stringify(text)}`, () => {
-        expect(scan(text).find((m) => m.category === "flowery phrasing")).toBeUndefined();
-      });
-    }
+    it.each(flag)("flags %j", (text) => {
+      expect(firstByTier(scan(text), "context")?.category).toBe("flowery phrasing");
+    });
+    it.each(allow)("allows %j", (text) => {
+      expect(scan(text).find((m) => m.category === "flowery phrasing")).toBeUndefined();
+    });
     it("does not fire in non-prose file context", () => {
       expect(
         scan("a single source of truth", "module.ts", "file").find(

--- a/plugins/writing/hooks/headings.test.ts
+++ b/plugins/writing/hooks/headings.test.ts
@@ -66,16 +66,14 @@ const titleCaseCases: { description: string; content: string; match: boolean }[]
 ];
 
 describe("checkTitleCase", () => {
-  for (const { description, content, match } of titleCaseCases) {
-    it(description, () => {
-      const result = checkTitleCase(content);
-      if (match) {
-        expect(result).not.toBeNull();
-      } else {
-        expect(result).toBeNull();
-      }
-    });
-  }
+  it.each(titleCaseCases)("$description", ({ content, match }) => {
+    const result = checkTitleCase(content);
+    if (match) {
+      expect(result).not.toBeNull();
+    } else {
+      expect(result).toBeNull();
+    }
+  });
 });
 
 const boldAsHeadingCases: { description: string; content: string; match: boolean }[] = [
@@ -95,16 +93,14 @@ const boldAsHeadingCases: { description: string; content: string; match: boolean
 ];
 
 describe("checkBoldAsHeading", () => {
-  for (const { description, content, match } of boldAsHeadingCases) {
-    it(description, () => {
-      const result = checkBoldAsHeading(content);
-      if (match) {
-        expect(result).not.toBeNull();
-      } else {
-        expect(result).toBeNull();
-      }
-    });
-  }
+  it.each(boldAsHeadingCases)("$description", ({ content, match }) => {
+    const result = checkBoldAsHeading(content);
+    if (match) {
+      expect(result).not.toBeNull();
+    } else {
+      expect(result).toBeNull();
+    }
+  });
 });
 
 const sentenceHeadingCases: { description: string; content: string; match: boolean }[] = [
@@ -214,16 +210,14 @@ const sentenceHeadingCases: { description: string; content: string; match: boole
 ];
 
 describe("checkSentenceHeading", () => {
-  for (const { description, content, match } of sentenceHeadingCases) {
-    it(description, () => {
-      const result = checkSentenceHeading(content);
-      if (match) {
-        expect(result).not.toBeNull();
-      } else {
-        expect(result).toBeNull();
-      }
-    });
-  }
+  it.each(sentenceHeadingCases)("$description", ({ content, match }) => {
+    const result = checkSentenceHeading(content);
+    if (match) {
+      expect(result).not.toBeNull();
+    } else {
+      expect(result).toBeNull();
+    }
+  });
 });
 
 describe("processInput", () => {

--- a/plugins/writing/linguistics/classifiers.test.ts
+++ b/plugins/writing/linguistics/classifiers.test.ts
@@ -147,11 +147,9 @@ describe("compromise candidates", () => {
   const npTest = npTestClassifier(compromiseTagger);
   const hybrid = hybridClassifier(compromiseTagger);
 
-  for (const testCase of compromiseCases) {
-    it(testCase.description, () => {
-      expect(finiteVerb.classify(testCase.heading).flagged).toBe(testCase.finiteVerb);
-      expect(npTest.classify(testCase.heading).flagged).toBe(testCase.npTest);
-      expect(hybrid.classify(testCase.heading).flagged).toBe(testCase.hybrid);
-    });
-  }
+  it.each(compromiseCases)("$description", (testCase) => {
+    expect(finiteVerb.classify(testCase.heading).flagged).toBe(testCase.finiteVerb);
+    expect(npTest.classify(testCase.heading).flagged).toBe(testCase.npTest);
+    expect(hybrid.classify(testCase.heading).flagged).toBe(testCase.hybrid);
+  });
 });

--- a/plugins/writing/linguistics/fixtures.test.ts
+++ b/plugins/writing/linguistics/fixtures.test.ts
@@ -23,11 +23,9 @@ import { classifyHeadingBaseline } from "./heading";
 describe("sentence-heading false-positive ceiling", () => {
   // The gate: the baseline that ships in the hook flags none of the
   // conventional heading shapes documented in linguistics.md.
-  for (const { description, heading } of sentenceHeadingNegatives) {
-    it(`baseline does not flag: ${description}`, () => {
-      expect(classifyHeadingBaseline(heading).flagged).toBe(false);
-    });
-  }
+  it.each(sentenceHeadingNegatives)("baseline does not flag: $description", ({ heading }) => {
+    expect(classifyHeadingBaseline(heading).flagged).toBe(false);
+  });
 
   // Regression visibility for the eval-only candidates: each flags a
   // known number of these negatives today. This is recorded, not gated;
@@ -58,30 +56,24 @@ describe("sentence-heading positives", () => {
   // within reach and flagged; imperatives outside the nine-opener word set
   // are recorded as misses (~20% recall per linguistics.md), so this is
   // current behavior, not a recall gate the baseline would fail.
-  for (const { description, heading, baselineFlagged, kind } of sentenceHeadingPositives) {
-    it(description, () => {
-      const verdict = classifyHeadingBaseline(heading);
-      expect(verdict.flagged).toBe(baselineFlagged);
-      if (kind != null) {
-        expect(verdict.kind).toBe(kind);
-      }
-    });
-  }
+  it.each(sentenceHeadingPositives)("$description", ({ heading, baselineFlagged, kind }) => {
+    const verdict = classifyHeadingBaseline(heading);
+    expect(verdict.flagged).toBe(baselineFlagged);
+    if (kind != null) {
+      expect(verdict.kind).toBe(kind);
+    }
+  });
 });
 
 describe("title-case false-positive ceiling", () => {
   // The gate: AP-correct headings from issue #769 must not be flagged.
-  for (const { description, heading } of titleCaseNegatives) {
-    it(`accepts: ${description}`, () => {
-      expect(checkTitleCase(`## ${heading}`)).toBeNull();
-    });
-  }
+  it.each(titleCaseNegatives)("accepts: $description", ({ heading }) => {
+    expect(checkTitleCase(`## ${heading}`)).toBeNull();
+  });
 
   // The checker's real job stays intact: genuinely mis-cased headings are
   // still flagged after extending the stopword list.
-  for (const { description, heading } of titleCasePositives) {
-    it(`flags: ${description}`, () => {
-      expect(checkTitleCase(`## ${heading}`)).not.toBeNull();
-    });
-  }
+  it.each(titleCasePositives)("flags: $description", ({ heading }) => {
+    expect(checkTitleCase(`## ${heading}`)).not.toBeNull();
+  });
 });

--- a/plugins/writing/linguistics/grammar.test.ts
+++ b/plugins/writing/linguistics/grammar.test.ts
@@ -152,9 +152,7 @@ describe("isNounPhrase", () => {
     },
   ];
 
-  for (const { description, tokens, want } of cases) {
-    it(description, () => {
-      expect(isNounPhrase(tokens)).toBe(want);
-    });
-  }
+  it.each(cases)("$description", ({ tokens, want }) => {
+    expect(isNounPhrase(tokens)).toBe(want);
+  });
 });

--- a/plugins/writing/linguistics/heading.test.ts
+++ b/plugins/writing/linguistics/heading.test.ts
@@ -126,13 +126,11 @@ export const seedCases: Array<{
 ];
 
 describe("classifyHeadingBaseline", () => {
-  for (const { description, heading, flagged, kind } of seedCases) {
-    it(description, () => {
-      const verdict = classifyHeadingBaseline(heading);
-      expect(verdict.flagged).toBe(flagged);
-      if (kind != null) {
-        expect(verdict.kind).toBe(kind);
-      }
-    });
-  }
+  it.each(seedCases)("$description", ({ heading, flagged, kind }) => {
+    const verdict = classifyHeadingBaseline(heading);
+    expect(verdict.flagged).toBe(flagged);
+    if (kind != null) {
+      expect(verdict.kind).toBe(kind);
+    }
+  });
 });

--- a/plugins/writing/linguistics/preprocess.test.ts
+++ b/plugins/writing/linguistics/preprocess.test.ts
@@ -86,12 +86,10 @@ const cases: Array<{
 ];
 
 describe("preprocessHeading", () => {
-  for (const { description, input, text, codeSpans, enumerator } of cases) {
-    it(description, () => {
-      const result = preprocessHeading(input);
-      expect(result.text).toBe(text);
-      expect(result.codeSpans).toBe(codeSpans ?? 0);
-      expect(result.enumerator).toBe(enumerator ?? false);
-    });
-  }
+  it.each(cases)("$description", ({ input, text, codeSpans, enumerator }) => {
+    const result = preprocessHeading(input);
+    expect(result.text).toBe(text);
+    expect(result.codeSpans).toBe(codeSpans ?? 0);
+    expect(result.enumerator).toBe(enumerator ?? false);
+  });
 });


### PR DESCRIPTION
Enables oxlint's `vitest/prefer-each` and converts the 39 loops it flags into `it.each`/`describe.each` across 9 test files.

The oxlint vitest plugin matches on the Jest-style test API shape rather than the import path, so `prefer-each` applies correctly even though this repo tests with `bun:test`. Each conversion keeps the same cases and assertions. The shape (object array with `$property` titles, tuple array with `%s`/`%j` placeholders, or `describe.each` nesting `it.each`) follows whatever the existing case table already looked like.

Enabling the plugin's category rules also turned on `vitest/no-commented-out-tests` repo-wide, which fired once in `db.ts`. That hit is a false positive: a prose comment ("... it (00_pinned.sql), so ...") happens to read like a commented-out `it(...)` call. The rule only means something in test files, so it's off at the top level in `lint/base.json` and enabled only under the existing `**/*.test.ts` override, where a commented-out test can actually occur and running it over source prose can't misfire.

One case table (`sideEffectOnly scoping` in `tropes.test.ts`) wrapped three separate `it()` calls per loop iteration. That became three `it.each` blocks over the same array instead of one, which changes test execution order but not which cases run or what each asserts.
