### PR TITLE
mac: drop the sandbox hook's zod dependency

### DIFF
--- a/plugins/mac/hooks/sandbox.test.ts
+++ b/plugins/mac/hooks/sandbox.test.ts
@@ -109,10 +109,14 @@ describe("processInput", () => {
     expect(result).toBeNull();
   });
 
-  test("returns null when command is undefined", async () => {
-    const input = makeInput({});
-    const result = await processInput(input, "darwin");
-    expect(result).toBeNull();
+  test.each([
+    ["command is undefined", {}],
+    ["command is empty", { command: "" }],
+    ["command is not a string", { command: 42 }],
+    ["tool input is not an object", "ls"],
+    ["tool input is absent", undefined],
+  ])("returns null when %s", async (_label, toolInput) => {
+    expect(await processInput(makeInput(toolInput), "darwin")).toBeNull();
   });
 
   test("disables sandbox for marked bun script", async () => {

--- a/plugins/mac/hooks/sandbox.ts
+++ b/plugins/mac/hooks/sandbox.ts
@@ -1,20 +1,28 @@
 #!/usr/bin/env bun
 
 import { basename, extname } from "node:path";
-import type { PreToolUseHookInput, SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
-import { z } from "zod";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
 
-const ToolInput = z.looseObject({ command: z.string().optional().catch(undefined) });
+// This hook gates every Bash call and cannot report a failure to load, so it
+// narrows its input by hand and carries no runtime dependency.
+interface HookInput {
+  tool_input?: unknown;
+}
 
-const HookInput = z.looseObject({
-  hook_event_name: z.literal("PreToolUse"),
-  session_id: z.string().catch(""),
-  transcript_path: z.string().catch(""),
-  cwd: z.string().catch(""),
-  tool_name: z.string().catch(""),
-  tool_input: z.unknown().catch(undefined),
-  tool_use_id: z.string().catch(""),
-}) satisfies z.ZodType<PreToolUseHookInput>;
+interface CommandInput {
+  command: string;
+}
+
+function hasCommand(toolInput: unknown): toolInput is CommandInput {
+  if (toolInput == null || typeof toolInput !== "object") return false;
+  if (!("command" in toolInput)) return false;
+  return typeof toolInput.command === "string" && toolInput.command !== "";
+}
+
+function isPreToolUse(value: unknown): value is HookInput {
+  if (value == null || typeof value !== "object") return false;
+  return "hook_event_name" in value && value.hook_event_name === "PreToolUse";
+}
 
 const SHELL_OPERATORS = /\s*(?:&&|\|\||[|;])\s*/;
 const SCRIPT_INTERPRETERS = new Set(["bun", "node"]);
@@ -77,7 +85,7 @@ export async function hasBypassMarker(path: string): Promise<boolean> {
   return head ? head.includes(SCRIPT_MARKER) : false;
 }
 
-function disableSandbox(toolInput: z.infer<typeof ToolInput>): SyncHookJSONOutput {
+function disableSandbox(toolInput: CommandInput): SyncHookJSONOutput {
   return {
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
@@ -87,13 +95,13 @@ function disableSandbox(toolInput: z.infer<typeof ToolInput>): SyncHookJSONOutpu
 }
 
 export async function processInput(
-  input: PreToolUseHookInput,
+  input: HookInput,
   platform = process.platform,
 ): Promise<SyncHookJSONOutput | null> {
   if (platform !== "darwin") return null;
 
-  const toolInput = ToolInput.safeParse(input.tool_input).data;
-  if (toolInput?.command == null || toolInput.command === "") return null;
+  const toolInput = input.tool_input;
+  if (!hasCommand(toolInput)) return null;
 
   for (const { scriptArg } of extractCommands(toolInput.command)) {
     // oxlint-disable-next-line no-await-in-loop -- first match wins: the scan stops at the first command carrying a bypass marker.
@@ -106,13 +114,18 @@ export async function processInput(
 }
 
 async function main(): Promise<void> {
-  let input: PreToolUseHookInput;
+  let input: unknown;
   try {
-    input = HookInput.parse(JSON.parse(await Bun.stdin.text()));
+    input = JSON.parse(await Bun.stdin.text());
   } catch (error) {
     console.error(
       `[mac/sandbox] Failed to parse hook input: ${error instanceof Error ? error.message : String(error)}`,
     );
+    return;
+  }
+
+  if (!isPreToolUse(input)) {
+    console.error("[mac/sandbox] Hook input is not a PreToolUse event");
     return;
   }
 


### PR DESCRIPTION
The marker hook decides whether a script gets a sandbox skip, and it runs ahead of every Bash call. Its only runtime dependency was `zod`, so with the plugin's `node_modules` missing the import fails at module load: `Cannot find package 'zod'`. Claude Code sees a hook that wrote nothing to stdout, so the bypass injection disappears and the script runs sandboxed.

#1409 fixed the resolution for versions cached since it landed, by shipping the lockfile that gets the dependency installed. Every plugin copy cached before it has no lockfile and no `node_modules`, so the silent loss stays reachable. Removing the dependency retires the failure mode for every cached copy.

The schema was doing no validation work. Every field carried a `.catch()` default, and the one value the hook reads is `tool_input.command` as an optional string. Two predicates cover it:

- `hasCommand` narrows the tool input to an object with a non-empty string `command`.
- `isPreToolUse` rejects input that is not a PreToolUse event.

`processInput` takes the one field it reads instead of the full SDK input type, so nothing has to synthesize the six fields it ignores. What remains is a `node:path` import and a type import, both of which resolve with nothing installed.

This cuts against `user/rules/typescript.md`, which says external data gets validated against a zod schema, so `.claude/rules/scripts.md` now carries the carve-out beside the existing plugin paragraph: a hook that gates a tool call has no channel for a load failure, so it drops the dependency and narrows by predicate over the one field it reads. The user rule keeps the unqualified form, since the plugin cache mechanics that force this are specific to this repo. Anywhere a schema would earn its cost the rule still holds.

`zod` stays in the plugin manifest because `scripts/jxa.ts` imports it. A skill invokes that script by name and a resolution error surfaces immediately, so it carries no comparable hazard.

A `dependency-free execution` block holds the property the change exists for. It copies the hook to a temp directory, asserts no `node_modules` sits in any ancestor, and runs it there with auto-install off, checking the bypass on stdout and a clean stderr. Against the previous version both cases fail on the zod resolution error, so the coverage discriminates rather than restating the unit tests.

Added table-driven cases for the inputs the `.catch()` defaults used to absorb: a non-string `command`, a tool input that is not an object, and an absent one.

Found while auditing this hook, so there is no Things todo behind it.

