### PR TITLE
writing: pair corpus contrasts by register

### DIFF
--- a/plugins/writing/skills/analyze/SKILL.md
+++ b/plugins/writing/skills/analyze/SKILL.md
@@ -85,9 +85,12 @@ See the "Meaning-Layer Judge" section of [references/methodology.md](references/
 ```bash
 bun ${CLAUDE_SKILL_DIR}/scripts/wordlist-overlap.ts
 bun ${CLAUDE_SKILL_DIR}/scripts/wordlist-overlap.ts --baseline github-issues.txt --sizes 1 --sizes 2
+bun ${CLAUDE_SKILL_DIR}/scripts/wordlist-overlap.ts --kind docs
 ```
 
 Corpora A and B must match register. Contrasting mismatched genres raises the split-half null floor far above any real term and makes the ranking uninterpretable. Every run prints that floor, which is the z a finding has to clear.
+
+Corpus A holds several genres, sorted by source path into the kinds `--kind` selects: `chat`, `plan`, `memory`, `scratch`, `docs`, and `other`. Only `docs`, the markdown committed to a repository for another reader, has a counterpart in a baseline of PR and issue text. Every run also splits each kind against itself, so the per-kind floors show what a pairing costs: unrestricted, the floor sits at 10.4 against a top score of 16.4, and `--kind docs` drops it to 4.3 against 13.9.
 
 `--json` omits the example sentences the human-readable report already withholds, so no corpus prose reaches a file.
 

--- a/plugins/writing/skills/analyze/SKILL.md
+++ b/plugins/writing/skills/analyze/SKILL.md
@@ -85,12 +85,14 @@ See the "Meaning-Layer Judge" section of [references/methodology.md](references/
 ```bash
 bun ${CLAUDE_SKILL_DIR}/scripts/wordlist-overlap.ts
 bun ${CLAUDE_SKILL_DIR}/scripts/wordlist-overlap.ts --baseline github-issues.txt --sizes 1 --sizes 2
-bun ${CLAUDE_SKILL_DIR}/scripts/wordlist-overlap.ts --kind docs
+bun ${CLAUDE_SKILL_DIR}/scripts/wordlist-overlap.ts --kind message
 ```
 
 Corpora A and B must match register. Contrasting mismatched genres raises the split-half null floor far above any real term and makes the ranking uninterpretable. Every run prints that floor, which is the z a finding has to clear.
 
-Corpus A holds several genres, sorted by source path into the kinds `--kind` selects: `chat`, `plan`, `memory`, `scratch`, `docs`, and `other`. Only `docs`, the markdown committed to a repository for another reader, has a counterpart in a baseline of PR and issue text. Every run also splits each kind against itself, so the per-kind floors show what a pairing costs: unrestricted, the floor sits at 10.4 against a top score of 16.4, and `--kind docs` drops it to 4.3 against 13.9.
+Corpus A holds several genres, sorted by source pointer into the kinds `--kind` selects: `message`, `plan`, `memory`, `scratch`, `docs`, and `other`. `message` is prose the miner found on a command line rather than in a file (`gh pr create --body`, `git commit -m`), which makes it the same register as a baseline of PR and issue text. `docs` is the prose committed to a repository for another reader. The rest have no counterpart to pair against. `--study-filter` narrows the selected kinds further by a regex over the source.
+
+Every run also splits each kind against itself, so the per-kind floors price the pairing. Unrestricted, the floor sits at 10.4 against a top score of 16.4; `--kind message` drops it to 3.9 against 17.0. Over a single kind the aggregate control would repeat that kind's floor, so it is omitted.
 
 `--json` omits the example sentences the human-readable report already withholds, so no corpus prose reaches a file.
 

--- a/plugins/writing/skills/analyze/scripts/voice-corpus.test.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-corpus.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import * as fc from "fast-check";
 import {
   documentKind,
+  type DocumentKind,
   groupByKind,
   isDocumentKind,
   mergeDocuments,
@@ -70,21 +71,23 @@ describe("serializeCorpus", () => {
 });
 
 describe("documentKind", () => {
-  test.each([
-    ["a3f9c1d2-7b44-4e10-9c8a-1f2e3d4b5a60#7", "chat"],
+  test.each<[string, DocumentKind]>([
+    ["a3f9c1d2-7b44-4e10-9c8a-1f2e3d4b5a60#7", "message"],
     ["/Users/ben/.claude/plans/2026-08-31-corpus.md#0", "plan"],
     ["/Users/ben/.claude/projects/-Users-ben-src/memory/project_voice.md#1", "memory"],
     ["/tmp/claude-501/scratchpad/notes.md#2", "scratch"],
     ["tmp/pr-body-writing.md#0", "scratch"],
     ["/Users/ben/src/bendrucker/claude/README.md#0", "docs"],
     ["/Users/ben/src/bendrucker/claude/.worktrees/x/docs/settings.md#4", "docs"],
+    // The miner captures .txt, .rst, and .adoc prose alongside markdown.
+    ["/Users/ben/src/bendrucker/claude/notes/design.rst#0", "docs"],
     ["/Users/ben/src/bendrucker/claude/plugins/writing/detection/tropes.ts#0", "other"],
   ])("%s is %s", (source, kind) => {
     expect(documentKind(source)).toBe(kind);
   });
 
   // The occurrence index sits past the extension, so stripping it is what lets
-  // the markdown check see the real suffix.
+  // the extension check see the real suffix.
   test("classifies by extension despite the occurrence index", () => {
     expect(documentKind("/repo/NOTES.md#118")).toBe("docs");
   });
@@ -94,17 +97,17 @@ describe("groupByKind", () => {
   test("groups only the kinds present, keeping document order", () => {
     const docs: VoiceDocument[] = [
       { source: "/repo/a.md#0", meta: "", body: "first" },
-      { source: "session-id#0", meta: "", body: "chatter" },
+      { source: "session-id#0", meta: "", body: "a commit message" },
       { source: "/repo/b.md#0", meta: "", body: "second" },
     ];
     const groups = groupByKind(docs);
-    expect([...groups.keys()].toSorted()).toEqual(["chat", "docs"]);
+    expect([...groups.keys()].toSorted()).toEqual(["docs", "message"]);
     expect(groups.get("docs")?.map((doc) => doc.body)).toEqual(["first", "second"]);
   });
 });
 
 describe("isDocumentKind", () => {
-  test.each([
+  test.each<[string, boolean]>([
     ["docs", true],
     ["prose", false],
   ])("%s is a kind: %p", (value, expected) => {

--- a/plugins/writing/skills/analyze/scripts/voice-corpus.test.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-corpus.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import * as fc from "fast-check";
-import { mergeDocuments, parseCorpus, serializeCorpus, type VoiceDocument } from "./voice-corpus";
+import {
+  documentKind,
+  groupByKind,
+  isDocumentKind,
+  mergeDocuments,
+  parseCorpus,
+  serializeCorpus,
+  type VoiceDocument,
+} from "./voice-corpus";
 
 // A document that survives serialize/parse: the source is a single non-empty
 // token (the delimiter captures \S+), meta carries no ")" or newline (it sits
@@ -58,6 +66,49 @@ describe("serializeCorpus", () => {
         expect(project(reparsed)).toEqual(project(docs));
       }),
     );
+  });
+});
+
+describe("documentKind", () => {
+  test.each([
+    ["a3f9c1d2-7b44-4e10-9c8a-1f2e3d4b5a60#7", "chat"],
+    ["/Users/ben/.claude/plans/2026-08-31-corpus.md#0", "plan"],
+    ["/Users/ben/.claude/projects/-Users-ben-src/memory/project_voice.md#1", "memory"],
+    ["/tmp/claude-501/scratchpad/notes.md#2", "scratch"],
+    ["tmp/pr-body-writing.md#0", "scratch"],
+    ["/Users/ben/src/bendrucker/claude/README.md#0", "docs"],
+    ["/Users/ben/src/bendrucker/claude/.worktrees/x/docs/settings.md#4", "docs"],
+    ["/Users/ben/src/bendrucker/claude/plugins/writing/detection/tropes.ts#0", "other"],
+  ])("%s is %s", (source, kind) => {
+    expect(documentKind(source)).toBe(kind);
+  });
+
+  // The occurrence index sits past the extension, so stripping it is what lets
+  // the markdown check see the real suffix.
+  test("classifies by extension despite the occurrence index", () => {
+    expect(documentKind("/repo/NOTES.md#118")).toBe("docs");
+  });
+});
+
+describe("groupByKind", () => {
+  test("groups only the kinds present, keeping document order", () => {
+    const docs: VoiceDocument[] = [
+      { source: "/repo/a.md#0", meta: "", body: "first" },
+      { source: "session-id#0", meta: "", body: "chatter" },
+      { source: "/repo/b.md#0", meta: "", body: "second" },
+    ];
+    const groups = groupByKind(docs);
+    expect([...groups.keys()].toSorted()).toEqual(["chat", "docs"]);
+    expect(groups.get("docs")?.map((doc) => doc.body)).toEqual(["first", "second"]);
+  });
+});
+
+describe("isDocumentKind", () => {
+  test.each([
+    ["docs", true],
+    ["prose", false],
+  ])("%s is a kind: %p", (value, expected) => {
+    expect(isDocumentKind(value)).toBe(expected);
   });
 });
 

--- a/plugins/writing/skills/analyze/scripts/voice-corpus.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-corpus.ts
@@ -1,3 +1,5 @@
+import { isProseFile } from "../../../detection/paths";
+
 export interface VoiceDocument {
   source: string;
   meta: string;
@@ -33,15 +35,13 @@ export function parseCorpus(text: string): VoiceDocument[] {
   return docs;
 }
 
-// Corpus A mixes genres the pre-agent baseline has no counterpart for. Ranking
-// a plan file against hand-written PR prose measures the gap between genres
-// rather than between authors, so a contrast pairs one kind against a matching
-// register. The kind falls out of the source pointer: the file the prose was
-// written to, or a session id when it never reached a file.
-export type DocumentKind = "chat" | "plan" | "memory" | "scratch" | "docs" | "other";
+// The genre of a document, read off its source pointer: the file the prose was
+// written to, or a session id when the miner found it on a command line instead
+// (`gh pr create --body`, `git commit -m`), which makes it a message.
+export type DocumentKind = "message" | "plan" | "memory" | "scratch" | "docs" | "other";
 
 export const DOCUMENT_KINDS: readonly DocumentKind[] = [
-  "chat",
+  "message",
   "plan",
   "memory",
   "scratch",
@@ -56,11 +56,11 @@ const SCRATCH_DIR = /(?:^|\/)tmp\//;
 
 export function documentKind(source: string): DocumentKind {
   const path = source.replace(OCCURRENCE_SUFFIX, "");
-  if (!path.includes("/")) return "chat";
+  if (!path.includes("/")) return "message";
   if (path.includes("/.claude/plans/")) return "plan";
   if (path.includes("/memory/")) return "memory";
   if (SCRATCH_DIR.test(path)) return "scratch";
-  if (path.endsWith(".md")) return "docs";
+  if (isProseFile(path)) return "docs";
   return "other";
 }
 
@@ -69,14 +69,7 @@ export function isDocumentKind(value: string): value is DocumentKind {
 }
 
 export function groupByKind(docs: VoiceDocument[]): Map<DocumentKind, VoiceDocument[]> {
-  const groups = new Map<DocumentKind, VoiceDocument[]>();
-  for (const doc of docs) {
-    const kind = documentKind(doc.source);
-    const group = groups.get(kind);
-    if (group === undefined) groups.set(kind, [doc]);
-    else group.push(doc);
-  }
-  return groups;
+  return Map.groupBy(docs, (doc) => documentKind(doc.source));
 }
 
 export function formatDocument(doc: VoiceDocument): string {

--- a/plugins/writing/skills/analyze/scripts/voice-corpus.ts
+++ b/plugins/writing/skills/analyze/scripts/voice-corpus.ts
@@ -33,6 +33,52 @@ export function parseCorpus(text: string): VoiceDocument[] {
   return docs;
 }
 
+// Corpus A mixes genres the pre-agent baseline has no counterpart for. Ranking
+// a plan file against hand-written PR prose measures the gap between genres
+// rather than between authors, so a contrast pairs one kind against a matching
+// register. The kind falls out of the source pointer: the file the prose was
+// written to, or a session id when it never reached a file.
+export type DocumentKind = "chat" | "plan" | "memory" | "scratch" | "docs" | "other";
+
+export const DOCUMENT_KINDS: readonly DocumentKind[] = [
+  "chat",
+  "plan",
+  "memory",
+  "scratch",
+  "docs",
+  "other",
+];
+
+// Sources carry an occurrence index so a file written repeatedly stays distinct.
+const OCCURRENCE_SUFFIX = /#\d+$/;
+// Tool inputs record scratch paths both absolutely and relative to a repo root.
+const SCRATCH_DIR = /(?:^|\/)tmp\//;
+
+export function documentKind(source: string): DocumentKind {
+  const path = source.replace(OCCURRENCE_SUFFIX, "");
+  if (!path.includes("/")) return "chat";
+  if (path.includes("/.claude/plans/")) return "plan";
+  if (path.includes("/memory/")) return "memory";
+  if (SCRATCH_DIR.test(path)) return "scratch";
+  if (path.endsWith(".md")) return "docs";
+  return "other";
+}
+
+export function isDocumentKind(value: string): value is DocumentKind {
+  return (DOCUMENT_KINDS as readonly string[]).includes(value);
+}
+
+export function groupByKind(docs: VoiceDocument[]): Map<DocumentKind, VoiceDocument[]> {
+  const groups = new Map<DocumentKind, VoiceDocument[]>();
+  for (const doc of docs) {
+    const kind = documentKind(doc.source);
+    const group = groups.get(kind);
+    if (group === undefined) groups.set(kind, [doc]);
+    else group.push(doc);
+  }
+  return groups;
+}
+
 export function formatDocument(doc: VoiceDocument): string {
   return `===== ${doc.source} (${doc.meta}) =====\n${doc.body.trim()}\n`;
 }

--- a/plugins/writing/skills/analyze/scripts/wordlist-overlap.test.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlist-overlap.test.ts
@@ -5,6 +5,7 @@ import {
   coverageOf,
   curatedEntries,
   type MeasuredTerm,
+  nullFloorByKind,
   recallOfCuratedEntries,
   renderReport,
   splitHalves,
@@ -186,6 +187,34 @@ describe("splitHalves", () => {
   });
 });
 
+describe("nullFloorByKind", () => {
+  const options = { sizes: [1], prior: 500, minCount: 1, minDocs: 1 };
+
+  // One body across every document, so any score the split produces is noise.
+  function sameBody(source: string): VoiceDocument {
+    return { source, meta: "", body: "The parser reads the file and returns the tree." };
+  }
+
+  test("scores each kind present against itself, in kind order", () => {
+    const docs = [
+      ...Array.from({ length: 6 }, (_, index) => sameBody(`session-${index}`)),
+      ...Array.from({ length: 4 }, (_, index) => sameBody(`/repo/doc-${index}.md`)),
+    ];
+    const floors = nullFloorByKind(docs, options);
+    expect(floors.map((floor) => [floor.kind, floor.docs])).toEqual([
+      ["chat", 6],
+      ["docs", 4],
+    ]);
+    for (const floor of floors) expect(Math.abs(floor.maxZ ?? 0)).toBeLessThan(0.5);
+  });
+
+  test("a kind holding one document has no split to score", () => {
+    expect(nullFloorByKind([makeDoc("/repo/only.md")], options)).toEqual([
+      { kind: "docs", docs: 1, maxZ: null },
+    ]);
+  });
+});
+
 describe("renderReport", () => {
   test("formats the whole measurement", () => {
     expect(
@@ -193,6 +222,11 @@ describe("renderReport", () => {
         studyPath: "/data/contrast-baseline/claude-deliverables.txt",
         studyDocs: 22,
         studyTokens: 1234,
+        kinds: ["docs", "other"],
+        kindFloors: [
+          { kind: "docs", docs: 18, maxZ: 6.31 },
+          { kind: "other", docs: 4, maxZ: null },
+        ],
         baselineNames: ["github-prs.txt"],
         baselineDocs: 342,
         baselineTokens: 5678,
@@ -220,7 +254,7 @@ describe("renderReport", () => {
         show: 2,
       }),
     ).toMatchInlineSnapshot(`
-      "corpus A  22 docs, 1,234 tokens  /data/contrast-baseline/claude-deliverables.txt
+      "corpus A  22 docs, 1,234 tokens  kinds docs,other  /data/contrast-baseline/claude-deliverables.txt
       corpus B  342 docs, 5,678 tokens  github-prs.txt
       prior 500  sizes 1,2  min-count 5  min-docs 3
 
@@ -230,6 +264,10 @@ describe("renderReport", () => {
         example sentence trips any rule at all  1 (50.0%)
 
       null control (corpus A split in half): max z=4.29, top terms noise
+
+      null floor by kind (each kind split against itself)
+        docs        18 docs  max z=6.31
+        other        4 docs  max z=n/a
 
       curated entries, ranked over 140,000 terms at min-count 1
         delve                #13  z=3.50

--- a/plugins/writing/skills/analyze/scripts/wordlist-overlap.test.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlist-overlap.test.ts
@@ -202,7 +202,7 @@ describe("nullFloorByKind", () => {
     ];
     const floors = nullFloorByKind(docs, options);
     expect(floors.map((floor) => [floor.kind, floor.docs])).toEqual([
-      ["chat", 6],
+      ["message", 6],
       ["docs", 4],
     ]);
     for (const floor of floors) expect(Math.abs(floor.maxZ ?? 0)).toBeLessThan(0.5);

--- a/plugins/writing/skills/analyze/scripts/wordlist-overlap.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlist-overlap.ts
@@ -18,8 +18,16 @@ import {
   WORDLISTS,
 } from "../../../detection/wordlists";
 import { contrastCorpusPath, registerPaths, resolveDataDir, voiceBaselineDir } from "./data-dir";
-import { rank, type RankedTerm, stemTerm, tokenizeCorpus } from "./fightin-words";
-import { parseCorpus, type VoiceDocument } from "./voice-corpus";
+import { rank, type RankedTerm, type RankOptions, stemTerm, tokenizeCorpus } from "./fightin-words";
+import {
+  DOCUMENT_KINDS,
+  documentKind,
+  type DocumentKind,
+  groupByKind,
+  isDocumentKind,
+  parseCorpus,
+  type VoiceDocument,
+} from "./voice-corpus";
 
 const LAYER_BY_CATEGORY = new Map<string, DetectorLayer>(
   [...PATTERNS, ...WEIGHTED_PATTERNS].map((pattern) => [pattern.category, pattern.layer]),
@@ -134,6 +142,30 @@ export function splitHalves(docs: VoiceDocument[]): [VoiceDocument[], VoiceDocum
   return [left, right];
 }
 
+export interface KindFloor {
+  kind: DocumentKind;
+  docs: number;
+  maxZ: number | null;
+}
+
+// Splitting each kind against itself prices the genre gap. A kind whose own
+// floor sits near the cross-corpus scores offers nothing a contrast can read as
+// voice, and a kind with no counterpart register cannot be paired at all.
+export function nullFloorByKind(docs: VoiceDocument[], options: RankOptions): KindFloor[] {
+  const groups = groupByKind(docs);
+  return DOCUMENT_KINDS.filter((kind) => groups.has(kind)).map((kind) => {
+    const group = groups.get(kind) ?? [];
+    if (group.length < 2) return { kind, docs: group.length, maxZ: null };
+    const [left, right] = splitHalves(group);
+    const ranked = rank(
+      tokenizeCorpus(left, options.sizes),
+      tokenizeCorpus(right, options.sizes),
+      options,
+    );
+    return { kind, docs: group.length, maxZ: ranked[0]?.z ?? null };
+  });
+}
+
 async function readCorpus(path: string): Promise<VoiceDocument[]> {
   const file = Bun.file(path);
   if (!(await file.exists())) throw new Error(`No corpus at ${path}`);
@@ -149,6 +181,8 @@ export interface OverlapReport {
   studyPath: string;
   studyDocs: number;
   studyTokens: number;
+  kinds: DocumentKind[];
+  kindFloors: KindFloor[];
   baselineNames: string[];
   baselineDocs: number;
   baselineTokens: number;
@@ -167,7 +201,8 @@ export interface OverlapReport {
 export function renderReport(report: OverlapReport): string {
   const { summary } = report;
   const lines = [
-    `corpus A  ${report.studyDocs} docs, ${report.studyTokens.toLocaleString()} tokens  ${report.studyPath}`,
+    `corpus A  ${report.studyDocs} docs, ${report.studyTokens.toLocaleString()} tokens  ` +
+      `kinds ${report.kinds.join(",")}  ${report.studyPath}`,
     `corpus B  ${report.baselineDocs} docs, ${report.baselineTokens.toLocaleString()} tokens  ${report.baselineNames.join(", ")}`,
     `prior ${report.prior}  sizes ${report.sizes.join(",")}  min-count ${report.minCount}  min-docs ${report.minDocs}`,
     "",
@@ -178,6 +213,13 @@ export function renderReport(report: OverlapReport): string {
     "",
     `null control (corpus A split in half): max z=${report.nullTop[0]?.z.toFixed(2) ?? "n/a"}, ` +
       `top terms ${report.nullTop.map((row) => row.term).join(", ")}`,
+    "",
+    "null floor by kind (each kind split against itself)",
+    ...report.kindFloors.map(
+      (floor) =>
+        `  ${floor.kind.padEnd(8)} ${String(floor.docs).padStart(5)} docs  ` +
+        `max z=${floor.maxZ === null ? "n/a" : floor.maxZ.toFixed(2)}`,
+    ),
     "",
     `curated entries, ranked over ${report.curatedPool.toLocaleString()} terms at min-count 1`,
     ...report.recall.map((row) => {
@@ -221,9 +263,9 @@ if (import.meta.main) {
         description:
           "Corpus B register filenames. Repeatable. Default: github-prs.txt, github-issues.txt",
       },
-      studyFilter: {
-        type: String,
-        description: "Keep only corpus A documents whose source matches this regex",
+      kind: {
+        type: [String],
+        description: `Corpus A document kinds to keep. Repeatable. One of ${DOCUMENT_KINDS.join(", ")}.`,
       },
       sizes: { type: [Number], description: "N-gram sizes. Default: 1 and 2" },
       prior: { type: Number, default: 500, description: "Dirichlet concentration (alpha-0)" },
@@ -250,12 +292,22 @@ if (import.meta.main) {
     return found;
   });
 
-  const filter = argv.flags.studyFilter === undefined ? null : new RegExp(argv.flags.studyFilter);
+  const kinds = argv.flags.kind.map((kind) => {
+    if (!isDocumentKind(kind)) {
+      throw new Error(`Unknown kind ${kind}. One of ${DOCUMENT_KINDS.join(", ")}.`);
+    }
+    return kind;
+  });
+  const selected = new Set(kinds);
+
   const [studyAll, ...perRegister] = await Promise.all([
     readCorpus(studyPath),
     ...baselinePaths.map(readCorpus),
   ]);
-  const studyDocs = filter === null ? studyAll : studyAll.filter((doc) => filter.test(doc.source));
+  const studyDocs =
+    selected.size === 0
+      ? studyAll
+      : studyAll.filter((doc) => selected.has(documentKind(doc.source)));
   const baselineDocs = perRegister.flat();
 
   // Min-count 1 over sizes 1 through 3 so every curated entry gets a position,
@@ -272,13 +324,15 @@ if (import.meta.main) {
     coverage: coverageOf(row.term, row.example),
   }));
 
+  const nullOptions = { sizes, prior, minCount, minDocs };
   const [leftDocs, rightDocs] = splitHalves(studyDocs);
-  const nullRanked = rank(tokenizeCorpus(leftDocs, sizes), tokenizeCorpus(rightDocs, sizes), {
-    sizes,
-    prior,
-    minCount,
-    minDocs,
-  });
+  const nullRanked = rank(
+    tokenizeCorpus(leftDocs, sizes),
+    tokenizeCorpus(rightDocs, sizes),
+    nullOptions,
+  );
+  const kindFloors = nullFloorByKind(studyDocs, nullOptions);
+  const reportedKinds = kinds.length > 0 ? kinds : [...DOCUMENT_KINDS];
 
   const [plain, weighted] = await Promise.all([
     Promise.all(PLAIN_LISTS.map(readWordlist)),
@@ -292,7 +346,11 @@ if (import.meta.main) {
     // Examples carry verbatim corpus prose, which stays out of any file.
     const terms = measured.map(({ row: { example, ...row }, coverage }) => ({ row, coverage }));
     process.stdout.write(
-      `${JSON.stringify({ summary: summarize(measured), recall, terms }, null, 2)}\n`,
+      `${JSON.stringify(
+        { kinds: reportedKinds, kindFloors, summary: summarize(measured), recall, terms },
+        null,
+        2,
+      )}\n`,
     );
   } else {
     process.stdout.write(
@@ -300,6 +358,8 @@ if (import.meta.main) {
         studyPath,
         studyDocs: studyDocs.length,
         studyTokens: a.tokens,
+        kinds: reportedKinds,
+        kindFloors,
         baselineNames,
         baselineDocs: baselineDocs.length,
         baselineTokens: b.tokens,

--- a/plugins/writing/skills/analyze/scripts/wordlist-overlap.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlist-overlap.ts
@@ -211,9 +211,13 @@ export function renderReport(report: OverlapReport): string {
     `  matched by any vocabulary-layer rule    ${summary.lexical} (${pct(summary.lexical, summary.considered)})`,
     `  example sentence trips any rule at all  ${summary.sentence} (${pct(summary.sentence, summary.considered)})`,
     "",
-    `null control (corpus A split in half): max z=${report.nullTop[0]?.z.toFixed(2) ?? "n/a"}, ` +
-      `top terms ${report.nullTop.map((row) => row.term).join(", ")}`,
-    "",
+    ...(report.nullTop.length > 0
+      ? [
+          `null control (corpus A split in half): max z=${report.nullTop[0]?.z.toFixed(2) ?? "n/a"}, ` +
+            `top terms ${report.nullTop.map((row) => row.term).join(", ")}`,
+          "",
+        ]
+      : []),
     "null floor by kind (each kind split against itself)",
     ...report.kindFloors.map(
       (floor) =>
@@ -246,6 +250,9 @@ export function renderReport(report: OverlapReport): string {
 if (import.meta.main) {
   const argv = cli({
     name: "wordlist-overlap",
+    // A mistyped flag would otherwise be ignored, and the report would answer a
+    // different question than the one asked.
+    strictFlags: true,
     help: {
       description:
         "Rank agent-authored prose against the pre-agent voice baseline by log-odds " +
@@ -266,6 +273,10 @@ if (import.meta.main) {
       kind: {
         type: [String],
         description: `Corpus A document kinds to keep. Repeatable. One of ${DOCUMENT_KINDS.join(", ")}.`,
+      },
+      studyFilter: {
+        type: String,
+        description: "Narrow the kinds further to corpus A sources matching this regex",
       },
       sizes: { type: [Number], description: "N-gram sizes. Default: 1 and 2" },
       prior: { type: Number, default: 500, description: "Dirichlet concentration (alpha-0)" },
@@ -298,16 +309,16 @@ if (import.meta.main) {
     }
     return kind;
   });
-  const selected = new Set(kinds);
+  const selected = new Set(kinds.length > 0 ? kinds : DOCUMENT_KINDS);
 
   const [studyAll, ...perRegister] = await Promise.all([
     readCorpus(studyPath),
     ...baselinePaths.map(readCorpus),
   ]);
-  const studyDocs =
-    selected.size === 0
-      ? studyAll
-      : studyAll.filter((doc) => selected.has(documentKind(doc.source)));
+  const filter = argv.flags.studyFilter === undefined ? null : new RegExp(argv.flags.studyFilter);
+  const studyDocs = studyAll.filter(
+    (doc) => selected.has(documentKind(doc.source)) && (filter?.test(doc.source) ?? true),
+  );
   const baselineDocs = perRegister.flat();
 
   // Min-count 1 over sizes 1 through 3 so every curated entry gets a position,
@@ -325,14 +336,16 @@ if (import.meta.main) {
   }));
 
   const nullOptions = { sizes, prior, minCount, minDocs };
-  const [leftDocs, rightDocs] = splitHalves(studyDocs);
+  const kindFloors = nullFloorByKind(studyDocs, nullOptions);
+  // Over a single kind the aggregate control splits the same documents into the
+  // same halves, so it would report that kind's floor a second time.
+  const [leftDocs, rightDocs]: [VoiceDocument[], VoiceDocument[]] =
+    kindFloors.length > 1 ? splitHalves(studyDocs) : [[], []];
   const nullRanked = rank(
     tokenizeCorpus(leftDocs, sizes),
     tokenizeCorpus(rightDocs, sizes),
     nullOptions,
   );
-  const kindFloors = nullFloorByKind(studyDocs, nullOptions);
-  const reportedKinds = kinds.length > 0 ? kinds : [...DOCUMENT_KINDS];
 
   const [plain, weighted] = await Promise.all([
     Promise.all(PLAIN_LISTS.map(readWordlist)),
@@ -347,7 +360,7 @@ if (import.meta.main) {
     const terms = measured.map(({ row: { example, ...row }, coverage }) => ({ row, coverage }));
     process.stdout.write(
       `${JSON.stringify(
-        { kinds: reportedKinds, kindFloors, summary: summarize(measured), recall, terms },
+        { kinds: [...selected], kindFloors, summary: summarize(measured), recall, terms },
         null,
         2,
       )}\n`,
@@ -358,7 +371,7 @@ if (import.meta.main) {
         studyPath,
         studyDocs: studyDocs.length,
         studyTokens: a.tokens,
-        kinds: reportedKinds,
+        kinds: [...selected],
         kindFloors,
         baselineNames,
         baselineDocs: baselineDocs.length,


### PR DESCRIPTION
Corpus A mixes genres the pre-agent baseline has no counterpart for. Plan files, memory notes, and scratch drafts outnumber the prose that resembles a PR description. An unrestricted contrast ends up measuring the distance between genres and reporting it as distance between authors.

The source pointer already records where each document was written. The genre derives from it at read time, with no change to the corpus format and no re-mining, and it runs against the 8,183 documents held locally today. `--kind` selects those genres. `--study-filter` narrows them further by a regex over the source.

Every run splits each kind against itself and prints the resulting floor, which is what prices the pairing:

- Unrestricted, the floor sits at 10.4 against a top score of 16.4.
- `--kind message` drops it to 3.9 against 17.0.
- Per-kind floors run 3.9 to 6.2, all far under the mixed 10.4. The mixed floor measured genre mixture.

Sampling the corpus surfaced a miner bug: it records prose passed on a command line (`gh pr create --body`, `git commit -m`) against a session id instead of a file path. Reading a slash-free source as chat mislabelled 559 PR bodies and commit messages, excluding the one genre that shares a register with the baseline. Fixing it added the `message` kind, the pairing with the best floor in the study.

What the ranking finds does not change across any of these pairings. Every version is topped by `the`, `so`, `and`, `and the`, `every`, and `one`. Zero of the top 200 discovered terms match a curated wordlist entry or any vocabulary-layer rule. Curated entries still score near zero in the matched contrast, with `delve` absent and `leverage` at z=0.28.

Register matching sharpens the measurement without changing what it finds. At the best signal-to-noise ratio in the study, the only thing clearing the floor is function-word distribution, the same input Burrows's Delta uses and nothing a wordlist can hold.

`cleye` ignores unknown flags unless `strictFlags` is set. On a tool whose entire output is a number a reader trusts, a typo would silently answer a different question. It now rejects unknown flags.

Corpus data stays out of this repo. `--json` omits the example sentences, and the counts above are the only corpus-derived figures here.
