### PR TITLE
review: promote the typed-failure angle into core

### DIFF
--- a/plugins/review/skills/code/angles.yaml
+++ b/plugins/review/skills/code/angles.yaml
@@ -99,6 +99,7 @@ angles:
     name: "Angle F — typed-failure auditor"
     kind: correctness
     sets:
+      - core
       - full
     text: |
       Flag an expected failure that leaves its module as a thrown exception, a rejected promise, or a panic while the signature promises a value: a lookup miss, a rejected payload, an unavailable dependency, a write that lost a race. A catch that flattens several of those into one error the caller cannot branch on counts too. Also flag input that reaches typed code in the shape it arrived in, with no parse between: a request body, a database row, a cache hit, an RPC response, an environment variable.

--- a/plugins/review/skills/code/scripts/__snapshots__/review-plan.test.ts.snap
+++ b/plugins/review/skills/code/scripts/__snapshots__/review-plan.test.ts.snap
@@ -26,7 +26,7 @@ exports[`renders the default / medium plan 1`] = `
 "CELL medium   family default   level medium
 
   mode        fan-out: one Agent per angle, subagent_type review:angle, model sonnet
-  angles      core (8)
+  angles      core (9)
   candidates  6 per angle
   verify      1 vote, 3-state ladder
   cap         8
@@ -81,6 +81,10 @@ Find the CLAUDE.md files that govern the changed code: the user-level \`~/.claud
 
 Only flag a violation when you can quote the exact rule and the exact line that breaks it — no style preferences, no vague "spirit of the doc" inferences. In the finding, name the CLAUDE.md path and quote the rule so the report can cite it. If no CLAUDE.md applies, return nothing for this angle.
 
+### Angle F — typed-failure auditor
+
+Flag an expected failure that leaves its module as a thrown exception, a rejected promise, or a panic while the signature promises a value: a lookup miss, a rejected payload, an unavailable dependency, a write that lost a race. A catch that flattens several of those into one error the caller cannot branch on counts too. Also flag input that reaches typed code in the shape it arrived in, with no parse between: a request body, a database row, a cache hit, an RPC response, an environment variable.
+
 CLEANUP PRECEDENCE
 Cleanup, altitude, and conventions candidates use the same \`file\`/\`line\`/\`summary\` shape; in \`failure_scenario\`, state the concrete cost (what is duplicated, wasted, harder to maintain, or which CLAUDE.md rule is broken) instead of a crash. Correctness bugs always outrank cleanup, altitude, and conventions findings when the output cap forces a cut."
 `;
@@ -89,7 +93,7 @@ exports[`renders the default / high plan 1`] = `
 "CELL high   family default   level high
 
   mode        fan-out: one Agent per angle, subagent_type review:angle, model sonnet
-  angles      core (8)
+  angles      core (9)
   candidates  6 per angle
   verify      1 vote, recall-biased ladder
   cap         10
@@ -143,6 +147,10 @@ Both need a fix inside the code this change introduced. Skip structure the diff 
 Find the CLAUDE.md files that govern the changed code: the user-level \`~/.claude/CLAUDE.md\`, the repo-root \`CLAUDE.md\`, plus any \`CLAUDE.md\` or \`CLAUDE.local.md\` in a directory that is an ancestor of a changed file (a directory's CLAUDE.md only applies to files at or below it). Read each one that exists, then check the diff for clear violations of the rules they state.
 
 Only flag a violation when you can quote the exact rule and the exact line that breaks it — no style preferences, no vague "spirit of the doc" inferences. In the finding, name the CLAUDE.md path and quote the rule so the report can cite it. If no CLAUDE.md applies, return nothing for this angle.
+
+### Angle F — typed-failure auditor
+
+Flag an expected failure that leaves its module as a thrown exception, a rejected promise, or a panic while the signature promises a value: a lookup miss, a rejected payload, an unavailable dependency, a write that lost a race. A catch that flattens several of those into one error the caller cannot branch on counts too. Also flag input that reaches typed code in the shape it arrived in, with no parse between: a request body, a database row, a cache hit, an RPC response, an environment variable.
 
 CLEANUP PRECEDENCE
 Cleanup, altitude, and conventions candidates use the same \`file\`/\`line\`/\`summary\` shape; in \`failure_scenario\`, state the concrete cost (what is duplicated, wasted, harder to maintain, or which CLAUDE.md rule is broken) instead of a crash. Correctness bugs always outrank cleanup, altitude, and conventions findings when the output cap forces a cut."
@@ -268,7 +276,7 @@ exports[`renders the claude-sonnet-5 / medium plan 1`] = `
 "CELL medium   family claude-sonnet-5   level medium
 
   mode        fan-out: one Agent per angle, subagent_type review:angle, model sonnet
-  angles      core (8)
+  angles      core (9)
   candidates  6 per angle
   verify      1 vote, 3-state ladder
   cap         8
@@ -323,6 +331,10 @@ Find the CLAUDE.md files that govern the changed code: the user-level \`~/.claud
 
 Only flag a violation when you can quote the exact rule and the exact line that breaks it — no style preferences, no vague "spirit of the doc" inferences. In the finding, name the CLAUDE.md path and quote the rule so the report can cite it. If no CLAUDE.md applies, return nothing for this angle.
 
+### Angle F — typed-failure auditor
+
+Flag an expected failure that leaves its module as a thrown exception, a rejected promise, or a panic while the signature promises a value: a lookup miss, a rejected payload, an unavailable dependency, a write that lost a race. A catch that flattens several of those into one error the caller cannot branch on counts too. Also flag input that reaches typed code in the shape it arrived in, with no parse between: a request body, a database row, a cache hit, an RPC response, an environment variable.
+
 CLEANUP PRECEDENCE
 Cleanup, altitude, and conventions candidates use the same \`file\`/\`line\`/\`summary\` shape; in \`failure_scenario\`, state the concrete cost (what is duplicated, wasted, harder to maintain, or which CLAUDE.md rule is broken) instead of a crash. Correctness bugs always outrank cleanup, altitude, and conventions findings when the output cap forces a cut."
 `;
@@ -331,7 +343,7 @@ exports[`renders the claude-sonnet-5 / high plan 1`] = `
 "CELL high   family claude-sonnet-5   level high
 
   mode        fan-out: one Agent per angle, subagent_type review:angle, model sonnet
-  angles      core (8)
+  angles      core (9)
   candidates  6 per angle
   verify      1 vote, recall-biased ladder
   cap         10
@@ -388,6 +400,10 @@ Both need a fix inside the code this change introduced. Skip structure the diff 
 Find the CLAUDE.md files that govern the changed code: the user-level \`~/.claude/CLAUDE.md\`, the repo-root \`CLAUDE.md\`, plus any \`CLAUDE.md\` or \`CLAUDE.local.md\` in a directory that is an ancestor of a changed file (a directory's CLAUDE.md only applies to files at or below it). Read each one that exists, then check the diff for clear violations of the rules they state.
 
 Only flag a violation when you can quote the exact rule and the exact line that breaks it — no style preferences, no vague "spirit of the doc" inferences. In the finding, name the CLAUDE.md path and quote the rule so the report can cite it. If no CLAUDE.md applies, return nothing for this angle.
+
+### Angle F — typed-failure auditor
+
+Flag an expected failure that leaves its module as a thrown exception, a rejected promise, or a panic while the signature promises a value: a lookup miss, a rejected payload, an unavailable dependency, a write that lost a race. A catch that flattens several of those into one error the caller cannot branch on counts too. Also flag input that reaches typed code in the shape it arrived in, with no parse between: a request body, a database row, a cache hit, an RPC response, an environment variable.
 
 CLEANUP PRECEDENCE
 Cleanup, altitude, and conventions candidates use the same \`file\`/\`line\`/\`summary\` shape; in \`failure_scenario\`, state the concrete cost (what is duplicated, wasted, harder to maintain, or which CLAUDE.md rule is broken) instead of a crash. Correctness bugs always outrank cleanup, altitude, and conventions findings when the output cap forces a cut."
@@ -517,7 +533,7 @@ exports[`renders the claude-opus-4-8 / medium plan 1`] = `
 "CELL inline-med   family claude-opus-4-8   level medium
 
   mode        inline: work through the angles in sequence in this context, no subagents
-  angles      core (8)
+  angles      core (9)
   candidates  6 per angle
   verify      dedup only, no verify pass
   cap         8
@@ -576,6 +592,10 @@ Find the CLAUDE.md files that govern the changed code: the user-level \`~/.claud
 
 Only flag a violation when you can quote the exact rule and the exact line that breaks it — no style preferences, no vague "spirit of the doc" inferences. In the finding, name the CLAUDE.md path and quote the rule so the report can cite it. If no CLAUDE.md applies, return nothing for this angle.
 
+### Angle F — typed-failure auditor
+
+Flag an expected failure that leaves its module as a thrown exception, a rejected promise, or a panic while the signature promises a value: a lookup miss, a rejected payload, an unavailable dependency, a write that lost a race. A catch that flattens several of those into one error the caller cannot branch on counts too. Also flag input that reaches typed code in the shape it arrived in, with no parse between: a request body, a database row, a cache hit, an RPC response, an environment variable.
+
 CLEANUP PRECEDENCE
 Cleanup, altitude, and conventions candidates use the same \`file\`/\`line\`/\`summary\` shape; in \`failure_scenario\`, state the concrete cost (what is duplicated, wasted, harder to maintain, or which CLAUDE.md rule is broken) instead of a crash. Correctness bugs always outrank cleanup, altitude, and conventions findings when the output cap forces a cut."
 `;
@@ -584,7 +604,7 @@ exports[`renders the claude-opus-4-8 / high plan 1`] = `
 "CELL inline-high   family claude-opus-4-8   level high
 
   mode        inline: work through the angles in sequence in this context, no subagents
-  angles      core (8)
+  angles      core (9)
   candidates  6 per angle
   verify      dedup only, no verify pass
   cap         10
@@ -642,6 +662,10 @@ Both need a fix inside the code this change introduced. Skip structure the diff 
 Find the CLAUDE.md files that govern the changed code: the user-level \`~/.claude/CLAUDE.md\`, the repo-root \`CLAUDE.md\`, plus any \`CLAUDE.md\` or \`CLAUDE.local.md\` in a directory that is an ancestor of a changed file (a directory's CLAUDE.md only applies to files at or below it). Read each one that exists, then check the diff for clear violations of the rules they state.
 
 Only flag a violation when you can quote the exact rule and the exact line that breaks it — no style preferences, no vague "spirit of the doc" inferences. In the finding, name the CLAUDE.md path and quote the rule so the report can cite it. If no CLAUDE.md applies, return nothing for this angle.
+
+### Angle F — typed-failure auditor
+
+Flag an expected failure that leaves its module as a thrown exception, a rejected promise, or a panic while the signature promises a value: a lookup miss, a rejected payload, an unavailable dependency, a write that lost a race. A catch that flattens several of those into one error the caller cannot branch on counts too. Also flag input that reaches typed code in the shape it arrived in, with no parse between: a request body, a database row, a cache hit, an RPC response, an environment variable.
 
 CLEANUP PRECEDENCE
 Cleanup, altitude, and conventions candidates use the same \`file\`/\`line\`/\`summary\` shape; in \`failure_scenario\`, state the concrete cost (what is duplicated, wasted, harder to maintain, or which CLAUDE.md rule is broken) instead of a crash. Correctness bugs always outrank cleanup, altitude, and conventions findings when the output cap forces a cut."
@@ -772,7 +796,7 @@ exports[`renders the claude-fable-5 / medium plan 1`] = `
 "CELL inline-med   family claude-fable-5   level medium
 
   mode        inline: work through the angles in sequence in this context, no subagents
-  angles      core (8)
+  angles      core (9)
   candidates  6 per angle
   verify      dedup only, no verify pass
   cap         8
@@ -831,6 +855,10 @@ Find the CLAUDE.md files that govern the changed code: the user-level \`~/.claud
 
 Only flag a violation when you can quote the exact rule and the exact line that breaks it — no style preferences, no vague "spirit of the doc" inferences. In the finding, name the CLAUDE.md path and quote the rule so the report can cite it. If no CLAUDE.md applies, return nothing for this angle.
 
+### Angle F — typed-failure auditor
+
+Flag an expected failure that leaves its module as a thrown exception, a rejected promise, or a panic while the signature promises a value: a lookup miss, a rejected payload, an unavailable dependency, a write that lost a race. A catch that flattens several of those into one error the caller cannot branch on counts too. Also flag input that reaches typed code in the shape it arrived in, with no parse between: a request body, a database row, a cache hit, an RPC response, an environment variable.
+
 CLEANUP PRECEDENCE
 Cleanup, altitude, and conventions candidates use the same \`file\`/\`line\`/\`summary\` shape; in \`failure_scenario\`, state the concrete cost (what is duplicated, wasted, harder to maintain, or which CLAUDE.md rule is broken) instead of a crash. Correctness bugs always outrank cleanup, altitude, and conventions findings when the output cap forces a cut."
 `;
@@ -839,7 +867,7 @@ exports[`renders the claude-fable-5 / high plan 1`] = `
 "CELL inline-high   family claude-fable-5   level high
 
   mode        inline: work through the angles in sequence in this context, no subagents
-  angles      core (8)
+  angles      core (9)
   candidates  6 per angle
   verify      dedup only, no verify pass
   cap         10
@@ -897,6 +925,10 @@ Both need a fix inside the code this change introduced. Skip structure the diff 
 Find the CLAUDE.md files that govern the changed code: the user-level \`~/.claude/CLAUDE.md\`, the repo-root \`CLAUDE.md\`, plus any \`CLAUDE.md\` or \`CLAUDE.local.md\` in a directory that is an ancestor of a changed file (a directory's CLAUDE.md only applies to files at or below it). Read each one that exists, then check the diff for clear violations of the rules they state.
 
 Only flag a violation when you can quote the exact rule and the exact line that breaks it — no style preferences, no vague "spirit of the doc" inferences. In the finding, name the CLAUDE.md path and quote the rule so the report can cite it. If no CLAUDE.md applies, return nothing for this angle.
+
+### Angle F — typed-failure auditor
+
+Flag an expected failure that leaves its module as a thrown exception, a rejected promise, or a panic while the signature promises a value: a lookup miss, a rejected payload, an unavailable dependency, a write that lost a race. A catch that flattens several of those into one error the caller cannot branch on counts too. Also flag input that reaches typed code in the shape it arrived in, with no parse between: a request body, a database row, a cache hit, an RPC response, an environment variable.
 
 CLEANUP PRECEDENCE
 Cleanup, altitude, and conventions candidates use the same \`file\`/\`line\`/\`summary\` shape; in \`failure_scenario\`, state the concrete cost (what is duplicated, wasted, harder to maintain, or which CLAUDE.md rule is broken) instead of a crash. Correctness bugs always outrank cleanup, altitude, and conventions findings when the output cap forces a cut."


### PR DESCRIPTION
Angle F, the typed-failure auditor, shipped into `full` alongside three cleanup angles and has never been dispatched. `full` is reachable only through the `xhigh` and `inline-xhigh` cells. `review:code` has run at xhigh twice ever, both on 2026-07-31, a month before Angle F merged on 2026-08-25. Moving it into `core` makes it reachable at medium and high. From the tune-or-delete review of #1246.

It is the only `kind: correctness` angle in that batch, and it hunts something core misses. An expected failure leaves a module as a thrown exception, a rejected promise, or a panic while the signature promises a value. Input reaches typed code in the shape it arrived in, with no parse between. Core's A, B, and C scan diff lines, removed behavior, and call sites. None of them look for that.

## Cost

- `low`, `low-sonnet5`, and `inline-low` set `angleSet: null`. Low effort is untouched.
- `medium` and `high` run `core` as a fan-out with no `finder-budget` modifier for the default family. Both go from 8 agents to 9.
- `claude-sonnet-5` at high carries `finder-budget`, which caps the fleet at `max: 8` and deals angles across it. That cell gains an angle in the deal rather than an agent.
- `inline-med` and `inline-high`, which `claude-opus-4-8` and `claude-fable-5` select at medium and high, work the angles in sequence in one context. They gain a ninth angle and no agents.

One correction to the framing this came in under: `claude-fable-5` reaches xhigh through the `xhigh` cell. Only `claude-opus-4-8` selects `inline-xhigh`.

## Scope

`type-discipline`, `discoverability`, and `coupling` stay in `full`. They are `kind: cleanup`, and medium is framed for precision ("every finding you surface should be one a maintainer would act on"). Three smell hunters is the wrong payload for that frame at a 50 percent agent cost. A third angle set between `core` and `full` was considered and rejected.

## Tests

Nothing asserts the size or membership of `core`, so no test changed. The invariant test that exists ("core is a subset of full") still holds. The rendered-plan snapshots for the eight family/level pairs that select a `core` cell were regenerated. Each now reads 9 angles and carries Angle F's text.

## Removal

Angle F now runs at medium and high. If it produces no finding that changes code within roughly two months, it goes back to `full` or gets deleted. `review-precision` in the session skill is where that gets checked, by looking for a typed-failure category among the categories that have recorded findings.
