### PR TITLE
github: send the copilot prompt on stdin

### DIFF
--- a/plugins/github/skills/copilot/SKILL.md
+++ b/plugins/github/skills/copilot/SKILL.md
@@ -59,7 +59,7 @@ Everything is optional and forwards to the script.
 - `--agentic`: review from a disposable checkout with tools instead of from inlined text. It is one capped session and refuses `--angles` above 1. See [Agentic Mode](#agentic-mode).
 - `--status`: print the tier and bands, spend nothing.
 - `--dry-run`: print the assembled prompts and their size, spend nothing.
-- `--max-bytes <n>`: raise or lower the 120 KB prompt cap. The 400 KB ceiling still refuses.
+- `--max-bytes <n>`: raise or lower the 120 KB prompt cap.
 - `--force`: run even when a prompt exceeds the size cap.
 
 ## Run It
@@ -125,7 +125,7 @@ The sandbox blocks Copilot writing to `~/.copilot`, which kills the run with `I/
 
 #### Prompt Size
 
-The prompt travels as an argv value. That bounds it by `ARG_MAX` as well as by cost. The 120 KB cap sits well under both, and `--max-bytes` moves it. A second ceiling at 400 KB refuses even under `--force`, because past that the spawn fails with `E2BIG` and no review runs at all.
+The prompt travels on stdin. Omitting `-p` is what selects that: Copilot reads stdin as the prompt and stays in the same non-interactive mode, so `ARG_MAX` does not bound it. The 120 KB cap is a spend guard rather than a size ceiling. `--max-bytes` moves it, and `--force` runs past it.
 
 #### What Reaches GitHub
 

--- a/plugins/github/skills/copilot/scripts/review.test.ts
+++ b/plugins/github/skills/copilot/scripts/review.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   AGENTIC_TOOL_ARGS,
   ALL_CLASSES,
+  type Angle,
   ANGLES,
   buildPrompt,
   copilotArgs,
@@ -11,7 +12,9 @@ import {
   exceedsEntitlement,
   type Meter,
   resolveTier,
+  runCopilot,
   type Snapshot,
+  type Spawn,
   splitPaths,
   type Tier,
 } from "./review";
@@ -156,7 +159,7 @@ describe("angles", () => {
 
 describe("copilotArgs", () => {
   const args = (agentic: boolean) =>
-    copilotArgs("review this", { model: "gpt-5.6-terra", cap: 30, cwd: ".", agentic });
+    copilotArgs({ model: "gpt-5.6-terra", cap: 30, cwd: ".", agentic });
 
   // The cap is the only per-session ceiling, and the preflight guard reserves exactly this
   // number before the spawn. A shape that omits it can bill past what was reserved.
@@ -194,8 +197,62 @@ describe("copilotArgs", () => {
     }
   });
 
-  test("the prompt is the last argument", () => {
-    const argv = args(true);
-    expect(argv.slice(-2)).toEqual(["-p", "review this"]);
+  // -p is what puts the prompt in argv. Omitting it is what makes Copilot read stdin, so its
+  // presence would silently put the prompt back under ARG_MAX.
+  test.each([
+    ["one-shot", false],
+    ["agentic", true],
+  ])("%s passes no -p, so Copilot reads the prompt from stdin", (_name, agentic) => {
+    expect(args(agentic)).not.toContain("-p");
+    expect(args(agentic)).not.toContain("--prompt");
+  });
+});
+
+describe("runCopilot", () => {
+  const angle: Angle = { id: "all", title: "All defect classes", focus: "FOCUS" };
+  const options = { model: "gpt-5.6-terra", cap: 30, cwd: "/", agentic: false };
+
+  const record = (output: string, exitCode = 0) => {
+    const seen: { args: string[]; stdin: string } = { args: [], stdin: "" };
+    const spawn: Spawn = (args, stdin) => {
+      seen.args = args;
+      seen.stdin = new TextDecoder().decode(stdin);
+      return {
+        stdout: new Blob([output]).stream(),
+        stderr: new Blob([]).stream(),
+        exited: Promise.resolve(exitCode),
+      };
+    };
+    return { seen, spawn };
+  };
+
+  // A stacked review assembles hundreds of KB. Every byte has to arrive on stdin, which has
+  // no size limit, and none of it in argv, which does.
+  test("hands a prompt far past ARG_MAX to stdin intact", async () => {
+    const prompt = `HEAD ${"lorem ipsum ".repeat(42_000)}TAIL`;
+    expect(Buffer.byteLength(prompt, "utf8")).toBeGreaterThan(500_000);
+    const { seen, spawn } = record("no defects");
+
+    await runCopilot(prompt, angle, options, spawn);
+
+    expect(seen.stdin).toBe(prompt);
+    expect(seen.args.some((arg) => arg.includes("HEAD") || arg.includes("TAIL"))).toBe(false);
+  });
+
+  // The spend this reports is what lands in the transcript, and a footer it cannot parse
+  // reports a review as free.
+  test.each<[string, string, number | null]>([
+    ["a billed run", "findings\n\nAI Credits    7.58\nDuration   35s", 7.58],
+    ["a run that reported none", "findings\n\nDuration   35s", null],
+  ])("reads the credits off %s", async (_name, output, credits) => {
+    const { spawn } = record(output);
+
+    expect((await runCopilot("p", angle, options, spawn)).credits).toBe(credits);
+  });
+
+  test("carries the child's failure back so a broken run is not read as a clean review", async () => {
+    const { spawn } = record("boom", 1);
+
+    expect((await runCopilot("p", angle, options, spawn)).exitCode).toBe(1);
   });
 });

--- a/plugins/github/skills/copilot/scripts/review.ts
+++ b/plugins/github/skills/copilot/scripts/review.ts
@@ -37,13 +37,9 @@ const DEGRADE_BELOW = 150;
 // The plan grants 1500/month and resets on the 1st, so this is the nominal daily allowance that `pace` is judged against.
 const NOMINAL_DAILY = 1500 / 31;
 
-// Copilot takes the prompt as an argv value, so the cap has to stay clear of ARG_MAX
-// as well as of the plan's credit budget. The budget is the tighter of the two.
+// The prompt reaches Copilot on stdin, so the only thing this cap governs is spend: a bigger
+// prompt is more input tokens against a fixed plan budget. --force is what lifts it.
 const DEFAULT_MAX_BYTES = 120_000;
-
-// --force lifts the budget guard, not the operating-system one. Past this the spawn fails
-// with E2BIG and no review runs at all, so refuse with an explanation instead.
-const ABSOLUTE_MAX_BYTES = 400_000;
 
 const DIM = "\x1b[2m";
 const RED = "\x1b[31m";
@@ -474,11 +470,14 @@ interface RunOptions {
  * --no-custom-instructions keeps the repo's own instructions out of the review, and memory
  * is off in prompt mode, so a shared home carries session history and nothing else.
  *
+ * No -p: omitting it is what makes Copilot read the prompt from stdin, which is the same
+ * non-interactive mode with no ceiling on how much prompt fits.
+ *
  * A one-shot run enables no tools and sits outside the repo, so it is one turn against
  * inlined text and Copilot never fans out. An agentic run trades that for a capped session
  * inside a throwaway checkout.
  */
-export function copilotArgs(prompt: string, options: RunOptions): string[] {
+export function copilotArgs(options: RunOptions): string[] {
   return [
     "copilot",
     "--model",
@@ -491,20 +490,33 @@ export function copilotArgs(prompt: string, options: RunOptions): string[] {
     "--no-ask-user",
     "--no-custom-instructions",
     ...(options.agentic ? AGENTIC_TOOL_ARGS : []),
-    "-p",
-    prompt,
   ];
 }
 
-async function runCopilot(prompt: string, angle: Angle, options: RunOptions): Promise<Result> {
-  const args = copilotArgs(prompt, options);
+export interface Spawned {
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+  exited: Promise<number>;
+}
 
-  const child = Bun.spawn(args, {
-    cwd: options.cwd,
+export type Spawn = (args: string[], stdin: Uint8Array, cwd: string) => Spawned;
+
+const spawnCopilot: Spawn = (args, stdin, cwd) =>
+  Bun.spawn(args, {
+    cwd,
     env: { ...process.env, HOME: COPILOT_HOME },
+    stdin,
     stdout: "pipe",
     stderr: "pipe",
   });
+
+export async function runCopilot(
+  prompt: string,
+  angle: Angle,
+  options: RunOptions,
+  spawn: Spawn = spawnCopilot,
+): Promise<Result> {
+  const child = spawn(copilotArgs(options), Buffer.from(prompt, "utf8"), options.cwd);
 
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(child.stdout).text(),
@@ -782,15 +794,6 @@ async function main(): Promise<void> {
       console.log(prompt);
     }
     return;
-  }
-
-  if (largest > ABSOLUTE_MAX_BYTES) {
-    console.error("");
-    console.error(
-      `${RED}Refusing: largest prompt is ${largest.toLocaleString()} bytes, past the ${ABSOLUTE_MAX_BYTES.toLocaleString()} argv ceiling that --force cannot lift.${RESET}`,
-    );
-    console.error(`${YELLOW}Narrow the diff with --base.${RESET}`);
-    process.exit(1);
   }
 
   if (largest > maxBytes && !argv.flags.force) {


### PR DESCRIPTION
Reviewing a stacked change hit the argv ceiling: the full diff assembled a 505 KB prompt against a 400 KB refusal that `--force` could not lift, and even the code-only diff needed `--max-bytes 330000` to get through. The prompt reached the Copilot CLI as a `-p` argument, so `ARG_MAX` capped how much change could be reviewed at once.

Omitting `-p` makes the CLI read the prompt from stdin instead. That removes the ceiling rather than shedding content to stay under it, so the alternatives (dropping inlined file bodies past a threshold, per-layer base ranges, agentic mode) are unnecessary.

Verified against the CLI (1.0.80) with a BYOK provider pointed at a local server that captured request bodies, which costs no credits:

- Piping a prompt with no `-p` sends it as the prompt. With `-p` present the CLI ignores stdin, and `-p -` treats `-` as literal prompt text.
- A 648 KB prompt arrived whole, both ends intact, in a 704 KB request body.
- stdin mode is the same non-interactive mode. `--attachment` rejected a file on type rather than on its non-interactive-only restriction, and `--allow-all-tools`, the `--deny-tool` list, `--max-ai-credits`, and `--no-ask-user` all parse and apply.
- The stats footer is identical, so the `AI Credits` parse that reports spend still matches. A real luna run on this diff confirmed it end to end, reporting 1.05 credits.

The 120 KB `--max-bytes` cap stays exactly as it was, now governing only spend, and `--force` still governs it. A 5.6 MB prompt assembles and is refused by that guard, not by an OS limit. The credit meter gate is untouched.

`copilotArgs` no longer takes the prompt, and `runCopilot` takes an injectable spawn so tests can assert the prompt reaches stdin and never argv. Added coverage for the credit parse and the child's exit code, neither of which had any.
