### PR TITLE
flock: classify rows by whether they need you

### DIFF
--- a/user/skills/flock/SKILL.md
+++ b/user/skills/flock/SKILL.md
@@ -36,11 +36,17 @@ One flock runs per server, and the `FLOCK` line settles which:
 - `ELSEWHERE`: `herdr workspace focus` that ID, say where it went, stop.
 - `UNCLAIMED`: rename this workspace to `flock` if it holds nothing else, then sweep. Otherwise create one, tell the user to run `/flock` there, and stop. A pane keeps the workspace it launched in, so moving this one reads `ELSEWHERE` on the next load.
 
-The PR column reads `#N`, `draft#N`, `merged#N`, `-`, or `?`. The board carries no CI state and no review scores, so fetch those only for a row you are about to merge.
+The board classifies every row and prints only the ones you can act on. `needs you`, `merge`, and `clean up` get a row each. `waiting`, `working`, `parked`, and `panes` collapse to one line apiece, and a disposition with nothing in it is omitted. The count line at the top is the whole board.
 
-The REPO column reads a bare name for a repository you own, and `owner/repo` for anything else, a fork's upstream target included. An owner there means the row is not yours to merge.
+Take the classification as given. It already read the checks, the review decision, and the merge state, so re-fetching them to second-guess a `parked` or `waiting` row spends tokens on rows with no action attached.
 
-FLAGS reads `clean` or a comma-joined list. Only `merged` clears a row for cleanup, and every other flag holds it. Three are not self-evident: `carries:N` counts gitignored files a recursive removal would take, `reused` means the `merged#N` beside it belongs to different work under a recycled branch name, and `unreadable` or `unpushed:?` mean git would not report the state at all.
+The PR column reads `#N`, `draft#N`, `merged#N`, `-`, or `?`. The REPO column reads a bare name for a repository you own, and `owner/repo` for anything else, a fork's upstream target included. An owner there means the row is not yours to merge, though a conflict or a red check on it is still yours to fix.
+
+FLAGS reads `clean` or a comma-joined list, forge state first. `failing:lint,build` names the jobs that went red, capped at three plus a count. `running` means CI has not finished, `conflicting` and `behind` come from the merge state, `blocked` marks a green pull request some other gate holds, `approved` and `changes-requested` come from the review, `checks:none` means the pull request runs no checks at all, and `checks:?` means the forge would not say.
+
+The checkout flags follow. Only `merged` clears a row for cleanup, and every other flag holds it. Three are not self-evident: `carries:N` counts gitignored files a recursive removal would take, `reused` means the `merged#N` beside it belongs to different work under a recycled branch name, and `unreadable` or `unpushed:?` mean git would not report the state at all, which raises the row rather than parking it.
+
+The AGENT column reads `<agent>/<status>`. A `blocked` status is an agent stopped on a prompt, which puts its row in `needs you` whatever else the row carries.
 
 An `incomplete:` line names what the board could not resolve. Retry it: `gh pr list --head <branch>` for the branches it names, `gh pr list` for a `?` PR column. Dispose of nothing the retry also leaves unresolved.
 
@@ -68,33 +74,23 @@ Below the bar, the row is a report. Name the failing job, the reviewer's finding
 
 ## Sweep
 
-Check every row against the deferred keys first. A deferred row is held unless the state block re-raised it as stale.
+Check the rendered rows against the deferred keys first. A deferred row is held unless the state block re-raised it as stale.
 
-Resolve the rest to one of three dispositions.
+**Clean up.** Merged with nothing left in the tree. Remove the worktree, close its workspace and panes, prune the branch. Read `open_workspace_id` out of `herdr worktree list --json` before removing the path, because herdr loses the mapping once the worktree is gone.
 
-**Clean up.** `merged#N` or the `merged` flag, and no other flag on the row. Remove the worktree, close its workspace and panes, prune the branch. Read `open_workspace_id` out of `herdr worktree list --json` before removing the path, because herdr loses the mapping once the worktree is gone.
+**Merge.** Checks green, merge state clean, your repo. Re-read the bar immediately before merging, because both the board and your first lookup predate the user's answer. `gh pr merge --squash --delete-branch`, and stop there. The worktree becomes a cleanup row on a later sweep, once a fresh board shows it carrying nothing.
 
-**Merge.** Bar met, your repo. Re-read the bar immediately before merging, because both the board and your first lookup predate the user's answer. `gh pr merge --squash --delete-branch`, and stop there. The worktree becomes a cleanup row on a later sweep, once a fresh board shows it carrying nothing.
+**Report.** A `needs you` row is a report unless the user asks for something else. Its flags say why: a named failing job, a conflict, a review holding it, or commits beside a `merged#N` that the merge did not take, which need a fresh branch rather than a removal. A blocked agent is a prompt to answer, so `herdr agent focus` its pane and say what it is asking.
 
-**Report.** Everything else, grouped rather than listed. Rows sharing a shape become one line carrying the count and the shape, and a single row is named only when it needs a decision. A `merged#N` row carrying any other flag holds work the merge did not take, so it needs a fresh branch rather than a removal.
-
-Skip the row whose pane matches `self=`. You do not sweep the pane you run in.
-
-A row mid-flight gets none of the three. An agent on a fresh branch with no PR and no flags is working rather than stuck. A clean worktree with no PR, no flags, and no agent is quiet under 30 days and aged out above it.
-
-A pane parked on an approval dialog is the user's to answer. Read it, `herdr agent focus` it, and say what it is asking.
+The collapsed lines are counts, not a queue. Each `waiting` entry names what holds it: `review` when a review is still required, `ci` while checks run, `draft` while the author holds it, and `merge` when it is green and only the maintainer can land it. Raise one only when the user asks, or when a `waiting` row has sat long enough to be worth a nudge, which the reason tells you how to word.
 
 Every disposal waits for the user, and nothing else stops one. Auto mode approves `gh pr merge` on your own green pull request with no prompt, and leaves worktree removal and workspace close to a classifier. Propose every disposal in the `AskUserQuestion` batch and run only what comes back approved.
 
 ## Close
 
-Close with a count, then the rows that need the user:
+Close with the board's own count line, then the rows that need the user. Do not restate the collapsed lines.
 
-```
-12 to clean up · 2 to merge · 6 need you · 43 mid-flight
-```
-
-Then batch the decisions into `AskUserQuestion`: the cleanups as one grouped question, the merges individually, and anything genuinely yours to raise.
+Batch the decisions into `AskUserQuestion`: the cleanups as one grouped question, the merges individually, and anything genuinely yours to raise.
 
 Between prompts, do nothing. `/loop 20m /flock` is how the user makes this proactive.
 

--- a/user/skills/flock/scripts/board.test.ts
+++ b/user/skills/flock/scripts/board.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { branchLabel, fit, jsonRow, renderBoard, sortWorktreeRows, type BoardRow } from "./board";
+import {
+  branchLabel,
+  fit,
+  jsonRow,
+  renderTable,
+  rowCells,
+  sortWorktreeRows,
+  type BoardRow,
+} from "./board";
 
 function row(overrides: Partial<BoardRow>): BoardRow {
   return {
@@ -19,6 +27,18 @@ function row(overrides: Partial<BoardRow>): BoardRow {
     prColumn: "-",
     age: 0,
     flags: ["clean"],
+    state: {
+      self: false,
+      working: false,
+      blocked: false,
+      pullUnknown: false,
+      status: "clean",
+      unpushed: 0,
+      carried: 0,
+      mergedBranch: false,
+      reused: false,
+    },
+    disposition: "cleanup",
     ...overrides,
   };
 }
@@ -44,34 +64,36 @@ test("branchLabel marks a detached worktree and blanks a pane row", () => {
 });
 
 test("the table pads, truncates, and keeps the flags column whole", () => {
-  const rendered = renderBoard([
-    row({
-      pane: "wB2:p1",
-      agent: "claude/working",
-      prColumn: "merged#30366",
-      age: 12,
-      flags: ["dirty", "carries:2"],
-    }),
-    row({
-      repoLabel: "backnotprop/plannotator",
-      repo: "plannotator",
-      branch: "a-branch-name-that-will-not-fit-in-the-column",
-      ownedByViewer: false,
-      age: null,
-      flags: ["unreadable"],
-    }),
-    row({
-      kind: "pane",
-      pane: "w9W:p1",
-      agent: "claude/idle",
-      repoLabel: "Herdr",
-      branch: null,
-      worktree: null,
-      age: null,
-      prColumn: "-",
-      flags: ["no worktree"],
-    }),
-  ]);
+  const rendered = renderTable(
+    [
+      row({
+        pane: "wB2:p1",
+        agent: "claude/working",
+        prColumn: "merged#30366",
+        age: 12,
+        flags: ["dirty", "carries:2"],
+      }),
+      row({
+        repoLabel: "backnotprop/plannotator",
+        repo: "plannotator",
+        branch: "a-branch-name-that-will-not-fit-in-the-column",
+        ownedByViewer: false,
+        age: null,
+        flags: ["unreadable"],
+      }),
+      row({
+        kind: "pane",
+        pane: "w9W:p1",
+        agent: "claude/idle",
+        repoLabel: "Herdr",
+        branch: null,
+        worktree: null,
+        age: null,
+        prColumn: "-",
+        flags: ["no worktree"],
+      }),
+    ].map(rowCells),
+  );
 
   expect(rendered).toMatchInlineSnapshot(`
 "PANE      AGENT          REPO                     BRANCH                     PR            AGE  FLAGS
@@ -110,10 +132,30 @@ test("a json row carries the fields the table truncates or omits", () => {
         ownedByViewer: false,
         repoLabel: "backnotprop/plannotator",
         branch: "doc-containment-gate",
-        pull: { ref: "#1437", number: 1437, state: "open" },
+        pull: {
+          ref: "#1437",
+          number: 1437,
+          state: "open",
+          checks: "passing",
+          failing: [],
+          review: "none",
+          mergeState: "clean",
+        },
         prColumn: "#1437",
         age: 3,
         flags: ["dirty", "carries:1"],
+        disposition: "waiting",
+        state: {
+          self: false,
+          working: false,
+          blocked: false,
+          pullUnknown: false,
+          status: "dirty",
+          unpushed: 0,
+          carried: 1,
+          mergedBranch: false,
+          reused: false,
+        },
       }),
     ),
   ).toEqual({
@@ -128,9 +170,29 @@ test("a json row carries the fields the table truncates or omits", () => {
     branch: "doc-containment-gate",
     detached: false,
     worktree: "/wt/topic",
-    pr: { ref: "#1437", number: 1437, state: "open" },
+    pr: {
+      ref: "#1437",
+      number: 1437,
+      state: "open",
+      checks: "passing",
+      failing: [],
+      review: "none",
+      mergeState: "clean",
+    },
     prColumn: "#1437",
     age: 3,
     flags: ["dirty", "carries:1"],
+    disposition: "waiting",
+    state: {
+      self: false,
+      working: false,
+      blocked: false,
+      pullUnknown: false,
+      status: "dirty",
+      unpushed: 0,
+      carried: 1,
+      mergedBranch: false,
+      reused: false,
+    },
   });
 });

--- a/user/skills/flock/scripts/board.ts
+++ b/user/skills/flock/scripts/board.ts
@@ -1,8 +1,44 @@
-export interface BoardPull {
+import type { PullState } from "./forge";
+import type { StatusRead } from "./worktree";
+
+export interface BoardPull extends PullState {
   readonly ref: string;
   readonly number: number;
   readonly state: "open" | "draft" | "merged";
 }
+
+/**
+ * Row state the table does not print but the sweep turns on. `flags` renders
+ * most of it, and re-reading a disposition out of rendered strings would make
+ * the classifier depend on how the board happens to spell them.
+ */
+export interface RowState {
+  /** The pane running this flock. It sweeps everything except itself. */
+  readonly self: boolean;
+  /** An agent is mid-turn in the pane holding this worktree. */
+  readonly working: boolean;
+  /** An agent has stopped on a prompt only the user can answer. */
+  readonly blocked: boolean;
+  /** The forge refused to list pull requests, so no absence here is trustworthy. */
+  readonly pullUnknown: boolean;
+  /** What `git status` reported, so a checkout it could not read stays distinct. */
+  readonly status: StatusRead;
+  readonly unpushed: number | null;
+  readonly carried: number;
+  readonly mergedBranch: boolean;
+  readonly reused: boolean;
+}
+
+/** Where a row lands in the sweep. `disposition.ts` decides which. */
+export type Disposition =
+  | "self"
+  | "needs-you"
+  | "merge"
+  | "cleanup"
+  | "waiting"
+  | "working"
+  | "parked"
+  | "panes";
 
 export interface BoardRow {
   readonly kind: "worktree" | "pane";
@@ -21,6 +57,8 @@ export interface BoardRow {
   readonly prColumn: string;
   readonly age: number | null;
   readonly flags: readonly string[];
+  readonly state: RowState;
+  readonly disposition: Disposition;
 }
 
 export const COLUMNS = [
@@ -58,28 +96,30 @@ export function rowCells(row: BoardRow): string[] {
   ];
 }
 
-export function renderTable(rows: readonly (readonly string[])[]): string {
-  const format = (cells: readonly string[], truncate: boolean): string =>
-    COLUMNS.map((column, index) => {
-      const raw = cells[index] ?? "";
-      if (column.width === null) return raw;
-      const value = truncate ? fit(raw, column.width) : raw;
-      return value.padEnd(column.width);
-    })
-      .join(" ")
-      .replace(/\s+$/, "");
-
-  return [
-    format(
-      COLUMNS.map((column) => column.header),
-      false,
-    ),
-    ...rows.map((cells) => format(cells, true)),
-  ].join("\n");
+function format(cells: readonly string[], truncate: boolean): string {
+  return COLUMNS.map((column, index) => {
+    const raw = cells[index] ?? "";
+    if (column.width === null) return raw;
+    const value = truncate ? fit(raw, column.width) : raw;
+    return value.padEnd(column.width);
+  })
+    .join(" ")
+    .replace(/\s+$/, "");
 }
 
-export function renderBoard(rows: readonly BoardRow[]): string {
-  return renderTable(rows.map(rowCells));
+export function headerRow(): string {
+  return format(
+    COLUMNS.map((column) => column.header),
+    false,
+  );
+}
+
+export function renderRows(rows: readonly (readonly string[])[]): string[] {
+  return rows.map((cells) => format(cells, true));
+}
+
+export function renderTable(rows: readonly (readonly string[])[]): string {
+  return [headerRow(), ...renderRows(rows)].join("\n");
 }
 
 function compare(left: string, right: string): number {
@@ -111,5 +151,7 @@ export function jsonRow(row: BoardRow): Record<string, unknown> {
     prColumn: row.prColumn,
     age: row.age,
     flags: [...row.flags],
+    disposition: row.disposition,
+    state: row.state,
   };
 }

--- a/user/skills/flock/scripts/claim.ts
+++ b/user/skills/flock/scripts/claim.ts
@@ -5,7 +5,8 @@ import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { z } from "zod";
 import { decodeJson } from "../../../../packages/decode/index";
-import { jsonRow, renderBoard, sortWorktreeRows, type BoardRow } from "./board";
+import { jsonRow, sortWorktreeRows, type BoardRow } from "./board";
+import { classify, pullFlags, renderBoard } from "./disposition";
 import { daysBefore, deferredPath, readDeferrals, staleKeys } from "./deferred";
 import { spawnRun, throttle, type Run } from "./exec";
 import {
@@ -377,13 +378,16 @@ async function scanRepository(ctx: Context, repository: Repository): Promise<Rep
       const scan = await scanWorktree(ctx, { path: record.path, base, commitDate });
 
       const pull = record.branch === null ? undefined : pulls.get(record.branch);
+      const merged = record.branch !== null && mergedBranches.has(record.branch);
+      const reused = isReusedBranch(pull, scan.commit);
       const flags = deriveFlags({
         detached: record.branch === null,
         status: scan.status,
         ahead: scan.ahead,
         carried: scan.carried,
-        merged: record.branch !== null && mergedBranches.has(record.branch),
-        reused: isReusedBranch(pull, scan.commit),
+        merged,
+        reused,
+        pull: pull === undefined ? [] : pullFlags(pull),
       });
 
       const row: BoardRow = {
@@ -402,10 +406,33 @@ async function scanRepository(ctx: Context, repository: Repository): Promise<Rep
         pull:
           pull === undefined
             ? null
-            : { ref: pullRequestRef(pull), number: pull.number, state: pull.state },
+            : {
+                ref: pullRequestRef(pull),
+                number: pull.number,
+                state: pull.state,
+                checks: pull.checks,
+                failing: pull.failing,
+                review: pull.review,
+                mergeState: pull.mergeState,
+              },
         prColumn: pull === undefined ? (unknownColumn ? "?" : "-") : pullRequestRef(pull),
         age: ageInDays(scan.commit, ctx.now),
         flags,
+        state: {
+          self: false,
+          working: false,
+          blocked: false,
+          pullUnknown: unknownColumn,
+          status: scan.status,
+          unpushed: scan.ahead,
+          carried: scan.carried,
+          mergedBranch: merged,
+          reused,
+        },
+        // A pane can claim this worktree only once every repository has been
+        // scanned, and the agent holding it changes the disposition, so the
+        // row is classified after `attachPanes` rather than here.
+        disposition: "parked",
       };
       return { row, commit: scan.commit };
     }),
@@ -467,6 +494,7 @@ function readPanes(snapshot: z.infer<typeof Snapshot>): {
 function attachPanes(
   rows: readonly BoardRow[],
   panes: readonly Pane[],
+  self: string,
 ): { rows: BoardRow[]; claimed: Set<string> } {
   const claimed = new Set<string>();
   const attached = rows.map((row) => {
@@ -477,9 +505,19 @@ function attachPanes(
     );
     if (pane === undefined) return row;
     claimed.add(pane.id);
-    return { ...row, pane: pane.id, agent: pane.agent };
+    const state = {
+      ...row.state,
+      self: pane.id === self,
+      working: pane.agent.endsWith("/working"),
+      blocked: pane.agent.endsWith("/blocked"),
+    };
+    return { ...row, pane: pane.id, agent: pane.agent, state };
   });
   return { rows: attached, claimed };
+}
+
+function disposeRows(rows: readonly BoardRow[]): BoardRow[] {
+  return rows.map((row) => ({ ...row, disposition: classify(row) }));
 }
 
 function idlePaneRows(
@@ -506,6 +544,18 @@ function idlePaneRows(
       prColumn: "-",
       age: null,
       flags: ["no worktree"],
+      state: {
+        self: false,
+        working: pane.agent.endsWith("/working"),
+        blocked: pane.agent.endsWith("/blocked"),
+        pullUnknown: false,
+        status: "clean",
+        unpushed: 0,
+        carried: 0,
+        mergedBranch: false,
+        reused: false,
+      },
+      disposition: "panes" as const,
     }));
 }
 
@@ -607,8 +657,10 @@ async function board(json: boolean): Promise<string> {
   );
   const warnings = scans.flatMap((scan) => scan.warnings);
   const sorted = sortWorktreeRows(scans.flatMap((scan) => scan.rows));
-  const { rows: withPanes, claimed } = attachPanes(sorted, panes);
-  const allRows = [...withPanes, ...idlePaneRows(panes, claimed, self)];
+  const { rows: withPanes, claimed } = attachPanes(sorted, panes, self);
+  const allRows = disposeRows([...withPanes, ...idlePaneRows(panes, claimed, self)]).filter(
+    (row) => row.disposition !== "self",
+  );
 
   const deferrals = await deferralLines(deferredPath(process.env), new Date());
   const selfWorkspace = process.env.HERDR_WORKSPACE_ID ?? "";

--- a/user/skills/flock/scripts/disposition.test.ts
+++ b/user/skills/flock/scripts/disposition.test.ts
@@ -1,0 +1,433 @@
+import { describe, expect, test } from "bun:test";
+import type { BoardPull, BoardRow, Disposition, RowState } from "./board";
+import { classify, collapsedLines, countLine, groupByDisposition, pullFlags } from "./disposition";
+import type { PullState } from "./forge";
+
+function pull(overrides: Partial<BoardPull> = {}): BoardPull {
+  return {
+    ref: "#1",
+    number: 1,
+    state: "open",
+    checks: "passing",
+    failing: [],
+    review: "none",
+    mergeState: "clean",
+    ...overrides,
+  };
+}
+
+function state(overrides: Partial<RowState> = {}): RowState {
+  return {
+    self: false,
+    working: false,
+    blocked: false,
+    pullUnknown: false,
+    status: "clean",
+    unpushed: 0,
+    carried: 0,
+    mergedBranch: false,
+    reused: false,
+    ...overrides,
+  };
+}
+
+function row(overrides: Partial<BoardRow> = {}): BoardRow {
+  return {
+    kind: "worktree",
+    pane: null,
+    agent: null,
+    owner: "bendrucker",
+    repo: "claude",
+    slug: "bendrucker/claude",
+    forkOf: null,
+    ownedByViewer: true,
+    repoLabel: "claude",
+    branch: "topic",
+    detached: false,
+    worktree: "/wt/topic",
+    pull: null,
+    prColumn: "-",
+    age: 0,
+    flags: ["clean"],
+    state: state(),
+    disposition: "parked",
+    ...overrides,
+  };
+}
+
+describe("an open pull request", () => {
+  test.each<{ name: string; row: BoardRow; expected: Disposition }>([
+    {
+      name: "green in your own repository is a merge decision",
+      row: row({ pull: pull() }),
+      expected: "merge",
+    },
+    {
+      name: "with a failing check is yours to fix",
+      row: row({ pull: pull({ checks: "failing", failing: ["lint"], mergeState: "blocked" }) }),
+      expected: "needs-you",
+    },
+    {
+      name: "that conflicts is yours to rebase",
+      row: row({ pull: pull({ mergeState: "conflicting" }) }),
+      expected: "needs-you",
+    },
+    {
+      name: "with changes requested is yours to address",
+      row: row({ pull: pull({ review: "changes-requested" }) }),
+      expected: "needs-you",
+    },
+    {
+      name: "green in a repository you do not own waits on its maintainer",
+      row: row({ ownedByViewer: false, pull: pull({ review: "review-required" }) }),
+      expected: "waiting",
+    },
+    {
+      name: "conflicting in a repository you do not own is still yours to rebase",
+      row: row({ ownedByViewer: false, pull: pull({ mergeState: "conflicting" }) }),
+      expected: "needs-you",
+    },
+    {
+      name: "failing in a repository you do not own is still yours to fix",
+      row: row({ ownedByViewer: false, pull: pull({ checks: "failing", failing: ["build"] }) }),
+      expected: "needs-you",
+    },
+    {
+      name: "with checks still running waits on CI",
+      row: row({ pull: pull({ checks: "running", mergeState: "blocked" }) }),
+      expected: "waiting",
+    },
+    {
+      name: "in draft is the author saying it is not ready",
+      row: row({ pull: pull({ state: "draft", checks: "failing", failing: ["lint"] }) }),
+      expected: "waiting",
+    },
+    {
+      name: "green but behind its base needs an update",
+      row: row({ pull: pull({ mergeState: "behind" }) }),
+      expected: "needs-you",
+    },
+    {
+      name: "green but blocked by a gate the board cannot name is read by hand",
+      row: row({ pull: pull({ mergeState: "blocked" }) }),
+      expected: "needs-you",
+    },
+    {
+      name: "whose forge would not report its checks is read by hand",
+      row: row({ pull: pull({ checks: "unknown", mergeState: "unknown", review: "unknown" }) }),
+      expected: "needs-you",
+    },
+    {
+      name: "with no checks configured at all does not pass for green",
+      row: row({ pull: pull({ checks: "none" }) }),
+      expected: "needs-you",
+    },
+  ])("$name", ({ row: subject, expected }) => {
+    expect(classify(subject)).toBe(expected);
+  });
+});
+
+describe("a merged pull request", () => {
+  const merged = pull({ state: "merged", ref: "merged#1", checks: "none", mergeState: "unknown" });
+
+  test.each<{ name: string; row: BoardRow; expected: Disposition }>([
+    {
+      name: "with nothing left in the tree is a cleanup",
+      row: row({ pull: merged }),
+      expected: "cleanup",
+    },
+    {
+      name: "with commits the merge did not take needs a fresh branch",
+      row: row({ pull: merged, state: state({ unpushed: 13 }) }),
+      expected: "needs-you",
+    },
+    {
+      name: "whose ahead count git would not report is not assumed pushed",
+      row: row({ pull: merged, state: state({ unpushed: null }) }),
+      expected: "needs-you",
+    },
+    {
+      name: "under a recycled branch name belongs to different work",
+      row: row({ pull: merged, state: state({ reused: true }) }),
+      expected: "needs-you",
+    },
+    {
+      name: "leaving only an uncommitted tree is parked",
+      row: row({ pull: merged, state: state({ status: "dirty" }) }),
+      expected: "parked",
+    },
+    {
+      name: "leaving only carried files is parked",
+      row: row({ pull: merged, state: state({ carried: 10 }) }),
+      expected: "parked",
+    },
+    {
+      name: "on a branch merged into the base without a pull request still cleans up",
+      row: row({ state: state({ mergedBranch: true }) }),
+      expected: "cleanup",
+    },
+  ])("$name", ({ row: subject, expected }) => {
+    expect(classify(subject)).toBe(expected);
+  });
+});
+
+describe("a row with no pull request", () => {
+  test("is parked, because nothing on the board will move it", () => {
+    expect(classify(row({ state: state({ status: "dirty", unpushed: 3 }) }))).toBe("parked");
+  });
+
+  // Absent because the forge refused to answer is not absent.
+  test("is raised when the forge would not list pull requests", () => {
+    expect(classify(row({ state: state({ pullUnknown: true }) }))).toBe("needs-you");
+  });
+
+  // git failing to read a checkout is the same class of silence.
+  test("is raised when git would not report the status", () => {
+    expect(classify(row({ state: state({ status: "unreadable" }) }))).toBe("needs-you");
+  });
+});
+
+describe("a detached worktree", () => {
+  const detached = (overrides: Partial<RowState> = {}): BoardRow =>
+    row({ branch: null, detached: true, state: state(overrides) });
+
+  // A branch deleted after its merge leaves the worktree detached, and its
+  // commits have no branch left to reach the forge on.
+  test.each<{ name: string; row: BoardRow; expected: Disposition }>([
+    { name: "carrying commits is raised", row: detached({ unpushed: 4 }), expected: "needs-you" },
+    {
+      name: "with an uncountable ahead is raised",
+      row: detached({ unpushed: null }),
+      expected: "needs-you",
+    },
+    { name: "with nothing above the base parks", row: detached(), expected: "parked" },
+    {
+      name: "is never offered for cleanup",
+      row: detached({ carried: 1 }),
+      expected: "parked",
+    },
+  ])("$name", ({ row: subject, expected }) => {
+    expect(classify(subject)).toBe(expected);
+  });
+});
+
+describe("an agent holding the worktree", () => {
+  test.each<{ name: string; row: BoardRow; expected: Disposition }>([
+    {
+      name: "mid-turn holds back a cleanup",
+      row: row({ pull: pull({ state: "merged" }), state: state({ working: true }) }),
+      expected: "working",
+    },
+    {
+      name: "mid-turn holds back a report",
+      row: row({
+        pull: pull({ mergeState: "conflicting" }),
+        state: state({ working: true }),
+      }),
+      expected: "working",
+    },
+    {
+      // The merge lands on the forge, and hiding it would drop the one row the
+      // sweep exists to raise.
+      name: "mid-turn does not hold back a merge",
+      row: row({ pull: pull(), state: state({ working: true }) }),
+      expected: "merge",
+    },
+    {
+      name: "finished leaves the row classified by its own state",
+      row: row({ pull: pull({ checks: "failing", failing: ["lint"] }) }),
+      expected: "needs-you",
+    },
+  ])("$name", ({ row: subject, expected }) => {
+    expect(classify(subject)).toBe(expected);
+  });
+});
+
+test("the flock's own row and a pane with no worktree bypass the rules", () => {
+  expect(classify(row({ state: state({ self: true }) }))).toBe("self");
+  expect(classify(row({ kind: "pane", worktree: null }))).toBe("panes");
+});
+
+// herdr reports an agent stopped on a prompt as blocked, and that prompt is
+// addressed to the user whatever else the row carries.
+describe("a blocked agent", () => {
+  test("raises a pane that has no worktree to classify by", () => {
+    expect(classify(row({ kind: "pane", worktree: null, state: state({ blocked: true }) }))).toBe(
+      "needs-you",
+    );
+  });
+
+  test("outranks a row that would otherwise collapse", () => {
+    expect(classify(row({ state: state({ blocked: true, mergedBranch: true }) }))).toBe(
+      "needs-you",
+    );
+  });
+});
+
+describe("pullFlags", () => {
+  test.each<{ name: string; pull: PullState & { state: string }; expected: string[] }>([
+    { name: "a clean green pull request adds nothing", pull: pull(), expected: [] },
+    {
+      name: "a failing check names its jobs",
+      pull: pull({ checks: "failing", failing: ["build", "hooks", "lint"] }),
+      expected: ["failing:build,hooks,lint"],
+    },
+    {
+      name: "more failing jobs than fit are counted",
+      pull: pull({ checks: "failing", failing: ["a", "b", "c", "d", "e"] }),
+      expected: ["failing:a,b,c+2"],
+    },
+    {
+      name: "a long job name is elided rather than widening the column",
+      pull: pull({ checks: "failing", failing: ["a-workflow-name-far-past-the-column"] }),
+      expected: ["failing:a-workflow-name-far-pas…"],
+    },
+    {
+      name: "a failure with no job names still reports",
+      pull: pull({ checks: "failing" }),
+      expected: ["failing"],
+    },
+    {
+      // Blocked is usually the failing check restated, and repeating it buries
+      // the job name that makes the row actionable.
+      name: "a blocked gate is not repeated beside the failure that caused it",
+      pull: pull({ checks: "failing", failing: ["lint"], mergeState: "blocked" }),
+      expected: ["failing:lint"],
+    },
+    {
+      name: "a blocked gate on a green pull request is reported",
+      pull: pull({ mergeState: "blocked" }),
+      expected: ["blocked"],
+    },
+    {
+      name: "a conflict is reported beside the failure",
+      pull: pull({ checks: "failing", failing: ["lint"], mergeState: "conflicting" }),
+      expected: ["failing:lint", "conflicting"],
+    },
+    { name: "running checks", pull: pull({ checks: "running" }), expected: ["running"] },
+    {
+      name: "checks the forge would not report",
+      pull: pull({ checks: "unknown", mergeState: "unknown" }),
+      expected: ["checks:?"],
+    },
+    {
+      name: "an approval and a change request are both worth a flag",
+      pull: pull({ review: "approved" }),
+      expected: ["approved"],
+    },
+    {
+      name: "changes requested",
+      pull: pull({ review: "changes-requested" }),
+      expected: ["changes-requested"],
+    },
+    {
+      name: "a merged pull request has no live state",
+      pull: pull({ state: "merged" }),
+      expected: [],
+    },
+    {
+      name: "a draft's red checks are expected rather than reportable",
+      pull: pull({ state: "draft", checks: "failing", failing: ["lint"] }),
+      expected: [],
+    },
+    {
+      name: "a pull request with no checks at all says so, rather than reading clean",
+      pull: pull({ checks: "none", mergeState: "unknown" }),
+      expected: ["checks:none"],
+    },
+    {
+      name: "a gate blocked on checks still running does not restate them",
+      pull: pull({ checks: "running", mergeState: "blocked" }),
+      expected: ["running"],
+    },
+    {
+      name: "a gate holding a settled green pull request is reported",
+      pull: pull({ mergeState: "blocked" }),
+      expected: ["blocked"],
+    },
+  ])("$name", ({ pull: subject, expected }) => {
+    expect(pullFlags(subject)).toEqual(expected);
+  });
+});
+
+describe("the report", () => {
+  const board = [
+    row({
+      branch: "oxlint-type-style",
+      pull: pull({ number: 1357, ref: "#1357", checks: "failing", failing: ["lint", "build"] }),
+      flags: ["failing:lint,build"],
+      disposition: "needs-you",
+    }),
+    row({
+      branch: "dev-worker",
+      repoLabel: "bendrucker.me",
+      pull: pull({ number: 667, ref: "merged#667", state: "merged" }),
+      prColumn: "merged#667",
+      flags: ["unpushed:13", "merged"],
+      disposition: "needs-you",
+    }),
+    row({
+      branch: "consent-origin-referrer-policy",
+      repoLabel: "tailgate",
+      pull: pull({ number: 28, ref: "#28", review: "approved" }),
+      prColumn: "#28",
+      flags: ["approved"],
+      disposition: "merge",
+    }),
+    row({
+      branch: "flock-keybind",
+      prColumn: "merged#699",
+      flags: ["merged"],
+      disposition: "cleanup",
+    }),
+    row({
+      branch: "multi-type-unions",
+      repoLabel: "oapi-codegen/oapi-codegen",
+      ownedByViewer: false,
+      pull: pull({ number: 2530, ref: "#2530", review: "review-required" }),
+      disposition: "waiting",
+    }),
+    row({
+      branch: "herdr-lazy",
+      repoLabel: "dotfiles",
+      pull: pull({ number: 700, ref: "#700", checks: "running" }),
+      disposition: "waiting",
+    }),
+    row({
+      branch: "remend-perf",
+      repoLabel: "vercel/streamdown",
+      ownedByViewer: false,
+      pull: pull({ number: 571, ref: "#571", review: "approved" }),
+      disposition: "waiting",
+    }),
+    row({ branch: "comments-gate-judge", disposition: "working" }),
+    ...["portless", "technical-debt"].map((branch) =>
+      row({ branch, repoLabel: "bendrucker.me", disposition: "parked" }),
+    ),
+    row({ branch: "topo-sort-err", repoLabel: "Homebrew/brew", disposition: "parked" }),
+    row({ kind: "pane", pane: "w59:p1", agent: "claude/done", disposition: "panes" }),
+  ];
+  const groups = groupByDisposition(board);
+
+  test("counts every disposition it rendered or collapsed", () => {
+    expect(countLine(groups)).toBe(
+      "needs you 2 · merge 1 · clean up 1 · waiting 3 · working 1 · parked 3 · panes 1",
+    );
+  });
+
+  test("collapses to one line each, keeping the identities worth a follow-up", () => {
+    expect(collapsedLines(groups)).toMatchInlineSnapshot(`
+[
+  "waiting 3: oapi-codegen/oapi-codegen#2530 review · dotfiles#700 ci · vercel/streamdown#571 merge",
+  "working 1: claude/comments-gate-judge",
+  "parked 3: bendrucker.me 2 · Homebrew/brew 1",
+  "panes 1: w59:p1 claude/done",
+]
+`);
+  });
+
+  test("an empty board says so rather than printing a bare header", () => {
+    expect(countLine(groupByDisposition([]))).toBe("nothing on the board");
+    expect(collapsedLines(groupByDisposition([]))).toEqual([]);
+  });
+});

--- a/user/skills/flock/scripts/disposition.ts
+++ b/user/skills/flock/scripts/disposition.ts
@@ -1,0 +1,237 @@
+import {
+  branchLabel,
+  fit,
+  headerRow,
+  renderRows,
+  rowCells,
+  type BoardPull,
+  type BoardRow,
+  type Disposition,
+} from "./board";
+import type { PullState } from "./forge";
+
+/**
+ * What the row needs from the user, and whether the board spends a row on it.
+ * The three rendered dispositions are the ones with an action attached. The
+ * rest collapse to a count, because a row nobody can move is a row the user
+ * reads and discards.
+ */
+export const RENDERED: readonly Disposition[] = ["needs-you", "merge", "cleanup"];
+
+const COLLAPSED: readonly Disposition[] = ["waiting", "working", "parked", "panes"];
+
+const LABELS: Record<Disposition, string> = {
+  self: "self",
+  "needs-you": "needs you",
+  merge: "merge",
+  cleanup: "clean up",
+  waiting: "waiting",
+  working: "working",
+  parked: "parked",
+  panes: "panes",
+};
+
+function openPull(row: BoardRow, pull: BoardPull): Disposition {
+  // A draft is the author saying the work is not ready, so its red checks and
+  // its stale base are expected rather than reportable.
+  if (pull.state === "draft") return "waiting";
+
+  // These three are the author's to fix wherever the pull request lives. A
+  // conflicting branch in someone else's repository is still yours to rebase.
+  if (pull.review === "changes-requested") return "needs-you";
+  if (pull.mergeState === "conflicting") return "needs-you";
+  if (pull.checks === "failing") return "needs-you";
+
+  if (!row.ownedByViewer) return "waiting";
+  if (pull.checks === "running") return "waiting";
+  if (pull.checks === "passing" && pull.mergeState === "clean") return "merge";
+
+  // Green but not mergeable, or a forge that would not say. Either way the bar
+  // has to be read by hand, which cannot happen from a collapsed count.
+  return "needs-you";
+}
+
+function settled(row: BoardRow): Disposition {
+  const state = row.state;
+  // Commits the merge did not take are the one thing here only the user can
+  // rescue, and a recycled branch name means the merged pull request beside it
+  // belongs to different work.
+  if (state.unpushed === null || state.unpushed > 0) return "needs-you";
+  if (state.reused) return "needs-you";
+  // A detached checkout with nothing above the base has nothing to rescue, but
+  // it has no branch to verify either, so it parks rather than being offered up.
+  if (row.detached) return "parked";
+  if (state.status === "dirty" || state.carried > 0) return "parked";
+  return "cleanup";
+}
+
+function verdict(row: BoardRow): Disposition {
+  // git could not read the checkout, so nothing else the row reports about it
+  // is trustworthy, the same way an unlistable forge makes a missing pull
+  // request untrustworthy.
+  if (row.state.status === "unreadable") return "needs-you";
+
+  const pull = row.pull;
+  if (pull !== null && pull.state !== "merged") return openPull(row, pull);
+  // A detached worktree has no branch to carry a pull request, so it reaches
+  // `settled` on its own to have its unpushed commits counted.
+  if (pull !== null || row.state.mergedBranch || row.detached) return settled(row);
+  if (row.state.pullUnknown) return "needs-you";
+  return "parked";
+}
+
+export function classify(row: BoardRow): Disposition {
+  if (row.state.self) return "self";
+  // herdr reports an agent stopped on a prompt as blocked, which is the one
+  // pane state that is a question addressed to the user.
+  if (row.state.blocked) return "needs-you";
+  if (row.kind === "pane") return "panes";
+
+  // An agent mid-turn owns the working tree, so nothing that touches the tree
+  // is the user's to decide yet. A merge happens on the forge instead, and
+  // holding it back would hide the one row the sweep exists to raise.
+  const disposition = verdict(row);
+  return row.state.working && disposition !== "merge" ? "working" : disposition;
+}
+
+const FAILING_SHOWN = 3;
+const CHECK_NAME_WIDTH = 24;
+
+function failingLabel(names: readonly string[]): string {
+  if (names.length === 0) return "failing";
+  const shown = names.slice(0, FAILING_SHOWN).map((name) => fit(name, CHECK_NAME_WIDTH));
+  const rest = names.length - shown.length;
+  return `failing:${shown.join(",")}${rest > 0 ? `+${rest}` : ""}`;
+}
+
+/**
+ * Forge state rendered as flags, so the reason a row needs the user rides in
+ * the column that already carries why a row is held.
+ */
+export function pullFlags(pull: PullState & { state: string }): string[] {
+  if (pull.state === "merged" || pull.state === "draft") return [];
+  const flags: string[] = [];
+
+  const settledChecks = pull.checks !== "failing" && pull.checks !== "running";
+  if (pull.checks === "failing") flags.push(failingLabel(pull.failing));
+  else if (pull.checks === "running") flags.push("running");
+  else if (pull.checks === "unknown") flags.push("checks:?");
+  else if (pull.checks === "none") flags.push("checks:none");
+
+  const gate = pull.mergeState;
+  if (gate === "conflicting" || gate === "behind") flags.push(gate);
+  // A blocked or unstable merge state restates a check that has not settled,
+  // and saying it twice buries the job name that makes the row actionable.
+  else if (settledChecks && (gate === "blocked" || gate === "unstable")) flags.push(gate);
+
+  if (pull.review === "changes-requested" || pull.review === "approved") flags.push(pull.review);
+  return flags;
+}
+
+export type Groups = ReadonlyMap<Disposition, readonly BoardRow[]>;
+
+export function groupByDisposition(rows: readonly BoardRow[]): Groups {
+  const groups = new Map<Disposition, BoardRow[]>();
+  for (const row of rows) {
+    const bucket = groups.get(row.disposition);
+    if (bucket === undefined) groups.set(row.disposition, [row]);
+    else bucket.push(row);
+  }
+  return groups;
+}
+
+function of(groups: Groups, disposition: Disposition): readonly BoardRow[] {
+  return groups.get(disposition) ?? [];
+}
+
+export function countLine(groups: Groups): string {
+  const counts = [...RENDERED, ...COLLAPSED]
+    .map((disposition) => ({ disposition, count: of(groups, disposition).length }))
+    .filter((entry) => entry.count > 0)
+    .map((entry) => `${LABELS[entry.disposition]} ${entry.count}`);
+  return counts.length === 0 ? "nothing on the board" : counts.join(" · ");
+}
+
+/**
+ * The rendered dispositions share one header, and a flush-left label opens
+ * each group, so a section costs one line rather than a repeated header. The
+ * label bypasses the column formatter, which would pad and truncate it.
+ */
+export function renderSections(groups: Groups): string[] {
+  const present = RENDERED.filter((disposition) => of(groups, disposition).length > 0);
+  if (present.length === 0) return [];
+
+  const lines = [headerRow()];
+  for (const disposition of present) {
+    lines.push(LABELS[disposition], ...renderRows(of(groups, disposition).map(rowCells)));
+  }
+  return lines;
+}
+
+/**
+ * A waiting row that is green and not yours is waiting on the maintainer to
+ * merge it, so calling that "review" asks for a review already given.
+ */
+function waitingReason(pull: BoardPull): string {
+  if (pull.state === "draft") return "draft";
+  if (pull.checks === "running") return "ci";
+  return pull.review === "review-required" ? "review" : "merge";
+}
+
+/** What a waiting row is waiting on, so the next question can name it. */
+function waitingEntry(row: BoardRow): string {
+  const pull = row.pull;
+  if (pull === null) return `${row.repoLabel}/${branchLabel(row)}`;
+  const reason = waitingReason(pull);
+  return `${row.repoLabel}#${pull.number} ${reason}`;
+}
+
+function paneLabel(row: BoardRow): string {
+  return `${row.pane ?? "-"} ${row.agent ?? "-"}`;
+}
+
+function byRepo(rows: readonly BoardRow[]): string[] {
+  const counts = new Map<string, number>();
+  for (const row of rows) counts.set(row.repoLabel, (counts.get(row.repoLabel) ?? 0) + 1);
+  return [...counts]
+    .toSorted(([leftRepo, left], [rightRepo, right]) =>
+      left === right ? leftRepo.localeCompare(rightRepo) : right - left,
+    )
+    .map(([repo, count]) => `${repo} ${count}`);
+}
+
+function line(
+  groups: Groups,
+  disposition: Disposition,
+  entries: (rows: readonly BoardRow[]) => string[],
+): string[] {
+  const rows = of(groups, disposition);
+  if (rows.length === 0) return [];
+  return [`${LABELS[disposition]} ${rows.length}: ${entries(rows).join(" · ")}`];
+}
+
+/**
+ * One line per collapsed disposition. Waiting and panes keep their identities,
+ * because the next question about either names a specific pull request or a
+ * specific pane. Parked keeps repository counts only: nothing in it has a
+ * pending action to attach a name to.
+ */
+export function collapsedLines(groups: Groups): string[] {
+  return [
+    ...line(groups, "waiting", (rows) => rows.map(waitingEntry)),
+    ...line(groups, "working", (rows) => rows.map((row) => `${row.repoLabel}/${branchLabel(row)}`)),
+    ...line(groups, "parked", byRepo),
+    ...line(groups, "panes", (rows) => rows.map(paneLabel)),
+  ];
+}
+
+export function renderBoard(rows: readonly BoardRow[]): string {
+  const groups = groupByDisposition(rows);
+  const sections = renderSections(groups);
+  const collapsed = collapsedLines(groups);
+  return [
+    countLine(groups),
+    ...(sections.length === 0 ? [] : ["", ...sections]),
+    ...(collapsed.length === 0 ? [] : ["", ...collapsed]),
+  ].join("\n");
+}

--- a/user/skills/flock/scripts/exec.ts
+++ b/user/skills/flock/scripts/exec.ts
@@ -51,7 +51,7 @@ export const spawnRun: Run = async (argv, options) => {
  */
 export function limiter(limit: number): <T>(task: () => Promise<T>) => Promise<T> {
   let active = 0;
-  const waiting: Array<() => void> = [];
+  const waiting: (() => void)[] = [];
 
   const release = (): void => {
     active -= 1;

--- a/user/skills/flock/scripts/forge.test.ts
+++ b/user/skills/flock/scripts/forge.test.ts
@@ -50,7 +50,7 @@ describe("parseRemote", () => {
 });
 
 describe("forgeKind", () => {
-  const cases: Array<[string, string | null, "github" | "gitlab" | null]> = [
+  const cases: [string, string | null, "github" | "gitlab" | null][] = [
     ["github.com", null, "github"],
     ["gitlab.com", null, "gitlab"],
     ["gitlab.internal.example", null, "gitlab"],

--- a/user/skills/flock/scripts/forge.test.ts
+++ b/user/skills/flock/scripts/forge.test.ts
@@ -10,6 +10,12 @@ import {
   parseRemote,
   pullRequestRef,
   slugParts,
+  gitlabChecks,
+  gitlabMergeState,
+  mergeState,
+  reviewState,
+  rollUpChecks,
+  SETTLED_STATE,
   type PullRequest,
 } from "./forge";
 
@@ -30,7 +36,7 @@ function pull(
   state: PullRequest["state"],
   mergedAt: number | null = null,
 ): PullRequest {
-  return { branch, number, state, mergedAt };
+  return { branch, number, state, mergedAt, ...SETTLED_STATE };
 }
 
 describe("parseRemote", () => {
@@ -145,18 +151,71 @@ describe("beyondMergedHorizon", () => {
 describe("github", () => {
   test("reads open and merged pull requests and marks drafts", async () => {
     const { run, calls } = stub({
-      "--state open": { stdout: '[{"number":1,"headRefName":"a","isDraft":true}]' },
+      "--state open": {
+        stdout: JSON.stringify([
+          {
+            number: 1,
+            headRefName: "a",
+            isDraft: true,
+            mergeStateStatus: "BLOCKED",
+            reviewDecision: "CHANGES_REQUESTED",
+            statusCheckRollup: [
+              { __typename: "CheckRun", name: "lint", status: "COMPLETED", conclusion: "FAILURE" },
+            ],
+          },
+        ]),
+      },
       "--state merged": {
         stdout: '[{"number":2,"headRefName":"b","mergedAt":"2026-01-01T00:00:00Z"}]',
       },
     });
     const listing = await createForge("github", run).pullRequests("o/r");
 
-    expect(listing.open).toEqual([{ branch: "a", number: 1, state: "draft", mergedAt: null }]);
+    expect(listing.open).toEqual([
+      {
+        branch: "a",
+        number: 1,
+        state: "draft",
+        mergedAt: null,
+        checks: "failing",
+        failing: ["lint"],
+        review: "changes-requested",
+        mergeState: "blocked",
+      },
+    ]);
     expect(listing.merged).toEqual([
-      { branch: "b", number: 2, state: "merged", mergedAt: 1_767_225_600 },
+      { branch: "b", number: 2, state: "merged", mergedAt: 1_767_225_600, ...SETTLED_STATE },
     ]);
     expect(calls.every((call) => call.includes("--author @me"))).toBe(true);
+  });
+
+  // The merged query returns a hundred rows whose check history nothing reads.
+  test("asks for check and review state on the open query only", async () => {
+    const { run, calls } = stub({ "pr list": { stdout: "[]" } });
+    await createForge("github", run).pullRequests("o/r");
+
+    const [open, merged] = calls.filter((call) => call.includes("pr list"));
+    expect(open).toContain("statusCheckRollup");
+    expect(merged).not.toContain("statusCheckRollup");
+  });
+
+  test("a listing without a rollup reports checks it cannot read", async () => {
+    const { run } = stub({
+      "--state open": { stdout: '[{"number":1,"headRefName":"a"}]' },
+      "--state merged": { stdout: "[]" },
+    });
+    expect((await createForge("github", run).pullRequests("o/r")).open).toEqual([
+      {
+        branch: "a",
+        number: 1,
+        state: "open",
+        mergedAt: null,
+        checks: "unknown",
+        failing: [],
+        review: "none",
+        mergeState: "unknown",
+      },
+    ]);
   });
 
   test("a failed listing reports null rather than an empty repository", async () => {
@@ -226,13 +285,34 @@ describe("gitlab", () => {
       "--merged": {
         stdout: '[{"iid":7,"source_branch":"done","merged_at":"2026-01-01T00:00:00Z"}]',
       },
-      "mr list": { stdout: '[{"iid":5,"source_branch":"wip","draft":true}]' },
+      "mr list": {
+        stdout: JSON.stringify([
+          {
+            iid: 5,
+            source_branch: "wip",
+            draft: true,
+            has_conflicts: true,
+            pipeline: { status: "failed" },
+          },
+        ]),
+      },
     });
     const listing = await createForge("gitlab", run).pullRequests("group/app");
 
-    expect(listing.open).toEqual([{ branch: "wip", number: 5, state: "draft", mergedAt: null }]);
+    expect(listing.open).toEqual([
+      {
+        branch: "wip",
+        number: 5,
+        state: "draft",
+        mergedAt: null,
+        checks: "failing",
+        failing: [],
+        review: "unknown",
+        mergeState: "conflicting",
+      },
+    ]);
     expect(listing.merged).toEqual([
-      { branch: "done", number: 7, state: "merged", mergedAt: 1_767_225_600 },
+      { branch: "done", number: 7, state: "merged", mergedAt: 1_767_225_600, ...SETTLED_STATE },
     ]);
     expect(calls.some((call) => call.includes("--author ben"))).toBe(true);
   });
@@ -260,5 +340,123 @@ describe("gitlab", () => {
       forkOf: "ben/app",
       resolved: true,
     });
+  });
+});
+
+describe("rollUpChecks", () => {
+  const run = (name: string, conclusion: string) => ({
+    name,
+    status: "COMPLETED",
+    conclusion,
+  });
+
+  test("no checks is not a passing bar", () => {
+    expect(rollUpChecks([])).toEqual({ checks: "none", failing: [] });
+  });
+
+  test("names every failing job, sorted and deduplicated", () => {
+    expect(
+      rollUpChecks([
+        run("lint", "FAILURE"),
+        run("build", "TIMED_OUT"),
+        run("lint", "FAILURE"),
+        run("test", "SUCCESS"),
+      ]),
+    ).toEqual({ checks: "failing", failing: ["build", "lint"] });
+  });
+
+  test("a failure outranks a job still running", () => {
+    expect(rollUpChecks([{ name: "slow", status: "IN_PROGRESS" }, run("lint", "FAILURE")])).toEqual(
+      { checks: "failing", failing: ["lint"] },
+    );
+  });
+
+  test("an incomplete run is not read through its missing conclusion", () => {
+    expect(rollUpChecks([{ name: "slow", status: "QUEUED" }])).toEqual({
+      checks: "running",
+      failing: [],
+    });
+  });
+
+  test("a StatusContext reports through state instead of conclusion", () => {
+    expect(rollUpChecks([{ context: "ci/legacy", state: "FAILURE" }])).toEqual({
+      checks: "failing",
+      failing: ["ci/legacy"],
+    });
+    expect(rollUpChecks([{ context: "ci/legacy", state: "PENDING" }])).toEqual({
+      checks: "running",
+      failing: [],
+    });
+    expect(rollUpChecks([{ context: "ci/legacy", state: "SUCCESS" }])).toEqual({
+      checks: "passing",
+      failing: [],
+    });
+  });
+
+  test.each(["SUCCESS", "NEUTRAL", "SKIPPED"])("%s does not hold the bar", (conclusion) => {
+    expect(rollUpChecks([run("optional", conclusion)]).checks).toBe("passing");
+  });
+
+  test("an unnamed check still reports", () => {
+    expect(rollUpChecks([{ status: "COMPLETED", conclusion: "FAILURE" }])).toEqual({
+      checks: "failing",
+      failing: ["check"],
+    });
+  });
+});
+
+describe("reviewState", () => {
+  test.each([
+    ["APPROVED", "approved"],
+    ["CHANGES_REQUESTED", "changes-requested"],
+    ["REVIEW_REQUIRED", "review-required"],
+    // GitHub answers with an empty string where no review is required.
+    ["", "none"],
+    [null, "none"],
+    ["SOMETHING_NEW", "unknown"],
+  ] as const)("%s", (decision, expected) => {
+    expect(reviewState(decision)).toBe(expected);
+  });
+});
+
+describe("mergeState", () => {
+  test.each([
+    ["CLEAN", "clean"],
+    ["HAS_HOOKS", "clean"],
+    ["DIRTY", "conflicting"],
+    ["BEHIND", "behind"],
+    ["BLOCKED", "blocked"],
+    ["UNSTABLE", "unstable"],
+    ["UNKNOWN", "unknown"],
+    [null, "unknown"],
+  ] as const)("%s", (status, expected) => {
+    expect(mergeState(status)).toBe(expected);
+  });
+});
+
+describe("gitlab state", () => {
+  test.each([
+    ["mergeable", undefined, "clean"],
+    ["conflict", undefined, "conflicting"],
+    ["not_approved", undefined, "blocked"],
+    ["need_rebase", undefined, "behind"],
+    [null, undefined, "unknown"],
+    // A conflict flag settles the row whatever the detailed status says.
+    ["mergeable", true, "conflicting"],
+  ] as const)("%s with conflicts %s", (detailed, conflicts, expected) => {
+    expect(gitlabMergeState(detailed, conflicts)).toBe(expected);
+  });
+
+  test.each([
+    ["success", "passing"],
+    ["failed", "failing"],
+    ["canceled", "failing"],
+    ["running", "running"],
+    ["skipped", "passing"],
+    // A listing with no pipeline attached says nothing about the checks.
+    [null, "unknown"],
+    ["invented", "unknown"],
+  ] as const)("pipeline %s", (status, expected) => {
+    expect(gitlabChecks(status)).toBe(expected);
   });
 });

--- a/user/skills/flock/scripts/forge.ts
+++ b/user/skills/flock/scripts/forge.ts
@@ -60,11 +60,175 @@ export function ownedBy(slug: string, viewer: string | null): boolean {
   return (slug.split("/")[0] ?? "") === viewer;
 }
 
-export interface PullRequest {
+/** How the forge's checks stand on a pull request the board did not open itself. */
+export type CheckState = "passing" | "failing" | "running" | "none" | "unknown";
+
+export type ReviewState = "approved" | "changes-requested" | "review-required" | "none" | "unknown";
+
+export type MergeState =
+  | "clean"
+  | "conflicting"
+  | "behind"
+  | "blocked"
+  | "unstable"
+  | "draft"
+  | "unknown";
+
+/**
+ * What the merge bar needs and the board cannot infer from a checkout. Only an
+ * open pull request carries it. A merged one reports `none` and `unknown`,
+ * because its disposition turns on the worktree beside it rather than on state
+ * the forge has already settled.
+ */
+export interface PullState {
+  readonly checks: CheckState;
+  readonly failing: readonly string[];
+  readonly review: ReviewState;
+  readonly mergeState: MergeState;
+}
+
+export const SETTLED_STATE: PullState = {
+  checks: "none",
+  failing: [],
+  review: "none",
+  mergeState: "unknown",
+};
+
+export interface PullRequest extends PullState {
   readonly branch: string;
   readonly number: number;
   readonly state: "open" | "draft" | "merged";
   readonly mergedAt: number | null;
+}
+
+/** One entry of GitHub's `statusCheckRollup`, which mixes two shapes. */
+export interface CheckEntry {
+  readonly name?: string | undefined;
+  readonly context?: string | undefined;
+  readonly status?: string | null | undefined;
+  readonly conclusion?: string | null | undefined;
+  readonly state?: string | null | undefined;
+}
+
+const FAILED_CONCLUSIONS = new Set([
+  "FAILURE",
+  "TIMED_OUT",
+  "CANCELLED",
+  "ACTION_REQUIRED",
+  "STARTUP_FAILURE",
+  "STALE",
+]);
+
+function checkVerdict(check: CheckEntry): "passing" | "failing" | "running" {
+  const status = check.status ?? "";
+  const state = check.state ?? "";
+  // A CheckRun reports `status` plus `conclusion`. A StatusContext reports only
+  // `state`, and reading a missing `conclusion` as a pass would call a running
+  // job green.
+  if (status !== "" && status !== "COMPLETED") return "running";
+  if (state === "FAILURE" || state === "ERROR") return "failing";
+  if (FAILED_CONCLUSIONS.has(check.conclusion ?? "")) return "failing";
+  if (state === "PENDING" || state === "EXPECTED") return "running";
+  return "passing";
+}
+
+function checkName(check: CheckEntry): string {
+  const named = check.name ?? check.context ?? "";
+  return named === "" ? "check" : named;
+}
+
+/**
+ * A failing job names itself so the report can say which one, and a single
+ * failure outranks any number of passes: the bar is every required check
+ * green, not most of them.
+ */
+export function rollUpChecks(checks: readonly CheckEntry[]): {
+  checks: CheckState;
+  failing: string[];
+} {
+  if (checks.length === 0) return { checks: "none", failing: [] };
+  const verdicts = checks.map((check) => ({
+    verdict: checkVerdict(check),
+    name: checkName(check),
+  }));
+  const failing = [
+    ...new Set(verdicts.filter((entry) => entry.verdict === "failing").map((entry) => entry.name)),
+  ].toSorted();
+  if (failing.length > 0) return { checks: "failing", failing };
+  const running = verdicts.some((entry) => entry.verdict === "running");
+  return { checks: running ? "running" : "passing", failing: [] };
+}
+
+const REVIEW_DECISIONS: Record<string, ReviewState> = {
+  APPROVED: "approved",
+  CHANGES_REQUESTED: "changes-requested",
+  REVIEW_REQUIRED: "review-required",
+};
+
+/** GitHub returns an empty decision where the repository requires no review. */
+export function reviewState(decision: string | null | undefined): ReviewState {
+  const raw = decision ?? "";
+  if (raw === "") return "none";
+  return REVIEW_DECISIONS[raw] ?? "unknown";
+}
+
+const MERGE_STATES: Record<string, MergeState> = {
+  CLEAN: "clean",
+  HAS_HOOKS: "clean",
+  DIRTY: "conflicting",
+  BEHIND: "behind",
+  BLOCKED: "blocked",
+  UNSTABLE: "unstable",
+  DRAFT: "draft",
+};
+
+export function mergeState(status: string | null | undefined): MergeState {
+  return MERGE_STATES[status ?? ""] ?? "unknown";
+}
+
+const GITLAB_MERGE_STATES: Record<string, MergeState> = {
+  mergeable: "clean",
+  conflict: "conflicting",
+  broken_status: "conflicting",
+  need_rebase: "behind",
+  not_approved: "blocked",
+  discussions_not_resolved: "blocked",
+  blocked_status: "blocked",
+  draft_status: "draft",
+  ci_must_pass: "unstable",
+  ci_still_running: "unstable",
+};
+
+export function gitlabMergeState(
+  detailed: string | null | undefined,
+  hasConflicts: boolean | undefined,
+): MergeState {
+  if (hasConflicts === true) return "conflicting";
+  return GITLAB_MERGE_STATES[detailed ?? ""] ?? "unknown";
+}
+
+const GITLAB_PIPELINE_STATES: Record<string, CheckState> = {
+  success: "passing",
+  skipped: "passing",
+  manual: "passing",
+  failed: "failing",
+  canceled: "failing",
+  created: "running",
+  waiting_for_resource: "running",
+  preparing: "running",
+  pending: "running",
+  running: "running",
+  scheduled: "running",
+};
+
+/**
+ * The merge-request listing carries a pipeline summary but never the job
+ * names behind it, so a GitLab failure is reported without one.
+ */
+export function gitlabChecks(status: string | null | undefined): CheckState {
+  const raw = status ?? "";
+  if (raw === "") return "unknown";
+  return GITLAB_PIPELINE_STATES[raw] ?? "unknown";
 }
 
 export function pullRequestRef(pull: PullRequest): string {
@@ -163,8 +327,51 @@ const GitHubPullRequests = z.array(
     headRefName: z.string(),
     isDraft: z.boolean().optional(),
     mergedAt: z.string().nullish(),
+    mergeStateStatus: z.string().nullish(),
+    reviewDecision: z.string().nullish(),
+    statusCheckRollup: z
+      .array(
+        z.looseObject({
+          name: z.string().optional(),
+          context: z.string().optional(),
+          status: z.string().nullish(),
+          conclusion: z.string().nullish(),
+          state: z.string().nullish(),
+        }),
+      )
+      .nullish(),
   }),
 );
+
+// Requested only on the open query. The merged query returns a hundred rows
+// whose check history no disposition reads, and asking for a rollup there
+// would multiply the response for nothing.
+const OPEN_FIELDS = "number,headRefName,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup";
+
+function githubPullRequest(
+  pull: z.infer<typeof GitHubPullRequests>[number],
+  state: "open" | "merged",
+): PullRequest {
+  const identity = {
+    branch: pull.headRefName,
+    number: pull.number,
+    state: state === "merged" ? "merged" : pull.isDraft === true ? "draft" : "open",
+    mergedAt: epochSeconds(pull.mergedAt),
+  } as const;
+  if (state === "merged") return { ...identity, ...SETTLED_STATE };
+
+  const rollup = pull.statusCheckRollup;
+  const checks =
+    rollup === null || rollup === undefined
+      ? { checks: "unknown" as const, failing: [] }
+      : rollUpChecks(rollup);
+  return {
+    ...identity,
+    ...checks,
+    review: reviewState(pull.reviewDecision),
+    mergeState: mergeState(pull.mergeStateStatus),
+  };
+}
 
 function githubForge(run: Run): Forge {
   const viewer = memo(async (): Promise<string | null> => {
@@ -219,7 +426,7 @@ function githubForge(run: Run): Forge {
           "--limit",
           String(OPEN_LIMIT),
           "--json",
-          "number,headRefName,isDraft",
+          OPEN_FIELDS,
         ]),
         run([
           "gh",
@@ -244,12 +451,9 @@ function githubForge(run: Run): Forge {
       ): PullRequest[] | null => {
         if (!result.ok) return null;
         try {
-          return decodeJson(GitHubPullRequests, result.stdout, "gh pr list").map((pull) => ({
-            branch: pull.headRefName,
-            number: pull.number,
-            state: state === "merged" ? "merged" : pull.isDraft === true ? "draft" : "open",
-            mergedAt: epochSeconds(pull.mergedAt),
-          }));
+          return decodeJson(GitHubPullRequests, result.stdout, "gh pr list").map((pull) =>
+            githubPullRequest(pull, state),
+          );
         } catch {
           return null;
         }
@@ -274,8 +478,39 @@ const GitLabMergeRequests = z.array(
     draft: z.boolean().optional(),
     work_in_progress: z.boolean().optional(),
     merged_at: z.string().nullish(),
+    has_conflicts: z.boolean().optional(),
+    detailed_merge_status: z.string().nullish(),
+    pipeline: z.looseObject({ status: z.string().nullish() }).nullish(),
   }),
 );
+
+function gitlabMergeRequest(
+  request: z.infer<typeof GitLabMergeRequests>[number],
+  state: "open" | "merged",
+): PullRequest {
+  const identity = {
+    branch: request.source_branch,
+    number: request.iid,
+    state:
+      state === "merged"
+        ? "merged"
+        : request.draft === true || request.work_in_progress === true
+          ? "draft"
+          : "open",
+    mergedAt: epochSeconds(request.merged_at),
+  } as const;
+  if (state === "merged") return { ...identity, ...SETTLED_STATE };
+
+  return {
+    ...identity,
+    checks: gitlabChecks(request.pipeline?.status),
+    failing: [],
+    // The listing carries no approval decision, and a review the board cannot
+    // read must not pass for one it has cleared.
+    review: "unknown",
+    mergeState: gitlabMergeState(request.detailed_merge_status, request.has_conflicts),
+  };
+}
 
 function gitlabForge(run: Run): Forge {
   const viewer = memo(async (): Promise<string | null> => {
@@ -333,17 +568,9 @@ function gitlabForge(run: Run): Forge {
       ): PullRequest[] | null => {
         if (!result.ok) return null;
         try {
-          return decodeJson(GitLabMergeRequests, result.stdout, "glab mr list").map((request) => ({
-            branch: request.source_branch,
-            number: request.iid,
-            state:
-              state === "merged"
-                ? "merged"
-                : request.draft === true || request.work_in_progress === true
-                  ? "draft"
-                  : "open",
-            mergedAt: epochSeconds(request.merged_at),
-          }));
+          return decodeJson(GitLabMergeRequests, result.stdout, "glab mr list").map((request) =>
+            gitlabMergeRequest(request, state),
+          );
         } catch {
           return null;
         }

--- a/user/skills/flock/scripts/worktree.test.ts
+++ b/user/skills/flock/scripts/worktree.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnRun, type CommandResult, type Run } from "./exec";
-import type { PullRequest } from "./forge";
+import { SETTLED_STATE, type PullRequest } from "./forge";
 import {
   ageInDays,
   carriedIgnoredPaths,
@@ -29,6 +29,7 @@ function flags(overrides: Partial<FlagInput>): string[] {
     carried: 0,
     merged: false,
     reused: false,
+    pull: [],
     ...overrides,
   });
 }
@@ -95,6 +96,7 @@ describe("deriveFlags", () => {
     [{ detached: true }, ["detached"]],
     [{ merged: true }, ["merged"]],
     [{ reused: true }, ["reused"]],
+    [{ pull: ["failing:lint", "conflicting"] }, ["failing:lint", "conflicting"]],
     [
       {
         detached: true,
@@ -103,8 +105,9 @@ describe("deriveFlags", () => {
         carried: 1,
         merged: true,
         reused: true,
+        pull: ["conflicting"],
       },
-      ["detached", "dirty", "unpushed:2", "carries:1", "merged", "reused"],
+      ["conflicting", "detached", "dirty", "unpushed:2", "carries:1", "merged", "reused"],
     ],
   ])("%o", (input, expected) => {
     expect(flags(input)).toEqual(expected);
@@ -163,7 +166,13 @@ describe("ageInDays", () => {
 });
 
 describe("isReusedBranch", () => {
-  const merged: PullRequest = { branch: "gzip", number: 2, state: "merged", mergedAt: 1000 };
+  const merged: PullRequest = {
+    branch: "gzip",
+    number: 2,
+    state: "merged",
+    mergedAt: 1000,
+    ...SETTLED_STATE,
+  };
 
   test.each([
     ["a commit after the merge", merged, 2000, true],

--- a/user/skills/flock/scripts/worktree.ts
+++ b/user/skills/flock/scripts/worktree.ts
@@ -181,10 +181,16 @@ export interface FlagInput {
   readonly carried: number;
   readonly merged: boolean;
   readonly reused: boolean;
+  /** What the forge contributed, from `pullFlags`. */
+  readonly pull: readonly string[];
 }
 
+/**
+ * Forge flags lead, because on a row that needs the user they carry the reason
+ * and the checkout flags beside them are context.
+ */
 export function deriveFlags(input: FlagInput): string[] {
-  const flags: string[] = [];
+  const flags: string[] = [...input.pull];
   if (input.detached) flags.push("detached");
   if (input.status !== "clean") flags.push(input.status === "dirty" ? "dirty" : "unreadable");
   if (input.ahead === null) flags.push("unpushed:?");


### PR DESCRIPTION
The board fetched no CI state and no review state, so it could not separate a pull request of yours with failing checks from one waiting on a maintainer you do not control. Last night's sweep printed 66 rows, about four of which needed you.

Adds check state, review decision and merge state to the open pull request query, and a classifier that routes every row to a disposition. `needs you`, `merge` and `clean up` render a row each. `waiting`, `working`, `parked` and `panes` collapse to one line apiece. The board goes from 57 lines to 19 on the same data.

## Shape

The brief sketched three buckets. I built seven plus an excluded one, because each names a different next move:

- `merge` is one `gh pr merge` on the forge, and the only disposition actionable without a worktree.
- `clean up` feeds the disposal `AskUserQuestion` batch, so folding it into `needs you` would make the report and the batch one list.
- `working` resolves itself when the agent finishes.
- `panes` has no checkout to classify on.
- `self` is excluded so the sweeping pane cannot propose removing itself.

An earlier draft had 7-day and 30-day staleness horizons. Dropping them reproduced your signal/noise split exactly, including the Homebrew worktrees at 46 to 78 days. Age only says how stale the noise is.

Panes read herdr's `blocked` status off the snapshot, which covers a pane parked on an approval dialog without reading each one.

## Cost

`gh pr list` returns `statusCheckRollup`, `reviewDecision` and `mergeStateStatus` on the list query, so this costs no extra round trip and no per-pull-request call. `mergeStateStatus` is list-available, confirmed against the live API.

Interleaved A/B against a baseline reconstructed from `main`: 3.92s mean before, 4.04s after.

## Evidence

vercel/streamdown#571 was on the noise list as green. The fetched state shows it `DIRTY` with a failing Vercel check, and it now renders in `needs you`.

A detached worktree skipped the unpushed-commit check, since a detached HEAD has no branch and never reached that path. `activity-hub` holds two commits with no branch left to reach the forge on, invisible until now.
