### PR TITLE
scripts: fail on a marketplace nothing uses

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -53,6 +53,7 @@
       matchDatasources: ["git-refs"],
       prBodyNotes: [
         "📜 **Changelog**: [`{{{currentDigestShort}}}` → `{{{newDigestShort}}}`](https://github.com/{{{depName}}}/compare/{{{currentDigest}}}...{{{newDigest}}})",
+        "⚠️ **Reinstall after merge**: `claude plugin update` moves an installed payload only when the plugin manifest's `version` changes between these commits. When it does not, reinstall on each machine (`claude plugin uninstall <id>` then `claude plugin install <id>`), or `claude-plugin-audit` reports the plugin `pinned` every night.",
       ],
     },
   ],

--- a/scripts/check-plugin-ids.test.ts
+++ b/scripts/check-plugin-ids.test.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "bun:test";
-import { type PluginId, parseId, sources, violations } from "./check-plugin-ids";
+import {
+  type PluginId,
+  parseId,
+  sources,
+  unusedMarketplaces,
+  violations,
+} from "./check-plugin-ids";
 
 test.each<{ name: string; id: string; expected: PluginId | null }>([
   {
@@ -31,6 +37,26 @@ test("a third-party name is not resolved", () => {
   expect(violations({ ids: ["no-such-plugin@worktrunk"], marketplaces, listed })).toBeEmpty();
 });
 
+test.each<{ name: string; ids: string[]; expected: string[] }>([
+  {
+    name: "every declared marketplace used",
+    ids: ["linear@bendrucker", "worktrunk@worktrunk"],
+    expected: [],
+  },
+  { name: "declared marketplace with no id", ids: ["linear@bendrucker"], expected: ["worktrunk"] },
+  {
+    name: "malformed id does not use a marketplace",
+    ids: ["bendrucker", "worktrunk@worktrunk"],
+    expected: ["bendrucker"],
+  },
+])("$name", ({ ids, expected }) => {
+  expect(unusedMarketplaces({ ids, marketplaces, listed })).toEqual(expected);
+});
+
 test("every enabled plugin in this repo resolves", async () => {
   expect(violations(await sources())).toBeEmpty();
+});
+
+test("every declared marketplace is used", async () => {
+  expect(unusedMarketplaces(await sources())).toBeEmpty();
 });

--- a/scripts/check-plugin-ids.ts
+++ b/scripts/check-plugin-ids.ts
@@ -59,6 +59,16 @@ export function violations({ ids, marketplaces, listed }: Sources): string[] {
   return messages;
 }
 
+/**
+ * Declared marketplaces that no enabled id names. Claude Code clones each one
+ * on every machine and checks it nightly, so a declaration nothing consumes is
+ * recurring work with no payoff.
+ */
+export function unusedMarketplaces({ ids, marketplaces }: Sources): string[] {
+  const used = new Set(ids.map((id) => parseId(id)?.marketplace).filter((name) => name != null));
+  return [...marketplaces].filter((name) => !used.has(name)).toSorted();
+}
+
 export async function sources(): Promise<Sources> {
   const [settings, plugins] = await Promise.all([loadSettings(), loadPlugins()]);
   return {
@@ -70,10 +80,18 @@ export async function sources(): Promise<Sources> {
 
 if (import.meta.main) {
   await runCheck(
-    async () => ({
-      header: "Enabled plugins that do not resolve:",
-      violations: violations(await sources()),
-    }),
-    { success: "Every enabled plugin id resolves" },
+    async () => {
+      const source = await sources();
+      return {
+        header: "Plugin ids and marketplaces that do not resolve:",
+        violations: [
+          ...violations(source),
+          ...unusedMarketplaces(source).map(
+            (name) => `${name}: declared in extraKnownMarketplaces, no enabled plugin uses it`,
+          ),
+        ],
+      };
+    },
+    { success: "Every enabled plugin id and declared marketplace resolves" },
   );
 }

--- a/user/settings.json
+++ b/user/settings.json
@@ -466,13 +466,6 @@
         "repo": "anthropics/claude-plugins-official"
       }
     },
-    "astral-sh": {
-      "source": {
-        "source": "github",
-        "repo": "astral-sh/claude-code-plugins",
-        "ref": "f3ce88a7ba830f53afd6d944c1d0278ed318e142"
-      }
-    },
     "ast-grep-marketplace": {
       "source": {
         "source": "github",


### PR DESCRIPTION
Adds the reverse of the check `check-plugin-ids.ts` already ran. It verified that every enabled plugin id names a marketplace that resolves. Nothing verified the other direction, so a marketplace declaration outlived the last plugin that used it.

#753 removed `astral@astral-sh` from `enabledPlugins` and left `astral-sh` in `extraKnownMarketplaces`. Claude Code has cloned that repo on every machine and checked it nightly ever since, for a plugin nothing enables. `unusedMarketplaces` flags it, and the declaration goes with this change.

Both directions run in the same CI step, so the next declaration that loses its last consumer fails the build instead of accumulating quietly.

The Renovate note covers a different trap on the same config. A digest bump for a pinned marketplace moves an installed payload only when the plugin manifest's `version` also changes between those commits. When it does not, merging the bump leaves every machine on the old payload, and the only thing that reports it is `claude-plugin-audit`'s nightly `pinned` verdict. The note tells whoever merges to reinstall.

Original Task: [Claude plugins are stale](https://things.bendrucker.me/show?id=VfANEX6WanEgStbq29ynLU)
