### PR TITLE
pull-request: auto-correct PR body heading case

### DIFF
--- a/plugins/pull-request/scripts/__snapshots__/body-rules.test.ts.snap
+++ b/plugins/pull-request/scripts/__snapshots__/body-rules.test.ts.snap
@@ -1,6 +1,6 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`validateBody bundles every deny and folds the warns in 1`] = `
+exports[`decide bundles every deny and folds the warns in 1`] = `
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
@@ -17,7 +17,7 @@ Also worth addressing in the same edit:
 }
 `;
 
-exports[`validateBody carries a title warn into an unreadable-body deny 1`] = `
+exports[`decide carries a title warn into an unreadable-body deny 1`] = `
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
@@ -32,7 +32,7 @@ Also worth addressing in the same edit:
 }
 `;
 
-exports[`validateBody lists several warns 1`] = `
+exports[`decide lists several warns 1`] = `
 {
   "hookSpecificOutput": {
     "additionalContext": 
@@ -45,7 +45,7 @@ exports[`validateBody lists several warns 1`] = `
 }
 `;
 
-exports[`validateBody notes a single warn 1`] = `
+exports[`decide notes a single warn 1`] = `
 {
   "hookSpecificOutput": {
     "additionalContext": 
@@ -57,4 +57,48 @@ exports[`validateBody notes a single warn 1`] = `
 }
 `;
 
-exports[`validateBody stays silent on a clean body 1`] = `null`;
+exports[`decide stays silent on a clean body 1`] = `null`;
+
+exports[`headingCaseCorrection corrects a body where heading case is the only deny 1`] = `
+"## Two Fixes Found While Testing
+
+Reshapes it."
+`;
+
+exports[`headingCaseCorrection corrects a body where heading case is the only deny 2`] = `
+[
+  {
+    "suggested": "Two Fixes Found While Testing",
+    "text": "Two fixes found while testing",
+  },
+]
+`;
+
+exports[`headingCaseCorrection corrects a body where a warn rides along with it 1`] = `
+"## Corpus Results
+
+The build is green."
+`;
+
+exports[`headingCaseCorrection corrects a body where a warn rides along with it 2`] = `
+[
+  {
+    "suggested": "Corpus Results",
+    "text": "Corpus results",
+  },
+]
+`;
+
+exports[`headingCaseCorrection reports the correction alongside the warns it does not fix 1`] = `
+{
+  "hookSpecificOutput": {
+    "additionalContext": 
+"Corrected: Corpus Results
+
+This PR has a structural-slop pattern:
+- The body states that lint, types, tests, or a build passed. The PR's status checks already show that. Drop it, unless the result is one CI won't post: a manual check CI doesn't run, an intentional exclusion, or a pre-existing warning you're leaving in place."
+,
+    "hookEventName": "PreToolUse",
+  },
+}
+`;

--- a/plugins/pull-request/scripts/__snapshots__/heading-case.test.ts.snap
+++ b/plugins/pull-request/scripts/__snapshots__/heading-case.test.ts.snap
@@ -1,0 +1,38 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`correctHeadingCase rewrites a sentence-case heading 1`] = `"## Two Fixes Found While Testing"`;
+
+exports[`correctHeadingCase rewrites a over-capitalized stopwords 1`] = `"## Changes to the Parser"`;
+
+exports[`correctHeadingCase rewrites a hyphenated compound 1`] = `"## Follow-Up Tasks"`;
+
+exports[`correctHeadingCase rewrites a inline code in the heading 1`] = `"## Changes to \`validate.ts\` and the Parser"`;
+
+exports[`correctHeadingCase rewrites a closing hash sequence 1`] = `"## Two Fixes Found While Testing ##"`;
+
+exports[`correctHeadingCase rewrites a deeper level under prose 1`] = `
+"Intro.
+
+#### Known Limitation
+
+Detail."
+`;
+
+exports[`correctHeadingCase rewrites a several headings at once 1`] = `
+"## Null Floor
+
+Text.
+
+### Corpus Results
+
+More."
+`;
+
+exports[`correctHeadingCase rewrites a heading beside a fence holding a hash line 1`] = `
+"## Latch Placement
+
+\`\`\`sh
+# not a heading
+\`\`\`
+"
+`;

--- a/plugins/pull-request/scripts/body-rules.test.ts
+++ b/plugins/pull-request/scripts/body-rules.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
   type BodyContext,
+  decide,
+  headingCaseCorrection,
   type RuleId,
   type RuleMatch,
   scanBody,
-  validateBody,
 } from "./body-rules";
 
 // Four short sentences, 29 words. Bulk for a test that needs a large body,
@@ -473,7 +474,7 @@ describe("rule messages", () => {
   });
 });
 
-describe("validateBody", () => {
+describe("decide", () => {
   test.each<[string, string, Partial<BodyContext>]>([
     [
       "bundles every deny and folds the warns in",
@@ -496,6 +497,42 @@ describe("validateBody", () => {
     ["notes a single warn", "The build is green.", {}],
     ["stays silent on a clean body", "## Summary\n\nFixes a bug.", {}],
   ])("%s", async (_name, body, context) => {
-    expect(await validateBody(body, context)).toMatchSnapshot();
+    expect(decide(await scanBody(body, context))).toMatchSnapshot();
+  });
+});
+
+describe("headingCaseCorrection", () => {
+  async function correctionFor(body: string, context: Partial<BodyContext> = {}) {
+    return headingCaseCorrection(body, await scanBody(body, context));
+  }
+
+  test.each<[string, string]>([
+    ["heading case is the only deny", "## Two fixes found while testing\n\nReshapes it."],
+    ["a warn rides along with it", "## Corpus results\n\nThe build is green."],
+  ])("corrects a body where %s", async (_name, body) => {
+    const correction = await correctionFor(body);
+    expect(correction?.body).toMatchSnapshot();
+    expect(correction?.headings).toMatchSnapshot();
+  });
+
+  test.each<[string, string, Partial<BodyContext>]>([
+    ["there is no heading violation", "## Summary\n\nFixes a bug.", {}],
+    ["another deny stands alongside it", "## Two fixes found while testing\n\nAdded 5 tests.", {}],
+    ["the flagged heading cannot be edited in place", "## **Two fixes** found while testing", {}],
+    ["the body is unreadable", "", { unreadable: "standard input" }],
+  ])("declines to correct when %s", async (_name, body, context) => {
+    expect(await correctionFor(body, context)).toBeNull();
+  });
+
+  test("reports the correction alongside the warns it does not fix", async () => {
+    const body = "## Corpus results\n\nThe build is green.";
+    const matches = await scanBody(body);
+    const correction = headingCaseCorrection(body, matches);
+    expect(
+      decide(
+        matches.filter((match) => match.id !== "heading-case"),
+        `Corrected: ${correction?.headings[0]?.suggested ?? ""}`,
+      ),
+    ).toMatchSnapshot();
   });
 });

--- a/plugins/pull-request/scripts/body-rules.ts
+++ b/plugins/pull-request/scripts/body-rules.ts
@@ -3,7 +3,11 @@
 // author gets the note and keeps the decision.
 
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { headingCaseViolations } from "./heading-case";
+import {
+  correctHeadingCase,
+  type HeadingCaseViolation,
+  headingCaseViolations,
+} from "./heading-case";
 import { LINKING_VERBS } from "./linguistics/heading";
 import { countProseWords, headingTexts, linesOutsideFences, stripEmphasis } from "./markdown";
 import {
@@ -363,10 +367,37 @@ function bullets(matches: RuleMatch[]): string {
   return matches.map(({ message }) => `- ${message.replaceAll("\n", "\n  ")}`).join("\n");
 }
 
+export interface HeadingCaseCorrection {
+  /** The body with every flagged heading re-cased, ready to write back. */
+  body: string;
+  headings: HeadingCaseViolation[];
+}
+
+/**
+ * The body a caller who can rewrite the source file should write, or null when
+ * a deny stands. Heading case is mechanical, so correcting it costs the caller
+ * a round trip and teaches nothing a deny does not. It is corrected only when
+ * it is the sole deny and every flagged heading can be edited in place, so a
+ * deny reason never lists a fix the hook already applied.
+ */
+export function headingCaseCorrection(
+  body: string,
+  matches: RuleMatch[],
+): HeadingCaseCorrection | null {
+  const denies = matches.filter((match) => match.tier === "deny");
+  if (denies.length !== 1 || denies[0]?.id !== "heading-case") return null;
+  const fix = correctHeadingCase(body);
+  if (fix.applied.length === 0 || fix.skipped.length > 0) return null;
+  return { body: fix.body, headings: fix.applied };
+}
+
 // A deny reason carries an exact fix, so the whole set is worth reporting at
 // once: the model would otherwise rewrite the body, retry, and be blocked again
 // by the next one. Warnings ride along on a deny for the same reason.
-function decide(matches: RuleMatch[]): SyncHookJSONOutput | null {
+export function decide(
+  matches: RuleMatch[],
+  note: string | null = null,
+): SyncHookJSONOutput | null {
   const denies = matches.filter((match) => match.tier === "deny");
   const warns = matches.filter((match) => match.tier === "warn");
   if (denies.length > 0) {
@@ -380,24 +411,22 @@ function decide(matches: RuleMatch[]): SyncHookJSONOutput | null {
       },
     };
   }
-  if (warns.length === 0) {
+  const sections: string[] = [];
+  if (note !== null) sections.push(note);
+  if (warns.length > 0) {
+    const intro =
+      warns.length === 1
+        ? "This PR has a structural-slop pattern:"
+        : "This PR has structural-slop patterns:";
+    sections.push(`${intro}\n${bullets(warns)}`);
+  }
+  if (sections.length === 0) {
     return null;
   }
-  const intro =
-    warns.length === 1
-      ? "This PR has a structural-slop pattern:"
-      : "This PR has structural-slop patterns:";
   return {
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
-      additionalContext: `${intro}\n${bullets(warns)}`,
+      additionalContext: sections.join("\n\n"),
     },
   };
-}
-
-export async function validateBody(
-  body: string,
-  context: Partial<BodyContext> = {},
-): Promise<SyncHookJSONOutput | null> {
-  return decide(await scanBody(body, context));
 }

--- a/plugins/pull-request/scripts/heading-case.test.ts
+++ b/plugins/pull-request/scripts/heading-case.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { extractHeadings, headingCaseViolations } from "./heading-case";
+import { correctHeadingCase, extractHeadings, headingCaseViolations } from "./heading-case";
 
 describe("headingCaseViolations", () => {
   test.each<[string, string, { text: string; suggested: string }[]]>([
@@ -113,5 +113,55 @@ describe("extractHeadings", () => {
 
   test("skips a `#` line inside a fenced code block", () => {
     expect(extractHeadings("```\n## fake\n```")).toEqual([]);
+  });
+});
+
+describe("correctHeadingCase", () => {
+  test.each<[string, string]>([
+    ["sentence-case heading", "## Two fixes found while testing"],
+    ["over-capitalized stopwords", "## Changes To The Parser"],
+    ["hyphenated compound", "## Follow-up tasks"],
+    ["inline code in the heading", "## Changes to `validate.ts` and the parser"],
+    ["closing hash sequence", "## Two fixes found while testing ##"],
+    ["deeper level under prose", "Intro.\n\n#### Known limitation\n\nDetail."],
+    ["several headings at once", "## Null floor\n\nText.\n\n### Corpus results\n\nMore."],
+    [
+      "heading beside a fence holding a hash line",
+      "## Latch placement\n\n```sh\n# not a heading\n```\n",
+    ],
+  ])("rewrites a %s", (_name, body) => {
+    const fix = correctHeadingCase(body);
+    expect(fix.skipped).toEqual([]);
+    expect(fix.applied.length).toBeGreaterThan(0);
+    expect(fix.body).toMatchSnapshot();
+    expect(headingCaseViolations(fix.body)).toEqual([]);
+    expect(correctHeadingCase(fix.body).body).toBe(fix.body);
+  });
+
+  test.each<[string, string]>([
+    ["already AP-cased headings", "## Changes to the Parser\n\nText.\n\n### API Notes"],
+    ["a hash line inside a fence", "Text.\n\n```md\n## two words lower\n```\n"],
+    ["an indented code block", "Text.\n\n    ## two words lower\n"],
+    ["a body with no headings", "Adds an LRU cache to the resolver.\n"],
+  ])("leaves %s untouched", (_name, body) => {
+    expect(correctHeadingCase(body)).toEqual({ body, applied: [], skipped: [] });
+  });
+
+  test.each<[string, string]>([
+    ["emphasis", "## **Two fixes** found while testing"],
+    ["a link", "## Two fixes found in [the resolver](https://example.com)"],
+    ["a setext underline", "Two fixes found while testing\n===\n"],
+  ])("reports a heading carrying %s as skipped", (_name, body) => {
+    const fix = correctHeadingCase(body);
+    expect(fix.body).toBe(body);
+    expect(fix.applied).toEqual([]);
+    expect(fix.skipped).toEqual(headingCaseViolations(body));
+  });
+
+  test("touches only the heading line", () => {
+    const body = "Intro prose stays as written.\n\n## Null floor\n\nProse below, also unchanged.\n";
+    expect(correctHeadingCase(body).body).toBe(
+      "Intro prose stays as written.\n\n## Null Floor\n\nProse below, also unchanged.\n",
+    );
   });
 });

--- a/plugins/pull-request/scripts/heading-case.test.ts
+++ b/plugins/pull-request/scripts/heading-case.test.ts
@@ -158,6 +158,17 @@ describe("correctHeadingCase", () => {
     expect(fix.skipped).toEqual(headingCaseViolations(body));
   });
 
+  test.each<[string, string, string]>([
+    ["a double space between words", "##  Two  fixes found", "##  Two  Fixes Found"],
+    ["a tab between words", "## Two\tfixes found", "## Two\tFixes Found"],
+    ["padding before a closing hash run", "## Two  fixes found  ##", "## Two  Fixes Found  ##"],
+  ])("keeps %s as written", (_name, body, expected) => {
+    const fix = correctHeadingCase(body);
+    expect(fix.body).toBe(expected);
+    expect(fix.skipped).toEqual([]);
+    expect(headingCaseViolations(fix.body)).toEqual([]);
+  });
+
   test("touches only the heading line", () => {
     const body = "Intro prose stays as written.\n\n## Null floor\n\nProse below, also unchanged.\n";
     expect(correctHeadingCase(body).body).toBe(

--- a/plugins/pull-request/scripts/heading-case.ts
+++ b/plugins/pull-request/scripts/heading-case.ts
@@ -142,6 +142,9 @@ interface ParsedHeading {
   depth: number;
   combined: string;
   codeSpans: string[];
+  /** Source offsets of the whole heading, or -1 when the parse carried no position. */
+  start: number;
+  end: number;
 }
 
 function parseHeadings(body: string): ParsedHeading[] {
@@ -149,7 +152,14 @@ function parseHeadings(body: string): ParsedHeading[] {
   const headings: ParsedHeading[] = [];
   visit(tree, "heading", (node: MdastHeading) => {
     const { combined, codeSpans } = reconstruct(node.children);
-    headings.push({ children: node.children, depth: node.depth, combined, codeSpans });
+    headings.push({
+      children: node.children,
+      depth: node.depth,
+      combined,
+      codeSpans,
+      start: node.position?.start.offset ?? -1,
+      end: node.position?.end.offset ?? -1,
+    });
   });
   return headings;
 }
@@ -162,30 +172,98 @@ export function extractHeadings(body: string): Heading[] {
   }));
 }
 
-export function headingCaseViolations(body: string): { text: string; suggested: string }[] {
-  const violations: { text: string; suggested: string }[] = [];
-  for (const { combined, codeSpans } of parseHeadings(body)) {
-    const trimmed = combined.trim();
-    if (trimmed.length === 0) continue;
+export interface HeadingCaseViolation {
+  text: string;
+  suggested: string;
+}
 
-    const original = trimmed.split(/\s+/);
-    const cased = apStyleTitleCase(trimmed, { stopwords: AP_STOPWORDS }).trim().split(/\s+/);
-    if (original.length !== cased.length) continue;
+function violationFor({ combined, codeSpans }: ParsedHeading): HeadingCaseViolation | null {
+  const trimmed = combined.trim();
+  if (trimmed.length === 0) return null;
 
-    const suggested: string[] = [];
-    let differs = false;
-    for (const [i, word] of original.entries()) {
-      const next = caseWord(word, cased[i] ?? word);
-      suggested.push(next);
-      if (next !== word) differs = true;
-    }
+  const original = trimmed.split(/\s+/);
+  const cased = apStyleTitleCase(trimmed, { stopwords: AP_STOPWORDS }).trim().split(/\s+/);
+  if (original.length !== cased.length) return null;
 
-    if (differs) {
-      violations.push({
-        text: restore(original.join(" "), codeSpans),
-        suggested: restore(suggested.join(" "), codeSpans),
-      });
-    }
+  const suggested: string[] = [];
+  let differs = false;
+  for (const [i, word] of original.entries()) {
+    const next = caseWord(word, cased[i] ?? word);
+    suggested.push(next);
+    if (next !== word) differs = true;
   }
-  return violations;
+  if (!differs) return null;
+
+  return {
+    text: restore(original.join(" "), codeSpans),
+    suggested: restore(suggested.join(" "), codeSpans),
+  };
+}
+
+export function headingCaseViolations(body: string): HeadingCaseViolation[] {
+  return parseHeadings(body)
+    .map(violationFor)
+    .filter((violation): violation is HeadingCaseViolation => violation !== null);
+}
+
+// An ATX heading split into its `#` marker, its display text, and any closing
+// `#` run. Trailing whitespace lands in the closing group because the text group
+// is lazy.
+const ATX_HEADING = /^(#{1,6}[ \t]+)(.*?)((?:[ \t]+#+)?[ \t]*)$/;
+
+interface Edit {
+  start: number;
+  end: number;
+  text: string;
+}
+
+// Offsets of the heading's display text, when the source is a plain ATX heading
+// whose raw text reads the same as the text the violation reports. A setext
+// heading, or one carrying emphasis, a link, or an escape, renders differently
+// than it is written, so rewriting it by offset would drop the syntax around
+// the words.
+function textEdit(
+  body: string,
+  heading: ParsedHeading,
+  violation: HeadingCaseViolation,
+): Edit | null {
+  if (heading.start < 0 || heading.end < 0) return null;
+  const match = body.slice(heading.start, heading.end).match(ATX_HEADING);
+  const marker = match?.[1];
+  const content = match?.[2];
+  if (marker === undefined || content === undefined) return null;
+  if (content.replaceAll(/\s+/g, " ") !== violation.text) return null;
+  const start = heading.start + marker.length;
+  return { start, end: start + content.length, text: violation.suggested };
+}
+
+export interface HeadingCaseFix {
+  /** The body with every applied heading rewritten and nothing else touched. */
+  body: string;
+  applied: HeadingCaseViolation[];
+  /** Violations whose source line the rewrite could not edit safely. */
+  skipped: HeadingCaseViolation[];
+}
+
+export function correctHeadingCase(body: string): HeadingCaseFix {
+  const applied: HeadingCaseViolation[] = [];
+  const skipped: HeadingCaseViolation[] = [];
+  const edits: Edit[] = [];
+  for (const heading of parseHeadings(body)) {
+    const violation = violationFor(heading);
+    if (violation === null) continue;
+    const edit = textEdit(body, heading, violation);
+    if (edit === null) {
+      skipped.push(violation);
+      continue;
+    }
+    applied.push(violation);
+    edits.push(edit);
+  }
+
+  let corrected = body;
+  for (const edit of edits.toReversed()) {
+    corrected = corrected.slice(0, edit.start) + edit.text + corrected.slice(edit.end);
+  }
+  return { body: corrected, applied, skipped };
 }

--- a/plugins/pull-request/scripts/heading-case.ts
+++ b/plugins/pull-request/scripts/heading-case.ts
@@ -232,9 +232,37 @@ function textEdit(
   const marker = match?.[1];
   const content = match?.[2];
   if (marker === undefined || content === undefined) return null;
-  if (content.replaceAll(/\s+/g, " ") !== violation.text) return null;
+  const recased = recase(content, violation);
+  if (recased === null) return null;
   const start = heading.start + marker.length;
-  return { start, end: start + content.length, text: violation.suggested };
+  return { start, end: start + content.length, text: recased };
+}
+
+// The source heading with only its words re-cased. The violation reports a
+// heading whose whitespace runs are each collapsed to one space, so writing it
+// back verbatim would retype a double space or a tab the author wrote. Each run
+// is copied from the source instead and only the words come from the
+// suggestion, which keeps the correction to the case it claims to change.
+// Null when the source does not word-for-word match the heading the violation
+// reports, which is how a heading carrying emphasis, a link, or an escape
+// declines the rewrite.
+function recase(content: string, violation: HeadingCaseViolation): string | null {
+  const source = content.split(/(\s+)/);
+  const reported = violation.text.split(/(\s+)/);
+  const suggested = violation.suggested.split(/(\s+)/);
+  if (source.length !== reported.length || source.length !== suggested.length) return null;
+  const out: string[] = [];
+  for (const [i, chunk] of source.entries()) {
+    const isGap = /^\s+$/.test(chunk);
+    if (isGap !== /^\s+$/.test(reported[i] ?? "")) return null;
+    if (isGap) {
+      out.push(chunk);
+      continue;
+    }
+    if (chunk !== reported[i]) return null;
+    out.push(suggested[i] ?? chunk);
+  }
+  return out.join("");
 }
 
 export interface HeadingCaseFix {

--- a/plugins/pull-request/scripts/resolve-body.test.ts
+++ b/plugins/pull-request/scripts/resolve-body.test.ts
@@ -304,7 +304,7 @@ describe("command forms the skills document", () => {
     await Bun.write(bodyPath, body);
     // Doc paths are placeholders (`tmp/pr-body-<branch>.md`, `file.md`).
     const command = snippet.replaceAll(/\S*\.md/g, bodyPath);
-    expect(await resolveBody(command, REPO_ROOT)).toEqual({ kind: "text", text: body });
+    expect(await resolveBody(command, REPO_ROOT)).toMatchObject({ kind: "text", text: body });
   });
 });
 

--- a/plugins/pull-request/scripts/resolve-body.ts
+++ b/plugins/pull-request/scripts/resolve-body.ts
@@ -489,8 +489,29 @@ export async function resolveBody(command: string, cwd: string): Promise<BodyRes
     files.push(path);
     chunks.push(text);
   }
-  const sole = spec.parts.length === 1 && files.length === 1 ? files[0] : undefined;
-  return { kind: "text", text: chunks.join(""), file: sole ?? null };
+  return { kind: "text", text: chunks.join(""), file: rewritableFile(command, spec.parts, files) };
+}
+
+/**
+ * The one file the whole body was read from, when rewriting it would survive to
+ * the PR. Null when the body is assembled from more than one source, and null
+ * when the command names that path ahead of the PR verb: a generator writing
+ * the same file (`gen.py > body.md && gh pr create --body-file body.md`)
+ * replaces it after the hook reads it, so a correction would be discarded and
+ * the hook would report a fix the PR never carried. Naming the path is the
+ * signal a redirect, a `tee`, or an output flag all leave in the text, and it
+ * is read loosely: a command that merely reads the file ahead of the verb loses
+ * the correction, which costs a round trip rather than correctness.
+ */
+function rewritableFile(command: string, parts: BodyPart[], files: string[]): string | null {
+  if (parts.length !== 1 || files.length !== 1) return null;
+  const part = parts[0];
+  if (part?.kind !== "file") return null;
+  const text = parseCommand(command).text;
+  const prIndex = text.search(PR_BODY_COMMAND_PATTERN);
+  if (prIndex === -1) return null;
+  if (text.slice(0, prIndex).includes(part.path.replace(/^\.\//, ""))) return null;
+  return files[0] ?? null;
 }
 
 // Anchored to the `gh pr`/`glab mr` verb with heredoc bodies stripped and the

--- a/plugins/pull-request/scripts/resolve-body.ts
+++ b/plugins/pull-request/scripts/resolve-body.ts
@@ -421,12 +421,21 @@ function precedingHeredocs(text: string, heredocs: Heredoc[]): Heredoc[] {
 /** The body text a command will send, or why the hook cannot see it. */
 export type BodyResolution =
   | { kind: "none" }
-  | { kind: "text"; text: string }
+  | {
+      kind: "text";
+      text: string;
+      /**
+       * Absolute path the whole body was read from, so a caller may rewrite it.
+       * Null when any of the body came from the command itself, where a rewrite
+       * would be overwritten by the command or would have to edit shell syntax.
+       */
+      file: string | null;
+    }
   | { kind: "unreadable"; detail: string };
 
-async function readBodyFile(path: string, cwd: string): Promise<string | null> {
+async function readBodyFile(path: string): Promise<string | null> {
   try {
-    return await Bun.file(isAbsolute(path) ? path : join(cwd, path)).text();
+    return await Bun.file(path).text();
   } catch {
     return null;
   }
@@ -462,22 +471,26 @@ export async function resolveBody(command: string, cwd: string): Promise<BodyRes
   if (spec.kind !== "parts") return spec;
   const base = effectiveCwd(command, cwd);
   const chunks: string[] = [];
+  const files: string[] = [];
   for (const part of spec.parts) {
     if (part.kind === "literal") {
       chunks.push(part.text);
       continue;
     }
+    const path = isAbsolute(part.path) ? part.path : join(base, part.path);
     // oxlint-disable-next-line no-await-in-loop -- returns on the first unreadable part, and a command carries at most a few.
-    const text = await readBodyFile(part.path, base);
+    const text = await readBodyFile(path);
     if (text === null) {
       return {
         kind: "unreadable",
         detail: `body file \`${part.path}\`, which does not exist yet or could not be read`,
       };
     }
+    files.push(path);
     chunks.push(text);
   }
-  return { kind: "text", text: chunks.join("") };
+  const sole = spec.parts.length === 1 && files.length === 1 ? files[0] : undefined;
+  return { kind: "text", text: chunks.join(""), file: sole ?? null };
 }
 
 // Anchored to the `gh pr`/`glab mr` verb with heredoc bodies stripped and the

--- a/plugins/pull-request/scripts/resolve-body.ts
+++ b/plugins/pull-request/scripts/resolve-body.ts
@@ -2,7 +2,7 @@
 // inline flag values, body files, and the `cd`s ahead of them.
 
 import { homedir } from "node:os";
-import { isAbsolute, join } from "node:path";
+import { basename, isAbsolute, join } from "node:path";
 
 // The `if` rules in hooks.json scope dispatch to `gh pr create`/`edit` and
 // `glab mr create`/`update`, covering compound (`cd <dir> && gh pr create ...`)
@@ -495,13 +495,17 @@ export async function resolveBody(command: string, cwd: string): Promise<BodyRes
 /**
  * The one file the whole body was read from, when rewriting it would survive to
  * the PR. Null when the body is assembled from more than one source, and null
- * when the command names that path ahead of the PR verb: a generator writing
- * the same file (`gen.py > body.md && gh pr create --body-file body.md`)
+ * when the command names that file ahead of the PR verb: a generator writing
+ * the same path (`gen.py > body.md && gh pr create --body-file body.md`)
  * replaces it after the hook reads it, so a correction would be discarded and
- * the hook would report a fix the PR never carried. Naming the path is the
- * signal a redirect, a `tee`, or an output flag all leave in the text, and it
- * is read loosely: a command that merely reads the file ahead of the verb loses
- * the correction, which costs a round trip rather than correctness.
+ * the hook would report a fix the PR never carried. Naming the file is the
+ * signal a redirect, a `tee`, or an output flag all leave in the text.
+ *
+ * The two spellings need not match, since `> body.md` and `--body-file
+ * $PWD/body.md` are the same file, so the match is on the file name alone.
+ * That also catches names that only look alike, which costs the author a round
+ * trip through the deny rather than a body the hook reported as fixed and did
+ * not fix.
  */
 function rewritableFile(command: string, parts: BodyPart[], files: string[]): string | null {
   if (parts.length !== 1 || files.length !== 1) return null;
@@ -510,7 +514,8 @@ function rewritableFile(command: string, parts: BodyPart[], files: string[]): st
   const text = parseCommand(command).text;
   const prIndex = text.search(PR_BODY_COMMAND_PATTERN);
   if (prIndex === -1) return null;
-  if (text.slice(0, prIndex).includes(part.path.replace(/^\.\//, ""))) return null;
+  const name = basename(part.path);
+  if (name === "" || text.slice(0, prIndex).includes(name)) return null;
   return files[0] ?? null;
 }
 

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, readdirSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -235,6 +235,48 @@ describe("processInput", () => {
     );
     expect(getPermissionDecision(result)).toBe("deny");
     expect(getDenyReason(result)).toContain("Two Fixes Found While Testing");
+  });
+
+  // A generator writing the same path replaces the file after the hook reads
+  // it, so a correction would never reach the PR.
+  it("denies a heading in a body file the command regenerates", async () => {
+    const bodyFile = join(tempDir, "body.md");
+    const body = "## Two fixes found while testing\n\nReshapes the resolver.";
+    await Bun.write(bodyFile, body);
+    const result = await processInput(
+      createInput(
+        `generate > ${bodyFile} && gh pr create --title T --body-file ${bodyFile}`,
+        repoRoot,
+      ),
+    );
+    expect(getPermissionDecision(result)).toBe("deny");
+    expect(getDenyReason(result)).toContain("Two Fixes Found While Testing");
+    expect(await Bun.file(bodyFile).text()).toBe(body);
+  });
+
+  it("re-cases without retyping the whitespace the author wrote", async () => {
+    const bodyFile = join(tempDir, "body.md");
+    await Bun.write(bodyFile, "##  Two  fixes\tfound\n\nReshapes the resolver.");
+    await processInput(createInput(`gh pr create --body-file ${bodyFile}`, repoRoot));
+    expect(await Bun.file(bodyFile).text()).toBe("##  Two  Fixes\tFound\n\nReshapes the resolver.");
+  });
+
+  it("leaves the body whole and denies when the correction cannot be written", async () => {
+    const bodyFile = join(tempDir, "body.md");
+    const body = "## Two fixes found while testing\n\nReshapes the resolver.";
+    await Bun.write(bodyFile, body);
+    spawnSync("chmod", ["500", tempDir]);
+    try {
+      const result = await processInput(
+        createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
+      );
+      expect(getPermissionDecision(result)).toBe("deny");
+      expect(getDenyReason(result)).toContain("Two Fixes Found While Testing");
+      expect(await Bun.file(bodyFile).text()).toBe(body);
+    } finally {
+      spawnSync("chmod", ["700", tempDir]);
+    }
+    expect(readdirSync(tempDir)).toEqual(["body.md"]);
   });
 
   it("re-cases once and stays silent on the retry", async () => {

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -237,22 +237,37 @@ describe("processInput", () => {
     expect(getDenyReason(result)).toContain("Two Fixes Found While Testing");
   });
 
-  // A generator writing the same path replaces the file after the hook reads
-  // it, so a correction would never reach the PR.
-  it("denies a heading in a body file the command regenerates", async () => {
-    const bodyFile = join(tempDir, "body.md");
-    const body = "## Two fixes found while testing\n\nReshapes the resolver.";
-    await Bun.write(bodyFile, body);
-    const result = await processInput(
-      createInput(
-        `generate > ${bodyFile} && gh pr create --title T --body-file ${bodyFile}`,
-        repoRoot,
-      ),
-    );
-    expect(getPermissionDecision(result)).toBe("deny");
-    expect(getDenyReason(result)).toContain("Two Fixes Found While Testing");
-    expect(await Bun.file(bodyFile).text()).toBe(body);
-  });
+  // A generator writing the same file replaces it after the hook reads it, so a
+  // correction would never reach the PR. The two spellings of the path need not
+  // match for it to be the same file.
+  test.each<[string, (dir: string) => string]>([
+    [
+      "the same spelling",
+      (dir) =>
+        `generate > ${join(dir, "body.md")} && gh pr create -T --body-file ${join(dir, "body.md")}`,
+    ],
+    [
+      "a relative generator and an absolute body file",
+      (dir) =>
+        `cd ${dir} && generate > body.md && gh pr create -T --body-file ${join(dir, "body.md")}`,
+    ],
+    [
+      "an absolute generator and a relative body file",
+      (dir) =>
+        `cd ${dir} && generate > ${join(dir, "body.md")} && gh pr create -T --body-file body.md`,
+    ],
+  ])(
+    "denies a heading in a body file the command regenerates, through %s",
+    async (_name, build) => {
+      const bodyFile = join(tempDir, "body.md");
+      const body = "## Two fixes found while testing\n\nReshapes the resolver.";
+      await Bun.write(bodyFile, body);
+      const result = await processInput(createInput(build(tempDir), repoRoot));
+      expect(getPermissionDecision(result)).toBe("deny");
+      expect(getDenyReason(result)).toContain("Two Fixes Found While Testing");
+      expect(await Bun.file(bodyFile).text()).toBe(body);
+    },
+  );
 
   it("re-cases without retyping the whitespace the author wrote", async () => {
     const bodyFile = join(tempDir, "body.md");

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -111,10 +111,10 @@ describe("processInput", () => {
     ["glab mr update -d", (body) => `glab mr update 3 -d "$(cat ${body})"`],
   ])("checks the body behind %s", async (_form, build) => {
     const bodyFile = join(tempDir, "body.md");
-    await Bun.write(bodyFile, "## Two fixes found while testing\n\nReshapes the resolver.");
+    await Bun.write(bodyFile, "Reshapes the resolver. Added 5 tests.");
     const result = await processInput(createInput(build(bodyFile), repoRoot));
     expect(getPermissionDecision(result)).toBe("deny");
-    expect(getDenyReason(result)).toContain("Two Fixes Found While Testing");
+    expect(getDenyReason(result)).toContain("test counts");
   });
 
   // The body file does not exist when the hook runs: the same command writes
@@ -134,16 +134,13 @@ describe("processInput", () => {
   });
 
   it("resolves a relative body file behind a cd", async () => {
-    const sub = join(tempDir, "sub");
-    await Bun.write(
-      join(sub, "body.md"),
-      "## Two fixes found while testing\n\nReshapes the resolver.",
-    );
+    const bodyFile = join(tempDir, "sub", "body.md");
+    await Bun.write(bodyFile, "Reshapes the resolver. Added 5 tests.");
     const result = await processInput(
       createInput("cd sub && gh pr create --title T --body-file body.md", tempDir),
     );
     expect(getPermissionDecision(result)).toBe("deny");
-    expect(getDenyReason(result)).toContain("Two Fixes Found While Testing");
+    expect(getDenyReason(result)).toContain("test counts");
   });
 
   it("denies body with test count", async () => {
@@ -183,14 +180,71 @@ describe("processInput", () => {
     expect(result).toBeNull();
   });
 
-  it("denies a sentence-case heading in a body file", async () => {
+  it("re-cases a sentence-case heading in the body file and lets the command run", async () => {
     const bodyFile = join(tempDir, "body.md");
     await Bun.write(bodyFile, "## Two fixes found while testing\n\nReshapes the resolver.");
     const result = await processInput(
       createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
     );
+    expect(getPermissionDecision(result)).toBeUndefined();
+    expect(getAdditionalContext(result)).toContain(
+      '"Two fixes found while testing" → "Two Fixes Found While Testing"',
+    );
+    expect(await Bun.file(bodyFile).text()).toBe(
+      "## Two Fixes Found While Testing\n\nReshapes the resolver.",
+    );
+  });
+
+  it("re-cases a relative body file behind a cd", async () => {
+    const bodyFile = join(tempDir, "sub", "body.md");
+    await Bun.write(bodyFile, "## Corpus results\n\nReshapes the resolver.");
+    const result = await processInput(
+      createInput("cd sub && gh pr create --title T --body-file body.md", tempDir),
+    );
+    expect(getAdditionalContext(result)).toContain(bodyFile);
+    expect(await Bun.file(bodyFile).text()).toBe("## Corpus Results\n\nReshapes the resolver.");
+  });
+
+  it("leaves the file alone and denies when another deny stands with the heading", async () => {
+    const bodyFile = join(tempDir, "body.md");
+    const body = "## Two fixes found while testing\n\nAdded 5 tests.";
+    await Bun.write(bodyFile, body);
+    const result = await processInput(
+      createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
+    );
     expect(getPermissionDecision(result)).toBe("deny");
     expect(getDenyReason(result)).toContain("Two Fixes Found While Testing");
+    expect(getDenyReason(result)).toContain("test counts");
+    expect(await Bun.file(bodyFile).text()).toBe(body);
+  });
+
+  // The file the command names does not exist yet: the command's own heredoc
+  // writes it, and would overwrite anything the hook put there.
+  it("denies a heading in a heredoc body instead of correcting it", async () => {
+    const bodyFile = join(tempDir, "body.md");
+    const command = `cat > ${bodyFile} <<'EOF'\n## Two fixes found while testing\n\nReshapes it.\nEOF\ngh pr create --title T --body-file ${bodyFile}`;
+    const result = await processInput(createInput(command, repoRoot));
+    expect(getPermissionDecision(result)).toBe("deny");
+    expect(getDenyReason(result)).toContain("Two Fixes Found While Testing");
+    expect(await Bun.file(bodyFile).exists()).toBe(false);
+  });
+
+  it("denies a heading in an inline body instead of correcting it", async () => {
+    const result = await processInput(
+      createInput(`gh pr create --title T --body '## Two fixes found while testing'`, repoRoot),
+    );
+    expect(getPermissionDecision(result)).toBe("deny");
+    expect(getDenyReason(result)).toContain("Two Fixes Found While Testing");
+  });
+
+  it("re-cases once and stays silent on the retry", async () => {
+    const bodyFile = join(tempDir, "body.md");
+    await Bun.write(bodyFile, "## Null floor\n\nReshapes the resolver.");
+    const command = `gh pr create --body-file ${bodyFile}`;
+    await processInput(createInput(command, repoRoot));
+    const corrected = await Bun.file(bodyFile).text();
+    expect(await processInput(createInput(command, repoRoot))).toBeNull();
+    expect(await Bun.file(bodyFile).text()).toBe(corrected);
   });
 
   it("combines a test-count and a backticked SHA into one deny", async () => {
@@ -238,7 +292,7 @@ describe("processInput", () => {
 
   it("carries warnings inside the deny instead of a separate warn", async () => {
     const bodyFile = join(tempDir, "body.md");
-    await Bun.write(bodyFile, "## Changes to the cache\n\n- **src/cache.ts**: adds a cache");
+    await Bun.write(bodyFile, "Added 5 tests.\n\n- **src/cache.ts**: adds a cache");
     const result = await processInput(
       createInput(`gh pr create --body-file ${bodyFile}`, repoRoot),
     );

--- a/plugins/pull-request/scripts/validate.ts
+++ b/plugins/pull-request/scripts/validate.ts
@@ -2,7 +2,8 @@
 
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
-import { validateBody } from "./body-rules";
+import { type BodyContext, decide, headingCaseCorrection, scanBody } from "./body-rules";
+import type { HeadingCaseViolation } from "./heading-case";
 import { gitRepo } from "./repo";
 import { effectiveCwd, extractTitle, isPrBodyCommand, resolveBody } from "./resolve-body";
 
@@ -14,6 +15,13 @@ export const HookInput = z.looseObject({
 });
 export type HookInput = z.infer<typeof HookInput>;
 
+function correctionNote(file: string, headings: HeadingCaseViolation[]): string {
+  const changes = headings
+    .map((heading) => `"${heading.text}" → "${heading.suggested}"`)
+    .join("; ");
+  return `Section headings in \`${file}\` were re-cased to AP title case before this command ran: ${changes}. Nothing else in the body changed. Carry the corrected headings into any later edit of it.`;
+}
+
 export async function processInput(input: HookInput): Promise<SyncHookJSONOutput | null> {
   const command = BashInput.safeParse(input.tool_input).data?.command;
   if (command === undefined || !isPrBodyCommand(command)) {
@@ -21,11 +29,27 @@ export async function processInput(input: HookInput): Promise<SyncHookJSONOutput
   }
   const cwd = input.cwd ?? process.cwd();
   const resolved = await resolveBody(command, cwd);
-  return validateBody(resolved.kind === "text" ? resolved.text : "", {
+  const body = resolved.kind === "text" ? resolved.text : "";
+  const context: Partial<BodyContext> = {
     title: extractTitle(command),
     unreadable: resolved.kind === "unreadable" ? resolved.detail : null,
     ...gitRepo(effectiveCwd(command, cwd)),
-  });
+  };
+  const matches = await scanBody(body, context);
+
+  const file = resolved.kind === "text" ? resolved.file : null;
+  if (file === null) return decide(matches);
+  const correction = headingCaseCorrection(body, matches);
+  if (correction === null) return decide(matches);
+  try {
+    await Bun.write(file, correction.body);
+  } catch {
+    return decide(matches);
+  }
+  return decide(
+    matches.filter((match) => match.id !== "heading-case"),
+    correctionNote(file, correction.headings),
+  );
 }
 
 function denyWithError(reason: string): void {

--- a/plugins/pull-request/scripts/validate.ts
+++ b/plugins/pull-request/scripts/validate.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
 
+// oxlint-disable-next-line no-restricted-imports -- Bun has no rename, and only a rename replaces the file atomically.
+import { rename } from "node:fs/promises";
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
 import { type BodyContext, decide, headingCaseCorrection, scanBody } from "./body-rules";
@@ -22,6 +24,27 @@ function correctionNote(file: string, headings: HeadingCaseViolation[]): string 
   return `Section headings in \`${file}\` were re-cased to AP title case before this command ran: ${changes}. Nothing else in the body changed. Carry the corrected headings into any later edit of it.`;
 }
 
+/**
+ * Replaces the file's contents, reporting whether it landed. The correction is
+ * written to a sibling and renamed over the source, so an interrupted or failed
+ * write leaves the author's body whole rather than truncated. The sibling
+ * shares the source's directory, and so its filesystem, which is what makes the
+ * rename atomic.
+ */
+async function replaceFile(file: string, text: string): Promise<boolean> {
+  const temp = `${file}.${process.pid}.hook`;
+  try {
+    await Bun.write(temp, text);
+    await rename(temp, file);
+    return true;
+  } catch {
+    await Bun.file(temp)
+      .delete()
+      .catch(() => {});
+    return false;
+  }
+}
+
 export async function processInput(input: HookInput): Promise<SyncHookJSONOutput | null> {
   const command = BashInput.safeParse(input.tool_input).data?.command;
   if (command === undefined || !isPrBodyCommand(command)) {
@@ -41,11 +64,7 @@ export async function processInput(input: HookInput): Promise<SyncHookJSONOutput
   if (file === null) return decide(matches);
   const correction = headingCaseCorrection(body, matches);
   if (correction === null) return decide(matches);
-  try {
-    await Bun.write(file, correction.body);
-  } catch {
-    return decide(matches);
-  }
+  if (!(await replaceFile(file, correction.body))) return decide(matches);
   return decide(
     matches.filter((match) => match.id !== "heading-case"),
     correctionNote(file, correction.headings),

--- a/plugins/pull-request/skills/create/references/sections.md
+++ b/plugins/pull-request/skills/create/references/sections.md
@@ -41,7 +41,7 @@ A heading carrying a comma, a colon, trailing punctuation, a linking verb, a rel
 
 ### AP Title Case
 
-The PR-body hook re-cases every heading through `heading-case.ts` and denies the create or edit command when its result differs from what you wrote. Capitalize each word, except these when they fall between the first and last word: `a`, `an`, `and`, `as`, `at`, `but`, `by`, `for`, `in`, `nor`, `of`, `on`, `or`, `per`, `so`, `the`, `to`, `via`, `vs`, `vs.`, `yet`. Every other word stays capitalized, `up` included, since the checker leaves it off the list (`Speed Up the Commit Hook`).
+The PR-body hook re-cases every heading through `heading-case.ts`. When the body reaches the command as a file already on disk, the hook rewrites the heading lines in that file and reports what it changed, so the command runs. Carry those headings into any later edit of the body. A body the hook cannot rewrite (written by a heredoc in the same command, or passed inline) is denied instead, as is a file whose heading carries emphasis or a link. Capitalize each word, except these when they fall between the first and last word: `a`, `an`, `and`, `as`, `at`, `but`, `by`, `for`, `in`, `nor`, `of`, `on`, `or`, `per`, `so`, `the`, `to`, `via`, `vs`, `vs.`, `yet`. Every other word stays capitalized, `up` included, since the checker leaves it off the list (`Speed Up the Commit Hook`).
 
 - Lowercase a listed word in the middle: `Heading Case Via the Hook` → `Heading Case via the Hook`; `Reasons To Defer` → `Reasons to Defer`.
 - A hyphenated compound capitalizes each element and applies the same list past the first: `Follow-up Tasks` → `Follow-Up Tasks`, while `Ready-to-Ship Checklist` keeps its lowercase `to`.

--- a/plugins/writing/hooks/heading-case.ts
+++ b/plugins/writing/hooks/heading-case.ts
@@ -142,6 +142,9 @@ interface ParsedHeading {
   depth: number;
   combined: string;
   codeSpans: string[];
+  /** Source offsets of the whole heading, or -1 when the parse carried no position. */
+  start: number;
+  end: number;
 }
 
 function parseHeadings(body: string): ParsedHeading[] {
@@ -149,7 +152,14 @@ function parseHeadings(body: string): ParsedHeading[] {
   const headings: ParsedHeading[] = [];
   visit(tree, "heading", (node: MdastHeading) => {
     const { combined, codeSpans } = reconstruct(node.children);
-    headings.push({ children: node.children, depth: node.depth, combined, codeSpans });
+    headings.push({
+      children: node.children,
+      depth: node.depth,
+      combined,
+      codeSpans,
+      start: node.position?.start.offset ?? -1,
+      end: node.position?.end.offset ?? -1,
+    });
   });
   return headings;
 }
@@ -162,30 +172,98 @@ export function extractHeadings(body: string): Heading[] {
   }));
 }
 
-export function headingCaseViolations(body: string): { text: string; suggested: string }[] {
-  const violations: { text: string; suggested: string }[] = [];
-  for (const { combined, codeSpans } of parseHeadings(body)) {
-    const trimmed = combined.trim();
-    if (trimmed.length === 0) continue;
+export interface HeadingCaseViolation {
+  text: string;
+  suggested: string;
+}
 
-    const original = trimmed.split(/\s+/);
-    const cased = apStyleTitleCase(trimmed, { stopwords: AP_STOPWORDS }).trim().split(/\s+/);
-    if (original.length !== cased.length) continue;
+function violationFor({ combined, codeSpans }: ParsedHeading): HeadingCaseViolation | null {
+  const trimmed = combined.trim();
+  if (trimmed.length === 0) return null;
 
-    const suggested: string[] = [];
-    let differs = false;
-    for (const [i, word] of original.entries()) {
-      const next = caseWord(word, cased[i] ?? word);
-      suggested.push(next);
-      if (next !== word) differs = true;
-    }
+  const original = trimmed.split(/\s+/);
+  const cased = apStyleTitleCase(trimmed, { stopwords: AP_STOPWORDS }).trim().split(/\s+/);
+  if (original.length !== cased.length) return null;
 
-    if (differs) {
-      violations.push({
-        text: restore(original.join(" "), codeSpans),
-        suggested: restore(suggested.join(" "), codeSpans),
-      });
-    }
+  const suggested: string[] = [];
+  let differs = false;
+  for (const [i, word] of original.entries()) {
+    const next = caseWord(word, cased[i] ?? word);
+    suggested.push(next);
+    if (next !== word) differs = true;
   }
-  return violations;
+  if (!differs) return null;
+
+  return {
+    text: restore(original.join(" "), codeSpans),
+    suggested: restore(suggested.join(" "), codeSpans),
+  };
+}
+
+export function headingCaseViolations(body: string): HeadingCaseViolation[] {
+  return parseHeadings(body)
+    .map(violationFor)
+    .filter((violation): violation is HeadingCaseViolation => violation !== null);
+}
+
+// An ATX heading split into its `#` marker, its display text, and any closing
+// `#` run. Trailing whitespace lands in the closing group because the text group
+// is lazy.
+const ATX_HEADING = /^(#{1,6}[ \t]+)(.*?)((?:[ \t]+#+)?[ \t]*)$/;
+
+interface Edit {
+  start: number;
+  end: number;
+  text: string;
+}
+
+// Offsets of the heading's display text, when the source is a plain ATX heading
+// whose raw text reads the same as the text the violation reports. A setext
+// heading, or one carrying emphasis, a link, or an escape, renders differently
+// than it is written, so rewriting it by offset would drop the syntax around
+// the words.
+function textEdit(
+  body: string,
+  heading: ParsedHeading,
+  violation: HeadingCaseViolation,
+): Edit | null {
+  if (heading.start < 0 || heading.end < 0) return null;
+  const match = body.slice(heading.start, heading.end).match(ATX_HEADING);
+  const marker = match?.[1];
+  const content = match?.[2];
+  if (marker === undefined || content === undefined) return null;
+  if (content.replaceAll(/\s+/g, " ") !== violation.text) return null;
+  const start = heading.start + marker.length;
+  return { start, end: start + content.length, text: violation.suggested };
+}
+
+export interface HeadingCaseFix {
+  /** The body with every applied heading rewritten and nothing else touched. */
+  body: string;
+  applied: HeadingCaseViolation[];
+  /** Violations whose source line the rewrite could not edit safely. */
+  skipped: HeadingCaseViolation[];
+}
+
+export function correctHeadingCase(body: string): HeadingCaseFix {
+  const applied: HeadingCaseViolation[] = [];
+  const skipped: HeadingCaseViolation[] = [];
+  const edits: Edit[] = [];
+  for (const heading of parseHeadings(body)) {
+    const violation = violationFor(heading);
+    if (violation === null) continue;
+    const edit = textEdit(body, heading, violation);
+    if (edit === null) {
+      skipped.push(violation);
+      continue;
+    }
+    applied.push(violation);
+    edits.push(edit);
+  }
+
+  let corrected = body;
+  for (const edit of edits.toReversed()) {
+    corrected = corrected.slice(0, edit.start) + edit.text + corrected.slice(edit.end);
+  }
+  return { body: corrected, applied, skipped };
 }

--- a/plugins/writing/hooks/heading-case.ts
+++ b/plugins/writing/hooks/heading-case.ts
@@ -232,9 +232,37 @@ function textEdit(
   const marker = match?.[1];
   const content = match?.[2];
   if (marker === undefined || content === undefined) return null;
-  if (content.replaceAll(/\s+/g, " ") !== violation.text) return null;
+  const recased = recase(content, violation);
+  if (recased === null) return null;
   const start = heading.start + marker.length;
-  return { start, end: start + content.length, text: violation.suggested };
+  return { start, end: start + content.length, text: recased };
+}
+
+// The source heading with only its words re-cased. The violation reports a
+// heading whose whitespace runs are each collapsed to one space, so writing it
+// back verbatim would retype a double space or a tab the author wrote. Each run
+// is copied from the source instead and only the words come from the
+// suggestion, which keeps the correction to the case it claims to change.
+// Null when the source does not word-for-word match the heading the violation
+// reports, which is how a heading carrying emphasis, a link, or an escape
+// declines the rewrite.
+function recase(content: string, violation: HeadingCaseViolation): string | null {
+  const source = content.split(/(\s+)/);
+  const reported = violation.text.split(/(\s+)/);
+  const suggested = violation.suggested.split(/(\s+)/);
+  if (source.length !== reported.length || source.length !== suggested.length) return null;
+  const out: string[] = [];
+  for (const [i, chunk] of source.entries()) {
+    const isGap = /^\s+$/.test(chunk);
+    if (isGap !== /^\s+$/.test(reported[i] ?? "")) return null;
+    if (isGap) {
+      out.push(chunk);
+      continue;
+    }
+    if (chunk !== reported[i]) return null;
+    out.push(suggested[i] ?? chunk);
+  }
+  return out.join("");
 }
 
 export interface HeadingCaseFix {


### PR DESCRIPTION
Original Task: [Auto-correct PR body heading case instead of denying](https://things.bendrucker.me/show?id=S6RJpj9UBCUtsoRzLpJHny)

The AP title case rule has been in `sections.md` since 5a52523d, and `create` directs a read of that file before drafting any body past a paragraph. Denials went up anyway: 31 across 21 sessions before that commit, 93 across 49 after, at roughly double the daily rate. The misses I sampled are plain sentence case ("Null floor", "Corpus results", "Latch placement"), not near misses on the stopword or hyphenation edges. Writing more of the rule down would not have helped. The hook now applies it.

`correctHeadingCase()` rewrites the flagged heading lines using the casing `headingCaseViolations()` already computes for its suggestion. It works off mdast heading positions, so a `#` line inside a fence is never a heading to begin with, and everything outside the heading's own text span is left byte for byte. Running it twice produces the same file.

## Scope

The hook rewrites the body file, so it can only correct a body that reaches the command as a file already on disk. Of the 136 heading-case denials I could tie back to their command in the transcripts, 94 are that shape. The other 42 write the file with a heredoc in the same command, where anything the hook writes is overwritten a moment later by the command's own `cat >`.

Rewriting the command string instead is unavailable: `updatedInput` does not take effect for Bash on CLI 2.1.263. I checked with a throwaway PreToolUse hook that rewrote `echo hello-original`, bare and paired with `permissionDecision: "allow"`, and the original command ran both times. So the heredoc form and an inline `--body` keep the deny.

Two more cases stay denied. A flagged heading carrying emphasis, a link, an entity, or a setext underline renders differently than it is written, so rewriting it by offset would drop the syntax around the words. `correctHeadingCase()` reports those as skipped. And the correction fires only when heading case is the sole deny, so a deny reason never lists a fix the hook already applied.

The correction comes back as `additionalContext` naming the file and every `"before" → "after"` pair. A silent rewrite would leave the model holding a body that no longer matches the file.

## Removal Criterion

The denial signature lives in `tool_errors.error_content`. A `hook_events`-only query returns nothing for it. Heading-case denials should fall to roughly zero from here, with the correction appearing in their place. If they hold steady, the remaining traffic is the heredoc form and the fix belongs in the skill's create step.

## Testing

Coverage runs over fenced and indented code, several headings in one body, a closing hash sequence, and idempotency on every rewritten case. Offsets are checked past an emoji and inside a blockquote and a list item. The gating is covered in both directions: a second deny, an uneditable heading, and an unreadable body each keep the deny, and the end-to-end tests assert what lands in the file.

Removed `validateBody()`, which lost its last production caller when `processInput()` moved to `scanBody()` plus `decide()`.
