### PR TITLE
agent-model: warn for Explore and review:angle

### DIFF
--- a/user/hooks/agent-model/index.test.ts
+++ b/user/hooks/agent-model/index.test.ts
@@ -32,6 +32,8 @@ function assistant(model: string): AssistantRecord {
 
 const bare = { description: "look up a symbol" };
 const generic = { subagent_type: "general-purpose" };
+const explore = { subagent_type: "Explore" };
+const angle = { subagent_type: "review:angle" };
 
 describe("decide", () => {
   test.each<[string, unknown, ModelFamily | null, ModelFamily | null, boolean]>([
@@ -39,6 +41,10 @@ describe("decide", () => {
     ["general-purpose under opus", generic, "opus", null, true],
     ["bare spawn under fable", bare, "fable", null, true],
     ["general-purpose under fable", generic, "fable", null, true],
+    ["Explore under opus", explore, "opus", null, true],
+    ["review:angle under opus", angle, "opus", null, true],
+    ["Explore with an explicit model", { ...explore, model: "haiku" }, "opus", null, false],
+    ["review:angle under sonnet", angle, "sonnet", null, false],
     ["empty model string under opus", { model: "" }, "opus", null, true],
     ["pinned type under opus", { subagent_type: "analyst" }, "opus", null, false],
     ["fork under opus", { subagent_type: "fork" }, "opus", null, false],
@@ -107,7 +113,10 @@ describe("spawnNeedsModel", () => {
     ["bare spawn", { description: "look up a symbol" }, true],
     ["general-purpose", { subagent_type: "general-purpose" }, true],
     ["empty model string", { subagent_type: "general-purpose", model: "" }, true],
+    ["Explore", { subagent_type: "Explore" }, true],
+    ["review:angle", { subagent_type: "review:angle" }, true],
     ["pinned type", { subagent_type: "analyst" }, false],
+    ["a review type outside the set", { subagent_type: "review:verifier" }, false],
     ["explicit model", { model: "sonnet" }, false],
     ["non-object input", 7, false],
   ])("%s", (_name, toolInput, expected) => {

--- a/user/hooks/agent-model/index.ts
+++ b/user/hooks/agent-model/index.ts
@@ -15,7 +15,7 @@ const AgentInput = z.looseObject({
 // Types that name no model of their own, so the spawn site has to supply one.
 // Every other type either pins a model in its definition or is a deliberate
 // choice the parent already made.
-const UNPINNED_TYPES = new Set(["general-purpose"]);
+const UNPINNED_TYPES = new Set(["general-purpose", "Explore", "review:angle"]);
 
 const EXPENSIVE_FAMILIES = new Set<ModelFamily>(["opus", "fable"]);
 


### PR DESCRIPTION
Original Task: [Widen agent-model UNPINNED_TYPES to Explore and review:angle](https://things.bendrucker.me/show?id=9b2jM4QZXHxksR3nFa95a2)

Adds `Explore` and `review:angle` to the `agent-model` hook's `UNPINNED_TYPES`. `user/CLAUDE.md` names three subagent types that pin no model, and the hook covered only `general-purpose`, so it enforced less than the policy its own warning text quotes back at the spawn site. This is the follow-up #1334 deferred.

Both additions check out against their definitions. `plugins/review/agents/angle.md` names no `model` in its frontmatter, and `Explore` is the CLI built-in that has inherited the conversation model since v2.1.198. Transcripts confirm the literal `subagent_type` strings are `Explore` and `review:angle`, so the set matches what arrives in `tool_input`.

The harmony rule holds. This hook returns `additionalContext` with no `permissionDecision`, so an `Explore` spawn still runs at whatever model it resolves to. The curation rule forbids hard-pinning `Explore` back to Haiku against the v2.1.198 change, and a warning the parent is free to ignore stays on the permitted side of that.

The removal criterion from #1334 covers this change too. Re-run the session skill's `delegation` query around 2026-10-15, and if the no-override count has not fallen, the hook goes. Widening the set inherits that rather than needing its own.

Counts since the hook shipped on 2026-09-01 point the same way without carrying the argument. `general-purpose` spawns under an opus parent with no model override fell to 1 of 76 over the following six days. `Explore` shows 6 of 6 with no override, all resolving to opus, a sample too small to rest on. The case for the change is the documented coverage gap.

`review:verifier` also names no model in its frontmatter. It stays out of the set because `user/CLAUDE.md` does not list it as a delegation choice, and the review skill picks it internally rather than a parent choosing it at a spawn site.

Added table rows covering both new types in `decide` and `spawnNeedsModel`, including an `Explore` spawn that supplies its own model and a `review:` type outside the set.
