### PR TITLE
oxlint: enable two platform-API lint rules

### DIFF
--- a/lint/base.json
+++ b/lint/base.json
@@ -29,6 +29,9 @@
     "prefer-template": "error",
     "import/no-named-as-default-member": "error",
     "oxc/no-map-spread": "error",
+    // A `new Promise` executor that only wraps an existing async API duplicates
+    // logic the platform already exposes, and drops its built-in error handling.
+    "promise/avoid-new": "error",
     "unicorn/prefer-array-find": "error",
     "unicorn/prefer-set-has": "error"
   },

--- a/lint/bun.json
+++ b/lint/bun.json
@@ -31,6 +31,9 @@
           }
         ]
       }
-    ]
+    ],
+    // `__dirname` rebuilt from `import.meta.url` recomputes what Bun already
+    // exposes on `import.meta`, and breaks if the URL parsing drifts.
+    "unicorn/prefer-import-meta-properties": "error"
   }
 }

--- a/plugins/comments/detection/provenance.ts
+++ b/plugins/comments/detection/provenance.ts
@@ -127,8 +127,11 @@ function limiter(max: number): <T>(task: () => Promise<T>) => Promise<T> {
   let active = 0;
   const waiting: (() => void)[] = [];
   return async (task) => {
-    if (active >= max) await new Promise<void>((resolve) => waiting.push(resolve));
-    else active++;
+    if (active >= max) {
+      const { promise, resolve } = Promise.withResolvers<void>();
+      waiting.push(resolve);
+      await promise;
+    } else active++;
     try {
       return await task();
     } finally {

--- a/plugins/github/skills/actions-monitor/scripts/watch.ts
+++ b/plugins/github/skills/actions-monitor/scripts/watch.ts
@@ -322,10 +322,6 @@ function emit(event: Event): void {
   console.log(JSON.stringify(event));
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 export type Mergeability = {
   mergeable: Probe["mergeable"];
   mergeStateStatus: MergeStateStatus;
@@ -352,7 +348,7 @@ export async function resolveMergeable(
   prNumber: number,
   repo: string,
   run: ExecFn = exec,
-  sleepFn: (ms: number) => Promise<void> = sleep,
+  sleepFn: (ms: number) => Promise<void> = Bun.sleep,
 ): Promise<Mergeability> {
   let current: Mergeability = { mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" };
   for (let attempt = 0; attempt < MERGEABLE_UNKNOWN_RETRIES; attempt += 1) {
@@ -765,7 +761,7 @@ async function watch(options: RunOptions): Promise<void> {
       let probe = result.probe;
       if (options.mode === "pr" && prNumber !== null && probeIsUndetermined(probe)) {
         // oxlint-disable-next-line no-await-in-loop -- poll loop: each cycle reads state the previous cycle left behind.
-        const resolved = await resolveMergeable(prNumber, repo, exec, sleep);
+        const resolved = await resolveMergeable(prNumber, repo, exec, Bun.sleep);
         probe = {
           ...probe,
           mergeable: resolved.mergeable,
@@ -791,7 +787,7 @@ async function watch(options: RunOptions): Promise<void> {
     }
 
     // oxlint-disable-next-line no-await-in-loop -- poll interval between API cycles.
-    await sleep((intervalSeconds ?? DEFAULT_INTERVAL_SECONDS) * 1000);
+    await Bun.sleep((intervalSeconds ?? DEFAULT_INTERVAL_SECONDS) * 1000);
   }
 }
 

--- a/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
+++ b/plugins/gitlab/skills/ci-monitor/scripts/watch.ts
@@ -433,10 +433,6 @@ function emit(event: Event): void {
   console.log(JSON.stringify(event));
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 type MrMetadata = {
   sha: string;
   sourceBranch: string;
@@ -495,7 +491,7 @@ export async function resolveMergeStatus(
   projectEncoded: string,
   iid: number,
   run: ExecFn = exec,
-  sleepFn: (ms: number) => Promise<void> = sleep,
+  sleepFn: (ms: number) => Promise<void> = Bun.sleep,
 ): Promise<MergeStatus> {
   let current: MergeStatus = {
     hasConflicts: false,
@@ -944,7 +940,7 @@ async function watch(options: RunOptions): Promise<void> {
       let probe = result.probe;
       if (target.mode === "mr" && iid !== null && probeIsUndetermined(probe)) {
         // oxlint-disable-next-line no-await-in-loop -- poll loop: each cycle reads state the previous cycle left behind.
-        const resolved = await resolveMergeStatus(projectEncoded, iid, exec, sleep);
+        const resolved = await resolveMergeStatus(projectEncoded, iid, exec, Bun.sleep);
         probe = {
           ...probe,
           hasConflicts: resolved.hasConflicts,
@@ -963,7 +959,7 @@ async function watch(options: RunOptions): Promise<void> {
     }
 
     // oxlint-disable-next-line no-await-in-loop -- poll interval between API cycles.
-    await sleep((intervalSeconds ?? DEFAULT_INTERVAL_SECONDS) * 1000);
+    await Bun.sleep((intervalSeconds ?? DEFAULT_INTERVAL_SECONDS) * 1000);
   }
 }
 

--- a/plugins/review/skills/inbox/scripts/watch.ts
+++ b/plugins/review/skills/inbox/scripts/watch.ts
@@ -4,10 +4,6 @@ import { cli } from "cleye";
 import { fetchUrls, newUrls } from "./poll";
 import { readState } from "./store";
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 async function iteration(queues: string[], dataDir: string | undefined): Promise<void> {
   const state = await readState(dataDir);
   const dispatched = new Set(state.dispatched.map((d) => d.url));
@@ -47,12 +43,12 @@ const argv = cli({
 
 const { dataDir, queue: queues, interval } = argv.flags;
 
-// Run immediately on start, then loop with an internal setTimeout sleep so
+// Run immediately on start, then loop with an internal sleep so
 // Monitor sees a single long-lived process (no shell while/sleep loop, which
 // breaks on macOS due to PATH-stripped eval and nice(5) restrictions).
 while (true) {
   // oxlint-disable-next-line no-await-in-loop -- poll loop: the next iteration only runs after this one finishes.
   await iteration(queues, dataDir);
   // oxlint-disable-next-line no-await-in-loop -- poll interval between iterations.
-  await sleep(interval * 1000);
+  await Bun.sleep(interval * 1000);
 }

--- a/plugins/writing/hooks/numbering.ts
+++ b/plugins/writing/hooks/numbering.ts
@@ -2,8 +2,7 @@ import { execSync } from "node:child_process";
 import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 import type { PreToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import type { Heading, Text } from "mdast";
 import { z } from "zod";
@@ -31,8 +30,6 @@ type MarkdownMatch = {
 const AstGrepMatches = z.array(z.looseObject({ message: z.string() }));
 
 const ExecFailure = z.looseObject({ stdout: z.string().optional() });
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Bare `N. ` headings are usually rankings or enumerations, not process steps,
 // so only explicit step labels count.
@@ -74,7 +71,7 @@ export async function checkCode(content: string, ext: string): Promise<string | 
 
   const tmpDir = mkdtempSync(join(tmpdir(), "hook-check-"));
   const tmpFile = join(tmpDir, `check.${ext}`);
-  const ruleFile = join(__dirname, "numbering.yml");
+  const ruleFile = join(import.meta.dirname, "numbering.yml");
 
   try {
     await Bun.write(tmpFile, content);

--- a/scripts/coverage/run.ts
+++ b/scripts/coverage/run.ts
@@ -61,6 +61,7 @@ async function readLcov(coverageDir: string): Promise<FileCoverage[]> {
 
 function runScope(scope: string): Promise<FileCoverage[]> {
   const coverageDir = mkdtempSync(join(tmpdir(), "cov-"));
+  // oxlint-disable-next-line promise/avoid-new -- child_process's close/error pair is callback-based, so this wraps it in a promise.
   return new Promise((resolve, reject) => {
     const child = spawn("bun", ["test", "--coverage", `--coverage-dir=${coverageDir}`, scope], {
       cwd: repoRoot,


### PR DESCRIPTION
Enables `promise/avoid-new` and `unicorn/prefer-import-meta-properties`, both targeting hand-rolled code with a direct platform replacement.

Three watch scripts (`plugins/gitlab/skills/ci-monitor`, `plugins/github/skills/actions-monitor`, `plugins/review/skills/inbox`) each defined their own `sleep` helper around `setTimeout`. All three now call `Bun.sleep`. A concurrency limiter in the comments plugin (`plugins/comments/detection/provenance.ts`) built a deferred promise by pushing its `resolve` callback onto a queue; it now uses `Promise.withResolvers`. `plugins/writing/hooks/numbering.ts` rebuilt `__dirname` from `import.meta.url`; it now reads `import.meta.dirname` directly.

One site has no platform equivalent. `scripts/coverage/run.ts` wraps a `child_process` close/error event pair, which has no promise-returning form to call instead, so it keeps an `oxlint-disable-next-line` with a one-line reason.

Fixing the `sleep` duplication also clears every `no-promise-executor-return` violation in the repo. That rule stays disabled here since enabling it is a separate scope.
