### PR TITLE
job: drop brief items whose next actor is not you

### DIFF
--- a/user/skills/job/SKILL.md
+++ b/user/skills/job/SKILL.md
@@ -92,6 +92,8 @@ The user is the next actor when someone asked the user a direct question, when t
 
 Someone else is the next actor when the user commented or reviewed last and nothing the user raised has been answered, when the item is approved or has changes requested and only the author can move it, and when it is blocked on work the user does not own. Open threads are not an exception: a thread carrying the user's unanswered comment is waiting on whoever it was addressed to.
 
+An entry collapsing several sources can carry both actors at once. The user wins that tie, because dropping the entry would drop a question addressed to the user. Carry only the parts that resolve to the user into the entry's summary and its recommended action, and leave the author-owned threads out of both.
+
 A re-review resolves on the revision rather than on its threads. Commits answering the user's earlier feedback make the user the next actor. Threads the author has not answered do not, and they stay out of the item's summary even when the item itself survives.
 
 Report the drop rather than hiding it. Each group ends with a one-line count of what the filter removed, such as `3 items waiting on their authors, not shown`. That count is how the user tells a filtered group from an empty one.

--- a/user/skills/job/SKILL.md
+++ b/user/skills/job/SKILL.md
@@ -84,6 +84,18 @@ One prioritized brief, grouped by project. Resolve each item to its project thro
 
 Within a group, order blocking items first, then oldest. Each item gets an identifier with a link, a one-line state, and a recommended action. The mode's phases set what to surface and label each item's role within its project.
 
+#### Next actor
+
+Every review-queue item, outbox item, and discussion thread resolves to a next actor before it earns a place in the brief. The test is who the item is waiting on. An open thread by itself does not answer that. Items waiting on someone else are dropped.
+
+The user is the next actor when someone asked the user a direct question, when the user has not reviewed the item at all or has not seen the revision now on the branch, when the user's own MR is blocked on something the user owns, or when the item needs a decision that is the user's to make.
+
+Someone else is the next actor when the user commented or reviewed last and nothing the user raised has been answered, when the item is approved or has changes requested and only the author can move it, and when it is blocked on work the user does not own. Open threads are not an exception: a thread carrying the user's unanswered comment is waiting on whoever it was addressed to.
+
+A re-review resolves on the revision rather than on its threads. Commits answering the user's earlier feedback make the user the next actor. Threads the author has not answered do not, and they stay out of the item's summary even when the item itself survives.
+
+Report the drop rather than hiding it. Each group ends with a one-line count of what the filter removed, such as `3 items waiting on their authors, not shown`. That count is how the user tells a filtered group from an empty one.
+
 An item with a matched agent gains one line under its existing entry:
 
 ```
@@ -94,7 +106,7 @@ A live session (`working`, `blocked`, or an interactive session whose `state` is
 
 An unmatched agent becomes its own entry only when it still wants something: `blocked`, `failed`, or `working`. Since gather runs with `--all`, unmatched `done` records are completed history and get dropped. Keeping them would fill a prioritized brief with finished work. Group what remains by the repo `cwd` resolves to, or `Misc` when it resolves to none. A blocked agent is blocking work and sorts with it under the ordering rule above.
 
-Close with the mode's cross-project synthesis: the day's sequence, or the night's open decisions. This is the triage gate. The brief covers everything gathered, and nothing executes until the user approves the order. Omit empty groups and never pad. An empty queue is a two-line brief.
+Close with the mode's cross-project synthesis: the day's sequence, or the night's open decisions. This is the triage gate. The brief covers everything that survived the next-actor filter, and nothing executes until the user approves the order. Omit groups that gathered nothing and never pad. A group whose items all resolved to another actor is not empty, so print its heading with the count line alone. An empty queue is a two-line brief.
 
 ### Act
 
@@ -105,7 +117,7 @@ Split recommended actions into two groups:
 
 Closing a tracker issue is safe only on evidence the orchestrator checked itself: that issue's own MR merged, or its acceptance criteria met in the code. A sub-agent reporting a merged MR is evidence about the MR. Confirm the MR belongs to the issue before it becomes evidence about the issue, since a linked MR may belong to a sibling.
 
-Drive inbound to zero. Every review request, message, notification, and email leaves the run with a terminal disposition: handled, reacted to or briefly acknowledged, deferred to the work tracker as a team-backlog item or to the personal inbox for your own next-steps and reminders when one is configured, or archived. Never stand up a tracker issue in place of a personal capture: when the user says "my inbox" that means the personal inbox, and when the destination is unclear, ask. Nothing stays in an ambiguous unread state. Where a reaction or brief acknowledgement closes a thread, prefer that over a filler reply. Draft a reply only when it carries real content, and keep it terse.
+Drive inbound to zero. Items the next-actor rule filtered out never enter this loop, since waiting on someone else is their disposition. Everything else that reached the brief leaves the run with a terminal disposition: handled, reacted to or briefly acknowledged, deferred to the work tracker as a team-backlog item or to the personal inbox for your own next-steps and reminders when one is configured, or archived. Never stand up a tracker issue in place of a personal capture: when the user says "my inbox" that means the personal inbox, and when the destination is unclear, ask. Nothing stays in an ambiguous unread state. Where a reaction or brief acknowledgement closes a thread, prefer that over a filler reply. Draft a reply only when it carries real content, and keep it terse.
 
 #### Questions
 

--- a/user/skills/job/references/end.md
+++ b/user/skills/job/references/end.md
@@ -28,12 +28,12 @@ Flag items that need collaboration lead time (a reviewer in another timezone, a 
 
 ## Review Debt
 
-Review debt is inbound requests you did not reach today, unanswered threads on others' PRs/MRs, and any message, notification, or email still awaiting your reply or filing. Choose one path per item:
+Review debt is what the next-actor rule in `SKILL.md` still resolves to you: inbound requests you did not reach today, threads on others' PRs/MRs awaiting your reply, and any message, notification, or email still awaiting your reply or filing. Choose one path per item:
 
 - Reply now: draft per the contract in `SKILL.md` and include it in the brief. Posting a draft the user approved is safe.
 - Carry to tomorrow: capture it where it belongs per Tracker Hygiene below, so tomorrow's start gather surfaces it rather than a memory.
 
-Never silently drop an item.
+Never silently drop an item. An item the next-actor rule sent back to its author is not debt, and the group's count line is where it gets reported.
 
 ## Unpushed Work Sweep
 

--- a/user/skills/job/references/start.md
+++ b/user/skills/job/references/start.md
@@ -8,7 +8,7 @@ Dispatch parallel read-only sub-agents, under the reporting contract and deadlin
 
 - Inbound: PRs/MRs where the configured username is a requested reviewer or approver, with age, author, and whether you reviewed before.
 - Outbox: your own open PRs/MRs, with CI status, unresolved threads, reviewer assignment, and draft state.
-- Tracker: issues assigned to the configured user, plus the current cycle as the config expresses it. Record each issue's project, since the brief groups by it. Include the tracker's notification inbox, which is separate from assigned issues, and recent comment activity on assigned and related issues regardless of read state: for each active thread, who commented last, when, and what they asked. A comment already read is still activity. Note where the user's own most recent comment has no reply.
+- Tracker: issues assigned to the configured user, plus the current cycle as the config expresses it. Record each issue's project, since the brief groups by it. Include the tracker's notification inbox, which is separate from assigned issues, and recent comment activity on assigned and related issues regardless of read state: for each active thread, who commented last, when, and what they asked. A comment already read is still activity. Note where the user's own most recent comment has no reply. The brief reads that to resolve who the thread waits on.
 - Messaging (when configured): direct messages and mentions to the configured user since the last working day that imply an action, with sender, link, and the ask.
 - Email (when configured): unhandled mail that needs a reply, an action, or filing, with sender, subject, and link.
 
@@ -20,7 +20,7 @@ Each sub-agent uses the delegated skill, MCP, or CLI for its source and returns 
 
 Order items blocking others first, then oldest.
 
-Separate fresh requests from re-reviews where the author responded to your earlier feedback. For re-reviews, delegate the addressed-or-not analysis to an installed review-follow-up skill if one exists. Otherwise compare the threads against your prior comments.
+Separate fresh requests from re-reviews where the author responded to your earlier feedback. For re-reviews, delegate the addressed-or-not analysis to an installed review-follow-up skill if one exists. Otherwise compare the threads against your prior comments. Resolve each item's next actor per `SKILL.md` and carry only the ones that resolve to you into the phases below.
 
 When merged discussion arrives with a queue item, fold it into the item's summary, since an active thread can change what the review should conclude. Before recommending an action, give each item a one-line summary of what it changes and an estimated review effort. Delegate both to the installed review skill's summary pass when it offers one, so the estimate uses the same effort scale the eventual review would, and the brief never starts the review itself. The estimate is what makes the queue schedulable: it shows the morning's total review load and lets a run of small reviews clear ahead of one deep one.
 
@@ -44,7 +44,7 @@ For each of your open PRs/MRs, flag:
 
 Triage each inbound item, whether a message, a tracker notification, or an email, into an action: a review handoff, a decision you owe someone, a question to answer, or a new task. An item often carries the only signal for a focus item, so a thread that names an MR or issue belongs with that work in the brief, not stranded in a separate inbox list. Map every item to the project it concerns, or to `Misc`.
 
-Read is not handled. Notification state records only what the user has seen, so judge each thread by who spoke last and what remains open, never by unread flags. Two states never collapse into background noise: a thread where the user's own most recent comment is unanswered, which is live work awaiting a reply rather than a closed loop, and active discussion on work that also has an open MR in the user's review queue, which is review context and merges into that review's entry, since the thread may be converging on a different fix than the diff shows.
+Read is not handled. Notification state records only what the user has seen, so judge each thread by who spoke last and what remains open, never by unread flags. Who spoke last is also what the next-actor rule in `SKILL.md` reads: a thread where the user's own most recent comment is unanswered is waiting on whoever it was addressed to. It leaves the brief as a counted drop rather than as an item. Active discussion on work that also has an open MR in the user's review queue never collapses into background noise: it is review context and merges into that review's entry, since the thread may be converging on a different fix than the diff shows.
 
 A blocked agent is an inbound item like any message or notification, and it gets the same terminal disposition: resumed by you, focused into its herdr pane when one matched, or deferred with a note recording what it is waiting on. Read is not handled applies here too. An agent you saw in `claude agents` and walked away from is still open work.
 


### PR DESCRIPTION
The brief treated "has open threads" as "needs you". A `/job start` run raised an MR you had already commented on with nothing left open, plus half of a re-review where your own suggestion sat unanswered by the author. Both were waiting on someone else.

The brief now resolves a next actor for every review-queue item, outbox item, and thread, and keeps only the ones that resolve to you. A direct question or an unreviewed item is yours. An item you reviewed last with nothing you raised still unanswered belongs to the author.

A re-review resolves on the revision rather than on its threads. New commits answering earlier feedback make it yours again. An unanswered thread does not, and it stays out of the item's summary even when the item survives.

Because the brief collapses an MR, its issue, and its threads into one entry, an entry can carry both actors. The user wins that tie, since dropping it would drop a question addressed to you. The entry then carries only the parts that are yours into its summary and recommended action.

Each group ends with a count of what the filter removed, so a filtered group reads differently from an empty one. The rule lives in the shared Brief contract in `SKILL.md`, which both modes already read.

## Reconciled Lines

Inbox Triage in `references/start.md` called a thread carrying your own unanswered comment "live work awaiting a reply rather than a closed loop", which is backwards under this rule. It now reads as waiting on the author. The rest of that sentence survives: discussion on work with an open MR in your review queue is still review context.

The Gather bullet reporting where your comment has no reply keeps reporting it, now as state the brief reads, which preserves the "sub-agents report state, not dispositions" boundary. End mode's Review Debt said "unanswered threads on others' PRs/MRs" without saying who owes the answer, and now scopes to threads awaiting your reply.

## Gather Sub-Agents Going Idle

Unrelated to this branch. During the same run, four of five gather sub-agents went idle without sending a report and had to be stopped and re-run inline. The reporting contract and five-minute deadline caught it, but 4-in-5 means they are carrying more weight than they should have to.
