### PR TITLE
review: state the real default effort

### DIFF
--- a/plugins/review/skills/code/SKILL.md
+++ b/plugins/review/skills/code/SKILL.md
@@ -31,7 +31,7 @@ Review the diff for correctness bugs and cleanups: $ARGUMENTS
 - **`<target>`**: everything else, free-form. A PR number, branch, ref range, path, or a plain-English scope restriction ("only `src/parser.ts`", "focus on error handling", "skip the test churn").
 - **`ultra`**: not supported here. Stop and tell the user to type `/code-review ultra` themselves.
 
-With no effort level, use the session's effort. Default to `medium`.
+With no effort level, pass none. The Phase 1 script resolves `medium`.
 
 ## Phase 0 — Scope
 


### PR DESCRIPTION
`review:code` told the model to use the session's effort when the user named no level. Nothing in the skill says how to obtain a session effort, and no caller supplies one, so the instruction had no mechanism behind it. #1246

What actually decides is `scripts/review-plan.ts`, which resolves a bare call to `medium`. The line now says that.

Threading a real session effort through was the alternative. It is rejected because it would change what every bare call resolves to. `user/scripts/effort.ts` and its `DEFAULT_EFFORT = "high"` drive the model's own reasoning-effort glyph, a separate axis that happens to share the level names. This skill never reads it.

The line has been near-inert in practice, which is why the gap went unnoticed. Of 446 recorded `review:code` and `code-review` invocations, 3 were bare. The rest passed a level explicitly: medium 177, low 125, high 118, xhigh or max 5. The dominant caller is `/ship`, whose Effort Inference table in `user/skills/ship/references/passes.md` always emits an explicit level.
