### PR TITLE
stop: install only where there is a manifest

### DIFF
--- a/.claude/hooks/stop/index.test.ts
+++ b/.claude/hooks/stop/index.test.ts
@@ -144,6 +144,55 @@ describe("processStop", () => {
     expect(await processStop(stopInput({ transcript_path: transcriptPath }))).toBeNull();
   });
 
+  // The hook spawns `bun` and `prek` by name, so a stub earlier on PATH records
+  // the calls without running either for real.
+  async function recordedCalls(cwd: string): Promise<string[]> {
+    const stubDir = await mkdtemp(join(tmpdir(), "stop-hook-stub-"));
+    const bin = join(stubDir, "bin");
+    const log = join(stubDir, "calls.log");
+    await Promise.all(
+      ["bun", "prek"].map(async (name) => {
+        const stub = join(bin, name);
+        await Bun.write(stub, `#!/bin/sh\necho "${name} $*" >> "${log}"\n`);
+        Bun.spawnSync(["chmod", "+x", stub]);
+      }),
+    );
+
+    const filePath = join(cwd, "touched.ts");
+    await Bun.write(filePath, "export {}");
+    const transcriptPath = join(cwd, "transcript.jsonl");
+    await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Edit" }]));
+
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${bin}:${originalPath ?? ""}`;
+    try {
+      expect(await processStop(stopInput({ transcript_path: transcriptPath, cwd }))).toBeNull();
+    } finally {
+      process.env.PATH = originalPath;
+    }
+
+    const file = Bun.file(log);
+    const text = (await file.exists()) ? await file.text() : "";
+    await rm(stubDir, { recursive: true, force: true });
+    return text.split("\n").filter((line) => line !== "");
+  }
+
+  it("installs before prek when the stop directory is a JS project", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "stop-hook-project-"));
+    await Bun.write(join(cwd, "package.json"), "{}");
+    expect(await recordedCalls(cwd)).toEqual([
+      `bun install --cwd ${cwd}`,
+      "prek run --files touched.ts",
+    ]);
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it("runs prek without installing when the stop directory has no manifest", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "stop-hook-bare-"));
+    expect(await recordedCalls(cwd)).toEqual(["prek run --files touched.ts"]);
+    await rm(cwd, { recursive: true, force: true });
+  });
+
   it("returns null when every collected file is out-of-tree", async () => {
     const sibling = join(tempDir, "sibling-worktree");
     const filePath = join(sibling, "plugins", "mac", "plugin.json");

--- a/.claude/hooks/stop/index.ts
+++ b/.claude/hooks/stop/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { execFile } from "node:child_process";
-import { isAbsolute, relative, sep } from "node:path";
+import { isAbsolute, join, relative, sep } from "node:path";
 import { promisify } from "node:util";
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
@@ -85,6 +85,22 @@ export async function parseTranscript(transcriptPath: string): Promise<string[]>
   return [...files];
 }
 
+// prek hooks run repo scripts that import workspace packages, so the tree needs
+// its dependencies present. A session can stop anywhere, including a directory
+// that is not a JS project at all, where there is nothing to install. Failing to
+// install is also not a check failure, and prek reports a missing dependency
+// itself, so neither case belongs in the block path.
+async function installDependencies(cwd: string): Promise<void> {
+  if (!(await fileExists(join(cwd, "package.json")))) {
+    return;
+  }
+  try {
+    await execFileAsync("bun", ["install", "--cwd", cwd]);
+  } catch {
+    // must never break the hook
+  }
+}
+
 export function scopePaths(files: string[], cwd: string): string[] {
   const scoped: string[] = [];
   for (const file of files) {
@@ -115,8 +131,9 @@ export async function processStop(input: StopInput): Promise<SyncHookJSONOutput 
     return null;
   }
 
+  await installDependencies(input.cwd);
+
   try {
-    await execFileAsync("bun", ["install", "--cwd", input.cwd]);
     await execFileAsync("prek", ["run", "--files", ...relativePaths], {
       cwd: input.cwd,
       timeout: PREK_TIMEOUT,


### PR DESCRIPTION
`bun install --cwd <cwd>` ran inside the same `try` that wraps prek, so a session stopping in a directory with no `package.json` failed on the install and fell into the catch. That catch formats everything as `Check failures:`, which meant Stop blocked with a prek error for a prek run that never happened, every time, with nothing the author could fix in their code.

The install moves ahead of the `try` and is skipped when the directory has no manifest. A failed install no longer blocks either: prek reports a missing dependency itself when it actually needs one, so the install is a convenience and has no business deciding whether the session can stop.

Both tests stub `bun` and `prek` onto `PATH` and assert which commands got invoked, since the behavior at stake is what runs rather than what it returns.

Found while this Stop hook blocked a session, so there is no Things todo behind it.
