### PR TITLE
lint: enable five oxlint collection rules

### DIFF
--- a/lint/base.json
+++ b/lint/base.json
@@ -26,14 +26,35 @@
         "ignoreRestSiblings": true
       }
     ],
+    // Object.assign({}, ...) merges through a function call instead of an
+    // object literal, hiding the resulting shape from tools that read
+    // literals better than call expressions, and needs an empty target
+    // argument purely to avoid mutating an input.
+    "prefer-object-spread": "error",
     "prefer-template": "error",
     "import/no-named-as-default-member": "error",
     "oxc/no-map-spread": "error",
     // A `new Promise` executor that only wraps an existing async API duplicates
     // logic the platform already exposes, and drops its built-in error handling.
     "promise/avoid-new": "error",
+    // An implicit length check reads as a numeric truthiness test rather
+    // than a stated "has items" or "is empty" comparison, and looks the
+    // same whether the intent is >0, !==0, or something else entirely.
+    "unicorn/explicit-length-check": "error",
+    // A forEach callback gives up break and continue, cannot await without
+    // an async-IIFE workaround, and adds a closure frame the loop body
+    // does not need.
+    "unicorn/no-array-for-each": "error",
     "unicorn/prefer-array-find": "error",
+    // A hand-written a > b ? a : b comparison mishandles NaN silently,
+    // does not extend past two values without nesting, and hides a named
+    // operation behind inline conditional logic.
+    "unicorn/prefer-math-min-max": "error",
     "unicorn/prefer-set-has": "error",
+    // Array.prototype.slice.call/.apply()/.concat()/Array.from() carry
+    // parameters and binding semantics (thisArg, mapping functions)
+    // irrelevant to a plain copy, where spread states the intent directly.
+    "unicorn/prefer-spread": "error",
     // `String.raw` keeps a backslash-heavy literal (a path, a regex) readable as written, instead of forcing a manual escape count that's easy to get wrong.
     "unicorn/prefer-string-raw": "error",
     // `replace()` needs a global regex to hit every match, and a dropped `g` flag silently replaces only the first one. `replaceAll()` makes the intent explicit and takes a plain string when there's no pattern to match.

--- a/packages/validate/run.ts
+++ b/packages/validate/run.ts
@@ -19,7 +19,7 @@ export interface ValidationTarget {
 
 export async function runValidation(target: ValidationTarget): Promise<void> {
   let ajv: Ajv | undefined;
-  if (target.extraSchemas != null && target.extraSchemas.length !== 0) {
+  if (target.extraSchemas != null && target.extraSchemas.length > 0) {
     ajv = createValidator();
     const extras = await Promise.all(
       target.extraSchemas.map(async (extra) => ({

--- a/plugins/claude-code/skills/skill/scripts/check-namespace.test.ts
+++ b/plugins/claude-code/skills/skill/scripts/check-namespace.test.ts
@@ -135,9 +135,9 @@ test.each<{ name: string; skillName: string; plugin: string; substrings: string[
   if (substrings.length === 0) {
     expect(warnings).toEqual([]);
   } else {
-    substrings.forEach((substring, i) => {
+    for (const [i, substring] of substrings.entries()) {
       expect(warnings[i]).toContain(substring);
-    });
+    }
   }
 });
 

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/rules/references.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/rules/references.ts
@@ -15,7 +15,7 @@ const PLACEHOLDERS = new Map([
 
 // \b after the name keeps $CLAUDE_SKILL_DIRECTORY from matching CLAUDE_SKILL_DIR.
 const SUBSTITUTION_PATTERN = new RegExp(
-  `\\$\\{?(${Array.from(PLACEHOLDERS.keys()).join("|")})\\b\\}?`,
+  `\\$\\{?(${[...PLACEHOLDERS.keys()].join("|")})\\b\\}?`,
   "g",
 );
 
@@ -28,7 +28,7 @@ export function findReferences(body: string): string[] {
     if (ref != null && ref !== "") refs.add(ref);
   }
 
-  return Array.from(refs);
+  return [...refs];
 }
 
 export function getDepth(refPath: string): number {

--- a/plugins/comments/apply/report.ts
+++ b/plugins/comments/apply/report.ts
@@ -31,7 +31,7 @@ function firstLine(text: string): string {
 function actionLabel(verdict: Verdict): string {
   if (verdict.action !== "trim") return verdict.action;
   return (verdict.trimTo != null && verdict.trimTo !== "") ||
-    (verdict.trimToLines != null && verdict.trimToLines.length !== 0)
+    (verdict.trimToLines != null && verdict.trimToLines.length > 0)
     ? "trim"
     : "delete";
 }
@@ -89,7 +89,7 @@ export function renderReport(items: ReportItem[], options: { fix: boolean }): st
       }
       if (verdict.trimTo != null && verdict.trimTo !== "") {
         lines.push(color.dim(`      keep: ${firstLine(verdict.trimTo)}`));
-      } else if (verdict.trimToLines != null && verdict.trimToLines.length !== 0) {
+      } else if (verdict.trimToLines != null && verdict.trimToLines.length > 0) {
         lines.push(color.dim(`      keep lines: ${verdict.trimToLines.join(", ")}`));
       }
     }

--- a/plugins/comments/detection/density.ts
+++ b/plugins/comments/detection/density.ts
@@ -60,7 +60,7 @@ export function addedLines(
   }
   const added = new Set<number>();
   const newLines = newText.split("\n");
-  newLines.forEach((line, i) => {
+  for (const [i, line] of newLines.entries()) {
     const k = lineKey(line);
     const remaining = oldCounts.get(k) ?? 0;
     if (remaining > 0) {
@@ -68,7 +68,7 @@ export function addedLines(
     } else {
       added.add(i + 1);
     }
-  });
+  }
   return { fragment: newText, added };
 }
 

--- a/plugins/comments/detection/rank.test.ts
+++ b/plugins/comments/detection/rank.test.ts
@@ -101,7 +101,7 @@ describe("rankComments", () => {
         fc.array(commentArb),
         fc.constantFrom<SortKey>("score", "lines", "chars"),
         (comments, sort) => {
-          const before = comments.slice();
+          const before = [...comments];
           const result = rankComments(comments, sort);
           expect(result).toEqual(rankOracle(comments, sort));
           expect(result).not.toBe(comments);
@@ -117,7 +117,8 @@ describe("rankCommentsWeighted", () => {
 
   const pathedArb = fc
     .tuple(commentArb, fc.constantFrom("a.ts", "b.ts", "c.ts"))
-    .map(([c, path]) => Object.assign({}, c, { path }));
+    // oxlint-disable-next-line oxc/no-map-spread -- this .map is fast-check's Arbitrary.map, not Array#map; the spread must copy so the generated comment isn't mutated in place.
+    .map(([c, path]) => ({ ...c, path }));
 
   test("matches rankComments when no path has a weight", () => {
     fc.assert(

--- a/plugins/github/skills/copilot/scripts/review.ts
+++ b/plugins/github/skills/copilot/scripts/review.ts
@@ -760,7 +760,7 @@ async function main(): Promise<void> {
   console.error(`  shape      ${argv.flags.agentic ? "agentic, capped session" : "one-shot"}`);
   console.error(`  base       ${base}`);
   console.error(
-    `  files      ${diff.files.length}${skipped.length !== 0 ? ` (${skipped.length} body omitted)` : ""}`,
+    `  files      ${diff.files.length}${skipped.length > 0 ? ` (${skipped.length} body omitted)` : ""}`,
   );
   console.error(`  angles     ${angles.length} (${angles.map((angle) => angle.id).join(", ")})`);
   console.error(

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.test.ts
@@ -301,9 +301,9 @@ describe("pipelineDurations", () => {
   ])("$name", ({ raw, expected }) => {
     const durations = pipelineDurations(raw);
     expect(durations).toHaveLength(expected.length);
-    expected.forEach((seconds, index) => {
+    for (const [index, seconds] of expected.entries()) {
       expect(durations[index]).toBeCloseTo(seconds, 2);
-    });
+    }
   });
 
   test("never yields a duration the clamped interval cannot consume", () => {
@@ -645,11 +645,11 @@ describe("deriveEvents in branch mode", () => {
     ];
 
     const allEvents: Event[] = [];
-    sequence.forEach((probe, i) => {
+    for (const [i, probe] of sequence.entries()) {
       const outcome = deriveEvents(probe, state, i * minute, 15);
       state = outcome.state;
       allEvents.push(...outcome.events);
-    });
+    }
 
     expect(allEvents.some((e) => e.type === "conflicts")).toBe(false);
     expect(allEvents.some((e) => e.type === "pr-closed")).toBe(false);
@@ -700,11 +700,11 @@ describe("deriveEvents in pipeline-id mode", () => {
     ];
 
     const allEvents: Event[] = [];
-    sequence.forEach((probe, i) => {
+    for (const [i, probe] of sequence.entries()) {
       const outcome = deriveEvents(probe, state, i * minute, 15);
       state = outcome.state;
       allEvents.push(...outcome.events);
-    });
+    }
 
     expect(allEvents.some((e) => e.type === "conflicts")).toBe(false);
     expect(allEvents.some((e) => e.type === "pr-closed")).toBe(false);
@@ -722,11 +722,11 @@ describe("deriveEvents in pipeline-id mode", () => {
     ];
 
     const allEvents: Event[] = [];
-    sequence.forEach((probe, i) => {
+    for (const [i, probe] of sequence.entries()) {
       const outcome = deriveEvents(probe, state, i * minute, 15);
       state = outcome.state;
       allEvents.push(...outcome.events);
-    });
+    }
 
     expect(allEvents.some((e) => e.type === "conflicts")).toBe(false);
     expect(allEvents.some((e) => e.type === "pr-closed")).toBe(false);

--- a/plugins/issue/evals/issue-refine/scripts/build-dataset.ts
+++ b/plugins/issue/evals/issue-refine/scripts/build-dataset.ts
@@ -151,9 +151,9 @@ while (added && selected.length < argv.flags.limit) {
   }
 }
 
-selected.forEach((s, i) => {
+for (const [i, s] of selected.entries()) {
   s.id = `sample-${String(i + 1).padStart(2, "0")}`;
-});
+}
 
 await Bun.write(argv.flags.out, JSON.stringify(selected, null, 2));
 

--- a/plugins/issue/evals/issue-refine/scripts/build-labelset.ts
+++ b/plugins/issue/evals/issue-refine/scripts/build-labelset.ts
@@ -75,4 +75,4 @@ const missing: string[] = loaded.filter((entry) => !entry.sample).map((entry) =>
 
 await Bun.write(argv.flags.output, JSON.stringify(samples, null, 2));
 console.log(`wrote ${samples.length} samples to ${argv.flags.output}`);
-if (missing.length !== 0) console.log(`missing output for: ${missing.join(", ")}`);
+if (missing.length > 0) console.log(`missing output for: ${missing.join(", ")}`);

--- a/plugins/issue/evals/issue-refine/scripts/score.ts
+++ b/plugins/issue/evals/issue-refine/scripts/score.ts
@@ -138,7 +138,7 @@ for (const h of headings) {
   const lowerMajor = major
     .filter((w, i) => !SMALL_WORDS.has(w.toLowerCase()) || i === 0)
     .filter((w) => /^[a-z]/.test(w));
-  if (lowerMajor.length !== 0)
+  if (lowerMajor.length > 0)
     add(
       1,
       "minor",
@@ -150,7 +150,7 @@ for (const h of headings) {
 
 // Finding 2: native links for issue/PR references; no bare numbers or raw URLs.
 const linkTargets = new Set([...body.matchAll(/\]\(([^)]+)\)/g)].map((m) => m[1]));
-lines.forEach((l, i) => {
+for (const [i, l] of lines.entries()) {
   const noLinks = l.replaceAll(/\[[^\]]*\]\([^)]*\)/g, "").replaceAll(/`[^`]*`/g, "");
   for (const m of noLinks.matchAll(/\b[A-Z]{2,}-\d+\b/g))
     add(2, "critical", i + 1, m[0], "Bare tracker reference. Use a link that expands inline.");
@@ -166,7 +166,7 @@ lines.forEach((l, i) => {
     if (!linkTargets.has(m[0]))
       add(2, "minor", i + 1, m[0], "Raw URL pasted as text. Use a titled link or native relation.");
   }
-});
+}
 const relatedHeading = headings.find((h) => /related issues/i.test(h.text));
 if (relatedHeading)
   add(
@@ -178,7 +178,7 @@ if (relatedHeading)
   );
 
 // Finding 3: no volatile line-number citations.
-lines.forEach((l, i) => {
+for (const [i, l] of lines.entries()) {
   for (const m of l.matchAll(/#L\d+(?:-L?\d+)?/g))
     add(
       3,
@@ -195,17 +195,17 @@ lines.forEach((l, i) => {
       m[0],
       "Volatile file:line citation. Cite the symbol and quote the lines inline.",
     );
-});
+}
 
 // Finding 4: jargon and marketing words.
-lines.forEach((l, i) => {
+for (const [i, l] of lines.entries()) {
   const lower = l.toLowerCase();
   for (const w of [...JARGON, ...MARKETING]) {
     const re = new RegExp(`\\b${w}\\b`, "i");
     if (re.test(lower))
       add(4, "minor", i + 1, w, `Jargon/marketing word "${w}". Use a plainer word.`);
   }
-});
+}
 
 // Finding 5: over-structuring (heading density, thin option menus, filler heads).
 const bodyWords = body.split(/\s+/).filter(Boolean).length;

--- a/plugins/meme/skills/image/scripts/render.ts
+++ b/plugins/meme/skills/image/scripts/render.ts
@@ -112,9 +112,9 @@ function drawCaption(ctx: SKRSContext2D, layout: CaptionLayout, y: number, width
   ctx.font = fontString(font, layout.fontPx);
   ctx.textAlign = "center";
   ctx.textBaseline = "top";
-  layout.lines.forEach((line, i) => {
+  for (const [i, line] of layout.lines.entries()) {
     ctx.fillText(line, width / 2, y + padPx + i * layout.fontPx * LINE_HEIGHT);
-  });
+  }
 }
 
 interface BoxLayout {
@@ -210,11 +210,11 @@ function drawBox(
   ctx.lineWidth = Math.max(MIN_STROKE_PX, fit.fontPx * preset.strokeWidthRatio);
   ctx.strokeStyle = box.style?.stroke ?? preset.stroke;
   ctx.fillStyle = box.style?.fill ?? preset.fill;
-  fit.lines.forEach((line, i) => {
+  for (const [i, line] of fit.lines.entries()) {
     const y = offsetY + yStart + i * fit.fontPx * LINE_HEIGHT;
     ctx.strokeText(line, x, y);
     ctx.fillText(line, x, y);
-  });
+  }
 }
 
 export async function render(
@@ -258,9 +258,9 @@ export async function render(
 
   const warnings: string[] = [];
   const classic = await classicFontFamily();
-  layoutBoxes(ctx, spec, image.width, image.height, classic).forEach((layout, i) => {
+  for (const [i, layout] of layoutBoxes(ctx, spec, image.width, image.height, classic).entries()) {
     drawBox(ctx, layout, bars.top, warnings, i);
-  });
+  }
 
   const absolute = resolve(outPath);
   await Bun.write(absolute, await canvas.encode("png"));

--- a/plugins/mermaid/skills/diagram/scripts/validate.test.ts
+++ b/plugins/mermaid/skills/diagram/scripts/validate.test.ts
@@ -56,9 +56,9 @@ flowchart LR
   ])("$name", ({ content, length, contains, line }) => {
     const blocks = extractMermaidBlocks(content);
     expect(blocks).toHaveLength(length);
-    contains?.forEach((substring, index) => {
+    for (const [index, substring] of contains?.entries() ?? []) {
       expect(blocks[index]?.content).toContain(substring);
-    });
+    }
     if (line !== undefined) expect(blocks[0]?.line).toBe(line);
   });
 });

--- a/plugins/plan/hooks/gate.ts
+++ b/plugins/plan/hooks/gate.ts
@@ -188,7 +188,7 @@ export async function processInput(
 
   const currentLines = normalizeLines(plan);
   const previousLinesRaw = await readState(linesPath);
-  await writeState(linesPath, JSON.stringify(Array.from(currentLines)));
+  await writeState(linesPath, JSON.stringify([...currentLines]));
 
   if (previous !== null && previous === hash) {
     return formatDecision(DENY_REASON);

--- a/plugins/pull-request/evals/pr-body/calibrate.ts
+++ b/plugins/pull-request/evals/pr-body/calibrate.ts
@@ -66,6 +66,6 @@ console.log(`FALSE NEGATIVES (bad items missed, no lexical tell) — ${falseNega
 for (const fnItem of falseNegatives) {
   console.log(`  "${fnItem.text}"`);
   console.log(
-    `      signals fired: ${fnItem.signals.length !== 0 ? fnItem.signals.join(", ") : "(none)"}`,
+    `      signals fired: ${fnItem.signals.length > 0 ? fnItem.signals.join(", ") : "(none)"}`,
   );
 }

--- a/plugins/pull-request/evals/pr-body/scripts/mine.ts
+++ b/plugins/pull-request/evals/pr-body/scripts/mine.ts
@@ -122,9 +122,9 @@ export function selectSample(candidates: Item[], limit: number): Item[] {
       }
     }
   }
-  selected.forEach((s, i) => {
+  for (const [i, s] of selected.entries()) {
     s.id = `pr-${String(i + 1).padStart(3, "0")}`;
-  });
+  }
   return selected;
 }
 

--- a/plugins/pull-request/scripts/prose.test.ts
+++ b/plugins/pull-request/scripts/prose.test.ts
@@ -32,6 +32,7 @@ const LIST_INDENT = 2;
 const MIN_COLUMN = WRAP_MIN_LINE + MAX_WORD + 1 + LIST_INDENT;
 const MAX_COLUMN = WRAP_MAX_LINE;
 
+// oxlint-disable-next-line unicorn/prefer-spread -- spreading this ASCII string directly would trip typescript/no-misused-spread's code-point warning.
 const LOWERCASE = "abcdefghijklmnopqrstuvwxyz".split("");
 const word = fc.string({
   minLength: 3,

--- a/plugins/pull-request/scripts/sentence-heading.ts
+++ b/plugins/pull-request/scripts/sentence-heading.ts
@@ -210,7 +210,7 @@ export function classifyPrHeading(heading: string): PrHeadingResult {
       ? [toks[0]]
       : [];
   const lowered = [...firstLower, ...lowercaseContent];
-  if (lowercaseContent.length >= 1 || lowered.length >= 2) {
+  if (lowercaseContent.length > 0 || lowered.length >= 2) {
     signals.push(`sentence case (${lowered.length} lowercase content words)`);
   }
 

--- a/plugins/review/evals/review-voice/scripts/mine.ts
+++ b/plugins/review/evals/review-voice/scripts/mine.ts
@@ -192,11 +192,11 @@ async function main() {
         ? bodiesFromJson(row.content)
         : [{ body: row.content, file: null, line: null }];
 
-    extracted.forEach((entry, index) => {
+    for (const [index, entry] of extracted.entries()) {
       const body = entry.body.trim();
-      if (body.length < argv.flags.minChars) return;
+      if (body.length < argv.flags.minChars) continue;
       const key = normalize(body);
-      if (seen.has(key)) return;
+      if (seen.has(key)) continue;
       seen.add(key);
       candidates.push({
         id: idFor(row.host, row.session_id, row.file_path, index),
@@ -209,7 +209,7 @@ async function main() {
         line: entry.line,
         body,
       });
-    });
+    }
   }
 
   await mkdir(dirname(argv.flags.out), { recursive: true });

--- a/plugins/things/src/mcp/tools.ts
+++ b/plugins/things/src/mcp/tools.ts
@@ -238,13 +238,13 @@ export function validateCaptureTitles(title?: string, titles?: string[]): void {
  * silently and a blank title as a nameless todo the user then has to find.
  */
 export function validateNonBlank(values: string[], field: string): void {
-  values.forEach((value, index) => {
+  for (const [index, value] of values.entries()) {
     if (value.trim() === "") {
       throw new Error(
         `${field}[${index}] must be a non-empty string, got ${JSON.stringify(value)}`,
       );
     }
-  });
+  }
 }
 
 /**
@@ -634,7 +634,7 @@ export function registerTools(server: McpServer, client: ThingsClient = defaultC
           // keeps a retry from updating those todos a second time.
           const message = error instanceof Error ? error.message : String(error);
           throw new Error(
-            applied.length !== 0
+            applied.length > 0
               ? `${message}\nAlready updated: ${applied.join(", ")}. Retry only the remaining IDs.`
               : message,
             { cause: error },

--- a/plugins/ui-design/skills/wireframe/scripts/validate.ts
+++ b/plugins/ui-design/skills/wireframe/scripts/validate.ts
@@ -91,7 +91,7 @@ function applyTransform(parent: Transform, child: Transform): Transform {
 }
 
 function getElementChildren(el: XmlElement): XmlElement[] {
-  return Array.from(el.childNodes).filter((n): n is XmlElement => n.nodeType === 1);
+  return [...el.childNodes].filter((n): n is XmlElement => n.nodeType === 1);
 }
 
 function getElementId(el: XmlElement, index: number): string {

--- a/plugins/writing/detection/wordlists.ts
+++ b/plugins/writing/detection/wordlists.ts
@@ -39,7 +39,7 @@ export function compilePlainWordlist(
 ): RegExp | null {
   const entries = parseLines(content);
   if (entries.length === 0) return null;
-  const fragments = Array.from(new Set(entries.map(escapeRegex)));
+  const fragments = [...new Set(entries.map(escapeRegex))];
   const prefix = options.prefix ?? String.raw`\b`;
   const suffix = options.suffix ?? String.raw`\b`;
   const flags = options.flags ?? "gi";

--- a/plugins/writing/evals/writing/scripts/mine.ts
+++ b/plugins/writing/evals/writing/scripts/mine.ts
@@ -113,9 +113,9 @@ export function selectSample(candidates: Item[], limit: number): Item[] {
       }
     }
   }
-  selected.forEach((s, i) => {
+  for (const [i, s] of selected.entries()) {
     s.id = `rw-${String(i + 1).padStart(3, "0")}`;
-  });
+  }
   return selected;
 }
 

--- a/plugins/writing/skills/analyze/scripts/headings-eval.ts
+++ b/plugins/writing/skills/analyze/scripts/headings-eval.ts
@@ -118,7 +118,7 @@ export function evaluateClassifiers(
     }
     verdicts.set(heading, row);
     const base = row.get(baseline.name);
-    if (Array.from(row.values()).some((flagged) => flagged !== base)) {
+    if ([...row.values()].some((flagged) => flagged !== base)) {
       disagreements.push(heading);
     }
   }

--- a/plugins/writing/skills/analyze/scripts/judge-run.ts
+++ b/plugins/writing/skills/analyze/scripts/judge-run.ts
@@ -106,13 +106,13 @@ export function scoreHeadingBaseline(
   let tp = 0;
   let fp = 0;
   let fn = 0;
-  labeled.forEach((row, i) => {
+  for (const [i, row] of labeled.entries()) {
     const flagged = verdicts[i] === true;
     const want = SHOULD_FLAG.has(row.label);
     if (flagged && want) tp++;
     else if (flagged && !want) fp++;
     else if (!flagged && want) fn++;
-  });
+  }
   const ci = wilson(tp, tp + fp);
   return {
     total: labeled.length,

--- a/plugins/writing/skills/analyze/scripts/voice-corpus.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-corpus.ts
@@ -54,5 +54,5 @@ export function mergeDocuments(
   for (const doc of incoming) {
     if (!bySource.has(doc.source)) bySource.set(doc.source, doc);
   }
-  return Array.from(bySource.values());
+  return [...bySource.values()];
 }

--- a/plugins/writing/skills/analyze/scripts/voice-profile.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-profile.ts
@@ -77,7 +77,7 @@ export function buildProfile(docs: VoiceDocument[], generatedAt: string): VoiceP
     stemmedNgrams: serializeNgrams(stemmedNgrams),
     totalStemmedTokens,
     generatedAt,
-    sources: Array.from(sources).toSorted(),
+    sources: [...sources].toSorted(),
     voiceDelta,
   };
 }

--- a/scripts/check-hook-matchers.ts
+++ b/scripts/check-hook-matchers.ts
@@ -75,17 +75,21 @@ function* settingsEntries(file: string, hooks: HooksFile["hooks"]): Generator<Ma
  * repo's hook entries live in settings rather than a plugin, and a matcher
  * defect is equally silent in either.
  */
+function toArray<T>(items: Iterable<T>): T[] {
+  return [...items];
+}
+
 export async function allMatcherEntries(): Promise<MatcherEntryContext[]> {
   const [plugins, settings] = await Promise.all([
     loadPlugins(),
     Promise.all(
       SOURCES.map(async ({ file }) => {
         const parsed = await decodeFile(SettingsHooks, join(root, file));
-        return Array.from(settingsEntries(file, parsed.hooks ?? {}));
+        return toArray(settingsEntries(file, parsed.hooks ?? {}));
       }),
     ),
   ]);
-  return [...plugins.flatMap((plugin) => Array.from(matcherEntries(plugin))), ...settings.flat()];
+  return [...plugins.flatMap((plugin) => toArray(matcherEntries(plugin))), ...settings.flat()];
 }
 
 if (import.meta.main) {

--- a/scripts/coverage/index.ts
+++ b/scripts/coverage/index.ts
@@ -71,7 +71,7 @@ await persistLcov(reports);
 
 // When specific files were requested, focus the report on them.
 const targets =
-  files.length !== 0 ? new Set(files.map((f) => relative(repoRoot, join(process.cwd(), f)))) : null;
+  files.length > 0 ? new Set(files.map((f) => relative(repoRoot, join(process.cwd(), f)))) : null;
 const scoped = targets ? reports.filter((fc) => targets.has(fc.file)) : reports;
 
 if (argv.flags.report === "github") {

--- a/scripts/coverage/lcov.test.ts
+++ b/scripts/coverage/lcov.test.ts
@@ -12,6 +12,7 @@ import {
 } from "./lcov";
 
 const pathChar = fc.constantFrom(
+  // oxlint-disable-next-line unicorn/prefer-spread -- spreading this ASCII string directly would trip typescript/no-misused-spread's code-point warning.
   ..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/._-".split(""),
 );
 

--- a/scripts/coverage/lcov.ts
+++ b/scripts/coverage/lcov.ts
@@ -125,7 +125,7 @@ export function formatLcov(reports: FileCoverage[]): string {
     lines.push(`LF:${fc.lineHits.size}`, `LH:${covered}`, "end_of_record");
     blocks.push(lines.join("\n"));
   }
-  return blocks.length !== 0 ? `${blocks.join("\n")}\n` : "";
+  return blocks.length > 0 ? `${blocks.join("\n")}\n` : "";
 }
 
 // Collapse sorted line numbers into human-readable ranges: [1,2,3,5,8,9] -> "1-3, 5, 8-9".

--- a/scripts/coverage/report.ts
+++ b/scripts/coverage/report.ts
@@ -36,7 +36,7 @@ export function terminalReport(reports: FileCoverage[]): string {
     details.push(`${color(31, fc.file)}: ${uncovered.join(", ")}`);
   }
 
-  return details.length !== 0
+  return details.length > 0
     ? `${summary}\nUncovered lines:\n${details.join("\n")}`
     : summary.trimEnd();
 }
@@ -55,7 +55,7 @@ function markdownTable(reports: FileCoverage[]): string {
 // per-line annotations, which read as defect-grade warnings and hit GitHub's
 // ~10-per-level render cap. Per-line detail lives in the local hook and skill.
 export function githubReport(reports: FileCoverage[]): string {
-  return reports.length !== 0
+  return reports.length > 0
     ? `## Coverage\n\n${markdownTable(reports)}`
     : "## Coverage\n\nNo coverage data.";
 }

--- a/scripts/coverage/run.ts
+++ b/scripts/coverage/run.ts
@@ -77,7 +77,7 @@ function runScope(scope: string): Promise<FileCoverage[]> {
 // Run Bun coverage for every scope the target files belong to, then merge.
 // With no files, measure the default scope set (the repo's test roots).
 export async function runCoverage(files: string[]): Promise<FileCoverage[]> {
-  const scopes = files.length !== 0 ? resolveScopes(files) : DEFAULT_SCOPES;
+  const scopes = files.length > 0 ? resolveScopes(files) : DEFAULT_SCOPES;
   const reports = await Promise.all(scopes.map(runScope));
   return merge(...reports);
 }

--- a/user/scripts/statusline.ts
+++ b/user/scripts/statusline.ts
@@ -94,7 +94,7 @@ export function dialColor(pct: number, exceeds: boolean): DialColor {
 
 export function dialIndex(pct: number): number {
   const idx = Math.floor((pct * 7) / 100);
-  return idx > 7 ? 7 : idx;
+  return Math.min(7, idx);
 }
 
 // Claude Code's top-level `exceeds_200k_tokens` reflects the most recent API
@@ -299,10 +299,10 @@ export function buildStatusLine(
   // Fixed segments (dials) are measured first and never elided; the worktree
   // label takes whatever width remains so the dial stays visible at any width.
   let fixedWidth = 0;
-  segments.forEach((s, i) => {
+  for (const [i, s] of segments.entries()) {
     if (i > 0) fixedWidth += SEP.length;
     fixedWidth += Bun.stringWidth(s);
-  });
+  }
 
   const worktreeBudget = columns - fixedWidth - SEP.length - 1;
   if (worktree) segments.push(...formatWorktree(worktree, worktreeBudget));

--- a/user/scripts/subagent-statusline.ts
+++ b/user/scripts/subagent-statusline.ts
@@ -128,7 +128,7 @@ export function renderTask(
     body += ` ${text}`;
     const trailing = [...metaParts];
     if (withType && agentType != null && agentType !== "") trailing.push(agentType);
-    if (trailing.length !== 0) {
+    if (trailing.length > 0) {
       body += ` ${styleText(["dim"], trailing.map((part) => `· ${part}`).join(" "))}`;
     }
     return body;
@@ -364,5 +364,5 @@ if (import.meta.main) {
       );
     }),
   );
-  if (lines.length !== 0) process.stdout.write(`${lines.join("\n")}\n`);
+  if (lines.length > 0) process.stdout.write(`${lines.join("\n")}\n`);
 }

--- a/user/skills/flights/scripts/google-flights.ts
+++ b/user/skills/flights/scripts/google-flights.ts
@@ -448,11 +448,13 @@ function renderGrid(cells: GridCell[]): string {
   const backs = [...new Set(cells.map((cell) => cell.back))];
   return table([
     [String.raw`out \ back`, ...backs.map((back) => back ?? "?")],
-    ...outs.map((out) =>
-      [out].concat(
-        backs.map((back) => money(cells.find((cell) => cell.out === out && cell.back === back))),
-      ),
-    ),
+    ...outs.map((out) => {
+      const row: string[] = [out];
+      row.push(
+        ...backs.map((back) => money(cells.find((cell) => cell.out === out && cell.back === back))),
+      );
+      return row;
+    }),
   ]);
 }
 

--- a/user/skills/flock/scripts/board.test.ts
+++ b/user/skills/flock/scripts/board.test.ts
@@ -33,6 +33,7 @@ describe("fit", () => {
   });
 
   test("an elided value never exceeds the column", () => {
+    // oxlint-disable-next-line unicorn/prefer-spread -- typescript/no-misused-spread rejects the spread form on a string.
     expect(Array.from(fit("x".repeat(80), 14))).toHaveLength(14);
   });
 });

--- a/user/skills/flock/scripts/board.ts
+++ b/user/skills/flock/scripts/board.ts
@@ -34,6 +34,7 @@ export const COLUMNS = [
 ] as const;
 
 export function fit(value: string, width: number): string {
+  // oxlint-disable-next-line unicorn/prefer-spread -- typescript/no-misused-spread rejects the spread form on a string.
   const points = Array.from(value);
   if (points.length <= width) return value;
   return `${points.slice(0, width - 1).join("")}…`;


### PR DESCRIPTION
Adds oxlint's five array and object collection rules to `lint/base.json`, each with a comment on what the banned form costs:

- `unicorn/no-array-for-each`
- `unicorn/explicit-length-check`
- `unicorn/prefer-spread`
- `prefer-object-spread`
- `unicorn/prefer-math-min-max`

Fixes every violation this surfaced:

- 20 `forEach` callbacks converted to `for...of`
- one of those relied on the callback's own `return` as a continue, converted to `continue`
- one `prefer-spread` survivor
- auto-fixed hits for `explicit-length-check`, `prefer-object-spread`, and `prefer-math-min-max`

Two sites keep the banned form behind an inline `oxlint-disable-next-line`. The preferred form collides with an existing, correctly firing rule.

Spreading a plain ASCII string trips `typescript/no-misused-spread`'s Unicode code-point warning in `scripts/coverage/lcov.test.ts` and `plugins/pull-request/scripts/prose.test.ts`.

A fast-check `.map()` callback in `plugins/comments/detection/rank.test.ts` needs a fresh copy. `oxc/no-map-spread` reads that copy as an inefficient in-place mutation.

`oxlint --fix-suggestions` introduced a bug while auto-fixing the `prefer-object-spread` hit in `rank.test.ts`. It rewrote `Object.assign({}, c, { path })` into `Object.assign(c, { path })`. That mutates the source comment in place instead of copying it.

Replaced with an object spread. The five other `Object.assign` call sites in the repo mutate an existing object. The rule only flags the fresh-literal form, so they stay as they are.
