### PR TITLE
writing: rank corpus contrasts by log-odds

### DIFF
--- a/plugins/writing/detection/tropes.ts
+++ b/plugins/writing/detection/tropes.ts
@@ -1273,18 +1273,34 @@ export function scan(text: string, filePath?: string, context?: ScanContext): Pa
   return scanIntroduced(text, "", filePath, context);
 }
 
+// The batch analyze surface audits every pattern, skillOnly included. The hook
+// path through scan() skips them.
+export function scanAudit(text: string): PatternMatch[] {
+  return collectMatches(text, "", undefined, undefined, true);
+}
+
 export function scanIntroduced(
   newText: string,
   oldText: string,
   filePath?: string,
   context?: ScanContext,
 ): PatternMatch[] {
+  return collectMatches(newText, oldText, filePath, context, false);
+}
+
+function collectMatches(
+  newText: string,
+  oldText: string,
+  filePath: string | undefined,
+  context: ScanContext | undefined,
+  includeSkillOnly: boolean,
+): PatternMatch[] {
   const newStripped = stripCode(newText);
   const oldStripped = stripCode(oldText);
   const matches: PatternMatch[] = [];
 
   for (const def of PATTERNS) {
-    if (def.skillOnly) continue;
+    if (def.skillOnly && !includeSkillOnly) continue;
     if (def.fileOnly && filePath != null && filePath !== "" && !isProseFile(filePath)) continue;
     if (def.sideEffectOnly && context === "file") continue;
 

--- a/plugins/writing/detection/wordlists.ts
+++ b/plugins/writing/detection/wordlists.ts
@@ -25,7 +25,7 @@ export function countWords(text: string): number {
   return text.match(WORD_TOKEN)?.length ?? 0;
 }
 
-function parseLines(content: string): string[] {
+export function parseLines(content: string): string[] {
   const lines: string[] = [];
   for (const raw of content.split(/\r?\n/)) {
     if (COMMENT_OR_BLANK.test(raw)) continue;
@@ -170,7 +170,7 @@ export function weightedStemHits(text: string, entries: StemmedWeight[]): Weight
 
 const WORDLISTS_DIR = join(import.meta.dirname, "..", "wordlists");
 
-async function readWordlist(name: string): Promise<string> {
+export async function readWordlist(name: string): Promise<string> {
   return Bun.file(join(WORDLISTS_DIR, name)).text();
 }
 

--- a/plugins/writing/skills/analyze/SKILL.md
+++ b/plugins/writing/skills/analyze/SKILL.md
@@ -78,6 +78,19 @@ bun ${CLAUDE_SKILL_DIR}/scripts/judge-run.ts headings tmp/heading-labels.tsv
 
 See the "Meaning-Layer Judge" section of [references/methodology.md](references/methodology.md) for the rubric, prompt versioning, gate, and calibration protocol.
 
+## Detector Coverage
+
+`wordlist-overlap.ts` ranks agent-authored prose (corpus A) against the pre-agent voice baseline (corpus B) by log-odds with an informative Dirichlet prior, then measures how much of that ranking the shipped detectors already cover. It reports both directions: discovered terms a detector matches, and curated entries the ranking independently places.
+
+```bash
+bun ${CLAUDE_SKILL_DIR}/scripts/wordlist-overlap.ts
+bun ${CLAUDE_SKILL_DIR}/scripts/wordlist-overlap.ts --baseline github-issues.txt --sizes 1 --sizes 2
+```
+
+Corpora A and B must match register. Contrasting mismatched genres raises the split-half null floor far above any real term and makes the ranking uninterpretable. Every run prints that floor, which is the z a finding has to clear.
+
+`--json` omits the example sentences the human-readable report already withholds, so no corpus prose reaches a file.
+
 ## Hook Health
 
 The PreToolUse dispatcher (`hooks/pretooluse.ts`) appends one JSONL line per run to `~/.claude/writing-hooks/log.jsonl` (controlled by `WRITING_HOOKS_LOG`, see the plugin README). That log is the runtime half of this skill's audit: the wordlist analysis judges rule precision from session history, and the health check judges hook behavior from what the dispatcher actually did.

--- a/plugins/writing/skills/analyze/scripts/fightin-words.test.ts
+++ b/plugins/writing/skills/analyze/scripts/fightin-words.test.ts
@@ -69,6 +69,12 @@ describe("fightinWords", () => {
     expect(rows.map((row) => row.term)).toEqual(["present"]);
   });
 
+  test.each([0, -1, Number.NaN])("a prior of %p is rejected", (prior) => {
+    expect(() =>
+      fightinWords({ a: counts({ x: 1 }), b: counts({}), totalA: 10, totalB: 10, prior }),
+    ).toThrow(/positive/);
+  });
+
   test("empty corpora yield no rows", () => {
     expect(
       fightinWords({ a: counts({}), b: counts({}), totalA: 0, totalB: 0, prior: 500 }),
@@ -95,6 +101,21 @@ describe("fightinWords", () => {
 });
 
 describe("tokenizeCorpus", () => {
+  // Monroe's alpha sums to alpha-0 only when the corpus size is the count of
+  // the feature being analyzed. A corpus holds one fewer bigram per sentence
+  // than it holds tokens.
+  test("counts each n-gram size separately from the token count", () => {
+    const corpus = tokenizeCorpus("one two three. four five.", [1, 2, 3]);
+    expect(corpus.tokens).toBe(5);
+    expect(corpus.totals.get(1)).toBe(5);
+    expect(corpus.totals.get(2)).toBe(3);
+    expect(corpus.totals.get(3)).toBe(1);
+  });
+
+  test("a size longer than every sentence contributes no features", () => {
+    expect(tokenizeCorpus("one two.", [5]).totals.get(5)).toBe(0);
+  });
+
   test("counts unigrams and bigrams and keeps the shortest example", () => {
     const corpus = tokenizeCorpus(
       "The load bearing part. This is the load bearing part again.",
@@ -141,6 +162,24 @@ describe("rank", () => {
     const zs = ranked.map((row) => row.z);
     expect(zs).toEqual(zs.toSorted((left, right) => right - left));
     expect(new Set(ranked.map((row) => row.n))).toEqual(new Set([1, 2]));
+  });
+
+  test("scores each size against its own feature total", () => {
+    const text = "alpha beta. alpha beta. alpha beta.";
+    const corpus = tokenizeCorpus(text, [2]);
+    const [row] = rank(corpus, tokenizeCorpus("gamma delta.", [2]), {
+      sizes: [2],
+      prior: 100,
+      minCount: 1,
+    });
+    const direct = fightinWords({
+      a: corpus.ngrams.get(2) ?? new Map(),
+      b: tokenizeCorpus("gamma delta.", [2]).ngrams.get(2) ?? new Map(),
+      totalA: corpus.totals.get(2) ?? 0,
+      totalB: 1,
+      prior: 100,
+    })[0];
+    expect(row?.z).toBeCloseTo(direct?.z ?? 0, 12);
   });
 
   test("carries an example sentence for each ranked term", () => {

--- a/plugins/writing/skills/analyze/scripts/fightin-words.test.ts
+++ b/plugins/writing/skills/analyze/scripts/fightin-words.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { fightinWords, rank, stemTerm, tokenizeCorpus } from "./fightin-words";
+import type { VoiceDocument } from "./voice-corpus";
 
 function counts(entries: Record<string, number>): Map<string, number> {
   return new Map(Object.entries(entries));
+}
+
+// One sentence per document unless a test needs the spread to differ.
+function docs(...bodies: string[]): VoiceDocument[] {
+  return bodies.map((body, index) => ({ source: `doc-${index}`, meta: "", body }));
 }
 
 describe("fightinWords", () => {
@@ -101,34 +107,29 @@ describe("fightinWords", () => {
 });
 
 describe("tokenizeCorpus", () => {
-  // Monroe's alpha sums to alpha-0 only when the corpus size is the count of
-  // the feature being analyzed. A corpus holds one fewer bigram per sentence
-  // than it holds tokens.
-  test("counts each n-gram size separately from the token count", () => {
-    const corpus = tokenizeCorpus("one two three. four five.", [1, 2, 3]);
-    expect(corpus.tokens).toBe(5);
-    expect(corpus.totals.get(1)).toBe(5);
-    expect(corpus.totals.get(2)).toBe(3);
-    expect(corpus.totals.get(3)).toBe(1);
-  });
-
-  test("a size longer than every sentence contributes no features", () => {
-    expect(tokenizeCorpus("one two.", [5]).totals.get(5)).toBe(0);
-  });
-
-  test("counts unigrams and bigrams and keeps the shortest example", () => {
+  test("counts each n-gram size and keeps the shortest example", () => {
     const corpus = tokenizeCorpus(
-      "The load bearing part. This is the load bearing part again.",
+      docs("The load bearing part. This is the load bearing part again."),
       [1, 2],
     );
+    expect(corpus.tokens).toBe(11);
     expect(corpus.ngrams.get(1)?.get("load")).toBe(2);
     expect(corpus.ngrams.get(2)?.get("load bearing")).toBe(2);
     expect(corpus.examples.get("load bearing")).toBe("The load bearing part");
   });
 
+  test("counts the documents a term appears in, not its occurrences", () => {
+    const corpus = tokenizeCorpus(
+      docs("Worth noting. Worth noting again.", "Worth noting here."),
+      [2],
+    );
+    expect(corpus.ngrams.get(2)?.get("worth noting")).toBe(3);
+    expect(corpus.spread.get("worth noting")).toBe(2);
+  });
+
   test("strips code, paths, and identifiers before counting", () => {
     const corpus = tokenizeCorpus(
-      "Consider `someCall()` on src/lib/thing.ts with --dry-run and snake_case names.",
+      docs("Consider `someCall()` on src/lib/thing.ts with --dry-run and snake_case names."),
       [1],
     );
     const unigrams = corpus.ngrams.get(1) ?? new Map();
@@ -139,53 +140,74 @@ describe("tokenizeCorpus", () => {
   });
 
   test("sentences do not bleed n-grams across boundaries", () => {
-    const corpus = tokenizeCorpus("First alpha. Beta second.", [2]);
-    expect(corpus.ngrams.get(2)?.has("alpha beta")).toBe(false);
+    expect(
+      tokenizeCorpus(docs("First alpha. Beta second."), [2]).ngrams.get(2)?.has("alpha beta"),
+    ).toBe(false);
+  });
+
+  test("documents do not bleed n-grams into each other", () => {
+    expect(
+      tokenizeCorpus(docs("First alpha", "Beta second"), [2]).ngrams.get(2)?.has("alpha beta"),
+    ).toBe(false);
+  });
+
+  test.each([0, -1, 1.5])("an n-gram size of %p is rejected", (size) => {
+    expect(() => tokenizeCorpus(docs("one two three."), [size])).toThrow(/positive integer/);
   });
 });
 
 describe("rank", () => {
   const a = tokenizeCorpus(
-    "Worth noting the tradeoff. Worth noting the risk. Worth noting.",
+    docs("Worth noting the tradeoff.", "Worth noting the risk.", "Worth noting."),
     [1, 2],
   );
-  const b = tokenizeCorpus("The tradeoff is fine. The risk is fine. Fine either way.", [1, 2]);
+  const b = tokenizeCorpus(
+    docs("The tradeoff is fine.", "The risk is fine.", "Fine either way."),
+    [1, 2],
+  );
+  const options = { sizes: [1, 2], prior: 100, minCount: 1, minDocs: 1 };
 
   test("drops terms below the minimum count in A", () => {
-    const kept = rank(a, b, { sizes: [1, 2], prior: 100, minCount: 3 });
+    const kept = rank(a, b, { ...options, minCount: 3 });
     expect(kept.every((row) => row.countA >= 3)).toBe(true);
     expect(kept.some((row) => row.term === "worth noting")).toBe(true);
   });
 
+  // A term confined to one document is that document's quirk, not a habit.
+  test("drops terms confined to fewer documents than the minimum", () => {
+    const kept = rank(a, b, { ...options, minDocs: 3 });
+    expect(kept.every((row) => row.docs >= 3)).toBe(true);
+    expect(kept.some((row) => row.term === "tradeoff")).toBe(false);
+    expect(kept.some((row) => row.term === "worth noting")).toBe(true);
+  });
+
   test("interleaves n-gram sizes into one ordering by z", () => {
-    const ranked = rank(a, b, { sizes: [1, 2], prior: 100, minCount: 1 });
+    const ranked = rank(a, b, options);
     const zs = ranked.map((row) => row.z);
     expect(zs).toEqual(zs.toSorted((left, right) => right - left));
     expect(new Set(ranked.map((row) => row.n))).toEqual(new Set([1, 2]));
   });
 
-  test("scores each size against its own feature total", () => {
-    const text = "alpha beta. alpha beta. alpha beta.";
-    const corpus = tokenizeCorpus(text, [2]);
-    const [row] = rank(corpus, tokenizeCorpus("gamma delta.", [2]), {
-      sizes: [2],
-      prior: 100,
-      minCount: 1,
-    });
+  // Monroe's alpha sums to alpha-0 only against the count of the feature being
+  // analyzed, and a corpus holds fewer bigrams than tokens.
+  test("scores each size against its own feature total, not the token count", () => {
+    const study = tokenizeCorpus(docs("alpha beta.", "alpha beta.", "alpha beta."), [2]);
+    const reference = tokenizeCorpus(docs("gamma delta."), [2]);
+    const [row] = rank(study, reference, { sizes: [2], prior: 100, minCount: 1, minDocs: 1 });
     const direct = fightinWords({
-      a: corpus.ngrams.get(2) ?? new Map(),
-      b: tokenizeCorpus("gamma delta.", [2]).ngrams.get(2) ?? new Map(),
-      totalA: corpus.totals.get(2) ?? 0,
+      a: study.ngrams.get(2) ?? new Map(),
+      b: reference.ngrams.get(2) ?? new Map(),
+      totalA: 3,
       totalB: 1,
       prior: 100,
     })[0];
+    expect(study.tokens).toBe(6);
     expect(row?.z).toBeCloseTo(direct?.z ?? 0, 12);
   });
 
   test("carries an example sentence for each ranked term", () => {
-    const ranked = rank(a, b, { sizes: [2], prior: 100, minCount: 3 });
-    const noting = ranked.find((row) => row.term === "worth noting");
-    expect(noting?.example).toContain("Worth noting");
+    const ranked = rank(a, b, { ...options, sizes: [2], minCount: 3 });
+    expect(ranked.find((row) => row.term === "worth noting")?.example).toContain("Worth noting");
   });
 });
 

--- a/plugins/writing/skills/analyze/scripts/fightin-words.test.ts
+++ b/plugins/writing/skills/analyze/scripts/fightin-words.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test";
+import { fightinWords, rank, stemTerm, tokenizeCorpus } from "./fightin-words";
+
+function counts(entries: Record<string, number>): Map<string, number> {
+  return new Map(Object.entries(entries));
+}
+
+describe("fightinWords", () => {
+  test("ranks the term concentrated in A above the term split evenly", () => {
+    const rows = fightinWords({
+      a: counts({ skewed: 200, even: 200 }),
+      b: counts({ skewed: 2, even: 200 }),
+      totalA: 10_000,
+      totalB: 10_000,
+      prior: 500,
+    });
+    expect(rows[0]?.term).toBe("skewed");
+    expect(rows[0]?.z).toBeGreaterThan(0);
+  });
+
+  test("orders A-heavy terms above B-heavy terms by sign of delta", () => {
+    const rows = fightinWords({
+      a: counts({ ours: 300, theirs: 5 }),
+      b: counts({ ours: 5, theirs: 300 }),
+      totalA: 10_000,
+      totalB: 10_000,
+      prior: 500,
+    });
+    expect(rows.map((row) => row.term)).toEqual(["ours", "theirs"]);
+    expect(rows[0]?.delta).toBeGreaterThan(0);
+    expect(rows[1]?.delta).toBeGreaterThan(rows[1]?.z ?? 0);
+  });
+
+  // The variance adjustment exists for this case: equal rate ratios, unequal
+  // evidence.
+  test("a frequent term outranks a rare term at the same rate ratio", () => {
+    const rows = fightinWords({
+      a: counts({ rare: 3, frequent: 300 }),
+      b: counts({ rare: 0, frequent: 0 }),
+      totalA: 100_000,
+      totalB: 100_000,
+      prior: 500,
+    });
+    const rare = rows.find((row) => row.term === "rare");
+    const frequent = rows.find((row) => row.term === "frequent");
+    expect(frequent?.z).toBeGreaterThan(rare?.z ?? 0);
+  });
+
+  test("a larger prior pulls a rare term further toward the pooled rate", () => {
+    const input = {
+      a: counts({ rare: 4 }),
+      b: counts({ rare: 0 }),
+      totalA: 50_000,
+      totalB: 50_000,
+    };
+    const weak = fightinWords({ ...input, prior: 10 })[0];
+    const strong = fightinWords({ ...input, prior: 5_000 })[0];
+    expect(strong?.delta).toBeLessThan(weak?.delta ?? 0);
+  });
+
+  test("a term present in neither corpus never appears", () => {
+    const rows = fightinWords({
+      a: counts({ present: 5 }),
+      b: counts({}),
+      totalA: 1_000,
+      totalB: 1_000,
+      prior: 100,
+    });
+    expect(rows.map((row) => row.term)).toEqual(["present"]);
+  });
+
+  test("empty corpora yield no rows", () => {
+    expect(
+      fightinWords({ a: counts({}), b: counts({}), totalA: 0, totalB: 0, prior: 500 }),
+    ).toEqual([]);
+  });
+
+  test("symmetric corpora produce mirrored deltas", () => {
+    const forward = fightinWords({
+      a: counts({ word: 50 }),
+      b: counts({ word: 10 }),
+      totalA: 5_000,
+      totalB: 5_000,
+      prior: 500,
+    })[0];
+    const reverse = fightinWords({
+      a: counts({ word: 10 }),
+      b: counts({ word: 50 }),
+      totalA: 5_000,
+      totalB: 5_000,
+      prior: 500,
+    })[0];
+    expect(forward?.delta).toBeCloseTo(-(reverse?.delta ?? 0), 10);
+  });
+});
+
+describe("tokenizeCorpus", () => {
+  test("counts unigrams and bigrams and keeps the shortest example", () => {
+    const corpus = tokenizeCorpus(
+      "The load bearing part. This is the load bearing part again.",
+      [1, 2],
+    );
+    expect(corpus.ngrams.get(1)?.get("load")).toBe(2);
+    expect(corpus.ngrams.get(2)?.get("load bearing")).toBe(2);
+    expect(corpus.examples.get("load bearing")).toBe("The load bearing part");
+  });
+
+  test("strips code, paths, and identifiers before counting", () => {
+    const corpus = tokenizeCorpus(
+      "Consider `someCall()` on src/lib/thing.ts with --dry-run and snake_case names.",
+      [1],
+    );
+    const unigrams = corpus.ngrams.get(1) ?? new Map();
+    for (const noise of ["somecall", "src", "ts", "dry", "run", "snake", "case"]) {
+      expect(unigrams.has(noise)).toBe(false);
+    }
+    expect(unigrams.has("names")).toBe(true);
+  });
+
+  test("sentences do not bleed n-grams across boundaries", () => {
+    const corpus = tokenizeCorpus("First alpha. Beta second.", [2]);
+    expect(corpus.ngrams.get(2)?.has("alpha beta")).toBe(false);
+  });
+});
+
+describe("rank", () => {
+  const a = tokenizeCorpus(
+    "Worth noting the tradeoff. Worth noting the risk. Worth noting.",
+    [1, 2],
+  );
+  const b = tokenizeCorpus("The tradeoff is fine. The risk is fine. Fine either way.", [1, 2]);
+
+  test("drops terms below the minimum count in A", () => {
+    const kept = rank(a, b, { sizes: [1, 2], prior: 100, minCount: 3 });
+    expect(kept.every((row) => row.countA >= 3)).toBe(true);
+    expect(kept.some((row) => row.term === "worth noting")).toBe(true);
+  });
+
+  test("interleaves n-gram sizes into one ordering by z", () => {
+    const ranked = rank(a, b, { sizes: [1, 2], prior: 100, minCount: 1 });
+    const zs = ranked.map((row) => row.z);
+    expect(zs).toEqual(zs.toSorted((left, right) => right - left));
+    expect(new Set(ranked.map((row) => row.n))).toEqual(new Set([1, 2]));
+  });
+
+  test("carries an example sentence for each ranked term", () => {
+    const ranked = rank(a, b, { sizes: [2], prior: 100, minCount: 3 });
+    const noting = ranked.find((row) => row.term === "worth noting");
+    expect(noting?.example).toContain("Worth noting");
+  });
+});
+
+describe("stemTerm", () => {
+  test.each([
+    ["delves", "delv"],
+    ["load bearing", "load bear"],
+    ["Worth Noting", "worth note"],
+  ])("%s stems to %s", (term, expected) => {
+    expect(stemTerm(term)).toBe(expected);
+  });
+
+  test("an inflected form and its base share a stem", () => {
+    expect(stemTerm("leveraged")).toBe(stemTerm("leverage"));
+  });
+});

--- a/plugins/writing/skills/analyze/scripts/fightin-words.ts
+++ b/plugins/writing/skills/analyze/scripts/fightin-words.ts
@@ -4,7 +4,8 @@
 // Identifying the Content of Political Conflict", section 3.5.
 
 import { stemmer } from "stemmer";
-import { addNgrams, cleanText, type NGramCounts, splitSentences, tokenizeSentence } from "./ngram";
+import { type NGramCounts, processRows } from "./ngram";
+import type { VoiceDocument } from "./voice-corpus";
 
 export interface FightinWordsInput {
   /** Term counts for the corpus under study. */
@@ -67,42 +68,39 @@ export function fightinWords({
 export interface TokenizedCorpus {
   tokens: number;
   ngrams: Map<number, NGramCounts>;
-  /** Feature count per n-gram size. A corpus holds fewer bigrams than tokens. */
-  totals: Map<number, number>;
+  /** Documents each term appears in. A term confined to one is an artifact. */
+  spread: Map<string, number>;
   /** Shortest sentence each term was seen in, for eyeballing what a term means. */
   examples: Map<string, string>;
 }
 
-// cleanText drops code, paths, and identifiers, which otherwise dominate any
-// contrast drawn over engineering prose.
-export function tokenizeCorpus(text: string, sizes: number[]): TokenizedCorpus {
-  const corpus: TokenizedCorpus = {
-    tokens: 0,
-    ngrams: new Map(sizes.map((n) => [n, new Map<string, number>()])),
-    totals: new Map(sizes.map((n) => [n, 0])),
-    examples: new Map(),
-  };
-
-  for (const sentence of splitSentences(cleanText(text))) {
-    const tokens = tokenizeSentence(sentence);
-    if (tokens.length === 0) continue;
-    corpus.tokens += tokens.length;
-    for (const n of sizes) {
-      const counts = corpus.ngrams.get(n);
-      if (!counts) continue;
-      addNgrams(counts, tokens, n);
-      corpus.totals.set(n, (corpus.totals.get(n) ?? 0) + Math.max(0, tokens.length - n + 1));
-      for (let i = 0; i <= tokens.length - n; i++) {
-        const key = tokens.slice(i, i + n).join(" ");
-        const seen = corpus.examples.get(key);
-        if (seen === undefined || sentence.length < seen.length) {
-          corpus.examples.set(key, sentence);
-        }
-      }
+function assertSizes(sizes: number[]): void {
+  for (const n of sizes) {
+    if (!Number.isInteger(n) || n < 1) {
+      throw new Error(`n-gram size must be a positive integer, got ${n}`);
     }
   }
+}
 
-  return corpus;
+// Counting per document rather than over one joined string keeps the spread,
+// which is what separates a habit from one document's quirk.
+export function tokenizeCorpus(docs: VoiceDocument[], sizes: number[]): TokenizedCorpus {
+  assertSizes(sizes);
+  const examples = new Map<string, string>();
+  const { stats, sessionSpread } = processRows(
+    docs.map((doc) => ({ session_id: doc.source, text: doc.body })),
+    sizes,
+    { examples },
+  );
+  return { tokens: stats.tokens, ngrams: stats.ngrams, spread: sessionSpread, examples };
+}
+
+// Monroe's alpha sums to alpha-0 only against the count of the feature being
+// analyzed, and a corpus holds fewer bigrams than tokens.
+function featureTotal(counts: NGramCounts | undefined): number {
+  let total = 0;
+  for (const count of counts?.values() ?? []) total += count;
+  return total;
 }
 
 // Stem as the detection wordlists do, so "delves" and "delve" are one entry.
@@ -119,10 +117,13 @@ export interface RankOptions {
   prior: number;
   /** Drop terms seen fewer times than this in A. Guards against hapax noise. */
   minCount: number;
+  /** Drop terms confined to fewer than this many documents of A. */
+  minDocs: number;
 }
 
 export interface RankedTerm extends FightinWordsRow {
   n: number;
+  docs: number;
   example: string;
 }
 
@@ -132,13 +133,15 @@ export function rank(a: TokenizedCorpus, b: TokenizedCorpus, options: RankOption
     const rows = fightinWords({
       a: a.ngrams.get(n) ?? new Map(),
       b: b.ngrams.get(n) ?? new Map(),
-      totalA: a.totals.get(n) ?? 0,
-      totalB: b.totals.get(n) ?? 0,
+      totalA: featureTotal(a.ngrams.get(n)),
+      totalB: featureTotal(b.ngrams.get(n)),
       prior: options.prior,
     });
     for (const row of rows) {
       if (row.countA < options.minCount) continue;
-      ranked.push({ ...row, n, example: a.examples.get(row.term) ?? "" });
+      const docs = a.spread.get(row.term) ?? 0;
+      if (docs < options.minDocs) continue;
+      ranked.push({ ...row, n, docs, example: a.examples.get(row.term) ?? "" });
     }
   }
   ranked.sort((left, right) => right.z - left.z);

--- a/plugins/writing/skills/analyze/scripts/fightin-words.ts
+++ b/plugins/writing/skills/analyze/scripts/fightin-words.ts
@@ -36,6 +36,9 @@ export function fightinWords({
   totalB,
   prior,
 }: FightinWordsInput): FightinWordsRow[] {
+  if (!Number.isFinite(prior) || prior <= 0) {
+    throw new Error(`prior must be a positive number, got ${prior}`);
+  }
   const background = totalA + totalB;
   if (background === 0) return [];
 
@@ -64,6 +67,8 @@ export function fightinWords({
 export interface TokenizedCorpus {
   tokens: number;
   ngrams: Map<number, NGramCounts>;
+  /** Feature count per n-gram size. A corpus holds fewer bigrams than tokens. */
+  totals: Map<number, number>;
   /** Shortest sentence each term was seen in, for eyeballing what a term means. */
   examples: Map<string, string>;
 }
@@ -74,6 +79,7 @@ export function tokenizeCorpus(text: string, sizes: number[]): TokenizedCorpus {
   const corpus: TokenizedCorpus = {
     tokens: 0,
     ngrams: new Map(sizes.map((n) => [n, new Map<string, number>()])),
+    totals: new Map(sizes.map((n) => [n, 0])),
     examples: new Map(),
   };
 
@@ -85,6 +91,7 @@ export function tokenizeCorpus(text: string, sizes: number[]): TokenizedCorpus {
       const counts = corpus.ngrams.get(n);
       if (!counts) continue;
       addNgrams(counts, tokens, n);
+      corpus.totals.set(n, (corpus.totals.get(n) ?? 0) + Math.max(0, tokens.length - n + 1));
       for (let i = 0; i <= tokens.length - n; i++) {
         const key = tokens.slice(i, i + n).join(" ");
         const seen = corpus.examples.get(key);
@@ -125,8 +132,8 @@ export function rank(a: TokenizedCorpus, b: TokenizedCorpus, options: RankOption
     const rows = fightinWords({
       a: a.ngrams.get(n) ?? new Map(),
       b: b.ngrams.get(n) ?? new Map(),
-      totalA: a.tokens,
-      totalB: b.tokens,
+      totalA: a.totals.get(n) ?? 0,
+      totalB: b.totals.get(n) ?? 0,
       prior: options.prior,
     });
     for (const row of rows) {

--- a/plugins/writing/skills/analyze/scripts/fightin-words.ts
+++ b/plugins/writing/skills/analyze/scripts/fightin-words.ts
@@ -1,0 +1,139 @@
+#!/usr/bin/env bun
+// Log-odds ratio with an informative Dirichlet prior. Monroe, Colaresi & Quinn
+// (2008), "Fightin' Words: Lexical Feature Selection and Evaluation for
+// Identifying the Content of Political Conflict", section 3.5.
+
+import { stemmer } from "stemmer";
+import { addNgrams, cleanText, type NGramCounts, splitSentences, tokenizeSentence } from "./ngram";
+
+export interface FightinWordsInput {
+  /** Term counts for the corpus under study. */
+  a: NGramCounts;
+  /** Term counts for the reference corpus. */
+  b: NGramCounts;
+  totalA: number;
+  totalB: number;
+  /** Dirichlet concentration (alpha-0). Monroe et al. use 500-1000. */
+  prior: number;
+}
+
+export interface FightinWordsRow {
+  term: string;
+  countA: number;
+  countB: number;
+  /** Difference of log-odds. Positive means overrepresented in A. */
+  delta: number;
+  /** delta divided by its standard deviation. The ranking statistic. */
+  z: number;
+}
+
+// Each term's prior is its pooled rate scaled to alpha-0, so the prior sums to
+// alpha-0 and pads both corpora by that same mass.
+export function fightinWords({
+  a,
+  b,
+  totalA,
+  totalB,
+  prior,
+}: FightinWordsInput): FightinWordsRow[] {
+  const background = totalA + totalB;
+  if (background === 0) return [];
+
+  const terms = new Set([...a.keys(), ...b.keys()]);
+  const nA = totalA + prior;
+  const nB = totalB + prior;
+
+  const rows: FightinWordsRow[] = [];
+  for (const term of terms) {
+    const countA = a.get(term) ?? 0;
+    const countB = b.get(term) ?? 0;
+    const alpha = (prior * (countA + countB)) / background;
+
+    const yA = countA + alpha;
+    const yB = countB + alpha;
+    const delta = Math.log(yA / (nA - yA)) - Math.log(yB / (nB - yB));
+    const variance = 1 / yA + 1 / yB;
+
+    rows.push({ term, countA, countB, delta, z: delta / Math.sqrt(variance) });
+  }
+
+  rows.sort((left, right) => right.z - left.z);
+  return rows;
+}
+
+export interface TokenizedCorpus {
+  tokens: number;
+  ngrams: Map<number, NGramCounts>;
+  /** Shortest sentence each term was seen in, for eyeballing what a term means. */
+  examples: Map<string, string>;
+}
+
+// cleanText drops code, paths, and identifiers, which otherwise dominate any
+// contrast drawn over engineering prose.
+export function tokenizeCorpus(text: string, sizes: number[]): TokenizedCorpus {
+  const corpus: TokenizedCorpus = {
+    tokens: 0,
+    ngrams: new Map(sizes.map((n) => [n, new Map<string, number>()])),
+    examples: new Map(),
+  };
+
+  for (const sentence of splitSentences(cleanText(text))) {
+    const tokens = tokenizeSentence(sentence);
+    if (tokens.length === 0) continue;
+    corpus.tokens += tokens.length;
+    for (const n of sizes) {
+      const counts = corpus.ngrams.get(n);
+      if (!counts) continue;
+      addNgrams(counts, tokens, n);
+      for (let i = 0; i <= tokens.length - n; i++) {
+        const key = tokens.slice(i, i + n).join(" ");
+        const seen = corpus.examples.get(key);
+        if (seen === undefined || sentence.length < seen.length) {
+          corpus.examples.set(key, sentence);
+        }
+      }
+    }
+  }
+
+  return corpus;
+}
+
+// Stem as the detection wordlists do, so "delves" and "delve" are one entry.
+export function stemTerm(term: string): string {
+  return term
+    .split(/\s+/)
+    .filter((word) => word.length > 0)
+    .map((word) => stemmer(word.toLowerCase()))
+    .join(" ");
+}
+
+export interface RankOptions {
+  sizes: number[];
+  prior: number;
+  /** Drop terms seen fewer times than this in A. Guards against hapax noise. */
+  minCount: number;
+}
+
+export interface RankedTerm extends FightinWordsRow {
+  n: number;
+  example: string;
+}
+
+export function rank(a: TokenizedCorpus, b: TokenizedCorpus, options: RankOptions): RankedTerm[] {
+  const ranked: RankedTerm[] = [];
+  for (const n of options.sizes) {
+    const rows = fightinWords({
+      a: a.ngrams.get(n) ?? new Map(),
+      b: b.ngrams.get(n) ?? new Map(),
+      totalA: a.tokens,
+      totalB: b.tokens,
+      prior: options.prior,
+    });
+    for (const row of rows) {
+      if (row.countA < options.minCount) continue;
+      ranked.push({ ...row, n, example: a.examples.get(row.term) ?? "" });
+    }
+  }
+  ranked.sort((left, right) => right.z - left.z);
+  return ranked;
+}

--- a/plugins/writing/skills/analyze/scripts/wordlist-overlap.test.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlist-overlap.test.ts
@@ -6,18 +6,29 @@ import {
   curatedEntries,
   type MeasuredTerm,
   recallOfCuratedEntries,
+  renderReport,
   splitHalves,
   summarize,
 } from "./wordlist-overlap";
 
 function makeTerm(overrides: Partial<RankedTerm> = {}): RankedTerm {
-  return { term: "term", countA: 10, countB: 1, delta: 1, z: 2, n: 1, example: "", ...overrides };
+  return {
+    term: "term",
+    countA: 10,
+    countB: 1,
+    delta: 1,
+    z: 2,
+    n: 1,
+    docs: 4,
+    example: "",
+    ...overrides,
+  };
 }
 
 function makeMeasured(coverage: Partial<MeasuredTerm["coverage"]> = {}): MeasuredTerm {
   return {
     row: makeTerm(),
-    coverage: { wordlist: false, lexical: false, sentence: false, categories: [], ...coverage },
+    coverage: { wordlist: false, lexical: false, categories: [], ...coverage },
   };
 }
 
@@ -26,23 +37,39 @@ function makeDoc(source: string): VoiceDocument {
 }
 
 describe("curatedEntries", () => {
-  test("skips comments and blank lines", () => {
-    expect(curatedEntries(["# a comment\n\ndelve\n  tapestry  \n"])).toEqual(["delve", "tapestry"]);
-  });
-
-  test("strips the trailing weight from a weighted list", () => {
-    expect(curatedEntries(["empower 2.5\ncleanly 1.5\n"])).toEqual(["empower", "cleanly"]);
-  });
-
-  test("keeps a multi-word phrase whole", () => {
-    expect(curatedEntries(["source of truth\nescape hatch\n"])).toEqual([
-      "source of truth",
-      "escape hatch",
-    ]);
-  });
-
-  test("concatenates every source list", () => {
-    expect(curatedEntries(["delve\n", "empower 2.5\n"])).toEqual(["delve", "empower"]);
+  test.each<{ name: string; plain: string[]; weighted: string[]; expected: string[] }>([
+    {
+      name: "skips comments and blank lines",
+      plain: ["# a comment\n\ndelve\n  tapestry  \n"],
+      weighted: [],
+      expected: ["delve", "tapestry"],
+    },
+    {
+      name: "strips the trailing weight from a weighted list",
+      plain: [],
+      weighted: ["empower 2.5\ncleanly 1.5\n"],
+      expected: ["empower", "cleanly"],
+    },
+    {
+      name: "keeps a trailing number in a plain list",
+      plain: ["web 3\n"],
+      weighted: [],
+      expected: ["web 3"],
+    },
+    {
+      name: "keeps a multi-word phrase whole",
+      plain: ["source of truth\nescape hatch\n"],
+      weighted: [],
+      expected: ["source of truth", "escape hatch"],
+    },
+    {
+      name: "concatenates every source list",
+      plain: ["delve\n"],
+      weighted: ["empower 2.5\n"],
+      expected: ["delve", "empower"],
+    },
+  ])("$name", ({ plain, weighted, expected }) => {
+    expect(curatedEntries(plain, weighted)).toEqual(expected);
   });
 });
 
@@ -62,25 +89,31 @@ describe("coverageOf", () => {
   });
 
   test("a sentence tripping a detector reports its category", () => {
-    const coverage = coverageOf("dig", "Let me dig into the failing test.");
-    expect(coverage.sentence).toBe(true);
-    expect(coverage.categories).toContain("dig into");
+    expect(coverageOf("dig", "Let me dig into the failing test.").categories).toContain("dig into");
+  });
+
+  // The hook skips skillOnly patterns; this batch surface exists to audit them.
+  test("a skill-only detector still counts as coverage", () => {
+    expect(coverageOf("rides", "The retry path rides on the same socket.").categories).toContain(
+      "rides on",
+    );
   });
 
   test("an empty example cannot trip a sentence-level detector", () => {
-    expect(coverageOf("the", "").sentence).toBe(false);
+    expect(coverageOf("the", "").categories).toEqual([]);
   });
 });
 
 describe("summarize", () => {
   test("counts each coverage kind independently", () => {
-    const summary = summarize([
-      makeMeasured({ wordlist: true, lexical: true, sentence: true }),
-      makeMeasured({ lexical: true, sentence: true }),
-      makeMeasured({ sentence: true }),
-      makeMeasured(),
-    ]);
-    expect(summary).toEqual({ considered: 4, wordlist: 1, lexical: 2, sentence: 3 });
+    expect(
+      summarize([
+        makeMeasured({ wordlist: true, lexical: true, categories: ["a"] }),
+        makeMeasured({ lexical: true, categories: ["a"] }),
+        makeMeasured({ categories: ["a"] }),
+        makeMeasured(),
+      ]),
+    ).toEqual({ considered: 4, wordlist: 1, lexical: 2, sentence: 3 });
   });
 
   test("an empty measurement is all zeroes", () => {
@@ -96,18 +129,27 @@ describe("recallOfCuratedEntries", () => {
   ];
 
   test("finds a curated entry through its stem", () => {
-    const [found] = recallOfCuratedEntries(["delve"], ranked, 3);
-    expect(found).toEqual({ entry: "delve", rankIndex: 0, z: 5 });
+    expect(recallOfCuratedEntries(["delve"], ranked, 3)[0]).toEqual({
+      entry: "delve",
+      rankIndex: 0,
+      z: 5,
+    });
   });
 
   test("reports an entry outside the cutoff as unplaced but keeps its score", () => {
-    const [found] = recallOfCuratedEntries(["robust"], ranked, 1);
-    expect(found).toEqual({ entry: "robust", rankIndex: null, z: 3 });
+    expect(recallOfCuratedEntries(["robust"], ranked, 1)[0]).toEqual({
+      entry: "robust",
+      rankIndex: null,
+      z: 3,
+    });
   });
 
   test("an entry absent from the ranking carries no score", () => {
-    const [found] = recallOfCuratedEntries(["tapestry"], ranked, 3);
-    expect(found).toEqual({ entry: "tapestry", rankIndex: null, z: null });
+    expect(recallOfCuratedEntries(["tapestry"], ranked, 3)[0]).toEqual({
+      entry: "tapestry",
+      rankIndex: null,
+      z: null,
+    });
   });
 
   test("keeps the highest-ranked occurrence when a stem repeats", () => {
@@ -134,11 +176,68 @@ describe("splitHalves", () => {
       body: "The parser reads the file and returns the tree.",
     }));
     const [left, right] = splitHalves(docs);
-    const ranked = rank(
-      tokenizeCorpus(left.map((doc) => doc.body).join("\n\n"), [1]),
-      tokenizeCorpus(right.map((doc) => doc.body).join("\n\n"), [1]),
-      { sizes: [1], prior: 500, minCount: 1 },
-    );
+    const ranked = rank(tokenizeCorpus(left, [1]), tokenizeCorpus(right, [1]), {
+      sizes: [1],
+      prior: 500,
+      minCount: 1,
+      minDocs: 1,
+    });
     expect(Math.abs(ranked[0]?.z ?? 0)).toBeLessThan(0.5);
+  });
+});
+
+describe("renderReport", () => {
+  test("formats the whole measurement", () => {
+    expect(
+      renderReport({
+        studyPath: "/data/contrast-baseline/claude-deliverables.txt",
+        studyDocs: 22,
+        studyTokens: 1234,
+        baselineNames: ["github-prs.txt"],
+        baselineDocs: 342,
+        baselineTokens: 5678,
+        prior: 500,
+        sizes: [1, 2],
+        minCount: 5,
+        minDocs: 3,
+        summary: { considered: 2, wordlist: 0, lexical: 1, sentence: 1 },
+        nullTop: [makeTerm({ term: "noise", z: 4.29 })],
+        recall: [
+          { entry: "delve", rankIndex: 12, z: 3.5 },
+          { entry: "tapestry", rankIndex: null, z: null },
+        ],
+        curatedPool: 140_000,
+        measured: [
+          {
+            row: makeTerm({ term: "worth noting", z: 12.3, countA: 40, countB: 2, docs: 18 }),
+            coverage: { wordlist: false, lexical: true, categories: ["hedging"] },
+          },
+          {
+            row: makeTerm({ term: "the", z: 1.1 }),
+            coverage: { wordlist: false, lexical: false, categories: [] },
+          },
+        ],
+        show: 2,
+      }),
+    ).toMatchInlineSnapshot(`
+      "corpus A  22 docs, 1,234 tokens  /data/contrast-baseline/claude-deliverables.txt
+      corpus B  342 docs, 5,678 tokens  github-prs.txt
+      prior 500  sizes 1,2  min-count 5  min-docs 3
+
+      top 2 discovered terms
+        matched by a curated wordlist entry     0 (0.0%)
+        matched by any vocabulary-layer rule    1 (50.0%)
+        example sentence trips any rule at all  1 (50.0%)
+
+      null control (corpus A split in half): max z=4.29, top terms noise
+
+      curated entries, ranked over 140,000 terms at min-count 1
+        delve                #13  z=3.50
+        tapestry             absent from corpus A
+
+      top 2 by z
+        1. -LS  z=  12.3  40/2 in 18 docs  worth noting
+        2. ---  z=   1.1  10/1 in 4 docs  the"
+    `);
   });
 });

--- a/plugins/writing/skills/analyze/scripts/wordlist-overlap.test.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlist-overlap.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import { rank, type RankedTerm, tokenizeCorpus } from "./fightin-words";
+import type { VoiceDocument } from "./voice-corpus";
+import {
+  coverageOf,
+  curatedEntries,
+  type MeasuredTerm,
+  recallOfCuratedEntries,
+  splitHalves,
+  summarize,
+} from "./wordlist-overlap";
+
+function makeTerm(overrides: Partial<RankedTerm> = {}): RankedTerm {
+  return { term: "term", countA: 10, countB: 1, delta: 1, z: 2, n: 1, example: "", ...overrides };
+}
+
+function makeMeasured(coverage: Partial<MeasuredTerm["coverage"]> = {}): MeasuredTerm {
+  return {
+    row: makeTerm(),
+    coverage: { wordlist: false, lexical: false, sentence: false, categories: [], ...coverage },
+  };
+}
+
+function makeDoc(source: string): VoiceDocument {
+  return { source, meta: "", body: `Body of ${source}.` };
+}
+
+describe("curatedEntries", () => {
+  test("skips comments and blank lines", () => {
+    expect(curatedEntries(["# a comment\n\ndelve\n  tapestry  \n"])).toEqual(["delve", "tapestry"]);
+  });
+
+  test("strips the trailing weight from a weighted list", () => {
+    expect(curatedEntries(["empower 2.5\ncleanly 1.5\n"])).toEqual(["empower", "cleanly"]);
+  });
+
+  test("keeps a multi-word phrase whole", () => {
+    expect(curatedEntries(["source of truth\nescape hatch\n"])).toEqual([
+      "source of truth",
+      "escape hatch",
+    ]);
+  });
+
+  test("concatenates every source list", () => {
+    expect(curatedEntries(["delve\n", "empower 2.5\n"])).toEqual(["delve", "empower"]);
+  });
+});
+
+describe("coverageOf", () => {
+  test("a curated vocabulary entry is reported as wordlist-covered", () => {
+    expect(coverageOf("delve", "").wordlist).toBe(true);
+  });
+
+  test("an inflected form of a curated entry still matches", () => {
+    expect(coverageOf("meticulously", "").wordlist).toBe(true);
+  });
+
+  test("an ordinary function word matches nothing", () => {
+    const coverage = coverageOf("the", "The change is in the parser.");
+    expect(coverage.wordlist).toBe(false);
+    expect(coverage.lexical).toBe(false);
+  });
+
+  test("a sentence tripping a detector reports its category", () => {
+    const coverage = coverageOf("dig", "Let me dig into the failing test.");
+    expect(coverage.sentence).toBe(true);
+    expect(coverage.categories).toContain("dig into");
+  });
+
+  test("an empty example cannot trip a sentence-level detector", () => {
+    expect(coverageOf("the", "").sentence).toBe(false);
+  });
+});
+
+describe("summarize", () => {
+  test("counts each coverage kind independently", () => {
+    const summary = summarize([
+      makeMeasured({ wordlist: true, lexical: true, sentence: true }),
+      makeMeasured({ lexical: true, sentence: true }),
+      makeMeasured({ sentence: true }),
+      makeMeasured(),
+    ]);
+    expect(summary).toEqual({ considered: 4, wordlist: 1, lexical: 2, sentence: 3 });
+  });
+
+  test("an empty measurement is all zeroes", () => {
+    expect(summarize([])).toEqual({ considered: 0, wordlist: 0, lexical: 0, sentence: 0 });
+  });
+});
+
+describe("recallOfCuratedEntries", () => {
+  const ranked = [
+    makeTerm({ term: "delves", z: 5 }),
+    makeTerm({ term: "robust", z: 3 }),
+    makeTerm({ term: "ordinary", z: 1 }),
+  ];
+
+  test("finds a curated entry through its stem", () => {
+    const [found] = recallOfCuratedEntries(["delve"], ranked, 3);
+    expect(found).toEqual({ entry: "delve", rankIndex: 0, z: 5 });
+  });
+
+  test("reports an entry outside the cutoff as unplaced but keeps its score", () => {
+    const [found] = recallOfCuratedEntries(["robust"], ranked, 1);
+    expect(found).toEqual({ entry: "robust", rankIndex: null, z: 3 });
+  });
+
+  test("an entry absent from the ranking carries no score", () => {
+    const [found] = recallOfCuratedEntries(["tapestry"], ranked, 3);
+    expect(found).toEqual({ entry: "tapestry", rankIndex: null, z: null });
+  });
+
+  test("keeps the highest-ranked occurrence when a stem repeats", () => {
+    const repeated = [makeTerm({ term: "delve", z: 9 }), makeTerm({ term: "delves", z: 2 })];
+    expect(recallOfCuratedEntries(["delving"], repeated, 2)[0]?.z).toBe(9);
+  });
+});
+
+describe("splitHalves", () => {
+  test("alternates documents so both halves span the corpus", () => {
+    const [left, right] = splitHalves(["a", "b", "c", "d", "e"].map(makeDoc));
+    expect(left.map((doc) => doc.source)).toEqual(["a", "c", "e"]);
+    expect(right.map((doc) => doc.source)).toEqual(["b", "d"]);
+  });
+
+  test("an empty corpus splits into two empty halves", () => {
+    expect(splitHalves([])).toEqual([[], []]);
+  });
+
+  test("a homogeneous corpus contrasted with itself stays near zero", () => {
+    const docs = Array.from({ length: 200 }, (_, index) => ({
+      source: `doc-${index}`,
+      meta: "",
+      body: "The parser reads the file and returns the tree.",
+    }));
+    const [left, right] = splitHalves(docs);
+    const ranked = rank(
+      tokenizeCorpus(left.map((doc) => doc.body).join("\n\n"), [1]),
+      tokenizeCorpus(right.map((doc) => doc.body).join("\n\n"), [1]),
+      { sizes: [1], prior: 500, minCount: 1 },
+    );
+    expect(Math.abs(ranked[0]?.z ?? 0)).toBeLessThan(0.5);
+  });
+});

--- a/plugins/writing/skills/analyze/scripts/wordlist-overlap.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlist-overlap.ts
@@ -4,23 +4,40 @@
 // ranking independently places.
 
 import { cli } from "cleye";
-import { stemmedPhraseHits, weightedStemHits, WORDLISTS } from "../../../detection/wordlists";
-import { type DetectorLayer, PATTERNS, scan } from "../../../detection/tropes";
-import { corpusPath, registerPaths, resolveDataDir, voiceBaselineDir } from "./data-dir";
+import {
+  type DetectorLayer,
+  PATTERNS,
+  scanAudit,
+  WEIGHTED_PATTERNS,
+} from "../../../detection/tropes";
+import {
+  parseLines,
+  readWordlist,
+  stemmedPhraseHits,
+  weightedStemHits,
+  WORDLISTS,
+} from "../../../detection/wordlists";
+import { contrastCorpusPath, registerPaths, resolveDataDir, voiceBaselineDir } from "./data-dir";
 import { rank, type RankedTerm, stemTerm, tokenizeCorpus } from "./fightin-words";
 import { parseCorpus, type VoiceDocument } from "./voice-corpus";
 
 const LAYER_BY_CATEGORY = new Map<string, DetectorLayer>(
-  PATTERNS.map((pattern) => [pattern.category, pattern.layer]),
+  [...PATTERNS, ...WEIGHTED_PATTERNS].map((pattern) => [pattern.category, pattern.layer]),
 );
+
+// Ranked terms are lowercased, while the openers list is compiled case-sensitive
+// for line-initial matching.
+const OPENERS_ANY_CASE =
+  WORDLISTS.openers === null || WORDLISTS.openers.flags.includes("i")
+    ? WORDLISTS.openers
+    : new RegExp(WORDLISTS.openers.source, `${WORDLISTS.openers.flags}i`);
 
 export interface Coverage {
   /** A curated wordlists/*.txt entry matches the term itself. */
   wordlist: boolean;
   /** Any vocabulary-layer detector fires on the term itself. */
   lexical: boolean;
-  /** Any detector at all fires on the sentence the term was discovered in. */
-  sentence: boolean;
+  /** Categories of every detector firing on the sentence the term came from. */
   categories: string[];
 }
 
@@ -29,21 +46,19 @@ function matchesWordlist(term: string): boolean {
   if (stemmedPhraseHits(term, WORDLISTS.floweryPhrases).count > 0) return true;
   if (weightedStemHits(term, WORDLISTS.marketingVerbs).totalWeight > 0) return true;
   if (weightedStemHits(term, WORDLISTS.softPhrasing).totalWeight > 0) return true;
-  const { openers } = WORDLISTS;
-  if (openers !== null) {
-    openers.lastIndex = 0;
-    if (openers.test(`${term},`)) return true;
+  if (OPENERS_ANY_CASE !== null) {
+    OPENERS_ANY_CASE.lastIndex = 0;
+    if (OPENERS_ANY_CASE.test(`${term},`)) return true;
   }
   return false;
 }
 
 export function coverageOf(term: string, example: string): Coverage {
-  const onTerm = scan(term);
-  const onSentence = example === "" ? [] : scan(example);
+  const onTerm = scanAudit(term);
+  const onSentence = example === "" ? [] : scanAudit(example);
   return {
     wordlist: matchesWordlist(term),
     lexical: onTerm.some((match) => LAYER_BY_CATEGORY.get(match.category) === "vocabulary"),
-    sentence: onSentence.length > 0,
     categories: [...new Set(onSentence.map((match) => match.category))],
   };
 }
@@ -65,8 +80,14 @@ export function summarize(rows: MeasuredTerm[]): OverlapSummary {
     considered: rows.length,
     wordlist: rows.filter((row) => row.coverage.wordlist).length,
     lexical: rows.filter((row) => row.coverage.lexical).length,
-    sentence: rows.filter((row) => row.coverage.sentence).length,
+    sentence: rows.filter((row) => row.coverage.categories.length > 0).length,
   };
+}
+
+export interface CuratedRecall {
+  entry: string;
+  rankIndex: number | null;
+  z: number | null;
 }
 
 // An entry the contrast scores near zero is one the corpus does not support.
@@ -74,7 +95,7 @@ export function recallOfCuratedEntries(
   curated: string[],
   ranked: RankedTerm[],
   topN: number,
-): { entry: string; rankIndex: number | null; z: number | null }[] {
+): CuratedRecall[] {
   const positions = new Map<string, { index: number; z: number }>();
   for (const [index, row] of ranked.entries()) {
     const stem = stemTerm(row.term);
@@ -89,30 +110,17 @@ export function recallOfCuratedEntries(
   });
 }
 
-const COMMENT_OR_BLANK = /^\s*(?:#|$)/;
+const WEIGHT_SUFFIX = /\s+[0-9]+(?:\.[0-9]+)?$/;
 
-export function curatedEntries(sources: string[]): string[] {
-  const entries: string[] = [];
-  for (const content of sources) {
-    for (const line of content.split(/\r?\n/)) {
-      if (COMMENT_OR_BLANK.test(line)) continue;
-      const trimmed = line.trim();
-      if (trimmed === "") continue;
-      // Weighted lists carry a trailing numeric weight.
-      entries.push(trimmed.replace(/\s+[0-9]+(?:\.[0-9]+)?$/, ""));
-    }
-  }
-  return entries;
+export function curatedEntries(plain: string[], weighted: string[]): string[] {
+  return [
+    ...plain.flatMap(parseLines),
+    ...weighted.flatMap(parseLines).map((line) => line.replace(WEIGHT_SUFFIX, "")),
+  ];
 }
 
-function select(docs: VoiceDocument[], sourceFilter: RegExp | null): VoiceDocument[] {
-  if (sourceFilter === null) return docs;
-  return docs.filter((doc) => sourceFilter.test(doc.source));
-}
-
-function bodies(docs: VoiceDocument[]): string {
-  return docs.map((doc) => doc.body).join("\n\n");
-}
+const PLAIN_LISTS = ["vocabulary.txt", "flowery-phrases.txt", "openers.txt"];
+const WEIGHTED_LISTS = ["marketing-verbs.txt", "soft-phrasing.txt"];
 
 // Alternate documents so both halves draw on the same sessions and dates.
 // Contrasting them gives the null: the largest z reachable with no difference to
@@ -127,12 +135,70 @@ export function splitHalves(docs: VoiceDocument[]): [VoiceDocument[], VoiceDocum
 }
 
 async function readCorpus(path: string): Promise<VoiceDocument[]> {
-  return parseCorpus(await Bun.file(path).text());
+  const file = Bun.file(path);
+  if (!(await file.exists())) throw new Error(`No corpus at ${path}`);
+  return parseCorpus(await file.text());
 }
 
 function pct(part: number, whole: number): string {
   if (whole === 0) return "0%";
   return `${((part / whole) * 100).toFixed(1)}%`;
+}
+
+export interface OverlapReport {
+  studyPath: string;
+  studyDocs: number;
+  studyTokens: number;
+  baselineNames: string[];
+  baselineDocs: number;
+  baselineTokens: number;
+  prior: number;
+  sizes: number[];
+  minCount: number;
+  minDocs: number;
+  summary: OverlapSummary;
+  nullTop: RankedTerm[];
+  recall: CuratedRecall[];
+  curatedPool: number;
+  measured: MeasuredTerm[];
+  show: number;
+}
+
+export function renderReport(report: OverlapReport): string {
+  const { summary } = report;
+  const lines = [
+    `corpus A  ${report.studyDocs} docs, ${report.studyTokens.toLocaleString()} tokens  ${report.studyPath}`,
+    `corpus B  ${report.baselineDocs} docs, ${report.baselineTokens.toLocaleString()} tokens  ${report.baselineNames.join(", ")}`,
+    `prior ${report.prior}  sizes ${report.sizes.join(",")}  min-count ${report.minCount}  min-docs ${report.minDocs}`,
+    "",
+    `top ${summary.considered} discovered terms`,
+    `  matched by a curated wordlist entry     ${summary.wordlist} (${pct(summary.wordlist, summary.considered)})`,
+    `  matched by any vocabulary-layer rule    ${summary.lexical} (${pct(summary.lexical, summary.considered)})`,
+    `  example sentence trips any rule at all  ${summary.sentence} (${pct(summary.sentence, summary.considered)})`,
+    "",
+    `null control (corpus A split in half): max z=${report.nullTop[0]?.z.toFixed(2) ?? "n/a"}, ` +
+      `top terms ${report.nullTop.map((row) => row.term).join(", ")}`,
+    "",
+    `curated entries, ranked over ${report.curatedPool.toLocaleString()} terms at min-count 1`,
+    ...report.recall.map((row) => {
+      const position =
+        row.rankIndex === null
+          ? "absent from corpus A"
+          : `#${(row.rankIndex + 1).toLocaleString()}`;
+      const score = row.z === null ? "" : `  z=${row.z.toFixed(2)}`;
+      return `  ${row.entry.padEnd(20)} ${position}${score}`;
+    }),
+    "",
+    `top ${report.show} by z`,
+  ];
+  for (const [index, { row, coverage }] of report.measured.slice(0, report.show).entries()) {
+    const marks = `${coverage.wordlist ? "W" : "-"}${coverage.lexical ? "L" : "-"}${coverage.categories.length > 0 ? "S" : "-"}`;
+    lines.push(
+      `${String(index + 1).padStart(3)}. ${marks}  z=${row.z.toFixed(1).padStart(6)}  ` +
+        `${row.countA}/${row.countB} in ${row.docs} docs  ${row.term}`,
+    );
+  }
+  return lines.join("\n");
 }
 
 if (import.meta.main) {
@@ -162,6 +228,7 @@ if (import.meta.main) {
       sizes: { type: [Number], description: "N-gram sizes. Default: 1 and 2" },
       prior: { type: Number, default: 500, description: "Dirichlet concentration (alpha-0)" },
       minCount: { type: Number, default: 5, description: "Minimum occurrences in corpus A" },
+      minDocs: { type: Number, default: 3, description: "Minimum corpus A documents per term" },
       top: { type: Number, default: 200, description: "Ranked terms to measure" },
       show: { type: Number, default: 40, description: "Ranked terms to print" },
       json: { type: Boolean, description: "Emit the measurement as JSON" },
@@ -170,7 +237,7 @@ if (import.meta.main) {
 
   const dataDir = resolveDataDir(argv.flags.dataDir);
   const sizes = argv.flags.sizes.length > 0 ? argv.flags.sizes : [1, 2];
-  const studyPath = argv.flags.study ?? `${dataDir}/contrast-baseline/claude-deliverables.txt`;
+  const studyPath = argv.flags.study ?? contrastCorpusPath(dataDir);
   const baselineNames =
     argv.flags.baseline.length > 0 ? argv.flags.baseline : ["github-prs.txt", "github-issues.txt"];
 
@@ -182,88 +249,71 @@ if (import.meta.main) {
     }
     return found;
   });
-  if (baselinePaths.length === 0) baselinePaths.push(corpusPath(dataDir));
 
   const filter = argv.flags.studyFilter === undefined ? null : new RegExp(argv.flags.studyFilter);
-  const studyDocs = select(await readCorpus(studyPath), filter);
-  const baselineDocs = (await Promise.all(baselinePaths.map(readCorpus))).flat();
+  const [studyAll, ...perRegister] = await Promise.all([
+    readCorpus(studyPath),
+    ...baselinePaths.map(readCorpus),
+  ]);
+  const studyDocs = filter === null ? studyAll : studyAll.filter((doc) => filter.test(doc.source));
+  const baselineDocs = perRegister.flat();
 
-  const a = tokenizeCorpus(bodies(studyDocs), sizes);
-  const b = tokenizeCorpus(bodies(baselineDocs), sizes);
+  // Min-count 1 over sizes 1 through 3 so every curated entry gets a position,
+  // including the three-word phrases. Tokenize once at the union of both.
+  const curatedSizes = [1, 2, 3];
+  const allSizes = [...new Set([...sizes, ...curatedSizes])].toSorted((x, y) => x - y);
+  const a = tokenizeCorpus(studyDocs, allSizes);
+  const b = tokenizeCorpus(baselineDocs, allSizes);
 
-  const ranked = rank(a, b, {
-    sizes,
-    prior: argv.flags.prior,
-    minCount: argv.flags.minCount,
-  });
-  const measured: MeasuredTerm[] = [];
-  for (const row of ranked.slice(0, argv.flags.top)) {
-    measured.push({ row, coverage: coverageOf(row.term, row.example) });
-  }
-  const summary = summarize(measured);
+  const { prior, minCount, minDocs } = argv.flags;
+  const ranked = rank(a, b, { sizes, prior, minCount, minDocs });
+  const measured: MeasuredTerm[] = ranked.slice(0, argv.flags.top).map((row) => ({
+    row,
+    coverage: coverageOf(row.term, row.example),
+  }));
 
   const [leftDocs, rightDocs] = splitHalves(studyDocs);
-  const nullRanked = rank(
-    tokenizeCorpus(bodies(leftDocs), sizes),
-    tokenizeCorpus(bodies(rightDocs), sizes),
-    { sizes, prior: argv.flags.prior, minCount: argv.flags.minCount },
-  );
+  const nullRanked = rank(tokenizeCorpus(leftDocs, sizes), tokenizeCorpus(rightDocs, sizes), {
+    sizes,
+    prior,
+    minCount,
+    minDocs,
+  });
 
-  // Min-count 1 over sizes 1 through 3 so every entry gets a position, including
-  // the three-word phrases.
-  const curated = curatedEntries(
-    await Promise.all(
-      ["vocabulary", "flowery-phrases", "marketing-verbs", "soft-phrasing", "openers"].map((name) =>
-        Bun.file(`${import.meta.dirname}/../../../wordlists/${name}.txt`).text(),
-      ),
-    ),
-  );
-  const curatedSizes = [1, 2, 3];
-  const fullRanked = rank(
-    tokenizeCorpus(bodies(studyDocs), curatedSizes),
-    tokenizeCorpus(bodies(baselineDocs), curatedSizes),
-    { sizes: curatedSizes, prior: argv.flags.prior, minCount: 1 },
-  );
+  const [plain, weighted] = await Promise.all([
+    Promise.all(PLAIN_LISTS.map(readWordlist)),
+    Promise.all(WEIGHTED_LISTS.map(readWordlist)),
+  ]);
+  const curated = curatedEntries(plain, weighted);
+  const fullRanked = rank(a, b, { sizes: curatedSizes, prior, minCount: 1, minDocs: 1 });
   const recall = recallOfCuratedEntries(curated, fullRanked, fullRanked.length);
 
   if (argv.flags.json) {
+    // Examples carry verbatim corpus prose, which stays out of any file.
+    const terms = measured.map(({ row: { example, ...row }, coverage }) => ({ row, coverage }));
     process.stdout.write(
-      `${JSON.stringify({ summary, recall, terms: measured, corpora: { a: a.tokens, b: b.tokens } }, null, 2)}\n`,
+      `${JSON.stringify({ summary: summarize(measured), recall, terms }, null, 2)}\n`,
     );
   } else {
-    const nullTop = nullRanked.slice(0, 5);
-    const lines = [
-      `corpus A  ${studyDocs.length} docs, ${a.tokens.toLocaleString()} tokens  ${studyPath}`,
-      `corpus B  ${baselineDocs.length} docs, ${b.tokens.toLocaleString()} tokens  ${baselineNames.join(", ")}`,
-      `prior ${argv.flags.prior}  sizes ${sizes.join(",")}  min-count ${argv.flags.minCount}`,
-      "",
-      `top ${summary.considered} discovered terms`,
-      `  matched by a curated wordlist entry     ${summary.wordlist} (${pct(summary.wordlist, summary.considered)})`,
-      `  matched by any vocabulary-layer rule    ${summary.lexical} (${pct(summary.lexical, summary.considered)})`,
-      `  example sentence trips any rule at all  ${summary.sentence} (${pct(summary.sentence, summary.considered)})`,
-      "",
-      `null control (corpus A split in half): max z=${nullTop[0]?.z.toFixed(2) ?? "n/a"}, ` +
-        `top terms ${nullTop.map((row) => row.term).join(", ")}`,
-      "",
-      `curated entries, ranked over ${fullRanked.length.toLocaleString()} terms at min-count 1`,
-      ...recall.map((row) => {
-        const position =
-          row.rankIndex === null
-            ? "absent from corpus A"
-            : `#${(row.rankIndex + 1).toLocaleString()}`;
-        const score = row.z === null ? "" : `  z=${row.z.toFixed(2)}`;
-        return `  ${row.entry.padEnd(20)} ${position}${score}`;
-      }),
-      "",
-      `top ${argv.flags.show} by z`,
-    ];
-    for (const [index, { row, coverage }] of measured.slice(0, argv.flags.show).entries()) {
-      const marks = `${coverage.wordlist ? "W" : "-"}${coverage.lexical ? "L" : "-"}${coverage.sentence ? "S" : "-"}`;
-      lines.push(
-        `${String(index + 1).padStart(3)}. ${marks}  z=${row.z.toFixed(1).padStart(6)}  ` +
-          `${row.countA}/${row.countB}  ${row.term}`,
-      );
-    }
-    process.stdout.write(`${lines.join("\n")}\n`);
+    process.stdout.write(
+      `${renderReport({
+        studyPath,
+        studyDocs: studyDocs.length,
+        studyTokens: a.tokens,
+        baselineNames,
+        baselineDocs: baselineDocs.length,
+        baselineTokens: b.tokens,
+        prior,
+        sizes,
+        minCount,
+        minDocs,
+        summary: summarize(measured),
+        nullTop: nullRanked.slice(0, 5),
+        recall,
+        curatedPool: fullRanked.length,
+        measured,
+        show: argv.flags.show,
+      })}\n`,
+    );
   }
 }

--- a/plugins/writing/skills/analyze/scripts/wordlist-overlap.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlist-overlap.ts
@@ -1,0 +1,270 @@
+#!/usr/bin/env bun
+// Measure how much of a Fightin' Words ranking the shipped detectors cover, in
+// both directions: discovered terms the detectors match, and curated entries the
+// ranking independently places.
+
+import { cli } from "cleye";
+import { stemmedPhraseHits, weightedStemHits, WORDLISTS } from "../../../detection/wordlists";
+import { type DetectorLayer, PATTERNS, scan } from "../../../detection/tropes";
+import { corpusPath, registerPaths, resolveDataDir, voiceBaselineDir } from "./data-dir";
+import { rank, type RankedTerm, stemTerm, tokenizeCorpus } from "./fightin-words";
+import { parseCorpus, type VoiceDocument } from "./voice-corpus";
+
+const LAYER_BY_CATEGORY = new Map<string, DetectorLayer>(
+  PATTERNS.map((pattern) => [pattern.category, pattern.layer]),
+);
+
+export interface Coverage {
+  /** A curated wordlists/*.txt entry matches the term itself. */
+  wordlist: boolean;
+  /** Any vocabulary-layer detector fires on the term itself. */
+  lexical: boolean;
+  /** Any detector at all fires on the sentence the term was discovered in. */
+  sentence: boolean;
+  categories: string[];
+}
+
+function matchesWordlist(term: string): boolean {
+  if (WORDLISTS.vocabulary(term).count > 0) return true;
+  if (stemmedPhraseHits(term, WORDLISTS.floweryPhrases).count > 0) return true;
+  if (weightedStemHits(term, WORDLISTS.marketingVerbs).totalWeight > 0) return true;
+  if (weightedStemHits(term, WORDLISTS.softPhrasing).totalWeight > 0) return true;
+  const { openers } = WORDLISTS;
+  if (openers !== null) {
+    openers.lastIndex = 0;
+    if (openers.test(`${term},`)) return true;
+  }
+  return false;
+}
+
+export function coverageOf(term: string, example: string): Coverage {
+  const onTerm = scan(term);
+  const onSentence = example === "" ? [] : scan(example);
+  return {
+    wordlist: matchesWordlist(term),
+    lexical: onTerm.some((match) => LAYER_BY_CATEGORY.get(match.category) === "vocabulary"),
+    sentence: onSentence.length > 0,
+    categories: [...new Set(onSentence.map((match) => match.category))],
+  };
+}
+
+export interface MeasuredTerm {
+  row: RankedTerm;
+  coverage: Coverage;
+}
+
+export interface OverlapSummary {
+  considered: number;
+  wordlist: number;
+  lexical: number;
+  sentence: number;
+}
+
+export function summarize(rows: MeasuredTerm[]): OverlapSummary {
+  return {
+    considered: rows.length,
+    wordlist: rows.filter((row) => row.coverage.wordlist).length,
+    lexical: rows.filter((row) => row.coverage.lexical).length,
+    sentence: rows.filter((row) => row.coverage.sentence).length,
+  };
+}
+
+// Place each curated entry in the ranking. An entry the contrast scores near
+// zero is one the corpus does not support.
+export function recallOfCuratedEntries(
+  curated: string[],
+  ranked: RankedTerm[],
+  topN: number,
+): { entry: string; rankIndex: number | null; z: number | null }[] {
+  const positions = new Map<string, { index: number; z: number }>();
+  for (const [index, row] of ranked.entries()) {
+    const stem = stemTerm(row.term);
+    if (!positions.has(stem)) positions.set(stem, { index, z: row.z });
+  }
+  return curated.map((entry) => {
+    const found = positions.get(stemTerm(entry));
+    if (found === undefined || found.index >= topN) {
+      return { entry, rankIndex: null, z: found?.z ?? null };
+    }
+    return { entry, rankIndex: found.index, z: found.z };
+  });
+}
+
+const COMMENT_OR_BLANK = /^\s*(?:#|$)/;
+
+export function curatedEntries(sources: string[]): string[] {
+  const entries: string[] = [];
+  for (const content of sources) {
+    for (const line of content.split(/\r?\n/)) {
+      if (COMMENT_OR_BLANK.test(line)) continue;
+      const trimmed = line.trim();
+      if (trimmed === "") continue;
+      // Weighted lists carry a trailing numeric weight.
+      entries.push(trimmed.replace(/\s+[0-9]+(?:\.[0-9]+)?$/, ""));
+    }
+  }
+  return entries;
+}
+
+function select(docs: VoiceDocument[], sourceFilter: RegExp | null): VoiceDocument[] {
+  if (sourceFilter === null) return docs;
+  return docs.filter((doc) => sourceFilter.test(doc.source));
+}
+
+function bodies(docs: VoiceDocument[]): string {
+  return docs.map((doc) => doc.body).join("\n\n");
+}
+
+// Alternate documents so both halves draw on the same sessions and dates.
+// Contrasting them gives the null: the largest z reachable with no difference to
+// find, which is the floor a real term has to clear.
+export function splitHalves(docs: VoiceDocument[]): [VoiceDocument[], VoiceDocument[]] {
+  const left: VoiceDocument[] = [];
+  const right: VoiceDocument[] = [];
+  for (const [index, doc] of docs.entries()) {
+    (index % 2 === 0 ? left : right).push(doc);
+  }
+  return [left, right];
+}
+
+async function readCorpus(path: string): Promise<VoiceDocument[]> {
+  return parseCorpus(await Bun.file(path).text());
+}
+
+function pct(part: number, whole: number): string {
+  if (whole === 0) return "0%";
+  return `${((part / whole) * 100).toFixed(1)}%`;
+}
+
+if (import.meta.main) {
+  const argv = cli({
+    name: "wordlist-overlap",
+    help: {
+      description:
+        "Rank agent-authored prose against the pre-agent voice baseline by log-odds " +
+        "with an informative Dirichlet prior, then measure how much of the ranking " +
+        "the shipped detectors already cover.",
+    },
+    flags: {
+      dataDir: { type: String, description: "Override the plugin data directory" },
+      study: {
+        type: String,
+        description: "Corpus A (agent-authored). Defaults to the contrast baseline.",
+      },
+      baseline: {
+        type: [String],
+        description:
+          "Corpus B register filenames. Repeatable. Default: github-prs.txt, github-issues.txt",
+      },
+      studyFilter: {
+        type: String,
+        description: "Keep only corpus A documents whose source matches this regex",
+      },
+      sizes: { type: [Number], description: "N-gram sizes. Default: 1 and 2" },
+      prior: { type: Number, default: 500, description: "Dirichlet concentration (alpha-0)" },
+      minCount: { type: Number, default: 5, description: "Minimum occurrences in corpus A" },
+      top: { type: Number, default: 200, description: "Ranked terms to measure" },
+      show: { type: Number, default: 40, description: "Ranked terms to print" },
+      json: { type: Boolean, description: "Emit the measurement as JSON" },
+    },
+  });
+
+  const dataDir = resolveDataDir(argv.flags.dataDir);
+  const sizes = argv.flags.sizes.length > 0 ? argv.flags.sizes : [1, 2];
+  const studyPath = argv.flags.study ?? `${dataDir}/contrast-baseline/claude-deliverables.txt`;
+  const baselineNames =
+    argv.flags.baseline.length > 0 ? argv.flags.baseline : ["github-prs.txt", "github-issues.txt"];
+
+  const registers = await registerPaths(dataDir);
+  const baselinePaths = baselineNames.map((name) => {
+    const found = registers.find((path) => path.endsWith(`/${name}`));
+    if (found === undefined) {
+      throw new Error(`No register ${name} under ${voiceBaselineDir(dataDir)}`);
+    }
+    return found;
+  });
+  if (baselinePaths.length === 0) baselinePaths.push(corpusPath(dataDir));
+
+  const filter = argv.flags.studyFilter === undefined ? null : new RegExp(argv.flags.studyFilter);
+  const studyDocs = select(await readCorpus(studyPath), filter);
+  const baselineDocs = (await Promise.all(baselinePaths.map(readCorpus))).flat();
+
+  const a = tokenizeCorpus(bodies(studyDocs), sizes);
+  const b = tokenizeCorpus(bodies(baselineDocs), sizes);
+
+  const ranked = rank(a, b, {
+    sizes,
+    prior: argv.flags.prior,
+    minCount: argv.flags.minCount,
+  });
+  const measured: MeasuredTerm[] = [];
+  for (const row of ranked.slice(0, argv.flags.top)) {
+    measured.push({ row, coverage: coverageOf(row.term, row.example) });
+  }
+  const summary = summarize(measured);
+
+  const [leftDocs, rightDocs] = splitHalves(studyDocs);
+  const nullRanked = rank(
+    tokenizeCorpus(bodies(leftDocs), sizes),
+    tokenizeCorpus(bodies(rightDocs), sizes),
+    { sizes, prior: argv.flags.prior, minCount: argv.flags.minCount },
+  );
+
+  // Min-count 1 over sizes 1 through 3 so every entry gets a position, including
+  // the three-word phrases.
+  const curated = curatedEntries(
+    await Promise.all(
+      ["vocabulary", "flowery-phrases", "marketing-verbs", "soft-phrasing", "openers"].map((name) =>
+        Bun.file(`${import.meta.dirname}/../../../wordlists/${name}.txt`).text(),
+      ),
+    ),
+  );
+  const curatedSizes = [1, 2, 3];
+  const fullRanked = rank(
+    tokenizeCorpus(bodies(studyDocs), curatedSizes),
+    tokenizeCorpus(bodies(baselineDocs), curatedSizes),
+    { sizes: curatedSizes, prior: argv.flags.prior, minCount: 1 },
+  );
+  const recall = recallOfCuratedEntries(curated, fullRanked, fullRanked.length);
+
+  if (argv.flags.json) {
+    process.stdout.write(
+      `${JSON.stringify({ summary, recall, terms: measured, corpora: { a: a.tokens, b: b.tokens } }, null, 2)}\n`,
+    );
+  } else {
+    const nullTop = nullRanked.slice(0, 5);
+    const lines = [
+      `corpus A  ${studyDocs.length} docs, ${a.tokens.toLocaleString()} tokens  ${studyPath}`,
+      `corpus B  ${baselineDocs.length} docs, ${b.tokens.toLocaleString()} tokens  ${baselineNames.join(", ")}`,
+      `prior ${argv.flags.prior}  sizes ${sizes.join(",")}  min-count ${argv.flags.minCount}`,
+      "",
+      `top ${summary.considered} discovered terms`,
+      `  matched by a curated wordlist entry     ${summary.wordlist} (${pct(summary.wordlist, summary.considered)})`,
+      `  matched by any vocabulary-layer rule    ${summary.lexical} (${pct(summary.lexical, summary.considered)})`,
+      `  example sentence trips any rule at all  ${summary.sentence} (${pct(summary.sentence, summary.considered)})`,
+      "",
+      `null control (corpus A split in half): max z=${nullTop[0]?.z.toFixed(2) ?? "n/a"}, ` +
+        `top terms ${nullTop.map((row) => row.term).join(", ")}`,
+      "",
+      `curated entries, ranked over ${fullRanked.length.toLocaleString()} terms at min-count 1`,
+      ...recall.map((row) => {
+        const position =
+          row.rankIndex === null
+            ? "absent from corpus A"
+            : `#${(row.rankIndex + 1).toLocaleString()}`;
+        const score = row.z === null ? "" : `  z=${row.z.toFixed(2)}`;
+        return `  ${row.entry.padEnd(20)} ${position}${score}`;
+      }),
+      "",
+      `top ${argv.flags.show} by z`,
+    ];
+    for (const [index, { row, coverage }] of measured.slice(0, argv.flags.show).entries()) {
+      const marks = `${coverage.wordlist ? "W" : "-"}${coverage.lexical ? "L" : "-"}${coverage.sentence ? "S" : "-"}`;
+      lines.push(
+        `${String(index + 1).padStart(3)}. ${marks}  z=${row.z.toFixed(1).padStart(6)}  ` +
+          `${row.countA}/${row.countB}  ${row.term}`,
+      );
+    }
+    process.stdout.write(`${lines.join("\n")}\n`);
+  }
+}

--- a/plugins/writing/skills/analyze/scripts/wordlist-overlap.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlist-overlap.ts
@@ -69,8 +69,7 @@ export function summarize(rows: MeasuredTerm[]): OverlapSummary {
   };
 }
 
-// Place each curated entry in the ranking. An entry the contrast scores near
-// zero is one the corpus does not support.
+// An entry the contrast scores near zero is one the corpus does not support.
 export function recallOfCuratedEntries(
   curated: string[],
   ranked: RankedTerm[],


### PR DESCRIPTION
Adds a corpus-statistics path for curating the writing rules, so a candidate tell is judged against how often the word appears in your own writing.

The statistic is Fightin' Words (Monroe, Colaresi & Quinn 2008, section 3.5): a log-odds ratio with an informative Dirichlet prior, variance-adjusted so a rare term cannot outrank a frequent one at the same rate ratio. It is pure counting, so it returns the same ranking every run. Corpus A is agent-authored deliverables, corpus B is your PR and issue text from before agent use.

The first question was whether this surfaces anything the curated wordlists already cover. It does not. Of the top 200 discovered terms:

- zero match a curated wordlist entry
- zero trip a vocabulary-layer rule
- two have an example sentence that trips any rule at all

Recall runs just as empty in the other direction. `delve` sits at rank 1,581,558 with z=0.06, and `tapestry`, `meticulous`, and `empower` never appear in corpus A. The top of the ranking is `the`, `so`, `and`, `one`, `no`, `and the`. That is function-word frequency, which Burrows's Delta measures and a vocabulary list cannot reach.

Two controls make those numbers readable. The split-half null contrasts corpus A against itself by alternating documents, giving the largest z reachable when there is no difference to find. Every run prints it as the floor a real term has to clear. Registers also have to match, because contrasting mismatched genres pushes that floor above nearly every real term.

Counting happens per document, so each term carries the number of documents it appeared in and `--min-docs` drops the ones confined to a handful. A phrase repeated twenty times inside one long deliverable is that document's quirk. Adding the guard lowered the null floor on the full contrast from z=16.3 to z=10.4.

The corpora live outside this repo, in the plugin data directory. `--json` withholds the example sentences for the same reason, so no corpus prose reaches a file.

Nothing routes to this yet. `analyze.ts` still ranks with `computeLift`. Replacing it belongs in a later change, alongside authorship distance and the structural rate features.
