### PR TITLE
plan: bound the transcript model read

### DIFF
--- a/plugins/plan/scripts/injection-content.sh
+++ b/plugins/plan/scripts/injection-content.sh
@@ -9,10 +9,20 @@ cat "$here/../references/guidelines.md"
 
 # The tail bounds cost on a large transcript. It counts JSONL entries, not lines
 # of one record, and the last assistant turn sits at the tail, so a generous
-# ceiling keeps it in range even in a long session. Empty model falls open.
+# ceiling keeps it in range even in a long session. Reversing that window lets
+# jq stop at the first assistant entry rather than parse every record in it.
+# tail -r is BSD, tac is GNU; neither ships both.
 model=""
 if [ -n "$transcript" ] && [ -f "$transcript" ]; then
-  model=$(tail -n 2000 "$transcript" | jq -rs '[.[] | select(.type == "assistant") | .message.model // empty] | last // empty' 2>/dev/null)
+  if tail -r </dev/null >/dev/null 2>&1; then
+    reverse=(tail -r)
+  else
+    reverse=(tac)
+  fi
+  model=$(
+    tail -n 2000 "$transcript" | "${reverse[@]}" |
+      jq -rn 'first(inputs | select(.type == "assistant") | .message.model // empty)' 2>/dev/null
+  )
 fi
 
 case "$model" in

--- a/plugins/plan/scripts/injection-content.test.ts
+++ b/plugins/plan/scripts/injection-content.test.ts
@@ -16,13 +16,18 @@ afterEach(async () => {
   await rm(dir, { recursive: true, force: true });
 });
 
-async function transcriptWith(models: string[]): Promise<string> {
-  const lines = models.map((model) =>
-    JSON.stringify({ type: "assistant", message: { role: "assistant", model, content: [] } }),
-  );
-  const path = join(dir, "transcript.jsonl");
+function assistantLine(model: string): string {
+  return JSON.stringify({ type: "assistant", message: { role: "assistant", model, content: [] } });
+}
+
+async function transcriptOf(lines: string[], name = "transcript.jsonl"): Promise<string> {
+  const path = join(dir, name);
   await Bun.write(path, `${lines.join("\n")}\n`);
   return path;
+}
+
+async function transcriptWith(models: string[]): Promise<string> {
+  return transcriptOf(models.map(assistantLine));
 }
 
 async function assemble(transcript: string | null): Promise<string> {
@@ -84,6 +89,33 @@ describe("fail open", () => {
       path,
       `${JSON.stringify({ type: "user", message: { role: "user", content: [] } })}\n`,
     );
+    const out = await assemble(path);
+    expect(out).toContain("Planning Guidelines");
+    expect(out).not.toContain("# Delegation");
+  });
+});
+
+describe("bounded reverse scan", () => {
+  test("stops before entries the last assistant turn sits above", async () => {
+    const path = await transcriptOf(["not json", "{also not", assistantLine("claude-opus-5")]);
+    const out = await assemble(path);
+    expect(out).toContain("# Delegation");
+  });
+
+  test("skips an assistant entry carrying no model", async () => {
+    const path = await transcriptOf([
+      assistantLine("claude-opus-5"),
+      JSON.stringify({ type: "assistant", message: { role: "assistant", content: [] } }),
+    ]);
+    const out = await assemble(path);
+    expect(out).toContain("# Delegation");
+  });
+
+  test("ignores an assistant entry older than the window", async () => {
+    const filler = Array.from({ length: 2000 }, () =>
+      JSON.stringify({ type: "user", message: { role: "user", content: [] } }),
+    );
+    const path = await transcriptOf([assistantLine("claude-opus-5"), ...filler]);
     const out = await assemble(path);
     expect(out).toContain("Planning Guidelines");
     expect(out).not.toContain("# Delegation");


### PR DESCRIPTION
The plan-mode injection needs one string from the transcript: the model on the last assistant entry. It was reading that with `jq -rs`, which slurps the bounded 2000-entry window into an array and parses every record in it, so the cost tracked how heavy those records were rather than the work being done. On a transcript averaging 14KB per entry the read took 417ms, and it lands in the wait for the first token on `UserPromptSubmit`, plus every `PreToolUse` in plan mode until the marker is set.

Reversing the window lets jq stop at the first assistant entry it finds, which in practice is within the last handful of lines.

Piping to `head -n1` was the obvious shape and it doesn't work. jq block-buffers its stdout, so a 20-byte model string never flushes, `head` never exits, and SIGPIPE never arrives to stop the parse. Measured against the old pipeline it saved nothing (274ms vs 276ms). `jq -rn 'first(inputs | ...)'` makes jq itself stop consuming, which is deterministic rather than a race on buffer timing.

`tail -r` is BSD and `tac` is GNU, and neither platform ships both. The script probes once and picks. Without that fallback the tests break in CI, which runs this plugin on `ubuntu-latest`.

The `// empty` stays inside `first()` so an assistant entry carrying no model falls through to the one before it, as the old `last` over a filtered array did. Output is byte-identical across 120 real transcripts.

## Measurements

Whole-script wall time, mean of 10 runs, on transcripts under `~/.claude/projects/`:

| entries | size | before | after |
|--------:|-----:|-------:|------:|
| 1896 | 27M | 417ms | 160ms |
| 1323 | 26M | 357ms | 175ms |
| 1712 | 12M | 239ms | 167ms |
| 10547 | 62M | 206ms | 152ms |
| 5170 | 29M | 204ms | 155ms |

The remaining time is `tail` plus jq startup. It no longer scales with record size, which is what the old shape was paying for.

Original Task: https://things.bendrucker.me/show?id=6j9YZm4dGZx7FnGRnhqcuj

Discovery: 16be21fee72c
