### PR TITLE
Automerge marketplaces an update can reach

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -47,6 +47,25 @@
       automerge: false,
     },
     {
+      // `claude plugin update` moves a payload only when the declared version
+      // string changes. These two track it to the release tag, so a merged bump
+      // reaches the install on its own. worktrunk declares no version and
+      // agent-browser no manifest, so their PRs stay manual as the reminder
+      // that only a forced reinstall will move them.
+      matchManagers: ["custom.regex"],
+      matchFileNames: ["user/settings.json"],
+      matchDatasources: ["github-releases"],
+      matchDepNames: ["backnotprop/plannotator", "schpet/linear-cli"],
+      automerge: true,
+    },
+    {
+      // Renovate splits majors into their own group, which stays manual: a
+      // major to a conditional action like paths-filter can pass CI by
+      // skipping the jobs it gates.
+      matchManagers: ["github-actions"],
+      groupName: "github-actions",
+    },
+    {
       // Digest bumps track a moving branch, so Renovate's version-delta changelog
       // engine has no release range to render. Link the GitHub compare view instead
       // so the commit list between the old and new SHA is one click away.


### PR DESCRIPTION
## Plugin Marketplaces

One `automerge: false` rule covers every `chore(plugins):` ref bump, so worktrunk, linear-cli, agent-browser, and plannotator all need a manual merge most weeks.

That rule draws its line at the manager. The line that decides anything is whether `claude plugin update` can move the payload. It compares the version string a plugin declares, so it moves nothing when that string is absent or fixed:

| marketplace | declares a version | merged bump reaches the install |
| --- | --- | --- |
| `backnotprop/plannotator` | yes, tracks the tag | yes |
| `schpet/linear-cli` | yes, tracks the tag | yes |
| `max-sixty/worktrunk` | no `version` field | no |
| `vercel-labs/agent-browser` | no plugin manifest | no |

Read the plugin manifest at both the old and new tag of each to confirm.

plannotator and linear-cli now automerge. The nightly sync carries the merged ref to the deployed clone and `claude plugin update` moves the payload, which is what the manual merge was accomplishing.

worktrunk and agent-browser stay manual. No update reaches their payload, so merging is half the work and the open PR is what signals a forced reinstall is due. Automerging them would retire that signal and leave `claude-plugin-audit` reporting `pinned` with nothing left to act on. Digest pins stay manual for the same reason.

## GitHub Actions

Grouped into one PR. Majors land in a separate group and stay manual. A major to a conditional action can pass CI by skipping the jobs it gates, and `dorny/paths-filter` decides which jobs run at all.

## Removal Criteria

Drop the automerge rule if a plannotator or linear-cli bump lands without the payload following, which `claude-plugin-audit` reports as `pinned` the next night. Revisit the split if worktrunk or agent-browser starts declaring a manifest version, which moves it to the automerge side.
