### PR TITLE
skills: add grill-docs

### DIFF
--- a/user/skills/grill-docs/SKILL.md
+++ b/user/skills/grill-docs/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: grill-docs
+description: Run the grilling interview and write what it settles to the repo as it settles, so the vocabulary and the decisions outlive the session window.
+argument-hint: "[<what to grill>]"
+disable-model-invocation: true
+allowed-tools:
+  - AskUserQuestion
+  - Agent
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+---
+
+# Grill With Docs
+
+Run the `grilling` skill's interview over $ARGUMENTS, and write what it settles to disk at the moment it settles.
+
+Writing as we go is the whole difference. A session that gets compacted or abandoned still leaves the repo holding what we agreed.
+
+## Where It Lands
+
+Choose both destinations before the first round and say them back to me.
+
+Vocabulary goes where the repo already keeps standing context:
+
+- A term governing one area of the tree goes in `.claude/rules/<area>.md` under a `paths` entry, so it loads when that area is touched.
+- A term governing the whole repo goes in `CLAUDE.md`.
+- Where the fitting file is missing, create that one.
+
+Decisions go beside the plan that produced them, as `<plan>-decisions.md` in the same directory.
+
+## Vocabulary
+
+Write a term the moment it resolves. A term is settled once I have picked both the word and what it denotes.
+
+Prefer a word already in the codebase. When a decision turns on what to call something, go find the candidates first and make them the options.
+
+A definition says what the thing is and what separates it from its nearest neighbor. Keep it to that.
+
+## Decisions
+
+Record a decision when all three hold:
+
+- Reversing it later costs real work.
+- It would surprise someone arriving without this conversation.
+- Something real was given up to make it.
+
+Most sessions clear none of these. That is the gate working, so hold it where it is.
+
+A record states the decision, what it rules out, and what it cost.
+
+## Close
+
+Write the escalation contract into the decisions file, then wait for me to confirm it.

--- a/user/skills/grill-docs/SKILL.md
+++ b/user/skills/grill-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: grill-docs
-description: Run the grilling interview and write what it settles to the repo as it settles, so the vocabulary and the decisions outlive the session window.
+description: Run the grilling interview and write each settled term and decision to the repo as it settles, so they survive compaction or an abandoned session.
 argument-hint: "[<what to grill>]"
 disable-model-invocation: true
 allowed-tools:
@@ -15,42 +15,42 @@ allowed-tools:
 
 # Grill With Docs
 
-Run the `grilling` skill's interview over $ARGUMENTS, and write what it settles to disk at the moment it settles.
+Run the `grilling` skill's interview over $ARGUMENTS, and write each term and decision to disk as soon as it is settled.
 
-Writing as we go is the whole difference. A session that gets compacted or abandoned still leaves the repo holding what we agreed.
+Writing as we go is the point. If the session is compacted or abandoned, the repo still holds what we agreed.
 
 ## Where It Lands
 
 Choose both destinations before the first round and say them back to me.
 
-Vocabulary goes where the repo already keeps standing context:
+Terms go where the repo already keeps instructions Claude loads automatically:
 
-- A term governing one area of the tree goes in `.claude/rules/<area>.md` under a `paths` entry, so it loads when that area is touched.
-- A term governing the whole repo goes in `CLAUDE.md`.
-- Where the fitting file is missing, create that one.
+- A term that applies to one part of the repo goes in `.claude/rules/<area>.md` under a `paths` entry, so it loads when that part is touched.
+- A term that applies everywhere goes in `CLAUDE.md`.
+- Create the file if it does not exist.
 
 Decisions go beside the plan that produced them, as `<plan>-decisions.md` in the same directory.
 
 ## Vocabulary
 
-Write a term the moment it resolves. A term is settled once I have picked both the word and what it denotes.
+Write a term as soon as it is settled, which means I have picked both the word and its meaning.
 
-Prefer a word already in the codebase. When a decision turns on what to call something, go find the candidates first and make them the options.
+Prefer a word the codebase already uses. When the question is what to call something, search the codebase for candidates first and offer those as the options.
 
-A definition says what the thing is and what separates it from its nearest neighbor. Keep it to that.
+A definition says what the thing is and how it differs from the thing it is most easily confused with. Keep it to that.
 
 ## Decisions
 
 Record a decision when all three hold:
 
-- Reversing it later costs real work.
-- It would surprise someone arriving without this conversation.
-- Something real was given up to make it.
+- Reversing it later would be expensive.
+- Someone who was not in this conversation would not guess it.
+- It was a tradeoff: a reasonable alternative was rejected.
 
-Most sessions clear none of these. That is the gate working, so hold it where it is.
+Most sessions produce no decision that meets all three, and that is expected.
 
-A record states the decision, what it rules out, and what it cost.
+A record states the decision, the alternatives it rejects, and the tradeoff.
 
 ## Close
 
-Write the escalation contract into the decisions file, then wait for me to confirm it.
+Write the interview's closing escalation contract (what to proceed on without asking, what to stop and consult on) into the decisions file, then wait for me to confirm it.


### PR DESCRIPTION
`grilling` keeps everything it settles in the session window, so a compaction or an abandoned session takes the vocabulary and the decisions with it. `grill-docs` runs the same interview and writes each result the moment it resolves.

Vocabulary goes to `.claude/rules/<area>.md` under a `paths` entry, or to `CLAUDE.md` when the term governs the whole repo. Both surfaces reload on their own, which a root glossary file does not. Decisions go beside the plan that produced them.

A decision earns a record only when reversing it costs real work, it would surprise someone arriving without the conversation, and something real was given up to make it. Most sessions clear none of the three, which keeps the file small enough to stay worth reading.

The interview itself stays in `grilling`. Copying the body would fork the round rules, and injecting it would carry `grilling`'s own bang-injection of `ask` through unexecuted.

Typed entry only, matching how `grilling` is reached when the user names it. That costs no recurring context, so `/skill-config-vs-observed` reporting zero `calls` and zero `typed` after a few weeks is the signal to delete it.
