### PR TITLE
lint: enable import-hygiene rules

### DIFF
--- a/evals/scripts/collect-ci-runs.ts
+++ b/evals/scripts/collect-ci-runs.ts
@@ -3,7 +3,7 @@
 import { readdirSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import * as path from "node:path";
+import { join } from "node:path";
 import { cli } from "cleye";
 import { z } from "zod";
 import { decodeJson } from "../../packages/decode/index";
@@ -86,7 +86,7 @@ export async function discoverExports(dir: string): Promise<DiscoveredExport[]> 
   const found: DiscoveredExport[] = [];
   for (const entry of entries.toSorted()) {
     if (!entry.endsWith(".json")) continue;
-    const full = path.join(dir, entry);
+    const full = join(dir, entry);
     // oxlint-disable-next-line no-await-in-loop -- artifact trees are small; sequential reads keep the order deterministic.
     const text = await Bun.file(full).text();
     const discovered = readExport(full, text);
@@ -114,7 +114,7 @@ export interface CollectOptions extends GhOptions {
 
 export async function collectRun(runId: number, options: CollectOptions): Promise<string[]> {
   const run = options.run ?? runCommand;
-  const staging = await mkdtemp(path.join(tmpdir(), `eval-ci-${runId}-`));
+  const staging = await mkdtemp(join(tmpdir(), `eval-ci-${runId}-`));
   try {
     const command = downloadCommand(runId, staging, options.repo);
     expectSuccess(command, await run(command));

--- a/evals/scripts/export-run.ts
+++ b/evals/scripts/export-run.ts
@@ -2,7 +2,7 @@
 
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import * as path from "node:path";
+import { join } from "node:path";
 import { cli } from "cleye";
 import { decodeFile } from "../../packages/decode/index";
 import { expectSuccess, type RunCommand, runCommand } from "./command";
@@ -53,8 +53,8 @@ export function assertSuiteMatch(payload: ExportPayload, suite: string): void {
 }
 
 export async function exportRun(options: ExportRunOptions): Promise<ExportedRun> {
-  const staging = await mkdtemp(path.join(tmpdir(), "eval-export-"));
-  const staged = path.join(staging, "export.json");
+  const staging = await mkdtemp(join(tmpdir(), "eval-export-"));
+  const staged = join(staging, "export.json");
   try {
     await exportEval(options.evalId, staged, { run: options.run, bin: options.bin });
 

--- a/evals/scripts/promptfoo.ts
+++ b/evals/scripts/promptfoo.ts
@@ -1,4 +1,4 @@
-import * as path from "node:path";
+import { join } from "node:path";
 import { expectSuccess, type RunCommand, runCommand } from "./command";
 
 export const CONFIG_DIR_VAR = "PROMPTFOO_CONFIG_DIR";
@@ -19,7 +19,7 @@ export function promptfooConfigDir(env: Record<string, string | undefined> = pro
   if (home == null || home === "") {
     throw new Error(`Cannot locate the promptfoo database: set ${CONFIG_DIR_VAR} or HOME`);
   }
-  return path.join(home, ".cache", "promptfoo");
+  return join(home, ".cache", "promptfoo");
 }
 
 export function promptfooEnv(

--- a/evals/scripts/report.ts
+++ b/evals/scripts/report.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { readdirSync } from "node:fs";
-import * as path from "node:path";
+import { join } from "node:path";
 import { cli } from "cleye";
 import { getBorderCharacters, table } from "table";
 import { z } from "zod";
@@ -59,7 +59,7 @@ export interface Summary {
  * `metadata.billing: "api"` in its export.
  */
 export function runsView(dir: string): string {
-  const glob = literal(path.join(dir, "**", "*.json"));
+  const glob = literal(join(dir, "**", "*.json"));
   const prefix = literal(`${dir}/`);
   return `
 CREATE OR REPLACE VIEW runs AS

--- a/evals/scripts/results.ts
+++ b/evals/scripts/results.ts
@@ -1,4 +1,4 @@
-import * as path from "node:path";
+import { join, resolve } from "node:path";
 import { z } from "zod";
 
 /** The shape `promptfoo export eval <id> -o <file>` writes. Only the fields read here. */
@@ -24,11 +24,11 @@ export type ExportPayload = z.infer<typeof ExportPayload>;
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
 export function repoRoot(): string {
-  return path.join(import.meta.dirname, "..", "..");
+  return join(import.meta.dirname, "..", "..");
 }
 
 export function resultsDir(override?: string): string {
-  return path.resolve(override ?? path.join(repoRoot(), "evals", "results"));
+  return resolve(override ?? join(repoRoot(), "evals", "results"));
 }
 
 function utcDate(stamp: string): string | undefined {
@@ -87,7 +87,7 @@ export function destination(
   options: { suite?: string | undefined; date?: string | undefined } = {},
 ): string {
   const date = runDate(payload, options.date);
-  return path.join(dir, suiteName(payload, options.suite), exportFilename(payload, date));
+  return join(dir, suiteName(payload, options.suite), exportFilename(payload, date));
 }
 
 export function runCost(payload: ExportPayload): number {

--- a/evals/scripts/test/collect-ci-runs.test.ts
+++ b/evals/scripts/test/collect-ci-runs.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import * as path from "node:path";
+import { join, relative } from "node:path";
 import type { CommandOptions, RunCommand } from "../command";
 import {
   collectRun,
@@ -12,7 +12,7 @@ import {
   type WorkflowRun,
 } from "../collect-ci-runs";
 
-const ARTIFACTS = path.join(import.meta.dirname, "artifacts");
+const ARTIFACTS = join(import.meta.dirname, "artifacts");
 
 function makeRun(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
   return {
@@ -77,14 +77,14 @@ test("listCommand asks gh for the fields the selection reads", () => {
 test("discoverExports keeps promptfoo exports and skips other artifact files", async () => {
   const found = await discoverExports(ARTIFACTS);
 
-  expect(found.map((entry) => path.relative(ARTIFACTS, entry.path))).toEqual([
-    path.join("eval-output", "output.json"),
+  expect(found.map((entry) => relative(ARTIFACTS, entry.path))).toEqual([
+    join("eval-output", "output.json"),
   ]);
   expect(found[0]?.payload.evalId).toBe("eval-ci1-2026-08-27T06:15:00");
 });
 
 test("discoverExports tolerates a run that downloaded nothing", async () => {
-  expect(await discoverExports(path.join(ARTIFACTS, "missing"))).toEqual([]);
+  expect(await discoverExports(join(ARTIFACTS, "missing"))).toEqual([]);
 });
 
 interface Call {
@@ -93,9 +93,9 @@ interface Call {
 }
 
 const ARTIFACT_FILES = [
-  path.join("eval-output", "output.json"),
-  path.join("eval-output", "summary.txt"),
-  path.join("notes", "metadata.json"),
+  join("eval-output", "output.json"),
+  join("eval-output", "summary.txt"),
+  join("notes", "metadata.json"),
 ];
 
 /** Stands in for gh and promptfoo: unpacks the artifact tree where `--dir` points. */
@@ -106,7 +106,7 @@ function ciRunner(calls: Call[]): RunCommand {
     if (command[1] === "run" && target !== undefined) {
       await Promise.all(
         ARTIFACT_FILES.map((file) =>
-          Bun.write(path.join(target, file), Bun.file(path.join(ARTIFACTS, file))),
+          Bun.write(join(target, file), Bun.file(join(ARTIFACTS, file))),
         ),
       );
     }
@@ -116,15 +116,15 @@ function ciRunner(calls: Call[]): RunCommand {
 
 test("collectRun imports each downloaded export and files a copy", async () => {
   const calls: Call[] = [];
-  const dir = await mkdtemp(path.join(tmpdir(), "eval-ci-results-"));
+  const dir = await mkdtemp(join(tmpdir(), "eval-ci-results-"));
   try {
     const collected = await collectRun(42, { dir, suite: "pr-body", run: ciRunner(calls) });
 
-    expect(collected.map((file) => path.relative(dir, file))).toEqual([
-      path.join("pr-body", "2026-08-27-eval-ci1-2026-08-27T06-15-00.json"),
+    expect(collected.map((file) => relative(dir, file))).toEqual([
+      join("pr-body", "2026-08-27-eval-ci1-2026-08-27T06-15-00.json"),
     ]);
     expect(await Bun.file(collected[0] ?? "").json()).toEqual(
-      await Bun.file(path.join(ARTIFACTS, "eval-output", "output.json")).json(),
+      await Bun.file(join(ARTIFACTS, "eval-output", "output.json")).json(),
     );
   } finally {
     await rm(dir, { recursive: true, force: true });

--- a/evals/scripts/test/export-run.test.ts
+++ b/evals/scripts/test/export-run.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import * as path from "node:path";
+import { join, relative } from "node:path";
 import type { CommandOptions, CommandResult, RunCommand } from "../command";
 import {
   assertSuiteMatch,
@@ -17,7 +17,7 @@ import {
 } from "../export-run";
 import { CONFIG_DIR_VAR } from "../promptfoo";
 
-const EXPORTS = path.join(import.meta.dirname, "exports");
+const EXPORTS = join(import.meta.dirname, "exports");
 
 interface Call {
   command: string[];
@@ -29,13 +29,13 @@ function exporter(fixture: string, calls: Call[]): RunCommand {
   return async (command, options) => {
     calls.push({ command: [...command], options });
     const target = command[command.indexOf("-o") + 1];
-    if (target !== undefined) await Bun.write(target, Bun.file(path.join(EXPORTS, fixture)));
+    if (target !== undefined) await Bun.write(target, Bun.file(join(EXPORTS, fixture)));
     return { code: 0, stdout: "", stderr: "" };
   };
 }
 
 async function withCorpus<T>(body: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await mkdtemp(path.join(tmpdir(), "eval-results-"));
+  const dir = await mkdtemp(join(tmpdir(), "eval-results-"));
   try {
     return await body(dir);
   } finally {
@@ -52,11 +52,11 @@ test("exportRun files the export under the derived suite and run date", async ()
       run: exporter("described.json", calls),
     });
 
-    expect(path.relative(dir, exported.path)).toBe(
+    expect(relative(dir, exported.path)).toBe(
       "pr-body-a-b/2026-08-27-eval-xyz-2026-08-27T14-05-00.json",
     );
     expect(await Bun.file(exported.path).json()).toEqual(
-      await Bun.file(path.join(EXPORTS, "described.json")).json(),
+      await Bun.file(join(EXPORTS, "described.json")).json(),
     );
     expect(exported.payload.evalId).toBe("eval-xyz-2026-08-27T14:05:00");
   });
@@ -64,7 +64,7 @@ test("exportRun files the export under the derived suite and run date", async ()
   const [call] = calls;
   expect(call?.command.slice(0, 4)).toEqual(["bunx", "promptfoo", "export", "eval"]);
   expect(call?.command).toContain("latest");
-  expect(call?.options?.env?.[CONFIG_DIR_VAR]).toContain(path.join(".cache", "promptfoo"));
+  expect(call?.options?.env?.[CONFIG_DIR_VAR]).toContain(join(".cache", "promptfoo"));
 });
 
 test("exportRun honors suite and date overrides", async () => {
@@ -77,7 +77,7 @@ test("exportRun honors suite and date overrides", async () => {
       run: exporter("undated.json", []),
     });
 
-    expect(path.relative(dir, exported.path)).toBe(
+    expect(relative(dir, exported.path)).toBe(
       "pr-body/2026-08-26-eval-nod-2026-08-26T11-00-00.json",
     );
   });

--- a/evals/scripts/test/report.test.ts
+++ b/evals/scripts/test/report.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import * as path from "node:path";
+import { join } from "node:path";
 import { z } from "zod";
 import { query } from "../duckdb";
 import {
@@ -14,7 +14,7 @@ import {
   WINDOW_DAYS,
 } from "../report";
 
-const CORPUS = path.join(import.meta.dirname, "results");
+const CORPUS = join(import.meta.dirname, "results");
 const NOW = new Date("2026-08-28T00:00:00.000Z");
 
 function epoch(iso: string): number {
@@ -23,7 +23,7 @@ function epoch(iso: string): number {
 
 test.each<{ name: string; dir: string; expected: boolean }>([
   { name: "a corpus with exports", dir: CORPUS, expected: true },
-  { name: "a directory that does not exist", dir: path.join(CORPUS, "missing"), expected: false },
+  { name: "a directory that does not exist", dir: join(CORPUS, "missing"), expected: false },
 ])("hasResults sees $name", ({ dir, expected }) => {
   expect(hasResults(dir)).toBe(expected);
 });
@@ -129,7 +129,7 @@ test("the runs view types every numeric column as a number", async () => {
 });
 
 test("loadSuites returns nothing for an empty corpus", async () => {
-  expect(await loadSuites(path.join(CORPUS, "missing"), NOW)).toEqual([]);
+  expect(await loadSuites(join(CORPUS, "missing"), NOW)).toEqual([]);
 });
 
 test("render lays out the rollup against the budget", async () => {

--- a/evals/scripts/test/results.test.ts
+++ b/evals/scripts/test/results.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import * as path from "node:path";
+import { join } from "node:path";
 import { decodeFile } from "../../../packages/decode/index";
 import {
   destination,
@@ -14,11 +14,11 @@ import {
 
 const described = await decodeFile(
   ExportPayload,
-  path.join(import.meta.dirname, "exports", "described.json"),
+  join(import.meta.dirname, "exports", "described.json"),
 );
 const undated = await decodeFile(
   ExportPayload,
-  path.join(import.meta.dirname, "exports", "undated.json"),
+  join(import.meta.dirname, "exports", "undated.json"),
 );
 const metadataOnly: ExportPayload = {
   evalId: "eval-mdo-2026-07-04T10:00:00",

--- a/lint/base.json
+++ b/lint/base.json
@@ -12,6 +12,8 @@
     "eqeqeq": ["error", "always", { "null": "ignore" }],
     "max-depth": "error",
     "no-await-in-loop": "error",
+    // splitting imports of the same module hides that they're related and invites drift
+    "no-duplicate-imports": "error",
     // An empty block silently swallows whatever it should have handled, hiding bugs.
     "no-empty": "error",
     // Nesting an if inside an else block obscures control flow that else if states directly.
@@ -37,6 +39,8 @@
     "prefer-object-spread": "error",
     "prefer-template": "error",
     "import/no-named-as-default-member": "error",
+    // a namespace binding hides which members a file uses from both readers and unused-import checks
+    "import/no-namespace": ["error", { "ignore": ["fast-check"] }],
     "oxc/no-map-spread": "error",
     // A `new Promise` executor that only wraps an existing async API duplicates
     // logic the platform already exposes, and drops its built-in error handling.
@@ -54,6 +58,8 @@
     // does not need.
     "unicorn/no-array-for-each": "error",
     "unicorn/prefer-array-find": "error",
+    // a split re-export keeps a name in local scope only to hand it back out, saying nothing about the module's own logic
+    "unicorn/prefer-export-from": "error",
     // A hand-written a > b ? a : b comparison mishandles NaN silently,
     // does not extend past two values without nesting, and hides a named
     // operation behind inline conditional logic.

--- a/packages/oxlint-rules/no-chained-type-assertions.ts
+++ b/packages/oxlint-rules/no-chained-type-assertions.ts
@@ -4,8 +4,7 @@
 // Detection is unmodified. The message points at the guidance in
 // user/rules/typescript.md rather than anti-slop's phrasing.
 
-import { defineRule } from "@oxlint/plugins";
-import type { ESTree } from "@oxlint/plugins";
+import { defineRule, type ESTree } from "@oxlint/plugins";
 
 type TypeAssertionExpression = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
 

--- a/packages/oxlint-rules/no-conditional-empty-object-spread.ts
+++ b/packages/oxlint-rules/no-conditional-empty-object-spread.ts
@@ -4,8 +4,7 @@
 // Detection is unmodified. The message names the form that typechecks under
 // this repo's `exactOptionalPropertyTypes`.
 
-import { defineRule } from "@oxlint/plugins";
-import type { ESTree } from "@oxlint/plugins";
+import { defineRule, type ESTree } from "@oxlint/plugins";
 
 function unwrapParentheses(node: ESTree.Expression): ESTree.Expression {
   let current = node;

--- a/packages/oxlint-rules/no-module-mocking.ts
+++ b/packages/oxlint-rules/no-module-mocking.ts
@@ -4,8 +4,13 @@
 // Extended for bun:test, which upstream does not cover. The framework table
 // replaces upstream's hardcoded vi/jest checks.
 
-import { defineRule } from "@oxlint/plugins";
-import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+import {
+  defineRule,
+  type ESTree,
+  type Scope,
+  type SourceCode,
+  type Variable,
+} from "@oxlint/plugins";
 
 /** Module-mocking entry points, keyed by the object they hang off. */
 const MOCKERS = new Map<string, { source: string; methods: ReadonlySet<string> }>([

--- a/packages/oxlint-rules/no-terminal-width.ts
+++ b/packages/oxlint-rules/no-terminal-width.ts
@@ -1,5 +1,10 @@
-import { defineRule } from "@oxlint/plugins";
-import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+import {
+  defineRule,
+  type ESTree,
+  type Scope,
+  type SourceCode,
+  type Variable,
+} from "@oxlint/plugins";
 
 const FORBIDDEN_PROPERTIES = new Set(["columns", "isTTY"]);
 

--- a/packages/oxlint-rules/no-unknown-returns.ts
+++ b/packages/oxlint-rules/no-unknown-returns.ts
@@ -4,9 +4,7 @@
 // Detection is unmodified. The message names the generic form that lets a
 // caller declare the shape at the call site instead of asserting after it.
 
-import { defineRule } from "@oxlint/plugins";
-
-import type { ESTree } from "@oxlint/plugins";
+import { defineRule, type ESTree } from "@oxlint/plugins";
 
 import { lexicalTypeParameterNames } from "./lexical-type-parameters.ts";
 

--- a/packages/skill-lint/cli.ts
+++ b/packages/skill-lint/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { readdirSync } from "node:fs";
-import * as path from "node:path";
+import { join } from "node:path";
 import { parseArgs } from "node:util";
 import { lintSkill } from "../../plugins/claude-code/skills/skill/scripts/skill-lint/index";
 import { formatJson, formatText } from "./format";
@@ -50,7 +50,7 @@ async function resolveSkillDirs(patterns: string[]): Promise<string[]> {
   const perPattern = await Promise.all(
     patterns.map(async (pattern) => {
       if (!pattern.includes("*")) {
-        return (await Bun.file(path.join(pattern, "SKILL.md")).exists()) ? [pattern] : [];
+        return (await Bun.file(join(pattern, "SKILL.md")).exists()) ? [pattern] : [];
       }
 
       const base = pattern.split("*")[0] ?? "";
@@ -60,9 +60,9 @@ async function resolveSkillDirs(patterns: string[]): Promise<string[]> {
       if (!entries) return [];
       const candidates = entries
         .filter((d) => d.isDirectory())
-        .map((d) => path.join(base, d.name, suffix.replace(/^\*?\/?/, "")));
+        .map((d) => join(base, d.name, suffix.replace(/^\*?\/?/, "")));
       const present = await Promise.all(
-        candidates.map((p) => Bun.file(path.join(p, "SKILL.md")).exists()),
+        candidates.map((p) => Bun.file(join(p, "SKILL.md")).exists()),
       );
       return candidates.filter((_, index) => present[index]);
     }),

--- a/plugins/claude-code/skills/session/scripts/catalog.test.ts
+++ b/plugins/claude-code/skills/session/scripts/catalog.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import * as path from "node:path";
+import { join } from "node:path";
 import { z } from "zod";
 import {
   CATALOG_PATH,
@@ -16,7 +16,7 @@ import {
 import { type Database, ensureIndex, getDb, runQuery } from "./db";
 import { loadQueryHeaders, parseQueryHeader, QUERIES_DIR, type QueryHeader } from "./query-header";
 
-const fixturesDir = path.join(import.meta.dirname, "..", "fixtures", "sessions");
+const fixturesDir = join(import.meta.dirname, "..", "fixtures", "sessions");
 
 const VALID = `-- ---
 -- name: demo
@@ -77,7 +77,7 @@ async function loadQueries(): Promise<[QueryHeader, string][]> {
   return Promise.all(
     headers.map(
       async (header) =>
-        [header, await Bun.file(path.join(QUERIES_DIR, `${header.name}.sql`)).text()] as [
+        [header, await Bun.file(join(QUERIES_DIR, `${header.name}.sql`)).text()] as [
           QueryHeader,
           string,
         ],
@@ -168,9 +168,7 @@ describe("generated reference docs", () => {
   });
 
   it("cites survey surfaces that exist as a query or a view", async () => {
-    const views = await Bun.file(
-      path.join(import.meta.dirname, "..", "resources", "views.sql"),
-    ).text();
+    const views = await Bun.file(join(import.meta.dirname, "..", "resources", "views.sql")).text();
     const known = new Set([
       ...(await loadQueryHeaders()).map((header) => header.name),
       ...[...views.matchAll(/CREATE OR REPLACE (?:VIEW|TABLE) ([a-z_]+)/g)].map(
@@ -231,9 +229,9 @@ describe("a header-bearing query", () => {
   let tmpDir: string;
 
   beforeEach(async () => {
-    tmpDir = mkdtempSync(path.join(tmpdir(), "session-catalog-"));
+    tmpDir = mkdtempSync(join(tmpdir(), "session-catalog-"));
     db = await getDb(tmpDir);
-    await ensureIndex(db, { projectsDir: fixturesDir, importsDir: path.join(tmpDir, "imports") });
+    await ensureIndex(db, { projectsDir: fixturesDir, importsDir: join(tmpDir, "imports") });
   });
 
   afterEach(async () => {
@@ -242,7 +240,7 @@ describe("a header-bearing query", () => {
   });
 
   it("still runs, because DuckDB reads the fence as comments", async () => {
-    expect(parseQueryHeader(await Bun.file(path.join(QUERIES_DIR, "stats.sql")).text()).name).toBe(
+    expect(parseQueryHeader(await Bun.file(join(QUERIES_DIR, "stats.sql")).text()).name).toBe(
       "stats",
     );
 

--- a/plugins/claude-code/skills/session/scripts/catalog.ts
+++ b/plugins/claude-code/skills/session/scripts/catalog.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env bun
-import * as path from "node:path";
+import { join, relative } from "node:path";
 import { loadQueryHeaders, type QueryHeader } from "./query-header";
 
-const REFERENCES_DIR = path.join(import.meta.dirname, "..", "references");
-export const CATALOG_PATH = path.join(REFERENCES_DIR, "catalog.md");
-export const DISCOVERY_PATH = path.join(REFERENCES_DIR, "discovery.md");
-export const SKILL_PATH = path.join(import.meta.dirname, "..", "SKILL.md");
+const REFERENCES_DIR = join(import.meta.dirname, "..", "references");
+export const CATALOG_PATH = join(REFERENCES_DIR, "catalog.md");
+export const DISCOVERY_PATH = join(REFERENCES_DIR, "discovery.md");
+export const SKILL_PATH = join(import.meta.dirname, "..", "SKILL.md");
 
 // Survey surfaces are per-dimension starting points, so the dimension registry lives here
 // and each query declares its membership in its own header.
@@ -152,7 +152,7 @@ if (import.meta.main) {
   await Promise.all(
     targets.map(async ([file, render]) => {
       await Bun.write(file, render(headers, await Bun.file(file).text()));
-      console.log(path.relative(process.cwd(), file));
+      console.log(relative(process.cwd(), file));
     }),
   );
 }

--- a/plugins/claude-code/skills/session/scripts/db.test.ts
+++ b/plugins/claude-code/skills/session/scripts/db.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test
 import { mkdirSync, mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import * as path from "node:path";
+import { join } from "node:path";
 import { $ } from "bun";
 import { z } from "zod";
 import {
@@ -25,12 +25,12 @@ async function backdate(target: string) {
   await $`/usr/bin/touch -t 200001010000 ${target}`.quiet();
 }
 
-const fixturesDir = path.join(import.meta.dirname, "..", "fixtures", "sessions");
-const resourcesDir = path.join(import.meta.dirname, "..", "resources");
-const plansFixtureDir = path.join(import.meta.dirname, "..", "fixtures", "plans");
+const fixturesDir = join(import.meta.dirname, "..", "fixtures", "sessions");
+const resourcesDir = join(import.meta.dirname, "..", "resources");
+const plansFixtureDir = join(import.meta.dirname, "..", "fixtures", "plans");
 
 async function loadExtensions(database: Database) {
-  await database.run(await Bun.file(path.join(resourcesDir, "extensions.sql")).text());
+  await database.run(await Bun.file(join(resourcesDir, "extensions.sql")).text());
 }
 
 function filterParams(overrides: Record<string, string | null> = {}) {
@@ -49,7 +49,7 @@ let importsDir: string;
 // the network, which can exceed the default per-test timeout on a cold CI runner.
 // Warm the shared extension cache once so the per-test LOAD reads from disk.
 beforeAll(async () => {
-  const warmDir = mkdtempSync(path.join(tmpdir(), "session-warm-"));
+  const warmDir = mkdtempSync(join(tmpdir(), "session-warm-"));
   const warm = await getDb(warmDir);
   try {
     await loadExtensions(warm);
@@ -60,11 +60,11 @@ beforeAll(async () => {
 }, 120_000);
 
 async function importFixtureHost(label: string, opts: { source?: string } = {}) {
-  const projects = path.join(importsDir, label, "projects");
+  const projects = join(importsDir, label, "projects");
   mkdirSync(projects, { recursive: true });
   await $`cp -R ${fixturesDir}/. ${projects}`.quiet();
   await Bun.write(
-    path.join(importsDir, label, "manifest.json"),
+    join(importsDir, label, "manifest.json"),
     `${JSON.stringify({
       host: label,
       source: opts.source ?? `${label}:.claude/projects/`,
@@ -79,8 +79,8 @@ async function reindex() {
 }
 
 beforeEach(async () => {
-  tmpDir = mkdtempSync(path.join(tmpdir(), "session-test-"));
-  importsDir = path.join(tmpDir, "imports");
+  tmpDir = mkdtempSync(join(tmpdir(), "session-test-"));
+  importsDir = join(tmpDir, "imports");
   mkdirSync(importsDir, { recursive: true });
   db = await getDb(tmpDir);
   await reindex();
@@ -701,7 +701,7 @@ describe("cross-machine history", () => {
     await importFixtureHost("archive");
     for (const rel of ["-Users-test-project/basic.jsonl", "-Users-test-webapp/webapp.jsonl"]) {
       // oxlint-disable-next-line no-await-in-loop -- two fixture files; concurrency buys nothing.
-      await backdate(path.join(importsDir, "archive", "projects", rel));
+      await backdate(join(importsDir, "archive", "projects", rel));
     }
     await reindex();
 
@@ -723,7 +723,7 @@ describe("cross-machine history", () => {
 
     const removed = await forgetHost(db, "gone");
     expect(removed).toBe(Number(before?.n));
-    await rm(path.join(importsDir, "gone"), { recursive: true, force: true });
+    await rm(join(importsDir, "gone"), { recursive: true, force: true });
 
     const [after] = await db.query(
       "SELECT COUNT(*) AS n FROM raw WHERE host = 'gone'",
@@ -735,7 +735,7 @@ describe("cross-machine history", () => {
       z.object({ host: z.string() }),
     );
     expect(sessions.map((r) => r.host)).toEqual(["local"]);
-    expect(dirExists(path.join(importsDir, "gone"))).toBe(false);
+    expect(dirExists(join(importsDir, "gone"))).toBe(false);
   });
 
   // forget marks the derived tables stale before it deletes, which is what makes the
@@ -747,7 +747,7 @@ describe("cross-machine history", () => {
 
     await invalidateDerived(db);
     await deleteHostRows(db, "gone");
-    await rm(path.join(importsDir, "gone"), { recursive: true, force: true });
+    await rm(join(importsDir, "gone"), { recursive: true, force: true });
 
     await reindex();
 
@@ -1427,7 +1427,7 @@ describe("change catalog", () => {
     await reindex();
 
     // rsync -a re-syncs deliver new files with preserved (old) source mtimes.
-    const late = path.join(importsDir, "work", "projects", "-Users-test-project", "late.jsonl");
+    const late = join(importsDir, "work", "projects", "-Users-test-project", "late.jsonl");
     await Bun.write(
       late,
       `${JSON.stringify({
@@ -1451,13 +1451,7 @@ describe("change catalog", () => {
   it("reimports a file whose content changed and drops its stale rows", async () => {
     await importFixtureHost("edited");
     await reindex();
-    const target = path.join(
-      importsDir,
-      "edited",
-      "projects",
-      "-Users-test-project",
-      "basic.jsonl",
-    );
+    const target = join(importsDir, "edited", "projects", "-Users-test-project", "basic.jsonl");
     const original = await Bun.file(target).text();
     await Bun.write(
       target,
@@ -1483,13 +1477,7 @@ describe("change catalog", () => {
   it("drops rows for files that disappear", async () => {
     await importFixtureHost("shrinking");
     await reindex();
-    const target = path.join(
-      importsDir,
-      "shrinking",
-      "projects",
-      "-Users-test-project",
-      "basic.jsonl",
-    );
+    const target = join(importsDir, "shrinking", "projects", "-Users-test-project", "basic.jsonl");
     const [before] = await db.query(
       "SELECT COUNT(*) AS n FROM raw WHERE host = 'shrinking' AND source_file = $path",
       z.object({ n: z.bigint() }),
@@ -1515,7 +1503,7 @@ describe("change catalog", () => {
   it("keeps a host's rows when its root directory is missing", async () => {
     await importFixtureHost("unmounted");
     await reindex();
-    await rm(path.join(importsDir, "unmounted", "projects"), { recursive: true, force: true });
+    await rm(join(importsDir, "unmounted", "projects"), { recursive: true, force: true });
     await reindex();
 
     const [row] = await db.query(
@@ -1537,7 +1525,7 @@ describe("change catalog", () => {
       );
       expect(Number(before?.n)).toBeGreaterThan(0);
 
-      const subdir = path.join(importsDir, "guarded", "projects", "-Users-test-project");
+      const subdir = join(importsDir, "guarded", "projects", "-Users-test-project");
       await $`chmod 000 ${subdir}`.quiet();
       try {
         expect(reindex()).rejects.toThrow();
@@ -1579,7 +1567,7 @@ describe("pinned column derivation", () => {
   // A root that does not exist is skipped rather than read, so ensureIndex touches no
   // file and anything that changes in raw came from raw itself.
   async function reindexWithoutDisk() {
-    const gone = path.join(tmpDir, "gone");
+    const gone = join(tmpDir, "gone");
     await ensureIndex(db, { projectsDir: gone, importsDir: gone });
   }
 
@@ -1745,7 +1733,7 @@ describe("index version migration", () => {
     );
     expect(Number(before?.n)).toBeGreaterThan(0);
 
-    await rm(path.join(importsDir, "detached", "projects"), { recursive: true, force: true });
+    await rm(join(importsDir, "detached", "projects"), { recursive: true, force: true });
     await db.run("UPDATE index_meta SET version = 0");
     await reindex();
 
@@ -1760,7 +1748,7 @@ describe("index version migration", () => {
     await importFixtureHost("archived");
     await reindex();
 
-    const projects = path.join(importsDir, "archived", "projects");
+    const projects = join(importsDir, "archived", "projects");
     await rm(projects, { recursive: true, force: true });
     mkdirSync(projects, { recursive: true });
 
@@ -2181,8 +2169,8 @@ describe("stop-hook-noop-detector query", () => {
 });
 
 describe("plan-sections query", () => {
-  const plansGlob = path.join(plansFixtureDir, "*.md");
-  const featurePlan = path.join(plansFixtureDir, "feature-plan.md");
+  const plansGlob = join(plansFixtureDir, "*.md");
+  const featurePlan = join(plansFixtureDir, "feature-plan.md");
 
   const Section = z.object({
     session_id: z.string().nullable(),
@@ -2271,7 +2259,7 @@ describe("plan-sections query", () => {
     const missing = [...byFile.entries()]
       .filter(([, titles]) => !titles.has("Verification"))
       .map(([file]) => file);
-    expect(missing).toContain(path.join(plansFixtureDir, "quick-plan.md"));
+    expect(missing).toContain(join(plansFixtureDir, "quick-plan.md"));
     expect(missing).not.toContain(featurePlan);
   });
 
@@ -2287,7 +2275,7 @@ describe("plan-sections query", () => {
     }
 
     // quick-plan.md has no matching plan_calls row, so the LEFT JOIN leaves it null.
-    const quick = rows.filter((r) => r.file_path === path.join(plansFixtureDir, "quick-plan.md"));
+    const quick = rows.filter((r) => r.file_path === join(plansFixtureDir, "quick-plan.md"));
     expect(quick.length).toBeGreaterThan(0);
     for (const r of quick) expect(r.session_id).toBeNull();
   });
@@ -2301,7 +2289,7 @@ describe("plan-sections query", () => {
 });
 
 describe("skill-config-vs-observed query", () => {
-  const skillsFixtureDir = path.join(import.meta.dirname, "..", "fixtures", "skills");
+  const skillsFixtureDir = join(import.meta.dirname, "..", "fixtures", "skills");
 
   const SkillRow = z.object({
     source: z.string(),
@@ -2325,9 +2313,9 @@ describe("skill-config-vs-observed query", () => {
       SkillRow,
       filterParams({
         skill: null,
-        plugin_skill_glob: path.join(skillsFixtureDir, "cache/*/*/*/skills/*/SKILL.md"),
-        user_skill_glob: path.join(skillsFixtureDir, "user/*/SKILL.md"),
-        project_skill_glob: path.join(skillsFixtureDir, "project/*/SKILL.md"),
+        plugin_skill_glob: join(skillsFixtureDir, "cache/*/*/*/skills/*/SKILL.md"),
+        user_skill_glob: join(skillsFixtureDir, "user/*/SKILL.md"),
+        project_skill_glob: join(skillsFixtureDir, "project/*/SKILL.md"),
         ...overrides,
       }),
     );
@@ -2372,7 +2360,7 @@ describe("skill-config-vs-observed query", () => {
 });
 
 describe("index-health query", () => {
-  const projectsGlob = path.join(fixturesDir, "**", "*.jsonl");
+  const projectsGlob = join(fixturesDir, "**", "*.jsonl");
 
   const Health = z.object({
     check_name: z.string(),
@@ -2454,17 +2442,17 @@ describe("index-health query", () => {
   });
 
   it("alerts on disk files missing from the index", async () => {
-    const extraDir = path.join(tmpDir, "extra-projects", "-Users-test-extra");
+    const extraDir = join(tmpDir, "extra-projects", "-Users-test-extra");
     mkdirSync(extraDir, { recursive: true });
     await Bun.write(
-      path.join(extraDir, "unindexed.jsonl"),
+      join(extraDir, "unindexed.jsonl"),
       '{"type":"user","message":{"role":"user","content":"hi"},"sessionId":"extra","timestamp":"2024-02-01T00:00:00.000Z","uuid":"ex-1"}\n',
     );
     const rows = await runQuery(
       db,
       "index-health",
       Health,
-      healthParams({ projects_glob: path.join(tmpDir, "extra-projects", "**", "*.jsonl") }),
+      healthParams({ projects_glob: join(tmpDir, "extra-projects", "**", "*.jsonl") }),
     );
     const missing = rows.find((r) => r.check_name === "disk-not-indexed");
     expect(missing?.status).toBe("alert");
@@ -2475,14 +2463,14 @@ describe("index-health query", () => {
   });
 
   it("alerts on an imported host whose newest record lags the corpus", async () => {
-    const staleProjects = path.join(importsDir, "stale", "projects", "-Users-test-stale");
+    const staleProjects = join(importsDir, "stale", "projects", "-Users-test-stale");
     mkdirSync(staleProjects, { recursive: true });
     await Bun.write(
-      path.join(staleProjects, "old.jsonl"),
+      join(staleProjects, "old.jsonl"),
       '{"type":"user","message":{"role":"user","content":"old work"},"sessionId":"stale-session","timestamp":"2023-12-01T00:00:00.000Z","uuid":"st-1"}\n',
     );
     await Bun.write(
-      path.join(importsDir, "stale", "manifest.json"),
+      join(importsDir, "stale", "manifest.json"),
       `${JSON.stringify({
         host: "stale",
         source: "stale:.claude/projects/",
@@ -2504,7 +2492,7 @@ describe("index-health query", () => {
 describe("frontmatter query", () => {
   it("parses name and description from a SKILL.md frontmatter", async () => {
     await loadExtensions(db);
-    const skill = path.join(import.meta.dirname, "..", "SKILL.md");
+    const skill = join(import.meta.dirname, "..", "SKILL.md");
     const rows = await runQuery(
       db,
       "frontmatter",
@@ -2834,7 +2822,7 @@ describe("schema map", () => {
 
   it("falls back to the committed map when the index cannot be reached", async () => {
     const dataDir = process.env.CLAUDE_PLUGIN_DATA;
-    process.env.CLAUDE_PLUGIN_DATA = path.join(tmpDir, "absent");
+    process.env.CLAUDE_PLUGIN_DATA = join(tmpDir, "absent");
     try {
       const lines = (await schemaMap()).split("\n");
       expect(lines.map((line) => line.split(":")[0])).toEqual([...SURFACES]);

--- a/plugins/claude-code/skills/session/scripts/db.ts
+++ b/plugins/claude-code/skills/session/scripts/db.ts
@@ -1,13 +1,13 @@
 import { readdirSync } from "node:fs";
 import { rm } from "node:fs/promises";
-import * as path from "node:path";
+import { join, sep } from "node:path";
 import { DuckDBInstance } from "@duckdb/node-api";
 import { $ } from "bun";
 import { z } from "zod";
 import { nodeAdapter, runQuery as runOnAdapter } from "./query";
 
-const RESOURCES_DIR = path.join(import.meta.dirname, "..", "resources");
-const SCHEMA_DIR = path.join(RESOURCES_DIR, "schema");
+const RESOURCES_DIR = join(import.meta.dirname, "..", "resources");
+const SCHEMA_DIR = join(RESOURCES_DIR, "schema");
 
 export const LOCAL_HOST = "local";
 
@@ -80,7 +80,7 @@ async function createDatabase(dbPath: string): Promise<Database> {
 }
 
 async function readSql(dir: string, name: string): Promise<string> {
-  return Bun.file(path.join(dir, `${name}.sql`)).text();
+  return Bun.file(join(dir, `${name}.sql`)).text();
 }
 
 function getLocalRoot(projectsDir?: string): string {
@@ -90,7 +90,7 @@ function getLocalRoot(projectsDir?: string): string {
   if (process.env.HOME == null || process.env.HOME === "") {
     throw new Error("Cannot locate projects directory: set CLAUDE_PROJECTS_DIR or HOME");
   }
-  return path.join(process.env.HOME, ".claude", "projects");
+  return join(process.env.HOME, ".claude", "projects");
 }
 
 export function getImportsDir(importsDir?: string): string {
@@ -100,11 +100,11 @@ export function getImportsDir(importsDir?: string): string {
   if (process.env.HOME == null || process.env.HOME === "") {
     throw new Error("Cannot locate imports directory: set CLAUDE_SESSION_IMPORTS_DIR or HOME");
   }
-  return path.join(process.env.HOME, ".claude", "session-imports");
+  return join(process.env.HOME, ".claude", "session-imports");
 }
 
 export function importRoot(label: string, importsDir?: string): string {
-  return path.join(getImportsDir(importsDir), label);
+  return join(getImportsDir(importsDir), label);
 }
 
 // The ${CLAUDE_PLUGIN_DATA} template expands only in skill text and hook/MCP
@@ -116,13 +116,13 @@ export function getDataDir(): string {
   if (process.env.CLAUDE_PLUGIN_DATA != null && process.env.CLAUDE_PLUGIN_DATA !== "")
     return process.env.CLAUDE_PLUGIN_DATA;
 
-  const segments = import.meta.dirname.split(path.sep);
+  const segments = import.meta.dirname.split(sep);
   const cacheIdx = segments.lastIndexOf("cache");
   if (cacheIdx > 0 && segments[cacheIdx - 1] === "plugins" && segments.length > cacheIdx + 2) {
     const marketplace = segments[cacheIdx + 1];
     const plugin = segments[cacheIdx + 2];
-    const pluginsDir = segments.slice(0, cacheIdx).join(path.sep);
-    return path.join(pluginsDir, "data", `${plugin}-${marketplace}`);
+    const pluginsDir = segments.slice(0, cacheIdx).join(sep);
+    return join(pluginsDir, "data", `${plugin}-${marketplace}`);
   }
 
   throw new Error(
@@ -131,7 +131,7 @@ export function getDataDir(): string {
 }
 
 export function sessionDbPath(dataDir: string): string {
-  return path.join(dataDir, "session.duckdb");
+  return join(dataDir, "session.duckdb");
 }
 
 export function dirExists(target: string): boolean {
@@ -164,8 +164,8 @@ export async function listImportedHosts(importsDir?: string): Promise<ImportedHo
     readDirEntries(root)
       .filter((entry) => entry.isDirectory())
       .map(async (entry) => {
-        const hostRoot = path.join(root, entry.name);
-        const manifestPath = path.join(hostRoot, "manifest.json");
+        const hostRoot = join(root, entry.name);
+        const manifestPath = join(hostRoot, "manifest.json");
         try {
           return {
             label: entry.name,
@@ -194,7 +194,7 @@ export async function enumerateHosts(
     // key on it); the manifest's host field is informational and may be hand-edited.
     hosts.push({
       host: imported.label,
-      root: path.join(imported.root, "projects"),
+      root: join(imported.root, "projects"),
       policy: imported.manifest.policy,
     });
   }
@@ -216,7 +216,7 @@ export function scanJsonlFiles(root: string): ScannedFile[] {
   const files: ScannedFile[] = [];
   for (const entry of readdirSync(root, { withFileTypes: true, recursive: true })) {
     if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
-    const full = path.join(entry.parentPath, entry.name);
+    const full = join(entry.parentPath, entry.name);
     const file = Bun.file(full);
     files.push({ path: full, mtime: Math.trunc(file.lastModified), size: file.size });
   }
@@ -229,7 +229,7 @@ async function applySchema(db: Database): Promise<void> {
     .toSorted();
   for (const file of files) {
     // oxlint-disable-next-line no-await-in-loop -- schema files apply in sorted order; later DDL depends on tables earlier DDL created.
-    const sql = await Bun.file(path.join(SCHEMA_DIR, file)).text();
+    const sql = await Bun.file(join(SCHEMA_DIR, file)).text();
     // oxlint-disable-next-line no-await-in-loop -- schema files apply in sorted order; later DDL depends on tables earlier DDL created.
     await db.run(sql);
   }

--- a/plugins/claude-code/skills/session/scripts/hosts.ts
+++ b/plugins/claude-code/skills/session/scripts/hosts.ts
@@ -2,7 +2,7 @@
 // claude:dangerouslyDisableSandbox: temporary. Opens the DuckDB index read-write in
 // the plugin data dir, which an upstream sandbox defect makes unwritable. Remove this
 // when the probe in docs/settings.md succeeds.
-import * as path from "node:path";
+import { join } from "node:path";
 import { cli } from "cleye";
 import { table } from "table";
 import { z } from "zod";
@@ -50,6 +50,6 @@ if (imported.length > 0) {
   for (const { label, root, manifest } of imported) {
     const source = manifest.source !== "" ? manifest.source : "<source>";
     console.log(`  ${label}:`);
-    console.log(`    rsync -av --update ${source} ${path.join(root, "projects")}/`);
+    console.log(`    rsync -av --update ${source} ${join(root, "projects")}/`);
   }
 }

--- a/plugins/claude-code/skills/session/scripts/import.ts
+++ b/plugins/claude-code/skills/session/scripts/import.ts
@@ -3,7 +3,7 @@
 // the plugin data dir, which an upstream sandbox defect makes unwritable. Remove this
 // when the probe in docs/settings.md succeeds.
 import { mkdir } from "node:fs/promises";
-import * as path from "node:path";
+import { join } from "node:path";
 import { $ } from "bun";
 import { cli } from "cleye";
 import {
@@ -58,7 +58,7 @@ if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(label)) {
 }
 
 const root = importRoot(label);
-const projectsDir = path.join(root, "projects");
+const projectsDir = join(root, "projects");
 if (!dirExists(projectsDir)) {
   console.error(`No corpus at ${projectsDir}.`);
   console.error("Sync the source machine's ~/.claude/projects/ there first, then re-run:");
@@ -71,7 +71,7 @@ if (!dirExists(projectsDir)) {
 // Re-running on a registered host is a re-sync: leave the manifest (source, policy,
 // imported_at) intact and just re-index the changed files.
 const existing = (await listImportedHosts()).find((h) => h.label === label)?.manifest;
-const manifestPath = path.join(root, "manifest.json");
+const manifestPath = join(root, "manifest.json");
 if (!existing) {
   await mkdir(getImportsDir(), { recursive: true, mode: 0o700 });
   const manifest: Manifest = {

--- a/plugins/claude-code/skills/session/scripts/query-header.ts
+++ b/plugins/claude-code/skills/session/scripts/query-header.ts
@@ -1,8 +1,8 @@
 import { readdirSync } from "node:fs";
-import * as path from "node:path";
+import { basename, join } from "node:path";
 import { z } from "zod";
 
-export const QUERIES_DIR = path.join(import.meta.dirname, "..", "resources", "queries");
+export const QUERIES_DIR = join(import.meta.dirname, "..", "resources", "queries");
 
 // A `-- ---` fence in line comments: DuckDB sees comments, the parser sees YAML, and the
 // file stays uniformly `--` commented so the free prose below reads as one block with it.
@@ -61,9 +61,9 @@ export async function loadQueryHeaders(dir: string = QUERIES_DIR): Promise<Query
     .toSorted();
   return Promise.all(
     files.map(async (file) => {
-      const name = path.basename(file, ".sql");
+      const name = basename(file, ".sql");
       try {
-        const header = parseQueryHeader(await Bun.file(path.join(dir, file)).text());
+        const header = parseQueryHeader(await Bun.file(join(dir, file)).text());
         if (header.name !== name) throw new Error(`header names "${header.name}"`);
         return header;
       } catch (error) {

--- a/plugins/claude-code/skills/session/scripts/query.test.ts
+++ b/plugins/claude-code/skills/session/scripts/query.test.ts
@@ -3,7 +3,7 @@ import { once } from "node:events";
 import { mkdirSync, mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import * as path from "node:path";
+import { join } from "node:path";
 import { z } from "zod";
 import { type Database, ensureIndex, getDb } from "./db";
 import {
@@ -53,12 +53,12 @@ describe("node adapter", () => {
   let tmpDir: string;
 
   beforeAll(async () => {
-    tmpDir = mkdtempSync(path.join(tmpdir(), "session-query-"));
-    const importsDir = path.join(tmpDir, "imports");
+    tmpDir = mkdtempSync(join(tmpdir(), "session-query-"));
+    const importsDir = join(tmpDir, "imports");
     mkdirSync(importsDir, { recursive: true });
     db = await getDb(tmpDir);
     await ensureIndex(db, {
-      projectsDir: path.join(import.meta.dirname, "..", "fixtures", "sessions"),
+      projectsDir: join(import.meta.dirname, "..", "fixtures", "sessions"),
       importsDir,
     });
   }, 60_000);

--- a/plugins/claude-code/skills/session/scripts/query.ts
+++ b/plugins/claude-code/skills/session/scripts/query.ts
@@ -1,8 +1,8 @@
-import * as path from "node:path";
+import { join } from "node:path";
 import { z } from "zod";
 import type { Database } from "./db";
 
-const QUERIES_DIR = path.join(import.meta.dirname, "..", "resources", "queries");
+const QUERIES_DIR = join(import.meta.dirname, "..", "resources", "queries");
 
 export type QueryValue = string | number | null | undefined;
 
@@ -133,9 +133,7 @@ export async function runQuery<T>(
   params: QueryParams = {},
 ): Promise<T[]> {
   const sql =
-    "name" in source
-      ? await Bun.file(path.join(QUERIES_DIR, `${source.name}.sql`)).text()
-      : source.sql;
+    "name" in source ? await Bun.file(join(QUERIES_DIR, `${source.name}.sql`)).text() : source.sql;
   const prefix = await adapter.bind(params);
   return adapter.execute(prefix + sql, schema);
 }

--- a/plugins/claude-code/skills/session/scripts/refresh.integration.ts
+++ b/plugins/claude-code/skills/session/scripts/refresh.integration.ts
@@ -2,22 +2,22 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import * as path from "node:path";
+import { join } from "node:path";
 import { $ } from "bun";
 import { z } from "zod";
 import { getDb } from "./db";
 
-const fixturesDir = path.join(import.meta.dirname, "..", "fixtures", "sessions");
-const refreshScript = path.join(import.meta.dirname, "refresh.ts");
+const fixturesDir = join(import.meta.dirname, "..", "fixtures", "sessions");
+const refreshScript = join(import.meta.dirname, "refresh.ts");
 
 let tmpDir: string;
 let dataDir: string;
 let corpusDir: string;
 
 beforeEach(async () => {
-  tmpDir = mkdtempSync(path.join(tmpdir(), "refresh-integration-"));
-  dataDir = path.join(tmpDir, "data");
-  corpusDir = path.join(tmpDir, "projects");
+  tmpDir = mkdtempSync(join(tmpdir(), "refresh-integration-"));
+  dataDir = join(tmpDir, "data");
+  corpusDir = join(tmpDir, "projects");
   mkdirSync(corpusDir, { recursive: true });
   mkdirSync(dataDir, { recursive: true });
   await $`cp -R ${fixturesDir}/. ${corpusDir}`.quiet();
@@ -32,7 +32,7 @@ function env() {
     ...process.env,
     CLAUDE_PLUGIN_DATA: dataDir,
     CLAUDE_PROJECTS_DIR: corpusDir,
-    CLAUDE_SESSION_IMPORTS_DIR: path.join(tmpDir, "imports"),
+    CLAUDE_SESSION_IMPORTS_DIR: join(tmpDir, "imports"),
   };
 }
 
@@ -61,15 +61,15 @@ async function countRows(): Promise<number> {
 }
 
 async function touchCorpusFile(rel: string): Promise<void> {
-  await $`touch ${path.join(corpusDir, rel)}`.quiet();
+  await $`touch ${join(corpusDir, rel)}`.quiet();
 }
 
 describe("refresh.ts", () => {
   it("prints the database path to stdout and writes a freshness stamp", async () => {
     const { stdout, exitCode } = await run();
     expect(exitCode).toBe(0);
-    expect(stdout.trim()).toBe(path.join(dataDir, "session.duckdb"));
-    expect(await Bun.file(path.join(dataDir, "last-refresh")).exists()).toBe(true);
+    expect(stdout.trim()).toBe(join(dataDir, "session.duckdb"));
+    expect(await Bun.file(join(dataDir, "last-refresh")).exists()).toBe(true);
   });
 
   it("is idempotent across repeated runs", async () => {
@@ -84,7 +84,7 @@ describe("refresh.ts", () => {
     const before = await countRows();
 
     await Bun.write(
-      path.join(corpusDir, "-Users-test-project", "extra.jsonl"),
+      join(corpusDir, "-Users-test-project", "extra.jsonl"),
       `${JSON.stringify({
         type: "user",
         sessionId: "extra-session",
@@ -107,7 +107,7 @@ describe("refresh.ts", () => {
     await run();
     const before = await countRows();
     await Bun.write(
-      path.join(corpusDir, "-Users-test-project", "extra.jsonl"),
+      join(corpusDir, "-Users-test-project", "extra.jsonl"),
       `${JSON.stringify({
         type: "user",
         sessionId: "extra-session",
@@ -122,12 +122,12 @@ describe("refresh.ts", () => {
 
   it("bounds file growth across repeated reimports of the same corpus", async () => {
     await run();
-    const dbPath = path.join(dataDir, "session.duckdb");
+    const dbPath = join(dataDir, "session.duckdb");
     const initial = Bun.file(dbPath).size;
 
     for (let i = 0; i < 5; i++) {
       // oxlint-disable-next-line no-await-in-loop -- the test measures growth across repeated reimports, so each cycle must follow the last.
-      await touchCorpusFile(path.join("-Users-test-project", "basic.jsonl"));
+      await touchCorpusFile(join("-Users-test-project", "basic.jsonl"));
       // oxlint-disable-next-line no-await-in-loop -- the test measures growth across repeated reimports, so each cycle must follow the last.
       const { exitCode } = await run("--refresh");
       expect(exitCode).toBe(0);

--- a/plugins/claude-code/skills/session/scripts/refresh.ts
+++ b/plugins/claude-code/skills/session/scripts/refresh.ts
@@ -5,7 +5,7 @@
 import { mkdirSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import * as path from "node:path";
+import { join, resolve } from "node:path";
 import { cli } from "cleye";
 import {
   compactDatabase,
@@ -37,7 +37,7 @@ const argv = cli({
 
 const dataDir = getDataDir();
 const dbPath = sessionDbPath(dataDir);
-const stampPath = path.join(dataDir, "last-refresh");
+const stampPath = join(dataDir, "last-refresh");
 
 // Earlier versions kept the index in TMPDIR. Those copies are stale derived
 // caches that silently diverge from the real one. Swept only when running
@@ -45,9 +45,9 @@ const stampPath = path.join(dataDir, "last-refresh");
 // test or dev run, which must not delete machine-wide state.
 async function cleanupStrayDatabases(): Promise<void> {
   if (process.env.CLAUDE_PLUGIN_DATA != null && process.env.CLAUDE_PLUGIN_DATA !== "") return;
-  const strayDirs = new Set([path.join(tmpdir(), "claude-session"), "/tmp/claude-session"]);
+  const strayDirs = new Set([join(tmpdir(), "claude-session"), "/tmp/claude-session"]);
   for (const dir of strayDirs) {
-    if (path.resolve(dir) === path.resolve(dataDir)) continue;
+    if (resolve(dir) === resolve(dataDir)) continue;
     // oxlint-disable-next-line no-await-in-loop -- two known stray directories; concurrency buys nothing.
     if (!(await Bun.file(sessionDbPath(dir)).exists())) continue;
     try {

--- a/plugins/claude-code/skills/session/scripts/schema.ts
+++ b/plugins/claude-code/skills/session/scripts/schema.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import * as path from "node:path";
+import { join } from "node:path";
 import { z } from "zod";
 import { getDataDir, sessionDbPath } from "./db";
 import { cliAdapter, runQuery } from "./query";
@@ -19,7 +19,7 @@ export const SURFACES = [
   "tool_errors",
 ] as const;
 
-export const FALLBACK_PATH = path.join(import.meta.dirname, "..", "resources", "schema-map.txt");
+export const FALLBACK_PATH = join(import.meta.dirname, "..", "resources", "schema-map.txt");
 
 const COLUMN_QUERY = `
 SELECT table_name, list(column_name ORDER BY ordinal_position) AS cols

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/index.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/index.ts
@@ -1,10 +1,10 @@
-import * as path from "node:path";
+import { join } from "node:path";
 import { estimateTokens, parseSkill } from "./parse";
 import { allRules, findReferences, lintReference } from "./rules";
 import type { RuleResult, SkillLintResult } from "./types";
 
 export async function lintSkill(skillDir: string): Promise<SkillLintResult> {
-  const skillPath = path.join(skillDir, "SKILL.md");
+  const skillPath = join(skillDir, "SKILL.md");
   const raw = await Bun.file(skillPath).text();
   const content = parseSkill(raw);
 
@@ -24,7 +24,7 @@ export async function lintSkill(skillDir: string): Promise<SkillLintResult> {
 
   const refTokens = await Promise.all(
     referenceResults.map(async (ref) => {
-      const refFile = Bun.file(path.join(skillDir, ref.path));
+      const refFile = Bun.file(join(skillDir, ref.path));
       if (!(await refFile.exists())) return 0;
       return estimateTokens(await refFile.text());
     }),

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/rules/references.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/rules/references.ts
@@ -1,4 +1,4 @@
-import * as path from "node:path";
+import { join } from "node:path";
 import { countLines } from "../parse";
 import type { ReferenceResult, RuleResult } from "../types";
 import { codeSpans, lineAt } from "./markdown";
@@ -73,7 +73,7 @@ export function substitutionResults(content: string, refPath: string): RuleResul
 }
 
 export async function lintReference(skillDir: string, refPath: string): Promise<ReferenceResult> {
-  const fullPath = path.join(skillDir, refPath);
+  const fullPath = join(skillDir, refPath);
   const results: RuleResult[] = [];
   let lines = 0;
   const depth = getDepth(refPath);

--- a/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
+++ b/plugins/claude-code/skills/skill/scripts/skill-lint/test/rules.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "bun:test";
-import * as path from "node:path";
+import { join } from "node:path";
 import { lintSkill } from "../index";
 import { parseSkill } from "../parse";
 import { bangExecutionMatcher } from "../rules/bang-execution";
@@ -18,7 +18,7 @@ import { namespaceMismatch, namespaceStutter } from "../rules/namespace";
 import { findReferences, substitutionResults } from "../rules/references";
 import type { RuleResult, Severity } from "../types";
 
-const fixturesDir = path.join(import.meta.dirname, "fixtures");
+const fixturesDir = join(import.meta.dirname, "fixtures");
 
 function single(result: RuleResult | RuleResult[]): RuleResult {
   if (Array.isArray(result)) {
@@ -446,14 +446,14 @@ describe("substitutionResults", () => {
 
   // These repo files describe the substitution syntax in prose. The rule must
   // not fire on any of them.
-  const repoRoot = path.join(import.meta.dirname, "../../../../../../..");
+  const repoRoot = join(import.meta.dirname, "../../../../../../..");
 
   test.each([
     "plugins/claude-code/skills/skill/references/patterns.md",
     "plugins/writing/skills/analyze/references/methodology.md",
     "plugins/claude-code/skills/hook/references/debugging.md",
   ])("passes prose in %s", async (relative) => {
-    const content = await Bun.file(path.join(repoRoot, relative)).text();
+    const content = await Bun.file(join(repoRoot, relative)).text();
     expect(failing(content, relative)).toEqual([]);
   });
 });
@@ -533,27 +533,27 @@ describe("namespace rules", () => {
 
 describe("lintSkill", () => {
   it("passes valid skill", async () => {
-    const result = await lintSkill(path.join(fixturesDir, "valid"));
+    const result = await lintSkill(join(fixturesDir, "valid"));
     expect(result.errors).toBe(0);
     expect(result.warnings).toBe(0);
   });
 
   it("reports invalid name format", async () => {
-    const result = await lintSkill(path.join(fixturesDir, "invalid-name"));
+    const result = await lintSkill(join(fixturesDir, "invalid-name"));
     expect(result.errors).toBeGreaterThan(0);
     const nameError = result.results.find((r) => r.rule === "name-format");
     expect(nameError?.passed).toBe(false);
   });
 
   it("reports missing description", async () => {
-    const result = await lintSkill(path.join(fixturesDir, "missing-description"));
+    const result = await lintSkill(join(fixturesDir, "missing-description"));
     expect(result.errors).toBeGreaterThan(0);
     const descError = result.results.find((r) => r.rule === "description-required");
     expect(descError?.passed).toBe(false);
   });
 
   it("warns on line-start bold labels without failing", async () => {
-    const result = await lintSkill(path.join(fixturesDir, "prefer-headers"));
+    const result = await lintSkill(join(fixturesDir, "prefer-headers"));
     expect(result.errors).toBe(0);
     const offenders = result.results.filter((r) => r.rule === "prefer-headers" && !r.passed);
     expect(offenders).toHaveLength(1);
@@ -561,13 +561,13 @@ describe("lintSkill", () => {
   });
 
   it("detects references", async () => {
-    const result = await lintSkill(path.join(fixturesDir, "with-references"));
+    const result = await lintSkill(join(fixturesDir, "with-references"));
     expect(result.references).toHaveLength(1);
     expect(result.references[0]?.path).toBe("references/language.md");
   });
 
   it("calculates token counts", async () => {
-    const result = await lintSkill(path.join(fixturesDir, "valid"));
+    const result = await lintSkill(join(fixturesDir, "valid"));
     expect(result.tokens.skill).toBeGreaterThan(0);
     expect(result.tokens.total).toBeGreaterThanOrEqual(result.tokens.skill);
   });

--- a/plugins/gitlab/scripts/merge.test.ts
+++ b/plugins/gitlab/scripts/merge.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, mock, test } from "bun:test";
-import type { MergeActions, MergeRequestDetail } from "./merge";
-import { arm, errorText, merge, mergeArgs, status, streamText } from "./merge";
+import {
+  type MergeActions,
+  type MergeRequestDetail,
+  arm,
+  errorText,
+  merge,
+  mergeArgs,
+  status,
+  streamText,
+} from "./merge";
 
 function shellError(streams: { stdout?: string; stderr?: string }): Error {
   return Object.assign(new Error("glab exited non-zero"), {

--- a/plugins/gitlab/skills/merge-request/scripts/discussions.test.ts
+++ b/plugins/gitlab/skills/merge-request/scripts/discussions.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, test } from "bun:test";
-import type { DiscussionSummary, FilterOptions } from "./discussions";
 import {
-  deduplicateDiscussions,
   Discussion,
+  type DiscussionSummary,
+  type FilterOptions,
+  deduplicateDiscussions,
   filterDiscussions,
   formatDigest,
   formatLocation,

--- a/plugins/mac/scripts/jxa.test.ts
+++ b/plugins/mac/scripts/jxa.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, test } from "bun:test";
 import { join } from "node:path";
-import type { RunResult } from "./jxa";
-import { isRetriableAppleEventsError, parseArgv, runWithRetry, validateAppScope } from "./jxa";
+import {
+  type RunResult,
+  isRetriableAppleEventsError,
+  parseArgv,
+  runWithRetry,
+  validateAppScope,
+} from "./jxa";
 
 type ScopeResult = { valid: boolean; violations: string[] };
 const valid: ScopeResult = { valid: true, violations: [] };

--- a/plugins/mac/scripts/jxa.ts
+++ b/plugins/mac/scripts/jxa.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 // claude:dangerouslyDisableSandbox: hands off to osascript for JXA Apple Events, which the command sandbox blocks
 
-import * as acorn from "acorn";
+import { type Node, parse } from "acorn";
 import { cli } from "cleye";
 import { z } from "zod";
 
@@ -47,9 +47,9 @@ function walkNode(node: AstNode, visitor: (n: AstNode) => void): void {
 
 export function validateAppScope(source: string, app: string): ValidationResult {
   const stripped = stripShebang(source);
-  let ast: acorn.Node;
+  let ast: Node;
   try {
-    ast = acorn.parse(stripped, { ecmaVersion: 5, sourceType: "script" });
+    ast = parse(stripped, { ecmaVersion: 5, sourceType: "script" });
   } catch (error) {
     throw new Error(
       `Failed to parse JXA source: ${error instanceof Error ? error.message : String(error)}`,

--- a/plugins/pull-request/evals/pr-body/scripts/score.ts
+++ b/plugins/pull-request/evals/pr-body/scripts/score.ts
@@ -13,21 +13,19 @@ import {
   hasClauseStacking,
   MAX_SENTENCES_PER_PARAGRAPH,
   NARRATION_TELLS,
-  type NarrationTell,
   narrationTellSource,
   proseParagraphs,
   RUN_ON_CHARS,
   splitSentences,
   TITLE_LENGTH_LIMIT,
 } from "../../../scripts/prose";
+export { type NarrationTell } from "../../../scripts/prose";
 import { classifyPrHeading } from "../classifier";
 
 // Deterministic metrics for one generated PR body. Everything here is
 // mechanical: the LLM judge scores the rest. The thresholds, splitters, and
 // wordlists come from the hook that enforces them, so the scorer and the hook
 // measure the same thing.
-
-export type { NarrationTell };
 
 export interface SentenceHeading {
   text: string;

--- a/plugins/pull-request/scripts/pr-template.test.ts
+++ b/plugins/pull-request/scripts/pr-template.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { execSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, realpathSync } from "node:fs";
 import { rm } from "node:fs/promises";
-import * as os from "node:os";
-import * as path from "node:path";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { findTemplate } from "./pr-template";
 
 type TemplateFile = [path: string, content: string];
@@ -12,7 +12,7 @@ describe("findTemplate", () => {
   let tempDir: string;
 
   beforeEach(() => {
-    tempDir = realpathSync(mkdtempSync(path.join(os.tmpdir(), "pr-template-")));
+    tempDir = realpathSync(mkdtempSync(join(tmpdir(), "pr-template-")));
     execSync("git init -q", { cwd: tempDir, stdio: "pipe" });
     execSync("git remote add origin git@github.com:user/repo.git", {
       cwd: tempDir,
@@ -27,8 +27,8 @@ describe("findTemplate", () => {
   async function writeFiles(files: TemplateFile[]) {
     await Promise.all(
       files.map(([file, content]) => {
-        const dest = path.join(tempDir, file);
-        mkdirSync(path.dirname(dest), { recursive: true });
+        const dest = join(tempDir, file);
+        mkdirSync(dirname(dest), { recursive: true });
         return Bun.write(dest, content);
       }),
     );

--- a/plugins/pull-request/scripts/resolve-body.test.ts
+++ b/plugins/pull-request/scripts/resolve-body.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
-import * as os from "node:os";
-import * as path from "node:path";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   type BodyPart,
   type BodySpec,
@@ -247,7 +247,7 @@ describe("extractBodySpec", () => {
   });
 });
 
-const REPO_ROOT = path.join(import.meta.dir, "..", "..", "..");
+const REPO_ROOT = join(import.meta.dir, "..", "..", "..");
 
 const SKILL_DOCS = [
   "plugins/pull-request/skills/create/SKILL.md",
@@ -281,7 +281,7 @@ function codeSnippets(markdown: string): string[] {
 const DOCUMENTED_FORMS: Array<[string, string]> = (
   await Promise.all(
     SKILL_DOCS.map(async (doc) => {
-      const markdown = await Bun.file(path.join(REPO_ROOT, doc)).text();
+      const markdown = await Bun.file(join(REPO_ROOT, doc)).text();
       return codeSnippets(markdown)
         .filter((snippet) => DOCUMENTED_BODY_ARG.test(snippet))
         .map((snippet): [string, string] => [doc, snippet]);
@@ -299,7 +299,7 @@ describe("command forms the skills document", () => {
   });
 
   test.each(DOCUMENTED_FORMS)("%s: %s reaches the body", async (_doc, snippet) => {
-    const bodyPath = path.join(mkdtempSync(path.join(os.tmpdir(), "doc-form-")), "body.md");
+    const bodyPath = join(mkdtempSync(join(tmpdir(), "doc-form-")), "body.md");
     const body = "## Summary\n\nResolved through the form the skill documents.\n";
     await Bun.write(bodyPath, body);
     // Doc paths are placeholders (`tmp/pr-body-<branch>.md`, `file.md`).
@@ -333,14 +333,14 @@ describe("extractTitle", () => {
 describe("effectiveCwd", () => {
   test.each<[string, string]>([
     ["gh pr create --body-file body.md", "/repo"],
-    ["cd sub && gh pr create --body-file body.md", path.join("/repo", "sub")],
+    ["cd sub && gh pr create --body-file body.md", join("/repo", "sub")],
     ["cd /abs && gh pr create --body-file body.md", "/abs"],
-    ["cd a && cd b && gh pr create --body-file body.md", path.join("/repo", "a", "b")],
+    ["cd a && cd b && gh pr create --body-file body.md", join("/repo", "a", "b")],
     ["gh pr create --body-file body.md && cd sub", "/repo"],
     ['cd "$DIR" && gh pr create --body-file body.md', "/repo"],
     ["cd - && gh pr create --body-file body.md", "/repo"],
     // The || fallback only runs when the first cd failed.
-    ["cd a || cd b && gh pr create --body-file body.md", path.join("/repo", "a")],
+    ["cd a || cd b && gh pr create --body-file body.md", join("/repo", "a")],
     // `~user` needs a passwd lookup the hook does not do.
     ["cd ~nobody && gh pr create --body-file body.md", "/repo"],
   ])("effectiveCwd(%p) -> %p", (command, expected) => {

--- a/plugins/pull-request/scripts/suggest-reviewers.test.ts
+++ b/plugins/pull-request/scripts/suggest-reviewers.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { execSync } from "node:child_process";
 import { mkdtempSync, realpathSync } from "node:fs";
 import { rm } from "node:fs/promises";
-import * as os from "node:os";
-import * as path from "node:path";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   areaRefs,
   blameOwners,
@@ -28,13 +28,13 @@ describe("suggest-reviewers", () => {
     author: typeof ME,
     subject: string,
   ): Promise<void> {
-    await Bun.write(path.join(dir, file), content);
+    await Bun.write(join(dir, file), content);
     git(`add "${file}"`);
     git(`commit --author="${author.name} <${author.email}>" -m "${subject}"`);
   }
 
   beforeEach(() => {
-    dir = realpathSync(mkdtempSync(path.join(os.tmpdir(), "suggest-reviewers-")));
+    dir = realpathSync(mkdtempSync(join(tmpdir(), "suggest-reviewers-")));
     git("init -q");
     git("symbolic-ref HEAD refs/heads/main");
     git(`config user.name "${ME.name}"`);

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
-import * as os from "node:os";
-import * as path from "node:path";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { type HookInput, processInput } from "./validate";
 
 function getPermissionDecision(result: Awaited<ReturnType<typeof processInput>>) {
@@ -34,14 +34,14 @@ describe("processInput", () => {
   let tempDir: string;
 
   beforeEach(() => {
-    tempDir = mkdtempSync(path.join(os.tmpdir(), "validate-test-"));
+    tempDir = mkdtempSync(join(tmpdir(), "validate-test-"));
   });
 
   afterEach(async () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  const repoRoot = path.join(import.meta.dir, "..", "..", "..");
+  const repoRoot = join(import.meta.dir, "..", "..", "..");
   const headSha = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8" })
     .stdout.trim()
     .slice(0, 12);
@@ -84,7 +84,7 @@ describe("processInput", () => {
   });
 
   it("returns null for valid body", async () => {
-    const bodyFile = path.join(tempDir, "body.md");
+    const bodyFile = join(tempDir, "body.md");
     await Bun.write(bodyFile, "## Summary\nFixes a bug");
     const result = await processInput(createInput(`gh pr create --body-file ${bodyFile}`));
     expect(result).toBeNull();
@@ -110,7 +110,7 @@ describe("processInput", () => {
     ["glab mr update --description", (body) => `glab mr update 3 --description "$(cat ${body})"`],
     ["glab mr update -d", (body) => `glab mr update 3 -d "$(cat ${body})"`],
   ])("checks the body behind %s", async (_form, build) => {
-    const bodyFile = path.join(tempDir, "body.md");
+    const bodyFile = join(tempDir, "body.md");
     await Bun.write(bodyFile, "## Two fixes found while testing\n\nReshapes the resolver.");
     const result = await processInput(createInput(build(bodyFile), repoRoot));
     expect(getPermissionDecision(result)).toBe("deny");
@@ -120,7 +120,7 @@ describe("processInput", () => {
   // The body file does not exist when the hook runs: the same command writes
   // it. The heredoc is the body.
   it("validates a body written by a heredoc in the same command", async () => {
-    const bodyFile = path.join(tempDir, "body.md");
+    const bodyFile = join(tempDir, "body.md");
     const command = `mkdir -p tmp && cat > ${bodyFile} <<'EOF'\n## Two fixes found while testing\n\nReshapes the resolver.\nEOF\ngh pr create --title T --body-file ${bodyFile}`;
     const result = await processInput(createInput(command, repoRoot));
     expect(getPermissionDecision(result)).toBe("deny");
@@ -128,15 +128,15 @@ describe("processInput", () => {
   });
 
   it("passes a clean body written by a heredoc in the same command", async () => {
-    const bodyFile = path.join(tempDir, "body.md");
+    const bodyFile = join(tempDir, "body.md");
     const command = `cat > ${bodyFile} <<'EOF'\n## Summary\n\nFixes a bug.\nEOF\ngh pr create --title T --body-file ${bodyFile}`;
     expect(await processInput(createInput(command, repoRoot))).toBeNull();
   });
 
   it("resolves a relative body file behind a cd", async () => {
-    const sub = path.join(tempDir, "sub");
+    const sub = join(tempDir, "sub");
     await Bun.write(
-      path.join(sub, "body.md"),
+      join(sub, "body.md"),
       "## Two fixes found while testing\n\nReshapes the resolver.",
     );
     const result = await processInput(
@@ -147,7 +147,7 @@ describe("processInput", () => {
   });
 
   it("denies body with test count", async () => {
-    const bodyFile = path.join(tempDir, "body.md");
+    const bodyFile = join(tempDir, "body.md");
     await Bun.write(bodyFile, "## Test plan\nAdded 5 tests");
     const result = await processInput(createInput(`gh pr create --body-file ${bodyFile}`));
     expect(result).not.toBeNull();
@@ -155,7 +155,7 @@ describe("processInput", () => {
   });
 
   it("denies a backticked real commit SHA", async () => {
-    const bodyFile = path.join(tempDir, "body.md");
+    const bodyFile = join(tempDir, "body.md");
     await Bun.write(bodyFile, `Builds on \`${headSha}\`.`);
     const result = await processInput(
       createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
@@ -165,7 +165,7 @@ describe("processInput", () => {
   });
 
   it("reports a verified SHA once when the body also has a backticked ref", async () => {
-    const bodyFile = path.join(tempDir, "body.md");
+    const bodyFile = join(tempDir, "body.md");
     await Bun.write(bodyFile, `Builds on \`${headSha}\`. Closes \`#12\`.`);
     const result = await processInput(
       createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
@@ -175,7 +175,7 @@ describe("processInput", () => {
   });
 
   it("does not warn on a bare commit SHA", async () => {
-    const bodyFile = path.join(tempDir, "body.md");
+    const bodyFile = join(tempDir, "body.md");
     await Bun.write(bodyFile, `Builds on ${headSha}.`);
     const result = await processInput(
       createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
@@ -184,7 +184,7 @@ describe("processInput", () => {
   });
 
   it("denies a sentence-case heading in a body file", async () => {
-    const bodyFile = path.join(tempDir, "body.md");
+    const bodyFile = join(tempDir, "body.md");
     await Bun.write(bodyFile, "## Two fixes found while testing\n\nReshapes the resolver.");
     const result = await processInput(
       createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
@@ -194,7 +194,7 @@ describe("processInput", () => {
   });
 
   it("combines a test-count and a backticked SHA into one deny", async () => {
-    const bodyFile = path.join(tempDir, "body.md");
+    const bodyFile = join(tempDir, "body.md");
     await Bun.write(bodyFile, `Builds on \`${headSha}\`.\n\nAdded 5 tests`);
     const result = await processInput(
       createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
@@ -206,7 +206,7 @@ describe("processInput", () => {
   });
 
   it("warns on the title the command sets", async () => {
-    const bodyFile = path.join(tempDir, "body.md");
+    const bodyFile = join(tempDir, "body.md");
     await Bun.write(bodyFile, "Adds an LRU cache to the resolver.");
     const result = await processInput(
       createInput(
@@ -220,7 +220,7 @@ describe("processInput", () => {
   it("carries the title warning into the deny when the body file is missing", async () => {
     const result = await processInput(
       createInput(
-        `gh pr create --title "Add an LRU Cache to the Resolver and Wire It Through" --body-file ${path.join(tempDir, "missing.md")}`,
+        `gh pr create --title "Add an LRU Cache to the Resolver and Wire It Through" --body-file ${join(tempDir, "missing.md")}`,
         repoRoot,
       ),
     );
@@ -237,7 +237,7 @@ describe("processInput", () => {
   });
 
   it("carries warnings inside the deny instead of a separate warn", async () => {
-    const bodyFile = path.join(tempDir, "body.md");
+    const bodyFile = join(tempDir, "body.md");
     await Bun.write(bodyFile, "## Changes to the cache\n\n- **src/cache.ts**: adds a cache");
     const result = await processInput(
       createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),

--- a/plugins/type-ignore/hooks/detect.ts
+++ b/plugins/type-ignore/hooks/detect.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env npx tsx
 
 import { mkdirSync } from "node:fs";
-import * as path from "node:path";
+import { join } from "node:path";
 import type { PostToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
 import { EXTENSION_MAP, LANGUAGES, TARGET_EXTENSIONS } from "./languages";
@@ -88,7 +88,7 @@ export function findLineNumber(content: string, pattern: string): number {
 }
 
 function getMarkerPath(sessionId: string): string {
-  return path.join(MARKER_DIR, sessionId !== "" ? sessionId : "unknown");
+  return join(MARKER_DIR, sessionId !== "" ? sessionId : "unknown");
 }
 
 export async function isCleanupAgentActive(sessionId: string): Promise<boolean> {

--- a/plugins/type-ignore/tests/detect.integration.ts
+++ b/plugins/type-ignore/tests/detect.integration.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync } from "node:fs";
 import { rm } from "node:fs/promises";
-import * as path from "node:path";
+import { join } from "node:path";
 import type { PostToolUseHookInput } from "@anthropic-ai/claude-agent-sdk";
 import { formatOutput, isCleanupAgentActive, processInput } from "../hooks/detect";
 
@@ -39,7 +39,7 @@ describe("type-ignore detection hook", () => {
 
     it("returns true when recent marker exists", async () => {
       const sessionId = "test-session";
-      const markerPath = path.join(MARKER_DIR, sessionId);
+      const markerPath = join(MARKER_DIR, sessionId);
 
       mkdirSync(MARKER_DIR, { recursive: true });
       await Bun.write(markerPath, String(Date.now()));
@@ -48,7 +48,7 @@ describe("type-ignore detection hook", () => {
     });
 
     it("keeps markers independent across session ids", async () => {
-      const markerPath = path.join(MARKER_DIR, "session-a");
+      const markerPath = join(MARKER_DIR, "session-a");
 
       mkdirSync(MARKER_DIR, { recursive: true });
       await Bun.write(markerPath, String(Date.now()));
@@ -116,7 +116,7 @@ describe("type-ignore detection hook", () => {
     });
 
     it("suppresses when cleanup agent is active for the same session", async () => {
-      const markerPath = path.join(MARKER_DIR, "test-session");
+      const markerPath = join(MARKER_DIR, "test-session");
 
       mkdirSync(MARKER_DIR, { recursive: true });
       await Bun.write(markerPath, String(Date.now()));
@@ -132,7 +132,7 @@ describe("type-ignore detection hook", () => {
     });
 
     it("does not suppress when cleanup agent is active for a different session", async () => {
-      const markerPath = path.join(MARKER_DIR, "other-session");
+      const markerPath = join(MARKER_DIR, "other-session");
 
       mkdirSync(MARKER_DIR, { recursive: true });
       await Bun.write(markerPath, String(Date.now()));

--- a/plugins/writing/hooks/io.ts
+++ b/plugins/writing/hooks/io.ts
@@ -1,7 +1,6 @@
 import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+export { type SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
-
-export type { SyncHookJSONOutput };
 
 // Every field any writing hook reads off `tool_input`, across the Write, Edit,
 // MultiEdit, and Bash surfaces.

--- a/plugins/writing/hooks/pretooluse.ts
+++ b/plugins/writing/hooks/pretooluse.ts
@@ -9,9 +9,9 @@ import {
   isPlanPath,
   isScratchPath,
 } from "../detection/paths";
-import * as tropes from "./check-tropes";
+import { check as checkTropes } from "./check-tropes";
 import { type HookResult, isPlanMode, type SyncHookJSONOutput, tierOf, toolInputOf } from "./io";
-import * as numbering from "./numbering";
+import { check as checkNumbering, type Mode } from "./numbering";
 import { appendRunLog, type RunLogEntry, type RunOutcome } from "./run-log";
 import { recentlyFired, recordFired } from "./session-state";
 
@@ -74,11 +74,11 @@ export async function dispatch(
   if (filePath != null && filePath !== "" && (isPlanPath(filePath) || isMemoryPath(filePath)))
     return finish(null, "silent");
 
-  const mode: numbering.Mode = input.tool_name === "Edit" ? "edit" : "write";
+  const mode: Mode = input.tool_name === "Edit" ? "edit" : "write";
   const checkers = [
-    () => numbering.check(input, mode),
+    () => checkNumbering(input, mode),
     () => (isMarkdownFile(ext) ? headingResult(input) : null),
-    () => tropes.check(input),
+    () => checkTropes(input),
   ];
 
   // One checker crashing must not take down the others or the run log.

--- a/plugins/writing/skills/analyze/scripts/analyze.test.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
-import * as path from "node:path";
+import { join } from "node:path";
 import { type AnalysisConfig, runAnalysis } from "./analyze";
 import { type Database, openSessionDb } from "./db";
 
@@ -53,9 +53,9 @@ async function seedRows(db: Database, projectPath: string): Promise<void> {
 }
 
 async function fixtureWordlists(): Promise<string> {
-  const dir = mkdtempSync(path.join(tmpdir(), "analyze-wordlists-"));
-  await Bun.write(path.join(dir, "vocabulary.txt"), "tapestry\ndelve\n");
-  await Bun.write(path.join(dir, "flowery-phrases.txt"), "source of truth\n");
+  const dir = mkdtempSync(join(tmpdir(), "analyze-wordlists-"));
+  await Bun.write(join(dir, "vocabulary.txt"), "tapestry\ndelve\n");
+  await Bun.write(join(dir, "flowery-phrases.txt"), "source of truth\n");
   return dir;
 }
 
@@ -74,7 +74,7 @@ function baseConfig(wordlistsDir: string): AnalysisConfig {
     wordlistsDir,
     // No profile on disk: loadProfile returns null and the deliverable-surface
     // rule is kept pending a baseline rather than measured for distinctiveness.
-    dataDir: path.join(tmpdir(), "analyze-no-such-data-dir"),
+    dataDir: join(tmpdir(), "analyze-no-such-data-dir"),
     pasteMaxChars: 2000,
     selfName: "",
     correctiveLimit: 25,

--- a/plugins/writing/skills/analyze/scripts/analyze.ts
+++ b/plugins/writing/skills/analyze/scripts/analyze.ts
@@ -2,7 +2,7 @@
 import { mkdirSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import * as path from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { cli } from "cleye";
 import { corpusPath, profilePath, resolveDataDir } from "./data-dir";
 import { type Database, openSessionDb } from "./db";
@@ -27,8 +27,7 @@ import { auditStructuralPatterns } from "./structural";
 import { type TagSignatureRow, tagSequence } from "./tag-ngram";
 import { computeCorpusRates } from "./voice-delta";
 import { loadProfile, phraseProfileStat } from "./voice-profile";
-import type { WordlistEntry } from "./wordlists";
-import { loadWordlists } from "./wordlists";
+import { loadWordlists, type WordlistEntry } from "./wordlists";
 
 // Everything runAnalysis needs once flag parsing and date defaulting are done.
 // generatedAt is supplied by the caller so the orchestration stays pure (no
@@ -182,14 +181,14 @@ async function main(): Promise<void> {
     tagMinLift: argv.flags.tagMinLift,
     tagTop: argv.flags.tagTop,
     wordlistsDir:
-      argv.flags.wordlistsDir ?? path.join(import.meta.dirname, "..", "..", "..", "wordlists"),
+      argv.flags.wordlistsDir ?? join(import.meta.dirname, "..", "..", "..", "wordlists"),
     dataDir: resolveDataDir(argv.flags.dataDir),
     pasteMaxChars: argv.flags.pasteMaxChars,
     selfName: argv.flags.selfName,
     correctiveLimit: argv.flags.correctiveLimit,
   };
-  const dbPath = path.resolve(argv.flags.sessionDb ?? "");
-  const outPath = argv.flags.out ?? path.join("tmp", `trope-analysis-${today}.md`);
+  const dbPath = resolve(argv.flags.sessionDb ?? "");
+  const outPath = argv.flags.out ?? join("tmp", `trope-analysis-${today}.md`);
 
   const detectors: BatchDetectors = {};
   if (argv.flags.judge) {
@@ -209,14 +208,14 @@ async function main(): Promise<void> {
   }
 
   const sessionId = process.env.CLAUDE_SESSION_ID ?? "anonymous";
-  const isolatedPath = path.join(tmpdir(), `session-analyze-${sessionId}.duckdb`);
+  const isolatedPath = join(tmpdir(), `session-analyze-${sessionId}.duckdb`);
   console.error(`Copying session DB to ${isolatedPath}`);
   await Bun.write(isolatedPath, Bun.file(dbPath));
 
   const db = await openSessionDb(isolatedPath);
   try {
     const report = renderReport(await runAnalysis(db, config, detectors));
-    mkdirSync(path.dirname(outPath), { recursive: true });
+    mkdirSync(dirname(outPath), { recursive: true });
     await Bun.write(outPath, report);
     console.error(`Wrote report to ${outPath}`);
     process.stdout.write(`${outPath}\n`);

--- a/plugins/writing/skills/analyze/scripts/db.ts
+++ b/plugins/writing/skills/analyze/scripts/db.ts
@@ -1,8 +1,8 @@
-import * as path from "node:path";
+import { join } from "node:path";
 import { DuckDBInstance } from "@duckdb/node-api";
 import { z } from "zod";
 
-const QUERIES_DIR = path.join(import.meta.dirname, "..", "resources", "queries");
+const QUERIES_DIR = join(import.meta.dirname, "..", "resources", "queries");
 
 export interface Database {
   run(sql: string): Promise<void>;
@@ -78,7 +78,7 @@ export async function openSessionDb(dbPath: string): Promise<Database> {
 }
 
 async function readSql(name: string): Promise<string> {
-  return Bun.file(path.join(QUERIES_DIR, `${name}.sql`)).text();
+  return Bun.file(join(QUERIES_DIR, `${name}.sql`)).text();
 }
 
 function narrowBigints(row: Record<string, unknown>): Record<string, unknown> {

--- a/plugins/writing/skills/analyze/scripts/headings-eval.ts
+++ b/plugins/writing/skills/analyze/scripts/headings-eval.ts
@@ -17,7 +17,7 @@
  * be quoted freely.
  */
 import { mkdirSync, readdirSync } from "node:fs";
-import * as path from "node:path";
+import { join, resolve } from "node:path";
 import { cli } from "cleye";
 import type { Heading, Text } from "mdast";
 import { fromMarkdown } from "mdast-util-from-markdown";
@@ -302,7 +302,7 @@ async function corpusFromDocs(dir: string): Promise<Array<{ session_id: string; 
   return Promise.all(
     files.map(async (name) => ({
       session_id: name,
-      text: await Bun.file(path.join(dir, name)).text(),
+      text: await Bun.file(join(dir, name)).text(),
     })),
   );
 }
@@ -313,7 +313,7 @@ async function corpusFromSessionDb(
 ): Promise<DeliverableRow[]> {
   const sessionId = process.env.CLAUDE_SESSION_ID ?? "anonymous";
   const tmp = process.env.TMPDIR;
-  const isolatedPath = path.join(
+  const isolatedPath = join(
     tmp != null && tmp !== "" ? tmp : "/tmp",
     `headings-eval-${sessionId}.duckdb`,
   );
@@ -386,11 +386,11 @@ async function main(): Promise<void> {
   let rows: Array<{ session_id: string; text?: string }>;
   let source: string;
   if (argv.flags.docs != null && argv.flags.docs !== "") {
-    const dir = path.resolve(argv.flags.docs);
+    const dir = resolve(argv.flags.docs);
     rows = await corpusFromDocs(dir);
     source = dir;
   } else if (argv.flags.sessionDb != null && argv.flags.sessionDb !== "") {
-    rows = await corpusFromSessionDb(path.resolve(argv.flags.sessionDb), {
+    rows = await corpusFromSessionDb(resolve(argv.flags.sessionDb), {
       after_date: since,
       before_date: until,
       project: argv.flags.project ?? null,
@@ -405,7 +405,7 @@ async function main(): Promise<void> {
   console.error(`${rows.length} corpus rows, ${headings.length} unique headings`);
 
   mkdirSync(argv.flags.out, { recursive: true });
-  const corpusPath = path.join(argv.flags.out, "headings-corpus.tsv");
+  const corpusPath = join(argv.flags.out, "headings-corpus.tsv");
   await Bun.write(
     corpusPath,
     `# heading\toccurrences\tsessions\n${headings
@@ -437,7 +437,7 @@ async function main(): Promise<void> {
       argv.flags.sample,
       argv.flags.disagreementCap,
     );
-    const labelsPath = path.join(argv.flags.out, "heading-labels.tsv");
+    const labelsPath = join(argv.flags.out, "heading-labels.tsv");
     await Bun.write(
       labelsPath,
       `# heading\tlabel\tsource\n# label one of: ${LABELS.join(", ")}\n${sample

--- a/plugins/writing/skills/analyze/scripts/judge.ts
+++ b/plugins/writing/skills/analyze/scripts/judge.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import * as path from "node:path";
+import { join } from "node:path";
 import Anthropic from "@anthropic-ai/sdk";
 import { z } from "zod";
 import type { DeliverableRow } from "./dump";
@@ -20,8 +20,8 @@ export const JUDGE_MODEL = "claude-haiku-4-5";
 export const CHUNK_WORD_LIMIT = 1500;
 export const MAX_SAMPLE_SPANS = 5;
 
-export const PROMPT_PATH = path.join(import.meta.dirname, "..", "resources", "judge", "prompt.md");
-export const HEADING_PROMPT_PATH = path.join(
+export const PROMPT_PATH = join(import.meta.dirname, "..", "resources", "judge", "prompt.md");
+export const HEADING_PROMPT_PATH = join(
   import.meta.dirname,
   "..",
   "resources",

--- a/plugins/writing/skills/analyze/scripts/rule-health.ts
+++ b/plugins/writing/skills/analyze/scripts/rule-health.ts
@@ -1,8 +1,7 @@
 import { z } from "zod";
 import { type DeliverableAudit, isDeliverableSurface } from "./deliverable-audit";
 import type { QuoteContext } from "./quote-context";
-import type { VoiceProfile } from "./voice-profile";
-import { phraseProfileStatStemmed } from "./voice-profile";
+import { phraseProfileStatStemmed, type VoiceProfile } from "./voice-profile";
 import type { WordlistEntry } from "./wordlists";
 
 export const FtsAuditRow = z.object({

--- a/plugins/writing/skills/analyze/scripts/voice-profile.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-profile.ts
@@ -39,7 +39,7 @@ export const VoiceProfile = z.object({
 });
 export type VoiceProfile = z.infer<typeof VoiceProfile>;
 
-export type { VoiceDeltaBaseline };
+export { VoiceDeltaBaseline } from "./voice-delta";
 
 export function buildProfile(docs: VoiceDocument[], generatedAt: string): VoiceProfile {
   const ngrams = new Map<number, Map<string, number>>(PROFILE_SIZES.map((n) => [n, new Map()]));

--- a/plugins/writing/skills/analyze/scripts/wordlists.test.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlists.test.ts
@@ -2,23 +2,23 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import * as path from "node:path";
+import { join } from "node:path";
 import { loadWordlists } from "./wordlists";
 
 describe("loadWordlists", () => {
   test("returns empty when directory is missing", async () => {
-    const result = await loadWordlists(path.join(tmpdir(), "does-not-exist-xyz"));
+    const result = await loadWordlists(join(tmpdir(), "does-not-exist-xyz"));
     expect(result).toEqual([]);
   });
 
   test("loads entries, strips comments and blank lines, attaches source filename", async () => {
-    const dir = mkdtempSync(path.join(tmpdir(), "wordlists-"));
+    const dir = mkdtempSync(join(tmpdir(), "wordlists-"));
     try {
       await Bun.write(
-        path.join(dir, "openers.txt"),
+        join(dir, "openers.txt"),
         "# top comment\nperfect\nexcellent  # inline comment\n\nyou're right\n",
       );
-      await Bun.write(path.join(dir, "verbs.txt"), "ensure\nverify\n");
+      await Bun.write(join(dir, "verbs.txt"), "ensure\nverify\n");
       const entries = await loadWordlists(dir);
       expect(entries.map((e) => e.phrase)).toEqual([
         "perfect",
@@ -35,9 +35,9 @@ describe("loadWordlists", () => {
   });
 
   test("strips trailing weight suffixes from entries", async () => {
-    const dir = mkdtempSync(path.join(tmpdir(), "wordlists-"));
+    const dir = mkdtempSync(join(tmpdir(), "wordlists-"));
     try {
-      await Bun.write(path.join(dir, "verbs.txt"), "empower 2.5\nstreamline 2.5\nensure\n");
+      await Bun.write(join(dir, "verbs.txt"), "empower 2.5\nstreamline 2.5\nensure\n");
       const entries = await loadWordlists(dir);
       expect(entries.map((e) => e.phrase)).toEqual(["empower", "streamline", "ensure"]);
     } finally {

--- a/plugins/writing/skills/analyze/scripts/wordlists.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlists.ts
@@ -1,5 +1,5 @@
 import { readdirSync } from "node:fs";
-import * as path from "node:path";
+import { join } from "node:path";
 import { z } from "zod";
 
 export interface WordlistEntry {
@@ -19,7 +19,7 @@ export async function loadWordlists(dir: string): Promise<WordlistEntry[]> {
   }
   const perFile = await Promise.all(
     files.toSorted().map(async (file) => {
-      const text = await Bun.file(path.join(dir, file)).text();
+      const text = await Bun.file(join(dir, file)).text();
       const entries: WordlistEntry[] = [];
       for (const rawLine of text.split("\n")) {
         const line = rawLine.replace(/#.*$/, "").trim();

--- a/user/skills/flock/scripts/deferred.ts
+++ b/user/skills/flock/scripts/deferred.ts
@@ -1,8 +1,8 @@
-import { mkdir, rm } from "node:fs/promises";
 // A durable swap needs rename(2), and a stale-lock check needs a directory's
-// mtime. Bun's file API exposes neither.
+// mtime. Bun's file API exposes neither. mkdir and rm are allowed outright, so
+// sharing the statement grants them nothing.
 // oxlint-disable-next-line no-restricted-imports
-import { rename, stat } from "node:fs/promises";
+import { mkdir, rename, rm, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { z } from "zod";
 import { decodeJson } from "../../../../packages/decode/index";


### PR DESCRIPTION
Enables three import-hygiene oxlint rules and fixes every violation they surface.

- `import/no-namespace` bans `import * as x from "mod"`. A namespace binding hides which members a file actually uses, from both a reader scanning the imports and the unused-import check.
- `no-duplicate-imports` bans two import statements pulling from the same module, which invites the bindings to drift out of sync.
- `unicorn/prefer-export-from` bans importing a name into local scope for the sole purpose of re-exporting it.

`import/no-namespace` ignores `fast-check`, whose documented idiom is `import * as fc from "fast-check"`.
The other namespace imports (`node:path`, `node:os`, `acorn`, and two local modules) had no equivalent justification, so they're converted to named imports with every call site rewritten to match.
`no-duplicate-imports` violations are merged into one statement per module, using an inline `type` specifier for the type-only bindings.
`unicorn/prefer-export-from`'s three sites were fixed automatically by oxlint's `--fix-suggestions`.

`bun run check` and `bun test` both pass.
