### PR TITLE
lint: cut config that restates ox defaults

### DIFF
--- a/.claude/hooks/ox/README.md
+++ b/.claude/hooks/ox/README.md
@@ -8,6 +8,8 @@ Runs [oxlint](https://oxc.rs/docs/guide/usage/linter.html) and [oxfmt](https://o
 
 When you `Edit` or `Write` a file oxlint understands, it runs and shows any issues as context. This is informational only. It never writes to the file, so your later edits in the same turn still match what is on disk. Formatting is deferred to the Stop and pre-commit gates.
 
+This pass reads `.oxlintrc.fast.json` where the working tree has one, falling back to the default config. Loading oxlint's JS plugin host costs a fixed ~150ms whatever rules it carries, so a tree that keeps its JS-plugin rules out of the fast config pays that only at the gates below, which always read the default config.
+
 #### Before Stopping (Stop)
 
 When the session ends, oxfmt formats all edited files, oxlint checks them, and a type check runs over each working tree those files belong to (`oxlint --type-aware --type-check`). If issues remain, the session is blocked until they're resolved or the budget below runs out.

--- a/.claude/hooks/ox/index.test.ts
+++ b/.claude/hooks/ox/index.test.ts
@@ -151,6 +151,25 @@ async function createIgnoredFixture(baseDir: string): Promise<string> {
   return filePath;
 }
 
+// A repo whose default config flags the file and whose fast config does not.
+// The per-file pass must read the fast config, so a passing result proves the
+// default was skipped rather than that the file happens to be clean.
+async function createFastConfigFixture(baseDir: string): Promise<string> {
+  const repoDir = await mkdtemp(join(baseDir, "fast-config-repo-"));
+  await execAsync("git init", { cwd: repoDir });
+  await Bun.write(
+    join(repoDir, ".oxlintrc.json"),
+    JSON.stringify({ rules: { "no-dupe-keys": "error" } }),
+  );
+  await Bun.write(
+    join(repoDir, ".oxlintrc.fast.json"),
+    JSON.stringify({ rules: { "no-dupe-keys": "off" } }),
+  );
+  const filePath = join(repoDir, "duplicate.ts");
+  await Bun.write(filePath, await Bun.file(join(FIXTURES_DIR, "unfixable.ts")).text());
+  return filePath;
+}
+
 // The type-aware pass is skipped where node_modules is absent and falls back to
 // the plain pass where it is present without tsgolint, so `nodeModules` picks
 // which of the three shapes a fixture exercises. The empty tree stands in for a
@@ -215,6 +234,11 @@ describe("ox hook", () => {
 
     it("returns null for files the ox config ignores", async () => {
       const filePath = await createIgnoredFixture(tempDir);
+      expect(await runOxlintAgent(filePath)).toBeNull();
+    });
+
+    it("prefers the fast config over the default one", async () => {
+      const filePath = await createFastConfigFixture(tempDir);
       expect(await runOxlintAgent(filePath)).toBeNull();
     });
   });

--- a/.claude/hooks/ox/index.ts
+++ b/.claude/hooks/ox/index.ts
@@ -363,13 +363,26 @@ async function runOxlintPass(
   return output != null && MISSING_CHECKER.test(output) ? runOx(command, args, cwd) : output;
 }
 
+// Loading oxlint's JS plugin host costs a fixed ~150ms on top of a per-file
+// type-aware pass, whatever rules it carries. A tree that keeps its JS-plugin
+// rules in .oxlintrc.json and mirrors the rest into .oxlintrc.fast.json pays
+// that only at the gate, where the batch and whole-tree passes below still read
+// the default config. A tree without the file lints against its default config.
+const FAST_CONFIG = ".oxlintrc.fast.json";
+
+async function fastConfigArgs(cwd: string | undefined): Promise<string[]> {
+  const path = join(cwd ?? process.cwd(), FAST_CONFIG);
+  return (await Bun.file(path).exists()) ? ["-c", path] : [];
+}
+
 export async function runOxlintAgent(filePath: string): Promise<string | null> {
   const command = await oxlintCommand();
   if (!command) {
     return null;
   }
   const cwd = await oxWorkingTree(filePath);
-  return runOxlintPass(command, [...LINT_ARGS, filePath], cwd);
+  const config = await fastConfigArgs(cwd);
+  return runOxlintPass(command, [...config, ...LINT_ARGS, filePath], cwd);
 }
 
 async function runOxlintAgentBatch(files: string[]): Promise<string | null> {

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,17 +1,5 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "useTabs": false,
-  "tabWidth": 2,
-  "printWidth": 100,
-  "singleQuote": false,
-  "jsxSingleQuote": false,
-  "quoteProps": "as-needed",
-  "trailingComma": "all",
-  "semi": true,
-  "arrowParens": "always",
-  "bracketSameLine": false,
-  "bracketSpacing": true,
-  "sortPackageJson": false,
   "ignorePatterns": [
     "**/*.md",
     "**/*.html",

--- a/.oxlintrc.fast.json
+++ b/.oxlintrc.fast.json
@@ -1,11 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "extends": [
-    "./lint/base.json",
-    "./lint/bun.json",
-    "./lint/typescript.json",
-    "./packages/oxlint-rules/config.json"
-  ],
+  "extends": ["./lint/base.json", "./lint/bun.json", "./lint/typescript.json"],
   "ignorePatterns": [
     "**/fixtures/**",
     "**/*.d.ts",

--- a/lint/base.json
+++ b/lint/base.json
@@ -5,18 +5,12 @@
     "correctness": "error",
     "suspicious": "error"
   },
-  "env": {
-    "builtin": true
-  },
   "rules": {
     "eqeqeq": ["error", "always", { "null": "ignore" }],
     "max-depth": "error",
     "no-await-in-loop": "error",
-    // splitting imports of the same module hides that they're related and invites drift
     "no-duplicate-imports": "error",
-    // An empty block silently swallows whatever it should have handled, hiding bugs.
     "no-empty": "error",
-    // Nesting an if inside an else block obscures control flow that else if states directly.
     "no-lonely-if": "error",
     "no-template-curly-in-string": "warn",
     "no-underscore-dangle": ["error", { "allow": ["__typename", "__dirname"] }],
@@ -32,62 +26,27 @@
         "ignoreRestSiblings": true
       }
     ],
-    // Object.assign({}, ...) merges through a function call instead of an
-    // object literal, hiding the resulting shape from tools that read
-    // literals better than call expressions, and needs an empty target
-    // argument purely to avoid mutating an input.
     "prefer-object-spread": "error",
     "prefer-template": "error",
-    "import/no-named-as-default-member": "error",
-    // a namespace binding hides which members a file uses from both readers and unused-import checks
     "import/no-namespace": ["error", { "ignore": ["fast-check"] }],
     "oxc/no-map-spread": "error",
-    // A `new Promise` executor that only wraps an existing async API duplicates
-    // logic the platform already exposes, and drops its built-in error handling.
     "promise/avoid-new": "error",
-    // A catch binding named anything but "error" reads as an unrelated value at the call site.
     "unicorn/catch-error-name": "error",
-    // A custom Error subclass that never sets name prints as "Error", losing which error it is.
     "unicorn/custom-error-definition": "error",
-    // An implicit length check reads as a numeric truthiness test rather
-    // than a stated "has items" or "is empty" comparison, and looks the
-    // same whether the intent is >0, !==0, or something else entirely.
     "unicorn/explicit-length-check": "error",
-    // A forEach callback gives up break and continue, cannot await without
-    // an async-IIFE workaround, and adds a closure frame the loop body
-    // does not need.
     "unicorn/no-array-for-each": "error",
     "unicorn/prefer-array-find": "error",
-    // a split re-export keeps a name in local scope only to hand it back out, saying nothing about the module's own logic
     "unicorn/prefer-export-from": "error",
-    // A hand-written a > b ? a : b comparison mishandles NaN silently,
-    // does not extend past two values without nesting, and hides a named
-    // operation behind inline conditional logic.
     "unicorn/prefer-math-min-max": "error",
     "unicorn/prefer-set-has": "error",
-    // Array.prototype.slice.call/.apply()/.concat()/Array.from() carry
-    // parameters and binding semantics (thisArg, mapping functions)
-    // irrelevant to a plain copy, where spread states the intent directly.
     "unicorn/prefer-spread": "error",
-    // `String.raw` keeps a backslash-heavy literal (a path, a regex) readable as written, instead of forcing a manual escape count that's easy to get wrong.
     "unicorn/prefer-string-raw": "error",
-    // `replace()` needs a global regex to hit every match, and a dropped `g` flag silently replaces only the first one. `replaceAll()` makes the intent explicit and takes a plain string when there's no pattern to match.
     "unicorn/prefer-string-replace-all": "error",
-    // `substring()` swaps out-of-order arguments and clamps negatives instead of indexing from the end. `substr()` is deprecated and its second argument is a length. `slice()` is the one method with consistent, current semantics.
     "unicorn/prefer-string-slice": "error",
-    // vitest/no-commented-out-tests only means something in test files.
-    // Enabled repo-wide via the plugin's categories, it runs over source
-    // prose too and produces false positives like db.ts's
-    // "... it (00_pinned.sql), so ...", which reads like a commented-out
-    // `it(...)` call but isn't one. Off here. Enabled only under
-    // **/*.test.ts below, where a commented-out test can actually occur.
+    // The vitest plugin matches the Jest-style API shape, not the import, so it
+    // covers this repo's bun:test suites. These two rules read source prose and
+    // ordinary loops as tests, so they run only over test files.
     "vitest/no-commented-out-tests": "off",
-    // This repo tests with bun:test, not vitest. The vitest plugin matches
-    // on the Jest-style API shape rather than the import, so it still
-    // applies correctly here. Like no-commented-out-tests, it only means
-    // something in test files: repo-wide it flags any loop whose body it
-    // reads as a repeated case, such as render.ts drawing one text line
-    // per iteration. Off here, on under **/*.test.ts below.
     "vitest/prefer-each": "off"
   },
   "overrides": [

--- a/lint/bun.json
+++ b/lint/bun.json
@@ -32,8 +32,6 @@
         ]
       }
     ],
-    // `__dirname` rebuilt from `import.meta.url` recomputes what Bun already
-    // exposes on `import.meta`, and breaks if the URL parsing drifts.
     "unicorn/prefer-import-meta-properties": "error"
   }
 }

--- a/lint/typescript.json
+++ b/lint/typescript.json
@@ -1,27 +1,21 @@
 {
   "$schema": "../node_modules/oxlint/configuration_schema.json",
   "rules": {
-    "typescript/array-type": "error", // Array<T> makes every array read like a lookup instead of a list
+    "typescript/array-type": "error",
     "typescript/ban-ts-comment": "error",
-    "typescript/consistent-generic-constructors": "error", // repeating the type on both sides of `new` is redundant work
-    // Extending an object shape with `&` reduces conflicting members to never
-    // and says nothing, where `interface extends` reports the conflict at the
-    // declaration. The accepted cost is that interface merges across duplicates.
+    "typescript/consistent-generic-constructors": "error",
     "typescript/consistent-type-definitions": "error",
     "typescript/explicit-module-boundary-types": "error",
     "typescript/no-deprecated": "error",
     "typescript/no-explicit-any": "error",
     "typescript/no-misused-promises": "error",
-    "typescript/no-misused-spread": "error",
     "typescript/no-non-null-assertion": "error",
     "typescript/no-unnecessary-condition": ["error", { "allowConstantLoopConditions": "always" }],
-    "typescript/no-unnecessary-type-assertion": "error",
     "typescript/no-unsafe-argument": "error",
     "typescript/no-unsafe-assignment": "error",
     "typescript/no-unsafe-call": "error",
     "typescript/no-unsafe-member-access": "error",
     "typescript/no-unsafe-return": "error",
-    "typescript/no-unsafe-type-assertion": "error",
     "typescript/only-throw-error": "error",
     "typescript/prefer-promise-reject-errors": "error",
     "typescript/require-await": "error",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@bendrucker/claude",
   "private": true,
-  "type": "module",
   "workspaces": [
     "packages/skill-lint",
     "plugins/claude-code",
@@ -35,6 +34,7 @@
     "plugins/pull-request/evals/pr-body",
     "packages/oxlint-rules"
   ],
+  "type": "module",
   "scripts": {
     "build": "oxlint --type-aware --type-check",
     "check": "oxlint --type-aware && oxfmt --check",
@@ -48,6 +48,13 @@
     "skill-lint": "bun ./packages/skill-lint/cli.ts",
     "test": "bun test",
     "test:unit": "bun test"
+  },
+  "dependencies": {
+    "cleye": "^2.2.1",
+    "table": "^6.9.0",
+    "typescript": "^6.0.0",
+    "url-pattern": "^1.0.3",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
@@ -63,13 +70,6 @@
     "oxlint": "^1.78.0",
     "oxlint-tsgolint": "^7.0.2001",
     "unist-util-visit": "^5.1.0"
-  },
-  "dependencies": {
-    "cleye": "^2.2.1",
-    "table": "^6.9.0",
-    "typescript": "^6.0.0",
-    "url-pattern": "^1.0.3",
-    "zod": "^4.4.3"
   },
   "overrides": {
     "@apidevtools/json-schema-ref-parser": "^15.0.0"

--- a/packages/skill-lint/package.json
+++ b/packages/skill-lint/package.json
@@ -1,10 +1,10 @@
 {
   "name": "skill-lint",
   "version": "0.0.1",
-  "type": "module",
   "bin": {
     "skill-lint": "./cli.ts"
   },
+  "type": "module",
   "scripts": {
     "test": "bun test"
   }

--- a/plugins/things/package.json
+++ b/plugins/things/package.json
@@ -2,16 +2,16 @@
   "name": "things",
   "version": "1.0.0",
   "description": "",
+  "keywords": [],
+  "license": "ISC",
+  "author": "",
+  "type": "commonjs",
   "main": "index.js",
   "scripts": {
     "types:generate": "sdef-to-dts /Applications/Things3.app --output src/Things3.d.ts",
     "build": "esbuild src/example.ts --bundle --platform=neutral --format=iife --log-level=error > /dev/null",
     "typecheck": "tsc --noEmit"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "type": "commonjs",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
     "@modelcontextprotocol/sdk": "^1.30.0",


### PR DESCRIPTION
Removes lint and format configuration that restates what oxlint and oxfmt already do, and moves the JS-plugin rules off the per-edit path.

## Defaults

Eleven of `.oxfmtrc.json`'s thirteen options were already oxfmt defaults, confirmed by checking the whole tree against a defaults-only config. The twelfth, `sortPackageJson`, now takes oxfmt's default as well, which reorders three `package.json` files into canonical key order.

In the oxlint configs, `env.builtin` is a default and `tmp/**` leaves `ignorePatterns` because oxlint honors `.gitignore`. Four rules were already denied by the `correctness` category:

- `import/no-named-as-default-member`
- `typescript/no-misused-spread`
- `typescript/no-unnecessary-type-assertion`
- `typescript/no-unsafe-type-assertion`

`oxlint --print-config` resolves byte-identically before and after, so nothing changed what gets enforced.

Two settings look like defaults and are not. Having a config file at all drops `correctness` to `warn`, so `"correctness": "error"` upgrades the category back to failing. And `plugins` replaces oxlint's default `unicorn`/`typescript`/`oxc` set rather than extending it, so all seven entries have to stay listed.

Comments in `lint/base.json` go from thirteen blocks to one. The rest paraphrased each rule's own documentation. The survivor covers what the rule names don't say: the vitest plugin matches the Jest-style API shape rather than the import, which is why it applies to `bun:test` suites, and why two of its rules run only over test files.

## Local Rule Plugins

Loading oxlint's JS plugin host costs a fixed ~400ms whatever rules it carries. Enabling one rule from `packages/oxlint-rules` costs what enabling all five does, so trimming rules recovers nothing. Only keeping the host out of a run does.

`.oxlintrc.json` stays the full config, leaving CI, `bun run check`, `bun run build`, and the hook's Stop and pre-commit gates unchanged. The new `.oxlintrc.fast.json` mirrors it without the local rules, and the hook's per-file `PostToolUse` pass prefers it where a working tree has one. That drops the per-edit lint from 0.40s to 0.30s. A tree without the file lints against its default config as before, so the hook stays usable in repos that set nothing up.

Added a test covering the preference, checked by reverting the hook change and confirming it fails.

The two configs repeat their five `ignorePatterns` entries because oxlint does not inherit them through `extends`. Nothing enforces that they stay in sync. Drift would show up as the per-edit pass reporting on a fixture or `.d.ts` the gates ignore, and `scripts/check-hook-paths.ts` is where a guard would go.
