### PR TITLE
flock: keep live work out of clean up

### DIFF
--- a/user/skills/flock/SKILL.md
+++ b/user/skills/flock/SKILL.md
@@ -46,7 +46,7 @@ FLAGS reads `clean` or a comma-joined list, forge state first. `failing:lint,bui
 
 The checkout flags follow. Only `merged` clears a row for cleanup, and every other flag holds it. Three are not self-evident: `carries:N` counts gitignored files a recursive removal would take, `reused` means the `merged#N` beside it belongs to different work under a recycled branch name, and `unreadable` or `unpushed:?` mean git would not report the state at all, which raises the row rather than parking it.
 
-The AGENT column reads `<agent>/<status>`. A `blocked` status is an agent stopped on a prompt, which puts its row in `needs you` whatever else the row carries.
+The AGENT column reads `<agent>/<status>`. A `blocked` status is an agent stopped on a prompt, which puts its row in `needs you` whatever else the row carries. Any other status still means the pane is occupied, and an occupied pane holds its row out of `clean up`. The two resting statuses, `idle` and `done`, differ only in whether the tab has been seen, so an agent between the turns of a running workflow reads idle.
 
 An `incomplete:` line names what the board could not resolve. Retry it: `gh pr list --head <branch>` for the branches it names, `gh pr list` for a `?` PR column. Dispose of nothing the retry also leaves unresolved.
 

--- a/user/skills/flock/SKILL.md
+++ b/user/skills/flock/SKILL.md
@@ -76,7 +76,7 @@ Below the bar, the row is a report. Name the failing job, the reviewer's finding
 
 Check the rendered rows against the deferred keys first. A deferred row is held unless the state block re-raised it as stale.
 
-**Clean up.** Merged with nothing left in the tree. Confirm the pane is still empty with `herdr agent get` immediately before removing anything, because an agent can take the pane between the board and the user's answer, and removal takes the tree out from under it. Then remove the worktree, close its workspace and panes, prune the branch. Read `open_workspace_id` out of `herdr worktree list --json` before removing the path, because herdr loses the mapping once the worktree is gone.
+**Clean up.** Merged with nothing left in the tree. Confirm the pane is still empty with `herdr agent get` first, because an agent can take it between the board and the user's answer, and the removal would take the tree out from under it. Remove the worktree, close its workspace and panes, prune the branch. Read `open_workspace_id` out of `herdr worktree list --json` before removing the path, because herdr loses the mapping once the worktree is gone.
 
 **Merge.** Checks green, merge state clean, your repo. Re-read the bar immediately before merging, because both the board and your first lookup predate the user's answer. `gh pr merge --squash --delete-branch`, and stop there. The worktree becomes a cleanup row on a later sweep, once a fresh board shows it carrying nothing.
 

--- a/user/skills/flock/SKILL.md
+++ b/user/skills/flock/SKILL.md
@@ -76,7 +76,7 @@ Below the bar, the row is a report. Name the failing job, the reviewer's finding
 
 Check the rendered rows against the deferred keys first. A deferred row is held unless the state block re-raised it as stale.
 
-**Clean up.** Merged with nothing left in the tree. Remove the worktree, close its workspace and panes, prune the branch. Read `open_workspace_id` out of `herdr worktree list --json` before removing the path, because herdr loses the mapping once the worktree is gone.
+**Clean up.** Merged with nothing left in the tree. Confirm the pane is still empty with `herdr agent get` immediately before removing anything, because an agent can take the pane between the board and the user's answer, and removal takes the tree out from under it. Then remove the worktree, close its workspace and panes, prune the branch. Read `open_workspace_id` out of `herdr worktree list --json` before removing the path, because herdr loses the mapping once the worktree is gone.
 
 **Merge.** Checks green, merge state clean, your repo. Re-read the bar immediately before merging, because both the board and your first lookup predate the user's answer. `gh pr merge --squash --delete-branch`, and stop there. The worktree becomes a cleanup row on a later sweep, once a fresh board shows it carrying nothing.
 

--- a/user/skills/flock/scripts/board.test.ts
+++ b/user/skills/flock/scripts/board.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   branchLabel,
   fit,
+  heldByAgent,
   jsonRow,
   renderTable,
   rowCells,
@@ -194,5 +195,19 @@ test("a json row carries the fields the table truncates or omits", () => {
       mergedBranch: false,
       reused: false,
     },
+  });
+});
+
+describe("heldByAgent", () => {
+  test.each([
+    ["a working agent", "claude/working", true],
+    ["an agent resting between turns", "claude/idle", true],
+    ["an agent whose tab has been seen", "claude/done", true],
+    ["an agent stopped on a prompt", "claude/blocked", true],
+    ["a status herdr would not report", "claude/?", true],
+    ["a person's own shell", "shell/idle", false],
+    ["no pane", null, false],
+  ] as const)("%s", (_name, agent, expected) => {
+    expect(heldByAgent(agent)).toBe(expected);
   });
 });

--- a/user/skills/flock/scripts/board.ts
+++ b/user/skills/flock/scripts/board.ts
@@ -91,8 +91,8 @@ export function branchLabel(row: Pick<BoardRow, "branch" | "detached" | "kind">)
  * leaves it. A shell is a person's prompt rather than an agent, and holds
  * nothing.
  */
-export function heldByAgent(row: Pick<BoardRow, "agent">): boolean {
-  return row.agent !== null && !row.agent.startsWith("shell/");
+export function heldByAgent(agent: string | null): boolean {
+  return agent !== null && !agent.startsWith("shell/");
 }
 
 export function rowCells(row: BoardRow): string[] {

--- a/user/skills/flock/scripts/board.ts
+++ b/user/skills/flock/scripts/board.ts
@@ -84,6 +84,17 @@ export function branchLabel(row: Pick<BoardRow, "branch" | "detached" | "kind">)
   return "(detached)";
 }
 
+/**
+ * herdr rests an agent in `idle` or `done`, one state split by whether the tab
+ * has been seen, so neither reports the work over: an agent between the turns
+ * of a running workflow reads idle. The pane is occupied until the agent
+ * leaves it. A shell is a person's prompt rather than an agent, and holds
+ * nothing.
+ */
+export function heldByAgent(row: Pick<BoardRow, "agent">): boolean {
+  return row.agent !== null && !row.agent.startsWith("shell/");
+}
+
 export function rowCells(row: BoardRow): string[] {
   return [
     row.pane ?? "-",

--- a/user/skills/flock/scripts/claim.ts
+++ b/user/skills/flock/scripts/claim.ts
@@ -5,7 +5,7 @@ import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { z } from "zod";
 import { decodeJson } from "../../../../packages/decode/index";
-import { jsonRow, sortWorktreeRows, type BoardRow } from "./board";
+import { heldByAgent, jsonRow, sortWorktreeRows, type BoardRow } from "./board";
 import { classify, pullFlags, renderBoard } from "./disposition";
 import { daysBefore, deferredPath, readDeferrals, staleKeys } from "./deferred";
 import { spawnRun, throttle, type Run } from "./exec";
@@ -487,6 +487,22 @@ function readPanes(snapshot: z.infer<typeof Snapshot>): {
   return { panes, repoRoots, flockWorkspace };
 }
 
+/**
+ * A worktree can hold several panes, and the row carries one. An agent's pane
+ * is the one whose state the sweep turns on, so a plain shell sharing the
+ * directory must not stand in for it and report the tree unoccupied.
+ */
+function occupant(panes: readonly Pane[], worktree: string, self: string): Pane | undefined {
+  const inside = panes.filter(
+    (candidate) => candidate.cwd === worktree || candidate.cwd.startsWith(`${worktree}/`),
+  );
+  return (
+    inside.find((candidate) => candidate.id === self) ??
+    inside.find((candidate) => heldByAgent(candidate.agent)) ??
+    inside[0]
+  );
+}
+
 function attachPanes(
   rows: readonly BoardRow[],
   panes: readonly Pane[],
@@ -496,9 +512,7 @@ function attachPanes(
   const attached = rows.map((row) => {
     const worktree = row.worktree;
     if (worktree === null) return row;
-    const pane = panes.find(
-      (candidate) => candidate.cwd === worktree || candidate.cwd.startsWith(`${worktree}/`),
-    );
+    const pane = occupant(panes, worktree, self);
     if (pane === undefined) return row;
     claimed.add(pane.id);
     const state = {
@@ -522,7 +536,7 @@ function idlePaneRows(
   self: string,
 ): BoardRow[] {
   return panes
-    .filter((pane) => !pane.agent.startsWith("shell/") && pane.id !== self && !claimed.has(pane.id))
+    .filter((pane) => heldByAgent(pane.agent) && pane.id !== self && !claimed.has(pane.id))
     .map((pane) => ({
       kind: "pane" as const,
       pane: pane.id,

--- a/user/skills/flock/scripts/claim.ts
+++ b/user/skills/flock/scripts/claim.ts
@@ -29,6 +29,7 @@ import {
   ageInDays,
   carriedIgnoredPaths,
   deriveFlags,
+  isMergedBranch,
   isReusedBranch,
   parseWorktreeList,
   readStatus,
@@ -287,6 +288,7 @@ async function scanWorktree(
   ctx: Context,
   options: {
     readonly path: string;
+    readonly branch: string | null;
     readonly base: string | null;
     readonly commitDate: number | null;
   },
@@ -295,21 +297,31 @@ async function scanWorktree(
   ahead: number | null;
   carried: number;
   commit: number | null;
+  merged: boolean;
 }> {
-  const [status, ahead, carried, detachedDate] = await Promise.all([
+  const [status, ahead, carried, detachedDate, cherry] = await Promise.all([
     ctx.git(["git", "-C", options.path, "status", "--porcelain", "-z", "--ignore-submodules=none"]),
     aheadCount(ctx.git, options.path, options.base),
     carriedIgnoredPaths(ctx.git, options.path),
     options.commitDate === null
       ? ctx.git(["git", "-C", options.path, "log", "-1", "--format=%ct", "HEAD"])
       : Promise.resolve(null),
+    options.branch === null || options.base === null
+      ? Promise.resolve(null)
+      : ctx.git(["git", "-C", options.path, "cherry", `origin/${options.base}`, "HEAD"]),
   ]);
 
   const commit =
     options.commitDate ??
     (detachedDate !== null && detachedDate.ok ? toCount(detachedDate.stdout) : null);
 
-  return { status: readStatus(status), ahead, carried: carried.length, commit };
+  return {
+    status: readStatus(status),
+    ahead,
+    carried: carried.length,
+    commit,
+    merged: cherry !== null && isMergedBranch(cherry),
+  };
 }
 
 async function scanRepository(ctx: Context, repository: Repository): Promise<RepoScan> {
@@ -340,26 +352,6 @@ async function scanRepository(ctx: Context, repository: Repository): Promise<Rep
     warnings.push(`${target}: worktrees could not be listed, so none of its rows appear below`);
   }
 
-  const mergedBranches =
-    base === null
-      ? new Set<string>()
-      : new Set(
-          (
-            await ctx.git([
-              "git",
-              "-C",
-              root,
-              "branch",
-              "--format=%(refname:short)",
-              "--merged",
-              `origin/${base}`,
-            ])
-          ).stdout
-            .split("\n")
-            .map((line) => line.trim())
-            .filter((line) => line !== ""),
-        );
-
   const commitDates = branchCommitDates(refs.stdout);
   const pulls = joinPullRequests(forge.listing.open ?? [], forge.listing.merged ?? []);
 
@@ -375,17 +367,21 @@ async function scanRepository(ctx: Context, repository: Repository): Promise<Rep
   const scanned = await Promise.all(
     records.map(async (record) => {
       const commitDate = record.branch === null ? null : (commitDates.get(record.branch) ?? null);
-      const scan = await scanWorktree(ctx, { path: record.path, base, commitDate });
+      const scan = await scanWorktree(ctx, {
+        path: record.path,
+        branch: record.branch,
+        base,
+        commitDate,
+      });
 
       const pull = record.branch === null ? undefined : pulls.get(record.branch);
-      const merged = record.branch !== null && mergedBranches.has(record.branch);
       const reused = isReusedBranch(pull, scan.commit);
       const flags = deriveFlags({
         detached: record.branch === null,
         status: scan.status,
         ahead: scan.ahead,
         carried: scan.carried,
-        merged,
+        merged: scan.merged,
         reused,
         pull: pull === undefined ? [] : pullFlags(pull),
       });
@@ -426,7 +422,7 @@ async function scanRepository(ctx: Context, repository: Repository): Promise<Rep
           status: scan.status,
           unpushed: scan.ahead,
           carried: scan.carried,
-          mergedBranch: merged,
+          mergedBranch: scan.merged,
           reused,
         },
         // A pane can claim this worktree only once every repository has been

--- a/user/skills/flock/scripts/disposition.test.ts
+++ b/user/skills/flock/scripts/disposition.test.ts
@@ -211,6 +211,56 @@ describe("a detached worktree", () => {
   });
 });
 
+describe("an agent resting in the pane", () => {
+  const merged = pull({ state: "merged", ref: "merged#1", checks: "none", mergeState: "unknown" });
+  const held = (agent: string, overrides: Partial<RowState> = {}): BoardRow =>
+    row({ pane: "wC1:p1", agent, pull: merged, state: state(overrides) });
+
+  // The pane holding an agent owns its worktree, and herdr splits one resting
+  // state into idle and done by whether the tab has been seen. An agent
+  // between the turns of a running workflow reads idle, so a cleanup offered
+  // against that row removes the tree the run is working in.
+  test.each<{ name: string; row: BoardRow; expected: Disposition }>([
+    { name: "idle never reads as finished", row: held("claude/idle"), expected: "working" },
+    { name: "done never reads as finished", row: held("claude/done"), expected: "working" },
+    {
+      name: "with a status herdr would not report holds the tree all the same",
+      row: held("claude/?"),
+      expected: "working",
+    },
+    {
+      name: "mid-turn holds the tree",
+      row: held("claude/working", { working: true }),
+      expected: "working",
+    },
+    {
+      name: "stopped on a prompt is the user's to answer",
+      row: held("claude/blocked", { blocked: true }),
+      expected: "needs-you",
+    },
+  ])("$name", ({ row: subject, expected }) => {
+    expect(classify(subject)).toBe(expected);
+  });
+
+  test("a shell sitting in the worktree is a person's prompt, not an agent", () => {
+    expect(classify(held("shell/idle"))).toBe("cleanup");
+  });
+
+  test("a worktree no pane holds is still a cleanup", () => {
+    expect(classify(row({ pull: merged }))).toBe("cleanup");
+  });
+
+  // Merge lands on the forge and leaves the tree alone, and the agent that
+  // finished the work is resting in the pane it finished in, so an occupied
+  // pane holding merges back would empty the disposition.
+  test.each<{ name: string; row: BoardRow; expected: Disposition }>([
+    { name: "resting", row: held("claude/idle", {}), expected: "merge" },
+    { name: "mid-turn", row: held("claude/working", { working: true }), expected: "merge" },
+  ])("a green pull request under an agent $name is still a merge", ({ row: subject, expected }) => {
+    expect(classify({ ...subject, pull: pull() })).toBe(expected);
+  });
+});
+
 describe("an agent holding the worktree", () => {
   test.each<{ name: string; row: BoardRow; expected: Disposition }>([
     {

--- a/user/skills/flock/scripts/disposition.ts
+++ b/user/skills/flock/scripts/disposition.ts
@@ -2,6 +2,7 @@ import {
   branchLabel,
   fit,
   headerRow,
+  heldByAgent,
   renderRows,
   rowCells,
   type BoardPull,
@@ -91,7 +92,12 @@ export function classify(row: BoardRow): Disposition {
   // is the user's to decide yet. A merge happens on the forge instead, and
   // holding it back would hide the one row the sweep exists to raise.
   const disposition = verdict(row);
-  return row.state.working && disposition !== "merge" ? "working" : disposition;
+  if (row.state.working) return disposition === "merge" ? disposition : "working";
+  // A resting agent owns the tree too, and cleanup is the one disposition that
+  // destroys it. Merge keeps its own path: an agent that finished the work
+  // rests in the pane it finished in, so holding merges on an occupied pane
+  // would empty the disposition rather than guard anything.
+  return disposition === "cleanup" && heldByAgent(row) ? "working" : disposition;
 }
 
 const FAILING_SHOWN = 3;

--- a/user/skills/flock/scripts/disposition.ts
+++ b/user/skills/flock/scripts/disposition.ts
@@ -88,16 +88,17 @@ export function classify(row: BoardRow): Disposition {
   if (row.state.blocked) return "needs-you";
   if (row.kind === "pane") return "panes";
 
-  // An agent mid-turn owns the working tree, so nothing that touches the tree
-  // is the user's to decide yet. A merge happens on the forge instead, and
-  // holding it back would hide the one row the sweep exists to raise.
   const disposition = verdict(row);
-  if (row.state.working) return disposition === "merge" ? disposition : "working";
-  // A resting agent owns the tree too, and cleanup is the one disposition that
-  // destroys it. Merge keeps its own path: an agent that finished the work
-  // rests in the pane it finished in, so holding merges on an occupied pane
-  // would empty the disposition rather than guard anything.
-  return disposition === "cleanup" && heldByAgent(row) ? "working" : disposition;
+  // A merge happens on the forge rather than in the tree, and the agent that
+  // finished the work is still resting in the pane it finished in, so gating
+  // merges on an occupied pane would empty the disposition rather than guard
+  // anything.
+  if (disposition === "merge") return disposition;
+  // An agent mid-turn owns the tree, so nothing that touches it is the user's
+  // to decide yet. A resting agent owns it too, and cleanup is the one
+  // remaining disposition that destroys it.
+  if (row.state.working) return "working";
+  return disposition === "cleanup" && heldByAgent(row.agent) ? "working" : disposition;
 }
 
 const FAILING_SHOWN = 3;

--- a/user/skills/flock/scripts/worktree.test.ts
+++ b/user/skills/flock/scripts/worktree.test.ts
@@ -11,6 +11,7 @@ import {
   deriveFlags,
   filterCarried,
   isConventionalIgnored,
+  isMergedBranch,
   isReusedBranch,
   parseWorktreeList,
   readStatus,
@@ -162,6 +163,29 @@ describe("ageInDays", () => {
     [null, null],
   ])("%s", (commit, expected) => {
     expect(ageInDays(commit, now)).toBe(expected);
+  });
+});
+
+describe("isMergedBranch", () => {
+  // A branch with no commits of its own is an ancestor of the default branch
+  // from the moment it is created, so `git branch --merged` listed a branch
+  // whose work had not started as merged, and the board offered its worktree
+  // for removal with an agent still running in it.
+  test("a branch with no commits of its own has not merged", () => {
+    expect(isMergedBranch(result({ stdout: "" }))).toBe(false);
+    expect(isMergedBranch(result({ stdout: "\n" }))).toBe(false);
+  });
+
+  test.each([
+    ["every commit already carried by the default branch", "- aaa\n- bbb\n", true],
+    ["one commit still out", "- aaa\n+ bbb\n", false],
+    ["nothing carried yet", "+ aaa\n", false],
+  ] as const)("%s", (_name, stdout, expected) => {
+    expect(isMergedBranch(result({ stdout }))).toBe(expected);
+  });
+
+  test("a cherry git would not run claims nothing", () => {
+    expect(isMergedBranch(result({ ok: false, stderr: "unknown revision" }))).toBe(false);
   });
 });
 

--- a/user/skills/flock/scripts/worktree.ts
+++ b/user/skills/flock/scripts/worktree.ts
@@ -207,6 +207,20 @@ export function ageInDays(commit: number | null, now: number): number | null {
 }
 
 /**
+ * `git cherry` marks a commit `-` once the default branch carries an equivalent
+ * patch, so a branch whose every commit reads `-` went in however it was
+ * squashed or rebased. Ancestry cannot stand in for this: a branch is an
+ * ancestor of the default branch from the moment it is created, which reads
+ * the same as one whose work landed, and a branch with no commits of its own
+ * has nothing that could have been merged.
+ */
+export function isMergedBranch(cherry: CommandResult): boolean {
+  if (!cherry.ok) return false;
+  const commits = cherry.stdout.split("\n").filter((line) => line.trim() !== "");
+  return commits.length > 0 && commits.every((line) => line.startsWith("-"));
+}
+
+/**
  * `headRefName` is historical text that survives the branch's deletion, so a
  * new branch created under a recycled name joins to the old merged pull
  * request and inherits its disposition.


### PR DESCRIPTION
The board offered a worktree for removal with an agent running in it: `wC1:p1  claude/idle  dotfiles  typescript-conversion  -  0  merged`. Three defects stacked to produce that row, and any one of them would have been caught by another.

The `merged` flag came from `git branch --merged`, which is ancestry, and ancestry is exactly zero commits ahead of the base. A branch created and never committed to reads as landed. `isMergedBranch` derives the flag from `git cherry origin/<base> HEAD` instead, which marks a commit `-` once the base carries an equivalent patch. A branch with no commits of its own has nothing that could have merged.

That still misses a fast-forward or merge-commit landing, whose commits become literal ancestors with nothing left to compare against. No test over the commit graph separates that from a branch that never started, since the two are the same topology. The miss parks a stale worktree rather than proposing its destruction.

`classify` did not read the pane at all, so the backstop that should have caught the bad flag did not exist. A row whose worktree holds an agent now routes to `working`. herdr splits one resting state into `idle` and `done` by whether the tab has been seen, so an agent between the turns of a running workflow reads idle.

A worktree can also hold more than one pane, and the row used to take whichever sorted first by id. A plain shell sharing the directory could sort ahead of the agent's pane and report the tree unoccupied. `occupant` prefers the sweep's own pane, then any pane an agent holds, then falls back to the first match. Both call sites that tested for a shell pane now share that test as `heldByAgent`.

Merge stays exempt from the occupied-pane check. It acts on the forge, and its normal case is an agent resting in the pane it finished in, so gating it on an occupied pane would empty the disposition rather than guard anything. Clean up in SKILL.md gains the re-check Merge already carries, confirming the pane is still empty with `herdr agent get` before removing anything, since an agent can take it between the board and the user's answer.

A second commit-count check inside the classifier was rejected. It derives one fact in two places, and it would park a legitimate merged-PR cleanup in any repo that lands work with merge commits. The regression lock lives at the derivation in `worktree.test.ts` instead.
