### PR TITLE
flock: surface merged worktrees the sweep hid

### DIFF
--- a/user/skills/flock/SKILL.md
+++ b/user/skills/flock/SKILL.md
@@ -77,9 +77,7 @@ Below the bar, the row is a report. Name the failing job, the reviewer's finding
 
 Check the rendered rows against the deferred keys first. A deferred row is held unless the state block re-raised it as stale.
 
-**Clean up.** Merged with nothing left in the tree. Confirm with `herdr agent get` that the pane is empty, or that the `occupied` agent is still the one that finished, because a removal takes the tree out from under whoever is in it. Remove the worktree, close its workspace and panes, prune the branch. The row's WS column is the workspace to close.
-
-`git worktree remove` cannot delete the directory under the sandbox, under either `.worktrees/` or `~/.herdr/worktrees/`, so run it with the sandbox disabled the first time.
+**Clean up.** Merged with nothing left in the tree. Confirm the pane first, because a removal takes the tree out from under whoever is in it. `herdr agent get` settles an empty one. An `occupied` row needs `herdr agent read`, because `idle` and `done` are one resting status whether the agent finished or is sitting between the turns of a running workflow, and only the pane's last output separates the two. Hold the row if it reads mid-workflow. Otherwise remove the worktree, close its workspace and panes, prune the branch. The row's WS column is the workspace to close.
 
 **Merge.** Checks green, merge state clean, your repo. Re-read the bar immediately before merging, because both the board and your first lookup predate the user's answer. `gh pr merge --squash --delete-branch`, and stop there. The worktree becomes a cleanup row on a later sweep, once a fresh board shows it carrying nothing.
 

--- a/user/skills/flock/SKILL.md
+++ b/user/skills/flock/SKILL.md
@@ -12,7 +12,6 @@ allowed-tools:
   - Bash(herdr agent read:*)
   - Bash(herdr agent focus:*)
   - Bash(herdr pane read:*)
-  - Bash(herdr worktree list:*)
   - Bash(herdr workspace focus:*)
   - Bash(herdr workspace rename:*)
   - Bash(herdr workspace create:*)
@@ -44,9 +43,11 @@ The PR column reads `#N`, `draft#N`, `merged#N`, `-`, or `?`. The REPO column re
 
 FLAGS reads `clean` or a comma-joined list, forge state first. `failing:lint,build` names the jobs that went red, capped at three plus a count. `running` means CI has not finished, `conflicting` and `behind` come from the merge state, `blocked` marks a green pull request some other gate holds, `approved` and `changes-requested` come from the review, `checks:none` means the pull request runs no checks at all, and `checks:?` means the forge would not say.
 
-The checkout flags follow. Only `merged` clears a row for cleanup, and every other flag holds it. Three are not self-evident: `carries:N` counts gitignored files a recursive removal would take, `reused` means the `merged#N` beside it belongs to different work under a recycled branch name, and `unreadable` or `unpushed:?` mean git would not report the state at all, which raises the row rather than parking it.
+The checkout flags follow. `merged` and `occupied` leave a row clear for cleanup, and every other flag holds it. Not self-evident: `carries:N` counts gitignored files a recursive removal would take, `occupied` means an agent is sitting in the pane, `reused` means the `merged#N` beside it belongs to different work under a recycled branch name, and `unreadable` or `unpushed:?` mean git would not report the state at all, which raises the row rather than parking it.
 
-The AGENT column reads `<agent>/<status>`. A `blocked` status is an agent stopped on a prompt, which puts its row in `needs you` whatever else the row carries. Any other status still means the pane is occupied, and an occupied pane holds its row out of `clean up`. The two resting statuses, `idle` and `done`, differ only in whether the tab has been seen, so an agent between the turns of a running workflow reads idle.
+`unpushed:N` counts commits the forge does not have. A row with a pull request is counted against the commit that pull request carries, so a branch whose merge deleted its remote still reads as fully pushed.
+
+The AGENT column reads `<agent>/<status>`. A `blocked` status is an agent stopped on a prompt, which puts its row in `needs you` whatever else the row carries. Only `working` holds a row back, because a turn in flight owns the tree. An agent resting in `idle` or `done`, which differ only in whether the tab has been seen, leaves the row where its own state puts it and adds `occupied`. WS names the workspace holding the pane, which is what closes it once the worktree is gone.
 
 An `incomplete:` line names what the board could not resolve. Retry it: `gh pr list --head <branch>` for the branches it names, `gh pr list` for a `?` PR column. Dispose of nothing the retry also leaves unresolved.
 
@@ -76,7 +77,9 @@ Below the bar, the row is a report. Name the failing job, the reviewer's finding
 
 Check the rendered rows against the deferred keys first. A deferred row is held unless the state block re-raised it as stale.
 
-**Clean up.** Merged with nothing left in the tree. Confirm the pane is still empty with `herdr agent get` first, because an agent can take it between the board and the user's answer, and the removal would take the tree out from under it. Remove the worktree, close its workspace and panes, prune the branch. Read `open_workspace_id` out of `herdr worktree list --json` before removing the path, because herdr loses the mapping once the worktree is gone.
+**Clean up.** Merged with nothing left in the tree. Confirm with `herdr agent get` that the pane is empty, or that the `occupied` agent is still the one that finished, because a removal takes the tree out from under whoever is in it. Remove the worktree, close its workspace and panes, prune the branch. The row's WS column is the workspace to close.
+
+`git worktree remove` cannot delete the directory under the sandbox, under either `.worktrees/` or `~/.herdr/worktrees/`, so run it with the sandbox disabled the first time.
 
 **Merge.** Checks green, merge state clean, your repo. Re-read the bar immediately before merging, because both the board and your first lookup predate the user's answer. `gh pr merge --squash --delete-branch`, and stop there. The worktree becomes a cleanup row on a later sweep, once a fresh board shows it carrying nothing.
 

--- a/user/skills/flock/scripts/board.test.ts
+++ b/user/skills/flock/scripts/board.test.ts
@@ -7,6 +7,7 @@ import {
   renderTable,
   rowCells,
   sortWorktreeRows,
+  withFlag,
   type BoardRow,
 } from "./board";
 
@@ -14,6 +15,7 @@ function row(overrides: Partial<BoardRow>): BoardRow {
   return {
     kind: "worktree",
     pane: null,
+    workspace: null,
     agent: null,
     owner: "bendrucker",
     repo: "claude",
@@ -69,6 +71,7 @@ test("the table pads, truncates, and keeps the flags column whole", () => {
     [
       row({
         pane: "wB2:p1",
+        workspace: "wB2",
         agent: "claude/working",
         prColumn: "merged#30366",
         age: 12,
@@ -85,6 +88,7 @@ test("the table pads, truncates, and keeps the flags column whole", () => {
       row({
         kind: "pane",
         pane: "w9W:p1",
+        workspace: "w9W",
         agent: "claude/idle",
         repoLabel: "Herdr",
         branch: null,
@@ -97,10 +101,10 @@ test("the table pads, truncates, and keeps the flags column whole", () => {
   );
 
   expect(rendered).toMatchInlineSnapshot(`
-"PANE      AGENT          REPO                     BRANCH                     PR            AGE  FLAGS
-wB2:p1    claude/working claude                   topic                      merged#30366  12   dirty,carries:2
--         -              backnotprop/plannotator  a-branch-name-that-will-n… -             ?    unreadable
-w9W:p1    claude/idle    Herdr                    -                          -             -    no worktree"
+"PANE      WS     AGENT          REPO                     BRANCH                     PR            AGE  FLAGS
+wB2:p1    wB2    claude/working claude                   topic                      merged#30366  12   dirty,carries:2
+-         -      -              backnotprop/plannotator  a-branch-name-that-will-n… -             ?    unreadable
+w9W:p1    w9W    claude/idle    Herdr                    -                          -             -    no worktree"
 `);
 });
 
@@ -125,6 +129,7 @@ test("a json row carries the fields the table truncates or omits", () => {
     jsonRow(
       row({
         pane: "wAW:p1",
+        workspace: "wAW",
         agent: "claude/idle",
         owner: "backnotprop",
         repo: "plannotator",
@@ -162,6 +167,7 @@ test("a json row carries the fields the table truncates or omits", () => {
   ).toEqual({
     kind: "worktree",
     pane: "wAW:p1",
+    workspace: "wAW",
     agent: "claude/idle",
     owner: "backnotprop",
     repo: "plannotator",
@@ -196,6 +202,11 @@ test("a json row carries the fields the table truncates or omits", () => {
       reused: false,
     },
   });
+});
+
+test("withFlag replaces the clean sentinel and appends to anything else", () => {
+  expect(withFlag(["clean"], "occupied")).toEqual(["occupied"]);
+  expect(withFlag(["merged"], "occupied")).toEqual(["merged", "occupied"]);
 });
 
 describe("heldByAgent", () => {

--- a/user/skills/flock/scripts/board.ts
+++ b/user/skills/flock/scripts/board.ts
@@ -43,6 +43,8 @@ export type Disposition =
 export interface BoardRow {
   readonly kind: "worktree" | "pane";
   readonly pane: string | null;
+  /** herdr loses the pane's workspace once the worktree is gone. */
+  readonly workspace: string | null;
   readonly agent: string | null;
   readonly owner: string;
   readonly repo: string;
@@ -63,6 +65,7 @@ export interface BoardRow {
 
 export const COLUMNS = [
   { header: "PANE", width: 9 },
+  { header: "WS", width: 6 },
   { header: "AGENT", width: 14 },
   { header: "REPO", width: 24 },
   { header: "BRANCH", width: 26 },
@@ -85,19 +88,24 @@ export function branchLabel(row: Pick<BoardRow, "branch" | "detached" | "kind">)
 }
 
 /**
- * herdr rests an agent in `idle` or `done`, one state split by whether the tab
- * has been seen, so neither reports the work over: an agent between the turns
- * of a running workflow reads idle. The pane is occupied until the agent
- * leaves it. A shell is a person's prompt rather than an agent, and holds
- * nothing.
+ * An agent occupies its pane whatever its status. herdr splits one resting
+ * state into `idle` and `done` by whether the tab has been seen, so an agent
+ * between the turns of a running workflow reads idle. A shell is a person's
+ * prompt rather than an agent, and occupies nothing.
  */
 export function heldByAgent(agent: string | null): boolean {
   return agent !== null && !agent.startsWith("shell/");
 }
 
+/** `clean` is the sentinel for no flags, so a later flag replaces it. */
+export function withFlag(flags: readonly string[], flag: string): string[] {
+  return [...flags.filter((entry) => entry !== "clean"), flag];
+}
+
 export function rowCells(row: BoardRow): string[] {
   return [
     row.pane ?? "-",
+    row.workspace ?? "-",
     row.agent ?? "-",
     row.repoLabel,
     branchLabel(row),
@@ -149,6 +157,7 @@ export function jsonRow(row: BoardRow): Record<string, unknown> {
   return {
     kind: row.kind,
     pane: row.pane,
+    workspace: row.workspace,
     agent: row.agent,
     owner: row.owner,
     repo: row.repo,

--- a/user/skills/flock/scripts/claim.ts
+++ b/user/skills/flock/scripts/claim.ts
@@ -5,7 +5,7 @@ import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { z } from "zod";
 import { decodeJson } from "../../../../packages/decode/index";
-import { heldByAgent, jsonRow, sortWorktreeRows, type BoardRow } from "./board";
+import { heldByAgent, jsonRow, sortWorktreeRows, withFlag, type BoardRow } from "./board";
 import { classify, pullFlags, renderBoard } from "./disposition";
 import { daysBefore, deferredPath, readDeferrals, staleKeys } from "./deferred";
 import { spawnRun, throttle, type Run } from "./exec";
@@ -27,6 +27,7 @@ import {
 } from "./forge";
 import {
   ageInDays,
+  aheadCount,
   carriedIgnoredPaths,
   deriveFlags,
   isMergedBranch,
@@ -70,6 +71,7 @@ const Snapshot = z.looseObject({
 
 interface Pane {
   readonly id: string;
+  readonly workspace: string;
   readonly label: string;
   readonly agent: string;
   readonly cwd: string;
@@ -202,28 +204,9 @@ async function defaultBranch(git: Run, root: string): Promise<string | null> {
   return master?.ok === true ? "master" : null;
 }
 
-function toCount(stdout: string): number | null {
+function toEpoch(stdout: string): number | null {
   const parsed = Number.parseInt(stdout.trim(), 10);
   return Number.isNaN(parsed) ? null : parsed;
-}
-
-/**
- * A worktree whose upstream branch has been deleted fails both counts, and the
- * shell original's `${ahead:-0}` turned that into a fully pushed row.
- */
-async function aheadCount(git: Run, worktree: string, base: string | null): Promise<number | null> {
-  const upstream = await git(["git", "-C", worktree, "rev-list", "--count", "@{u}..HEAD"]);
-  if (upstream.ok) return toCount(upstream.stdout);
-  if (base === null) return null;
-  const fallback = await git([
-    "git",
-    "-C",
-    worktree,
-    "rev-list",
-    "--count",
-    `origin/${base}..HEAD`,
-  ]);
-  return fallback.ok ? toCount(fallback.stdout) : null;
 }
 
 function branchCommitDates(stdout: string): Map<string, number> {
@@ -290,6 +273,7 @@ async function scanWorktree(
     readonly path: string;
     readonly branch: string | null;
     readonly base: string | null;
+    readonly headOid: string | null;
     readonly commitDate: number | null;
   },
 ): Promise<{
@@ -301,7 +285,7 @@ async function scanWorktree(
 }> {
   const [status, ahead, carried, detachedDate, cherry] = await Promise.all([
     ctx.git(["git", "-C", options.path, "status", "--porcelain", "-z", "--ignore-submodules=none"]),
-    aheadCount(ctx.git, options.path, options.base),
+    aheadCount(ctx.git, options.path, { headOid: options.headOid, base: options.base }),
     carriedIgnoredPaths(ctx.git, options.path),
     options.commitDate === null
       ? ctx.git(["git", "-C", options.path, "log", "-1", "--format=%ct", "HEAD"])
@@ -313,7 +297,7 @@ async function scanWorktree(
 
   const commit =
     options.commitDate ??
-    (detachedDate !== null && detachedDate.ok ? toCount(detachedDate.stdout) : null);
+    (detachedDate !== null && detachedDate.ok ? toEpoch(detachedDate.stdout) : null);
 
   return {
     status: readStatus(status),
@@ -367,14 +351,15 @@ async function scanRepository(ctx: Context, repository: Repository): Promise<Rep
   const scanned = await Promise.all(
     records.map(async (record) => {
       const commitDate = record.branch === null ? null : (commitDates.get(record.branch) ?? null);
+      const pull = record.branch === null ? undefined : pulls.get(record.branch);
       const scan = await scanWorktree(ctx, {
         path: record.path,
         branch: record.branch,
         base,
+        headOid: pull?.headOid ?? null,
         commitDate,
       });
 
-      const pull = record.branch === null ? undefined : pulls.get(record.branch);
       const reused = isReusedBranch(pull, scan.commit);
       const flags = deriveFlags({
         detached: record.branch === null,
@@ -389,6 +374,7 @@ async function scanRepository(ctx: Context, repository: Repository): Promise<Rep
       const row: BoardRow = {
         kind: "worktree",
         pane: null,
+        workspace: null,
         agent: null,
         owner,
         repo,
@@ -470,6 +456,7 @@ function readPanes(snapshot: z.infer<typeof Snapshot>): {
       const agent = pane.agent ?? "";
       return {
         id: pane.pane_id,
+        workspace: pane.workspace_id ?? "",
         label: labels.get(pane.workspace_id ?? "") ?? "",
         agent: `${agent === "" ? "shell" : agent}/${pane.agent_status ?? "?"}`,
         cwd: pane.foreground_cwd ?? pane.cwd ?? "",
@@ -521,7 +508,15 @@ function attachPanes(
       working: pane.agent.endsWith("/working"),
       blocked: pane.agent.endsWith("/blocked"),
     };
-    return { ...row, pane: pane.id, agent: pane.agent, state };
+    const flags = heldByAgent(pane.agent) ? withFlag(row.flags, "occupied") : row.flags;
+    return {
+      ...row,
+      pane: pane.id,
+      workspace: pane.workspace === "" ? null : pane.workspace,
+      agent: pane.agent,
+      flags,
+      state,
+    };
   });
   return { rows: attached, claimed };
 }
@@ -540,6 +535,7 @@ function idlePaneRows(
     .map((pane) => ({
       kind: "pane" as const,
       pane: pane.id,
+      workspace: pane.workspace === "" ? null : pane.workspace,
       agent: pane.agent,
       owner: "",
       repo: "",

--- a/user/skills/flock/scripts/disposition.test.ts
+++ b/user/skills/flock/scripts/disposition.test.ts
@@ -35,6 +35,7 @@ function row(overrides: Partial<BoardRow> = {}): BoardRow {
   return {
     kind: "worktree",
     pane: null,
+    workspace: null,
     agent: null,
     owner: "bendrucker",
     repo: "claude",
@@ -216,17 +217,15 @@ describe("an agent resting in the pane", () => {
   const held = (agent: string, overrides: Partial<RowState> = {}): BoardRow =>
     row({ pane: "wC1:p1", agent, pull: merged, state: state(overrides) });
 
-  // The pane holding an agent owns its worktree, and herdr splits one resting
-  // state into idle and done by whether the tab has been seen. An agent
-  // between the turns of a running workflow reads idle, so a cleanup offered
-  // against that row removes the tree the run is working in.
+  // Holding a resting agent's merged worktree back collapsed the row into
+  // `working`, where nobody ever saw it was ready for cleanup.
   test.each<{ name: string; row: BoardRow; expected: Disposition }>([
-    { name: "idle never reads as finished", row: held("claude/idle"), expected: "working" },
-    { name: "done never reads as finished", row: held("claude/done"), expected: "working" },
+    { name: "idle is ready for cleanup", row: held("claude/idle"), expected: "cleanup" },
+    { name: "done is ready for cleanup", row: held("claude/done"), expected: "cleanup" },
     {
-      name: "with a status herdr would not report holds the tree all the same",
+      name: "with a status herdr would not report is ready for cleanup",
       row: held("claude/?"),
-      expected: "working",
+      expected: "cleanup",
     },
     {
       name: "mid-turn holds the tree",
@@ -250,9 +249,6 @@ describe("an agent resting in the pane", () => {
     expect(classify(row({ pull: merged }))).toBe("cleanup");
   });
 
-  // Merge lands on the forge and leaves the tree alone, and the agent that
-  // finished the work is resting in the pane it finished in, so an occupied
-  // pane holding merges back would empty the disposition.
   test.each<{ name: string; row: BoardRow; expected: Disposition }>([
     { name: "resting", row: held("claude/idle", {}), expected: "merge" },
     { name: "mid-turn", row: held("claude/working", { working: true }), expected: "merge" },
@@ -267,6 +263,11 @@ describe("an agent holding the worktree", () => {
       name: "mid-turn holds back a cleanup",
       row: row({ pull: pull({ state: "merged" }), state: state({ working: true }) }),
       expected: "working",
+    },
+    {
+      name: "resting does not hold back a cleanup",
+      row: row({ agent: "claude/idle", pull: pull({ state: "merged" }) }),
+      expected: "cleanup",
     },
     {
       name: "mid-turn holds back a report",

--- a/user/skills/flock/scripts/disposition.ts
+++ b/user/skills/flock/scripts/disposition.ts
@@ -2,7 +2,6 @@ import {
   branchLabel,
   fit,
   headerRow,
-  heldByAgent,
   renderRows,
   rowCells,
   type BoardPull,
@@ -89,16 +88,11 @@ export function classify(row: BoardRow): Disposition {
   if (row.kind === "pane") return "panes";
 
   const disposition = verdict(row);
-  // A merge happens on the forge rather than in the tree, and the agent that
-  // finished the work is still resting in the pane it finished in, so gating
-  // merges on an occupied pane would empty the disposition rather than guard
-  // anything.
+  // A merge happens on the forge rather than in the tree.
   if (disposition === "merge") return disposition;
-  // An agent mid-turn owns the tree, so nothing that touches it is the user's
-  // to decide yet. A resting agent owns it too, and cleanup is the one
-  // remaining disposition that destroys it.
-  if (row.state.working) return "working";
-  return disposition === "cleanup" && heldByAgent(row.agent) ? "working" : disposition;
+  // Only a turn in flight owns the tree. A resting agent is one that finished,
+  // and the `occupied` flag carries its pane to the sweep's confirmation.
+  return row.state.working ? "working" : disposition;
 }
 
 const FAILING_SHOWN = 3;

--- a/user/skills/flock/scripts/disposition.ts
+++ b/user/skills/flock/scripts/disposition.ts
@@ -90,8 +90,8 @@ export function classify(row: BoardRow): Disposition {
   const disposition = verdict(row);
   // A merge happens on the forge rather than in the tree.
   if (disposition === "merge") return disposition;
-  // Only a turn in flight owns the tree. A resting agent is one that finished,
-  // and the `occupied` flag carries its pane to the sweep's confirmation.
+  // Only a turn in flight owns the tree. A resting status cannot say whether
+  // the agent finished, so `occupied` carries the pane to the sweep to read.
   return row.state.working ? "working" : disposition;
 }
 

--- a/user/skills/flock/scripts/forge.test.ts
+++ b/user/skills/flock/scripts/forge.test.ts
@@ -36,7 +36,7 @@ function pull(
   state: PullRequest["state"],
   mergedAt: number | null = null,
 ): PullRequest {
-  return { branch, number, state, mergedAt, ...SETTLED_STATE };
+  return { branch, number, state, mergedAt, headOid: null, ...SETTLED_STATE };
 }
 
 describe("parseRemote", () => {
@@ -101,6 +101,13 @@ describe("joinPullRequests", () => {
     expect(pullRequestRef(joined.get("done")!)).toBe("merged#4");
   });
 
+  // The open listing comes from a search index that lags a merge by a minute or
+  // so, which rendered a landed pull request as conflicting.
+  test("a pull request in both listings takes its merged record", () => {
+    const joined = joinPullRequests([pull("ship", 9, "open")], [pull("ship", 9, "merged")]);
+    expect(pullRequestRef(joined.get("ship")!)).toBe("merged#9");
+  });
+
   test("the first of several open pull requests on a branch wins", () => {
     const joined = joinPullRequests([pull("b", 1, "open"), pull("b", 2, "draft")], []);
     expect(joined.get("b")?.number).toBe(1);
@@ -156,6 +163,7 @@ describe("github", () => {
           {
             number: 1,
             headRefName: "a",
+            headRefOid: "aaa111",
             isDraft: true,
             mergeStateStatus: "BLOCKED",
             reviewDecision: "CHANGES_REQUESTED",
@@ -166,7 +174,8 @@ describe("github", () => {
         ]),
       },
       "--state merged": {
-        stdout: '[{"number":2,"headRefName":"b","mergedAt":"2026-01-01T00:00:00Z"}]',
+        stdout:
+          '[{"number":2,"headRefName":"b","headRefOid":"bbb222","mergedAt":"2026-01-01T00:00:00Z"}]',
       },
     });
     const listing = await createForge("github", run).pullRequests("o/r");
@@ -177,6 +186,7 @@ describe("github", () => {
         number: 1,
         state: "draft",
         mergedAt: null,
+        headOid: "aaa111",
         checks: "failing",
         failing: ["lint"],
         review: "changes-requested",
@@ -184,7 +194,14 @@ describe("github", () => {
       },
     ]);
     expect(listing.merged).toEqual([
-      { branch: "b", number: 2, state: "merged", mergedAt: 1_767_225_600, ...SETTLED_STATE },
+      {
+        branch: "b",
+        number: 2,
+        state: "merged",
+        mergedAt: 1_767_225_600,
+        headOid: "bbb222",
+        ...SETTLED_STATE,
+      },
     ]);
     expect(calls.every((call) => call.includes("--author @me"))).toBe(true);
   });
@@ -199,6 +216,13 @@ describe("github", () => {
     expect(merged).not.toContain("statusCheckRollup");
   });
 
+  test("asks both queries for the head oid", async () => {
+    const { run, calls } = stub({ "pr list": { stdout: "[]" } });
+    await createForge("github", run).pullRequests("o/r");
+
+    expect(calls.filter((call) => call.includes("headRefOid"))).toHaveLength(2);
+  });
+
   test("a listing without a rollup reports checks it cannot read", async () => {
     const { run } = stub({
       "--state open": { stdout: '[{"number":1,"headRefName":"a"}]' },
@@ -210,6 +234,7 @@ describe("github", () => {
         number: 1,
         state: "open",
         mergedAt: null,
+        headOid: null,
         checks: "unknown",
         failing: [],
         review: "none",
@@ -283,13 +308,15 @@ describe("gitlab", () => {
     const { run, calls } = stub({
       "api user": { stdout: '{"username":"ben"}' },
       "--merged": {
-        stdout: '[{"iid":7,"source_branch":"done","merged_at":"2026-01-01T00:00:00Z"}]',
+        stdout:
+          '[{"iid":7,"source_branch":"done","sha":"ddd444","merged_at":"2026-01-01T00:00:00Z"}]',
       },
       "mr list": {
         stdout: JSON.stringify([
           {
             iid: 5,
             source_branch: "wip",
+            sha: "ccc333",
             draft: true,
             has_conflicts: true,
             pipeline: { status: "failed" },
@@ -305,6 +332,7 @@ describe("gitlab", () => {
         number: 5,
         state: "draft",
         mergedAt: null,
+        headOid: "ccc333",
         checks: "failing",
         failing: [],
         review: "unknown",
@@ -312,7 +340,14 @@ describe("gitlab", () => {
       },
     ]);
     expect(listing.merged).toEqual([
-      { branch: "done", number: 7, state: "merged", mergedAt: 1_767_225_600, ...SETTLED_STATE },
+      {
+        branch: "done",
+        number: 7,
+        state: "merged",
+        mergedAt: 1_767_225_600,
+        headOid: "ddd444",
+        ...SETTLED_STATE,
+      },
     ]);
     expect(calls.some((call) => call.includes("--author ben"))).toBe(true);
   });

--- a/user/skills/flock/scripts/forge.ts
+++ b/user/skills/flock/scripts/forge.ts
@@ -99,6 +99,7 @@ export interface PullRequest extends PullState {
   readonly number: number;
   readonly state: "open" | "draft" | "merged";
   readonly mergedAt: number | null;
+  readonly headOid: string | null;
 }
 
 /** One entry of GitHub's `statusCheckRollup`, which mixes two shapes. */
@@ -237,15 +238,17 @@ export function pullRequestRef(pull: PullRequest): string {
 }
 
 /**
- * A branch reused after its pull request merged appears in both listings, and
- * the open row is the truthful one.
+ * A branch reused after its pull request merged appears in both listings under
+ * two numbers, and the open row is the truthful one. One number in both is a
+ * pull request that merged after the open listing was indexed.
  */
 export function joinPullRequests(
   open: readonly PullRequest[],
   merged: readonly PullRequest[],
 ): Map<string, PullRequest> {
+  const landed = new Set(merged.map((pull) => pull.number));
   const byBranch = new Map<string, PullRequest>();
-  for (const pull of [...open, ...merged]) {
+  for (const pull of [...open.filter((entry) => !landed.has(entry.number)), ...merged]) {
     if (!byBranch.has(pull.branch)) byBranch.set(pull.branch, pull);
   }
   return byBranch;
@@ -325,6 +328,7 @@ const GitHubPullRequests = z.array(
   z.looseObject({
     number: z.number(),
     headRefName: z.string(),
+    headRefOid: z.string().nullish(),
     isDraft: z.boolean().optional(),
     mergedAt: z.string().nullish(),
     mergeStateStatus: z.string().nullish(),
@@ -343,10 +347,11 @@ const GitHubPullRequests = z.array(
   }),
 );
 
-// Requested only on the open query. The merged query returns a hundred rows
-// whose check history no disposition reads, and asking for a rollup there
-// would multiply the response for nothing.
-const OPEN_FIELDS = "number,headRefName,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup";
+// A rollup on the merged query's hundred rows would multiply the response for
+// a check history no disposition reads.
+const OPEN_FIELDS =
+  "number,headRefName,headRefOid,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup";
+const MERGED_FIELDS = "number,headRefName,headRefOid,mergedAt";
 
 function githubPullRequest(
   pull: z.infer<typeof GitHubPullRequests>[number],
@@ -357,6 +362,7 @@ function githubPullRequest(
     number: pull.number,
     state: state === "merged" ? "merged" : pull.isDraft === true ? "draft" : "open",
     mergedAt: epochSeconds(pull.mergedAt),
+    headOid: pull.headRefOid ?? null,
   } as const;
   if (state === "merged") return { ...identity, ...SETTLED_STATE };
 
@@ -441,7 +447,7 @@ function githubForge(run: Run): Forge {
           "--limit",
           String(MERGED_LIMIT),
           "--json",
-          "number,headRefName,mergedAt",
+          MERGED_FIELDS,
         ]),
       ]);
 
@@ -475,6 +481,7 @@ const GitLabMergeRequests = z.array(
   z.looseObject({
     iid: z.number(),
     source_branch: z.string(),
+    sha: z.string().nullish(),
     draft: z.boolean().optional(),
     work_in_progress: z.boolean().optional(),
     merged_at: z.string().nullish(),
@@ -498,6 +505,7 @@ function gitlabMergeRequest(
           ? "draft"
           : "open",
     mergedAt: epochSeconds(request.merged_at),
+    headOid: request.sha ?? null,
   } as const;
   if (state === "merged") return { ...identity, ...SETTLED_STATE };
 

--- a/user/skills/flock/scripts/worktree.test.ts
+++ b/user/skills/flock/scripts/worktree.test.ts
@@ -6,6 +6,7 @@ import { spawnRun, type CommandResult, type Run } from "./exec";
 import { SETTLED_STATE, type PullRequest } from "./forge";
 import {
   ageInDays,
+  aheadCount,
   carriedIgnoredPaths,
   CONVENTIONAL_IGNORED,
   deriveFlags,
@@ -166,6 +167,55 @@ describe("ageInDays", () => {
   });
 });
 
+describe("aheadCount", () => {
+  const ranges = (counts: Record<string, string>): { run: Run; seen: string[] } => {
+    const seen: string[] = [];
+    const run: Run = (argv) => {
+      const range = argv.at(-1) ?? "";
+      seen.push(range);
+      const stdout = counts[range];
+      return Promise.resolve(
+        stdout === undefined ? result({ ok: false, stderr: "bad revision" }) : result({ stdout }),
+      );
+    };
+    return { run, seen };
+  };
+
+  test("counts against the pull request's head, not the upstream", async () => {
+    const { run, seen } = ranges({ "abc123..HEAD": "2\n" });
+    expect(await aheadCount(run, "/wt", { headOid: "abc123", base: "main" })).toBe(2);
+    expect(seen).toEqual(["abc123..HEAD"]);
+  });
+
+  // Counting from the base instead reported every commit the merge had taken.
+  test("a checkout sitting on the merged head is fully pushed", async () => {
+    const { run } = ranges({ "abc123..HEAD": "0\n" });
+    expect(await aheadCount(run, "/wt", { headOid: "abc123", base: "main" })).toBe(0);
+  });
+
+  test("a head this checkout does not carry leaves the count unreadable", async () => {
+    const { run, seen } = ranges({});
+    expect(await aheadCount(run, "/wt", { headOid: "abc123", base: "main" })).toBeNull();
+    expect(seen).toEqual(["abc123..HEAD"]);
+  });
+
+  test("a branch with no pull request counts against its upstream", async () => {
+    const { run } = ranges({ "@{u}..HEAD": "3\n" });
+    expect(await aheadCount(run, "/wt", { headOid: null, base: "main" })).toBe(3);
+  });
+
+  test("a branch with no upstream falls back to the base", async () => {
+    const { run, seen } = ranges({ "origin/main..HEAD": "5\n" });
+    expect(await aheadCount(run, "/wt", { headOid: null, base: "main" })).toBe(5);
+    expect(seen).toEqual(["@{u}..HEAD", "origin/main..HEAD"]);
+  });
+
+  test("no upstream and no base reports nothing rather than zero", async () => {
+    const { run } = ranges({});
+    expect(await aheadCount(run, "/wt", { headOid: null, base: null })).toBeNull();
+  });
+});
+
 describe("isMergedBranch", () => {
   // A branch with no commits of its own is an ancestor of the default branch
   // from the moment it is created, so `git branch --merged` listed a branch
@@ -195,6 +245,7 @@ describe("isReusedBranch", () => {
     number: 2,
     state: "merged",
     mergedAt: 1000,
+    headOid: null,
     ...SETTLED_STATE,
   };
 

--- a/user/skills/flock/scripts/worktree.ts
+++ b/user/skills/flock/scripts/worktree.ts
@@ -174,6 +174,36 @@ export async function carriedIgnoredPaths(run: Run, worktree: string): Promise<s
   return filterCarried(await descend(run, worktree, [""], CARRY_DEPTH));
 }
 
+function toCount(result: CommandResult): number | null {
+  const parsed = Number.parseInt(result.stdout.trim(), 10);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * Commits the forge does not have. A pull request's head oid survives the branch
+ * deletion a merge performs, where `@{u}` does not and the base counts the whole
+ * branch.
+ */
+export async function aheadCount(
+  run: Run,
+  worktree: string,
+  options: { readonly headOid: string | null; readonly base: string | null },
+): Promise<number | null> {
+  const count = (range: string): Promise<CommandResult> =>
+    run(["git", "-C", worktree, "rev-list", "--count", range]);
+
+  if (options.headOid !== null) {
+    const pushed = await count(`${options.headOid}..HEAD`);
+    return pushed.ok ? toCount(pushed) : null;
+  }
+
+  const upstream = await count("@{u}..HEAD");
+  if (upstream.ok) return toCount(upstream);
+  if (options.base === null) return null;
+  const fallback = await count(`origin/${options.base}..HEAD`);
+  return fallback.ok ? toCount(fallback) : null;
+}
+
 export interface FlagInput {
   readonly detached: boolean;
   readonly status: StatusRead;


### PR DESCRIPTION
Four mistakes from today's sweeps, all of them rows the user had to point at.

A merged worktree whose pane still held a resting agent collapsed into the `working` line, which carries no action. The old rule read `idle` and `done` as "may be mid-workflow", which held back nearly every cleanup. Only a turn in flight holds a row back now. A resting agent adds an `occupied` flag, and that flag sends the sweep to `herdr agent get` before it removes the tree.

`unpushed:N` counted the whole branch once a merge deleted the remote and `@{u}` stopped resolving. Both forge queries now return the pull request's head commit, and a row with a pull request counts against that instead. A branch without one keeps the `@{u}` path. An oid the checkout does not carry reads `unpushed:?` and raises the row, because a count that cannot be taken is not a zero.

Rows carry their pane's workspace in a new `WS` column. `herdr worktree list --json` fails with `not_git_worktree` when the flock pane's cwd is not a checkout, and deriving one id from the other is out: herdr mints workspace-qualified pane ids on `pane move`.

A pull request in both listings takes its merged record. The open listing comes from a search index that lags a merge, which rendered dotfiles #750 as `conflicting` after it landed. The old preference for the open row exists for a branch reused under a recycled name, which appears under two numbers rather than one.

Clean up now runs `git worktree remove` with the sandbox disabled, which is the only way it can delete the directory.
