### PR TITLE
user: name the statusline report race on timeout

### DIFF
--- a/user/scripts/statusline.test.ts
+++ b/user/scripts/statusline.test.ts
@@ -410,6 +410,12 @@ describe("pane metadata report", () => {
     },
   });
 
+  // A detached child racing a poll needs slack on a loaded machine. The poll has
+  // to expire inside the test's own budget so the named error surfaces instead of
+  // bun:test's generic timeout.
+  const reportPollMs = 20_000;
+  const reportTestMs = reportPollMs + 5_000;
+
   async function recordedArgs(transcript: string): Promise<string[]> {
     const dir = mkdtempSync(join(tmpdir(), "statusline-herdr-"));
     const bin = join(dir, "bin");
@@ -448,7 +454,7 @@ describe("pane metadata report", () => {
       // The reporting child is detached so the line renders at its own speed,
       // which lands the stub's log after the status line has already exited.
       // oxlint-disable no-await-in-loop -- polling for another process's write is sequential by nature.
-      const deadline = Date.now() + 10_000;
+      const deadline = Date.now() + reportPollMs;
       while (Date.now() < deadline) {
         const text = await Bun.file(log)
           .text()
@@ -457,7 +463,7 @@ describe("pane metadata report", () => {
         await Bun.sleep(25);
       }
       // oxlint-enable no-await-in-loop
-      return [];
+      throw new Error(`herdr stub never recorded report-metadata within ${reportPollMs}ms`);
     } finally {
       await Promise.all([
         rm(dir, { recursive: true, force: true }),
@@ -467,20 +473,28 @@ describe("pane metadata report", () => {
     }
   }
 
-  test("carries the title token and the dial to herdr", async () => {
-    const args = await recordedArgs(
-      `${JSON.stringify({ type: "ai-title", aiTitle: "Herdr sidebar redesign", sessionId })}\n`,
-    );
-    const tokens = args.filter((_arg, i) => args[i - 1] === "--token");
-    expect(tokens).toEqual(["title=Herdr sidebar redesign", dialToken]);
-  });
+  test(
+    "carries the title token and the dial to herdr",
+    async () => {
+      const args = await recordedArgs(
+        `${JSON.stringify({ type: "ai-title", aiTitle: "Herdr sidebar redesign", sessionId })}\n`,
+      );
+      const tokens = args.filter((_arg, i) => args[i - 1] === "--token");
+      expect(tokens).toEqual(["title=Herdr sidebar redesign", dialToken]);
+    },
+    reportTestMs,
+  );
 
-  test("clears the title before the session is named", async () => {
-    const args = await recordedArgs(
-      `${JSON.stringify({ type: "user", message: { role: "user", content: "hi" } })}\n`,
-    );
-    const tokens = args.filter((_arg, i) => args[i - 1] === "--token");
-    expect(tokens).toEqual([dialToken]);
-    expect(args.filter((_arg, i) => args[i - 1] === "--clear-token")).toContain("title");
-  });
+  test(
+    "clears the title before the session is named",
+    async () => {
+      const args = await recordedArgs(
+        `${JSON.stringify({ type: "user", message: { role: "user", content: "hi" } })}\n`,
+      );
+      const tokens = args.filter((_arg, i) => args[i - 1] === "--token");
+      expect(tokens).toEqual([dialToken]);
+      expect(args.filter((_arg, i) => args[i - 1] === "--clear-token")).toContain("title");
+    },
+    reportTestMs,
+  );
 });

--- a/user/scripts/statusline.test.ts
+++ b/user/scripts/statusline.test.ts
@@ -410,13 +410,15 @@ describe("pane metadata report", () => {
     },
   });
 
-  // A detached child racing a poll needs slack on a loaded machine. The poll has
-  // to expire inside the test's own budget so the named error surfaces instead of
-  // bun:test's generic timeout.
-  const reportPollMs = 20_000;
-  const reportTestMs = reportPollMs + 5_000;
+  // A detached child racing a poll needs slack on a loaded machine. The budget
+  // runs from test entry, not from the poll, so slow setup cannot push the poll
+  // past bun:test's timeout and trade the named error for a generic one. The
+  // remainder covers cleanup.
+  const reportBudgetMs = 20_000;
+  const reportTestMs = reportBudgetMs + 5_000;
 
   async function recordedArgs(transcript: string): Promise<string[]> {
+    const deadline = Date.now() + reportBudgetMs;
     const dir = mkdtempSync(join(tmpdir(), "statusline-herdr-"));
     const bin = join(dir, "bin");
     const log = join(dir, "argv");
@@ -454,7 +456,6 @@ describe("pane metadata report", () => {
       // The reporting child is detached so the line renders at its own speed,
       // which lands the stub's log after the status line has already exited.
       // oxlint-disable no-await-in-loop -- polling for another process's write is sequential by nature.
-      const deadline = Date.now() + reportPollMs;
       while (Date.now() < deadline) {
         const text = await Bun.file(log)
           .text()
@@ -463,7 +464,7 @@ describe("pane metadata report", () => {
         await Bun.sleep(25);
       }
       // oxlint-enable no-await-in-loop
-      throw new Error(`herdr stub never recorded report-metadata within ${reportPollMs}ms`);
+      throw new Error(`herdr stub never recorded report-metadata within ${reportBudgetMs}ms`);
     } finally {
       await Promise.all([
         rm(dir, { recursive: true, force: true }),


### PR DESCRIPTION
The pane-metadata tests poll a log file that the detached reporting child writes, and the helper returned an empty array when the poll expired. That turned a timeout into `expect([]).toEqual(["title=Herdr sidebar redesign", ...])`, which reads like the status line sent the wrong tokens. It had sent nothing yet. Throwing a named error puts the real cause in the failure output.

The poll budget goes from 10s to 20s, with a per-test timeout 5s above it so the poll is always what expires first. Leaving the test on bun:test's default would hand back a generic timeout and lose the message.

This last failed while concurrent eval runs had the machine loaded, which fits a detached child losing a 10s race rather than anything wrong with the token plumbing. Nothing in the assertions changed, so a real regression in what the status line sends still fails the same way.

Original Task: [Flaky test in the bendrucker/claude full suite](https://things.bendrucker.me/show?id=DvrrRrGjuDgWZcyMinbhBE)
