### PR TITLE
ox: gate Stop on files under the session's dir

### DIFF
--- a/.claude/hooks/ox/index.test.ts
+++ b/.claude/hooks/ox/index.test.ts
@@ -98,7 +98,8 @@ function mockStopHookInput(
     session_id: sessionId,
     hook_event_name: "Stop",
     transcript_path: transcriptPath,
-    cwd: process.cwd(),
+    // The gate reads only files under cwd, and these fixtures live in tempDir.
+    cwd: tempDir,
     stop_hook_active: stopHookActive,
   };
 }
@@ -245,7 +246,7 @@ describe("ox hook", () => {
 
   describe("parseTranscript", () => {
     it("returns empty array for non-existent transcript", async () => {
-      expect(await parseTranscript("/nonexistent/path.jsonl")).toEqual([]);
+      expect(await parseTranscript("/nonexistent/path.jsonl", tempDir)).toEqual([]);
     });
 
     test.each(["Edit", "Write"])("extracts file paths from %s tool uses", async (tool) => {
@@ -253,7 +254,7 @@ describe("ox hook", () => {
       const transcriptPath = join(tempDir, `transcript-${tool}-${Date.now()}.jsonl`);
       await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool }]));
 
-      const files = await parseTranscript(transcriptPath);
+      const files = await parseTranscript(transcriptPath, tempDir);
       expect(files).toContain(filePath);
     });
 
@@ -263,7 +264,7 @@ describe("ox hook", () => {
       const transcriptPath = join(tempDir, `transcript-md-${Date.now()}.jsonl`);
       await Bun.write(transcriptPath, createTranscriptContent([{ path: mdPath, tool: "Write" }]));
 
-      const files = await parseTranscript(transcriptPath);
+      const files = await parseTranscript(transcriptPath, tempDir);
       expect(files).toEqual([]);
     });
 
@@ -274,7 +275,7 @@ describe("ox hook", () => {
       const transcriptPath = join(tempDir, `transcript-wf-${Date.now()}.jsonl`);
       await Bun.write(transcriptPath, createTranscriptContent([{ path: wfPath, tool: "Edit" }]));
 
-      const files = await parseTranscript(transcriptPath);
+      const files = await parseTranscript(transcriptPath, tempDir);
       expect(files).toEqual([]);
     });
 
@@ -283,7 +284,7 @@ describe("ox hook", () => {
       const transcriptPath = join(tempDir, `transcript-read-${Date.now()}.jsonl`);
       await Bun.write(transcriptPath, createTranscriptContent([{ path: filePath, tool: "Read" }]));
 
-      const files = await parseTranscript(transcriptPath);
+      const files = await parseTranscript(transcriptPath, tempDir);
       expect(files).toEqual([]);
     });
 
@@ -298,7 +299,7 @@ describe("ox hook", () => {
         ]),
       );
 
-      const files = await parseTranscript(transcriptPath);
+      const files = await parseTranscript(transcriptPath, tempDir);
       expect(files).toHaveLength(1);
     });
 
@@ -309,7 +310,7 @@ describe("ox hook", () => {
         createTranscriptContent([{ path: "/nonexistent/deleted.ts", tool: "Write" }]),
       );
 
-      const files = await parseTranscript(transcriptPath);
+      const files = await parseTranscript(transcriptPath, tempDir);
       expect(files).toEqual([]);
     });
 
@@ -331,8 +332,28 @@ describe("ox hook", () => {
         ]),
       );
 
-      const files = await parseTranscript(transcriptPath);
+      const files = await parseTranscript(transcriptPath, tempDir);
       expect(files).toEqual([tracked]);
+    });
+
+    it("drops a file edited outside the session's working directory", async () => {
+      const outside = await mkdtemp(join(tmpdir(), "ox-scratchpad-"));
+      const scratch = join(outside, "probe.ts");
+      await Bun.write(scratch, "const a: any = 1;\n");
+      const inside = join(tempDir, "kept.ts");
+      await Bun.write(inside, "export const b = 1;\n");
+
+      const transcriptPath = join(tempDir, `transcript-outside-${Date.now()}.jsonl`);
+      await Bun.write(
+        transcriptPath,
+        createTranscriptContent([
+          { path: scratch, tool: "Write" },
+          { path: inside, tool: "Write" },
+        ]),
+      );
+
+      expect(await parseTranscript(transcriptPath, tempDir)).toEqual([inside]);
+      await rm(outside, { recursive: true, force: true });
     });
 
     it("does not shell-evaluate a path containing a command substitution", async () => {
@@ -349,7 +370,7 @@ describe("ox hook", () => {
         createTranscriptContent([{ path: malicious, tool: "Write" }]),
       );
 
-      const files = await parseTranscript(transcriptPath);
+      const files = await parseTranscript(transcriptPath, tempDir);
       expect(files).toEqual([malicious]);
       expect(await Bun.file(join(repoDir, "pwned")).exists()).toBe(false);
     });

--- a/.claude/hooks/ox/index.ts
+++ b/.claude/hooks/ox/index.ts
@@ -3,7 +3,7 @@
 import { execFile } from "node:child_process";
 import { readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
@@ -32,6 +32,7 @@ const StopInput = z.looseObject({
   hook_event_name: z.literal("Stop"),
   session_id: z.string(),
   transcript_path: z.string(),
+  cwd: z.string(),
   stop_hook_active: z.boolean().optional(),
 });
 
@@ -118,8 +119,7 @@ async function fileExists(filePath: string): Promise<boolean> {
 // A gitignored path (scratch under tmp/, a nested worktree) can never be
 // committed, so gating Stop on its lint errors blocks the session on throwaway
 // content. git check-ignore drops those while keeping new untracked source
-// files in scope, which `git ls-files` would not. Paths outside any repo exit
-// 128 and stay in scope.
+// files in scope, which `git ls-files` would not.
 async function isIgnored(filePath: string): Promise<boolean> {
   try {
     await execFileAsync("git", ["check-ignore", "-q", filePath], { cwd: dirname(filePath) });
@@ -127,6 +127,16 @@ async function isIgnored(filePath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+// The gate speaks for one project, so it considers only what lies under the
+// directory the session is working in. A file edited elsewhere belongs to
+// another repo or to no repo at all, such as a scratch script under the
+// session's own temp directory, and its lint errors are not this project's to
+// block on.
+function withinCwd(filePath: string, cwd: string): boolean {
+  const rel = relative(cwd, filePath);
+  return rel !== "" && !isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${sep}`);
 }
 
 // An argv array rather than a shell string, so a file path is never spliced
@@ -244,7 +254,7 @@ async function runOx(
   }
 }
 
-export async function parseTranscript(transcriptPath: string): Promise<string[]> {
+export async function parseTranscript(transcriptPath: string, cwd: string): Promise<string[]> {
   if (!(await fileExists(transcriptPath))) {
     return [];
   }
@@ -276,7 +286,7 @@ export async function parseTranscript(transcriptPath: string): Promise<string[]>
 
   const checks = [...candidates].map(async (path) => ({
     path,
-    keep: (await fileExists(path)) && !(await isIgnored(path)),
+    keep: withinCwd(path, cwd) && (await fileExists(path)) && !(await isIgnored(path)),
   }));
   const results = await Promise.all(checks);
   return results.filter((result) => result.keep).map((result) => result.path);
@@ -617,7 +627,7 @@ export async function processStop(input: StopInput): Promise<SyncHookJSONOutput 
     return null;
   }
 
-  const sections = await runOxGate(await parseTranscript(input.transcript_path));
+  const sections = await runOxGate(await parseTranscript(input.transcript_path, input.cwd));
   if (sections == null || sections === "") {
     await clearBlocks(input.session_id);
     return null;


### PR DESCRIPTION
The Stop gate collected every file the transcript showed edited, with no regard for where it was. A scratch script written to this session's own temp directory was therefore linted and blocked Stop, over code that could never be committed and that no edit to the project would fix. The existing `isIgnored` filter was aimed at exactly this class of file, but it only recognized gitignored paths, and the comment noted that paths outside any repo stay in scope.

The fix scopes the collected set to paths under `cwd`, which is what the prek Stop hook next door already does with `scopePaths`. A file edited in another repo, or outside every repo, is no longer this project's Stop gate to answer for. `StopInput` picks up `cwd` to make that available.

I first tried keying off `git check-ignore`'s exit 128 to detect "outside any repository". That is a more literal reading of committability, but it broke twelve tests whose fixtures live in a bare temp dir and lean on the hook resolving no working tree so oxlint picks up this repo's own config. Scoping by `cwd` gets the same outcome, matches the sibling hook, and needs no git call.

The PostToolUse path takes its `file_path` straight from the tool input and does not go through this collector, so advisory lint feedback on a file anywhere still works. Only the blocking gate narrowed.

Found while this hook blocked a session on a throwaway script, so there is no Things todo behind it.
