### PR TITLE
writing: share corpus selection

### DIFF
--- a/plugins/writing/skills/analyze/SKILL.md
+++ b/plugins/writing/skills/analyze/SKILL.md
@@ -98,7 +98,7 @@ Every run also splits each kind against itself, so the per-kind floors price the
 
 ## Authorship Distance
 
-`burrows-delta.ts` scores agent-authored prose against the voice baseline by Burrows's Delta, the mean absolute difference of standardized frequencies over the most frequent words of the reference corpus. Burrows, "'Delta': a Measure of Stylistic Difference and a Guide to Likely Authorship", Literary and Linguistic Computing 17(3), 267-287 (2002).
+`burrows-delta.ts` scores agent-authored prose against the voice baseline by Burrows's Delta, the mean absolute difference of standardized frequencies over the most frequent words of the reference corpus. Burrows, ["'Delta': a Measure of Stylistic Difference and a Guide to Likely Authorship"](https://doi.org/10.1093/llc/17.3.267), Literary and Linguistic Computing 17(3), 267-287 (2002).
 
 ```bash
 bun ${CLAUDE_SKILL_DIR}/scripts/burrows-delta.ts --kind message

--- a/plugins/writing/skills/analyze/scripts/burrows-delta.test.ts
+++ b/plugins/writing/skills/analyze/scripts/burrows-delta.test.ts
@@ -7,7 +7,6 @@ import {
   measure,
   mostFrequentWords,
   positiveInteger,
-  quantile,
   renderReport,
   standardize,
   summarizeDeltas,
@@ -128,23 +127,18 @@ describe("deltaFromCentroid", () => {
   });
 });
 
-describe("quantile", () => {
-  test.each<[string, number, number]>([
-    ["median", 0.5, 3],
-    ["p95 clamps to the last value", 0.95, 5],
-    ["floor", 0, 1],
-  ])("%s", (_name, p, expected) => {
-    expect(quantile([5, 1, 4, 2, 3], p)).toBe(expected);
-  });
-
-  test("an empty sample has no quantile", () => {
-    expect(quantile([], 0.5)).toBe(0);
-  });
-});
-
 describe("summarizeDeltas", () => {
   test("counts the bins and reports the middle and the tail", () => {
-    expect(summarizeDeltas([1, 2, 3, 4])).toEqual({ bins: 4, median: 3, p95: 4 });
+    expect(summarizeDeltas([5, 1, 4, 2, 3])).toEqual({ bins: 5, median: 3, p95: 5 });
+  });
+
+  // Nearest rank, so at 20 or fewer bins the tail is the sample maximum.
+  test("p95 is the largest value at this sample size", () => {
+    expect(summarizeDeltas([1, 2, 3, 4]).p95).toBe(4);
+  });
+
+  test("an empty sample has nothing to report", () => {
+    expect(summarizeDeltas([])).toEqual({ bins: 0, median: 0, p95: 0 });
   });
 });
 
@@ -237,13 +231,13 @@ describe("renderReport", () => {
     );
     expect(
       renderReport({
-        studyPath: "/data/contrast-baseline/claude-deliverables.txt",
-        studyDocs: 559,
-        studyTokens: 78_424,
-        kinds: ["message"],
-        baselineNames: ["github-prs.txt"],
-        baselineDocs: 342,
-        baselineTokens: 28_411,
+        study: {
+          path: "/data/contrast-baseline/claude-deliverables.txt",
+          kinds: ["message"],
+          docs: 559,
+          tokens: 78_424,
+        },
+        baseline: { names: ["github-prs.txt"], docs: 342, tokens: 28_411 },
         binWords: 1000,
         wordCount: 150,
         measurement,

--- a/plugins/writing/skills/analyze/scripts/burrows-delta.ts
+++ b/plugins/writing/skills/analyze/scripts/burrows-delta.ts
@@ -8,6 +8,7 @@
 import { cli } from "cleye";
 import {
   CORPUS_FLAGS,
+  corpusHeader,
   type CorpusHeader,
   corpusHeaderLines,
   selectCorpora,
@@ -355,17 +356,10 @@ if (import.meta.main) {
   } else {
     process.stdout.write(
       `${renderReport({
-        study: {
-          path: selection.study.path,
-          kinds: selection.study.kinds,
-          docs: selection.study.documents.length,
-          tokens: totalTokens(study.bins),
-        },
-        baseline: {
-          names: baseline.names,
-          docs: baseline.documents.length,
-          tokens: totalTokens(referenceBins),
-        },
+        ...corpusHeader(selection, {
+          study: totalTokens(study.bins),
+          baseline: totalTokens(referenceBins),
+        }),
         binWords,
         wordCount,
         measurement,

--- a/plugins/writing/skills/analyze/scripts/burrows-delta.ts
+++ b/plugins/writing/skills/analyze/scripts/burrows-delta.ts
@@ -3,19 +3,17 @@
 // standardized frequencies over the most frequent words of a reference corpus.
 // Burrows (2002), "'Delta': a Measure of Stylistic Difference and a Guide to
 // Likely Authorship", Literary and Linguistic Computing 17(3), 267-287.
+// https://doi.org/10.1093/llc/17.3.267
 
 import { cli } from "cleye";
-import { contrastCorpusPath, registerPaths, resolveDataDir, voiceBaselineDir } from "./data-dir";
-import { type NGramCounts, processCorpus } from "./ngram";
 import {
-  DOCUMENT_KINDS,
-  documentKind,
-  type DocumentKind,
-  isDocumentKind,
-  readCorpus,
-  splitHalves,
-  type VoiceDocument,
-} from "./voice-corpus";
+  CORPUS_FLAGS,
+  type CorpusHeader,
+  corpusHeaderLines,
+  selectCorpora,
+} from "./corpus-selection";
+import { type NGramCounts, processCorpus } from "./ngram";
+import { readCorpus, splitHalves, type VoiceDocument } from "./voice-corpus";
 
 export interface Bin {
   tokens: number;
@@ -126,13 +124,6 @@ export function deltaFromCentroid(
 function quantileOfSorted(sorted: number[], p: number): number {
   if (sorted.length === 0) return 0;
   return sorted[Math.min(sorted.length - 1, Math.floor(p * sorted.length))] ?? 0;
-}
-
-export function quantile(values: number[], p: number): number {
-  return quantileOfSorted(
-    values.toSorted((x, y) => x - y),
-    p,
-  );
 }
 
 export interface DeltaSummary {
@@ -274,14 +265,7 @@ function signed(value: number): string {
   return `${value >= 0 ? "+" : ""}${value.toFixed(2)}`;
 }
 
-export interface DeltaReport {
-  studyPath: string;
-  studyDocs: number;
-  studyTokens: number;
-  kinds: DocumentKind[];
-  baselineNames: string[];
-  baselineDocs: number;
-  baselineTokens: number;
+export interface DeltaReport extends CorpusHeader {
   binWords: number;
   wordCount: number;
   measurement: DeltaMeasurement;
@@ -291,9 +275,7 @@ export interface DeltaReport {
 export function renderReport(report: DeltaReport): string {
   const { measurement } = report;
   return [
-    `corpus A  ${report.studyDocs} docs, ${report.studyTokens.toLocaleString()} tokens  ` +
-      `kinds ${report.kinds.join(",")}  ${report.studyPath}`,
-    `corpus B  ${report.baselineDocs} docs, ${report.baselineTokens.toLocaleString()} tokens  ${report.baselineNames.join(", ")}`,
+    ...corpusHeaderLines(report),
     `bin ${report.binWords.toLocaleString()} words  words ${report.wordCount}  ` +
       `scored over ${measurement.scored.length} of ${measurement.words.length} carrying spread`,
     "",
@@ -328,24 +310,7 @@ if (import.meta.main) {
         "voice baseline by Burrows's Delta over the most frequent words of the baseline.",
     },
     flags: {
-      dataDir: { type: String, description: "Override the plugin data directory" },
-      study: {
-        type: String,
-        description: "Corpus A (agent-authored). Defaults to the contrast baseline.",
-      },
-      baseline: {
-        type: [String],
-        description:
-          "Corpus B register filenames. Repeatable. Default: github-prs.txt, github-issues.txt",
-      },
-      kind: {
-        type: [String],
-        description: `Corpus A document kinds to keep. Repeatable. One of ${DOCUMENT_KINDS.join(", ")}.`,
-      },
-      studyFilter: {
-        type: String,
-        description: "Narrow the kinds further to corpus A sources matching this regex",
-      },
+      ...CORPUS_FLAGS,
       binWords: { type: Number, default: 1000, description: "Words pooled into each bin" },
       words: { type: Number, default: 150, description: "Most frequent words to score over" },
       show: { type: Number, default: 25, description: "Words to print in the drift table" },
@@ -353,52 +318,18 @@ if (import.meta.main) {
     },
   });
 
-  const dataDir = resolveDataDir(argv.flags.dataDir);
-  const studyPath = argv.flags.study ?? contrastCorpusPath(dataDir);
-  const baselineNames = [
-    ...new Set(
-      argv.flags.baseline.length > 0
-        ? argv.flags.baseline
-        : ["github-prs.txt", "github-issues.txt"],
-    ),
-  ];
-
-  const registers = await registerPaths(dataDir);
-  const baselinePaths = baselineNames.map((name) => {
-    const found = registers.find((path) => path.endsWith(`/${name}`));
-    if (found === undefined) {
-      throw new Error(`No register ${name} under ${voiceBaselineDir(dataDir)}`);
-    }
-    return found;
-  });
-
-  const kinds = argv.flags.kind.map((kind) => {
-    if (!isDocumentKind(kind)) {
-      throw new Error(`Unknown kind ${kind}. One of ${DOCUMENT_KINDS.join(", ")}.`);
-    }
-    return kind;
-  });
-  const selected = new Set(kinds.length > 0 ? kinds : DOCUMENT_KINDS);
+  const selection = await selectCorpora(argv.flags);
+  const { baseline } = selection;
 
   // Every register under the voice baseline is the same author, so the ones not
   // spent on the reference price what a register shift alone costs.
-  const controlPaths = registers.filter((path) => !baselinePaths.includes(path));
-
-  const [studyAll, perRegister, perControl] = await Promise.all([
-    readCorpus(studyPath),
-    Promise.all(baselinePaths.map(readCorpus)),
-    Promise.all(controlPaths.map(readCorpus)),
-  ]);
-  const filter = argv.flags.studyFilter === undefined ? null : new RegExp(argv.flags.studyFilter);
-  const studyDocs = studyAll.filter(
-    (doc) => selected.has(documentKind(doc.source)) && (filter?.test(doc.source) ?? true),
-  );
-  const baselineDocs = perRegister.flat();
+  const controlPaths = selection.registers.filter((path) => !baseline.paths.includes(path));
+  const perControl = await Promise.all(controlPaths.map(readCorpus));
 
   const { binWords, words: wordCount } = argv.flags;
   const show = positiveInteger("show", argv.flags.show);
-  const study = { name: "study", bins: binDocuments(studyDocs, binWords) };
-  const referenceBins = binDocuments(baselineDocs, binWords);
+  const study = { name: "study", bins: binDocuments(selection.study.documents, binWords) };
+  const referenceBins = binDocuments(baseline.documents, binWords);
   const controls = perControl.map((docs, index) => ({
     name: controlPaths[index]?.split("/").pop() ?? "control",
     bins: binDocuments(docs, binWords),
@@ -409,7 +340,7 @@ if (import.meta.main) {
     process.stdout.write(
       `${JSON.stringify(
         {
-          kinds: [...selected],
+          kinds: selection.study.kinds,
           binWords,
           scored: measurement.scored,
           reference: measurement.reference,
@@ -424,13 +355,17 @@ if (import.meta.main) {
   } else {
     process.stdout.write(
       `${renderReport({
-        studyPath,
-        studyDocs: studyDocs.length,
-        studyTokens: totalTokens(study.bins),
-        kinds: [...selected],
-        baselineNames,
-        baselineDocs: baselineDocs.length,
-        baselineTokens: totalTokens(referenceBins),
+        study: {
+          path: selection.study.path,
+          kinds: selection.study.kinds,
+          docs: selection.study.documents.length,
+          tokens: totalTokens(study.bins),
+        },
+        baseline: {
+          names: baseline.names,
+          docs: baseline.documents.length,
+          tokens: totalTokens(referenceBins),
+        },
         binWords,
         wordCount,
         measurement,

--- a/plugins/writing/skills/analyze/scripts/corpus-selection.test.ts
+++ b/plugins/writing/skills/analyze/scripts/corpus-selection.test.ts
@@ -10,7 +10,13 @@ import {
   selectCorpora,
 } from "./corpus-selection";
 
-const NO_FLAGS: CorpusFlags = { baseline: [], kind: [] };
+const NO_FLAGS: CorpusFlags = {
+  baseline: [],
+  kind: [],
+  dataDir: undefined,
+  study: undefined,
+  studyFilter: undefined,
+};
 
 function document(source: string, body: string): string {
   return `===== ${source} (2026-01-01) =====\n${body}\n`;

--- a/plugins/writing/skills/analyze/scripts/corpus-selection.test.ts
+++ b/plugins/writing/skills/analyze/scripts/corpus-selection.test.ts
@@ -3,7 +3,12 @@ import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { type CorpusFlags, corpusHeaderLines, selectCorpora } from "./corpus-selection";
+import {
+  type CorpusFlags,
+  corpusHeader,
+  corpusHeaderLines,
+  selectCorpora,
+} from "./corpus-selection";
 
 const NO_FLAGS: CorpusFlags = { baseline: [], kind: [] };
 
@@ -91,8 +96,24 @@ describe("selectCorpora", () => {
   });
 });
 
+describe("corpusHeader", () => {
+  test("counts what survived selection, not what was on disk", async () => {
+    await withDataDir(async (dataDir) => {
+      const selection = await selectCorpora({ ...NO_FLAGS, dataDir, kind: ["message"] });
+      expect(corpusHeader(selection, { study: 78_424, baseline: 28_411 })).toEqual({
+        study: { path: selection.study.path, kinds: ["message"], docs: 1, tokens: 78_424 },
+        baseline: {
+          names: ["github-prs.txt", "github-issues.txt"],
+          docs: 2,
+          tokens: 28_411,
+        },
+      });
+    });
+  });
+});
+
 describe("corpusHeaderLines", () => {
-  test("names both corpora and what survived selection", () => {
+  test("names both corpora on one line each", () => {
     expect(
       corpusHeaderLines({
         study: { path: "/data/deliverables.txt", kinds: ["message"], docs: 559, tokens: 78_424 },

--- a/plugins/writing/skills/analyze/scripts/corpus-selection.test.ts
+++ b/plugins/writing/skills/analyze/scripts/corpus-selection.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type CorpusFlags, corpusHeaderLines, selectCorpora } from "./corpus-selection";
+
+const NO_FLAGS: CorpusFlags = { baseline: [], kind: [] };
+
+function document(source: string, body: string): string {
+  return `===== ${source} (2026-01-01) =====\n${body}\n`;
+}
+
+// A data dir holding one study corpus and the two registers the defaults name.
+async function makeDataDir(): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "corpus-selection-"));
+  await Bun.write(
+    join(dir, "contrast-baseline", "claude-deliverables.txt"),
+    document("session-a", "a message on a command line") +
+      document("repo/docs/guide.md", "prose committed for another reader") +
+      document("repo/tmp/notes.md", "scratch"),
+  );
+  await Bun.write(join(dir, "voice-baseline", "github-prs.txt"), document("pr/1", "pull request"));
+  await Bun.write(join(dir, "voice-baseline", "github-issues.txt"), document("i/1", "issue"));
+  await Bun.write(join(dir, "voice-baseline", "sent-mail.txt"), document("m/1", "mail"));
+  return dir;
+}
+
+async function withDataDir<T>(run: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await makeDataDir();
+  try {
+    return await run(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("selectCorpora", () => {
+  test("defaults to the contrast corpus and the two shipped registers", async () => {
+    await withDataDir(async (dataDir) => {
+      const { study, baseline, registers } = await selectCorpora({ ...NO_FLAGS, dataDir });
+      expect(study.path).toEndWith("/contrast-baseline/claude-deliverables.txt");
+      expect(study.documents).toHaveLength(3);
+      expect(baseline.names).toEqual(["github-prs.txt", "github-issues.txt"]);
+      expect(baseline.documents).toHaveLength(2);
+      // Every register on disk, so a caller can score the unspent ones as controls.
+      expect(registers.map((path) => path.split("/").pop())).toEqual([
+        "github-issues.txt",
+        "github-prs.txt",
+        "sent-mail.txt",
+      ]);
+    });
+  });
+
+  test("keeps only the named kinds", async () => {
+    await withDataDir(async (dataDir) => {
+      const { study } = await selectCorpora({ ...NO_FLAGS, dataDir, kind: ["message", "docs"] });
+      expect(study.kinds).toEqual(["message", "docs"]);
+      expect(study.documents.map((doc) => doc.source)).toEqual(["session-a", "repo/docs/guide.md"]);
+    });
+  });
+
+  test("narrows the kinds further by source regex", async () => {
+    await withDataDir(async (dataDir) => {
+      const { study } = await selectCorpora({ ...NO_FLAGS, dataDir, studyFilter: "guide" });
+      expect(study.documents.map((doc) => doc.source)).toEqual(["repo/docs/guide.md"]);
+    });
+  });
+
+  test("scores a register named twice only once", async () => {
+    await withDataDir(async (dataDir) => {
+      const { baseline } = await selectCorpora({
+        ...NO_FLAGS,
+        dataDir,
+        baseline: ["github-prs.txt", "github-prs.txt"],
+      });
+      expect(baseline.documents).toHaveLength(1);
+    });
+  });
+
+  test.each<[string, Partial<CorpusFlags>, RegExp]>([
+    ["an unknown kind", { kind: ["prose"] }, /Unknown kind prose/],
+    ["a register that is not on disk", { baseline: ["blog.txt"] }, /No register blog.txt/],
+  ])("refuses %s", async (_name, flags, message) => {
+    await withDataDir(async (dataDir) => {
+      const failure = await selectCorpora({ ...NO_FLAGS, dataDir, ...flags }).catch(
+        (error: Error) => error.message,
+      );
+      expect(failure).toMatch(message);
+    });
+  });
+});
+
+describe("corpusHeaderLines", () => {
+  test("names both corpora and what survived selection", () => {
+    expect(
+      corpusHeaderLines({
+        study: { path: "/data/deliverables.txt", kinds: ["message"], docs: 559, tokens: 78_424 },
+        baseline: { names: ["github-prs.txt", "github-issues.txt"], docs: 342, tokens: 28_411 },
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        "corpus A  559 docs, 78,424 tokens  kinds message  /data/deliverables.txt",
+        "corpus B  342 docs, 28,411 tokens  github-prs.txt, github-issues.txt",
+      ]
+    `);
+  });
+});

--- a/plugins/writing/skills/analyze/scripts/corpus-selection.ts
+++ b/plugins/writing/skills/analyze/scripts/corpus-selection.ts
@@ -1,6 +1,4 @@
-// Corpus A is agent-authored prose, corpus B one or more registers of the
-// pre-agent voice baseline. Every contrast script selects the pair the same way,
-// so the flags and the resolution live here rather than in each script.
+// Corpus A is agent-authored prose, corpus B one or more registers of the pre-agent voice baseline.
 
 import { contrastCorpusPath, registerPaths, resolveDataDir, voiceBaselineDir } from "./data-dir";
 import {
@@ -106,8 +104,7 @@ export async function selectCorpora(flags: CorpusFlags): Promise<CorpusSelection
   };
 }
 
-// What each report opens with, so the pair a run scored is legible from its
-// first two lines. Both counts are of what survived selection.
+// Both counts are of what survived selection.
 export interface CorpusHeader {
   study: { path: string; kinds: DocumentKind[]; docs: number; tokens: number };
   baseline: { names: string[]; docs: number; tokens: number };

--- a/plugins/writing/skills/analyze/scripts/corpus-selection.ts
+++ b/plugins/writing/skills/analyze/scripts/corpus-selection.ts
@@ -1,5 +1,6 @@
 // Corpus A is agent-authored prose, corpus B one or more registers of the pre-agent voice baseline.
 
+import type { TypeFlag } from "cleye";
 import { contrastCorpusPath, registerPaths, resolveDataDir, voiceBaselineDir } from "./data-dir";
 import {
   DOCUMENT_KINDS,
@@ -32,13 +33,9 @@ export const CORPUS_FLAGS = {
   },
 } as const;
 
-export interface CorpusFlags {
-  dataDir?: string | undefined;
-  study?: string | undefined;
-  baseline: string[];
-  kind: string[];
-  studyFilter?: string | undefined;
-}
+// Derived, so a flag added above reaches selectCorpora rather than parsing into
+// a field nothing reads.
+export type CorpusFlags = TypeFlag<typeof CORPUS_FLAGS>["flags"];
 
 export interface StudyCorpus {
   path: string;
@@ -103,14 +100,13 @@ export async function selectCorpora(flags: CorpusFlags): Promise<CorpusSelection
   };
 }
 
-// Both counts are of what survived selection.
+// docs counts what selection kept. tokens counts what the script went on to
+// measure, which for Delta is post-binning and so drops the trailing part-bin.
 export interface CorpusHeader {
   study: { path: string; kinds: DocumentKind[]; docs: number; tokens: number };
   baseline: { names: string[]; docs: number; tokens: number };
 }
 
-// Tokens come from the caller because each script counts them at a different
-// stage: Delta after binning, overlap after tokenizing.
 export function corpusHeader(
   { study, baseline }: CorpusSelection,
   tokens: { study: number; baseline: number },

--- a/plugins/writing/skills/analyze/scripts/corpus-selection.ts
+++ b/plugins/writing/skills/analyze/scripts/corpus-selection.ts
@@ -1,0 +1,121 @@
+// Corpus A is agent-authored prose, corpus B one or more registers of the
+// pre-agent voice baseline. Every contrast script selects the pair the same way,
+// so the flags and the resolution live here rather than in each script.
+
+import { contrastCorpusPath, registerPaths, resolveDataDir, voiceBaselineDir } from "./data-dir";
+import {
+  DOCUMENT_KINDS,
+  documentKind,
+  type DocumentKind,
+  isDocumentKind,
+  readCorpus,
+  type VoiceDocument,
+} from "./voice-corpus";
+
+export const CORPUS_FLAGS = {
+  dataDir: { type: String, description: "Override the plugin data directory" },
+  study: {
+    type: String,
+    description: "Corpus A (agent-authored). Defaults to the contrast baseline.",
+  },
+  baseline: {
+    type: [String],
+    description:
+      "Corpus B register filenames. Repeatable. Default: github-prs.txt, github-issues.txt",
+  },
+  kind: {
+    type: [String],
+    description: `Corpus A document kinds to keep. Repeatable. One of ${DOCUMENT_KINDS.join(", ")}.`,
+  },
+  studyFilter: {
+    type: String,
+    description: "Narrow the kinds further to corpus A sources matching this regex",
+  },
+} as const;
+
+export interface CorpusFlags {
+  dataDir?: string | undefined;
+  study?: string | undefined;
+  baseline: string[];
+  kind: string[];
+  studyFilter?: string | undefined;
+}
+
+export interface StudyCorpus {
+  path: string;
+  kinds: DocumentKind[];
+  documents: VoiceDocument[];
+}
+
+export interface BaselineCorpus {
+  names: string[];
+  paths: string[];
+  documents: VoiceDocument[];
+}
+
+export interface CorpusSelection {
+  study: StudyCorpus;
+  baseline: BaselineCorpus;
+  /** Every register on disk, reference and control alike. */
+  registers: string[];
+}
+
+const DEFAULT_BASELINES = ["github-prs.txt", "github-issues.txt"];
+
+export async function selectCorpora(flags: CorpusFlags): Promise<CorpusSelection> {
+  const dataDir = resolveDataDir(flags.dataDir);
+  const studyPath = flags.study ?? contrastCorpusPath(dataDir);
+  const baselineNames = [
+    ...new Set(flags.baseline.length > 0 ? flags.baseline : DEFAULT_BASELINES),
+  ];
+
+  const registers = await registerPaths(dataDir);
+  const baselinePaths = baselineNames.map((name) => {
+    const found = registers.find((path) => path.endsWith(`/${name}`));
+    if (found === undefined) {
+      throw new Error(`No register ${name} under ${voiceBaselineDir(dataDir)}`);
+    }
+    return found;
+  });
+
+  const named = flags.kind.map((kind) => {
+    if (!isDocumentKind(kind)) {
+      throw new Error(`Unknown kind ${kind}. One of ${DOCUMENT_KINDS.join(", ")}.`);
+    }
+    return kind;
+  });
+  const kinds = named.length > 0 ? [...new Set(named)] : [...DOCUMENT_KINDS];
+  const selected = new Set(kinds);
+  const filter = flags.studyFilter === undefined ? null : new RegExp(flags.studyFilter);
+
+  const [studyAll, perRegister] = await Promise.all([
+    readCorpus(studyPath),
+    Promise.all(baselinePaths.map(readCorpus)),
+  ]);
+
+  return {
+    study: {
+      path: studyPath,
+      kinds,
+      documents: studyAll.filter(
+        (doc) => selected.has(documentKind(doc.source)) && (filter?.test(doc.source) ?? true),
+      ),
+    },
+    baseline: { names: baselineNames, paths: baselinePaths, documents: perRegister.flat() },
+    registers,
+  };
+}
+
+// What each report opens with, so the pair a run scored is legible from its
+// first two lines. Both counts are of what survived selection.
+export interface CorpusHeader {
+  study: { path: string; kinds: DocumentKind[]; docs: number; tokens: number };
+  baseline: { names: string[]; docs: number; tokens: number };
+}
+
+export function corpusHeaderLines({ study, baseline }: CorpusHeader): string[] {
+  return [
+    `corpus A  ${study.docs} docs, ${study.tokens.toLocaleString()} tokens  kinds ${study.kinds.join(",")}  ${study.path}`,
+    `corpus B  ${baseline.docs} docs, ${baseline.tokens.toLocaleString()} tokens  ${baseline.names.join(", ")}`,
+  ];
+}

--- a/plugins/writing/skills/analyze/scripts/corpus-selection.ts
+++ b/plugins/writing/skills/analyze/scripts/corpus-selection.ts
@@ -10,6 +10,8 @@ import {
   type VoiceDocument,
 } from "./voice-corpus";
 
+const DEFAULT_BASELINES = ["github-prs.txt", "github-issues.txt"];
+
 export const CORPUS_FLAGS = {
   dataDir: { type: String, description: "Override the plugin data directory" },
   study: {
@@ -18,8 +20,7 @@ export const CORPUS_FLAGS = {
   },
   baseline: {
     type: [String],
-    description:
-      "Corpus B register filenames. Repeatable. Default: github-prs.txt, github-issues.txt",
+    description: `Corpus B register filenames. Repeatable. Default: ${DEFAULT_BASELINES.join(", ")}`,
   },
   kind: {
     type: [String],
@@ -58,8 +59,6 @@ export interface CorpusSelection {
   registers: string[];
 }
 
-const DEFAULT_BASELINES = ["github-prs.txt", "github-issues.txt"];
-
 export async function selectCorpora(flags: CorpusFlags): Promise<CorpusSelection> {
   const dataDir = resolveDataDir(flags.dataDir);
   const studyPath = flags.study ?? contrastCorpusPath(dataDir);
@@ -82,8 +81,8 @@ export async function selectCorpora(flags: CorpusFlags): Promise<CorpusSelection
     }
     return kind;
   });
-  const kinds = named.length > 0 ? [...new Set(named)] : [...DOCUMENT_KINDS];
-  const selected = new Set(kinds);
+  const selected = new Set(named.length > 0 ? named : DOCUMENT_KINDS);
+  const kinds = [...selected];
   const filter = flags.studyFilter === undefined ? null : new RegExp(flags.studyFilter);
 
   const [studyAll, perRegister] = await Promise.all([
@@ -108,6 +107,23 @@ export async function selectCorpora(flags: CorpusFlags): Promise<CorpusSelection
 export interface CorpusHeader {
   study: { path: string; kinds: DocumentKind[]; docs: number; tokens: number };
   baseline: { names: string[]; docs: number; tokens: number };
+}
+
+// Tokens come from the caller because each script counts them at a different
+// stage: Delta after binning, overlap after tokenizing.
+export function corpusHeader(
+  { study, baseline }: CorpusSelection,
+  tokens: { study: number; baseline: number },
+): CorpusHeader {
+  return {
+    study: {
+      path: study.path,
+      kinds: study.kinds,
+      docs: study.documents.length,
+      tokens: tokens.study,
+    },
+    baseline: { names: baseline.names, docs: baseline.documents.length, tokens: tokens.baseline },
+  };
 }
 
 export function corpusHeaderLines({ study, baseline }: CorpusHeader): string[] {

--- a/plugins/writing/skills/analyze/scripts/wordlist-overlap.test.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlist-overlap.test.ts
@@ -208,17 +208,17 @@ describe("renderReport", () => {
   test("formats the whole measurement", () => {
     expect(
       renderReport({
-        studyPath: "/data/contrast-baseline/claude-deliverables.txt",
-        studyDocs: 22,
-        studyTokens: 1234,
-        kinds: ["docs", "other"],
+        study: {
+          path: "/data/contrast-baseline/claude-deliverables.txt",
+          kinds: ["docs", "other"],
+          docs: 22,
+          tokens: 1234,
+        },
+        baseline: { names: ["github-prs.txt"], docs: 342, tokens: 5678 },
         kindFloors: [
           { kind: "docs", docs: 18, maxZ: 6.31 },
           { kind: "other", docs: 4, maxZ: null },
         ],
-        baselineNames: ["github-prs.txt"],
-        baselineDocs: 342,
-        baselineTokens: 5678,
         prior: 500,
         sizes: [1, 2],
         minCount: 5,

--- a/plugins/writing/skills/analyze/scripts/wordlist-overlap.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlist-overlap.ts
@@ -19,6 +19,7 @@ import {
 } from "../../../detection/wordlists";
 import {
   CORPUS_FLAGS,
+  corpusHeader,
   type CorpusHeader,
   corpusHeaderLines,
   selectCorpora,
@@ -250,7 +251,8 @@ if (import.meta.main) {
   });
 
   const sizes = argv.flags.sizes.length > 0 ? argv.flags.sizes : [1, 2];
-  const { study, baseline } = await selectCorpora(argv.flags);
+  const selection = await selectCorpora(argv.flags);
+  const { study, baseline } = selection;
 
   // Min-count 1 over sizes 1 through 3 so every curated entry gets a position,
   // including the three-word phrases. Tokenize once at the union of both.
@@ -299,13 +301,7 @@ if (import.meta.main) {
   } else {
     process.stdout.write(
       `${renderReport({
-        study: {
-          path: study.path,
-          kinds: study.kinds,
-          docs: study.documents.length,
-          tokens: a.tokens,
-        },
-        baseline: { names: baseline.names, docs: baseline.documents.length, tokens: b.tokens },
+        ...corpusHeader(selection, { study: a.tokens, baseline: b.tokens }),
         kindFloors,
         prior,
         sizes,

--- a/plugins/writing/skills/analyze/scripts/wordlist-overlap.ts
+++ b/plugins/writing/skills/analyze/scripts/wordlist-overlap.ts
@@ -17,15 +17,17 @@ import {
   weightedStemHits,
   WORDLISTS,
 } from "../../../detection/wordlists";
-import { contrastCorpusPath, registerPaths, resolveDataDir, voiceBaselineDir } from "./data-dir";
+import {
+  CORPUS_FLAGS,
+  type CorpusHeader,
+  corpusHeaderLines,
+  selectCorpora,
+} from "./corpus-selection";
 import { rank, type RankedTerm, type RankOptions, stemTerm, tokenizeCorpus } from "./fightin-words";
 import {
   DOCUMENT_KINDS,
-  documentKind,
   type DocumentKind,
   groupByKind,
-  isDocumentKind,
-  readCorpus,
   splitHalves,
   type VoiceDocument,
 } from "./voice-corpus";
@@ -162,15 +164,8 @@ function pct(part: number, whole: number): string {
   return `${((part / whole) * 100).toFixed(1)}%`;
 }
 
-export interface OverlapReport {
-  studyPath: string;
-  studyDocs: number;
-  studyTokens: number;
-  kinds: DocumentKind[];
+export interface OverlapReport extends CorpusHeader {
   kindFloors: KindFloor[];
-  baselineNames: string[];
-  baselineDocs: number;
-  baselineTokens: number;
   prior: number;
   sizes: number[];
   minCount: number;
@@ -186,9 +181,7 @@ export interface OverlapReport {
 export function renderReport(report: OverlapReport): string {
   const { summary } = report;
   const lines = [
-    `corpus A  ${report.studyDocs} docs, ${report.studyTokens.toLocaleString()} tokens  ` +
-      `kinds ${report.kinds.join(",")}  ${report.studyPath}`,
-    `corpus B  ${report.baselineDocs} docs, ${report.baselineTokens.toLocaleString()} tokens  ${report.baselineNames.join(", ")}`,
+    ...corpusHeaderLines(report),
     `prior ${report.prior}  sizes ${report.sizes.join(",")}  min-count ${report.minCount}  min-docs ${report.minDocs}`,
     "",
     `top ${summary.considered} discovered terms`,
@@ -245,24 +238,7 @@ if (import.meta.main) {
         "the shipped detectors already cover.",
     },
     flags: {
-      dataDir: { type: String, description: "Override the plugin data directory" },
-      study: {
-        type: String,
-        description: "Corpus A (agent-authored). Defaults to the contrast baseline.",
-      },
-      baseline: {
-        type: [String],
-        description:
-          "Corpus B register filenames. Repeatable. Default: github-prs.txt, github-issues.txt",
-      },
-      kind: {
-        type: [String],
-        description: `Corpus A document kinds to keep. Repeatable. One of ${DOCUMENT_KINDS.join(", ")}.`,
-      },
-      studyFilter: {
-        type: String,
-        description: "Narrow the kinds further to corpus A sources matching this regex",
-      },
+      ...CORPUS_FLAGS,
       sizes: { type: [Number], description: "N-gram sizes. Default: 1 and 2" },
       prior: { type: Number, default: 500, description: "Dirichlet concentration (alpha-0)" },
       minCount: { type: Number, default: 5, description: "Minimum occurrences in corpus A" },
@@ -273,45 +249,15 @@ if (import.meta.main) {
     },
   });
 
-  const dataDir = resolveDataDir(argv.flags.dataDir);
   const sizes = argv.flags.sizes.length > 0 ? argv.flags.sizes : [1, 2];
-  const studyPath = argv.flags.study ?? contrastCorpusPath(dataDir);
-  const baselineNames =
-    argv.flags.baseline.length > 0 ? argv.flags.baseline : ["github-prs.txt", "github-issues.txt"];
-
-  const registers = await registerPaths(dataDir);
-  const baselinePaths = baselineNames.map((name) => {
-    const found = registers.find((path) => path.endsWith(`/${name}`));
-    if (found === undefined) {
-      throw new Error(`No register ${name} under ${voiceBaselineDir(dataDir)}`);
-    }
-    return found;
-  });
-
-  const kinds = argv.flags.kind.map((kind) => {
-    if (!isDocumentKind(kind)) {
-      throw new Error(`Unknown kind ${kind}. One of ${DOCUMENT_KINDS.join(", ")}.`);
-    }
-    return kind;
-  });
-  const selected = new Set(kinds.length > 0 ? kinds : DOCUMENT_KINDS);
-
-  const [studyAll, ...perRegister] = await Promise.all([
-    readCorpus(studyPath),
-    ...baselinePaths.map(readCorpus),
-  ]);
-  const filter = argv.flags.studyFilter === undefined ? null : new RegExp(argv.flags.studyFilter);
-  const studyDocs = studyAll.filter(
-    (doc) => selected.has(documentKind(doc.source)) && (filter?.test(doc.source) ?? true),
-  );
-  const baselineDocs = perRegister.flat();
+  const { study, baseline } = await selectCorpora(argv.flags);
 
   // Min-count 1 over sizes 1 through 3 so every curated entry gets a position,
   // including the three-word phrases. Tokenize once at the union of both.
   const curatedSizes = [1, 2, 3];
   const allSizes = [...new Set([...sizes, ...curatedSizes])].toSorted((x, y) => x - y);
-  const a = tokenizeCorpus(studyDocs, allSizes);
-  const b = tokenizeCorpus(baselineDocs, allSizes);
+  const a = tokenizeCorpus(study.documents, allSizes);
+  const b = tokenizeCorpus(baseline.documents, allSizes);
 
   const { prior, minCount, minDocs } = argv.flags;
   const ranked = rank(a, b, { sizes, prior, minCount, minDocs });
@@ -321,11 +267,11 @@ if (import.meta.main) {
   }));
 
   const nullOptions = { sizes, prior, minCount, minDocs };
-  const kindFloors = nullFloorByKind(studyDocs, nullOptions);
+  const kindFloors = nullFloorByKind(study.documents, nullOptions);
   // Over a single kind the aggregate control splits the same documents into the
   // same halves, so it would report that kind's floor a second time.
   const [leftDocs, rightDocs]: [VoiceDocument[], VoiceDocument[]] =
-    kindFloors.length > 1 ? splitHalves(studyDocs) : [[], []];
+    kindFloors.length > 1 ? splitHalves(study.documents) : [[], []];
   const nullRanked = rank(
     tokenizeCorpus(leftDocs, sizes),
     tokenizeCorpus(rightDocs, sizes),
@@ -345,7 +291,7 @@ if (import.meta.main) {
     const terms = measured.map(({ row: { example, ...row }, coverage }) => ({ row, coverage }));
     process.stdout.write(
       `${JSON.stringify(
-        { kinds: [...selected], kindFloors, summary: summarize(measured), recall, terms },
+        { kinds: study.kinds, kindFloors, summary: summarize(measured), recall, terms },
         null,
         2,
       )}\n`,
@@ -353,14 +299,14 @@ if (import.meta.main) {
   } else {
     process.stdout.write(
       `${renderReport({
-        studyPath,
-        studyDocs: studyDocs.length,
-        studyTokens: a.tokens,
-        kinds: [...selected],
+        study: {
+          path: study.path,
+          kinds: study.kinds,
+          docs: study.documents.length,
+          tokens: a.tokens,
+        },
+        baseline: { names: baseline.names, docs: baseline.documents.length, tokens: b.tokens },
         kindFloors,
-        baselineNames,
-        baselineDocs: baselineDocs.length,
-        baselineTokens: b.tokens,
         prior,
         sizes,
         minCount,


### PR DESCRIPTION
Both contrast scripts resolved the same corpus pair through the same five flags, the same data-dir lookup, the same register-name to path mapping, the same kind validation, and the same regex narrowing. Neither copy was reachable from a test, because the logic lived in the CLI body.

`corpus-selection.ts` now owns it, along with the header both reports open on. `corpus-selection.test.ts` covers the defaults, each filter, and both refusal paths.

Duplicate flag values collapse now. Repeating a `--baseline` register used to read it twice in `wordlist-overlap` and double its weight in corpus B. Repeating a `--kind` printed the kind twice in the report header. Deduping both is the one behavior change here.

`DeltaReport` and `OverlapReport` extend a shared `CorpusHeader` rather than carrying seven flat fields. `corpusHeader` derives that header from the selection, so a document count and the documents it counted cannot drift apart at a call site.

`quantile` was a public wrapper nothing but its own test called. Its nearest-rank cases moved onto `summarizeDeltas`, which is what the report calls.

Behavior is otherwise unchanged. Both scripts produce byte-identical output on the real corpus for the default run, `--kind message --json`, and `--baseline github-issues.txt --sizes 1`, and every guard still refuses with the same message.

Deduping two ~40-line copies lands near break-even on line count rather than deeply red. The shared module has to carry a flag schema and explicit types that the inline copies got free from local `const`s. Code-only is 176 added against 171 removed, and the rest is the new test file.

Stacked on #1377.
