### PR TITLE
Drop the duplicate type-aware lint id from prek

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,13 +46,6 @@ repos:
         pass_filenames: false
         entry: bun packages/validate/settings.ts
 
-      - id: lint
-        name: Lint
-        language: system
-        files: \.ts$
-        pass_filenames: false
-        entry: bun run lint
-
       - id: marketplace-check
         name: Marketplace completeness
         language: system


### PR DESCRIPTION
Removes prek's `lint` id, which ran `oxlint --type-aware` across the whole tree whenever a `.ts` file changed.

The ox hook's Stop gate already runs `oxlint --type-aware --type-check` over the same tree. That pass reports every rule the plain run reports, plus tsgolint diagnostics the plain run cannot produce. The one thing `--quiet` drops is warnings, and warnings exit 0, so neither run gated on them.

Both hooks fire at Stop in parallel with no ordering guarantee. prek was linting files while ox's `oxfmt --write` rewrote them, and that race goes away with the id.

This is not a latency win. Hooks run concurrently and nothing records how much of a `prek run` the `lint` id accounted for.

Coverage that survives:

- `bun run check` in CI lints and format-checks independently of prek
- prek is reachable only from the Stop hook. No workflow invokes it and no `pre-commit` git hook is installed
- prek's other ids are untouched, including `plugin-test`, which catches generated-artifact drift `bun run check` misses

Original Task: https://things.bendrucker.me/show?id=CTXTktnqCAZA9KhRCQPwbx

Discovery: 58f3efcfd485
