### PR TITLE
tech-spec: add Non-Goals to the spec template

### DIFF
--- a/plugins/tech-spec/skills/create/references/template.md
+++ b/plugins/tech-spec/skills/create/references/template.md
@@ -10,6 +10,10 @@ The feature or project name.
 
 Restate the problem from product requirements. Keep it concise.
 
+### Non-Goals
+
+Name what this spec deliberately does not cover, and why, so a reader stops looking for it.
+
 ### Architecture
 
 High-level system design:


### PR DESCRIPTION
Adds a Non-Goals section to the tech-spec template. #1246

Wave 2 of #1246 planned six additions here: Invariants, Non-Goals, Alternatives Considered, Call Stacks/Data Flow, Files to Add/Change/Delete, and an RGR section. It never shipped, so the template still carries Title, Problem, Architecture, Implementation, Milestones, and References.

Checked that plan against the specs actually written with this skill. One section got added by hand that the template did not provide, and it was Non-Goals. Alternatives Considered and Call Stacks never appeared in a real spec. The evidence supports adding one of the six and dropping the rest as speculative.

Non-Goals goes after Problem because a non-goal only means something once the problem is stated, and it bounds scope before Architecture commits to a shape. `SKILL.md` points at the template file instead of listing its sections, so it needed no change.

skill-lint on `plugins/tech-spec/skills/create`: ~775 tokens for `SKILL.md` and ~1,182 total before, ~775 and ~1,209 after.
