### PR TITLE
writing: route slop complaints to no-diary

### DIFF
--- a/plugins/writing/skills/no-diary/SKILL.md
+++ b/plugins/writing/skills/no-diary/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: writing:no-diary
 description: >-
-  Cut process narration, past states, session leakage, and provenance from a
-  deliverable (PR or MR body, code comment, doc, skill, review comment, issue,
-  plan) so it states the result rather than how the work happened.
+  Cut slop, jargon, process narration, past states, session leakage, and
+  provenance from a deliverable (PR or MR body, code comment, doc, skill, review
+  comment, issue, plan) so it states the result rather than how the work
+  happened. Use when asked to de-slop, de-jargon, trim, shorten, or cut down one
+  of those, or when told that one reads as slop or runs too long.
 argument-hint: "[<file> | <pr> | <section> | <text>]"
 user-invocable: true
 allowed-tools:
@@ -26,6 +28,7 @@ allowed-tools:
 - A PR or MR number or URL reads the body through `gh` or `glab`, with the commands in `references/surfaces.md`.
 - A section name or heading locates it in the artifact under discussion.
 - A description with no target names the problem in the deliverable in play.
+- A fraction or a keep-list (`50%`, `keep: the warning and the upstream link`) sets the target length. Cut to it, taking the `Removals` in order, and say what went beyond the diary.
 
 With no arguments, resolve the target in this order: text the user pasted this turn, the file this session last wrote or edited, then the PR for the current branch. Ask only when two candidates are equally live.
 


### PR DESCRIPTION
Across 23 slop complaints in the last two weeks, the target was almost always a deliverable already on disk: a PR or MR body, a docstring, `LANGUAGES.md`, a config file's comments. `no-diary` already edits every one of those in place, resolves a path or a PR number, and carries per-surface rules for each. Its description scoped it to process narration and never said slop, jargon, trim, or too long, which are the words the complaints use.

Five of the complaints set a size rather than naming a defect ("cut it down by 50%", "Edit it down to: the warning, the link", "thr 1 too long"). Nothing in the library took a target length, so `## Arguments` gains one.

Broadening `writing:rewrite` instead was the obvious move and is wrong. It holds `Bash`, `Read`, `Skill` with no `Edit` or `Write`, so the most it can do is print a replacement to paste back by hand, and its body is a thin wrapper over `writing:writing`. Giving it write tools would rebuild what `no-diary` already has.

Routing is also not the whole story. `writing:writing` was already loaded in 14 of the 23 sessions, so the prose was authored with the style guide in context and the complaint came anyway. Those turns are second drafts failing, which points at the PreToolUse hook and at first-draft quality rather than at which skill loads. This change is worth making on its own, and it does not address that.

Removal: rerun the complaint query on 2026-11-08. If `no-diary` fires on fewer than half the reaction turns, revert the description and accept that these route to bare edits plus the hook. If no invocation carries a fraction or keep-list in 60 days, cut that bullet.
