### PR TITLE
pull-request: add entity-level diff context

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -240,6 +240,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.0",
         "ap-style-title-case": "^2.0.0",
+        "cleye": "^2.0.0",
         "mdast-util-from-markdown": "^2.0.2",
         "unist-util-visit": "^5.1.0",
         "zod": "^4.4.3",

--- a/plugins/pull-request/package.json
+++ b/plugins/pull-request/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.0",
     "ap-style-title-case": "^2.0.0",
+    "cleye": "^2.0.0",
     "mdast-util-from-markdown": "^2.0.2",
     "unist-util-visit": "^5.1.0",
     "zod": "^4.4.3"

--- a/plugins/pull-request/scripts/__snapshots__/sem-context.test.ts.snap
+++ b/plugins/pull-request/scripts/__snapshots__/sem-context.test.ts.snap
@@ -1,0 +1,14 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`render renders a mixed diff grouped by file 1`] = `
+"Entities (origin/main...HEAD, structural only):
+  hooks/pretooluse.ts
+    M function dispatch
+    A function targetOf
+    R function oldName → newName
+    R function hooks/legacy.ts:relocated → relocated
+    M function ordering
+  scripts/scan.ts
+    D method retired
+  cosmetic-only: 1 entity · module-level: 1 · unparsed: 1 file"
+`;

--- a/plugins/pull-request/scripts/sem-context.test.ts
+++ b/plugins/pull-request/scripts/sem-context.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from "bun:test";
+import { type BaseLookups, type Change, render, resolveBase, stackParent } from "./sem-context";
+
+function change(overrides: Partial<Change> & Pick<Change, "entityName" | "filePath">): Change {
+  return {
+    entityId: overrides.entityName,
+    changeType: "modified",
+    entityType: "function",
+    oldEntityName: null,
+    oldFilePath: null,
+    structuralChange: true,
+    ...overrides,
+  };
+}
+
+describe("render", () => {
+  test("renders a mixed diff grouped by file", () => {
+    const changes = [
+      change({ entityName: "dispatch", filePath: "hooks/pretooluse.ts" }),
+      change({ entityName: "targetOf", filePath: "hooks/pretooluse.ts", changeType: "added" }),
+      change({
+        entityName: "newName",
+        filePath: "hooks/pretooluse.ts",
+        changeType: "renamed",
+        oldEntityName: "oldName",
+      }),
+      change({
+        entityName: "relocated",
+        filePath: "hooks/pretooluse.ts",
+        changeType: "moved",
+        oldFilePath: "hooks/legacy.ts",
+      }),
+      change({ entityName: "ordering", filePath: "hooks/pretooluse.ts", changeType: "reordered" }),
+      change({
+        entityName: "retired",
+        filePath: "scripts/scan.ts",
+        changeType: "deleted",
+        entityType: "method",
+      }),
+      change({ entityName: "spacing", filePath: "scripts/scan.ts", structuralChange: false }),
+      change({ entityName: "imports", filePath: "scripts/scan.ts", entityType: "orphan" }),
+      change({
+        entityName: "chunk-1",
+        filePath: "scripts/__snapshots__/a.snap",
+        entityType: "chunk",
+      }),
+      change({
+        entityName: "chunk-2",
+        filePath: "scripts/__snapshots__/a.snap",
+        entityType: "chunk",
+      }),
+    ];
+
+    expect(render(changes, { base: "origin/main" })).toMatchSnapshot();
+  });
+
+  test.each<[string, Change[], string, string]>([
+    [
+      "reports a cosmetic-only diff",
+      [
+        change({ entityName: "a", filePath: "src/a.ts", structuralChange: false }),
+        change({ entityName: "b", filePath: "src/a.ts", structuralChange: false }),
+      ],
+      "origin/main",
+      "Entities (origin/main...HEAD, structural only):\n  cosmetic-only diff\n  cosmetic-only: 2 entities",
+    ],
+    [
+      "keeps the count line beside a cosmetic-only body",
+      [
+        change({ entityName: "a", filePath: "src/a.ts", structuralChange: false }),
+        change({ entityName: "chunk-1", filePath: "a.snap", entityType: "chunk" }),
+      ],
+      "origin/main",
+      "Entities (origin/main...HEAD, structural only):\n  cosmetic-only diff\n  cosmetic-only: 1 entity · unparsed: 1 file",
+    ],
+    ["reports no changes at all", [], "origin/main", "Entities (origin/main...HEAD): none"],
+    [
+      "omits the count line when nothing was dropped",
+      [change({ entityName: "dispatch", filePath: "src/a.ts" })],
+      "origin/main",
+      "Entities (origin/main...HEAD, structural only):\n  src/a.ts\n    M function dispatch",
+    ],
+    [
+      "counts module-level rows with no body of their own",
+      [change({ entityName: "imports", filePath: "src/a.ts", entityType: "orphan" })],
+      "origin/main",
+      "Entities (origin/main...HEAD, structural only):\n  module-level: 1",
+    ],
+    [
+      "drops a chunk row that also reports no structural change",
+      [
+        change({
+          entityName: "chunk-1",
+          filePath: "a.snap",
+          entityType: "chunk",
+          structuralChange: false,
+        }),
+      ],
+      "origin/main",
+      "Entities (origin/main...HEAD, structural only):\n  unparsed: 1 file",
+    ],
+    [
+      "keeps a row whose structural flag is unknown",
+      [change({ entityName: "widget", filePath: "src/a.ts", structuralChange: null })],
+      "origin/main",
+      "Entities (origin/main...HEAD, structural only):\n  src/a.ts\n    M function widget",
+    ],
+    [
+      "names the resolved base in the header",
+      [change({ entityName: "dispatch", filePath: "src/a.ts" })],
+      "origin/feature",
+      "Entities (origin/feature...HEAD, structural only):\n  src/a.ts\n    M function dispatch",
+    ],
+    [
+      "falls back to a modified marker on an unrecognized change type",
+      [change({ entityName: "dispatch", filePath: "src/a.ts", changeType: "resurrected" })],
+      "origin/main",
+      "Entities (origin/main...HEAD, structural only):\n  src/a.ts\n    M function dispatch",
+    ],
+    [
+      "prints a rename with no path change as a bare name",
+      [
+        change({
+          entityName: "dispatch",
+          filePath: "src/a.ts",
+          changeType: "renamed",
+          oldEntityName: "dispatch",
+        }),
+      ],
+      "origin/main",
+      "Entities (origin/main...HEAD, structural only):\n  src/a.ts\n    R function dispatch",
+    ],
+  ])("%s", (_name, changes, base, expected) => {
+    expect(render(changes, { base })).toBe(expected);
+  });
+});
+
+describe("stackParent", () => {
+  const stack = ["root", "\tchild", "\t\tgrandchild", "\tsibling", "", "loner"].join("\n");
+
+  test.each<[string, string, string | null]>([
+    ["finds the parent one tab up", "child", "root"],
+    ["finds the nearest parent for a deeper layer", "grandchild", "child"],
+    ["skips past a deeper preceding layer", "sibling", "root"],
+    ["returns null at depth zero", "root", null],
+    ["returns null for another branch at depth zero", "loner", null],
+    ["returns null for a branch the stack does not list", "absent", null],
+  ])("%s", (_name, branch, expected) => {
+    expect(stackParent(stack, branch)).toBe(expected);
+  });
+});
+
+describe("resolveBase", () => {
+  const stack = ["root", "\tchild"].join("\n");
+
+  function lookups(overrides: Partial<BaseLookups>): BaseLookups {
+    return {
+      prBase: () => Promise.resolve(null),
+      currentBranch: () => Promise.resolve("child"),
+      stackFile: () => Promise.resolve(null),
+      originHead: () => Promise.resolve(null),
+      ...overrides,
+    };
+  }
+
+  test("prefers the PR base ref", async () => {
+    const base = await resolveBase(
+      lookups({
+        prBase: () => Promise.resolve("release"),
+        stackFile: () => Promise.resolve(stack),
+        originHead: () => Promise.resolve("refs/remotes/origin/trunk"),
+      }),
+    );
+    expect(base).toBe("origin/release");
+  });
+
+  test("falls back to the stack parent", async () => {
+    const base = await resolveBase(
+      lookups({
+        stackFile: () => Promise.resolve(stack),
+        originHead: () => Promise.resolve("refs/remotes/origin/trunk"),
+      }),
+    );
+    expect(base).toBe("origin/root");
+  });
+
+  test("falls back to the default branch when the stack lists no parent", async () => {
+    const base = await resolveBase(
+      lookups({
+        currentBranch: () => Promise.resolve("root"),
+        stackFile: () => Promise.resolve(stack),
+        originHead: () => Promise.resolve("refs/remotes/origin/trunk"),
+      }),
+    );
+    expect(base).toBe("origin/trunk");
+  });
+
+  test("falls back to origin/main when every lookup misses", async () => {
+    expect(await resolveBase(lookups({}))).toBe("origin/main");
+  });
+});

--- a/plugins/pull-request/scripts/sem-context.ts
+++ b/plugins/pull-request/scripts/sem-context.ts
@@ -1,0 +1,251 @@
+#!/usr/bin/env bun
+
+// Entity-level context for a PR body: what changed at the function and class
+// level, from `sem diff`. An input for the body writer, never a gate, so every
+// failure path prints nothing and exits 0.
+
+import { join } from "node:path";
+import { cli } from "cleye";
+import { z } from "zod";
+
+export const Change = z.looseObject({
+  entityId: z.string(),
+  changeType: z.string(),
+  entityType: z.string(),
+  entityName: z.string(),
+  oldEntityName: z.string().nullable().optional(),
+  filePath: z.string(),
+  oldFilePath: z.string().nullable().optional(),
+  structuralChange: z.boolean().nullable().optional(),
+});
+
+export type Change = z.infer<typeof Change>;
+
+export const SemDiff = z.looseObject({
+  changes: z.array(Change),
+});
+
+export type SemResult =
+  | { kind: "ok"; changes: Change[] }
+  | { kind: "missing" }
+  | { kind: "failed" };
+
+const STATUS: Record<string, string> = {
+  added: "A",
+  modified: "M",
+  deleted: "D",
+  renamed: "R",
+  moved: "R",
+  reordered: "M",
+};
+
+function entityRow(change: Change): string {
+  const letter = STATUS[change.changeType] ?? "M";
+  const prefix = `${letter} ${change.entityType} `;
+  if (letter !== "R") return prefix + change.entityName;
+
+  const movedFrom =
+    change.oldFilePath != null && change.oldFilePath !== change.filePath
+      ? `${change.oldFilePath}:`
+      : "";
+  const from = `${movedFrom}${change.oldEntityName ?? change.entityName}`;
+  return from === change.entityName
+    ? prefix + change.entityName
+    : `${prefix}${from} → ${change.entityName}`;
+}
+
+function plural(count: number, singular: string, many: string): string {
+  return `${count} ${count === 1 ? singular : many}`;
+}
+
+export function render(changes: Change[], options: { base: string }): string {
+  const header = `Entities (${options.base}...HEAD`;
+  if (changes.length === 0) return `${header}): none`;
+
+  const unparsed = new Set<string>();
+  let cosmetic = 0;
+  let moduleLevel = 0;
+  const byFile = new Map<string, string[]>();
+
+  for (const change of changes) {
+    if (change.entityType === "chunk") {
+      unparsed.add(change.filePath);
+      continue;
+    }
+    if (change.structuralChange === false) {
+      cosmetic += 1;
+      continue;
+    }
+    if (change.entityType === "orphan") {
+      moduleLevel += 1;
+      continue;
+    }
+    const rows = byFile.get(change.filePath) ?? [];
+    rows.push(entityRow(change));
+    byFile.set(change.filePath, rows);
+  }
+
+  const counts: string[] = [];
+  if (cosmetic > 0) counts.push(`cosmetic-only: ${plural(cosmetic, "entity", "entities")}`);
+  if (moduleLevel > 0) counts.push(`module-level: ${moduleLevel}`);
+  if (unparsed.size > 0) counts.push(`unparsed: ${plural(unparsed.size, "file", "files")}`);
+
+  const lines = [`${header}, structural only):`];
+  if (byFile.size === 0 && cosmetic > 0) {
+    lines.push("  cosmetic-only diff");
+  }
+  for (const [filePath, rows] of byFile) {
+    lines.push(`  ${filePath}`);
+    for (const row of rows) lines.push(`    ${row}`);
+  }
+  if (counts.length > 0) lines.push(`  ${counts.join(" · ")}`);
+
+  return lines.join("\n");
+}
+
+export interface BaseLookups {
+  prBase: () => Promise<string | null>;
+  currentBranch: () => Promise<string | null>;
+  stackFile: () => Promise<string | null>;
+  originHead: () => Promise<string | null>;
+}
+
+function depth(line: string): number {
+  return line.length - line.replace(/^\t+/, "").length;
+}
+
+export function stackParent(stack: string, branch: string): string | null {
+  const lines = stack.split("\n");
+  const index = lines.findIndex((line) => line.trim() === branch);
+  const own = lines[index];
+  if (own === undefined) return null;
+
+  const parentDepth = depth(own) - 1;
+  if (parentDepth < 0) return null;
+
+  for (let i = index - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    if (line === undefined || line.trim() === "") continue;
+    if (depth(line) === parentDepth) return line.trim();
+  }
+  return null;
+}
+
+export async function resolveBase(lookups: BaseLookups): Promise<string> {
+  const [prBase, branch, stack, originHead] = await Promise.all([
+    lookups.prBase(),
+    lookups.currentBranch(),
+    lookups.stackFile(),
+    lookups.originHead(),
+  ]);
+
+  if (prBase != null && prBase !== "") return `origin/${prBase}`;
+
+  if (branch != null && branch !== "" && stack != null) {
+    const parent = stackParent(stack, branch);
+    if (parent != null) return `origin/${parent}`;
+  }
+
+  if (originHead != null && originHead !== "") {
+    return originHead.replace(/^refs\/remotes\//, "");
+  }
+
+  return "origin/main";
+}
+
+const TIMEOUT_MS = 15_000;
+
+async function capture(command: string[]): Promise<string | null> {
+  try {
+    const proc = Bun.spawn(command, { stdout: "pipe", stderr: "ignore", timeout: TIMEOUT_MS });
+    const stdout = await new Response(proc.stdout).text();
+    return (await proc.exited) === 0 ? stdout.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+export function gitLookups(): BaseLookups {
+  return {
+    prBase: () => capture(["gh", "pr", "view", "--json", "baseRefName", "--jq", ".baseRefName"]),
+    currentBranch: () => capture(["git", "branch", "--show-current"]),
+    stackFile: async () => {
+      const commonDir = await capture(["git", "rev-parse", "--git-common-dir"]);
+      if (commonDir === null) return null;
+      try {
+        return await Bun.file(join(commonDir, "wt", "stack")).text();
+      } catch {
+        return null;
+      }
+    },
+    originHead: () => capture(["git", "symbolic-ref", "refs/remotes/origin/HEAD"]),
+  };
+}
+
+function isMissingBinary(error: unknown): boolean {
+  if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+    return true;
+  }
+  return String(error).includes("ENOENT");
+}
+
+export async function runSem(ref: string): Promise<SemResult> {
+  let stdout: string;
+  let exitCode: number;
+  try {
+    const proc = Bun.spawn(["sem", "diff", ref, "--format", "json"], {
+      stdout: "pipe",
+      stderr: "ignore",
+      timeout: TIMEOUT_MS,
+      env: { ...process.env, SEM_NO_UPDATE_CHECK: "1", SEM_NO_TELEMETRY: "1" },
+    });
+    stdout = await new Response(proc.stdout).text();
+    exitCode = await proc.exited;
+  } catch (error) {
+    return isMissingBinary(error) ? { kind: "missing" } : { kind: "failed" };
+  }
+
+  if (exitCode !== 0) return { kind: "failed" };
+
+  try {
+    return { kind: "ok", changes: SemDiff.parse(JSON.parse(stdout)).changes };
+  } catch {
+    return { kind: "failed" };
+  }
+}
+
+async function mergeBase(ref: string): Promise<string | null> {
+  return capture(["git", "merge-base", ref, "HEAD"]);
+}
+
+async function diffRef(base: string): Promise<string> {
+  const remote = await mergeBase(base);
+  if (remote !== null) return remote;
+  const local = base.replace(/^origin\//, "");
+  return (local === base ? null : await mergeBase(local)) ?? base;
+}
+
+if (import.meta.main) {
+  const argv = cli({
+    name: "sem-context",
+    help: {
+      description: "Print the branch's entity-level changes as context for a PR body.",
+    },
+    flags: {
+      base: {
+        type: String,
+        description:
+          "Base ref to diff against. Default: the PR base, then the worktree stack parent, then the repo default branch.",
+      },
+    },
+  });
+
+  const base = argv.flags.base ?? (await resolveBase(gitLookups()));
+  const result = await runSem(await diffRef(base));
+
+  if (result.kind === "missing") {
+    console.log("sem: not installed (brew install sem-cli)");
+  } else if (result.kind === "ok") {
+    console.log(render(result.changes, { base }));
+  }
+}

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -33,6 +33,8 @@ allowed-tools:
 
 !`bun ${CLAUDE_PLUGIN_ROOT}/scripts/git-context.ts`
 
+!`bun ${CLAUDE_PLUGIN_ROOT}/scripts/sem-context.ts`
+
 !`bun ${CLAUDE_PLUGIN_ROOT}/scripts/contributing.ts`
 
 ## Title
@@ -47,6 +49,8 @@ allowed-tools:
 ## Body
 
 Lead with intent: why the change exists, the decisions a reviewer can't reconstruct from the diff, and how you know it works. Don't restate what the diff, the git log, or the status checks show. Review the session for content that never reached the code (rejected alternatives, scope changes, test observations) and state each as a self-contained decision, never as a delta against a plan the reviewer hasn't seen.
+
+The `Entities` block in the context lists what changed at the function and class level, so use it to judge what the change did, but lead the body with intent and never reproduce the list.
 
 - Open with a bare verb ("Adds", "Fixes", "Removes") when the change is self-evident, or with the problem when it needs justifying. Don't restate the title.
 - Default to prose. Write a small PR as one paragraph with no headings. Add `##` sections only when the body is long enough to need them. Base length on substance, not diff size.

--- a/plugins/pull-request/skills/update/SKILL.md
+++ b/plugins/pull-request/skills/update/SKILL.md
@@ -28,6 +28,8 @@ The PR body documents what will happen when merged, not the journey. Don't echo 
 
 !`bun ${CLAUDE_PLUGIN_ROOT}/scripts/git-context.ts`
 
+!`bun ${CLAUDE_PLUGIN_ROOT}/scripts/sem-context.ts`
+
 !`bun ${CLAUDE_PLUGIN_ROOT}/scripts/contributing.ts`
 
 ## Workflow
@@ -42,7 +44,7 @@ The PR body documents what will happen when merged, not the journey. Don't echo 
 
 ## Writing
 
-1. Rewrite the PR body per [`sections.md`](../create/references/sections.md), the same rules the create skill follows. Load the `writing` skill for the full set of tropes to avoid. If a PR template is provided in context, preserve its structure.
+1. Rewrite the PR body per [`sections.md`](../create/references/sections.md), the same rules the create skill follows. Load the `writing` skill for the full set of tropes to avoid. If a PR template is provided in context, preserve its structure. The `Entities` block in the context lists what changed at the function and class level, so use it to judge what the change did, but lead the body with intent and never reproduce the list.
 2. Write the updated body to a temp file (e.g., `tmp/pr-body-<branch>.md`) and apply:
    - **GitHub**: `gh pr edit --body-file tmp/pr-body-<branch>.md`
    - **GitLab**: `glab mr update --description-file tmp/pr-body-<branch>.md`


### PR DESCRIPTION
Adds an entity-level view of the branch to the context that `pull-request:create` and `pull-request:update` load, printed by [sem](https://github.com/Ataraxy-Labs/sem) beside the working-tree diff. The body writer already reads the diff line by line. The entity block tells it which functions, classes, tests, and headings changed and which of those changes are structural, which is the level a body is written at. Both skills say the block is an input for judging what changed and never something to reproduce in the body.

I took sem's diff output and nothing else it ships. Its bundled skill is a navigation manual with a sales pitch, and its MCP server steers every session toward sem over Grep and Read, which is a global change this scope does not cover. The review plugin gets its own copy of the same script in a separate PR, since distributed plugins resolve dependencies through npm and cannot share a workspace package.

The base ref is stack-aware: the PR's own base when a PR exists, then the parent in the worktree stack file, then the remote default branch. A stack parent that exists only locally falls back to the local ref. The diff runs from the merge base against the working tree so uncommitted work is included, matching what `git-context.ts` prints. A missing `sem` binary prints a one-line install note, every other failure prints nothing, and each subprocess times out after fifteen seconds so a hung `gh` call cannot stall the skill load.

Retire this if a later pr-body A/B run shows no lift, or if the block routinely runs past about forty lines on ordinary diffs. This PR's own block is forty-seven lines, since a brand-new file lists every entity it contains as added. Collapsing wholly new files to one row is the first lever if that pattern holds.
