### PR TITLE
x-callback-url: deflake the run.sh scenario test

### DIFF
--- a/plugins/things/scripts/url.test.ts
+++ b/plugins/things/scripts/url.test.ts
@@ -164,6 +164,12 @@ describe("xcallBackstopMs", () => {
     },
     { name: "a non-numeric bound", env: { XCALL_TIMEOUT_SECONDS: "soon" } },
     { name: "a zero bound", env: { XCALL_TIMEOUT_SECONDS: "0" } },
+    { name: "a raised lock wait", env: { XCALL_LOCK_WAIT_SECONDS: "120" } },
+    {
+      name: "a raised lock wait and callback bound",
+      env: { XCALL_LOCK_WAIT_SECONDS: "120", XCALL_TIMEOUT_SECONDS: "60" },
+    },
+    { name: "a non-numeric lock wait", env: { XCALL_LOCK_WAIT_SECONDS: "soon" } },
   ])("outwaits run.sh with $name", ({ env }) => {
     const bound = (name: string) => {
       const parsed = Number(env[name]);
@@ -172,8 +178,10 @@ describe("xcallBackstopMs", () => {
     // run.sh waits out a lock holder's whole turn before starting its own, so
     // the callback bound counts once for the wait and once for the call.
     const callback = bound("XCALL_TIMEOUT_SECONDS");
-    const runnerCeilingMs =
-      (bound("XCALL_BUILD_TIMEOUT_SECONDS") + (callback + 2 + 1) + callback + 2) * 1000;
+    const configuredLock = Number(env.XCALL_LOCK_WAIT_SECONDS);
+    const lockWait =
+      Number.isFinite(configuredLock) && configuredLock > 0 ? configuredLock : callback + 2 + 1;
+    const runnerCeilingMs = (bound("XCALL_BUILD_TIMEOUT_SECONDS") + lockWait + callback + 2) * 1000;
 
     expect(xcallBackstopMs(env)).toBeGreaterThan(runnerCeilingMs);
   });
@@ -182,10 +190,12 @@ describe("xcallBackstopMs", () => {
     expect({
       defaults: xcallBackstopMs({}),
       raised: xcallBackstopMs({ XCALL_BUILD_TIMEOUT_SECONDS: "90", XCALL_TIMEOUT_SECONDS: "60" }),
+      raisedLockWait: xcallBackstopMs({ XCALL_LOCK_WAIT_SECONDS: "120" }),
     }).toMatchInlineSnapshot(`
       {
         "defaults": 80000,
         "raised": 230000,
+        "raisedLockWait": 177000,
       }
     `);
   });

--- a/plugins/things/scripts/url.ts
+++ b/plugins/things/scripts/url.ts
@@ -219,9 +219,13 @@ const XCALL_KILL_GRACE_SECONDS = 2;
 /** Slack over run.sh's own bounds, covering process startup and the Swift build. */
 const XCALL_BACKSTOP_MARGIN_MS = 15_000;
 
-function boundSeconds(env: Record<string, string | undefined>, name: string): number {
+function boundSeconds(
+  env: Record<string, string | undefined>,
+  name: string,
+  fallback = XCALL_BOUND_DEFAULT_SECONDS,
+): number {
   const seconds = Number(env[name]);
-  return Number.isFinite(seconds) && seconds > 0 ? seconds : XCALL_BOUND_DEFAULT_SECONDS;
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : fallback;
 }
 
 /**
@@ -233,11 +237,16 @@ function boundSeconds(env: Record<string, string | undefined>, name: string): nu
  *
  * The callback timeout counts twice. run.sh serializes on a lock first, and a
  * caller that finds the bridge busy waits out the holder's full turn before
- * starting its own.
+ * starting its own. XCALL_LOCK_WAIT_SECONDS overrides that wait, so the
+ * backstop reads it rather than assuming the derivation it defaults to.
  */
 export function xcallBackstopMs(env: Record<string, string | undefined>): number {
   const callback = boundSeconds(env, "XCALL_TIMEOUT_SECONDS");
-  const lockWait = callback + XCALL_KILL_GRACE_SECONDS + 1;
+  const lockWait = boundSeconds(
+    env,
+    "XCALL_LOCK_WAIT_SECONDS",
+    callback + XCALL_KILL_GRACE_SECONDS + 1,
+  );
   const bounds =
     boundSeconds(env, "XCALL_BUILD_TIMEOUT_SECONDS") +
     lockWait +

--- a/plugins/x-callback-url/README.md
+++ b/plugins/x-callback-url/README.md
@@ -20,7 +20,7 @@ That one handler is why a callback needs to say who it belongs to. Every waiting
 
 The token makes a stray callback harmless, not deliverable, so `run.sh` also serializes on `~/.cache/claude/x-callback-url/xcall.lock` and one invocation waits at a time (exit 5 if the bridge stays busy). The two together are what make concurrent callers safe: the token rules out a wrong answer, and the lock rules out a lost one.
 
-Both shell scripts carry the `mac` plugin's `claude:dangerouslyDisableSandbox` marker. The command sandbox blocks Launch Services registration and the URL-scheme round trip alike, and a sandboxed `xcall` hangs instead of failing, so `run.sh` owns the deadline for both phases: `XCALL_BUILD_TIMEOUT_SECONDS` (exit 3) and `XCALL_TIMEOUT_SECONDS` (exit 4), 20 seconds each by default. A caller that waits out the lock instead exits 5.
+Both shell scripts carry the `mac` plugin's `claude:dangerouslyDisableSandbox` marker. The command sandbox blocks Launch Services registration and the URL-scheme round trip alike, and a sandboxed `xcall` hangs instead of failing, so `run.sh` owns the deadline for both phases: `XCALL_BUILD_TIMEOUT_SECONDS` (exit 3) and `XCALL_TIMEOUT_SECONDS` (exit 4), 20 seconds each by default. A caller that waits out the lock instead exits 5, bounded by `XCALL_LOCK_WAIT_SECONDS`.
 
 ## Tests
 

--- a/plugins/x-callback-url/scripts/run.sh
+++ b/plugins/x-callback-url/scripts/run.sh
@@ -33,10 +33,17 @@ run_bounded() {
   # ordinary foreground children, and either one keeps holding the stdout this
   # function's caller reads through. The watchdog would fire, the child would
   # die, and the read would go on waiting on a grandchild nobody bounded.
+  #
+  # Parent and child both set that group, so neither has to win. When the child
+  # execs first the parent's call is refused (EPERM on BSD) and bash warns about
+  # a group that is already correct. Fd 9 carries the command's own stderr past
+  # the /dev/null that keeps that warning off the caller's.
+  exec 9>&2
   set -m
-  "$@" &
+  { "$@" 2>&9 9>&- & } 2>/dev/null
   local pid=$!
   set +m
+  exec 9>&-
 
   (
     # The timer runs as a child so the trap can end it. A foreground sleep here

--- a/plugins/x-callback-url/scripts/run.sh
+++ b/plugins/x-callback-url/scripts/run.sh
@@ -38,12 +38,10 @@ run_bounded() {
   # execs first the parent's call is refused (EPERM on BSD) and bash warns about
   # a group that is already correct. Fd 9 carries the command's own stderr past
   # the /dev/null that keeps that warning off the caller's.
-  exec 9>&2
   set -m
-  { "$@" 2>&9 9>&- & } 2>/dev/null
+  { "$@" 2>&9 9>&- & } 9>&2 2>/dev/null
   local pid=$!
   set +m
-  exec 9>&-
 
   (
     # The timer runs as a child so the trap can end it. A foreground sleep here
@@ -97,7 +95,9 @@ mkdir -p "$(dirname "$LOCK_FILE")"
 # A holder cannot outlive its own watchdog, so the wait covers one full turn
 # plus the grace the watchdog allows before SIGKILL. shlock reclaims a lock
 # whose recorded pid is gone, which covers a holder killed outside that path.
-LOCK_WAIT_SECONDS=$((TIMEOUT_SECONDS + KILL_GRACE_SECONDS + 1))
+# The budget assumes a single holder ahead. XCALL_LOCK_WAIT_SECONDS overrides it
+# for a caller queued behind more than one.
+LOCK_WAIT_SECONDS="${XCALL_LOCK_WAIT_SECONDS:-$((TIMEOUT_SECONDS + KILL_GRACE_SECONDS + 1))}"
 lock_deadline=$((SECONDS + LOCK_WAIT_SECONDS))
 until shlock -f "$LOCK_FILE" -p $$; do
   if ((SECONDS >= lock_deadline)); then

--- a/plugins/x-callback-url/scripts/run.test.ts
+++ b/plugins/x-callback-url/scripts/run.test.ts
@@ -103,6 +103,10 @@ async function runScenario(scenario: Scenario): Promise<Outcome> {
   const proc = Bun.spawn([runner, "things:///version"], {
     env: {
       ...process.env,
+      // Scenarios run concurrently and run.sh serializes on a lock under
+      // XDG_CACHE_HOME. Sharing one would queue them behind each other, and the
+      // lock wait budgets for a single holder ahead, so a loser would exit 5.
+      XDG_CACHE_HOME: dir,
       XCALL_TIMEOUT_SECONDS: String(BOUND),
       XCALL_BUILD_TIMEOUT_SECONDS: String(BOUND),
     },

--- a/plugins/x-callback-url/scripts/run.test.ts
+++ b/plugins/x-callback-url/scripts/run.test.ts
@@ -24,7 +24,15 @@ const BOUNDED_MS = 5_000;
 // temp dirs they then delete.
 const dirs: string[] = [];
 afterAll(() => {
-  for (const dir of dirs) Bun.spawnSync(["rm", "-rf", dir]);
+  for (const dir of dirs) {
+    // A scenario that parks a lock holder leaves it sleeping out the rest of
+    // its bound, which a repeated run would otherwise accumulate.
+    const holder = Bun.spawnSync(["cat", join(dir, "holder.pid")])
+      .stdout.toString()
+      .trim();
+    if (holder !== "") Bun.spawnSync(["kill", holder]);
+    Bun.spawnSync(["rm", "-rf", dir]);
+  }
 });
 
 interface Scenario {
@@ -75,12 +83,14 @@ const scenarios: Scenario[] = [
     // shlock reclaims a lock whose recorded pid is gone, so the holder has to
     // outlive the wait. Its output goes to /dev/null because a child holding
     // the stdout run.sh reads the binary path from would stall the build read.
+    // Cleanup reaps it through the pid file rather than waiting it out.
     name: "another instance holds the bridge",
     build: [
       'lock="$XDG_CACHE_HOME/claude/x-callback-url/xcall.lock"',
       'mkdir -p "$(dirname "$lock")"',
       `sleep ${STUCK_SECONDS} >/dev/null 2>&1 &`,
-      'shlock -f "$lock" -p $!',
+      'echo $! > "$SCRIPT_DIR/holder.pid"',
+      'shlock -f "$lock" -p "$(cat "$SCRIPT_DIR/holder.pid")"',
       'echo "$SCRIPT_DIR/xcall-stub"',
     ].join("\n"),
     binary: 'echo "unreachable"',

--- a/plugins/x-callback-url/scripts/run.test.ts
+++ b/plugins/x-callback-url/scripts/run.test.ts
@@ -71,6 +71,20 @@ const scenarios: Scenario[] = [
     build: 'echo "$SCRIPT_DIR/xcall-stub"',
     binary: 'echo "canceled" >&2; exit 2',
   },
+  {
+    // shlock reclaims a lock whose recorded pid is gone, so the holder has to
+    // outlive the wait. Its output goes to /dev/null because a child holding
+    // the stdout run.sh reads the binary path from would stall the build read.
+    name: "another instance holds the bridge",
+    build: [
+      'lock="$XDG_CACHE_HOME/claude/x-callback-url/xcall.lock"',
+      'mkdir -p "$(dirname "$lock")"',
+      `sleep ${STUCK_SECONDS} >/dev/null 2>&1 &`,
+      'shlock -f "$lock" -p $!',
+      'echo "$SCRIPT_DIR/xcall-stub"',
+    ].join("\n"),
+    binary: 'echo "unreachable"',
+  },
 ];
 
 async function writeExecutable(path: string, contents: string): Promise<string> {
@@ -109,6 +123,7 @@ async function runScenario(scenario: Scenario): Promise<Outcome> {
       XDG_CACHE_HOME: dir,
       XCALL_TIMEOUT_SECONDS: String(BOUND),
       XCALL_BUILD_TIMEOUT_SECONDS: String(BOUND),
+      XCALL_LOCK_WAIT_SECONDS: String(BOUND),
     },
     stdout: "pipe",
     stderr: "pipe",
@@ -178,6 +193,10 @@ test("run.sh bounds every wait and maps each outcome to its own exit code", asyn
     user cancels
       exit:   2
       stdout: (none)
-      stderr: canceled"
+      stderr: canceled
+    another instance holds the bridge
+      exit:   5
+      stdout: (none)
+      stderr: another xcall held the xcall-claude:// bridge for more than 1s"
   `);
 }, 15_000);

--- a/plugins/x-callback-url/skills/xcall/SKILL.md
+++ b/plugins/x-callback-url/skills/xcall/SKILL.md
@@ -27,6 +27,7 @@ The marker hook reads the script named at the head of a command, past any `VAR=v
 
 - `XCALL_BUILD_TIMEOUT_SECONDS` (default 20) bounds the build, and exits 3
 - `XCALL_TIMEOUT_SECONDS` (default 20) bounds the callback, and exits 4
+- `XCALL_LOCK_WAIT_SECONDS` (default `XCALL_TIMEOUT_SECONDS` + 3) bounds the wait for the bridge lock, and exits 5. The default covers one holder ahead, so raise it for a caller queued behind several
 
 ## Usage
 


### PR DESCRIPTION
Fixes an intermittent failure in the `x-callback-url` scenario test, seen twice on macos-latest and reproducing locally. Two independent causes, neither a timeout that was merely too tight.

The seven scenarios run concurrently, but `run.sh` serializes on a lock whose path comes from `XDG_CACHE_HOME`, which every scenario inherited from the ambient environment. Four get past the build and contend for that one file. The scenario whose callback never arrives holds it for its bound plus the watchdog's kill grace, while the lock wait budgets for a single holder ahead. The test puts three there, so whichever loser queued longest crossed the budget and exited 5.

Each scenario now gets its own `XDG_CACHE_HOME`. That removes the queue instead of widening the budget, and stops the suite writing to the real `~/.cache` lock.

The second cause looked like sandbox noise and is not. Under `set -m`, bash sets the child's process group from both sides so neither has to win. When the child execs first the parent's call is refused, BSD reports `EPERM` where POSIX names `EACCES`, and bash warns about a group that is already correct. That warning displaced the real first line of stderr, and it reproduces with no sandbox involved. Fd 9 now carries the command's stderr past the `/dev/null` that catches bash's job-control chatter.

`XCALL_LOCK_WAIT_SECONDS` names the one bound with no knob of its own, keeping the old derivation as its default. That makes the wait short enough to assert, so a scenario holds the lock with a live pid and pins exit 5. Nothing covered that branch before, since it was reachable only when the suite flaked. It also anchors the `XDG_CACHE_HOME` coupling, which would otherwise regress into a flake rather than a red test.

Deliberate residual: the `/dev/null` covers the whole launch group, so a fork failure at that instant is discarded too. Anything the child writes, including exec failures, still surfaces on fd 9.

`run.sh` was also driven end to end against Things, compiling and registering the real bundle.
