### PR TITLE
review: add human-review skill

### DIFF
--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Create a pull request, merge request, or change request with proper formatting and content guidelines.
   Invoke when the user wants to create, open, or submit a PR, MR, or CR, including after committing changes.
 
-argument-hint: "[--draft] [--no-auto] [--base <ref>] [--label <name>] [--no-review]"
+argument-hint: "[--draft] [--no-auto] [--base <ref>] [--label <name>] [--no-review] [--review-body] [--no-review-body]"
 allowed-tools:
   - mcp__github
   - Agent
@@ -13,6 +13,7 @@ allowed-tools:
   - Skill(gitlab:merge-request)
   - Skill(gitlab:api)
   - Skill(github:attach)
+  - Skill(review:human)
   - "Bash(git add:*)"
   - "Bash(git commit:*)"
   - "Bash(git push:*)"
@@ -71,6 +72,7 @@ Parse `$ARGUMENTS` for these flags. With none, create a PR/MR that is ready for 
 - `--base <ref>`: parent branch to target. A branch whose parent is another topic branch is a stack layer. Only this flag or the user identifies one. The upstream ref tracks the branch's own remote copy, so it can't identify the parent. Default: the repo's default branch.
 - `--label <name>`: apply a label, repeatable. Confirm each label exists first, per [`references/labels.md`](references/labels.md). Default: none.
 - `--no-review`: don't request the hosted review. Default: on a repo that gates its hosted bot on a label, request it when the diff clears the metered-review gate and no local pass ran. See [`references/labels.md`](references/labels.md).
+- `--review-body`: put the drafted body in front of you before creating. Default: on when the Remote URL above names an owner other than you, off on your own repos. `--no-review-body` skips it.
 
 ## Workflow
 
@@ -81,6 +83,7 @@ Parse `$ARGUMENTS` for these flags. With none, create a PR/MR that is ready for 
 1. Push the branch to remote: `git push -u origin HEAD`
 1. Resolve the label set against the repo before creating: any `--label` values, plus the review label when the local bot review step's gate said the diff warrants a metered review and that pass didn't already spend the credit. See [`references/labels.md`](references/labels.md).
 1. Draft the body. Past a single paragraph, read [`references/sections.md`](references/sections.md) first: audience tiers, session content, density and heading rules, evidence, optional sections, slop to cut.
+1. Review the body when `--review-body` applies: write it to `tmp/pr-body-<branch>.md`, run `review:human --doc tmp/pr-body-<branch>.md --summary "PR body for <repo>"`, and fold the feedback into the file before creating. Under `/ship` the diff was already reviewed, so this covers only the body.
 1. Create the PR/MR, appending `--draft` when set, `--base <parent>` when the branch is a stack layer, and `--label <name>` for each label that resolved:
    - **GitHub**: `gh pr create --title "..." --body-file tmp/pr-body-<branch>.md`
    - **GitLab**: `glab mr create --title "..." --description-file tmp/pr-body-<branch>.md`

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -83,7 +83,7 @@ Parse `$ARGUMENTS` for these flags. With none, create a PR/MR that is ready for 
 1. Push the branch to remote: `git push -u origin HEAD`
 1. Resolve the label set against the repo before creating: any `--label` values, plus the review label when the local bot review step's gate said the diff warrants a metered review and that pass didn't already spend the credit. See [`references/labels.md`](references/labels.md).
 1. Draft the body. Past a single paragraph, read [`references/sections.md`](references/sections.md) first: audience tiers, session content, density and heading rules, evidence, optional sections, slop to cut.
-1. Review the body when `--review-body` applies: write it to `tmp/pr-body-<branch>.md`, run `review:human --doc tmp/pr-body-<branch>.md --summary "PR body for <repo>"`, and fold the feedback into the file before creating. Under `/ship` the diff was already reviewed, so this covers only the body.
+1. Review the body when `--review-body` applies: write it to `tmp/pr-body-<branch>.md`, run `review:human --doc tmp/pr-body-<branch>.md --summary "PR body for <repo>"`, and fold the feedback into the file before creating. Inside herdr that ends the turn, and the steps below resume when the review comes back. Under `/ship` the diff was already reviewed. This step covers only the body.
 1. Create the PR/MR, appending `--draft` when set, `--base <parent>` when the branch is a stack layer, and `--label <name>` for each label that resolved:
    - **GitHub**: `gh pr create --title "..." --body-file tmp/pr-body-<branch>.md`
    - **GitLab**: `glab mr create --title "..." --description-file tmp/pr-body-<branch>.md`

--- a/plugins/pull-request/skills/create/SKILL.md
+++ b/plugins/pull-request/skills/create/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Create a pull request, merge request, or change request with proper formatting and content guidelines.
   Invoke when the user wants to create, open, or submit a PR, MR, or CR, including after committing changes.
 
-argument-hint: "[--draft] [--no-auto] [--base <ref>] [--label <name>] [--no-review] [--review-body] [--no-review-body]"
+argument-hint: "[--draft] [--no-auto] [--base <ref>] [--label <name>] [--no-review] [--[no-]review-body]"
 allowed-tools:
   - mcp__github
   - Agent
@@ -72,7 +72,7 @@ Parse `$ARGUMENTS` for these flags. With none, create a PR/MR that is ready for 
 - `--base <ref>`: parent branch to target. A branch whose parent is another topic branch is a stack layer. Only this flag or the user identifies one. The upstream ref tracks the branch's own remote copy, so it can't identify the parent. Default: the repo's default branch.
 - `--label <name>`: apply a label, repeatable. Confirm each label exists first, per [`references/labels.md`](references/labels.md). Default: none.
 - `--no-review`: don't request the hosted review. Default: on a repo that gates its hosted bot on a label, request it when the diff clears the metered-review gate and no local pass ran. See [`references/labels.md`](references/labels.md).
-- `--review-body`: put the drafted body in front of you before creating. Default: on when the Remote URL above names an owner other than you, off on your own repos. `--no-review-body` skips it.
+- `--[no-]review-body`: put the drafted body in front of you before creating. Default: on when the Remote URL above names an owner other than you, off on your own repos.
 
 ## Workflow
 

--- a/plugins/review/README.md
+++ b/plugins/review/README.md
@@ -10,6 +10,11 @@ Code review workflows for Claude Code.
 - **`peer`**: Review PRs when requested by a peer (GitHub or GitLab). Maps proposed comments to platform positions with an in-diff pre-check, then posts them as a batch.
 - **`follow-up`**: Follow up on a PR/MR you reviewed: check if your comments were addressed, find silent resolves, decide whether to re-approve
 - **`inbox`**: Dispatch inbound PR/MR reviews as background sessions that collect in `claude agents` (GitHub and GitLab)
+- **`human`**: Request Ben's own review of the working diff or a document, in the terminal (reviewr, plannotator-tui) or the browser (plannotator). Raises a herdr pane label and toast that the plugin's `UserPromptSubmit` hook clears when he replies
+
+### Hooks
+
+- **`UserPromptSubmit`**: clears the `review` pane label `human` raised, once the reply lands
 
 ### Agents
 

--- a/plugins/review/README.md
+++ b/plugins/review/README.md
@@ -14,7 +14,7 @@ Code review workflows for Claude Code.
 
 ### Hooks
 
-- **`UserPromptSubmit`**: clears the `review` pane label `human` raised, once the reply lands
+- **`UserPromptSubmit`**: Clears the `review` pane label `human` raised, once the reply lands
 
 ### Agents
 

--- a/plugins/review/hooks/hooks.json
+++ b/plugins/review/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "description": "Clear the pane's review-requested label when the reviewer replies",
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$HERDR_PANE_ID\" ] && [ -f \"$HOME/.cache/claude/review-human/$(printf %s \"$HERDR_PANE_ID\" | tr : -)\" ] && bun \"${CLAUDE_PLUGIN_ROOT}/scripts/attention.ts\" clear; exit 0"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/review/scripts/attention.test.ts
+++ b/plugins/review/scripts/attention.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, test } from "bun:test";
+import {
+  clearArgs,
+  currentPane,
+  docOpenArgs,
+  existingReviewr,
+  markerPath,
+  notificationArgs,
+  openedPane,
+  raiseArgs,
+  reviewGlyph,
+  reviewrOpenArgs,
+} from "./attention";
+
+describe("raiseArgs", () => {
+  test("labels every resting state and sets the review token", () => {
+    const args = raiseArgs("wE5:p1");
+    // The glyph stands in as `<eye>`: a private-use codepoint inlined here is
+    // one bad paste from snapshotting another icon. Its codepoint is asserted
+    // below instead.
+    expect(args.map((arg) => (arg === `review=${reviewGlyph}` ? "review=<eye>" : arg)))
+      .toMatchInlineSnapshot(`
+      [
+        "pane",
+        "report-metadata",
+        "wE5:p1",
+        "--source",
+        "claude-review-human",
+        "--agent",
+        "claude",
+        "--state-label",
+        "idle=review",
+        "--state-label",
+        "done=review",
+        "--state-label",
+        "working=review",
+        "--token",
+        "review=<eye>",
+        "--ttl-ms",
+        "28800000",
+      ]
+    `);
+  });
+
+  test("renders nf-fa-eye", () => {
+    expect(reviewGlyph.codePointAt(0)).toBe(0xf06e);
+  });
+});
+
+describe("clearArgs", () => {
+  test("clears the labels and token under the same source", () => {
+    expect(clearArgs("wE5:p1")).toMatchInlineSnapshot(`
+      [
+        "pane",
+        "report-metadata",
+        "wE5:p1",
+        "--source",
+        "claude-review-human",
+        "--agent",
+        "claude",
+        "--clear-state-labels",
+        "--clear-token",
+        "review",
+      ]
+    `);
+    expect(clearArgs("wE5:p1")[4]).toBe(raiseArgs("wE5:p1")[4]);
+  });
+});
+
+describe("notificationArgs", () => {
+  test.each<[string, string | undefined, string[]]>([
+    ["with a summary", "claude main: hook wiring", ["--body", "claude main: hook wiring"]],
+    ["without a summary", undefined, []],
+    ["with an empty summary", "", []],
+  ])("%s", (_name, summary, body) => {
+    expect(notificationArgs(summary)).toEqual([
+      "notification",
+      "show",
+      "Review requested",
+      ...body,
+      "--sound",
+      "request",
+    ]);
+  });
+});
+
+describe("markerPath", () => {
+  test.each<[string, string]>([
+    ["wE5:p1", "wE5-p1"],
+    ["a:b:c", "a-b-c"],
+    ["plain", "plain"],
+  ])("%s maps to %s under the cache dir", (paneId, name) => {
+    expect(markerPath(paneId, "/home/x")).toBe(`/home/x/.cache/claude/review-human/${name}`);
+  });
+});
+
+describe("currentPane", () => {
+  test.each<[string, Record<string, string | undefined>, string | null]>([
+    ["inside herdr", { HERDR_ENV: "1", HERDR_PANE_ID: "wE5:p1" }, "wE5:p1"],
+    ["outside herdr", { HERDR_PANE_ID: "wE5:p1" }, null],
+    ["herdr env with no pane", { HERDR_ENV: "1" }, null],
+    ["herdr env with an empty pane", { HERDR_ENV: "1", HERDR_PANE_ID: "" }, null],
+  ])("%s", (_name, env, expected) => {
+    expect(currentPane(env)).toBe(expected);
+  });
+});
+
+describe("open targets", () => {
+  test("reviewr splits beside the pane without taking focus", () => {
+    expect(reviewrOpenArgs("wE5:p1", "/repo")).toMatchInlineSnapshot(`
+      [
+        "plugin",
+        "pane",
+        "open",
+        "--plugin",
+        "persiyanov.reviewr",
+        "--entrypoint",
+        "pane",
+        "--placement",
+        "split",
+        "--target-pane",
+        "wE5:p1",
+        "--direction",
+        "right",
+        "--cwd",
+        "/repo",
+        "--no-focus",
+      ]
+    `);
+  });
+
+  test("plannotator-tui gets the file and the pane to deliver into", () => {
+    expect(docOpenArgs("wE5:p1", "/repo/tmp/pr-body.md")).toMatchInlineSnapshot(`
+      [
+        "plugin",
+        "pane",
+        "open",
+        "--plugin",
+        "annotate",
+        "--entrypoint",
+        "doc",
+        "--placement",
+        "split",
+        "--target-pane",
+        "wE5:p1",
+        "--direction",
+        "right",
+        "--cwd",
+        "/repo/tmp",
+        "--no-focus",
+        "--env",
+        "PLANNOTATOR_TUI_FILE=/repo/tmp/pr-body.md",
+        "--env",
+        "PLANNOTATOR_TUI_DELIVER_TO=wE5:p1",
+        "--env",
+        "PLANNOTATOR_TUI_DELIVER_AGENT=claude",
+      ]
+    `);
+  });
+
+  test("both open as a targeted, unfocused split", () => {
+    for (const args of [reviewrOpenArgs("wE5:p1"), docOpenArgs("wE5:p1", "x.md")]) {
+      expect(args[args.indexOf("--target-pane") + 1]).toBe("wE5:p1");
+      expect(args).toContain("--no-focus");
+      expect(args).not.toContain("--focus");
+    }
+  });
+});
+
+const opened = (paneId: string) =>
+  JSON.stringify({
+    result: { type: "plugin_pane_opened", plugin_pane: { pane: { pane_id: paneId } } },
+  });
+
+describe("openedPane", () => {
+  test.each<[string, string, ReturnType<typeof openedPane>]>([
+    ["an opened pane", opened("wE5:p3"), { pane: "wE5:p3" }],
+    [
+      "a herdr error",
+      JSON.stringify({ error: { code: "plugin_not_found", message: "plugin not found" } }),
+      { error: "plugin not found" },
+    ],
+    ["no output", "", { error: "herdr returned no pane" }],
+    [
+      "an unexpected envelope",
+      JSON.stringify({ result: { type: "ok" } }),
+      { error: "herdr returned no pane" },
+    ],
+  ])("%s", (_name, stdout, expected) => {
+    expect(openedPane(stdout)).toEqual(expected);
+  });
+});
+
+describe("existingReviewr", () => {
+  const list = (panes: { pane_id: string; label?: string | null }[]) =>
+    JSON.stringify({ result: { panes } });
+
+  test.each<[string, string, string | null]>([
+    [
+      "a labeled pane",
+      list([{ pane_id: "wE5:p1" }, { pane_id: "wE5:p4", label: "reviewr" }]),
+      "wE5:p4",
+    ],
+    [
+      "no reviewr pane",
+      list([
+        { pane_id: "wE5:p1", label: null },
+        { pane_id: "wE5:p3", label: "Annotate" },
+      ]),
+      null,
+    ],
+    ["an error envelope", JSON.stringify({ error: { code: "server_unavailable" } }), null],
+    ["no output", "", null],
+  ])("%s", (_name, json, expected) => {
+    expect(existingReviewr(json)).toBe(expected);
+  });
+});

--- a/plugins/review/scripts/attention.test.ts
+++ b/plugins/review/scripts/attention.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { z } from "zod";
 import {
   clearArgs,
   currentPane,
@@ -188,6 +190,27 @@ describe("openedPane", () => {
     ],
   ])("%s", (_name, stdout, expected) => {
     expect(openedPane(stdout)).toEqual(expected);
+  });
+});
+
+describe("hook marker path", () => {
+  const Hooks = z.object({
+    hooks: z.object({
+      UserPromptSubmit: z.tuple([
+        z.object({ hooks: z.tuple([z.object({ command: z.string() })]) }),
+      ]),
+    }),
+  });
+
+  test("the shell fast path resolves to markerPath()", async () => {
+    const file = Bun.file(join(import.meta.dirname, "..", "hooks", "hooks.json"));
+    const { command } = Hooks.parse(await file.json()).hooks.UserPromptSubmit[0].hooks[0];
+    const [, expr] = command.match(/\[ -f (.+?) \] &&/) ?? [];
+    expect(expr).toBeDefined();
+    const shell = Bun.spawnSync(["sh", "-c", `printf %s ${expr}`], {
+      env: { HOME: "/h", HERDR_PANE_ID: "wE5:p1", PATH: process.env.PATH },
+    });
+    expect(shell.stdout.toString()).toBe(markerPath("wE5:p1", "/h"));
   });
 });
 

--- a/plugins/review/scripts/attention.test.ts
+++ b/plugins/review/scripts/attention.test.ts
@@ -192,26 +192,36 @@ describe("openedPane", () => {
 });
 
 describe("existingReviewr", () => {
-  const list = (panes: { pane_id: string; label?: string | null }[]) =>
+  const tree = "/repo/one";
+  const list = (panes: { pane_id: string; label?: string | null; cwd?: string }[]) =>
     JSON.stringify({ result: { panes } });
 
   test.each<[string, string, string | null]>([
     [
-      "a labeled pane",
-      list([{ pane_id: "wE5:p1" }, { pane_id: "wE5:p4", label: "reviewr" }]),
+      "a labeled pane over the same tree",
+      list([
+        { pane_id: "wE5:p1", cwd: tree },
+        { pane_id: "wE5:p4", label: "reviewr", cwd: tree },
+      ]),
       "wE5:p4",
     ],
     [
+      "a labeled pane over another tree",
+      list([{ pane_id: "wE5:p4", label: "reviewr", cwd: "/repo/two" }]),
+      null,
+    ],
+    ["a labeled pane with no cwd", list([{ pane_id: "wE5:p4", label: "reviewr" }]), null],
+    [
       "no reviewr pane",
       list([
-        { pane_id: "wE5:p1", label: null },
-        { pane_id: "wE5:p3", label: "Annotate" },
+        { pane_id: "wE5:p1", label: null, cwd: tree },
+        { pane_id: "wE5:p3", label: "Annotate", cwd: tree },
       ]),
       null,
     ],
     ["an error envelope", JSON.stringify({ error: { code: "server_unavailable" } }), null],
     ["no output", "", null],
   ])("%s", (_name, json, expected) => {
-    expect(existingReviewr(json)).toBe(expected);
+    expect(existingReviewr(json, tree)).toBe(expected);
   });
 });

--- a/plugins/review/scripts/attention.ts
+++ b/plugins/review/scripts/attention.ts
@@ -1,0 +1,267 @@
+#!/usr/bin/env bun
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { cli, command } from "cleye";
+import { z } from "zod";
+
+// nf-fa-eye, the mark the sidebar row bound to `$review` renders.
+export const reviewGlyph = String.fromCodePoint(0xf06e);
+
+const SOURCE = "claude-review-human";
+const TOKEN = "review";
+const LABEL = "review";
+const TTL_MS = 28_800_000;
+const HERDR_TIMEOUT_MS = 5_000;
+const REVIEWR_PLUGIN = "persiyanov.reviewr";
+const ANNOTATE_PLUGIN = "annotate";
+
+export function markerPath(paneId: string, home = homedir()): string {
+  return join(home, ".cache", "claude", "review-human", paneId.replaceAll(":", "-"));
+}
+
+export function raiseArgs(paneId: string): string[] {
+  return [
+    "pane",
+    "report-metadata",
+    paneId,
+    "--source",
+    SOURCE,
+    "--agent",
+    "claude",
+    "--state-label",
+    `idle=${LABEL}`,
+    "--state-label",
+    `done=${LABEL}`,
+    "--state-label",
+    `working=${LABEL}`,
+    "--token",
+    `${TOKEN}=${reviewGlyph}`,
+    "--ttl-ms",
+    String(TTL_MS),
+  ];
+}
+
+export function clearArgs(paneId: string): string[] {
+  return [
+    "pane",
+    "report-metadata",
+    paneId,
+    "--source",
+    SOURCE,
+    "--agent",
+    "claude",
+    "--clear-state-labels",
+    "--clear-token",
+    TOKEN,
+  ];
+}
+
+export function notificationArgs(summary: string | undefined): string[] {
+  const args = ["notification", "show", "Review requested"];
+  if (summary != null && summary !== "") args.push("--body", summary);
+  args.push("--sound", "request");
+  return args;
+}
+
+// Every surface opens as a split beside the requesting pane with focus left
+// where it is. The plugins' own open actions read the focused pane from the
+// invocation context, which is whatever Ben is looking at when the request
+// lands, so this script names the pane itself.
+function paneOpenArgs(plugin: string, entrypoint: string, paneId: string, cwd: string): string[] {
+  return [
+    "plugin",
+    "pane",
+    "open",
+    "--plugin",
+    plugin,
+    "--entrypoint",
+    entrypoint,
+    "--placement",
+    "split",
+    "--target-pane",
+    paneId,
+    "--direction",
+    "right",
+    "--cwd",
+    cwd,
+    "--no-focus",
+  ];
+}
+
+export function reviewrOpenArgs(paneId: string, cwd = process.cwd()): string[] {
+  return paneOpenArgs(REVIEWR_PLUGIN, "pane", paneId, cwd);
+}
+
+// The doc entrypoint runs plannotator-tui, which takes the file and the pane
+// to deliver into from its environment rather than from argv.
+export function docOpenArgs(paneId: string, file: string): string[] {
+  const path = resolve(file);
+  return [
+    ...paneOpenArgs(ANNOTATE_PLUGIN, "doc", paneId, dirname(path)),
+    "--env",
+    `PLANNOTATOR_TUI_FILE=${path}`,
+    "--env",
+    `PLANNOTATOR_TUI_DELIVER_TO=${paneId}`,
+    "--env",
+    "PLANNOTATOR_TUI_DELIVER_AGENT=claude",
+  ];
+}
+
+const PaneOpened = z.object({
+  result: z.object({
+    plugin_pane: z.object({ pane: z.object({ pane_id: z.string() }) }),
+  }),
+});
+
+const HerdrError = z.object({ error: z.object({ code: z.string(), message: z.string() }) });
+
+export type OpenOutcome = { pane: string } | { error: string };
+
+export function openedPane(stdout: string): OpenOutcome {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return { error: "herdr returned no pane" };
+  }
+  const opened = PaneOpened.safeParse(parsed);
+  if (opened.success) return { pane: opened.data.result.plugin_pane.pane.pane_id };
+  const failed = HerdrError.safeParse(parsed);
+  if (failed.success) return { error: failed.data.error.message };
+  return { error: "herdr returned no pane" };
+}
+
+const PaneList = z.object({
+  result: z.object({
+    panes: z.array(z.object({ pane_id: z.string(), label: z.string().nullish() })),
+  }),
+});
+
+// reviewr labels its pane on launch. One per workspace is enough: a second
+// request re-uses the sidebar that is already up.
+export function existingReviewr(paneList: string): string | null {
+  let json: unknown;
+  try {
+    json = JSON.parse(paneList);
+  } catch {
+    return null;
+  }
+  const parsed = PaneList.safeParse(json);
+  if (!parsed.success) return null;
+  return parsed.data.result.panes.find((pane) => pane.label === "reviewr")?.pane_id ?? null;
+}
+
+export function currentPane(env: Record<string, string | undefined> = process.env): string | null {
+  const paneId = env.HERDR_PANE_ID;
+  if (env.HERDR_ENV !== "1" || paneId == null || paneId === "") return null;
+  return paneId;
+}
+
+// Attention is best effort: a herdr that is down or slow must not fail the
+// skill that asked for it.
+function herdr(args: string[]): void {
+  try {
+    Bun.spawnSync(["herdr", ...args], {
+      timeout: HERDR_TIMEOUT_MS,
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+  } catch {
+    return;
+  }
+}
+
+function herdrJson(args: string[]): string {
+  try {
+    return Bun.spawnSync(["herdr", ...args], { timeout: HERDR_TIMEOUT_MS }).stdout.toString();
+  } catch {
+    return "";
+  }
+}
+
+function openPane(args: string[]): never {
+  const outcome = openedPane(herdrJson(args));
+  if ("error" in outcome) fail(outcome.error);
+  console.log(`opened ${outcome.pane}`);
+  process.exit(0);
+}
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+const raiseCmd = command(
+  {
+    name: "raise",
+    help: { description: "Label the pane as awaiting review and show a toast" },
+    flags: {
+      summary: { type: String, description: "What is up for review, shown in the toast" },
+    },
+  },
+  async (parsed) => {
+    const paneId = currentPane();
+    if (paneId == null) return;
+    herdr(raiseArgs(paneId));
+    herdr(notificationArgs(parsed.flags.summary));
+    const marker = markerPath(paneId);
+    mkdirSync(join(marker, ".."), { recursive: true });
+    await Bun.write(marker, "");
+  },
+);
+
+const clearCmd = command(
+  { name: "clear", help: { description: "Drop the review label once the review has landed" } },
+  async () => {
+    const paneId = currentPane();
+    if (paneId == null) return;
+    const marker = Bun.file(markerPath(paneId));
+    if (!(await marker.exists())) return;
+    herdr(clearArgs(paneId));
+    await marker.delete();
+  },
+);
+
+const openCmd = command(
+  {
+    name: "open",
+    help: { description: "Open a review surface beside this pane, delivering into it" },
+    flags: {
+      diff: { type: Boolean, description: "Open reviewr over the working diff" },
+      doc: { type: String, description: "Open plannotator-tui over this file" },
+    },
+  },
+  (parsed) => {
+    if (!parsed.flags.diff && parsed.flags.doc == null) {
+      parsed.showHelp();
+      process.exit(1);
+    }
+    const paneId = currentPane() ?? fail("open needs a herdr pane (HERDR_PANE_ID unset)");
+    if (parsed.flags.doc != null) {
+      const outcome = openedPane(herdrJson(docOpenArgs(paneId, parsed.flags.doc)));
+      if ("error" in outcome && outcome.error.includes("plugin not found")) {
+        fail(`plannotator-tui not found: install the \`${ANNOTATE_PLUGIN}\` herdr plugin`);
+      }
+      if ("error" in outcome) fail(outcome.error);
+      console.log(`opened ${outcome.pane}`);
+      process.exit(0);
+    }
+    const workspace = process.env.HERDR_WORKSPACE_ID;
+    const open =
+      workspace == null
+        ? null
+        : existingReviewr(herdrJson(["pane", "list", "--workspace", workspace]));
+    if (open != null) {
+      console.log(`reviewr already open (${open})`);
+      process.exit(0);
+    }
+    openPane(reviewrOpenArgs(paneId));
+  },
+);
+
+if (import.meta.main) {
+  await cli({ name: "attention", commands: [raiseCmd, clearCmd, openCmd] }, (parsed) => {
+    parsed.showHelp();
+    process.exit(1);
+  });
+}

--- a/plugins/review/scripts/attention.ts
+++ b/plugins/review/scripts/attention.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { mkdirSync } from "node:fs";
+import { mkdirSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { cli, command } from "cleye";
@@ -134,13 +134,23 @@ export function openedPane(stdout: string): OpenOutcome {
 
 const PaneList = z.object({
   result: z.object({
-    panes: z.array(z.object({ pane_id: z.string(), label: z.string().nullish() })),
+    panes: z.array(
+      z.object({ pane_id: z.string(), label: z.string().nullish(), cwd: z.string().nullish() }),
+    ),
   }),
 });
 
-// reviewr labels its pane on launch. One per workspace is enough: a second
-// request re-uses the sidebar that is already up.
-export function existingReviewr(paneList: string): string | null {
+function canonical(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+// reviewr labels its pane on launch. A sidebar already up over the same
+// working tree is re-used; one over another tree would show the wrong diff.
+export function existingReviewr(paneList: string, cwd: string): string | null {
   let json: unknown;
   try {
     json = JSON.parse(paneList);
@@ -149,7 +159,12 @@ export function existingReviewr(paneList: string): string | null {
   }
   const parsed = PaneList.safeParse(json);
   if (!parsed.success) return null;
-  return parsed.data.result.panes.find((pane) => pane.label === "reviewr")?.pane_id ?? null;
+  const tree = canonical(cwd);
+  return (
+    parsed.data.result.panes.find(
+      (pane) => pane.label === "reviewr" && pane.cwd != null && canonical(pane.cwd) === tree,
+    )?.pane_id ?? null
+  );
 }
 
 export function currentPane(env: Record<string, string | undefined> = process.env): string | null {
@@ -160,14 +175,16 @@ export function currentPane(env: Record<string, string | undefined> = process.en
 
 // Attention is best effort: a herdr that is down or slow must not fail the
 // skill that asked for it.
-function herdr(args: string[]): void {
+function herdr(args: string[]): boolean {
   try {
-    Bun.spawnSync(["herdr", ...args], {
-      timeout: HERDR_TIMEOUT_MS,
-      stdio: ["ignore", "ignore", "ignore"],
-    });
+    return (
+      Bun.spawnSync(["herdr", ...args], {
+        timeout: HERDR_TIMEOUT_MS,
+        stdio: ["ignore", "ignore", "ignore"],
+      }).exitCode === 0
+    );
   } catch {
-    return;
+    return false;
   }
 }
 
@@ -217,8 +234,8 @@ const clearCmd = command(
     if (paneId == null) return;
     const marker = Bun.file(markerPath(paneId));
     if (!(await marker.exists())) return;
-    herdr(clearArgs(paneId));
-    await marker.delete();
+    // The marker outlives a failed clear so the next prompt retries it.
+    if (herdr(clearArgs(paneId))) await marker.delete();
   },
 );
 
@@ -236,7 +253,8 @@ const openCmd = command(
       parsed.showHelp();
       process.exit(1);
     }
-    const paneId = currentPane() ?? fail("open needs a herdr pane (HERDR_PANE_ID unset)");
+    const paneId =
+      currentPane() ?? fail("not inside a herdr pane (HERDR_PANE_ID unset): use --browser");
     if (parsed.flags.doc != null) {
       const outcome = openedPane(herdrJson(docOpenArgs(paneId, parsed.flags.doc)));
       if ("error" in outcome && outcome.error.includes("plugin not found")) {
@@ -250,7 +268,7 @@ const openCmd = command(
     const open =
       workspace == null
         ? null
-        : existingReviewr(herdrJson(["pane", "list", "--workspace", workspace]));
+        : existingReviewr(herdrJson(["pane", "list", "--workspace", workspace]), process.cwd());
     if (open != null) {
       console.log(`reviewr already open (${open})`);
       process.exit(0);

--- a/plugins/review/scripts/attention.ts
+++ b/plugins/review/scripts/attention.ts
@@ -196,8 +196,11 @@ function herdrJson(args: string[]): string {
   }
 }
 
-function openPane(args: string[]): never {
+function openPane(args: string[], missingPlugin?: string): never {
   const outcome = openedPane(herdrJson(args));
+  if ("error" in outcome && missingPlugin != null && outcome.error.includes("plugin not found")) {
+    fail(missingPlugin);
+  }
   if ("error" in outcome) fail(outcome.error);
   console.log(`opened ${outcome.pane}`);
   process.exit(0);
@@ -222,7 +225,7 @@ const raiseCmd = command(
     // The marker lands first so a reply that follows the toast at once still
     // finds it and clears the label.
     const marker = markerPath(paneId);
-    mkdirSync(join(marker, ".."), { recursive: true });
+    mkdirSync(dirname(marker), { recursive: true });
     await Bun.write(marker, "");
     herdr(raiseArgs(paneId));
     herdr(notificationArgs(parsed.flags.summary));
@@ -236,8 +239,10 @@ const clearCmd = command(
     if (paneId == null) return;
     const marker = Bun.file(markerPath(paneId));
     if (!(await marker.exists())) return;
-    // The marker outlives a failed clear so the next prompt retries it.
-    if (herdr(clearArgs(paneId))) await marker.delete();
+    // The marker outlives a failed clear so the next prompt retries it, until
+    // the label's own TTL has expired it anyway.
+    const expired = Date.now() - marker.lastModified > TTL_MS;
+    if (herdr(clearArgs(paneId)) || expired) await marker.delete();
   },
 );
 
@@ -250,7 +255,7 @@ const openCmd = command(
       doc: { type: String, description: "Open plannotator-tui over this file" },
     },
   },
-  (parsed) => {
+  async (parsed) => {
     if (!parsed.flags.diff && parsed.flags.doc == null) {
       parsed.showHelp();
       process.exit(1);
@@ -258,13 +263,11 @@ const openCmd = command(
     const paneId =
       currentPane() ?? fail("not inside a herdr pane (HERDR_PANE_ID unset): use --browser");
     if (parsed.flags.doc != null) {
-      const outcome = openedPane(herdrJson(docOpenArgs(paneId, parsed.flags.doc)));
-      if ("error" in outcome && outcome.error.includes("plugin not found")) {
-        fail(`plannotator-tui not found: install the \`${ANNOTATE_PLUGIN}\` herdr plugin`);
-      }
-      if ("error" in outcome) fail(outcome.error);
-      console.log(`opened ${outcome.pane}`);
-      process.exit(0);
+      if (!(await Bun.file(parsed.flags.doc).exists())) fail(`no such file: ${parsed.flags.doc}`);
+      openPane(
+        docOpenArgs(paneId, parsed.flags.doc),
+        `plannotator-tui not found: install the \`${ANNOTATE_PLUGIN}\` herdr plugin`,
+      );
     }
     const workspace = process.env.HERDR_WORKSPACE_ID;
     const open =

--- a/plugins/review/scripts/attention.ts
+++ b/plugins/review/scripts/attention.ts
@@ -278,7 +278,10 @@ const openCmd = command(
       console.log(`reviewr already open (${open})`);
       process.exit(0);
     }
-    openPane(reviewrOpenArgs(paneId));
+    openPane(
+      reviewrOpenArgs(paneId),
+      `reviewr not found: install the \`${REVIEWR_PLUGIN}\` herdr plugin`,
+    );
   },
 );
 

--- a/plugins/review/scripts/attention.ts
+++ b/plugins/review/scripts/attention.ts
@@ -219,11 +219,13 @@ const raiseCmd = command(
   async (parsed) => {
     const paneId = currentPane();
     if (paneId == null) return;
-    herdr(raiseArgs(paneId));
-    herdr(notificationArgs(parsed.flags.summary));
+    // The marker lands first so a reply that follows the toast at once still
+    // finds it and clears the label.
     const marker = markerPath(paneId);
     mkdirSync(join(marker, ".."), { recursive: true });
     await Bun.write(marker, "");
+    herdr(raiseArgs(paneId));
+    herdr(notificationArgs(parsed.flags.summary));
   },
 );
 

--- a/plugins/review/skills/human/SKILL.md
+++ b/plugins/review/skills/human/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review:human
 description: >-
-  Request Ben's own review of the working diff or a document before it leaves the machine. He reviews architecture and AI-slop patterns, not bugs, so it runs after the mechanical passes (review:code or simplify, comments:audit). Terminal by default: the pane rests until his comments arrive as the next turn. --browser blocks on plannotator instead. Use for "get my review", "let me look at this first", or as the last pre-PR pass.
+  Request Ben's own review of the working diff or a document before it leaves the machine, for architecture and slop rather than bugs. Runs after the mechanical passes (review:code or simplify, comments:audit). Use for "get my review", "let me look at this first", or as the last pre-PR pass.
 argument-hint: "[--doc <file>] [--browser] [--summary <text>]"
 allowed-tools:
   - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/attention.ts:*)"
@@ -11,7 +11,11 @@ allowed-tools:
 
 # Human Review
 
-Put the change in front of Ben and act on what comes back. `attention.ts` labels the herdr pane `review`, sets its `$review` token, and raises a toast. Outside herdr it exits silently and the browser surfaces still work.
+Put the change in front of Ben and act on what comes back. `attention.ts` labels the herdr pane `review`, sets its `$review` token, and raises a toast. Outside herdr, `raise` and `clear` are no-ops and `open` exits 1.
+
+## Context
+
+- herdr pane: !`[ "$HERDR_ENV" = 1 ] && printf %s "${HERDR_PANE_ID:-none}" || printf none`
 
 ## Modes
 
@@ -19,24 +23,24 @@ Put the change in front of Ben and act on what comes back. `attention.ts` labels
 |---|---|---|
 | Terminal (default), diff | reviewr sidebar over the working diff | Ends. Comments arrive as the next user turn |
 | Terminal (default), `--doc <file>` | plannotator-tui over the file | Ends. Annotations arrive as the next user turn |
-| `--browser`, diff | `plannotator review --git` | Blocks. Feedback is the tool result |
+| `--browser`, diff | `plannotator review --git --json [--base <ref>]` | Blocks. The decision is the tool result |
 | `--browser`, `--doc <file>` | `plannotator annotate <file> --gate --json --require-approval` | Blocks. The decision is the tool result |
 
-Terminal surfaces open as a split beside this pane, named explicitly and without taking focus, and deliver into it once it is idle. So the turn has to end before Send can land. They need a herdr pane: outside herdr (`HERDR_PANE_ID` unset) run the gate instead, as if `--browser` were passed.
+Terminal surfaces open as a split beside this pane, named explicitly and without taking focus, and deliver into it once it is idle. So the turn has to end before Send can land. They need the herdr pane above. When it reads `none`, run the gate as if `--browser` were passed.
 
 ## Precondition
 
-Request after the mechanical passes have run. `/ship` orders them. Standalone on an unreviewed diff, say so in the summary rather than running them here.
+Request after the mechanical passes have run. `/ship` orders them. Standalone on an unreviewed diff, say so in the `--summary` text rather than running them here.
 
 ## Request
 
-1. `bun ${CLAUDE_PLUGIN_ROOT}/scripts/attention.ts raise --summary "<repo> <branch>: <what to review>"`
-2. `bun ${CLAUDE_PLUGIN_ROOT}/scripts/attention.ts open --diff`, or `open --doc <file>` for a document.
-3. End the turn with exactly one line naming the surface and that Send resumes the work. The surface shows the change, so the line carries no recap.
+1. `bun ${CLAUDE_PLUGIN_ROOT}/scripts/attention.ts raise --summary "<repo> <branch>: <what to review>"`. A caller's `--summary` passes through verbatim.
+2. `bun ${CLAUDE_PLUGIN_ROOT}/scripts/attention.ts open --diff`, or `open --doc <file>` for a document. `open --diff` re-uses a reviewr sidebar already up over this working tree.
+3. End the turn with exactly one line naming the surface and that Send resumes the work. The surface shows the change. The line carries no recap.
 
 ## Resume
 
-The next user turn carries the comment batch plus Ben's own remarks. Each block is a `path:lines` header, the verbatim snippet, and his text. The herdr plugin's `skills/herdr/references/reviewr.md` covers the shape in full. Act on all of it. Sending cleared reviewr's store, so the batch in the turn is the only copy. This plugin's `UserPromptSubmit` hook has already cleared the pane label.
+The next user turn carries the comment batch plus Ben's own remarks. Each block is a `path:lines` header, the verbatim snippet, and his text. The herdr plugin's `skills/herdr/references/reviewr.md` covers the shape in full. Act on all of it. Sending cleared reviewr's store. The batch in the turn is the only copy. This plugin's `UserPromptSubmit` hook has already cleared the pane label.
 
 The review ends when Ben says approve, ship, or no further comments. Otherwise act on the batch and request again.
 
@@ -45,6 +49,6 @@ The review ends when Ben says approve, ship, or no further comments. Otherwise a
 With `--browser`:
 
 1. `attention.ts raise --summary "..."`
-2. `plannotator review --git`, or `plannotator annotate <file> --gate --json --require-approval`
+2. `plannotator review --git --json`, adding `--base <ref>` when the caller resolved one, or `plannotator annotate <file> --gate --json --require-approval`
 3. `attention.ts clear`
-4. Act on the feedback. Exit 1 from the annotate gate means not approved: fold the annotations into the file and run the gate again.
+4. Act on the decision. `approved` ends the review. `annotated` means act on the annotations and run the gate again. `dismissed`, or exit 1 from the annotate gate, means not approved: fold the feedback in and run the gate again. Exit 2 is a startup error: report it and stop.

--- a/plugins/review/skills/human/SKILL.md
+++ b/plugins/review/skills/human/SKILL.md
@@ -22,7 +22,7 @@ Put the change in front of Ben and act on what comes back. `attention.ts` labels
 | `--browser`, diff | `plannotator review --git` | Blocks. Feedback is the tool result |
 | `--browser`, `--doc <file>` | `plannotator annotate <file> --gate --json --require-approval` | Blocks. The decision is the tool result |
 
-Terminal surfaces open as a split beside this pane, named explicitly and without taking focus, and deliver into it once it is idle. So the turn has to end before Send can land.
+Terminal surfaces open as a split beside this pane, named explicitly and without taking focus, and deliver into it once it is idle. So the turn has to end before Send can land. They need a herdr pane: outside herdr (`HERDR_PANE_ID` unset) run the gate instead, as if `--browser` were passed.
 
 ## Precondition
 

--- a/plugins/review/skills/human/SKILL.md
+++ b/plugins/review/skills/human/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: review:human
+description: >-
+  Request Ben's own review of the working diff or a document before it leaves the machine. He reviews architecture and AI-slop patterns, not bugs, so it runs after the mechanical passes (review:code or simplify, comments:audit). Terminal by default: the pane rests until his comments arrive as the next turn. --browser blocks on plannotator instead. Use for "get my review", "let me look at this first", or as the last pre-PR pass.
+argument-hint: "[--doc <file>] [--browser] [--summary <text>]"
+allowed-tools:
+  - "Bash(bun ${CLAUDE_PLUGIN_ROOT}/scripts/attention.ts:*)"
+  - Bash(plannotator review:*)
+  - Bash(plannotator annotate:*)
+---
+
+# Human Review
+
+Put the change in front of Ben and act on what comes back. `attention.ts` labels the herdr pane `review`, sets its `$review` token, and raises a toast. Outside herdr it exits silently and the browser surfaces still work.
+
+## Modes
+
+| Mode | Surface | Turn |
+|---|---|---|
+| Terminal (default), diff | reviewr sidebar over the working diff | Ends. Comments arrive as the next user turn |
+| Terminal (default), `--doc <file>` | plannotator-tui over the file | Ends. Annotations arrive as the next user turn |
+| `--browser`, diff | `plannotator review --git` | Blocks. Feedback is the tool result |
+| `--browser`, `--doc <file>` | `plannotator annotate <file> --gate --json --require-approval` | Blocks. The decision is the tool result |
+
+Terminal surfaces open as a split beside this pane, named explicitly and without taking focus, and deliver into it once it is idle. So the turn has to end before Send can land.
+
+## Precondition
+
+Request after the mechanical passes have run. `/ship` orders them. Standalone on an unreviewed diff, say so in the summary rather than running them here.
+
+## Request
+
+1. `bun ${CLAUDE_PLUGIN_ROOT}/scripts/attention.ts raise --summary "<repo> <branch>: <what to review>"`
+2. `bun ${CLAUDE_PLUGIN_ROOT}/scripts/attention.ts open --diff`, or `open --doc <file>` for a document.
+3. End the turn with exactly one line naming the surface and that Send resumes the work. The surface shows the change, so the line carries no recap.
+
+## Resume
+
+The next user turn carries the comment batch plus Ben's own remarks. Each block is a `path:lines` header, the verbatim snippet, and his text. The herdr plugin's `skills/herdr/references/reviewr.md` covers the shape in full. Act on all of it. Sending cleared reviewr's store, so the batch in the turn is the only copy. This plugin's `UserPromptSubmit` hook has already cleared the pane label.
+
+The review ends when Ben says approve, ship, or no further comments. Otherwise act on the batch and request again.
+
+## Gate
+
+With `--browser`:
+
+1. `attention.ts raise --summary "..."`
+2. `plannotator review --git`, or `plannotator annotate <file> --gate --json --require-approval`
+3. `attention.ts clear`
+4. Act on the feedback. Exit 1 from the annotate gate means not approved: fold the annotations into the file and run the gate again.

--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -17,6 +17,7 @@ allowed-tools:
   - Skill(comments:audit)
   - Skill(github:copilot)
   - Skill(writing:review)
+  - Skill(review:human)
   - Skill(pull-request:create)
   - Skill(pull-request:babysit)
   - Skill(pull-request:follow-up)
@@ -43,6 +44,7 @@ Resolve the base to a **remote** ref so ship's view matches what the PR merges a
 - **`github:copilot`**: code changed on a repo I own *and* the diff clears the [Cross-Model Gate](references/passes.md). A second model reads the diff before the PR exists.
 - **`writing:review`**: diff touches prose (`.md`, `.mdx`, `.rst`, docs).
 - **`run`**: diff has a runtime surface. Drive the change in the real app, not just tests. Skip on docs-only and tests-only.
+- **`review:human`**: always, not diff-gated. Ben reads the cleaned diff last, for architecture and slop. `--skip human` drops it.
 
 Infer, don't interrogate. Present the plan in one line, then proceed. `AskUserQuestion` only on a real toss-up: refactor versus behavior change, or `medium` versus `high` effort.
 
@@ -51,7 +53,7 @@ Infer, don't interrogate. Present the plan in one line, then proceed. `AskUserQu
 - `--merge`: drive to merged (babysit `--merge`). Default: green and ready.
 - `--effort <low|medium|high|xhigh>`: override inferred `review:code` effort.
 - `--simplify`: force `simplify` over `review:code`.
-- `--skip <pass>` (repeatable): drop a gated pass. Names: `plan`, `review:code` (the old `code-review` is accepted as an alias), `simplify`, `comments`, `bot`, `copilot`, `writing`, `run` (the old `verify` is accepted as an alias).
+- `--skip <pass>` (repeatable): drop a gated pass. Names: `plan`, `review:code` (the old `code-review` is accepted as an alias), `simplify`, `comments`, `bot`, `copilot`, `writing`, `run` (the old `verify` is accepted as an alias), `human`.
 - `--base <ref>`: base branch for gating. Default `main`; on a stack, the parent branch. Resolved to its upstream tracking ref (e.g. `origin/...`) before diffing.
 
 ## Pre-PR Reviews
@@ -64,6 +66,7 @@ Serialized before create: `review:code --fix`, `simplify`, and comment trims all
 4. **Correctness and quality**: `review:code <effort> --fix` or `simplify`.
 5. **`writing:review`** over touched prose. Address salient findings before the body is written.
 6. **`run`** to drive the change end to end.
+7. **`review:human`**: after every fix pass, so the cleaned diff is what gets seen. Terminal mode by default: it ends the turn, and Create runs only when the review resumes with approval.
 
 Dirty tree at the comment pass: ask whether to commit first. `comments:audit` operates on `HEAD` and needs a clean tree.
 

--- a/user/skills/ship/SKILL.md
+++ b/user/skills/ship/SKILL.md
@@ -37,14 +37,14 @@ Default end state **green and ready**: CI green, bot comments triaged, body refr
 
 Resolve the base to a **remote** ref so ship's view matches what the PR merges against. From the base branch (default `main`, or `--base <parent>` on a stack), take its tracking ref via `git rev-parse --abbrev-ref --symbolic-full-name <base>@{u}`, falling back to `origin/<base>`. Fetch it first (`git fetch`) so a stale local `<base>` never inflates the diff with already-merged commits. Diff `git diff <resolved>...HEAD`, plus a plain `git diff` for uncommitted work, and thread the resolved ref as `--base` to every gated pass (including `review:code`). Gate each pass on the file set, its size, and the content behind any judgment call (new comments, refactor or new behavior). Full matrix and heuristics: [`references/passes.md`](references/passes.md).
 
-- **`plan:review`**: a substantial approved plan is in context (`~/.claude/plans/` file) *and* the session ran long or redirected enough that the diff could have drifted from it. Skip otherwise ([full gate](references/passes.md)).
+- **`plan:review`**: a substantial approved plan is in context (`~/.claude/plans/` file) *and* the session ran long or redirected enough that the diff could have drifted from it. Skip otherwise ([full gate](references/passes.md#plan-review)).
 - **Correctness and quality**: code changed. Exactly one of `review:code <effort> --fix` (default) or `simplify` (pure refactor, no new behavior). Skip on docs/config-only.
 - **`comments:audit`**: diff adds code comments.
-- **`pull-request:follow-up --local`**: a supported review bot is available for the repo *and* the diff clears the [Bot Review Gate](references/passes.md). Runs the hosted reviewer locally before the PR exists.
-- **`github:copilot`**: code changed on a repo I own *and* the diff clears the [Cross-Model Gate](references/passes.md). A second model reads the diff before the PR exists.
+- **`pull-request:follow-up --local`**: a supported review bot is available for the repo *and* the diff clears the [Bot Review Gate](references/passes.md#bot-review-gate). Runs the hosted reviewer locally before the PR exists.
+- **`github:copilot`**: code changed on a repo I own *and* the diff clears the [Cross-Model Gate](references/passes.md#cross-model-gate). A second model reads the diff before the PR exists.
 - **`writing:review`**: diff touches prose (`.md`, `.mdx`, `.rst`, docs).
 - **`run`**: diff has a runtime surface. Drive the change in the real app, not just tests. Skip on docs-only and tests-only.
-- **`review:human`**: always, not diff-gated. Ben reads the cleaned diff last, for architecture and slop. `--skip human` drops it.
+- **`review:human`**: always on. Ben reads the cleaned diff last, for architecture and slop. `--skip human` drops it, and passes `--no-review-body` through to create.
 
 Infer, don't interrogate. Present the plan in one line, then proceed. `AskUserQuestion` only on a real toss-up: refactor versus behavior change, or `medium` versus `high` effort.
 
@@ -66,13 +66,14 @@ Serialized before create: `review:code --fix`, `simplify`, and comment trims all
 4. **Correctness and quality**: `review:code <effort> --fix` or `simplify`.
 5. **`writing:review`** over touched prose. Address salient findings before the body is written.
 6. **`run`** to drive the change end to end.
-7. **`review:human`**: after every fix pass, so the cleaned diff is what gets seen. Terminal mode by default: it ends the turn, and Create runs only when the review resumes with approval.
+7. **Join `plan:review`** when it was gated in, and act on fix-worthy drift before the human review sees the diff. Carry deferred follow-ups into the report.
+8. **`review:human`**: after every fix pass and the join, so the cleaned diff is what gets seen ([Human Review](references/passes.md#human-review)). Terminal mode by default: it ends the turn, and Create runs only when the review resumes with approval.
 
 Dirty tree at the comment pass: ask whether to commit first. `comments:audit` operates on `HEAD` and needs a clean tree.
 
 #### Comment Trims
 
-`comments:audit` commits trims to a fresh `comments/audit-<hash>` branch off `HEAD`, leaving the tree untouched. Run `comments:audit --base <base> --fix` and capture the branch name. No branch means nothing to trim: skip. Otherwise dispatch a short-lived `general-purpose` Agent with that name to fast-forward and delete it (rationale and rejected alternatives: [`references/passes.md`](references/passes.md)):
+`comments:audit` commits trims to a fresh `comments/audit-<hash>` branch off `HEAD`, leaving the tree untouched. Run `comments:audit --base <base> --fix` and capture the branch name. No branch means nothing to trim: skip. Otherwise dispatch a short-lived `general-purpose` Agent with that name to fast-forward and delete it (rationale and rejected alternatives: [`references/passes.md`](references/passes.md#comment-trims)):
 
 ```
 git merge --ff-only comments/audit-<hash>
@@ -81,17 +82,19 @@ git branch -d comments/audit-<hash>
 
 ## Create
 
-Join the background `plan:review` first if it was gated in. Act on fix-worthy drift before the PR exists, and carry any deferred follow-ups into the report. Then `pull-request:create` commits the working-tree fixes, pushes, opens the PR. Capture the URL: babysit and body-refresh need it.
+The plan-review join and the human review are behind you. `pull-request:create` commits the working-tree fixes, pushes, opens the PR. Capture the URL: babysit and body-refresh need it.
+
+Pass `--no-review-body` through when `/ship --skip human` was given, so create's own body review honors the skip.
 
 Pass `--base <parent>` through when `/ship --base` named a stack parent. Create needs it to target the PR at the parent and to link the layer into the stack on GitHub. Without it the PR opens against the default branch and carries every lower layer's diff.
 
-Pass `--label review` only when the [Bot Review Gate](references/passes.md) routed to the hosted channel (local CLI unavailable); the review then starts with the PR. A local pass already covered the diff, so labeling after it pays a second credit for the same review.
+Pass `--label review` only when the [Bot Review Gate](references/passes.md#bot-review-gate) routed to the hosted channel (local CLI unavailable); the review then starts with the PR. A local pass already covered the diff, so labeling after it pays a second credit for the same review.
 
 ## Babysit
 
 `pull-request:babysit <url>` watches CI and fixes trivial failures to green.
 
-- `--reviews` (default on): after first green, hand bot comments to `pull-request:follow-up --auto`. Covers a bot review landing after the green push with no CI event to key off ([why](references/passes.md)).
+- `--reviews` (default on): after first green, hand bot comments to `pull-request:follow-up --auto`. Covers a bot review landing after the green push with no CI event to key off ([why](references/passes.md#babysit-and-reviews)).
 - `--merge`: only when `/ship --merge` was passed; else stop at green.
 
 ## Refresh the Body

--- a/user/skills/ship/references/passes.md
+++ b/user/skills/ship/references/passes.md
@@ -4,7 +4,7 @@ Gating decisions for ship's pre-PR reviews: which pass runs, `review:code` effor
 
 ## Gating Matrix
 
-Most passes gate on the diff against the resolved base (the upstream tracking ref, resolved per `SKILL.md`) plus the working tree. `plan:review` gates on the plan and the session, not the diff (see [Plan Review](#plan-review)).
+Most passes gate on the diff against the resolved base (the upstream tracking ref, resolved per `SKILL.md`) plus the working tree. `plan:review` gates on the plan and the session (see [Plan Review](#plan-review)), and `review:human` is always on (see [Human Review](#human-review)).
 
 | Trigger | Pass | Notes |
 |---|---|---|
@@ -15,7 +15,7 @@ Most passes gate on the diff against the resolved base (the upstream tracking re
 | Code changes on a repo whose remote owner is `bendrucker`, clearing the [Cross-Model Gate](#cross-model-gate) | `github:copilot` | Same slot as the local bot pass. Findings fix in-branch |
 | Prose (`.md`, `.mdx`, `.rst`, docs) | `writing:review` | |
 | A runtime surface | `run` | Ship declines docs-only and tests-only |
-| Always, unless `--skip human` | `review:human` | Last pre-PR pass. Rests the session until the review comes back |
+| Always, unless `--skip human` | `review:human` | Last pre-PR pass. Ends the turn until the review comes back |
 
 Gating is the cost lever: never run a reviewer the change does not warrant. `--skip <pass>` drops any of them (`plan`, `review:code`, `simplify`, `comments`, `bot`, `copilot`, `writing`, `run`, `human`). `code-review` is still accepted for `review:code`, and `verify` for `run`, so an old invocation does not silently run the pass it meant to skip.
 
@@ -70,7 +70,7 @@ It is read-only and writes nothing, so it runs as a background dispatch rather t
 flowchart TD
     S([ship start]) --> G{plan:review gated in?}
     G -->|no| F1[fix passes: comments:audit, local bot, github:copilot, review:code or simplify, writing, run]
-    F1 --> H[review:human, rests until the review returns]
+    F1 --> H[review:human, ends the turn until the review returns]
     H --> C([create PR])
     G -->|yes| D[dispatch plan:review in background]
     D --> F2[fix passes: comments:audit, local bot, github:copilot, review:code or simplify, writing, run]
@@ -78,9 +78,8 @@ flowchart TD
     F2 --> J{join: findings?}
     R -.-> J
     J -->|fix-worthy drift| A[act on the drift]
-    J -->|none, common| H2[review:human, rests until the review returns]
-    A --> H2
-    H2 --> C
+    J -->|none, common| H
+    A --> H
 ```
 
 ## Effort Inference
@@ -102,7 +101,7 @@ Alternatives, not a pair. Pick `simplify` for a pure refactor or cleanup with no
 
 ## Human Review
 
-`review:human` runs last so Ben sees the diff the fix passes left, with nothing in it a later pass would rewrite. Terminal mode is the default because it rests the pane: Moshi learns state from the Stop hook and sees a rested pane with a one-line request, where a Bash call blocked on a browser review reads as ordinary work. The DAG's create node waits on it: the turn ends at the request, and Create runs when the review resumes with approval.
+`review:human` runs last so Ben sees the diff the fix passes left, with nothing in it a later pass would rewrite. Terminal mode is the default. The DAG's create node waits on it: the turn ends at the request, and Create runs when the review resumes with approval.
 
 ## Babysit and Reviews
 

--- a/user/skills/ship/references/passes.md
+++ b/user/skills/ship/references/passes.md
@@ -15,8 +15,9 @@ Most passes gate on the diff against the resolved base (the upstream tracking re
 | Code changes on a repo whose remote owner is `bendrucker`, clearing the [Cross-Model Gate](#cross-model-gate) | `github:copilot` | Same slot as the local bot pass. Findings fix in-branch |
 | Prose (`.md`, `.mdx`, `.rst`, docs) | `writing:review` | |
 | A runtime surface | `run` | Ship declines docs-only and tests-only |
+| Always, unless `--skip human` | `review:human` | Last pre-PR pass. Rests the session until the review comes back |
 
-Gating is the cost lever: never run a reviewer the change does not warrant. `--skip <pass>` drops any of them (`plan`, `review:code`, `simplify`, `comments`, `bot`, `copilot`, `writing`, `run`). `code-review` is still accepted for `review:code`, and `verify` for `run`, so an old invocation does not silently run the pass it meant to skip.
+Gating is the cost lever: never run a reviewer the change does not warrant. `--skip <pass>` drops any of them (`plan`, `review:code`, `simplify`, `comments`, `bot`, `copilot`, `writing`, `run`, `human`). `code-review` is still accepted for `review:code`, and `verify` for `run`, so an old invocation does not silently run the pass it meant to skip.
 
 ## Bot Review Gate
 
@@ -69,15 +70,17 @@ It is read-only and writes nothing, so it runs as a background dispatch rather t
 flowchart TD
     S([ship start]) --> G{plan:review gated in?}
     G -->|no| F1[fix passes: comments:audit, local bot, github:copilot, review:code or simplify, writing, run]
-    F1 --> C([create PR])
+    F1 --> H[review:human, rests until the review returns]
+    H --> C([create PR])
     G -->|yes| D[dispatch plan:review in background]
     D --> F2[fix passes: comments:audit, local bot, github:copilot, review:code or simplify, writing, run]
     D -. concurrent .-> R[plan:review reasons over plan + diff]
     F2 --> J{join: findings?}
     R -.-> J
-    J -->|fix-worthy drift| A[act before create]
-    J -->|none, common| C
-    A --> C
+    J -->|fix-worthy drift| A[act on the drift]
+    J -->|none, common| H2[review:human, rests until the review returns]
+    A --> H2
+    H2 --> C
 ```
 
 ## Effort Inference
@@ -96,6 +99,10 @@ Infer `review:code` effort from the diff unless `--effort` overrides. `high` is 
 ## Code-Review Versus Simplify
 
 Alternatives, not a pair. Pick `simplify` for a pure refactor or cleanup with no new behavior: extraction, renaming, dedup, dead-code removal, moving code. It covers reuse, simplification, efficiency, and altitude, and does not hunt bugs. Pick `review:code` for anything with new behavior, a bug fix, or a feature, which need the correctness coverage `simplify` skips. `--simplify` forces the `simplify` path.
+
+## Human Review
+
+`review:human` runs last so Ben sees the diff the fix passes left, with nothing in it a later pass would rewrite. Terminal mode is the default because it rests the pane: Moshi learns state from the Stop hook and sees a rested pane with a one-line request, where a Bash call blocked on a browser review reads as ordinary work. The DAG's create node waits on it: the turn ends at the request, and Create runs when the review resumes with approval.
 
 ## Babysit and Reviews
 


### PR DESCRIPTION
Ben reviews AI output by hand for architecture and slop, in reviewr or plannotator, at points a skill chooses: the cleaned diff before a PR exists, and a drafted body before it lands on a third-party repo. `review:human` is that request. It succeeds the retired `review:self`, which only launched a TUI. What earns it a skill is the attention signal, the document mode, and the default wiring into `/ship` and `pull-request:create`.

## Attention

herdr's manifest is the sole authority on agent state, so a Claude pane cannot be set to `blocked` from the client. Attention is display only: `review` labels on every resting state, a `$review` token rendered as an eye glyph (bendrucker/dotfiles#750, merged), and a toast. A marker under `~/.cache/claude/review-human/`, the one temp location both the sandboxed Bash tool and the unsandboxed hook can write, records the raised pane. The plugin's `UserPromptSubmit` hook clears the label when the reply lands, behind a shell stat so ordinary prompts never spawn `bun`.

## Targeting

Every surface opens with `herdr plugin pane open --target-pane <this pane> --no-focus`. The plugins' own `plugin action invoke` entry points read the focused pane, so from a Claude pane they open wherever Ben is looking. A second `open --diff` re-uses a reviewr sidebar already up over the same working tree.

## Modes

Terminal mode is the default and ends the turn, because reviewr and plannotator-tui deliver into an idle pane. Moshi reads state from the Stop hook and sees a rested pane with a one-line request. `--browser` runs the plannotator gate inline and keys on its JSON decision. Outside herdr the skill injects `none` as the pane at load and runs the gate instead.

`/ship` runs it last, after the plan-review join, with `--skip human` forwarded to create as `--no-review-body`. `pull-request:create` reviews the drafted body by default only on a repo you do not own.

## Verification

Drove raise, clear, the hook, the doc pane, and reviewr live from this pane. The end-to-end ran on this branch: the reviewr comment on the argument hint arrived as the next turn and produced the last commit. Greptile and Copilot local reviews each found ordering and retry defects in the script, fixed here.

Skill sizes: `human` ~852 tokens, `ship` 1,787 to 1,966, `create` 1,893 to 2,043.

## Removal

The skill earns its cost if `/ship` runs end in a resumed review rather than `--skip human`. Labels sitting for the full 8h TTL, or `--browser` as the usual path, mean the attention step is inert and the skill should shrink to the plannotator gate.
