### PR TITLE
comments: gate the rubric on the judge that ships

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,12 +57,13 @@ Per-skill harnesses live inside the plugin they measure, at `plugins/<plugin>/ev
 - `bun plugins/issue/evals/issue-refine/scripts/build-dataset.ts`, then `label/server.ts`, then `scripts/ab-report.ts` and `scripts/judge.ts`
 - `bun plugins/review/evals/review-voice/scripts/mine.ts`, then `label/server.ts`, then `scripts/report.ts`
 - `bun plugins/writing/evals/writing/scripts/mine.ts`, then `label/server.ts` (scorer and judge are not built yet)
+- `bun plugins/comments/evals/eval.ts build`, hand the printed `<preflight>` block to the Workflow tool, then `score --job <dir> --gate`. This is the comments judge's ship gate: it scores the labeled corpus through the workflow that ships, on subscription auth. `eval.ts --gate` scores the same corpus through the SDK oracle as a keyed cross-check
 
 `pull-request:create`, `pull-request:follow-up`, `review:follow-up`, and `writing:no-diary` each carry a `promptfooconfig.yaml` under their `evals/` dir: an in-repo promptfoo suite that loads the plugin and grades cases with `llm-rubric` asserts. Those four run manually; `eval.yml` wires only the pr-body suite into CI. [`evals/scripts/`](evals/scripts/) files promptfoo runs into the durable corpus and reports what they cost.
 
 Every promptfoo suite runs unkeyed against the logged-in Claude Code CLI, so leave `ANTHROPIC_API_KEY` unset for a local run. The provider hands its whole environment to the spawned CLI, where an API key overrides the subscription login and bills the run. `ANTHROPIC_GRADER_API_KEY` is the optional override that grades through the API instead. CI spends subscription credits too, via a `CLAUDE_CODE_OAUTH_TOKEN` secret from `claude setup-token`.
 
-The older runners still read `ANTHROPIC_API_KEY` from the environment: the pr-body harness's `scripts/run-eval.ts` and `scripts/judge.ts`, `plugins/comments/evals/eval.ts --gate`, and `plugins/writing/skills/analyze` with `--judge`. [`evals/op.env`](evals/op.env) holds the 1Password secret reference, which `op run` resolves at run time, so no secret rests on disk. Reserve it for those runners, since injecting a key into a promptfoo run bills it:
+The older runners still read `ANTHROPIC_API_KEY` from the environment: the pr-body harness's `scripts/run-eval.ts` and `scripts/judge.ts`, `plugins/comments/evals/eval.ts --gate` (the oracle cross-check, not the gate itself), and `plugins/writing/skills/analyze` with `--judge`. [`evals/op.env`](evals/op.env) holds the 1Password secret reference, which `op run` resolves at run time, so no secret rests on disk. Reserve it for those runners, since injecting a key into a promptfoo run bills it:
 
 ```bash
 op run --env-file=evals/op.env -- bun plugins/pull-request/evals/pr-body/scripts/judge.ts <run-dir>

--- a/evals/op.env
+++ b/evals/op.env
@@ -1,3 +1,7 @@
 # 1Password secret references, resolved at run time by `op run --env-file`.
 # Values here are pointers. Never paste a secret into this file.
-ANTHROPIC_API_KEY=op://f2imbgudvqh7kvc2spl2ddnf34/jx63slqb27yjg6lo7db6s42bde/credential
+#
+# The form is op://<vault>/<item>/<field>. The item is addressed by id because
+# its title carries a "/", which is the path separator: "Anthropic
+# (bendrucker/claude Evals)" in the Private vault.
+ANTHROPIC_API_KEY=op://Private/krp5wbgnkc6mu33hzismcpfd3e/password

--- a/plugins/comments/README.md
+++ b/plugins/comments/README.md
@@ -20,7 +20,7 @@ Both run extraction, intrinsic-complexity ranking, an agent fan-out for judging,
 - **`judge/`**: the versioned `prompt.md`, the verdict schema, per-verdict validation, and the job builder that shards comments for the Workflow.
 - **`workflow/`**: the committed Workflow script the skill hands the job to.
 - **`apply/`**: the deterministic edit engine, the verdict id-match against re-extracted comments, the branch writer, and the report renderer.
-- **`evals/`**: the labeled fixture corpus, the action-accuracy eval, and the SDK calibration oracle behind a must-keep ship gate.
+- **`evals/`**: the labeled fixture corpus and the action-accuracy eval, which scores it either through the production Workflow judge (the ship gate) or through the SDK oracle (a batched cross-check).
 - A preventive steering rule lives at `user/rules/code-comments.md`, scoped by path to code files.
 
 ## Density Hook
@@ -41,10 +41,18 @@ Deterministic extraction, ranking, the job builder, the edit engine, the verdict
 bun test plugins/comments
 ```
 
-The eval's ship gate runs the SDK oracle and needs `ANTHROPIC_API_KEY`:
+The ship gate scores the fixture corpus through the judge that ships. `build` shards the fixtures with the same writer `preflight` uses and prints a `<preflight>` block. Hand that to the Workflow tool as `preflight` does, then score the verdicts it wrote:
+
+```bash
+bun run plugins/comments/evals/eval.ts build
+# Workflow({ scriptPath: <scriptPath>, args: <parsed job-args.json> })
+bun run plugins/comments/evals/eval.ts score --job <jobDir> --gate
+```
+
+The gate holds the must-keep comments at `keep` (canonical-API docstrings, genuine why-comments, regression-test rationale). Trimming or rewriting one of those is the destructive error the gate guards against.
+
+The SDK oracle scores the same corpus in one batched Messages call, as a cross-check on the rubric rather than the gate. It needs `ANTHROPIC_API_KEY`, and models after Opus 4.6 reject `temperature`, so it pins `effort` instead and repeated runs can differ:
 
 ```bash
 bun run plugins/comments/evals/eval.ts --gate
 ```
-
-The gate holds the must-keep comments at `keep` (canonical-API docstrings, genuine why-comments, regression-test rationale). Trimming or rewriting one of those is the destructive error the gate guards against.

--- a/plugins/comments/README.md
+++ b/plugins/comments/README.md
@@ -45,13 +45,13 @@ The ship gate scores the fixture corpus through the judge that ships. `build` sh
 
 ```bash
 bun run plugins/comments/evals/eval.ts build
-# Workflow({ scriptPath: <scriptPath>, args: <parsed job-args.json> })
+# Workflow({ scriptPath: <scriptPath>, args: <the parsed contents of argsPath> })
 bun run plugins/comments/evals/eval.ts score --job <jobDir> --gate
 ```
 
 The gate holds the must-keep comments at `keep` (canonical-API docstrings, genuine why-comments, regression-test rationale). Trimming or rewriting one of those is the destructive error the gate guards against.
 
-The SDK oracle scores the same corpus in one batched Messages call, as a cross-check on the rubric rather than the gate. It needs `ANTHROPIC_API_KEY`, and models after Opus 4.6 reject `temperature`, so it pins `effort` instead and repeated runs can differ:
+The SDK oracle cross-checks the rubric over the same corpus, scoring it in batched Messages calls. It needs `ANTHROPIC_API_KEY`, and it samples, so repeated runs can differ:
 
 ```bash
 bun run plugins/comments/evals/eval.ts --gate

--- a/plugins/comments/evals/eval.test.ts
+++ b/plugins/comments/evals/eval.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { loadPrompt } from "../judge/judge";
 import type { Verdict } from "../judge/schema";
 import {
   alignVerdicts,
+  clearVerdicts,
   type Fixture,
   fixtureToInput,
   fixtureToShardComment,
@@ -109,8 +113,28 @@ describe("alignVerdicts", () => {
       ],
       /Verdicts name 1 unknown comment\(s\): c/,
     ],
+    [
+      "a job dir belonging to another corpus, naming both causes",
+      [["x", verdict({})]],
+      /No verdict for 2 fixture\(s\): a, b\. Verdicts name 1 unknown comment\(s\): x/,
+    ],
   ] as const)("rejects %s", (_name, entries, error) => {
     expect(() => alignVerdicts(fixtures, new Map(entries))).toThrow(error);
+  });
+});
+
+describe("clearVerdicts", () => {
+  test("drops a previous run's verdicts and leaves the rest of the job dir alone", async () => {
+    const verdictsDir = join(await mkdtemp(join(tmpdir(), "comments-eval-test-")), "verdicts");
+    await Bun.write(join(verdictsDir, "verdict-0.json"), "{}");
+    await Bun.write(join(verdictsDir, "verdict-1.json"), "{}");
+    await Bun.write(join(verdictsDir, "notes.txt"), "keep me");
+
+    await clearVerdicts(verdictsDir);
+
+    expect(await Bun.file(join(verdictsDir, "verdict-0.json")).exists()).toBe(false);
+    expect(await Bun.file(join(verdictsDir, "verdict-1.json")).exists()).toBe(false);
+    expect(await Bun.file(join(verdictsDir, "notes.txt")).exists()).toBe(true);
   });
 });
 
@@ -134,8 +158,9 @@ describe("fixture corpus", () => {
 
 // The oracle's must-keep cross-check: it must never trim or rewrite a justified
 // comment. The gate of record runs the same corpus through the production
-// workflow (`eval.ts build`, then `score --gate`); this is the batched SDK
-// second opinion. Self-skips without an API key so CI stays deterministic.
+// workflow (`eval.ts build`, then `score --gate`). This is the batched SDK
+// second opinion, and it samples, so a run can differ. Self-skips without an
+// API key, keeping CI off the API.
 const hasKey = Boolean(process.env.ANTHROPIC_API_KEY);
 
 describe("oracle must-keep check", () => {

--- a/plugins/comments/evals/eval.test.ts
+++ b/plugins/comments/evals/eval.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { loadPrompt } from "../judge/judge";
 import type { Verdict } from "../judge/schema";
-import { type Fixture, fixtureToInput, loadFixtures, scoreResults } from "./eval";
+import {
+  alignVerdicts,
+  type Fixture,
+  fixtureToInput,
+  fixtureToShardComment,
+  loadFixtures,
+  scoreResults,
+} from "./eval";
 import { anthropicCommentJudge, judgeComments } from "./oracle";
 
 function fixture(over: Partial<Fixture>): Fixture {
@@ -77,6 +84,36 @@ describe("scoreResults", () => {
   });
 });
 
+describe("alignVerdicts", () => {
+  const fixtures = [fixture({ id: "a" }), fixture({ id: "b" })];
+
+  test("orders verdicts by fixture, not by the order the agents wrote them", () => {
+    const map = new Map([
+      ["b", verdict({ category: "narration" })],
+      ["a", verdict({ category: "restate-the-what" })],
+    ]);
+    expect(alignVerdicts(fixtures, map).map((v) => v.category)).toEqual([
+      "restate-the-what",
+      "narration",
+    ]);
+  });
+
+  test.each([
+    ["a fixture the judge skipped", [["a", verdict({})]], /No verdict for 1 fixture\(s\): b/],
+    [
+      "a verdict from another job",
+      [
+        ["a", verdict({})],
+        ["b", verdict({})],
+        ["c", verdict({})],
+      ],
+      /Verdicts name 1 unknown comment\(s\): c/,
+    ],
+  ] as const)("rejects %s", (_name, entries, error) => {
+    expect(() => alignVerdicts(fixtures, new Map(entries))).toThrow(error);
+  });
+});
+
 describe("fixture corpus", () => {
   test("every committed fixture is valid and the corpus spans all three actions", async () => {
     const fixtures = await loadFixtures();
@@ -89,17 +126,19 @@ describe("fixture corpus", () => {
     for (const f of fixtures) {
       expect(f.context.length).toBeGreaterThan(0);
       expect(fixtureToInput(f).text).toBe(f.comment);
+      expect(fixtureToShardComment(f)).toMatchObject({ id: f.id, text: f.comment });
       if (f.action === "rewrite") expect(f.rewrite?.length).toBeGreaterThan(0);
     }
   });
 });
 
-// Live ship gate: the judge must keep every must-keep fixture (never trim or
-// rewrite a justified comment). Self-skips without an API key so CI stays
-// deterministic; run locally with ANTHROPIC_API_KEY.
+// The oracle's must-keep cross-check: it must never trim or rewrite a justified
+// comment. The gate of record runs the same corpus through the production
+// workflow (`eval.ts build`, then `score --gate`); this is the batched SDK
+// second opinion. Self-skips without an API key so CI stays deterministic.
 const hasKey = Boolean(process.env.ANTHROPIC_API_KEY);
 
-describe("ship gate", () => {
+describe("oracle must-keep check", () => {
   test.skipIf(!hasKey)(
     "judge keeps every must-keep comment",
     async () => {

--- a/plugins/comments/evals/eval.ts
+++ b/plugins/comments/evals/eval.ts
@@ -1,12 +1,16 @@
 #!/usr/bin/env bun
 
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Glob } from "bun";
-import { cli } from "cleye";
+import { cli, command } from "cleye";
 import { table } from "table";
 import { z } from "zod";
+import { collectVerdicts } from "../apply/join";
 import { type Provenance, ProvenanceSchema } from "../detection/provenance";
 import type { CommentKind, Language } from "../detection/types";
+import { workflowJudge } from "../judge/adapter";
+import { buildJob, type ShardComment, writeJob } from "../judge/job";
 import { loadPrompt } from "../judge/judge";
 import {
   SLOP_CATEGORIES,
@@ -17,7 +21,6 @@ import {
 } from "../judge/schema";
 import {
   anthropicCommentJudge,
-  type CommentJudge,
   type CommentJudgeInput,
   JUDGE_MODEL,
   judgeComments,
@@ -139,6 +142,19 @@ function validateFixture(value: unknown, file: string): Fixture {
   return fixture;
 }
 
+/** The fixture as the production judge sees it, so `buildJob` shards it unchanged. */
+export function fixtureToShardComment(fixture: Fixture): ShardComment {
+  return {
+    id: fixture.id,
+    path: fixture.path,
+    language: fixture.language,
+    kind: fixture.kind,
+    text: fixture.comment,
+    context: fixture.context,
+    provenance: fixture.provenance,
+  };
+}
+
 export function fixtureToInput(fixture: Fixture): CommentJudgeInput {
   return {
     path: fixture.path,
@@ -232,13 +248,75 @@ function report(fixtures: Fixture[], verdicts: Verdict[], metrics: Metrics): str
   return `${table(rows)}\n${summary}`;
 }
 
-async function run(judge: CommentJudge, gate: boolean): Promise<number> {
+/**
+ * Align the verdicts a judge wrote to the fixture order `scoreResults` expects,
+ * matching on the id `buildJob` carried into the shards. A fixture with no
+ * verdict, or a verdict naming no fixture, fails the run: the first means the
+ * judge skipped a comment, the second means the verdicts belong to another job.
+ */
+export function alignVerdicts(fixtures: Fixture[], verdicts: Map<string, Verdict>): Verdict[] {
+  const aligned: Verdict[] = [];
+  const unjudged: string[] = [];
+  for (const fixture of fixtures) {
+    const verdict = verdicts.get(fixture.id);
+    if (verdict) aligned.push(verdict);
+    else unjudged.push(fixture.id);
+  }
+  if (unjudged.length > 0) {
+    throw new Error(`No verdict for ${unjudged.length} fixture(s): ${unjudged.join(", ")}`);
+  }
+  const ids = new Set(fixtures.map((fixture) => fixture.id));
+  const foreign = [...verdicts.keys()].filter((id) => !ids.has(id));
+  if (foreign.length > 0) {
+    throw new Error(`Verdicts name ${foreign.length} unknown comment(s): ${foreign.join(", ")}`);
+  }
+  return aligned;
+}
+
+/** Where `build` materializes a job, kept apart from the audit's own job dirs. */
+const EVAL_JOB_BASE = join(tmpdir(), "comments-eval");
+
+/**
+ * Shard the corpus through the production job writer and emit the `<preflight>`
+ * block for the Workflow tool, so the gate judges fixtures on the path that
+ * ships rather than through the SDK oracle.
+ */
+async function build(jobBase: string): Promise<number> {
   const fixtures = await loadFixtures();
   if (fixtures.length === 0) {
     console.error("No fixtures found.");
     return 1;
   }
-  const verdicts = await judgeComments(judge, fixtures.map(fixtureToInput));
+  const descriptor = await buildJob(fixtures.map(fixtureToShardComment), { fix: false });
+  const written = await writeJob(descriptor, jobBase);
+  console.error(
+    `${written.count} fixtures / ${written.shardCount} shards (prompt ${descriptor.promptSha.slice(0, 12)})`,
+  );
+  await workflowJudge((line) => {
+    console.log(line);
+  })(written);
+  console.error(`\nScore with: bun ${import.meta.path} score --job ${written.jobDir}`);
+  return 0;
+}
+
+/** Every verdict file the judging agents wrote for a job, folded into one id map. */
+async function readJobVerdicts(jobDir: string): Promise<Map<string, Verdict>> {
+  if (!(await Bun.file(join(jobDir, "job-args.json")).exists())) {
+    throw new Error(`No job at ${jobDir}. Pass the job dir printed by build.`);
+  }
+  const verdictsDir = join(jobDir, "verdicts");
+  const glob = new Glob("verdict-*.json");
+  const contents: unknown[] = [];
+  for await (const file of glob.scan(verdictsDir)) {
+    contents.push(JSON.parse(await Bun.file(join(verdictsDir, file)).text()));
+  }
+  if (contents.length === 0) {
+    throw new Error(`No verdict files in ${verdictsDir}. Run the judge workflow first.`);
+  }
+  return collectVerdicts(contents);
+}
+
+function gateOn(fixtures: Fixture[], verdicts: Verdict[], gate: boolean): number {
   const metrics = scoreResults(fixtures, verdicts);
   console.log(report(fixtures, verdicts, metrics));
   if (gate && metrics.keepViolations.length > 0) {
@@ -250,20 +328,81 @@ async function run(judge: CommentJudge, gate: boolean): Promise<number> {
   return 0;
 }
 
+async function score(jobDir: string | undefined, gate: boolean): Promise<number> {
+  if (jobDir == null || jobDir === "") throw new Error("--job <dir> is required.");
+  const fixtures = await loadFixtures();
+  return gateOn(fixtures, alignVerdicts(fixtures, await readJobVerdicts(jobDir)), gate);
+}
+
+async function oracle(model: string, gate: boolean): Promise<number> {
+  const fixtures = await loadFixtures();
+  if (fixtures.length === 0) {
+    console.error("No fixtures found.");
+    return 1;
+  }
+  const prompt = await loadPrompt();
+  console.error(`Judging fixtures on ${model} (prompt ${prompt.sha256.slice(0, 12)})`);
+  const judge = anthropicCommentJudge({ prompt: prompt.text, model });
+  return gateOn(fixtures, await judgeComments(judge, fixtures.map(fixtureToInput)), gate);
+}
+
+const GATE_FLAG = {
+  type: Boolean,
+  default: false,
+  description: "Exit non-zero when the judge trims or rewrites a must-keep comment",
+} as const;
+
 if (import.meta.main) {
-  const argv = cli({
-    name: "eval",
-    flags: {
-      model: { type: String, default: JUDGE_MODEL, description: "Judge model id" },
-      gate: {
-        type: Boolean,
-        default: false,
-        description: "Exit non-zero when the judge trims or rewrites a must-keep comment",
+  // cleye dispatches synchronously, so each handler parks its work here for the
+  // top-level await below. `--help` parks nothing and exits 0.
+  const tasks: Promise<number>[] = [];
+
+  const buildCmd = command(
+    {
+      name: "build",
+      flags: {
+        jobBase: { type: String, default: EVAL_JOB_BASE, description: "Where the job dir lands" },
       },
     },
-  });
-  const prompt = await loadPrompt();
-  console.error(`Judging fixtures on ${argv.flags.model} (prompt ${prompt.sha256.slice(0, 12)})`);
-  const judge = anthropicCommentJudge({ prompt: prompt.text, model: argv.flags.model });
-  process.exit(await run(judge, argv.flags.gate));
+    (parsed) => {
+      tasks.push(build(parsed.flags.jobBase));
+    },
+  );
+
+  const scoreCmd = command(
+    {
+      name: "score",
+      flags: {
+        job: { type: String, description: "The job dir printed by build" },
+        gate: GATE_FLAG,
+      },
+    },
+    (parsed) => {
+      tasks.push(score(parsed.flags.job, parsed.flags.gate));
+    },
+  );
+
+  await cli(
+    {
+      name: "eval",
+      flags: {
+        model: { type: String, default: JUDGE_MODEL, description: "Judge model id" },
+        gate: GATE_FLAG,
+      },
+      commands: [buildCmd, scoreCmd],
+    },
+    (parsed) => {
+      tasks.push(oracle(parsed.flags.model, parsed.flags.gate));
+    },
+  );
+
+  const codes = await Promise.all(
+    tasks.map((task) =>
+      task.catch((error: unknown) => {
+        console.error(error instanceof Error ? error.message : String(error));
+        return 1;
+      }),
+    ),
+  );
+  process.exit(codes.find((code) => code !== 0) ?? 0);
 }

--- a/plugins/comments/evals/eval.ts
+++ b/plugins/comments/evals/eval.ts
@@ -279,7 +279,7 @@ const EVAL_JOB_BASE = join(tmpdir(), "comments-eval");
 /**
  * Shard the corpus through the production job writer and emit the `<preflight>`
  * block for the Workflow tool, so the gate judges fixtures on the path that
- * ships rather than through the SDK oracle.
+ * ships.
  */
 async function build(jobBase: string): Promise<number> {
   const fixtures = await loadFixtures();

--- a/plugins/comments/evals/eval.ts
+++ b/plugins/comments/evals/eval.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 
+import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Glob } from "bun";
@@ -262,19 +263,39 @@ export function alignVerdicts(fixtures: Fixture[], verdicts: Map<string, Verdict
     if (verdict) aligned.push(verdict);
     else unjudged.push(fixture.id);
   }
-  if (unjudged.length > 0) {
-    throw new Error(`No verdict for ${unjudged.length} fixture(s): ${unjudged.join(", ")}`);
-  }
   const ids = new Set(fixtures.map((fixture) => fixture.id));
   const foreign = [...verdicts.keys()].filter((id) => !ids.has(id));
-  if (foreign.length > 0) {
-    throw new Error(`Verdicts name ${foreign.length} unknown comment(s): ${foreign.join(", ")}`);
+  const problems: string[] = [];
+  if (unjudged.length > 0) {
+    problems.push(`No verdict for ${unjudged.length} fixture(s): ${unjudged.join(", ")}`);
   }
+  if (foreign.length > 0) {
+    problems.push(`Verdicts name ${foreign.length} unknown comment(s): ${foreign.join(", ")}`);
+  }
+  if (problems.length > 0) throw new Error(problems.join(". "));
   return aligned;
 }
 
 /** Where `build` materializes a job, kept apart from the audit's own job dirs. */
 const EVAL_JOB_BASE = join(tmpdir(), "comments-eval");
+
+/** Every verdict file in a job's verdicts dir, by absolute path. */
+async function verdictFiles(verdictsDir: string): Promise<string[]> {
+  const paths: string[] = [];
+  for await (const file of new Glob("verdict-*.json").scan(verdictsDir)) {
+    paths.push(join(verdictsDir, file));
+  }
+  return paths;
+}
+
+/**
+ * A job dir is keyed on the corpus and the rubric, so a re-run of an unchanged
+ * gate reuses the dir the last one wrote. Clearing it leaves a failed judging
+ * run with no verdicts for `score` to read, rather than the previous run's.
+ */
+export async function clearVerdicts(verdictsDir: string): Promise<void> {
+  await Promise.all((await verdictFiles(verdictsDir)).map((path) => rm(path)));
+}
 
 /**
  * Shard the corpus through the production job writer and emit the `<preflight>`
@@ -289,6 +310,7 @@ async function build(jobBase: string): Promise<number> {
   }
   const descriptor = await buildJob(fixtures.map(fixtureToShardComment), { fix: false });
   const written = await writeJob(descriptor, jobBase);
+  await clearVerdicts(written.verdictsDir);
   console.error(
     `${written.count} fixtures / ${written.shardCount} shards (prompt ${descriptor.promptSha.slice(0, 12)})`,
   );
@@ -305,13 +327,14 @@ async function readJobVerdicts(jobDir: string): Promise<Map<string, Verdict>> {
     throw new Error(`No job at ${jobDir}. Pass the job dir printed by build.`);
   }
   const verdictsDir = join(jobDir, "verdicts");
-  const glob = new Glob("verdict-*.json");
-  const contents: unknown[] = [];
-  for await (const file of glob.scan(verdictsDir)) {
-    contents.push(JSON.parse(await Bun.file(join(verdictsDir, file)).text()));
-  }
-  if (contents.length === 0) {
+  const files = await verdictFiles(verdictsDir);
+  if (files.length === 0) {
     throw new Error(`No verdict files in ${verdictsDir}. Run the judge workflow first.`);
+  }
+  const texts = await Promise.all(files.map((path) => Bun.file(path).text()));
+  const contents: unknown[] = [];
+  for (const text of texts) {
+    contents.push(JSON.parse(text));
   }
   return collectVerdicts(contents);
 }
@@ -353,9 +376,10 @@ const GATE_FLAG = {
 } as const;
 
 if (import.meta.main) {
-  // cleye dispatches synchronously, so each handler parks its work here for the
-  // top-level await below. `--help` parks nothing and exits 0.
-  const tasks: Promise<number>[] = [];
+  // cleye runs one handler synchronously, either a command's or the root's, so
+  // the handler parks its work here for the top-level await below. `--help`
+  // parks nothing and exits 0.
+  let task: Promise<number> | undefined;
 
   const buildCmd = command(
     {
@@ -365,7 +389,7 @@ if (import.meta.main) {
       },
     },
     (parsed) => {
-      tasks.push(build(parsed.flags.jobBase));
+      task = build(parsed.flags.jobBase);
     },
   );
 
@@ -378,7 +402,7 @@ if (import.meta.main) {
       },
     },
     (parsed) => {
-      tasks.push(score(parsed.flags.job, parsed.flags.gate));
+      task = score(parsed.flags.job, parsed.flags.gate);
     },
   );
 
@@ -392,17 +416,14 @@ if (import.meta.main) {
       commands: [buildCmd, scoreCmd],
     },
     (parsed) => {
-      tasks.push(oracle(parsed.flags.model, parsed.flags.gate));
+      task = oracle(parsed.flags.model, parsed.flags.gate);
     },
   );
 
-  const codes = await Promise.all(
-    tasks.map((task) =>
-      task.catch((error: unknown) => {
-        console.error(error instanceof Error ? error.message : String(error));
-        return 1;
-      }),
-    ),
+  process.exit(
+    await (task?.catch((error: unknown) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      return 1;
+    }) ?? 0),
   );
-  process.exit(codes.find((code) => code !== 0) ?? 0);
 }

--- a/plugins/comments/evals/oracle.ts
+++ b/plugins/comments/evals/oracle.ts
@@ -10,7 +10,7 @@ import { batchVerdictSchema, type Verdict } from "../judge/schema";
 /**
  * The calibration oracle: the Anthropic SDK judge used only under `evals/`. It
  * renders an indexed batch, scores it in one Messages call, and validates the
- * response. It is a cross-check on the rubric; `eval.ts build` and `eval.ts
+ * response. It is a cross-check on the rubric. `eval.ts build` and `eval.ts
  * score` gate the rubric through the production Workflow judge.
  */
 

--- a/plugins/comments/evals/oracle.ts
+++ b/plugins/comments/evals/oracle.ts
@@ -10,14 +10,14 @@ import { batchVerdictSchema, type Verdict } from "../judge/schema";
 /**
  * The calibration oracle: the Anthropic SDK judge used only under `evals/`. It
  * renders an indexed batch, scores it in one Messages call, and validates the
- * response. It is a cross-check on the rubric, not the ship gate: `eval.ts build`
- * and `eval.ts score` gate the rubric through the production Workflow judge.
+ * response. It is a cross-check on the rubric; `eval.ts build` and `eval.ts
+ * score` gate the rubric through the production Workflow judge.
  */
 
 /**
  * Pinned to the generation `judge.workflow.js` runs on, so the oracle scores the
  * rubric on the model that ships. Models after Opus 4.6 reject `temperature`, so
- * the batch pins `effort` instead of sampling, and repeated runs can differ.
+ * the batch pins `effort`, and repeated runs can differ.
  */
 export const JUDGE_MODEL = "claude-sonnet-5";
 

--- a/plugins/comments/evals/oracle.ts
+++ b/plugins/comments/evals/oracle.ts
@@ -8,12 +8,28 @@ import { BATCH_SIZE, parseVerdict } from "../judge/judge";
 import { batchVerdictSchema, type Verdict } from "../judge/schema";
 
 /**
- * The calibration oracle: the Anthropic SDK judge used only under `evals/`, the
- * deterministic ground truth the fixture corpus is scored against. It renders an
- * indexed batch, scores it at temperature 0, and validates the response.
+ * The calibration oracle: the Anthropic SDK judge used only under `evals/`. It
+ * renders an indexed batch, scores it in one Messages call, and validates the
+ * response. It is a cross-check on the rubric, not the ship gate: `eval.ts build`
+ * and `eval.ts score` gate the rubric through the production Workflow judge.
  */
 
-export const JUDGE_MODEL = "claude-sonnet-4-6";
+/**
+ * Pinned to the generation `judge.workflow.js` runs on, so the oracle scores the
+ * rubric on the model that ships. Models after Opus 4.6 reject `temperature`, so
+ * the batch pins `effort` instead of sampling, and repeated runs can differ.
+ */
+export const JUDGE_MODEL = "claude-sonnet-5";
+
+/** Pinned so a shift in the API's default effort cannot silently move the numbers. */
+const JUDGE_EFFORT = "high";
+
+/**
+ * Adaptive thinking is on by default from Sonnet 5, and its tokens come out of
+ * this budget alongside the verdicts, so a batch needs far more room than the
+ * verdict JSON alone. Too low truncates the JSON mid-string.
+ */
+const MAX_TOKENS = 16_000;
 
 /** One comment the oracle scores, with the context the rubric needs. */
 export interface CommentJudgeInput {
@@ -128,7 +144,7 @@ export interface AnthropicJudgeOptions {
 }
 
 /**
- * Real judge over the Messages API: temperature 0, structured JSON output,
+ * Real judge over the Messages API: structured JSON output at a pinned effort,
  * prompt cached as a stable system prefix so repeated calls share it.
  */
 export function anthropicCommentJudge(options: AnthropicJudgeOptions): CommentJudge {
@@ -138,13 +154,19 @@ export function anthropicCommentJudge(options: AnthropicJudgeOptions): CommentJu
     if (inputs.length === 0) return [];
     const response = await client.messages.create({
       model,
-      max_tokens: 4096,
-      // oxlint-disable-next-line typescript/no-deprecated -- the pinned model still honors temperature, and dropping it costs the judge its determinism.
-      temperature: 0,
+      max_tokens: MAX_TOKENS,
       system: [{ type: "text", text: options.prompt, cache_control: { type: "ephemeral" } }],
-      output_config: { format: { type: "json_schema", schema: batchVerdictSchema() } },
+      output_config: {
+        effort: JUDGE_EFFORT,
+        format: { type: "json_schema", schema: batchVerdictSchema() },
+      },
       messages: [{ role: "user", content: formatBatch(inputs) }],
     });
+    if (response.stop_reason === "max_tokens") {
+      throw new Error(
+        `Judge hit max_tokens (${MAX_TOKENS}) on a batch of ${inputs.length}, truncating its JSON. Raise the budget or lower BATCH_SIZE.`,
+      );
+    }
     const block = response.content.find((b) => b.type === "text");
     if (!block) {
       throw new Error(`Judge response contained no text block (stop: ${response.stop_reason})`);

--- a/plugins/comments/evals/oracle.ts
+++ b/plugins/comments/evals/oracle.ts
@@ -171,7 +171,17 @@ export function anthropicCommentJudge(options: AnthropicJudgeOptions): CommentJu
     if (!block) {
       throw new Error(`Judge response contained no text block (stop: ${response.stop_reason})`);
     }
-    return parseBatchVerdicts(block.text, inputs.length);
+    try {
+      return parseBatchVerdicts(block.text, inputs.length);
+    } catch (error) {
+      // Structured output constrains the grammar, so malformed JSON means a cut
+      // short response. Report what the API said about why, since a stop reason
+      // other than max_tokens points somewhere other than the token budget.
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)} (stop: ${response.stop_reason}, batch of ${inputs.length}, output ${response.usage.output_tokens} of ${MAX_TOKENS} tokens, text ends: ${JSON.stringify(block.text.slice(-160))})`,
+        { cause: error },
+      );
+    }
   };
 }
 

--- a/plugins/comments/judge/job.ts
+++ b/plugins/comments/judge/job.ts
@@ -75,8 +75,8 @@ function toShardComment(comment: ShardComment): ShardComment {
  * wins judge and stream first, and pin the prompt. The Bun side shards once. The
  * sandboxed Workflow cannot re-shard, so one shard maps 1:1 to one agent.
  *
- * Takes the shard fields alone, so the audit passes `CollectedComment`s and the
- * eval passes fixtures, and both reach the agents through the same writer.
+ * Reads only the shard fields off each comment, so a caller may pass a wider
+ * type and the extra fields stay out of the shard files.
  */
 export async function buildJob(
   comments: ShardComment[],

--- a/plugins/comments/judge/job.ts
+++ b/plugins/comments/judge/job.ts
@@ -2,7 +2,6 @@ import { mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { z } from "zod";
-import type { CollectedComment } from "../detection/collect";
 import { type Provenance, ProvenanceSchema } from "../detection/provenance";
 import type { CommentKind, Language } from "../detection/types";
 import { BATCH_SIZE, loadPrompt, sha256 } from "./judge";
@@ -59,7 +58,7 @@ export interface BuildJobOptions {
 const FIX_INSTRUCTION =
   "For this run, populate suggestedFix for every flagged comment with a concrete rewrite, trim, or delete.";
 
-function toShardComment(comment: CollectedComment): ShardComment {
+function toShardComment(comment: ShardComment): ShardComment {
   return {
     id: comment.id,
     path: comment.path,
@@ -75,9 +74,12 @@ function toShardComment(comment: CollectedComment): ShardComment {
  * Partition ranked comments into shards, preserving rank order so the biggest
  * wins judge and stream first, and pin the prompt. The Bun side shards once. The
  * sandboxed Workflow cannot re-shard, so one shard maps 1:1 to one agent.
+ *
+ * Takes the shard fields alone, so the audit passes `CollectedComment`s and the
+ * eval passes fixtures, and both reach the agents through the same writer.
  */
 export async function buildJob(
-  comments: CollectedComment[],
+  comments: ShardComment[],
   options: BuildJobOptions,
 ): Promise<JobDescriptor> {
   const shardSize = options.shardSize ?? BATCH_SIZE;

--- a/plugins/comments/workflow/judge.workflow.js
+++ b/plugins/comments/workflow/judge.workflow.js
@@ -15,9 +15,10 @@ export const meta = {
 
 const job = typeof args === "string" ? JSON.parse(args) : args;
 
-// The eval gate (evals/eval.ts --gate) has cleared the rubric on sonnet, so the
-// judge is pinned there rather than inheriting the session model. Re-clear the
-// gate on a cheaper model before lowering this.
+// The eval gate judges the labeled fixture corpus through this workflow
+// (evals/eval.ts build, then score --gate), so the rubric is cleared on the
+// model pinned here rather than on whatever the session runs. Re-clear the gate
+// on a cheaper model before lowering this.
 const JUDGE_MODEL = "sonnet";
 
 const SUMMARY_SCHEMA = {

--- a/plugins/comments/workflow/judge.workflow.js
+++ b/plugins/comments/workflow/judge.workflow.js
@@ -17,8 +17,7 @@ const job = typeof args === "string" ? JSON.parse(args) : args;
 
 // The eval gate judges the labeled fixture corpus through this workflow
 // (evals/eval.ts build, then score --gate), so the rubric is cleared on the
-// model pinned here rather than on whatever the session runs. Re-clear the gate
-// on a cheaper model before lowering this.
+// model pinned here. Re-clear the gate on a cheaper model before lowering this.
 const JUDGE_MODEL = "sonnet";
 
 const SUMMARY_SCHEMA = {


### PR DESCRIPTION
The eval gate pinned its SDK oracle to `claude-sonnet-4-6` while `judge.workflow.js` runs the judging agents on the `sonnet` alias, so the gate certified a generation production never uses. It also read `ANTHROPIC_API_KEY` through `op run`, which needs someone at a 1Password prompt. That is how #1348 rewrote the rubric and merged without the gate running at all.

`eval.ts build` now shards the labeled corpus through the same writer the audit's `preflight` uses and prints a `<preflight>` block. Hand that to the Workflow tool, then `eval.ts score --job <dir> --gate` scores the verdicts the agents wrote. That path runs on subscription auth.

## Gate of Record

The workflow path gates, because it exercises the code that ships and runs unattended.

The oracle is a keyed cross-check and is no longer a calibration reference. Models after Opus 4.6 reject `temperature` with a 400, confirmed against the installed SDK's `@deprecated` annotation, so the batch pins `output_config.effort` and samples. Two runs over one corpus can disagree. `max_tokens` rose to 16,000 because Sonnet 5's adaptive thinking draws on the output budget and truncated the verdict JSON at the old 4,096.

`evals/op.env` held an item ID in the vault slot of its `op://<vault>/<item>/<field>` reference, breaking every keyed runner in the repo. The item's title contains the path separator, so it is addressed by ID.

## Results

The workflow gate scores the corpus at accuracy 1.00 with zero keep violations.

The oracle scores it at 0.96, also with zero keep violations. Its one disagreement reads `db-host-variable-voice-rewrite` as `keep` where the label says `rewrite`, which leaves a comment's voice alone rather than destroying a justified one. The gate keys on keep violations for that reason: an over-cautious judge is a worse eval score and a safe apply.

An oracle batch twice died parsing an unterminated string without the `max_tokens` guard firing, then passed on a retry. The parse failure now carries the stop reason, the output tokens against the budget, and the tail of the response, so a third occurrence names its cause.

## Limits

No CI check requires the gate. The workflow path needs the Workflow tool that only a Claude Code session provides, so a rubric change can still merge unvetted.

The oracle's `claude-sonnet-5` pin and the workflow's `sonnet` alias drift apart on their own when the alias moves.
