### PR TITLE
statusline: report the session title to herdr

### DIFF
--- a/user/scripts/pane-metadata.test.ts
+++ b/user/scripts/pane-metadata.test.ts
@@ -12,7 +12,7 @@ import {
   readSessionTitle,
   reportArgs,
   reportSignature,
-  scanTitles,
+  latestTitle,
   shouldReport,
   titleCachePath,
 } from "./pane-metadata";
@@ -187,38 +187,27 @@ const customTitle = (title: string) =>
 const turn = (text: string) =>
   `${JSON.stringify({ type: "user", message: { role: "user", content: text } })}\n`;
 
-describe("scanTitles", () => {
+describe("latestTitle", () => {
   test.each([
     ["names the session", aiTitle("Herdr sidebar redesign"), "Herdr sidebar redesign"],
     ["takes a /title rename", customTitle("screens"), "screens"],
     ["takes the latest of either kind", aiTitle("First") + customTitle("Second"), "Second"],
     ["takes the latest rename", customTitle("Second") + aiTitle("Third"), "Third"],
     ["flattens a multi-line title", aiTitle("Two\nlines"), "Two lines"],
+    ["reads a multi-byte title", aiTitle("Café ☕"), "Café ☕"],
     ["ignores a turn quoting the record", turn(JSON.stringify({ type: "ai-title" })), null],
     ["ignores a record with no title", `${JSON.stringify({ type: "ai-title" })}\n`, null],
     ["ignores a malformed line", '{"type":"ai-title",\n', null],
     ["ignores a blank title", aiTitle("   "), null],
+    ["ignores a record still being written", aiTitle("Named").slice(0, 30), null],
   ])("%s", (_name, chunk, expected) => {
-    expect(scanTitles(chunk, null).title).toBe(expected);
+    expect(latestTitle(chunk, false)).toBe(expected);
   });
 
-  test("carries the standing title through a chunk that names none", () => {
-    expect(scanTitles(turn("hello"), "Standing").title).toBe("Standing");
-  });
-
-  test("leaves a half-written record for the render that sees it finished", () => {
-    const chunk = `${turn("hello")}${aiTitle("Named").trimEnd()}`;
-    const scan = scanTitles(chunk, null);
-    expect(scan.title).toBeNull();
-    expect(scan.consumed).toBe(Buffer.byteLength(turn("hello")));
-  });
-
-  test("resumes on a line boundary through a multi-byte title", () => {
-    const chunk = aiTitle("Café ☕");
-    expect(scanTitles(chunk, null)).toEqual({
-      title: "Café ☕",
-      consumed: Buffer.byteLength(chunk),
-    });
+  test("drops the truncated line a mid-file window opens on", () => {
+    const chunk = `Title"}\n${aiTitle("Named")}`;
+    expect(latestTitle(chunk, true)).toBe("Named");
+    expect(latestTitle(aiTitle("Cut off"), true)).toBeNull();
   });
 });
 
@@ -266,18 +255,30 @@ describe("readSessionTitle", () => {
     });
   });
 
-  test("scans only the bytes appended since the last render", async () => {
+  test("caches against the size that produced it", async () => {
     await withTranscript(async (path, sessionId) => {
       await Bun.write(path, aiTitle("Named"));
       expect(await readSessionTitle(path, sessionId)).toBe("Named");
       expect(await Bun.file(titleCachePath(sessionId)).json()).toEqual({
-        offset: Bun.file(path).size,
+        size: Bun.file(path).size,
         title: "Named",
       });
+    });
+  });
 
-      // A record already behind the cached offset is never reread, so a
-      // transcript that grows without naming a new title costs one short read.
-      await Bun.write(path, aiTitle("Rewritten") + turn("hello"));
+  test("reads a title a transcript longer than the tail window ends with", async () => {
+    await withTranscript(async (path, sessionId) => {
+      await Bun.write(path, turn("x".repeat(400_000)) + aiTitle("Named"));
+      expect(await readSessionTitle(path, sessionId)).toBe("Named");
+    });
+  });
+
+  test("stands by the cached title once the tail window slides past it", async () => {
+    await withTranscript(async (path, sessionId) => {
+      await Bun.write(path, aiTitle("Named"));
+      expect(await readSessionTitle(path, sessionId)).toBe("Named");
+
+      await Bun.write(path, aiTitle("Named") + turn("x".repeat(400_000)));
       expect(await readSessionTitle(path, sessionId)).toBe("Named");
     });
   });

--- a/user/scripts/pane-metadata.test.ts
+++ b/user/scripts/pane-metadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -248,7 +248,7 @@ describe("readSessionTitle", () => {
     } finally {
       await Promise.all([
         rm(dir, { recursive: true, force: true }),
-        rm(titleCachePath(sessionId), { force: true }),
+        rm(titleCachePath(sessionId), { recursive: true, force: true }),
       ]);
     }
   }
@@ -289,6 +289,16 @@ describe("readSessionTitle", () => {
 
       await Bun.write(path, aiTitle("Fresh"));
       expect(await readSessionTitle(path, sessionId)).toBe("Fresh");
+    });
+  });
+
+  test("stands by a scanned title the cache could not be written for", async () => {
+    await withTranscript(async (path, sessionId) => {
+      // A directory where the cache file goes fails the write and nothing else,
+      // so the scan still has the title the transcript names.
+      mkdirSync(titleCachePath(sessionId), { recursive: true });
+      await Bun.write(path, aiTitle("Named"));
+      expect(await readSessionTitle(path, sessionId)).toBe("Named");
     });
   });
 

--- a/user/scripts/pane-metadata.test.ts
+++ b/user/scripts/pane-metadata.test.ts
@@ -1,12 +1,20 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { brandGlyph } from "./glyphs";
 import {
   CONTEXT_TOKENS,
   cachePath,
+  childArgs,
   findPane,
+  readSessionTitle,
   reportArgs,
   reportSignature,
+  scanTitles,
   shouldReport,
+  titleCachePath,
 } from "./pane-metadata";
 
 const HOUR_MS = 3_600_000;
@@ -62,7 +70,7 @@ describe("shouldReport", () => {
 
 describe("reportArgs", () => {
   test("sets the live token and clears the other levels", () => {
-    const args = reportArgs("w2:p2", { token: "ctx_high", value: "\u{f0aa2}" });
+    const args = reportArgs("w2:p2", { token: "ctx_high", value: "\u{f0aa2}" }, null);
     // The mark stands in as `<brand>`: a private-use glyph inlined here is one
     // bad paste away from silently snapshotting some other icon. Its codepoint
     // is asserted below instead.
@@ -90,7 +98,7 @@ describe("reportArgs", () => {
   });
 
   test("carries the brand mark with no dial to report", () => {
-    const args = reportArgs("w2:p2", null);
+    const args = reportArgs("w2:p2", null, null);
     expect(args).toEqual([
       "pane",
       "report-metadata",
@@ -106,15 +114,35 @@ describe("reportArgs", () => {
 
   test("brands the pane whether or not a dial rides along", () => {
     for (const report of [null, { token: "ctx_low", value: "x" } as const]) {
-      const args = reportArgs("w2:p2", report);
+      const args = reportArgs("w2:p2", report, null);
       expect(args[args.indexOf("--display-agent") + 1]).toBe(brandGlyph);
     }
+  });
+
+  test("sets the title token the sidebar binds to", () => {
+    const args = reportArgs("w2:p2", null, "Herdr sidebar redesign");
+    expect(args.slice(args.indexOf("--token"))).toEqual([
+      "--token",
+      "title=Herdr sidebar redesign",
+    ]);
+  });
+
+  test("carries the title alongside the dial", () => {
+    const args = reportArgs("w2:p2", { token: "ctx_mid", value: "x" }, "Named");
+    const tokens = args.filter((_arg, i) => args[i - 1] === "--token");
+    expect(tokens).toEqual(["title=Named", "ctx_mid=x"]);
+  });
+
+  test("leaves the title standing when the session has no name yet", () => {
+    const args = reportArgs("w2:p2", { token: "ctx_mid", value: "x" }, null);
+    expect(args).not.toContain("title");
+    expect(args.filter((_arg, i) => args[i - 1] === "--clear-token")).not.toContain("title");
   });
 
   const levels = CONTEXT_TOKENS.map((token) => [token] as const);
 
   test.each(levels)("%s clears every other level", (token) => {
-    const args = reportArgs("w2:p2", { token, value: "\u{f0a9e}" });
+    const args = reportArgs("w2:p2", { token, value: "\u{f0a9e}" }, null);
     const cleared = args.filter((_arg, i) => args[i - 1] === "--clear-token");
     expect(cleared).toEqual(CONTEXT_TOKENS.filter((other) => other !== token));
   });
@@ -122,11 +150,22 @@ describe("reportArgs", () => {
 
 describe("reportSignature", () => {
   test("separates a dial from no dial, so the first one re-reports", () => {
-    expect(reportSignature({ token: "ctx_low", value: "x" })).not.toBe(reportSignature(null));
+    expect(reportSignature({ token: "ctx_low", value: "x" }, null)).not.toBe(
+      reportSignature(null, null),
+    );
   });
 
   test("moves when the mark moves, so a changed glyph is not cached away", () => {
-    expect(reportSignature(null)).toStartWith(brandGlyph);
+    expect(reportSignature(null, null)).toStartWith(brandGlyph);
+  });
+
+  test("moves on a rename, so the new title reaches herdr", () => {
+    const dial = { token: "ctx_low", value: "x" } as const;
+    expect(reportSignature(dial, "Pane title token")).not.toBe(reportSignature(dial, "Renamed"));
+  });
+
+  test("separates a named session from an unnamed one", () => {
+    expect(reportSignature(null, "Named")).not.toBe(reportSignature(null, null));
   });
 });
 
@@ -138,5 +177,134 @@ describe("cachePath", () => {
 
   test("sanitizes a session id that would escape the directory", () => {
     expect(cachePath("../../etc/passwd")).toEndWith("claude-pane-metadata/..-..-etc-passwd.json");
+  });
+});
+
+const aiTitle = (title: string) =>
+  `${JSON.stringify({ type: "ai-title", aiTitle: title, sessionId: "session-a" })}\n`;
+const customTitle = (title: string) =>
+  `${JSON.stringify({ type: "custom-title", customTitle: title, sessionId: "session-a" })}\n`;
+const turn = (text: string) =>
+  `${JSON.stringify({ type: "user", message: { role: "user", content: text } })}\n`;
+
+describe("scanTitles", () => {
+  test.each([
+    ["names the session", aiTitle("Herdr sidebar redesign"), "Herdr sidebar redesign"],
+    ["takes a /title rename", customTitle("screens"), "screens"],
+    ["takes the latest of either kind", aiTitle("First") + customTitle("Second"), "Second"],
+    ["takes the latest rename", customTitle("Second") + aiTitle("Third"), "Third"],
+    ["flattens a multi-line title", aiTitle("Two\nlines"), "Two lines"],
+    ["ignores a turn quoting the record", turn(JSON.stringify({ type: "ai-title" })), null],
+    ["ignores a record with no title", `${JSON.stringify({ type: "ai-title" })}\n`, null],
+    ["ignores a malformed line", '{"type":"ai-title",\n', null],
+    ["ignores a blank title", aiTitle("   "), null],
+  ])("%s", (_name, chunk, expected) => {
+    expect(scanTitles(chunk, null).title).toBe(expected);
+  });
+
+  test("carries the standing title through a chunk that names none", () => {
+    expect(scanTitles(turn("hello"), "Standing").title).toBe("Standing");
+  });
+
+  test("leaves a half-written record for the render that sees it finished", () => {
+    const chunk = `${turn("hello")}${aiTitle("Named").trimEnd()}`;
+    const scan = scanTitles(chunk, null);
+    expect(scan.title).toBeNull();
+    expect(scan.consumed).toBe(Buffer.byteLength(turn("hello")));
+  });
+
+  test("resumes on a line boundary through a multi-byte title", () => {
+    const chunk = aiTitle("Café ☕");
+    expect(scanTitles(chunk, null)).toEqual({
+      title: "Café ☕",
+      consumed: Buffer.byteLength(chunk),
+    });
+  });
+});
+
+describe("childArgs", () => {
+  test("passes the title alongside the dial", () => {
+    expect(childArgs("session-a", { token: "ctx_mid", value: "x" }, "Named")).toEqual([
+      "session-a",
+      "ctx_mid",
+      "x",
+      "Named",
+    ]);
+  });
+
+  test("holds an absent dial's place so the title stays readable by position", () => {
+    expect(childArgs("session-a", null, "Named")).toEqual(["session-a", "", "", "Named"]);
+  });
+});
+
+describe("readSessionTitle", () => {
+  async function withTranscript(
+    body: (path: string, sessionId: string) => Promise<void>,
+  ): Promise<void> {
+    const dir = mkdtempSync(join(tmpdir(), "pane-title-"));
+    const sessionId = `test-${crypto.randomUUID()}`;
+    try {
+      await body(join(dir, "transcript.jsonl"), sessionId);
+    } finally {
+      await Promise.all([
+        rm(dir, { recursive: true, force: true }),
+        rm(titleCachePath(sessionId), { force: true }),
+      ]);
+    }
+  }
+
+  test("reads a title appended after the session was already scanned", async () => {
+    await withTranscript(async (path, sessionId) => {
+      await Bun.write(path, turn("hello"));
+      expect(await readSessionTitle(path, sessionId)).toBeNull();
+
+      await Bun.write(path, turn("hello") + aiTitle("Named"));
+      expect(await readSessionTitle(path, sessionId)).toBe("Named");
+
+      await Bun.write(path, turn("hello") + aiTitle("Named") + customTitle("Renamed"));
+      expect(await readSessionTitle(path, sessionId)).toBe("Renamed");
+    });
+  });
+
+  test("scans only the bytes appended since the last render", async () => {
+    await withTranscript(async (path, sessionId) => {
+      await Bun.write(path, aiTitle("Named"));
+      expect(await readSessionTitle(path, sessionId)).toBe("Named");
+      expect(await Bun.file(titleCachePath(sessionId)).json()).toEqual({
+        offset: Bun.file(path).size,
+        title: "Named",
+      });
+
+      // A record already behind the cached offset is never reread, so a
+      // transcript that grows without naming a new title costs one short read.
+      await Bun.write(path, aiTitle("Rewritten") + turn("hello"));
+      expect(await readSessionTitle(path, sessionId)).toBe("Named");
+    });
+  });
+
+  test("rereads a transcript that was replaced rather than appended to", async () => {
+    await withTranscript(async (path, sessionId) => {
+      await Bun.write(path, turn("hello") + aiTitle("Named"));
+      expect(await readSessionTitle(path, sessionId)).toBe("Named");
+
+      await Bun.write(path, aiTitle("Fresh"));
+      expect(await readSessionTitle(path, sessionId)).toBe("Fresh");
+    });
+  });
+
+  test("yields no title for a transcript that does not exist", async () => {
+    await withTranscript(async (_path, sessionId) => {
+      expect(await readSessionTitle("/nonexistent/transcript.jsonl", sessionId)).toBeNull();
+    });
+  });
+});
+
+describe("titleCachePath", () => {
+  test("sits beside the report cache without colliding with it", () => {
+    const sessionId = "4cba0d0a-8875-48eb-b6cd-90874f2a875b";
+    expect(titleCachePath(sessionId)).toEndWith(
+      "claude-pane-metadata/4cba0d0a-8875-48eb-b6cd-90874f2a875b.title.json",
+    );
+    expect(titleCachePath(sessionId)).not.toBe(cachePath(sessionId));
   });
 });

--- a/user/scripts/pane-metadata.test.ts
+++ b/user/scripts/pane-metadata.test.ts
@@ -85,6 +85,8 @@ describe("reportArgs", () => {
         "86400000",
         "--display-agent",
         "<brand>",
+        "--clear-token",
+        "title",
         "--token",
         "ctx_high=󰪢",
         "--clear-token",
@@ -109,6 +111,8 @@ describe("reportArgs", () => {
       "86400000",
       "--display-agent",
       brandGlyph,
+      "--clear-token",
+      "title",
     ]);
   });
 
@@ -125,6 +129,7 @@ describe("reportArgs", () => {
       "--token",
       "title=Herdr sidebar redesign",
     ]);
+    expect(args).not.toContain("--clear-token");
   });
 
   test("carries the title alongside the dial", () => {
@@ -133,16 +138,32 @@ describe("reportArgs", () => {
     expect(tokens).toEqual(["title=Named", "ctx_mid=x"]);
   });
 
-  test("leaves the title standing when the session has no name yet", () => {
+  test("clears the title when the session has no name yet", () => {
+    // A pane carries the previous session's title until something replaces it,
+    // so a new session drops it rather than wearing it as its own.
     const args = reportArgs("w2:p2", { token: "ctx_mid", value: "x" }, null);
-    expect(args).not.toContain("title");
-    expect(args.filter((_arg, i) => args[i - 1] === "--clear-token")).not.toContain("title");
+    expect(args.filter((_arg, i) => args[i - 1] === "--clear-token")).toContain("title");
+    expect(args.filter((_arg, i) => args[i - 1] === "--token")).toEqual(["ctx_mid=x"]);
+  });
+
+  test("clears the title an empty argv placeholder stands for", () => {
+    const args = reportArgs("w2:p2", null, "");
+    expect(args.filter((_arg, i) => args[i - 1] === "--clear-token")).toEqual(["title"]);
+  });
+
+  test("sets or clears the title, never both", () => {
+    for (const title of [null, "", "Named"]) {
+      const args = reportArgs("w2:p2", null, title);
+      const set = args.filter((_arg, i) => args[i - 1] === "--token");
+      const cleared = args.filter((_arg, i) => args[i - 1] === "--clear-token");
+      expect(set.length + cleared.length).toBe(1);
+    }
   });
 
   const levels = CONTEXT_TOKENS.map((token) => [token] as const);
 
   test.each(levels)("%s clears every other level", (token) => {
-    const args = reportArgs("w2:p2", { token, value: "\u{f0a9e}" }, null);
+    const args = reportArgs("w2:p2", { token, value: "\u{f0a9e}" }, "Named");
     const cleared = args.filter((_arg, i) => args[i - 1] === "--clear-token");
     expect(cleared).toEqual(CONTEXT_TOKENS.filter((other) => other !== token));
   });

--- a/user/scripts/pane-metadata.ts
+++ b/user/scripts/pane-metadata.ts
@@ -151,11 +151,22 @@ export function scanTitles(
   return { title, consumed: Buffer.byteLength(complete) };
 }
 
-async function readTitleCache(path: string): Promise<CachedTitle | null> {
+async function readCacheFile<T>(path: string, schema: z.ZodType<T>): Promise<T | null> {
   try {
-    return CachedTitle.parse(await Bun.file(path).json());
+    return schema.parse(await Bun.file(path).json());
   } catch {
     return null;
+  }
+}
+
+// Caching is best effort. A render that cannot write costs the next one a
+// rescan or a repeated report, so a failure here must not reach the value the
+// caller went to the trouble of computing.
+async function writeCacheFile(path: string, value: unknown): Promise<void> {
+  try {
+    await Bun.write(path, JSON.stringify(value));
+  } catch {
+    // Rendering the line takes priority over remembering what was rendered.
   }
 }
 
@@ -168,7 +179,7 @@ export async function readSessionTitle(
   sessionId: string,
 ): Promise<string | null> {
   const path = titleCachePath(sessionId);
-  const cached = await readTitleCache(path);
+  const cached = await readCacheFile(path, CachedTitle);
   try {
     const file = Bun.file(transcriptPath);
     const size = file.size;
@@ -179,7 +190,7 @@ export async function readSessionTitle(
       await file.slice(resume.offset, size).text(),
       resume.title,
     );
-    await Bun.write(path, JSON.stringify({ offset: resume.offset + consumed, title }));
+    await writeCacheFile(path, { offset: resume.offset + consumed, title });
     return title;
   } catch {
     return cached?.title ?? null;
@@ -219,14 +230,6 @@ export function findPane(paneList: string, sessionId: string): string | null {
   return pane?.pane_id ?? null;
 }
 
-async function readCache(path: string): Promise<CachedReport | null> {
-  try {
-    return CachedReport.parse(await Bun.file(path).json());
-  } catch {
-    return null;
-  }
-}
-
 // The dial and the title are each optional and the child reads them by
 // position, so an absent one is passed as an empty placeholder rather than
 // shifting the argument after it.
@@ -250,18 +253,22 @@ export async function reportPaneMetadata(
   const paneId = process.env.HERDR_PANE_ID;
   if (paneId == null || paneId === "") return;
 
-  const title =
+  // The dedup cache and the transcript are unrelated files, so the render waits
+  // on one round trip rather than two.
+  const path = cachePath(sessionId);
+  const [cached, title] = await Promise.all([
+    readCacheFile(path, CachedReport),
     transcriptPath != null && transcriptPath !== ""
-      ? await readSessionTitle(transcriptPath, sessionId)
-      : null;
+      ? readSessionTitle(transcriptPath, sessionId)
+      : null,
+  ]);
 
   const sig = reportSignature(report, title);
-  const path = cachePath(sessionId);
-  if (!shouldReport(await readCache(path), sig, Date.now())) return;
+  if (!shouldReport(cached, sig, Date.now())) return;
 
   // The cache records the attempt rather than the outcome. A herdr that is down
   // would otherwise turn every later render back into a spawn.
-  await Bun.write(path, JSON.stringify({ sig, at: Date.now() }));
+  await writeCacheFile(path, { sig, at: Date.now() });
 
   Bun.spawn([process.execPath, import.meta.path, ...childArgs(sessionId, report, title)], {
     stdio: ["ignore", "ignore", "ignore"],

--- a/user/scripts/pane-metadata.ts
+++ b/user/scripts/pane-metadata.ts
@@ -82,9 +82,9 @@ export function reportSignature(report: DialReport | null, title: string | null)
 // `context_window` is absent until a turn has closed, and the pane should be
 // branded before then.
 //
-// The title rides along the same way, and is only ever set: a session that has
-// not been named yet keeps whatever herdr already shows, where clearing would
-// blank the sidebar row that renders it.
+// The title rides along the same way. A session that has not been named yet
+// clears the token instead of leaving it, so a pane reused by a new session
+// drops the last one's title rather than showing it as this session's.
 export function reportArgs(
   paneId: string,
   report: DialReport | null,
@@ -102,6 +102,7 @@ export function reportArgs(
     brandGlyph,
   ];
   if (title != null && title !== "") args.push("--token", `${TITLE_TOKEN}=${title}`);
+  else args.push("--clear-token", TITLE_TOKEN);
   if (!report) return args;
 
   args.push("--token", `${report.token}=${report.value}`);

--- a/user/scripts/pane-metadata.ts
+++ b/user/scripts/pane-metadata.ts
@@ -24,14 +24,34 @@ const CachedReport = z.object({
 });
 type CachedReport = z.infer<typeof CachedReport>;
 
+// The byte offset the transcript had been read to, and the title standing at
+// that point. Resuming from the offset is what keeps a transcript that grows
+// through the turn from being reread on every render.
+const CachedTitle = z.object({
+  offset: z.number(),
+  title: z.string().nullable(),
+});
+type CachedTitle = z.infer<typeof CachedTitle>;
+
+// The name the herdr sidebar config binds to as `$title`.
+const TITLE_TOKEN = "title";
+
 const SOURCE = "claude-statusline";
 const TTL_MS = 86_400_000;
 const REFRESH_MS = 3_600_000;
 const HERDR_TIMEOUT_MS = 5_000;
 const UNSAFE_NAME = /[^A-Za-z0-9._-]+/g;
 
+function cacheFile(sessionId: string, suffix: string): string {
+  return join(tmpdir(), "claude-pane-metadata", `${sessionId.replace(UNSAFE_NAME, "-")}${suffix}`);
+}
+
 export function cachePath(sessionId: string): string {
-  return join(tmpdir(), "claude-pane-metadata", `${sessionId.replace(UNSAFE_NAME, "-")}.json`);
+  return cacheFile(sessionId, ".json");
+}
+
+export function titleCachePath(sessionId: string): string {
+  return cacheFile(sessionId, ".title.json");
 }
 
 export function shouldReport(cached: CachedReport | null, sig: string, now: number): boolean {
@@ -41,8 +61,8 @@ export function shouldReport(cached: CachedReport | null, sig: string, now: numb
   return now - cached.at >= REFRESH_MS;
 }
 
-export function reportSignature(report: DialReport | null): string {
-  return `${brandGlyph}:${report ? `${report.token}=${report.value}` : ""}`;
+export function reportSignature(report: DialReport | null, title: string | null): string {
+  return `${brandGlyph}:${report ? `${report.token}=${report.value}` : ""}:${title ?? ""}`;
 }
 
 // The brand mark rides along on the dial's call rather than getting one of its
@@ -55,7 +75,15 @@ export function reportSignature(report: DialReport | null): string {
 // The dial is optional so that riding along costs the mark nothing:
 // `context_window` is absent until a turn has closed, and the pane should be
 // branded before then.
-export function reportArgs(paneId: string, report: DialReport | null): string[] {
+//
+// The title rides along the same way, and is only ever set: a session that has
+// not been named yet keeps whatever herdr already shows, where clearing would
+// blank the sidebar row that renders it.
+export function reportArgs(
+  paneId: string,
+  report: DialReport | null,
+  title: string | null,
+): string[] {
   const args = [
     "pane",
     "report-metadata",
@@ -67,6 +95,7 @@ export function reportArgs(paneId: string, report: DialReport | null): string[] 
     "--display-agent",
     brandGlyph,
   ];
+  if (title != null && title !== "") args.push("--token", `${TITLE_TOKEN}=${title}`);
   if (!report) return args;
 
   args.push("--token", `${report.token}=${report.value}`);
@@ -74,6 +103,87 @@ export function reportArgs(paneId: string, report: DialReport | null): string[] 
     if (name !== report.token) args.push("--clear-token", name);
   }
   return args;
+}
+
+const TitleRecord = z.looseObject({
+  type: z.string().optional().catch(undefined),
+  aiTitle: z.string().optional().catch(undefined),
+  customTitle: z.string().optional().catch(undefined),
+});
+
+// Claude Code names a session by appending a record to its transcript, and
+// appends another on every rename, so the last such record is the live title.
+// `/title` writes `custom-title` where the model's own naming writes `ai-title`.
+function recordTitle(line: string): string | null {
+  // Nearly every line is a turn, and a prompt quoting these names parses to some
+  // other `type`. Testing the raw line first keeps the scan off `JSON.parse` for
+  // all but a handful of lines in a transcript that runs to megabytes.
+  if (!line.includes("-title")) return null;
+  let record: z.infer<typeof TitleRecord>;
+  try {
+    record = TitleRecord.parse(JSON.parse(line));
+  } catch {
+    return null;
+  }
+  if (record.type === "ai-title") return record.aiTitle ?? null;
+  if (record.type === "custom-title") return record.customTitle ?? null;
+  return null;
+}
+
+// Reads the complete lines in a chunk of transcript, carrying `previous` forward
+// when the chunk names no title, and reports how many bytes it consumed so the
+// next chunk resumes on a line boundary. A trailing partial line is left for the
+// render that sees it finished.
+export function scanTitles(
+  chunk: string,
+  previous: string | null,
+): { title: string | null; consumed: number } {
+  const end = chunk.lastIndexOf("\n") + 1;
+  const complete = chunk.slice(0, end);
+
+  let title = previous;
+  for (const line of complete.split("\n")) {
+    // herdr strips control bytes out of token values, which would glue the words
+    // of a multi-line title together, so flatten whitespace here instead.
+    const found = recordTitle(line)?.replaceAll(/\s+/gu, " ").trim();
+    if (found != null && found !== "") title = found;
+  }
+  return { title, consumed: Buffer.byteLength(complete) };
+}
+
+async function readTitleCache(path: string): Promise<CachedTitle | null> {
+  try {
+    return CachedTitle.parse(await Bun.file(path).json());
+  } catch {
+    return null;
+  }
+}
+
+// The session title Claude Code has settled on, or null before it names one.
+// Read on every status line render, so only the bytes appended since the last
+// one are scanned. A transcript shorter than the cached offset was replaced
+// rather than appended to, and is read from the start.
+export async function readSessionTitle(
+  transcriptPath: string,
+  sessionId: string,
+): Promise<string | null> {
+  const path = titleCachePath(sessionId);
+  const cached = await readTitleCache(path);
+  try {
+    const file = Bun.file(transcriptPath);
+    const size = file.size;
+    const resume = cached != null && cached.offset <= size ? cached : { offset: 0, title: null };
+    if (resume.offset === size) return resume.title;
+
+    const { title, consumed } = scanTitles(
+      await file.slice(resume.offset, size).text(),
+      resume.title,
+    );
+    await Bun.write(path, JSON.stringify({ offset: resume.offset + consumed, title }));
+    return title;
+  } catch {
+    return cached?.title ?? null;
+  }
 }
 
 // `agent_session.value` is the Claude session UUID herdr's integration hook
@@ -117,6 +227,17 @@ async function readCache(path: string): Promise<CachedReport | null> {
   }
 }
 
+// The dial and the title are each optional and the child reads them by
+// position, so an absent one is passed as an empty placeholder rather than
+// shifting the argument after it.
+export function childArgs(
+  sessionId: string,
+  report: DialReport | null,
+  title: string | null,
+): string[] {
+  return [sessionId, report?.token ?? "", report?.value ?? "", title ?? ""];
+}
+
 // Called on every status line render, so the steady state has to be a file read
 // and nothing else. Only a changed report reaches herdr, and it reaches it
 // through a detached child: the status line must render at the same speed
@@ -124,11 +245,17 @@ async function readCache(path: string): Promise<CachedReport | null> {
 export async function reportPaneMetadata(
   sessionId: string,
   report: DialReport | null,
+  transcriptPath: string | null,
 ): Promise<void> {
   const paneId = process.env.HERDR_PANE_ID;
   if (paneId == null || paneId === "") return;
 
-  const sig = reportSignature(report);
+  const title =
+    transcriptPath != null && transcriptPath !== ""
+      ? await readSessionTitle(transcriptPath, sessionId)
+      : null;
+
+  const sig = reportSignature(report, title);
   const path = cachePath(sessionId);
   if (!shouldReport(await readCache(path), sig, Date.now())) return;
 
@@ -136,9 +263,9 @@ export async function reportPaneMetadata(
   // would otherwise turn every later render back into a spawn.
   await Bun.write(path, JSON.stringify({ sig, at: Date.now() }));
 
-  const argv = [process.execPath, import.meta.path, sessionId];
-  if (report) argv.push(report.token, report.value);
-  Bun.spawn(argv, { stdio: ["ignore", "ignore", "ignore"] }).unref();
+  Bun.spawn([process.execPath, import.meta.path, ...childArgs(sessionId, report, title)], {
+    stdio: ["ignore", "ignore", "ignore"],
+  }).unref();
 }
 
 function parseToken(value: string | undefined): ContextToken | null {
@@ -146,14 +273,16 @@ function parseToken(value: string | undefined): ContextToken | null {
 }
 
 if (import.meta.main) {
-  const [sessionId, token, value] = process.argv.slice(2);
+  const [sessionId, token, value, title] = process.argv.slice(2);
   const name = parseToken(token);
   if (sessionId != null && sessionId !== "") {
     const list = Bun.spawnSync(["herdr", "pane", "list"], { timeout: HERDR_TIMEOUT_MS });
     const paneId = list.success ? findPane(list.stdout.toString(), sessionId) : null;
     if (paneId != null && paneId !== "") {
       const report = name != null && value != null && value !== "" ? { token: name, value } : null;
-      Bun.spawnSync(["herdr", ...reportArgs(paneId, report)], { timeout: HERDR_TIMEOUT_MS });
+      Bun.spawnSync(["herdr", ...reportArgs(paneId, report, title ?? null)], {
+        timeout: HERDR_TIMEOUT_MS,
+      });
     }
   }
 }

--- a/user/scripts/pane-metadata.ts
+++ b/user/scripts/pane-metadata.ts
@@ -24,17 +24,23 @@ const CachedReport = z.object({
 });
 type CachedReport = z.infer<typeof CachedReport>;
 
-// The byte offset the transcript had been read to, and the title standing at
-// that point. Resuming from the offset is what keeps a transcript that grows
-// through the turn from being reread on every render.
+// The size the transcript had when the title beside it was read. An unchanged
+// size means nothing has been appended, so the next render needs no read at all.
 const CachedTitle = z.object({
-  offset: z.number(),
+  size: z.number(),
   title: z.string().nullable(),
 });
 type CachedTitle = z.infer<typeof CachedTitle>;
 
 // The name the herdr sidebar config binds to as `$title`.
 const TITLE_TOKEN = "title";
+
+// Claude Code rewrites the title record as a session goes, so the live title
+// sits near the end of the transcript rather than wherever it was first named.
+// Across 376 named transcripts the last record was within 53 KB of the end, so
+// this window carries several times that and keeps the read a fixed cost a
+// transcript running to megabytes cannot grow.
+const TITLE_TAIL_BYTES = 262_144;
 
 const SOURCE = "claude-statusline";
 const TTL_MS = 86_400_000;
@@ -130,25 +136,21 @@ function recordTitle(line: string): string | null {
   return null;
 }
 
-// Reads the complete lines in a chunk of transcript, carrying `previous` forward
-// when the chunk names no title, and reports how many bytes it consumed so the
-// next chunk resumes on a line boundary. A trailing partial line is left for the
-// render that sees it finished.
-export function scanTitles(
-  chunk: string,
-  previous: string | null,
-): { title: string | null; consumed: number } {
-  const end = chunk.lastIndexOf("\n") + 1;
-  const complete = chunk.slice(0, end);
+// The last title a chunk of transcript names, or null when it names none. A
+// chunk taken from mid-file opens on a partial line, which is dropped rather
+// than parsed. A half-written record at the end fails to parse and is ignored.
+export function latestTitle(chunk: string, partialFirstLine: boolean): string | null {
+  const lines = chunk.split("\n");
+  if (partialFirstLine) lines.shift();
 
-  let title = previous;
-  for (const line of complete.split("\n")) {
+  let title: string | null = null;
+  for (const line of lines) {
     // herdr strips control bytes out of token values, which would glue the words
     // of a multi-line title together, so flatten whitespace here instead.
     const found = recordTitle(line)?.replaceAll(/\s+/gu, " ").trim();
     if (found != null && found !== "") title = found;
   }
-  return { title, consumed: Buffer.byteLength(complete) };
+  return title;
 }
 
 async function readCacheFile<T>(path: string, schema: z.ZodType<T>): Promise<T | null> {
@@ -171,9 +173,8 @@ async function writeCacheFile(path: string, value: unknown): Promise<void> {
 }
 
 // The session title Claude Code has settled on, or null before it names one.
-// Read on every status line render, so only the bytes appended since the last
-// one are scanned. A transcript shorter than the cached offset was replaced
-// rather than appended to, and is read from the start.
+// Read on every status line render, so an unchanged transcript costs a stat and
+// a changed one a bounded read of the tail. The file is never read end to end.
 export async function readSessionTitle(
   transcriptPath: string,
   sessionId: string,
@@ -183,14 +184,14 @@ export async function readSessionTitle(
   try {
     const file = Bun.file(transcriptPath);
     const size = file.size;
-    const resume = cached != null && cached.offset <= size ? cached : { offset: 0, title: null };
-    if (resume.offset === size) return resume.title;
+    if (cached?.size === size) return cached.title;
 
-    const { title, consumed } = scanTitles(
-      await file.slice(resume.offset, size).text(),
-      resume.title,
-    );
-    await writeCacheFile(path, { offset: resume.offset + consumed, title });
+    const start = Math.max(0, size - TITLE_TAIL_BYTES);
+    // Standing by the cached title is what carries a name across a stretch of
+    // transcript long enough to push every title record out of the window.
+    const title =
+      latestTitle(await file.slice(start, size).text(), start > 0) ?? cached?.title ?? null;
+    await writeCacheFile(path, { size, title });
     return title;
   } catch {
     return cached?.title ?? null;

--- a/user/scripts/pane-metadata.ts
+++ b/user/scripts/pane-metadata.ts
@@ -169,13 +169,10 @@ async function writeCacheFile(path: string, value: unknown): Promise<void> {
   try {
     await Bun.write(path, JSON.stringify(value));
   } catch {
-    // Rendering the line takes priority over remembering what was rendered.
   }
 }
 
-// The session title Claude Code has settled on, or null before it names one.
-// Read on every status line render, so an unchanged transcript costs a stat and
-// a changed one a bounded read of the tail. The file is never read end to end.
+// The session title Claude Code has settled on, or null before it names one. Read on every status line render, so an unchanged transcript costs a stat and a changed one a bounded read of the tail.
 export async function readSessionTitle(
   transcriptPath: string,
   sessionId: string,
@@ -255,8 +252,6 @@ export async function reportPaneMetadata(
   const paneId = process.env.HERDR_PANE_ID;
   if (paneId == null || paneId === "") return;
 
-  // The dedup cache and the transcript are unrelated files, so the render waits
-  // on one round trip rather than two.
   const path = cachePath(sessionId);
   const [cached, title] = await Promise.all([
     readCacheFile(path, CachedReport),

--- a/user/scripts/pane-metadata.ts
+++ b/user/scripts/pane-metadata.ts
@@ -166,13 +166,12 @@ async function readCacheFile<T>(path: string, schema: z.ZodType<T>): Promise<T |
 // rescan or a repeated report, so a failure here must not reach the value the
 // caller went to the trouble of computing.
 async function writeCacheFile(path: string, value: unknown): Promise<void> {
-  try {
-    await Bun.write(path, JSON.stringify(value));
-  } catch {
-  }
+  await Bun.write(path, JSON.stringify(value)).catch(() => undefined);
 }
 
-// The session title Claude Code has settled on, or null before it names one. Read on every status line render, so an unchanged transcript costs a stat and a changed one a bounded read of the tail.
+// The session title Claude Code has settled on, or null before it names one.
+// Read on every status line render, so an unchanged transcript costs a stat and
+// a changed one a bounded read of the tail.
 export async function readSessionTitle(
   transcriptPath: string,
   sessionId: string,

--- a/user/scripts/statusline.test.ts
+++ b/user/scripts/statusline.test.ts
@@ -392,7 +392,9 @@ describe("emitRateLimits", () => {
   });
 });
 
-// The dial and the title only mean something once they reach herdr, and the chain that carries them (stdin schema, transcript scan, detached child, argv) has no seam a unit test can reach.
+// The dial and the title only mean something once they reach herdr, and the
+// chain that carries them (stdin schema, transcript scan, detached child,
+// argv) has no seam a unit test can reach.
 describe("pane metadata report", () => {
   const sessionId = "9f0b1c2d-3e4f-5061-7283-94a5b6c7d8e9";
 

--- a/user/scripts/statusline.test.ts
+++ b/user/scripts/statusline.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ContextToken } from "./pane-metadata";
+import { cachePath, type ContextToken, titleCachePath } from "./pane-metadata";
 import {
   buildStatusLine,
   contextDial,
@@ -389,5 +389,98 @@ describe("emitRateLimits", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+});
+
+// The dial and the title only mean something once they reach herdr, and the
+// chain that carries them (stdin schema, transcript scan, detached child,
+// argv) has no seam a unit test can reach. Drive the real script against a
+// `herdr` stubbed onto PATH and assert on what the stub recorded.
+describe("pane metadata report", () => {
+  const sessionId = "9f0b1c2d-3e4f-5061-7283-94a5b6c7d8e9";
+
+  // Derived rather than inlined: a private-use glyph pasted into an assertion is
+  // one bad paste away from asserting some other icon.
+  const dial = contextDial({ context_window: { used_percentage: 30 } });
+  const dialToken = `${dial?.token}=${dial?.value}`;
+
+  const paneList = JSON.stringify({
+    result: {
+      type: "pane_list",
+      panes: [{ pane_id: "w2:p2", agent_session: { agent: "claude", value: sessionId } }],
+    },
+  });
+
+  async function recordedArgs(transcript: string): Promise<string[]> {
+    const dir = mkdtempSync(join(tmpdir(), "statusline-herdr-"));
+    const bin = join(dir, "bin");
+    const log = join(dir, "argv");
+    const transcriptPath = join(dir, "transcript.jsonl");
+
+    try {
+      mkdirSync(bin);
+      const herdr = join(bin, "herdr");
+      await Bun.write(
+        herdr,
+        [
+          "#!/bin/sh",
+          `if [ "$2" = list ]; then printf '%s' '${paneList}'; exit 0; fi`,
+          `for arg in "$@"; do printf '%s\\n' "$arg" >> ${log}; done`,
+          "",
+        ].join("\n"),
+      );
+      Bun.spawnSync(["chmod", "+x", herdr]);
+      await Bun.write(transcriptPath, transcript);
+
+      const child = Bun.spawn([process.execPath, join(import.meta.dir, "statusline.ts")], {
+        env: { ...process.env, HERDR_PANE_ID: "w2:p2", PATH: `${bin}:${process.env.PATH ?? ""}` },
+        stdin: Buffer.from(
+          JSON.stringify({
+            session_id: sessionId,
+            transcript_path: transcriptPath,
+            context_window: { used_percentage: 30 },
+          }),
+        ),
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      await child.exited;
+
+      // The reporting child is detached so the line renders at its own speed,
+      // which lands the stub's log after the status line has already exited.
+      // oxlint-disable no-await-in-loop -- polling for another process's write is sequential by nature.
+      const deadline = Date.now() + 10_000;
+      while (Date.now() < deadline) {
+        const text = await Bun.file(log)
+          .text()
+          .catch(() => "");
+        if (text.includes("report-metadata")) return text.trimEnd().split("\n");
+        await Bun.sleep(25);
+      }
+      // oxlint-enable no-await-in-loop
+      return [];
+    } finally {
+      await Promise.all([
+        rm(dir, { recursive: true, force: true }),
+        rm(cachePath(sessionId), { force: true }),
+        rm(titleCachePath(sessionId), { force: true }),
+      ]);
+    }
+  }
+
+  test("carries the title token and the dial to herdr", async () => {
+    const args = await recordedArgs(
+      `${JSON.stringify({ type: "ai-title", aiTitle: "Herdr sidebar redesign", sessionId })}\n`,
+    );
+    const tokens = args.filter((_arg, i) => args[i - 1] === "--token");
+    expect(tokens).toEqual(["title=Herdr sidebar redesign", dialToken]);
+  });
+
+  test("reports the dial alone before the session is named", async () => {
+    const args = await recordedArgs(
+      `${JSON.stringify({ type: "user", message: { role: "user", content: "hi" } })}\n`,
+    );
+    const tokens = args.filter((_arg, i) => args[i - 1] === "--token");
+    expect(tokens).toEqual([dialToken]);
   });
 });

--- a/user/scripts/statusline.test.ts
+++ b/user/scripts/statusline.test.ts
@@ -476,11 +476,12 @@ describe("pane metadata report", () => {
     expect(tokens).toEqual(["title=Herdr sidebar redesign", dialToken]);
   });
 
-  test("reports the dial alone before the session is named", async () => {
+  test("clears the title before the session is named", async () => {
     const args = await recordedArgs(
       `${JSON.stringify({ type: "user", message: { role: "user", content: "hi" } })}\n`,
     );
     const tokens = args.filter((_arg, i) => args[i - 1] === "--token");
     expect(tokens).toEqual([dialToken]);
+    expect(args.filter((_arg, i) => args[i - 1] === "--clear-token")).toContain("title");
   });
 });

--- a/user/scripts/statusline.test.ts
+++ b/user/scripts/statusline.test.ts
@@ -392,10 +392,7 @@ describe("emitRateLimits", () => {
   });
 });
 
-// The dial and the title only mean something once they reach herdr, and the
-// chain that carries them (stdin schema, transcript scan, detached child,
-// argv) has no seam a unit test can reach. Drive the real script against a
-// `herdr` stubbed onto PATH and assert on what the stub recorded.
+// The dial and the title only mean something once they reach herdr, and the chain that carries them (stdin schema, transcript scan, detached child, argv) has no seam a unit test can reach.
 describe("pane metadata report", () => {
   const sessionId = "9f0b1c2d-3e4f-5061-7283-94a5b6c7d8e9";
 

--- a/user/scripts/statusline.ts
+++ b/user/scripts/statusline.ts
@@ -22,6 +22,7 @@ const CurrentUsage = z.looseObject({
 
 const StatusInput = z.looseObject({
   session_id: str,
+  transcript_path: str,
   model: z.looseObject({ id: str, display_name: str }).nullish().catch(undefined),
   effort: z.looseObject({ level: str }).nullish().catch(undefined),
   context_window: z
@@ -376,11 +377,16 @@ if (import.meta.main) {
     const columns = Number.isInteger(parsed) && parsed > 0 ? parsed : 80;
     process.stdout.write(buildStatusLine(input, columns, resolveWorktree()));
 
-    // Not gated on the dial: the same report carries the brand mark, which has
-    // to keep being sent even on the renders before `context_window` shows up.
+    // Not gated on the dial: the same report carries the brand mark and the
+    // session title, which have to keep being sent even on the renders before
+    // `context_window` shows up.
     if (input.session_id != null && input.session_id !== "") {
       try {
-        await reportPaneMetadata(input.session_id, contextDial(input));
+        await reportPaneMetadata(
+          input.session_id,
+          contextDial(input),
+          input.transcript_path ?? null,
+        );
       } catch {
         // The sidebar mirror is best-effort, and the line is already written.
       }


### PR DESCRIPTION
The herdr sidebar renders a row per agent pane and had nothing to name a Claude session by beyond its workspace directory. This reports the session's title as a pane metadata token named `title`, riding along on the call that already reports the context dial. The consumer is the `[ui.sidebar.agents.rows_by_agent] claude` config on the `herdr-side-redux` branch in `bendrucker/dotfiles`, which renders `$title` bold with the workspace dimmed beneath it.

Claude Code appends an `ai-title` record to the transcript once it names a session, and a `custom-title` record when `/title` renames it. The last record of either kind is the live title. `~/.claude/sessions/<pid>.json` names a session in 600 bytes, but with a slug (`pane-title-token-db`) rather than the title the sidebar wants. herdr strips control bytes out of token values, so a multi-line title is flattened to one line before it's sent. It splits a token value on the first `=`, so a title containing one survives intact.

The status line renders many times per turn against a transcript that can run to megabytes, so it never reads one end to end. Claude Code rewrites the title record as a session goes, which puts the live title near the end of the file: across 376 named transcripts the last record sat within 53 KB of EOF, so a 256 KB tail read finds it with room to spare. The cache keys on the transcript's size, and an unchanged size returns the cached title with no read at all. A stretch long enough to push every record out of the window falls back to the cached title rather than dropping the name.

A pane holds a reported token until something replaces it, so the token is cleared at session start: a session with no title yet sends `--clear-token title`, which drops the previous session's title from a reused pane and leaves the row unnamed until this session is named. The set path is unchanged, and the dedup cache is keyed per session, so a new session always reports rather than inheriting the old one's signature.

Verified against the live herdr, which showed `title` alongside the dial for this session's own pane and dropped it on the clear while leaving the dial standing. On a 2.9 MB transcript the read costs 0.3 ms against 2.0 ms for the whole file, and 0.08 ms once cached.
