### PR TITLE
pull-request: narrow the body hook's deny

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -256,11 +256,13 @@
         "ap-style-title-case": "^2.0.0",
         "cleye": "^2.0.0",
         "mdast-util-from-markdown": "^2.0.2",
+        "mvdan-sh": "^0.10.1",
         "unist-util-visit": "^5.1.0",
         "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/mdast": "^4.0.4",
+        "@types/mvdan-sh": "^0.10.9",
         "fast-check": "^4.8.0",
       },
     },
@@ -1193,6 +1195,8 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
+    "@types/mvdan-sh": ["@types/mvdan-sh@0.10.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-Ij8QpItwUelmWKFwrRs/kV3/RDS41YBTz3nlLiqOlRwPNtzjqILpngxE8mJb1zr9cE2L5c2O4rIou+hRjbLxSQ=="],
+
     "@types/mz": ["@types/mz@0.0.32", "", { "dependencies": { "@types/node": "*" } }, "sha512-cy3yebKhrHuOcrJGkfwNHhpTXQLgmXSv1BX+4p32j+VUQ6aP2eJ5cL7OvGcAQx75fCTFaAIIAKewvqL+iwSd4g=="],
 
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
@@ -2104,6 +2108,8 @@
     "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
 
     "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
+
+    "mvdan-sh": ["mvdan-sh@0.10.1", "", {}, "sha512-kMbrH0EObaKmK3nVRKUIIya1dpASHIEusM13S4V1ViHFuxuNxCo+arxoa6j/dbV22YBGjl7UKJm9QQKJ2Crzhg=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 

--- a/plugins/pull-request/package-lock.json
+++ b/plugins/pull-request/package-lock.json
@@ -10,31 +10,33 @@
         "ap-style-title-case": "^2.0.0",
         "cleye": "^2.0.0",
         "mdast-util-from-markdown": "^2.0.2",
+        "mvdan-sh": "^0.10.1",
         "unist-util-visit": "^5.1.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/mdast": "^4.0.4",
+        "@types/mvdan-sh": "^0.10.9",
         "fast-check": "^4.8.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.268",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.268.tgz",
-      "integrity": "sha512-24oj+nuSjSYF/yrZefXdjUIYPJ+OnbTNP5GkaSiOiY4lfPF9PPwtDviDp3hojYpgvL5wDKaueNWmbfc/DVVbWQ==",
+      "version": "0.3.269",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.269.tgz",
+      "integrity": "sha512-IzghXcFmIEGvkf4WOswDFrYb7twhCNnZxDU+3R0lz5PYPe0K0+QJ+/KzOT9xi5n8ZGn15bKfR2s65k3dFHUz1A==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.268",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.268",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.268",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.268",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.268",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.268",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.268",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.268"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.269",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.269",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.269",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.269",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.269",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.269",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.269",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.269"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -43,9 +45,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.268",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.268.tgz",
-      "integrity": "sha512-LdWLd0osGaDWXX6iYtDjUBRiY5ORoTSPfdkGRo7egbTYumRhHQi/B7JmbGUMqfNxpmKgTI8YsW+YTniUsBEVsw==",
+      "version": "0.3.269",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.269.tgz",
+      "integrity": "sha512-o7vdVlbJjkX9RL7+Mwa6owEGFvHNVfbNRRpoYSJ0jzyvimxKa+8kSjwZo7nYBRr+5WydxB/ApSE+xrWflDUhKQ==",
       "cpu": [
         "arm64"
       ],
@@ -56,9 +58,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.268",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.268.tgz",
-      "integrity": "sha512-MHu24qCzyRjnfiaXOUB5vwtNPUUTuv1T1dAovbF3IQhKoPANVVt7dYW4uGczcVwrrDjiYWd5R6NLnFrz2//mkQ==",
+      "version": "0.3.269",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.269.tgz",
+      "integrity": "sha512-cRipBje68i3Irqw0coNEo2KSuVnBRZr317G+tohpas3dUPvJ9BfawMTPy+TBTVcg0kZln1TziUOMBIpnLLogyw==",
       "cpu": [
         "x64"
       ],
@@ -69,9 +71,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.268",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.268.tgz",
-      "integrity": "sha512-IgvuEx9s1F+dhq8B9XqEoUGJCYK1d1yN4TkDILeWQ5tI/Y6fX7MKppF1GVgiRd1R7YI2L4IGBkFcry5gJAunkg==",
+      "version": "0.3.269",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.269.tgz",
+      "integrity": "sha512-S2bX/sYXBMNkYuQ4PVCIigmCUG3HUuq57+URWz47ZSi/mA+bAMFDAew2Rvmn5SJZ384oKGPDeZknaL/2ypPD4A==",
       "cpu": [
         "arm64"
       ],
@@ -85,9 +87,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.268",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.268.tgz",
-      "integrity": "sha512-qQcJ5iIepKU1eHy6KTtE0PUJ5DDtb+HkokcLpVRZeIowCF4RSbOso5siiO/TUFNwoSrIB7ri7ji6ge5juHYrrg==",
+      "version": "0.3.269",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.269.tgz",
+      "integrity": "sha512-mKPC61EpvkcziR3WuXgOJqBjyKDQgX6xdkPXpybKvjJ3vLLB+ulII6duJF+XBjzhh4d4jkKaJjxZilU1Ol/tCw==",
       "cpu": [
         "arm64"
       ],
@@ -101,9 +103,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.268",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.268.tgz",
-      "integrity": "sha512-mIvSW1iyZpdq+G7nv+GSLhPSLG3OyhWKbL2BZ2/Zn9VSgtKjwMtnINW19pU84D+J+heRlqKUMAx4EbH4DOHolw==",
+      "version": "0.3.269",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.269.tgz",
+      "integrity": "sha512-uPiNkQu6CjdnC61Sz0zs4vLdFwkqes90gZwCHl9tCFDPU2Eu3a8UZZ/RALAq10myEMwXcJsKOhszoyaEqO3Pww==",
       "cpu": [
         "x64"
       ],
@@ -117,9 +119,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.268",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.268.tgz",
-      "integrity": "sha512-BguDX5ZRLHeEI7R+lKu0BI2iv8SmlMwZCNnqWRo2x79yRsdjD2Hcvjsj79HholtzD6YPA/R2USlxuT7Ygj9k0w==",
+      "version": "0.3.269",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.269.tgz",
+      "integrity": "sha512-t0s+neygaBe9/f7h4n73vFPWEv7ud5WP/7NRIWpihdDZvLS/SvKNoAt3IJR0Js2DMbAh0XF2I9TDAiHRZhUM4A==",
       "cpu": [
         "x64"
       ],
@@ -133,9 +135,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.268",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.268.tgz",
-      "integrity": "sha512-p8Aj7iohK2TddsQZ+tNhG2w6np1MmdpPVqHpOuElab7Iu4OA3iOerc/21T+Z3fza/gOPaTV0nKiEIO0tbAQrLA==",
+      "version": "0.3.269",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.269.tgz",
+      "integrity": "sha512-1nRPu6seuvFJMd+QzRX5pvruJiaRYvY1kHhEficUNSG5jsXbM/6mrZ6WFUsNxPc5SgHK15u2YvAxesRAlRSD7A==",
       "cpu": [
         "arm64"
       ],
@@ -146,9 +148,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.268",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.268.tgz",
-      "integrity": "sha512-zT56NISgATcVk6hVLr/CIl+5H/G6mqjhd1t/V/JMVupMuc3ffirEPu47cVJldGf0DVMa+sZ17uRwXvIM2Vi4iA==",
+      "version": "0.3.269",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.269.tgz",
+      "integrity": "sha512-AQFeH8B6/WlPuuHivKo8FzMdvA8vb4ewZ9QBaHKLq0grzk6Kc517fk6yHEnJpCHHKN0s5Kiwih4CyDXo51zt0A==",
       "cpu": [
         "x64"
       ],
@@ -274,6 +276,26 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
+    },
+    "node_modules/@types/mvdan-sh": {
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@types/mvdan-sh/-/mvdan-sh-0.10.9.tgz",
+      "integrity": "sha512-Ij8QpItwUelmWKFwrRs/kV3/RDS41YBTz3nlLiqOlRwPNtzjqILpngxE8mJb1zr9cE2L5c2O4rIou+hRjbLxSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.2.tgz",
+      "integrity": "sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -748,9 +770,9 @@
       }
     },
     "node_modules/fast-check": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
-      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.10.0.tgz",
+      "integrity": "sha512-hhqQL+IJllZi3aM4TKvmCj3bywLEcycNTTLZeLhA9ttMxBrCqM07q7Di4kl+j9EWSTXvJH1+EpIgsDbF/+8H5Q==",
       "dev": true,
       "funding": [
         {
@@ -1607,6 +1629,13 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mvdan-sh": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/mvdan-sh/-/mvdan-sh-0.10.1.tgz",
+      "integrity": "sha512-kMbrH0EObaKmK3nVRKUIIya1dpASHIEusM13S4V1ViHFuxuNxCo+arxoa6j/dbV22YBGjl7UKJm9QQKJ2Crzhg==",
+      "deprecated": "See https://github.com/mvdan/sh/issues/1145",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/negotiator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
@@ -2078,6 +2107,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unist-util-is": {
       "version": "6.0.1",

--- a/plugins/pull-request/package.json
+++ b/plugins/pull-request/package.json
@@ -7,11 +7,13 @@
     "ap-style-title-case": "^2.0.0",
     "cleye": "^2.0.0",
     "mdast-util-from-markdown": "^2.0.2",
+    "mvdan-sh": "^0.10.1",
     "unist-util-visit": "^5.1.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/mdast": "^4.0.4",
+    "@types/mvdan-sh": "^0.10.9",
     "fast-check": "^4.8.0"
   }
 }

--- a/plugins/pull-request/scripts/resolve-body.test.ts
+++ b/plugins/pull-request/scripts/resolve-body.test.ts
@@ -31,6 +31,11 @@ describe("isPrBodyCommand", () => {
     ["for f in *.ts; do wc -l $f; done", false],
     ["cat <<'EOF' > notes.md\nnothing here\nEOF", false],
     ["cat > notes.md <<'EOF'\nrun gh pr create --body-file x.md later\nEOF", false],
+    // The verb as an argument to something else: a note, a log line, a doc.
+    ["bun url.ts add --notes 'retry with gh pr edit 12 --body-file body.md'", false],
+    ['bun url.ts add --notes "Blocked.\nRun gh pr edit 12 --body-file body.md\nThen push."', false],
+    ["echo gh pr create --body-file body.md", false],
+    ["grep -r 'glab mr update' plugins/", false],
   ])("isPrBodyCommand(%p) -> %p", (command, expected) => {
     expect(isPrBodyCommand(command)).toBe(expected);
   });
@@ -222,6 +227,38 @@ describe("extractBodySpec", () => {
     ],
     // The shell feeds the last stdin redirection to the CLI.
     ["gh pr create --body-file - <<'A' <<'B'\nfirst\nA\nsecond\nB", parts(literal("second\n"))],
+    // Reading the PR back into the file it will be written from: the hook runs
+    // before the shell, so the path holds nothing the CLI will send.
+    [
+      "gh pr view 12 --json body -q .body > body.md && sed -i '' 's/a/b/' body.md && gh pr edit 12 --body-file body.md",
+      { kind: "none" },
+    ],
+    [
+      "gh pr view --json body --jq .body > body.md\ngh pr edit --body-file body.md",
+      { kind: "none" },
+    ],
+    [
+      "glab mr view 3 --output json | jq -r .description > d.md && glab mr update 3 --description-file d.md",
+      { kind: "none" },
+    ],
+    // A different PR, a different file, or no read at all: still the hook's
+    // business, because the body is not a copy of what is already published.
+    [
+      "gh pr view 12 --json body -q .body > body.md && gh pr edit 34 --body-file body.md",
+      parts(file("body.md")),
+    ],
+    [
+      "gh pr view 12 --json body -q .body > other.md && gh pr edit 12 --body-file body.md",
+      parts(file("body.md")),
+    ],
+    [
+      String.raw`printf 'Prose.\n' > body.md && gh pr edit 12 --body-file body.md`,
+      parts(file("body.md")),
+    ],
+    [
+      "gh pr view 12 --json body -q .body > body.md && cat > body.md <<'EOF'\nProse.\nEOF\ngh pr edit 12 --body-file body.md",
+      parts(literal("Prose.\n")),
+    ],
   ])("extractBodySpec(%p) -> %p", (command, expected) => {
     expect(extractBodySpec(command)).toEqual(expected);
   });

--- a/plugins/pull-request/scripts/resolve-body.test.ts
+++ b/plugins/pull-request/scripts/resolve-body.test.ts
@@ -9,8 +9,6 @@ import {
   extractBodySpec,
   extractTitle,
   isPrBodyCommand,
-  parseCommand,
-  type ParsedCommand,
   resolveBody,
 } from "./resolve-body";
 
@@ -38,114 +36,6 @@ describe("isPrBodyCommand", () => {
     ["grep -r 'glab mr update' plugins/", false],
   ])("isPrBodyCommand(%p) -> %p", (command, expected) => {
     expect(isPrBodyCommand(command)).toBe(expected);
-  });
-});
-
-describe("parseCommand", () => {
-  test.each<[string, string, ParsedCommand]>([
-    [
-      "strips the body and captures a > redirect target",
-      "cat > body.md <<'EOF'\nProse.\nEOF\ngh pr create --body-file body.md",
-      {
-        text: "cat > body.md <<'EOF'\ngh pr create --body-file body.md",
-        heredocs: [
-          {
-            content: "Prose.\n",
-            quoted: true,
-            segment: "cat > body.md <<'EOF'",
-            target: "body.md",
-            offset: 14,
-          },
-        ],
-      },
-    ],
-    [
-      "finds a redirect written after the operator",
-      "cat <<'EOF' > body.md\nProse.\nEOF",
-      {
-        text: "cat <<'EOF' > body.md",
-        heredocs: [
-          {
-            content: "Prose.\n",
-            quoted: true,
-            segment: "cat <<'EOF' > body.md",
-            target: "body.md",
-            offset: 4,
-          },
-        ],
-      },
-    ],
-    [
-      "finds a tee sink and scopes the segment to its command",
-      "mkdir -p tmp && tee tmp/body.md <<'EOF'\nProse.\nEOF",
-      {
-        text: "mkdir -p tmp && tee tmp/body.md <<'EOF'",
-        heredocs: [
-          {
-            content: "Prose.\n",
-            quoted: true,
-            segment: " tee tmp/body.md <<'EOF'",
-            target: "tmp/body.md",
-            offset: 32,
-          },
-        ],
-      },
-    ],
-    [
-      "marks an unquoted delimiter and skips an append target",
-      "cat >> log.md <<EOF\n$VERSION\nEOF",
-      {
-        text: "cat >> log.md <<EOF",
-        heredocs: [
-          {
-            content: "$VERSION\n",
-            quoted: false,
-            segment: "cat >> log.md <<EOF",
-            target: null,
-            offset: 14,
-          },
-        ],
-      },
-    ],
-    [
-      "strips tabs under <<- and matches a tab-indented terminator",
-      "cat > body.md <<-'EOF'\n\tProse.\n\tEOF",
-      {
-        text: "cat > body.md <<-'EOF'",
-        heredocs: [
-          {
-            content: "Prose.\n",
-            quoted: true,
-            segment: "cat > body.md <<-'EOF'",
-            target: "body.md",
-            offset: 14,
-          },
-        ],
-      },
-    ],
-    [
-      "ignores a << inside a quoted argument",
-      'echo "<<EOF"\ngh pr create --body-file body.md',
-      { text: 'echo "<<EOF"\ngh pr create --body-file body.md', heredocs: [] },
-    ],
-    [
-      "gives an unterminated heredoc the rest of the command",
-      "cat > body.md <<'EOF'\nProse.\nMore prose.",
-      {
-        text: "cat > body.md <<'EOF'",
-        heredocs: [
-          {
-            content: "Prose.\nMore prose.\n",
-            quoted: true,
-            segment: "cat > body.md <<'EOF'",
-            target: "body.md",
-            offset: 14,
-          },
-        ],
-      },
-    ],
-  ])("%s", (_name, command, expected) => {
-    expect(parseCommand(command)).toEqual(expected);
   });
 });
 
@@ -326,6 +216,16 @@ const DOCUMENTED_FORMS: [string, string][] = (
   )
 ).flat();
 
+// Prose names a flag on its own, without the subcommand that takes it. The
+// contract is about the flag reaching the body, so a bare form is run inside the
+// command it belongs to.
+function documentedCommand(snippet: string): string {
+  if (/^(?:gh|glab)\s/.test(snippet)) return snippet;
+  return /--description|(?<![\w-])-d\s/.test(snippet)
+    ? `glab mr update ${snippet}`
+    : `gh pr edit ${snippet}`;
+}
+
 // The skills are the only place a command form is written down, so a form that
 // lands there without the extractor learning it is invisible until an unchecked
 // body ships. These docs are read back and every body-carrying command in them
@@ -340,7 +240,7 @@ describe("command forms the skills document", () => {
     const body = "## Summary\n\nResolved through the form the skill documents.\n";
     await Bun.write(bodyPath, body);
     // Doc paths are placeholders (`tmp/pr-body-<branch>.md`, `file.md`).
-    const command = snippet.replaceAll(/\S*\.md/g, bodyPath);
+    const command = documentedCommand(snippet).replaceAll(/\S*\.md/g, bodyPath);
     expect(await resolveBody(command, REPO_ROOT)).toMatchObject({ kind: "text", text: body });
   });
 });

--- a/plugins/pull-request/scripts/resolve-body.ts
+++ b/plugins/pull-request/scripts/resolve-body.ts
@@ -1,286 +1,92 @@
 // Where a `gh pr` / `glab mr` command gets its body and title from: heredocs,
-// inline flag values, body files, and the `cd`s ahead of them.
+// inline flag values, body files, and the `cd`s ahead of them. `shell.ts`
+// answers what the command runs; this decides what that means for the body the
+// CLI will send.
 
 import { homedir } from "node:os";
 import { basename, isAbsolute, join } from "node:path";
-
-// The `if` rules in hooks.json scope dispatch to `gh pr create`/`edit` and
-// `glab mr create`/`update`, covering compound (`cd <dir> && gh pr create ...`)
-// and env-prefixed (`GH_PAGER=cat gh pr create ...`) forms. The guards below
-// repeat the check in-script so the validator is inert under any other
-// dispatch, and run before the hook reads a body file or shells out to git.
-const PR_BODY_VERB = /gh pr (?:create|edit)|glab mr (?:create|update)/;
-
-// The verb has to sit where the shell would run it: at the start of the text or
-// after a separator, with env assignments allowed ahead of it. The same words
-// anywhere else are an argument to some other program, which is how a `--notes`
-// value quoting a PR command reaches this hook at all.
-function invocationPattern(verb: RegExp): RegExp {
-  return new RegExp(String.raw`(?:^|[\n;|&(){}])[ \t]*(?:\w+=\S*[ \t]+)*(${verb.source})\b`, "g");
-}
-
-const PR_BODY_INVOCATION = invocationPattern(PR_BODY_VERB);
-
-/** Offset of the verb itself, or -1 when the text holds no such invocation. */
-function invocationIndex(text: string, pattern: RegExp): number {
-  const match = firstUnquotedMatch(text, pattern, quotedSpans(text));
-  const verb = match?.[1];
-  if (match == null || verb === undefined) return -1;
-  return match.index + match[0].length - verb.length;
-}
-
-export function isPrBodyCommand(command: string): boolean {
-  return invocationIndex(parseCommand(command).text, PR_BODY_INVOCATION) !== -1;
-}
-
-function unquote(value: string): string {
-  const match = value.match(/^(['"])(.*)\1$/s);
-  return match?.[2] ?? value;
-}
-
-function unescapeDoubleQuoted(text: string): string {
-  return text.replaceAll(/\\(["`$\\])/g, "$1");
-}
-
-function expandTmpdir(path: string): string {
-  const tmpdir = process.env.TMPDIR?.replace(/\/$/, "");
-  if (tmpdir == null || tmpdir === "") return path;
-  return path.replaceAll(/\$\{TMPDIR\}|\$TMPDIR/g, tmpdir);
-}
-
-function normalizeBodyPath(raw: string): string {
-  return expandTmpdir(unquote(raw)).replace(/^\.\//, "");
-}
-
-// A heredoc operator with its delimiter word. The lookbehind keeps `<<<`
-// herestrings out. A quoted or escaped delimiter makes the body literal.
-const HEREDOC_OPERATOR = /(?<!<)<<(-?)[ \t]*(?:'([^']+)'|"([^"]+)"|(\\)?([A-Za-z_][A-Za-z0-9_]*))/g;
-
-// Simple-command boundaries. `|` stays inside a segment so a heredoc piped
-// into the CLI remains attached to the command it feeds.
-const SEGMENT_SEPARATOR = /&&|\|\||;|\n/g;
-
-// Where a segment writes its heredoc: a single `>` redirect or a `tee` sink.
-// The redirect lookbehind skips `>>` (an append mixes the heredoc with the
-// file's prior content), fd forms (`2>`), and `&>`. The tee pattern's leading
-// character class skips flags, so `tee -a` also resolves to no target.
-const REDIRECT_TARGET = /(?<![>\d&])>[ \t]*("(?:[^"\\]|\\.)*"|'[^']*'|[^\s;|&<>]+)/g;
-const TEE_TARGET = /\btee\s+("(?:[^"\\]|\\.)*"|'[^']*'|[^\s;|&<>-][^\s;|&<>]*)/g;
-
-export interface Heredoc {
-  /** Body text as the shell delivers it, with `<<-` tab stripping applied. */
-  content: string;
-  /** The delimiter was quoted or escaped, so the shell expands nothing in the body. */
-  quoted: boolean;
-  /** The simple command the operator sits in. */
-  segment: string;
-  /** Normalized path the segment redirects or tees the body into, or null when it feeds stdin/stdout. */
-  target: string | null;
-  /** Offset of the operator in the stripped text, for ordering against the PR command. */
-  offset: number;
-}
-
-export interface ParsedCommand {
-  /** Command text with heredoc bodies removed, so verb and flag matching runs on shell syntax alone. */
-  text: string;
-  heredocs: Heredoc[];
-}
-
-interface PendingHeredoc {
-  delimiter: string;
-  quoted: boolean;
-  stripTabs: boolean;
-  segment: string;
-  target: string | null;
-  offset: number;
-  lines: string[];
-}
-
-// Spans covered by a quoted string, so a `<<` inside an argument (`grep "<<EOF"
-// f`) is not read as an operator. Backslash escapes a quote outside single
-// quotes, where the shell treats it literally. Quoting runs across newlines, so
-// a multi-line flag value scanned whole is one span.
-function quotedSpans(line: string): [number, number][] {
-  const spans: [number, number][] = [];
-  let open: string | null = null;
-  let start = 0;
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i];
-    if (ch === "\\" && open !== "'") {
-      i++;
-      continue;
-    }
-    if (open === null) {
-      if (ch === "'" || ch === '"') {
-        open = ch;
-        start = i;
-      }
-    } else if (ch === open) {
-      spans.push([start, i]);
-      open = null;
-    }
-  }
-  if (open !== null) spans.push([start, line.length]);
-  return spans;
-}
-
-function withinSpans(index: number, spans: [number, number][]): boolean {
-  return spans.some(([start, end]) => index > start && index <= end);
-}
-
-// First match whose own start sits outside every quoted span. The value a
-// match captures may still be quoted. Only the operator or flag itself must
-// not be.
-function firstUnquotedMatch(
-  text: string,
-  pattern: RegExp,
-  spans: [number, number][],
-): RegExpExecArray | null {
-  for (const match of text.matchAll(pattern)) {
-    if (!withinSpans(match.index, spans)) return match;
-  }
-  return null;
-}
-
-function segmentAt(line: string, index: number, spans: [number, number][]): string {
-  let start = 0;
-  let end = line.length;
-  for (const sep of line.matchAll(SEGMENT_SEPARATOR)) {
-    if (withinSpans(sep.index, spans)) continue;
-    if (sep.index < index) {
-      start = sep.index + sep[0].length;
-    } else {
-      end = sep.index;
-      break;
-    }
-  }
-  return line.slice(start, end);
-}
-
-function segmentTarget(segment: string): string | null {
-  const spans = quotedSpans(segment);
-  const value =
-    firstUnquotedMatch(segment, REDIRECT_TARGET, spans)?.[1] ??
-    firstUnquotedMatch(segment, TEE_TARGET, spans)?.[1];
-  return value === undefined ? null : normalizeBodyPath(value);
-}
-
-// Line-oriented heredoc scan: a body runs from the line after its operator to
-// the delimiter line, and several operators on one line consume bodies in
-// order. An unterminated heredoc owns the rest of the command, which is also
-// what the shell would feed it.
-export function parseCommand(command: string): ParsedCommand {
-  const kept: string[] = [];
-  const heredocs: Heredoc[] = [];
-  const queue: PendingHeredoc[] = [];
-
-  const close = (pending: PendingHeredoc): void => {
-    heredocs.push({
-      content: pending.lines.length === 0 ? "" : `${pending.lines.join("\n")}\n`,
-      quoted: pending.quoted,
-      segment: pending.segment,
-      target: pending.target,
-      offset: pending.offset,
-    });
-  };
-
-  let textOffset = 0;
-  for (const line of command.split("\n")) {
-    const open = queue[0];
-    if (open !== undefined) {
-      const body = open.stripTabs ? line.replace(/^\t+/, "") : line;
-      if (body === open.delimiter) {
-        queue.shift();
-        close(open);
-      } else {
-        open.lines.push(body);
-      }
-      continue;
-    }
-    kept.push(line);
-    const spans = quotedSpans(line);
-    for (const match of line.matchAll(HEREDOC_OPERATOR)) {
-      if (withinSpans(match.index, spans)) continue;
-      const segment = segmentAt(line, match.index, spans);
-      queue.push({
-        delimiter: match[2] ?? match[3] ?? match[5] ?? "",
-        quoted: match[2] !== undefined || match[3] !== undefined || match[4] !== undefined,
-        stripTabs: match[1] === "-",
-        segment,
-        target: segmentTarget(segment),
-        offset: textOffset + match.index,
-        lines: [],
-      });
-    }
-    textOffset += line.length + 1;
-  }
-  for (const pending of queue) close(pending);
-  return { text: kept.join("\n"), heredocs };
-}
-
-// One flag value as the shell would word-split it: a quoted string, a command
-// substitution, or a bare word.
-const VALUE_PATTERN = String.raw`("(?:[^"\\]|\\.)*"|'[^']*'|\$\((?:[^()]|\([^()]*\))*\)|[^\s]+)`;
+import { literal, parseShell, type ShellCommand, type Word } from "./shell";
 
 type PrCli = "gh" | "glab";
 
-const CLI_PATTERNS: readonly (readonly [PrCli, RegExp])[] = [
-  ["gh", /\bgh pr (?:create|edit)\b/],
-  ["glab", /\bglab mr (?:create|update)\b/],
+interface PrVerb {
+  cli: PrCli;
+  /** The words that name the subcommand, e.g. `gh pr create`. */
+  argv: string[];
+}
+
+// The `if` rules in hooks.json scope dispatch to these four subcommands. The
+// hook repeats the check against the parsed command so it stays inert under any
+// other dispatch, including a command that merely quotes one of them.
+const PR_VERBS: PrVerb[] = [
+  { cli: "gh", argv: ["gh", "pr", "create"] },
+  { cli: "gh", argv: ["gh", "pr", "edit"] },
+  { cli: "glab", argv: ["glab", "mr", "create"] },
+  { cli: "glab", argv: ["glab", "mr", "update"] },
 ];
+
+const VIEW_VERBS: Record<PrCli, string[]> = {
+  gh: ["gh", "pr", "view"],
+  glab: ["glab", "mr", "view"],
+};
 
 // `-b` is `--body` on gh and `--target-branch` on glab; `-d` is `--description`
 // on glab and `--draft` on gh. A shorthand means a body only on the CLI that
-// owns it, so the flag sets are keyed by CLI. A fragment naming neither verb
-// falls back to the union, so a bare flag form lifted out of a skill doc still
-// resolves.
+// owns it, so the flag sets are keyed by CLI.
 const BODY_FLAGS: Record<PrCli, { file: string[]; inline: string[] }> = {
   gh: { file: ["--body-file"], inline: ["--body", "-b"] },
   glab: { file: ["--description-file"], inline: ["--description", "-d"] },
 };
 
-function commandCli(command: string): PrCli | null {
-  let earliest: PrCli | null = null;
-  let earliestIndex = Number.POSITIVE_INFINITY;
-  for (const [cli, pattern] of CLI_PATTERNS) {
-    const index = command.search(pattern);
-    if (index !== -1 && index < earliestIndex) {
-      earliestIndex = index;
-      earliest = cli;
-    }
+const TITLE_FLAGS = ["--title", "-t"];
+
+function startsWith(command: ShellCommand, words: string[]): boolean {
+  return words.every((word, index) => literal(command.argv[index]) === word);
+}
+
+interface PrInvocation {
+  cli: PrCli;
+  verb: string[];
+  command: ShellCommand;
+  /** Commands the shell runs first, which is what can have written a body file. */
+  preceding: ShellCommand[];
+}
+
+function findPrCommand(command: string): PrInvocation | null {
+  const commands = parseShell(command);
+  for (const [index, candidate] of commands.entries()) {
+    const verb = PR_VERBS.find((entry) => startsWith(candidate, entry.argv));
+    if (verb === undefined) continue;
+    return {
+      cli: verb.cli,
+      verb: verb.argv,
+      command: candidate,
+      preceding: commands.slice(0, index),
+    };
   }
-  return earliest;
+  return null;
 }
 
-function bodyFlags(command: string): { file: string[]; inline: string[] } {
-  const cli = commandCli(command);
-  if (cli !== null) return BODY_FLAGS[cli];
-  return {
-    file: [...BODY_FLAGS.gh.file, ...BODY_FLAGS.glab.file],
-    inline: [...BODY_FLAGS.gh.inline, ...BODY_FLAGS.glab.inline],
-  };
+export function isPrBodyCommand(command: string): boolean {
+  return findPrCommand(command) !== null;
 }
 
-function flagValuePattern(flags: string[], global = false): RegExp {
-  const alternation = flags
-    .map((flag) => (flag.startsWith("--") ? flag : `(?<!\\w)${flag}`))
-    .join("|");
-  return new RegExp(`(?:${alternation})[=\\s]${VALUE_PATTERN}`, global ? "g" : "");
+// A flag's value: the next word for `--body x`, or the tail of the word itself
+// for `--body=x`. Splitting on segments rather than text keeps the expansion in
+// `--body="$X"` an expansion.
+function flagValue(argv: Word[], flags: string[]): Word | undefined {
+  for (const [index, word] of argv.entries()) {
+    const text = literal(word);
+    if (text !== null && flags.includes(text)) return argv[index + 1];
+    const first = word.segments[0];
+    if (first?.kind !== "literal") continue;
+    const flag = flags.find((entry) => first.text.startsWith(`${entry}=`));
+    if (flag === undefined) continue;
+    const head = { kind: "literal" as const, text: first.text.slice(flag.length + 1) };
+    return { source: word.source, segments: [head, ...word.segments.slice(1)] };
+  }
+  return undefined;
 }
-
-// An unescaped `$(...)` or backtick run. The shell replaces it before the CLI
-// sees it, so its source text is not the body.
-const SUBSTITUTION_PATTERN = /(?<!\\)\$\((?:[^()]|\([^()]*\))*\)|(?<!\\)`[^`]*`/g;
-
-// A substitution whose whole job is to read a file: `$(cat f)`, `$(< f)`,
-// `` `cat f` ``. GitLab has no way to pass a body inline from a file, so this
-// is the form every historical `glab mr` invocation uses.
-const FILE_READ_PATTERN = /^(?:cat\s+|<\s*)("[^"]+"|'[^']+'|[^\s]+)$/;
-
-// A `$VAR`, `${VAR}`, `$(...)`, or backtick left over after the file reads are
-// taken out. The shell resolves it and the hook cannot, so the text the hook
-// holds is not the text the CLI will receive.
-const SHELL_EXPANSION_PATTERN = /(?<!\\)(?:\$\{[^}]*\}?|\$[A-Za-z_]\w*|\$\([^)]*\)?|`)/;
 
 export type BodyPart = { kind: "literal"; text: string } | { kind: "file"; path: string };
 
@@ -297,126 +103,60 @@ function unreadableExpansion(source: string): BodySpec {
   };
 }
 
-// Null when the path itself is a variable the shell resolves and the hook
-// cannot, so the caller reports it unreadable rather than reading the wrong
-// file.
-function filePart(rawPath: string): BodyPart | null {
-  const path = expandTmpdir(unquote(rawPath));
-  if (SHELL_EXPANSION_PATTERN.test(path)) return null;
-  return { kind: "file", path };
+// Both spellings of stdin. `/dev/stdin` matters because reading it from the
+// hook would consume the hook's own (already-drained) stdin and validate an
+// empty body.
+const STDIN_PATHS = new Set(["-", "/dev/stdin"]);
+
+/** Where a command leaves its stdout: a `>` redirect, or the sink `tee` names. */
+function writeTarget(command: ShellCommand): string | null {
+  if (command.output !== null) return literal(command.output);
+  if (literal(command.argv[0]) !== "tee") return null;
+  const sink = command.argv.slice(1).find((word) => !(literal(word) ?? "-").startsWith("-"));
+  return sink === undefined ? null : literal(sink);
 }
 
-// A double-quoted value is a mix of literal runs and substitutions, so it is
-// walked rather than matched: each `$(cat f)` becomes a file part, each run
-// between them a literal. Escapes are stripped from the literal runs only, so a
-// `\"` inside the file's own text survives. Single quotes suppress every
-// expansion, so that value is literal whatever it holds.
-function parseInlineValue(raw: string): BodySpec {
-  const single = raw.match(/^'(.*)'$/s);
-  if (single) return { kind: "parts", parts: [{ kind: "literal", text: single[1] ?? "" }] };
-  if (unquote(raw) === "-") {
-    return { kind: "unreadable", detail: "a body typed into an editor (`-`)" };
+// `> body.md` and `--body-file $PWD/body.md` are the same file, so the match is
+// on the name alone. That also catches names that only look alike, which costs
+// the author a round trip through the deny rather than a body the hook reported
+// as checked and did not check.
+function sameFile(target: string | null, path: string): boolean {
+  const name = basename(path);
+  return target !== null && name !== "" && basename(target) === name;
+}
+
+/**
+ * The command whose output the last write to `path` ahead of the PR command
+ * carries. The redirect lands on a pipeline's last stage, while the content
+ * comes from its first, so the pipeline is followed back to its source.
+ */
+function lastWriteTo(preceding: ShellCommand[], path: string): ShellCommand | undefined {
+  const write = preceding.findLast((command) => sameFile(writeTarget(command), path));
+  if (write === undefined) return undefined;
+  return preceding.find((command) => command.pipeline === write.pipeline);
+}
+
+// The last heredoc a command is fed, which is the one the shell leaves on its
+// stdin when several are attached.
+function heredocSpec(command: ShellCommand): BodySpec {
+  const heredoc = command.heredocs.at(-1);
+  if (heredoc === undefined) return { kind: "none" };
+  const expansion = heredoc.expansions[0];
+  if (expansion !== undefined) {
+    return {
+      kind: "unreadable",
+      detail: `an unquoted heredoc holding a shell expansion the hook cannot evaluate (\`${expansion.trim()}\`)`,
+    };
   }
-  const inner = raw.match(/^"(.*)"$/s)?.[1] ?? raw;
-
-  const parts: BodyPart[] = [];
-  let cursor = 0;
-  const pushLiteral = (segment: string): BodySpec | null => {
-    const stray = segment.match(SHELL_EXPANSION_PATTERN);
-    if (stray) return unreadableExpansion(stray[0]);
-    if (segment.length > 0) parts.push({ kind: "literal", text: unescapeDoubleQuoted(segment) });
-    return null;
-  };
-
-  for (const match of inner.matchAll(SUBSTITUTION_PATTERN)) {
-    const source = match[0];
-    const index = match.index;
-    const literal = pushLiteral(inner.slice(cursor, index));
-    if (literal) return literal;
-    const substituted = source.startsWith("`") ? source.slice(1, -1) : source.slice(2, -1);
-    const read = substituted.trim().match(FILE_READ_PATTERN)?.[1];
-    if (read === undefined) return unreadableExpansion(source);
-    const part = filePart(read);
-    if (part === null) return unreadableExpansion(read);
-    parts.push(part);
-    cursor = index + source.length;
-  }
-  const tail = pushLiteral(inner.slice(cursor));
-  if (tail) return tail;
-  return { kind: "parts", parts };
+  return { kind: "parts", parts: [{ kind: "literal", text: heredoc.content }] };
 }
 
-// Null when the delimiter is unquoted and the body holds an expansion the
-// shell will rewrite before the CLI sees it.
-function heredocLiteral(heredoc: Heredoc): BodyPart | null {
-  if (!heredoc.quoted && SHELL_EXPANSION_PATTERN.test(heredoc.content)) return null;
-  return { kind: "literal", text: heredoc.content };
-}
-
-function heredocExpansion(heredoc: Heredoc): BodySpec {
-  const source = heredoc.content.match(SHELL_EXPANSION_PATTERN)?.[0] ?? "";
-  return {
-    kind: "unreadable",
-    detail: `an unquoted heredoc holding a shell expansion the hook cannot evaluate (\`${source.trim()}\`)`,
-  };
-}
-
-function heredocSpec(heredoc: Heredoc): BodySpec {
-  const part = heredocLiteral(heredoc);
-  if (part === null) return heredocExpansion(heredoc);
-  return { kind: "parts", parts: [part] };
-}
-
-// Swap each file part for the heredoc that writes that path in the same
-// command, so a body created and passed in one call validates without touching
-// a file the command has not written yet. Only writes ahead of the PR command
-// count (a later write is not what the CLI reads), and the last of those wins,
-// as it would in the shell.
-function resolveHeredocParts(parts: BodyPart[], heredocs: Heredoc[]): BodySpec {
-  const resolved: BodyPart[] = [];
-  for (const part of parts) {
-    if (part.kind === "file") {
-      const heredoc = heredocs.findLast((doc) => doc.target === normalizeBodyPath(part.path));
-      if (heredoc !== undefined) {
-        const replacement = heredocLiteral(heredoc);
-        if (replacement === null) return heredocExpansion(heredoc);
-        resolved.push(replacement);
-        continue;
-      }
-    }
-    resolved.push(part);
-  }
-  return { kind: "parts", parts: resolved };
-}
-
-// Simple commands ahead of an offset, so a segment keeps its own redirect.
-function segmentsBefore(text: string, index: number): string[] {
-  const scope = text.slice(0, index);
-  const spans = quotedSpans(scope);
-  const segments: string[] = [];
-  let start = 0;
-  for (const separator of scope.matchAll(SEGMENT_SEPARATOR)) {
-    if (withinSpans(separator.index, spans)) continue;
-    segments.push(scope.slice(start, separator.index));
-    start = separator.index + separator[0].length;
-  }
-  segments.push(scope.slice(start));
-  return segments;
-}
-
-const PR_VIEW_INVOCATIONS: Record<PrCli, { verb: RegExp; pattern: RegExp }> = {
-  gh: { verb: /gh pr view/, pattern: invocationPattern(/gh pr view/) },
-  glab: { verb: /glab mr view/, pattern: invocationPattern(/glab mr view/) },
-};
-
-// The verb's first positional argument: a PR number, URL, or branch. Null when
-// the command leaves it off and the CLI resolves the current branch's PR, which
-// both commands in a round trip do.
-function prSelector(text: string, verb: RegExp): string | null {
-  const value = text.match(
-    new RegExp(String.raw`^(?:${verb.source})[ \t]+("[^"]*"|'[^']*'|[^-\s;|&<>][^\s;|&<>]*)`),
-  )?.[1];
-  return value === undefined ? null : unquote(value);
+// The subcommand's first positional argument: a PR number, URL, or branch. Null
+// when the command leaves it off and the CLI resolves the current branch's PR,
+// which both commands in a round trip do.
+function prSelector(command: ShellCommand, verb: string[]): string | null {
+  const text = literal(command.argv[verb.length]);
+  return text === null || text.startsWith("-") ? null : text;
 }
 
 /**
@@ -426,64 +166,64 @@ function prSelector(text: string, verb: RegExp): string | null {
  * not what the CLI will send, and no content the hook could read would change
  * the outcome. The trade is that an edit-in-place round trip ships unvalidated.
  *
- * A generator writing the same path (`printf ... > body.md`) is not this shape
- * and still has to hand the hook a body it can read.
+ * A generator writing the same path (`printf ... > body.md`) is a different
+ * shape and still has to hand the hook a body it can read.
  */
-function readsBackSamePr(text: string, path: string): boolean {
-  const cli = commandCli(text);
-  const editIndex = invocationIndex(text, PR_BODY_INVOCATION);
-  if (cli === null || editIndex === -1) return false;
-  const name = basename(normalizeBodyPath(path));
-  if (name === "") return false;
-  const selector = prSelector(text.slice(editIndex), PR_BODY_VERB);
-  const view = PR_VIEW_INVOCATIONS[cli];
-  return segmentsBefore(text, editIndex).some((segment) => {
-    const viewIndex = invocationIndex(segment, view.pattern);
-    if (viewIndex === -1) return false;
-    const target = segmentTarget(segment);
-    if (target === null || basename(target) !== name) return false;
-    return prSelector(segment.slice(viewIndex), view.verb) === selector;
-  });
+function readsBackSamePr(invocation: PrInvocation, write: ShellCommand): boolean {
+  const verb = VIEW_VERBS[invocation.cli];
+  if (!startsWith(write, verb)) return false;
+  return prSelector(write, verb) === prSelector(invocation.command, invocation.verb);
 }
 
-// Both spellings of stdin. `/dev/stdin` matters because reading it from the
-// hook would consume the hook's own (already-drained) stdin and validate an
-// empty body.
-const STDIN_PATHS = new Set(["-", "/dev/stdin"]);
+// What a path holds by the time the CLI reads it. A body written and passed in
+// one call resolves to the heredoc that wrote it, without touching a file the
+// command has not created yet.
+function pathSpec(invocation: PrInvocation, path: string): BodySpec {
+  const asFile: BodySpec = { kind: "parts", parts: [{ kind: "file", path }] };
+  const write = lastWriteTo(invocation.preceding, path);
+  if (write === undefined) return asFile;
+  if (readsBackSamePr(invocation, write)) return { kind: "none" };
+  const written = heredocSpec(write);
+  return written.kind === "none" ? asFile : written;
+}
+
+function fileSpec(invocation: PrInvocation, value: Word): BodySpec {
+  const path = literal(value);
+  if (path === null) return unreadableExpansion(value.source);
+  if (STDIN_PATHS.has(path)) {
+    const fed = heredocSpec(invocation.command);
+    if (fed.kind !== "none") return fed;
+    return { kind: "unreadable", detail: `a body piped in on standard input (\`${path}\`)` };
+  }
+  return pathSpec(invocation, path);
+}
+
+function inlineSpec(invocation: PrInvocation, value: Word): BodySpec {
+  if (literal(value) === "-") {
+    return { kind: "unreadable", detail: "a body typed into an editor (`-`)" };
+  }
+  const parts: BodyPart[] = [];
+  for (const segment of value.segments) {
+    if (segment.kind === "unresolved") return unreadableExpansion(segment.source);
+    if (segment.kind === "literal") {
+      if (segment.text !== "") parts.push({ kind: "literal", text: segment.text });
+      continue;
+    }
+    const held = pathSpec(invocation, segment.path);
+    if (held.kind !== "parts") return held;
+    parts.push(...held.parts);
+  }
+  return { kind: "parts", parts };
+}
 
 export function extractBodySpec(command: string): BodySpec {
-  const { text, heredocs } = parseCommand(command);
-  const flags = bodyFlags(text);
-  const spans = quotedSpans(text);
-  const fileValue = firstUnquotedMatch(text, flagValuePattern(flags.file, true), spans)?.[1];
-  if (fileValue != null && fileValue !== "") {
-    const path = unquote(fileValue);
-    if (STDIN_PATHS.has(path)) {
-      // The last stdin redirection wins, as it does in the shell.
-      const fed = heredocs.findLast(
-        (doc) => doc.target === null && invocationIndex(doc.segment, PR_BODY_INVOCATION) !== -1,
-      );
-      if (fed !== undefined) return heredocSpec(fed);
-      return { kind: "unreadable", detail: `a body piped in on standard input (\`${path}\`)` };
-    }
-    const part = filePart(fileValue);
-    if (part === null) return unreadableExpansion(path);
-    const spec = resolveHeredocParts([part], precedingHeredocs(text, heredocs));
-    const only = spec.kind === "parts" && spec.parts.length === 1 ? spec.parts[0] : undefined;
-    if (only?.kind === "file" && readsBackSamePr(text, only.path)) return { kind: "none" };
-    return spec;
-  }
-  const inlineValue = firstUnquotedMatch(text, flagValuePattern(flags.inline, true), spans)?.[1];
-  if (inlineValue == null || inlineValue === "") return { kind: "none" };
-  const inline = parseInlineValue(inlineValue);
-  if (inline.kind !== "parts") return inline;
-  return resolveHeredocParts(inline.parts, precedingHeredocs(text, heredocs));
-}
-
-function precedingHeredocs(text: string, heredocs: Heredoc[]): Heredoc[] {
-  const prIndex = invocationIndex(text, PR_BODY_INVOCATION);
-  if (prIndex === -1) return [];
-  return heredocs.filter((doc) => doc.offset < prIndex);
+  const invocation = findPrCommand(command);
+  if (invocation === null) return { kind: "none" };
+  const flags = BODY_FLAGS[invocation.cli];
+  const fileValue = flagValue(invocation.command.argv, flags.file);
+  if (fileValue !== undefined) return fileSpec(invocation, fileValue);
+  const inlineValue = flagValue(invocation.command.argv, flags.inline);
+  return inlineValue === undefined ? { kind: "none" } : inlineSpec(invocation, inlineValue);
 }
 
 /** The body text a command will send, or why the hook cannot see it. */
@@ -510,19 +250,16 @@ async function readBodyFile(path: string): Promise<string | null> {
 }
 
 // A `cd` ahead of the PR command moves where the CLI resolves a relative body
-// path, so the hook follows each one it can evaluate before reading files.
-// `||` is excluded from the lead-ins: a `cd a || cd b` fallback only runs when
-// the first cd failed, so the hook follows the success path.
-const CD_PATTERN = /(?:^|&&|;|\n)\s*cd\s+("(?:[^"\\]|\\.)*"|'[^']*'|[^\s;|&]+)/g;
-
+// path, so the hook follows each one it can evaluate before reading files. A
+// `cd` on the failure side of a `||` runs only when the one before it failed,
+// which is not the path that reaches the PR command.
 export function effectiveCwd(command: string, cwd: string): string {
-  const text = parseCommand(command).text;
-  const start = invocationIndex(text, PR_BODY_INVOCATION);
-  const scope = start === -1 ? text : text.slice(0, start);
+  const invocation = findPrCommand(command);
   let dir = cwd;
-  for (const match of scope.matchAll(CD_PATTERN)) {
-    const target = expandTmpdir(unquote(match[1] ?? ""));
-    if (target === "" || target === "-" || SHELL_EXPANSION_PATTERN.test(target)) continue;
+  for (const step of invocation?.preceding ?? parseShell(command)) {
+    if (step.fallback || literal(step.argv[0]) !== "cd") continue;
+    const target = literal(step.argv[1]);
+    if (target === null || target === "" || target === "-") continue;
     if (target.startsWith("~")) {
       // `~user` needs a passwd lookup the hook does not do, so leave dir as-is.
       if (target !== "~" && !target.startsWith("~/")) continue;
@@ -534,9 +271,34 @@ export function effectiveCwd(command: string, cwd: string): string {
   return dir;
 }
 
+/**
+ * The one file the whole body was read from, when rewriting it would survive to
+ * the PR. Null when the body is assembled from more than one source, and null
+ * when a command ahead of the PR verb names that file: a generator writing the
+ * same path replaces it after the hook reads it, so a correction would be
+ * discarded and the hook would report a fix the PR never carried.
+ */
+function rewritableFile(
+  invocation: PrInvocation,
+  parts: BodyPart[],
+  files: string[],
+): string | null {
+  const part = parts[0];
+  if (parts.length !== 1 || files.length !== 1 || part?.kind !== "file") return null;
+  const name = basename(part.path);
+  if (name === "") return null;
+  const named = invocation.preceding.some(
+    (command) =>
+      sameFile(writeTarget(command), part.path) ||
+      command.argv.some((word) => word.source.includes(name)),
+  );
+  return named ? null : (files[0] ?? null);
+}
+
 export async function resolveBody(command: string, cwd: string): Promise<BodyResolution> {
   const spec = extractBodySpec(command);
-  if (spec.kind !== "parts") return spec;
+  const invocation = findPrCommand(command);
+  if (spec.kind !== "parts" || invocation === null) return spec;
   const base = effectiveCwd(command, cwd);
   const chunks: string[] = [];
   const files: string[] = [];
@@ -557,48 +319,16 @@ export async function resolveBody(command: string, cwd: string): Promise<BodyRes
     files.push(path);
     chunks.push(text);
   }
-  return { kind: "text", text: chunks.join(""), file: rewritableFile(command, spec.parts, files) };
+  return {
+    kind: "text",
+    text: chunks.join(""),
+    file: rewritableFile(invocation, spec.parts, files),
+  };
 }
 
-/**
- * The one file the whole body was read from, when rewriting it would survive to
- * the PR. Null when the body is assembled from more than one source, and null
- * when the command names that file ahead of the PR verb: a generator writing
- * the same path (`gen.py > body.md && gh pr create --body-file body.md`)
- * replaces it after the hook reads it, so a correction would be discarded and
- * the hook would report a fix the PR never carried. Naming the file is the
- * signal a redirect, a `tee`, or an output flag all leave in the text.
- *
- * The two spellings need not match, since `> body.md` and `--body-file
- * $PWD/body.md` are the same file, so the match is on the file name alone.
- * That also catches names that only look alike, which costs the author a round
- * trip through the deny rather than a body the hook reported as fixed and did
- * not fix.
- */
-function rewritableFile(command: string, parts: BodyPart[], files: string[]): string | null {
-  if (parts.length !== 1 || files.length !== 1) return null;
-  const part = parts[0];
-  if (part?.kind !== "file") return null;
-  const text = parseCommand(command).text;
-  const prIndex = invocationIndex(text, PR_BODY_INVOCATION);
-  if (prIndex === -1) return null;
-  const name = basename(part.path);
-  if (name === "" || text.slice(0, prIndex).includes(name)) return null;
-  return files[0] ?? null;
-}
-
-// Anchored to the `gh pr`/`glab mr` verb with heredoc bodies stripped and the
-// body values blanked first: an unanchored scan reads a ` -t ` from an earlier
-// command in a compound (`mktemp -t`), and a `--title` mentioned inside a body
-// string, as the PR title.
 export function extractTitle(command: string): string | null {
-  const text = parseCommand(command).text;
-  const start = invocationIndex(text, PR_BODY_INVOCATION);
-  const flags = bodyFlags(text);
-  const scope = (start === -1 ? text : text.slice(start))
-    .replace(flagValuePattern(flags.file, true), " ")
-    .replace(flagValuePattern(flags.inline, true), " ");
-  const value = scope.match(/(?:--title|(?<![\w-])-t)[=\s]("(?:[^"\\]|\\.)*"|'[^']*'|[^\s]+)/)?.[1];
-  if (value == null || value === "") return null;
-  return unescapeDoubleQuoted(unquote(value));
+  const invocation = findPrCommand(command);
+  if (invocation === null) return null;
+  const title = literal(flagValue(invocation.command.argv, TITLE_FLAGS));
+  return title === null || title === "" ? null : title;
 }

--- a/plugins/pull-request/scripts/resolve-body.ts
+++ b/plugins/pull-request/scripts/resolve-body.ts
@@ -6,15 +6,31 @@ import { basename, isAbsolute, join } from "node:path";
 
 // The `if` rules in hooks.json scope dispatch to `gh pr create`/`edit` and
 // `glab mr create`/`update`, covering compound (`cd <dir> && gh pr create ...`)
-// and env-prefixed (`GH_PAGER=cat gh pr create ...`) forms. This guard repeats
-// the check in-script so the validator is inert under any other dispatch, and
-// runs before the hook reads a body file or shells out to git. It matches the
-// heredoc-stripped text, so a heredoc body that merely mentions a create
-// command stays inert.
-const PR_BODY_COMMAND_PATTERN = /\b(?:gh pr (?:create|edit)|glab mr (?:create|update))\b/;
+// and env-prefixed (`GH_PAGER=cat gh pr create ...`) forms. The guards below
+// repeat the check in-script so the validator is inert under any other
+// dispatch, and run before the hook reads a body file or shells out to git.
+const PR_BODY_VERB = /gh pr (?:create|edit)|glab mr (?:create|update)/;
+
+// The verb has to sit where the shell would run it: at the start of the text or
+// after a separator, with env assignments allowed ahead of it. The same words
+// anywhere else are an argument to some other program, which is how a `--notes`
+// value quoting a PR command reaches this hook at all.
+function invocationPattern(verb: RegExp): RegExp {
+  return new RegExp(String.raw`(?:^|[\n;|&(){}])[ \t]*(?:\w+=\S*[ \t]+)*(${verb.source})\b`, "g");
+}
+
+const PR_BODY_INVOCATION = invocationPattern(PR_BODY_VERB);
+
+/** Offset of the verb itself, or -1 when the text holds no such invocation. */
+function invocationIndex(text: string, pattern: RegExp): number {
+  const match = firstUnquotedMatch(text, pattern, quotedSpans(text));
+  const verb = match?.[1];
+  if (match == null || verb === undefined) return -1;
+  return match.index + match[0].length - verb.length;
+}
 
 export function isPrBodyCommand(command: string): boolean {
-  return PR_BODY_COMMAND_PATTERN.test(parseCommand(command).text);
+  return invocationIndex(parseCommand(command).text, PR_BODY_INVOCATION) !== -1;
 }
 
 function unquote(value: string): string {
@@ -40,9 +56,9 @@ function normalizeBodyPath(raw: string): string {
 // herestrings out. A quoted or escaped delimiter makes the body literal.
 const HEREDOC_OPERATOR = /(?<!<)<<(-?)[ \t]*(?:'([^']+)'|"([^"]+)"|(\\)?([A-Za-z_][A-Za-z0-9_]*))/g;
 
-// Simple-command boundaries within one line. `|` stays inside a segment so a
-// heredoc piped into the CLI remains attached to the command it feeds.
-const SEGMENT_SEPARATOR = /&&|\|\||;/g;
+// Simple-command boundaries. `|` stays inside a segment so a heredoc piped
+// into the CLI remains attached to the command it feeds.
+const SEGMENT_SEPARATOR = /&&|\|\||;|\n/g;
 
 // Where a segment writes its heredoc: a single `>` redirect or a `tee` sink.
 // The redirect lookbehind skips `>>` (an append mixes the heredoc with the
@@ -80,9 +96,10 @@ interface PendingHeredoc {
   lines: string[];
 }
 
-// Spans of a line covered by a quoted string, so a `<<` inside an argument
-// (`grep "<<EOF" f`) is not read as an operator. Backslash escapes a quote
-// outside single quotes, where the shell treats it literally.
+// Spans covered by a quoted string, so a `<<` inside an argument (`grep "<<EOF"
+// f`) is not read as an operator. Backslash escapes a quote outside single
+// quotes, where the shell treats it literally. Quoting runs across newlines, so
+// a multi-line flag value scanned whole is one span.
 function quotedSpans(line: string): [number, number][] {
   const spans: [number, number][] = [];
   let open: string | null = null;
@@ -107,16 +124,8 @@ function quotedSpans(line: string): [number, number][] {
   return spans;
 }
 
-// Quoted spans across the whole (stripped) text, line by line, so flag
-// matching can skip a flag word sitting inside another flag's quoted value.
-function quotedSpansAll(text: string): [number, number][] {
-  const spans: [number, number][] = [];
-  let offset = 0;
-  for (const line of text.split("\n")) {
-    for (const [start, end] of quotedSpans(line)) spans.push([offset + start, offset + end]);
-    offset += line.length + 1;
-  }
-  return spans;
+function withinSpans(index: number, spans: [number, number][]): boolean {
+  return spans.some(([start, end]) => index > start && index <= end);
 }
 
 // First match whose own start sits outside every quoted span. The value a
@@ -128,7 +137,7 @@ function firstUnquotedMatch(
   spans: [number, number][],
 ): RegExpExecArray | null {
   for (const match of text.matchAll(pattern)) {
-    if (!spans.some(([start, end]) => match.index > start && match.index <= end)) return match;
+    if (!withinSpans(match.index, spans)) return match;
   }
   return null;
 }
@@ -137,8 +146,7 @@ function segmentAt(line: string, index: number, spans: [number, number][]): stri
   let start = 0;
   let end = line.length;
   for (const sep of line.matchAll(SEGMENT_SEPARATOR)) {
-    if (spans.some(([spanStart, spanEnd]) => sep.index > spanStart && sep.index <= spanEnd))
-      continue;
+    if (withinSpans(sep.index, spans)) continue;
     if (sep.index < index) {
       start = sep.index + sep[0].length;
     } else {
@@ -192,7 +200,7 @@ export function parseCommand(command: string): ParsedCommand {
     kept.push(line);
     const spans = quotedSpans(line);
     for (const match of line.matchAll(HEREDOC_OPERATOR)) {
-      if (spans.some(([start, end]) => match.index > start && match.index <= end)) continue;
+      if (withinSpans(match.index, spans)) continue;
       const segment = segmentAt(line, match.index, spans);
       queue.push({
         delimiter: match[2] ?? match[3] ?? match[5] ?? "",
@@ -381,6 +389,63 @@ function resolveHeredocParts(parts: BodyPart[], heredocs: Heredoc[]): BodySpec {
   return { kind: "parts", parts: resolved };
 }
 
+// Simple commands ahead of an offset, so a segment keeps its own redirect.
+function segmentsBefore(text: string, index: number): string[] {
+  const scope = text.slice(0, index);
+  const spans = quotedSpans(scope);
+  const segments: string[] = [];
+  let start = 0;
+  for (const separator of scope.matchAll(SEGMENT_SEPARATOR)) {
+    if (withinSpans(separator.index, spans)) continue;
+    segments.push(scope.slice(start, separator.index));
+    start = separator.index + separator[0].length;
+  }
+  segments.push(scope.slice(start));
+  return segments;
+}
+
+const PR_VIEW_INVOCATIONS: Record<PrCli, { verb: RegExp; pattern: RegExp }> = {
+  gh: { verb: /gh pr view/, pattern: invocationPattern(/gh pr view/) },
+  glab: { verb: /glab mr view/, pattern: invocationPattern(/glab mr view/) },
+};
+
+// The verb's first positional argument: a PR number, URL, or branch. Null when
+// the command leaves it off and the CLI resolves the current branch's PR, which
+// both commands in a round trip do.
+function prSelector(text: string, verb: RegExp): string | null {
+  const value = text.match(
+    new RegExp(String.raw`^(?:${verb.source})[ \t]+("[^"]*"|'[^']*'|[^-\s;|&<>][^\s;|&<>]*)`),
+  )?.[1];
+  return value === undefined ? null : unquote(value);
+}
+
+/**
+ * Whether the command reads the same PR it is about to edit into the body file:
+ * `gh pr view <n> ... > body.md && <edit body.md> && gh pr edit <n> --body-file
+ * body.md`. The hook runs before the shell, so whatever that path holds now is
+ * not what the CLI will send, and no content the hook could read would change
+ * the outcome. The trade is that an edit-in-place round trip ships unvalidated.
+ *
+ * A generator writing the same path (`printf ... > body.md`) is not this shape
+ * and still has to hand the hook a body it can read.
+ */
+function readsBackSamePr(text: string, path: string): boolean {
+  const cli = commandCli(text);
+  const editIndex = invocationIndex(text, PR_BODY_INVOCATION);
+  if (cli === null || editIndex === -1) return false;
+  const name = basename(normalizeBodyPath(path));
+  if (name === "") return false;
+  const selector = prSelector(text.slice(editIndex), PR_BODY_VERB);
+  const view = PR_VIEW_INVOCATIONS[cli];
+  return segmentsBefore(text, editIndex).some((segment) => {
+    const viewIndex = invocationIndex(segment, view.pattern);
+    if (viewIndex === -1) return false;
+    const target = segmentTarget(segment);
+    if (target === null || basename(target) !== name) return false;
+    return prSelector(segment.slice(viewIndex), view.verb) === selector;
+  });
+}
+
 // Both spellings of stdin. `/dev/stdin` matters because reading it from the
 // hook would consume the hook's own (already-drained) stdin and validate an
 // empty body.
@@ -389,21 +454,24 @@ const STDIN_PATHS = new Set(["-", "/dev/stdin"]);
 export function extractBodySpec(command: string): BodySpec {
   const { text, heredocs } = parseCommand(command);
   const flags = bodyFlags(text);
-  const spans = quotedSpansAll(text);
+  const spans = quotedSpans(text);
   const fileValue = firstUnquotedMatch(text, flagValuePattern(flags.file, true), spans)?.[1];
   if (fileValue != null && fileValue !== "") {
     const path = unquote(fileValue);
     if (STDIN_PATHS.has(path)) {
       // The last stdin redirection wins, as it does in the shell.
       const fed = heredocs.findLast(
-        (doc) => doc.target === null && PR_BODY_COMMAND_PATTERN.test(doc.segment),
+        (doc) => doc.target === null && invocationIndex(doc.segment, PR_BODY_INVOCATION) !== -1,
       );
       if (fed !== undefined) return heredocSpec(fed);
       return { kind: "unreadable", detail: `a body piped in on standard input (\`${path}\`)` };
     }
     const part = filePart(fileValue);
     if (part === null) return unreadableExpansion(path);
-    return resolveHeredocParts([part], precedingHeredocs(text, heredocs));
+    const spec = resolveHeredocParts([part], precedingHeredocs(text, heredocs));
+    const only = spec.kind === "parts" && spec.parts.length === 1 ? spec.parts[0] : undefined;
+    if (only?.kind === "file" && readsBackSamePr(text, only.path)) return { kind: "none" };
+    return spec;
   }
   const inlineValue = firstUnquotedMatch(text, flagValuePattern(flags.inline, true), spans)?.[1];
   if (inlineValue == null || inlineValue === "") return { kind: "none" };
@@ -413,7 +481,7 @@ export function extractBodySpec(command: string): BodySpec {
 }
 
 function precedingHeredocs(text: string, heredocs: Heredoc[]): Heredoc[] {
-  const prIndex = text.search(PR_BODY_COMMAND_PATTERN);
+  const prIndex = invocationIndex(text, PR_BODY_INVOCATION);
   if (prIndex === -1) return [];
   return heredocs.filter((doc) => doc.offset < prIndex);
 }
@@ -449,7 +517,7 @@ const CD_PATTERN = /(?:^|&&|;|\n)\s*cd\s+("(?:[^"\\]|\\.)*"|'[^']*'|[^\s;|&]+)/g
 
 export function effectiveCwd(command: string, cwd: string): string {
   const text = parseCommand(command).text;
-  const start = text.search(PR_BODY_COMMAND_PATTERN);
+  const start = invocationIndex(text, PR_BODY_INVOCATION);
   const scope = start === -1 ? text : text.slice(0, start);
   let dir = cwd;
   for (const match of scope.matchAll(CD_PATTERN)) {
@@ -512,7 +580,7 @@ function rewritableFile(command: string, parts: BodyPart[], files: string[]): st
   const part = parts[0];
   if (part?.kind !== "file") return null;
   const text = parseCommand(command).text;
-  const prIndex = text.search(PR_BODY_COMMAND_PATTERN);
+  const prIndex = invocationIndex(text, PR_BODY_INVOCATION);
   if (prIndex === -1) return null;
   const name = basename(part.path);
   if (name === "" || text.slice(0, prIndex).includes(name)) return null;
@@ -525,7 +593,7 @@ function rewritableFile(command: string, parts: BodyPart[], files: string[]): st
 // string, as the PR title.
 export function extractTitle(command: string): string | null {
   const text = parseCommand(command).text;
-  const start = text.search(PR_BODY_COMMAND_PATTERN);
+  const start = invocationIndex(text, PR_BODY_INVOCATION);
   const flags = bodyFlags(text);
   const scope = (start === -1 ? text : text.slice(start))
     .replace(flagValuePattern(flags.file, true), " ")

--- a/plugins/pull-request/scripts/resolve-body.ts
+++ b/plugins/pull-request/scripts/resolve-body.ts
@@ -1,7 +1,5 @@
 // Where a `gh pr` / `glab mr` command gets its body and title from: heredocs,
-// inline flag values, body files, and the `cd`s ahead of them. `shell.ts`
-// answers what the command runs; this decides what that means for the body the
-// CLI will send.
+// inline flag values, body files, and the `cd`s ahead of them.
 
 import { homedir } from "node:os";
 import { basename, isAbsolute, join } from "node:path";
@@ -15,9 +13,8 @@ interface PrVerb {
   argv: string[];
 }
 
-// The `if` rules in hooks.json scope dispatch to these four subcommands. The
-// hook repeats the check against the parsed command so it stays inert under any
-// other dispatch, including a command that merely quotes one of them.
+// The `if` rules in hooks.json scope dispatch to these four subcommands, and
+// the hook repeats the check so it stays inert under any other dispatch.
 const PR_VERBS: PrVerb[] = [
   { cli: "gh", argv: ["gh", "pr", "create"] },
   { cli: "gh", argv: ["gh", "pr", "edit"] },
@@ -30,9 +27,8 @@ const VIEW_VERBS: Record<PrCli, string[]> = {
   glab: ["glab", "mr", "view"],
 };
 
-// `-b` is `--body` on gh and `--target-branch` on glab; `-d` is `--description`
-// on glab and `--draft` on gh. A shorthand means a body only on the CLI that
-// owns it, so the flag sets are keyed by CLI.
+// `-b` is `--body` on gh and `--target-branch` on glab. `-d` is `--description`
+// on glab and `--draft` on gh. So the flag sets are keyed by CLI.
 const BODY_FLAGS: Record<PrCli, { file: string[]; inline: string[] }> = {
   gh: { file: ["--body-file"], inline: ["--body", "-b"] },
   glab: { file: ["--description-file"], inline: ["--description", "-d"] },
@@ -71,9 +67,8 @@ export function isPrBodyCommand(command: string): boolean {
   return findPrCommand(command) !== null;
 }
 
-// A flag's value: the next word for `--body x`, or the tail of the word itself
-// for `--body=x`. Splitting on segments rather than text keeps the expansion in
-// `--body="$X"` an expansion.
+// Splitting on segments rather than text keeps the expansion in `--body="$X"`
+// an expansion.
 function flagValue(argv: Word[], flags: string[]): Word | undefined {
   for (const [index, word] of argv.entries()) {
     const text = literal(word);
@@ -103,9 +98,8 @@ function unreadableExpansion(source: string): BodySpec {
   };
 }
 
-// Both spellings of stdin. `/dev/stdin` matters because reading it from the
-// hook would consume the hook's own (already-drained) stdin and validate an
-// empty body.
+// Reading `/dev/stdin` would consume the hook's own (already-drained) stdin and
+// validate an empty body.
 const STDIN_PATHS = new Set(["-", "/dev/stdin"]);
 
 /** Where a command leaves its stdout: a `>` redirect, or the sink `tee` names. */
@@ -117,27 +111,22 @@ function writeTarget(command: ShellCommand): string | null {
 }
 
 // `> body.md` and `--body-file $PWD/body.md` are the same file, so the match is
-// on the name alone. That also catches names that only look alike, which costs
-// the author a round trip through the deny rather than a body the hook reported
-// as checked and did not check.
+// on the name alone. Names that only look alike cost the author a deny, which
+// beats a body the hook reports as checked and did not check.
 function sameFile(target: string | null, path: string): boolean {
   const name = basename(path);
   return target !== null && name !== "" && basename(target) === name;
 }
 
-/**
- * The command whose output the last write to `path` ahead of the PR command
- * carries. The redirect lands on a pipeline's last stage, while the content
- * comes from its first, so the pipeline is followed back to its source.
- */
+// The redirect lands on a pipeline's last stage while the content comes from
+// its first, so the last write to `path` is followed back to its source.
 function lastWriteTo(preceding: ShellCommand[], path: string): ShellCommand | undefined {
   const write = preceding.findLast((command) => sameFile(writeTarget(command), path));
   if (write === undefined) return undefined;
   return preceding.find((command) => command.pipeline === write.pipeline);
 }
 
-// The last heredoc a command is fed, which is the one the shell leaves on its
-// stdin when several are attached.
+// The shell leaves the last of several heredocs on the command's stdin.
 function heredocSpec(command: ShellCommand): BodySpec {
   const heredoc = command.heredocs.at(-1);
   if (heredoc === undefined) return { kind: "none" };
@@ -151,23 +140,18 @@ function heredocSpec(command: ShellCommand): BodySpec {
   return { kind: "parts", parts: [{ kind: "literal", text: heredoc.content }] };
 }
 
-// The subcommand's first positional argument: a PR number, URL, or branch. Null
-// when the command leaves it off and the CLI resolves the current branch's PR,
-// which both commands in a round trip do.
+// A PR number, URL, or branch. Null when the command leaves it off and the CLI
+// resolves the current branch's PR, which both commands in a round trip do.
 function prSelector(command: ShellCommand, verb: string[]): string | null {
   const text = literal(command.argv[verb.length]);
   return text === null || text.startsWith("-") ? null : text;
 }
 
 /**
- * Whether the command reads the same PR it is about to edit into the body file:
- * `gh pr view <n> ... > body.md && <edit body.md> && gh pr edit <n> --body-file
- * body.md`. The hook runs before the shell, so whatever that path holds now is
- * not what the CLI will send, and no content the hook could read would change
- * the outcome. The trade is that an edit-in-place round trip ships unvalidated.
- *
- * A generator writing the same path (`printf ... > body.md`) is a different
- * shape and still has to hand the hook a body it can read.
+ * Whether the write into the body file read back the PR the command is about to
+ * edit. The hook runs before the shell, so that path holds nothing the CLI will
+ * send, and every check is skipped: an edit-in-place round trip ships
+ * unvalidated. A generator writing the same path still owes a readable body.
  */
 function readsBackSamePr(invocation: PrInvocation, write: ShellCommand): boolean {
   const verb = VIEW_VERBS[invocation.cli];
@@ -176,8 +160,7 @@ function readsBackSamePr(invocation: PrInvocation, write: ShellCommand): boolean
 }
 
 // What a path holds by the time the CLI reads it. A body written and passed in
-// one call resolves to the heredoc that wrote it, without touching a file the
-// command has not created yet.
+// one call resolves to its heredoc, since the file does not exist yet.
 function pathSpec(invocation: PrInvocation, path: string): BodySpec {
   const asFile: BodySpec = { kind: "parts", parts: [{ kind: "file", path }] };
   const write = lastWriteTo(invocation.preceding, path);
@@ -235,11 +218,7 @@ export type BodyResolution =
   | {
       kind: "text";
       text: string;
-      /**
-       * Absolute path the whole body was read from, so a caller may rewrite it.
-       * Null when any of the body came from the command itself, where a rewrite
-       * would be overwritten by the command or would have to edit shell syntax.
-       */
+      /** Absolute path the whole body was read from, when a caller may rewrite it. */
       file: string | null;
     }
   | { kind: "unreadable"; detail: string };
@@ -253,9 +232,8 @@ async function readBodyFile(path: string): Promise<string | null> {
 }
 
 // A `cd` ahead of the PR command moves where the CLI resolves a relative body
-// path, so the hook follows each one it can evaluate before reading files. A
-// `cd` on the failure side of a `||` runs only when the one before it failed,
-// which is not the path that reaches the PR command.
+// path. One on the failure side of a `||` runs only when the one before it
+// failed, so it is off the path that reaches the PR command.
 export function effectiveCwd(command: string, cwd: string): string {
   const invocation = findPrCommand(command);
   let dir = cwd;
@@ -277,9 +255,8 @@ export function effectiveCwd(command: string, cwd: string): string {
 /**
  * The one file the whole body was read from, when rewriting it would survive to
  * the PR. Null when the body is assembled from more than one source, and null
- * when a command ahead of the PR verb names that file: a generator writing the
- * same path replaces it after the hook reads it, so a correction would be
- * discarded and the hook would report a fix the PR never carried.
+ * when a command ahead of the PR verb names that file: it would replace the
+ * correction, and the hook would report a fix the PR never carried.
  */
 function rewritableFile(
   invocation: PrInvocation,

--- a/plugins/pull-request/scripts/resolve-body.ts
+++ b/plugins/pull-request/scripts/resolve-body.ts
@@ -216,14 +216,17 @@ function inlineSpec(invocation: PrInvocation, value: Word): BodySpec {
   return { kind: "parts", parts };
 }
 
-export function extractBodySpec(command: string): BodySpec {
-  const invocation = findPrCommand(command);
-  if (invocation === null) return { kind: "none" };
+function bodySpec(invocation: PrInvocation): BodySpec {
   const flags = BODY_FLAGS[invocation.cli];
   const fileValue = flagValue(invocation.command.argv, flags.file);
   if (fileValue !== undefined) return fileSpec(invocation, fileValue);
   const inlineValue = flagValue(invocation.command.argv, flags.inline);
   return inlineValue === undefined ? { kind: "none" } : inlineSpec(invocation, inlineValue);
+}
+
+export function extractBodySpec(command: string): BodySpec {
+  const invocation = findPrCommand(command);
+  return invocation === null ? { kind: "none" } : bodySpec(invocation);
 }
 
 /** The body text a command will send, or why the hook cannot see it. */
@@ -296,9 +299,10 @@ function rewritableFile(
 }
 
 export async function resolveBody(command: string, cwd: string): Promise<BodyResolution> {
-  const spec = extractBodySpec(command);
   const invocation = findPrCommand(command);
-  if (spec.kind !== "parts" || invocation === null) return spec;
+  if (invocation === null) return { kind: "none" };
+  const spec = bodySpec(invocation);
+  if (spec.kind !== "parts") return spec;
   const base = effectiveCwd(command, cwd);
   const chunks: string[] = [];
   const files: string[] = [];

--- a/plugins/pull-request/scripts/shell.test.ts
+++ b/plugins/pull-request/scripts/shell.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { literal, parseShell, type ShellCommand } from "./shell";
 
-// The parse layer is what every body rule stands on, so these cases pin the
-// shell facts the resolver reads back: where a command sends its output, what a
-// heredoc delivers, and which words survive quoting as data.
+// The parse layer is what every body rule stands on.
 function summarize(command: string, env: NodeJS.ProcessEnv = {}) {
   return parseShell(command, env).map((entry: ShellCommand) => ({
     argv: entry.argv.map((word) => literal(word)),

--- a/plugins/pull-request/scripts/shell.test.ts
+++ b/plugins/pull-request/scripts/shell.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+import { literal, parseShell, type ShellCommand } from "./shell";
+
+// The parse layer is what every body rule stands on, so these cases pin the
+// shell facts the resolver reads back: where a command sends its output, what a
+// heredoc delivers, and which words survive quoting as data.
+function summarize(command: string, env: NodeJS.ProcessEnv = {}) {
+  return parseShell(command, env).map((entry: ShellCommand) => ({
+    argv: entry.argv.map((word) => literal(word)),
+    output: literal(entry.output ?? undefined),
+    heredocs: entry.heredocs,
+  }));
+}
+
+describe("parseShell", () => {
+  test("captures a redirect target and the heredoc it writes", () => {
+    expect(
+      summarize("cat > body.md <<'EOF'\nProse.\nEOF\ngh pr create --body-file body.md"),
+    ).toEqual([
+      { argv: ["cat"], output: "body.md", heredocs: [{ content: "Prose.\n", expansions: [] }] },
+      {
+        argv: ["gh", "pr", "create", "--body-file", "body.md"],
+        output: null,
+        heredocs: [],
+      },
+    ]);
+  });
+
+  test("finds a redirect written after the heredoc operator", () => {
+    expect(summarize("cat <<'EOF' > body.md\nProse.\nEOF")).toEqual([
+      { argv: ["cat"], output: "body.md", heredocs: [{ content: "Prose.\n", expansions: [] }] },
+    ]);
+  });
+
+  test("reports an unquoted heredoc's expansions", () => {
+    expect(summarize("cat > body.md <<EOF\nRelease $VERSION\nEOF")).toEqual([
+      {
+        argv: ["cat"],
+        output: "body.md",
+        heredocs: [{ content: "Release $VERSION\n", expansions: ["$VERSION"] }],
+      },
+    ]);
+  });
+
+  test("strips tabs under <<- including the terminator's own indent", () => {
+    expect(summarize("cat > body.md <<-'EOF'\n\tProse.\n\tEOF")).toEqual([
+      { argv: ["cat"], output: "body.md", heredocs: [{ content: "Prose.\n", expansions: [] }] },
+    ]);
+  });
+
+  // Neither leaves the file holding just this command's output, so neither is a
+  // target the resolver may read a body back from.
+  test.each<[string]>([["cat >> log.md <<'EOF'\nProse.\nEOF"], ["cat 2> err.md"]])(
+    "reports no output target for %p",
+    (command) => {
+      expect(summarize(command)[0]?.output).toBeNull();
+    },
+  );
+
+  test("keeps a << inside a quoted argument as data", () => {
+    expect(summarize('echo "<<EOF"\ngh pr create --body-file body.md')).toEqual([
+      { argv: ["echo", "<<EOF"], output: null, heredocs: [] },
+      {
+        argv: ["gh", "pr", "create", "--body-file", "body.md"],
+        output: null,
+        heredocs: [],
+      },
+    ]);
+  });
+
+  // A quoted argument is one word however many command-shaped phrases it holds,
+  // which is what keeps a note or a log line from reading as an invocation.
+  test("keeps a quoted command as one word", () => {
+    expect(
+      summarize(
+        'bun url.ts add --notes "Blocked.\nRun gh pr edit 12 --body-file b.md\nThen push."',
+      ),
+    ).toEqual([
+      {
+        argv: [
+          "bun",
+          "url.ts",
+          "add",
+          "--notes",
+          "Blocked.\nRun gh pr edit 12 --body-file b.md\nThen push.",
+        ],
+        output: null,
+        heredocs: [],
+      },
+    ]);
+  });
+
+  test("reaches a command inside a subshell, pipeline, or brace group", () => {
+    const commands = summarize("(cd /r && gh pr view 3 | tee out) ; { echo one; }");
+    expect(commands.map((entry) => entry.argv)).toEqual([
+      ["cd", "/r"],
+      ["gh", "pr", "view", "3"],
+      ["tee", "out"],
+      ["echo", "one"],
+    ]);
+  });
+
+  // `&&` and `||` bind equally and associate left, so `a || b && c` groups as
+  // `(a || b) && c` and the last command runs down either branch.
+  test.each<[string, boolean[]]>([
+    ["cd a || cd b", [false, true]],
+    ["cd a && cd b || cd c", [false, false, true]],
+    ["cd a || cd b && cd c", [false, true, false]],
+  ])("marks what %p reaches only after a failure", (command, expected) => {
+    expect(parseShell(command).map((entry) => entry.fallback)).toEqual(expected);
+  });
+
+  // The redirect lands on the last stage while the content comes from the
+  // first, so a caller following a file back to its source needs the grouping.
+  test("gives the stages of one pipeline a shared identifier", () => {
+    const commands = parseShell("gh pr view 3 --json body | jq -r .body > body.md\ncat body.md");
+    expect(commands[0]?.pipeline).toBe(commands[1]?.pipeline);
+    expect(commands[2]?.pipeline).not.toBe(commands[0]?.pipeline);
+  });
+
+  // A substitution is evaluated by the word that holds it, so its inner command
+  // is not a step in the outer sequence.
+  test("does not descend into a command substitution", () => {
+    expect(summarize('glab mr create --description "$(cat body.md)"').map((e) => e.argv)).toEqual([
+      ["glab", "mr", "create", "--description", null],
+    ]);
+  });
+
+  test("resolves a variable from the environment and leaves an unset one alone", () => {
+    expect(
+      summarize("gh pr create --body-file $TMPDIR/b.md", { TMPDIR: "/scratch" })[0]?.argv,
+    ).toEqual(["gh", "pr", "create", "--body-file", "/scratch/b.md"]);
+    expect(summarize("gh pr create --body-file $NOPE/b.md")[0]?.argv).toEqual([
+      "gh",
+      "pr",
+      "create",
+      "--body-file",
+      null,
+    ]);
+  });
+
+  // No shell would run it either, so there is nothing for a caller to act on.
+  test.each<[string]>([["cat > body.md <<'EOF'\nUnterminated."], ["gh pr create 'unclosed"]])(
+    "returns nothing for %p, which is not valid shell",
+    (command) => {
+      expect(parseShell(command)).toEqual([]);
+    },
+  );
+});

--- a/plugins/pull-request/scripts/shell.ts
+++ b/plugins/pull-request/scripts/shell.ts
@@ -1,0 +1,297 @@
+// A shell command as the list of simple commands it runs, with each word
+// evaluated as far as the hook can take it. This layer knows nothing about `gh`
+// or `glab`: it answers what the shell would do, and the caller decides what
+// that means for a PR body.
+
+import sh, {
+  type BinaryCmd,
+  type CallExpr,
+  type CmdSubst,
+  type DblQuoted,
+  type Lit,
+  type Node,
+  type ParamExp,
+  type Redirect,
+  type SglQuoted,
+  type Stmt,
+  type Word as SyntaxWord,
+  type WordPart,
+} from "mvdan-sh";
+
+const { syntax } = sh;
+
+/**
+ * What a word evaluates to. A word holds a sequence of these, because the shell
+ * builds one argument out of literal runs and expansions side by side
+ * (`$TMPDIR/body.md`).
+ */
+export type WordSegment =
+  | { kind: "literal"; text: string }
+  /** A substitution whose whole job is reading a file: `$(cat f)`, `$(< f)`. */
+  | { kind: "file"; path: string }
+  /** An expansion the hook cannot evaluate, kept as source for the message. */
+  | { kind: "unresolved"; source: string };
+
+/** One argument, as written and as evaluated. */
+export interface Word {
+  source: string;
+  segments: WordSegment[];
+}
+
+export interface Heredoc {
+  /** Body text as the shell delivers it, with `<<-` tab stripping applied. */
+  content: string;
+  /** Sources of expansions the shell rewrites before the command sees the body. */
+  expansions: string[];
+}
+
+export interface ShellCommand {
+  /** The command and its arguments, after any env assignments. */
+  argv: Word[];
+  /** Names assigned ahead of the command (`GH_PAGER=cat gh pr ...`). */
+  assigns: string[];
+  /** Path this command truncates its stdout into. Null for `>>`, `2>`, and no redirect. */
+  output: Word | null;
+  /** Heredoc bodies fed to this command, in the order the shell delivers them. */
+  heredocs: Heredoc[];
+  /** True when the shell reaches this command only after an earlier one failed (`||`). */
+  fallback: boolean;
+  /** Shared by the stages of one pipeline. A command outside a pipeline has its own. */
+  pipeline: number;
+}
+
+/** Text of a word the shell resolves to a plain string, or null when it does not. */
+export function literal(word: Word | undefined): string | null {
+  if (word === undefined) return null;
+  let text = "";
+  for (const segment of word.segments) {
+    if (segment.kind !== "literal") return null;
+    text += segment.text;
+  }
+  return text;
+}
+
+// Every node carries its own type name, so a predicate keyed on that name
+// narrows as soundly as the parser itself does.
+const isCall = (node: Node): node is CallExpr => syntax.NodeType(node) === "CallExpr";
+const isStatement = (node: Node): node is Stmt => syntax.NodeType(node) === "Stmt";
+const isLit = (node: Node): node is Lit => syntax.NodeType(node) === "Lit";
+const isSingleQuoted = (node: Node): node is SglQuoted => syntax.NodeType(node) === "SglQuoted";
+const isDoubleQuoted = (node: Node): node is DblQuoted => syntax.NodeType(node) === "DblQuoted";
+const isParameter = (node: Node): node is ParamExp => syntax.NodeType(node) === "ParamExp";
+const isSubstitution = (node: Node): node is CmdSubst => syntax.NodeType(node) === "CmdSubst";
+const isBinary = (node: Node): node is BinaryCmd => syntax.NodeType(node) === "BinaryCmd";
+
+// The parser exposes its operators as compile-time constants only, so each
+// value is read back from a command whose operator is known. That stays correct
+// across parser versions, where a copied literal would not.
+function redirectOperatorOf(source: string): Redirect["Op"] | undefined {
+  return syntax.NewParser().Parse(source, "probe.sh").Stmts[0]?.Redirs[0]?.Op;
+}
+
+const OPERATORS = {
+  write: redirectOperatorOf("x > f"),
+  heredoc: redirectOperatorOf("x <<E\nE"),
+  dashHeredoc: redirectOperatorOf("x <<-E\nE"),
+  input: redirectOperatorOf("x < f"),
+};
+
+function binaryOperatorOf(source: string): BinaryCmd["Op"] | undefined {
+  const command = syntax.NewParser().Parse(source, "probe.sh").Stmts[0]?.Cmd;
+  return command != null && isBinary(command) ? command.Op : undefined;
+}
+
+const OR_OPERATOR = binaryOperatorOf("x || y");
+const PIPE_OPERATORS = new Set([binaryOperatorOf("x | y"), binaryOperatorOf("x |& y")]);
+
+function sourceOf(node: Node, command: string): string {
+  return command.slice(node.Pos().Offset(), node.End().Offset());
+}
+
+/** Half-open byte range a node covers in the command text. */
+type Span = [number, number];
+
+function spanOf(node: Node): Span {
+  return [node.Pos().Offset(), node.End().Offset()];
+}
+
+function holds([start, end]: Span, offset: number): boolean {
+  return offset >= start && offset < end;
+}
+
+interface Context {
+  command: string;
+  env: NodeJS.ProcessEnv;
+}
+
+// A `$(...)` or backtick run whose only job is reading a file, which is the one
+// expansion the hook can follow: `cat f`, or a bare `< f` with no command.
+function substitutedFile(substitution: CmdSubst, context: Context): string | null {
+  const statements = substitution.Stmts.filter((statement) => statement !== null);
+  const statement = statements.length === 1 ? statements[0] : undefined;
+  if (statement === undefined) return null;
+  const call = isCall(statement.Cmd) ? statement.Cmd : null;
+  const args = (call?.Args ?? []).filter((arg) => arg !== null);
+  if (args.length === 0) {
+    const inputs = statement.Redirs.filter(
+      (redirect) => redirect !== null && redirect.Op === OPERATORS.input,
+    );
+    const target = inputs.length === 1 ? inputs[0]?.Word : undefined;
+    return target == null ? null : literal(evaluateWord(target, context));
+  }
+
+  const [verb, operand] = args;
+  if (args.length !== 2 || verb == null || operand == null) return null;
+  if (literal(evaluateWord(verb, context)) !== "cat") return null;
+  return literal(evaluateWord(operand, context));
+}
+
+// A variable resolves from the environment the hook runs in, which is the
+// environment the command will run in. An unset name stays unresolved rather
+// than expanding to nothing, so the hook reports it instead of reading the
+// wrong path.
+function parameterSegment(expansion: ParamExp, context: Context): WordSegment {
+  const source = sourceOf(expansion, context.command);
+  const name = expansion.Param?.Value;
+  const value = name == null ? undefined : context.env[name];
+  const plain =
+    !expansion.Excl && !expansion.Length && expansion.Slice == null && expansion.Repl == null;
+  if (!plain || value == null) return { kind: "unresolved", source };
+  return { kind: "literal", text: value };
+}
+
+// Double quotes protect everything but `$`, a backtick, and a quote of their
+// own, so a backslash survives into the argument unless it precedes one of
+// those or a newline. The parser hands the run back as written.
+function unescapeQuoted(text: string): string {
+  return text.replaceAll(/\\([$`"\\\n])/g, (_, escaped: string) =>
+    escaped === "\n" ? "" : escaped,
+  );
+}
+
+function partSegments(part: WordPart, context: Context, quoted = false): WordSegment[] {
+  if (isLit(part))
+    return [{ kind: "literal", text: quoted ? unescapeQuoted(part.Value) : part.Value }];
+  if (isSingleQuoted(part)) return [{ kind: "literal", text: part.Value }];
+  if (isDoubleQuoted(part))
+    return part.Parts.flatMap((inner) => partSegments(inner, context, true));
+  if (isParameter(part)) return [parameterSegment(part, context)];
+  if (isSubstitution(part)) {
+    const path = substitutedFile(part, context);
+    if (path !== null) return [{ kind: "file", path }];
+  }
+  return [{ kind: "unresolved", source: sourceOf(part, context.command) }];
+}
+
+function evaluateWord(word: SyntaxWord, context: Context): Word {
+  const segments: WordSegment[] = [];
+  for (const part of word.Parts) {
+    for (const segment of partSegments(part, context)) {
+      const last = segments.at(-1);
+      if (segment.kind === "literal" && last?.kind === "literal") last.text += segment.text;
+      else segments.push({ ...segment });
+    }
+  }
+  return { source: sourceOf(word, context.command), segments };
+}
+
+// A heredoc body reaches the CLI as written, so its literal runs are taken
+// verbatim rather than evaluated. Any other part is an expansion the shell
+// rewrites first, which is what a caller needs to be told about.
+function heredocOf(redirect: Redirect, context: Context): Heredoc | null {
+  if (redirect.Op !== OPERATORS.heredoc && redirect.Op !== OPERATORS.dashHeredoc) return null;
+  const parts = redirect.Hdoc?.Parts ?? [];
+  const content = parts
+    .map((part) => (isLit(part) ? part.Value : sourceOf(part, context.command)))
+    .join("");
+  return {
+    content: redirect.Op === OPERATORS.dashHeredoc ? stripLeadingTabs(content) : content,
+    expansions: parts.filter((part) => !isLit(part)).map((part) => sourceOf(part, context.command)),
+  };
+}
+
+// `<<-` drops leading tabs from every body line, including the one the closing
+// delimiter sat on, which the parser leaves as a trailing run.
+function stripLeadingTabs(content: string): string {
+  return content
+    .split("\n")
+    .map((line) => line.replace(/^\t+/, ""))
+    .join("\n");
+}
+
+// `>>` appends and `2>` is a different stream, so neither leaves the file
+// holding just this command's output. The last write wins, as it does in the
+// shell.
+function outputOf(redirects: Redirect[], context: Context): Word | null {
+  const write = redirects.findLast(
+    (redirect) =>
+      redirect.Op === OPERATORS.write && (redirect.N == null || redirect.N.Value === "1"),
+  );
+  const target = write?.Word;
+  return target == null ? null : evaluateWord(target, context);
+}
+
+/** Where a command sits among the others, which the statement itself does not say. */
+type Placement = Pick<ShellCommand, "fallback" | "pipeline">;
+
+function statementCommand(
+  statement: Stmt,
+  context: Context,
+  placement: Placement,
+): ShellCommand | null {
+  if (!isCall(statement.Cmd)) return null;
+  const redirects = statement.Redirs.filter((redirect) => redirect !== null);
+  return {
+    ...placement,
+    argv: statement.Cmd.Args.filter((arg) => arg !== null).map((arg) => evaluateWord(arg, context)),
+    assigns: statement.Cmd.Assigns.filter((assign) => assign !== null).map(
+      (assign) => assign.Name?.Value ?? "",
+    ),
+    output: outputOf(redirects, context),
+    heredocs: redirects
+      .map((redirect) => heredocOf(redirect, context))
+      .filter((heredoc): heredoc is Heredoc => heredoc !== null),
+  };
+}
+
+/**
+ * The simple commands a shell command runs, in source order. The walk descends
+ * into pipelines, subshells, brace groups, loops, and conditionals, so a
+ * command is reached wherever it sits.
+ *
+ * Empty when the text is not valid shell, which is also when no shell would run
+ * it, so a caller reading that as "nothing to act on" matches what happens.
+ */
+export function parseShell(command: string, env: NodeJS.ProcessEnv = process.env): ShellCommand[] {
+  const context: Context = { command, env };
+  const commands: ShellCommand[] = [];
+  // Source spans of the `||` right operands and of the pipelines. A binary is
+  // visited before the statements inside it, so by the time one of those is
+  // reached its span is already here, and the outermost pipeline is first.
+  const fallbacks: Span[] = [];
+  const pipelines: Span[] = [];
+  try {
+    const file = syntax.NewParser().Parse(command, "command.sh");
+    syntax.Walk(file, (node) => {
+      // A command substitution belongs to the word that holds it, which
+      // evaluates it on its own. It is not a step in this command's sequence.
+      if (isSubstitution(node)) return false;
+      if (isBinary(node)) {
+        if (PIPE_OPERATORS.has(node.Op)) pipelines.push(spanOf(node));
+        else if (node.Op === OR_OPERATOR && node.Y != null) fallbacks.push(spanOf(node.Y));
+      }
+      if (isStatement(node)) {
+        const at = node.Pos().Offset();
+        const found = statementCommand(node, context, {
+          fallback: fallbacks.some((span) => holds(span, at)),
+          pipeline: pipelines.find((span) => holds(span, at))?.[0] ?? at,
+        });
+        if (found !== null) commands.push(found);
+      }
+      return true;
+    });
+  } catch {
+    return [];
+  }
+  return commands;
+}

--- a/plugins/pull-request/scripts/shell.ts
+++ b/plugins/pull-request/scripts/shell.ts
@@ -1,7 +1,5 @@
 // A shell command as the list of simple commands it runs, with each word
-// evaluated as far as the hook can take it. This layer knows nothing about `gh`
-// or `glab`: it answers what the shell would do, and the caller decides what
-// that means for a PR body.
+// evaluated as far as the hook can take it.
 
 import sh, {
   type BinaryCmd,
@@ -20,11 +18,7 @@ import sh, {
 
 const { syntax } = sh;
 
-/**
- * What a word evaluates to. A word holds a sequence of these, because the shell
- * builds one argument out of literal runs and expansions side by side
- * (`$TMPDIR/body.md`).
- */
+/** A word holds a sequence of these, since `$TMPDIR/body.md` is one argument. */
 export type WordSegment =
   | { kind: "literal"; text: string }
   /** A substitution whose whole job is reading a file: `$(cat f)`, `$(< f)`. */
@@ -71,8 +65,6 @@ export function literal(word: Word | undefined): string | null {
   return text;
 }
 
-// Every node carries its own type name, so a predicate keyed on that name
-// narrows as soundly as the parser itself does.
 const isCall = (node: Node): node is CallExpr => syntax.NodeType(node) === "CallExpr";
 const isStatement = (node: Node): node is Stmt => syntax.NodeType(node) === "Stmt";
 const isLit = (node: Node): node is Lit => syntax.NodeType(node) === "Lit";
@@ -82,9 +74,8 @@ const isParameter = (node: Node): node is ParamExp => syntax.NodeType(node) === 
 const isSubstitution = (node: Node): node is CmdSubst => syntax.NodeType(node) === "CmdSubst";
 const isBinary = (node: Node): node is BinaryCmd => syntax.NodeType(node) === "BinaryCmd";
 
-// The parser exposes its operators as compile-time constants only, so each
-// value is read back from a command whose operator is known. That stays correct
-// across parser versions, where a copied literal would not.
+// The parser exposes its operators as compile-time constants only, so each is
+// read back from a command whose operator is known.
 function redirectOperatorOf(source: string): Redirect["Op"] | undefined {
   return syntax.NewParser().Parse(source, "probe.sh").Stmts[0]?.Redirs[0]?.Op;
 }
@@ -146,10 +137,8 @@ function substitutedFile(substitution: CmdSubst, context: Context): string | nul
   return literal(evaluateWord(operand, context));
 }
 
-// A variable resolves from the environment the hook runs in, which is the
-// environment the command will run in. An unset name stays unresolved rather
-// than expanding to nothing, so the hook reports it instead of reading the
-// wrong path.
+// An unset name stays unresolved rather than expanding to nothing, so a caller
+// reports it instead of reading the wrong path.
 function parameterSegment(expansion: ParamExp, context: Context): WordSegment {
   const source = sourceOf(expansion, context.command);
   const name = expansion.Param?.Value;
@@ -160,9 +149,8 @@ function parameterSegment(expansion: ParamExp, context: Context): WordSegment {
   return { kind: "literal", text: value };
 }
 
-// Double quotes protect everything but `$`, a backtick, and a quote of their
-// own, so a backslash survives into the argument unless it precedes one of
-// those or a newline. The parser hands the run back as written.
+// The parser hands back the run as written. A backslash survives into the
+// argument unless it precedes one of the characters quoting cannot protect.
 function unescapeQuoted(text: string): string {
   return text.replaceAll(/\\([$`"\\\n])/g, (_, escaped: string) =>
     escaped === "\n" ? "" : escaped,
@@ -195,9 +183,8 @@ function evaluateWord(word: SyntaxWord, context: Context): Word {
   return { source: sourceOf(word, context.command), segments };
 }
 
-// A heredoc body reaches the CLI as written, so its literal runs are taken
-// verbatim rather than evaluated. Any other part is an expansion the shell
-// rewrites first, which is what a caller needs to be told about.
+// A heredoc body reaches the CLI as written, so literal runs are taken
+// verbatim. Any other part is an expansion the shell rewrites first.
 function heredocOf(redirect: Redirect, context: Context): Heredoc | null {
   if (redirect.Op !== OPERATORS.heredoc && redirect.Op !== OPERATORS.dashHeredoc) return null;
   const parts = redirect.Hdoc?.Parts ?? [];
@@ -210,8 +197,8 @@ function heredocOf(redirect: Redirect, context: Context): Heredoc | null {
   };
 }
 
-// `<<-` drops leading tabs from every body line, including the one the closing
-// delimiter sat on, which the parser leaves as a trailing run.
+// `<<-` also strips the closing delimiter's own indent, which the parser leaves
+// as a trailing run.
 function stripLeadingTabs(content: string): string {
   return content
     .split("\n")
@@ -220,8 +207,7 @@ function stripLeadingTabs(content: string): string {
 }
 
 // `>>` appends and `2>` is a different stream, so neither leaves the file
-// holding just this command's output. The last write wins, as it does in the
-// shell.
+// holding just this command's output.
 function outputOf(redirects: Redirect[], context: Context): Word | null {
   const write = redirects.findLast(
     (redirect) =>
@@ -255,26 +241,21 @@ function statementCommand(
 }
 
 /**
- * The simple commands a shell command runs, in source order. The walk descends
- * into pipelines, subshells, brace groups, loops, and conditionals, so a
- * command is reached wherever it sits.
- *
+ * The simple commands a shell command runs, in source order, wherever they sit.
  * Empty when the text is not valid shell, which is also when no shell would run
- * it, so a caller reading that as "nothing to act on" matches what happens.
+ * it.
  */
 export function parseShell(command: string, env: NodeJS.ProcessEnv = process.env): ShellCommand[] {
   const context: Context = { command, env };
   const commands: ShellCommand[] = [];
-  // Source spans of the `||` right operands and of the pipelines. A binary is
-  // visited before the statements inside it, so by the time one of those is
-  // reached its span is already here, and the outermost pipeline is first.
+  // A binary is visited before the statements inside it, so a statement's spans
+  // are already here, outermost first.
   const fallbacks: Span[] = [];
   const pipelines: Span[] = [];
   try {
     const file = syntax.NewParser().Parse(command, "command.sh");
     syntax.Walk(file, (node) => {
-      // A command substitution belongs to the word that holds it, which
-      // evaluates it on its own. It is not a step in this command's sequence.
+      // The word holding it evaluates it, so it is no step in this sequence.
       if (isSubstitution(node)) return false;
       if (isBinary(node)) {
         if (PIPE_OPERATORS.has(node.Op)) pipelines.push(spanOf(node));

--- a/plugins/pull-request/scripts/validate.test.ts
+++ b/plugins/pull-request/scripts/validate.test.ts
@@ -64,6 +64,38 @@ describe("processInput", () => {
     },
   );
 
+  // A PR command quoted inside another program's argument is prose, not an
+  // invocation, so the hook never reaches the body file its text names.
+  test.each<[string]>([
+    ["bun url.ts add --notes 'retry with gh pr edit 12 --body-file /nonexistent.md'"],
+    [
+      'bun url.ts add --notes "Blocked.\nRun gh pr edit 12 --body-file /nonexistent.md\nThen push."',
+    ],
+  ])("returns null for %p, where the PR command is an argument", async (command) => {
+    expect(await processInput(createInput(command))).toBeNull();
+  });
+
+  // The round trip: read the PR, edit the file, write it back. The hook runs
+  // before the shell, so no body it could read is the one the CLI sends.
+  test.each<[string]>([
+    [
+      "gh pr view 12 --json body -q .body > /nonexistent.md && gh pr edit 12 --body-file /nonexistent.md",
+    ],
+    [
+      "glab mr view 3 --output json | jq -r .description > /nonexistent.md && glab mr update 3 --description-file /nonexistent.md",
+    ],
+  ])("returns null for %p, a round trip through the same PR", async (command) => {
+    expect(await processInput(createInput(command))).toBeNull();
+  });
+
+  it("denies a generator writing the body file it will pass", async () => {
+    const result = await processInput(
+      createInput("printf 'Prose.' > /nonexistent.md && gh pr edit 12 --body-file /nonexistent.md"),
+    );
+    expect(getPermissionDecision(result)).toBe("deny");
+    expect(getDenyReason(result)).toContain("/nonexistent.md");
+  });
+
   it("returns null when tool_input has no command", async () => {
     const result = await processInput({ tool_input: {} });
     expect(result).toBeNull();


### PR DESCRIPTION
The PR body hook denied two things it should not have. A `gh pr edit` command quoted inside another program's argument was read as a PR edit and validated. And a round trip that reads a body to a file, edits the file, and writes it back could not pass at all: the hook runs before the shell, so the file it was asked to read did not exist yet.

Both came out of the same machinery. `resolve-body.ts` read commands with a stack of regexes that tracked quoting by scanning line by line, so an open quote was lost at every newline. Fixing each shape meant another pattern layered on the ones already there.

This replaces that with `mvdan-sh`, the parser behind shfmt, and an AST walk. `shell.ts` is a new layer that answers what the shell runs and knows nothing about `gh` or `glab`:

- argv, with each word evaluated as far as the hook can take it
- redirect targets and heredoc bodies
- which commands belong to one pipeline
- which commands a `||` reaches only after a failure

`resolve-body.ts` keeps its exported API and decides what all that means for the body the CLI will send. Quoting, nesting, and multi-line arguments now come from the grammar rather than from pattern order, and both denials disappear as a consequence.

A command that merely contains PR-edit text is inert because the parse puts that text in an argument. A round trip is recognized because the parser reports the pipeline that fills the body file and the PR each command names.

The trade: when the write into the body file reads back the same PR the command is about to edit, the hook resolves to no body and every check is skipped. Nothing it could read at that moment is what the CLI will send, so an edit-in-place round trip ships unvalidated. A generator writing that same path is a different shape and still has to hand over a body the hook can read.

Discovery: a093455418b2

Original Task: https://things.bendrucker.me/show?id=3sT6JviUiq7vZMejSPdULJ
